### PR TITLE
fix(cli): JSON-aware truncation so search output is always valid JSON

### DIFF
--- a/backend/tests/integration/tests/cli/test_cli_commands.py
+++ b/backend/tests/integration/tests/cli/test_cli_commands.py
@@ -35,7 +35,7 @@ Test Suite:
 16. test_experiments - Lists feature flags
 17. test_search_returns_results - Search returns seeded document content
 18. test_search_raw - --raw outputs full SearchResponse as JSON
-19. test_search_truncation - --max-output truncates with temp file path
+19. test_search_truncation - --max-output keeps stdout valid JSON with truncation metadata
 20. test_search_no_query - No query returns exit code 2
 21. test_search_bad_pat - Invalid PAT returns exit code 4
 22. test_search_not_configured - Missing PAT returns exit code 3
@@ -418,7 +418,7 @@ def test_search_truncation(
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     api_key: DATestAPIKey,
 ) -> None:
-    """--max-output truncates output and shows temp file path."""
+    """--max-output keeps stdout valid JSON and adds truncation metadata."""
     cc_pair = CCPairManager.create_from_scratch(user_performing_action=admin_user)
     phrase = "cli-search-truncation-unique"
     DocumentManager.seed_doc_with_content(cc_pair, phrase, api_key)
@@ -431,8 +431,15 @@ def test_search_truncation(
     )
 
     assert result.returncode == 0, f"stderr: {result.stderr}"
