### PR TITLE
refactor: agent knowledge pane

### DIFF
--- a/web/src/sections/knowledge/AgentKnowledgePane.tsx
+++ b/web/src/sections/knowledge/AgentKnowledgePane.tsx
@@ -1,1348 +1,45 @@
 "use client";
 
 import React, {
-  useState,
-  useMemo,
-  useRef,
-  memo,
   useCallback,
   useEffect,
+  useMemo,
+  useRef,
+  useState,
 } from "react";
 import * as GeneralLayouts from "@/layouts/general-layouts";
-import { Content, InputHorizontal } from "@opal/layouts";
 import * as TableLayouts from "@/layouts/table-layouts";
 import { Card } from "@/refresh-components/cards";
-import { Button, Divider } from "@opal/components";
-import Text from "@/refresh-components/texts/Text";
-import Truncated from "@/refresh-components/texts/Truncated";
-import LineItem from "@/refresh-components/buttons/LineItem";
-import { Switch } from "@opal/components";
-import { Checkbox } from "@opal/components";
-import { InputTypeIn } from "@opal/components";
-import {
-  SvgPlusCircle,
-  SvgArrowUpRight,
-  SvgFiles,
-  SvgFolder,
-  SvgArrowLeft,
-  SvgSearch,
-  SvgXCircle,
-  SvgChevronRight,
-  SvgFileText,
-  SvgFilter,
-} from "@opal/icons";
-import type { CCPairSummary } from "@/lib/types";
-import { getSourceMetadata } from "@/lib/sources";
-import { ValidSources, DocumentSetSummary } from "@/lib/types";
 import useCCPairs from "@/hooks/useCCPairs";
-import { ConnectedSource } from "@/lib/hierarchy/interfaces";
-import { ProjectFile } from "@/lib/projects/types";
-import { AgentAttachedDocument, AgentHierarchyNode } from "@/lib/agents/types";
-import { timeAgo } from "@opal/time";
-import { Spacer } from "@opal/components";
-import { Disabled } from "@opal/core";
-import SourceHierarchyBrowser from "./SourceHierarchyBrowser";
-import { searchDocuments } from "@/ee/lib/search/svc";
 import { fetchHierarchyNodeSearch } from "@/lib/hierarchy/svc";
