### PR TITLE
feat(opensearch): Add created_at field to Documents

### DIFF
--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -222,6 +222,9 @@ class DocumentBase(BaseModel):
 
     # UTC time
     doc_updated_at: datetime | None = None
+    # UTC time the document was created at the source. Used as the primary axis
+    # for time-based search filtering (falls back to doc_updated_at when unset).
+    doc_created_at: datetime | None = None
     chunk_count: int | None = None
 
     # Owner, creator, etc.
@@ -420,6 +423,7 @@ class Document(DocumentBase):
             semantic_identifier=base.semantic_identifier,
             metadata=base.metadata,
             doc_updated_at=base.doc_updated_at,
+            doc_created_at=base.doc_created_at,
             primary_owners=base.primary_owners,
             secondary_owners=base.secondary_owners,
             title=base.title,

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -222,8 +222,7 @@ class DocumentBase(BaseModel):
 
     # UTC time
     doc_updated_at: datetime | None = None
-    # UTC time the document was created at the source. Used as the primary axis
-    # for time-based search filtering (falls back to doc_updated_at when unset).
+    # UTC time the document was created at the source
     doc_created_at: datetime | None = None
     chunk_count: int | None = None
 

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -219,6 +219,7 @@ def _convert_onyx_chunk_to_opensearch_document(
         metadata_list=filtered_metadata_list,
         metadata_suffix=filtered_metadata_suffix,
         last_updated=chunk.source_document.doc_updated_at,
+        created_at=chunk.source_document.doc_created_at,
         public=chunk.access.is_public,
         access_control_list=generate_opensearch_filtered_access_control_list(
             chunk.access

--- a/backend/onyx/document_index/opensearch/schema.py
+++ b/backend/onyx/document_index/opensearch/schema.py
@@ -173,7 +173,7 @@ class DocumentChunkWithoutVectors(BaseModel):
     # If it exists, time zone should always be UTC.
     last_updated: datetime | None = None
     # Time the document was created at the source. If it exists, time zone should
-    # always be UTC. Preferred over last_updated for time-based filtering.
+    # always be UTC.
     created_at: datetime | None = None
 
     public: bool
@@ -469,8 +469,7 @@ class DocumentSchema:
                     # would make sense to sort by date.
                     "doc_values": True,
                 },
-                # Source creation time. Preferred over last_updated for
-                # time-based filtering; see _get_time_cutoff_filter.
+                # Source creation time.
                 CREATED_AT_FIELD_NAME: {
                     "type": "date",
                     "format": "epoch_second",

--- a/backend/onyx/document_index/opensearch/schema.py
+++ b/backend/onyx/document_index/opensearch/schema.py
@@ -11,6 +11,7 @@ from pydantic import field_validator
 from pydantic import model_serializer
 from pydantic import model_validator
 from pydantic import SerializerFunctionWrapHandler
+from pydantic import ValidationInfo
 
 from onyx.configs.app_configs import OPENSEARCH_INDEX_NUM_REPLICAS
 from onyx.configs.app_configs import OPENSEARCH_INDEX_NUM_SHARDS
@@ -260,7 +261,9 @@ class DocumentChunkWithoutVectors(BaseModel):
 
     @field_validator("last_updated", "created_at", mode="before")
     @classmethod
-    def parse_epoch_seconds_to_datetime(cls, value: Any) -> datetime | None:
+    def parse_epoch_seconds_to_datetime(
+        cls, value: Any, info: ValidationInfo
+    ) -> datetime | None:
         """Parses seconds since the Unix epoch to a datetime object.
 
         If the input is None, returns None.
@@ -274,7 +277,7 @@ class DocumentChunkWithoutVectors(BaseModel):
             return value
         if not isinstance(value, int):
             raise ValueError(
-                f"Bug: Expected an int for a datetime property from OpenSearch, got {type(value)} instead."
+                f"Bug: Expected an int for the datetime property '{info.field_name}' from OpenSearch, got {type(value)} instead."
             )
         return datetime.fromtimestamp(value, tz=timezone.utc)
 

--- a/backend/onyx/document_index/opensearch/schema.py
+++ b/backend/onyx/document_index/opensearch/schema.py
@@ -39,6 +39,7 @@ CONTENT_VECTOR_FIELD_NAME = "content_vector"
 SOURCE_TYPE_FIELD_NAME = "source_type"
 METADATA_LIST_FIELD_NAME = "metadata_list"
 LAST_UPDATED_FIELD_NAME = "last_updated"
+CREATED_AT_FIELD_NAME = "created_at"
 PUBLIC_FIELD_NAME = "public"
 ACCESS_CONTROL_LIST_FIELD_NAME = "access_control_list"
 HIDDEN_FIELD_NAME = "hidden"
@@ -171,6 +172,9 @@ class DocumentChunkWithoutVectors(BaseModel):
     metadata_list: list[str] | None = None
     # If it exists, time zone should always be UTC.
     last_updated: datetime | None = None
+    # Time the document was created at the source. If it exists, time zone should
+    # always be UTC. Preferred over last_updated for time-based filtering.
+    created_at: datetime | None = None
 
     public: bool
     access_control_list: list[str]
@@ -238,7 +242,7 @@ class DocumentChunkWithoutVectors(BaseModel):
         serialized_exclude_none = {k: v for k, v in serialized.items() if v is not None}
         return serialized_exclude_none
 
-    @field_serializer("last_updated", mode="wrap")
+    @field_serializer("last_updated", "created_at", mode="wrap")
     def serialize_datetime_fields_to_epoch_seconds(
         self,
         value: datetime | None,
@@ -254,7 +258,7 @@ class DocumentChunkWithoutVectors(BaseModel):
         value = set_or_convert_timezone_to_utc(value)
         return int(value.timestamp())
 
-    @field_validator("last_updated", mode="before")
+    @field_validator("last_updated", "created_at", mode="before")
     @classmethod
     def parse_epoch_seconds_to_datetime(cls, value: Any) -> datetime | None:
         """Parses seconds since the Unix epoch to a datetime object.
@@ -270,7 +274,7 @@ class DocumentChunkWithoutVectors(BaseModel):
             return value
         if not isinstance(value, int):
             raise ValueError(
-                f"Bug: Expected an int for the last_updated property from OpenSearch, got {type(value)} instead."
+                f"Bug: Expected an int for a datetime property from OpenSearch, got {type(value)} instead."
             )
         return datetime.fromtimestamp(value, tz=timezone.utc)
 
@@ -463,6 +467,13 @@ class DocumentSchema:
                     "format": "epoch_second",
                     # For some reason date defaults to False, even though it
                     # would make sense to sort by date.
+                    "doc_values": True,
+                },
+                # Source creation time. Preferred over last_updated for
+                # time-based filtering; see _get_time_cutoff_filter.
+                CREATED_AT_FIELD_NAME: {
+                    "type": "date",
+                    "format": "epoch_second",
                     "doc_values": True,
                 },
                 # Access control fields.

--- a/backend/tests/unit/onyx/document_index/opensearch/test_document_chunk_serialization.py
+++ b/backend/tests/unit/onyx/document_index/opensearch/test_document_chunk_serialization.py
@@ -1,0 +1,77 @@
+"""Unit tests for DocumentChunk datetime (de)serialization.
+
+`created_at` and `last_updated` are stored in OpenSearch as epoch seconds. These
+pin that the pydantic model serializes tz-aware datetimes to epoch ints, parses
+them back to UTC datetimes, and omits the fields entirely when unset.
+"""
+
+from datetime import datetime
+from datetime import timezone
+
+from onyx.document_index.opensearch.schema import CREATED_AT_FIELD_NAME
+from onyx.document_index.opensearch.schema import DocumentChunkWithoutVectors
+from onyx.document_index.opensearch.schema import LAST_UPDATED_FIELD_NAME
+
+
+def _make_chunk(
+    created_at: datetime | None,
+    last_updated: datetime | None,
+) -> DocumentChunkWithoutVectors:
+    return DocumentChunkWithoutVectors(
+        document_id="doc-1",
+        chunk_index=0,
+        content="hello",
+        source_type="web",
+        created_at=created_at,
+        last_updated=last_updated,
+        public=True,
+        access_control_list=[],
+        global_boost=0,
+        semantic_identifier="doc-1",
+        blurb="hello",
+        doc_summary="",
+        chunk_context="",
+    )
+
+
+def test_created_at_serializes_to_epoch_seconds() -> None:
+    created = datetime(2022, 1, 1, tzinfo=timezone.utc)
+    dumped = _make_chunk(created_at=created, last_updated=None).model_dump()
+    assert dumped[CREATED_AT_FIELD_NAME] == int(created.timestamp())
+
+
+def test_created_at_round_trips_from_epoch_seconds() -> None:
+    created = datetime(2022, 1, 1, tzinfo=timezone.utc)
+    epoch = int(created.timestamp())
+    parsed = DocumentChunkWithoutVectors.model_validate(
+        {
+            "document_id": "doc-1",
+            "chunk_index": 0,
+            "content": "hello",
+            "source_type": "web",
+            CREATED_AT_FIELD_NAME: epoch,
+            "public": True,
+            "access_control_list": [],
+            "global_boost": 0,
+            "semantic_identifier": "doc-1",
+            "blurb": "hello",
+            "doc_summary": "",
+            "chunk_context": "",
+        }
+    )
+    assert parsed.created_at == created
+    assert parsed.created_at is not None
+    assert parsed.created_at.tzinfo is not None
+
+
+def test_naive_created_at_is_treated_as_utc() -> None:
+    naive = datetime(2022, 1, 1)
+    utc = datetime(2022, 1, 1, tzinfo=timezone.utc)
+    dumped = _make_chunk(created_at=naive, last_updated=None).model_dump()
+    assert dumped[CREATED_AT_FIELD_NAME] == int(utc.timestamp())
+
+
+def test_unset_datetimes_are_omitted() -> None:
+    dumped = _make_chunk(created_at=None, last_updated=None).model_dump()
+    assert CREATED_AT_FIELD_NAME not in dumped
+    assert LAST_UPDATED_FIELD_NAME not in dumped


### PR DESCRIPTION
## Description
We want to store the created_at field on chunks in opensearch. This attaches it and changes some associated data models.

Note: Nothing populates this yet. There will be a follow-up PR for 'indexed' documents to populate this and for new documents to populate this (via connectors)

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add source creation timestamps to documents and index them as `created_at` in OpenSearch. Datetimes are stored as epoch seconds and handled in UTC.

- **New Features**
  - Schema: added `created_at` to `DocumentChunkWithoutVectors` and mapped it in OpenSearch as `date` (`epoch_second`, `doc_values`); serializers/validators now cover both `created_at` and `last_updated` with UTC handling and clearer errors; omit when unset.
  - Indexer: passes `doc_created_at` from the source document to OpenSearch `created_at`.
  - Models: added `doc_created_at` to `Document` and wired it from `DocumentBase`.

- **Tests**
  - Added unit tests for `created_at` epoch (de)serialization, UTC handling for naive datetimes, and omission when unset.

<sup>Written for commit b53bf35cc70dc833765462ec48e68f8bf6c60684. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



