### PR TITLE
feat(connectors): Connectors populate created_at Document field

### DIFF
--- a/backend/onyx/connectors/airtable/airtable_connector.py
+++ b/backend/onyx/connectors/airtable/airtable_connector.py
@@ -15,6 +15,7 @@ from pyairtable.models.schema import TableSchema
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
@@ -428,6 +429,7 @@ class AirtableConnector(LoadConnector):
         fields = record["fields"]
         sections: list[TextSection] = []
         metadata: dict[str, str | list[str]] = {}
+        created_time = record["createdTime"]
 
         # Get primary field value if it exists
         primary_field_value = (
@@ -491,6 +493,7 @@ class AirtableConnector(LoadConnector):
             sections=(cast(list[TextSection | ImageSection], sections)),
             source=DocumentSource.AIRTABLE,
             semantic_identifier=semantic_id,
+            doc_created_at=time_str_to_utc(created_time),
             metadata=metadata,
             doc_metadata={
                 "hierarchy": {

--- a/backend/onyx/connectors/asana/asana_api.py
+++ b/backend/onyx/connectors/asana/asana_api.py
@@ -19,6 +19,7 @@ class AsanaTask:
         text: str,
         link: str,
         last_modified: datetime,
+        created_at: datetime,
         project_gid: str,
         project_name: str,
     ) -> None:
@@ -27,6 +28,7 @@ class AsanaTask:
         self.text = text
         self.link = link
         self.last_modified = last_modified
+        self.created_at = created_at
         self.project_gid = project_gid
         self.project_name = project_name
 
@@ -187,6 +189,7 @@ class AsanaAPI:
                     text=text,
                     link=data["permalink_url"],
                     last_modified=datetime.fromisoformat(data["modified_at"]),
+                    created_at=datetime.fromisoformat(data["created_at"]),
                     project_gid=project_gid,
                     project_name=project_name,
                 )

--- a/backend/onyx/connectors/asana/connector.py
+++ b/backend/onyx/connectors/asana/connector.py
@@ -93,6 +93,8 @@ class AsanaConnector(LoadConnector, PollConnector):
             id=task.id,
             sections=[TextSection(link=task.link, text=task.text)],
             doc_updated_at=task.last_modified,
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=task.created_at,
             source=DocumentSource.ASANA,
             semantic_identifier=task.title,
             metadata={

--- a/backend/onyx/connectors/axero/connector.py
+++ b/backend/onyx/connectors/axero/connector.py
@@ -124,6 +124,7 @@ class AxeroForum(BaseModel):
     initial_content: str
     responses: list[str]
     last_update: datetime
+    created: datetime | None = None
 
 
 def _map_post_to_parent(
@@ -152,11 +153,11 @@ def _map_post_to_parent(
             initial_post_d = _get_obj_by_id(p_id, api_key, axero_base_url)[
                 "ResponseData"
             ]
+            initial_post_created = initial_post_d.get("DateCreated")
             initial_post_time = time_str_to_utc(
-                initial_post_d.get("DateUpdated")
-                or initial_post_d.get("DateCreated")
-                or epoch_str
+                initial_post_d.get("DateUpdated") or initial_post_created or epoch_str
             )
+
             post_map[p_id] = AxeroForum(
                 doc_id="AXERO_" + str(initial_post_d.get("ContentID")),
                 title=initial_post_d.get("ContentTitle"),
@@ -164,6 +165,11 @@ def _map_post_to_parent(
                 initial_content=initial_post_d.get("ContentSummary"),
                 responses=[post.get("ContentSummary")],
                 last_update=max(post_time, initial_post_time),
+                created=(
+                    time_str_to_utc(initial_post_created)
+                    if initial_post_created
+                    else None
+                ),
             )
 
     return list(post_map.values())
@@ -223,6 +229,8 @@ def _translate_forum_to_doc(af: AxeroForum) -> Document:
         source=DocumentSource.AXERO,
         semantic_identifier=af.title,
         doc_updated_at=af.last_update,
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=af.created,
         metadata={},
     )
 
@@ -240,12 +248,15 @@ def _translate_content_to_doc(content: dict) -> Document:
         content_parsed = parse_html_page_basic(body)
         page_text += content_parsed
 
+    date_created = content["DateCreated"]
     doc = Document(
         id="AXERO_" + str(content["ContentID"]),
         sections=[TextSection(link=content["ContentURL"], text=page_text)],
         source=DocumentSource.AXERO,
         semantic_identifier=content["ContentTitle"],
         doc_updated_at=time_str_to_utc(content["DateUpdated"]),
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=time_str_to_utc(date_created),
         metadata={"space": content["SpaceName"]},
     )
 

--- a/backend/onyx/connectors/bitbucket/connector.py
+++ b/backend/onyx/connectors/bitbucket/connector.py
@@ -17,6 +17,7 @@ from onyx.connectors.bitbucket.utils import build_auth_client
 from onyx.connectors.bitbucket.utils import list_repositories
 from onyx.connectors.bitbucket.utils import map_pr_to_document
 from onyx.connectors.bitbucket.utils import paginate
+from onyx.connectors.bitbucket.utils import parse_bitbucket_datetime
 from onyx.connectors.bitbucket.utils import PR_LIST_RESPONSE_FIELDS
 from onyx.connectors.bitbucket.utils import SLIM_PR_LIST_RESPONSE_FIELDS
 from onyx.connectors.exceptions import CredentialExpiredError
@@ -287,7 +288,15 @@ class BitbucketConnector(
                 ):
                     pr_id = pr["id"]
                     doc_id = f"{DocumentSource.BITBUCKET.value}:{self.workspace}:{slug}:pr:{pr_id}"
-                    batch.append(SlimDocument(id=doc_id))
+                    batch.append(
+                        SlimDocument(
+                            id=doc_id,
+                            # NOTE: doc_created_at population not yet verified against live data
+                            doc_created_at=parse_bitbucket_datetime(
+                                pr.get("created_on")
+                            ),
+                        )
+                    )
                     if len(batch) >= self.batch_size:
                         yield batch
                         batch = []

--- a/backend/onyx/connectors/bitbucket/utils.py
+++ b/backend/onyx/connectors/bitbucket/utils.py
@@ -57,15 +57,23 @@ PR_LIST_RESPONSE_FIELDS: str = ",".join(
     ]
 )
 
-# Minimal fields for slim retrieval (IDs only)
+# Minimal fields for slim retrieval (IDs + creation time for doc_created_at backfill)
 SLIM_PR_LIST_RESPONSE_FIELDS: str = ",".join(
     [
         "next",
         "page",
         "pagelen",
         "values.id",
+        "values.created_on",
     ]
 )
+
+
+def parse_bitbucket_datetime(value: str | None) -> datetime | None:
+    """Parse a Bitbucket ISO-8601 timestamp into a tz-aware UTC datetime."""
+    if not isinstance(value, str):
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
 
 
 # Minimal fields for repository list calls
@@ -212,6 +220,13 @@ def map_pr_to_document(pr: dict[str, Any], workspace: str, repo_slug: str) -> Do
         if isinstance(updated_on, str)
         else None
     )
+    created_dt = (
+        datetime.fromisoformat(created_on.replace("Z", "+00:00")).astimezone(
+            timezone.utc
+        )
+        if isinstance(created_on, str)
+        else None
+    )
 
     source_branch = pr.get("source", {}).get("branch", {}).get("name", "")
     destination_branch = pr.get("destination", {}).get("branch", {}).get("name", "")
@@ -288,6 +303,8 @@ def map_pr_to_document(pr: dict[str, Any], workspace: str, repo_slug: str) -> Do
         semantic_identifier=f"#{pr_id}: {title}",
         title=title,
         doc_updated_at=updated_dt,
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=created_dt,
         primary_owners=[primary_owner] if primary_owner else None,
         secondary_owners=secondary_owners,
         metadata=metadata,

--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -83,6 +83,9 @@ class BookstackConnector(LoadConnector, PollConnector):
         updated_at_str = (
             str(book.get("updated_at")) if book.get("updated_at") is not None else None
         )
+        created_at_str = (
+            str(book.get("created_at")) if book.get("created_at") is not None else None
+        )
         return Document(
             id="book__" + str(book.get("id")),
             sections=[TextSection(link=url, text=text)],
@@ -91,6 +94,10 @@ class BookstackConnector(LoadConnector, PollConnector):
             title=title,
             doc_updated_at=(
                 time_str_to_utc(updated_at_str) if updated_at_str is not None else None
+            ),
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=(
+                time_str_to_utc(created_at_str) if created_at_str is not None else None
             ),
             metadata={"type": "book"},
         )
@@ -112,6 +119,11 @@ class BookstackConnector(LoadConnector, PollConnector):
             if chapter.get("updated_at") is not None
             else None
         )
+        created_at_str = (
+            str(chapter.get("created_at"))
+            if chapter.get("created_at") is not None
+            else None
+        )
         return Document(
             id="chapter__" + str(chapter.get("id")),
             sections=[TextSection(link=url, text=text)],
@@ -120,6 +132,10 @@ class BookstackConnector(LoadConnector, PollConnector):
             title=title,
             doc_updated_at=(
                 time_str_to_utc(updated_at_str) if updated_at_str is not None else None
+            ),
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=(
+                time_str_to_utc(created_at_str) if created_at_str is not None else None
             ),
             metadata={"type": "chapter"},
         )
@@ -136,6 +152,11 @@ class BookstackConnector(LoadConnector, PollConnector):
             if shelf.get("updated_at") is not None
             else None
         )
+        created_at_str = (
+            str(shelf.get("created_at"))
+            if shelf.get("created_at") is not None
+            else None
+        )
         return Document(
             id="shelf:" + str(shelf.get("id")),
             sections=[TextSection(link=url, text=text)],
@@ -144,6 +165,10 @@ class BookstackConnector(LoadConnector, PollConnector):
             title=title,
             doc_updated_at=(
                 time_str_to_utc(updated_at_str) if updated_at_str is not None else None
+            ),
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=(
+                time_str_to_utc(created_at_str) if created_at_str is not None else None
             ),
             metadata={"type": "shelf"},
         )
