### PR TITLE
feat(helm): distroless model-server chart — nonroot + 0.7.0

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.17
+version: 0.7.0
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,16 +16,13 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: Add the Box connector with permission sync, and expose its configuration env
-        vars (BOX_CONNECTOR_SIZE_THRESHOLD, BOX_PERMISSION_DOC_SYNC_FREQUENCY,
-        BOX_PERMISSION_GROUP_SYNC_FREQUENCY) in the background config map values.
-    - kind: added
-      description: Add configurable per-user LLM usage accounting and fallback pricing.
-    - kind: added
-      description: Add authenticated Prometheus scraping for the MCP server.
-    - kind: fixed
-      description: Scope metrics credentials and ServiceMonitor selectors to the intended workloads.
+    - kind: changed
+      description: The inference and indexing model servers now run on a distroless Docker
+        Hardened Image (no shell or package manager) as nonroot (UID 65532). Custom CA
+        certificates for the model servers are merged with certifi's public roots in Python
+        at startup instead of via update-ca-certificates. This chart version requires the
+        distroless model-server image — upgrade the chart and the model-server image
+        together (see values.yaml).
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -18,7 +18,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: The inference and indexing model servers now run on a distroless Docker
-        Hardened Image (no shell or package manager) as nonroot (UID 65532). Custom CA
+        Hardened Image (no shell or package manager) as nonroot (the onyx user, UID 1001). Custom CA
         certificates for the model servers are merged with certifi's public roots in Python
         at startup instead of via update-ca-certificates. This chart version requires the
         distroless model-server image — upgrade the chart and the model-server image

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -16,14 +16,24 @@ global:
   host: "0.0.0.0"
 
 # -- Custom (private/internal) CA certificates for outbound TLS.
-# When enabled, every pod that makes outbound TLS connections (api server,
-# celery workers, bots, MCP server, model servers) mounts the referenced
-# Secret/ConfigMap at /usr/local/share/ca-certificates, runs
-# `update-ca-certificates` at startup, and sets REQUESTS_CA_BUNDLE /
-# SSL_CERT_FILE so Python HTTP clients trust the updated bundle.
-# Keys must be PEM certs ending in `.crt`.
-# NOTE: requires the containers to run as root (the chart default);
-# incompatible with runAsNonRoot overrides.
+# When enabled, every pod that makes outbound TLS connections mounts the
+# referenced Secret/ConfigMap and trusts its roots. Keys must be PEM certs
+# ending in `.crt` (model servers also accept `.pem`). Two mechanisms, by pod
+# type:
+#   - Shell-based pods (api server, celery workers, bots, MCP server) mount at
+#     /usr/local/share/ca-certificates, run `update-ca-certificates` at startup,
+#     and get REQUESTS_CA_BUNDLE / SSL_CERT_FILE pointed at the merged system
+#     bundle. These require the container to run as root (the chart default);
+#     incompatible with runAsNonRoot overrides.
+#   - Model servers run on a distroless image with no shell, so they mount at
+#     /etc/onyx/certs and merge the mounted roots with certifi's public roots in
+#     Python at startup (additive — public roots stay trusted). No root required.
+# Version coupling: chart >= 0.7.0 pairs with the distroless model-server image
+# and can't run older ones — the model servers now run nonroot (65532, see their
+# securityContext below) and read ONYX_CUSTOM_CA_CERTS_DIR. Upgrade the chart and
+# the model-server image together: an old chart on the new image crash-loops (no
+# shell for update-ca-certificates), and this chart on an old, root-built image
+# can't write the image's root-owned dirs as 65532.
 customCACerts:
   enabled: false
   # Exactly one of secretName / configMapName must be set when enabled.
@@ -177,13 +187,24 @@ inferenceCapability:
   startupProbe: {}
   readinessProbe: {}
   livenessProbe: {}
-  podSecurityContext: {}
+  # Runs as the distroless image's nonroot UID (65532), which owns the venv, HF
+  # cache, and /var/log/onyx. customCACerts no longer needs root — the distroless
+  # server merges custom roots in Python, not via update-ca-certificates. NOTE:
+  # requires the distroless model-server image; an older, root-built image can't
+  # write its root-owned dirs as 65532. To run as root, set runAsUser: 0 here and
+  # in podSecurityContext.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    fsGroup: 65532
   securityContext:
-    # `privileged` is not needed by this workload and is intentionally omitted.
-    # root is kept only so the optional customCACerts feature can run
-    # update-ca-certificates; to run non-root, override this and
-    # podSecurityContext (see codeInterpreter below for the pattern).
-    runAsUser: 0
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 65532
+    allowPrivilegeEscalation: false
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -238,13 +259,24 @@ indexCapability:
   startupProbe: {}
   readinessProbe: {}
   livenessProbe: {}
