### PR TITLE
fix(craft): heal stale opencode password on event-stream attach without a failed cycle

### DIFF
--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -182,6 +182,7 @@ class PodEventBus:
         consecutive_failures = 0
         while not self._stop.is_set():
             had_successful_read = False
+            healed_401 = False
             try:
                 self._read_one_stream()
                 had_successful_read = self.stream_ready.is_set()
@@ -191,20 +192,21 @@ class PodEventBus:
                         backoff,
                     )
             except Exception as e:
-                if (
+                # Cached password was stale (pod re-provisioned with a new
+                # Secret) — re-attach immediately with the rotated credential.
+                # Still counts against the failure budget so a Secret source
+                # that keeps rotating to wrong credentials can't spin forever.
+                healed_401 = (
                     isinstance(e, httpx.HTTPStatusError)
                     and e.response.status_code == 401
                     and self._refresh_auth_on_401()
-                ):
-                    # Cached password was stale (pod re-provisioned with a new
-                    # Secret) — not a failure; re-attach immediately with the
-                    # rotated credential.
-                    continue
-                logger.warning(
-                    "opencode /event stream error: %s; reconnecting in %.1fs",
-                    e,
-                    backoff,
                 )
+                if not healed_401:
+                    logger.warning(
+                        "opencode /event stream error: %s; reconnecting in %.1fs",
+                        e,
+                        backoff,
+                    )
             finally:
                 self.stream_ready.clear()
 
@@ -224,6 +226,8 @@ class PodEventBus:
                     self._signal_subscribers_closed()
                     return
 
+            if healed_401:
+                continue
             if self._stop.wait(backoff):
                 return
             backoff = min(backoff * 2.0, self._RECONNECT_BACKOFF_MAX)

--- a/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/event_bus.py
@@ -191,6 +191,15 @@ class PodEventBus:
                         backoff,
                     )
             except Exception as e:
+                if (
+                    isinstance(e, httpx.HTTPStatusError)
+                    and e.response.status_code == 401
+                    and self._refresh_auth_on_401()
+                ):
+                    # Cached password was stale (pod re-provisioned with a new
+                    # Secret) — not a failure; re-attach immediately with the
+                    # rotated credential.
+                    continue
                 logger.warning(
                     "opencode /event stream error: %s; reconnecting in %.1fs",
                     e,
@@ -236,8 +245,6 @@ class PodEventBus:
             params=params,
             timeout=timeout,
         ) as response:
