### PR TITLE
refactor(craft): move sandbox sleep transition into lifecycle

### DIFF
--- a/backend/onyx/background/celery/tasks/build/tasks.py
+++ b/backend/onyx/background/celery/tasks/build/tasks.py
@@ -11,23 +11,19 @@ from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.enums import SandboxStatus
 from onyx.db.models import Sandbox
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
-from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_user
-from onyx.server.features.build.db.build_session import (
-    mark_user_sessions_idle__no_commit,
-)
 from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_session
 from onyx.server.features.build.db.sandbox import get_running_sandboxes
-from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.db.sandbox import user_has_stale_active_session
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.session.sandbox_lifecycle import (
     create_session_snapshot_keep_latest,
 )
+from onyx.server.features.build.session.sandbox_lifecycle import is_sandbox_idle
+from onyx.server.features.build.session.sandbox_lifecycle import sleep_sandbox
 
 # 100 minutes - snapshotting can take time
 TIMEOUT_SECONDS = 6000
@@ -36,13 +32,6 @@ TIMEOUT_SECONDS = 6000
 # its latest snapshot is older than idle_timeout/4 (15 min at the default 1h),
 # so the data-loss bound scales with the pace of sandboxes going to sleep.
 SNAPSHOT_INTERVAL_DIVISOR = 4
