### PR TITLE
fix(craft): serialize sandbox provisioning with per-sandbox redis lock

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -50,6 +50,7 @@ import tempfile
 import threading
 import time
 from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import cast
 from uuid import UUID
@@ -59,6 +60,8 @@ from kubernetes import watch
 from kubernetes.client.rest import ApiException
 from kubernetes.stream import stream as k8s_stream
 
+from onyx.cache.factory import get_cache_backend
+from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.db.enums import SandboxStatus
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.configs import OPENCODE_DISABLED_TOOLS
@@ -124,6 +127,9 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import RetriableWriteError
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.serve_transport import (
+    OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
+)
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.util.agent_instructions import (
@@ -143,10 +149,19 @@ logger = setup_logger()
 # request. In K8s, HOSTNAME is set to the pod name (e.g., "api-server-dpgg7").
 _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 
-POD_READY_TIMEOUT_SECONDS = 60
+POD_READY_TIMEOUT_SECONDS = 30
 
-OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS = 300.0
+# Shared deadline for IP assignment (scheduling + image pull) and the restore.
+OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS = 60.0
 POD_IP_POLL_INTERVAL_SECONDS = 0.5
+
+# Lock TTL and waiter blocking timeout; must cover the worst-case hold.
+# Expiry falls open to provision()'s 409/pod-exists fallbacks.
+PROVISION_LOCK_TIMEOUT_SECONDS = (
+    OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
+    + POD_READY_TIMEOUT_SECONDS
+    + OPENCODE_SERVE_READY_TIMEOUT_SECONDS
+)
 
 # Resource deletion timeout and polling interval
 # Kubernetes deletes are async - we need to wait for resources to actually be
@@ -174,6 +189,52 @@ _OPENCODE_CONNECT_APP_PLUGIN_PATH = "/workspace/opencode-plugins/connect-app.ts"
 
 _PROXY_RESOLVE_RETRY_ATTEMPTS = 5
 _PROXY_RESOLVE_RETRY_BACKOFF_S = 0.5
+
+
+def _provisioning_lock_key(sandbox_id: UUID) -> str:
+    return f"sandbox_provision_{sandbox_id}"
+
+
+@contextmanager
+def _provisioning_lock(sandbox_id: UUID, tenant_id: str) -> Iterator[None]:
+    """Serialize pod creation + startup restore for one sandbox across
+    api-server replicas; losers block, then reuse the ready pod via the
+    pod-exists check in provision(). Fails open on cache outages."""
+    try:
+        lock = get_cache_backend(tenant_id=tenant_id).lock(
+            _provisioning_lock_key(sandbox_id),
+            timeout=PROVISION_LOCK_TIMEOUT_SECONDS,
+        )
+        acquired = lock.acquire(
+            blocking=True,
+            blocking_timeout=PROVISION_LOCK_TIMEOUT_SECONDS,
+        )
+    except CACHE_TRANSIENT_ERRORS as e:
+        logger.warning(
+            "Provisioning lock unavailable for sandbox %s (%s); "
+            "proceeding without cross-replica serialization",
+            sandbox_id,
+            e,
+        )
+        yield
+        return
+
+    if not acquired:
+        raise RuntimeError(
+            f"Timed out waiting for a concurrent provisioner of sandbox {sandbox_id}"
+        )
+    try:
+        yield
+    finally:
+        try:
+            if lock.owned():
+                lock.release()
+        except CACHE_TRANSIENT_ERRORS:
+            logger.warning(
+                "Provisioning lock release failed for sandbox %s; relying on TTL",
+                sandbox_id,
+                exc_info=True,
+            )
 
 
 def _placeholder_llm_configs(
@@ -1013,8 +1074,8 @@ class KubernetesSandboxManager(SandboxManager):
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
         This method is idempotent - if a pod already exists and is healthy,
-        it will be reused. This prevents race conditions when multiple requests
-        try to provision the same sandbox concurrently.
+        it will be reused. Concurrent provisioners are serialized by a
+        per-sandbox lock; losers reuse the pod the winner created.
 
         Creates pod with:
         1. Sessions/ directory for per-session workspaces
@@ -1045,8 +1106,6 @@ class KubernetesSandboxManager(SandboxManager):
             tenant_id,
         )
 
-        pod_name = self._get_pod_name(str(sandbox_id))
-
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Kubernetes sandbox provisioning")
         if not SANDBOX_API_SERVER_URL:
@@ -1058,179 +1117,187 @@ class KubernetesSandboxManager(SandboxManager):
                 "SANDBOX_PROXY_HOST must be set for Kubernetes sandbox provisioning"
             )
 
