### PR TITLE
revert(sandbox): unpin chromium — take patched 150, pass image audit over browser CI (#12717)

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -50,13 +50,6 @@ ARG ENABLE_SKILLS=true
 ARG ENABLE_BROWSER=true
 ARG OPENCODE_VERSION=1.15.7
 ARG AGENT_BROWSER_VERSION=0.31.1
-# trixie-security's chromium 150.0.7871.46-1~deb13u1 SIGTRAPs at launch
-# (https://bugs.debian.org/chromium — also broke grafana-image-renderer and
-# linuxserver/docker-chromium), which kills the Craft `browser` command and the
-# craft-k8s browser CI lane. Pin the last known-good build (from
-# trixie-proposed-updates) until a fixed security build lands, then drop the
-# pin and the proposed-updates apt source below.
-ARG CHROMIUM_VERSION=149.0.7827.196-1~deb13u1
 
 # firewall-init.sh needs: iptables (egress lockdown), ca-certificates (trust
 # store), gosu (legacy, not currently invoked). setpriv ships with util-linux in
@@ -103,13 +96,9 @@ RUN if [ "$ENABLE_SKILLS" = "true" ]; then \
 # Chromium's NSS db). Its own layer: big and rarely-changing, so an
 # AGENT_BROWSER_VERSION bump below re-pulls only the small CLI layer, not this.
 RUN if [ "$ENABLE_BROWSER" = "true" ]; then \
-    echo "deb http://deb.debian.org/debian trixie-proposed-updates main" \
-    > /etc/apt/sources.list.d/trixie-proposed-updates.list && \
     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    chromium="${CHROMIUM_VERSION}" \
-    chromium-common="${CHROMIUM_VERSION}" \
+    chromium \
     libnss3-tools \
-    && rm /etc/apt/sources.list.d/trixie-proposed-updates.list \
     && rm -rf /var/lib/apt/lists/*; \
     fi
 


### PR DESCRIPTION
## Description

Reverts #12717 (chromium 149 pin). The pin holds the sandbox image on chromium `149.0.7827.196-1~deb13u1`, which now carries 62 CRITICAL CVEs (the Chrome 150 security batch) and fails the `image-audit (sandbox)` gate on tag builds and nightlies (e.g. the `v4.3.0-cloud.2` release build). Debian marks trixie-security's `150.0.7871.46-1~deb13u1` as the fixed version, so unpinning makes the audit pass again.

Known trade-off: the trixie-security 150 build SIGTRAPs at launch, which is what the pin was working around — this re-breaks the Craft `browser` command and the craft-k8s browser CI lane until a fixed chromium build lands. We're deliberately choosing passing image audits over that lane.

## How Has This Been Tested?

Clean `git revert` of 49f0390cf4; verified the Dockerfile chromium install block is back to the unpinned state (no version pin, no trixie-proposed-updates apt source). Verified via OSV that `DEBIAN-CVE-2026-13775` (and the rest of the batch) are fixed at `150.0.7871.46-1~deb13u1` in Debian:13.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unpins `chromium` in the sandbox image to take Debian’s patched 150 build and pass the image audit. This temporarily re-breaks the Craft `browser` command and the `craft-k8s` browser CI lane (SIGTRAP) until a fixed build lands.

- **Dependencies**
  - Unpinned `chromium` in the Dockerfile and removed the `trixie-proposed-updates` APT source and versioned install.
  - Install now pulls `chromium` 150.0.7871.46-1~deb13u1 from trixie-security, clearing the image-audit gate and resolving the Chrome 150 CVEs.

<sup>Written for commit bbbb15c3d766bbf17719818705124adeb60495d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

