### PR TITLE
fix(auth): restore chat access for LIMITED service-account keys

### DIFF
--- a/backend/alembic/versions/20f09b642ed0_backfill_write_chat_for_limited_service_.py
+++ b/backend/alembic/versions/20f09b642ed0_backfill_write_chat_for_limited_service_.py
@@ -1,0 +1,58 @@
+"""backfill write chat for limited service accounts
+
+LIMITED service-account keys created before insert_api_key granted them
+write:chat directly (#11763) have an empty effective_permissions column,
+which locks them out of the scoped chat APIs. Backfill the grant
+(write:chat implies read:chat at read time).
+
+Revision ID: 20f09b642ed0
+Revises: 2e0b2b146de1
+Create Date: 2026-07-07 09:46:01.019413
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "20f09b642ed0"
+down_revision = "2e0b2b146de1"
+branch_labels: str | None = None
+depends_on: str | Sequence[str] | None = None
+
+user_table = sa.table(
+    "user",
+    sa.column("role", sa.String),
+    sa.column("account_type", sa.String),
+    sa.column("effective_permissions", postgresql.JSONB),
+)
+
+WRITE_CHAT_PERMS = ["write:chat"]
+
+
+def upgrade() -> None:
+    op.execute(
+        user_table.update()
+        .where(
+            user_table.c.account_type == "SERVICE_ACCOUNT",
+            user_table.c.role == "LIMITED",
+            user_table.c.effective_permissions == sa.cast([], postgresql.JSONB),
+        )
+        .values(effective_permissions=WRITE_CHAT_PERMS)
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        user_table.update()
+        .where(
+            user_table.c.account_type == "SERVICE_ACCOUNT",
+            user_table.c.role == "LIMITED",
+            user_table.c.effective_permissions
+            == sa.cast(WRITE_CHAT_PERMS, postgresql.JSONB),
+        )
+        .values(effective_permissions=[])
+    )

--- a/backend/alembic/versions/20f09b642ed0_backfill_write_chat_for_limited_service_.py
+++ b/backend/alembic/versions/20f09b642ed0_backfill_write_chat_for_limited_service_.py
@@ -46,13 +46,7 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.execute(
-        user_table.update()
-        .where(
-            user_table.c.account_type == "SERVICE_ACCOUNT",
-            user_table.c.role == "LIMITED",
-            user_table.c.effective_permissions
-            == sa.cast(WRITE_CHAT_PERMS, postgresql.JSONB),
-        )
-        .values(effective_permissions=[])
-    )
+    # No-op: backfilled rows are indistinguishable from keys the API-key
+    # code granted write:chat after this migration, and clearing those
+    # would break them. Leaving the grant in place is harmless.
+    pass

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -16,7 +16,6 @@ from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.configs.constants import DANSWER_API_KEY_PREFIX
 from onyx.configs.constants import UNNAMED_KEY_PLACEHOLDER
 from onyx.db.enums import AccountType
-from onyx.db.enums import Permission
 from onyx.db.models import ApiKey
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
@@ -76,12 +75,6 @@ def get_api_key_fake_email(
     return f"{DANSWER_API_KEY_PREFIX}{name}@{unique_id}{DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN}"
 
 
-def _grant_limited_key_scope(api_key_user: User) -> None:
-    """LIMITED keys join no group; chat scope is granted directly
-    (WRITE_CHAT implies READ_CHAT)."""
-    api_key_user.effective_permissions = [Permission.WRITE_CHAT.value]
-
-
 def insert_api_key(
     db_session: Session, api_key_args: APIKeyArgs, user_id: uuid.UUID | None
 ) -> ApiKeyDescriptor:
@@ -125,8 +118,8 @@ def insert_api_key(
             api_key_user_row,
             is_admin=(api_key_args.role == UserRole.ADMIN),
         )
-    elif api_key_args.role == UserRole.LIMITED:
-        _grant_limited_key_scope(api_key_user_row)
+    else:
+        recompute_user_permissions__no_commit(api_key_user_id, db_session)
 
     db_session.commit()
 
@@ -180,13 +173,10 @@ def update_api_key(
                 api_key_user,
                 is_admin=(api_key_args.role == UserRole.ADMIN),
             )
-        elif api_key_args.role != UserRole.LIMITED:
-            # Recompute since we just removed the old default-group membership.
-            recompute_user_permissions__no_commit(api_key_user.id, db_session)
 
-    # On every update, not just role changes, so edits repair legacy keys.
-    if api_key_args.role == UserRole.LIMITED:
-        _grant_limited_key_scope(api_key_user)
+    # Converge on every update, not just role changes, so edits repair
+    # keys with stale permissions.
+    recompute_user_permissions__no_commit(api_key_user.id, db_session)
 
     db_session.commit()
 
@@ -220,8 +210,8 @@ def regenerate_api_key(db_session: Session, api_key_id: int) -> ApiKeyDescriptor
     existing_api_key.hashed_api_key = hash_api_key(new_api_key)
     existing_api_key.api_key_display = build_displayable_api_key(new_api_key)
 
-    if api_key_user.role == UserRole.LIMITED:
-        _grant_limited_key_scope(api_key_user)
+    # Converge so rotation repairs keys with stale permissions.
+    recompute_user_permissions__no_commit(api_key_user.id, db_session)
 
     db_session.commit()
 

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -76,6 +76,12 @@ def get_api_key_fake_email(
     return f"{DANSWER_API_KEY_PREFIX}{name}@{unique_id}{DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN}"
 
 
+def _grant_limited_key_scope(api_key_user: User) -> None:
+    """LIMITED keys join no group; chat scope is granted directly
+    (WRITE_CHAT implies READ_CHAT)."""
+    api_key_user.effective_permissions = [Permission.WRITE_CHAT.value]
+
+
 def insert_api_key(
     db_session: Session, api_key_args: APIKeyArgs, user_id: uuid.UUID | None
 ) -> ApiKeyDescriptor:
@@ -120,10 +126,7 @@ def insert_api_key(
             is_admin=(api_key_args.role == UserRole.ADMIN),
         )
     elif api_key_args.role == UserRole.LIMITED:
-        # LIMITED keys join no group, so they get no group-derived permissions.
-        # Grant chat scope directly to preserve their chat-only capability
-        # (WRITE_CHAT implies READ_CHAT).
-        api_key_user_row.effective_permissions = [Permission.WRITE_CHAT.value]
+        _grant_limited_key_scope(api_key_user_row)
 
     db_session.commit()
 
@@ -177,13 +180,13 @@ def update_api_key(
                 api_key_user,
                 is_admin=(api_key_args.role == UserRole.ADMIN),
             )
-        elif api_key_args.role == UserRole.LIMITED:
-            # LIMITED keys join no group; grant chat scope directly to match
-            # insert_api_key (WRITE_CHAT implies READ_CHAT).
-            api_key_user.effective_permissions = [Permission.WRITE_CHAT.value]
-        else:
+        elif api_key_args.role != UserRole.LIMITED:
             # Recompute since we just removed the old default-group membership.
             recompute_user_permissions__no_commit(api_key_user.id, db_session)
+
+    # On every update, not just role changes, so edits repair legacy keys.
+    if api_key_args.role == UserRole.LIMITED:
+        _grant_limited_key_scope(api_key_user)
 
     db_session.commit()
 
@@ -216,6 +219,10 @@ def regenerate_api_key(db_session: Session, api_key_id: int) -> ApiKeyDescriptor
     new_api_key = generate_api_key(tenant_id)
     existing_api_key.hashed_api_key = hash_api_key(new_api_key)
     existing_api_key.api_key_display = build_displayable_api_key(new_api_key)
+
+    if api_key_user.role == UserRole.LIMITED:
+        _grant_limited_key_scope(api_key_user)
+
     db_session.commit()
 
     return ApiKeyDescriptor(

--- a/backend/onyx/db/discord_bot.py
+++ b/backend/onyx/db/discord_bot.py
@@ -15,7 +15,6 @@ from onyx.auth.api_key import hash_api_key
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import DISCORD_SERVICE_API_KEY_NAME
 from onyx.db.api_key import insert_api_key
-from onyx.db.enums import Permission
 from onyx.db.models import ApiKey
 from onyx.db.models import DiscordBotConfig
 from onyx.db.models import DiscordChannelConfig
@@ -107,12 +106,6 @@ def get_or_create_discord_service_api_key(
         new_api_key = generate_api_key(tenant_id)
         existing.hashed_api_key = hash_api_key(new_api_key)
         existing.api_key_display = build_displayable_api_key(new_api_key)
-        # Backfill chat scope on keys provisioned before chat APIs were scoped.
-        service_user = db_session.scalar(
-            select(User).where(User.id == existing.user_id)  # ty: ignore[invalid-argument-type]
-        )
-        if service_user is not None:
-            service_user.effective_permissions = [Permission.WRITE_CHAT.value]
         db_session.flush()
         return new_api_key
 

--- a/backend/onyx/db/permissions.py
+++ b/backend/onyx/db/permissions.py
@@ -79,7 +79,9 @@ def recompute_user_permissions__no_commit(
         .scalars()
         .all()
     }
-    uid_list = [uid for uid in uid_list if str(uid) not in limited_service_account_ids]
+    uid_list = [
+        uid for uid in uid_list if str(uid).lower() not in limited_service_account_ids
+    ]
 
     if not uid_list:
         return

--- a/backend/onyx/db/permissions.py
+++ b/backend/onyx/db/permissions.py
@@ -42,20 +42,24 @@ def parse_permission_values(values: Iterable[str]) -> list[Permission]:
     return parsed
 
 
+def role_derived_permissions(account_type: AccountType, role: UserRole) -> set[str]:
+    """Permissions a user holds by virtue of what they are, independent of
+    group grants. LIMITED service accounts join no group; their chat scope
+    derives from the role (WRITE_CHAT implies READ_CHAT at read time)."""
+    if account_type == AccountType.SERVICE_ACCOUNT and role == UserRole.LIMITED:
+        return {Permission.WRITE_CHAT.value}
+    return set()
+
+
 def recompute_user_permissions__no_commit(
     user_ids: UUID | str | list[UUID] | list[str], db_session: Session
 ) -> None:
-    """Recompute granted permissions for one or more users.
+    """Recompute granted permissions for one or more users: group grants
+    plus role-derived permissions. Implication expansion happens at read
+    time via get_effective_permissions().
 
     Accepts a single UUID or a list.  Uses a single query regardless of
     how many users are passed, avoiding N+1 issues.
-
-    Stores only directly granted permissions — implication expansion
-    happens at read time via get_effective_permissions().
-
-    LIMITED service accounts are skipped: their permissions are set
-    directly by the API-key code (not derived from groups), so a group
-    recompute must not overwrite them.
 
     Does NOT commit — caller must commit the session.
     """
