### PR TITLE
chore: bump sandbox onyx-cli to 1.2.2

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
@@ -24,7 +24,7 @@ lxml==6.1.1               # via python-pptx, -r initial-requirements.in
 matplotlib==3.11.0        # via -r initial-requirements.in
 matplotlib-inline==0.2.2  # via -r initial-requirements.in
 numpy==2.4.6              # via contourpy, matplotlib, pandas, -r initial-requirements.in
-onyx-cli==1.2.1           # via -r initial-requirements.in
+onyx-cli==1.2.2           # via -r initial-requirements.in
 openpyxl==3.1.5           # via -r initial-requirements.in
 packaging==26.2           # via matplotlib
 pandas==3.0.3             # via -r initial-requirements.in


### PR DESCRIPTION
## Description

Bumps the sandbox image's pinned `onyx-cli` dependency from `1.2.1` to `1.2.2` in `initial-requirements.txt`.

## How Has This Been Tested?



## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the sandbox build image to use `onyx-cli` 1.2.2 (was 1.2.1) in `initial-requirements.txt`. Keeps the sandbox aligned with the latest CLI patch fixes.

<sup>Written for commit 06f32e54d145f7892f687286f2cdc037de16a2d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