-
-
-def is_sandbox_idle(sandbox: Sandbox, now: datetime.datetime) -> bool:
-    """Idle = no heartbeat for the timeout (NULL heartbeat falls back to
-    created_at so legacy/edge-case rows don't sit RUNNING forever)."""
-    reference = sandbox.last_heartbeat or sandbox.created_at
-    return reference < now - datetime.timedelta(seconds=SANDBOX_IDLE_TIMEOUT_SECONDS)
 
 
 @shared_task(
@@ -59,8 +48,9 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
     sessions whose latest snapshot is fresher than that interval are skipped
     without touching the pod (except at reap — the pod is about to die, so
     always snapshot).
-    Reap stays fail-closed: snapshot failure on a reachable pod keeps the
-    sandbox RUNNING for retry next sweep.
+    The reap itself is ``sleep_sandbox`` (sandbox lifecycle), which stays
+    fail-closed: snapshot failure on a reachable pod keeps the sandbox
+    RUNNING for retry next sweep.
     """
     task_logger.info(f"cleanup_idle_sandboxes_task starting for tenant {tenant_id}")
 
@@ -93,9 +83,8 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                 seconds=SANDBOX_IDLE_TIMEOUT_SECONDS // SNAPSHOT_INTERVAL_DIVISOR
             )
 
-            # Partition in a single pass so idle sandboxes are reaped first
-            # (reclaiming pods is time-sensitive) before the rest are
-            # background-snapshotted.
+            # Partition so idle sandboxes are reaped first (reclaiming pods
+            # is time-sensitive) before the rest are background-snapshotted.
             idle_sandboxes: list[Sandbox] = []
             non_idle_sandboxes: list[Sandbox] = []
             for sandbox in running_sandboxes:
@@ -105,37 +94,32 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                     else non_idle_sandboxes
                 ).append(sandbox)
 
-            for idle, sandbox in [(True, s) for s in idle_sandboxes] + [
-                (False, s) for s in non_idle_sandboxes
-            ]:
+            for sandbox in idle_sandboxes:
+                try:
+                    sleep_sandbox(
+                        db_session=db_session,
+                        sandbox_manager=sandbox_manager,
+                        sandbox=sandbox,
+                        tenant_id=tenant_id,
+                    )
+                except Exception as e:
+                    task_logger.error(
+                        f"Failed to sweep sandbox {sandbox.id}: {e}",
+                        exc_info=True,
+                    )
+                    db_session.rollback()
+
+            for sandbox in non_idle_sandboxes:
                 sandbox_id = sandbox.id
 
                 try:
                     # DB-only prefilter: listing workspaces is a pod exec, so
                     # skip it when every ACTIVE session already has a fresh
-                    # snapshot (idle sandboxes always proceed — they're about
-                    # to be reaped).
-                    if not idle and not user_has_stale_active_session(
+                    # snapshot.
+                    if not user_has_stale_active_session(
                         db_session, sandbox.user_id, snapshot_cutoff
                     ):
                         continue
-
-                    if idle and sandbox_manager.supports_opencode_history_persistence:
-                        try:
-                            sandbox_manager.create_opencode_history_snapshot(
-                                sandbox_id, tenant_id
-                            )
-                        except Exception as e:
-                            if sandbox_manager.health_check(sandbox_id, timeout=5.0):
-                                task_logger.error(
-                                    f"opencode history snapshot failed for sandbox "
-                                    f"{sandbox_id}; leaving it RUNNING: {e}"
-                                )
-                                continue
-                            task_logger.warning(
-                                f"Sandbox {sandbox_id} pod unreachable; sleeping "
-                                f"without a fresh opencode history snapshot: {e}"
-                            )
 
                     # List session directories in the sandbox via the
                     # backend-agnostic manager API. K8s lists pod paths via
@@ -143,18 +127,15 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                     # walks the on-disk sessions/ directory.
                     session_ids = sandbox_manager.list_session_workspaces(sandbox_id)
 
-                    snapshot_failed = False
+                    # Background snapshot failures are log-only (unlike the
+                    # reap path, nothing is about to be terminated).
                     snapshots_created = 0
                     for session_id in session_ids:
                         try:
                             latest = get_latest_snapshot_for_session(
                                 db_session, session_id
                             )
-                            if (
-                                not idle
-                                and latest
-                                and latest.created_at > snapshot_cutoff
-                            ):
+                            if latest and latest.created_at > snapshot_cutoff:
                                 continue
 
                             snapshot_start = time.monotonic()
@@ -174,85 +155,26 @@ def cleanup_idle_sandboxes_task(self: Task, *, tenant_id: str) -> None:  # noqa:
                                     f"in {snapshot_elapsed:.1f}s"
                                 )
                         except Exception as e:
-                            snapshot_failed = True
                             task_logger.warning(
                                 f"Failed to create snapshot for session {session_id}: {e}"
                             )
                             db_session.rollback()
 
-                    # snapshot_failed only gates reap (below); background
-                    # snapshot failures are log-only.
-                    if not idle:
-                        # Chat history lives outside session workspaces;
-                        # keep it equally fresh.
-                        if (
-                            snapshots_created
-                            and sandbox_manager.supports_opencode_history_persistence
-                        ):
-                            try:
-                                sandbox_manager.create_opencode_history_snapshot(
-                                    sandbox_id, tenant_id
-                                )
-                            except Exception as e:
-                                task_logger.warning(
-                                    f"Background opencode history snapshot failed "
-                                    f"for sandbox {sandbox_id}: {e}"
-                                )
-                        continue
-
-                    task_logger.info(f"Putting sandbox {sandbox_id} to sleep")
-
-                    # Fail-closed: terminating with an unsnapshotted workspace
-                    # loses it (restore falls back to a fresh template). Keep the
-                    # sandbox RUNNING to retry next cycle — unless the pod is
-                    # unreachable, where snapshots can never succeed and the
-                    # workspace is already gone, so don't pin it RUNNING forever.
-                    if snapshot_failed:
-                        if sandbox_manager.health_check(sandbox_id, timeout=5.0):
-                            task_logger.error(
-                                f"Snapshot failed for sandbox {sandbox_id}; "
-                                f"leaving it RUNNING to retry next cycle"
-                            )
-                            continue
-                        task_logger.warning(
-                            f"Sandbox {sandbox_id} pod is unreachable; "
-                            f"terminating despite snapshot failure (cannot recover "
-                            f"its workspace, won't pin it RUNNING forever)"
-                        )
-
-                    # Snapshotting above can take minutes; re-check idleness
-                    # right before the kill.
-                    db_session.refresh(sandbox)
-                    if sandbox.status != SandboxStatus.RUNNING or not is_sandbox_idle(
-                        sandbox, datetime.datetime.now(datetime.timezone.utc)
+                    # Chat history lives outside session workspaces;
+                    # keep it equally fresh.
+                    if (
+                        snapshots_created
+                        and sandbox_manager.supports_opencode_history_persistence
                     ):
-                        task_logger.info(
-                            f"Sandbox {sandbox_id} went active mid-sweep; skipping reap"
-                        )
-                        continue
-
-                    # Terminate the pod (but keep sandbox record)
-                    sandbox_manager.terminate(sandbox_id)
-
-                    # Zero out nextjs ports for all sessions (ports are no longer in use)
-                    cleared = clear_nextjs_ports_for_user(db_session, sandbox.user_id)
-                    task_logger.debug(
-                        f"Cleared {cleared} nextjs_port allocations for user {sandbox.user_id}"
-                    )
-
-                    # Mark all active sessions as IDLE
-                    idled = mark_user_sessions_idle__no_commit(
-                        db_session, sandbox.user_id
-                    )
-                    task_logger.debug(
-                        f"Marked {idled} sessions as IDLE for user {sandbox.user_id}"
-                    )
-
-                    update_sandbox_status__no_commit(
-                        db_session, sandbox_id, SandboxStatus.SLEEPING
-                    )
-                    db_session.commit()
-                    task_logger.info(f"Sandbox {sandbox_id} is now sleeping")
+                        try:
+                            sandbox_manager.create_opencode_history_snapshot(
+                                sandbox_id, tenant_id
+                            )
+                        except Exception as e:
+                            task_logger.warning(
+                                f"Background opencode history snapshot failed "
+                                f"for sandbox {sandbox_id}: {e}"
+                            )
 
                 except Exception as e:
                     task_logger.error(

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -3,6 +3,9 @@ interactive (``create_session__no_commit``) and headless
 (``ensure_sandbox_running``) flows."""
 
 import time
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
 from enum import Enum
 from uuid import UUID
 
@@ -13,7 +16,12 @@ from onyx.db.models import Sandbox
 from onyx.db.models import User
 from onyx.db.users import fetch_user_by_id
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.build.configs import SANDBOX_IDLE_TIMEOUT_SECONDS
 from onyx.server.features.build.configs import SANDBOX_MAX_CONCURRENT_PER_ORG
+from onyx.server.features.build.db.build_session import clear_nextjs_ports_for_user
+from onyx.server.features.build.db.build_session import (
+    mark_user_sessions_idle__no_commit,
+)
 from onyx.server.features.build.db.sandbox import create_sandbox__no_commit
 from onyx.server.features.build.db.sandbox import create_snapshot__no_commit
 from onyx.server.features.build.db.sandbox import delete_snapshot__no_commit
@@ -304,3 +312,128 @@ def ensure_sandbox_ready(
         all_llm_configs,
     )
     return sandbox
+
+
+def is_sandbox_idle(sandbox: Sandbox, now: datetime) -> bool:
+    """Idle = no heartbeat for the timeout (NULL heartbeat falls back to
+    created_at so legacy/edge-case rows don't sit RUNNING forever)."""
+    reference = sandbox.last_heartbeat or sandbox.created_at
+    return reference < now - timedelta(seconds=SANDBOX_IDLE_TIMEOUT_SECONDS)
+
+
+def sleep_sandbox(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    sandbox: Sandbox,
+    tenant_id: str,
+) -> None:
+    """Snapshot an idle ``RUNNING`` sandbox, terminate its pod, and mark it
+    ``SLEEPING``. Commits on success; on abort the sandbox stays ``RUNNING``.
+
+    Invariant: snapshot before terminate, fail-closed — a snapshot failure on
+    a reachable pod aborts the reap so the next sweep retries, while an
+    unreachable pod is terminated anyway (its workspace is unrecoverable;
+    never pin it RUNNING forever). Idleness is re-checked right before the
+    kill since snapshotting can take minutes.
+    """
+    sandbox_id = sandbox.id
+
+    # Chat history lives outside session workspaces; capture it before the
+    # pod dies.
+    if sandbox_manager.supports_opencode_history_persistence:
+        try:
+            sandbox_manager.create_opencode_history_snapshot(sandbox_id, tenant_id)
+        except Exception as e:
+            if sandbox_manager.health_check(
+                sandbox_id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+            ):
+                logger.error(
+                    "opencode history snapshot failed for sandbox "
+                    "%s; leaving it RUNNING: %s",
+                    sandbox_id,
+                    e,
+                )
+                return
+            logger.warning(
+                "Sandbox %s pod unreachable; sleeping "
+                "without a fresh opencode history snapshot: %s",
+                sandbox_id,
+                e,
+            )
+
+    session_ids = sandbox_manager.list_session_workspaces(sandbox_id)
+
+    snapshot_failed = False
+    for session_id in session_ids:
+        try:
+            snapshot_start = time.monotonic()
+            snapshot_result = create_session_snapshot_keep_latest(
+                sandbox_manager=sandbox_manager,
+                db_session=db_session,
+                sandbox_id=sandbox_id,
+                session_id=session_id,
+                tenant_id=tenant_id,
+            )
+            snapshot_elapsed = time.monotonic() - snapshot_start
+            if snapshot_result:
+                logger.info(
+                    "Snapshot created for session %s: %.1f MiB in %.1fs",
+                    session_id,
+                    snapshot_result.size_bytes / 1_048_576,
+                    snapshot_elapsed,
+                )
+        except Exception as e:
+            snapshot_failed = True
+            logger.warning(
+                "Failed to create snapshot for session %s: %s", session_id, e
+            )
+            db_session.rollback()
+
+    logger.info("Putting sandbox %s to sleep", sandbox_id)
+
+    # Fail-closed: terminating with an unsnapshotted workspace loses it
+    # (restore falls back to a fresh template). Keep the sandbox RUNNING to
+    # retry next cycle — unless the pod is unreachable, where snapshots can
+    # never succeed and the workspace is already gone, so don't pin it
+    # RUNNING forever.
+    if snapshot_failed:
+        if sandbox_manager.health_check(
+            sandbox_id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+        ):
+            logger.error(
+                "Snapshot failed for sandbox %s; "
+                "leaving it RUNNING to retry next cycle",
+                sandbox_id,
+            )
+            return
+        logger.warning(
+            "Sandbox %s pod is unreachable; "
+            "terminating despite snapshot failure (cannot recover "
+            "its workspace, won't pin it RUNNING forever)",
+            sandbox_id,
+        )
+
+    # Snapshotting above can take minutes; re-check idleness right before
+    # the kill.
+    db_session.refresh(sandbox)
+    if sandbox.status != SandboxStatus.RUNNING or not is_sandbox_idle(
+        sandbox, datetime.now(timezone.utc)
+    ):
+        logger.info("Sandbox %s went active mid-sweep; skipping reap", sandbox_id)
+        return
+
+    # Terminate the pod (but keep the sandbox record).
+    sandbox_manager.terminate(sandbox_id)
+
+    # Ports are no longer in use once the pod is gone.
+    cleared = clear_nextjs_ports_for_user(db_session, sandbox.user_id)
+    logger.debug(
+        "Cleared %s nextjs_port allocations for user %s", cleared, sandbox.user_id
+    )
+
+    idled = mark_user_sessions_idle__no_commit(db_session, sandbox.user_id)
+    logger.debug("Marked %s sessions as IDLE for user %s", idled, sandbox.user_id)
+
+    update_sandbox_status__no_commit(db_session, sandbox_id, SandboxStatus.SLEEPING)
+    db_session.commit()
+    logger.info("Sandbox %s is now sleeping", sandbox_id)

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -1,9 +1,10 @@
 """Idle cleanup (Celery task).
 
 Exercises ``cleanup_idle_sandboxes_task`` end-to-end against real Postgres +
-Redis. The sandbox operations (``list_session_workspaces``,
+Redis; the per-sandbox reap runs through ``sleep_sandbox`` (sandbox
+lifecycle). The sandbox operations (``list_session_workspaces``,
 ``create_snapshot``, ``terminate``) are routed through the
-``StubSandboxManager`` from ``conftest.py``. The task body is
+``StubSandboxManager`` from ``conftest.py``. The sweep is
 backend-agnostic, so we only need to install the stub via
 ``get_sandbox_manager``.
 """
@@ -30,6 +31,9 @@ from onyx.db.models import Snapshot
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.session import (
+    sandbox_lifecycle as sandbox_lifecycle_module,
+)
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.common.craft.stubs import StubSandboxManager
@@ -48,7 +52,7 @@ def stubbed_cleanup(
 ) -> StubSandboxManager:
     """Wire the stub so the cleanup task runs entirely against it.
 
-    The task body is backend-agnostic now: it calls
+    The sweep is backend-agnostic: it calls
     ``sandbox_manager.list_session_workspaces(sandbox_id)`` rather than a
     Kubernetes-only helper, so we just need to redirect
     ``get_sandbox_manager`` to the stub. Per-test bodies can override
@@ -64,11 +68,18 @@ def stubbed_cleanup(
 def short_idle_threshold(monkeypatch: pytest.MonkeyPatch) -> int:
     """Lower the idle threshold so tests can backdate a heartbeat cheaply.
 
+    Patched in both consuming modules: the task reads it for the background
+    snapshot cutoff; ``is_sandbox_idle`` (sandbox lifecycle) reads it for the
+    idle partition and the pre-kill re-check.
+
     Returns the threshold (seconds) so tests can reason about boundary
     conditions without hard-coding magic numbers.
     """
     threshold = 60
     monkeypatch.setattr(tasks_module, "SANDBOX_IDLE_TIMEOUT_SECONDS", threshold)
+    monkeypatch.setattr(
+        sandbox_lifecycle_module, "SANDBOX_IDLE_TIMEOUT_SECONDS", threshold
+    )
     return threshold
 
 

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -20,7 +20,6 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
-from onyx.background.celery.tasks.build.tasks import is_sandbox_idle
 from onyx.db.enums import BuildSessionStatus
 from onyx.db.enums import SandboxStatus
 from onyx.db.models import BuildSession
@@ -33,6 +32,7 @@ from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.session.api import restore_session
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.features.build.session.sandbox_lifecycle import is_sandbox_idle
 from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.common.craft.payloads import default_llm_config


### PR DESCRIPTION
## Description

Follow-up to #12789 (Craft sandbox layering: `SandboxManager` = substrate-polymorphic ops, `sandbox_lifecycle` = status transitions + ordering invariants, callers write no status).

The sleep/reap transition lived inline in `cleanup_idle_sandboxes_task`, so its invariant — *snapshot before terminate, fail-closed* — was enforced only by celery task code. This moves the per-sandbox reap sequence into `sandbox_lifecycle.sleep_sandbox`; the task keeps the beat lock, tenant gating, idle/non-idle partitioning, and the background-snapshot path for non-idle sandboxes.

Semantics preserved exactly (each is deliberate and pinned by tests):
1. opencode-history snapshot first; on failure, reachable pod → leave RUNNING, unreachable → sleep without a fresh history snapshot
2. per-session workspace snapshots with per-failure rollback
3. fail-closed reap gate: any snapshot failure + reachable pod → stay RUNNING for retry; unreachable → terminate anyway (never pin an unreachable sandbox RUNNING forever)
4. mid-sweep idleness re-check right before the kill
5. reap order: terminate → clear nextjs ports → mark sessions IDLE → SLEEPING → commit
6. equivalent log lines (ops-debugging surface; ENG-4269 was diagnosed from them)

`is_sandbox_idle` moved to lifecycle with it (reap policy; the pre-kill re-check needs it) — importers updated, no re-export shim. Also dropped a dead `get_latest_snapshot_for_session` call whose result was unused on the idle path.

`sandbox_lifecycle.py` changes are purely additive; expect a trivial rebase after #12789 merges.

## How Has This Been Tested?

Existing EDU suites `test_idle_cleanup.py` (10 tests pinning all six semantics) and `test_background_snapshots.py` updated to the refactored structure — the idle-timeout fixture now patches the constant in both modules; CI-only. Pure unit suite for the build package passes locally (549 passed; 16 pre-existing environmental failures verified identical on the base commit). ruff/ty clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the sandbox sleep/reap flow from the Celery task into `sandbox_lifecycle` to centralize lifecycle rules and keep cleanup backend‑agnostic. Behavior is unchanged; the task now calls `sleep_sandbox` and `is_sandbox_idle`, and tests were updated.

- **Refactors**
  - Added `sandbox_lifecycle.sleep_sandbox` with snapshot‑before‑terminate, fail‑closed gating, idle re‑check, and the same log lines as before.
  - `cleanup_idle_sandboxes_task` now delegates idle reaps to `sleep_sandbox` and keeps background snapshots for non‑idle sandboxes.
  - Moved `is_sandbox_idle` into lifecycle; removed a dead `get_latest_snapshot_for_session` use on the idle path; tests patch `SANDBOX_IDLE_TIMEOUT_SECONDS` in both modules.

<sup>Written for commit 8753c45a35f76a97fac1f137b7071c3bf42c08de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