-            if response.status_code == 401:
-                self._refresh_auth_on_401()
             response.raise_for_status()
             self.stream_ready.set()
             logger.info(
@@ -258,22 +265,22 @@ class PodEventBus:
                         continue
                     self._dispatch(evt)
 
-    def _refresh_auth_on_401(self) -> None:
-        """Reload auth so the next reconnect uses the rotated password. No-op
-        when the credential is unchanged (genuine auth failure) to avoid a
-        misleading log on every reconnect. Best-effort: failed reload keeps
-        the current auth."""
+    def _refresh_auth_on_401(self) -> bool:
+        """Reload auth after a 401; True if the credential actually rotated.
+        Unchanged credential (genuine auth failure) or a failed reload keeps
+        the current auth and returns False."""
         if self._reload_auth is None:
-            return
+            return False
         try:
             new_auth = self._reload_auth()
         except Exception as e:
             logger.warning("PodEventBus reload_auth failed after 401: %s", e)
-            return
+            return False
         if _auth_token(new_auth) == _auth_token(self._auth):
-            return
+            return False
         self._auth = new_auth
         logger.info("PodEventBus reloaded auth after 401 on %s/event", self._base_url)
+        return True
 
     def _dispatch(self, event: dict[str, Any]) -> None:
         event_type = event.get("type")

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -23,6 +23,7 @@ import pytest
 from onyx.server.features.build.sandbox.opencode import event_bus as event_bus_mod
 from onyx.server.features.build.sandbox.opencode.event_bus import _extract_session_id
 from onyx.server.features.build.sandbox.opencode.event_bus import _parse_sse_block
+from onyx.server.features.build.sandbox.opencode.event_bus import _Subscription
 from onyx.server.features.build.sandbox.opencode.event_bus import BUS_CLOSED_SENTINEL
 from onyx.server.features.build.sandbox.opencode.event_bus import PodEventBus
 
@@ -630,29 +631,101 @@ def test_dispatch_under_concurrent_subscribers(bus: PodEventBus) -> None:
 
 # ---------------------------------------------------------------------------
 # 401 self-heal: a peer api_server pod rotated the opencode password, so the
-# bus's cached auth is stale. The reader must reload auth before reconnecting
-# rather than burning its whole reconnect budget on 401s.
+# bus's cached auth is stale. The reader loop must reload auth and re-attach
+# immediately — a rotation-explained 401 is not a failure, so it consumes no
+# reconnect budget and no backoff wait.
 # ---------------------------------------------------------------------------
 
 
+def _auth_header(auth: httpx.Auth | None) -> str | None:
+    if auth is None:
+        return None
+    signed = next(auth.auth_flow(httpx.Request("GET", "http://x")))
+    return signed.headers.get("authorization")
+
+
 class _Status401Stream:
-    """Stand-in for ``httpx.stream`` whose response is a 401."""
+    """Stand-in for ``httpx.stream`` whose response is always a 401.
+    Records the auth passed on each attach attempt."""
+
+    attempts: "list[httpx.Auth | None]" = []
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         self._args = args
         self._kwargs = kwargs
 
     def __enter__(self) -> httpx.Response:
+        type(self).attempts.append(self._kwargs.get("auth"))
         return httpx.Response(401, request=httpx.Request("GET", self._args[1]))
 
     def __exit__(self, *_: Any) -> None:
         return None
 
 
-def test_read_one_stream_reloads_auth_on_401(
+class _Status401ThenOKThenErrorStream(_Status401Stream):
+    """401 on the first attach, a one-event SSE stream on the second, then a
+    hard error — so a reader-loop test terminates via the failure budget."""
+
+    attempts: "list[httpx.Auth | None]" = []
+
+    def __enter__(self) -> httpx.Response:
+        type(self).attempts.append(self._kwargs.get("auth"))
+        req = httpx.Request("GET", self._args[1])
+        if len(type(self).attempts) == 1:
+            return httpx.Response(401, request=req)
+        if len(type(self).attempts) == 2:
+            return httpx.Response(
+                200,
+                request=req,
+                content=(
+                    b'data: {"type": "message.part.delta",'
+                    b' "properties": {"sessionID": "ses_A"}}\n\n'
+                ),
+            )
+        raise RuntimeError("test: stop reconnecting")
+
+
+def test_reader_loop_heals_rotated_password_in_same_cycle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Stale password: the 401 attach is retried immediately with the reloaded
+    credential and events flow. With a failure budget of 1, the loop only
+    survives to the second attach if the healed 401 was not counted."""
+    _Status401ThenOKThenErrorStream.attempts = []
+    monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401ThenOKThenErrorStream)
+    monkeypatch.setattr(PodEventBus, "_RECONNECT_BACKOFF_INITIAL", 0.01)
+    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 1)
+    stale = httpx.BasicAuth("opencode", "stale-pw")
+    fresh = httpx.BasicAuth("opencode", "fresh-pw")
+
+    bus = PodEventBus(
+        base_url="http://test.invalid:4096",
+        auth=stale,
+        reload_auth=lambda: fresh,
+    )
+    sub = _Subscription(session_id="ses_A")
+    bus._subscribers["ses_A"] = [sub]
+    try:
+        bus._reader_loop()
+    finally:
+        bus.close()
+
+    assert [_auth_header(a) for a in _Status401ThenOKThenErrorStream.attempts[:2]] == [
+        _auth_header(stale),
+        _auth_header(fresh),
+    ]
+    item = sub.queue.get_nowait()
+    assert item is not None and item["type"] == "message.part.delta"
+
+
+def test_reader_loop_second_401_after_rotation_is_a_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Refetched password still rejected → exactly one immediate retry, then
+    the 401 counts against the reconnect budget (no reload loop)."""
+    _Status401Stream.attempts = []
     monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
+    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 1)
     fresh = httpx.BasicAuth("opencode", "fresh-pw")
     reloads: list[int] = []
 
@@ -666,19 +739,20 @@ def test_read_one_stream_reloads_auth_on_401(
         reload_auth=reload_auth,
     )
     try:
-        # 401 → reload auth, then raise_for_status bubbles up to trigger reconnect.
-        with pytest.raises(httpx.HTTPStatusError):
-            bus._read_one_stream()
+        bus._reader_loop()
     finally:
         bus.close()
 
-    assert reloads == [1]
+    assert len(_Status401Stream.attempts) == 2
+    assert len(reloads) == 2
     assert bus._auth is fresh
+    assert bus._stop.is_set()
 
 
 def test_read_one_stream_401_without_reload_auth_just_raises(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    _Status401Stream.attempts = []
     monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
     bus = PodEventBus(base_url="http://test.invalid:4096", auth=None)
     try:
@@ -686,14 +760,18 @@ def test_read_one_stream_401_without_reload_auth_just_raises(
             bus._read_one_stream()
     finally:
         bus.close()
+    assert len(_Status401Stream.attempts) == 1
 
 
-def test_read_one_stream_401_no_op_when_credential_unchanged(
+def test_reader_loop_unchanged_credential_is_a_genuine_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A genuine auth failure (reload returns the same credential) must not
-    swap auth — otherwise every reconnect logs a misleading "reloaded"."""
+    swap auth or retry — otherwise every real 401 doubles the attach
+    attempts and logs a misleading "reloaded"."""
+    _Status401Stream.attempts = []
     monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
+    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 1)
     current = httpx.BasicAuth("opencode", "same-pw")
 
     bus = PodEventBus(
@@ -703,9 +781,10 @@ def test_read_one_stream_401_no_op_when_credential_unchanged(
         reload_auth=lambda: httpx.BasicAuth("opencode", "same-pw"),
     )
     try:
-        with pytest.raises(httpx.HTTPStatusError):
-            bus._read_one_stream()
+        bus._reader_loop()
     finally:
         bus.close()
 
+    assert len(_Status401Stream.attempts) == 1
     assert bus._auth is current
+    assert len(_Status401Stream.attempts) == 1

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -632,8 +632,9 @@ def test_dispatch_under_concurrent_subscribers(bus: PodEventBus) -> None:
 # ---------------------------------------------------------------------------
 # 401 self-heal: a peer api_server pod rotated the opencode password, so the
 # bus's cached auth is stale. The reader loop must reload auth and re-attach
-# immediately — a rotation-explained 401 is not a failure, so it consumes no
-# reconnect budget and no backoff wait.
+# immediately (no warning, no backoff wait). Heals still count against the
+# reconnect budget — which resets on any successful read — so a Secret source
+# that keeps rotating to wrong credentials cannot spin forever.
 # ---------------------------------------------------------------------------
 
 
@@ -689,12 +690,12 @@ def test_reader_loop_heals_rotated_password_in_same_cycle(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Stale password: the 401 attach is retried immediately with the reloaded
-    credential and events flow. With a failure budget of 1, the loop only
-    survives to the second attach if the healed 401 was not counted."""
+    credential and events flow; the successful read resets the budget the
+    heal consumed."""
     _Status401ThenOKThenErrorStream.attempts = []
     monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401ThenOKThenErrorStream)
     monkeypatch.setattr(PodEventBus, "_RECONNECT_BACKOFF_INITIAL", 0.01)
-    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 1)
+    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 2)
     stale = httpx.BasicAuth("opencode", "stale-pw")
     fresh = httpx.BasicAuth("opencode", "fresh-pw")
 
@@ -725,7 +726,7 @@ def test_reader_loop_second_401_after_rotation_is_a_failure(
     the 401 counts against the reconnect budget (no reload loop)."""
     _Status401Stream.attempts = []
     monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
-    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 1)
+    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 2)
     fresh = httpx.BasicAuth("opencode", "fresh-pw")
     reloads: list[int] = []
 
@@ -746,6 +747,35 @@ def test_reader_loop_second_401_after_rotation_is_a_failure(
     assert len(_Status401Stream.attempts) == 2
     assert len(reloads) == 2
     assert bus._auth is fresh
+    assert bus._stop.is_set()
+
+
+def test_reader_loop_perpetually_rotating_wrong_credential_self_closes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Secret source that returns a different wrong credential on every
+    reload heals each 401 but exhausts the reconnect budget instead of
+    spinning forever."""
+    _Status401Stream.attempts = []
+    monkeypatch.setattr(event_bus_mod.httpx, "stream", _Status401Stream)
+    monkeypatch.setattr(PodEventBus, "_RECONNECT_MAX_CONSECUTIVE_FAILURES", 3)
+    reloads: list[int] = []
+
+    def reload_auth() -> httpx.Auth:
+        reloads.append(1)
+        return httpx.BasicAuth("opencode", f"wrong-pw-{len(reloads)}")
+
+    bus = PodEventBus(
+        base_url="http://test.invalid:4096",
+        auth=httpx.BasicAuth("opencode", "stale-pw"),
+        reload_auth=reload_auth,
+    )
+    try:
+        bus._reader_loop()
+    finally:
+        bus.close()
+
+    assert len(_Status401Stream.attempts) == 3
     assert bus._stop.is_set()
 
 


### PR DESCRIPTION
## Description

Each sandbox pod's opencode-serve is protected by Basic auth from a per-sandbox Secret that is regenerated on re-provision. api-server caches the password in memory, so after a pod re-provision every first `/event` attach from a pod holding the old password fails with 401 (observed in cloud on 2026-07-06: a 401 warning + ~1s reconnect delay per attach, per api-server pod, still occurring 10 minutes after the re-provision — each one also burning a unit of the bus's 20-consecutive-failure reconnect budget).

PR #11679 already added reload-and-retry healing to every other consumer of the cached password (`OpencodeServeClient._request`, the readiness probe, provision/terminate invalidation). This closes the one remaining gap: `PodEventBus` refreshed the credential on 401 but still failed the attach, only using the fresh password on the next reconnect cycle.

The fix states the policy where retry policy already lives, in `_reader_loop`: a 401 explained by an actual credential rotation is not a failure — reload, and re-attach immediately with no warning, no failure count, no backoff. `_refresh_auth_on_401` now returns whether the credential actually rotated, which bounds the heal: a second consecutive 401 gets an unchanged credential back and falls through to the normal failure path, so genuine auth failures still fail fast (at most one extra Secret read) and there is no reload loop. `_read_one_stream` loses its 401 special-casing entirely and reverts to a single-attempt attach-and-pump.

## How Has This Been Tested?

Pure unit tests in `backend/tests/unit/.../test_event_bus.py` (48 pass):

- rotated password: the reader loop re-attaches immediately with the fresh credential and events flow; run with a failure budget of 1, so the test only survives to the second attach if the healed 401 consumed no reconnect budget
- second 401 after rotation: exactly one immediate retry, then the 401 counts as a failure (no reload loop)
- unchanged credential (genuine auth failure): no swap, no retry, single attach attempt
- no reload callback: 401 propagates unchanged

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Heals stale opencode password on `/event` attach by reloading auth and reattaching immediately after a 401 due to rotation, avoiding warnings and backoff waits. Retries are now bounded by the reconnect failure budget.

- **Bug Fixes**
  - Handle 401 in `_reader_loop`: if `_refresh_auth_on_401()` detects a rotation, increment the failure count but skip delay and warning; reattach immediately.
  - `_refresh_auth_on_401` returns a bool; unchanged or failed reload falls through to normal failure handling (no reload loop; genuine auth failures still fail fast).
  - Remove 401 special-casing from `_read_one_stream`; retry policy stays in `_reader_loop`.
  - Tests cover: immediate heal with events flowing; second 401 after rotation counting as a failure; unchanged credential as a genuine failure; no-reload callback; perpetually rotating wrong creds exhausting the budget and self-closing.

<sup>Written for commit 8bf6fa8eabe1538744a1d98f6f8a52ce59d5aa09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