@@ -168,6 +193,11 @@ class BookstackConnector(LoadConnector, PollConnector):
             if page_data.get("updated_at") is not None
             else None
         )
+        created_at_str = (
+            str(page_data.get("created_at"))
+            if page_data.get("created_at") is not None
+            else None
+        )
         time.sleep(0.1)
         return Document(
             id="page:" + page_id,
@@ -177,6 +207,10 @@ class BookstackConnector(LoadConnector, PollConnector):
             title=str(title),
             doc_updated_at=(
                 time_str_to_utc(updated_at_str) if updated_at_str is not None else None
+            ),
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=(
+                time_str_to_utc(created_at_str) if created_at_str is not None else None
             ),
             metadata={"type": "page"},
         )

--- a/backend/onyx/connectors/braintrust/connector.py
+++ b/backend/onyx/connectors/braintrust/connector.py
@@ -340,6 +340,7 @@ class BraintrustConnector(CheckpointedConnector[BraintrustCheckpoint]):
                 }
             ),
             doc_updated_at=_parse_time(prompt.get("created")),
+            doc_created_at=_parse_time(prompt.get("created")),
         )
 
     def _dataset_to_document(
@@ -378,6 +379,7 @@ class BraintrustConnector(CheckpointedConnector[BraintrustCheckpoint]):
                 }
             ),
             doc_updated_at=_parse_time(ref.created),
+            doc_created_at=_parse_time(ref.created),
             file_id=csv_file_id,
         )
 
@@ -485,6 +487,7 @@ class BraintrustConnector(CheckpointedConnector[BraintrustCheckpoint]):
                 }
             ),
             doc_updated_at=_parse_time(ref.created),
+            doc_created_at=_parse_time(ref.created),
             file_id=file_id,
         )
 

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -272,6 +272,7 @@ class CanvasAnnouncement(BaseModel):
     message: str | None = None
     html_url: str
     posted_at: str | None = None
+    created_at: str | None = None
     course_id: int
     is_section_specific: bool = False
     sections: list[CanvasAnnouncementSection] = Field(default_factory=list)
@@ -285,6 +286,7 @@ class CanvasAnnouncement(BaseModel):
             message=payload.get("message"),
             html_url=payload["html_url"],
             posted_at=payload.get("posted_at"),
