### PR TITLE
refactor(model-server): gate DISABLE_MODEL_SERVER in python entrypoint

### DIFF
--- a/backend/Dockerfile.model_server
+++ b/backend/Dockerfile.model_server
@@ -82,4 +82,4 @@ ENV PYTHONPATH=/app
 ARG ONYX_VERSION=0.0.0-dev
 ENV ONYX_VERSION=${ONYX_VERSION}
 
-CMD ["uvicorn", "model_server.main:app", "--host", "0.0.0.0", "--port", "9000"]
+CMD ["python", "-m", "model_server"]

--- a/backend/model_server/__main__.py
+++ b/backend/model_server/__main__.py
@@ -1,0 +1,32 @@
+"""Process entry point for the Onyx model server (`python -m model_server`).
+
+The `DISABLE_MODEL_SERVER` short-circuit used to live in the container command as a
+shell `if`. Hardened base images ship without `sh`/`bash`, so the gate runs here in
+Python instead. It is intentionally kept in front of `model_server.main`'s imports so a
+disabled container exits without pulling in torch / the ML stack — matching the old
+behavior where the shell exited before Python ever started.
+"""
+
+import sys
+
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import DISABLE_MODEL_SERVER
+
+logger = setup_logger()
+
+
+def main() -> None:
+    if DISABLE_MODEL_SERVER:
+        # The deployment points inference/indexing at an external model server, so this
+        # container has nothing to run. Exit cleanly instead of starting uvicorn.
+        logger.notice("DISABLE_MODEL_SERVER is set; skipping model server startup.")
+        sys.exit(0)
+
+    # Imported lazily so the disabled path above stays free of the heavy ML imports.
+    from model_server.main import run_server
+
+    run_server()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/model_server/__main__.py
+++ b/backend/model_server/__main__.py
@@ -1,10 +1,7 @@
-"""Process entry point for the Onyx model server (`python -m model_server`).
+"""Process entry point for the model server (`python -m model_server`).
 
