### PR TITLE
fix(craft): allow proxied origin for webapp dev server + fix preview 404 flapping

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -125,6 +125,7 @@ from onyx.server.features.build.sandbox.models import FilesystemEntry
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
 from onyx.server.features.build.sandbox.serve_transport import ServeConnectionInfo
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.util.agent_instructions import (
@@ -249,50 +250,6 @@ def _stream_stdout_from_container_as_sandbox_user(
         environment=SANDBOX_EXEC_ENV,
         chunk_size=chunk_size,
     )
-
-
-def _build_nextjs_start_script(
-    session_path: str,
-    nextjs_port: int,
-    check_node_modules: bool = False,
-) -> str:
-    """Shell script to spawn Next.js in the background and record its PID."""
-    install_check = ""
-    if check_node_modules:
-        install_check = f"""
-if [ ! -d "node_modules" ]; then
-    echo "Installing dependencies with bun..."
-    BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \
-        bun install --frozen-lockfile --backend=hardlink
-fi
-"""
-
-    return f"""
-set -e
-cd {session_path}/outputs/web
-{install_check}
-export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/$(basename {session_path})/webapp"
-if grep -q "WEBAPP_ASSET_PREFIX" next.config.ts 2>/dev/null; then
-    cat > next.config.ts <<'EOF'
-import type {{ NextConfig }} from "next";
-
-const webappBasePath = process.env.ONYX_WEBAPP_BASE_PATH || undefined;
-
-const nextConfig: NextConfig = {{
-  ...(webappBasePath
-    ? {{ basePath: webappBasePath, assetPrefix: webappBasePath }}
-    : {{}}),
-}};
-
-export default nextConfig;
-EOF
-fi
-echo "Starting Next.js dev server on port {nextjs_port}..."
-nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
-NEXTJS_PID=$!
-echo "Next.js server started with PID $NEXTJS_PID"
-echo $NEXTJS_PID > {session_path}/nextjs.pid
-"""
 
 
 def _sandbox_container_name(sandbox_id: str | UUID) -> str:
@@ -1142,7 +1099,7 @@ class DockerSandboxManager(SandboxManager):
         )
 
         nextjs_start = (
-            _build_nextjs_start_script(session_path, nextjs_port)
+            build_nextjs_start_script(session_path, nextjs_port)
             if nextjs_port is not None
             else ""
         )
@@ -1550,7 +1507,7 @@ fi
         )
 
         if nextjs_port is not None:
