### PR TITLE
fix(desktop): stop opening browser tabs for third-party iframes

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -93,6 +93,14 @@ const CHAT_LINK_INTERCEPT_SCRIPT: &str = r##"
     }
   }
 
+  function isSameOrigin(parsedUrl) {
+    try {
+      return parsedUrl.origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+
   function handleChatNavigation(rawUrl) {
     const parsedUrl = getAllowedNavigationUrl(rawUrl);
     if (!parsedUrl) {
@@ -101,16 +109,22 @@ const CHAT_LINK_INTERCEPT_SCRIPT: &str = r##"
 
     const safeUrl = parsedUrl.toString();
     const scheme = parsedUrl.protocol.toLowerCase();
-    if (scheme === "mailto:" || scheme === "tel:") {
-      void openWithTauri(safeUrl).then((opened) => {
-        if (!opened) {
-          window.location.assign(safeUrl);
-        }
-      });
+
+    // Same-origin links navigate in place so the app stays in-window. Everything
+    // else (mailto/tel and cross-origin http(s) links) is handed to the OS default
+    // handler from here — a genuine click / window.open. Keeping this decision in JS
+    // (rather than the Rust navigation handler) avoids opening third-party iframe
+    // sub-resource loads externally, e.g. Stripe's hidden fraud-detection iframe.
+    if (scheme !== "mailto:" && scheme !== "tel:" && isSameOrigin(parsedUrl)) {
+      window.location.assign(safeUrl);
       return true;
     }
 
-    window.location.assign(safeUrl);
+    void openWithTauri(safeUrl).then((opened) => {
+      if (!opened) {
+        window.location.assign(safeUrl);
+      }
+    });
     return true;
   }
 
@@ -511,12 +525,6 @@ fn open_settings(app: &AppHandle) {
     }
 }
 
-fn same_origin(left: &Url, right: &Url) -> bool {
-    left.scheme() == right.scheme()
-        && left.host_str() == right.host_str()
-        && left.port_or_known_default() == right.port_or_known_default()
-}
-
 fn is_chat_session_url(url: &Url) -> bool {
     url.path().starts_with("/app") && url.query_pairs().any(|(key, _)| key == "chatId")
 }
@@ -526,11 +534,12 @@ fn should_open_in_external_browser(current_url: &Url, destination_url: &Url) -> 
         return false;
     }
 
-    match destination_url.scheme() {
-        "mailto" | "tel" => true,
-        "http" | "https" => !same_origin(current_url, destination_url),
-        _ => false,
-    }
+    // Only non-web schemes are handed to the OS from this navigation handler.
+    // Cross-origin http(s) links are opened externally by the injected chat-link
+    // script on genuine clicks / window.open. Routing http(s) through here too would
+    // also catch third-party iframe sub-resource loads (e.g. Stripe's hidden
+    // fraud-detection iframe at js.stripe.com), spuriously popping open browser tabs.
+    matches!(destination_url.scheme(), "mailto" | "tel")
 }
 
 fn open_in_default_browser(url: &str) -> bool {


### PR DESCRIPTION
## Problem

Closes #12746.

On the macOS desktop app, opening a new chat frequently pops open a browser tab pointing at `https://js.stripe.com/v3/m-outer-*.html`.

## Root cause

The desktop app registers a `chat-external-navigation-handler` Tauri plugin whose `on_navigation` callback opens **any cross-origin http(s) navigation** in the default browser while the top-level page is a chat session (`/app?chatId=...`).

Tauri/wry fires `on_navigation` for **iframe sub-resource loads**, not just top-level navigations. Onyx Cloud loads Stripe.js, which injects a hidden fraud-detection (Radar) iframe at `js.stripe.com/v3/m-outer-*.html`. Each new chat re-runs Stripe.js init and (re)creates that iframe; its cross-origin load was matched by `should_open_in_external_browser` and shelled out via `open`, producing the stray browser tab.

## Fix

`on_navigation` receives only `(&Webview, &Url)` — no frame context — so it can't tell a genuine top-level navigation from an iframe sub-resource load. The decision to open cross-origin http(s) links externally therefore moves to the injected `CHAT_LINK_INTERCEPT_SCRIPT`, which only ever acts on **real anchor clicks (`target="_blank"`) and `window.open` calls** — never iframe loads.

- **JS (`handleChatNavigation`)**: same-origin links navigate in place; mailto/tel **and** cross-origin http(s) links are handed to the OS via the existing `open_in_browser` command (with an in-place-navigation fallback if the Tauri invoke is unavailable).
- **Rust (`should_open_in_external_browser`)**: now only hands off `mailto`/`tel` — schemes an iframe can't legitimately load — so third-party iframe loads (Stripe and any future embeds) are never opened externally. The now-unused `same_origin` helper is removed.

Net user-facing behavior is unchanged for real link clicks (external links still open in the default browser, in-app links still navigate in-window); only the spurious iframe-triggered tabs are gone.

## Testing

The desktop Rust code has no test harness and builds only via `bunx tauri build` (exercised by the Build Desktop App CI job). Verified locally:
- Embedded JS passes `node --check`.
- Rust change is a pure refactor of two functions (verified by reading; no cargo toolchain in the dev container — the CI Linux build compiles it).

Manual verification (requires a signed macOS build against an Onyx Cloud instance that loads Stripe.js): open several new chats and confirm no `js.stripe.com` tab appears, while external citation links still open in the default browser and same-origin links stay in-window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the macOS desktop app from opening stray browser tabs (e.g., `https://js.stripe.com/v3/m-outer-*.html`) when starting a new chat by moving external link handling to the in-page script. Fixes #12746.

- **Bug Fixes**
  - JS (`CHAT_LINK_INTERCEPT_SCRIPT`): only intercepts real clicks and `window.open`; same-origin navigates in app, `mailto:`/`tel:` and cross-origin http(s) hand off to the OS via `open_in_browser` (with fallback).
  - Rust (`should_open_in_external_browser`): now only opens `mailto`/`tel`; removes cross-origin http(s) logic to avoid iframe subresource triggers (e.g., Stripe Radar).
  - User behavior unchanged: external links still open in the default browser; in-app links stay in-window.

<sup>Written for commit 8a0a52cf5456edda248c55b55011307b0b39f052. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