-  podSecurityContext: {}
+  # Runs as the distroless image's nonroot UID (65532), which owns the venv, HF
+  # cache, and /var/log/onyx. customCACerts no longer needs root — the distroless
+  # server merges custom roots in Python, not via update-ca-certificates. NOTE:
+  # requires the distroless model-server image; an older, root-built image can't
+  # write its root-owned dirs as 65532. To run as root, set runAsUser: 0 here and
+  # in podSecurityContext.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65532
+    fsGroup: 65532
   securityContext:
-    # `privileged` is not needed by this workload and is intentionally omitted.
-    # root is kept only so the optional customCACerts feature can run
-    # update-ca-certificates; to run non-root, override this and
-    # podSecurityContext (see codeInterpreter below for the pattern).
-    runAsUser: 0
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: false
+    runAsNonRoot: true
+    runAsUser: 65532
+    allowPrivilegeEscalation: false
   nodeSelector: {}
   tolerations: []
   affinity: {}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -191,8 +191,9 @@ inferenceCapability:
   # /var/log/onyx. customCACerts no longer needs root — the distroless server
   # merges custom roots in Python, not via update-ca-certificates. NOTE: requires
   # the distroless model-server image; an older, root-built image can't write its
-  # root-owned dirs as 1001. To run as root, set runAsUser: 0 here and in
-  # podSecurityContext.
+  # root-owned dirs as 1001. To run as root, set runAsNonRoot: false and
+  # runAsUser: 0 in both this block and podSecurityContext (setting only
+  # runAsUser: 0 while runAsNonRoot stays true is rejected at admission).
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 1001
@@ -263,8 +264,9 @@ indexCapability:
   # /var/log/onyx. customCACerts no longer needs root — the distroless server
   # merges custom roots in Python, not via update-ca-certificates. NOTE: requires
   # the distroless model-server image; an older, root-built image can't write its
-  # root-owned dirs as 1001. To run as root, set runAsUser: 0 here and in
-  # podSecurityContext.
+  # root-owned dirs as 1001. To run as root, set runAsNonRoot: false and
+  # runAsUser: 0 in both this block and podSecurityContext (setting only
+  # runAsUser: 0 while runAsNonRoot stays true is rejected at admission).
   podSecurityContext:
     runAsNonRoot: true
     runAsUser: 1001

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -29,11 +29,11 @@ global:
 #     /etc/onyx/certs and merge the mounted roots with certifi's public roots in
 #     Python at startup (additive — public roots stay trusted). No root required.
 # Version coupling: chart >= 0.7.0 pairs with the distroless model-server image
-# and can't run older ones — the model servers now run nonroot (65532, see their
+# and can't run older ones — the model servers now run nonroot (1001, see their
 # securityContext below) and read ONYX_CUSTOM_CA_CERTS_DIR. Upgrade the chart and
 # the model-server image together: an old chart on the new image crash-loops (no
 # shell for update-ca-certificates), and this chart on an old, root-built image
-# can't write the image's root-owned dirs as 65532.
+# can't write the image's root-owned dirs as 1001.
 customCACerts:
   enabled: false
   # Exactly one of secretName / configMapName must be set when enabled.
@@ -187,23 +187,23 @@ inferenceCapability:
   startupProbe: {}
   readinessProbe: {}
   livenessProbe: {}
-  # Runs as the distroless image's nonroot UID (65532), which owns the venv, HF
-  # cache, and /var/log/onyx. customCACerts no longer needs root — the distroless
-  # server merges custom roots in Python, not via update-ca-certificates. NOTE:
-  # requires the distroless model-server image; an older, root-built image can't
-  # write its root-owned dirs as 65532. To run as root, set runAsUser: 0 here and
-  # in podSecurityContext.
+  # Runs as the image's onyx user (UID 1001), which owns the venv, HF cache, and
+  # /var/log/onyx. customCACerts no longer needs root — the distroless server
+  # merges custom roots in Python, not via update-ca-certificates. NOTE: requires
+  # the distroless model-server image; an older, root-built image can't write its
+  # root-owned dirs as 1001. To run as root, set runAsUser: 0 here and in
+  # podSecurityContext.
   podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 65532
-    fsGroup: 65532
+    runAsUser: 1001
+    fsGroup: 1001
   securityContext:
     capabilities:
       drop:
         - ALL
     readOnlyRootFilesystem: false
     runAsNonRoot: true
-    runAsUser: 65532
+    runAsUser: 1001
     allowPrivilegeEscalation: false
   nodeSelector: {}
   tolerations: []
