### PR TITLE
fix(prompts): stress stateless sandbox + batching in python tool guidance

### DIFF
--- a/backend/onyx/prompts/tool_prompts.py
+++ b/backend/onyx/prompts/tool_prompts.py
@@ -59,7 +59,9 @@ The current directory in the file system can be used to save and persist user fi
 Use this to give the user a way to download the file OR to display generated images.
 Internet access for this session is disabled. Do not make external web requests or API calls as they will fail.
 Use `openpyxl` to read and write Excel files. You have access to libraries like numpy, pandas, scipy, matplotlib, and PIL.
-IMPORTANT: each call to this tool is independent. Variables from previous calls will NOT be available in the current call.
+IMPORTANT: each call to this tool runs in a fresh, stateless sandbox. Variables, imports, and in-memory state from previous calls will NOT be available, \
+and files written by a previous call will NOT be in the working directory (only files uploaded to the chat are staged into each call). \
+Therefore batch multi-step work into a single script per call: e.g. load a workbook once, read all needed sheets, apply all edits, and save the result in one execution — not one small step per call.
 """.lstrip()
 
 GENERATE_IMAGE_GUIDANCE = """

--- a/backend/onyx/prompts/tool_prompts.py
+++ b/backend/onyx/prompts/tool_prompts.py
@@ -60,7 +60,7 @@ Use this to give the user a way to download the file OR to display generated ima
 Internet access for this session is disabled. Do not make external web requests or API calls as they will fail.
 Use `openpyxl` to read and write Excel files. You have access to libraries like numpy, pandas, scipy, matplotlib, and PIL.
 IMPORTANT: each call to this tool runs in a fresh, stateless sandbox. Variables, imports, and in-memory state from previous calls will NOT be available, \
-and files written by a previous call will NOT be in the working directory (only files uploaded to the chat are staged into each call). \
+and files written by a previous call will NOT be available in later calls. \
 Therefore batch multi-step work into a single script per call: e.g. load a workbook once, read all needed sheets, apply all edits, and save the result in one execution — not one small step per call.
 """.lstrip()
 


### PR DESCRIPTION
## Description

When users ask for multi-step spreadsheet/file edits via the code interpreter (`python`) tool, models tend to (a) assume a persistent kernel — reusing variables like `wb` from a previous tool call, which fails with `NameError` because every execution runs in a fresh stateless sandbox — and (b) read one sheet per tool call. Combined with the `MAX_LLM_CYCLES` cap (default 6), complex file tasks exhaust their tool budget on reads and never finish. We saw a real production case where a 6-step xlsx edit burned 1 cycle on a `NameError` and 4 more reading one sheet at a time before hitting the cap.

This PR only tightens `PYTHON_TOOL_GUIDANCE` in `backend/onyx/prompts/tool_prompts.py`:

- States that each call runs in a fresh, stateless sandbox: variables, imports, in-memory state, AND files written by a previous call do not carry over (verified: each tool call is an independent `/v1/execute` request; generated files are exported to the file store and deleted from the interpreter, and only chat-staged files are uploaded into each run).
- Tells the model to batch multi-step work into a single script per call (load the workbook once, read all sheets, apply all edits, save once).

No config changes (`MAX_LLM_CYCLES` untouched) and no code-path changes — prompt text only.

## How Has This Been Tested?

- Prompt-copy-only change; no tests assert on this prompt text (grepped for `PYTHON_TOOL_GUIDANCE` and fragments of the surrounding guidance).
- `pre-commit run --files backend/onyx/prompts/tool_prompts.py` passes.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies `PYTHON_TOOL_GUIDANCE` for the `python` tool to note each call runs in a fresh, stateless sandbox; variables, imports, and files from prior calls aren’t available. Batches multi-step workbook edits into one script (load/read/edit/save once) to avoid `NameError` and wasted cycles, and removes staging-mechanics language that implied persistence.

<sup>Written for commit 5f6d499ffc390f58c0146fc9acf172d67ca19e50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