-import type { SearchDocWithContent } from "@/lib/search/interfaces";
-import type { HierarchyNodeSearchSummary } from "@/lib/hierarchy/interfaces";
-
-// Knowledge pane view states
-type KnowledgeView = "main" | "add" | "document-sets" | "sources" | "recent";
-
-// ============================================================================
-// KNOWLEDGE SIDEBAR - Left column showing all knowledge categories
-// ============================================================================
-
-interface KnowledgeSidebarProps {
-  activeView: KnowledgeView;
-  activeSource?: ValidSources;
-  connectedSources: ConnectedSource[];
-  selectedSources: ValidSources[];
-  selectedDocumentSetIds: number[];
-  selectedFileIds: string[];
-  sourceSelectionCounts: Map<ValidSources, number>;
-  onNavigateToRecent: () => void;
-  onNavigateToDocumentSets: () => void;
-  onNavigateToSource: (source: ValidSources) => void;
-  vectorDbEnabled: boolean;
-}
-
-function KnowledgeSidebar({
-  activeView,
-  activeSource,
-  connectedSources,
-  selectedSources,
-  selectedDocumentSetIds,
-  selectedFileIds,
-  sourceSelectionCounts,
-  onNavigateToRecent,
-  onNavigateToDocumentSets,
-  onNavigateToSource,
-  vectorDbEnabled,
-}: KnowledgeSidebarProps) {
-  return (
-    <TableLayouts.SidebarLayout aria-label="knowledge-sidebar">
-      <LineItem
-        icon={SvgFiles}
-        onClick={onNavigateToRecent}
-        selected={activeView === "recent"}
-        emphasized={activeView === "recent" || selectedFileIds.length > 0}
-        aria-label="knowledge-sidebar-files"
-        rightChildren={
-          selectedFileIds.length > 0 ? (
-            <Text mainUiAction className="text-action-link-05">
-              {selectedFileIds.length}
-            </Text>
-          ) : undefined
-        }
-      >
-        Your Files
-      </LineItem>
-
-      {vectorDbEnabled && (
-        <>
-          <LineItem
-            icon={SvgFolder}
-            onClick={onNavigateToDocumentSets}
-            selected={activeView === "document-sets"}
-            emphasized={
-              activeView === "document-sets" ||
-              selectedDocumentSetIds.length > 0
-            }
-            aria-label="knowledge-sidebar-document-sets"
-            rightChildren={
-              selectedDocumentSetIds.length > 0 ? (
-                <Text mainUiAction className="text-action-link-05">
-                  {selectedDocumentSetIds.length}
-                </Text>
-              ) : undefined
-            }
-          >
-            Document Set
-          </LineItem>
-
-          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
-
-          {connectedSources.map((connectedSource) => {
-            const sourceMetadata = getSourceMetadata(connectedSource.source);
-            const isSelected = selectedSources.includes(connectedSource.source);
-            const isActive =
-              activeView === "sources" &&
-              activeSource === connectedSource.source;
-            const selectionCount =
-              sourceSelectionCounts.get(connectedSource.source) ?? 0;
-
-            return (
-              <LineItem
-                key={connectedSource.source}
-                icon={sourceMetadata.icon}
-                strokeIcon={false}
-                onClick={() => onNavigateToSource(connectedSource.source)}
-                selected={isActive}
-                emphasized={isActive || isSelected || selectionCount > 0}
-                aria-label={`knowledge-sidebar-source-${connectedSource.source}`}
-                rightChildren={
-                  selectionCount > 0 ? (
-                    <Text mainUiAction className="text-action-link-05">
-                      {selectionCount}
-                    </Text>
-                  ) : undefined
-                }
-              >
-                {sourceMetadata.displayName}
-              </LineItem>
-            );
-          })}
-        </>
-      )}
-    </TableLayouts.SidebarLayout>
-  );
-}
-
-// ============================================================================
-// KNOWLEDGE SEARCH BAR - Top row shown in any expanded view
-// ============================================================================
-
-interface KnowledgeSearchBarProps {
-  query: string;
-  onQueryChange: (q: string) => void;
-  onSubmit: () => void;
-  onClear: () => void;
-  onBack: () => void;
-  onFocus: () => void;
-  isSearchMode: boolean;
-}
-
-function KnowledgeSearchBar({
-  query,
-  onQueryChange,
-  onSubmit,
-  onClear,
-  onBack,
-  onFocus,
-  isSearchMode,
-}: KnowledgeSearchBarProps) {
-  function handleKeyDown(e: React.KeyboardEvent) {
-    if (e.key === "Enter") onSubmit();
-    if (e.key === "Escape" && isSearchMode) onBack();
-  }
-
-  return (
-    <GeneralLayouts.Section
-      flexDirection="row"
-      alignItems="center"
-      gap={0.25}
-      height="auto"
-    >
-      {isSearchMode ? (
-        <Button
-          icon={SvgArrowLeft}
-          prominence="tertiary"
-          onClick={onBack}
-          aria-label="exit-search"
-        />
-      ) : null}
-      <GeneralLayouts.Section height="auto">
-        <InputTypeIn
-          searchIcon={!isSearchMode}
-          value={query}
-          onChange={(e) => onQueryChange(e.target.value)}
-          onKeyDown={handleKeyDown}
-          onFocus={onFocus}
-          placeholder="Search documents..."
-          variant="internal"
-        />
-      </GeneralLayouts.Section>
-      {isSearchMode && query ? (
-        <Button
-          icon={SvgXCircle}
-          prominence="tertiary"
-          size="sm"
-          onClick={onClear}
-          aria-label="clear-search"
-        />
-      ) : null}
-      {isSearchMode ? (
-        <Button
-          icon={SvgSearch}
-          prominence="tertiary"
-          size="sm"
-          onClick={onSubmit}
-          aria-label="submit-search"
-        />
-      ) : null}
-    </GeneralLayouts.Section>
-  );
-}
-
-// ============================================================================
-// KNOWLEDGE SEARCH SIDEBAR - Source filter list shown during search mode
-// ============================================================================
-
-interface KnowledgeSearchSidebarProps {
-  connectedSources: ConnectedSource[];
-  activeSourceFilter: ValidSources | null;
-  onSourceFilterClick: (source: ValidSources | null) => void;
-  resultCountBySource: Map<ValidSources, number>;
-  vectorDbEnabled: boolean;
-}
-
-function KnowledgeSearchSidebar({
-  connectedSources,
-  activeSourceFilter,
-  onSourceFilterClick,
-  resultCountBySource,
-  vectorDbEnabled,
-}: KnowledgeSearchSidebarProps) {
-  const totalCount = Array.from(resultCountBySource.values()).reduce(
-    (a, b) => a + b,
-    0
-  );
-
-  return (
-    <TableLayouts.SidebarLayout aria-label="knowledge-search-sidebar">
-      <LineItem
-        icon={SvgFiles}
-        selected={activeSourceFilter === null}
-        onClick={() => onSourceFilterClick(null)}
-        rightChildren={
-          totalCount > 0 ? (
-            <Text mainUiAction className="text-action-link-05">
-              {totalCount}
-            </Text>
-          ) : undefined
-        }
-      >
-        All
-      </LineItem>
-
-      {vectorDbEnabled &&
-        connectedSources.map((cs) => {
-          const sourceMetadata = getSourceMetadata(cs.source);
-          const count = resultCountBySource.get(cs.source) ?? 0;
-          return (
-            <LineItem
-              key={cs.source}
-              icon={sourceMetadata.icon}
-              strokeIcon={false}
-              selected={activeSourceFilter === cs.source}
-              onClick={() => onSourceFilterClick(cs.source)}
-              rightChildren={
-                count > 0 ? (
-                  <Text mainUiAction className="text-action-link-05">
-                    {count}
-                  </Text>
-                ) : undefined
-              }
-            >
-              {sourceMetadata.displayName}
-            </LineItem>
-          );
-        })}
-    </TableLayouts.SidebarLayout>
-  );
-}
-
-// ============================================================================
-// KNOWLEDGE SEARCH RESULTS PANEL - Right panel shown during search mode
-// ============================================================================
-
-interface KnowledgeSearchResultsPanelProps {
-  committedQuery: string;
-  searchQuery: string;
-  isSearching: boolean;
-  searchError: boolean;
-  results: {
-    docs: SearchDocWithContent[];
-    nodes: HierarchyNodeSearchSummary[];
-  } | null;
-  activeSourceFilter: ValidSources | null;
-  selectedDocumentIds: string[];
-  selectedFolderIds: number[];
-  onToggleDocument: (id: string) => void;
-  onToggleFolder: (id: number) => void;
-  onNavigateToNode: (node: HierarchyNodeSearchSummary) => void;
-}
-
-function KnowledgeSearchResultsPanel({
-  committedQuery,
-  searchQuery,
-  isSearching,
-  searchError,
-  results,
-  activeSourceFilter,
-  selectedDocumentIds,
-  selectedFolderIds,
-  onToggleDocument,
-  onToggleFolder,
-  onNavigateToNode,
-}: KnowledgeSearchResultsPanelProps) {
-  // Empty state — nothing searched yet
-  if (!committedQuery) {
-    return (
-      <GeneralLayouts.Section
-        alignItems="center"
-        justifyContent="center"
-        gap={0.5}
-        aria-label="search-empty-state"
-      >
-        <SvgSearch size={32} className="stroke-text-04" />
-        <Text secondaryBody text03>
-          Input a search term and hit enter.
-        </Text>
-      </GeneralLayouts.Section>
-    );
-  }
-
-  // Loading
-  if (isSearching) {
-    return (
-      <GeneralLayouts.Section
-        alignItems="center"
-        justifyContent="center"
-        aria-label="search-loading"
-      >
-        <Text secondaryBody text03>
-          Searching...
-        </Text>
-      </GeneralLayouts.Section>
-    );
-  }
-
-  // Error — request failed, distinct from a legitimately empty result set
-  if (searchError && committedQuery === searchQuery) {
-    return (
-      <GeneralLayouts.Section
-        alignItems="center"
-        justifyContent="center"
-        gap={0.5}
-        aria-label="search-error"
-      >
-        <Text secondaryBody text03>
-          Search failed, please try again.
-        </Text>
-      </GeneralLayouts.Section>
-    );
-  }
-
-  const allResults: Array<
-    | { kind: "node"; item: HierarchyNodeSearchSummary }
-    | { kind: "doc"; item: SearchDocWithContent }
-  > = [
-    ...(results?.nodes ?? []).map((n) => ({ kind: "node" as const, item: n })),
-    ...(results?.docs ?? []).map((d) => ({ kind: "doc" as const, item: d })),
-  ];
-
-  const isStale = committedQuery !== searchQuery;
-
-  const listContent =
-    allResults.length === 0 ? (
-      <GeneralLayouts.Section
-        alignItems="center"
-        justifyContent="center"
-        gap={0.5}
-        aria-label="search-no-results"
-      >
-        <Text secondaryBody text03>
-          No results found
-          {activeSourceFilter
-            ? ` in ${getSourceMetadata(activeSourceFilter).displayName}`
-            : ""}
-          .
-        </Text>
-      </GeneralLayouts.Section>
-    ) : (
-      <GeneralLayouts.Section gap={0} alignItems="stretch" height="auto">
-        {/* Table header */}
-        <TableLayouts.TableRow>
-          <TableLayouts.CheckboxCell />
-          <TableLayouts.TableCell flex>
-            <Text secondaryBody text03>
-              Name
-            </Text>
-          </TableLayouts.TableCell>
-          <TableLayouts.TableCell width={8}>
-            <Text secondaryBody text03>
-              Sources
-            </Text>
-          </TableLayouts.TableCell>
-        </TableLayouts.TableRow>
-
-        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
-
-        {/* Plain div required: GeneralLayouts.Section (display:flex) breaks overflow-y scrolling */}
-        <div className="overflow-y-auto max-h-80">
-          {allResults.map((entry) => {
-            if (entry.kind === "node") {
-              const node = entry.item;
-              const isSelected = selectedFolderIds.includes(node.id);
-              const sourceMeta = getSourceMetadata(node.source);
-
-              return (
-                <TableLayouts.TableRow
-                  key={`node-${node.id}`}
-                  selected={isSelected}
-                  onClick={() => onToggleFolder(node.id)}
-                  aria-label={`search-node-${node.id}`}
-                >
-                  <TableLayouts.CheckboxCell>
-                    <Checkbox
-                      checked={isSelected}
-                      onCheckedChange={() => onToggleFolder(node.id)}
-                    />
-                  </TableLayouts.CheckboxCell>
-                  <TableLayouts.TableCell flex>
-                    <GeneralLayouts.Section
-                      flexDirection="row"
-                      justifyContent="start"
-                      alignItems="center"
-                      gap={0.25}
-                      height="auto"
-                    >
-                      <SvgFolder size={16} />
-                      <GeneralLayouts.Section
-                        flexDirection="column"
-                        justifyContent="start"
-                        alignItems="start"
-                        gap={0}
-                        height="auto"
-                        className="min-w-0 grow"
-                      >
-                        <Truncated>{node.title}</Truncated>
-                        {node.link && (
-                          <Truncated text03 secondaryBody>
-                            {node.link
-                              .replace(/^https?:\/\//i, "")
-                              .replace(/^www\./i, "")
-                              .replace(/\/+$/, "")}
-                          </Truncated>
-                        )}
-                      </GeneralLayouts.Section>
-                      <Button
-                        icon={SvgChevronRight}
-                        prominence="tertiary"
-                        size="sm"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          onNavigateToNode(node);
-                        }}
-                        aria-label={`navigate-to-node-${node.id}`}
-                      />
-                    </GeneralLayouts.Section>
-                  </TableLayouts.TableCell>
-                  <TableLayouts.TableCell width={8}>
-                    <TableLayouts.SourceIconsRow>
-                      <sourceMeta.icon size={16} />
-                    </TableLayouts.SourceIconsRow>
-                  </TableLayouts.TableCell>
-                </TableLayouts.TableRow>
-              );
-            }
-
-            // doc entry
-            const doc = entry.item;
-            const isSelected = selectedDocumentIds.includes(doc.document_id);
-            const sourceMeta = getSourceMetadata(doc.source_type);
-
-            return (
-              <TableLayouts.TableRow
-                key={`doc-${doc.document_id}-${doc.chunk_ind}`}
-                selected={isSelected}
-                onClick={() => onToggleDocument(doc.document_id)}
-                aria-label={`search-doc-${doc.document_id}`}
-              >
-                <TableLayouts.CheckboxCell>
-                  <Checkbox
-                    checked={isSelected}
-                    onCheckedChange={() => onToggleDocument(doc.document_id)}
-                  />
-                </TableLayouts.CheckboxCell>
-                <TableLayouts.TableCell flex>
-                  <GeneralLayouts.Section
-                    flexDirection="row"
-                    justifyContent="start"
-                    alignItems="center"
-                    gap={0.25}
-                    height="auto"
-                  >
-                    <SvgFileText size={16} />
-                    <GeneralLayouts.Section
-                      flexDirection="column"
-                      justifyContent="start"
-                      alignItems="start"
-                      gap={0}
-                      height="auto"
-                      className="min-w-0 grow"
-                    >
-                      <Truncated>{doc.semantic_identifier}</Truncated>
-                      {doc.blurb && (
-                        <Truncated text03 secondaryBody>
-                          {doc.blurb}
-                        </Truncated>
-                      )}
-                    </GeneralLayouts.Section>
-                  </GeneralLayouts.Section>
-                </TableLayouts.TableCell>
-                <TableLayouts.TableCell width={8}>
-                  <TableLayouts.SourceIconsRow>
-                    <sourceMeta.icon size={16} />
-                  </TableLayouts.SourceIconsRow>
-                </TableLayouts.TableCell>
-              </TableLayouts.TableRow>
-            );
-          })}
-        </div>
-      </GeneralLayouts.Section>
-    );
-
-  if (isStale) {
-    return (
-      <GeneralLayouts.Section
-        alignItems="stretch"
-        justifyContent="start"
-        className="relative"
-      >
-        <GeneralLayouts.Section
-          alignItems="stretch"
-          justifyContent="start"
-          className="opacity-40 pointer-events-none"
-        >
-          {listContent}
-        </GeneralLayouts.Section>
-        <GeneralLayouts.Section
-          alignItems="center"
-          justifyContent="center"
-          className="absolute inset-0 z-10"
-        >
-          <Text secondaryBody text03>
-            Press Enter for new results.
-          </Text>
-        </GeneralLayouts.Section>
-      </GeneralLayouts.Section>
-    );
-  }
-
-  return listContent;
-}
-
-// ============================================================================
-// KNOWLEDGE TABLE - Generic table component for knowledge items
-// ============================================================================
-
-interface KnowledgeTableColumn<T> {
-  key: string;
-  header: string;
-  sortable?: boolean;
-  width?: number; // Width in rem
-  render: (item: T) => React.ReactNode;
-}
-
-interface KnowledgeTableProps<T> {
-  items: T[];
-  columns: KnowledgeTableColumn<T>[];
-  getItemId: (item: T) => string | number;
-  selectedIds: (string | number)[];
-  onToggleItem: (id: string | number) => void;
-  searchValue?: string;
-  onSearchChange?: (value: string) => void;
-  searchPlaceholder?: string;
-  headerActions?: React.ReactNode;
-  emptyMessage?: string;
-}
-
-function KnowledgeTable<T>({
-  items,
-  columns,
-  getItemId,
-  selectedIds,
-  onToggleItem,
-  searchValue,
-  onSearchChange,
-  searchPlaceholder = "Filter...",
-  headerActions,
-  emptyMessage = "No items available.",
-  ariaLabelPrefix,
-}: KnowledgeTableProps<T> & { ariaLabelPrefix?: string }) {
-  return (
-    <GeneralLayouts.Section gap={0} alignItems="stretch" justifyContent="start">
-      {/* Header with search and actions */}
-      <GeneralLayouts.Section
-        flexDirection="row"
-        justifyContent="start"
-        alignItems="center"
-        gap={0.5}
-        height="auto"
-      >
-        {onSearchChange !== undefined && (
-          <GeneralLayouts.Section height="auto">
-            <InputTypeIn
-              value={searchValue ?? ""}
-              onChange={(e) => onSearchChange?.(e.target.value)}
-              placeholder={searchPlaceholder}
-              variant="internal"
-              rightChildren={
-                <SvgFilter className="w-4 h-4 stroke-text-02 shrink-0" />
-              }
-            />
-          </GeneralLayouts.Section>
-        )}
-        {headerActions}
-      </GeneralLayouts.Section>
-
-      <Spacer rem={0.5} />
-
-      {/* Table header */}
-      <TableLayouts.TableRow>
-        <TableLayouts.CheckboxCell />
-        {columns.map((column) => (
-          <TableLayouts.TableCell
-            key={column.key}
-            flex={!column.width}
-            width={column.width}
-          >
-            <GeneralLayouts.Section
-              flexDirection="row"
-              justifyContent="start"
-              alignItems="center"
-              gap={0.25}
-              height="auto"
-            >
-              <Text secondaryBody text03>
-                {column.header}
-              </Text>
-            </GeneralLayouts.Section>
-          </TableLayouts.TableCell>
-        ))}
-      </TableLayouts.TableRow>
-
-      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
-
-      {/* Table body */}
-      {items.length === 0 ? (
-        <GeneralLayouts.Section height="auto" padding={1}>
-          <Text text03 secondaryBody>
-            {emptyMessage}
-          </Text>
-        </GeneralLayouts.Section>
-      ) : (
-        <GeneralLayouts.Section gap={0} alignItems="stretch" height="auto">
-          {items.map((item) => {
-            const id = getItemId(item);
-            const isSelected = selectedIds.includes(id);
-
-            return (
-              <TableLayouts.TableRow
-                key={String(id)}
-                selected={isSelected}
-                onClick={() => onToggleItem(id)}
-                aria-label={
-                  ariaLabelPrefix ? `${ariaLabelPrefix}-${id}` : undefined
-                }
-              >
-                <TableLayouts.CheckboxCell>
-                  <Checkbox
-                    checked={isSelected}
-                    onCheckedChange={() => onToggleItem(id)}
-                  />
-                </TableLayouts.CheckboxCell>
-                {columns.map((column) => (
-                  <TableLayouts.TableCell
-                    key={column.key}
-                    flex={!column.width}
-                    width={column.width}
-                  >
-                    {column.render(item)}
-                  </TableLayouts.TableCell>
-                ))}
-              </TableLayouts.TableRow>
-            );
-          })}
-        </GeneralLayouts.Section>
-      )}
-    </GeneralLayouts.Section>
-  );
-}
-
-// ============================================================================
-// DOCUMENT SETS TABLE - Table content for document sets view
-// ============================================================================
-
-interface DocumentSetsTableContentProps {
-  documentSets: DocumentSetSummary[];
-  selectedDocumentSetIds: number[];
-  onDocumentSetToggle: (documentSetId: number) => void;
-}
-
-function DocumentSetsTableContent({
-  documentSets,
-  selectedDocumentSetIds,
-  onDocumentSetToggle,
-}: DocumentSetsTableContentProps) {
-  const [searchValue, setSearchValue] = useState("");
-
-  const filteredDocumentSets = useMemo(() => {
-    if (!searchValue) return documentSets;
-    const lower = searchValue.toLowerCase();
-    return documentSets.filter((ds) => ds.name.toLowerCase().includes(lower));
-  }, [documentSets, searchValue]);
-
-  const columns: KnowledgeTableColumn<DocumentSetSummary>[] = [
-    {
-      key: "name",
-      header: "Name",
-      sortable: true,
-      render: (ds) => (
-        <Content
-          icon={SvgFolder}
-          title={ds.name}
-          sizePreset="main-ui"
-          variant="section"
-        />
-      ),
-    },
-    {
-      key: "sources",
-      header: "Sources",
-      width: 8,
-      render: (ds) => (
-        <TableLayouts.SourceIconsRow>
-          {ds.cc_pair_summaries
-            ?.slice(0, 4)
-            .map((summary: CCPairSummary, idx: number) => {
-              const sourceMetadata = getSourceMetadata(summary.source);
-              return <sourceMetadata.icon key={idx} size={16} />;
-            })}
-          {(ds.cc_pair_summaries?.length ?? 0) > 4 && (
-            <Text text03 secondaryBody>
-              +{(ds.cc_pair_summaries?.length ?? 0) - 4}
-            </Text>
-          )}
-        </TableLayouts.SourceIconsRow>
-      ),
-    },
-  ];
-
-  return (
-    <KnowledgeTable
-      items={filteredDocumentSets}
-      columns={columns}
-      getItemId={(ds) => ds.id}
-      selectedIds={selectedDocumentSetIds}
-      onToggleItem={(id) => onDocumentSetToggle(id as number)}
-      searchValue={searchValue}
-      onSearchChange={setSearchValue}
-      searchPlaceholder="Filter document sets..."
-      emptyMessage="No document sets available."
-      ariaLabelPrefix="document-set-row"
-    />
-  );
-}
-
-interface SourcesTableContentProps {
-  source: ValidSources;
-  selectedDocumentIds: string[];
-  onToggleDocument: (documentId: string) => void;
-  onSetDocumentIds: (ids: string[]) => void;
-  selectedFolderIds: number[];
-  onToggleFolder: (folderId: number) => void;
-  onSetFolderIds: (ids: number[]) => void;
-  onDeselectAllDocuments: () => void;
-  onDeselectAllFolders: () => void;
-  initialAttachedDocuments?: AgentAttachedDocument[];
-  onSelectionCountChange?: (source: ValidSources, count: number) => void;
-  initialNodeId?: number;
-}
-
-function SourcesTableContent({
-  source,
-  selectedDocumentIds,
-  onToggleDocument,
-  onSetDocumentIds,
-  selectedFolderIds,
-  onToggleFolder,
-  onSetFolderIds,
-  onDeselectAllDocuments,
-  onDeselectAllFolders,
-  initialAttachedDocuments,
-  onSelectionCountChange,
-  initialNodeId,
-}: SourcesTableContentProps) {
-  return (
-    <GeneralLayouts.Section gap={0.5} alignItems="stretch">
-      {/* Hierarchy browser */}
-      <SourceHierarchyBrowser
-        source={source}
-        selectedDocumentIds={selectedDocumentIds}
-        onToggleDocument={onToggleDocument}
-        onSetDocumentIds={onSetDocumentIds}
-        selectedFolderIds={selectedFolderIds}
-        onToggleFolder={onToggleFolder}
-        onSetFolderIds={onSetFolderIds}
-        initialAttachedDocuments={initialAttachedDocuments}
-        onDeselectAllDocuments={onDeselectAllDocuments}
-        onDeselectAllFolders={onDeselectAllFolders}
-        onSelectionCountChange={onSelectionCountChange}
-        initialNodeId={initialNodeId}
-      />
-    </GeneralLayouts.Section>
-  );
-}
-
-// ============================================================================
-// RECENT FILES TABLE - Table content for user files view
-// ============================================================================
-
-interface RecentFilesTableContentProps {
-  allRecentFiles: ProjectFile[];
-  selectedFileIds: string[];
-  onToggleFile: (fileId: string) => void;
-  onUploadChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  hasProcessingFiles: boolean;
-}
-
-function RecentFilesTableContent({
-  allRecentFiles,
-  selectedFileIds,
-  onToggleFile,
-  onUploadChange,
-  hasProcessingFiles,
-}: RecentFilesTableContentProps) {
-  const [searchValue, setSearchValue] = useState("");
-
-  const filteredFiles = useMemo(() => {
-    if (!searchValue) return allRecentFiles;
-    const lower = searchValue.toLowerCase();
-    return allRecentFiles.filter((f) => f.name.toLowerCase().includes(lower));
-  }, [allRecentFiles, searchValue]);
-
-  const columns: KnowledgeTableColumn<ProjectFile>[] = [
-    {
-      key: "name",
-      header: "Name",
-      sortable: true,
-      render: (file) => (
-        <Content
-          icon={SvgFiles}
-          title={file.name}
-          sizePreset="main-ui"
-          variant="section"
-        />
-      ),
-    },
-    {
-      key: "lastUpdated",
-      header: "Last Updated",
-      sortable: true,
-      width: 8,
-      render: (file) => (
-        <Text text03 secondaryBody>
-          {timeAgo(file.last_accessed_at || file.created_at)}
-        </Text>
-      ),
-    },
-  ];
-
-  const fileInputRef = React.useRef<HTMLInputElement>(null);
-
-  return (
-    <GeneralLayouts.Section gap={0.5} alignItems="stretch">
-      <TableLayouts.HiddenInput
-        inputRef={fileInputRef}
-        type="file"
-        multiple
-        onChange={onUploadChange}
-      />
-
-      <KnowledgeTable
-        items={filteredFiles}
-        columns={columns}
-        getItemId={(file) => file.id}
-        selectedIds={selectedFileIds}
-        onToggleItem={(id) => onToggleFile(id as string)}
-        searchValue={searchValue}
-        onSearchChange={setSearchValue}
-        searchPlaceholder="Filter files..."
-        ariaLabelPrefix="user-file-row"
-        headerActions={
-          <Button
-            prominence="internal"
-            icon={SvgPlusCircle}
-            onClick={() => fileInputRef.current?.click()}
-          >
-            Add File
-          </Button>
-        }
-        emptyMessage="No files available. Upload files to get started."
-      />
-
-      {hasProcessingFiles && (
-        <GeneralLayouts.Section height="auto" alignItems="start">
-          <Text as="p" text03 secondaryBody>
-            Onyx is still processing your uploaded files. You can create the
-            agent now, but it will not have access to all files until processing
-            completes.
-          </Text>
-        </GeneralLayouts.Section>
-      )}
-    </GeneralLayouts.Section>
-  );
-}
-
-// ============================================================================
-// TWO-COLUMN LAYOUT - Sidebar + Table for detailed views
-// ============================================================================
-
-interface KnowledgeTwoColumnViewProps {
-  activeView: KnowledgeView;
-  activeSource?: ValidSources;
-  connectedSources: ConnectedSource[];
-  selectedSources: ValidSources[];
-  selectedDocumentSetIds: number[];
-  selectedFileIds: string[];
-  selectedDocumentIds: string[];
-  selectedFolderIds: number[];
-  sourceSelectionCounts: Map<ValidSources, number>;
-  documentSets: DocumentSetSummary[];
-  allRecentFiles: ProjectFile[];
-  onNavigateToRecent: () => void;
-  onNavigateToDocumentSets: () => void;
-  onNavigateToSource: (source: ValidSources) => void;
-  onDocumentSetToggle: (id: number) => void;
-  onSourceToggle: (source: ValidSources) => void;
-  onFileToggle: (fileId: string) => void;
-  onToggleDocument: (documentId: string) => void;
-  onToggleFolder: (folderId: number) => void;
-  onSetDocumentIds: (ids: string[]) => void;
-  onSetFolderIds: (ids: number[]) => void;
-  onDeselectAllDocuments: () => void;
-  onDeselectAllFolders: () => void;
-  onUploadChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
-  hasProcessingFiles: boolean;
-  initialAttachedDocuments?: AgentAttachedDocument[];
-  onSelectionCountChange: (source: ValidSources, count: number) => void;
-  vectorDbEnabled: boolean;
-  // Search props
-  isSearchMode: boolean;
-  searchQuery: string;
-  committedQuery: string;
-  activeSourceFilter: ValidSources | null;
-  searchResults: {
-    docs: SearchDocWithContent[];
-    nodes: HierarchyNodeSearchSummary[];
-  } | null;
-  isSearching: boolean;
-  searchError: boolean;
-  resultCountBySource: Map<ValidSources, number>;
-  onSearchQueryChange: (q: string) => void;
-  onSearchSubmit: () => void;
-  onSearchClear: () => void;
-  onEnterSearchMode: () => void;
-  onExitSearchMode: () => void;
-  onSourceFilterClick: (source: ValidSources | null) => void;
-  onNavigateToSearchNode: (node: HierarchyNodeSearchSummary) => void;
-  searchNavigateNodeId?: number;
-}
-
-const KnowledgeTwoColumnView = memo(function KnowledgeTwoColumnView({
-  activeView,
-  activeSource,
-  connectedSources,
-  selectedSources,
-  selectedDocumentSetIds,
-  selectedFileIds,
-  selectedDocumentIds,
-  selectedFolderIds,
-  sourceSelectionCounts,
-  documentSets,
-  allRecentFiles,
-  onNavigateToRecent,
-  onNavigateToDocumentSets,
-  onNavigateToSource,
-  onDocumentSetToggle,
-  onSourceToggle,
-  onFileToggle,
-  onToggleDocument,
-  onToggleFolder,
-  onSetDocumentIds,
-  onSetFolderIds,
-  onDeselectAllDocuments,
-  onDeselectAllFolders,
-  onUploadChange,
-  hasProcessingFiles,
-  initialAttachedDocuments,
-  onSelectionCountChange,
-  vectorDbEnabled,
-  isSearchMode,
-  searchQuery,
-  committedQuery,
-  activeSourceFilter,
-  searchResults,
-  isSearching,
-  searchError,
-  resultCountBySource,
-  onSearchQueryChange,
-  onSearchSubmit,
-  onSearchClear,
-  onEnterSearchMode,
-  onExitSearchMode,
-  onSourceFilterClick,
-  onNavigateToSearchNode,
-  searchNavigateNodeId,
-}: KnowledgeTwoColumnViewProps) {
-  return (
-    <GeneralLayouts.Section gap={0.5} alignItems="stretch" height="auto">
-      {/* Search bar row — visible in expanded mode; requires a vector DB */}
-      {vectorDbEnabled && (
-        <KnowledgeSearchBar
-          query={searchQuery}
-          onQueryChange={onSearchQueryChange}
-          onSubmit={onSearchSubmit}
-          onClear={onSearchClear}
-          onBack={onExitSearchMode}
-          onFocus={onEnterSearchMode}
-          isSearchMode={isSearchMode}
-        />
-      )}
-
-      {isSearchMode ? (
-        <TableLayouts.TwoColumnLayout minHeight={18.75}>
-          <KnowledgeSearchSidebar
-            connectedSources={connectedSources}
-            activeSourceFilter={activeSourceFilter}
-            onSourceFilterClick={onSourceFilterClick}
-            resultCountBySource={resultCountBySource}
-            vectorDbEnabled={vectorDbEnabled}
-          />
-          <TableLayouts.ContentColumn>
-            <KnowledgeSearchResultsPanel
-              committedQuery={committedQuery}
-              searchQuery={searchQuery}
-              isSearching={isSearching}
-              searchError={searchError}
-              results={searchResults}
-              activeSourceFilter={activeSourceFilter}
-              selectedDocumentIds={selectedDocumentIds}
-              selectedFolderIds={selectedFolderIds}
-              onToggleDocument={onToggleDocument}
-              onToggleFolder={onToggleFolder}
-              onNavigateToNode={onNavigateToSearchNode}
-            />
-          </TableLayouts.ContentColumn>
-        </TableLayouts.TwoColumnLayout>
-      ) : (
-        <TableLayouts.TwoColumnLayout minHeight={18.75}>
-          <KnowledgeSidebar
-            activeView={activeView}
-            activeSource={activeSource}
-            connectedSources={connectedSources}
-            selectedSources={selectedSources}
-            selectedDocumentSetIds={selectedDocumentSetIds}
-            selectedFileIds={selectedFileIds}
-            sourceSelectionCounts={sourceSelectionCounts}
-            onNavigateToRecent={onNavigateToRecent}
-            onNavigateToDocumentSets={onNavigateToDocumentSets}
-            onNavigateToSource={onNavigateToSource}
-            vectorDbEnabled={vectorDbEnabled}
-          />
-
-          <TableLayouts.ContentColumn>
-            {activeView === "document-sets" && (
-              <DocumentSetsTableContent
-                documentSets={documentSets}
-                selectedDocumentSetIds={selectedDocumentSetIds}
-                onDocumentSetToggle={onDocumentSetToggle}
-              />
-            )}
-            {activeView === "sources" && activeSource && (
-              <SourcesTableContent
-                source={activeSource}
-                selectedDocumentIds={selectedDocumentIds}
-                onToggleDocument={onToggleDocument}
-                onSetDocumentIds={onSetDocumentIds}
-                selectedFolderIds={selectedFolderIds}
-                onToggleFolder={onToggleFolder}
-                onSetFolderIds={onSetFolderIds}
-                onDeselectAllDocuments={onDeselectAllDocuments}
-                onDeselectAllFolders={onDeselectAllFolders}
-                initialAttachedDocuments={initialAttachedDocuments}
-                onSelectionCountChange={onSelectionCountChange}
-                initialNodeId={searchNavigateNodeId}
-              />
-            )}
-            {activeView === "recent" && (
-              <RecentFilesTableContent
-                allRecentFiles={allRecentFiles}
-                selectedFileIds={selectedFileIds}
-                onToggleFile={onFileToggle}
-                onUploadChange={onUploadChange}
-                hasProcessingFiles={hasProcessingFiles}
-              />
-            )}
-          </TableLayouts.ContentColumn>
-        </TableLayouts.TwoColumnLayout>
-      )}
-    </GeneralLayouts.Section>
-  );
-});
-
-// ============================================================================
-// KNOWLEDGE ADD VIEW - Initial pill selection view
-// ============================================================================
-
-interface KnowledgeAddViewProps {
-  connectedSources: ConnectedSource[];
-  onNavigateToDocumentSets: () => void;
-  onNavigateToRecent: () => void;
-  onNavigateToSource: (source: ValidSources) => void;
-  selectedDocumentSetIds: number[];
-  selectedFileIds: string[];
-  selectedSources: ValidSources[];
-  sourceSelectionCounts: Map<ValidSources, number>;
-  vectorDbEnabled: boolean;
-}
-
-const KnowledgeAddView = memo(function KnowledgeAddView({
-  connectedSources,
-  onNavigateToDocumentSets,
-  onNavigateToRecent,
-  onNavigateToSource,
-  selectedDocumentSetIds,
-  selectedFileIds,
-  selectedSources,
-  sourceSelectionCounts,
-  vectorDbEnabled,
-}: KnowledgeAddViewProps) {
-  return (
-    <GeneralLayouts.Section
-      gap={0.5}
-      alignItems="start"
-      height="auto"
-      aria-label="knowledge-add-view"
-    >
-      <GeneralLayouts.Section
-        flexDirection="row"
-        justifyContent="start"
-        gap={0.5}
-        height="auto"
-        wrap
-      >
-        {vectorDbEnabled && (
-          <LineItem
-            icon={SvgFolder}
-            onClick={onNavigateToDocumentSets}
-            emphasized={selectedDocumentSetIds.length > 0}
-            aria-label="knowledge-add-document-sets"
-            rightChildren={
-              selectedDocumentSetIds.length > 0 ? (
-                <Text mainUiAction className="text-action-link-05">
-                  {selectedDocumentSetIds.length}
-                </Text>
-              ) : undefined
-            }
-          >
-            Document Sets
-          </LineItem>
-        )}
-
-        <LineItem
-          icon={SvgFiles}
-          description="Recent or new uploads"
-          onClick={onNavigateToRecent}
-          emphasized={selectedFileIds.length > 0}
-          aria-label="knowledge-add-files"
-          rightChildren={
-            selectedFileIds.length > 0 ? (
-              <Text mainUiAction className="text-action-link-05">
-                {selectedFileIds.length}
-              </Text>
-            ) : undefined
-          }
-        >
-          Your Files
-        </LineItem>
-      </GeneralLayouts.Section>
-
-      {vectorDbEnabled && connectedSources.length > 0 && (
-        <>
-          <Text as="p" text03 secondaryBody>
-            Connected Sources
-          </Text>
-          {connectedSources.map((connectedSource) => {
-            const sourceMetadata = getSourceMetadata(connectedSource.source);
-            const isSelected = selectedSources.includes(connectedSource.source);
-            const selectionCount =
-              sourceSelectionCounts.get(connectedSource.source) ?? 0;
-            return (
-              <LineItem
-                key={connectedSource.source}
-                icon={sourceMetadata.icon}
-                strokeIcon={false}
-                onClick={() => onNavigateToSource(connectedSource.source)}
-                emphasized={isSelected || selectionCount > 0}
-                aria-label={`knowledge-add-source-${connectedSource.source}`}
-                rightChildren={
-                  selectionCount > 0 ? (
-                    <Text mainUiAction className="text-action-link-05">
-                      {selectionCount}
-                    </Text>
-                  ) : undefined
-                }
-              >
-                {sourceMetadata.displayName}
-              </LineItem>
-            );
-          })}
-        </>
-      )}
-    </GeneralLayouts.Section>
-  );
-});
-
-// ============================================================================
-// KNOWLEDGE MAIN CONTENT - Empty state and preview
-// ============================================================================
-
-interface KnowledgeMainContentProps {
-  hasAnyKnowledge: boolean;
-  selectedDocumentSetIds: number[];
-  selectedDocumentIds: string[];
-  selectedFolderIds: number[];
-  selectedFileIds: string[];
-  selectedSources: ValidSources[];
-  documentSets: DocumentSetSummary[];
-  allRecentFiles: ProjectFile[];
-  connectedSources: ConnectedSource[];
-  onAddKnowledge: () => void;
-  onViewEdit: () => void;
-  onFileClick?: (file: ProjectFile) => void;
-}
-
-const KnowledgeMainContent = memo(function KnowledgeMainContent({
-  hasAnyKnowledge,
-  selectedDocumentSetIds,
-  selectedDocumentIds,
-  selectedFolderIds,
-  selectedFileIds,
-  selectedSources,
-  onAddKnowledge,
-  onViewEdit,
-}: KnowledgeMainContentProps) {
-  if (!hasAnyKnowledge) {
-    return (
-      <GeneralLayouts.Section
-        flexDirection="row"
-        justifyContent="between"
-        alignItems="center"
-        height="auto"
-      >
-        <Text text03 secondaryBody>
-          Add documents or connected sources to use for this agent.
-        </Text>
-        <Button
-          icon={SvgPlusCircle}
-          onClick={onAddKnowledge}
-          prominence="tertiary"
-          aria-label="knowledge-add-button"
-        />
-      </GeneralLayouts.Section>
-    );
-  }
-
-  // Has knowledge - show preview with count
-  const totalSelected =
-    selectedDocumentSetIds.length +
-    selectedDocumentIds.length +
-    selectedFolderIds.length +
-    selectedFileIds.length +
-    selectedSources.length;
-
-  return (
-    <GeneralLayouts.Section
-      flexDirection="row"
-      justifyContent="between"
-      alignItems="center"
-      height="auto"
-    >
-      <Text as="p" text03 secondaryBody>
-        {totalSelected} knowledge source{totalSelected !== 1 ? "s" : ""}{" "}
-        selected
-      </Text>
-      <Button
-        prominence="internal"
-        icon={SvgArrowUpRight}
-        onClick={onViewEdit}
-        aria-label="knowledge-view-edit"
-      >
-        View / Edit
-      </Button>
-    </GeneralLayouts.Section>
-  );
-});
-
-// ============================================================================
-// MAIN COMPONENT - AgentKnowledgePane
-// ============================================================================
+import type {
+  AgentAttachedDocument,
+  AgentHierarchyNode,
+} from "@/lib/agents/types";
+import type {
+  ConnectedSource,
+  HierarchyNodeSearchSummary,
+} from "@/lib/hierarchy/interfaces";
+import type { ProjectFile } from "@/lib/projects/types";
+import type { DocumentSetSummary, ValidSources } from "@/lib/types";
+import { searchDocuments } from "@/ee/lib/search/svc";
+import { Disabled } from "@opal/core";
+import { Switch } from "@opal/components";
+import { Content, InputHorizontal } from "@opal/layouts";
+
+import { KnowledgeAddView } from "@/sections/knowledge/agent-knowledge/KnowledgeAddView";
+import { KnowledgeMainContent } from "@/sections/knowledge/agent-knowledge/KnowledgeMainContent";
+import {
+  KnowledgeSearchBar,
+  KnowledgeSearchResultsPanel,
+  KnowledgeSearchSidebar,
+} from "@/sections/knowledge/agent-knowledge/KnowledgeSearch";
+import { KnowledgeTwoColumnView } from "@/sections/knowledge/agent-knowledge/KnowledgeTwoColumnView";
+import type {
+  KnowledgeNavState,
+  KnowledgeSearchResults,
+  KnowledgeView,
+} from "@/sections/knowledge/agent-knowledge/interfaces";
 
 interface AgentKnowledgePaneProps {
   enableKnowledge: boolean;
@@ -1362,12 +59,8 @@ interface AgentKnowledgePaneProps {
   onFileClick?: (file: ProjectFile) => void;
   onUploadChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   hasProcessingFiles: boolean;
-  // Initial attached documents for existing agents (to populate selectedDocumentDetails)
   initialAttachedDocuments?: AgentAttachedDocument[];
-  // Initial hierarchy nodes for existing agents (to calculate per-source counts)
   initialHierarchyNodes?: AgentHierarchyNode[];
-  // When false, hides document sets, connected sources, and hierarchy nodes
-  // (these require a vector DB). User files are still shown.
   vectorDbEnabled?: boolean;
 }
 
@@ -1375,7 +68,6 @@ export default function AgentKnowledgePane({
   enableKnowledge,
   onEnableKnowledgeChange,
   selectedSources,
-  onSourcesChange,
   documentSets,
   selectedDocumentSetIds,
   onDocumentSetIdsChange,
@@ -1386,42 +78,33 @@ export default function AgentKnowledgePane({
   selectedFileIds,
   onFileIdsChange,
   allRecentFiles,
-  onFileClick,
   onUploadChange,
   hasProcessingFiles,
   initialAttachedDocuments,
   initialHierarchyNodes,
   vectorDbEnabled = true,
 }: AgentKnowledgePaneProps) {
-  // View state
   const [view, setView] = useState<KnowledgeView>("main");
   const [activeSource, setActiveSource] = useState<ValidSources | undefined>();
 
-  // Search state
   const [isSearchMode, setIsSearchMode] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [committedQuery, setCommittedQuery] = useState("");
   const [activeSourceFilter, setActiveSourceFilter] =
     useState<ValidSources | null>(null);
-  const [searchResults, setSearchResults] = useState<{
-    docs: SearchDocWithContent[];
-    nodes: HierarchyNodeSearchSummary[];
-  } | null>(null);
+  const [searchResults, setSearchResults] =
+    useState<KnowledgeSearchResults | null>(null);
   const [isSearching, setIsSearching] = useState(false);
   const [searchError, setSearchError] = useState(false);
-  // Guards against a stale, slower search request overwriting a newer one
   const searchRequestIdRef = useRef(0);
-  // Node ID to navigate to after exiting search mode into a source
   const [searchNavigateNodeId, setSearchNavigateNodeId] = useState<
     number | undefined
   >();
-  // Snapshot nav state when entering search mode so ← can restore it
-  const navStateRef = useRef<{
-    view: KnowledgeView;
-    activeSource: ValidSources | undefined;
-  }>({ view: "add", activeSource: undefined });
+  const navStateRef = useRef<KnowledgeNavState>({
+    view: "add",
+    activeSource: undefined,
+  });
 
-  // Reset view to main when knowledge is disabled
   useEffect(() => {
     if (!enableKnowledge) {
       setView("main");
@@ -1435,7 +118,6 @@ export default function AgentKnowledgePane({
     }
   }, [enableKnowledge, isSearchMode]);
 
-  // Get connected sources from CC pairs
   const { ccPairs } = useCCPairs(vectorDbEnabled);
   const connectedSources: ConnectedSource[] = useMemo(() => {
     if (!ccPairs || ccPairs.length === 0) return [];
@@ -1447,14 +129,11 @@ export default function AgentKnowledgePane({
     }));
   }, [ccPairs]);
 
-  // Track per-source selection counts
-  // Initialized from initialHierarchyNodes and initialAttachedDocuments
   const [sourceSelectionCounts, setSourceSelectionCounts] = useState<
     Map<ValidSources, number>
   >(() => {
     const counts = new Map<ValidSources, number>();
 
-    // Count folders from initialHierarchyNodes (which have source info)
     if (initialHierarchyNodes) {
       for (const node of initialHierarchyNodes) {
         const current = counts.get(node.source) ?? 0;
@@ -1462,7 +141,6 @@ export default function AgentKnowledgePane({
       }
     }
 
-    // Count documents from initialAttachedDocuments (which now include source)
     if (initialAttachedDocuments) {
       for (const doc of initialAttachedDocuments) {
         if (doc.source) {
@@ -1475,7 +153,6 @@ export default function AgentKnowledgePane({
     return counts;
   });
 
-  // Handler for selection count changes from SourceHierarchyBrowser
   const handleSelectionCountChange = useCallback(
     (source: ValidSources, count: number) => {
       setSourceSelectionCounts((prev) => {
@@ -1491,7 +168,6 @@ export default function AgentKnowledgePane({
     []
   );
 
-  // Per-source result counts from search results
   const resultCountBySource = useMemo(() => {
     const counts = new Map<ValidSources, number>();
     if (!searchResults) return counts;
@@ -1504,7 +180,6 @@ export default function AgentKnowledgePane({
     return counts;
   }, [searchResults]);
 
-  // Check if any knowledge is selected
   const hasAnyKnowledge =
     selectedDocumentSetIds.length > 0 ||
     selectedDocumentIds.length > 0 ||
@@ -1512,9 +187,7 @@ export default function AgentKnowledgePane({
     selectedFileIds.length > 0 ||
     selectedSources.length > 0;
 
-  // Navigation handlers - memoized to prevent unnecessary re-renders
   const handleNavigateToAdd = useCallback(() => setView("add"), []);
-  const handleNavigateToMain = useCallback(() => setView("main"), []);
   const handleNavigateToDocumentSets = useCallback(
     () => setView("document-sets"),
     []
@@ -1525,16 +198,11 @@ export default function AgentKnowledgePane({
     setView("sources");
   }, []);
 
-  // Search handlers
   const handleEnterSearchMode = useCallback(() => {
-    // Search hits vector-backed endpoints (send-search-message, hierarchy
-    // node search), which require a vector DB — same gate as document
-    // sets/connected sources.
     if (!vectorDbEnabled) return;
     if (!isSearchMode) {
       navStateRef.current = { view, activeSource };
       setIsSearchMode(true);
-      // Make sure the pane is expanded
       if (view === "main" || view === "add") {
         setView("add");
       }
@@ -1627,7 +295,6 @@ export default function AgentKnowledgePane({
     []
   );
 
-  // Toggle handlers - memoized to prevent unnecessary re-renders
   const handleDocumentSetToggle = useCallback(
     (documentSetId: number) => {
       const newIds = selectedDocumentSetIds.includes(documentSetId)
@@ -1636,16 +303,6 @@ export default function AgentKnowledgePane({
       onDocumentSetIdsChange(newIds);
     },
     [selectedDocumentSetIds, onDocumentSetIdsChange]
-  );
-
-  const handleSourceToggle = useCallback(
-    (source: ValidSources) => {
-      const newSources = selectedSources.includes(source)
-        ? selectedSources.filter((s) => s !== source)
-        : [...selectedSources, source];
-      onSourcesChange(newSources);
-    },
-    [selectedSources, onSourcesChange]
   );
 
   const handleFileToggle = useCallback(
@@ -1686,7 +343,6 @@ export default function AgentKnowledgePane({
     onFolderIdsChange([]);
   }, [onFolderIdsChange]);
 
-  // Memoized content based on view - prevents unnecessary re-renders
   const renderedContent = useMemo(() => {
     switch (view) {
       case "main":
@@ -1698,12 +354,8 @@ export default function AgentKnowledgePane({
             selectedFolderIds={selectedFolderIds}
             selectedFileIds={selectedFileIds}
             selectedSources={selectedSources}
-            documentSets={documentSets}
-            allRecentFiles={allRecentFiles}
-            connectedSources={connectedSources}
             onAddKnowledge={handleNavigateToAdd}
             onViewEdit={handleNavigateToAdd}
-            onFileClick={onFileClick}
           />
         );
 
@@ -1782,7 +434,6 @@ export default function AgentKnowledgePane({
             onNavigateToDocumentSets={handleNavigateToDocumentSets}
             onNavigateToSource={handleNavigateToSource}
             onDocumentSetToggle={handleDocumentSetToggle}
-            onSourceToggle={handleSourceToggle}
             onFileToggle={handleFileToggle}
             onToggleDocument={handleDocumentToggle}
             onToggleFolder={handleFolderToggle}
@@ -1833,7 +484,6 @@ export default function AgentKnowledgePane({
     hasProcessingFiles,
     initialAttachedDocuments,
     vectorDbEnabled,
-    onFileClick,
     onUploadChange,
     onDocumentIdsChange,
     onFolderIdsChange,
@@ -1851,7 +501,6 @@ export default function AgentKnowledgePane({
     handleNavigateToRecent,
     handleNavigateToSource,
     handleDocumentSetToggle,
-    handleSourceToggle,
     handleFileToggle,
     handleDocumentToggle,
     handleFolderToggle,

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeAddView.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeAddView.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { memo } from "react";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import LineItem from "@/refresh-components/buttons/LineItem";
+import Text from "@/refresh-components/texts/Text";
+import { getSourceMetadata } from "@/lib/sources";
+import type { ConnectedSource } from "@/lib/hierarchy/interfaces";
+import type { ValidSources } from "@/lib/types";
+import { SvgFiles, SvgFolder } from "@opal/icons";
+
+interface KnowledgeAddViewProps {
+  connectedSources: ConnectedSource[];
+  onNavigateToDocumentSets: () => void;
+  onNavigateToRecent: () => void;
+  onNavigateToSource: (source: ValidSources) => void;
+  selectedDocumentSetIds: number[];
+  selectedFileIds: string[];
+  selectedSources: ValidSources[];
+  sourceSelectionCounts: Map<ValidSources, number>;
+  vectorDbEnabled: boolean;
+}
+
+export const KnowledgeAddView = memo(function KnowledgeAddView({
+  connectedSources,
+  onNavigateToDocumentSets,
+  onNavigateToRecent,
+  onNavigateToSource,
+  selectedDocumentSetIds,
+  selectedFileIds,
+  selectedSources,
+  sourceSelectionCounts,
+  vectorDbEnabled,
+}: KnowledgeAddViewProps) {
+  return (
+    <GeneralLayouts.Section
+      gap={0.5}
+      alignItems="start"
+      height="auto"
+      aria-label="knowledge-add-view"
+    >
+      <GeneralLayouts.Section
+        flexDirection="row"
+        justifyContent="start"
+        gap={0.5}
+        height="auto"
+        wrap
+      >
+        {vectorDbEnabled && (
+          <LineItem
+            icon={SvgFolder}
+            onClick={onNavigateToDocumentSets}
+            emphasized={selectedDocumentSetIds.length > 0}
+            aria-label="knowledge-add-document-sets"
+            rightChildren={
+              selectedDocumentSetIds.length > 0 ? (
+                <Text mainUiAction className="text-action-link-05">
+                  {selectedDocumentSetIds.length}
+                </Text>
+              ) : undefined
+            }
+          >
+            Document Sets
+          </LineItem>
+        )}
+
+        <LineItem
+          icon={SvgFiles}
+          description="Recent or new uploads"
+          onClick={onNavigateToRecent}
+          emphasized={selectedFileIds.length > 0}
+          aria-label="knowledge-add-files"
+          rightChildren={
+            selectedFileIds.length > 0 ? (
+              <Text mainUiAction className="text-action-link-05">
+                {selectedFileIds.length}
+              </Text>
+            ) : undefined
+          }
+        >
+          Your Files
+        </LineItem>
+      </GeneralLayouts.Section>
+
+      {vectorDbEnabled && connectedSources.length > 0 && (
+        <>
+          <Text as="p" text03 secondaryBody>
+            Connected Sources
+          </Text>
+          {connectedSources.map((connectedSource) => {
+            const sourceMetadata = getSourceMetadata(connectedSource.source);
+            const isSelected = selectedSources.includes(connectedSource.source);
+            const selectionCount =
+              sourceSelectionCounts.get(connectedSource.source) ?? 0;
+            return (
+              <LineItem
+                key={connectedSource.source}
+                icon={sourceMetadata.icon}
+                strokeIcon={false}
+                onClick={() => onNavigateToSource(connectedSource.source)}
+                emphasized={isSelected || selectionCount > 0}
+                aria-label={`knowledge-add-source-${connectedSource.source}`}
+                rightChildren={
+                  selectionCount > 0 ? (
+                    <Text mainUiAction className="text-action-link-05">
+                      {selectionCount}
+                    </Text>
+                  ) : undefined
+                }
+              >
+                {sourceMetadata.displayName}
+              </LineItem>
+            );
+          })}
+        </>
+      )}
+    </GeneralLayouts.Section>
+  );
+});

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeMainContent.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeMainContent.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { memo } from "react";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import Text from "@/refresh-components/texts/Text";
+import type { ValidSources } from "@/lib/types";
+import { Button } from "@opal/components";
+import { SvgArrowUpRight, SvgPlusCircle } from "@opal/icons";
+
+interface KnowledgeMainContentProps {
+  hasAnyKnowledge: boolean;
+  selectedDocumentSetIds: number[];
+  selectedDocumentIds: string[];
+  selectedFolderIds: number[];
+  selectedFileIds: string[];
+  selectedSources: ValidSources[];
+  onAddKnowledge: () => void;
+  onViewEdit: () => void;
+}
+
+export const KnowledgeMainContent = memo(function KnowledgeMainContent({
+  hasAnyKnowledge,
+  selectedDocumentSetIds,
+  selectedDocumentIds,
+  selectedFolderIds,
+  selectedFileIds,
+  selectedSources,
+  onAddKnowledge,
+  onViewEdit,
+}: KnowledgeMainContentProps) {
+  if (!hasAnyKnowledge) {
+    return (
+      <GeneralLayouts.Section
+        flexDirection="row"
+        justifyContent="between"
+        alignItems="center"
+        height="auto"
+      >
+        <Text text03 secondaryBody>
+          Add documents or connected sources to use for this agent.
+        </Text>
+        <Button
+          icon={SvgPlusCircle}
+          onClick={onAddKnowledge}
+          prominence="tertiary"
+          aria-label="knowledge-add-button"
+        />
+      </GeneralLayouts.Section>
+    );
+  }
+
+  const totalSelected =
+    selectedDocumentSetIds.length +
+    selectedDocumentIds.length +
+    selectedFolderIds.length +
+    selectedFileIds.length +
+    selectedSources.length;
+
+  return (
+    <GeneralLayouts.Section
+      flexDirection="row"
+      justifyContent="between"
+      alignItems="center"
+      height="auto"
+    >
+      <Text as="p" text03 secondaryBody>
+        {totalSelected} knowledge source{totalSelected !== 1 ? "s" : ""}{" "}
+        selected
+      </Text>
+      <Button
+        prominence="internal"
+        icon={SvgArrowUpRight}
+        onClick={onViewEdit}
+        aria-label="knowledge-view-edit"
+      >
+        View / Edit
+      </Button>
+    </GeneralLayouts.Section>
+  );
+});

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeSearch.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import React from "react";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import * as TableLayouts from "@/layouts/table-layouts";
+import LineItem from "@/refresh-components/buttons/LineItem";
+import Text from "@/refresh-components/texts/Text";
+import Truncated from "@/refresh-components/texts/Truncated";
+import { getSourceMetadata } from "@/lib/sources";
+import type {
+  ConnectedSource,
+  HierarchyNodeSearchSummary,
+} from "@/lib/hierarchy/interfaces";
+import type { SearchDocWithContent } from "@/lib/search/interfaces";
+import type { ValidSources } from "@/lib/types";
+import { Button, Checkbox, Divider, InputTypeIn } from "@opal/components";
+import {
+  SvgArrowLeft,
+  SvgChevronRight,
+  SvgFileText,
+  SvgFiles,
+  SvgFolder,
+  SvgSearch,
+  SvgXCircle,
+} from "@opal/icons";
+
+import type { KnowledgeSearchResults } from "@/sections/knowledge/agent-knowledge/interfaces";
+
+interface KnowledgeSearchBarProps {
+  query: string;
+  onQueryChange: (q: string) => void;
+  onSubmit: () => void;
+  onClear: () => void;
+  onBack: () => void;
+  onFocus: () => void;
+  isSearchMode: boolean;
+}
+
+export function KnowledgeSearchBar({
+  query,
+  onQueryChange,
+  onSubmit,
+  onClear,
+  onBack,
+  onFocus,
+  isSearchMode,
+}: KnowledgeSearchBarProps) {
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter") onSubmit();
+    if (e.key === "Escape" && isSearchMode) onBack();
+  }
+
+  return (
+    <GeneralLayouts.Section
+      flexDirection="row"
+      alignItems="center"
+      gap={0.25}
+      height="auto"
+    >
+      {isSearchMode ? (
+        <Button
+          icon={SvgArrowLeft}
+          prominence="tertiary"
+          onClick={onBack}
+          aria-label="exit-search"
+        />
+      ) : null}
+      <GeneralLayouts.Section height="auto">
+        <InputTypeIn
+          searchIcon={!isSearchMode}
+          value={query}
+          onChange={(e) => onQueryChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onFocus={onFocus}
+          placeholder="Search documents..."
+          variant="internal"
+        />
+      </GeneralLayouts.Section>
+      {isSearchMode && query ? (
+        <Button
+          icon={SvgXCircle}
+          prominence="tertiary"
+          size="sm"
+          onClick={onClear}
+          aria-label="clear-search"
+        />
+      ) : null}
+      {isSearchMode ? (
+        <Button
+          icon={SvgSearch}
+          prominence="tertiary"
+          size="sm"
+          onClick={onSubmit}
+          aria-label="submit-search"
+        />
+      ) : null}
+    </GeneralLayouts.Section>
+  );
+}
+
+interface KnowledgeSearchSidebarProps {
+  connectedSources: ConnectedSource[];
+  activeSourceFilter: ValidSources | null;
+  onSourceFilterClick: (source: ValidSources | null) => void;
+  resultCountBySource: Map<ValidSources, number>;
+  vectorDbEnabled: boolean;
+}
+
+export function KnowledgeSearchSidebar({
+  connectedSources,
+  activeSourceFilter,
+  onSourceFilterClick,
+  resultCountBySource,
+  vectorDbEnabled,
+}: KnowledgeSearchSidebarProps) {
+  const totalCount = Array.from(resultCountBySource.values()).reduce(
+    (a, b) => a + b,
+    0
+  );
+
+  return (
+    <TableLayouts.SidebarLayout aria-label="knowledge-search-sidebar">
+      <LineItem
+        icon={SvgFiles}
+        selected={activeSourceFilter === null}
+        onClick={() => onSourceFilterClick(null)}
+        rightChildren={
+          totalCount > 0 ? (
+            <Text mainUiAction className="text-action-link-05">
+              {totalCount}
+            </Text>
+          ) : undefined
+        }
+      >
+        All
+      </LineItem>
+
+      {vectorDbEnabled &&
+        connectedSources.map((cs) => {
+          const sourceMetadata = getSourceMetadata(cs.source);
+          const count = resultCountBySource.get(cs.source) ?? 0;
+          return (
+            <LineItem
+              key={cs.source}
+              icon={sourceMetadata.icon}
+              strokeIcon={false}
+              selected={activeSourceFilter === cs.source}
+              onClick={() => onSourceFilterClick(cs.source)}
+              rightChildren={
+                count > 0 ? (
+                  <Text mainUiAction className="text-action-link-05">
+                    {count}
+                  </Text>
+                ) : undefined
+              }
+            >
+              {sourceMetadata.displayName}
+            </LineItem>
+          );
+        })}
+    </TableLayouts.SidebarLayout>
+  );
+}
+
+interface KnowledgeSearchResultsPanelProps {
+  committedQuery: string;
+  searchQuery: string;
+  isSearching: boolean;
+  searchError: boolean;
+  results: KnowledgeSearchResults | null;
+  activeSourceFilter: ValidSources | null;
+  selectedDocumentIds: string[];
+  selectedFolderIds: number[];
+  onToggleDocument: (id: string) => void;
+  onToggleFolder: (id: number) => void;
+  onNavigateToNode: (node: HierarchyNodeSearchSummary) => void;
+}
+
+export function KnowledgeSearchResultsPanel({
+  committedQuery,
+  searchQuery,
+  isSearching,
+  searchError,
+  results,
+  activeSourceFilter,
+  selectedDocumentIds,
+  selectedFolderIds,
+  onToggleDocument,
+  onToggleFolder,
+  onNavigateToNode,
+}: KnowledgeSearchResultsPanelProps) {
+  if (!committedQuery) {
+    return (
+      <GeneralLayouts.Section
+        alignItems="center"
+        justifyContent="center"
+        gap={0.5}
+        aria-label="search-empty-state"
+      >
+        <SvgSearch size={32} className="stroke-text-04" />
+        <Text secondaryBody text03>
+          Input a search term and hit enter.
+        </Text>
+      </GeneralLayouts.Section>
+    );
+  }
+
+  if (isSearching) {
+    return (
+      <GeneralLayouts.Section
+        alignItems="center"
+        justifyContent="center"
+        aria-label="search-loading"
+      >
+        <Text secondaryBody text03>
+          Searching...
+        </Text>
+      </GeneralLayouts.Section>
+    );
+  }
+
+  if (searchError && committedQuery === searchQuery) {
+    return (
+      <GeneralLayouts.Section
+        alignItems="center"
+        justifyContent="center"
+        gap={0.5}
+        aria-label="search-error"
+      >
+        <Text secondaryBody text03>
+          Search failed, please try again.
+        </Text>
+      </GeneralLayouts.Section>
+    );
+  }
+
+  const allResults: Array<
+    | { kind: "node"; item: HierarchyNodeSearchSummary }
+    | { kind: "doc"; item: SearchDocWithContent }
+  > = [
+    ...(results?.nodes ?? []).map((n) => ({ kind: "node" as const, item: n })),
+    ...(results?.docs ?? []).map((d) => ({ kind: "doc" as const, item: d })),
+  ];
+
+  const isStale = committedQuery !== searchQuery;
+
+  const listContent =
+    allResults.length === 0 ? (
+      <GeneralLayouts.Section
+        alignItems="center"
+        justifyContent="center"
+        gap={0.5}
+        aria-label="search-no-results"
+      >
+        <Text secondaryBody text03>
+          No results found
+          {activeSourceFilter
+            ? ` in ${getSourceMetadata(activeSourceFilter).displayName}`
+            : ""}
+          .
+        </Text>
+      </GeneralLayouts.Section>
+    ) : (
+      <GeneralLayouts.Section gap={0} alignItems="stretch" height="auto">
+        <TableLayouts.TableRow>
+          <TableLayouts.CheckboxCell />
+          <TableLayouts.TableCell flex>
+            <Text secondaryBody text03>
+              Name
+            </Text>
+          </TableLayouts.TableCell>
+          <TableLayouts.TableCell width={8}>
+            <Text secondaryBody text03>
+              Sources
+            </Text>
+          </TableLayouts.TableCell>
+        </TableLayouts.TableRow>
+
+        <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+        <div className="overflow-y-auto max-h-80">
+          {allResults.map((entry) => {
+            if (entry.kind === "node") {
+              const node = entry.item;
+              const isSelected = selectedFolderIds.includes(node.id);
+              const sourceMeta = getSourceMetadata(node.source);
+
+              return (
+                <TableLayouts.TableRow
+                  key={`node-${node.id}`}
+                  selected={isSelected}
+                  onClick={() => onToggleFolder(node.id)}
+                  aria-label={`search-node-${node.id}`}
+                >
+                  <TableLayouts.CheckboxCell>
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => onToggleFolder(node.id)}
+                    />
+                  </TableLayouts.CheckboxCell>
+                  <TableLayouts.TableCell flex>
+                    <GeneralLayouts.Section
+                      flexDirection="row"
+                      justifyContent="start"
+                      alignItems="center"
+                      gap={0.25}
+                      height="auto"
+                    >
+                      <SvgFolder size={16} />
+                      <GeneralLayouts.Section
+                        flexDirection="column"
+                        justifyContent="start"
+                        alignItems="start"
+                        gap={0}
+                        height="auto"
+                        className="min-w-0 grow"
+                      >
+                        <Truncated>{node.title}</Truncated>
+                        {node.link && (
+                          <Truncated text03 secondaryBody>
+                            {node.link
+                              .replace(/^https?:\/\//i, "")
+                              .replace(/^www\./i, "")
+                              .replace(/\/+$/, "")}
+                          </Truncated>
+                        )}
+                      </GeneralLayouts.Section>
+                      <Button
+                        icon={SvgChevronRight}
+                        prominence="tertiary"
+                        size="sm"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onNavigateToNode(node);
+                        }}
+                        aria-label={`navigate-to-node-${node.id}`}
+                      />
+                    </GeneralLayouts.Section>
+                  </TableLayouts.TableCell>
+                  <TableLayouts.TableCell width={8}>
+                    <TableLayouts.SourceIconsRow>
+                      <sourceMeta.icon size={16} />
+                    </TableLayouts.SourceIconsRow>
+                  </TableLayouts.TableCell>
+                </TableLayouts.TableRow>
+              );
+            }
+
+            const doc = entry.item;
+            const isSelected = selectedDocumentIds.includes(doc.document_id);
+            const sourceMeta = getSourceMetadata(doc.source_type);
+
+            return (
+              <TableLayouts.TableRow
+                key={`doc-${doc.document_id}-${doc.chunk_ind}`}
+                selected={isSelected}
+                onClick={() => onToggleDocument(doc.document_id)}
+                aria-label={`search-doc-${doc.document_id}`}
+              >
+                <TableLayouts.CheckboxCell>
+                  <Checkbox
+                    checked={isSelected}
+                    onCheckedChange={() => onToggleDocument(doc.document_id)}
+                  />
+                </TableLayouts.CheckboxCell>
+                <TableLayouts.TableCell flex>
+                  <GeneralLayouts.Section
+                    flexDirection="row"
+                    justifyContent="start"
+                    alignItems="center"
+                    gap={0.25}
+                    height="auto"
+                  >
+                    <SvgFileText size={16} />
+                    <GeneralLayouts.Section
+                      flexDirection="column"
+                      justifyContent="start"
+                      alignItems="start"
+                      gap={0}
+                      height="auto"
+                      className="min-w-0 grow"
+                    >
+                      <Truncated>{doc.semantic_identifier}</Truncated>
+                      {doc.blurb && (
+                        <Truncated text03 secondaryBody>
+                          {doc.blurb}
+                        </Truncated>
+                      )}
+                    </GeneralLayouts.Section>
+                  </GeneralLayouts.Section>
+                </TableLayouts.TableCell>
+                <TableLayouts.TableCell width={8}>
+                  <TableLayouts.SourceIconsRow>
+                    <sourceMeta.icon size={16} />
+                  </TableLayouts.SourceIconsRow>
+                </TableLayouts.TableCell>
+              </TableLayouts.TableRow>
+            );
+          })}
+        </div>
+      </GeneralLayouts.Section>
+    );
+
+  if (isStale) {
+    return (
+      <GeneralLayouts.Section
+        alignItems="stretch"
+        justifyContent="start"
+        className="relative"
+      >
+        <GeneralLayouts.Section
+          alignItems="stretch"
+          justifyContent="start"
+          className="opacity-40 pointer-events-none"
+        >
+          {listContent}
+        </GeneralLayouts.Section>
+        <GeneralLayouts.Section
+          alignItems="center"
+          justifyContent="center"
+          className="absolute inset-0 z-10"
+        >
+          <Text secondaryBody text03>
+            Press Enter for new results.
+          </Text>
+        </GeneralLayouts.Section>
+      </GeneralLayouts.Section>
+    );
+  }
+
+  return listContent;
+}

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeSidebar.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeSidebar.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import * as TableLayouts from "@/layouts/table-layouts";
+import LineItem from "@/refresh-components/buttons/LineItem";
+import Text from "@/refresh-components/texts/Text";
+import { getSourceMetadata } from "@/lib/sources";
+import type { ConnectedSource } from "@/lib/hierarchy/interfaces";
+import type { ValidSources } from "@/lib/types";
+import { Divider } from "@opal/components";
+import { SvgFiles, SvgFolder } from "@opal/icons";
+
+import type { KnowledgeView } from "@/sections/knowledge/agent-knowledge/interfaces";
+
+interface KnowledgeSidebarProps {
+  activeView: KnowledgeView;
+  activeSource?: ValidSources;
+  connectedSources: ConnectedSource[];
+  selectedSources: ValidSources[];
+  selectedDocumentSetIds: number[];
+  selectedFileIds: string[];
+  sourceSelectionCounts: Map<ValidSources, number>;
+  onNavigateToRecent: () => void;
+  onNavigateToDocumentSets: () => void;
+  onNavigateToSource: (source: ValidSources) => void;
+  vectorDbEnabled: boolean;
+}
+
+export function KnowledgeSidebar({
+  activeView,
+  activeSource,
+  connectedSources,
+  selectedSources,
+  selectedDocumentSetIds,
+  selectedFileIds,
+  sourceSelectionCounts,
+  onNavigateToRecent,
+  onNavigateToDocumentSets,
+  onNavigateToSource,
+  vectorDbEnabled,
+}: KnowledgeSidebarProps) {
+  return (
+    <TableLayouts.SidebarLayout aria-label="knowledge-sidebar">
+      <LineItem
+        icon={SvgFiles}
+        onClick={onNavigateToRecent}
+        selected={activeView === "recent"}
+        emphasized={activeView === "recent" || selectedFileIds.length > 0}
+        aria-label="knowledge-sidebar-files"
+        rightChildren={
+          selectedFileIds.length > 0 ? (
+            <Text mainUiAction className="text-action-link-05">
+              {selectedFileIds.length}
+            </Text>
+          ) : undefined
+        }
+      >
+        Your Files
+      </LineItem>
+
+      {vectorDbEnabled && (
+        <>
+          <LineItem
+            icon={SvgFolder}
+            onClick={onNavigateToDocumentSets}
+            selected={activeView === "document-sets"}
+            emphasized={
+              activeView === "document-sets" ||
+              selectedDocumentSetIds.length > 0
+            }
+            aria-label="knowledge-sidebar-document-sets"
+            rightChildren={
+              selectedDocumentSetIds.length > 0 ? (
+                <Text mainUiAction className="text-action-link-05">
+                  {selectedDocumentSetIds.length}
+                </Text>
+              ) : undefined
+            }
+          >
+            Document Set
+          </LineItem>
+
+          <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+          {connectedSources.map((connectedSource) => {
+            const sourceMetadata = getSourceMetadata(connectedSource.source);
+            const isSelected = selectedSources.includes(connectedSource.source);
+            const isActive =
+              activeView === "sources" &&
+              activeSource === connectedSource.source;
+            const selectionCount =
+              sourceSelectionCounts.get(connectedSource.source) ?? 0;
+
+            return (
+              <LineItem
+                key={connectedSource.source}
+                icon={sourceMetadata.icon}
+                strokeIcon={false}
+                onClick={() => onNavigateToSource(connectedSource.source)}
+                selected={isActive}
+                emphasized={isActive || isSelected || selectionCount > 0}
+                aria-label={`knowledge-sidebar-source-${connectedSource.source}`}
+                rightChildren={
+                  selectionCount > 0 ? (
+                    <Text mainUiAction className="text-action-link-05">
+                      {selectionCount}
+                    </Text>
+                  ) : undefined
+                }
+              >
+                {sourceMetadata.displayName}
+              </LineItem>
+            );
+          })}
+        </>
+      )}
+    </TableLayouts.SidebarLayout>
+  );
+}

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTable.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTable.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import React from "react";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import * as TableLayouts from "@/layouts/table-layouts";
+import Text from "@/refresh-components/texts/Text";
+import { Checkbox, Divider, InputTypeIn, Spacer } from "@opal/components";
+import { SvgFilter } from "@opal/icons";
+
+export interface KnowledgeTableColumn<T> {
+  key: string;
+  header: string;
+  sortable?: boolean;
+  width?: number;
+  render: (item: T) => React.ReactNode;
+}
+
+interface KnowledgeTableProps<T> {
+  items: T[];
+  columns: KnowledgeTableColumn<T>[];
+  getItemId: (item: T) => string | number;
+  selectedIds: (string | number)[];
+  onToggleItem: (id: string | number) => void;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
+  searchPlaceholder?: string;
+  headerActions?: React.ReactNode;
+  emptyMessage?: string;
+}
+
+export function KnowledgeTable<T>({
+  items,
+  columns,
+  getItemId,
+  selectedIds,
+  onToggleItem,
+  searchValue,
+  onSearchChange,
+  searchPlaceholder = "Filter...",
+  headerActions,
+  emptyMessage = "No items available.",
+  ariaLabelPrefix,
+}: KnowledgeTableProps<T> & { ariaLabelPrefix?: string }) {
+  return (
+    <GeneralLayouts.Section gap={0} alignItems="stretch" justifyContent="start">
+      <GeneralLayouts.Section
+        flexDirection="row"
+        justifyContent="start"
+        alignItems="center"
+        gap={0.5}
+        height="auto"
+      >
+        {onSearchChange !== undefined && (
+          <GeneralLayouts.Section height="auto">
+            <InputTypeIn
+              value={searchValue ?? ""}
+              onChange={(e) => onSearchChange?.(e.target.value)}
+              placeholder={searchPlaceholder}
+              variant="internal"
+              rightChildren={
+                <SvgFilter className="w-4 h-4 stroke-text-02 shrink-0" />
+              }
+            />
+          </GeneralLayouts.Section>
+        )}
+        {headerActions}
+      </GeneralLayouts.Section>
+
+      <Spacer rem={0.5} />
+
+      <TableLayouts.TableRow>
+        <TableLayouts.CheckboxCell />
+        {columns.map((column) => (
+          <TableLayouts.TableCell
+            key={column.key}
+            flex={!column.width}
+            width={column.width}
+          >
+            <GeneralLayouts.Section
+              flexDirection="row"
+              justifyContent="start"
+              alignItems="center"
+              gap={0.25}
+              height="auto"
+            >
+              <Text secondaryBody text03>
+                {column.header}
+              </Text>
+            </GeneralLayouts.Section>
+          </TableLayouts.TableCell>
+        ))}
+      </TableLayouts.TableRow>
+
+      <Divider paddingParallel="fit" paddingPerpendicular="fit" />
+
+      {items.length === 0 ? (
+        <GeneralLayouts.Section height="auto" padding={1}>
+          <Text text03 secondaryBody>
+            {emptyMessage}
+          </Text>
+        </GeneralLayouts.Section>
+      ) : (
+        <GeneralLayouts.Section gap={0} alignItems="stretch" height="auto">
+          {items.map((item) => {
+            const id = getItemId(item);
+            const isSelected = selectedIds.includes(id);
+
+            return (
+              <TableLayouts.TableRow
+                key={String(id)}
+                selected={isSelected}
+                onClick={() => onToggleItem(id)}
+                aria-label={
+                  ariaLabelPrefix ? `${ariaLabelPrefix}-${id}` : undefined
+                }
+              >
+                <TableLayouts.CheckboxCell>
+                  <Checkbox
+                    checked={isSelected}
+                    onCheckedChange={() => onToggleItem(id)}
+                  />
+                </TableLayouts.CheckboxCell>
+                {columns.map((column) => (
+                  <TableLayouts.TableCell
+                    key={column.key}
+                    flex={!column.width}
+                    width={column.width}
+                  >
+                    {column.render(item)}
+                  </TableLayouts.TableCell>
+                ))}
+              </TableLayouts.TableRow>
+            );
+          })}
+        </GeneralLayouts.Section>
+      )}
+    </GeneralLayouts.Section>
+  );
+}

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTableContent.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTableContent.tsx
@@ -1,0 +1,240 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import * as TableLayouts from "@/layouts/table-layouts";
+import Text from "@/refresh-components/texts/Text";
+import { getSourceMetadata } from "@/lib/sources";
+import type { AgentAttachedDocument } from "@/lib/agents/types";
+import type { ProjectFile } from "@/lib/projects/types";
+import type {
+  CCPairSummary,
+  DocumentSetSummary,
+  ValidSources,
+} from "@/lib/types";
+import SourceHierarchyBrowser from "@/sections/knowledge/SourceHierarchyBrowser";
+import { Button } from "@opal/components";
+import { Content } from "@opal/layouts";
+import { timeAgo } from "@opal/time";
+import { SvgFiles, SvgFolder, SvgPlusCircle } from "@opal/icons";
+
+import {
+  KnowledgeTable,
+  type KnowledgeTableColumn,
+} from "@/sections/knowledge/agent-knowledge/KnowledgeTable";
+
+interface DocumentSetsTableContentProps {
+  documentSets: DocumentSetSummary[];
+  selectedDocumentSetIds: number[];
+  onDocumentSetToggle: (documentSetId: number) => void;
+}
+
+export function DocumentSetsTableContent({
+  documentSets,
+  selectedDocumentSetIds,
+  onDocumentSetToggle,
+}: DocumentSetsTableContentProps) {
+  const [searchValue, setSearchValue] = useState("");
+
+  const filteredDocumentSets = useMemo(() => {
+    if (!searchValue) return documentSets;
+    const lower = searchValue.toLowerCase();
+    return documentSets.filter((ds) => ds.name.toLowerCase().includes(lower));
+  }, [documentSets, searchValue]);
+
+  const columns: KnowledgeTableColumn<DocumentSetSummary>[] = [
+    {
+      key: "name",
+      header: "Name",
+      sortable: true,
+      render: (ds) => (
+        <Content
+          icon={SvgFolder}
+          title={ds.name}
+          sizePreset="main-ui"
+          variant="section"
+        />
+      ),
+    },
+    {
+      key: "sources",
+      header: "Sources",
+      width: 8,
+      render: (ds) => (
+        <TableLayouts.SourceIconsRow>
+          {ds.cc_pair_summaries
+            ?.slice(0, 4)
+            .map((summary: CCPairSummary, idx: number) => {
+              const sourceMetadata = getSourceMetadata(summary.source);
+              return <sourceMetadata.icon key={idx} size={16} />;
+            })}
+          {(ds.cc_pair_summaries?.length ?? 0) > 4 && (
+            <Text text03 secondaryBody>
+              +{(ds.cc_pair_summaries?.length ?? 0) - 4}
+            </Text>
+          )}
+        </TableLayouts.SourceIconsRow>
+      ),
+    },
+  ];
+
+  return (
+    <KnowledgeTable
+      items={filteredDocumentSets}
+      columns={columns}
+      getItemId={(ds) => ds.id}
+      selectedIds={selectedDocumentSetIds}
+      onToggleItem={(id) => onDocumentSetToggle(id as number)}
+      searchValue={searchValue}
+      onSearchChange={setSearchValue}
+      searchPlaceholder="Filter document sets..."
+      emptyMessage="No document sets available."
+      ariaLabelPrefix="document-set-row"
+    />
+  );
+}
+
+interface SourcesTableContentProps {
+  source: ValidSources;
+  selectedDocumentIds: string[];
+  onToggleDocument: (documentId: string) => void;
+  onSetDocumentIds: (ids: string[]) => void;
+  selectedFolderIds: number[];
+  onToggleFolder: (folderId: number) => void;
+  onSetFolderIds: (ids: number[]) => void;
+  onDeselectAllDocuments: () => void;
+  onDeselectAllFolders: () => void;
+  initialAttachedDocuments?: AgentAttachedDocument[];
+  onSelectionCountChange?: (source: ValidSources, count: number) => void;
+  initialNodeId?: number;
+}
+
+export function SourcesTableContent({
+  source,
+  selectedDocumentIds,
+  onToggleDocument,
+  onSetDocumentIds,
+  selectedFolderIds,
+  onToggleFolder,
+  onSetFolderIds,
+  onDeselectAllDocuments,
+  onDeselectAllFolders,
+  initialAttachedDocuments,
+  onSelectionCountChange,
+  initialNodeId,
+}: SourcesTableContentProps) {
+  return (
+    <GeneralLayouts.Section gap={0.5} alignItems="stretch">
+      <SourceHierarchyBrowser
+        source={source}
+        selectedDocumentIds={selectedDocumentIds}
+        onToggleDocument={onToggleDocument}
+        onSetDocumentIds={onSetDocumentIds}
+        selectedFolderIds={selectedFolderIds}
+        onToggleFolder={onToggleFolder}
+        onSetFolderIds={onSetFolderIds}
+        initialAttachedDocuments={initialAttachedDocuments}
+        onDeselectAllDocuments={onDeselectAllDocuments}
+        onDeselectAllFolders={onDeselectAllFolders}
+        onSelectionCountChange={onSelectionCountChange}
+        initialNodeId={initialNodeId}
+      />
+    </GeneralLayouts.Section>
+  );
+}
+
+interface RecentFilesTableContentProps {
+  allRecentFiles: ProjectFile[];
+  selectedFileIds: string[];
+  onToggleFile: (fileId: string) => void;
+  onUploadChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  hasProcessingFiles: boolean;
+}
+
+export function RecentFilesTableContent({
+  allRecentFiles,
+  selectedFileIds,
+  onToggleFile,
+  onUploadChange,
+  hasProcessingFiles,
+}: RecentFilesTableContentProps) {
+  const [searchValue, setSearchValue] = useState("");
+
+  const filteredFiles = useMemo(() => {
+    if (!searchValue) return allRecentFiles;
+    const lower = searchValue.toLowerCase();
+    return allRecentFiles.filter((f) => f.name.toLowerCase().includes(lower));
+  }, [allRecentFiles, searchValue]);
+
+  const columns: KnowledgeTableColumn<ProjectFile>[] = [
+    {
+      key: "name",
+      header: "Name",
+      sortable: true,
+      render: (file) => (
+        <Content
+          icon={SvgFiles}
+          title={file.name}
+          sizePreset="main-ui"
+          variant="section"
+        />
+      ),
+    },
+    {
+      key: "lastUpdated",
+      header: "Last Updated",
+      sortable: true,
+      width: 8,
+      render: (file) => (
+        <Text text03 secondaryBody>
+          {timeAgo(file.last_accessed_at || file.created_at)}
+        </Text>
+      ),
+    },
+  ];
+
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  return (
+    <GeneralLayouts.Section gap={0.5} alignItems="stretch">
+      <TableLayouts.HiddenInput
+        inputRef={fileInputRef}
+        type="file"
+        multiple
+        onChange={onUploadChange}
+      />
+
+      <KnowledgeTable
+        items={filteredFiles}
+        columns={columns}
+        getItemId={(file) => file.id}
+        selectedIds={selectedFileIds}
+        onToggleItem={(id) => onToggleFile(id as string)}
+        searchValue={searchValue}
+        onSearchChange={setSearchValue}
+        searchPlaceholder="Filter files..."
+        ariaLabelPrefix="user-file-row"
+        headerActions={
+          <Button
+            prominence="internal"
+            icon={SvgPlusCircle}
+            onClick={() => fileInputRef.current?.click()}
+          >
+            Add File
+          </Button>
+        }
+        emptyMessage="No files available. Upload files to get started."
+      />
+
+      {hasProcessingFiles && (
+        <GeneralLayouts.Section height="auto" alignItems="start">
+          <Text as="p" text03 secondaryBody>
+            Onyx is still processing your uploaded files. You can create the
+            agent now, but it will not have access to all files until processing
+            completes.
+          </Text>
+        </GeneralLayouts.Section>
+      )}
+    </GeneralLayouts.Section>
+  );
+}

--- a/web/src/sections/knowledge/agent-knowledge/KnowledgeTwoColumnView.tsx
+++ b/web/src/sections/knowledge/agent-knowledge/KnowledgeTwoColumnView.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { memo, type ChangeEvent } from "react";
+import * as GeneralLayouts from "@/layouts/general-layouts";
+import * as TableLayouts from "@/layouts/table-layouts";
+import type { AgentAttachedDocument } from "@/lib/agents/types";
+import type {
+  ConnectedSource,
+  HierarchyNodeSearchSummary,
+} from "@/lib/hierarchy/interfaces";
+import type { DocumentSetSummary, ValidSources } from "@/lib/types";
+import type { ProjectFile } from "@/lib/projects/types";
+
+import { KnowledgeSidebar } from "@/sections/knowledge/agent-knowledge/KnowledgeSidebar";
+import {
+  DocumentSetsTableContent,
+  RecentFilesTableContent,
+  SourcesTableContent,
+} from "@/sections/knowledge/agent-knowledge/KnowledgeTableContent";
+import {
+  KnowledgeSearchBar,
+  KnowledgeSearchResultsPanel,
+  KnowledgeSearchSidebar,
+} from "@/sections/knowledge/agent-knowledge/KnowledgeSearch";
+import type {
+  KnowledgeSearchResults,
+  KnowledgeView,
+} from "@/sections/knowledge/agent-knowledge/interfaces";
+
+interface KnowledgeTwoColumnViewProps {
+  activeView: KnowledgeView;
+  activeSource?: ValidSources;
+  connectedSources: ConnectedSource[];
+  selectedSources: ValidSources[];
+  selectedDocumentSetIds: number[];
+  selectedFileIds: string[];
+  selectedDocumentIds: string[];
+  selectedFolderIds: number[];
+  sourceSelectionCounts: Map<ValidSources, number>;
+  documentSets: DocumentSetSummary[];
+  allRecentFiles: ProjectFile[];
+  onNavigateToRecent: () => void;
+  onNavigateToDocumentSets: () => void;
+  onNavigateToSource: (source: ValidSources) => void;
+  onDocumentSetToggle: (id: number) => void;
+  onFileToggle: (fileId: string) => void;
+  onToggleDocument: (documentId: string) => void;
+  onToggleFolder: (folderId: number) => void;
+  onSetDocumentIds: (ids: string[]) => void;
+  onSetFolderIds: (ids: number[]) => void;
+  onDeselectAllDocuments: () => void;
+  onDeselectAllFolders: () => void;
+  onUploadChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  hasProcessingFiles: boolean;
+  initialAttachedDocuments?: AgentAttachedDocument[];
+  onSelectionCountChange: (source: ValidSources, count: number) => void;
+  vectorDbEnabled: boolean;
+  isSearchMode: boolean;
+  searchQuery: string;
+  committedQuery: string;
+  activeSourceFilter: ValidSources | null;
+  searchResults: KnowledgeSearchResults | null;
+  isSearching: boolean;
+  searchError: boolean;
+  resultCountBySource: Map<ValidSources, number>;
+  onSearchQueryChange: (q: string) => void;
+  onSearchSubmit: () => void;
+  onSearchClear: () => void;
+  onEnterSearchMode: () => void;
+  onExitSearchMode: () => void;
+  onSourceFilterClick: (source: ValidSources | null) => void;
+  onNavigateToSearchNode: (node: HierarchyNodeSearchSummary) => void;
+  searchNavigateNodeId?: number;
+}
+
+export const KnowledgeTwoColumnView = memo(function KnowledgeTwoColumnView({
+  activeView,
+  activeSource,
+  connectedSources,
+  selectedSources,
+  selectedDocumentSetIds,
+  selectedFileIds,
+  selectedDocumentIds,
+  selectedFolderIds,
+  sourceSelectionCounts,
+  documentSets,
+  allRecentFiles,
+  onNavigateToRecent,
+  onNavigateToDocumentSets,
+  onNavigateToSource,
+  onDocumentSetToggle,
+  onFileToggle,
+  onToggleDocument,
+  onToggleFolder,
+  onSetDocumentIds,
+  onSetFolderIds,
+  onDeselectAllDocuments,
+  onDeselectAllFolders,
+  onUploadChange,
+  hasProcessingFiles,
+  initialAttachedDocuments,
+  onSelectionCountChange,
+  vectorDbEnabled,
+  isSearchMode,
+  searchQuery,
+  committedQuery,
+  activeSourceFilter,
+  searchResults,
+  isSearching,
+  searchError,
+  resultCountBySource,
+  onSearchQueryChange,
+  onSearchSubmit,
+  onSearchClear,
+  onEnterSearchMode,
+  onExitSearchMode,
+  onSourceFilterClick,
+  onNavigateToSearchNode,
+  searchNavigateNodeId,
+}: KnowledgeTwoColumnViewProps) {
+  return (
+    <GeneralLayouts.Section gap={0.5} alignItems="stretch" height="auto">
+      {vectorDbEnabled && (
+        <KnowledgeSearchBar
+          query={searchQuery}
+          onQueryChange={onSearchQueryChange}
+          onSubmit={onSearchSubmit}
+          onClear={onSearchClear}
+          onBack={onExitSearchMode}
+          onFocus={onEnterSearchMode}
+          isSearchMode={isSearchMode}
+        />
+      )}
+
+      {isSearchMode ? (
+        <TableLayouts.TwoColumnLayout minHeight={18.75}>
+          <KnowledgeSearchSidebar
+            connectedSources={connectedSources}
+            activeSourceFilter={activeSourceFilter}
+            onSourceFilterClick={onSourceFilterClick}
+            resultCountBySource={resultCountBySource}
+            vectorDbEnabled={vectorDbEnabled}
+          />
+          <TableLayouts.ContentColumn>
+            <KnowledgeSearchResultsPanel
+              committedQuery={committedQuery}
+              searchQuery={searchQuery}
+              isSearching={isSearching}
+              searchError={searchError}
+              results={searchResults}
+              activeSourceFilter={activeSourceFilter}
+              selectedDocumentIds={selectedDocumentIds}
+              selectedFolderIds={selectedFolderIds}
+              onToggleDocument={onToggleDocument}
+              onToggleFolder={onToggleFolder}
+              onNavigateToNode={onNavigateToSearchNode}
+            />
+          </TableLayouts.ContentColumn>
+        </TableLayouts.TwoColumnLayout>
+      ) : (
+        <TableLayouts.TwoColumnLayout minHeight={18.75}>
+          <KnowledgeSidebar
+            activeView={activeView}
+            activeSource={activeSource}
+            connectedSources={connectedSources}
+            selectedSources={selectedSources}
+            selectedDocumentSetIds={selectedDocumentSetIds}
+            selectedFileIds={selectedFileIds}
+            sourceSelectionCounts={sourceSelectionCounts}
+            onNavigateToRecent={onNavigateToRecent}
+            onNavigateToDocumentSets={onNavigateToDocumentSets}
+            onNavigateToSource={onNavigateToSource}
+            vectorDbEnabled={vectorDbEnabled}
+          />
+
+          <TableLayouts.ContentColumn>
+            {activeView === "document-sets" && (
+              <DocumentSetsTableContent
+                documentSets={documentSets}
+                selectedDocumentSetIds={selectedDocumentSetIds}
+                onDocumentSetToggle={onDocumentSetToggle}
+              />
+            )}
+            {activeView === "sources" && activeSource && (
+              <SourcesTableContent
+                source={activeSource}
+                selectedDocumentIds={selectedDocumentIds}
+                onToggleDocument={onToggleDocument}
+                onSetDocumentIds={onSetDocumentIds}
+                selectedFolderIds={selectedFolderIds}
+                onToggleFolder={onToggleFolder}
+                onSetFolderIds={onSetFolderIds}
+                onDeselectAllDocuments={onDeselectAllDocuments}
+                onDeselectAllFolders={onDeselectAllFolders}
+                initialAttachedDocuments={initialAttachedDocuments}
+                onSelectionCountChange={onSelectionCountChange}
+                initialNodeId={searchNavigateNodeId}
+              />
+            )}
+            {activeView === "recent" && (
+              <RecentFilesTableContent
+                allRecentFiles={allRecentFiles}
+                selectedFileIds={selectedFileIds}
+                onToggleFile={onFileToggle}
+                onUploadChange={onUploadChange}
+                hasProcessingFiles={hasProcessingFiles}
+              />
+            )}
+          </TableLayouts.ContentColumn>
+        </TableLayouts.TwoColumnLayout>
+      )}
+    </GeneralLayouts.Section>
+  );
+});

--- a/web/src/sections/knowledge/agent-knowledge/interfaces.ts
+++ b/web/src/sections/knowledge/agent-knowledge/interfaces.ts
@@ -1,0 +1,20 @@
+import type { ValidSources } from "@/lib/types";
+import type { HierarchyNodeSearchSummary } from "@/lib/hierarchy/interfaces";
+import type { SearchDocWithContent } from "@/lib/search/interfaces";
+
+export type KnowledgeView =
+  | "main"
+  | "add"
+  | "document-sets"
+  | "sources"
+  | "recent";
+
+export interface KnowledgeSearchResults {
+  docs: SearchDocWithContent[];
+  nodes: HierarchyNodeSearchSummary[];
+}
+
+export interface KnowledgeNavState {
+  view: KnowledgeView;
+  activeSource: ValidSources | undefined;
+}


### PR DESCRIPTION
## Description

refactor bloated knowledge pane file

## How Has This Been Tested?

checked that the UI looks the same

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the Agent Knowledge Pane into smaller, focused components without changing UI or behavior. This makes the code easier to maintain, test, and reuse.

- **Refactors**
  - Split `AgentKnowledgePane.tsx` into `KnowledgeTwoColumnView`, `KnowledgeSidebar`, `KnowledgeSearch*`, `KnowledgeTable*`, `KnowledgeAddView`, `KnowledgeMainContent`, and `interfaces.ts`.
  - Extracted reusable table and search components for document sets, sources, files, and search results.
  - Centralized view, nav, and search types in `interfaces.ts` (`KnowledgeView`, `KnowledgeSearchResults`, `KnowledgeNavState`).
  - Preserved search flow, sidebar behavior, and vector DB gating.
  - Reduced `AgentKnowledgePane.tsx` by ~1.3k LOC.

- **Migration**
  - `AgentKnowledgePane` no longer accepts `onSourcesChange`; selection happens via folders/documents in source views. Remove this prop where used.

<sup>Written for commit 8123d6dfa8ded9668f5419a2cb342fe4482cfeda. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

