### PR TITLE
fix: resolve license notification EE import

### DIFF
--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -65,7 +65,7 @@ def _ensure_license_expiry_notification(user: User, db_session: Session) -> None
     task. No-op on non-EE builds (and for non-admins / no active warning)."""
     try:
         fetch_ee_implementation_or_noop(
-            "ee.onyx.utils.license_notifications",
+            "onyx.utils.license_notifications",
             "ensure_license_expiry_notification_for_user",
         )(user, db_session)
     except Exception:


### PR DESCRIPTION
## Description

Fix the license expiry notification lazy ensure path so `fetch_ee_implementation_or_noop` receives the unprefixed CE module path and resolves it to `ee.onyx...` in EE mode. This prevents local EE-enabled API servers from trying to import `ee.ee.onyx.utils.license_notifications` when reading notifications.
```
variable_functionality.py  195: [API:3LnSsAxv] [t:dev] Failed to fetch implementation for ee.onyx.utils.license_notifications.ensure_license_expiry_notification_for_user: No module named 'ee.ee'
```
## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
