### PR TITLE
feat(ods): dual-format audit output + runbook + non-interactive ignore add

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -67,7 +67,9 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         # Don't fail the report job on findings; the SARIF upload surfaces them.
-        run: uv run --no-sync --with onyx-devtools ods audit --format=sarif > audit.sarif || true
+        # SARIF goes to stdout (the uploaded file); the text report goes to stderr
+        # so the run's findings are also readable in the log.
+        run: uv run --no-sync --with onyx-devtools ods audit --format=sarif,text > audit.sarif || true
 
       - name: Upload SARIF file
         if: github.event_name != 'pull_request'

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -1899,12 +1899,15 @@ jobs:
 
       - name: Run image vulnerability audit
         if: steps.should-run.outputs.run == 'true'
-        # Exits non-zero on unsuppressed CRITICAL (gates the release). On a hard
-        # scan failure nothing is written, so seed a valid empty SARIF to keep the
-        # always() upload below from choking; either way it reaches the Security tab.
+        # Exits non-zero on unsuppressed CRITICAL (gates the release). --format
+        # writes SARIF to stdout (redirected to the file for the Security tab
+        # upload) and the human-readable report + runbook to stderr, so the CI log
+        # shows which advisories blocked and how to resolve/suppress them. On a
+        # hard scan failure nothing is written, so seed a valid empty SARIF to keep
+        # the always() upload below from choking.
         run: |
           uv run --no-sync --with onyx-devtools ods audit image "$IMAGE" \
-            --fail-on=critical --format=sarif > image-audit.sarif || status=$?
+            --fail-on=critical --format=sarif,text > image-audit.sarif || status=$?
           if [ ! -s image-audit.sarif ]; then
             # $schema is a literal SARIF key, not a shell variable.
             # shellcheck disable=SC2016

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -339,8 +339,18 @@ finding at or above `--fail-on` (default `critical`) remains, which is how it
 gates deploys.
 
 ```shell
-ods audit [--web] [--python] [--dependabot] [--format text|json|sarif] [--fail-on critical|high|moderate|low] [--ignore-url s3://...]
+ods audit [--web] [--python] [--dependabot] [--format text[,json][,sarif]] [--fail-on critical|high|moderate|low] [--ignore-url s3://...]
 ```
+
+`--format` takes a comma-separated list. The machine-readable formats (`json`,
+`sarif`) are written to **stdout**, while the human-readable text report is
+written to **stderr** when combined with one of them. This lets a single run
+produce a SARIF file for upload *and* a readable report in the log: `ods audit
+--format=sarif,text > audit.sarif` sends SARIF to the file and the report (plus,
+when the gate fails, a runbook explaining how to resolve or suppress each
+finding) to the terminal. A lone format always goes to stdout, so
+`--format=sarif > audit.sarif` is unchanged. At most one machine-readable format
+may be requested.
 
 **Examples:**
 
@@ -353,7 +363,27 @@ ods audit --python
 
 # Emit a SARIF report (used by the nightly GitHub code-scanning job)
 ods audit --python --format=sarif > audit.sarif
+
+# SARIF to a file for upload, readable report to the log (used by CI gates)
+ods audit --format=sarif,text > audit.sarif
 ```
+
+#### Managing the allowlist
+
+Suppress a reviewed-and-accepted advisory so it stops blocking the gate:
+
+```shell
+# Interactive editor (add/edit/delete rows, then upload after a confirmation)
+ods audit ignore
+
+# Non-interactive add of a single suppression (a --reason is required)
+ods audit ignore add GHSA-xxxx-xxxx-xxxx --ecosystem npm \
+  --reason "not reachable in our usage" --expires 2026-09-01
+```
+
+`ods audit ignore add` stamps `added_by` from your git email, shows a diff, and
+uploads the updated allowlist to S3 after a confirmation prompt (`--yes` skips
+it). Suppress only advisories you've assessed — the allowlist gates every deploy.
 
 The allowlist is a JSON document of the form:
 

--- a/tools/ods/cmd/audit.go
+++ b/tools/ods/cmd/audit.go
@@ -47,7 +47,7 @@ how it gates deploys.`,
 	cmd.Flags().BoolVar(&opts.Python, "python", false, "Audit Python dependencies (uv.lock)")
 	cmd.Flags().BoolVar(&opts.Dependabot, "dependabot", false, "Audit open Dependabot security alerts")
 	cmd.Flags().BoolVar(&opts.Actions, "actions", false, "Audit GitHub Actions in .github/workflows and .github/actions")