@@ -259,23 +259,23 @@ indexCapability:
   startupProbe: {}
   readinessProbe: {}
   livenessProbe: {}
-  # Runs as the distroless image's nonroot UID (65532), which owns the venv, HF
-  # cache, and /var/log/onyx. customCACerts no longer needs root — the distroless
-  # server merges custom roots in Python, not via update-ca-certificates. NOTE:
-  # requires the distroless model-server image; an older, root-built image can't
-  # write its root-owned dirs as 65532. To run as root, set runAsUser: 0 here and
-  # in podSecurityContext.
+  # Runs as the image's onyx user (UID 1001), which owns the venv, HF cache, and
+  # /var/log/onyx. customCACerts no longer needs root — the distroless server
+  # merges custom roots in Python, not via update-ca-certificates. NOTE: requires
+  # the distroless model-server image; an older, root-built image can't write its
+  # root-owned dirs as 1001. To run as root, set runAsUser: 0 here and in
+  # podSecurityContext.
   podSecurityContext:
     runAsNonRoot: true
-    runAsUser: 65532
-    fsGroup: 65532
+    runAsUser: 1001
+    fsGroup: 1001
   securityContext:
     capabilities:
       drop:
         - ALL
     readOnlyRootFilesystem: false
     runAsNonRoot: true
-    runAsUser: 65532
+    runAsUser: 1001
     allowPrivilegeEscalation: false
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
## What

Chart half of the model-server distroless split (image half: #12636). Updates the Helm chart to match the distroless model-server image:

- **Nonroot** — both the inference and indexing model deployments now run as `1001` (the image's `onyx` user; #12636 keeps that UID for `-u onyx` / volume-ownership compat): `podSecurityContext` `runAsNonRoot` + `runAsUser`/`fsGroup: 1001`, container `securityContext` drops all caps and disallows privilege escalation (`readOnlyRootFilesystem: false`, since the server writes the HF cache, `/var/log/onyx`, and the `/tmp` CA bundle). Overridable back to root via `runAsUser: 0`.
- **`customCACerts` docs** — the `values.yaml` `customCACerts` block and the model-server `securityContext` comments now describe the distroless path (Python CA merge via `ONYX_CUSTOM_CA_CERTS_DIR`, mounted at `/etc/onyx/certs`, no `update-ca-certificates`, no root) instead of the old shell path. The shell-based pods' docs are untouched.
- **`Chart.yaml` 0.6.10 → 0.7.0** — minor bump signalling the coupling to the distroless image; `artifacthub.io/changes` refreshed.

> The deployment templates themselves (plain `uvicorn`, `ONYX_CUSTOM_CA_CERTS_DIR`, `/etc/onyx/certs` mount) already landed on `main`; this PR is only the `values.yaml` + `Chart.yaml` changes on top.

## ⚠️ Merge order — do not merge before the image is `:latest`

This chart requires the distroless model-server image. Because the chart's model-server image tag defaults to `global.version: "latest"`, if this is released while `:latest` is still the older root-built slim image, **every** model-server pod fails to start (nonroot `1001` can't write the slim image's root-owned dirs).

**Sequence:** merge #12636 (image) → wait for the distroless image to publish as `:latest` → then merge this chart PR. Held as a draft until then.

## Validated locally

`helm template` renders both model deployments correctly in all three modes — `customCACerts` off, on (secret), on (configMap): nonroot `securityContext`/`podSecurityContext`, plain `uvicorn` command, `ONYX_CUSTOM_CA_CERTS_DIR=/etc/onyx/certs`, and the CA volume mounted read-only there.

Still needs a live cluster to confirm nonroot boot + `fsGroup` behavior on real volumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the model-server Helm chart for the distroless image: inference and indexing now run as nonroot (UID 1001) with dropped caps and no privilege escalation, and custom CAs are merged in Python from `/etc/onyx/certs` via `ONYX_CUSTOM_CA_CERTS_DIR` (.crt or .pem). Bumps the chart to 0.7.0.

- **Migration**
  - Publish the distroless model-server image as `:latest` first, then upgrade the chart.
  - Upgrade image and chart together; mixing versions breaks pods.
    - Old (root-built) image + new chart: 1001 can’t write root-owned dirs.
    - New image + old chart: no shell for `update-ca-certificates`.
  - Temporary root override: set `runAsNonRoot: false` and `runAsUser: 0` in both `podSecurityContext` and `securityContext` for `inferenceCapability` and `indexCapability`.

<sup>Written for commit 94e58352bb2e1141b4fa98402793d5d0cb660437. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

