### PR TITLE
chore: [Running GitHub actions for #12734]

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -84,6 +84,8 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 _ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
     "claude-opus-4-7",
     "claude-opus-4-8",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
     "claude-fable-5",
     "claude-5-fable",
     "claude-mythos-5",
@@ -105,6 +107,8 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
     "claude-fable-5",
     "claude-5-fable",
     "claude-mythos-5",

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -437,6 +437,8 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-opus-4.8",
     "claude-4-8-opus",
     "claude-4.8-opus",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
     "claude-fable-5",
     "claude-fable-5@20260101",
     "claude-5-fable",
@@ -473,6 +475,8 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
     [
         "claude-opus-4-7",
         "claude-opus-4-8",
+        "claude-sonnet-5",
+        "claude-5-sonnet",
         "claude-fable-5",
         "claude-5-fable",
         "claude-mythos-5",


### PR DESCRIPTION
This PR runs GitHub Actions CI for #12734.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for Claude Sonnet 5 by treating it as an adaptive-thinking model that rejects sampling params, preventing 400s. Updated tests to cover the new model IDs.

- **Bug Fixes**
  - Added `claude-sonnet-5` and `claude-5-sonnet` to `_ANTHROPIC_ADAPTIVE_THINKING_MODELS` and `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS`.
  - Extended parameterized tests in `test_multi_llm.py` for streaming/tool-calls and no-sampling cases to include the new IDs.

<sup>Written for commit 404c9d28ec0c97f586846ee2d6b2639d57033ddb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12737?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