@@ -63,25 +67,6 @@ def recompute_user_permissions__no_commit(
         uid_list = [user_ids]
     else:
         uid_list = list(user_ids)
-
-    if not uid_list:
-        return
-
-    limited_service_account_ids = {
-        str(uid)
-        for uid in db_session.execute(
-            select(User.id).where(  # ty: ignore[no-matching-overload]
-                User.id.in_(uid_list),  # ty: ignore[unresolved-attribute]
-                User.account_type == AccountType.SERVICE_ACCOUNT,
-                User.role == UserRole.LIMITED,
-            )
-        )
-        .scalars()
-        .all()
-    }
-    uid_list = [
-        uid for uid in uid_list if str(uid).lower() not in limited_service_account_ids
-    ]
 
     if not uid_list:
         return
@@ -100,6 +85,15 @@ def recompute_user_permissions__no_commit(
         )
     ).all()
 
+    role_derived_by_user: dict[str, set[str]] = {
+        str(user_id).lower(): role_derived_permissions(account_type, role)
+        for user_id, account_type, role in db_session.execute(
+            select(User.id, User.account_type, User.role).where(  # ty: ignore[no-matching-overload]
+                User.id.in_(uid_list)  # ty: ignore[unresolved-attribute]
+            )
+        ).all()
+    }
+
     # Group permissions by user; users with no grants get an empty set.
     perms_by_user: dict[UUID | str, set[str]] = defaultdict(set)
     for uid in uid_list:
