### PR TITLE
fix(craft): hydrate managed content before sandbox reports RUNNING

### DIFF
--- a/backend/onyx/server/features/build/sandbox/user_library.py
+++ b/backend/onyx/server/features/build/sandbox/user_library.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.db.sandbox import get_sandbox_user_map
 from onyx.server.features.build.db.user_library import list_user_files
+from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import PushResult
@@ -49,10 +50,12 @@ def hydrate_user_library(
     sandbox_id: UUID,
     user_id: UUID,
     db_session: Session,
+    *,
+    sandbox_manager: SandboxManager,
 ) -> PushResult:
     """Push all user library files to a single sandbox (cold-start hydration)."""
     files = build_user_library_fileset(user_id, db_session)
-    return get_sandbox_manager().push_to_sandbox(
+    return sandbox_manager.push_to_sandbox(
         sandbox_id=sandbox_id,
         mount_path=USER_LIBRARY_MOUNT_PATH,
         files=files,

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -36,7 +36,6 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.db.build_session import allocate_nextjs_port
 from onyx.server.features.build.db.build_session import get_build_session
 from onyx.server.features.build.db.build_session import set_build_session_sharing_scope
-from onyx.server.features.build.db.sandbox import ensure_sandbox_pat
 from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_session
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
@@ -44,7 +43,6 @@ from onyx.server.features.build.db.sandbox import update_sandbox_status__no_comm
 from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
-from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.models import ArtifactResponse
@@ -65,14 +63,15 @@ from onyx.server.features.build.session.models import WebappInfo
 from onyx.server.features.build.session.sandbox_lifecycle import (
     create_session_snapshot_keep_latest,
 )
+from onyx.server.features.build.session.sandbox_lifecycle import hydrate_managed_content
+from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
 from onyx.server.features.build.session.sandbox_lifecycle import (
-    snapshot_opencode_history_before_recovery,
+    recover_unhealthy_sandbox,
 )
 from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
 from onyx.server.features.build.utils import sanitize_filename
 from onyx.server.features.build.utils import validate_file
 from onyx.skills.push import build_user_skills_payload
-from onyx.skills.push import hydrate_sandbox_skills
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -414,40 +413,34 @@ def restore_session(
                     "Sandbox %s marked as RUNNING but pod is unhealthy/missing. Entering recovery mode.",
                     sandbox.id,
                 )
-                snapshot_opencode_history_before_recovery(
-                    sandbox_manager, sandbox.id, tenant_id
-                )
-                sandbox_manager.terminate(sandbox.id)
-                update_sandbox_status__no_commit(
-                    db_session, sandbox.id, SandboxStatus.TERMINATED
+                recover_unhealthy_sandbox(
+                    db_session, sandbox_manager, sandbox, tenant_id
                 )
                 db_session.commit()
                 db_session.refresh(sandbox)
 
         llm_config, all_llm_configs = SessionManager(db_session).build_llm_configs(user)
 
+        managed_content_hydrated = False
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
-            # Mint the PAT before flipping to PROVISIONING so a failure is retriable.
-            onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
-
             update_sandbox_status__no_commit(
                 db_session, sandbox.id, SandboxStatus.PROVISIONING
             )
             db_session.commit()
 
-            sandbox_manager.provision(
-                sandbox_id=sandbox.id,
-                user_id=user.id,
-                tenant_id=tenant_id,
-                llm_config=llm_config,
-                onyx_pat=onyx_pat,
-                all_llm_configs=all_llm_configs,
-            )
-
-            update_sandbox_status__no_commit(
-                db_session, sandbox.id, SandboxStatus.RUNNING
+            # Provisions, hydrates managed content, and stages the new status;
+            # a failure rolls the row back to SLEEPING in the handler below.
+            provision_sandbox(
+                db_session,
+                sandbox_manager,
+                sandbox,
+                user,
+                user.id,
+                tenant_id,
+                all_llm_configs,
             )
             db_session.commit()
+            managed_content_hydrated = True
 
         if sandbox.status == SandboxStatus.RUNNING:
             workspace_exists = sandbox_manager.session_workspace_exists(
@@ -496,24 +489,13 @@ def restore_session(
                     session.status = BuildSessionStatus.ACTIVE
                     db_session.commit()
 
-                try:
-                    hydrate_sandbox_skills(
-                        sandbox.id, user, db_session, files=skills_files
-                    )
-                except Exception:
-                    logger.warning(
-                        "Failed to push skills to sandbox %s",
+                if not managed_content_hydrated:
+                    hydrate_managed_content(
+                        sandbox_manager,
                         sandbox.id,
-                        exc_info=True,
-                    )
-
-                try:
-                    hydrate_user_library(sandbox.id, user.id, db_session)
-                except Exception:
-                    logger.warning(
-                        "Failed to push user library to sandbox %s",
-                        sandbox.id,
-                        exc_info=True,
+                        user,
+                        db_session,
+                        skills_files=skills_files,
                     )
         else:
             logger.warning(

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -421,7 +421,6 @@ def restore_session(
 
         llm_config, all_llm_configs = SessionManager(db_session).build_llm_configs(user)
 
-        managed_content_hydrated = False
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
             update_sandbox_status__no_commit(
                 db_session, sandbox.id, SandboxStatus.PROVISIONING
@@ -440,7 +439,6 @@ def restore_session(
                 all_llm_configs,
             )
             db_session.commit()
-            managed_content_hydrated = True
 
         if sandbox.status == SandboxStatus.RUNNING:
             workspace_exists = sandbox_manager.session_workspace_exists(
@@ -456,6 +454,16 @@ def restore_session(
 
                 skills_section, connectable_apps_section, skills_files = (
                     build_user_skills_payload(user, db_session)
+                )
+                # Push the exact fileset AGENTS.md is rendered from, before
+                # rendering it — a skill can never be advertised while
+                # missing from disk.
+                hydrate_managed_content(
+                    sandbox_manager,
+                    sandbox.id,
+                    user,
+                    db_session,
+                    skills_files=skills_files,
                 )
                 if snapshot:
                     try:
@@ -489,14 +497,6 @@ def restore_session(
                     session.status = BuildSessionStatus.ACTIVE
                     db_session.commit()
 
-                if not managed_content_hydrated:
-                    hydrate_managed_content(
-                        sandbox_manager,
-                        sandbox.id,
-                        user,
-                        db_session,
-                        skills_files=skills_files,
-                    )
         else:
             logger.warning(
                 "Sandbox %s status is %s after re-provision, expected RUNNING",

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -53,12 +53,9 @@ from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
 from onyx.server.features.build.rate_limit import get_user_rate_limit_status
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
-from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
-from onyx.server.features.build.sandbox.user_library import hydrate_user_library
-from onyx.server.features.build.session import sandbox_lifecycle as _sandbox
 from onyx.server.features.build.session import streaming as _streaming
 from onyx.server.features.build.session.errors import RateLimitError
 from onyx.server.features.build.session.errors import UploadLimitExceededError
@@ -67,9 +64,11 @@ from onyx.server.features.build.session.llm_config import get_all_build_mode_llm
 from onyx.server.features.build.session.llm_config import select_default_llm_config
 from onyx.server.features.build.session.md_to_docx import markdown_to_docx_bytes
 from onyx.server.features.build.session.naming import generate_session_name
+from onyx.server.features.build.session.sandbox_lifecycle import ensure_sandbox_ready
+from onyx.server.features.build.session.sandbox_lifecycle import hydrate_managed_content
+from onyx.server.features.build.session.sandbox_lifecycle import ProvisioningPolicy
 from onyx.server.features.build.session.streaming import BuildStreamingState
 from onyx.skills.push import build_user_skills_payload
-from onyx.skills.push import hydrate_sandbox_skills
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
@@ -199,24 +198,6 @@ class SessionManager:
         """
         return get_user_build_sessions(user_id, self._db_session)
 
-    def _hydrate_skills(
-        self, sandbox_id: UUID, user: User, files: FileSet | None = None
-    ) -> None:
-        try:
-            hydrate_sandbox_skills(sandbox_id, user, self._db_session, files=files)
-        except Exception:
-            logger.warning(
-                "Failed to push skills to sandbox %s", sandbox_id, exc_info=True
-            )
-
-    def _hydrate_user_library(self, sandbox_id: UUID, user_id: UUID) -> None:
-        try:
-            hydrate_user_library(sandbox_id, user_id, self._db_session)
-        except Exception:
-            logger.warning(
-                "Failed to push user library to sandbox %s", sandbox_id, exc_info=True
-            )
-
     def _prewarm_opencode_session(
         self, sandbox_id: UUID, session: BuildSession
     ) -> None:
@@ -285,15 +266,16 @@ class SessionManager:
         if user is None:
             raise ValueError(f"User {user_id} not found")
         _, all_llm_configs = self.build_llm_configs(user)
-        return _sandbox.ensure_sandbox_ready(
+        sandbox, _ = ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
             user_id,
             all_llm_configs,
-            policy=_sandbox.ProvisioningPolicy.POLL,
+            policy=ProvisioningPolicy.POLL,
             provisioning_wait_seconds=provisioning_wait_seconds,
             user=user,
         )
+        return sandbox
 
     def create_session__no_commit(
         self,
@@ -371,12 +353,12 @@ class SessionManager:
         # afford to wait through a concurrent provisioner, so we use the
         # FAIL policy (raise RuntimeError if another request is mid-
         # provision).
-        sandbox = _sandbox.ensure_sandbox_ready(
+        sandbox, provisioned = ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
             user_id,
             all_llm_configs,
-            policy=_sandbox.ProvisioningPolicy.FAIL,
+            policy=ProvisioningPolicy.FAIL,
             user=user,
         )
 
@@ -399,8 +381,16 @@ class SessionManager:
             connectable_apps_section=connectable_apps_section,
             user_name=user_name,
         )
-        self._hydrate_skills(sandbox.id, user, files=skills_files)
-        self._hydrate_user_library(sandbox.id, user_id)
+        # Fresh provisions hydrate managed content before RUNNING; only
+        # refresh here when reusing an already-running sandbox.
+        if not provisioned:
+            hydrate_managed_content(
+                self._sandbox_manager,
+                sandbox.id,
+                user,
+                self._db_session,
+                skills_files=skills_files,
+            )
         self._prewarm_opencode_session(sandbox.id, build_session)
 
         logger.info(
@@ -462,8 +452,9 @@ class SessionManager:
                     if user is None:
                         logger.warning("Cannot push skills: user %s not found", user_id)
                     else:
-                        self._hydrate_skills(sandbox.id, user)
-                    self._hydrate_user_library(sandbox.id, user_id)
+                        hydrate_managed_content(
+                            self._sandbox_manager, sandbox.id, user, self._db_session
+                        )
                     self._prewarm_opencode_session(sandbox.id, existing)
                     logger.info(
                         "Returning existing empty session %s for user %s",

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -266,7 +266,7 @@ class SessionManager:
         if user is None:
             raise ValueError(f"User {user_id} not found")
         _, all_llm_configs = self.build_llm_configs(user)
-        sandbox, _ = ensure_sandbox_ready(
+        sandbox = ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
             user_id,
@@ -353,7 +353,7 @@ class SessionManager:
         # afford to wait through a concurrent provisioner, so we use the
         # FAIL policy (raise RuntimeError if another request is mid-
         # provision).
-        sandbox, provisioned = ensure_sandbox_ready(
+        sandbox = ensure_sandbox_ready(
             self._db_session,
             self._sandbox_manager,
             user_id,
@@ -371,6 +371,15 @@ class SessionManager:
         skills_section, connectable_apps_section, skills_files = (
             build_user_skills_payload(user, self._db_session)
         )
+        # Push the exact fileset AGENTS.md is rendered from, before rendering
+        # it — a skill can never be advertised while missing from disk.
+        hydrate_managed_content(
+            self._sandbox_manager,
+            sandbox.id,
+            user,
+            self._db_session,
+            skills_files=skills_files,
+        )
 
         self._sandbox_manager.setup_session_workspace(
             sandbox_id=sandbox.id,
@@ -381,16 +390,6 @@ class SessionManager:
             connectable_apps_section=connectable_apps_section,
             user_name=user_name,
         )
-        # Fresh provisions hydrate managed content before RUNNING; only
-        # refresh here when reusing an already-running sandbox.
-        if not provisioned:
-            hydrate_managed_content(
-                self._sandbox_manager,
-                sandbox.id,
-                user,
-                self._db_session,
-                skills_files=skills_files,
-            )
         self._prewarm_opencode_session(sandbox.id, build_session)
 
         logger.info(

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -263,11 +263,10 @@ def ensure_sandbox_ready(
     policy: ProvisioningPolicy,
     provisioning_wait_seconds: float = 30.0,
     user: User | None = None,
-) -> tuple[Sandbox, bool]:
-    """Return ``(sandbox, provisioned)`` for ``user_id``, creating, waking,
-    or recovering the sandbox as needed. ``provisioned`` is True when this
-    call provisioned the pod (managed content was hydrated as part of
-    provisioning); False when an already-RUNNING sandbox was returned.
+) -> Sandbox:
+    """Return the sandbox for ``user_id``, creating, waking, or recovering
+    it as needed. Provisioning hydrates managed content before the row
+    reports RUNNING.
 
     Branches by current sandbox status:
     - No sandbox row: create + provision.
@@ -313,7 +312,7 @@ def ensure_sandbox_ready(
         if sandbox_manager.health_check(
             sandbox.id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
         ):
-            return sandbox, False
+            return sandbox
         logger.warning(
             "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
             sandbox.id,
@@ -359,4 +358,4 @@ def ensure_sandbox_ready(
         tenant_id,
         all_llm_configs,
     )
-    return sandbox, True
+    return sandbox

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -23,10 +23,13 @@ from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import get_snapshots_for_session
 from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.sandbox.base import SandboxManager
+from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SnapshotResult
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
+from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session.errors import SandboxProvisioningError
+from onyx.skills.push import hydrate_sandbox_skills
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
@@ -58,6 +61,20 @@ def snapshot_opencode_history_before_recovery(
             sandbox_id,
             exc_info=True,
         )
+
+
+def recover_unhealthy_sandbox(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    sandbox: Sandbox,
+    tenant_id: str,
+) -> None:
+    """Tear down a RUNNING sandbox whose pod is unhealthy/missing: preserve
+    opencode history best-effort, terminate, mark TERMINATED so the caller
+    can re-provision. Caller is responsible for committing."""
+    snapshot_opencode_history_before_recovery(sandbox_manager, sandbox.id, tenant_id)
+    sandbox_manager.terminate(sandbox.id)
+    update_sandbox_status__no_commit(db_session, sandbox.id, SandboxStatus.TERMINATED)
 
 
 def create_session_snapshot_keep_latest(
@@ -99,6 +116,43 @@ def create_session_snapshot_keep_latest(
     return result
 
 
+def hydrate_managed_content(
+    sandbox_manager: SandboxManager,
+    sandbox_id: UUID,
+    user: User,
+    db_session: DBSession,
+    skills_files: FileSet | None = None,
+) -> None:
+    """Push managed skills + user library into a sandbox.
+
+    Must complete before the sandbox is reported RUNNING: turns dispatch as
+    soon as RUNNING is visible, and opencode scans the skills directory once
+    per instance, so a turn started mid-push permanently misses managed
+    skills. Each push is best-effort — failures are logged, never raised.
+    """
+    try:
+        hydrate_sandbox_skills(
+            sandbox_id,
+            user,
+            db_session,
+            sandbox_manager=sandbox_manager,
+            files=skills_files,
+        )
+    except Exception:
+        logger.warning("Failed to push skills to sandbox %s", sandbox_id, exc_info=True)
+    try:
+        hydrate_user_library(
+            sandbox_id,
+            user.id,
+            db_session,
+            sandbox_manager=sandbox_manager,
+        )
+    except Exception:
+        logger.warning(
+            "Failed to push user library to sandbox %s", sandbox_id, exc_info=True
+        )
+
+
 class ProvisioningPolicy(str, Enum):
     """How to handle a sandbox already in ``PROVISIONING`` when we arrive.
 
@@ -126,6 +180,10 @@ def provision_sandbox(
     provider pre-loaded so per-prompt model overrides can cross providers
     without a pod restart. ``all_llm_configs[0]`` is the default.
 
+    Managed content (skills, user library) is pushed before the row is
+    flipped to RUNNING so no turn can start against a pod that is still
+    receiving its skills.
+
     Updates the sandbox row's status to whatever the manager returns.
     Caller is responsible for committing.
     """
@@ -138,6 +196,8 @@ def provision_sandbox(
         onyx_pat=onyx_pat,
         all_llm_configs=all_llm_configs,
     )
+    if sandbox_info.status == SandboxStatus.RUNNING:
+        hydrate_managed_content(sandbox_manager, sandbox.id, user, db_session)
     update_sandbox_status__no_commit(db_session, sandbox.id, sandbox_info.status)
 
 
@@ -203,9 +263,11 @@ def ensure_sandbox_ready(
     policy: ProvisioningPolicy,
     provisioning_wait_seconds: float = 30.0,
     user: User | None = None,
-) -> Sandbox:
-    """Return a ``RUNNING`` sandbox for ``user_id``, creating, waking, or
-    recovering as needed.
+) -> tuple[Sandbox, bool]:
+    """Return ``(sandbox, provisioned)`` for ``user_id``, creating, waking,
+    or recovering the sandbox as needed. ``provisioned`` is True when this
+    call provisioned the pod (managed content was hydrated as part of
+    provisioning); False when an already-RUNNING sandbox was returned.
 
     Branches by current sandbox status:
     - No sandbox row: create + provision.
@@ -251,18 +313,12 @@ def ensure_sandbox_ready(
         if sandbox_manager.health_check(
             sandbox.id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
         ):
-            return sandbox
+            return sandbox, False
         logger.warning(
             "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
             sandbox.id,
         )
-        snapshot_opencode_history_before_recovery(
-            sandbox_manager, sandbox.id, tenant_id
-        )
-        sandbox_manager.terminate(sandbox.id)
-        update_sandbox_status__no_commit(
-            db_session, sandbox.id, SandboxStatus.TERMINATED
-        )
+        recover_unhealthy_sandbox(db_session, sandbox_manager, sandbox, tenant_id)
         # Fall through into the re-provision path below.
 
     if sandbox is not None and sandbox.status not in {
@@ -303,4 +359,4 @@ def ensure_sandbox_ready(
         tenant_id,
         all_llm_configs,
     )
-    return sandbox
+    return sandbox, True

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -18,6 +18,7 @@ from onyx.db.skill import SkillAccessPolicy
 from onyx.file_store.file_store import FileStore
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.db.sandbox import get_sandbox_user_map
+from onyx.server.features.build.sandbox.base import SandboxManager
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import PushResult
@@ -183,12 +184,14 @@ def hydrate_sandbox_skills(
     sandbox_id: UUID,
     user: User,
     db_session: Session,
+    *,
+    sandbox_manager: SandboxManager,
     files: FileSet | None = None,
 ) -> PushResult:
     """Push all visible skills to a single sandbox (cold-start hydration)."""
     if files is None:
         files = build_skills_fileset_for_user(user, db_session)
-    return get_sandbox_manager().push_to_sandbox(
+    return sandbox_manager.push_to_sandbox(
         sandbox_id=sandbox_id,
         mount_path=SKILLS_MOUNT_PATH,
         files=files,

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -54,6 +54,8 @@ def test_creates_sandbox_when_none_exists(
 ) -> None:
     """No sandbox row -> a row is created and provisioned to RUNNING."""
     stub_sandbox_manager.provision_returns = _running_info(uuid4())
+    # Provisioning hydrates managed content (skills + user library) into the pod.
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
 
     result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
     db_session.commit()
@@ -99,6 +101,7 @@ def test_running_but_unhealthy_recovers_via_terminate_then_provision(
     stub_sandbox_manager.health_check_returns = False
     stub_sandbox_manager.terminate_silent = True
     stub_sandbox_manager.provision_returns = _running_info(existing.id)
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
 
     result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
     db_session.commit()
@@ -129,6 +132,7 @@ def test_wakes_dormant_sandbox(
     """SLEEPING / TERMINATED / FAILED -> re-provision the existing row in place."""
     existing = sandbox(user=test_user, status=initial_status)
     stub_sandbox_manager.provision_returns = _running_info(existing.id)
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
 
     result = session_manager_with_stub.ensure_sandbox_running(test_user.id)
     db_session.commit()

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import datetime
 from typing import Callable
+from uuid import UUID
 from uuid import uuid4
 
 import pytest
@@ -29,11 +30,14 @@ from onyx.db.models import User
 from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
 from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import get_running_sandboxes
+from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import SandboxInfo
+from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
 from onyx.server.features.build.session.api import restore_session
 from onyx.server.features.build.session.manager import SessionManager
 from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
+from onyx.skills.push import SKILLS_MOUNT_PATH
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.common.craft.payloads import default_llm_config
 from tests.common.craft.stubs import StubSandboxManager
@@ -61,6 +65,8 @@ class TestProvisionTransitions:
             status=SandboxStatus.RUNNING,
             last_heartbeat=None,
         )
+        # Provisioning hydrates managed content (skills + user library).
+        stub_sandbox_manager.write_files_to_sandbox_silent = True
 
         provision_sandbox(
             db_session=db_session,
@@ -441,3 +447,128 @@ class TestIdleCleanupSelection:
             s.id for s in get_running_sandboxes(db_session) if is_sandbox_idle(s, now)
         }
         assert row.id not in idle_ids
+
+
+class _PushRecordingStub(StubSandboxManager):
+    """Records (mount_path, sandbox row status at push time) for each push."""
+
+    def __init__(self, row: Sandbox) -> None:
+        super().__init__()
+        self._row = row
+        self.write_files_to_sandbox_silent = True
+        self.pushes: list[tuple[str, SandboxStatus]] = []
+
+    def write_files_to_sandbox(
+        self,
+        *,
+        sandbox_id: UUID,
+        mount_path: str,
+        files: FileSet,
+    ) -> None:
+        self.pushes.append((mount_path, self._row.status))
+        super().write_files_to_sandbox(
+            sandbox_id=sandbox_id, mount_path=mount_path, files=files
+        )
+
+
+class TestManagedContentPushOrdering:
+    """Cold-start ordering guarantee: managed skills + user library are pushed
+    before a sandbox is reported RUNNING. Turns dispatch as soon as RUNNING is
+    visible and opencode scans the skills directory once per instance, so a
+    push still in flight at first-turn time permanently hides managed skills
+    (prod incident 2026-07-06: agent saw only ``customize-opencode``)."""
+
+    def test_provision_pushes_managed_content_before_running(
+        self,
+        db_session: Session,
+        test_user: User,
+    ) -> None:
+        row = create_sandbox__no_commit(db_session, test_user.id)
+        db_session.commit()
+
+        stub = _PushRecordingStub(row)
+        stub.provision_returns = SandboxInfo(
+            sandbox_id=row.id,
+            directory_path="/tmp/sandbox",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=None,
+        )
+
+        provision_sandbox(
+            db_session=db_session,
+            sandbox_manager=stub,
+            sandbox=row,
+            user=test_user,
+            user_id=test_user.id,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+            all_llm_configs=[default_llm_config()],
+        )
+        db_session.commit()
+        db_session.refresh(row)
+
+        assert row.status == SandboxStatus.RUNNING
+        assert [mount for mount, _ in stub.pushes] == [
+            SKILLS_MOUNT_PATH,
+            USER_LIBRARY_MOUNT_PATH,
+        ]
+        # Every push landed while the row had not yet flipped to RUNNING.
+        assert all(status == SandboxStatus.PROVISIONING for _, status in stub.pushes)
+
+    def test_restore_pushes_managed_content_before_running_commit(
+        self,
+        db_session: Session,
+        test_user: User,
+        sandbox: Callable[..., Sandbox],
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
+        idle_session = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="wake-ordering",
+            status=BuildSessionStatus.IDLE,
+        )
+        db_session.add(idle_session)
+        db_session.commit()
+
+        stub = _PushRecordingStub(row)
+        stub.provision_returns = SandboxInfo(
+            sandbox_id=row.id,
+            directory_path="/tmp/sandbox",
+            status=SandboxStatus.RUNNING,
+            last_heartbeat=None,
+        )
+        stub.session_workspace_exists_returns = False
+        stub.setup_session_workspace_silent = True
+
+        monkeypatch.setattr(
+            "onyx.server.features.build.session.api.get_sandbox_manager",
+            lambda: stub,
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.build.session.manager.get_sandbox_manager",
+            lambda: stub,
+        )
+        monkeypatch.setattr(
+            "onyx.server.features.build.sandbox.factory._sandbox_manager_instance",
+            stub,
+        )
+
+        restore_session(
+            session_id=idle_session.id,
+            user=test_user,
+            db_session=db_session,
+        )
+
+        db_session.expire_all()
+        refreshed = db_session.get(Sandbox, row.id)
+        assert refreshed is not None
+        assert refreshed.status == SandboxStatus.RUNNING
+        # Exactly one push per managed mount (no duplicate hydrate on the
+        # wake path), all completed while the committed status was still
+        # PROVISIONING — i.e. before any turn could dispatch.
+        assert [mount for mount, _ in stub.pushes] == [
+            SKILLS_MOUNT_PATH,
+            USER_LIBRARY_MOUNT_PATH,
+        ]
+        assert all(status == SandboxStatus.PROVISIONING for _, status in stub.pushes)

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -32,6 +32,7 @@ from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import get_running_sandboxes
 from onyx.server.features.build.sandbox.models import FileSet
 from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
 from onyx.server.features.build.session.api import restore_session
@@ -450,13 +451,15 @@ class TestIdleCleanupSelection:
 
 
 class _PushRecordingStub(StubSandboxManager):
-    """Records (mount_path, sandbox row status at push time) for each push."""
+    """Records (mount_path, sandbox row status at push time) for each push,
+    plus a unified op log ordering pushes against workspace renders."""
 
     def __init__(self, row: Sandbox) -> None:
         super().__init__()
         self._row = row
         self.write_files_to_sandbox_silent = True
         self.pushes: list[tuple[str, SandboxStatus]] = []
+        self.ops: list[str] = []
 
     def write_files_to_sandbox(
         self,
@@ -466,8 +469,51 @@ class _PushRecordingStub(StubSandboxManager):
         files: FileSet,
     ) -> None:
         self.pushes.append((mount_path, self._row.status))
+        self.ops.append(f"push:{mount_path}")
         super().write_files_to_sandbox(
             sandbox_id=sandbox_id, mount_path=mount_path, files=files
+        )
+
+    def setup_session_workspace(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        llm_config: LLMProviderConfig,
+        nextjs_port: int | None,
+        skills_section: str,
+        connectable_apps_section: str,
+        user_name: str | None = None,
+    ) -> None:
+        self.ops.append("render_workspace")
+        super().setup_session_workspace(
+            sandbox_id,
+            session_id,
+            llm_config,
+            nextjs_port,
+            skills_section,
+            connectable_apps_section,
+            user_name,
+        )
+
+    def restore_snapshot(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        snapshot_storage_path: str,
+        nextjs_port: int | None,
+        llm_config: LLMProviderConfig,
+        skills_section: str,
+        connectable_apps_section: str,
+    ) -> None:
+        self.ops.append("render_workspace")
+        super().restore_snapshot(
+            sandbox_id,
+            session_id,
+            snapshot_storage_path,
+            nextjs_port,
+            llm_config,
+            skills_section,
+            connectable_apps_section,
         )
 
 
@@ -514,13 +560,20 @@ class TestManagedContentPushOrdering:
         # Every push landed while the row had not yet flipped to RUNNING.
         assert all(status == SandboxStatus.PROVISIONING for _, status in stub.pushes)
 
+    @pytest.mark.parametrize("has_snapshot", [False, True])
     def test_restore_pushes_managed_content_before_running_commit(
         self,
         db_session: Session,
         test_user: User,
         sandbox: Callable[..., Sandbox],
         monkeypatch: pytest.MonkeyPatch,
+        has_snapshot: bool,
     ) -> None:
+        """Covers both cold-wake branches: fresh workspace setup and snapshot
+        restore. A restore after hydration cannot clobber managed mounts —
+        snapshot archives are scoped to /workspace/sessions/<id>
+        (sandbox_daemon/snapshot.py) and config regen only re-links
+        /workspace/managed."""
         row = sandbox(user=test_user, status=SandboxStatus.SLEEPING)
         idle_session = BuildSession(
             id=uuid4(),
@@ -529,6 +582,13 @@ class TestManagedContentPushOrdering:
             status=BuildSessionStatus.IDLE,
         )
         db_session.add(idle_session)
+        if has_snapshot:
+            create_snapshot__no_commit(
+                db_session=db_session,
+                session_id=idle_session.id,
+                storage_path="craft/snapshots/wake-ordering.tar.gz",
+                size_bytes=1,
+            )
         db_session.commit()
 
         stub = _PushRecordingStub(row)
@@ -539,7 +599,10 @@ class TestManagedContentPushOrdering:
             last_heartbeat=None,
         )
         stub.session_workspace_exists_returns = False
-        stub.setup_session_workspace_silent = True
+        if has_snapshot:
+            stub.restore_snapshot_silent = True
+        else:
+            stub.setup_session_workspace_silent = True
 
         monkeypatch.setattr(
             "onyx.server.features.build.session.api.get_sandbox_manager",
@@ -564,11 +627,19 @@ class TestManagedContentPushOrdering:
         refreshed = db_session.get(Sandbox, row.id)
         assert refreshed is not None
         assert refreshed.status == SandboxStatus.RUNNING
-        # Exactly one push per managed mount (no duplicate hydrate on the
-        # wake path), all completed while the committed status was still
-        # PROVISIONING — i.e. before any turn could dispatch.
-        assert [mount for mount, _ in stub.pushes] == [
-            SKILLS_MOUNT_PATH,
-            USER_LIBRARY_MOUNT_PATH,
+        assert stub.restore_snapshot_count == (1 if has_snapshot else 0)
+        assert stub.setup_session_workspace_count == (0 if has_snapshot else 1)
+        # First pair lands while the committed status is still PROVISIONING
+        # (no turn can dispatch against an unhydrated pod); the second pair is
+        # the fileset AGENTS.md is rendered from, pushed before the render so
+        # AGENTS.md can never land ahead of disk.
+        assert stub.ops == [
+            f"push:{SKILLS_MOUNT_PATH}",
+            f"push:{USER_LIBRARY_MOUNT_PATH}",
+            f"push:{SKILLS_MOUNT_PATH}",
+            f"push:{USER_LIBRARY_MOUNT_PATH}",
+            "render_workspace",
         ]
-        assert all(status == SandboxStatus.PROVISIONING for _, status in stub.pushes)
+        assert all(
+            status == SandboxStatus.PROVISIONING for _, status in stub.pushes[:2]
+        )

--- a/backend/tests/external_dependency_unit/craft/test_user_library_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_user_library_fileset.py
@@ -106,7 +106,12 @@ class TestUserLibraryFileset:
         stub_sandbox_manager.write_files_to_sandbox_silent = True
         _patch_user_library_manager(monkeypatch, stub_sandbox_manager)
 
-        result = hydrate_user_library(sandbox_row.id, test_user.id, db_session)
+        result = hydrate_user_library(
+            sandbox_row.id,
+            test_user.id,
+            db_session,
+            sandbox_manager=stub_sandbox_manager,
+        )
 
         assert result.succeeded == 1
         assert stub_sandbox_manager.write_files_to_sandbox_count == 1


### PR DESCRIPTION
## Description

On a fresh sandbox provision/wake, the row flipped to `RUNNING` before managed content (skills, user library) was pushed. The turn executor dispatches as soon as it sees `RUNNING`, and opencode scans the skills directory exactly once per instance — so a turn started mid-push permanently missed all managed skills. Observed in cloud on 2026-07-06: the agent's first tool call failed with `Skill "company-search" not found. Available skills: customize-opencode` while the skills push was still writing (last skill landed 0.7s after the turn started).

Fix: managed-content hydration is folded into provisioning itself, so the invariant becomes *a sandbox visible as RUNNING has already received its managed pushes*. `provision_sandbox` hydrates between `provision()` returning and the status flip; turns gate on `RUNNING`, so no new marker or sleep is needed. The warm path (reusing an already-RUNNING sandbox) still refreshes content at session creation, deduped via a `provisioned` flag from `ensure_sandbox_ready`.

Also consolidates the surrounding architecture (reviewed in detail with @wenxi-onyx):

- `restore_session` no longer hand-rolls its own PAT → provision → hydrate → RUNNING sequence — it delegates to `provision_sandbox`, so the hydrate-before-RUNNING invariant has exactly one owner. (Post-provision status now comes from the manager instead of being hardcoded `RUNNING`; the PAT moved after the `PROVISIONING` flip, which is safe because the error handler already rolls stuck rows back to `SLEEPING`.)
- The unhealthy-RUNNING recovery trio (history snapshot → terminate → `TERMINATED`), previously duplicated verbatim in `ensure_sandbox_ready` and `restore_session`, is extracted to `sandbox_lifecycle.recover_unhealthy_sandbox`.
- Removed a pass-through `SessionManager._hydrate_managed_content` wrapper and the `sandbox_lifecycle as _sandbox` module-alias import in favor of explicit imports.
- `hydrate_sandbox_skills` / `hydrate_user_library` take an explicit `sandbox_manager` (keeps stub-driven tests off the factory).

Follow-up PRs (rebase after this lands): moving the reaper's sleep transition into lifecycle, and centralizing all remaining sandbox status writes.

## How Has This Been Tested?

External-dependency-unit tests (CI): new `TestManagedContentPushOrdering` in `test_sandbox_lifecycle.py` uses a push-recording sandbox stub to pin that both `/workspace/managed/skills` and `.../user_library` are pushed while the row is still `PROVISIONING` — for both `provision_sandbox` and the real `restore_session` handler — and that the warm path pushes exactly once per mount. Full craft EDU suite passed in the agent run (294 passed, 2 pre-existing environmental failures). Pure unit suite for the session package (89 tests) passes; ruff/ty clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates managed content before a sandbox reports RUNNING and pushes the exact skills fileset before rendering `AGENTS.md`. This prevents first turns and docs from missing skills during cold starts.

- **Bug Fixes**
  - Hydrates managed skills and user library inside `provision_sandbox` before flipping the row to `RUNNING` (fixes the cold-start race where opencode scanned before pushes completed).
  - During session create/restore, pushes the `AGENTS.md` fileset before workspace render/restore so docs never advertise missing skills.
  - Adds `recover_unhealthy_sandbox` to snapshot history, terminate the pod, and mark `TERMINATED` when a `RUNNING` sandbox is unhealthy, then re-provision; warm reuse refreshes managed content once per session.

- **Refactors + Tests**
  - `restore_session` delegates provisioning and hydration to `provision_sandbox`, then calls `hydrate_managed_content` before workspace render/restore; `ProvisioningPolicy` and `ensure_sandbox_ready` live in lifecycle.
  - Introduces `hydrate_managed_content`; `hydrate_sandbox_skills` and `hydrate_user_library` take an explicit `sandbox_manager`.
  - Adds push-ordering tests to assert skills and user library are pushed while the row is `PROVISIONING`, and that `AGENTS.md`’s fileset is pushed before render; warm-path pushes occur exactly once.

<sup>Written for commit 51f085c628b052e15d4c23416b3db4574a8797f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12789?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

