### PR TITLE
fix(user-files): drop Vespa-hardcoded chunk-count in delete path (#12417) to release v4.0

### DIFF
--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -1,15 +1,12 @@
 import datetime
 import time
-from typing import Any
 from uuid import UUID
 
-import httpx
 import sqlalchemy as sa
 from celery import Celery
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
-from retry import retry
 from sqlalchemy import select
 
 from onyx.access.access import build_access_for_user_files
@@ -48,7 +45,6 @@ from onyx.db.search_settings import get_active_search_settings_list
 from onyx.db.user_file import fetch_user_files_with_access_relationships
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
-from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.utils import store_user_file_plaintext
 from onyx.file_store.utils import user_file_id_to_plaintext_file_name
@@ -146,52 +142,6 @@ def enqueue_user_file_project_sync_task(
         raise
 
     return True
-
-
-@retry(tries=3, delay=1, backoff=2, jitter=(0.0, 1.0))
-def _visit_chunks(
-    *,
-    http_client: httpx.Client,
-    index_name: str,
-    selection: str,
-    continuation: str | None = None,
-) -> tuple[list[dict[str, Any]], str | None]:
-    task_logger.info(
-        f"Visiting chunks for index={index_name} with selection={selection}"
-    )
-    base_url = DOCUMENT_ID_ENDPOINT.format(index_name=index_name)
-    params: dict[str, str] = {
-        "selection": selection,
-        "wantedDocumentCount": "100",  # Use smaller batch size to avoid timeouts
-    }
-    if continuation:
-        params["continuation"] = continuation
-    resp = http_client.get(base_url, params=params, timeout=None)
-    resp.raise_for_status()
-    payload = resp.json()
-    return payload.get("documents", []), payload.get("continuation")
-
-
-def _get_document_chunk_count(
-    *,
-    index_name: str,
-    selection: str,
-) -> int:
-    chunk_count = 0
-    continuation = None
-    while True:
-        docs, continuation = _visit_chunks(
-            http_client=HttpxPool.get("vespa"),
-            index_name=index_name,
-            selection=selection,
-            continuation=continuation,
-        )
-        if not docs:
-            break
-        chunk_count += len(docs)
-        if not continuation:
-            break
-    return chunk_count
 
 
 @shared_task(
@@ -693,8 +643,6 @@ def delete_user_file_impl(
         skip_vespa = DISABLE_VECTOR_DB
         retry_document_indices: list[RetryDocumentIndex] = []
         chunk_count_from_db: int | None = None
-        index_name: str = ""
-        selection: str = ""
         file_id: str = ""
 
         if not skip_vespa:
@@ -728,18 +676,16 @@ def delete_user_file_impl(
                     RetryDocumentIndex(document_index)
                     for document_index in document_indices
                 ]
-                index_name = active_search_settings.primary.index_name
-                selection = f"{index_name}.document_id=='{user_file_id}'"
 
-        # Phase 2: Vespa deletes + file store deletes (no DB session held)
+        # Phase 2: vector DB deletes + file store deletes (no DB session held).
+        # Pass the DB chunk count when known; otherwise None, which each document
+        # index resolves itself (Vespa fans out to find chunks, OpenSearch deletes
+        # by document id). This keeps the path backend-agnostic.
         if not skip_vespa:
-            chunk_count: int = (
+            chunk_count: int | None = (
                 chunk_count_from_db
                 if chunk_count_from_db is not None and chunk_count_from_db > 0
-                else _get_document_chunk_count(
-                    index_name=index_name,
-                    selection=selection,
-                )
+                else None
             )
             for retry_document_index in retry_document_indices:
                 retry_document_index.delete(


### PR DESCRIPTION
## Description

Cherry-pick of #12417 (squash commit `ec84e6efb1`) onto `release/v4.0`. See the original PR for full context and review discussion.

`delete_user_file_impl` computed a user file's chunk count via a raw Vespa visit (`HttpxPool.get("vespa")` + Vespa's `DOCUMENT_ID_ENDPOINT`), bypassing the `DocumentIndex` abstraction. On deployments migrated to OpenSearch the `vespa` host no longer resolves, so user-file deletes crash with `httpx.ConnectError` and the user-file worker OOM-loops on the retrying deletes. This removes the `_visit_chunks` / `_get_document_chunk_count` helpers and passes the DB chunk count when known, else `None` — both backends resolve `None` themselves (Vespa fans out via `_enrich_basic_chunk_info`; OpenSearch ignores `chunk_count` and deletes by `document_id`).

**Backport notes:** one trivial conflict — on `release/v4.0` the deleted helper used `@retry` from the `retry` package instead of main's `retry_builder`, so the now-unused `from retry import retry` import was removed as part of the resolution. Everything else applied as-is. Verified on this branch that `RetryDocumentIndex.delete`, the OpenSearch index `delete()` (ignores `chunk_count`), and the Vespa index `delete()` (resolves `chunk_count=None` via `_enrich_basic_chunk_info`) all accept `chunk_count=None`.

## How Has This Been Tested?

- `python -m py_compile` on the edited file
- `ruff check` (incl. `--select F`, no unused imports/vars) and `ruff format --check` pass
- Grepped the branch for leftover references to the deleted helpers — none remain
- Verified both backend `delete()` implementations on this branch handle `chunk_count=None` by inspection

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes user-file deletions failing on OpenSearch by removing Vespa-only chunk-count logic and deferring chunk resolution to the document index. Deletes are now backend-agnostic and stop the worker retry/OOM loops.

- **Bug Fixes**
  - Removed Vespa visits and helpers; no direct HTTP calls to Vespa.
  - `delete_user_file_impl` now passes the DB `chunk_count` when known, else `None`.
  - Both backends handle `chunk_count=None` (Vespa fans out; OpenSearch deletes by `document_id`), avoiding `ConnectError` when the `vespa` host is missing.
  - Dropped unused `retry` import and related code.

<sup>Written for commit 675afcea4026fe4230870f0982ac07f2c76fa258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