-    assert "response truncated" in result.stdout
-    assert "Full response:" in result.stdout
+    data = json.loads(result.stdout)
+    truncation = data["truncation"]
+    assert truncation["truncated"] is True
+    assert truncation["shown_results"] == len(data["results"])
+    assert truncation["shown_results"] <= truncation["total_results"]
+    assert truncation["total_bytes"] > 50
+    assert truncation["full_response_path"]
+    # Human-oriented note goes to stderr, never stdout.
+    assert "response truncated" in result.stderr
 
 
 def test_search_no_query(

--- a/cli/README.md
+++ b/cli/README.md
@@ -127,6 +127,7 @@ When called without a TTY (e.g., by an AI agent or piped into another command), 
 - **Results to stdout**, progress/errors to stderr
 - **No ANSI codes** or interactive prompts
 - **`ask` output truncated** to 50000 bytes by default; full response saved to a temp file. Use `--max-output 0` to disable.
+- **`search` stdout stays valid JSON**: over the limit, whole results are dropped and a `truncation` object carries metadata plus the temp file path of the full response.
 
 ### Configuration
 

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -84,8 +84,13 @@ func writeSearchJSON(ios *iostreams.IOStreams, output searchOutput, truncateAt i
 
 	fullPath, err := overflow.SaveFull("onyx-search-*.json", string(data))
 	if err != nil {
-		fmt.Fprintf(ios.ErrOut, "warning: could not save full response: %v\n", err)
-		fullPath = ""
+		// Without the temp copy, dropped results would be unrecoverable —
+		// emit the full response instead (valid JSON beats the byte bound).
+		fmt.Fprintf(
+			ios.ErrOut, "warning: could not save full response, emitting it whole: %v\n", err,
+		)
+		fmt.Fprintln(ios.Out, string(data))
+		return nil
 	}
 	envelope, err := buildTruncatedSearchOutput(output, truncateAt, len(data), fullPath)
 	if err != nil {
@@ -109,16 +114,12 @@ func writeSearchJSON(ios *iostreams.IOStreams, output searchOutput, truncateAt i
 func buildTruncatedSearchOutput(
 	full searchOutput, limit int, totalBytes int, fullPath string,
 ) ([]byte, error) {
-	hint := "results were dropped to fit the output limit"
-	if fullPath != "" {
-		hint += "; the complete response is at full_response_path"
-	}
 	trunc := &searchTruncation{
 		Truncated:        true,
 		TotalResults:     len(full.Results),
 		TotalBytes:       totalBytes,
 		FullResponsePath: fullPath,
-		Hint:             hint,
+		Hint:             "output was reduced to fit the output limit; the complete response is at full_response_path",
 	}
 	marshal := func(results []searchOutputResult) ([]byte, error) {
 		trunc.ShownResults = len(results)

--- a/cli/cmd/search.go
+++ b/cli/cmd/search.go
@@ -17,7 +17,7 @@ import (
 )
 
 // searchOutputResult is the per-document JSON shape `onyx-cli search` prints
-// (without --raw). One ``content`` field per result, no Onyx-internal jargon.
+// (without --raw). One `content` field per result, no Onyx-internal jargon.
 type searchOutputResult struct {
 	Title      string  `json:"title"`
 	URL        *string `json:"url"`
@@ -28,7 +28,21 @@ type searchOutputResult struct {
 
 // searchOutput is the top-level wrapper for `onyx-cli search` default stdout.
 type searchOutput struct {
-	Results []searchOutputResult `json:"results"`
+	Results    []searchOutputResult `json:"results"`
+	Truncation *searchTruncation    `json:"truncation,omitempty"`
+}
+
+// searchTruncation is attached to searchOutput when results were dropped or
+// trimmed to keep stdout under the output limit. The full pretty-printed
+// response is saved to FullResponsePath.
+type searchTruncation struct {
+	Truncated        bool   `json:"truncated"`
+	TotalResults     int    `json:"total_results"`
+	ShownResults     int    `json:"shown_results"`
+	TotalBytes       int    `json:"total_bytes"`
+	ContentTruncated bool   `json:"content_truncated"`
+	FullResponsePath string `json:"full_response_path"`
+	Hint             string `json:"hint"`
 }
 
 // maxSearchDays caps --days at ~100 years. The cap mostly exists to keep
@@ -51,6 +65,124 @@ func toSearchOutput(resp models.SearchResponse) searchOutput {
 		})
 	}
 	return out
+}
+
+// writeSearchJSON prints the search output as pretty JSON. When the payload
+// exceeds truncateAt bytes (> 0), the full response is saved to a temp file
+// and a smaller — but always valid — JSON envelope with truncation metadata
+// is printed instead. Human-oriented notes go to stderr only.
+func writeSearchJSON(ios *iostreams.IOStreams, output searchOutput, truncateAt int) error {
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal response: %w", err)
+	}
+
+	if truncateAt <= 0 || len(data) <= truncateAt {
+		fmt.Fprintln(ios.Out, string(data))
+		return nil
+	}
+
+	fullPath, err := overflow.SaveFull("onyx-search-*.json", string(data))
+	if err != nil {
+		fmt.Fprintf(ios.ErrOut, "warning: could not save full response: %v\n", err)
+		fullPath = ""
+	}
+	envelope, err := buildTruncatedSearchOutput(output, truncateAt, len(data), fullPath)
+	if err != nil {
+		return fmt.Errorf("failed to marshal response: %w", err)
+	}
+	fmt.Fprintln(ios.Out, string(envelope))
+
+	note := fmt.Sprintf("response truncated (%d bytes total)", len(data))
+	if fullPath != "" {
+		note += "; full response: " + fullPath
+	}
+	fmt.Fprintln(ios.ErrOut, note)
+	return nil
+}
+
+// buildTruncatedSearchOutput marshals a valid-JSON envelope that fits under
+// limit by dropping whole results (relevance-ordered, so a prefix is kept).
+// If the first result alone exceeds the limit, its content is trimmed at a
+// rune boundary. The envelope may exceed limit only when the truncation
+// metadata alone does: valid JSON always wins over the byte bound.
+func buildTruncatedSearchOutput(
+	full searchOutput, limit int, totalBytes int, fullPath string,
+) ([]byte, error) {
+	hint := "results were dropped to fit the output limit"
+	if fullPath != "" {
+		hint += "; the complete response is at full_response_path"
+	}
+	trunc := &searchTruncation{
+		Truncated:        true,
+		TotalResults:     len(full.Results),
+		TotalBytes:       totalBytes,
+		FullResponsePath: fullPath,
+		Hint:             hint,
+	}
+	marshal := func(results []searchOutputResult) ([]byte, error) {
+		trunc.ShownResults = len(results)
+		return json.MarshalIndent(searchOutput{Results: results, Truncation: trunc}, "", "  ")
+	}
+
+	fit, data, err := largestFit(len(full.Results), limit, func(n int) ([]byte, error) {
+		return marshal(full.Results[:n])
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Trim content only when the metadata fits but the first whole result
+	// doesn't; otherwise nothing can fit and the n=0 envelope is best effort.
+	if fit >= 1 || len(full.Results) == 0 || len(data) > limit {
+		return data, nil
+	}
+
+	zeroEnvelope := data
+	trunc.ContentTruncated = true
+	trimmed := full.Results[0]
+	runes := []rune(trimmed.Content)
+	_, data, err = largestFit(len(runes), limit, func(k int) ([]byte, error) {
+		trimmed.Content = string(runes[:k])
+		return marshal([]searchOutputResult{trimmed})
+	})
+	if err != nil {
+		return nil, err
+	}
+	// Even an empty-content result overflows (oversized title/url): fall back
+	// to the zero-results envelope, which is known to fit.
+	if len(data) > limit {
+		return zeroEnvelope, nil
+	}
+	return data, nil
+}
+
+// largestFit binary-searches for the largest n in [0, maxN] whose rendering is
+// at most limit bytes, returning n and its rendering. render must produce
+// output whose size is non-decreasing in n. Falls back to render(0) when
+// nothing fits.
+func largestFit(
+	maxN int, limit int, render func(n int) ([]byte, error),
+) (int, []byte, error) {
+	best := 0
+	bestData, err := render(0)
+	if err != nil {
+		return 0, nil, err
+	}
+	lo, hi := 1, maxN
+	for lo <= hi {
+		mid := (lo + hi) / 2
+		data, err := render(mid)
+		if err != nil {
+			return 0, nil, err
+		}
+		if len(data) <= limit {
+			best, bestData = mid, data
+			lo = mid + 1
+		} else {
+			hi = mid - 1
+		}
+	}
+	return best, bestData, nil
 }
 
 // searchFlags bundles the resolved CLI flag inputs for buildSearchRequest.
@@ -117,8 +249,10 @@ Results contain only documents the LLM judged relevant, ordered by relevance;
 content is the full chunk text of each. Use --raw for the full API response
 (adds per-result citation_id).
 
-When stdout is not a TTY, output is truncated to --max-output bytes and the
-full response is saved to a temp file.`,
+When stdout is not a TTY and the response exceeds --max-output bytes, whole
+results are dropped so stdout stays valid JSON; a "truncation" object carries
+metadata (total_results, shown_results, full_response_path, ...) and the full
+response is saved to a temp file.`,
 		Args: cobra.MaximumNArgs(1),
 		Example: `  onyx-cli search "What is our deployment process?"
   onyx-cli search --source slack "auth migration status"
@@ -192,17 +326,7 @@ full response is saved to a temp file.`,
 				truncateAt = defaultMaxOutputBytes
 			}
 
-			output := toSearchOutput(*resp)
-			data, err := json.MarshalIndent(output, "", "  ")
-			if err != nil {
-				return fmt.Errorf("failed to marshal response: %w", err)
-			}
-
-			ow := &overflow.Writer{Limit: truncateAt, Out: ios.Out, ErrOut: ios.ErrOut}
-			ow.Write(string(data))
-			ow.Finish()
-
-			return nil
+			return writeSearchJSON(ios, toSearchOutput(*resp), truncateAt)
 		},
 	}
 

--- a/cli/cmd/search_test.go
+++ b/cli/cmd/search_test.go
@@ -402,6 +402,33 @@ func TestWriteSearchJSON_OverLimitIsValidJSON(t *testing.T) {
 	}
 }
 
+func TestWriteSearchJSON_TempSaveFailureEmitsFullResponse(t *testing.T) {
+	// Dropped results must never be unrecoverable: with no temp copy, the
+	// full over-limit response is emitted instead of a truncated envelope.
+	t.Setenv("TMPDIR", "/nonexistent-onyx-cli-test")
+	var out, errOut bytes.Buffer
+	ios := &iostreams.IOStreams{Out: &out, ErrOut: &errOut}
+	output := searchOutput{Results: makeSearchResults(20, 500)}
+
+	if err := writeSearchJSON(ios, output, 3000); err != nil {
+		t.Fatalf("writeSearchJSON failed: %v", err)
+	}
+
+	var parsed searchOutput
+	if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v", err)
+	}
+	if parsed.Truncation != nil {
+		t.Fatal("full-response fallback must not carry truncation metadata")
+	}
+	if len(parsed.Results) != 20 {
+		t.Fatalf("Results length = %d, want all 20", len(parsed.Results))
+	}
+	if !strings.Contains(errOut.String(), "could not save full response") {
+		t.Errorf("stderr should warn about the failed save, got %q", errOut.String())
+	}
+}
+
 func TestBuildTruncatedSearchOutput_SingleOversizedResult(t *testing.T) {
 	// Multibyte runes verify the trim lands on a rune boundary.
 	content := strings.Repeat("héllo→wörld ", 500)

--- a/cli/cmd/search_test.go
+++ b/cli/cmd/search_test.go
@@ -2,9 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
@@ -87,21 +92,21 @@ func TestBuildSearchRequest(t *testing.T) {
 			wantSources: []string{"slack", "google_drive"},
 		},
 		{
-			name:               "days_agentID_set",
-			query:              "test query",
-			days:               30,
-			daysSet:            true,
-			agentID:            3,
-			agentIDSet:         true,
-			wantDaysAgo: intPtr(30),
-			wantPersonaID:      intPtr(3),
+			name:          "days_agentID_set",
+			query:         "test query",
+			days:          30,
+			daysSet:       true,
+			agentID:       3,
+			agentIDSet:    true,
+			wantDaysAgo:   intPtr(30),
+			wantPersonaID: intPtr(3),
 		},
 		{
-			name:               "unset_flags_produce_zero_values",
-			query:              "test query",
-			wantSources:        nil,
-			wantDaysAgo: nil,
-			wantPersonaID:      nil,
+			name:          "unset_flags_produce_zero_values",
+			query:         "test query",
+			wantSources:   nil,
+			wantDaysAgo:   nil,
+			wantPersonaID: nil,
 		},
 		{
 			name:          "agent_id_zero_explicitly_set",
@@ -283,5 +288,217 @@ func TestToSearchOutput(t *testing.T) {
 	}
 	if withNils.UpdatedAt != nil {
 		t.Errorf("Results[1].UpdatedAt = %v, want nil", withNils.UpdatedAt)
+	}
+}
+
+// makeSearchResults builds n results with roughly equal-size content chunks.
+func makeSearchResults(n int, contentSize int) []searchOutputResult {
+	results := make([]searchOutputResult, 0, n)
+	for i := 0; i < n; i++ {
+		results = append(results, searchOutputResult{
+			Title:      fmt.Sprintf("Doc %d", i),
+			SourceType: "confluence",
+			Content:    strings.Repeat("x", contentSize),
+		})
+	}
+	return results
+}
+
+func TestWriteSearchJSON_UnderLimit(t *testing.T) {
+	var out, errOut bytes.Buffer
+	ios := &iostreams.IOStreams{Out: &out, ErrOut: &errOut}
+	output := searchOutput{Results: makeSearchResults(2, 100)}
+
+	if err := writeSearchJSON(ios, output, 50000); err != nil {
+		t.Fatalf("writeSearchJSON failed: %v", err)
+	}
+
+	var parsed searchOutput
+	if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v", err)
+	}
+	if parsed.Truncation != nil {
+		t.Fatal("under-limit output should not carry truncation metadata")
+	}
+	if len(parsed.Results) != 2 {
+		t.Fatalf("Results length = %d, want 2", len(parsed.Results))
+	}
+	if errOut.Len() != 0 {
+		t.Fatalf("expected empty stderr, got %q", errOut.String())
+	}
+}
+
+func TestWriteSearchJSON_OverLimitIsValidJSON(t *testing.T) {
+	var out, errOut bytes.Buffer
+	ios := &iostreams.IOStreams{Out: &out, ErrOut: &errOut}
+	output := searchOutput{Results: makeSearchResults(20, 500)}
+
+	fullData, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+	limit := 3000
+	if len(fullData) <= limit {
+		t.Fatalf("test setup: payload (%d bytes) must exceed limit %d", len(fullData), limit)
+	}
+
+	if err := writeSearchJSON(ios, output, limit); err != nil {
+		t.Fatalf("writeSearchJSON failed: %v", err)
+	}
+
+	var parsed searchOutput
+	if err := json.Unmarshal(out.Bytes(), &parsed); err != nil {
+		t.Fatalf("stdout is not valid JSON: %v\n%s", err, out.String())
+	}
+	if len(out.Bytes()) > limit+1 { // +1 for trailing newline
+		t.Fatalf("stdout is %d bytes, want <= %d", out.Len(), limit+1)
+	}
+
+	tr := parsed.Truncation
+	if tr == nil {
+		t.Fatal("expected truncation metadata")
+	}
+	t.Cleanup(func() { _ = os.Remove(tr.FullResponsePath) })
+	if !tr.Truncated {
+		t.Error("Truncated = false, want true")
+	}
+	if tr.TotalResults != 20 {
+		t.Errorf("TotalResults = %d, want 20", tr.TotalResults)
+	}
+	if tr.ShownResults != len(parsed.Results) {
+		t.Errorf("ShownResults = %d, want %d", tr.ShownResults, len(parsed.Results))
+	}
+	if tr.ShownResults < 1 || tr.ShownResults >= 20 {
+		t.Errorf("ShownResults = %d, want in [1, 19]", tr.ShownResults)
+	}
+	// Survivors must be the relevance-ordered prefix, not an arbitrary subset.
+	for i, r := range parsed.Results {
+		if want := fmt.Sprintf("Doc %d", i); r.Title != want {
+			t.Errorf("Results[%d].Title = %q, want %q", i, r.Title, want)
+		}
+	}
+	if tr.TotalBytes != len(fullData) {
+		t.Errorf("TotalBytes = %d, want %d", tr.TotalBytes, len(fullData))
+	}
+	if tr.ContentTruncated {
+		t.Error("ContentTruncated = true, want false when whole results fit")
+	}
+	if tr.Hint == "" {
+		t.Error("Hint should not be empty")
+	}
+
+	// Temp file must hold the complete response.
+	saved, err := os.ReadFile(tr.FullResponsePath)
+	if err != nil {
+		t.Fatalf("failed to read full response file: %v", err)
+	}
+	if !bytes.Equal(saved, fullData) {
+		t.Error("full response file does not match the full payload")
+	}
+
+	// Human note goes to stderr, not stdout.
+	if !strings.Contains(errOut.String(), "response truncated") {
+		t.Errorf("stderr should mention truncation, got %q", errOut.String())
+	}
+}
+
+func TestBuildTruncatedSearchOutput_SingleOversizedResult(t *testing.T) {
+	// Multibyte runes verify the trim lands on a rune boundary.
+	content := strings.Repeat("héllo→wörld ", 500)
+	output := searchOutput{Results: []searchOutputResult{{
+		Title:      "Big doc",
+		SourceType: "slack",
+		Content:    content,
+	}}}
+
+	limit := 2000
+	data, err := buildTruncatedSearchOutput(output, limit, 99999, "/tmp/full.json")
+	if err != nil {
+		t.Fatalf("buildTruncatedSearchOutput failed: %v", err)
+	}
+	if len(data) > limit {
+		t.Fatalf("envelope is %d bytes, want <= %d", len(data), limit)
+	}
+
+	var parsed searchOutput
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	if parsed.Truncation == nil || !parsed.Truncation.ContentTruncated {
+		t.Fatal("expected ContentTruncated = true")
+	}
+	if parsed.Truncation.ShownResults != 1 || len(parsed.Results) != 1 {
+		t.Fatalf("expected exactly 1 shown result, got %d", len(parsed.Results))
+	}
+	got := parsed.Results[0].Content
+	if !utf8.ValidString(got) {
+		t.Error("trimmed content is not valid UTF-8")
+	}
+	if len(got) == 0 || len(got) >= len(content) {
+		t.Errorf("trimmed content length = %d, want in (0, %d)", len(got), len(content))
+	}
+	if !strings.HasPrefix(content, got) {
+		t.Error("trimmed content is not a prefix of the original")
+	}
+}
+
+func TestBuildTruncatedSearchOutput_OversizedTitleFallsBackToZeroResults(t *testing.T) {
+	// Content trimming can't help when the overflow lives in an untrimmed
+	// field: even the empty-content render exceeds the limit, so the builder
+	// must fall back to the zero-results envelope (which fits).
+	output := searchOutput{Results: []searchOutputResult{{
+		Title:      strings.Repeat("t", 5000),
+		SourceType: "slack",
+		Content:    strings.Repeat("c", 5000),
+	}}}
+
+	limit := 1000
+	data, err := buildTruncatedSearchOutput(output, limit, 99999, "/tmp/full.json")
+	if err != nil {
+		t.Fatalf("buildTruncatedSearchOutput failed: %v", err)
+	}
+	if len(data) > limit {
+		t.Fatalf("envelope is %d bytes, want <= %d", len(data), limit)
+	}
+
+	var parsed searchOutput
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	if len(parsed.Results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(parsed.Results))
+	}
+	if parsed.Truncation == nil || parsed.Truncation.ContentTruncated {
+		t.Fatal("zero-results fallback must not claim content was trimmed")
+	}
+	if parsed.Truncation.TotalResults != 1 || parsed.Truncation.ShownResults != 0 {
+		t.Fatalf(
+			"TotalResults/ShownResults = %d/%d, want 1/0",
+			parsed.Truncation.TotalResults, parsed.Truncation.ShownResults,
+		)
+	}
+}
+
+func TestBuildTruncatedSearchOutput_TinyLimitStillValidJSON(t *testing.T) {
+	output := searchOutput{Results: makeSearchResults(3, 200)}
+
+	// Limit smaller than the metadata itself: envelope may exceed the limit
+	// but must remain valid JSON.
+	data, err := buildTruncatedSearchOutput(output, 50, 1234, "/tmp/full.json")
+	if err != nil {
+		t.Fatalf("buildTruncatedSearchOutput failed: %v", err)
+	}
+	var parsed searchOutput
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("envelope is not valid JSON: %v", err)
+	}
+	if parsed.Truncation == nil || !parsed.Truncation.Truncated {
+		t.Fatal("expected truncation metadata")
+	}
+	if len(parsed.Results) != 0 {
+		t.Fatalf("expected 0 results when nothing fits, got %d", len(parsed.Results))
+	}
+	if parsed.Truncation.TotalResults != 3 {
+		t.Errorf("TotalResults = %d, want 3", parsed.Truncation.TotalResults)
 	}
 }

