### PR TITLE
ci(helm): require Chart.yaml version bump when chart files change

### DIFF
--- a/.github/workflows/pr-helm-chart-version.yml
+++ b/.github/workflows/pr-helm-chart-version.yml
@@ -1,0 +1,77 @@
+name: Helm Chart Version Check
+concurrency:
+  group: Helm-Chart-Version-Check-${{ github.workflow }}-${{ github.head_ref || github.event.workflow_run.head_branch || github.run_id }}
+  cancel-in-progress: true
+
+# Requires deployment/helm/charts/onyx/Chart.yaml `version` to be bumped above the
+# version on main whenever the packaged chart changes. helm-chart-releases.yml
+# republishes the chart on every push to main and will NOT overwrite an
+# already-published version, so a chart change that reuses main's version is
+# silently never released. This gate prevents that.
+#
+# Uses native path filtering: the workflow only runs when watched chart files
+# change (onyx-cnpg-crds is bundled into the onyx chart via Chart.lock, so it
+# counts too). Because of this it cannot be a *required* branch-protection check
+# -- a required check that is filtered out on unrelated PRs stays stuck "pending"
+# and blocks merges. It is enforced as a visible failing check on chart PRs.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "deployment/helm/charts/onyx/**"
+      - "deployment/helm/charts/onyx-cnpg-crds/**"
+
+permissions:
+  contents: read
+
+jobs:
+  helm-chart-version-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Require Chart.yaml version bump above main
+        run: |
+          set -euo pipefail
+
+          CHART_FILE="deployment/helm/charts/onyx/Chart.yaml"
+
+          # Compare against the current tip of main (what the release publishes
+          # from), so concurrent PRs can't both ship the same new version.
+          git fetch --no-tags --depth=1 origin +refs/heads/main:refs/remotes/origin/main
+
+          # Top-level `version:` only (dependency versions are indented; appVersion differs).
+          extract_version() {
+            awk '/^version:/ {print $2; exit}' | tr -d "\"'"
+          }
+
+          NEW_VERSION="$(extract_version < "$CHART_FILE" || true)"
+          MAIN_VERSION="$(git show origin/main:"$CHART_FILE" 2>/dev/null | extract_version || true)"
+
+          echo "main version: ${MAIN_VERSION:-<none>}"
+          echo "PR version:   ${NEW_VERSION:-<none>}"
+
+          SEMVER_RE='^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)*$'
+          if [[ ! "$NEW_VERSION" =~ $SEMVER_RE ]]; then
+            echo "::error file=$CHART_FILE::'version: ${NEW_VERSION:-<empty>}' is not valid semver."
+            exit 1
+          fi
+
+          # Chart not on main yet (new chart): any valid semver is acceptable.
+          if [[ -z "$MAIN_VERSION" ]]; then
+            echo "No version on main (new chart). Version '$NEW_VERSION' accepted."
+            exit 0
+          fi
+
+          # NEW_VERSION must be a strict semver increase over main's version.
+          GREATER="$(printf '%s\n%s\n' "$MAIN_VERSION" "$NEW_VERSION" | sort -V | tail -n1)"
+          if [[ "$NEW_VERSION" == "$MAIN_VERSION" || "$GREATER" != "$NEW_VERSION" ]]; then
+            echo "::error file=$CHART_FILE::Helm chart files changed but version $NEW_VERSION is not greater than main's $MAIN_VERSION. Bump 'version' in $CHART_FILE above $MAIN_VERSION so the chart re-publishes on merge to main."
+            exit 1
+          fi
+
+          echo "Chart version $MAIN_VERSION (main) -> $NEW_VERSION (PR). Check passed."


### PR DESCRIPTION
## Description

Adds a CI gate that fails a PR when Helm chart files change but the onyx chart's `version` is not bumped **above the version currently on `main`**.

**Why:** `helm-chart-releases.yml` republishes the onyx chart to `gh-pages` on every push to `main`, and chart-releaser will not overwrite an already-published version. So a chart change that reuses a version already on `main` is silently never released.

**Why compare against `main`'s tip (not the PR's branch point):** the chart publishes from `main`, so the version that matters is `main`'s current one. Two PRs could otherwise both bump `0.6.9 -> 0.6.10` off an old `main`; the second to merge would collide with the already-published `0.6.10`. Comparing against `origin/main` catches that.

**How it triggers:** native GitHub Actions path filtering (`on.pull_request.paths`) on:
- `deployment/helm/charts/onyx/**`
- `deployment/helm/charts/onyx-cnpg-crds/**` (bundled into the onyx chart via `Chart.lock`)

When it runs, it requires `deployment/helm/charts/onyx/Chart.yaml` `version` to be a **strictly-greater, valid semver** than `origin/main`'s version. No override.

**Trade-off (intentional):** a trigger-level path-filtered workflow can't be a *required* branch-protection check — a required check that's filtered out on unrelated PRs stays stuck "pending" and blocks merges. So this is enforced as a **visible failing check on chart PRs**, not a hard merge blocker. `merge_group` is intentionally not a trigger (it ignores `paths`, so it would run on — and falsely fail — non-chart queued batches). If a hard merge-block is needed later, pair it with an always-pass companion job sharing the check name (the pattern used in `merge-group.yml`).

## How Has This Been Tested?

Version comparison logic exercised against a stand-in `main`:

- Chart file changed, forgot to bump (`0.6.9` vs `0.6.9`) → **FAIL**
- Normal bump `0.6.9 -> 0.6.10` → **PASS**
- Concurrent collision: `main` already `0.6.10`, PR also `0.6.10` → **FAIL**
- Stale branch behind main (`main 0.6.11`, PR `0.6.9`) → **FAIL**
- Minor bump `0.6.9 -> 0.7.0` → **PASS**
- New chart not yet on `main` → **PASS** for any valid semver
- Non-semver value → **FAIL**

`extract_version` confirmed to read only the top-level `version:` (not indented dependency versions or `appVersion`). Workflow YAML validated with a parser.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)