-            start_script = _build_nextjs_start_script(
+            start_script = build_nextjs_start_script(
                 session_path, nextjs_port, check_node_modules=True
             )
             try:

--- a/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
+++ b/backend/onyx/server/features/build/sandbox/image/templates/outputs/web/next.config.ts
@@ -1,12 +1,20 @@
 import type { NextConfig } from "next";
 
 const webappBasePath = process.env.ONYX_WEBAPP_BASE_PATH || undefined;
+const allowedDevOrigins = (process.env.ONYX_WEBAPP_ALLOWED_DEV_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
 
 const nextConfig: NextConfig = {};
 
 if (webappBasePath) {
   nextConfig.basePath = webappBasePath;
   nextConfig.assetPrefix = webappBasePath;
+}
+
+if (allowedDevOrigins.length > 0) {
+  nextConfig.allowedDevOrigins = allowedDevOrigins;
 }
 
 export default nextConfig;

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -127,6 +127,7 @@ from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.models import RetriableWriteError
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.models import SnapshotResult
+from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
 from onyx.server.features.build.sandbox.serve_transport import (
     OPENCODE_SERVE_READY_TIMEOUT_SECONDS,
 )
@@ -277,60 +278,6 @@ def _build_targz(files: FileSet) -> tuple[bytes, str]:
             tar.addfile(info, io.BytesIO(data))
     raw = buf.getvalue()
     return raw, hashlib.sha256(raw).hexdigest()
-
-
-def _build_nextjs_start_script(
-    session_path: str,
-    nextjs_port: int,
-    check_node_modules: bool = False,
-) -> str:
-    """Builds shell script to start the NextJS dev server.
-
-    Args:
-        session_path: Path to the session directory (should be shell-safe).
-        nextjs_port: Port number for the NextJS dev server.
-        check_node_modules: If True, check for node_modules and run bun install
-            if missing.
-
-    Returns:
-        Shell script string to start the NextJS server.
-    """
-    install_check = ""
-    if check_node_modules:
-        install_check = f"""
-if [ ! -d "node_modules" ]; then
-    echo "Installing dependencies with bun..."
-    BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \\
-        bun install --frozen-lockfile --backend=hardlink
-fi
-"""
-
-    return f"""
-set -e
-cd {session_path}/outputs/web
-{install_check}
-export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/$(basename {session_path})/webapp"
-if grep -q "WEBAPP_ASSET_PREFIX" next.config.ts 2>/dev/null; then
-    cat > next.config.ts <<'EOF'
-import type {{ NextConfig }} from "next";
-
-const webappBasePath = process.env.ONYX_WEBAPP_BASE_PATH || undefined;
-
-const nextConfig: NextConfig = {{
-  ...(webappBasePath
-    ? {{ basePath: webappBasePath, assetPrefix: webappBasePath }}
-    : {{}}),
-}};
-
-export default nextConfig;
-EOF
-fi
-echo "Starting Next.js dev server on port {nextjs_port}..."
-nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
-NEXTJS_PID=$!
-echo "Next.js server started with PID $NEXTJS_PID"
-echo $NEXTJS_PID > {session_path}/nextjs.pid
-"""
 
 
 class KubernetesSandboxManager(SandboxManager):
@@ -1512,7 +1459,7 @@ fi
         # Headless callers (scheduled tasks) pass nextjs_port=None — the
         # agent's tools work without a dev server.
         nextjs_start_script = (
-            _build_nextjs_start_script(
+            build_nextjs_start_script(
                 session_path, nextjs_port, check_node_modules=False
             )
             if nextjs_port is not None
@@ -1956,7 +1903,7 @@ echo "Session cleanup complete"
             )
 
             if nextjs_port is not None:
-                start_script = _build_nextjs_start_script(
+                start_script = build_nextjs_start_script(
                     safe_session_path, nextjs_port, check_node_modules=True
                 )
                 k8s_stream(

--- a/backend/onyx/server/features/build/sandbox/nextjs_dev.py
+++ b/backend/onyx/server/features/build/sandbox/nextjs_dev.py
@@ -1,0 +1,83 @@
+"""Builds the shell script that starts a session's Next.js dev server.
+
+Shared by the Docker and Kubernetes sandbox managers so the dev-server
+environment (base path, allowed dev origins) stays identical across backends.
+"""
+
+from urllib.parse import urlparse
+
+from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.server.features.build.sandbox.base import BUN_CACHE_DIR
+
+
+def allowed_dev_origins() -> str:
+    """Hostname(s) allowed by Next dev's cross-origin check, comma-separated.
+
+    Next 16 `allowedDevOrigins` entries are hostnames (no scheme/port); the
+    deployment origin varies per install, so it is derived from WEB_DOMAIN.
+    """
+    return urlparse(WEB_DOMAIN).hostname or ""
+
+
+def build_nextjs_start_script(
+    session_path: str,
+    nextjs_port: int,
+    check_node_modules: bool = False,
+) -> str:
+    """Builds shell script to start the NextJS dev server.
+
+    Args:
+        session_path: Path to the session directory (should be shell-safe).
+        nextjs_port: Port number for the NextJS dev server.
+        check_node_modules: If True, check for node_modules and run bun install
+            if missing.
+
+    Returns:
+        Shell script string to start the NextJS server.
+    """
+    install_check = ""
+    if check_node_modules:
+        install_check = f"""
+if [ ! -d "node_modules" ]; then
+    echo "Installing dependencies with bun..."
+    BUN_INSTALL_CACHE_DIR={BUN_CACHE_DIR} \\
+        bun install --frozen-lockfile --backend=hardlink
+fi
+"""
+
+    return f"""
+set -e
+cd {session_path}/outputs/web
+{install_check}
+export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/$(basename {session_path})/webapp"
+export ONYX_WEBAPP_ALLOWED_DEV_ORIGINS="{allowed_dev_origins()}"
+if grep -q "WEBAPP_ASSET_PREFIX" next.config.ts 2>/dev/null; then
+    cat > next.config.ts <<'EOF'
+import type {{ NextConfig }} from "next";
+
+const webappBasePath = process.env.ONYX_WEBAPP_BASE_PATH || undefined;
+const allowedDevOrigins = (process.env.ONYX_WEBAPP_ALLOWED_DEV_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const nextConfig: NextConfig = {{}};
+
+if (webappBasePath) {{
+  nextConfig.basePath = webappBasePath;
+  nextConfig.assetPrefix = webappBasePath;
+}}
+
+if (allowedDevOrigins.length > 0) {{
+  nextConfig.allowedDevOrigins = allowedDevOrigins;
+}}
+
+export default nextConfig;
+EOF
+fi
+echo "Starting Next.js dev server on port {nextjs_port}..."
+nohup bun run dev -- -H 0.0.0.0 -p {nextjs_port} > {session_path}/nextjs.log 2>&1 &
+NEXTJS_PID=$!
+echo "Next.js server started with PID $NEXTJS_PID"
+echo $NEXTJS_PID > {session_path}/nextjs.pid
+"""

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -1191,18 +1191,23 @@ class SessionManager:
     ) -> bool:
         """Check if the NextJS dev server is responding.
 
-        Probes the session's basePath route with a short timeout — the dev
-        server 404s anything outside its configured basePath, so probing bare
-        "/" would render a spurious 404 on every poll. Returns True on any
-        non-5xx response, False on timeout or connection error.
+        Probes a basePath-scoped dev-asset path with a short timeout: probing
+        outside the basePath renders a spurious 404 page on every poll, and
+        probing the app page itself would report not-ready whenever generated
+        app code 500s (the iframe's error overlay is the right surface for
+        that). A missing /_next/static asset returns a plain 404 without
+        executing app code, so any response means the server is up.
         """
         try:
             sandbox_manager = get_sandbox_manager()
             internal_url = sandbox_manager.get_webapp_url(sandbox_id, port)
-            probe_url = f"{internal_url}/api/build/sessions/{session_id}/webapp"
+            probe_url = (
+                f"{internal_url}/api/build/sessions/{session_id}/webapp"
+                "/_next/static/onyx-ready-probe.js"
+            )
             with httpx.Client(timeout=2.0) as client:
-                resp = client.get(probe_url)
-                return resp.status_code < 500
+                client.get(probe_url)
+            return True
         except Exception:
             return False
 

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -1174,7 +1174,9 @@ class SessionManager:
             webapp_url = f"{WEB_DOMAIN}/api/build/sessions/{session_id}/webapp"
 
             # Quick health check: can the API server reach the NextJS dev server?
-            ready = self._check_nextjs_ready(sandbox.id, session.nextjs_port)
+            ready = self._check_nextjs_ready(
+                sandbox.id, session_id, session.nextjs_port
+            )
 
         return {
             "has_webapp": session.nextjs_port is not None,
@@ -1184,21 +1186,24 @@ class SessionManager:
             "sharing_scope": session.sharing_scope,
         }
 
-    def _check_nextjs_ready(self, sandbox_id: UUID, port: int) -> bool:
+    def _check_nextjs_ready(
+        self, sandbox_id: UUID, session_id: UUID, port: int
+    ) -> bool:
         """Check if the NextJS dev server is responding.
 
-        Does a quick HTTP GET to the sandbox's internal URL with a short timeout.
-        Returns True if the server responds with any status code, False on timeout
-        or connection error.
+        Probes the session's basePath route with a short timeout — the dev
+        server 404s anything outside its configured basePath, so probing bare
+        "/" would render a spurious 404 on every poll. Returns True on any
+        non-5xx response, False on timeout or connection error.
         """
         try:
             sandbox_manager = get_sandbox_manager()
             internal_url = sandbox_manager.get_webapp_url(sandbox_id, port)
+            probe_url = f"{internal_url}/api/build/sessions/{session_id}/webapp"
             with httpx.Client(timeout=2.0) as client:
-                resp = client.get(internal_url)
-                # Any response (even 500) means the server is up
+                resp = client.get(probe_url)
                 return resp.status_code < 500
-        except (httpx.TimeoutException, httpx.ConnectError, Exception):
+        except Exception:
             return False
 
     def download_webapp_zip(

--- a/backend/onyx/server/features/build/webapp_proxy.py
+++ b/backend/onyx/server/features/build/webapp_proxy.py
@@ -107,6 +107,10 @@ EXCLUDED_REQUEST_HEADERS = {
     # CSRF.
     "x-csrf-token",
     "x-xsrf-token",
+    # Browser context. cors-mode fetches send the product Origin even
+    # same-origin; Next dev blocks /_next/* requests from unlisted origins.
+    # The proxy is the trust boundary (sec-fetch-* is stripped by prefix).
+    "origin",
     # Client identity (RFC 7239 + common ingress/IDP conventions).
     "forwarded",
     "x-forwarded-for",
@@ -185,6 +189,7 @@ async def _proxy_request(
         if not (
             (lowered := key.lower()) in EXCLUDED_REQUEST_HEADERS
             or lowered.startswith("x-onyx-")
+            or lowered.startswith("sec-fetch-")
         )
     }
 

--- a/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
+++ b/backend/tests/integration/tests/craft/k8s/k8s_fixtures.py
@@ -832,15 +832,21 @@ def k8s_manager() -> Generator[KubernetesSandboxManager, None, None]:
 
 @pytest.fixture(scope="function")
 def pool_session(
+    request: pytest.FixtureRequest,
     _pool_pod: _PoolPod,
 ) -> PoolSession:
     """Fresh API-created session on the module pool pod; returns ``(sandbox_id, session_id, pod_name)``.
 
     Same shape as ``live_pod`` but reuses the pool pod. Use this unless the test
     mutates pod-level state (lifecycle/terminate/restart); those must use ``live_pod``.
+    Sessions are headless (no dev server) by default; parametrize indirectly
+    with ``{"headless": False}`` for webapp/preview tests.
     """
+    headless = getattr(request, "param", {}).get("headless", True)
     _cleanup_pool_workspace(_pool_pod.k8s_client, _pool_pod.pod_name)
-    session_id, sandbox_id = BuildSessionManager.create_with_sandbox(_pool_pod.api_user)
+    session_id, sandbox_id = BuildSessionManager.create_with_sandbox(
+        _pool_pod.api_user, headless=headless
+    )
     _SUITE_SANDBOX_IDS.add(sandbox_id)
     if sandbox_id != _pool_pod.sandbox_id:
         # Pool invariant broke (pool pod terminated externally). Reap the stray and fail loudly.

--- a/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
+++ b/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
@@ -18,10 +18,18 @@ from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser
 from tests.integration.tests.craft.k8s.k8s_fixtures import PoolSession
 
-pytestmark = pytest.mark.skipif(
-    SANDBOX_BACKEND != SandboxBackend.KUBERNETES,
-    reason="K8s tests require SANDBOX_BACKEND=kubernetes; run in the dedicated K8s CI job.",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        SANDBOX_BACKEND != SandboxBackend.KUBERNETES,
+        reason="K8s tests require SANDBOX_BACKEND=kubernetes; run in the dedicated K8s CI job.",
+    ),
+    # Preview tests need a dev server; pool sessions are headless by default.
+    pytest.mark.parametrize(
+        "pool_session",
+        [pytest.param({"headless": False}, id="interactive")],
+        indirect=True,
+    ),
+]
 
 _WEBAPP_READY_TIMEOUT_S = 120.0
 _POLL_INTERVAL_S = 2.0

--- a/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
+++ b/backend/tests/integration/tests/craft/k8s/test_webapp_preview.py
@@ -1,0 +1,97 @@
+"""Webapp preview behavior against a real Next dev server.
+
+Pins the Next-side contracts the preview fixes depend on, which unit tests
+cannot see: the dev-resource origin gate and basePath serving.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+from onyx.server.features.build.configs import SANDBOX_BACKEND
+from onyx.server.features.build.configs import SandboxBackend
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.tests.craft.k8s.k8s_fixtures import PoolSession
+
+pytestmark = pytest.mark.skipif(
+    SANDBOX_BACKEND != SandboxBackend.KUBERNETES,
+    reason="K8s tests require SANDBOX_BACKEND=kubernetes; run in the dedicated K8s CI job.",
+)
+
+_WEBAPP_READY_TIMEOUT_S = 120.0
+_POLL_INTERVAL_S = 2.0
+
+
+def _wait_for_webapp_ready(user: DATestUser, session_id: str) -> None:
+    deadline = time.monotonic() + _WEBAPP_READY_TIMEOUT_S
+    info: dict[str, object] = {}
+    while time.monotonic() < deadline:
+        resp = client.get(
+            f"{API_SERVER_URL}/build/sessions/{session_id}/webapp-info",
+            headers=user.headers,
+            cookies=user.cookies,
+        )
+        resp.raise_for_status()
+        info = resp.json()
+        if info.get("has_webapp") and info.get("ready"):
+            return
+        time.sleep(_POLL_INTERVAL_S)
+    pytest.fail(f"webapp never became ready within timeout: {info}")
+
+
+def _proxy_get(user: DATestUser, session_id: str, path: str = "") -> httpx.Response:
+    url = f"{API_SERVER_URL}/build/sessions/{session_id}/webapp"
+    if path:
+        url = f"{url}/{path.lstrip('/')}"
+    return client.get(
+        url,
+        headers={
+            **user.headers,
+            # What a browser cors-mode fetch attaches even same-origin; the
+            # proxy must strip these or Next dev 403s every /_next/* request.
+            # Non-localhost on purpose: Next dev allows localhost origins by
+            # default, which would mask a strip regression in CI.
+            "Origin": "https://cloud.onyx.app",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Dest": "empty",
+        },
+        cookies=user.cookies,
+        follow_redirects=True,
+    )
+
+
+def test_preview_serves_at_base_path_and_reports_ready(
+    pool_session: PoolSession,
+    pool_api_user: DATestUser,
+) -> None:
+    """``ready`` flips true and the route users actually load returns 200."""
+    session_id = str(pool_session.session_id)
+    _wait_for_webapp_ready(pool_api_user, session_id)
+
+    resp = _proxy_get(pool_api_user, session_id)
+    assert resp.status_code == 200, resp.text[:500]
+
+
+def test_dev_resources_not_blocked_by_origin_gate(
+    pool_session: PoolSession,
+    pool_api_user: DATestUser,
+) -> None:
+    """A browser-shaped dev-resource request must not hit Next's cross-origin
+    403 (``blockCrossSiteDEV`` rejects /_next/* when the Origin hostname is
+    not allowlisted — the exact failure from the 2026-07-06 incident)."""
+    session_id = str(pool_session.session_id)
+    _wait_for_webapp_ready(pool_api_user, session_id)
+
+    resp = _proxy_get(
+        pool_api_user, session_id, "_next/static/onyx-origin-gate-probe.js"
+    )
+    # 404 for a nonexistent asset is fine; the gate rejects before routing,
+    # so a 403 means Origin/sec-fetch-* leaked through the proxy or the
+    # allowlist regressed on a Next upgrade.
+    assert resp.status_code != 403, resp.text[:500]

--- a/backend/tests/unit/build/test_nextjs_dev.py
+++ b/backend/tests/unit/build/test_nextjs_dev.py
@@ -49,9 +49,10 @@ def test_start_script_config_rewrite_matches_scaffold_template() -> None:
     assert _TEMPLATE_NEXT_CONFIG.read_text().strip() in script
 
 
-def test_nextjs_ready_probe_targets_session_base_path() -> None:
-    """Probing bare "/" is outside the dev server's basePath and would render
-    a spurious 404 on every poll — the probe must hit the basePath route."""
+def test_nextjs_ready_probe_targets_base_path_dev_asset() -> None:
+    """Probing bare "/" renders a spurious 404 page per poll, and probing the
+    app page reports not-ready when generated app code 500s — the probe must
+    hit a basePath-scoped /_next/static path and accept any response."""
     session_id = UUID("0d9ed7f2-8757-4d09-9812-bd7e4a45e232")
     sandbox_id = UUID("11111111-2222-3333-4444-555555555555")
 
@@ -59,7 +60,7 @@ def test_nextjs_ready_probe_targets_session_base_path() -> None:
     sandbox_manager.get_webapp_url.return_value = "http://sandbox-x:3010"
 
     response = MagicMock()
-    response.status_code = 200
+    response.status_code = 500
     http_client = MagicMock()
     http_client.__enter__.return_value = http_client
     http_client.get.return_value = response
@@ -80,4 +81,5 @@ def test_nextjs_ready_probe_targets_session_base_path() -> None:
     assert ready is True
     http_client.get.assert_called_once_with(
         f"http://sandbox-x:3010/api/build/sessions/{session_id}/webapp"
+        "/_next/static/onyx-ready-probe.js"
     )

--- a/backend/tests/unit/build/test_nextjs_dev.py
+++ b/backend/tests/unit/build/test_nextjs_dev.py
@@ -1,0 +1,83 @@
+"""Next.js dev server start script and readiness probe behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import UUID
+
+from onyx.server.features.build.sandbox import nextjs_dev
+from onyx.server.features.build.sandbox.nextjs_dev import build_nextjs_start_script
+from onyx.server.features.build.session.manager import SessionManager
+
+_SESSION_PATH = "/workspace/sessions/0d9ed7f2-8757-4d09-9812-bd7e4a45e232"
+
+_TEMPLATE_NEXT_CONFIG = (
+    Path(nextjs_dev.__file__).parent
+    / "image"
+    / "templates"
+    / "outputs"
+    / "web"
+    / "next.config.ts"
+)
+
+
+def test_start_script_exports_allowed_dev_origins() -> None:
+    with patch.object(nextjs_dev, "WEB_DOMAIN", "https://cloud.onyx.app"):
+        script = build_nextjs_start_script(_SESSION_PATH, 3010)
+
+    assert 'export ONYX_WEBAPP_ALLOWED_DEV_ORIGINS="cloud.onyx.app"' in script
+    assert (
+        'export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/'
+        f'$(basename {_SESSION_PATH})/webapp"' in script
+    )
+    assert "-p 3010" in script
+
+
+def test_start_script_allowed_dev_origins_is_hostname_only() -> None:
+    # Next 16 allowedDevOrigins entries are hostnames — no scheme, no port.
+    with patch.object(nextjs_dev, "WEB_DOMAIN", "http://localhost:3000"):
+        script = build_nextjs_start_script(_SESSION_PATH, 3010)
+
+    assert 'export ONYX_WEBAPP_ALLOWED_DEV_ORIGINS="localhost"' in script
+
+
+def test_start_script_config_rewrite_matches_scaffold_template() -> None:
+    """The legacy next.config.ts rewrite must produce the current template."""
+    script = build_nextjs_start_script(_SESSION_PATH, 3010)
+    assert _TEMPLATE_NEXT_CONFIG.read_text().strip() in script
+
+
+def test_nextjs_ready_probe_targets_session_base_path() -> None:
+    """Probing bare "/" is outside the dev server's basePath and would render
+    a spurious 404 on every poll — the probe must hit the basePath route."""
+    session_id = UUID("0d9ed7f2-8757-4d09-9812-bd7e4a45e232")
+    sandbox_id = UUID("11111111-2222-3333-4444-555555555555")
+
+    sandbox_manager = MagicMock()
+    sandbox_manager.get_webapp_url.return_value = "http://sandbox-x:3010"
+
+    response = MagicMock()
+    response.status_code = 200
+    http_client = MagicMock()
+    http_client.__enter__.return_value = http_client
+    http_client.get.return_value = response
+
+    with (
+        patch(
+            "onyx.server.features.build.session.manager.get_sandbox_manager",
+            return_value=sandbox_manager,
+        ),
+        patch(
+            "onyx.server.features.build.session.manager.httpx.Client",
+            return_value=http_client,
+        ),
+    ):
+        manager = SessionManager(MagicMock())
+        ready = manager._check_nextjs_ready(sandbox_id, session_id, 3010)
+
+    assert ready is True
+    http_client.get.assert_called_once_with(
+        f"http://sandbox-x:3010/api/build/sessions/{session_id}/webapp"
+    )

--- a/backend/tests/unit/build/test_rewrite_asset_paths.py
+++ b/backend/tests/unit/build/test_rewrite_asset_paths.py
@@ -30,6 +30,7 @@ KUBERNETES_SANDBOX_MANAGER = (
     Path(api.__file__).resolve().parents[0]
     / "sandbox/kubernetes/kubernetes_sandbox_manager.py"
 )
+NEXTJS_DEV_SCRIPT = Path(api.__file__).resolve().parents[0] / "sandbox/nextjs_dev.py"
 WEB_NEXT_CONFIG = Path(__file__).resolve().parents[4] / "web/next.config.js"
 
 
@@ -48,20 +49,26 @@ class TestNextjsProxyMountContract:
         assert "assetPrefix" in config_source
         assert re.search(r"\bbasePath\s*[:=]", config_source)
 
-    def test_sandbox_start_scripts_export_next_base_path(self) -> None:
+    def test_sandbox_start_script_exports_next_base_path(self) -> None:
+        source = NEXTJS_DEV_SCRIPT.read_text()
+
+        assert (
+            'export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/$(basename '
+            '{session_path})/webapp"'
+        ) in source
+        assert "export WEBAPP_ASSET_PREFIX" not in source
+        assert 'grep -q "WEBAPP_ASSET_PREFIX" next.config.ts' in source
+        assert "nextConfig.basePath = webappBasePath" in source
+        assert "nextConfig.assetPrefix = webappBasePath" in source
+
+    def test_sandbox_managers_use_shared_start_script(self) -> None:
         for manager_source in (DOCKER_SANDBOX_MANAGER, KUBERNETES_SANDBOX_MANAGER):
             source = manager_source.read_text()
 
             assert (
-                'export ONYX_WEBAPP_BASE_PATH="/api/build/sessions/$(basename '
-                '{session_path})/webapp"'
+                "from onyx.server.features.build.sandbox.nextjs_dev import "
+                "build_nextjs_start_script"
             ) in source
-            assert "export WEBAPP_ASSET_PREFIX" not in source
-            assert 'grep -q "WEBAPP_ASSET_PREFIX" next.config.ts' in source
-            assert (
-                "? {{ basePath: webappBasePath, assetPrefix: webappBasePath }}"
-                in source
-            )
 
     def test_web_dev_rewrites_hmr_websocket_to_backend(self) -> None:
         """Local Next dev cannot proxy websocket upgrades via /api/[...path]."""
@@ -314,6 +321,13 @@ class TestProxyRequestWiring:
             "X-Forwarded-User": "victim@example.com",
             "X-Forwarded-Email": "victim@example.com",
             "X-Forwarded-Preferred-Username": "victim",
+            # Browser context — Next dev blocks /_next/* on unlisted Origins.
+            "Origin": "https://cloud.onyx.app",
+            # sec-fetch-* prefix matcher (not literal deny-list entries).
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            "Sec-Fetch-Dest": "empty",
+            "Sec-Fetch-User": "?1",
             # x-onyx-* prefix matcher (not literal deny-list entries).
             "X-Onyx-Authorization": "Bearer alt-victim-token",
             "X-Onyx-Tenant-ID": "victim-tenant",

--- a/backend/tests/unit/build/test_webapp_proxy_header_stripping.py
+++ b/backend/tests/unit/build/test_webapp_proxy_header_stripping.py
@@ -1,4 +1,5 @@
-"""The webapp proxy must strip Set-Cookie from upstream responses."""
+"""The webapp proxy must strip Set-Cookie from upstream responses and
+browser-context headers (Origin, sec-fetch-*) from forwarded requests."""
 
 from __future__ import annotations
 
@@ -16,7 +17,7 @@ from starlette.responses import Response
 from onyx.server.features.build import webapp_proxy
 
 
-def _make_request() -> Request:
+def _make_request(headers: list[tuple[bytes, bytes]] | None = None) -> Request:
     return Request(
         {
             "type": "http",
@@ -24,7 +25,7 @@ def _make_request() -> Request:
             "scheme": "http",
             "path": "/",
             "query_string": b"",
-            "headers": [],
+            "headers": headers or [],
         }
     )
 
@@ -34,23 +35,16 @@ async def _no_bytes(chunk_size: int = 8192) -> AsyncGenerator[bytes, None]:  # n
     yield b""  # pragma: no cover
 
 
-def test_proxy_strips_set_cookie_keeps_other_headers() -> None:
+def _make_upstream() -> MagicMock:
     upstream = MagicMock(spec=httpx.Response)
     upstream.status_code = 200
-    upstream.headers = httpx.Headers(
-        {
-            "content-type": "text/html",
-            "set-cookie": "sid=leak; Path=/",
-            "x-upstream": "kept",
-        }
-    )
+    upstream.headers = httpx.Headers({"content-type": "text/html"})
     upstream.aiter_bytes = _no_bytes
     upstream.aclose = AsyncMock()
+    return upstream
 
-    client = MagicMock()
-    client.build_request = MagicMock()
-    client.send = AsyncMock(return_value=upstream)
 
+def _run_proxy_request(request: Request, client: MagicMock) -> Response:
     with (
         patch.object(
             webapp_proxy,
@@ -59,10 +53,53 @@ def test_proxy_strips_set_cookie_keeps_other_headers() -> None:
         ),
         patch.object(webapp_proxy, "_get_proxy_client", return_value=client),
     ):
-        response: Response = asyncio.run(
-            webapp_proxy._proxy_request("", _make_request(), uuid4())
-        )
+        return asyncio.run(webapp_proxy._proxy_request("", request, uuid4()))
+
+
+def test_proxy_strips_set_cookie_keeps_other_headers() -> None:
+    upstream = _make_upstream()
+    upstream.headers = httpx.Headers(
+        {
+            "content-type": "text/html",
+            "set-cookie": "sid=leak; Path=/",
+            "x-upstream": "kept",
+        }
+    )
+
+    client = MagicMock()
+    client.build_request = MagicMock()
+    client.send = AsyncMock(return_value=upstream)
+
+    response = _run_proxy_request(_make_request(), client)
 
     header_names = {name.lower() for name in response.headers}
     assert "set-cookie" not in header_names
     assert response.headers.get("x-upstream") == "kept"
+
+
+def test_proxy_strips_browser_context_request_headers() -> None:
+    """Origin/sec-fetch-* must not reach the sandbox dev server — Next dev
+    blocks /_next/* requests whose Origin isn't allowlisted."""
+    client = MagicMock()
+    client.build_request = MagicMock()
+    client.send = AsyncMock(return_value=_make_upstream())
+
+    request = _make_request(
+        headers=[
+            (b"origin", b"https://cloud.onyx.app"),
+            (b"sec-fetch-mode", b"cors"),
+            (b"sec-fetch-site", b"same-origin"),
+            (b"sec-fetch-dest", b"empty"),
+            (b"cookie", b"fastapiusersauth=secret"),
+            (b"accept", b"text/html"),
+            (b"user-agent", b"test-agent"),
+        ]
+    )
+    _run_proxy_request(request, client)
+
+    forwarded = client.build_request.call_args.kwargs["headers"]
+    forwarded_names = {name.lower() for name in forwarded}
+    assert "origin" not in forwarded_names
+    assert not any(name.startswith("sec-fetch-") for name in forwarded_names)
+    assert "cookie" not in forwarded_names
+    assert forwarded_names >= {"accept", "user-agent"}


### PR DESCRIPTION
## Description

Two Craft webapp-preview bugs from the 2026-07-06 cloud incident.

**A — hot reload / dev resources 403'd behind the proxy.** The preview iframe is same-origin with the product, but per the fetch spec, cors-mode fetches (the `fetch()` default, used by Next's HMR client) attach `Origin` even on same-origin requests. The webapp proxy forwarded `Origin`/`sec-fetch-*` verbatim, and Next 16's `blockCrossSiteDEV` guard 403s any `/_next/*` request whose Origin hostname isn't in `allowedDevOrigins` (verified in Next's source; entries are hostnames only, universal wildcard rejected — so the value can't be hardcoded). Fixed in two independent layers:

1. **Proxy strip** (`webapp_proxy.py`): `origin` and `sec-fetch-*` are stripped from forwarded requests. The proxy is already the auth/trust boundary and strips cookies/CSRF/client identity; the websocket HMR path already sent no Origin. Fixes all existing sessions on an api-server deploy alone.
2. **Canonical config**: the scaffold's `next.config.ts` reads `ONYX_WEBAPP_ALLOWED_DEV_ORIGINS` into `allowedDevOrigins`; the dev-server start script exports it, derived from `WEB_DOMAIN`'s hostname — adapting to cloud, self-hosted, and localhost. Takes effect for new sessions after the next sandbox image release. Existing sessions' scaffolded configs are deliberately not force-rewritten (agents may have edited them; layer 1 covers them).

The start script was duplicated verbatim across the docker and k8s managers (each with its own legacy config-regen heredoc) — extracted to a shared `sandbox/nextjs_dev.py`, with the heredoc updated to the same canonical config and a test pinning heredoc↔template consistency.

**B — `GET /` flapping 404/200 with the preview intermittently showing Next's global-error page.** Two different URLs that log identically: `_check_nextjs_ready` (polled every ~2s by the frontend) probed bare `/`, which is outside the configured `basePath`, so every poll rendered a real 404 — while proxied requests hit `<basePath>/` and 200'd. Next strips the basePath from `req.url` before its dev logger prints, so both log as `GET /`. The probe now targets the session's basePath route, eliminating the spurious 404 renders and making `ready` mean "the route users actually load responds" (previously a 404 on a nonexistent route counted as ready).

## How Has This Been Tested?

- Unit (`tests/unit/build/`, 53 pass): script env exports, hostname-only derivation from `WEB_DOMAIN`, heredoc↔template consistency, probe URL construction; `origin`/`sec-fetch-*` stripping added to the proxy header tests; asset-path rewrite tests updated for the canonical config.
- Integration (Craft k8s lane, new `test_webapp_preview.py`): the Next-side contracts unit tests can't see, against the real dev server on the pooled pod — (1) `webapp-info` reports ready and the proxied preview root returns 200 (basePath contract); (2) a browser-shaped dev-resource request (`Origin` + `sec-fetch-*`) through the real proxy is not 403'd. The Origin is deliberately non-localhost, since Next allows localhost origins by default and CI's `WEB_DOMAIN` would mask a strip regression. These also pin against Next version bumps in the sandbox image changing the gating rules.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Craft webapp preview by stopping Next dev asset 403s behind the proxy and eliminating 404/500 flapping in the preview iframe. Dev resources now load reliably, and “ready” reflects the dev server being up on the session basePath.

- **Bug Fixes**
  - Strip `Origin` and `sec-fetch-*` from proxied requests to avoid Next 16 `blockCrossSiteDEV` 403s on `/_next/*`.
  - Set `allowedDevOrigins` in `next.config.ts` from `ONYX_WEBAPP_ALLOWED_DEV_ORIGINS`, exported by a shared start script using the hostname from `WEB_DOMAIN`.
  - Probe a basePath-scoped dev asset (`/_next/static/onyx-ready-probe.js`) instead of `/` or the app route, avoiding spurious 404s and app-code 500s in readiness.
  - Extract shared Next dev start script (`sandbox/nextjs_dev.py`) and update Docker/K8s managers; add unit tests for header stripping and readiness probing, plus K8s integration tests using a non-headless pool session to verify basePath serving and no 403s on browser-shaped dev-resource requests.

<sup>Written for commit 2c54a6755301a2965b540119dd0ea222412099f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