@@ -108,6 +102,7 @@ def recompute_user_permissions__no_commit(
         perms_by_user[uid].add(perm.value)
 
     for uid, perms in perms_by_user.items():
+        perms |= role_derived_by_user.get(str(uid).lower(), set())
         db_session.execute(
             update(User)
             .where(User.id == uid)  # ty: ignore[invalid-argument-type]

--- a/backend/onyx/db/permissions.py
+++ b/backend/onyx/db/permissions.py
@@ -15,6 +15,8 @@ from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
 from onyx.db.enums import Permission
 from onyx.db.models import PermissionGrant
 from onyx.db.models import User
@@ -51,12 +53,33 @@ def recompute_user_permissions__no_commit(
     Stores only directly granted permissions — implication expansion
     happens at read time via get_effective_permissions().
 
+    LIMITED service accounts are skipped: their permissions are set
+    directly by the API-key code (not derived from groups), so a group
+    recompute must not overwrite them.
+
     Does NOT commit — caller must commit the session.
     """
     if isinstance(user_ids, (UUID, str)):
         uid_list = [user_ids]
     else:
         uid_list = list(user_ids)
+
+    if not uid_list:
+        return
+
+    limited_service_account_ids = {
+        str(uid)
+        for uid in db_session.execute(
+            select(User.id).where(  # ty: ignore[no-matching-overload]
+                User.id.in_(uid_list),  # ty: ignore[unresolved-attribute]
+                User.account_type == AccountType.SERVICE_ACCOUNT,
+                User.role == UserRole.LIMITED,
+            )
+        )
+        .scalars()
+        .all()
+    }
+    uid_list = [uid for uid in uid_list if str(uid) not in limited_service_account_ids]
 
     if not uid_list:
         return

--- a/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
@@ -1,5 +1,6 @@
-"""Editing or rotating a LIMITED key re-asserts its chat scope, repairing
-legacy keys created before the grant existed."""
+"""Editing or rotating a key recomputes its permissions: legacy LIMITED
+keys with a blank grant are repaired, and healthy keys keep the
+permissions they already had."""
 
 from uuid import UUID
 
@@ -15,11 +16,16 @@ from onyx.db.models import User
 from onyx.server.api_key.models import APIKeyArgs
 
 
-def _blank_permissions(db_session: Session, user_id: UUID) -> User:
+def _get_key_user(db_session: Session, user_id: UUID) -> User:
     user = db_session.scalar(
         select(User).where(User.id == user_id)  # ty: ignore[invalid-argument-type]
     )
     assert user is not None
+    return user
+
+
+def _blank_permissions(db_session: Session, user_id: UUID) -> User:
+    user = _get_key_user(db_session, user_id)
     user.effective_permissions = []
     db_session.commit()
     return user
@@ -47,5 +53,62 @@ def test_regenerate_repairs_legacy_limited_key(db_session: Session) -> None:
 
     db_session.refresh(user)
     assert user.effective_permissions == ["write:chat"]
+
+    remove_api_key(db_session, descriptor.api_key_id)
+
+
+def test_update_preserves_limited_key_permissions(db_session: Session) -> None:
+    descriptor = insert_api_key(
+        db_session,
+        APIKeyArgs(name="limited-rename", role=UserRole.LIMITED),
+        user_id=None,
+    )
+    user = _get_key_user(db_session, descriptor.user_id)
+    assert user.effective_permissions == ["write:chat"]
+
+    update_api_key(
+        db_session,
+        descriptor.api_key_id,
+        APIKeyArgs(name="limited-renamed", role=UserRole.LIMITED),
+    )
+
+    db_session.refresh(user)
+    assert user.effective_permissions == ["write:chat"]
+
+    remove_api_key(db_session, descriptor.api_key_id)
+
+
+def test_update_preserves_basic_key_permissions(db_session: Session) -> None:
+    descriptor = insert_api_key(
+        db_session, APIKeyArgs(name="basic-rename", role=UserRole.BASIC), user_id=None
+    )
+    user = _get_key_user(db_session, descriptor.user_id)
+    perms_before = list(user.effective_permissions)
+    assert perms_before
+
+    update_api_key(
+        db_session,
+        descriptor.api_key_id,
+        APIKeyArgs(name="basic-renamed", role=UserRole.BASIC),
+    )
+
+    db_session.refresh(user)
+    assert user.effective_permissions == perms_before
+
+    remove_api_key(db_session, descriptor.api_key_id)
+
+
+def test_regenerate_preserves_basic_key_permissions(db_session: Session) -> None:
+    descriptor = insert_api_key(
+        db_session, APIKeyArgs(name="basic-regen", role=UserRole.BASIC), user_id=None
+    )
+    user = _get_key_user(db_session, descriptor.user_id)
+    perms_before = list(user.effective_permissions)
+    assert perms_before
+
+    regenerate_api_key(db_session, descriptor.api_key_id)
+
+    db_session.refresh(user)
+    assert user.effective_permissions == perms_before
 
     remove_api_key(db_session, descriptor.api_key_id)

--- a/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
@@ -98,6 +98,33 @@ def test_update_preserves_basic_key_permissions(db_session: Session) -> None:
     remove_api_key(db_session, descriptor.api_key_id)
 
 
+def test_update_role_change_swaps_permission_source(db_session: Session) -> None:
+    descriptor = insert_api_key(
+        db_session, APIKeyArgs(name="role-swap", role=UserRole.BASIC), user_id=None
+    )
+    user = _get_key_user(db_session, descriptor.user_id)
+    basic_perms = list(user.effective_permissions)
+    assert basic_perms
+
+    update_api_key(
+        db_session,
+        descriptor.api_key_id,
+        APIKeyArgs(name="role-swap", role=UserRole.LIMITED),
+    )
+    db_session.refresh(user)
+    assert user.effective_permissions == ["write:chat"]
+
+    update_api_key(
+        db_session,
+        descriptor.api_key_id,
+        APIKeyArgs(name="role-swap", role=UserRole.BASIC),
+    )
+    db_session.refresh(user)
+    assert user.effective_permissions == basic_perms
+
+    remove_api_key(db_session, descriptor.api_key_id)
+
+
 def test_regenerate_preserves_basic_key_permissions(db_session: Session) -> None:
     descriptor = insert_api_key(
         db_session, APIKeyArgs(name="basic-regen", role=UserRole.BASIC), user_id=None

--- a/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_api_key_permissions.py
@@ -1,0 +1,51 @@
+"""Editing or rotating a LIMITED key re-asserts its chat scope, repairing
+legacy keys created before the grant existed."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.api_key import insert_api_key
+from onyx.db.api_key import regenerate_api_key
+from onyx.db.api_key import remove_api_key
+from onyx.db.api_key import update_api_key
+from onyx.db.models import User
+from onyx.server.api_key.models import APIKeyArgs
+
+
+def _blank_permissions(db_session: Session, user_id: UUID) -> User:
+    user = db_session.scalar(
+        select(User).where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+    )
+    assert user is not None
+    user.effective_permissions = []
+    db_session.commit()
+    return user
+
+
+def test_update_repairs_legacy_limited_key(db_session: Session) -> None:
+    args = APIKeyArgs(name="legacy-limited-update", role=UserRole.LIMITED)
+    descriptor = insert_api_key(db_session, args, user_id=None)
+    user = _blank_permissions(db_session, descriptor.user_id)
+
+    update_api_key(db_session, descriptor.api_key_id, args)
+
+    db_session.refresh(user)
+    assert user.effective_permissions == ["write:chat"]
+
+    remove_api_key(db_session, descriptor.api_key_id)
+
+
+def test_regenerate_repairs_legacy_limited_key(db_session: Session) -> None:
+    args = APIKeyArgs(name="legacy-limited-regen", role=UserRole.LIMITED)
+    descriptor = insert_api_key(db_session, args, user_id=None)
+    user = _blank_permissions(db_session, descriptor.user_id)
+
+    regenerate_api_key(db_session, descriptor.api_key_id)
+
+    db_session.refresh(user)
+    assert user.effective_permissions == ["write:chat"]
+
+    remove_api_key(db_session, descriptor.api_key_id)

--- a/backend/tests/external_dependency_unit/db/test_recompute_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_recompute_permissions.py
@@ -1,0 +1,52 @@
+"""LIMITED service accounts hold a direct write:chat grant (set by the
+API-key code, not derived from groups), so group-based recomputes must
+leave them untouched while still recomputing everyone else."""
+
+from uuid import UUID
+
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import AccountType
+from onyx.db.permissions import recompute_user_permissions__no_commit
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def test_recompute_skips_limited_service_account(db_session: Session) -> None:
+    limited_key_user = create_test_user(
+        db_session,
+        "limited_key",
+        role=UserRole.LIMITED,
+        account_type=AccountType.SERVICE_ACCOUNT,
+    )
+    limited_key_user.effective_permissions = ["write:chat"]
+    db_session.commit()
+
+    recompute_user_permissions__no_commit(limited_key_user.id, db_session)
+    db_session.commit()
+
+    db_session.refresh(limited_key_user)
+    assert limited_key_user.effective_permissions == ["write:chat"]
+
+
+def test_recompute_still_updates_other_users_in_batch(db_session: Session) -> None:
+    limited_key_user = create_test_user(
+        db_session,
+        "limited_key",
+        role=UserRole.LIMITED,
+        account_type=AccountType.SERVICE_ACCOUNT,
+    )
+    limited_key_user.effective_permissions = ["write:chat"]
+    standard_user = create_test_user(db_session, "standard")
+    standard_user.effective_permissions = ["basic"]
+    db_session.commit()
+
+    user_ids: list[UUID] = [limited_key_user.id, standard_user.id]
+    recompute_user_permissions__no_commit(user_ids, db_session)
+    db_session.commit()
+
+    db_session.refresh(limited_key_user)
+    db_session.refresh(standard_user)
+    assert limited_key_user.effective_permissions == ["write:chat"]
+    # standard user is in no groups, so a recompute clears the stale grant
+    assert standard_user.effective_permissions == []

--- a/backend/tests/external_dependency_unit/db/test_recompute_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_recompute_permissions.py
@@ -1,6 +1,5 @@
-"""LIMITED service accounts hold a direct write:chat grant (set by the
-API-key code, not derived from groups), so group-based recomputes must
-leave them untouched while still recomputing everyone else."""
+"""LIMITED service accounts hold chat scope derived from their role, not
+from groups, so any recompute converges them to it instead of wiping it."""
 
 from uuid import UUID
 
@@ -12,15 +11,14 @@ from onyx.db.permissions import recompute_user_permissions__no_commit
 from tests.external_dependency_unit.conftest import create_test_user
 
 
-def test_recompute_skips_limited_service_account(db_session: Session) -> None:
+def test_recompute_derives_limited_key_scope(db_session: Session) -> None:
     limited_key_user = create_test_user(
         db_session,
         "limited_key",
         role=UserRole.LIMITED,
         account_type=AccountType.SERVICE_ACCOUNT,
     )
-    limited_key_user.effective_permissions = ["write:chat"]
-    db_session.commit()
+    assert limited_key_user.effective_permissions == []
 
     recompute_user_permissions__no_commit(limited_key_user.id, db_session)
     db_session.commit()
@@ -29,14 +27,13 @@ def test_recompute_skips_limited_service_account(db_session: Session) -> None:
     assert limited_key_user.effective_permissions == ["write:chat"]
 
 
-def test_recompute_still_updates_other_users_in_batch(db_session: Session) -> None:
+def test_recompute_batch_handles_mixed_users(db_session: Session) -> None:
     limited_key_user = create_test_user(
         db_session,
         "limited_key",
         role=UserRole.LIMITED,
         account_type=AccountType.SERVICE_ACCOUNT,
     )
-    limited_key_user.effective_permissions = ["write:chat"]
     standard_user = create_test_user(db_session, "standard")
     standard_user.effective_permissions = ["basic"]
     db_session.commit()

--- a/backend/tests/integration/tests/api_key/test_api_key.py
+++ b/backend/tests/integration/tests/api_key/test_api_key.py
@@ -156,8 +156,8 @@ def test_api_key_admin_service_account(reset: None) -> None:  # noqa: ARG001
 
 
 def test_limited_key_blocked_by_current_user(reset: None) -> None:  # noqa: ARG001
-    """A LIMITED API key (service account, no permissions) should be rejected
-    by endpoints behind current_user but allowed through current_limited_user."""
+    """A LIMITED API key (service account, chat scope only) should be rejected
+    by BASIC_ACCESS-scoped endpoints but allowed through current_limited_user."""
     admin_user: DATestUser = UserManager.create(name="admin_user")
 
     limited_key: DATestAPIKey = APIKeyManager.create(

--- a/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
+++ b/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
@@ -651,37 +651,6 @@ class TestServiceApiKeyAPI:
         delete_discord_service_api_key(db_session)
         db_session.commit()
 
-    def test_get_or_create_backfills_legacy_key_scope(
-        self, db_session: Session
-    ) -> None:
-        """A key provisioned before chat APIs were scoped (empty permissions) is
-        repaired with chat scope on the next get_or_create call."""
-        delete_discord_service_api_key(db_session)
-        db_session.commit()
-
-        get_or_create_discord_service_api_key(db_session, "public")
-        db_session.commit()
-
-        # Simulate a legacy key whose backing user has no permissions.
-        stored_key = get_discord_service_api_key(db_session)
-        assert stored_key is not None
-        legacy_user = db_session.scalar(
-            select(User).where(User.id == stored_key.user_id)  # ty: ignore[invalid-argument-type]
-        )
-        assert legacy_user is not None
-        legacy_user.effective_permissions = []
-        db_session.commit()
-
-        get_or_create_discord_service_api_key(db_session, "public")
-        db_session.commit()
-
-        db_session.refresh(legacy_user)
-        perms = get_effective_permissions(legacy_user)
-        assert {Permission.READ_CHAT, Permission.WRITE_CHAT} <= perms
-
-        delete_discord_service_api_key(db_session)
-        db_session.commit()
-
     def test_delete_service_api_key(self, db_session: Session) -> None:
         """Delete service API key removes it from DB."""
         # Clean up any existing key first


### PR DESCRIPTION
## Description

When the chat APIs were scoped with fine-grained permissions (#11672), LIMITED service-account keys needed a direct `write:chat` grant to keep working. #11763 added that grant — but only for newly created/updated keys (plus a lazy backfill for the Discord service key on regenerate). LIMITED keys created before that fix still have an empty `effective_permissions` column, so `is_limited_user()` blocks them at `current_user` and they fail every `require_permission` check — locking them out of the entire chat surface (`create-chat-session`, `send-message`, `get-chat-session`, …), which is the one thing a LIMITED key exists to do.

Two-part fix — repair the existing broken rows, then remove the class of bug:

- **Backfill migration**: grants `["write:chat"]` to `SERVICE_ACCOUNT` users with role `LIMITED` and empty `effective_permissions`. The anonymous user (role LIMITED but account_type ANONYMOUS) and keys with existing grants are untouched. Downgrade is a no-op: backfilled rows are indistinguishable from keys granted write:chat by the API-key code after the migration, and clearing those would break them.
- **Makes the LIMITED grant role-derived**: `role_derived_permissions` in `permissions.py` is the single place that knows LIMITED service accounts carry `write:chat`, and `recompute_user_permissions__no_commit` computes group grants ∪ role-derived permissions. Previously the grant existed only in the stored column, so every recompute path (SCIM sync, group membership edits) could silently wipe it and every writer had to remember to re-assert it.
- **Removes the now-redundant Discord regenerate-path backfill** and its legacy test — the migration covers existing keys and recompute now derives the grant.
- **`insert_api_key`/`update_api_key`/`regenerate_api_key` now just recompute** (update and rotation unconditionally), so any admin edit or rotation converges a key with stale permissions. Previously rotation only swapped the secret on the same permission-less virtual user — reproduced live with the onyx.app widget key, which kept returning 403 after rotation.
- Refreshes the stale "no permissions" docstring in `test_api_key.py`.

## How Has This Been Tested?

- Exercised the migration's `upgrade()` and `downgrade()` against a real Postgres in a rolled-back transaction with three fixture rows (pre-fix LIMITED key, anonymous user, LIMITED key with custom grants): only the pre-fix key is backfilled, downgrade inverts it exactly.
- New external-dependency-unit tests: recompute derives `write:chat` for LIMITED service accounts (alone and in a mixed batch where a standard user's stale grant is cleared); update/rotation repair a blanked legacy LIMITED key; update/rotation preserve a healthy LIMITED key's scope and a BASIC key's group-derived permissions. All pass.
- Pre-commit (ty, ruff, etc.) passes on all changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores chat access for older LIMITED service-account keys by backfilling `write:chat` and deriving it from the role during permission recompute. Key edits and rotation now converge stale keys; removes the Discord-specific backfill and its legacy test.

- **Bug Fixes**
  - Alembic migration grants `["write:chat"]` to `SERVICE_ACCOUNT` users with role `LIMITED` and empty `effective_permissions`; downgrade is a no-op.
  - `recompute_user_permissions__no_commit` derives `write:chat` for LIMITED service accounts and normalizes UUIDs for consistent behavior.
  - `update_api_key`/`regenerate_api_key` recompute to re-assert `write:chat` for LIMITED keys and preserve other roles’ grants.
  - Removes the Discord regenerate-path backfill and its legacy test.
  - Tests cover recompute derivation, update/rotation repair, and role-change permission source swaps; updates a stale test docstring.

<sup>Written for commit aace9bfff5caf0d22824b162ef970de237bb2044. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

