### PR TITLE
fix(cli): preserve symbols for govulncheck

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -229,10 +229,15 @@ jobs:
       - pypi
     runs-on: ubuntu-latest
     permissions:
+      contents: read # needed to checkout the repo for SARIF source locations
       actions: read # needed to download the wheel artifact from the release job
       security-events: write # needed for SARIF uploads
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v4
         with:
           name: onyx-cli-wheels
@@ -276,9 +281,10 @@ jobs:
               exit 1
             fi
 
-            if ! govulncheck -mode=binary -format=sarif "$binary" > "$sarif_file"; then
+            if ! govulncheck -mode=binary "$binary"; then
               scan_exit=1
             fi
+            govulncheck -mode=binary -format=sarif "$binary" > "$sarif_file"
           done
 
           python3 <<'PY'
@@ -292,12 +298,31 @@ jobs:
               "runs": [],
           }
 
-          for sarif_path in sorted(raw_results_dir.glob("*.sarif")):
+          sarif_paths = sorted(raw_results_dir.glob("*.sarif"))
+          if not sarif_paths:
+              raise SystemExit("No govulncheck SARIF files were generated")
+
+          for sarif_path in sarif_paths:
               data = json.loads(sarif_path.read_text())
               for run in data.get("runs", []):
                   run["automationDetails"] = {
                       "id": f"onyx-cli-govulncheck/{sarif_path.stem}",
                   }
+                  results = []
+                  for result in run.get("results", []):
+                      if result.get("level") != "error":
+                          continue
+                      if not result.get("locations"):
+                          result["locations"] = [
+                              {
+                                  "physicalLocation": {
+                                      "artifactLocation": {"uri": "cli/go.mod"},
+                                      "region": {"startLine": 1},
+                                  }
+                              }
+                          ]
+                      results.append(result)
+                  run["results"] = results
                   merged["runs"].append(run)
 
           if not merged["runs"]:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -309,8 +309,9 @@ jobs:
                       "id": f"onyx-cli-govulncheck/{sarif_path.stem}",
                   }
                   results = []
+                  upload_levels = {"error", "warning"}
                   for result in run.get("results", []):
-                      if result.get("level") != "error":
+                      if result.get("level") not in upload_levels:
                           continue
                       if not result.get("locations"):
                           result["locations"] = [

--- a/cli/hatch_build.py
+++ b/cli/hatch_build.py
@@ -43,7 +43,7 @@ class CustomBuildHook(BuildHookInterface):
             print(f"Reusing Go binary '{binary_name}'...")
         else:
             print(f"Building Go binary '{binary_name}'...")
-            ldflags = f"-X main.version={tag} -X main.commit={commit} -s -w"
+            ldflags = f"-X main.version={tag} -X main.commit={commit} -w"
             env = os.environ.copy()
             if goos == "linux":
                 env.setdefault("CGO_ENABLED", "0")


### PR DESCRIPTION
## Description

Fixes the Release CLI `govulncheck` failure from run `28963520072`.

The released wheel binaries were built with `-s -w`, which strips the Go symbol table that `govulncheck -mode=binary` needs for precise reachability analysis. That caused a locationless `GO-2026-5932` SARIF result, and GitHub Code Scanning rejected the upload with `locationFromSarifResult: expected at least one location`.

This PR keeps DWARF stripping via `-w` but preserves Go symbols by removing `-s`. It also makes the release workflow use text `govulncheck` output for pass/fail, generate SARIF separately, and add a `cli/go.mod` fallback location for actionable error results before upload.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve Go symbols in released CLI binaries and fix `govulncheck` SARIF uploads so GitHub Code Scanning accepts our results. Restores precise reachability, includes warnings, and adds fallback locations for locationless findings.

- **Bug Fixes**
  - Build: remove `-s` from Go `-ldflags` (keep `-w`) so `govulncheck -mode=binary` can produce locations.
  - Workflow: run `govulncheck` in text mode for pass/fail, then generate SARIF for each wheel.
  - SARIF: set `automationDetails.id` per artifact, upload `error` and `warning` results, and add a fallback location `cli/go.mod:1` when missing.
  - CI: add `actions/checkout` with `contents: read` to enable source-backed SARIF locations.

<sup>Written for commit 07d35ba070a2e7abbc81495051a8c713833a6e3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