-        # Check if pod already exists and is healthy (idempotency check)
-        if self._pod_exists_and_healthy(pod_name):
-            logger.info(
-                "Pod %s already exists and is healthy, reusing existing pod", pod_name
-            )
-            # Ensure service exists and is not terminating
-            self._ensure_service_exists(sandbox_id, tenant_id)
+        with _provisioning_lock(sandbox_id, tenant_id):
+            pod_name = self._get_pod_name(str(sandbox_id))
 
-            # Wait for pod to be ready if it's still pending
-            logger.info("Waiting for existing pod %s to become ready...", pod_name)
-            if not self._wait_for_pod_ready(pod_name):
-                raise RuntimeError(
-                    f"Timeout waiting for existing sandbox pod {pod_name} to become ready"
+            # Idempotency check; also the lock-loser path (the pod the winner
+            # just provisioned is found here and reused).
+            if self._pod_exists_and_healthy(pod_name):
+                logger.info(
+                    "Pod %s already exists and is healthy, reusing existing pod",
+                    pod_name,
                 )
+                # Ensure service exists and is not terminating
+                self._ensure_service_exists(sandbox_id, tenant_id)
 
-            # Reusing a live pod: clear any stale tombstone so event-bus
-            # creation can attach. A stale password heals via the 401 path in
-            # the readiness probe below.
-            with self._event_buses_lock:
-                self._terminated_sandboxes.discard(sandbox_id)
-
-            if not self._wait_for_opencode_serve_ready(sandbox_id):
-                raise RuntimeError(
-                    f"opencode-serve never became ready in existing sandbox pod {pod_name}"
-                )
-
-            logger.info(
-                "Reusing existing Kubernetes sandbox %s, pod: %s", sandbox_id, pod_name
-            )
-            return SandboxInfo(
-                sandbox_id=sandbox_id,
-                directory_path=f"k8s://{self._namespace}/{pod_name}",
-                status=SandboxStatus.RUNNING,
-                last_heartbeat=None,
-            )
-
-        created_pod = False
-
-        try:
-            # Re-provision: clear tombstone + cached info so subscribes
-            # build a fresh bus with the new Secret's password.
-            with self._event_buses_lock:
-                self._terminated_sandboxes.discard(sandbox_id)
-            self._invalidate_serve_connection_info(sandbox_id)
-
-            # Secret must exist before the Pod (secretKeyRef). Pre-load every
-            # provider for cross-provider model overrides; keys are swapped for
-            # the proxy placeholder so the pod never holds them.
-            providers = _placeholder_llm_configs(all_llm_configs or [llm_config])
-            opencode_config_json = json.dumps(
-                build_multi_provider_opencode_config(
-                    providers=providers,
-                    default_provider=llm_config.provider,
-                    default_model=llm_config.model_name,
-                    disabled_tools=OPENCODE_DISABLED_TOOLS,
-                    plugins=[
-                        _OPENCODE_CONNECT_APP_PLUGIN_PATH,
-                        _OPENCODE_SESSION_TAG_PLUGIN_PATH,
-                    ],
-                )
-            )
-            self._provision_opencode_secret(str(sandbox_id), opencode_config_json)
-
-            # 1. Create Pod (user-level only, no session setup)
-            logger.debug("Creating Pod %s", pod_name)
-            startup_restore_required = True
-            pod = self._create_sandbox_pod(
-                sandbox_id=str(sandbox_id),
-                tenant_id=tenant_id,
-            )
-            try:
-                self._core_api.create_namespaced_pod(
-                    namespace=self._namespace,
-                    body=pod,
-                )
-                created_pod = True
-            except ApiException as e:
-                if e.status == 409:
-                    logger.warning(
-                        "Pod %s already exists (409 conflict, this shouldn't normally happen), checking if it's healthy...",
-                        pod_name,
+                # Wait for pod to be ready if it's still pending
+                logger.info("Waiting for existing pod %s to become ready...", pod_name)
+                if not self._wait_for_pod_ready(pod_name):
+                    raise RuntimeError(
+                        f"Timeout waiting for existing sandbox pod {pod_name} to become ready"
                     )
-                    if self._pod_exists_and_healthy(pod_name):
-                        # Another provisioner completed startup restore while this
-                        # request was creating the pod. Reuse the live pod instead
-                        # of sending a redundant restore request.
+
+                # Reusing a live pod: clear any stale tombstone so event-bus
+                # creation can attach. A stale password heals via the 401 path in
+                # the readiness probe below.
+                with self._event_buses_lock:
+                    self._terminated_sandboxes.discard(sandbox_id)
+
+                if not self._wait_for_opencode_serve_ready(sandbox_id):
+                    raise RuntimeError(
+                        f"opencode-serve never became ready in existing sandbox pod {pod_name}"
+                    )
+
+                logger.info(
+                    "Reusing existing Kubernetes sandbox %s, pod: %s",
+                    sandbox_id,
+                    pod_name,
+                )
+                return SandboxInfo(
+                    sandbox_id=sandbox_id,
+                    directory_path=f"k8s://{self._namespace}/{pod_name}",
+                    status=SandboxStatus.RUNNING,
+                    last_heartbeat=None,
+                )
+
+            created_pod = False
+
+            try:
+                # Re-provision: clear tombstone + cached info so subscribes
+                # build a fresh bus with the new Secret's password.
+                with self._event_buses_lock:
+                    self._terminated_sandboxes.discard(sandbox_id)
+                self._invalidate_serve_connection_info(sandbox_id)
+
+                # Secret must exist before the Pod (secretKeyRef). Pre-load every
+                # provider for cross-provider model overrides; keys are swapped for
+                # the proxy placeholder so the pod never holds them.
+                providers = _placeholder_llm_configs(all_llm_configs or [llm_config])
+                opencode_config_json = json.dumps(
+                    build_multi_provider_opencode_config(
+                        providers=providers,
+                        default_provider=llm_config.provider,
+                        default_model=llm_config.model_name,
+                        disabled_tools=OPENCODE_DISABLED_TOOLS,
+                        plugins=[
+                            _OPENCODE_CONNECT_APP_PLUGIN_PATH,
+                            _OPENCODE_SESSION_TAG_PLUGIN_PATH,
+                        ],
+                    )
+                )
+                self._provision_opencode_secret(str(sandbox_id), opencode_config_json)
+
+                # 1. Create Pod (user-level only, no session setup)
+                logger.debug("Creating Pod %s", pod_name)
+                startup_restore_required = True
+                pod = self._create_sandbox_pod(
+                    sandbox_id=str(sandbox_id),
+                    tenant_id=tenant_id,
+                )
+                try:
+                    self._core_api.create_namespaced_pod(
+                        namespace=self._namespace,
+                        body=pod,
+                    )
+                    created_pod = True
+                except ApiException as e:
+                    if e.status == 409:
                         logger.warning(
-                            "During provisioning, discovered that pod %s already exists. Reusing",
+                            "Pod %s already exists (409 conflict; the provisioning "
+                            "lock should prevent this), checking if it's healthy...",
                             pod_name,
                         )
-                        startup_restore_required = False
+                        if self._pod_exists_and_healthy(pod_name):
+                            # Another provisioner completed startup restore while this
+                            # request was creating the pod. Reuse the live pod instead
+                            # of sending a redundant restore request.
+                            logger.warning(
+                                "During provisioning, discovered that pod %s already exists. Reusing",
+                                pod_name,
+                            )
+                            startup_restore_required = False
+                        else:
+                            logger.warning(
+                                "Pod %s exists but is not ready; running startup restore "
+                                "handshake without cleanup ownership",
+                                pod_name,
+                            )
+                    else:
+                        raise
+
+                # 2. Create Service (handles terminating services)
+                self._ensure_service_exists(sandbox_id, tenant_id)
+
+                # 3. Restore opencode history before the sandbox app container starts;
+                # the init sidecar serves the restore endpoint while its startup probe
+                # stays blocked, so opencode-serve can't open an empty DB first. The IP
+                # wait and the restore draw from one deadline so slow scheduling leaves
+                # less budget for the restore rather than stacking two full timeouts.
+                if startup_restore_required:
+                    restore_deadline = (
+                        time.monotonic() + OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
+                    )
+                    if not self._wait_for_pod_ip(pod_name, restore_deadline):
+                        raise RuntimeError(
+                            f"Timeout waiting for sandbox pod {pod_name} to be assigned an IP"
+                        )
+                    self.restore_opencode_history_snapshot(
+                        sandbox_id,
+                        tenant_id,
+                        timeout_seconds=restore_deadline - time.monotonic(),
+                    )
+
+                # 4. Wait for pod to be ready
+                logger.info("Waiting for pod %s to become ready...", pod_name)
+                if not self._wait_for_pod_ready(pod_name):
+                    raise RuntimeError(
+                        f"Timeout waiting for sandbox pod {pod_name} to become ready"
+                    )
+
+                # 5. Wait for opencode-serve to bind :4096 .
+                if not self._wait_for_opencode_serve_ready(sandbox_id):
+                    raise RuntimeError(
+                        f"opencode-serve never became ready in sandbox pod {pod_name}"
+                    )
+
+                logger.info(
+                    "Provisioned Kubernetes sandbox %s, pod: %s (no sessions yet)",
+                    sandbox_id,
+                    pod_name,
+                )
+
+                return SandboxInfo(
+                    sandbox_id=sandbox_id,
+                    directory_path=f"k8s://{self._namespace}/{pod_name}",
+                    status=SandboxStatus.RUNNING,
+                    last_heartbeat=None,
+                )
+
+            except Exception as e:
+                # Only clean up resources created by this provision call. If a
+                # concurrent provisioner finished successfully, leave the live pod alone.
+                if self._pod_exists_and_healthy(pod_name):
+                    logger.warning(
+                        "Kubernetes sandbox provisioning failed for sandbox %s: %s, but pod is healthy (likely owned by concurrent request), not cleaning up",
+                        sandbox_id,
+                        e,
+                    )
+                else:
+                    logger.error(
+                        "Kubernetes sandbox provisioning failed for sandbox %s: %s",
+                        sandbox_id,
+                        e,
+                        exc_info=True,
+                    )
+                    if created_pod:
+                        self._cleanup_kubernetes_resources(str(sandbox_id))
                     else:
                         logger.warning(
-                            "Pod %s exists but is not ready; running startup restore "
-                            "handshake without cleanup ownership",
-                            pod_name,
+                            "Not cleaning up sandbox %s after provisioning failure "
+                            "because this provisioner did not create the pod",
+                            sandbox_id,
                         )
-                else:
-                    raise
-
-            # 2. Create Service (handles terminating services)
-            self._ensure_service_exists(sandbox_id, tenant_id)
-
-            # 3. Restore opencode history before the sandbox app container starts;
-            # the init sidecar serves the restore endpoint while its startup probe
-            # stays blocked, so opencode-serve can't open an empty DB first. The IP
-            # wait and the restore draw from one deadline so slow scheduling leaves
-            # less budget for the restore rather than stacking two full timeouts.
-            if startup_restore_required:
-                restore_deadline = (
-                    time.monotonic() + OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
-                )
-                if not self._wait_for_pod_ip(pod_name, restore_deadline):
-                    raise RuntimeError(
-                        f"Timeout waiting for sandbox pod {pod_name} to be assigned an IP"
-                    )
-                self.restore_opencode_history_snapshot(
-                    sandbox_id,
-                    tenant_id,
-                    timeout_seconds=restore_deadline - time.monotonic(),
-                )
-
-            # 4. Wait for pod to be ready
-            logger.info("Waiting for pod %s to become ready...", pod_name)
-            if not self._wait_for_pod_ready(pod_name):
-                raise RuntimeError(
-                    f"Timeout waiting for sandbox pod {pod_name} to become ready"
-                )
-
-            # 5. Wait for opencode-serve to bind :4096 .
-            if not self._wait_for_opencode_serve_ready(sandbox_id):
-                raise RuntimeError(
-                    f"opencode-serve never became ready in sandbox pod {pod_name}"
-                )
-
-            logger.info(
-                "Provisioned Kubernetes sandbox %s, pod: %s (no sessions yet)",
-                sandbox_id,
-                pod_name,
-            )
-
-            return SandboxInfo(
-                sandbox_id=sandbox_id,
-                directory_path=f"k8s://{self._namespace}/{pod_name}",
-                status=SandboxStatus.RUNNING,
-                last_heartbeat=None,
-            )
-
-        except Exception as e:
-            # Only clean up resources created by this provision call. If a
-            # concurrent provisioner finished successfully, leave the live pod alone.
-            if self._pod_exists_and_healthy(pod_name):
-                logger.warning(
-                    "Kubernetes sandbox provisioning failed for sandbox %s: %s, but pod is healthy (likely owned by concurrent request), not cleaning up",
-                    sandbox_id,
-                    e,
-                )
-            else:
-                logger.error(
-                    "Kubernetes sandbox provisioning failed for sandbox %s: %s",
-                    sandbox_id,
-                    e,
-                    exc_info=True,
-                )
-                if created_pod:
-                    self._cleanup_kubernetes_resources(str(sandbox_id))
-                else:
-                    logger.warning(
-                        "Not cleaning up sandbox %s after provisioning failure "
-                        "because this provisioner did not create the pod",
-                        sandbox_id,
-                    )
-            raise
+                raise
 
     def _wait_for_resource_deletion(
         self,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -155,19 +155,22 @@ POD_READY_TIMEOUT_SECONDS = 30
 OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS = 60.0
 POD_IP_POLL_INTERVAL_SECONDS = 0.5
 
-# Lock TTL and waiter blocking timeout; must cover the worst-case hold.
-# Expiry falls open to provision()'s 409/pod-exists fallbacks.
-PROVISION_LOCK_TIMEOUT_SECONDS = (
-    OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
-    + POD_READY_TIMEOUT_SECONDS
-    + OPENCODE_SERVE_READY_TIMEOUT_SECONDS
-)
-
 # Resource deletion timeout and polling interval
 # Kubernetes deletes are async - we need to wait for resources to actually be
 # gone.
 RESOURCE_DELETION_TIMEOUT_SECONDS = 30
 RESOURCE_DELETION_POLL_INTERVAL_SECONDS = 0.5
+
+# Lock TTL and waiter blocking timeout; the sum of every bounded wait a holder
+# can spend inside the lock (incl. a terminating-Service deletion wait in
+# _ensure_service_exists). Expiry falls open to provision()'s 409/pod-exists
+# fallbacks.
+PROVISION_LOCK_TIMEOUT_SECONDS = (
+    OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
+    + POD_READY_TIMEOUT_SECONDS
+    + OPENCODE_SERVE_READY_TIMEOUT_SECONDS
+    + RESOURCE_DELETION_TIMEOUT_SECONDS
+)
 
 
 # Pinned to the proxy IP via pod hostAliases — the iptables lockdown blocks DNS,

--- a/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
+++ b/backend/tests/external_dependency_unit/craft/test_provisioning_lock.py
@@ -1,0 +1,277 @@
+"""Cross-replica sandbox provisioning serialization, against a real Redis.
+
+Two ``KubernetesSandboxManager`` instances stand in for two api_server
+replicas sharing one Redis. Exactly one replica may create the pod and run
+the startup restore handshake; a concurrent provisioner must wait on the
+per-sandbox lock and then reuse the ready pod — never stream a second
+restore into the same pod (the 08fe79d8 production race).
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from uuid import UUID
+from uuid import uuid4
+
+import pytest
+from kubernetes.client.rest import ApiException
+
+from onyx.cache import factory
+from onyx.cache.interface import CacheBackendType
+from onyx.db.enums import SandboxStatus
+from onyx.server.features.build.sandbox.kubernetes import kubernetes_sandbox_manager
+from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
+    KubernetesSandboxManager,
+)
+from onyx.server.features.build.sandbox.models import SandboxInfo
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from tests.common.craft.payloads import default_llm_config
+
+
+class _FakeCluster:
+    """Shared fake cluster state: pod existence/readiness + call records."""
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.pods: set[str] = set()
+        self.ready: set[str] = set()
+        self.pod_creates: list[str] = []
+        self.restores: list[UUID] = []
+
+
+class _FakeCoreApi:
+    def __init__(self, cluster: _FakeCluster) -> None:
+        self._cluster = cluster
+
+    def create_namespaced_pod(self, namespace: str, body: object) -> None:  # noqa: ARG002
+        pod_name = str(body)
+        with self._cluster.lock:
+            if pod_name in self._cluster.pods:
+                raise ApiException(status=409, reason="Conflict")
+            self._cluster.pods.add(pod_name)
+            self._cluster.pod_creates.append(pod_name)
+
+
+def _make_replica(
+    cluster: _FakeCluster,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    on_restore: Callable[[], None] | None = None,
+) -> KubernetesSandboxManager:
+    """A fresh manager (like a separate api_server pod) with all k8s I/O
+    faked against the shared cluster state; skips ``_initialize`` so no kube
+    config is needed. The restore handshake and pod creation are recorded so
+    tests can assert exactly-once semantics."""
+    m: KubernetesSandboxManager = object.__new__(KubernetesSandboxManager)
+    m._init_serve_state()
+    monkeypatch.setattr(m, "_namespace", "test-ns", raising=False)
+    monkeypatch.setattr(m, "_core_api", _FakeCoreApi(cluster), raising=False)
+
+    def _pod_exists_and_healthy(pod_name: str) -> bool:
+        with cluster.lock:
+            return pod_name in cluster.ready
+
+    def _ensure_service_exists(sandbox_id: UUID, tenant_id: str) -> None:  # noqa: ARG001
+        return None
+
+    def _provision_opencode_secret(sandbox_id: str, config_json: str) -> None:  # noqa: ARG001
+        return None
+
+    def _create_sandbox_pod(*, sandbox_id: str, tenant_id: str) -> str:  # noqa: ARG001
+        return m._get_pod_name(sandbox_id)
+
+    def _wait_for_pod_ip(pod_name: str, deadline: float) -> bool:  # noqa: ARG001
+        return True
+
+    def _restore_opencode_history_snapshot(
+        sandbox_id: UUID,
+        tenant_id: str,  # noqa: ARG001
+        timeout_seconds: float = 300.0,  # noqa: ARG001
+    ) -> bool:
+        with cluster.lock:
+            cluster.restores.append(sandbox_id)
+        if on_restore is not None:
+            on_restore()
+        return True
+
+    def _wait_for_pod_ready(pod_name: str, timeout: float = 60.0) -> bool:  # noqa: ARG001
+        # Real pods flip Ready only after the sidecar handshake completes.
+        with cluster.lock:
+            if pod_name not in cluster.pods:
+                return False
+            cluster.ready.add(pod_name)
+            return True
+
+    def _wait_for_opencode_serve_ready(
+        sandbox_id: UUID,  # noqa: ARG001
+        timeout: float = 30.0,  # noqa: ARG001
+    ) -> bool:
+        return True
+
+    monkeypatch.setattr(m, "_pod_exists_and_healthy", _pod_exists_and_healthy)
+    monkeypatch.setattr(m, "_ensure_service_exists", _ensure_service_exists)
+    monkeypatch.setattr(m, "_provision_opencode_secret", _provision_opencode_secret)
+    monkeypatch.setattr(m, "_create_sandbox_pod", _create_sandbox_pod)
+    monkeypatch.setattr(m, "_wait_for_pod_ip", _wait_for_pod_ip)
+    monkeypatch.setattr(
+        m, "restore_opencode_history_snapshot", _restore_opencode_history_snapshot
+    )
+    monkeypatch.setattr(m, "_wait_for_pod_ready", _wait_for_pod_ready)
+    monkeypatch.setattr(
+        m, "_wait_for_opencode_serve_ready", _wait_for_opencode_serve_ready
+    )
+    return m
+
+
+@pytest.fixture
+def lock_env(
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tenant context + Redis backend forced on + the provisioning
+    preconditions (URL/proxy host) satisfied."""
+    monkeypatch.setattr(factory, "CACHE_BACKEND", CacheBackendType.REDIS)
+    monkeypatch.setattr(
+        kubernetes_sandbox_manager, "SANDBOX_API_SERVER_URL", "http://api-server"
+    )
+    monkeypatch.setattr(
+        kubernetes_sandbox_manager, "SANDBOX_PROXY_HOST", "sandbox-proxy"
+    )
+
+
+def _provision(
+    replica: KubernetesSandboxManager,
+    sandbox_id: UUID,
+) -> SandboxInfo:
+    return replica.provision(
+        sandbox_id=sandbox_id,
+        user_id=uuid4(),
+        tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+        llm_config=default_llm_config(),
+        onyx_pat="test-pat",
+    )
+
+
+def test_concurrent_provision_runs_exactly_one_restore(
+    lock_env: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cluster = _FakeCluster()
+    sandbox_id = uuid4()
+    pod_name = f"sandbox-{str(sandbox_id)[:8]}"
+
+    restore_entered = threading.Event()
+    release_restore = threading.Event()
+
+    def _hold_restore() -> None:
+        restore_entered.set()
+        assert release_restore.wait(timeout=10)
+
+    winner = _make_replica(cluster, monkeypatch, on_restore=_hold_restore)
+    loser = _make_replica(cluster, monkeypatch)
+
+    results: dict[str, SandboxInfo] = {}
+    errors: list[BaseException] = []
+
+    def _run(name: str, replica: KubernetesSandboxManager) -> None:
+        try:
+            results[name] = _provision(replica, sandbox_id)
+        except BaseException as e:
+            errors.append(e)
+
+    t_winner = threading.Thread(target=_run, args=("winner", winner))
+    t_winner.start()
+    assert restore_entered.wait(timeout=10)
+
+    t_loser = threading.Thread(target=_run, args=("loser", loser))
+    t_loser.start()
+    time.sleep(0.5)
+
+    # Loser must be parked on the lock while the winner is mid-restore.
+    assert t_loser.is_alive()
+    assert "loser" not in results
+    assert cluster.pod_creates == [pod_name]
+    assert cluster.restores == [sandbox_id]
+
+    release_restore.set()
+    t_winner.join(timeout=10)
+    t_loser.join(timeout=10)
+    assert not t_winner.is_alive() and not t_loser.is_alive()
+
+    assert errors == []
+    assert results["winner"].status == SandboxStatus.RUNNING
+    assert results["loser"].status == SandboxStatus.RUNNING
+    assert cluster.pod_creates == [pod_name]
+    assert cluster.restores == [sandbox_id]
+
+
+def test_loser_times_out_while_winner_holds_lock(
+    lock_env: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cluster = _FakeCluster()
+    sandbox_id = uuid4()
+
+    restore_entered = threading.Event()
+    release_restore = threading.Event()
+
+    def _hold_restore() -> None:
+        restore_entered.set()
+        assert release_restore.wait(timeout=10)
+
+    winner = _make_replica(cluster, monkeypatch, on_restore=_hold_restore)
+    loser = _make_replica(cluster, monkeypatch)
+
+    winner_result: list[SandboxInfo] = []
+    t_winner = threading.Thread(
+        target=lambda: winner_result.append(_provision(winner, sandbox_id))
+    )
+    t_winner.start()
+    assert restore_entered.wait(timeout=10)
+    # Patch only after the winner acquires: the constant is also the TTL.
+    monkeypatch.setattr(
+        kubernetes_sandbox_manager, "PROVISION_LOCK_TIMEOUT_SECONDS", 0.5
+    )
+
+    try:
+        with pytest.raises(RuntimeError, match="Timed out waiting"):
+            _provision(loser, sandbox_id)
+    finally:
+        release_restore.set()
+        t_winner.join(timeout=10)
+
+    assert len(winner_result) == 1
+    assert winner_result[0].status == SandboxStatus.RUNNING
+    assert cluster.restores == [sandbox_id]
+
+
+def test_lock_released_after_provision_failure(
+    lock_env: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cluster = _FakeCluster()
+    sandbox_id = uuid4()
+    pod_name = f"sandbox-{str(sandbox_id)[:8]}"
+
+    failing = _make_replica(cluster, monkeypatch)
+
+    def _boom(sandbox_id: str, config_json: str) -> None:  # noqa: ARG001
+        raise ApiException(status=500, reason="secret create failed")
+
+    monkeypatch.setattr(failing, "_provision_opencode_secret", _boom)
+    # If the failed attempt orphaned the lock, the retry would time out.
+    monkeypatch.setattr(
+        kubernetes_sandbox_manager, "PROVISION_LOCK_TIMEOUT_SECONDS", 3.0
+    )
+
+    with pytest.raises(ApiException):
+        _provision(failing, sandbox_id)
+
+    retry = _make_replica(cluster, monkeypatch)
+    info = _provision(retry, sandbox_id)
+
+    assert info.status == SandboxStatus.RUNNING
+    assert cluster.pod_creates == [pod_name]
+    assert cluster.restores == [sandbox_id]


### PR DESCRIPTION
## Description

Two api-server replicas can provision the same sandbox concurrently (observed in cloud on 2026-07-06): both raced into `provision()`, one hit a 409 on pod create, and both ran the startup restore handshake — two concurrent opencode-history restores streaming into the same live pod.

This serializes pod creation + startup restore with a per-sandbox Redis lock (same cache-backend lock the prompt slot uses, so `thread_local=False` release semantics are already handled). The winner provisions and restores; losers block on the lock and then reuse the ready pod via the existing pod-exists check. The 409 handling is kept as a defensive fallback — on cache outages the lock fails open to it.

Timeout budget was also tightened while sizing the lock TTL. The TTL is derived as the sum of the step budgets a holder can spend inside the lock:

- IP assignment + history restore (shared deadline): 300s → 60s — snapshots are capped at 100MB (~1MB typical); the budget is really for scheduling + image pull
- pod Ready: 60s → 30s — everything slow precedes this wait; Ready only needs the sidecar probes to flip (2s period) and the probe-less sandbox container to reach Running
- opencode-serve ready: 30s (unchanged)
- lock TTL / waiter blocking timeout: 150s derived; typical hold is ~10s, and TTL expiry falls open to the 409 fallback rather than deadlocking

Follow-up candidate (not in this PR): the Helm sidecar `startupProbe` (2s × 180 = 360s) was sized against the old 300s restore deadline and could be tightened to match; harmless in the loose direction.

## How Has This Been Tested?

New external dependency unit tests (`backend/tests/external_dependency_unit/craft/test_provisioning_lock.py`) with real Redis and two sandbox-manager replicas driving a faked k8s cluster:

- concurrent provision runs exactly one pod create + one restore; the loser parks on the lock and reuses the winner's pod
- a waiter times out with a clear error while the winner holds the lock
- a failed provision releases the lock so an immediate retry proceeds

EDU (not integration) because a working lock and the 409 fallback are indistinguishable from outside the process — the fix's effect (exactly one restore) is only observable via internal call counts, and the race requires freezing the winner mid-restore. Redis, the dependency whose semantics matter here, is real.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize Kubernetes sandbox provisioning with a per-sandbox `Redis` lock to prevent concurrent pod creation and duplicate startup restores. Tighten timeouts and extend the lock TTL to include service deletion; keep the 409 fallback if the cache is unavailable.

- **Bug Fixes**
  - Added per-sandbox `Redis` lock to serialize pod create + startup restore; non-winners wait and then reuse the ready pod.
  - Fails open on cache transient errors; 409 conflict handling and pod-exists check remain as a defensive fallback.
  - Reduced timeouts: history restore 300s→60s, pod Ready 60s→30s; lock TTL = restore + Ready + `OPENCODE_SERVE_READY_TIMEOUT_SECONDS` + service-deletion wait.
  - Added EDU tests with real `Redis` to verify exactly one pod create and restore, waiter timeout behavior, and lock release after failures.

<sup>Written for commit a505a52b456a7a28ac9cf127546e379ff2c3bf23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

