### PR TITLE
refactor(craft): centralize sandbox status writes in lifecycle

### DIFF
--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -15,7 +15,6 @@ from sqlalchemy.orm import Session
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import MessageType
 from onyx.db.enums import BuildSessionStatus
-from onyx.db.enums import SandboxStatus
 from onyx.db.enums import SessionOrigin
 from onyx.db.enums import SharingScope
 from onyx.db.llm import can_user_access_llm_provider
@@ -225,23 +224,6 @@ def delete_build_session__no_commit(
 # Sandbox operations
 # NOTE: Most sandbox operations have moved to sandbox.py
 # These remain here for convenience in session-related workflows
-
-
-def update_sandbox_status(
-    sandbox_id: UUID,
-    status: SandboxStatus,
-    db_session: Session,
-    container_id: str | None = None,
-) -> None:
-    """Update the status of a sandbox."""
-    sandbox = db_session.query(Sandbox).filter(Sandbox.id == sandbox_id).one_or_none()
-    if sandbox:
-        sandbox.status = status
-        if container_id is not None:
-            sandbox.container_id = container_id
-        sandbox.last_heartbeat = datetime.now(tz=timezone.utc)
-        db_session.commit()
-        logger.info("Updated sandbox %s status to %s", sandbox_id, status)
 
 
 def update_sandbox_heartbeat(

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -427,7 +427,7 @@ def restore_session(
         llm_config, all_llm_configs = SessionManager(db_session).build_llm_configs(user)
 
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
-            mark_sandbox_provisioning(db_session, sandbox.id)
+            mark_sandbox_provisioning(db_session, sandbox)
 
             # Provisions, hydrates managed content, and stages the new status;
             # a failure rolls the row back to SLEEPING in the handler below.

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -39,7 +39,6 @@ from onyx.server.features.build.db.build_session import set_build_session_sharin
 from onyx.server.features.build.db.sandbox import get_latest_snapshot_for_session
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.db.sandbox import update_sandbox_heartbeat
-from onyx.server.features.build.db.sandbox import update_sandbox_status__no_commit
 from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
@@ -64,9 +63,15 @@ from onyx.server.features.build.session.sandbox_lifecycle import (
     create_session_snapshot_keep_latest,
 )
 from onyx.server.features.build.session.sandbox_lifecycle import hydrate_managed_content
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    mark_sandbox_provisioning,
+)
 from onyx.server.features.build.session.sandbox_lifecycle import provision_sandbox
 from onyx.server.features.build.session.sandbox_lifecycle import (
     recover_unhealthy_sandbox,
+)
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    rollback_failed_provisioning,
 )
 from onyx.server.features.build.session.streaming import SSE_KEEPALIVE
 from onyx.server.features.build.utils import sanitize_filename
@@ -422,10 +427,7 @@ def restore_session(
         llm_config, all_llm_configs = SessionManager(db_session).build_llm_configs(user)
 
         if sandbox.status in (SandboxStatus.SLEEPING, SandboxStatus.TERMINATED):
-            update_sandbox_status__no_commit(
-                db_session, sandbox.id, SandboxStatus.PROVISIONING
-            )
-            db_session.commit()
+            mark_sandbox_provisioning(db_session, sandbox.id)
 
             # Provisions, hydrates managed content, and stages the new status;
             # a failure rolls the row back to SLEEPING in the handler below.
@@ -513,24 +515,17 @@ def restore_session(
         try:
             db_session.rollback()
             stuck = get_sandbox_by_user_id(db_session, user.id)
-            if stuck is not None and stuck.status == SandboxStatus.PROVISIONING:
-                # provision() failed — back to SLEEPING so it isn't stuck.
-                update_sandbox_status__no_commit(
-                    db_session, stuck.id, SandboxStatus.SLEEPING
-                )
-                db_session.commit()
-                logger.info(
-                    "Rolled sandbox %s back to SLEEPING after failed restore",
-                    stuck.id,
-                )
-            elif stuck is not None and stuck.status == SandboxStatus.RUNNING:
-                # Workspace load failed after provision — drop the partial dir
-                # so session_workspace_exists() doesn't later report it restored.
-                sandbox_manager.cleanup_session_workspace(stuck.id, session_id)
-                logger.info(
-                    "Cleaned up partial workspace for session %s after failed restore",
-                    session_id,
-                )
+            if stuck is not None and not rollback_failed_provisioning(
+                db_session, stuck
+            ):
+                if stuck.status == SandboxStatus.RUNNING:
+                    # Workspace load failed after provision — drop the partial dir
+                    # so session_workspace_exists() doesn't later report it restored.
+                    sandbox_manager.cleanup_session_workspace(stuck.id, session_id)
+                    logger.info(
+                        "Cleaned up partial workspace for session %s after failed restore",
+                        session_id,
+                    )
         except Exception as rollback_err:
             logger.warning(
                 "Failed to recover sandbox state after restore failure: %s",

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -492,3 +492,28 @@ def sleep_sandbox(
     update_sandbox_status__no_commit(db_session, sandbox_id, SandboxStatus.SLEEPING)
     db_session.commit()
     logger.info("Sandbox %s is now sleeping", sandbox_id)
+
+
+def mark_sandbox_provisioning(db_session: DBSession, sandbox_id: UUID) -> None:
+    """Mark a SLEEPING/TERMINATED sandbox as PROVISIONING before re-provisioning.
+
+    Commits deliberately so the transition is immediately visible to concurrent
+    pollers of the state machine (e.g. ``_wait_for_provisioning_to_complete``).
+    """
+    update_sandbox_status__no_commit(db_session, sandbox_id, SandboxStatus.PROVISIONING)
+    db_session.commit()
+
+
+def rollback_failed_provisioning(db_session: DBSession, sandbox: Sandbox) -> bool:
+    """Compensating transition for provisioning that died mid-flight:
+    return the sandbox to ``SLEEPING`` (committed) so the stuck status
+    doesn't block the next attempt. Returns whether a rollback was applied.
+    """
+    if sandbox.status != SandboxStatus.PROVISIONING:
+        return False
+    update_sandbox_status__no_commit(db_session, sandbox.id, SandboxStatus.SLEEPING)
+    db_session.commit()
+    logger.info(
+        "Rolled sandbox %s back to SLEEPING after failed provisioning", sandbox.id
+    )
+    return True

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -47,6 +47,15 @@ logger = setup_logger()
 
 _HEALTHCHECK_TIMEOUT_SECONDS = 5.0
 
+# Statuses from which (re-)provisioning a pod is legal.
+_REPROVISIONABLE_STATUSES: frozenset[SandboxStatus] = frozenset(
+    {
+        SandboxStatus.SLEEPING,
+        SandboxStatus.TERMINATED,
+        SandboxStatus.FAILED,
+    }
+)
+
 
 def snapshot_opencode_history_before_recovery(
     sandbox_manager: SandboxManager,
@@ -328,11 +337,7 @@ def ensure_sandbox_ready(
         recover_unhealthy_sandbox(db_session, sandbox_manager, sandbox, tenant_id)
         # Fall through into the re-provision path below.
 
-    if sandbox is not None and sandbox.status not in {
-        SandboxStatus.SLEEPING,
-        SandboxStatus.TERMINATED,
-        SandboxStatus.FAILED,
-    }:
+    if sandbox is not None and sandbox.status not in _REPROVISIONABLE_STATUSES:
         raise RuntimeError(
             f"Sandbox {sandbox.id} in unexpected status "
             f"{sandbox.status.value}; refusing to provision"
@@ -494,13 +499,22 @@ def sleep_sandbox(
     logger.info("Sandbox %s is now sleeping", sandbox_id)
 
 
-def mark_sandbox_provisioning(db_session: DBSession, sandbox_id: UUID) -> None:
-    """Mark a SLEEPING/TERMINATED sandbox as PROVISIONING before re-provisioning.
+def mark_sandbox_provisioning(db_session: DBSession, sandbox: Sandbox) -> None:
+    """Mark a re-provisionable sandbox as PROVISIONING before re-provisioning.
 
     Commits deliberately so the transition is immediately visible to concurrent
     pollers of the state machine (e.g. ``_wait_for_provisioning_to_complete``).
+
+    Raises:
+        RuntimeError: sandbox is not in a re-provisionable status (guards
+            against clobbering RUNNING or a concurrent PROVISIONING).
     """
-    update_sandbox_status__no_commit(db_session, sandbox_id, SandboxStatus.PROVISIONING)
+    if sandbox.status not in _REPROVISIONABLE_STATUSES:
+        raise RuntimeError(
+            f"Sandbox {sandbox.id} in unexpected status "
+            f"{sandbox.status.value}; refusing to mark PROVISIONING"
+        )
+    update_sandbox_status__no_commit(db_session, sandbox.id, SandboxStatus.PROVISIONING)
     db_session.commit()
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_sandbox_status_writers.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_sandbox_status_writers.py
@@ -1,0 +1,62 @@
+"""Pins the invariant that Craft sandbox status transitions live exclusively
+in the lifecycle module (plus the db layer that implements the mutation).
+
+Any new module referencing ``update_sandbox_status__no_commit`` fails this
+test and forces a conscious decision: route the transition through
+``sandbox_lifecycle`` instead, or (rarely) extend the allowed set here.
+"""
+
+from pathlib import Path
+
+# Modules that MUST reference the status mutation (the spec).
+ALLOWED_REFERENCES: set[str] = {
+    # Canonical DB mutation.
+    "onyx/server/features/build/db/sandbox.py",
+    # Substrate-invariant transitions + invariants.
+    "onyx/server/features/build/session/sandbox_lifecycle.py",
+}
+
+# References that in-flight branches remove; tolerated (not required) so the
+# test keeps passing as each branch merges. Delete entries once stale.
+TEMPORARILY_TOLERATED: set[str] = {
+    # whuang/craft-skills-push-race moves restore_session's remaining writes
+    # (unhealthy-RUNNING recovery, post-provision RUNNING) into lifecycle.
+    "onyx/server/features/build/session/api.py",
+    # whuang/craft-sleep-lifecycle moves the reaper's sleep transition into
+    # lifecycle.
+    "onyx/background/celery/tasks/build/tasks.py",
+}
+
+
+def _modules_referencing_status_mutation() -> set[str]:
+    backend_dir = Path(__file__).resolve().parents[7]
+    assert backend_dir.name == "backend", (
+        f"Unexpected repo layout; expected 'backend', got {backend_dir}"
+    )
+    scan_roots = (
+        backend_dir / "onyx" / "server" / "features" / "build",
+        backend_dir / "onyx" / "background",
+    )
+    found: set[str] = set()
+    for root in scan_roots:
+        for path in sorted(root.rglob("*.py")):
+            if "update_sandbox_status__no_commit" in path.read_text(encoding="utf-8"):
+                found.add(path.relative_to(backend_dir).as_posix())
+    return found
+
+
+def test_sandbox_status_writers_confined_to_lifecycle_and_db_layer() -> None:
+    found = _modules_referencing_status_mutation()
+
+    unexpected = found - ALLOWED_REFERENCES - TEMPORARILY_TOLERATED
+    assert not unexpected, (
+        "New module(s) reference update_sandbox_status__no_commit: "
+        f"{sorted(unexpected)}. Sandbox status transitions must go through "
+        "onyx/server/features/build/session/sandbox_lifecycle.py."
+    )
+
+    missing = ALLOWED_REFERENCES - found
+    assert not missing, (
+        f"Expected writer(s) no longer reference the mutation: {sorted(missing)}. "
+        "Update ALLOWED_REFERENCES if this was intentional."
+    )

--- a/backend/tests/unit/onyx/server/features/build/session/test_sandbox_status_writers.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_sandbox_status_writers.py
@@ -16,17 +16,6 @@ ALLOWED_REFERENCES: set[str] = {
     "onyx/server/features/build/session/sandbox_lifecycle.py",
 }
 
-# References that in-flight branches remove; tolerated (not required) so the
-# test keeps passing as each branch merges. Delete entries once stale.
-TEMPORARILY_TOLERATED: set[str] = {
-    # whuang/craft-skills-push-race moves restore_session's remaining writes
-    # (unhealthy-RUNNING recovery, post-provision RUNNING) into lifecycle.
-    "onyx/server/features/build/session/api.py",
-    # whuang/craft-sleep-lifecycle moves the reaper's sleep transition into
-    # lifecycle.
-    "onyx/background/celery/tasks/build/tasks.py",
-}
-
 
 def _modules_referencing_status_mutation() -> set[str]:
     backend_dir = Path(__file__).resolve().parents[7]
@@ -48,7 +37,7 @@ def _modules_referencing_status_mutation() -> set[str]:
 def test_sandbox_status_writers_confined_to_lifecycle_and_db_layer() -> None:
     found = _modules_referencing_status_mutation()
 
-    unexpected = found - ALLOWED_REFERENCES - TEMPORARILY_TOLERATED
+    unexpected = found - ALLOWED_REFERENCES
     assert not unexpected, (
         "New module(s) reference update_sandbox_status__no_commit: "
         f"{sorted(unexpected)}. Sandbox status transitions must go through "


### PR DESCRIPTION
## Description

Follow-up to #12789 (Craft sandbox layering: status transitions belong in `sandbox_lifecycle`, callers write no status).

Audited every `Sandbox.status` writer and moved the out-of-place ones into cohesive lifecycle functions:

- `mark_sandbox_provisioning` — the flip-to-`PROVISIONING` + commit before re-provisioning a SLEEPING/TERMINATED sandbox in `restore_session`; the commit is deliberate (makes the transition immediately visible to concurrent pollers like `_wait_for_provisioning_to_complete`) and the docstring now records that.
- `rollback_failed_provisioning` — the compensating transition in restore's error handler: stuck `PROVISIONING` → `SLEEPING` + commit; returns whether it applied so the handler falls through to partial-workspace cleanup otherwise.
- Deleted a dead legacy `update_sandbox_status` in `db/build_session.py` (zero callers).

Deliberately left in place, owned by sibling PRs: the unhealthy-recovery + post-provision writes in `restore_session` (removed by #12789) and the reaper's SLEEPING write in `tasks.py` (removed by #12790).

Completeness pin: a new pure unit test walks `server/features/build` + `background` sources and asserts the set of modules referencing `update_sandbox_status__no_commit` is exactly the allowed set (db layer + lifecycle) — any new writer fails and forces a conscious decision, and a vanished expected writer fails too. With #12789 and #12790 merged (this branch is rebased on both), the invariant holds with no carve-outs, so the transition-window tolerated-set machinery was deleted.

## How Has This Been Tested?

New unit test `test_sandbox_status_writers.py` (the completeness pin) passes; full session-package unit suite (90 tests) passes; ruff/ty clean. No behavioral changes beyond moving the two transitions verbatim.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes Craft sandbox status transitions in `sandbox_lifecycle`, adds guarded helpers for provisioning, replaces ad‑hoc writes in `restore_session`, and enforces allowed writers via a unit test. No behavior change.

- **Refactors**
  - Added `mark_sandbox_provisioning` that commits immediately and only runs from `SLEEPING`/`TERMINATED`/`FAILED`, guarded by `_REPROVISIONABLE_STATUSES` (also used by `ensure_sandbox_ready`).
  - Added `rollback_failed_provisioning` to revert failed `PROVISIONING` → `SLEEPING` and report if applied.
  - Replaced direct status writes in `restore_session` with these lifecycle helpers; kept workspace cleanup after post‑provision failures.
  - Removed legacy `update_sandbox_status` from `db/build_session.py`. Added `test_sandbox_status_writers.py` to assert only the DB layer and `sandbox_lifecycle` reference `update_sandbox_status__no_commit`.

<sup>Written for commit c8d736beef92cec40a29a91eb85bd5f23cc2ca99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