-	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format: text, json, or sarif")
+	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format(s), comma-separated: text, json, sarif (e.g. sarif,text)")
 	cmd.Flags().StringVar(&opts.FailOn, "fail-on", "critical", "Minimum severity that fails the audit: critical, high, moderate, or low")
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")
 
@@ -71,7 +71,8 @@ func runAudit(opts *AuditOptions) {
 		Format:     opts.Format,
 		FailOn:     failOn,
 		IgnoreURL:  opts.IgnoreURL,
-		Writer:     os.Stdout,
+		Stdout:     os.Stdout,
+		Stderr:     os.Stderr,
 	})
 	if err != nil {
 		log.Fatalf("Audit failed: %v", err)

--- a/tools/ods/cmd/audit_ignore.go
+++ b/tools/ods/cmd/audit_ignore.go
@@ -41,6 +41,7 @@ on disk instead.`,
 	cmd.PersistentFlags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL or local path of the advisory allowlist")
 
 	cmd.AddCommand(newAuditIgnoreEditCommand(opts))
+	cmd.AddCommand(newAuditIgnoreAddCommand(opts))
 
 	return cmd
 }

--- a/tools/ods/cmd/audit_ignore_add.go
+++ b/tools/ods/cmd/audit_ignore_add.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/audit"
+	"github.com/onyx-dot-app/onyx/tools/ods/internal/prompt"
+)
+
+// AuditIgnoreAddOptions holds options for `ods audit ignore add`.
+type AuditIgnoreAddOptions struct {
+	Ecosystem string
+	Reason    string
+	Expires   string
+	AddedBy   string
+	Yes       bool
+}
+
+// newAuditIgnoreAddCommand creates the `ods audit ignore add` subcommand: a
+// non-interactive way to append one suppression to the allowlist. It shares the
+// parent's --ignore-url via the passed options.
+func newAuditIgnoreAddCommand(parent *AuditIgnoreOptions) *cobra.Command {
+	opts := &AuditIgnoreAddOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "add <id>",
+		Short: "Add a suppression to the audit advisory allowlist",
+		Long: `Add a single suppression to the audit advisory allowlist without opening the editor.
+
+<id> is the advisory id (e.g. GHSA-xxxx-xxxx-xxxx or CVE-2023-1234); it matches a
+finding's id or any of its aliases. A --reason is required so every suppression
+records why the advisory was accepted, and --added-by defaults to your git email.
+The updated allowlist is uploaded to S3 (shared by the whole team) after a diff
+and a confirmation prompt; pass --yes to skip the prompt in automation.
+
+Suppress only advisories you've reviewed and accepted — this allowlist gates
+every deploy.`,
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runAuditIgnoreAdd(args[0], parent.IgnoreURL, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Ecosystem, "ecosystem", "", "Restrict the suppression to this ecosystem (e.g. npm, PyPI, Debian:12)")
+	cmd.Flags().StringVar(&opts.Reason, "reason", "", "Why the advisory is accepted (required)")
+	cmd.Flags().StringVar(&opts.Expires, "expires", "", "Inclusive expiry date YYYY-MM-DD; omit for no expiry")
+	cmd.Flags().StringVar(&opts.AddedBy, "added-by", "", "Who added the suppression (defaults to git user email)")
+	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip the confirmation prompt")
+
+	return cmd
+}
+
+func runAuditIgnoreAdd(id, url string, opts *AuditIgnoreAddOptions) {
+	// A reason is mandatory: it's the record of why an advisory was accepted and
+	// the main guardrail against casually burying a real issue.
+	if strings.TrimSpace(opts.Reason) == "" {
+		log.Fatal("A --reason is required to suppress an advisory")
+	}
+
+	addedBy := opts.AddedBy
+	if addedBy == "" {
+		addedBy = gitUserEmail()
+	}
+
+	entry := audit.IgnoreEntry{
+		ID:        strings.TrimSpace(id),
+		Ecosystem: strings.TrimSpace(opts.Ecosystem),
+		Reason:    strings.TrimSpace(opts.Reason),
+		AddedBy:   addedBy,
+		Expires:   strings.TrimSpace(opts.Expires),
+	}
+	if err := audit.ValidateEntry(entry); err != nil {
+		log.Fatalf("Invalid suppression: %v", err)
+	}
+
+	orig, err := audit.LoadIgnoresForEdit(url)
+	if err != nil {
+		log.Fatalf("Failed to fetch allowlist from %s: %v", url, err)
+	}
+
+	edited := append(append([]audit.IgnoreEntry{}, orig...), entry)
+	// A colliding id+ecosystem would silently collapse on save; surface it and
+	// point at the editor rather than overwriting the existing reason/expiry.
+	if dups := audit.DuplicateKeys(edited); len(dups) > 0 {
+		log.Fatalf("An allowlist entry for %s already exists; update it with `ods audit ignore edit`", strings.Join(dups, ", "))
+	}
+	audit.SortIgnores(edited)
+
+	added, removed, changed := audit.DiffIgnores(orig, edited)
+	printDiff(added, removed, changed)
+
+	if !opts.Yes && !prompt.Confirm(fmt.Sprintf("Upload updated allowlist (%d entries) to %s? [Y/n] ", len(edited), url)) {
+		fmt.Println("Aborted; nothing uploaded.")
+		return
+	}
+
+	if err := audit.SaveIgnores(url, edited); err != nil {
+		log.Fatalf("Failed to save allowlist: %v", err)
+	}
+	fmt.Printf("Uploaded %d entries to %s\n", len(edited), url)
+}

--- a/tools/ods/cmd/audit_ignore_add.go
+++ b/tools/ods/cmd/audit_ignore_add.go
@@ -77,7 +77,11 @@ func runAuditIgnoreAdd(id, url string, opts *AuditIgnoreAddOptions) {
 		log.Fatalf("Invalid suppression: %v", err)
 	}
 
-	orig, err := audit.LoadIgnoresForEdit(url)
+	// Use FetchIgnores, not LoadIgnoresForEdit: a missing local file must error
+	// rather than bootstrap an empty list. Unlike the interactive editor (which
+	// shows the empty table), a typo'd --ignore-url here would silently append to
+	// a fresh file and drop the real allowlist's entries on save.
+	orig, err := audit.FetchIgnores(url)
 	if err != nil {
 		log.Fatalf("Failed to fetch allowlist from %s: %v", url, err)
 	}

--- a/tools/ods/cmd/audit_image.go
+++ b/tools/ods/cmd/audit_image.go
@@ -33,6 +33,12 @@ release can be unblocked without a code change.
 The ref may be a remote image (e.g. docker.io/onyxdotapp/onyx-backend:v1.2.3),
 which is pulled using the ambient Docker credentials.
 
+--format accepts a comma-separated list. Machine formats (json, sarif) write to
+stdout while the human-readable text report writes to stderr, so a single run can
+feed a SARIF upload and still print a readable report to the log:
+
+  ods audit image "$IMAGE" --format=sarif,text > image-audit.sarif
+
 Exits non-zero when an unignored finding at or above --fail-on remains, which is
 how it gates deploys.`,
 		Args: cobra.ExactArgs(1),
@@ -41,7 +47,7 @@ how it gates deploys.`,
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format: text, json, or sarif")
+	cmd.Flags().StringVar(&opts.Format, "format", "text", "Output format(s), comma-separated: text, json, sarif (e.g. sarif,text)")
 	cmd.Flags().StringVar(&opts.FailOn, "fail-on", "critical", "Minimum severity that fails the audit: critical, high, moderate, or low")
 	cmd.Flags().StringVar(&opts.IgnoreURL, "ignore-url", audit.DefaultIgnoreURL, "S3 URL of the advisory allowlist")
 
@@ -59,7 +65,8 @@ func runAuditImage(ref string, opts *AuditImageOptions) {
 		Format:    opts.Format,
 		FailOn:    failOn,
 		IgnoreURL: opts.IgnoreURL,
-		Writer:    os.Stdout,
+		Stdout:    os.Stdout,
+		Stderr:    os.Stderr,
 	})
 	if err != nil {
 		log.Fatalf("Image audit failed: %v", err)

--- a/tools/ods/internal/audit/audit.go
+++ b/tools/ods/internal/audit/audit.go
@@ -114,10 +114,14 @@ type Options struct {
 	Python     bool
 	Dependabot bool
 	Actions    bool
-	Format     string // text|json|sarif
+	Format     string // comma-separated list of text|json|sarif
 	FailOn     Severity
 	IgnoreURL  string
-	Writer     io.Writer
+	// Stdout receives the machine-readable formats (json, sarif), or the text
+	// report when it is the only format requested. Stderr receives the text
+	// report when it is combined with a machine format. See renderReport.
+	Stdout io.Writer
+	Stderr io.Writer
 }
 
 // Result is the outcome of an audit run.
@@ -128,8 +132,8 @@ type Result struct {
 }
 
 // Run executes the selected audit backends, applies the allowlist, renders a
-// report to opts.Writer, and returns the result. With no selector flags set,
-// all backends are run.
+// report to opts.Stdout/opts.Stderr, and returns the result. With no selector
+// flags set, all backends are run.
 func Run(opts Options) (*Result, error) {
 	runAll := !opts.Web && !opts.Python && !opts.Dependabot && !opts.Actions
 	scanWeb := runAll || opts.Web
@@ -208,7 +212,7 @@ func Run(opts Options) (*Result, error) {
 		Blocking: blockingFindings(kept, opts.FailOn),
 	}
 
-	if err := render(opts.Writer, opts.Format, result); err != nil {
+	if err := renderReport(opts.Stdout, opts.Stderr, opts.Format, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/tools/ods/internal/audit/image.go
+++ b/tools/ods/internal/audit/image.go
@@ -15,16 +15,18 @@ import (
 // ImageOptions configures a container image audit run.
 type ImageOptions struct {
 	Image     string
-	Format    string // text|json|sarif
+	Format    string // comma-separated list of text|json|sarif
 	FailOn    Severity
 	IgnoreURL string
-	Writer    io.Writer
+	// Stdout/Stderr route the requested formats; see Options and renderReport.
+	Stdout io.Writer
+	Stderr io.Writer
 }
 
 // RunImage scans a container image for known vulnerabilities, applies the same
-// S3 allowlist used by Run, renders a report to opts.Writer, and returns the
-// result. Findings at or above opts.FailOn are reported as Blocking, which is
-// how it gates a release.
+// S3 allowlist used by Run, renders a report to opts.Stdout/opts.Stderr, and
+// returns the result. Findings at or above opts.FailOn are reported as Blocking,
+// which is how it gates a release.
 func RunImage(opts ImageOptions) (*Result, error) {
 	findings, err := scanImage(opts.Image)
 	if err != nil {
@@ -51,7 +53,7 @@ func RunImage(opts ImageOptions) (*Result, error) {
 		Blocking: blockingFindings(kept, opts.FailOn),
 	}
 
-	if err := render(opts.Writer, opts.Format, result); err != nil {
+	if err := renderReport(opts.Stdout, opts.Stderr, opts.Format, result); err != nil {
 		return nil, err
 	}
 	return result, nil

--- a/tools/ods/internal/audit/report.go
+++ b/tools/ods/internal/audit/report.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-// render writes the result to w in the requested format.
+// render writes the result to w in a single format.
 func render(w io.Writer, format string, res *Result) error {
 	switch strings.ToLower(strings.TrimSpace(format)) {
 	case "", "text":
@@ -20,6 +20,78 @@ func render(w io.Writer, format string, res *Result) error {
 	default:
 		return fmt.Errorf("unknown format %q (want text, json, or sarif)", format)
 	}
+}
+
+// renderReport renders res in each format named in a comma-separated list,
+// routing the human-readable text report and the machine-readable formats to
+// separate streams so both can be produced in one run. Machine formats (json,
+// sarif) go to stdout — where CI redirects them to a file — while the text
+// report goes to stderr, keeping it out of that file but visible in the log. A
+// lone format always goes to stdout, so `--format=sarif > file` is unchanged.
+//
+// At most one machine format may be requested (two would concatenate into
+// invalid output on stdout). All formats are validated before anything is
+// written, so an unknown format can't leave a half-written report behind.
+func renderReport(stdout, stderr io.Writer, format string, res *Result) error {
+	formats := parseFormats(format)
+
+	dataFormats := 0
+	for _, f := range formats {
+		if !knownFormat(f) {
+			return fmt.Errorf("unknown format %q (want text, json, or sarif)", f)
+		}
+		if isDataFormat(f) {
+			dataFormats++
+		}
+	}
+	if dataFormats > 1 {
+		return fmt.Errorf("at most one machine-readable format (json, sarif) may be requested; got %q", format)
+	}
+
+	lone := len(formats) == 1
+	for _, f := range formats {
+		w := stdout
+		// The text report shares stdout only when it's the sole format; combined
+		// with a data format it moves to stderr so it can't corrupt the data.
+		if f == "text" && !lone {
+			w = stderr
+		}
+		if err := render(w, f, res); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// parseFormats splits a comma-separated --format value into a normalized,
+// order-preserving, de-duplicated list. An empty or whitespace-only value
+// defaults to text.
+func parseFormats(format string) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, part := range strings.Split(format, ",") {
+		f := strings.ToLower(strings.TrimSpace(part))
+		if f == "" || seen[f] {
+			continue
+		}
+		seen[f] = true
+		out = append(out, f)
+	}
+	if len(out) == 0 {
+		return []string{"text"}
+	}
+	return out
+}
+
+// knownFormat reports whether f is a format render understands.
+func knownFormat(f string) bool {
+	return f == "text" || f == "json" || f == "sarif"
+}
+
+// isDataFormat reports whether f is a machine-readable format written to stdout,
+// as opposed to the human-readable text report.
+func isDataFormat(f string) bool {
+	return f == "json" || f == "sarif"
 }
 
 func renderText(w io.Writer, res *Result) error {
@@ -51,7 +123,42 @@ func renderText(w io.Writer, res *Result) error {
 	}
 
 	_, _ = fmt.Fprintf(w, "\n%s\n", summaryLine(res))
+	if rb := runbook(res); rb != "" {
+		_, _ = fmt.Fprint(w, rb)
+	}
 	return nil
+}
+
+// runbook returns operator guidance shown beneath the text report when findings
+// are blocking the audit (i.e. the gate will fail). It spells out the two ways
+// to clear the gate — resolve the advisory, or suppress a reviewed-and-accepted
+// one — and prints a ready-to-fill `ods audit ignore add` command seeded from
+// the first blocking finding. It intentionally shows one example rather than a
+// command per finding, so suppressing every advisory takes a deliberate step.
+// Returns "" when nothing is blocking.
+func runbook(res *Result) string {
+	if len(res.Blocking) == 0 {
+		return ""
+	}
+
+	f := res.Blocking[0]
+	add := "ods audit ignore add " + f.ID
+	if f.Ecosystem != "" {
+		add += fmt.Sprintf(" --ecosystem %q", f.Ecosystem)
+	}
+	add += ` --reason "<why this is not exploitable in Onyx>"`
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nAction required: %d finding(s) at or above the fail-on threshold are blocking this audit.\n", len(res.Blocking))
+	b.WriteString("  - Resolve (preferred): upgrade or remove the affected package. Look up each\n")
+	b.WriteString("    advisory by its ID at https://osv.dev to find the fixed version.\n")
+	b.WriteString("  - Accept: if you've reviewed an advisory and it isn't exploitable in Onyx,\n")
+	b.WriteString("    suppress it in the shared allowlist (a --reason is required; add\n")
+	b.WriteString("    --expires YYYY-MM-DD to time-box it), then re-run the audit:\n\n")
+	fmt.Fprintf(&b, "      %s\n\n", add)
+	b.WriteString("    Repeat per advisory, and suppress only advisories you've assessed — this\n")
+	b.WriteString("    allowlist gates every deploy.\n")
+	return b.String()
 }
 
 // summaryLine builds a one-line tally of findings by severity.

--- a/tools/ods/internal/audit/report_test.go
+++ b/tools/ods/internal/audit/report_test.go
@@ -113,6 +113,117 @@ func TestRenderUnknownFormat(t *testing.T) {
 	}
 }
 
+func TestParseFormats(t *testing.T) {
+	cases := map[string][]string{
+		"":                {"text"},
+		"   ":             {"text"},
+		"sarif":           {"sarif"},
+		"SARIF, Text":     {"sarif", "text"},
+		"text,sarif,text": {"text", "sarif"}, // de-duped, order preserved
+		",json,":          {"json"},
+	}
+	for in, want := range cases {
+		got := parseFormats(in)
+		if strings.Join(got, ",") != strings.Join(want, ",") {
+			t.Errorf("parseFormats(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestRenderReportRouting is the core of the CI use case: a combined
+// sarif,text run must put valid SARIF on stdout (redirected to a file) and the
+// human report on stderr (visible in the log), never mixing the two.
+func TestRenderReportRouting(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := renderReport(&stdout, &stderr, "sarif,text", sampleResult()); err != nil {
+		t.Fatalf("renderReport: %v", err)
+	}
+
+	// stdout is pure SARIF.
+	var doc map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
+		t.Fatalf("stdout is not valid SARIF JSON: %v\n%s", err, stdout.String())
+	}
+	if strings.Contains(stdout.String(), "Dependency vulnerabilities:") {
+		t.Error("text report leaked into the SARIF stdout stream")
+	}
+
+	// stderr is the text report, and JSON must not have leaked into it.
+	if !strings.Contains(stderr.String(), "GHSA-crit") {
+		t.Errorf("stderr missing text report:\n%s", stderr.String())
+	}
+	if strings.Contains(stderr.String(), "\"$schema\"") {
+		t.Error("SARIF leaked into the text stderr stream")
+	}
+}
+
+func TestRenderReportLoneTextGoesToStdout(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := renderReport(&stdout, &stderr, "text", sampleResult()); err != nil {
+		t.Fatalf("renderReport: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "GHSA-crit") {
+		t.Errorf("lone text should render to stdout, got stdout=%q", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("lone text should not write to stderr, got %q", stderr.String())
+	}
+}
+
+func TestRenderReportRejectsTwoDataFormats(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := renderReport(&stdout, &stderr, "json,sarif", sampleResult()); err == nil {
+		t.Error("renderReport should reject two machine-readable formats")
+	}
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Error("nothing should be written when the format set is rejected")
+	}
+}
+
+func TestRenderReportRejectsUnknownFormat(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if err := renderReport(&stdout, &stderr, "sarif,xml", sampleResult()); err == nil {
+		t.Error("renderReport should reject an unknown format")
+	}
+	// Validation happens before any writing, so a valid format alongside the bad
+	// one must not produce partial output.
+	if stdout.Len() != 0 || stderr.Len() != 0 {
+		t.Errorf("no output expected on bad format set; stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}
+
+func TestRunbookShownOnlyWhenBlocking(t *testing.T) {
+	// A realistic blocking finding carries an ecosystem (blockingFindings copies
+	// the full finding), which the runbook threads into the example command.
+	blocking := Finding{ID: "GHSA-crit", Ecosystem: "npm", Package: "a", Version: "1.0.0", Severity: SeverityCritical}
+	res := &Result{Findings: []Finding{blocking}, Blocking: []Finding{blocking}}
+
+	var withBlocking bytes.Buffer
+	if err := renderText(&withBlocking, res); err != nil {
+		t.Fatalf("renderText: %v", err)
+	}
+	out := withBlocking.String()
+	if !strings.Contains(out, "ods audit ignore add GHSA-crit") {
+		t.Errorf("runbook should print a ready-to-fill ignore command:\n%s", out)
+	}
+	if !strings.Contains(out, "--ecosystem \"npm\"") {
+		t.Errorf("runbook command should carry the finding's ecosystem:\n%s", out)
+	}
+	if !strings.Contains(out, "Action required") {
+		t.Errorf("runbook header missing:\n%s", out)
+	}
+
+	// No blocking findings -> no runbook.
+	nonBlocking := &Result{Findings: []Finding{{ID: "GHSA-low", Severity: SeverityLow, Ecosystem: "npm", Package: "c"}}}
+	var buf bytes.Buffer
+	if err := renderText(&buf, nonBlocking); err != nil {
+		t.Fatalf("renderText: %v", err)
+	}
+	if strings.Contains(buf.String(), "Action required") {
+		t.Errorf("runbook should not appear without blocking findings:\n%s", buf.String())
+	}
+}
+
 func TestBlockingFindings(t *testing.T) {
 	findings := []Finding{
 		{ID: "c", Severity: SeverityCritical},


### PR DESCRIPTION
## Problem

The `image-audit` deploy gate piped `--format=sarif` straight to a file, so a failing run logged only:

```
level=error msg="6 finding(s) at or above critical severity must be resolved or suppressed"
```

No advisory IDs, no fixed-in info, no next steps — you had to open the Security tab to learn anything ([example run](https://github.com/onyx-dot-app/onyx/actions/runs/28893057774/job/85712254345)). The dependency `audit-gate` step (text format) already prints a full table; the image job just threw its report away.

## What changed

**Dual-format output.** `--format` now takes a comma-separated list. Machine formats (`json`, `sarif`) write to **stdout**; the human text report writes to **stderr** when combined with one. So a single run feeds the SARIF upload *and* prints a readable report to the log:

```shell
ods audit image "$IMAGE" --format=sarif,text > image-audit.sarif
```

A lone format is unchanged (`--format=sarif > file` still works); at most one machine format may be requested.

**Runbook on failure.** When findings block the gate, the text report appends operator guidance — resolve vs. suppress — with a ready-to-fill command seeded from the first blocking finding:

```
Action required: 6 finding(s) at or above the fail-on threshold are blocking this audit.
  - Resolve (preferred): upgrade or remove the affected package. Look up each
    advisory by its ID at https://osv.dev to find the fixed version.
  - Accept: if you've reviewed an advisory and it isn't exploitable in Onyx,
    suppress it in the shared allowlist (a --reason is required; add
    --expires YYYY-MM-DD to time-box it), then re-run the audit:

      ods audit ignore add GHSA-6v7p-g79w-8964 --ecosystem "PyPI" --reason "<why this is not exploitable in Onyx>"

    Repeat per advisory, and suppress only advisories you've assessed — this
    allowlist gates every deploy.
```

It shows **one** example (not one per finding) and forces you to write a `--reason` — QOL without making it trivial to bury valid issues.

**`ods audit ignore add <id>`.** A non-interactive counterpart to the TUI editor: required `--reason`, git-email `added_by` default, optional `--ecosystem`/`--expires`, a diff and confirmation before the S3 upload (`--yes` to skip in automation), and duplicate id+ecosystem protection.

**CI.** `deployment.yml` (image-audit) and `audit.yml` (SARIF report) now use `--format=sarif,text` — SARIF still lands in the uploaded file, the report + runbook now show in the log.

## Verification

- `go build` / `go vet` / gofmt clean; new unit tests for format parsing, stdout↔stderr routing (no cross-contamination, rejects dual data formats & unknown formats), and runbook gating pass.
- Ran the built binary against the repo: `ods audit --python --format=sarif,text > out.sarif` produced valid SARIF (9 results, no text leak) on stdout and the report on stderr; `--fail-on=high` rendered the runbook with the real finding's ID + ecosystem and exited 1.
- Ran `ignore add` against a local allowlist: reason-required, invalid-expiry, git-email default, diff, duplicate-block, and same-id/different-ecosystem all behave correctly.

## Reviewer note

The next release run's image-audit log will look different (full report instead of the one-liner) — worth a heads-up to whoever watches deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dual-format audit output so CI uploads SARIF while printing a readable report in logs. Adds a failure runbook and a non-interactive `ods audit ignore add` command; workflows now use the new mode.

- **New Features**
  - `--format` accepts comma-separated formats; machine formats (`json`, `sarif`) go to stdout, and `text` goes to stderr when combined. One machine format max; a lone format is unchanged.
  - Text report appends a runbook on gate failure with a ready-to-fill `ods audit ignore add` example seeded from the first blocking finding.
  - New `ods audit ignore add <id>`: requires `--reason`, optional `--ecosystem`/`--expires`, stamps `added_by` from git email, shows diff + confirmation (`--yes` for CI), and blocks duplicate id+ecosystem.

- **Bug Fixes**
  - `ods audit ignore add` now errors if the allowlist path is missing or mistyped, avoiding accidental empty-list uploads.

<sup>Written for commit b695ca625f490b4beb82498543eacc56c4907e56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

