### PR TITLE
fix(files): render xlsx chat attachments via backend-parsed spreadsheet preview

### DIFF
--- a/backend/onyx/file_processing/file_types.py
+++ b/backend/onyx/file_processing/file_types.py
@@ -5,6 +5,11 @@ PRESENTATION_MIME_TYPE = (
 SPREADSHEET_MIME_TYPE = (
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 )
+# Macro-enabled Excel workbooks (.xlsm) — parseable by openpyxl just like xlsx.
+# Stored lowercase; chat MIME classification normalizes to lowercase before
+# membership checks.
+SPREADSHEET_MACRO_MIME_TYPE = "application/vnd.ms-excel.sheet.macroenabled.12"
+SPREADSHEET_MIME_TYPES = {SPREADSHEET_MIME_TYPE, SPREADSHEET_MACRO_MIME_TYPE}
 WORD_PROCESSING_MIME_TYPE = (
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 )
@@ -15,7 +20,7 @@ PLAIN_TEXT_MIME_TYPE = "text/plain"
 class OnyxMimeTypes:
     IMAGE_MIME_TYPES = {"image/jpg", "image/jpeg", "image/png", "image/webp"}
     CSV_MIME_TYPES = {"text/csv"}
-    TABULAR_MIME_TYPES = CSV_MIME_TYPES | {SPREADSHEET_MIME_TYPE}
+    TABULAR_MIME_TYPES = CSV_MIME_TYPES | SPREADSHEET_MIME_TYPES
     TEXT_MIME_TYPES = {
         PLAIN_TEXT_MIME_TYPE,
         "text/markdown",

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from fastapi import Query
 from fastapi import Request
 from fastapi import Response
+from fastapi.responses import JSONResponse
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -80,6 +81,8 @@ from onyx.llm.factory import get_llm_token_counter
 from onyx.secondary_llm_flows.chat_session_naming import generate_chat_session_name
 from onyx.server.api_key_usage import check_api_key_usage
 from onyx.server.middleware.rate_limiting import get_feedback_rate_limiters
+from onyx.server.query_and_chat.chat_utils import is_spreadsheet_mime_type
+from onyx.server.query_and_chat.chat_utils import parse_spreadsheet_for_preview
 from onyx.server.query_and_chat.models import ChatFeedbackRequest
 from onyx.server.query_and_chat.models import ChatMessageIdentifier
 from onyx.server.query_and_chat.models import ChatRenameRequest
@@ -893,6 +896,7 @@ def seed_chat_from_slack(
 def fetch_chat_file(
     file_id: str,
     request: Request,
+    parsed: bool = Query(False),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> Response:
@@ -912,11 +916,13 @@ def fetch_chat_file(
         raise HTTPException(status_code=404, detail="File not found")
 
     media_type = file_record.file_type
-    file_io = file_store.read_file(file_id, mode="b")
+    # `parsed` only changes behavior for spreadsheet files (xlsx is a binary zip
+    # the frontend cannot render); everything else is served raw as usual.
+    parse_spreadsheet = parsed and is_spreadsheet_mime_type(media_type)
 
     # Files served here are immutable (content-addressed by file_id), so allow long-lived caching.
     # Use `private` because this is behind auth / tenant scoping.
-    etag = f'"{file_id}"'
+    etag = f'"{file_id}-parsed"' if parse_spreadsheet else f'"{file_id}"'
     cache_headers = {
         "Cache-Control": "private, max-age=31536000, immutable",
         "ETag": etag,
@@ -926,6 +932,16 @@ def fetch_chat_file(
     if request.headers.get("if-none-match") == etag:
         return Response(status_code=304, headers=cache_headers)
 
+    if parse_spreadsheet:
+        # Use a tempfile since openpyxl needs a seekable file and the workbook
+        # may be large.
+        with file_store.read_file(file_id, mode="b", use_tempfile=True) as xlsx_io:
+            preview = parse_spreadsheet_for_preview(
+                xlsx_io, file_record.display_name or ""
+            )
+        return JSONResponse(content=preview.model_dump(), headers=cache_headers)
+
+    file_io = file_store.read_file(file_id, mode="b")
     return StreamingResponse(file_io, media_type=media_type, headers=cache_headers)
 
 

--- a/backend/onyx/server/query_and_chat/chat_utils.py
+++ b/backend/onyx/server/query_and_chat/chat_utils.py
@@ -5,18 +5,12 @@ from pydantic import BaseModel
 
 from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
 from onyx.file_processing.file_types import OnyxMimeTypes
-from onyx.file_processing.file_types import SPREADSHEET_MIME_TYPE
+from onyx.file_processing.file_types import SPREADSHEET_MIME_TYPES
 from onyx.file_store.models import ChatFileType
 
 # Per-sheet cap on CSV text returned for in-chat spreadsheet previews. Sheets are
 # truncated (at a row boundary) beyond this to keep preview payloads bounded.
 MAX_PREVIEW_CHARS_PER_SHEET = 500_000
-
-# MIME types that can be parsed into per-sheet CSV previews by openpyxl.
-_SPREADSHEET_PREVIEW_MIME_TYPES = {
-    SPREADSHEET_MIME_TYPE,
-    "application/vnd.ms-excel.sheet.macroenabled.12",
-}
 
 
 class SpreadsheetSheetPreview(BaseModel):
@@ -36,19 +30,26 @@ def _normalize_mime_type(mime_type: str) -> str:
 def is_spreadsheet_mime_type(mime_type: str | None) -> bool:
     return (
         mime_type is not None
-        and _normalize_mime_type(mime_type) in _SPREADSHEET_PREVIEW_MIME_TYPES
+        and _normalize_mime_type(mime_type) in SPREADSHEET_MIME_TYPES
     )
 
 
 def _truncate_csv_at_row_boundary(csv_text: str, max_chars: int) -> str:
-    """Cut CSV text to at most max_chars, ending on a row boundary. A newline is
-    only a row boundary when the preceding text has balanced quotes (i.e. we are
-    not inside a quoted multi-line field). If no complete row fits within the
+    """Cut CSV text to at most max_chars, ending on a row boundary. Single
+    forward pass tracking quote parity: a newline only counts as a row boundary
+    when it falls outside a quoted field. If no complete row fits within the
     cap, return an empty string rather than emitting malformed CSV."""
-    cut = csv_text.rfind("\n", 0, max_chars)
-    while cut > 0 and csv_text.count('"', 0, cut) % 2 == 1:
-        cut = csv_text.rfind("\n", 0, cut)
-    return csv_text[:cut] if cut > 0 else ""
+    if len(csv_text) <= max_chars:
+        return csv_text
+    last_boundary = 0
+    in_quotes = False
+    for i in range(max_chars):
+        char = csv_text[i]
+        if char == '"':
+            in_quotes = not in_quotes
+        elif char == "\n" and not in_quotes:
+            last_boundary = i
+    return csv_text[:last_boundary]
 
 
 def parse_spreadsheet_for_preview(

--- a/backend/onyx/server/query_and_chat/chat_utils.py
+++ b/backend/onyx/server/query_and_chat/chat_utils.py
@@ -43,11 +43,12 @@ def is_spreadsheet_mime_type(mime_type: str | None) -> bool:
 def _truncate_csv_at_row_boundary(csv_text: str, max_chars: int) -> str:
     """Cut CSV text to at most max_chars, ending on a row boundary. A newline is
     only a row boundary when the preceding text has balanced quotes (i.e. we are
-    not inside a quoted multi-line field)."""
+    not inside a quoted multi-line field). If no complete row fits within the
+    cap, return an empty string rather than emitting malformed CSV."""
     cut = csv_text.rfind("\n", 0, max_chars)
     while cut > 0 and csv_text.count('"', 0, cut) % 2 == 1:
         cut = csv_text.rfind("\n", 0, cut)
-    return csv_text[:cut] if cut > 0 else csv_text[:max_chars]
+    return csv_text[:cut] if cut > 0 else ""
 
 
 def parse_spreadsheet_for_preview(

--- a/backend/onyx/server/query_and_chat/chat_utils.py
+++ b/backend/onyx/server/query_and_chat/chat_utils.py
@@ -1,9 +1,73 @@
+from typing import Any
+from typing import IO
+
+from pydantic import BaseModel
+
+from onyx.file_processing.extract_file_text import xlsx_sheet_extraction
 from onyx.file_processing.file_types import OnyxMimeTypes
+from onyx.file_processing.file_types import SPREADSHEET_MIME_TYPE
 from onyx.file_store.models import ChatFileType
+
+# Per-sheet cap on CSV text returned for in-chat spreadsheet previews. Sheets are
+# truncated (at a row boundary) beyond this to keep preview payloads bounded.
+MAX_PREVIEW_CHARS_PER_SHEET = 500_000
+
+# MIME types that can be parsed into per-sheet CSV previews by openpyxl.
+_SPREADSHEET_PREVIEW_MIME_TYPES = {
+    SPREADSHEET_MIME_TYPE,
+    "application/vnd.ms-excel.sheet.macroenabled.12",
+}
+
+
+class SpreadsheetSheetPreview(BaseModel):
+    name: str
+    csv: str
+    truncated: bool
+
+
+class SpreadsheetPreview(BaseModel):
+    sheets: list[SpreadsheetSheetPreview]
 
 
 def _normalize_mime_type(mime_type: str) -> str:
     return mime_type.split(";", 1)[0].strip().lower()
+
+
+def is_spreadsheet_mime_type(mime_type: str | None) -> bool:
+    return (
+        mime_type is not None
+        and _normalize_mime_type(mime_type) in _SPREADSHEET_PREVIEW_MIME_TYPES
+    )
+
+
+def _truncate_csv_at_row_boundary(csv_text: str, max_chars: int) -> str:
+    """Cut CSV text to at most max_chars, ending on a row boundary. A newline is
+    only a row boundary when the preceding text has balanced quotes (i.e. we are
+    not inside a quoted multi-line field)."""
+    cut = csv_text.rfind("\n", 0, max_chars)
+    while cut > 0 and csv_text.count('"', 0, cut) % 2 == 1:
+        cut = csv_text.rfind("\n", 0, cut)
+    return csv_text[:cut] if cut > 0 else csv_text[:max_chars]
+
+
+def parse_spreadsheet_for_preview(
+    file: IO[Any], file_name: str = ""
+) -> SpreadsheetPreview:
+    """Convert a stored xlsx file into per-sheet CSV text suitable for rendering
+    a preview table in the frontend. Sheets larger than
+    MAX_PREVIEW_CHARS_PER_SHEET are truncated at a row boundary."""
+    sheet_previews: list[SpreadsheetSheetPreview] = []
+    for csv_text, title in xlsx_sheet_extraction(file, file_name):
+        truncated = False
+        if len(csv_text) > MAX_PREVIEW_CHARS_PER_SHEET:
+            csv_text = _truncate_csv_at_row_boundary(
+                csv_text, MAX_PREVIEW_CHARS_PER_SHEET
+            )
+            truncated = True
+        sheet_previews.append(
+            SpreadsheetSheetPreview(name=title, csv=csv_text, truncated=truncated)
+        )
+    return SpreadsheetPreview(sheets=sheet_previews)
 
 
 def mime_type_to_chat_file_type(mime_type: str | None) -> ChatFileType:

--- a/backend/tests/external_dependency_unit/chat/test_spreadsheet_preview.py
+++ b/backend/tests/external_dependency_unit/chat/test_spreadsheet_preview.py
@@ -1,0 +1,108 @@
+"""Tests for the parsed spreadsheet preview path used by
+GET /chat/file/{file_id}?parsed=true (xlsx chat attachments rendered as tables
+in the frontend instead of raw binary bytes)."""
+
+import csv
+import io
+from typing import cast
+from unittest.mock import patch
+
+import openpyxl
+import pytest
+from openpyxl.worksheet.worksheet import Worksheet
+
+from onyx.configs.constants import FileOrigin
+from onyx.file_processing.file_types import SPREADSHEET_MIME_TYPE
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.query_and_chat.chat_utils import is_spreadsheet_mime_type
+from onyx.server.query_and_chat.chat_utils import parse_spreadsheet_for_preview
+
+
+def _build_xlsx() -> bytes:
+    workbook = openpyxl.Workbook()
+
+    first_sheet = cast(Worksheet, workbook.active)
+    first_sheet.title = "Revenue"
+    first_sheet.append(["Region", "Quarter", "Amount"])
+    first_sheet.append(["EMEA", "Q1", 1250.5])
+    # Value with a comma + quote to exercise CSV escaping
+    first_sheet.append(['APAC, "South"', "Q2", 900])
+
+    second_sheet = workbook.create_sheet("Notes")
+    second_sheet.append(["Note"])
+    second_sheet.append(["multi\nline"])
+
+    buf = io.BytesIO()
+    workbook.save(buf)
+    return buf.getvalue()
+
+
+@pytest.mark.usefixtures("db_session", "tenant_context", "initialize_file_store")
+def test_parse_spreadsheet_for_preview_from_file_store() -> None:
+    """Round-trip: save an xlsx to the real file store, read it back the same
+    way the endpoint does, and verify the parsed per-sheet CSV payload."""
+    file_store = get_default_file_store()
+    file_id = file_store.save_file(
+        content=io.BytesIO(_build_xlsx()),
+        display_name="report.xlsx",
+        file_origin=FileOrigin.CHAT_UPLOAD,
+        file_type=SPREADSHEET_MIME_TYPE,
+    )
+
+    file_record = file_store.read_file_record(file_id)
+    assert file_record is not None
+    assert is_spreadsheet_mime_type(file_record.file_type)
+
+    with file_store.read_file(file_id, mode="b", use_tempfile=True) as xlsx_io:
+        preview = parse_spreadsheet_for_preview(xlsx_io, "report.xlsx")
+
+    assert [sheet.name for sheet in preview.sheets] == ["Revenue", "Notes"]
+    assert all(not sheet.truncated for sheet in preview.sheets)
+
+    revenue_rows = list(csv.reader(io.StringIO(preview.sheets[0].csv)))
+    assert revenue_rows == [
+        ["Region", "Quarter", "Amount"],
+        ["EMEA", "Q1", "1250.5"],
+        ['APAC, "South"', "Q2", "900"],
+    ]
+
+    notes_rows = list(csv.reader(io.StringIO(preview.sheets[1].csv)))
+    assert notes_rows == [["Note"], ["multi\nline"]]
+
+
+def test_parse_spreadsheet_for_preview_truncates_large_sheets() -> None:
+    """Sheets bigger than the preview cap are cut at a row boundary and
+    flagged as truncated."""
+    workbook = openpyxl.Workbook()
+    sheet = cast(Worksheet, workbook.active)
+    sheet.title = "Big"
+    for i in range(50):
+        sheet.append([f"row-{i}", "x" * 20])
+    buf = io.BytesIO()
+    workbook.save(buf)
+    buf.seek(0)
+
+    with patch(
+        "onyx.server.query_and_chat.chat_utils.MAX_PREVIEW_CHARS_PER_SHEET", 200
+    ):
+        preview = parse_spreadsheet_for_preview(buf, "big.xlsx")
+
+    assert len(preview.sheets) == 1
+    big_sheet = preview.sheets[0]
+    assert big_sheet.truncated
+    assert len(big_sheet.csv) <= 200
+    # Still valid CSV, cut on a row boundary
+    rows = list(csv.reader(io.StringIO(big_sheet.csv)))
+    assert rows
+    assert all(len(row) == 2 for row in rows)
+    assert rows[0] == ["row-0", "x" * 20]
+
+
+def test_is_spreadsheet_mime_type() -> None:
+    assert is_spreadsheet_mime_type(SPREADSHEET_MIME_TYPE)
+    assert is_spreadsheet_mime_type(SPREADSHEET_MIME_TYPE + "; charset=utf-8")
+    assert is_spreadsheet_mime_type("application/vnd.ms-excel.sheet.macroEnabled.12")
+    # `parsed=true` must be a no-op for non-spreadsheet files
+    assert not is_spreadsheet_mime_type("text/csv")
+    assert not is_spreadsheet_mime_type("application/pdf")
+    assert not is_spreadsheet_mime_type(None)

--- a/backend/tests/external_dependency_unit/chat/test_spreadsheet_preview.py
+++ b/backend/tests/external_dependency_unit/chat/test_spreadsheet_preview.py
@@ -14,7 +14,9 @@ from openpyxl.worksheet.worksheet import Worksheet
 from onyx.configs.constants import FileOrigin
 from onyx.file_processing.file_types import SPREADSHEET_MIME_TYPE
 from onyx.file_store.file_store import get_default_file_store
+from onyx.file_store.models import ChatFileType
 from onyx.server.query_and_chat.chat_utils import is_spreadsheet_mime_type
+from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
 from onyx.server.query_and_chat.chat_utils import parse_spreadsheet_for_preview
 
 
@@ -103,6 +105,37 @@ def test_parse_spreadsheet_for_preview_truncates_large_sheets() -> None:
         preview = parse_spreadsheet_for_preview(buf, "big.xlsx")
     assert preview.sheets[0].truncated
     assert preview.sheets[0].csv == ""
+
+
+def test_truncation_skips_newlines_inside_quoted_cells() -> None:
+    """A pathological quoted cell packed with newlines must not be treated as
+    row boundaries — the cut lands after the last complete row before it."""
+    workbook = openpyxl.Workbook()
+    sheet = cast(Worksheet, workbook.active)
+    sheet.title = "Quoted"
+    sheet.append(["col_a", "col_b"])
+    # Second row's cell is a quoted multi-line value far larger than the cap
+    sheet.append(["a", "line\n" * 500])
+    buf = io.BytesIO()
+    workbook.save(buf)
+    buf.seek(0)
+
+    with patch("onyx.server.query_and_chat.chat_utils.MAX_PREVIEW_CHARS_PER_SHEET", 50):
+        preview = parse_spreadsheet_for_preview(buf, "quoted.xlsx")
+
+    quoted_sheet = preview.sheets[0]
+    assert quoted_sheet.truncated
+    # Only the complete header row survives; no partial quoted field leaks out
+    rows = list(csv.reader(io.StringIO(quoted_sheet.csv)))
+    assert rows == [["col_a", "col_b"]]
+
+
+def test_xlsm_mime_type_classifies_as_tabular() -> None:
+    """XLSM must classify TABULAR so chat routes it to the spreadsheet preview."""
+    assert (
+        mime_type_to_chat_file_type("application/vnd.ms-excel.sheet.macroEnabled.12")
+        == ChatFileType.TABULAR
+    )
 
 
 def test_is_spreadsheet_mime_type() -> None:

--- a/backend/tests/external_dependency_unit/chat/test_spreadsheet_preview.py
+++ b/backend/tests/external_dependency_unit/chat/test_spreadsheet_preview.py
@@ -97,6 +97,13 @@ def test_parse_spreadsheet_for_preview_truncates_large_sheets() -> None:
     assert all(len(row) == 2 for row in rows)
     assert rows[0] == ["row-0", "x" * 20]
 
+    # A first row larger than the cap yields empty CSV (never a mid-row slice)
+    buf.seek(0)
+    with patch("onyx.server.query_and_chat.chat_utils.MAX_PREVIEW_CHARS_PER_SHEET", 5):
+        preview = parse_spreadsheet_for_preview(buf, "big.xlsx")
+    assert preview.sheets[0].truncated
+    assert preview.sheets[0].csv == ""
+
 
 def test_is_spreadsheet_mime_type() -> None:
     assert is_spreadsheet_mime_type(SPREADSHEET_MIME_TYPE)

--- a/web/src/app/app/message/FileDisplay.tsx
+++ b/web/src/app/app/message/FileDisplay.tsx
@@ -6,6 +6,9 @@ import { ChatFileType, FileDescriptor } from "@/app/app/interfaces";
 import Attachment from "@/refresh-components/Attachment";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import CsvContent from "@/components/tools/CSVContent";
+import SpreadsheetContent, {
+  isSpreadsheetFileName,
+} from "@/components/tools/SpreadsheetContent";
 import PreviewModal from "@/sections/modals/PreviewModal";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import ExpandableContentWrapper from "@/components/tools/ExpandableContentWrapper";
@@ -42,9 +45,6 @@ export default function FileDisplay({ files }: FileDisplayProps) {
       file.type === ChatFileType.DOCUMENT
   );
   const imageFiles = files.filter((file) => file.type === ChatFileType.IMAGE);
-  // TODO(danelegend): XLSX files are binary (OOXML) and will fail to parse in CsvContent.
-  // The backend should convert XLSX to CSV text before serving via /api/chat/file,
-  // or XLSX should be split into a separate ChatFileType and rendered as an Attachment.
   const tabularFiles = files.filter(
     (file) => file.type === ChatFileType.TABULAR
   );
@@ -91,7 +91,13 @@ export default function FileDisplay({ files }: FileDisplayProps) {
                 key={file.id}
                 fileDescriptor={file}
                 close={() => setClose(false)}
-                ContentComponent={CsvContent}
+                // XLSX is binary (OOXML zip) — render it via the backend-parsed
+                // spreadsheet preview instead of decoding raw bytes as CSV text.
+                ContentComponent={
+                  isSpreadsheetFileName(file.name)
+                    ? SpreadsheetContent
+                    : CsvContent
+                }
               />
             ) : (
               <Attachment

--- a/web/src/app/app/message/FileDisplay.tsx
+++ b/web/src/app/app/message/FileDisplay.tsx
@@ -7,7 +7,7 @@ import Attachment from "@/refresh-components/Attachment";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
 import CsvContent from "@/components/tools/CSVContent";
 import SpreadsheetContent, {
-  isSpreadsheetFileName,
+  isCsvFileName,
 } from "@/components/tools/SpreadsheetContent";
 import PreviewModal from "@/sections/modals/PreviewModal";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
@@ -91,12 +91,13 @@ export default function FileDisplay({ files }: FileDisplayProps) {
                 key={file.id}
                 fileDescriptor={file}
                 close={() => setClose(false)}
-                // XLSX is binary (OOXML zip) — render it via the backend-parsed
-                // spreadsheet preview instead of decoding raw bytes as CSV text.
+                // Only files clearly named as CSVs keep the raw CsvContent
+                // path. Everything else TABULAR (xlsx — a binary OOXML zip —
+                // or files with missing/renamed names) goes through the
+                // parsed preview, which handles both spreadsheet JSON and
+                // raw CSV passthrough based on the response content type.
                 ContentComponent={
-                  isSpreadsheetFileName(file.name)
-                    ? SpreadsheetContent
-                    : CsvContent
+                  isCsvFileName(file.name) ? CsvContent : SpreadsheetContent
                 }
               />
             ) : (

--- a/web/src/app/app/message/FileDisplay.tsx
+++ b/web/src/app/app/message/FileDisplay.tsx
@@ -5,10 +5,7 @@ import { cn } from "@opal/utils";
 import { ChatFileType, FileDescriptor } from "@/app/app/interfaces";
 import Attachment from "@/refresh-components/Attachment";
 import { InMessageImage } from "@/app/app/components/files/images/InMessageImage";
-import CsvContent from "@/components/tools/CSVContent";
-import SpreadsheetContent, {
-  isCsvFileName,
-} from "@/components/tools/SpreadsheetContent";
+import SpreadsheetContent from "@/components/tools/SpreadsheetContent";
 import PreviewModal from "@/sections/modals/PreviewModal";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import ExpandableContentWrapper from "@/components/tools/ExpandableContentWrapper";
@@ -91,14 +88,12 @@ export default function FileDisplay({ files }: FileDisplayProps) {
                 key={file.id}
                 fileDescriptor={file}
                 close={() => setClose(false)}
-                // Only files clearly named as CSVs keep the raw CsvContent
-                // path. Everything else TABULAR (xlsx — a binary OOXML zip —
-                // or files with missing/renamed names) goes through the
-                // parsed preview, which handles both spreadsheet JSON and
-                // raw CSV passthrough based on the response content type.
-                ContentComponent={
-                  isCsvFileName(file.name) ? CsvContent : SpreadsheetContent
-                }
+                // All TABULAR files render via the parsed preview, which
+                // dispatches on the response content type: spreadsheet JSON
+                // (xlsx is a binary OOXML zip the browser can't decode as
+                // text) or raw CSV passthrough. Display names are never
+                // trusted — a renamed xlsx/csv still renders correctly.
+                ContentComponent={SpreadsheetContent}
               />
             ) : (
               <Attachment

--- a/web/src/components/tools/SpreadsheetContent.tsx
+++ b/web/src/components/tools/SpreadsheetContent.tsx
@@ -1,0 +1,252 @@
+// SpreadsheetContent — renders xlsx chat files using the backend-parsed
+// per-sheet CSV payload (`/api/chat/file/{id}?parsed=true`) instead of
+// attempting to decode the raw binary xlsx bytes as text.
+import React, { useState, useEffect } from "react";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { ContentComponentProps } from "./ExpandableContentWrapper";
+import { parseCSV } from "./CSVContent";
+import { SvgAlertCircle, SvgSimpleLoader } from "@opal/icons";
+import { Button, Text } from "@opal/components";
+import { cn } from "@opal/utils";
+import { fetchChatFile } from "@/lib/chat/svc";
+
+export interface SpreadsheetSheet {
+  name: string;
+  csv: string;
+  truncated: boolean;
+}
+
+export interface SpreadsheetPreviewData {
+  sheets: SpreadsheetSheet[];
+}
+
+const SPREADSHEET_EXTENSIONS = [".xlsx", ".xlsm"];
+
+export function isSpreadsheetFileName(
+  fileName: string | null | undefined
+): boolean {
+  if (!fileName) return false;
+  const lowered = fileName.toLowerCase();
+  return SPREADSHEET_EXTENSIONS.some((ext) => lowered.endsWith(ext));
+}
+
+export function parseSpreadsheetPreview(
+  jsonText: string
+): SpreadsheetPreviewData | null {
+  try {
+    const parsed: unknown = JSON.parse(jsonText);
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      !Array.isArray((parsed as SpreadsheetPreviewData).sheets)
+    ) {
+      return null;
+    }
+    return parsed as SpreadsheetPreviewData;
+  } catch {
+    return null;
+  }
+}
+
+interface SheetTableProps {
+  sheet: SpreadsheetSheet;
+}
+
+function SheetTable({ sheet }: SheetTableProps) {
+  let rows: string[][] = [];
+  try {
+    rows = parseCSV(sheet.csv.trim());
+  } catch {
+    rows = [];
+  }
+  const headers = rows[0];
+
+  if (!headers || headers.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-8">
+        <Text as="p" font="main-ui-body" color="text-03">
+          This sheet is empty.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <Table>
+      <TableHeader className="sticky top-0 z-sticky">
+        <TableRow className="bg-background-tint-01">
+          {headers.map((header, index) => (
+            <TableHead key={index}>
+              <Text as="p" maxLines={2} font="main-ui-action" color="text-03">
+                {header}
+              </Text>
+            </TableHead>
+          ))}
+        </TableRow>
+      </TableHeader>
+
+      <TableBody>
+        {rows.slice(1).map((row, rowIndex) => (
+          <TableRow key={rowIndex}>
+            {headers.map((_, cellIndex) => (
+              <TableCell
+                className={cn(
+                  cellIndex === 0 && "sticky left-0 bg-background-tint-01",
+                  "py-0 px-4"
+                )}
+                key={cellIndex}
+              >
+                {row[cellIndex] ?? ""}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))}
+        {sheet.truncated && (
+          <TableRow>
+            <TableCell colSpan={headers.length} className="py-2 px-4">
+              <Text as="p" font="secondary-body" color="text-04">
+                Preview truncated — download the file to see all rows.
+              </Text>
+            </TableCell>
+          </TableRow>
+        )}
+      </TableBody>
+    </Table>
+  );
+}
+
+interface SpreadsheetSheetsViewProps {
+  sheets: SpreadsheetSheet[];
+  className?: string;
+}
+
+export function SpreadsheetSheetsView({
+  sheets,
+  className,
+}: SpreadsheetSheetsViewProps) {
+  const [activeSheetIndex, setActiveSheetIndex] = useState(0);
+  const activeSheet = sheets[activeSheetIndex] ?? sheets[0];
+
+  if (!activeSheet) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-8">
+        <SvgAlertCircle className="w-8 h-8 stroke-error" />
+        <Text as="p" font="main-ui-body" color="text-03">
+          Unable to preview this spreadsheet.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("flex flex-col w-full", className)}>
+      {sheets.length > 1 && (
+        <div className="flex flex-row gap-1 p-2 overflow-x-auto shrink-0">
+          {sheets.map((sheet, index) => (
+            <Button
+              key={index}
+              size="sm"
+              prominence={index === activeSheetIndex ? "secondary" : "tertiary"}
+              onClick={() => setActiveSheetIndex(index)}
+            >
+              {sheet.name}
+            </Button>
+          ))}
+        </div>
+      )}
+      <div className="flex relative min-h-0 overflow-auto">
+        <SheetTable sheet={activeSheet} />
+      </div>
+    </div>
+  );
+}
+
+function SpreadsheetContent({
+  fileDescriptor,
+  expanded = false,
+}: ContentComponentProps) {
+  const [sheets, setSheets] = useState<SpreadsheetSheet[] | null>(null);
+  const [isFetching, setIsFetching] = useState(true);
+
+  // Cache parsed sheets across mounts so closing other modals doesn't force a
+  // refetch. Keyed by file id; safe because chat file ids are unique.
+  const cacheKey = fileDescriptor.id;
+
+  useEffect(() => {
+    const cached = spreadsheetCache.get(cacheKey);
+    if (cached) {
+      setSheets(cached);
+      setIsFetching(false);
+      return;
+    }
+
+    let cancelled = false;
+    const fetchSheets = async () => {
+      setIsFetching(true);
+      try {
+        const response = await fetchChatFile(cacheKey, true);
+        const preview = parseSpreadsheetPreview(await response.text());
+        if (!preview) {
+          throw new Error("Failed to parse spreadsheet preview");
+        }
+        if (!cancelled) {
+          setSheets(preview.sheets);
+          spreadsheetCache.set(cacheKey, preview.sheets);
+        }
+      } catch (error) {
+        console.error("Error fetching spreadsheet preview:", error);
+        if (!cancelled) {
+          setSheets(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsFetching(false);
+        }
+      }
+    };
+    fetchSheets();
+    return () => {
+      cancelled = true;
+    };
+  }, [cacheKey]);
+
+  if (isFetching) {
+    return (
+      <div className="flex items-center justify-center h-[300px]">
+        <SvgSimpleLoader />
+      </div>
+    );
+  }
+
+  if (!sheets || sheets.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-8">
+        <SvgAlertCircle className="w-8 h-8 stroke-error" />
+        <Text as="p" font="main-ui-body" color="text-03">
+          Error loading spreadsheet
+        </Text>
+        <Text as="p" font="main-ui-body" color="text-04">
+          The spreadsheet may be corrupted or couldn&apos;t be loaded properly.
+        </Text>
+      </div>
+    );
+  }
+
+  return (
+    <SpreadsheetSheetsView
+      sheets={sheets}
+      className={expanded ? "max-h-[600px]" : "max-h-[300px]"}
+    />
+  );
+}
+
+export default SpreadsheetContent;
+
+const spreadsheetCache = new Map<string, SpreadsheetSheet[]>();

--- a/web/src/components/tools/SpreadsheetContent.tsx
+++ b/web/src/components/tools/SpreadsheetContent.tsx
@@ -1,6 +1,8 @@
-// SpreadsheetContent — renders xlsx chat files using the backend-parsed
-// per-sheet CSV payload (`/api/chat/file/{id}?parsed=true`) instead of
-// attempting to decode the raw binary xlsx bytes as text.
+// SpreadsheetContent — renders tabular chat files via `?parsed=true`.
+// Spreadsheets (xlsx) come back as a backend-parsed JSON payload of per-sheet
+// CSV text (instead of raw binary bytes); anything else (e.g. a real CSV) is
+// passed through raw by the backend and rendered as a single CSV sheet, so
+// routing here never depends solely on the file's display name.
 import React, { useState, useEffect } from "react";
 import {
   Table,
@@ -29,12 +31,20 @@ export interface SpreadsheetPreviewData {
 
 const SPREADSHEET_EXTENSIONS = [".xlsx", ".xlsm"];
 
+// Matches the guard CsvContent applies when rendering raw CSV bodies.
+const MAX_RAW_CSV_SIZE_MB = 5;
+
 export function isSpreadsheetFileName(
   fileName: string | null | undefined
 ): boolean {
   if (!fileName) return false;
   const lowered = fileName.toLowerCase();
   return SPREADSHEET_EXTENSIONS.some((ext) => lowered.endsWith(ext));
+}
+
+export function isCsvFileName(fileName: string | null | undefined): boolean {
+  if (!fileName) return false;
+  return fileName.toLowerCase().endsWith(".csv");
 }
 
 export function parseSpreadsheetPreview(
@@ -63,7 +73,11 @@ function SheetTable({ sheet }: SheetTableProps) {
   let rows: string[][] = [];
   try {
     rows = parseCSV(sheet.csv.trim());
-  } catch {
+  } catch (error) {
+    console.error(
+      `Failed to parse CSV for spreadsheet preview sheet "${sheet.name}":`,
+      error
+    );
     rows = [];
   }
   const headers = rows[0];
@@ -72,7 +86,9 @@ function SheetTable({ sheet }: SheetTableProps) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 py-8">
         <Text as="p" font="main-ui-body" color="text-03">
-          This sheet is empty.
+          {sheet.truncated
+            ? "This sheet is too large to preview — download the file to view it."
+            : "This sheet is empty."}
         </Text>
       </div>
     );
@@ -192,13 +208,37 @@ function SpreadsheetContent({
       setIsFetching(true);
       try {
         const response = await fetchChatFile(cacheKey, true);
-        const preview = parseSpreadsheetPreview(await response.text());
-        if (!preview) {
-          throw new Error("Failed to parse spreadsheet preview");
+        const contentType = response.headers.get("Content-Type") ?? "";
+
+        let fetchedSheets: SpreadsheetSheet[];
+        if (contentType.toLowerCase().includes("application/json")) {
+          // Backend-parsed spreadsheet payload
+          const preview = parseSpreadsheetPreview(await response.text());
+          if (!preview) {
+            throw new Error("Failed to parse spreadsheet preview");
+          }
+          fetchedSheets = preview.sheets;
+        } else {
+          // `parsed=true` is a passthrough for non-spreadsheet files (e.g. a
+          // CSV whose display name is missing or renamed) — the body is plain
+          // CSV text, rendered as a single sheet.
+          const contentLength = response.headers.get("Content-Length");
+          const fileSizeInMB = contentLength
+            ? parseInt(contentLength) / (1024 * 1024)
+            : 0;
+          if (fileSizeInMB > MAX_RAW_CSV_SIZE_MB) {
+            throw new Error(
+              `File size exceeds the maximum limit of ${MAX_RAW_CSV_SIZE_MB}MB`
+            );
+          }
+          fetchedSheets = [
+            { name: "Sheet 1", csv: await response.text(), truncated: false },
+          ];
         }
+
         if (!cancelled) {
-          setSheets(preview.sheets);
-          spreadsheetCache.set(cacheKey, preview.sheets);
+          setSheets(fetchedSheets);
+          spreadsheetCache.set(cacheKey, fetchedSheets);
         }
       } catch (error) {
         console.error("Error fetching spreadsheet preview:", error);

--- a/web/src/components/tools/SpreadsheetContent.tsx
+++ b/web/src/components/tools/SpreadsheetContent.tsx
@@ -67,7 +67,9 @@ interface SheetTableProps {
 function SheetTable({ sheet }: SheetTableProps) {
   let rows: string[][] = [];
   try {
-    rows = parseCSV(sheet.csv.trim());
+    // Drop at most one trailing newline; trimming any further would mutate
+    // cell data (significant leading/trailing whitespace).
+    rows = parseCSV(sheet.csv.replace(/\r?\n$/, ""));
   } catch (error) {
     console.error(
       `Failed to parse CSV for spreadsheet preview sheet "${sheet.name}":`,

--- a/web/src/components/tools/SpreadsheetContent.tsx
+++ b/web/src/components/tools/SpreadsheetContent.tsx
@@ -42,11 +42,6 @@ export function isSpreadsheetFileName(
   return SPREADSHEET_EXTENSIONS.some((ext) => lowered.endsWith(ext));
 }
 
-export function isCsvFileName(fileName: string | null | undefined): boolean {
-  if (!fileName) return false;
-  return fileName.toLowerCase().endsWith(".csv");
-}
-
 export function parseSpreadsheetPreview(
   jsonText: string
 ): SpreadsheetPreviewData | null {

--- a/web/src/lib/chat/svc.ts
+++ b/web/src/lib/chat/svc.ts
@@ -5,10 +5,19 @@ const CHAT_FILE_PREFIX = "/api/chat/file";
  *
  * The caller is responsible for consuming the body (e.g. `.blob()`,
  * `.text()`) since different consumers need different formats.
+ *
+ * When `parsed` is true, spreadsheet files (xlsx) are returned as a JSON
+ * payload of per-sheet CSV text instead of raw binary bytes; the param is a
+ * no-op for all other file types.
  */
-export async function fetchChatFile(fileId: string): Promise<Response> {
+export async function fetchChatFile(
+  fileId: string,
+  parsed: boolean = false
+): Promise<Response> {
   const response = await fetch(
-    `${CHAT_FILE_PREFIX}/${encodeURIComponent(fileId)}`,
+    `${CHAT_FILE_PREFIX}/${encodeURIComponent(fileId)}${
+      parsed ? "?parsed=true" : ""
+    }`,
     {
       method: "GET",
       cache: "force-cache",

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -104,9 +104,8 @@ export default function PreviewModal({
 
       const response = await fetchChatFile(fileIdLocal);
 
-      const blob = await response.blob();
-      updateFileUrl(window.URL.createObjectURL(blob));
-
+      // Re-resolve using the stored MIME from the response headers, which is
+      // authoritative, BEFORE materializing the body as a blob.
       const rawContentType =
         response.headers.get("Content-Type") || "application/octet-stream";
       const resolvedMime =
@@ -120,11 +119,20 @@ export default function PreviewModal({
         resolvedMime
       );
       if (resolved.needsParsedContent) {
-        // Name alone didn't identify the file, but the stored MIME did
-        // (e.g. an xlsx with a renamed/missing display name).
+        // Name alone didn't identify a spreadsheet, but the stored MIME did
+        // (e.g. an xlsx with a renamed/missing display name). Discard the raw
+        // workbook body and render from the parsed payload instead.
+        await response.body?.cancel();
+        updateFileUrl(rawFileUrl);
         const parsedResponse = await fetchChatFile(fileIdLocal, true);
         setFileContent(await parsedResponse.text());
-      } else if (resolved.needsTextContent) {
+        return;
+      }
+
+      const blob = await response.blob();
+      updateFileUrl(window.URL.createObjectURL(blob));
+
+      if (resolved.needsTextContent) {
         setFileContent(await blob.text());
       }
     } catch (error) {

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -97,7 +97,10 @@ export default function PreviewModal({
         presentingDocument.semantic_identifier,
         resolvedMime
       );
-      if (resolved.needsTextContent) {
+      if (resolved.needsParsedContent) {
+        const parsedResponse = await fetchChatFile(fileIdLocal, true);
+        setFileContent(await parsedResponse.text());
+      } else if (resolved.needsTextContent) {
         setFileContent(await blob.text());
       }
     } catch {

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo } from "react";
 import { MinimalOnyxDocument } from "@/lib/search/interfaces";
 import Modal from "@/refresh-components/Modal";
 import Text from "@/refresh-components/texts/Text";
+import { Button } from "@opal/components";
 import { SvgSimpleLoader } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import FloatingFooter from "@/sections/modals/PreviewModal/FloatingFooter";
@@ -70,20 +71,41 @@ export default function PreviewModal({
     const fileIdLocal =
       presentingDocument.document_id.split("__")[1] ||
       presentingDocument.document_id;
+    const originalFileName =
+      presentingDocument.semantic_identifier || "document";
+    // Direct raw-file URL — usable for downloads without materializing a blob.
+    const rawFileUrl = `/api/chat/file/${encodeURIComponent(fileIdLocal)}`;
 
-    try {
-      const response = await fetchChatFile(fileIdLocal);
-
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
+    const updateFileUrl = (url: string) =>
       setFileUrl((prev) => {
-        if (prev) window.URL.revokeObjectURL(prev);
+        if (prev.startsWith("blob:")) window.URL.revokeObjectURL(prev);
         return url;
       });
 
-      const originalFileName =
-        presentingDocument.semantic_identifier || "document";
+    try {
       setFileName(originalFileName);
+
+      // Variants that render from backend-parsed content (spreadsheets) don't
+      // need the raw binary blob — skip downloading the full workbook and let
+      // the download button point at the raw URL directly.
+      const preResolved = resolveVariant(
+        presentingDocument.semantic_identifier,
+        "application/octet-stream"
+      );
+      if (preResolved.needsParsedContent) {
+        updateFileUrl(rawFileUrl);
+        setMimeType(
+          mime.getType(originalFileName) ?? "application/octet-stream"
+        );
+        const parsedResponse = await fetchChatFile(fileIdLocal, true);
+        setFileContent(await parsedResponse.text());
+        return;
+      }
+
+      const response = await fetchChatFile(fileIdLocal);
+
+      const blob = await response.blob();
+      updateFileUrl(window.URL.createObjectURL(blob));
 
       const rawContentType =
         response.headers.get("Content-Type") || "application/octet-stream";
@@ -98,12 +120,20 @@ export default function PreviewModal({
         resolvedMime
       );
       if (resolved.needsParsedContent) {
+        // Name alone didn't identify the file, but the stored MIME did
+        // (e.g. an xlsx with a renamed/missing display name).
         const parsedResponse = await fetchChatFile(fileIdLocal, true);
         setFileContent(await parsedResponse.text());
       } else if (resolved.needsTextContent) {
         setFileContent(await blob.text());
       }
-    } catch {
+    } catch (error) {
+      console.error(
+        `Failed to load preview for chat file ${fileIdLocal}:`,
+        error
+      );
+      // Keep a usable download link even when the preview itself failed.
+      setFileUrl((prev) => prev || rawFileUrl);
       setLoadError("Failed to load document.");
     } finally {
       setIsLoading(false);
@@ -116,7 +146,7 @@ export default function PreviewModal({
 
   useEffect(() => {
     return () => {
-      if (fileUrl) window.URL.revokeObjectURL(fileUrl);
+      if (fileUrl.startsWith("blob:")) window.URL.revokeObjectURL(fileUrl);
     };
   }, [fileUrl]);
 
@@ -186,6 +216,11 @@ export default function PreviewModal({
               <Text text03 mainUiBody>
                 {loadError}
               </Text>
+              {fileUrl && (
+                <a href={fileUrl} download={fileName}>
+                  <Button>Download File</Button>
+                </a>
+              )}
             </Section>
           ) : (
             variant.renderContent(ctx)

--- a/web/src/sections/modals/PreviewModal/PreviewModal.tsx
+++ b/web/src/sections/modals/PreviewModal/PreviewModal.tsx
@@ -140,8 +140,9 @@ export default function PreviewModal({
         `Failed to load preview for chat file ${fileIdLocal}:`,
         error
       );
-      // Keep a usable download link even when the preview itself failed.
-      setFileUrl((prev) => prev || rawFileUrl);
+      // Keep a usable download link for the CURRENT file even when the
+      // preview itself failed (a stale previous-file URL must never win).
+      updateFileUrl(rawFileUrl);
       setLoadError("Failed to load document.");
     } finally {
       setIsLoading(false);

--- a/web/src/sections/modals/PreviewModal/interfaces.ts
+++ b/web/src/sections/modals/PreviewModal/interfaces.ts
@@ -20,6 +20,10 @@ export interface PreviewVariant extends Required<
   matches: (semanticIdentifier: string | null, mimeType: string) => boolean;
   /** Whether the fetcher should read the blob as text. */
   needsTextContent: boolean;
+  /** Whether the fetcher should fetch backend-parsed content
+   * (`?parsed=true`, JSON) into fileContent instead of the raw blob text.
+   * Used for binary spreadsheet files. */
+  needsParsedContent?: boolean;
   /** Whether the variant renders on a code-style background (bg-background-code-01). */
   codeBackground: boolean;
   /** String shown below the title in the modal header. */

--- a/web/src/sections/modals/PreviewModal/variants/index.ts
+++ b/web/src/sections/modals/PreviewModal/variants/index.ts
@@ -3,6 +3,7 @@ import { codeVariant } from "@/sections/modals/PreviewModal/variants/codeVariant
 import { imageVariant } from "@/sections/modals/PreviewModal/variants/imageVariant";
 import { pdfVariant } from "@/sections/modals/PreviewModal/variants/pdfVariant";
 import { csvVariant } from "@/sections/modals/PreviewModal/variants/csvVariant";
+import { xlsxVariant } from "@/sections/modals/PreviewModal/variants/xlsxVariant";
 import { markdownVariant } from "@/sections/modals/PreviewModal/variants/markdownVariant";
 import { dataVariant } from "@/sections/modals/PreviewModal/variants/dataVariant";
 import { textVariant } from "@/sections/modals/PreviewModal/variants/textVariant";
@@ -15,6 +16,7 @@ const PREVIEW_VARIANTS: PreviewVariant[] = [
   imageVariant,
   pdfVariant,
   csvVariant,
+  xlsxVariant,
   markdownVariant,
   docxVariant,
   textVariant,

--- a/web/src/sections/modals/PreviewModal/variants/xlsxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/xlsxVariant.tsx
@@ -8,12 +8,19 @@ import {
 } from "@/components/tools/SpreadsheetContent";
 import { Text } from "@opal/components";
 
-const SPREADSHEET_MIME_TYPE =
-  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+const SPREADSHEET_MIME_TYPES = [
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.ms-excel.sheet.macroenabled.12",
+];
+
+function isSpreadsheetMimeType(mime: string): boolean {
+  const normalized = mime.split(";")[0]?.trim().toLowerCase() ?? "";
+  return SPREADSHEET_MIME_TYPES.includes(normalized);
+}
 
 export const xlsxVariant: PreviewVariant = {
   matches: (name, mime) =>
-    mime === SPREADSHEET_MIME_TYPE || isSpreadsheetFileName(name),
+    isSpreadsheetMimeType(mime) || isSpreadsheetFileName(name),
   width: "full",
   height: "full",
   needsTextContent: false,

--- a/web/src/sections/modals/PreviewModal/variants/xlsxVariant.tsx
+++ b/web/src/sections/modals/PreviewModal/variants/xlsxVariant.tsx
@@ -1,0 +1,62 @@
+import { Section } from "@/layouts/general-layouts";
+import { PreviewVariant } from "@/sections/modals/PreviewModal/interfaces";
+import { DownloadButton } from "@/sections/modals/PreviewModal/variants/shared";
+import {
+  isSpreadsheetFileName,
+  parseSpreadsheetPreview,
+  SpreadsheetSheetsView,
+} from "@/components/tools/SpreadsheetContent";
+import { Text } from "@opal/components";
+
+const SPREADSHEET_MIME_TYPE =
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+export const xlsxVariant: PreviewVariant = {
+  matches: (name, mime) =>
+    mime === SPREADSHEET_MIME_TYPE || isSpreadsheetFileName(name),
+  width: "full",
+  height: "full",
+  needsTextContent: false,
+  needsParsedContent: true,
+  codeBackground: false,
+
+  headerDescription: (ctx) => {
+    const preview = parseSpreadsheetPreview(ctx.fileContent);
+    if (!preview) return "";
+    const count = preview.sheets.length;
+    return `Spreadsheet - ${count} ${count === 1 ? "sheet" : "sheets"}`;
+  },
+
+  renderContent: (ctx) => {
+    const preview = parseSpreadsheetPreview(ctx.fileContent);
+    if (!preview || preview.sheets.length === 0) {
+      return (
+        <Section padding={1}>
+          <Text as="p" font="main-ui-body" color="text-03">
+            Unable to preview this spreadsheet.
+          </Text>
+        </Section>
+      );
+    }
+    return (
+      <SpreadsheetSheetsView
+        sheets={preview.sheets}
+        className="flex-1 min-h-0 p-1"
+      />
+    );
+  },
+
+  renderFooterLeft: (ctx) => {
+    const preview = parseSpreadsheetPreview(ctx.fileContent);
+    if (!preview) return null;
+    const count = preview.sheets.length;
+    return (
+      <Text font="main-ui-body" color="text-03">
+        {`${count} ${count === 1 ? "sheet" : "sheets"}`}
+      </Text>
+    );
+  },
+  renderFooterRight: (ctx) => (
+    <DownloadButton fileUrl={ctx.fileUrl} fileName={ctx.fileName} />
+  ),
+};


### PR DESCRIPTION
## Description

Fixes the garbled XLSX chat-attachment preview.

**Regression:** PR #9785 moved xlsx from the `DOC` bucket into `TABULAR` (`TABULAR_MIME_TYPES = CSV_MIME_TYPES | {SPREADSHEET_MIME_TYPE}`), so xlsx chat attachments started rendering inline through `CsvContent`. That component downloads the raw file from `/api/chat/file/{id}` and calls `response.text()` — decoding the binary OOXML zip as UTF-8 and displaying rows of `?`/U+FFFD mojibake. The file-card `PreviewModal` path showed "This file format is not supported for preview." for xlsx.

**Fix (backend-parsing approach, no new frontend deps):**

Backend:
- `GET /chat/file/{file_id}?parsed=true` — for spreadsheet MIME types only, the stored xlsx is converted server-side (via the existing `xlsx_sheet_extraction` / openpyxl path used for LLM plaintext) into a JSON payload of per-sheet CSV text: `{"sheets": [{"name", "csv", "truncated"}]}`. Each sheet's CSV is defensively capped (500K chars, cut at a row boundary respecting quoted fields) and flagged `truncated`. For non-spreadsheet files `parsed=true` is a no-op — raw behavior (including CSV) is byte-for-byte unchanged. Parsed responses use a distinct ETag (`"{id}-parsed"`) so caching stays correct.

Frontend:
- New `SpreadsheetContent` component fetches the parsed payload and renders a real table (same table rendering/styling as `CsvContent`), with sheet tabs when the workbook has multiple sheets and a truncation notice row when a sheet was cut.
- `FileDisplay` routes `.xlsx`/`.xlsm` tabular files to `SpreadsheetContent`; CSV files keep using `CsvContent` exactly as before.
- New `xlsxVariant` for `PreviewModal` (file cards / expanded view) renders the same sheet-tabbed table instead of "not supported"; download still serves the original xlsx bytes.

## How Has This Been Tested?

- New external-dependency-unit tests (`backend/tests/external_dependency_unit/chat/test_spreadsheet_preview.py`): round-trips a generated two-sheet xlsx through the real file store and verifies per-sheet CSV output (incl. comma/quote/newline escaping), verifies large-sheet truncation lands on a valid row boundary, and verifies the MIME gate so `parsed=true` stays a no-op for CSV/PDF. All 3 pass.
- Existing `parseCSV` frontend tests (13) and `chat_utils` unit tests pass.
- `pre-commit` (ruff, ty, oxlint/oxfmt, tsgo typecheck) passes on all changed files.
- Screenshots: manual end-to-end verification against a running deployment wasn't possible in this environment (services run the main checkout, not this branch).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes garbled `.xlsx` chat attachment previews by parsing spreadsheets on the backend and rendering a sheet‑tabbed table in the app. Adds `.xlsm` support, trusts stored MIME over file names, and skips downloading raw blobs for parsed previews; CSV and other file types are unchanged.

- **Bug Fixes**
  - Backend: `GET /chat/file/{id}?parsed=true` returns per‑sheet CSV JSON for spreadsheet MIME types (`.xlsx`, `.xlsm); uses a single‑pass, row‑safe truncation cap (500k chars/sheet; empty sheet if the first row alone exceeds the cap); uses a tempfile for large files; caches with a `"{id}-parsed"` ETag; non‑spreadsheets still stream raw bytes unchanged.
  - Frontend: `SpreadsheetContent` renders parsed sheets with tabs and a truncation note; no cell trimming (drops at most one trailing newline); dispatches by response `Content-Type` (JSON vs raw CSV) so renamed/missing extensions still render correctly; caches sheets per file and guards large raw CSV size. `FileDisplay` routes all `TABULAR` files through `SpreadsheetContent`. `fetchChatFile(id, parsed)` supports `?parsed=true`. `PreviewModal` adds `xlsxVariant` (`needsParsedContent`) to fetch parsed content, resolves using stored MIME over the display name, skips fetching the raw workbook blob, shows sheet count, logs errors, preserves a working download link for the current file on failure, and only revokes blob URLs.
  - Tests: coverage for multi‑sheet parsing, row‑safe truncation (incl. empty sheet when the first row exceeds the cap and quoted‑newline cases), XLSM MIME gating, and CSV passthrough. Existing frontend tests pass.

<sup>Written for commit 43f3e23d4b0b98f4c53ddb1c81ebe8e6da19d95b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