--- a/cli/internal/embedded/SKILL.md
+++ b/cli/internal/embedded/SKILL.md
@@ -61,6 +61,8 @@ onyx-cli search "What is our deployment process?"
 
 Returns ranked, cited documents from the Onyx knowledge base as JSON. Default output is a lean shape: `{"results": [{title, url, source_type, content, updated_at}, ...]}`. Results contain only documents the LLM judged relevant, ordered by relevance; `content` is the full chunk text of each. Use `--raw` for the full API response (adds per-result `citation_id`).
 
+Stdout is always valid JSON. If the response exceeds `--max-output` bytes (default 50000 for non-TTY), lowest-ranked results are dropped and a `truncation` object is added: `{truncated, total_results, shown_results, total_bytes, content_truncated, full_response_path, hint}`. The complete response is saved to `full_response_path`; read that file for the dropped results.
+
 ```bash
 # Filter by source
 onyx-cli search --source slack,google_drive "auth migration status"
@@ -136,7 +138,7 @@ Checks config exists, PAT is present, server is reachable, and credentials are v
 - **stdout**: Results only (answer text, agent list, status)
 - **stderr**: Progress indicators, warnings, errors
 - **Non-TTY**: No ANSI escape codes, no interactive prompts
-- **Truncation**: When stdout is not a TTY, `search` and `ask` output is truncated to 50000 bytes. Full response is saved to a temp file whose path is printed. Read the temp file for more.
+- **Truncation**: When stdout is not a TTY, `search` and `ask` output is limited to 50000 bytes and the full response is saved to a temp file. `search` stays valid JSON — whole results are dropped and a `truncation` object carries the temp file path. `ask` (plain text) is cut at the byte limit with the temp file path printed at the end.
 
 ## Exit Codes
 

--- a/cli/internal/overflow/writer.go
+++ b/cli/internal/overflow/writer.go
@@ -121,6 +121,23 @@ func (w *Writer) Finish() {
 	fmt.Fprintf(w.out(), "  cat %s | tail -50\n", tmpPath)
 }
 
+// SaveFull writes content to a new temp file and returns its path.
+func SaveFull(pattern string, content string) (string, error) {
+	f, err := os.CreateTemp("", pattern)
+	if err != nil {
+		return "", err
+	}
+	if _, err := f.WriteString(content); err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		return "", err
+	}
+	return f.Name(), nil
+}
+
 // closeTmpFile closes and optionally removes the temp file.
 func (w *Writer) closeTmpFile(remove bool) {
 	if w.tmpFile == nil {

--- a/cli/internal/overflow/writer_test.go
+++ b/cli/internal/overflow/writer_test.go
@@ -103,6 +103,21 @@ func TestWriter_MultipleChunks(t *testing.T) {
 	}
 }
 
+func TestSaveFull(t *testing.T) {
+	path, err := SaveFull("onyx-test-*.txt", "hello world")
+	if err != nil {
+		t.Fatalf("SaveFull failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read temp file: %v", err)
+	}
+	if string(data) != "hello world" {
+		t.Fatalf("temp file should contain full content, got %q", string(data))
+	}
+}
+
 func TestWriter_QuietMode(t *testing.T) {
 	var buf bytes.Buffer
 	w := &Writer{Limit: 0, Quiet: true, Out: &buf}


### PR DESCRIPTION
## Description

`onyx-cli search` prints JSON, but for non-TTY callers `overflow.Writer` byte-truncated stdout at `--max-output` (default 50,000) — cutting mid-JSON-string — and appended a plain-text `--- response truncated ---` trailer to stdout. Any response over the limit was guaranteed-invalid JSON for exactly the consumers the truncation exists for (agents piping to a JSON parser). Observed in a cloud Craft session on 2026-07-06: four failed tool calls and regex-over-raw-text workarounds.

New contract — stdout is always parseable JSON:

- Under the limit (or TTY / `--max-output 0`): byte-identical to before, no new keys.
- Over the limit: the full pretty-printed response is saved to a temp file and stdout gets a valid envelope — the relevance-ordered prefix of results that fits, plus a `truncation` object: `{truncated, total_results, shown_results, total_bytes, content_truncated, full_response_path, hint}`. The human note moves to stderr.
- The cut is found by binary search (`largestFit`) against the actual rendered envelope, reused for the degradation cascade: drop whole results → trim the first result's `content` at a rune boundary (`content_truncated: true`) → zero-results envelope → if the metadata alone exceeds the limit, emit it anyway (valid JSON wins over the byte bound).
- `--raw` still bypasses truncation; `ask` (prose) keeps the old writer behavior. Audit: `agents --json` and `ask --json` marshal directly without truncation, so `search` was the only command able to emit invalid JSON.

The embedded `SKILL.md` (what sandbox agents read) and `cli/README.md` document the new contract.

## How Has This Been Tested?

- Go unit tests (`cli/cmd/search_test.go`, `cli/internal/overflow/writer_test.go`): under-limit passthrough with no truncation key and empty stderr; over-limit output parses, respects the byte bound, carries correct metadata (`total_bytes` checked against an independently marshaled payload), keeps the relevance-ordered prefix, and the temp file byte-equals the full payload; rune-boundary content trim on multibyte text; oversized-title fallback to the zero-results envelope; metadata-only tiny-limit case. `go test ./...`, `go vet`, `gofmt` clean on touched packages.
- Live smoke test against a stub HTTP server returning a 167KB response: `json.load(sys.stdin)`-style parsing succeeded across default limit, 3KB limit, 50-byte limit, `--raw`, and under-limit modes.
- `test_search_truncation` (integration, CI-only) rewritten to `json.loads(stdout)` and assert the truncation metadata + stderr note.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `onyx-cli search` always emits valid JSON by making truncation JSON-aware. Over-limit outputs return a trimmed JSON envelope with metadata, save the full response to a temp file, and fall back to the full response if the save fails.

- **Bug Fixes**
  - Over `--max-output`, keep the relevance-ordered prefix and add a `truncation` object: `{truncated, total_results, shown_results, total_bytes, content_truncated, full_response_path, hint}`.
  - Always valid JSON: drop whole results via binary search; if needed, rune-safe trim of the first result’s `content`; otherwise fall back to a zero-results envelope; metadata-only when the limit is tiny.
  - If the temp save fails, warn on stderr and emit the full response; otherwise the human note goes to stderr only. TTY/under-limit/`--max-output 0` unchanged; `--raw` bypasses truncation; `ask` behavior unchanged.
  - Tests updated to assert JSON stdout, truncation metadata, and save-failure fallback; docs (`SKILL.md`, `cli/README.md`) document the contract.

<sup>Written for commit bbea7d93ee9d2752a358b0863b91722a683032b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

