### PR TITLE
refactor(llm): gate Anthropic thinking/sampling on parsed model version

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import re
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -79,41 +80,22 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
     "claude-opus-4-8",
 )
 
-# Anthropic models that require the adaptive thinking API (thinking.type.adaptive
-# + output_config.effort) instead of the legacy thinking.type.enabled + budget_tokens.
-_ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-fable-5",
-    "claude-5-fable",
-    "claude-mythos-5",
-    "claude-5-mythos",
-    "claude-sonnet-5",
-    "claude-5-sonnet",
-)
+# Starting with Claude Opus 4.7, Anthropic requires the adaptive thinking API
+# (thinking.type.adaptive + output_config.effort) in place of the legacy
+# thinking.type.enabled + budget_tokens, and rejects any non-default sampling
+# parameter (temperature/top_p/top_k) with a 400 invalid_request_error. Every
+# later model — Opus 4.8, the Claude 5 line (fable/mythos/sonnet), and beyond —
+# inherits both behaviors, so we gate on the parsed model version rather than an
+# explicit list. This lets new releases be handled without a code change, and
+# avoids relying on LiteLLM's drop_params (unreliable here, since AnthropicConfig
+# still advertises temperature as supported).
+_ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
 
-# Anthropic models that reject any non-default sampling parameter (temperature,
-# top_p, top_k). For these models we must omit these params entirely from the
-# request payload — passing them returns a 400 invalid_request_error. LiteLLM's
-# drop_params is unreliable here because AnthropicConfig still lists temperature
-# as supported. Match on substring to cover proxy/Vertex naming variants (e.g.
-# "claude-4.7-opus" via litellm_proxy).
-_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
-    "claude-opus-4-7",
-    "claude-opus-4.7",
-    "claude-4-7-opus",
-    "claude-4.7-opus",
-    "claude-opus-4-8",
-    "claude-opus-4.8",
-    "claude-4-8-opus",
-    "claude-4.8-opus",
-    "claude-fable-5",
-    "claude-5-fable",
-    "claude-mythos-5",
-    "claude-5-mythos",
-    "claude-sonnet-5",
-    "claude-5-sonnet",
-)
+# Named tiers spanning Claude's naming schemes, including the Claude 5 line whose
+# version digit can precede or follow the tier ("claude-sonnet-5" vs
+# "claude-5-sonnet").
+_ANTHROPIC_MODEL_TIERS = ("opus", "sonnet", "haiku", "fable", "mythos")
+_ANTHROPIC_VERSION_PATTERN = r"\d+(?:[.-]\d+)?"
 
 
 class LLMTimeoutError(Exception):
@@ -276,20 +258,53 @@ def _is_vertex_model_rejecting_output_config(model_name: str) -> bool:
     )
 
 
+def _parse_anthropic_model_version(model_name: str) -> tuple[int, int] | None:
+    """Extract the (major, minor) version from a Claude model name.
+
+    Handles the naming variants that reach LiteLLM: tier-first
+    ("claude-opus-4-8"), version-first ("claude-4-8-opus"), dot-separated
+    ("claude-opus-4.8"), the named Claude 5 tiers ("claude-fable-5",
+    "claude-5-sonnet"), legacy names ("claude-3-5-sonnet-20241022"), and
+    provider-prefixed / date-snapshot forms. Returns None when the name is not a
+    Claude model or carries no parseable version.
+    """
+    name = model_name.lower()
+    if "claude" not in name:
+        return None
+    # Drop any provider prefix (e.g. "anthropic/", "bedrock/anthropic.").
+    name = name[name.index("claude") :]
+    # Drop date/snapshot suffixes ("@20260101", "-20241022") so their digits
+    # can't be mistaken for a version.
+    name = name.split("@")[0]
+    name = re.sub(r"\d{6,}", "", name)
+
+    tier = next((t for t in _ANTHROPIC_MODEL_TIERS if t in name), None)
+    if tier is not None:
+        # The version can sit on either side of the tier depending on scheme.
+        match = re.search(
+            rf"{tier}[.-]?({_ANTHROPIC_VERSION_PATTERN})", name
+        ) or re.search(rf"({_ANTHROPIC_VERSION_PATTERN})[.-]?{tier}", name)
+        version_str = match.group(1) if match else None
+    else:
+        match = re.search(_ANTHROPIC_VERSION_PATTERN, name)
+        version_str = match.group(0) if match else None
+
+    if not version_str:
+        return None
+    parts = re.split(r"[.-]", version_str)
+    major = int(parts[0])
+    minor = int(parts[1]) if len(parts) > 1 else 0
+    return (major, minor)
+
+
 def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
-    normalized_model_name = model_name.lower()
-    return any(
-        adaptive_model in normalized_model_name
-        for adaptive_model in _ANTHROPIC_ADAPTIVE_THINKING_MODELS
-    )
+    version = _parse_anthropic_model_version(model_name)
+    return version is not None and version >= _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
 
 
 def _anthropic_omits_sampling_params(model_name: str) -> bool:
-    normalized_model_name = model_name.lower()
-    return any(
-        no_sampling_model in normalized_model_name
-        for no_sampling_model in _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS
-    )
+    version = _parse_anthropic_model_version(model_name)
+    return version is not None and version >= _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
 
 
 class LitellmLLM(LLM):

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -23,6 +23,7 @@ from onyx.llm.models import LanguageModelInput
 from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import ToolCall
 from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import _parse_anthropic_model_version
 from onyx.llm.multi_llm import LitellmLLM
 from onyx.llm.utils import get_max_input_tokens
 