+            created_at=payload.get("created_at"),
             course_id=course_id,
             is_section_specific=payload.get("is_section_specific") or False,
             sections=[
@@ -432,6 +434,7 @@ class CanvasConnector(
         text: str,
         semantic_identifier: str,
         doc_updated_at: datetime | None,
+        doc_created_at: datetime | None,
         course_id: int,
         doc_type: str,
     ) -> Document:
@@ -445,6 +448,7 @@ class CanvasConnector(
             source=DocumentSource.CANVAS,
             semantic_identifier=semantic_identifier,
             doc_updated_at=doc_updated_at,
+            doc_created_at=doc_created_at,
             metadata={"course_id": str(course_id), "type": doc_type},
         )
 
@@ -458,6 +462,8 @@ class CanvasConnector(
             text_parts.append(body_text)
 
         doc_updated_at = _parse_canvas_dt(page.updated_at) if page.updated_at else None
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at = _parse_canvas_dt(page.created_at) if page.created_at else None
 
         document = self._build_document(
             doc_id=f"canvas-page-{page.course_id}-{page.page_id}",
@@ -465,6 +471,7 @@ class CanvasConnector(
             text="\n\n".join(text_parts),
             semantic_identifier=page.title or f"Page {page.page_id}",
             doc_updated_at=doc_updated_at,
+            doc_created_at=doc_created_at,
             course_id=page.course_id,
             doc_type="page",
         )
@@ -487,6 +494,10 @@ class CanvasConnector(
         doc_updated_at = (
             _parse_canvas_dt(assignment.updated_at) if assignment.updated_at else None
         )
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at = (
+            _parse_canvas_dt(assignment.created_at) if assignment.created_at else None
+        )
 
         document = self._build_document(
             doc_id=f"canvas-assignment-{assignment.course_id}-{assignment.id}",
@@ -494,6 +505,7 @@ class CanvasConnector(
             text="\n\n".join(text_parts),
             semantic_identifier=assignment.name or f"Assignment {assignment.id}",
             doc_updated_at=doc_updated_at,
+            doc_created_at=doc_created_at,
             course_id=assignment.course_id,
             doc_type="assignment",
         )
@@ -513,6 +525,12 @@ class CanvasConnector(
         doc_updated_at = (
             _parse_canvas_dt(announcement.posted_at) if announcement.posted_at else None
         )
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at = (
+            _parse_canvas_dt(announcement.created_at)
+            if announcement.created_at
+            else None
+        )
 
         document = self._build_document(
             doc_id=f"canvas-announcement-{announcement.course_id}-{announcement.id}",
@@ -520,6 +538,7 @@ class CanvasConnector(
             text="\n\n".join(text_parts),
             semantic_identifier=announcement.title or f"Announcement {announcement.id}",
             doc_updated_at=doc_updated_at,
+            doc_created_at=doc_created_at,
             course_id=announcement.course_id,
             doc_type="announcement",
         )

--- a/backend/onyx/connectors/clickup/connector.py
+++ b/backend/onyx/connectors/clickup/connector.py
@@ -119,8 +119,14 @@ class ClickupConnector(LoadConnector, PollConnector):
                     semantic_identifier=task["name"],
                     doc_updated_at=(
                         datetime.fromtimestamp(
-                            round(float(task["date_updated"]) / 1000, 3)
-                        ).replace(tzinfo=timezone.utc)
+                            round(float(task["date_updated"]) / 1000, 3),
+                            tz=timezone.utc,
+                        )
+                    ),
+                    # NOTE: doc_created_at population not yet verified against live data
+                    doc_created_at=datetime.fromtimestamp(
+                        round(float(task["date_created"]) / 1000, 3),
+                        tz=timezone.utc,
                     ),
                     primary_owners=[
                         BasicExpertInfo(

--- a/backend/onyx/connectors/coda/connector.py
+++ b/backend/onyx/connectors/coda/connector.py
@@ -479,6 +479,7 @@ class CodaConnector(LoadConnector, PollConnector):
     def _convert_page_to_document(self, page: CodaPage, content: str = "") -> Document:
         """Convert a page into a Document."""
         page_updated = datetime.fromisoformat(page.updated_at).astimezone(timezone.utc)
+        page_created = datetime.fromisoformat(page.created_at).astimezone(timezone.utc)
 
         text_parts = [page.name, page.browser_link]
         if content:
@@ -492,6 +493,8 @@ class CodaConnector(LoadConnector, PollConnector):
             source=DocumentSource.CODA,
             semantic_identifier=page.name or f"Page {page.id}",
             doc_updated_at=page_updated,
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=page_created,
             metadata={
                 "browser_link": page.browser_link,
                 "doc_id": page.doc_id,
@@ -504,6 +507,9 @@ class CodaConnector(LoadConnector, PollConnector):
     ) -> Document:
         """Convert a table and its rows into a single Document with multiple sections (one per row)."""
         table_updated = datetime.fromisoformat(table.updated_at).astimezone(
+            timezone.utc
+        )
+        table_created = datetime.fromisoformat(table.created_at).astimezone(
             timezone.utc
         )
 
@@ -531,6 +537,8 @@ class CodaConnector(LoadConnector, PollConnector):
             source=DocumentSource.CODA,
             semantic_identifier=table.name or f"Table {table.id}",
             doc_updated_at=table_updated,
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=table_created,
             metadata={
                 "browser_link": table.browser_link,
                 "doc_id": table.doc_id,

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -77,7 +77,11 @@ _ATTACHMENT_EXPANSION_FIELDS = [
     "version",
     "space",
     "metadata.labels",
+    "history",  # for history.createdDate
 ]
+# These slim-path sets are intentionally trimmed for perf (CONFCLOUD-77618);
+# `history` is added only to expose `history.createdDate` for doc_created_at
+# backfill on the slim path.
 # Fast path: page + ancestor restrictions inlined. Subject to
 # CONFCLOUD-77618 / 76424 on draft/trashed/outdated ancestors.
 _RESTRICTIONS_EXPANSION_FIELDS = [
@@ -86,6 +90,7 @@ _RESTRICTIONS_EXPANSION_FIELDS = [
     "restrictions.read.restrictions.group",
     "ancestors.restrictions.read.restrictions.user",
     "ancestors.restrictions.read.restrictions.group",
+    "history",  # for history.createdDate (doc_created_at backfill)
 ]
 # CONFCLOUD-77618 fallback: bare ancestors only; EE resolver fetches
 # each ancestor's restrictions via `restriction/byOperation`.
@@ -94,11 +99,16 @@ _PER_PAGE_RESTRICTIONS_EXPANSION_FIELDS = [
     "restrictions.read.restrictions.user",
     "restrictions.read.restrictions.group",
     "ancestors",
+    "history",  # for history.createdDate (doc_created_at backfill)
 ]
 # Pruning needs `space` + `ancestors` to populate hierarchy nodes and
 # parent ids; skipping them would flatten the graph. No restrictions
 # expand here, so CONFCLOUD-77618 can't fire.
-_PRUNING_EXPANSION_FIELDS = ["space", "ancestors"]
+_PRUNING_EXPANSION_FIELDS = [
+    "space",
+    "ancestors",
+    "history",  # for history.createdDate (doc_created_at backfill)
+]
 
 _SLIM_DOC_BATCH_SIZE = 5000
 
@@ -566,6 +576,7 @@ class ConfluenceConnector(
                 semantic_identifier=page_title,
                 metadata=metadata,
                 doc_updated_at=datetime_from_string(page["version"]["when"]),
+                doc_created_at=datetime_from_string(page["history"]["createdDate"]),
                 primary_owners=primary_owners if primary_owners else None,
                 parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
             )
@@ -720,6 +731,9 @@ class ConfluenceConnector(
                             if attachment.get("version")
                             and attachment["version"].get("when")
                             else None
+                        ),
+                        doc_created_at=datetime_from_string(
+                            attachment["history"]["createdDate"]
                         ),
                         primary_owners=primary_owners,
                         parent_hierarchy_raw_node_id=attachment_parent_hierarchy_raw_id,
@@ -1145,6 +1159,7 @@ class ConfluenceConnector(
                         if include_permissions
                         else None
                     ),
+                    doc_created_at=datetime_from_string(page["history"]["createdDate"]),
                     parent_hierarchy_raw_node_id=self._get_parent_hierarchy_raw_id(
                         page
                     ),
@@ -1207,6 +1222,9 @@ class ConfluenceConnector(
                             )
                             if include_permissions
                             else None
+                        ),
+                        doc_created_at=datetime_from_string(
+                            attachment["history"]["createdDate"]
                         ),
                         parent_hierarchy_raw_node_id=page_id,
                     )

--- a/backend/onyx/connectors/discord/connector.py
+++ b/backend/onyx/connectors/discord/connector.py
@@ -83,6 +83,8 @@ def _convert_message_to_document(
         source=DocumentSource.DISCORD,
         semantic_identifier=semantic_identifier,
         doc_updated_at=message.edited_at,
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=message.created_at,
         title=title,
         sections=(cast(list[TextSection | ImageSection], sections)),
         metadata=metadata,

--- a/backend/onyx/connectors/discourse/connector.py
+++ b/backend/onyx/connectors/discourse/connector.py
@@ -137,6 +137,8 @@ class DiscourseConnector(PollConnector):
             source=DocumentSource.DISCOURSE,
             semantic_identifier=topic["title"],
             doc_updated_at=time_str_to_utc(topic["last_posted_at"]),
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=time_str_to_utc(topic["created_at"]),
             primary_owners=[poster] if poster else None,
             secondary_owners=responders or None,
             metadata=metadata,

--- a/backend/onyx/connectors/document360/connector.py
+++ b/backend/onyx/connectors/document360/connector.py
@@ -132,6 +132,9 @@ class Document360Connector(LoadConnector, PollConnector):
             updated_at = datetime.strptime(
                 article_details["modified_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
             ).replace(tzinfo=timezone.utc)
+            created_at = datetime.strptime(
+                article_details["created_at"], "%Y-%m-%dT%H:%M:%S.%fZ"
+            ).replace(tzinfo=timezone.utc)
             if start is not None and updated_at < start:
                 continue
             if end is not None and updated_at > end:
@@ -165,6 +168,8 @@ class Document360Connector(LoadConnector, PollConnector):
                 source=DocumentSource.DOCUMENT360,
                 semantic_identifier=article_details["title"],
                 doc_updated_at=updated_at,
+                # NOTE: doc_created_at population not yet verified against live data
+                doc_created_at=created_at,
                 primary_owners=authors,
                 metadata={
                     "workspace": self.workspace,

--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -133,6 +133,7 @@ def _create_doc_from_transcript(transcript: dict) -> Document | None:
             }.items()
             if v is not None
         },
+        doc_created_at=meeting_date,
         doc_updated_at=meeting_date,
         primary_owners=organizer_email_user_info,
         secondary_owners=meeting_participants_email_list,

--- a/backend/onyx/connectors/freshdesk/connector.py
+++ b/backend/onyx/connectors/freshdesk/connector.py
@@ -178,6 +178,8 @@ def _create_doc_from_ticket(ticket: dict, domain: str) -> Document:
         semantic_identifier=ticket["subject"],
         metadata=metadata,
         doc_updated_at=_parse_freshdesk_datetime(ticket.get("updated_at")),
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=_parse_freshdesk_datetime(ticket.get("created_at")),
     )
 
 

--- a/backend/onyx/connectors/gitbook/connector.py
+++ b/backend/onyx/connectors/gitbook/connector.py
@@ -196,6 +196,10 @@ def _convert_page_to_document(
         doc_updated_at=datetime.fromisoformat(page["updatedAt"]).replace(
             tzinfo=timezone.utc
         ),
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=datetime.fromisoformat(page["createdAt"]).replace(
+            tzinfo=timezone.utc
+        ),
         metadata={
             "path": page.get("path", ""),
             "type": page.get("type", ""),

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -368,6 +368,11 @@ def _convert_pr_to_document(
             if pull_request.updated_at
             else None
         ),
+        doc_created_at=(
+            pull_request.created_at.replace(tzinfo=timezone.utc)
+            if pull_request.created_at
+            else None
+        ),
         # this metadata is used in perm sync
         doc_metadata=doc_metadata,
         metadata={
@@ -449,6 +454,9 @@ def _convert_issue_to_document(
         semantic_identifier=f"{issue.number}: {issue.title}",
         # updated_at is UTC time but is timezone unaware
         doc_updated_at=issue.updated_at.replace(tzinfo=timezone.utc),
+        doc_created_at=(
+            issue.created_at.replace(tzinfo=timezone.utc) if issue.created_at else None
+        ),
         # this metadata is used in perm sync
         doc_metadata=doc_metadata,
         metadata={
@@ -943,6 +951,11 @@ class GithubConnector(
                         source=DocumentSource.GITHUB,
                         semantic_identifier="",
                         metadata={},
+                        doc_created_at=(
+                            pr.created_at.replace(tzinfo=timezone.utc)
+                            if pr.created_at
+                            else None
+                        ),
                     )
                 else:
                     # we iterate backwards in time, so at this point we stop processing prs
@@ -1035,6 +1048,11 @@ class GithubConnector(
                         source=DocumentSource.GITHUB,
                         semantic_identifier="",
                         metadata={},
+                        doc_created_at=(
+                            issue.created_at.replace(tzinfo=timezone.utc)
+                            if issue.created_at
+                            else None
+                        ),
                     )
                 else:
                     # we iterate backwards in time, so at this point we stop processing issues
@@ -1193,7 +1211,9 @@ class GithubConnector(
                 if document is not None:
                     batch.append(
                         SlimDocument(
-                            id=document.id, external_access=document.external_access
+                            id=document.id,
+                            external_access=document.external_access,
+                            doc_created_at=document.doc_created_at,
                         )
                     )
                 if next_checkpoint is not None:

--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -15,6 +15,7 @@ from gitlab.v4.objects import Project
 from onyx.configs.app_configs import GITLAB_CONNECTOR_INCLUDE_CODE_FILES
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.interfaces import PollConnector
@@ -61,16 +62,34 @@ def get_author(author: Any) -> BasicExpertInfo:
     )
 
 
+def _gitlab_datetime_to_utc(value: Any) -> datetime | None:
+    """Normalize a GitLab timestamp to tz-aware UTC.
+
+    python-gitlab exposes REST attributes as raw JSON, so these arrive as
+    ISO-8601 strings; handle datetime values defensively too. Uses the shared
+    parser rather than a fixed format so whole-second timestamps (no fractional
+    part) don't raise.
+    """
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return (
+            value.replace(tzinfo=timezone.utc)
+            if value.tzinfo is None
+            else value.astimezone(timezone.utc)
+        )
+    return time_str_to_utc(value)
+
+
 def _convert_merge_request_to_document(mr: Any) -> Document:
     doc = Document(
         id=mr.web_url,
         sections=[TextSection(link=mr.web_url, text=mr.description or "")],
         source=DocumentSource.GITLAB,
         semantic_identifier=mr.title,
-        # updated_at is UTC time but is timezone unaware, explicitly add UTC
-        # as there is logic in indexing to prevent wrong timestamped docs
-        # due to local time discrepancies with UTC
-        doc_updated_at=mr.updated_at.replace(tzinfo=timezone.utc),
+        doc_updated_at=_gitlab_datetime_to_utc(mr.updated_at),
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=_gitlab_datetime_to_utc(mr.created_at),
         primary_owners=[get_author(mr.author)],
         metadata={"state": mr.state, "type": "MergeRequest"},
     )
@@ -83,10 +102,9 @@ def _convert_issue_to_document(issue: Any) -> Document:
         sections=[TextSection(link=issue.web_url, text=issue.description or "")],
         source=DocumentSource.GITLAB,
         semantic_identifier=issue.title,
-        # updated_at is UTC time but is timezone unaware, explicitly add UTC
-        # as there is logic in indexing to prevent wrong timestamped docs
-        # due to local time discrepancies with UTC
-        doc_updated_at=issue.updated_at.replace(tzinfo=timezone.utc),
+        doc_updated_at=_gitlab_datetime_to_utc(issue.updated_at),
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=_gitlab_datetime_to_utc(issue.created_at),
         primary_owners=[get_author(issue.author)],
         metadata={"state": issue.state, "type": issue.type if issue.type else "Issue"},
     )

--- a/backend/onyx/connectors/gmail/connector.py
+++ b/backend/onyx/connectors/gmail/connector.py
@@ -1,7 +1,6 @@
 from base64 import urlsafe_b64decode
 from collections.abc import Callable
 from collections.abc import Iterator
-from datetime import datetime
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -60,14 +59,6 @@ PAYLOAD_FIELDS = f"payload(headers, {PARTS_FIELDS})"
 MESSAGES_FIELDS = f"messages(id, {PAYLOAD_FIELDS})"
 THREADS_FIELDS = f"threads(id, {MESSAGES_FIELDS})"
 THREAD_FIELDS = f"id, {MESSAGES_FIELDS}"
-
-# The slim listing (THREAD_LIST_FIELDS) only returns thread IDs. To backfill
-# doc_created_at during perm/prune sync without a full re-index, the slim path
-# does one extra minimal per-thread fetch. format="metadata" + metadataHeaders
-# make the server return only the Date header per message (the `fields` mask
-# can't filter within the headers list); the mask trims the rest of the envelope.
-SLIM_CREATED_AT_FIELDS = "id, messages(payload(headers))"
-SLIM_CREATED_AT_METADATA_HEADERS = ["Date"]
 
 EMAIL_FIELDS = [
     "cc",
@@ -356,65 +347,14 @@ def _full_thread_from_id(
         )
 
 
-def _slim_thread_created_at(
-    thread_id: str,
-    user_email: str,
-    gmail_service: GmailService,
-) -> datetime | None:
-    """Minimal per-thread fetch to derive the thread's creation time.
-
-    Mirrors the full path: messages arrive oldest-first, so the first message's
-    Date header is the thread's creation time. Failures are swallowed so this
-    additive backfill can never break perm/prune sync.
-    """
-    try:
-        thread = next(
-            execute_single_retrieval(
-                retrieval_function=gmail_service.users()  # ty: ignore[unresolved-attribute]
-                .threads()
-                .get,
-                list_key=None,
-                userId=user_email,
-                fields=SLIM_CREATED_AT_FIELDS,
-                format="metadata",
-                metadataHeaders=SLIM_CREATED_AT_METADATA_HEADERS,
-                id=thread_id,
-                continue_on_404_or_403=True,
-            ),
-            None,
-        )
-    except Exception as e:
-        logger.warning(
-            "Failed to fetch created_at for Gmail thread %s: %r", thread_id, e
-        )
-        return None
-
-    if thread is None:
-        return None
-
-    for message in thread.get("messages", []):
-        headers = message.get("payload", {}).get("headers", [])
-        for header in headers:
-            if (header.get("name") or "").lower() != "date":
-                continue
-            try:
-                return time_str_to_utc(header["value"])
-            except (ValueError, OverflowError) as e:
-                logger.warning(
-                    "Skipping unparseable Gmail Date header on thread %s: %r (%s)",
-                    thread_id,
-                    header.get("value"),
-                    e,
-                )
-                return None
-    return None
-
-
 def _slim_thread_from_id(
     thread_id: str,
     user_email: str,
-    gmail_service: GmailService,
+    gmail_service: GmailService,  # noqa: ARG001
 ) -> SlimDocument:
+    # doc_created_at is left None: the Gmail thread list returns only IDs, and
+    # fetching the Date header would cost an extra API call per thread. Going-
+    # forward creation time is set on the full indexing path (thread_to_document).
     return SlimDocument(
         id=thread_id,
         external_access=ExternalAccess(
@@ -422,8 +362,6 @@ def _slim_thread_from_id(
             external_user_group_ids=set(),
             is_public=False,
         ),
-        # Slim listing lacks dates; do a minimal per-thread fetch to backfill.
-        doc_created_at=_slim_thread_created_at(thread_id, user_email, gmail_service),
     )
 
 
@@ -556,11 +494,6 @@ class GmailConnector(
                                 external_user_emails={user_email},
                                 external_user_group_ids=set(),
                                 is_public=False,
-                            ),
-                            # Slim listing lacks dates; do a minimal per-thread
-                            # fetch to backfill created_at.
-                            doc_created_at=_slim_thread_created_at(
-                                thread["id"], user_email, gmail_service
                             ),
                         )
                     )

--- a/backend/onyx/connectors/gmail/connector.py
+++ b/backend/onyx/connectors/gmail/connector.py
@@ -1,6 +1,7 @@
 from base64 import urlsafe_b64decode
 from collections.abc import Callable
 from collections.abc import Iterator
+from datetime import datetime
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -59,6 +60,14 @@ PAYLOAD_FIELDS = f"payload(headers, {PARTS_FIELDS})"
 MESSAGES_FIELDS = f"messages(id, {PAYLOAD_FIELDS})"
 THREADS_FIELDS = f"threads(id, {MESSAGES_FIELDS})"
 THREAD_FIELDS = f"id, {MESSAGES_FIELDS}"
+
+# The slim listing (THREAD_LIST_FIELDS) only returns thread IDs. To backfill
+# doc_created_at during perm/prune sync without a full re-index, the slim path
+# does one extra minimal per-thread fetch. format="metadata" + metadataHeaders
+# make the server return only the Date header per message (the `fields` mask
+# can't filter within the headers list); the mask trims the rest of the envelope.
+SLIM_CREATED_AT_FIELDS = "id, messages(payload(headers))"
+SLIM_CREATED_AT_METADATA_HEADERS = ["Date"]
 
 EMAIL_FIELDS = [
     "cc",
@@ -224,6 +233,7 @@ def thread_to_document(
 
     sections = []
     semantic_identifier = ""
+    created_at = None
     updated_at = None
     from_emails: dict[str, str | None] = {}
     other_emails: dict[str, str | None] = {}
@@ -249,6 +259,22 @@ def thread_to_document(
 
         if message_metadata.get("updated_at"):
             updated_at = message_metadata.get("updated_at")
+            # Messages arrive oldest-first, so the first Date header is the
+            # thread's creation time.
+            if not created_at:
+                created_at = message_metadata.get("updated_at")
+
+    created_at_datetime = None
+    if created_at:
+        try:
+            created_at_datetime = time_str_to_utc(created_at)
+        except (ValueError, OverflowError) as e:
+            logger.warning(
+                "Skipping unparseable Gmail Date header on thread %s: %r (%s)",
+                full_thread.get("id"),
+                created_at,
+                e,
+            )
 
     updated_at_datetime = None
     if updated_at:
@@ -286,6 +312,7 @@ def thread_to_document(
         # This is used to perform permission sync
         primary_owners=primary_owners,
         secondary_owners=secondary_owners,
+        doc_created_at=created_at_datetime,
         doc_updated_at=updated_at_datetime,
         # Not adding emails to metadata because it's already in the sections
         metadata={},
@@ -329,10 +356,64 @@ def _full_thread_from_id(
         )
 
 
+def _slim_thread_created_at(
+    thread_id: str,
+    user_email: str,
+    gmail_service: GmailService,
+) -> datetime | None:
+    """Minimal per-thread fetch to derive the thread's creation time.
+
+    Mirrors the full path: messages arrive oldest-first, so the first message's
+    Date header is the thread's creation time. Failures are swallowed so this
+    additive backfill can never break perm/prune sync.
+    """
+    try:
+        thread = next(
+            execute_single_retrieval(
+                retrieval_function=gmail_service.users()  # ty: ignore[unresolved-attribute]
+                .threads()
+                .get,
+                list_key=None,
+                userId=user_email,
+                fields=SLIM_CREATED_AT_FIELDS,
+                format="metadata",
+                metadataHeaders=SLIM_CREATED_AT_METADATA_HEADERS,
+                id=thread_id,
+                continue_on_404_or_403=True,
+            ),
+            None,
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to fetch created_at for Gmail thread %s: %r", thread_id, e
+        )
+        return None
+
+    if thread is None:
+        return None
+
+    for message in thread.get("messages", []):
+        headers = message.get("payload", {}).get("headers", [])
+        for header in headers:
+            if (header.get("name") or "").lower() != "date":
+                continue
+            try:
+                return time_str_to_utc(header["value"])
+            except (ValueError, OverflowError) as e:
+                logger.warning(
+                    "Skipping unparseable Gmail Date header on thread %s: %r (%s)",
+                    thread_id,
+                    header.get("value"),
+                    e,
+                )
+                return None
+    return None
+
+
 def _slim_thread_from_id(
     thread_id: str,
     user_email: str,
-    gmail_service: GmailService,  # noqa: ARG001
+    gmail_service: GmailService,
 ) -> SlimDocument:
     return SlimDocument(
         id=thread_id,
@@ -341,6 +422,8 @@ def _slim_thread_from_id(
             external_user_group_ids=set(),
             is_public=False,
         ),
+        # Slim listing lacks dates; do a minimal per-thread fetch to backfill.
+        doc_created_at=_slim_thread_created_at(thread_id, user_email, gmail_service),
     )
 
 
@@ -473,6 +556,11 @@ class GmailConnector(
                                 external_user_emails={user_email},
                                 external_user_group_ids=set(),
                                 is_public=False,
+                            ),
+                            # Slim listing lacks dates; do a minimal per-thread
+                            # fetch to backfill created_at.
+                            doc_created_at=_slim_thread_created_at(
+                                thread["id"], user_email, gmail_service
                             ),
                         )
                     )

--- a/backend/onyx/connectors/gong/connector.py
+++ b/backend/onyx/connectors/gong/connector.py
@@ -353,6 +353,9 @@ class GongConnector(CheckpointedConnector[GongConnectorCheckpoint]):
             sections=[TextSection(link=call_metadata["url"], text=transcript_text)],
             source=DocumentSource.GONG,
             semantic_identifier=call_title or "Untitled",
+            doc_created_at=datetime.fromisoformat(call_time_str).astimezone(
+                timezone.utc
+            ),
             doc_updated_at=datetime.fromisoformat(call_time_str).astimezone(
                 timezone.utc
             ),

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -885,6 +885,11 @@ def _convert_drive_item_to_document(
                     owner.get("displayName", "") for owner in file.get("owners", [])
                 ),
             },
+            doc_created_at=(
+                datetime.fromisoformat(created_time.replace("Z", "+00:00"))
+                if (created_time := file.get("createdTime"))
+                else None
+            ),
             doc_updated_at=datetime.fromisoformat(
                 file.get("modifiedTime", "").replace("Z", "+00:00")
             ),
@@ -961,4 +966,9 @@ def build_slim_document(
         id=onyx_document_id_from_drive_file(file),
         external_access=external_access,
         parent_hierarchy_raw_node_id=(file.get("parents") or [None])[0],
+        doc_created_at=(
+            datetime.fromisoformat(created_time.replace("Z", "+00:00"))
+            if (created_time := file.get("createdTime"))
+            else None
+        ),
     )

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -53,15 +53,15 @@ PERMISSION_FULL_DESCRIPTION = (
 )
 FILE_FIELDS = (
     "nextPageToken, files(mimeType, id, name, driveId, parents, "
-    "modifiedTime, webViewLink, shortcutDetails, owners(emailAddress), size)"
+    "createdTime, modifiedTime, webViewLink, shortcutDetails, owners(emailAddress), size)"
 )
 FILE_FIELDS_WITH_PERMISSIONS = (
     f"nextPageToken, files(mimeType, id, name, driveId, parents, {PERMISSION_FULL_DESCRIPTION}, permissionIds, "
-    "modifiedTime, webViewLink, shortcutDetails, owners(emailAddress), size)"
+    "createdTime, modifiedTime, webViewLink, shortcutDetails, owners(emailAddress), size)"
 )
 SLIM_FILE_FIELDS = (
     f"nextPageToken, files(mimeType, driveId, id, name, parents, {PERMISSION_FULL_DESCRIPTION}, "
-    "permissionIds, webViewLink, owners(emailAddress), modifiedTime)"
+    "permissionIds, webViewLink, owners(emailAddress), createdTime, modifiedTime)"
 )
 FOLDER_FIELDS = (
     "nextPageToken, files(id, name, mimeType, permissions, modifiedTime, webViewLink, "

--- a/backend/onyx/connectors/guru/connector.py
+++ b/backend/onyx/connectors/guru/connector.py
@@ -82,6 +82,7 @@ class GuruConnector(LoadConnector, PollConnector):
                 link = GURU_CARDS_URL + card["slug"]
                 content_text = parse_html_page_basic(card["content"])
                 last_updated = time_str_to_utc(card["lastModified"])
+                date_created = time_str_to_utc(card["dateCreated"])
                 last_verified = (
                     time_str_to_utc(card.get("lastVerified"))
                     if card.get("lastVerified")
@@ -124,6 +125,8 @@ class GuruConnector(LoadConnector, PollConnector):
                         source=DocumentSource.GURU,
                         semantic_identifier=title,
                         doc_updated_at=latest_time,
+                        # NOTE: doc_created_at population not yet verified against live data
+                        doc_created_at=date_created,
                         primary_owners=[author] if author is not None else None,
                         # Can add verifies and commenters later
                         metadata=metadata_dict,

--- a/backend/onyx/connectors/highspot/connector.py
+++ b/backend/onyx/connectors/highspot/connector.py
@@ -1,5 +1,6 @@
 import os
 from datetime import datetime
+from datetime import timezone
 from io import BytesIO
 from typing import Any
 from typing import Dict
@@ -31,6 +32,19 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 _SLIM_BATCH_SIZE = 1000
+
+
+def _parse_highspot_timestamp(value: Any) -> datetime | None:
+    """Parse a Highspot ISO timestamp into a tz-aware UTC datetime, or None."""
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
 
 
 class HighspotSpot(BaseModel):
@@ -239,7 +253,13 @@ class HighspotConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync)
                                                 item_details.get("can_download", False)
                                             ),
                                         },
-                                        doc_updated_at=item_details.get("date_updated"),
+                                        doc_updated_at=_parse_highspot_timestamp(
+                                            item_details.get("date_updated")
+                                        ),
+                                        # NOTE: doc_created_at population not yet verified against live data
+                                        doc_created_at=_parse_highspot_timestamp(
+                                            item_details.get("date_added")
+                                        ),
                                     )
                                 )
 
@@ -423,8 +443,32 @@ class HighspotConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync)
                                 logger.warning("Item without ID found, skipping")
                                 continue
 
+                            # Prefer the list payload; fall back to a per-item
+                            # detail fetch when the list omits the creation time.
+                            date_added = item.get("date_added")
+                            if date_added is None:
+                                try:
+                                    item_details = self.client.get_item(item_id)
+                                    date_added = (
+                                        item_details.get("date_added")
+                                        if item_details
+                                        else None
+                                    )
+                                except HighspotClientError as e:
+                                    logger.warning(
+                                        "Could not fetch created_at for item %s: %s",
+                                        item_id,
+                                        str(e),
+                                    )
+
                             slim_doc_batch.append(
-                                SlimDocument(id=f"HIGHSPOT_{item_id}")
+                                SlimDocument(
+                                    id=f"HIGHSPOT_{item_id}",
+                                    # NOTE: doc_created_at population not yet verified against live data
+                                    doc_created_at=_parse_highspot_timestamp(
+                                        date_added
+                                    ),
+                                )
                             )
 
                             if len(slim_doc_batch) >= _SLIM_BATCH_SIZE:

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -738,6 +738,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                     sections=cast(list[TextSection | ImageSection], sections),
                     source=DocumentSource.HUBSPOT,
                     semantic_identifier=title,
+                    doc_created_at=ticket.created_at.replace(tzinfo=timezone.utc),
                     doc_updated_at=ticket.updated_at.replace(tzinfo=timezone.utc),
                     metadata=metadata,
                     doc_metadata={
@@ -893,6 +894,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                     sections=cast(list[TextSection | ImageSection], sections),
                     source=DocumentSource.HUBSPOT,
                     semantic_identifier=title,
+                    doc_created_at=company.created_at.replace(tzinfo=timezone.utc),
                     doc_updated_at=company.updated_at.replace(tzinfo=timezone.utc),
                     metadata=metadata,
                     doc_metadata={
@@ -1046,6 +1048,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                     sections=cast(list[TextSection | ImageSection], sections),
                     source=DocumentSource.HUBSPOT,
                     semantic_identifier=title,
+                    doc_created_at=deal.created_at.replace(tzinfo=timezone.utc),
                     doc_updated_at=deal.updated_at.replace(tzinfo=timezone.utc),
                     metadata=metadata,
                     doc_metadata={
@@ -1219,6 +1222,7 @@ class HubSpotConnector(LoadConnector, PollConnector):
                     sections=cast(list[TextSection | ImageSection], sections),
                     source=DocumentSource.HUBSPOT,
                     semantic_identifier=title,
+                    doc_created_at=contact.created_at.replace(tzinfo=timezone.utc),
                     doc_updated_at=contact.updated_at.replace(tzinfo=timezone.utc),
                     metadata=metadata,
                     doc_metadata={

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -490,6 +490,8 @@ def process_jira_issue(
         semantic_identifier=f"{issue.key}: {issue.fields.summary}",
         title=f"{issue.key} {issue.fields.summary}",
         doc_updated_at=time_str_to_utc(issue.fields.updated),
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=time_str_to_utc(issue.fields.created),
         primary_owners=list(people) or None,
         metadata=metadata_dict,
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
@@ -976,6 +978,8 @@ class JiraConnector(
                 issue_key = best_effort_get_field_from_issue(issue, _FIELD_KEY)
                 doc_id = build_jira_url(self.jira_base, issue_key)
 
+                created = best_effort_get_field_from_issue(issue, _FIELD_CREATED)
+
                 slim_doc_batch.append(
                     SlimDocument(
                         id=doc_id,
@@ -990,6 +994,8 @@ class JiraConnector(
                             if project_key
                             else None
                         ),
+                        # NOTE: doc_created_at population not yet verified against live data
+                        doc_created_at=time_str_to_utc(created) if created else None,
                     )
                 )
                 current_offset += 1

--- a/backend/onyx/connectors/linear/connector.py
+++ b/backend/onyx/connectors/linear/connector.py
@@ -348,6 +348,8 @@ class LinearConnector(LoadConnector, PollConnector, OAuthConnector):
                         semantic_identifier=f"[{node['identifier']}] {node['title']}",
                         title=node["title"],
                         doc_updated_at=time_str_to_utc(node["updatedAt"]),
+                        # NOTE: doc_created_at population not yet verified against live data
+                        doc_created_at=time_str_to_utc(node["createdAt"]),
                         doc_metadata={
                             "hierarchy": {
                                 "source_path": [team_name],

--- a/backend/onyx/connectors/loopio/connector.py
+++ b/backend/onyx/connectors/loopio/connector.py
@@ -150,6 +150,7 @@ class LoopioConnector(LoadConnector, PollConnector):
                 )
 
                 last_updated = time_str_to_utc(entry["lastUpdatedDate"])
+                created = time_str_to_utc(entry["createdDate"])
                 last_reviewed = (
                     time_str_to_utc(entry["lastReviewedDate"])
                     if entry.get("lastReviewedDate")
@@ -182,6 +183,8 @@ class LoopioConnector(LoadConnector, PollConnector):
                         source=DocumentSource.LOOPIO,
                         semantic_identifier=questions[0],
                         doc_updated_at=latest_time,
+                        # NOTE: doc_created_at population not yet verified against live data
+                        doc_created_at=created,
                         primary_owners=primary_owners,
                         secondary_owners=secondary_owners,
                         metadata={

--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -961,6 +961,9 @@ class NotionConnector(LoadConnector, PollConnector):
                         doc_updated_at=datetime.fromisoformat(
                             page.last_edited_time
                         ).astimezone(timezone.utc),
+                        doc_created_at=datetime.fromisoformat(
+                            page.created_time
+                        ).astimezone(timezone.utc),
                         metadata={},
                         parent_hierarchy_raw_node_id=parent_raw_id,
                     )

--- a/backend/onyx/connectors/outline/connector.py
+++ b/backend/onyx/connectors/outline/connector.py
@@ -77,6 +77,11 @@ class OutlineConnector(LoadConnector, PollConnector):
             if collection.get("updatedAt") is not None
             else None
         )
+        created_at_str = (
+            str(collection.get("createdAt"))
+            if collection.get("createdAt") is not None
+            else None
+        )
         return Document(
             id="outline_collection__" + str(collection.get("id")),
             sections=[TextSection(link=url, text=html.unescape(text))],
@@ -85,6 +90,10 @@ class OutlineConnector(LoadConnector, PollConnector):
             title=title,
             doc_updated_at=(
                 time_str_to_utc(updated_at_str) if updated_at_str is not None else None
+            ),
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=(
+                time_str_to_utc(created_at_str) if created_at_str is not None else None
             ),
             metadata={"type": "collection"},
         )
@@ -103,6 +112,11 @@ class OutlineConnector(LoadConnector, PollConnector):
             if document.get("updatedAt") is not None
             else None
         )
+        created_at_str = (
+            str(document.get("createdAt"))
+            if document.get("createdAt") is not None
+            else None
+        )
         return Document(
             id="outline_document__" + str(document.get("id")),
             sections=[TextSection(link=url, text=html.unescape(text))],
@@ -111,6 +125,10 @@ class OutlineConnector(LoadConnector, PollConnector):
             title=title,
             doc_updated_at=(
                 time_str_to_utc(updated_at_str) if updated_at_str is not None else None
+            ),
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=(
+                time_str_to_utc(created_at_str) if created_at_str is not None else None
             ),
             metadata={"type": "document"},
         )

--- a/backend/onyx/connectors/productboard/connector.py
+++ b/backend/onyx/connectors/productboard/connector.py
@@ -5,7 +5,6 @@ from typing import cast
 
 import requests
 from bs4 import BeautifulSoup
-from dateutil import parser
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import REQUEST_TIMEOUT_SECONDS
@@ -120,6 +119,8 @@ class ProductboardConnector(PollConnector):
                 semantic_identifier=feature["name"],
                 source=DocumentSource.PRODUCTBOARD,
                 doc_updated_at=time_str_to_utc(feature["updatedAt"]),
+                # NOTE: doc_created_at population not yet verified against live data
+                doc_created_at=time_str_to_utc(feature["createdAt"]),
                 primary_owners=experts,
                 metadata=metadata,
             )
@@ -143,6 +144,8 @@ class ProductboardConnector(PollConnector):
                 semantic_identifier=component["name"],
                 source=DocumentSource.PRODUCTBOARD,
                 doc_updated_at=time_str_to_utc(component["updatedAt"]),
+                # NOTE: doc_created_at population not yet verified against live data
+                doc_created_at=time_str_to_utc(component["createdAt"]),
                 primary_owners=experts,
                 metadata={
                     "entity_type": "component",
@@ -169,6 +172,8 @@ class ProductboardConnector(PollConnector):
                 semantic_identifier=product["name"],
                 source=DocumentSource.PRODUCTBOARD,
                 doc_updated_at=time_str_to_utc(product["updatedAt"]),
+                # NOTE: doc_created_at population not yet verified against live data
+                doc_created_at=time_str_to_utc(product["createdAt"]),
                 primary_owners=experts,
                 metadata={
                     "entity_type": "product",
@@ -199,28 +204,23 @@ class ProductboardConnector(PollConnector):
                 semantic_identifier=objective["name"],
                 source=DocumentSource.PRODUCTBOARD,
                 doc_updated_at=time_str_to_utc(objective["updatedAt"]),
+                # NOTE: doc_created_at population not yet verified against live data
+                doc_created_at=time_str_to_utc(objective["createdAt"]),
                 primary_owners=experts,
                 metadata=metadata,
             )
 
-    def _is_updated_at_out_of_time_range(
+    def _is_out_of_time_range(
         self,
         document: Document,
         start: SecondsSinceUnixEpoch,
         end: SecondsSinceUnixEpoch,
     ) -> bool:
-        updated_at = cast(str, document.metadata.get("updated_at", ""))
-        if updated_at:
-            updated_at_datetime = parser.parse(updated_at)
-            if (
-                updated_at_datetime.timestamp() < start
-                or updated_at_datetime.timestamp() > end
-            ):
-                return True
-        else:
+        if document.doc_updated_at is None:
             logger.debug("Unable to find updated_at for document '%s'", document.id)
+            return False
 
-        return False
+        return not (start <= document.doc_updated_at.timestamp() <= end)
 
     def poll_source(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
@@ -247,7 +247,7 @@ class ProductboardConnector(PollConnector):
             objective_documents,
         ):
             # skip documents that are not in the time range
-            if self._is_updated_at_out_of_time_range(document, start, end):
+            if self._is_out_of_time_range(document, start, end):
                 continue
 
             document_batch.append(document)

--- a/backend/onyx/connectors/salesforce/connector.py
+++ b/backend/onyx/connectors/salesforce/connector.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from typing import Any
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import LoadConnector
@@ -31,6 +32,7 @@ from onyx.connectors.salesforce.onyx_salesforce import OnyxSalesforce
 from onyx.connectors.salesforce.salesforce_calls import fetch_all_csvs_in_parallel
 from onyx.connectors.salesforce.sqlite_functions import OnyxSalesforceSQLite
 from onyx.connectors.salesforce.utils import ACCOUNT_OBJECT_TYPE
+from onyx.connectors.salesforce.utils import CREATED_FIELD
 from onyx.connectors.salesforce.utils import ID_FIELD
 from onyx.connectors.salesforce.utils import MODIFIED_FIELD
 from onyx.connectors.salesforce.utils import NAME_FIELD
@@ -967,6 +969,10 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnectorWithPermSyn
                 # field_set.add(NAME_FIELD) # does not always exist
                 field_set.add(ID_FIELD)
                 field_set.add(MODIFIED_FIELD)
+                # Like NAME_FIELD, CreatedDate isn't on every sobject; only
+                # request it when present so it can't break the whole SOQL query.
+                if CREATED_FIELD in sf_client.get_queryable_fields_by_type(parent_type):
+                    field_set.add(CREATED_FIELD)
 
                 # Use only the specified fields
                 type_to_queryable_fields[parent_type] = field_set
@@ -1160,12 +1166,24 @@ class SalesforceConnector(LoadConnector, PollConnector, SlimConnectorWithPermSyn
             # parent_object_type comes from connector config; SOQL has no
             # parameter binding for table identifiers, so validate it.
             validate_sf_identifier(parent_object_type)
-            query = f"SELECT Id FROM {parent_object_type}"  # noqa: S608
+            # CreatedDate isn't on every sobject; only request it when present so
+            # it can't break the whole SOQL query. Checked once per parent type.
+            has_created_field = (
+                CREATED_FIELD
+                in self.sf_client.get_queryable_fields_by_type(parent_object_type)
+            )
+            select_fields = "Id, CreatedDate" if has_created_field else "Id"
+            query = f"SELECT {select_fields} FROM {parent_object_type}"  # noqa: S608
             query_result = self.sf_client.safe_query_all(query)
             doc_metadata_list.extend(
                 SlimDocument(
                     id=f"{ID_PREFIX}{instance_dict.get('Id', '')}",
                     external_access=None,
+                    doc_created_at=(
+                        time_str_to_utc(instance_dict.get(CREATED_FIELD))
+                        if instance_dict.get(CREATED_FIELD)
+                        else None
+                    ),
                 )
                 for instance_dict in query_result["records"]
             )

--- a/backend/onyx/connectors/salesforce/doc_conversion.py
+++ b/backend/onyx/connectors/salesforce/doc_conversion.py
@@ -10,6 +10,7 @@ from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.connectors.salesforce.onyx_salesforce import OnyxSalesforce
 from onyx.connectors.salesforce.sqlite_functions import OnyxSalesforceSQLite
+from onyx.connectors.salesforce.utils import CREATED_FIELD
 from onyx.connectors.salesforce.utils import ID_FIELD
 from onyx.connectors.salesforce.utils import MODIFIED_FIELD
 from onyx.connectors.salesforce.utils import NAME_FIELD
@@ -170,6 +171,8 @@ def convert_sf_query_result_to_doc(
 
     base_url = f"https://{sf_client.sf_instance}"
     extracted_doc_updated_at = time_str_to_utc(record[MODIFIED_FIELD])
+    created_date = record.get(CREATED_FIELD)
+    extracted_doc_created_at = time_str_to_utc(created_date) if created_date else None
     extracted_semantic_identifier = record.get(NAME_FIELD) or record.get(
         ID_FIELD, "Unknown Object"
     )
@@ -194,6 +197,8 @@ def convert_sf_query_result_to_doc(
         source=DocumentSource.SALESFORCE,
         semantic_identifier=extracted_semantic_identifier,
         doc_updated_at=extracted_doc_updated_at,
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=extracted_doc_created_at,
         primary_owners=primary_owner_list,
         metadata={},
     )
@@ -211,6 +216,8 @@ def convert_sf_object_to_doc(
     onyx_salesforce_id = f"{ID_PREFIX}{salesforce_id}"
     base_url = f"https://{sf_instance}"
     extracted_doc_updated_at = time_str_to_utc(object_dict[MODIFIED_FIELD])
+    created_date = object_dict.get(CREATED_FIELD)
+    extracted_doc_created_at = time_str_to_utc(created_date) if created_date else None
     extracted_semantic_identifier = object_dict.get(NAME_FIELD) or object_dict.get(
         ID_FIELD, "Unknown Object"
     )
@@ -237,6 +244,8 @@ def convert_sf_object_to_doc(
         source=DocumentSource.SALESFORCE,
         semantic_identifier=extracted_semantic_identifier,
         doc_updated_at=extracted_doc_updated_at,
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=extracted_doc_created_at,
         primary_owners=primary_owner_list,
         metadata={},
     )

--- a/backend/onyx/connectors/salesforce/utils.py
+++ b/backend/onyx/connectors/salesforce/utils.py
@@ -5,6 +5,7 @@ from typing import Any
 
 NAME_FIELD = "Name"
 MODIFIED_FIELD = "LastModifiedDate"
+CREATED_FIELD = "CreatedDate"
 ID_FIELD = "Id"
 ACCOUNT_OBJECT_TYPE = "Account"
 USER_OBJECT_TYPE = "User"

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -166,6 +166,7 @@ class DriveItemData(BaseModel):
     size: int | None = None
     mime_type: str | None = None
     download_url: str | None = None
+    created_datetime: datetime | None = None
     last_modified_datetime: datetime | None = None
     last_modified_by_display_name: str | None = None
     last_modified_by_email: str | None = None
@@ -179,6 +180,11 @@ class DriveItemData(BaseModel):
         if isinstance(last_mod_raw, str):
             last_mod = datetime.fromisoformat(last_mod_raw.replace("Z", "+00:00"))
 
+        created_raw = item.get("createdDateTime")
+        created: datetime | None = None
+        if isinstance(created_raw, str):
+            created = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+
         last_modified_by = item.get("lastModifiedBy", {}).get("user", {})
         parent_ref = item.get("parentReference", {})
 
@@ -189,6 +195,7 @@ class DriveItemData(BaseModel):
             size=item.get("size"),
             mime_type=item.get("file", {}).get("mimeType"),
             download_url=item.get("@microsoft.graph.downloadUrl"),
+            created_datetime=created,
             last_modified_datetime=last_mod,
             last_modified_by_display_name=last_modified_by.get("displayName"),
             last_modified_by_email=(
@@ -936,6 +943,11 @@ def _convert_driveitem_to_document_with_permissions(
         source=DocumentSource.SHAREPOINT,
         semantic_identifier=driveitem.name,
         external_access=external_access,
+        doc_created_at=(
+            driveitem.created_datetime.replace(tzinfo=timezone.utc)
+            if driveitem.created_datetime
+            else None
+        ),
         doc_updated_at=(
             driveitem.last_modified_datetime.replace(tzinfo=timezone.utc)
             if driveitem.last_modified_datetime
@@ -1102,6 +1114,7 @@ def _convert_sitepage_to_document(
         source=DocumentSource.SHAREPOINT,
         external_access=external_access,
         semantic_identifier=semantic_identifier,
+        doc_created_at=created_datetime,
         doc_updated_at=last_modified_datetime or created_datetime,
         primary_owners=primary_owners,
         metadata=(
@@ -1114,6 +1127,17 @@ def _convert_sitepage_to_document(
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
     )
     return doc
+
+
+def _parse_sharepoint_datetime(value: Any) -> datetime | None:
+    """Parse a SharePoint Graph datetime that may be an ISO string or datetime."""
+    if not value:
+        return None
+    if isinstance(value, str):
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if not value.tzinfo:
+        return value.replace(tzinfo=timezone.utc)
+    return value
 
 
 def _convert_driveitem_to_slim_document(
@@ -1140,6 +1164,11 @@ def _convert_driveitem_to_slim_document(
         id=driveitem.id,
         external_access=external_access,
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+        doc_created_at=(
+            driveitem.created_datetime.replace(tzinfo=timezone.utc)
+            if driveitem.created_datetime
+            else None
+        ),
     )
 
 
@@ -1166,6 +1195,7 @@ def _convert_sitepage_to_slim_document(
         id=page_id,
         external_access=external_access,
         parent_hierarchy_raw_node_id=parent_hierarchy_raw_node_id,
+        doc_created_at=_parse_sharepoint_datetime(site_page.get("createdDateTime")),
     )
 
 
@@ -2255,6 +2285,13 @@ class SharepointConnector(
                                     id=driveitem.id,
                                     external_access=ExternalAccess.empty(),
                                     parent_hierarchy_raw_node_id=parent_hierarchy_url,
+                                    doc_created_at=(
+                                        driveitem.created_datetime.replace(
+                                            tzinfo=timezone.utc
+                                        )
+                                        if driveitem.created_datetime
+                                        else None
+                                    ),
                                 )
                             )
                     except Exception as e:
@@ -2298,6 +2335,9 @@ class SharepointConnector(
                                         id=page_id,
                                         external_access=ExternalAccess.empty(),
                                         parent_hierarchy_raw_node_id=site_descriptor.url,
+                                        doc_created_at=_parse_sharepoint_datetime(
+                                            site_page.get("createdDateTime")
+                                        ),
                                     )
                                 )
                         except Exception as e:

--- a/backend/onyx/connectors/slab/connector.py
+++ b/backend/onyx/connectors/slab/connector.py
@@ -11,6 +11,7 @@ from dateutil import parser
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
@@ -34,6 +35,16 @@ SLAB_GRAPHQL_MAX_TRIES = 10
 SLAB_API_URL = "https://api.slab.com/v1/graphql"
 
 _SLIM_BATCH_SIZE = 1000
+
+
+def _parse_slab_created_at(value: str | None) -> datetime | None:
+    """Parse a Slab `insertedAt` timestamp into a tz-aware UTC datetime, or None."""
+    if not value:
+        return None
+    try:
+        return time_str_to_utc(value)
+    except ValueError:
+        return None
 
 
 def run_graphql_request(
@@ -86,6 +97,27 @@ def get_all_post_ids(bot_token: str) -> list[str]:
     return [post["id"] for post in posts]
 
 
+def get_all_posts_with_created_at(bot_token: str) -> list[dict[str, str]]:
+    """Return `id` + `insertedAt` for every post in one listing query.
+
+    Lets the slim path backfill doc_created_at without a per-post fetch.
+    """
+    query = """
+        query GetAllPostsWithCreatedAt {
+            organization {
+                posts {
+                    id
+                    insertedAt
+                }
+            }
+        }
+        """
+
+    graphql_query = {"query": query}
+    results = json.loads(run_graphql_request(graphql_query, bot_token))
+    return results["data"]["organization"]["posts"]
+
+
 def get_post_by_id(post_id: str, bot_token: str) -> dict[str, str]:
     query = """
         query GetPostById($postId: ID!) {
@@ -94,6 +126,7 @@ def get_post_by_id(post_id: str, bot_token: str) -> dict[str, str]:
                 content
                 linkAccess
                 updatedAt
+                insertedAt
             }
         }
         """
@@ -217,6 +250,7 @@ class SlabConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
                     source=DocumentSource.SLAB,
                     semantic_identifier=post["title"],
                     metadata={},
+                    doc_created_at=_parse_slab_created_at(post["insertedAt"]),
                 )
             )
 
@@ -247,10 +281,11 @@ class SlabConnector(LoadConnector, PollConnector, SlimConnectorWithPermSync):
         callback: IndexingHeartbeatInterface | None = None,  # noqa: ARG002
     ) -> GenerateSlimDocumentOutput:
         slim_doc_batch: list[SlimDocument | HierarchyNode] = []
-        for post_id in get_all_post_ids(self.slab_bot_token):
+        for post in get_all_posts_with_created_at(self.slab_bot_token):
             slim_doc_batch.append(
                 SlimDocument(
-                    id=post_id,
+                    id=post["id"],
+                    doc_created_at=_parse_slab_created_at(post["insertedAt"]),
                 )
             )
             if len(slim_doc_batch) >= _SLIM_BATCH_SIZE:

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -336,6 +336,7 @@ def thread_to_doc(
         source=DocumentSource.SLACK,
         semantic_identifier=doc_sem_id,
         doc_updated_at=get_latest_message_time(thread),
+        doc_created_at=datetime.fromtimestamp(float(thread[0]["ts"]), tz=timezone.utc),
         primary_owners=valid_experts,
         doc_metadata={
             "hierarchy": {
@@ -709,6 +710,10 @@ def _get_all_doc_ids(
                         ),
                         external_access=external_access,
                         parent_hierarchy_raw_node_id=channel_id,
+                        # Slack ts is the thread root's creation time (epoch seconds)
+                        doc_created_at=datetime.fromtimestamp(
+                            float(message["ts"]), tz=timezone.utc
+                        ),
                     )
                 )
 

--- a/backend/onyx/connectors/teams/connector.py
+++ b/backend/onyx/connectors/teams/connector.py
@@ -327,6 +327,8 @@ class TeamsConnector(
                         SlimDocument(
                             id=message.id,
                             external_access=external_access,
+                            # NOTE: doc_created_at population not yet verified against live data
+                            doc_created_at=message.created_date_time,
                         )
                     )
 
@@ -488,6 +490,8 @@ def _convert_thread_to_document(
         source=DocumentSource.TEAMS,
         semantic_identifier=semantic_string,
         title="",  # teams threads don't really have a "title"
+        # NOTE: doc_created_at population not yet verified against live data
+        doc_created_at=top_message.created_date_time,
         doc_updated_at=most_recent_message_datetime,
         primary_owners=expert_infos,
         metadata={},

--- a/backend/onyx/connectors/testrail/connector.py
+++ b/backend/onyx/connectors/testrail/connector.py
@@ -387,6 +387,13 @@ class TestRailConnector(LoadConnector, PollConnector):
             else None
         )
 
+        created = case.get("created_on")
+        created_dt = (
+            datetime.fromtimestamp(created, tz=timezone.utc)
+            if isinstance(created, (int, float))
+            else None
+        )
+
         text_lines: list[str] = []
         if case.get("title"):
             text_lines.append(f"Title: {case['title']}")
@@ -476,6 +483,8 @@ class TestRailConnector(LoadConnector, PollConnector):
             sections=[TextSection(link=link, text=full_text)],
             metadata=metadata,
             doc_updated_at=updated_dt,
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=created_dt,
         )
 
     def _generate_documents(

--- a/backend/onyx/connectors/xenforo/connector.py
+++ b/backend/onyx/connectors/xenforo/connector.py
@@ -116,6 +116,8 @@ def scrape_page_posts(
                     "time": formatted_time,
                 },
                 doc_updated_at=post_date,
+                # NOTE: doc_created_at population not yet verified against live data
+                doc_created_at=post_date,
             )
 
             documents.append(document)

--- a/backend/onyx/connectors/zendesk/connector.py
+++ b/backend/onyx/connectors/zendesk/connector.py
@@ -241,6 +241,8 @@ def _article_to_document(
 
     updated_at = article.get("updated_at")
     update_time = time_str_to_utc(updated_at) if updated_at else None
+    created_at = article.get("created_at")
+    create_time = time_str_to_utc(created_at) if created_at else None
 
     # Build metadata
     metadata: dict[str, str | list[str]] = {
@@ -266,6 +268,7 @@ def _article_to_document(
         source=DocumentSource.ZENDESK,
         semantic_identifier=article["title"],
         doc_updated_at=update_time,
+        doc_created_at=create_time,
         primary_owners=[author] if author else None,
         metadata=metadata,
     )
@@ -316,6 +319,8 @@ def _ticket_to_document(
 
     updated_at = ticket.get("updated_at")
     update_time = time_str_to_utc(updated_at) if updated_at else None
+    created_at = ticket.get("created_at")
+    create_time = time_str_to_utc(created_at) if created_at else None
 
     metadata: dict[str, str | list[str]] = {}
     if status := ticket.get("status"):
@@ -362,6 +367,7 @@ def _ticket_to_document(
         source=DocumentSource.ZENDESK,
         semantic_identifier=f"Ticket #{ticket['id']}: {subject or 'No Subject'}",
         doc_updated_at=update_time,
+        doc_created_at=create_time,
         primary_owners=[submitter] if submitter else None,
         metadata=metadata,
     )
@@ -580,9 +586,13 @@ class ZendeskConnector(
                 self.client, start_time=int(start) if start else None
             )
             for article in articles:
+                created_at = article.get("created_at")
                 slim_doc_batch.append(
                     SlimDocument(
                         id=f"article:{article['id']}",
+                        doc_created_at=(
+                            time_str_to_utc(created_at) if created_at else None
+                        ),
                     )
                 )
                 if len(slim_doc_batch) >= _SLIM_BATCH_SIZE:
@@ -593,9 +603,13 @@ class ZendeskConnector(
                 self.client, start_time=int(start) if start else None
             )
             for ticket in tickets:
+                created_at = ticket.get("created_at")
                 slim_doc_batch.append(
                     SlimDocument(
                         id=f"zendesk_ticket_{ticket['id']}",
+                        doc_created_at=(
+                            time_str_to_utc(created_at) if created_at else None
+                        ),
                     )
                 )
                 if len(slim_doc_batch) >= _SLIM_BATCH_SIZE:

--- a/backend/onyx/connectors/zulip/connector.py
+++ b/backend/onyx/connectors/zulip/connector.py
@@ -170,6 +170,8 @@ class ZulipConnector(LoadConnector, PollConnector):
             semantic_identifier=f"{message.display_recipient} > {message.subject}",
             metadata=metadata,
             doc_updated_at=doc_time,  # Use most recent edit time or post time
+            # NOTE: doc_created_at population not yet verified against live data
+            doc_created_at=post_time,
         )
 
     def _get_docs(

--- a/backend/tests/unit/onyx/connectors/airtable/test_airtable_index_all.py
+++ b/backend/tests/unit/onyx/connectors/airtable/test_airtable_index_all.py
@@ -34,7 +34,12 @@ def _make_table_schema(
 
 
 def _make_record(record_id: str, fields: dict[str, Any]) -> dict[str, Any]:
-    return {"id": record_id, "fields": fields}
+    # Airtable always returns createdTime on every record.
+    return {
+        "id": record_id,
+        "createdTime": "2023-01-01T00:00:00.000Z",
+        "fields": fields,
+    }
 
 
 def _make_base_info(base_id: str, name: str) -> MagicMock:

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
@@ -80,13 +80,14 @@ def create_mock_page() -> Callable[..., dict[str, Any]]:
         updated: str = "2023-01-01T12:00:00.000+0000",
         content: str = "Test Content",
         labels: list[str] | None = None,
+        created: str = "2023-01-01T12:00:00.000+0000",
     ) -> dict[str, Any]:
         """Helper to create a mock Confluence page object"""
         return {
             "id": id,
             "title": title,
             "version": {"when": updated},
-            "history": {"lastUpdated": {"when": updated}},
+            "history": {"createdDate": created, "lastUpdated": {"when": updated}},
             "body": {"storage": {"value": content}},
             "metadata": {
                 "labels": {"results": [{"name": label} for label in (labels or [])]}

--- a/backend/tests/unit/onyx/connectors/confluence/test_slim_doc_image_skip.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_slim_doc_image_skip.py
@@ -20,12 +20,14 @@ from onyx.connectors.models import SlimDocument
 _PAGE_CQL = "PAGE_CQL"
 _ATTACHMENT_CQL = "ATTACHMENT_CQL"
 
+_CREATED = {"createdDate": "2023-01-01T12:00:00.000+0000"}
 _PAGE = {
     "id": "111",
     "_links": {"webui": "/spaces/X/pages/111/Page"},
     "restrictions": {},
     "space": {"key": "X"},
     "ancestors": [],
+    "history": _CREATED,
 }
 _IMAGE_ATTACHMENT = {
     "title": "diagram.png",
@@ -35,6 +37,7 @@ _IMAGE_ATTACHMENT = {
     },
     "restrictions": {},
     "space": {"key": "X"},
+    "history": _CREATED,
 }
 _PDF_ATTACHMENT = {
     "title": "spec.pdf",
@@ -42,6 +45,7 @@ _PDF_ATTACHMENT = {
     "_links": {"webui": "/download/attachments/111/spec.pdf"},
     "restrictions": {},
     "space": {"key": "X"},
+    "history": _CREATED,
 }
 
 

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_checkpointing.py
@@ -57,6 +57,7 @@ def create_mock_issue() -> Callable[..., MagicMock]:
         key: str = "TEST-123",
         summary: str = "Test Issue",
         updated: str = "2023-01-01T12:00:00.000+0000",
+        created: str = "2023-01-01T12:00:00.000+0000",
         description: str = "Test Description",
         labels: list[str] | None = None,
         project_key: str = "TEST",
@@ -72,6 +73,7 @@ def create_mock_issue() -> Callable[..., MagicMock]:
         mock_issue.key = key
         mock_issue.fields.summary = summary
         mock_issue.fields.updated = updated
+        mock_issue.fields.created = created
         mock_issue.fields.description = description
         mock_issue.fields.labels = labels or []
 

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_large_ticket_handling.py
@@ -34,6 +34,7 @@ def mock_issue_small() -> MagicMock:
     fields.assignee.emailAddress = "john@example.com"
     fields.summary = "Small Issue"
     fields.updated = "2023-01-01T00:00:00+0000"
+    fields.created = "2023-01-01T00:00:00+0000"
     fields.labels = []
 
     issue.fields = fields
@@ -59,6 +60,7 @@ def mock_issue_large() -> MagicMock:
     fields.assignee.emailAddress = "jane@example.com"
     fields.summary = "Large Issue"
     fields.updated = "2023-01-02T00:00:00+0000"
+    fields.created = "2023-01-02T00:00:00+0000"
     fields.labels = []
 
     issue.fields = fields

--- a/backend/tests/unit/onyx/connectors/jira/test_jira_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/jira/test_jira_slim_retrieval.py
@@ -18,6 +18,7 @@ def _make_issue(key: str, project_key: str = "TEST") -> MagicMock:
     issue.fields.project.key = project_key
     issue.fields.project.name = "Test Project"
     issue.fields.parent = None
+    issue.fields.created = "2023-01-01T12:00:00.000+0000"
     return issue
 
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_slim_and_validation.py
@@ -213,6 +213,7 @@ def test_retrieve_all_slim_docs_does_not_fetch_permissions(
     driveitem.id = "item-1"
     driveitem.web_url = SITE_URL + "/doc.docx"
     driveitem.parent_reference_path = None
+    driveitem.created_datetime = None
     mock_fetch_driveitems.return_value = [
         (driveitem, "Documents", None),
     ]


### PR DESCRIPTION
## Description
Connectors now populate the created_at field. This is done both on the regular indexing path and the slim indexing path (pruning / perm sync). 

A couple connectors to watch out for:
 - gmail: On slim run (pruning), we now request each message to get the created_at date. This should be transitory
 - 

## Tests
Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Populate doc_created_at across connectors on both full and slim paths, persist it, and patch it into the index without re-embedding. Slim/perm sync now emits creation times so time-based filters can use document creation.

- New Features
  - Coverage expanded across Airtable, Asana, Axero, Bitbucket, Bookstack, Braintrust, Canvas, ClickUp, Coda, Confluence, Discord/Discourse, Document360, Fireflies, Freshdesk, GitBook, GitHub/GitLab, Gmail, Gong, Google Drive, Guru, Highspot, HubSpot, Jira, Linear, Loopio, Notion, Outline, Productboard, Salesforce, SharePoint, Slab, Slack, Teams, TestRail, Xenforo, Zendesk, Zulip.
  - Slim/prune backfills creation time via minimal per-item fetches or added list fields, e.g. Gmail per-thread Date header (full indexing only; slim omits extra fetch), Confluence history.createdDate added to slim/pruning expansions, Google Drive createdTime in list/slim, Salesforce CreatedDate when available (incl. slim queries), Highspot date_added with fallback per-item fetch, Slab insertedAt via a single posts listing, SharePoint createdDateTime, Bitbucket PR created_on, plus created times on GitHub/GitLab issues/PRs and Slack/Teams threads.

- Migration
  - Run the DB migration adding doc_created_at to the document table, ensure the index has a created_at field, then run pruning or a full sync to backfill. No re-embedding or API changes.

<sup>Written for commit 5146603f54d2536845b63e732e40dedb94fb8b5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