-The `DISABLE_MODEL_SERVER` short-circuit used to live in the container command as a
-shell `if`. Hardened base images ship without `sh`/`bash`, so the gate runs here in
-Python instead. It is intentionally kept in front of `model_server.main`'s imports so a
-disabled container exits without pulling in torch / the ML stack — matching the old
-behavior where the shell exited before Python ever started.
+The `DISABLE_MODEL_SERVER` gate runs here, ahead of `model_server.main`'s heavy ML
+imports, so a disabled container exits without loading torch / the model stack.
 """
 
 import sys

--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -24,7 +24,6 @@ from onyx.utils.middleware import add_onyx_request_id_middleware
 from onyx.utils.middleware import add_onyx_tenant_id_middleware
 from shared_configs.configs import INDEXING_ONLY
 from shared_configs.configs import MIN_THREADS_ML_MODELS
-from shared_configs.configs import MODEL_SERVER_ALLOWED_HOST
 from shared_configs.configs import MODEL_SERVER_PORT
 from shared_configs.configs import SENTRY_DSN
 from shared_configs.configs import SENTRY_TRACES_SAMPLE_RATE
@@ -142,13 +141,18 @@ app = get_model_app()
 
 
 def run_server() -> None:
+    # Bind all interfaces (loopback included) so the container healthcheck's
+    # localhost probe reaches the server. Mirrors the old shell command's
+    # `--host 0.0.0.0`; MODEL_SERVER_HOST is a client-side address and must not
+    # drive the bind host.
+    host = "0.0.0.0"  # noqa: S104
     logger.notice(
         "Starting Onyx Model Server on http://%s:%s/",
-        MODEL_SERVER_ALLOWED_HOST,
+        host,
         str(MODEL_SERVER_PORT),
     )
     logger.notice("Model Server Version: %s", __version__)
-    uvicorn.run(app, host=MODEL_SERVER_ALLOWED_HOST, port=MODEL_SERVER_PORT)
+    uvicorn.run(app, host=host, port=MODEL_SERVER_PORT)
 
 
 if __name__ == "__main__":

--- a/backend/model_server/main.py
+++ b/backend/model_server/main.py
@@ -141,7 +141,7 @@ def get_model_app() -> FastAPI:
 app = get_model_app()
 
 
-if __name__ == "__main__":
+def run_server() -> None:
     logger.notice(
         "Starting Onyx Model Server on http://%s:%s/",
         MODEL_SERVER_ALLOWED_HOST,
@@ -149,3 +149,7 @@ if __name__ == "__main__":
     )
     logger.notice("Model Server Version: %s", __version__)
     uvicorn.run(app, host=MODEL_SERVER_ALLOWED_HOST, port=MODEL_SERVER_PORT)
+
+
+if __name__ == "__main__":
+    run_server()

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_indexing_service_template.yaml
@@ -120,12 +120,6 @@ Resources:
           Image: onyxdotapp/onyx-model-server:latest
           Cpu: 0
           Essential: true
-          Command:
-            - "/bin/sh"
-            - "-c"
-            - >
-              if [ "${DISABLE_MODEL_SERVER}" = "True" ] || [ "${DISABLE_MODEL_SERVER}" = "true" ]; then echo 'Skipping service...';
-              exit 0; else exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000; fi
           PortMappings:
             - Name: model-server
               ContainerPort: 9000

--- a/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
+++ b/deployment/aws_ecs_fargate/cloudformation/services/onyx_model_server_inference_service_template.yaml
@@ -120,12 +120,6 @@ Resources:
           Image: onyxdotapp/onyx-model-server:latest
           Cpu: 0
           Essential: true
-          Command:
-            - "/bin/sh"
-            - "-c"
-            - >
-              if [ "${DISABLE_MODEL_SERVER}" = "True" ] || [ "${DISABLE_MODEL_SERVER}" = "true" ]; then echo 'Skipping service...';
-              exit 0; else exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000; fi
           PortMappings:
             - Name: model-server
               ContainerPort: 9000

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -350,13 +350,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
@@ -379,13 +372,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - INDEX_BATCH_SIZE=${INDEX_BATCH_SIZE:-}

--- a/deployment/docker_compose/docker-compose.prod-cloud.yml
+++ b/deployment/docker_compose/docker-compose.prod-cloud.yml
@@ -164,13 +164,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
@@ -190,13 +183,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -165,13 +165,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
@@ -193,13 +186,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -201,13 +201,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: unless-stopped
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
@@ -229,13 +222,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: unless-stopped
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -113,13 +113,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}
@@ -137,13 +130,6 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile.model_server
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     restart: on-failure
     environment:
       - MIN_THREADS_ML_MODELS=${MIN_THREADS_ML_MODELS:-}

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -274,13 +274,6 @@ services:
     #         - driver: nvidia
     #           count: all
     #           capabilities: [gpu]
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     env_file:
       - path: .env
         required: false
@@ -324,13 +317,6 @@ services:
     #         - driver: nvidia
     #           count: all
     #           capabilities: [gpu]
-    command: >
-      /bin/sh -c "if [ \"${DISABLE_MODEL_SERVER:-}\" = \"True\" ] || [ \"${DISABLE_MODEL_SERVER:-}\" = \"true\" ]; then
-        echo 'Skipping service...';
-        exit 0;
-      else
-        exec uvicorn model_server.main:app --host 0.0.0.0 --port 9000;
-      fi"
     env_file:
       - path: .env
         required: false


### PR DESCRIPTION
## Summary

Preps the model server for a **hardened base image** (no `sh`/`bash`) by moving the `DISABLE_MODEL_SERVER` gate out of the container's shell command and into a Python entrypoint.

- **`model_server/__main__.py`** (new, `python -m model_server`) — checks `DISABLE_MODEL_SERVER` *before* the heavy `torch`/ML imports and exits 0 when set. This matches the old shell fast-exit, which matters because these containers restart-loop under `restart: unless-stopped` — we don't want to import torch on every cycle of a disabled container.
- **`model_server/main.py`** — extracted the `__main__` block into `run_server()` (no logic change).
- **`Dockerfile.model_server`** — CMD → `["python", "-m", "model_server"]`, now the single source of truth for launch.
- **Dropped the `/bin/sh -c "if …"` command overrides** from all 6 compose files and both ECS task definitions so they inherit the image CMD.

## Testing

Triggered the **Model Server Tests** workflow against this branch — it builds the `model-server` image via bake, boots `inference_model_server` from `docker-compose.yml` (exactly the path this PR changes), and runs the embedding suite:

https://github.com/onyx-dot-app/onyx/actions/runs/28904175661

Also verified locally: `DISABLE_MODEL_SERVER=true python -m model_server` logs the skip notice and exits 0 without importing torch.

## Notes

- **Helm is intentionally untouched.** Its model deployments use `uvicorn … --host --limit-concurrency` with no disable gate (k8s simply doesn't schedule the deployment when unwanted). Switching them to `python -m model_server` would drop those CLI flags. Its `customCACerts` path also still injects `/bin/sh`, so hardened-base support on k8s is a separate follow-up.
- `run_server()` binds `MODEL_SERVER_ALLOWED_HOST` (defaults to `0.0.0.0`), preserving the existing `__main__` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate `DISABLE_MODEL_SERVER` in a Python entrypoint so hardened images without `/bin/sh` work and disabled containers exit before importing `torch`. Switch the image CMD to `python -m model_server` and pin the bind host to `0.0.0.0` so localhost healthchecks pass.

- **Refactors**
  - Added `model_server/__main__.py` to check `DISABLE_MODEL_SERVER` and exit 0 before ML imports; trimmed its docstring.
  - Extracted `run_server()` and bound `uvicorn` to `0.0.0.0` (no longer uses `MODEL_SERVER_ALLOWED_HOST`).
  - Updated `Dockerfile.model_server` CMD to `["python","-m","model_server"]`; removed compose/ECS shell overrides.

- **Migration**
  - Helm unchanged; k8s deployments still run `uvicorn` with flags and no disable gate.
  - To skip startup locally or in CI, set `DISABLE_MODEL_SERVER=true`.

<sup>Written for commit 4c71a5263a82477b1f7bd1e94b68bcc388e615d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