@@ -561,6 +562,50 @@ def test_keeps_temperature_for_older_sonnet_models(model_name: str) -> None:
 
         kwargs = mock_completion.call_args.kwargs
         assert "temperature" in kwargs
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        # Tier-first, hyphenated
+        ("claude-opus-4-8", (4, 8)),
+        ("claude-opus-4-7", (4, 7)),
+        ("claude-sonnet-4-6", (4, 6)),
+        ("claude-sonnet-4-5", (4, 5)),
+        # Tier-first, dot-separated
+        ("claude-opus-4.8", (4, 8)),
+        ("claude-opus-4.7", (4, 7)),
+        # Version-first (litellm_proxy / reversed schemes)
+        ("claude-4-8-opus", (4, 8)),
+        ("claude-4.8-opus", (4, 8)),
+        ("claude-4-7-opus", (4, 7)),
+        ("claude-4.7-opus", (4, 7)),
+        # Claude 5 named tiers, version digit on either side
+        ("claude-sonnet-5", (5, 0)),
+        ("claude-5-sonnet", (5, 0)),
+        ("claude-fable-5", (5, 0)),
+        ("claude-5-fable", (5, 0)),
+        ("claude-mythos-5", (5, 0)),
+        ("claude-5-mythos", (5, 0)),
+        # Date/snapshot suffixes stripped
+        ("claude-opus-4-8@20260101", (4, 8)),
+        ("claude-sonnet-5@20260203", (5, 0)),
+        ("claude-opus-4-5@20251101", (4, 5)),
+        ("claude-3-5-sonnet-20241022", (3, 5)),
+        # Legacy naming
+        ("claude-3-7-sonnet", (3, 7)),
+        # Provider-prefixed
+        ("anthropic/claude-opus-4-8", (4, 8)),
+        ("bedrock/anthropic.claude-opus-4-7", (4, 7)),
+        # Non-Claude models parse to None
+        ("gpt-5.2", None),
+        ("gemini-2.5-pro", None),
+    ],
+)
+def test_parse_anthropic_model_version(
+    model_name: str, expected: tuple[int, int] | None
+) -> None:
+    assert _parse_anthropic_model_version(model_name) == expected
 
 
 @pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)


### PR DESCRIPTION
## What

Every new Claude release forced a manual edit to two hard-coded lists in `backend/onyx/llm/multi_llm.py` — most recently #12735, which added `claude-sonnet-5` to both `_ANTHROPIC_ADAPTIVE_THINKING_MODELS` and `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS`.

Both lists encoded the same rule: **the model is Claude ≥ 4.7**. Anthropic introduced the adaptive-thinking API (`thinking.type=adaptive` + `output_config.effort`) and stopped accepting sampling params (`temperature`/`top_p`/`top_k`, which now 400) starting with Opus 4.7, and every later model — Opus 4.8, the Claude 5 line (Fable/Mythos/Sonnet 5), and beyond — inherits both behaviors.

This replaces the lists with a small version parser plus one threshold constant, so **new releases classify themselves without a code change**.

## How

- `_parse_anthropic_model_version(model_name) -> (major, minor) | None` handles the naming variants that reach LiteLLM: tier-first (`claude-opus-4-8`), version-first (`claude-4-8-opus`), dot-separated (`claude-opus-4.8`), the Claude 5 named tiers with the version digit on either side (`claude-sonnet-5` / `claude-5-sonnet`, plus fable/mythos), legacy names (`claude-3-5-sonnet-20241022`), and provider-prefixed / `@`-snapshot forms.
- `_anthropic_uses_adaptive_thinking` and `_anthropic_omits_sampling_params` now check `version >= (4, 7)` instead of substring-matching a literal list.

Boundary behavior is preserved (Opus/Sonnet 4.6 stay on the legacy path; 4.7+ and all Claude 5 use the modern path), and future models auto-classify (`claude-opus-5`, `claude-opus-4-9`, etc. → modern path).

## Scope

Deliberately limited to the two lists that release commits keep editing. The Vertex `_VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG` list and everything outside `multi_llm.py` are untouched.

> Heads-up (out of scope): `backend/onyx/server/features/build/sandbox/util/opencode_config.py` keeps its own parallel `_ADAPTIVE_THINKING_MODELS` list that's already missing every Claude 5 model — Build-mode sandbox would send `budgetTokens` to `claude-sonnet-5` and 400. A good candidate for the same parser in a follow-up.

## Tests

- Added `test_parse_anthropic_model_version` — a parametrized table pinning version extraction across all naming variants plus non-Claude → `None`.
- Existing adaptive-thinking / no-sampling / keeps-temperature tests pass unchanged under the parser.
- `tests/unit/onyx/llm/`: 292 passed. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Anthropic adaptive thinking and sampling params by parsed Claude version (>= 4.7) instead of hard-coded lists, so new releases work without manual edits. Boundary behavior is unchanged (≤4.6 legacy; 4.7+ modern).

- **Refactors**
  - Added `_parse_anthropic_model_version` to extract (major, minor) across naming variants (tier-first, version-first, dot-separated, Claude 5 named tiers, legacy, provider-prefixed, `@` snapshots).
  - `_anthropic_uses_adaptive_thinking` and `_anthropic_omits_sampling_params` now check `version >= (4, 7)` instead of string lists, avoiding reliance on `LiteLLM` drop_params.
  - Added tests for version parsing; existing behavior tests remain unchanged and pass.

<sup>Written for commit ddfe6771dd5448df11d000e92c5d3f024b01a187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

