### PR TITLE
fix(chat): render full multi-model comparison in shared chats

### DIFF
--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -106,11 +106,13 @@ export default function MultiModelPanel({
         rightChildren={
           readOnly ? (
             isPreferred ? (
-              <span className="text-action-link-05 shrink-0 px-2">
-                <Text font="secondary-body" color="inherit" nowrap>
-                  Preferred Response
-                </Text>
-              </span>
+              <div className="flex items-center px-2">
+                <span className="text-action-link-05 shrink-0">
+                  <Text font="secondary-body" color="inherit" nowrap>
+                    Preferred Response
+                  </Text>
+                </span>
+              </div>
             ) : undefined
           ) : (
             <div className="flex items-center gap-1 px-2">

--- a/web/src/app/app/message/MultiModelPanel.tsx
+++ b/web/src/app/app/message/MultiModelPanel.tsx
@@ -26,6 +26,8 @@ export interface MultiModelPanelProps {
   isHidden: boolean;
   /** Whether this is a non-preferred panel in selection mode (pushed off-screen) */
   isNonPreferredInSelection: boolean;
+  /** Read-only (shared) view: no select/hide controls, header is a static label */
+  readOnly?: boolean;
   /** Callback when user clicks this panel to select as preferred */
   onSelect: () => void;
   /** Callback to deselect this panel as preferred */
@@ -66,6 +68,7 @@ export default function MultiModelPanel({
   isPreferred,
   isHidden,
   isNonPreferredInSelection,
+  readOnly = false,
   onSelect,
   onDeselect,
   onToggleVisibility,
@@ -79,7 +82,7 @@ export default function MultiModelPanel({
 }: MultiModelPanelProps) {
   const ModelIcon = getModelIcon(provider, modelName);
 
-  const canSelect = !isHidden && !isPreferred && !isGenerating;
+  const canSelect = !isHidden && !isPreferred && !isGenerating && !readOnly;
 
   const handlePanelClick = useCallback(() => {
     if (canSelect) onSelect();
@@ -101,41 +104,51 @@ export default function MultiModelPanel({
         icon={ModelIcon}
         title={isHidden ? markdown(`~~${displayName}~~`) : displayName}
         rightChildren={
-          <div className="flex items-center gap-1 px-2">
-            {isPreferred && (
-              <>
-                <span className="text-action-link-05 shrink-0">
-                  <Text font="secondary-body" color="inherit" nowrap>
-                    Preferred Response
-                  </Text>
-                </span>
-                {onDeselect && (
-                  <Button
-                    prominence="tertiary"
-                    icon={SvgX}
-                    size="sm"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onDeselect();
-                    }}
-                    tooltip="Deselect preferred response"
-                  />
-                )}
-              </>
-            )}
-            {!isPreferred && (
-              <Button
-                prominence="tertiary"
-                icon={isHidden ? SvgEyeOff : SvgX}
-                size="md"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onToggleVisibility();
-                }}
-                tooltip={isHidden ? "Show response" : "Hide response"}
-              />
-            )}
-          </div>
+          readOnly ? (
+            isPreferred ? (
+              <span className="text-action-link-05 shrink-0 px-2">
+                <Text font="secondary-body" color="inherit" nowrap>
+                  Preferred Response
+                </Text>
+              </span>
+            ) : undefined
+          ) : (
+            <div className="flex items-center gap-1 px-2">
+              {isPreferred && (
+                <>
+                  <span className="text-action-link-05 shrink-0">
+                    <Text font="secondary-body" color="inherit" nowrap>
+                      Preferred Response
+                    </Text>
+                  </span>
+                  {onDeselect && (
+                    <Button
+                      prominence="tertiary"
+                      icon={SvgX}
+                      size="sm"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onDeselect();
+                      }}
+                      tooltip="Deselect preferred response"
+                    />
+                  )}
+                </>
+              )}
+              {!isPreferred && (
+                <Button
+                  prominence="tertiary"
+                  icon={isHidden ? SvgEyeOff : SvgX}
+                  size="md"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onToggleVisibility();
+                  }}
+                  tooltip={isHidden ? "Show response" : "Hide response"}
+                />
+              )}
+            </div>
+          )
         }
       />
     </div>

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -29,9 +29,9 @@ export interface MultiModelResponseViewProps {
   /** Called whenever the set of hidden panel indices changes */
   onHiddenPanelsChange?: (hidden: Set<number>) => void;
   /**
-   * Read-only mode for the shared view: every panel renders equal-width and
-   * fully visible, selection/hide interactions are disabled, and nothing
-   * persists. Used so a shared link mirrors the author's model comparison.
+   * Read-only mode for the shared view: same layout as live (a preferred
+   * response centers with the others peeking), but select/hide interactions are
+   * disabled and nothing persists. Mirrors the author's model comparison.
    */
   readOnly?: boolean;
 }
@@ -393,7 +393,6 @@ export default function MultiModelResponseView({
   );
 
   const isActivelySelected =
-    !readOnly &&
     preferredIndex !== null &&
     preferredIdx !== -1 &&
     !isGenerating &&
@@ -403,12 +402,11 @@ export default function MultiModelResponseView({
     if (isActivelySelected) setHasEnteredSelection(true);
   }, [isActivelySelected]);
 
-  // Use the selection layout once a preferred response has been chosen,
-  // even after deselect. Only fall through to generation layout before
-  // the first selection or during active streaming. Read-only views never
-  // enter selection mode — they always show every panel equal-width.
-  const showSelectionMode =
-    !readOnly && (isActivelySelected || hasEnteredSelection);
+  // Use the selection layout once a preferred response has been chosen, even
+  // after deselect. Only fall through to generation layout before the first
+  // selection or during active streaming. The read-only (shared) view uses the
+  // same layout so a shared preferred response is centered like the author saw.
+  const showSelectionMode = isActivelySelected || hasEnteredSelection;
 
   // Trigger the slide-out animation one frame after a preferred panel is selected.
   // Uses isActivelySelected (not showSelectionMode) so re-selecting after a

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -29,9 +29,9 @@ export interface MultiModelResponseViewProps {
   /** Called whenever the set of hidden panel indices changes */
   onHiddenPanelsChange?: (hidden: Set<number>) => void;
   /**
-   * Read-only mode for the shared view: same layout as live (a preferred
-   * response centers with the others peeking), but select/hide interactions are
-   * disabled and nothing persists. Mirrors the author's model comparison.
+   * Read-only mode for the shared view: every response stays equal-width and
+   * fully visible (no selection carousel), select/hide interactions are
+   * disabled, and nothing persists. The preferred response is still marked.
    */
   readOnly?: boolean;
 }
@@ -393,6 +393,7 @@ export default function MultiModelResponseView({
   );
 
   const isActivelySelected =
+    !readOnly &&
     preferredIndex !== null &&
     preferredIdx !== -1 &&
     !isGenerating &&
@@ -404,9 +405,10 @@ export default function MultiModelResponseView({
 
   // Use the selection layout once a preferred response has been chosen, even
   // after deselect. Only fall through to generation layout before the first
-  // selection or during active streaming. The read-only (shared) view uses the
-  // same layout so a shared preferred response is centered like the author saw.
-  const showSelectionMode = isActivelySelected || hasEnteredSelection;
+  // selection or during active streaming. The read-only (shared) view stays in
+  // generation layout so every response is shown equal-width.
+  const showSelectionMode =
+    !readOnly && (isActivelySelected || hasEnteredSelection);
 
   // Trigger the slide-out animation one frame after a preferred panel is selected.
   // Uses isActivelySelected (not showSelectionMode) so re-selecting after a

--- a/web/src/app/app/message/MultiModelResponseView.tsx
+++ b/web/src/app/app/message/MultiModelResponseView.tsx
@@ -28,6 +28,12 @@ export interface MultiModelResponseViewProps {
   onMessageSelection?: (nodeId: number) => void;
   /** Called whenever the set of hidden panel indices changes */
   onHiddenPanelsChange?: (hidden: Set<number>) => void;
+  /**
+   * Read-only mode for the shared view: every panel renders equal-width and
+   * fully visible, selection/hide interactions are disabled, and nothing
+   * persists. Used so a shared link mirrors the author's model comparison.
+   */
+  readOnly?: boolean;
 }
 
 // How many pixels of a non-preferred panel are visible at the viewport edge
@@ -70,11 +76,15 @@ export default function MultiModelResponseView({
   otherMessagesCanSwitchTo,
   onMessageSelection,
   onHiddenPanelsChange,
+  readOnly = false,
 }: MultiModelResponseViewProps) {
-  // Initialize preferredIndex from the backend's preferred_response_id when
-  // loading an existing conversation.
+  // Initialize preferredIndex from the backend's preferred_response_id. When a
+  // preferred response is picked the backend also points latest_child at it, so
+  // this marks the response the flow continued through. A turn the user never
+  // picked from (e.g. a final multi-model turn) has no preference and stays
+  // unhighlighted.
   const [preferredIndex, setPreferredIndex] = useState<number | null>(() => {
-    if (!parentMessage?.preferredResponseId) return null;
+    if (parentMessage?.preferredResponseId == null) return null;
     const match = responses.find(
       (r) => r.messageId === parentMessage.preferredResponseId
     );
@@ -383,6 +393,7 @@ export default function MultiModelResponseView({
   );
 
   const isActivelySelected =
+    !readOnly &&
     preferredIndex !== null &&
     preferredIdx !== -1 &&
     !isGenerating &&
@@ -394,8 +405,10 @@ export default function MultiModelResponseView({
 
   // Use the selection layout once a preferred response has been chosen,
   // even after deselect. Only fall through to generation layout before
-  // the first selection or during active streaming.
-  const showSelectionMode = isActivelySelected || hasEnteredSelection;
+  // the first selection or during active streaming. Read-only views never
+  // enter selection mode — they always show every panel equal-width.
+  const showSelectionMode =
+    !readOnly && (isActivelySelected || hasEnteredSelection);
 
   // Trigger the slide-out animation one frame after a preferred panel is selected.
   // Uses isActivelySelected (not showSelectionMode) so re-selecting after a
@@ -418,6 +431,7 @@ export default function MultiModelResponseView({
       isPreferred: preferredIndex === response.modelIndex,
       isHidden: hiddenPanels.has(response.modelIndex),
       isNonPreferredInSelection: isNonPreferred,
+      readOnly,
       onSelect: () => handleSelectPreferred(response.modelIndex),
       onDeselect: handleDeselectPreferred,
       onToggleVisibility: () => toggleVisibility(response.modelIndex),
@@ -444,6 +458,7 @@ export default function MultiModelResponseView({
     [
       preferredIndex,
       hiddenPanels,
+      readOnly,
       handleSelectPreferred,
       handleDeselectPreferred,
       toggleVisibility,

--- a/web/src/app/app/message/messageComponents/AgentMessage.tsx
+++ b/web/src/app/app/message/messageComponents/AgentMessage.tsx
@@ -378,6 +378,7 @@ const AgentMessage = React.memo(function AgentMessage({
           parentMessage={parentMessage}
           llmManager={llmManager}
           currentModelName={chatState.overriddenModel}
+          currentModelProvider={chatState.overriddenModelProvider}
           citations={citations}
           documentMap={documentMap}
         />

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -30,6 +30,7 @@ import TTSButton from "@/app/app/message/messageComponents/TTSButton";
 import { useVoiceMode } from "@/providers/VoiceModeProvider";
 import { useVoiceStatus } from "@/hooks/useVoiceStatus";
 import { findModelConfigId } from "@/lib/languageModels/options";
+import { getModelIcon } from "@/lib/languageModels";
 
 interface SouurcesTagWrapperProps {
   citations: StreamingCitation[];
@@ -112,6 +113,9 @@ export interface MessageToolbarProps {
   parentMessage?: Message | null;
   llmManager: LlmManager | null;
   currentModelName?: string;
+  /** Provider slug for `currentModelName`; used to resolve the model icon in
+   * the read-only footer chip shown when there's no `llmManager`. */
+  currentModelProvider?: string;
 
   // Citations
   citations: StreamingCitation[];
@@ -134,6 +138,7 @@ export default function MessageToolbar({
   parentMessage,
   llmManager,
   currentModelName,
+  currentModelProvider,
   citations,
   documentMap,
 }: MessageToolbarProps) {
@@ -290,6 +295,20 @@ export default function MessageToolbar({
                   removeThinkingTokens(getTextContent(rawPackets)) as string
                 }
               />
+            )}
+
+            {/* Read-only model label for the shared view: no llmManager to
+                power the interactive selector, so surface which model answered. */}
+            {!llmManager && currentModelName && (
+              <OpenButton
+                disabled
+                icon={getModelIcon(
+                  currentModelProvider ?? "",
+                  currentModelName
+                )}
+              >
+                {currentModelName}
+              </OpenButton>
             )}
 
             {onRegenerate &&

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -113,7 +113,7 @@ export interface MessageToolbarProps {
   parentMessage?: Message | null;
   llmManager: LlmManager | null;
   currentModelName?: string;
-  /** Provider slug for `currentModelName`; used to resolve the model icon in
+  /** Provider slug for `currentModelName`, used to resolve the model icon in
    * the read-only footer chip shown when there's no `llmManager`. */
   currentModelProvider?: string;
 

--- a/web/src/app/app/message/messageComponents/interfaces.ts
+++ b/web/src/app/app/message/messageComponents/interfaces.ts
@@ -33,6 +33,9 @@ export interface FullChatState {
   // Regenerate functionality
   regenerate?: (modelOverRide: LlmDescriptor) => Promise<void>;
   overriddenModel?: string;
+  /** Provider slug for `overriddenModel`, used to resolve its icon in the
+   * read-only (shared) footer where there's no `llmManager` to look it up. */
+  overriddenModelProvider?: string;
   researchType?: string | null;
 }
 

--- a/web/src/app/app/message/multiModel.ts
+++ b/web/src/app/app/message/multiModel.ts
@@ -12,7 +12,7 @@ import { MultiModelResponse } from "@/app/app/message/interfaces";
  *
  * `modelProviderLookup` maps a model identifier → provider slug for icon
  * resolution. Pass an empty map when the provider list is unavailable (e.g. the
- * read-only shared view); `getModelIcon` then falls back to the model name.
+ * read-only shared view). `getModelIcon` then falls back to the model name.
  */
 export function getMultiModelResponses(
   userMessage: Message,

--- a/web/src/app/app/message/multiModel.ts
+++ b/web/src/app/app/message/multiModel.ts
@@ -1,0 +1,61 @@
+import { Message } from "@/app/app/interfaces";
+import { MultiModelResponse } from "@/app/app/message/interfaces";
+
+/**
+ * Group a user message's sibling assistant responses into multi-model panels.
+ *
+ * A multi-model turn is a user message with 2+ assistant/error children that
+ * each carry a model name (`modelDisplayName` or `overridden_model`). That
+ * metadata is what distinguishes a real multi-model turn from a plain
+ * regeneration, which also produces sibling assistant messages. Returns null
+ * when the message isn't a multi-model turn.
+ *
+ * `modelProviderLookup` maps a model identifier → provider slug for icon
+ * resolution. Pass an empty map when the provider list is unavailable (e.g. the
+ * read-only shared view); `getModelIcon` then falls back to the model name.
+ */
+export function getMultiModelResponses(
+  userMessage: Message,
+  messageTree: Map<number, Message>,
+  modelProviderLookup: Map<string, string>
+): MultiModelResponse[] | null {
+  const childIds = userMessage.childrenNodeIds ?? [];
+  if (childIds.length < 2) return null;
+
+  const assistantChildren = childIds
+    .map((id) => messageTree.get(id))
+    .filter(
+      (msg): msg is Message =>
+        msg !== undefined && (msg.type === "assistant" || msg.type === "error")
+    );
+
+  const multiModelChildren = assistantChildren.filter(
+    (msg) => msg.modelDisplayName || msg.overridden_model
+  );
+  if (multiModelChildren.length < 2) return null;
+
+  return multiModelChildren.map((msg, idx): MultiModelResponse => {
+    const modelVersion =
+      msg.overridden_model || msg.modelDisplayName || "Model";
+    const provider = modelProviderLookup.get(modelVersion) ?? "";
+    const displayName = msg.modelDisplayName || modelVersion;
+    const isError = msg.type === "error";
+    return {
+      modelIndex: idx,
+      provider,
+      modelName: modelVersion,
+      displayName,
+      packets: msg.packets || [],
+      packetCount: msg.packetCount || msg.packets?.length || 0,
+      nodeId: msg.nodeId,
+      messageId: msg.messageId,
+      currentFeedback: msg.currentFeedback,
+      isGenerating: msg.is_generating || false,
+      errorMessage: isError ? msg.message : null,
+      errorCode: isError ? msg.errorCode : null,
+      isRetryable: isError ? msg.isRetryable : undefined,
+      errorStackTrace: isError ? msg.stackTrace : null,
+      errorDetails: isError ? msg.errorDetails : null,
+    };
+  });
+}

--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -39,7 +39,7 @@ export default function SharedChatDisplay({
   const isMounted = useOnMount();
 
   // The shared viewer is authenticated, so the user-facing provider list is
-  // available for resolving each model's provider icon — same as the live view.
+  // available for resolving each model's provider icon, same as the live view.
   const { llmProviders } = useLLMProviders();
   const modelProviderLookup = useMemo(
     () => buildModelProviderLookup(llmProviders),
@@ -159,7 +159,7 @@ export default function SharedChatDisplay({
                 }
 
                 // Non-user (assistant or error): skip the single child the
-                // chain surfaced when its parent is a multi-model turn — the
+                // chain surfaced when its parent is a multi-model turn. The
                 // panels already render every response, including failures.
                 const previousMessage = i !== 0 ? messages[i - 1] : null;
                 if (
@@ -187,7 +187,7 @@ export default function SharedChatDisplay({
                           citations: message.citations,
                           setPresentingDocument: setPresentingDocument,
                           // Shared payload carries the model as `modelDisplayName`,
-                          // not `overridden_model`; surface it in the read-only footer.
+                          // not `overridden_model`. Surface it in the read-only footer.
                           overriddenModel:
                             message.modelDisplayName ?? undefined,
                           overriddenModelProvider: message.modelDisplayName

--- a/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
+++ b/web/src/app/app/shared/[chatId]/SharedChatDisplay.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { humanReadableFormat } from "@opal/time";
 import { BackendChatSession } from "@/app/app/interfaces";
 import { processRawChatHistory } from "@/app/app/services/lib";
 import { getLatestMessageChain } from "@/app/app/services/messageTree";
 import HumanMessage from "@/app/app/message/HumanMessage";
 import AgentMessage from "@/app/app/message/messageComponents/AgentMessage";
+import MultiModelResponseView from "@/app/app/message/MultiModelResponseView";
+import { getMultiModelResponses } from "@/app/app/message/multiModel";
+import { useLLMProviders } from "@/lib/languageModels/hooks";
+import { buildModelProviderLookup } from "@/lib/languageModels/options";
 import OnyxInitializingLoader from "@/components/OnyxInitializingLoader";
 import { Section } from "@/layouts/general-layouts";
 import { IllustrationContent } from "@opal/layouts";
@@ -34,6 +38,14 @@ export default function SharedChatDisplay({
 
   const isMounted = useOnMount();
 
+  // The shared viewer is authenticated, so the user-facing provider list is
+  // available for resolving each model's provider icon — same as the live view.
+  const { llmProviders } = useLLMProviders();
+  const modelProviderLookup = useMemo(
+    () => buildModelProviderLookup(llmProviders),
+    [llmProviders]
+  );
+
   if (!chatSession) {
     return (
       <div className="h-full w-full flex flex-col items-center justify-center">
@@ -51,9 +63,11 @@ export default function SharedChatDisplay({
     );
   }
 
-  const messages = getLatestMessageChain(
-    processRawChatHistory(chatSession.messages, chatSession.packets)
+  const messageTree = processRawChatHistory(
+    chatSession.messages,
+    chatSession.packets
   );
+  const messages = getLatestMessageChain(messageTree);
 
   const firstMessage = messages[0];
 
@@ -102,47 +116,106 @@ export default function SharedChatDisplay({
           </div>
 
           {isMounted ? (
-            <div className="w-[min(50rem,100%)]">
+            <div className="w-full flex flex-col items-center">
               {messages.map((message, i) => {
                 if (message.type === "user") {
-                  return (
-                    <HumanMessage
-                      key={message.messageId}
-                      content={message.message}
-                      files={message.files}
-                      nodeId={message.nodeId}
-                    />
+                  const multiModelResponses = getMultiModelResponses(
+                    message,
+                    messageTree,
+                    modelProviderLookup
                   );
-                } else if (message.type === "assistant") {
                   return (
-                    <AgentMessage
+                    <div
                       key={message.messageId}
-                      rawPackets={message.packets}
-                      chatState={{
-                        agent: persona,
-                        docs: message.documents,
-                        citations: message.citations,
-                        setPresentingDocument: setPresentingDocument,
-                        overriddenModel: message.overridden_model,
-                      }}
-                      nodeId={message.nodeId}
-                      llmManager={null}
-                      otherMessagesCanSwitchTo={undefined}
-                      onMessageSelection={undefined}
-                    />
-                  );
-                } else {
-                  // Error message case
-                  return (
-                    <div key={message.messageId} className="py-5 ml-4 lg:px-5">
-                      <div className="mx-auto w-[90%] max-w-message-max">
-                        <p className="text-status-text-error-05 text-sm my-auto">
-                          {message.message}
-                        </p>
+                      className="w-full flex flex-col items-center"
+                    >
+                      <div className="w-[min(50rem,100%)]">
+                        <HumanMessage
+                          content={message.message}
+                          files={message.files}
+                          nodeId={message.nodeId}
+                        />
                       </div>
+                      {/* Multi-model turns render every response side-by-side,
+                          full width, mirroring the author's comparison. */}
+                      {multiModelResponses && (
+                        <div className="w-full px-4 pt-12">
+                          <MultiModelResponseView
+                            responses={multiModelResponses}
+                            chatState={{
+                              agent: persona,
+                              docs: [],
+                              citations: undefined,
+                              setPresentingDocument,
+                            }}
+                            llmManager={null}
+                            parentMessage={message}
+                            readOnly
+                          />
+                        </div>
+                      )}
                     </div>
                   );
                 }
+
+                // Non-user (assistant or error): skip the single child the
+                // chain surfaced when its parent is a multi-model turn — the
+                // panels already render every response, including failures.
+                const previousMessage = i !== 0 ? messages[i - 1] : null;
+                if (
+                  previousMessage?.type === "user" &&
+                  getMultiModelResponses(
+                    previousMessage,
+                    messageTree,
+                    modelProviderLookup
+                  )
+                ) {
+                  return null;
+                }
+
+                if (message.type === "assistant") {
+                  return (
+                    <div
+                      key={message.messageId}
+                      className="w-[min(50rem,100%)]"
+                    >
+                      <AgentMessage
+                        rawPackets={message.packets}
+                        chatState={{
+                          agent: persona,
+                          docs: message.documents,
+                          citations: message.citations,
+                          setPresentingDocument: setPresentingDocument,
+                          // Shared payload carries the model as `modelDisplayName`,
+                          // not `overridden_model`; surface it in the read-only footer.
+                          overriddenModel:
+                            message.modelDisplayName ?? undefined,
+                          overriddenModelProvider: message.modelDisplayName
+                            ? modelProviderLookup.get(message.modelDisplayName)
+                            : undefined,
+                        }}
+                        nodeId={message.nodeId}
+                        llmManager={null}
+                        otherMessagesCanSwitchTo={undefined}
+                        onMessageSelection={undefined}
+                      />
+                    </div>
+                  );
+                }
+
+                // Error message case
+                return (
+                  <div
+                    key={message.messageId}
+                    className="py-5 ml-4 lg:px-5 w-[min(50rem,100%)]"
+                  >
+                    <div className="mx-auto w-[90%] max-w-message-max">
+                      <p className="text-status-text-error-05 text-sm my-auto">
+                        {message.message}
+                      </p>
+                    </div>
+                  </div>
+                );
               })}
             </div>
           ) : (

--- a/web/src/lib/languageModels/options.ts
+++ b/web/src/lib/languageModels/options.ts
@@ -97,6 +97,26 @@ export function buildLlmOptions(
 }
 
 // ---------------------------------------------------------------------------
+// buildModelProviderLookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Model identifier → provider slug map for icon resolution. Indexes by both
+ * raw model name ("gpt-4.1") and display name ("GPT-4.1") so it resolves for
+ * both live streaming and history reload, where only one of the two is known.
+ */
+export function buildModelProviderLookup(
+  llmProviders: LLMProviderDescriptor[] | undefined
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const opt of buildLlmOptions(llmProviders)) {
+    map.set(opt.modelName, opt.provider);
+    map.set(opt.displayName, opt.provider);
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
 // groupLlmOptions
 // ---------------------------------------------------------------------------
 

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -145,7 +145,7 @@ const ChatUI = React.memo(
 
     // Group a user message's sibling assistant responses into multi-model
     // panels. Memoized on the tree + provider lookup so identity is stable
-    // across renders; the grouping itself lives in the shared util so the
+    // across renders. The grouping itself lives in the shared util so the
     // read-only shared view can reuse it.
     const getMultiModelResponsesForMessage = useCallback(
       (userMessage: Message): MultiModelResponse[] | null =>

--- a/web/src/sections/chat/ChatUI.tsx
+++ b/web/src/sections/chat/ChatUI.tsx
@@ -10,8 +10,9 @@ import { LlmDescriptor, LlmManager } from "@/lib/hooks";
 import AgentMessage from "@/app/app/message/messageComponents/AgentMessage";
 import MultiModelResponseView from "@/app/app/message/MultiModelResponseView";
 import { MultiModelResponse } from "@/app/app/message/interfaces";
+import { getMultiModelResponses } from "@/app/app/message/multiModel";
 import { SelectedModel } from "@/sections/model-selector/MultiModelSelector";
-import { buildLlmOptions } from "@/lib/languageModels/options";
+import { buildModelProviderLookup } from "@/lib/languageModels/options";
 import DynamicBottomSpacer from "@/components/chat/DynamicBottomSpacer";
 import {
   useCurrentMessageHistory,
@@ -92,16 +93,10 @@ const ChatUI = React.memo(
     const msgWidth = fullWidthChat ? undefined : MSG_MAX_W;
 
     // Lookup: model identifier → provider slug (for icon resolution).
-    // Indexes by both raw model name ("claude-sonnet-4-6") and display name
-    // ("Claude Sonnet 4.6") so it works for live streaming AND history reload.
-    const modelProviderLookup = useMemo(() => {
-      const map = new Map<string, string>();
-      for (const opt of buildLlmOptions(llmManager.llmProviders)) {
-        map.set(opt.modelName, opt.provider);
-        map.set(opt.displayName, opt.provider);
-      }
-      return map;
-    }, [llmManager.llmProviders]);
+    const modelProviderLookup = useMemo(
+      () => buildModelProviderLookup(llmManager.llmProviders),
+      [llmManager.llmProviders]
+    );
 
     // Use refs to keep callbacks stable while always using latest values
     const onSubmitRef = useRef(onSubmit);
@@ -148,65 +143,20 @@ const ChatUI = React.memo(
       []
     );
 
-    /**
-     * Detect multi-model responses: a user message whose children are 2+
-     * assistant messages each carrying modelDisplayName or overridden_model.
-     * Distinguishes from regeneration (which also creates sibling assistants)
-     * because regenerated messages don't have model display metadata.
-     */
-    // Use ref to avoid modelProviderLookup triggering callback recreation
-    const modelProviderLookupRef = useRef(modelProviderLookup);
-    modelProviderLookupRef.current = modelProviderLookup;
-
-    const getMultiModelResponses = useCallback(
-      (userMessage: Message): MultiModelResponse[] | null => {
-        if (!messageTree) return null;
-
-        const childIds = userMessage.childrenNodeIds ?? [];
-        if (childIds.length < 2) return null;
-
-        const assistantChildren = childIds
-          .map((id) => messageTree.get(id))
-          .filter(
-            (msg): msg is Message =>
-              msg !== undefined &&
-              (msg.type === "assistant" || msg.type === "error")
-          );
-
-        // Multi-model messages have modelDisplayName or overridden_model set.
-        // Regenerations don't — that's how we distinguish them.
-        const multiModelChildren = assistantChildren.filter(
-          (msg) => msg.modelDisplayName || msg.overridden_model
-        );
-        if (multiModelChildren.length < 2) return null;
-
-        const lookup = modelProviderLookupRef.current;
-        return multiModelChildren.map((msg, idx): MultiModelResponse => {
-          const modelVersion =
-            msg.overridden_model || msg.modelDisplayName || "Model";
-          const provider = lookup.get(modelVersion) ?? "";
-          const displayName = msg.modelDisplayName || modelVersion;
-          const isError = msg.type === "error";
-          return {
-            modelIndex: idx,
-            provider,
-            modelName: modelVersion,
-            displayName,
-            packets: msg.packets || [],
-            packetCount: msg.packetCount || msg.packets?.length || 0,
-            nodeId: msg.nodeId,
-            messageId: msg.messageId,
-            currentFeedback: msg.currentFeedback,
-            isGenerating: msg.is_generating || false,
-            errorMessage: isError ? msg.message : null,
-            errorCode: isError ? msg.errorCode : null,
-            isRetryable: isError ? msg.isRetryable : undefined,
-            errorStackTrace: isError ? msg.stackTrace : null,
-            errorDetails: isError ? msg.errorDetails : null,
-          };
-        });
-      },
-      [messageTree]
+    // Group a user message's sibling assistant responses into multi-model
+    // panels. Memoized on the tree + provider lookup so identity is stable
+    // across renders; the grouping itself lives in the shared util so the
+    // read-only shared view can reuse it.
+    const getMultiModelResponsesForMessage = useCallback(
+      (userMessage: Message): MultiModelResponse[] | null =>
+        messageTree
+          ? getMultiModelResponses(
+              userMessage,
+              messageTree,
+              modelProviderLookup
+            )
+          : null,
+      [messageTree, modelProviderLookup]
     );
 
     return (
@@ -227,7 +177,8 @@ const ChatUI = React.memo(
             if (message.type === "user") {
               const nextMessage =
                 messages.length > i + 1 ? messages[i + 1] : null;
-              const multiModelResponses = getMultiModelResponses(message);
+              const multiModelResponses =
+                getMultiModelResponsesForMessage(message);
 
               return (
                 <div
@@ -299,7 +250,7 @@ const ChatUI = React.memo(
               // Skip assistant messages already rendered in MultiModelResponseView
               if (
                 previousMessage?.type === "user" &&
-                getMultiModelResponses(previousMessage)
+                getMultiModelResponsesForMessage(previousMessage)
               ) {
                 return null;
               }


### PR DESCRIPTION
## Description

Sharing a chat where multiple models were prompted at once only rendered one model's response — the chain walk collapses a user turn's sibling responses down to the latest child.

- Shared multi-model turns now render every response side-by-side, read-only (no select/hide, nothing persists), mirroring what the author saw.
- Provider icons resolve through the user-facing LLM provider list, so each panel shows its real vendor icon instead of the generic fallback.
- The response the flow continued through is highlighted as "Preferred Response". A turn the user never picked from stays unhighlighted, and follow-ups only show the branch that was selected at share time.
- Single-model shared chats now show the answering model in the message footer.

Frontend only — the shared payload already returns every sibling and its packets. The grouping + provider-lookup are extracted so the shared view reuses the live view's logic.

## How Has This Been Tested?
<img width="1115" height="913" alt="Screenshot 2026-07-08 at 2 58 49 PM" src="https://github.com/user-attachments/assets/c715d66e-b364-438a-b6f7-66c5de5e6f40" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
