### PR TITLE
feat(auth): parametric multi-provider OIDC/Google login from sso_provider rows

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -11,6 +11,7 @@ from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from functools import partial
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -2388,8 +2389,8 @@ async def complete_login_flow(
     # take this early return.
     if is_mobile_sso(state_data):
         redirect_response = await complete_mobile_sso(user, state_data, strategy)
-        # Fire analytics like the web/bearer-login paths (PostHog identify).
-        # No web response here, so its anon-cookie cleanup no-ops.
+        # Call on_after_login on the mobile early-return so login analytics and
+        # audit still fire. No web response, so its anon-cookie cleanup no-ops.
         await user_manager.on_after_login(user, request)
         return redirect_response
 
@@ -2727,26 +2728,8 @@ def get_oauth_router(
                 )
             state_data = decode_and_validate_state(callback_state)
 
-        if enable_pkce:
-            try:
-                redirect_response = await complete_login_flow(
-                    oauth_client=oauth_client,
-                    token=token,
-                    state_data=state_data,
-                    request=request,
-                    user_manager=user_manager,
-                    backend=backend,
-                    strategy=strategy,
-                    associate_by_email=associate_by_email,
-                    is_verified_by_default=is_verified_by_default,
-                    allowed_email_domains_override=None,
-                )
-            except OnyxError as e:
-                return build_error_response(e)
-            delete_pkce_cookie(redirect_response)
-            return redirect_response
-
-        return await complete_login_flow(
+        login = partial(
+            complete_login_flow,
             oauth_client=oauth_client,
             token=token,
             state_data=state_data,
@@ -2756,7 +2739,15 @@ def get_oauth_router(
             strategy=strategy,
             associate_by_email=associate_by_email,
             is_verified_by_default=is_verified_by_default,
-            allowed_email_domains_override=None,
         )
+        if enable_pkce:
+            try:
+                redirect_response = await login()
+            except OnyxError as e:
+                return build_error_response(e)
+            delete_pkce_cookie(redirect_response)
+            return redirect_response
+
+        return await login()
 
     return router

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2267,6 +2267,67 @@ def get_pkce_cookie_name(state: str) -> str:
     return f"{PKCE_COOKIE_NAME_PREFIX}_{state_hash}"
 
 
+def decode_and_validate_oauth_state(
+    *,
+    request: Request,
+    state_value: str,
+    state_secret: SecretType,
+    csrf_token_cookie_name: str = CSRF_TOKEN_COOKIE_NAME,
+    expected_provider_name: str | None = None,
+) -> Dict[str, str]:
+    """Decode the signed OAuth state and enforce the CSRF double-submit.
+    Optionally bind the flow to a provider so a state minted for one provider
+    cannot be replayed on another provider's callback."""
+    try:
+        state_data = decode_jwt(state_value, state_secret, [STATE_TOKEN_AUDIENCE])
+    except jwt.DecodeError:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(
+                ErrorCode, "ACCESS_TOKEN_DECODE_ERROR", "ACCESS_TOKEN_DECODE_ERROR"
+            ),
+        )
+    except jwt.ExpiredSignatureError:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(
+                ErrorCode,
+                "ACCESS_TOKEN_ALREADY_EXPIRED",
+                "ACCESS_TOKEN_ALREADY_EXPIRED",
+            ),
+        )
+    except jwt.PyJWTError:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(
+                ErrorCode, "ACCESS_TOKEN_DECODE_ERROR", "ACCESS_TOKEN_DECODE_ERROR"
+            ),
+        )
+
+    cookie_csrf_token = request.cookies.get(csrf_token_cookie_name)
+    state_csrf_token = state_data.get(CSRF_TOKEN_KEY)
+    if (
+        not cookie_csrf_token
+        or not state_csrf_token
+        or not secrets.compare_digest(cookie_csrf_token, state_csrf_token)
+    ):
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
+        )
+
+    if (
+        expected_provider_name is not None
+        and state_data.get("provider_name") != expected_provider_name
+    ):
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "SSO state does not match the callback provider",
+        )
+
+    return state_data
+
+
 async def complete_login_flow(
     *,
     oauth_client: BaseOAuth2[Any],
@@ -2280,10 +2341,10 @@ async def complete_login_flow(
     is_verified_by_default: bool,
     allowed_email_domains_override: Sequence[str] | None = None,
 ) -> RedirectResponse:
-    # A failed or rejected userinfo fetch (bad status, malformed body,
-    # unverified email) must land as a controlled login rejection, not
-    # an unhandled 500. OnyxError has a global handler that GetIdEmailError
-    # does not.
+    """Shared post-token OAuth/OIDC login: read the verified identity, create or
+    authenticate the user, and return a web or mobile redirect."""
+    # Convert a failed or unverified userinfo fetch into a controlled login
+    # rejection. OnyxError has a global handler, GetIdEmailError would 500.
     try:
         account_id, account_email = await oauth_client.get_id_email(
             token["access_token"]
@@ -2311,7 +2372,6 @@ async def complete_login_flow(
 
     request.state.referral_source = referral_source
 
-    # Proceed to authenticate or create the user
     try:
         user = await user_manager.oauth_callback(  # ty: ignore[invalid-argument-type]
             oauth_client.name,
@@ -2337,9 +2397,9 @@ async def complete_login_flow(
             ErrorCode.LOGIN_BAD_CREDENTIALS,
         )
 
-    # Mobile clients get a PKCE one-time code over a deep link, not a web
-    # cookie. Guarded on the signed-state marker, so the web path below is
-    # byte-for-byte unchanged.
+    # Mobile SSO returns a one-time PKCE code over a deep link instead of a web
+    # session cookie. Gated on the signed-state marker so only mobile clients
+    # take this early return.
     if is_mobile_sso(state_data):
         redirect_response = await complete_mobile_sso(user, state_data, strategy)
         # Fire analytics like the web/bearer-login paths (PostHog identify).
@@ -2347,20 +2407,17 @@ async def complete_login_flow(
         await user_manager.on_after_login(user, request)
         return redirect_response
 
-    # Login user
     response = await backend.login(strategy, user)
     await user_manager.on_after_login(user, request, response)
 
-    # Prepare redirect response
     if tenant_id is None:
-        # Use URL utility to add parameters
         redirect_destination = add_url_params(next_url, {"new_team": "true"})
         redirect_response = RedirectResponse(redirect_destination, status_code=302)
     else:
-        # No parameters to add
         redirect_response = RedirectResponse(next_url, status_code=302)
 
-    # Copy headers from auth response to redirect response, with special handling for Set-Cookie
+    # Carry auth headers onto the redirect. Set-Cookie may repeat, so append each
+    # rather than assign, which would collapse them.
     for header_name, header_value in response.headers.items():
         header_name_lower = header_name.lower()
         if header_name_lower == "set-cookie":
@@ -2600,51 +2657,12 @@ def get_oauth_router(
             return error_response
 
         def decode_and_validate_state(state_value: str) -> Dict[str, str]:
-            try:
-                state_data = decode_jwt(
-                    state_value, state_secret, [STATE_TOKEN_AUDIENCE]
-                )
-            except jwt.DecodeError:
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    getattr(
-                        ErrorCode,
-                        "ACCESS_TOKEN_DECODE_ERROR",
-                        "ACCESS_TOKEN_DECODE_ERROR",
-                    ),
-                )
-            except jwt.ExpiredSignatureError:
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    getattr(
-                        ErrorCode,
-                        "ACCESS_TOKEN_ALREADY_EXPIRED",
-                        "ACCESS_TOKEN_ALREADY_EXPIRED",
-                    ),
-                )
-            except jwt.PyJWTError:
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    getattr(
-                        ErrorCode,
-                        "ACCESS_TOKEN_DECODE_ERROR",
-                        "ACCESS_TOKEN_DECODE_ERROR",
-                    ),
-                )
-
-            cookie_csrf_token = request.cookies.get(csrf_token_cookie_name)
-            state_csrf_token = state_data.get(CSRF_TOKEN_KEY)
-            if (
-                not cookie_csrf_token
-                or not state_csrf_token
-                or not secrets.compare_digest(cookie_csrf_token, state_csrf_token)
-            ):
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
-                )
-
-            return state_data
+            return decode_and_validate_oauth_state(
+                request=request,
+                state_value=state_value,
+                state_secret=state_secret,
+                csrf_token_cookie_name=csrf_token_cookie_name,
+            )
 
         token: OAuth2Token
         state_data: Dict[str, str]

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -861,6 +861,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         *,
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
+        allowed_email_domains_override: Sequence[str] | None = None,
     ) -> User:
         referral_source = (
             getattr(request.state, "referral_source", None) if request else None
@@ -886,9 +887,14 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
             verify_email_in_whitelist(account_email, tenant_id)
             oauth_security_settings = get_security_settings()
+            effective_valid_email_domains = (
+                allowed_email_domains_override
+                if allowed_email_domains_override is not None
+                else oauth_security_settings.valid_email_domains
+            )
             verify_email_domain(
                 account_email,
-                valid_email_domains=oauth_security_settings.valid_email_domains,
+                valid_email_domains=effective_valid_email_domains,
             )
 
             # NOTE(rkuo): If this UserManager is instantiated per connection
@@ -937,7 +943,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     # per account, so dot-alias abuse isn't possible here.
                     verify_email_domain(
                         account_email,
-                        valid_email_domains=oauth_security_settings.valid_email_domains,
+                        valid_email_domains=effective_valid_email_domains,
                     )
 
                     # Lock + check on the same session that does the insert.
@@ -2261,6 +2267,112 @@ def get_pkce_cookie_name(state: str) -> str:
     return f"{PKCE_COOKIE_NAME_PREFIX}_{state_hash}"
 
 
+async def complete_login_flow(
+    *,
+    oauth_client: BaseOAuth2[Any],
+    token: OAuth2Token,
+    state_data: Dict[str, str],
+    request: Request,
+    user_manager: BaseUserManager[models.UP, models.ID],
+    backend: AuthenticationBackend,
+    strategy: Strategy[models.UP, models.ID],
+    associate_by_email: bool,
+    is_verified_by_default: bool,
+    allowed_email_domains_override: Sequence[str] | None = None,
+) -> RedirectResponse:
+    # A failed or rejected userinfo fetch (bad status, malformed body,
+    # unverified email) must land as a controlled login rejection, not
+    # an unhandled 500. OnyxError has a global handler that GetIdEmailError
+    # does not.
+    try:
+        account_id, account_email = await oauth_client.get_id_email(
+            token["access_token"]
+        )
+    except GetIdEmailError as e:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Could not retrieve a verified identity from the SSO provider",
+        ) from e
+
+    if account_email is None:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            ErrorCode.OAUTH_NOT_AVAILABLE_EMAIL,
+        )
+
+    next_url = sanitize_next_url(state_data.get("next_url"))
+    referral_source = state_data.get("referral_source", None)
+    try:
+        tenant_id = fetch_ee_implementation_or_noop(
+            "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
+        )(account_email)
+    except exceptions.UserNotExists:
+        tenant_id = None
+
+    request.state.referral_source = referral_source
+
+    # Proceed to authenticate or create the user
+    try:
+        user = await user_manager.oauth_callback(  # ty: ignore[invalid-argument-type]
+            oauth_client.name,
+            token["access_token"],
+            account_id,
+            account_email,
+            token.get("expires_at"),
+            token.get("refresh_token"),
+            request,
+            associate_by_email=associate_by_email,
+            is_verified_by_default=is_verified_by_default,
+            allowed_email_domains_override=allowed_email_domains_override,  # ty: ignore[unknown-argument]
+        )
+    except UserAlreadyExists:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            ErrorCode.OAUTH_USER_ALREADY_EXISTS,
+        )
+
+    if not user.is_active:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            ErrorCode.LOGIN_BAD_CREDENTIALS,
+        )
+
+    # Mobile clients get a PKCE one-time code over a deep link, not a web
+    # cookie. Guarded on the signed-state marker, so the web path below is
+    # byte-for-byte unchanged.
+    if is_mobile_sso(state_data):
+        redirect_response = await complete_mobile_sso(user, state_data, strategy)
+        # Fire analytics like the web/bearer-login paths (PostHog identify).
+        # No web response here, so its anon-cookie cleanup no-ops.
+        await user_manager.on_after_login(user, request)
+        return redirect_response
+
+    # Login user
+    response = await backend.login(strategy, user)
+    await user_manager.on_after_login(user, request, response)
+
+    # Prepare redirect response
+    if tenant_id is None:
+        # Use URL utility to add parameters
+        redirect_destination = add_url_params(next_url, {"new_team": "true"})
+        redirect_response = RedirectResponse(redirect_destination, status_code=302)
+    else:
+        # No parameters to add
+        redirect_response = RedirectResponse(next_url, status_code=302)
+
+    # Copy headers from auth response to redirect response, with special handling for Set-Cookie
+    for header_name, header_value in response.headers.items():
+        header_name_lower = header_name.lower()
+        if header_name_lower == "set-cookie":
+            redirect_response.headers.append(header_name, header_value)
+            continue
+        if header_name_lower in {"location", "content-length"}:
+            continue
+        redirect_response.headers[header_name] = header_value
+
+    return redirect_response
+
+
 # refer to https://github.com/fastapi-users/fastapi-users/blob/42ddc241b965475390e2bce887b084152ae1a2cd/fastapi_users/fastapi_users.py#L91
 def create_onyx_oauth_router(
     oauth_client: BaseOAuth2,
@@ -2611,112 +2723,36 @@ def get_oauth_router(
                 )
             state_data = decode_and_validate_state(callback_state)
 
-        async def complete_login_flow(
-            token: OAuth2Token, state_data: Dict[str, str]
-        ) -> RedirectResponse:
-            # A failed or rejected userinfo fetch (bad status, malformed body,
-            # unverified email) must land as a controlled login rejection, not
-            # an unhandled 500. OnyxError has a global handler that GetIdEmailError
-            # does not.
-            try:
-                account_id, account_email = await oauth_client.get_id_email(
-                    token["access_token"]
-                )
-            except GetIdEmailError as e:
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    "Could not retrieve a verified identity from the SSO provider",
-                ) from e
-
-            if account_email is None:
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    ErrorCode.OAUTH_NOT_AVAILABLE_EMAIL,
-                )
-
-            next_url = sanitize_next_url(state_data.get("next_url"))
-            referral_source = state_data.get("referral_source", None)
-            try:
-                tenant_id = fetch_ee_implementation_or_noop(
-                    "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
-                )(account_email)
-            except exceptions.UserNotExists:
-                tenant_id = None
-
-            request.state.referral_source = referral_source
-
-            # Proceed to authenticate or create the user
-            try:
-                user = await user_manager.oauth_callback(  # ty: ignore[invalid-argument-type]
-                    oauth_client.name,
-                    token["access_token"],
-                    account_id,
-                    account_email,
-                    token.get("expires_at"),
-                    token.get("refresh_token"),
-                    request,
-                    associate_by_email=associate_by_email,
-                    is_verified_by_default=is_verified_by_default,
-                )
-            except UserAlreadyExists:
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    ErrorCode.OAUTH_USER_ALREADY_EXISTS,
-                )
-
-            if not user.is_active:
-                raise OnyxError(
-                    OnyxErrorCode.VALIDATION_ERROR,
-                    ErrorCode.LOGIN_BAD_CREDENTIALS,
-                )
-
-            # Mobile clients get a PKCE one-time code over a deep link, not a web
-            # cookie. Guarded on the signed-state marker, so the web path below is
-            # byte-for-byte unchanged.
-            if is_mobile_sso(state_data):
-                redirect_response = await complete_mobile_sso(
-                    user, state_data, strategy
-                )
-                # Fire analytics like the web/bearer-login paths (PostHog
-                # identify). No web response here, so its anon-cookie cleanup no-ops.
-                await user_manager.on_after_login(user, request)
-                return redirect_response
-
-            # Login user
-            response = await backend.login(strategy, user)
-            await user_manager.on_after_login(user, request, response)
-
-            # Prepare redirect response
-            if tenant_id is None:
-                # Use URL utility to add parameters
-                redirect_destination = add_url_params(next_url, {"new_team": "true"})
-                redirect_response = RedirectResponse(
-                    redirect_destination, status_code=302
-                )
-            else:
-                # No parameters to add
-                redirect_response = RedirectResponse(next_url, status_code=302)
-
-            # Copy headers from auth response to redirect response, with special handling for Set-Cookie
-            for header_name, header_value in response.headers.items():
-                header_name_lower = header_name.lower()
-                if header_name_lower == "set-cookie":
-                    redirect_response.headers.append(header_name, header_value)
-                    continue
-                if header_name_lower in {"location", "content-length"}:
-                    continue
-                redirect_response.headers[header_name] = header_value
-
-            return redirect_response
-
         if enable_pkce:
             try:
-                redirect_response = await complete_login_flow(token, state_data)
+                redirect_response = await complete_login_flow(
+                    oauth_client=oauth_client,
+                    token=token,
+                    state_data=state_data,
+                    request=request,
+                    user_manager=user_manager,
+                    backend=backend,
+                    strategy=strategy,
+                    associate_by_email=associate_by_email,
+                    is_verified_by_default=is_verified_by_default,
+                    allowed_email_domains_override=None,
+                )
             except OnyxError as e:
                 return build_error_response(e)
             delete_pkce_cookie(redirect_response)
             return redirect_response
 
-        return await complete_login_flow(token, state_data)
+        return await complete_login_flow(
+            oauth_client=oauth_client,
+            token=token,
+            state_data=state_data,
+            request=request,
+            user_manager=user_manager,
+            backend=backend,
+            strategy=strategy,
+            associate_by_email=associate_by_email,
+            is_verified_by_default=is_verified_by_default,
+            allowed_email_domains_override=None,
+        )
 
     return router

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2282,26 +2282,15 @@ def decode_and_validate_oauth_state(
         state_data = decode_jwt(state_value, state_secret, [STATE_TOKEN_AUDIENCE])
     except jwt.DecodeError:
         raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(
-                ErrorCode, "ACCESS_TOKEN_DECODE_ERROR", "ACCESS_TOKEN_DECODE_ERROR"
-            ),
+            OnyxErrorCode.VALIDATION_ERROR, ErrorCode.ACCESS_TOKEN_DECODE_ERROR
         )
     except jwt.ExpiredSignatureError:
         raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(
-                ErrorCode,
-                "ACCESS_TOKEN_ALREADY_EXPIRED",
-                "ACCESS_TOKEN_ALREADY_EXPIRED",
-            ),
+            OnyxErrorCode.VALIDATION_ERROR, ErrorCode.ACCESS_TOKEN_ALREADY_EXPIRED
         )
     except jwt.PyJWTError:
         raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(
-                ErrorCode, "ACCESS_TOKEN_DECODE_ERROR", "ACCESS_TOKEN_DECODE_ERROR"
-            ),
+            OnyxErrorCode.VALIDATION_ERROR, ErrorCode.ACCESS_TOKEN_DECODE_ERROR
         )
 
     cookie_csrf_token = request.cookies.get(csrf_token_cookie_name)
@@ -2311,10 +2300,7 @@ def decode_and_validate_oauth_state(
         or not state_csrf_token
         or not secrets.compare_digest(cookie_csrf_token, state_csrf_token)
     ):
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
-        )
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, ErrorCode.OAUTH_INVALID_STATE)
 
     if (
         expected_provider_name is not None

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -923,20 +923,19 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
             except exceptions.UserNotExists:
                 try:
-                    # Attempt to get user by email
+                    # The user_db adapter returns None for a missing email, it
+                    # does not raise UserNotExists like the manager method.
                     user = await self.user_db.get_by_email(account_email)
+                    if user is None:
+                        raise exceptions.UserNotExists()
                     if not associate_by_email:
+                        # Linking a login to an existing same-email account is
+                        # an account-takeover vector unless explicitly enabled.
                         raise exceptions.UserAlreadyExists()
 
-                    # Make sure user is not None before adding OAuth account
-                    if user is not None:
-                        user = await self.user_db.add_oauth_account(
-                            user, oauth_account_dict
-                        )
-                    else:
-                        # This shouldn't happen since get_by_email would raise UserNotExists
-                        # but adding as a safeguard
-                        raise exceptions.UserNotExists()
+                    user = await self.user_db.add_oauth_account(
+                        user, oauth_account_dict
+                    )
 
                 except exceptions.UserNotExists:
                     # OAuth-created accounts are not subject to the dotted-Gmail

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2306,10 +2306,7 @@ def decode_and_validate_oauth_state(
         expected_provider_name is not None
         and state_data.get("provider_name") != expected_provider_name
     ):
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            "SSO state does not match the callback provider",
-        )
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, ErrorCode.OAUTH_INVALID_STATE)
 
     return state_data
 

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -61,7 +61,7 @@ class SAMLProviderConfig(_ProviderConfig):
 
 
 # provider_type selects the config shape. A new auth method adds a model here.
-_CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
+CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
     SSOProviderType.GOOGLE_OAUTH: GoogleProviderConfig,
     SSOProviderType.OIDC: OIDCProviderConfig,
     SSOProviderType.SAML: SAMLProviderConfig,
@@ -75,7 +75,7 @@ def validate_sso_config(
     dict for storage. Raises ValueError on a missing or unknown field so callers
     see one exception type regardless of the provider."""
     try:
-        return _CONFIG_MODEL_BY_TYPE[provider_type].model_validate(config).model_dump()
+        return CONFIG_MODEL_BY_TYPE[provider_type].model_validate(config).model_dump()
     except ValidationError as e:
         raise ValueError(f"invalid {provider_type.value} provider config: {e}") from e
 

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -61,7 +61,7 @@ class SAMLProviderConfig(_ProviderConfig):
 
 
 # provider_type selects the config shape. A new auth method adds a model here.
-CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
+_CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
     SSOProviderType.GOOGLE_OAUTH: GoogleProviderConfig,
     SSOProviderType.OIDC: OIDCProviderConfig,
     SSOProviderType.SAML: SAMLProviderConfig,
@@ -75,7 +75,7 @@ def validate_sso_config(
     dict for storage. Raises ValueError on a missing or unknown field so callers
     see one exception type regardless of the provider."""
     try:
-        return CONFIG_MODEL_BY_TYPE[provider_type].model_validate(config).model_dump()
+        return _CONFIG_MODEL_BY_TYPE[provider_type].model_validate(config).model_dump()
     except ValidationError as e:
         raise ValueError(f"invalid {provider_type.value} provider config: {e}") from e
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -148,6 +148,7 @@ from onyx.server.middleware.rate_limiting import close_auth_limiter
 from onyx.server.middleware.rate_limiting import get_auth_rate_limiters
 from onyx.server.middleware.rate_limiting import RATE_LIMITING_ENABLED
 from onyx.server.middleware.rate_limiting import setup_auth_limiter
+from onyx.server.oidc_multi import router as oidc_multi_router
 from onyx.server.onyx_api.ingestion import router as onyx_api_router
 from onyx.server.pat.api import router as pat_router
 from onyx.server.query_and_chat.chat_backend import router as chat_router
@@ -721,6 +722,14 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_auth_router_with_prefix(
         application,
         saml_multi_router,
+    )
+
+    # DB-backed multi-provider OIDC/Google router. Always mounted: resolves
+    # provider rows per request and 404s when none exist, so it ships dark next
+    # to the single-provider /auth/oidc and /auth/oauth routes.
+    include_auth_router_with_prefix(
+        application,
+        oidc_multi_router,
     )
 
     if (

--- a/backend/onyx/server/auth_check.py
+++ b/backend/onyx/server/auth_check.py
@@ -72,6 +72,9 @@ PUBLIC_ENDPOINT_SPECS = [
     # oidc
     ("/auth/oidc/authorize", {"GET"}),
     ("/auth/oidc/callback", {"GET"}),
+    # db-backed multi-provider oidc/google (oidc_multi router)
+    ("/auth/oidc/{provider_name}/authorize", {"GET"}),
+    ("/auth/oidc/{provider_name}/callback", {"GET"}),
     # saml (single router: legacy-compatible + parametric authorize, one
     # issuer-resolved callback)
     ("/auth/saml/authorize", {"GET"}),

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -66,6 +66,7 @@ _ALLOW_AUTO_LINK = False
 _CLIENT_CACHE: TTLCache[tuple[str, str, SSOProviderType, str], BaseOAuth2[Any]] = (
     TTLCache(maxsize=128, ttl=_CLIENT_CACHE_TTL_SECONDS)
 )
+_COOKIE_SECURE = WEB_DOMAIN.startswith("https")
 
 
 def _resolve_oidc_provider(
@@ -78,9 +79,9 @@ def _resolve_oidc_provider(
     )
     if provider is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider")
-    if (
-        provider.provider_type is not SSOProviderType.GOOGLE_OAUTH
-        and provider.provider_type is not SSOProviderType.OIDC
+    if provider.provider_type not in (
+        SSOProviderType.GOOGLE_OAUTH,
+        SSOProviderType.OIDC,
     ):
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider")
     if provider.config is None:
@@ -132,9 +133,9 @@ def _get_cache_key(
 async def _get_oauth_client(
     provider: SSOProvider, config: dict[str, Any]
 ) -> BaseOAuth2[Any]:
-    # Constructing an OIDC client fetches the IdP discovery doc over the network.
-    # Cache per provider+config. The TTL bounds how long a rotated upstream
-    # discovery doc stays stale. A config edit re-keys and rebuilds at once.
+    # Building an OIDC client fetches the IdP discovery doc over the network, so
+    # cache per provider+config (Google clients share the cache, no fetch). The
+    # TTL bounds how long a rotated upstream config stays stale before a re-key.
     cache_key = _get_cache_key(provider, config)
     cached_client = _CLIENT_CACHE.get(cache_key)
     if cached_client is not None:
@@ -156,7 +157,7 @@ def _set_oauth_cookie(
         value=value,
         max_age=STATE_TOKEN_LIFETIME_SECONDS,
         path="/",
-        secure=WEB_DOMAIN.startswith("https"),
+        secure=_COOKIE_SECURE,
         httponly=True,
         samesite="lax",
     )
@@ -166,7 +167,7 @@ def _delete_pkce_cookie(response: Response, state: str) -> None:
     response.delete_cookie(
         key=get_pkce_cookie_name(state),
         path="/",
-        secure=WEB_DOMAIN.startswith("https"),
+        secure=_COOKIE_SECURE,
         httponly=True,
         samesite="lax",
     )
@@ -229,9 +230,7 @@ async def oidc_login_for_provider(
         key=CSRF_TOKEN_COOKIE_NAME,
         value=csrf_token,
     )
-    if OIDC_PKCE_ENABLED:
-        if code_verifier is None:
-            raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "Missing PKCE verifier")
+    if code_verifier is not None:
         _set_oauth_cookie(
             response,
             key=get_pkce_cookie_name(state),

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -22,7 +22,6 @@ from httpx_oauth.clients.google import GoogleOAuth2
 from httpx_oauth.clients.openid import BASE_SCOPES
 from httpx_oauth.oauth2 import BaseOAuth2
 from httpx_oauth.oauth2 import GetAccessTokenError
-from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from onyx.auth.oidc_client import VerifiedEmailOpenID
@@ -47,15 +46,13 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
 from onyx.db.models import User
-from onyx.db.sso_provider import CONFIG_MODEL_BY_TYPE
 from onyx.db.sso_provider import fetch_sso_provider_by_name
+from onyx.db.sso_provider import validate_sso_config
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.utils.logger import setup_logger
 from onyx.utils.url import sanitize_next_url
 from shared_configs.contextvars import get_current_tenant_id
 
-logger = setup_logger()
 router = APIRouter(prefix="/auth/oidc")
 
 _CLIENT_CACHE_TTL_SECONDS = 600
@@ -89,12 +86,8 @@ def _resolve_oidc_provider(
 
     raw_config = provider.config.get_value(apply_mask=False)
     try:
-        config = (
-            CONFIG_MODEL_BY_TYPE[provider.provider_type]
-            .model_validate(raw_config)
-            .model_dump()
-        )
-    except ValidationError as e:
+        config = validate_sso_config(provider.provider_type, raw_config)
+    except ValueError as e:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider") from e
     return provider, config
 
@@ -135,7 +128,7 @@ async def _get_oauth_client(
 ) -> BaseOAuth2[Any]:
     # Building an OIDC client fetches the IdP discovery doc over the network, so
     # cache per provider+config (Google clients share the cache, no fetch). The
-    # TTL bounds how long a rotated upstream config stays stale before a re-key.
+    # TTL bounds how long stale IdP discovery data lives before a rebuild.
     cache_key = _get_cache_key(provider, config)
     cached_client = _CLIENT_CACHE.get(cache_key)
     if cached_client is not None:

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -7,12 +7,10 @@ matching provider rows exist.
 
 import hashlib
 import json
-import secrets
-import time
 import uuid
 from typing import Any
 
-import jwt
+from cachetools import TTLCache
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Request
@@ -20,8 +18,6 @@ from fastapi import Response
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 from fastapi_users.authentication import Strategy
-from fastapi_users.jwt import decode_jwt
-from fastapi_users.router.common import ErrorCode
 from httpx_oauth.clients.google import GoogleOAuth2
 from httpx_oauth.clients.openid import BASE_SCOPES
 from httpx_oauth.oauth2 import BaseOAuth2
@@ -34,13 +30,13 @@ from onyx.auth.users import auth_backend
 from onyx.auth.users import complete_login_flow
 from onyx.auth.users import CSRF_TOKEN_COOKIE_NAME
 from onyx.auth.users import CSRF_TOKEN_KEY
+from onyx.auth.users import decode_and_validate_oauth_state
 from onyx.auth.users import generate_csrf_token
 from onyx.auth.users import generate_pkce_pair
 from onyx.auth.users import generate_state_token
 from onyx.auth.users import get_pkce_cookie_name
 from onyx.auth.users import get_user_manager
 from onyx.auth.users import OAuth2AuthorizeResponse
-from onyx.auth.users import STATE_TOKEN_AUDIENCE
 from onyx.auth.users import STATE_TOKEN_LIFETIME_SECONDS
 from onyx.auth.users import UserManager
 from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
@@ -51,9 +47,8 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
 from onyx.db.models import User
+from onyx.db.sso_provider import CONFIG_MODEL_BY_TYPE
 from onyx.db.sso_provider import fetch_sso_provider_by_name
-from onyx.db.sso_provider import GoogleProviderConfig
-from onyx.db.sso_provider import OIDCProviderConfig
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
@@ -64,15 +59,13 @@ logger = setup_logger()
 router = APIRouter(prefix="/auth/oidc")
 
 _CLIENT_CACHE_TTL_SECONDS = 600
-# Off by default: linking a second provider to an existing account by verified
-# email is an account-takeover vector when two IdPs can assert the same domain.
-# An admin opt-in belongs on the provider row.
+# Hardcoded off: linking a second IdP to an existing account by verified email is
+# an account-takeover vector when two IdPs can assert one domain.
 _ALLOW_AUTO_LINK = False
 
-_CLIENT_CACHE: dict[
-    tuple[str, str, SSOProviderType, str],
-    tuple[BaseOAuth2[Any], float],
-] = {}
+_CLIENT_CACHE: TTLCache[tuple[str, str, SSOProviderType, str], BaseOAuth2[Any]] = (
+    TTLCache(maxsize=128, ttl=_CLIENT_CACHE_TTL_SECONDS)
+)
 
 
 def _resolve_oidc_provider(
@@ -95,13 +88,14 @@ def _resolve_oidc_provider(
 
     raw_config = provider.config.get_value(apply_mask=False)
     try:
-        if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
-            return provider, GoogleProviderConfig.model_validate(
-                raw_config
-            ).model_dump()
-        return provider, OIDCProviderConfig.model_validate(raw_config).model_dump()
+        config = (
+            CONFIG_MODEL_BY_TYPE[provider.provider_type]
+            .model_validate(raw_config)
+            .model_dump()
+        )
     except ValidationError as e:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider") from e
+    return provider, config
 
 
 def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
@@ -138,17 +132,16 @@ def _get_cache_key(
 async def _get_oauth_client(
     provider: SSOProvider, config: dict[str, Any]
 ) -> BaseOAuth2[Any]:
-    # Building an OIDC client fetches the discovery doc over the network, so
-    # cache per provider+config. The TTL bounds staleness after an admin edit.
+    # Constructing an OIDC client fetches the IdP discovery doc over the network.
+    # Cache per provider+config. The TTL bounds how long a rotated upstream
+    # discovery doc stays stale. A config edit re-keys and rebuilds at once.
     cache_key = _get_cache_key(provider, config)
     cached_client = _CLIENT_CACHE.get(cache_key)
     if cached_client is not None:
-        client, stamp = cached_client
-        if time.monotonic() - stamp <= _CLIENT_CACHE_TTL_SECONDS:
-            return client
+        return cached_client
 
     client = await run_in_threadpool(_build_client, provider, config)
-    _CLIENT_CACHE[cache_key] = (client, time.monotonic())
+    _CLIENT_CACHE[cache_key] = client
     return client
 
 
@@ -179,60 +172,10 @@ def _delete_pkce_cookie(response: Response, state: str) -> None:
     )
 
 
-def _decode_and_validate_state(
-    request: Request, state: str, provider_name: str
-) -> dict[str, str]:
-    try:
-        state_data = decode_jwt(state, USER_AUTH_SECRET, [STATE_TOKEN_AUDIENCE])
-    except jwt.DecodeError:
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(
-                ErrorCode,
-                "ACCESS_TOKEN_DECODE_ERROR",
-                "ACCESS_TOKEN_DECODE_ERROR",
-            ),
-        )
-    except jwt.ExpiredSignatureError:
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(
-                ErrorCode,
-                "ACCESS_TOKEN_ALREADY_EXPIRED",
-                "ACCESS_TOKEN_ALREADY_EXPIRED",
-            ),
-        )
-    except jwt.PyJWTError:
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(
-                ErrorCode,
-                "ACCESS_TOKEN_DECODE_ERROR",
-                "ACCESS_TOKEN_DECODE_ERROR",
-            ),
-        )
-
-    cookie_csrf_token = request.cookies.get(CSRF_TOKEN_COOKIE_NAME)
-    state_csrf_token = state_data.get(CSRF_TOKEN_KEY)
-    if (
-        not cookie_csrf_token
-        or not state_csrf_token
-        or not secrets.compare_digest(cookie_csrf_token, state_csrf_token)
-    ):
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
-        )
-
-    # Bind the flow to its provider so a state minted for one provider cannot be
-    # replayed against another provider's callback.
-    if state_data.get("provider_name") != provider_name:
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            "SSO state does not match the callback provider",
-        )
-
-    return state_data
+def _callback_uri(provider_name: str) -> str:
+    # The IdP redirects the browser here, so route it through /api to reach
+    # FastAPI. The bare /auth/oidc path is served by the web app, not the API.
+    return f"{WEB_DOMAIN}/api/auth/oidc/{provider_name}/callback"
 
 
 @router.get("/{provider_name}/authorize")
@@ -243,9 +186,7 @@ async def oidc_login_for_provider(
 ) -> Response:
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
-    # The IdP redirects the browser here, so route it through /api to reach
-    # FastAPI. The bare /auth/oidc path is served by the web app, not the API.
-    redirect_uri = f"{WEB_DOMAIN}/api/auth/oidc/{provider_name}/callback"
+    redirect_uri = _callback_uri(provider_name)
     next_url = sanitize_next_url(request.query_params.get("next"))
     csrf_token = generate_csrf_token()
     state = generate_state_token(
@@ -313,7 +254,7 @@ async def oidc_login_callback_for_provider(
 ) -> Response:
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
-    redirect_uri = f"{WEB_DOMAIN}/api/auth/oidc/{provider_name}/callback"
+    redirect_uri = _callback_uri(provider_name)
 
     if error is not None:
         raise OnyxError(
@@ -331,7 +272,12 @@ async def oidc_login_callback_for_provider(
             "Missing state parameter in OAuth callback",
         )
 
-    state_data = _decode_and_validate_state(request, state, provider_name)
+    state_data = decode_and_validate_oauth_state(
+        request=request,
+        state_value=state,
+        state_secret=USER_AUTH_SECRET,
+        expected_provider_name=provider_name,
+    )
 
     code_verifier: str | None = None
     if OIDC_PKCE_ENABLED:

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -1,0 +1,349 @@
+"""Per-request-resolved multi-provider OAuth2/OIDC login.
+
+Resolves the enabled provider row from the database on each request so one
+deployment can serve multiple Google and generic OIDC IdPs. Ships dark when no
+matching provider rows exist.
+"""
+
+import hashlib
+import json
+import secrets
+import time
+import uuid
+from typing import Any
+
+import jwt
+from fastapi import APIRouter
+from fastapi import Depends
+from fastapi import Request
+from fastapi import Response
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import JSONResponse
+from fastapi_users.authentication import Strategy
+from fastapi_users.jwt import decode_jwt
+from fastapi_users.router.common import ErrorCode
+from httpx_oauth.clients.google import GoogleOAuth2
+from httpx_oauth.clients.openid import BASE_SCOPES
+from httpx_oauth.oauth2 import BaseOAuth2
+from httpx_oauth.oauth2 import GetAccessTokenError
+from pydantic import ValidationError
+from sqlalchemy.orm import Session
+
+from onyx.auth.oidc_client import VerifiedEmailOpenID
+from onyx.auth.users import auth_backend
+from onyx.auth.users import complete_login_flow
+from onyx.auth.users import CSRF_TOKEN_COOKIE_NAME
+from onyx.auth.users import CSRF_TOKEN_KEY
+from onyx.auth.users import generate_csrf_token
+from onyx.auth.users import generate_pkce_pair
+from onyx.auth.users import generate_state_token
+from onyx.auth.users import get_pkce_cookie_name
+from onyx.auth.users import get_user_manager
+from onyx.auth.users import OAuth2AuthorizeResponse
+from onyx.auth.users import STATE_TOKEN_AUDIENCE
+from onyx.auth.users import STATE_TOKEN_LIFETIME_SECONDS
+from onyx.auth.users import UserManager
+from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
+from onyx.configs.app_configs import OIDC_PKCE_ENABLED
+from onyx.configs.app_configs import USER_AUTH_SECRET
+from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import SSOProviderType
+from onyx.db.models import SSOProvider
+from onyx.db.models import User
+from onyx.db.sso_provider import fetch_sso_provider_by_name
+from onyx.db.sso_provider import GoogleProviderConfig
+from onyx.db.sso_provider import OIDCProviderConfig
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.logger import setup_logger
+from onyx.utils.url import sanitize_next_url
+
+logger = setup_logger()
+router = APIRouter(prefix="/auth/oidc")
+
+_CLIENT_CACHE_TTL_SECONDS = 600
+# Link a second provider to an existing account by verified email. Same-domain
+# deployments (two IdPs sharing an email domain) must run this off.
+_ALLOW_AUTO_LINK = True
+
+_CLIENT_CACHE: dict[
+    tuple[str, SSOProviderType, str],
+    tuple[BaseOAuth2[Any], float],
+] = {}
+
+
+def _resolve_oidc_provider(
+    db_session: Session, provider_name: str
+) -> tuple[SSOProvider, dict[str, Any]]:
+    provider = fetch_sso_provider_by_name(
+        db_session=db_session,
+        name=provider_name,
+        enabled_only=True,
+    )
+    if provider is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider")
+    if (
+        provider.provider_type is not SSOProviderType.GOOGLE_OAUTH
+        and provider.provider_type is not SSOProviderType.OIDC
+    ):
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider")
+    if provider.config is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider")
+
+    raw_config = provider.config.get_value(apply_mask=False)
+    try:
+        if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
+            return provider, GoogleProviderConfig.model_validate(
+                raw_config
+            ).model_dump()
+        return provider, OIDCProviderConfig.model_validate(raw_config).model_dump()
+    except ValidationError as e:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider") from e
+
+
+def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
+    if provider.provider_type is SSOProviderType.OIDC:
+        return VerifiedEmailOpenID(
+            config["client_id"],
+            config["client_secret"],
+            config["openid_config_url"],
+            name=provider.name,
+            base_scopes=list(BASE_SCOPES) + ["offline_access"],
+        )
+    if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
+        return GoogleOAuth2(
+            config["client_id"],
+            config["client_secret"],
+            scopes=list(GOOGLE_LOGIN_BASE_SCOPES),
+            name=provider.name,
+        )
+
+    raise OnyxError(OnyxErrorCode.NOT_FOUND, "unknown OIDC provider")
+
+
+def _get_cache_key(
+    provider: SSOProvider, config: dict[str, Any]
+) -> tuple[str, SSOProviderType, str]:
+    config_hash = hashlib.sha256(
+        json.dumps(config, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return provider.name, provider.provider_type, config_hash
+
+
+async def _get_oauth_client(
+    provider: SSOProvider, config: dict[str, Any]
+) -> BaseOAuth2[Any]:
+    # Building an OIDC client fetches the discovery doc over the network, so
+    # cache per provider+config. The TTL bounds staleness after an admin edit.
+    cache_key = _get_cache_key(provider, config)
+    cached_client = _CLIENT_CACHE.get(cache_key)
+    if cached_client is not None:
+        client, stamp = cached_client
+        if time.monotonic() - stamp <= _CLIENT_CACHE_TTL_SECONDS:
+            return client
+
+    client = await run_in_threadpool(_build_client, provider, config)
+    _CLIENT_CACHE[cache_key] = (client, time.monotonic())
+    return client
+
+
+def _set_oauth_cookie(
+    response: Response,
+    *,
+    key: str,
+    value: str,
+) -> None:
+    response.set_cookie(
+        key=key,
+        value=value,
+        max_age=STATE_TOKEN_LIFETIME_SECONDS,
+        path="/",
+        secure=WEB_DOMAIN.startswith("https"),
+        httponly=True,
+        samesite="lax",
+    )
+
+
+def _delete_pkce_cookie(response: Response, state: str) -> None:
+    response.delete_cookie(
+        key=get_pkce_cookie_name(state),
+        path="/",
+        secure=WEB_DOMAIN.startswith("https"),
+        httponly=True,
+        samesite="lax",
+    )
+
+
+def _decode_and_validate_state(request: Request, state: str) -> dict[str, str]:
+    try:
+        state_data = decode_jwt(state, USER_AUTH_SECRET, [STATE_TOKEN_AUDIENCE])
+    except jwt.DecodeError:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(
+                ErrorCode,
+                "ACCESS_TOKEN_DECODE_ERROR",
+                "ACCESS_TOKEN_DECODE_ERROR",
+            ),
+        )
+    except jwt.ExpiredSignatureError:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(
+                ErrorCode,
+                "ACCESS_TOKEN_ALREADY_EXPIRED",
+                "ACCESS_TOKEN_ALREADY_EXPIRED",
+            ),
+        )
+    except jwt.PyJWTError:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(
+                ErrorCode,
+                "ACCESS_TOKEN_DECODE_ERROR",
+                "ACCESS_TOKEN_DECODE_ERROR",
+            ),
+        )
+
+    cookie_csrf_token = request.cookies.get(CSRF_TOKEN_COOKIE_NAME)
+    state_csrf_token = state_data.get(CSRF_TOKEN_KEY)
+    if (
+        not cookie_csrf_token
+        or not state_csrf_token
+        or not secrets.compare_digest(cookie_csrf_token, state_csrf_token)
+    ):
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
+        )
+
+    return state_data
+
+
+@router.get("/{provider_name}/authorize")
+async def oidc_login_for_provider(
+    provider_name: str,
+    request: Request,
+    db_session: Session = Depends(get_session),
+) -> Response:
+    provider, config = _resolve_oidc_provider(db_session, provider_name)
+    client = await _get_oauth_client(provider, config)
+    redirect_uri = f"{WEB_DOMAIN}/auth/oidc/{provider_name}/callback"
+    next_url = sanitize_next_url(request.query_params.get("next"))
+    csrf_token = generate_csrf_token()
+    state = generate_state_token(
+        {"next_url": next_url, CSRF_TOKEN_KEY: csrf_token},
+        USER_AUTH_SECRET,
+    )
+
+    extras: dict[str, str] | None = None
+    if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
+        extras = {"access_type": "offline", "prompt": "consent"}
+
+    code_verifier: str | None = None
+    if OIDC_PKCE_ENABLED:
+        code_verifier, code_challenge = generate_pkce_pair()
+        authorization_url = await client.get_authorization_url(
+            redirect_uri,
+            state=state,
+            code_challenge=code_challenge,
+            code_challenge_method="S256",
+            extras_params=extras,
+        )
+    else:
+        authorization_url = await client.get_authorization_url(
+            redirect_uri,
+            state=state,
+            extras_params=extras,
+        )
+
+    response = JSONResponse(
+        content=OAuth2AuthorizeResponse(
+            authorization_url=authorization_url
+        ).model_dump()
+    )
+    _set_oauth_cookie(
+        response,
+        key=CSRF_TOKEN_COOKIE_NAME,
+        value=csrf_token,
+    )
+    if OIDC_PKCE_ENABLED:
+        if code_verifier is None:
+            raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "Missing PKCE verifier")
+        _set_oauth_cookie(
+            response,
+            key=get_pkce_cookie_name(state),
+            value=code_verifier,
+        )
+
+    return response
+
+
+@router.get("/{provider_name}/callback")
+async def oidc_login_callback_for_provider(
+    provider_name: str,
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+    db_session: Session = Depends(get_session),
+    strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
+    user_manager: UserManager = Depends(get_user_manager),
+) -> Response:
+    provider, config = _resolve_oidc_provider(db_session, provider_name)
+    client = await _get_oauth_client(provider, config)
+    redirect_uri = f"{WEB_DOMAIN}/auth/oidc/{provider_name}/callback"
+
+    if error is not None:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Authorization request failed or was denied",
+        )
+    if code is None:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Missing authorization code in OAuth callback",
+        )
+    if state is None:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Missing state parameter in OAuth callback",
+        )
+
+    state_data = _decode_and_validate_state(request, state)
+
+    code_verifier: str | None = None
+    if OIDC_PKCE_ENABLED:
+        code_verifier = request.cookies.get(get_pkce_cookie_name(state))
+        if not code_verifier:
+            raise OnyxError(
+                OnyxErrorCode.VALIDATION_ERROR,
+                "Missing PKCE verifier cookie in OAuth callback",
+            )
+
+    try:
+        token = await client.get_access_token(code, redirect_uri, code_verifier)
+    except GetAccessTokenError as e:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Authorization code exchange failed",
+        ) from e
+
+    redirect_response = await complete_login_flow(
+        oauth_client=client,
+        token=token,
+        state_data=state_data,
+        request=request,
+        user_manager=user_manager,
+        backend=auth_backend,
+        strategy=strategy,
+        associate_by_email=_ALLOW_AUTO_LINK,
+        is_verified_by_default=True,
+        allowed_email_domains_override=provider.allowed_email_domains,
+    )
+
+    if OIDC_PKCE_ENABLED:
+        _delete_pkce_cookie(redirect_response, state)
+
+    return redirect_response

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -58,17 +58,19 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from onyx.utils.url import sanitize_next_url
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 router = APIRouter(prefix="/auth/oidc")
 
 _CLIENT_CACHE_TTL_SECONDS = 600
-# Link a second provider to an existing account by verified email. Same-domain
-# deployments (two IdPs sharing an email domain) must run this off.
-_ALLOW_AUTO_LINK = True
+# Off by default: linking a second provider to an existing account by verified
+# email is an account-takeover vector when two IdPs can assert the same domain.
+# An admin opt-in belongs on the provider row.
+_ALLOW_AUTO_LINK = False
 
 _CLIENT_CACHE: dict[
-    tuple[str, SSOProviderType, str],
+    tuple[str, str, SSOProviderType, str],
     tuple[BaseOAuth2[Any], float],
 ] = {}
 
@@ -124,11 +126,13 @@ def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[A
 
 def _get_cache_key(
     provider: SSOProvider, config: dict[str, Any]
-) -> tuple[str, SSOProviderType, str]:
+) -> tuple[str, str, SSOProviderType, str]:
     config_hash = hashlib.sha256(
         json.dumps(config, sort_keys=True).encode("utf-8")
     ).hexdigest()
-    return provider.name, provider.provider_type, config_hash
+    # Tenant-scope the key so two tenants with a same-named provider never share
+    # a client.
+    return get_current_tenant_id(), provider.name, provider.provider_type, config_hash
 
 
 async def _get_oauth_client(
@@ -175,7 +179,9 @@ def _delete_pkce_cookie(response: Response, state: str) -> None:
     )
 
 
-def _decode_and_validate_state(request: Request, state: str) -> dict[str, str]:
+def _decode_and_validate_state(
+    request: Request, state: str, provider_name: str
+) -> dict[str, str]:
     try:
         state_data = decode_jwt(state, USER_AUTH_SECRET, [STATE_TOKEN_AUDIENCE])
     except jwt.DecodeError:
@@ -218,6 +224,14 @@ def _decode_and_validate_state(request: Request, state: str) -> dict[str, str]:
             getattr(ErrorCode, "OAUTH_INVALID_STATE", "OAUTH_INVALID_STATE"),
         )
 
+    # Bind the flow to its provider so a state minted for one provider cannot be
+    # replayed against another provider's callback.
+    if state_data.get("provider_name") != provider_name:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "SSO state does not match the callback provider",
+        )
+
     return state_data
 
 
@@ -229,11 +243,17 @@ async def oidc_login_for_provider(
 ) -> Response:
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
-    redirect_uri = f"{WEB_DOMAIN}/auth/oidc/{provider_name}/callback"
+    # The IdP redirects the browser here, so route it through /api to reach
+    # FastAPI. The bare /auth/oidc path is served by the web app, not the API.
+    redirect_uri = f"{WEB_DOMAIN}/api/auth/oidc/{provider_name}/callback"
     next_url = sanitize_next_url(request.query_params.get("next"))
     csrf_token = generate_csrf_token()
     state = generate_state_token(
-        {"next_url": next_url, CSRF_TOKEN_KEY: csrf_token},
+        {
+            "next_url": next_url,
+            "provider_name": provider_name,
+            CSRF_TOKEN_KEY: csrf_token,
+        },
         USER_AUTH_SECRET,
     )
 
@@ -293,7 +313,7 @@ async def oidc_login_callback_for_provider(
 ) -> Response:
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
-    redirect_uri = f"{WEB_DOMAIN}/auth/oidc/{provider_name}/callback"
+    redirect_uri = f"{WEB_DOMAIN}/api/auth/oidc/{provider_name}/callback"
 
     if error is not None:
         raise OnyxError(
@@ -311,7 +331,7 @@ async def oidc_login_callback_for_provider(
             "Missing state parameter in OAuth callback",
         )
 
-    state_data = _decode_and_validate_state(request, state)
+    state_data = _decode_and_validate_state(request, state, provider_name)
 
     code_verifier: str | None = None
     if OIDC_PKCE_ENABLED:

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -12,6 +12,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.users import CSRF_TOKEN_COOKIE_NAME
 from onyx.auth.users import CSRF_TOKEN_KEY
+from onyx.auth.users import decode_and_validate_oauth_state
 from onyx.auth.users import generate_csrf_token
 from onyx.auth.users import generate_state_token
 from onyx.db.enums import SSOProviderType
@@ -126,7 +127,7 @@ def test_build_client_oidc_uses_provider_name(monkeypatch: pytest.MonkeyPatch) -
 
 
 @pytest.mark.asyncio
-async def test_client_cache_hits_then_rebuilds_after_ttl(
+async def test_client_cache_hits_and_rebuilds_on_config_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     oidc_multi._CLIENT_CACHE.clear()
@@ -141,59 +142,68 @@ async def test_client_cache_hits_then_rebuilds_after_ttl(
 
     await oidc_multi._get_oauth_client(provider, dict(_OIDC_CONFIG))
     await oidc_multi._get_oauth_client(provider, dict(_OIDC_CONFIG))
-    assert builds["count"] == 1  # second call is a cache hit
+    assert builds["count"] == 1  # same key is a cache hit
 
-    # Age the cached entry past the TTL, then it must rebuild.
-    key = oidc_multi._get_cache_key(provider, dict(_OIDC_CONFIG))
-    client, stamp = oidc_multi._CLIENT_CACHE[key]
-    oidc_multi._CLIENT_CACHE[key] = (
-        client,
-        stamp - oidc_multi._CLIENT_CACHE_TTL_SECONDS - 1,
+    # A rotated secret changes the config hash, so the key changes and rebuilds.
+    await oidc_multi._get_oauth_client(
+        provider, {**_OIDC_CONFIG, "client_secret": "rotated"}
     )
-    await oidc_multi._get_oauth_client(provider, dict(_OIDC_CONFIG))
     assert builds["count"] == 2
     oidc_multi._CLIENT_CACHE.clear()
 
 
-def test_decode_state_accepts_valid(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
+def test_decode_state_accepts_valid() -> None:
     csrf = generate_csrf_token()
     state = generate_state_token(
         {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
     )
     request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
-    data = oidc_multi._decode_and_validate_state(request, state, "okta")
+    data = decode_and_validate_oauth_state(
+        request=request,
+        state_value=state,
+        state_secret=_TEST_SECRET,
+        expected_provider_name="okta",
+    )
     assert data[CSRF_TOKEN_KEY] == csrf
 
 
-def test_decode_state_rejects_mismatched_csrf(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
+def test_decode_state_rejects_mismatched_csrf() -> None:
     csrf = generate_csrf_token()
     state = generate_state_token(
         {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
     )
     request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: "different"}))
     with pytest.raises(OnyxError):
-        oidc_multi._decode_and_validate_state(request, state, "okta")
+        decode_and_validate_oauth_state(
+            request=request,
+            state_value=state,
+            state_secret=_TEST_SECRET,
+            expected_provider_name="okta",
+        )
 
 
-def test_decode_state_rejects_wrong_provider(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_decode_state_rejects_wrong_provider() -> None:
     # A state minted for one provider must not validate on another's callback.
-    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
     csrf = generate_csrf_token()
     state = generate_state_token(
         {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
     )
     request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
     with pytest.raises(OnyxError):
-        oidc_multi._decode_and_validate_state(request, state, "google")
+        decode_and_validate_oauth_state(
+            request=request,
+            state_value=state,
+            state_secret=_TEST_SECRET,
+            expected_provider_name="google",
+        )
 
 
 def test_decode_state_rejects_bad_jwt() -> None:
     request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: "x"}))
     with pytest.raises(OnyxError):
-        oidc_multi._decode_and_validate_state(request, "not-a-jwt", "okta")
+        decode_and_validate_oauth_state(
+            request=request,
+            state_value="not-a-jwt",
+            state_secret=_TEST_SECRET,
+            expected_provider_name="okta",
+        )

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -1,0 +1,181 @@
+"""Unit coverage for the DB-backed OIDC/Google router: fail-closed provider
+resolution, the per-provider client cache (keying, TTL, config-rotation bust),
+per-provider client construction, and OAuth state/CSRF validation. No DB, no
+network, no live IdP."""
+
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import CSRF_TOKEN_COOKIE_NAME
+from onyx.auth.users import CSRF_TOKEN_KEY
+from onyx.auth.users import generate_csrf_token
+from onyx.auth.users import generate_state_token
+from onyx.db.enums import SSOProviderType
+from onyx.db.models import SSOProvider
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server import oidc_multi
+from onyx.utils.sensitive import make_mock_sensitive_value
+
+_OIDC_CONFIG = {
+    "client_id": "cid",
+    "client_secret": "secret",
+    "openid_config_url": "https://idp.example.com/.well-known/openid-configuration",
+}
+_GOOGLE_CONFIG = {"client_id": "gid", "client_secret": "gsecret"}
+_DB = cast(Session, object())
+_TEST_SECRET = "unit-test-secret"
+
+
+def _provider(**overrides: object) -> SSOProvider:
+    base: dict[str, Any] = dict(
+        name="okta",
+        provider_type=SSOProviderType.OIDC,
+        allowed_email_domains=["companya.com"],
+        config=make_mock_sensitive_value(dict(_OIDC_CONFIG)),
+    )
+    base.update(overrides)
+    return cast(SSOProvider, SimpleNamespace(**base))
+
+
+def test_resolve_oidc_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _provider()
+    monkeypatch.setattr(
+        oidc_multi, "fetch_sso_provider_by_name", lambda **_kw: provider
+    )
+    resolved, config = oidc_multi._resolve_oidc_provider(_DB, "okta")
+    assert resolved is provider
+    assert config == dict(_OIDC_CONFIG)
+
+
+def test_resolve_google_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _provider(
+        name="google",
+        provider_type=SSOProviderType.GOOGLE_OAUTH,
+        config=make_mock_sensitive_value(dict(_GOOGLE_CONFIG)),
+    )
+    monkeypatch.setattr(
+        oidc_multi, "fetch_sso_provider_by_name", lambda **_kw: provider
+    )
+    _resolved, config = oidc_multi._resolve_oidc_provider(_DB, "google")
+    assert config == dict(_GOOGLE_CONFIG)
+
+
+def test_resolve_fail_closed_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oidc_multi, "fetch_sso_provider_by_name", lambda **_kw: None)
+    with pytest.raises(OnyxError):
+        oidc_multi._resolve_oidc_provider(_DB, "missing")
+
+
+def test_resolve_fail_closed_saml_type(monkeypatch: pytest.MonkeyPatch) -> None:
+    provider = _provider(provider_type=SSOProviderType.SAML)
+    monkeypatch.setattr(
+        oidc_multi, "fetch_sso_provider_by_name", lambda **_kw: provider
+    )
+    with pytest.raises(OnyxError):
+        oidc_multi._resolve_oidc_provider(_DB, "saml-row")
+
+
+def test_resolve_fail_closed_incomplete_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    # An OIDC row missing openid_config_url fails model validation -> fail closed.
+    provider = _provider(
+        config=make_mock_sensitive_value({"client_id": "c", "client_secret": "s"})
+    )
+    monkeypatch.setattr(
+        oidc_multi, "fetch_sso_provider_by_name", lambda **_kw: provider
+    )
+    with pytest.raises(OnyxError):
+        oidc_multi._resolve_oidc_provider(_DB, "okta")
+
+
+def test_cache_key_stable_and_config_sensitive() -> None:
+    provider = _provider()
+    key = oidc_multi._get_cache_key(provider, dict(_OIDC_CONFIG))
+    assert key == oidc_multi._get_cache_key(provider, dict(_OIDC_CONFIG))
+    rotated = oidc_multi._get_cache_key(
+        provider, {**_OIDC_CONFIG, "client_secret": "rotated"}
+    )
+    assert key != rotated
+
+
+def test_build_client_google_uses_provider_name() -> None:
+    provider = _provider(name="google", provider_type=SSOProviderType.GOOGLE_OAUTH)
+    client = oidc_multi._build_client(provider, dict(_GOOGLE_CONFIG))
+    assert client.name == "google"
+
+
+def test_build_client_oidc_uses_provider_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    # VerifiedEmailOpenID.__init__ fetches the discovery doc over the network.
+    # Stub it so the unit test stays offline.
+    def _fake_openid(
+        _client_id: str,
+        _client_secret: str,
+        _config_url: str,
+        *,
+        name: str,
+        **_kwargs: Any,
+    ) -> Any:
+        return SimpleNamespace(name=name)
+
+    monkeypatch.setattr(oidc_multi, "VerifiedEmailOpenID", _fake_openid)
+    client = oidc_multi._build_client(_provider(name="okta"), dict(_OIDC_CONFIG))
+    assert client.name == "okta"
+
+
+@pytest.mark.asyncio
+async def test_client_cache_hits_then_rebuilds_after_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    oidc_multi._CLIENT_CACHE.clear()
+    builds = {"count": 0}
+
+    def _fake_build(provider: SSOProvider, _config: dict[str, Any]) -> Any:
+        builds["count"] += 1
+        return SimpleNamespace(name=provider.name)
+
+    monkeypatch.setattr(oidc_multi, "_build_client", _fake_build)
+    provider = _provider()
+
+    await oidc_multi._get_oauth_client(provider, dict(_OIDC_CONFIG))
+    await oidc_multi._get_oauth_client(provider, dict(_OIDC_CONFIG))
+    assert builds["count"] == 1  # second call is a cache hit
+
+    # Age the cached entry past the TTL, then it must rebuild.
+    key = oidc_multi._get_cache_key(provider, dict(_OIDC_CONFIG))
+    client, stamp = oidc_multi._CLIENT_CACHE[key]
+    oidc_multi._CLIENT_CACHE[key] = (
+        client,
+        stamp - oidc_multi._CLIENT_CACHE_TTL_SECONDS - 1,
+    )
+    await oidc_multi._get_oauth_client(provider, dict(_OIDC_CONFIG))
+    assert builds["count"] == 2
+    oidc_multi._CLIENT_CACHE.clear()
+
+
+def test_decode_state_accepts_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
+    csrf = generate_csrf_token()
+    state = generate_state_token({"next_url": "/", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET)
+    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
+    data = oidc_multi._decode_and_validate_state(request, state)
+    assert data[CSRF_TOKEN_KEY] == csrf
+
+
+def test_decode_state_rejects_mismatched_csrf(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
+    csrf = generate_csrf_token()
+    state = generate_state_token({"next_url": "/", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET)
+    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: "different"}))
+    with pytest.raises(OnyxError):
+        oidc_multi._decode_and_validate_state(request, state)
+
+
+def test_decode_state_rejects_bad_jwt() -> None:
+    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: "x"}))
+    with pytest.raises(OnyxError):
+        oidc_multi._decode_and_validate_state(request, "not-a-jwt")

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -158,9 +158,11 @@ async def test_client_cache_hits_then_rebuilds_after_ttl(
 def test_decode_state_accepts_valid(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
     csrf = generate_csrf_token()
-    state = generate_state_token({"next_url": "/", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET)
+    state = generate_state_token(
+        {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
+    )
     request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
-    data = oidc_multi._decode_and_validate_state(request, state)
+    data = oidc_multi._decode_and_validate_state(request, state, "okta")
     assert data[CSRF_TOKEN_KEY] == csrf
 
 
@@ -169,13 +171,29 @@ def test_decode_state_rejects_mismatched_csrf(
 ) -> None:
     monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
     csrf = generate_csrf_token()
-    state = generate_state_token({"next_url": "/", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET)
+    state = generate_state_token(
+        {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
+    )
     request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: "different"}))
     with pytest.raises(OnyxError):
-        oidc_multi._decode_and_validate_state(request, state)
+        oidc_multi._decode_and_validate_state(request, state, "okta")
+
+
+def test_decode_state_rejects_wrong_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A state minted for one provider must not validate on another's callback.
+    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
+    csrf = generate_csrf_token()
+    state = generate_state_token(
+        {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
+    )
+    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
+    with pytest.raises(OnyxError):
+        oidc_multi._decode_and_validate_state(request, state, "google")
 
 
 def test_decode_state_rejects_bad_jwt() -> None:
     request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: "x"}))
     with pytest.raises(OnyxError):
-        oidc_multi._decode_and_validate_state(request, "not-a-jwt")
+        oidc_multi._decode_and_validate_state(request, "not-a-jwt", "okta")

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -1,5 +1,5 @@
 """Unit coverage for the DB-backed OIDC/Google router: fail-closed provider
-resolution, the per-provider client cache (keying, TTL, config-rotation bust),
+resolution, the per-provider client cache (keying, config-rotation bust),
 per-provider client construction, and OAuth state/CSRF validation. No DB, no
 network, no live IdP."""
 


### PR DESCRIPTION
## Description

Multi-provider OIDC/Google login driven by `sso_provider` rows, the OAuth analog of the merged SAML router. Ships dark (no rows means the routes 404).

- Parametric `/auth/oidc/<name>/authorize|callback` resolve a provider row per request and run the OAuth flow with a per-provider client (the hardened `VerifiedEmailOpenID`, or `GoogleOAuth2`), each built with `name=provider.name` and its own `redirect_uri`. Clients are cached per row (600s TTL, discovery fetch off the event loop).
- Wires the previously-dormant hardened client (verified-email + issuer-owns-config). Per-provider isolation blocks most of the OIDC mix-up class, since each callback exchanges the code with its own client secret.
- Domain gate is the provider's own `allowed_email_domains`, passed into `oauth_callback` as an override, so provider logins don't consult the global `VALID_EMAIL_DOMAINS`. Empty list means the provider accepts any domain it authenticates.
- Reuses the state/CSRF/PKCE helpers, `complete_login_flow` (extracted from the oauth-router closure to module level), and `oauth_callback`, so linking, session, and IdP-expiry offboarding are unchanged. The single-provider flow is preserved: the override defaults to None and 268 existing auth tests pass.
- Fixes a latent `oauth_callback` bug the live verification exposed: the adapter's `get_by_email` returns None instead of raising, so every new user under `associate_by_email=False` got `OAUTH_USER_ALREADY_EXISTS` instead of a JIT-provisioned account.

Follow-ups (separate PRs): a committed live-IdP integration test, id_token audience pinning, and SSRF protection on the discovery fetch.

## How Has This Been Tested?

Live two-IdP verification against a local Keycloak 26, plus unit tests.

- Stood up two Keycloak realms (two issuers) and seeded two `sso_provider` rows on one instance, gated to different email domains.
- Drove the full authorization-code flow for both providers end-to-end through the Next.js proxy: discovery fetch, IdP login, code exchange, userinfo, JIT user creation, session cookie. `/api/me` returns the right identity per provider and each user is linked with the right per-provider `oauth_name`.
- Negative case: a verified `companyb.com` user authenticating through the `companya.com`-gated provider is rejected ("Email domain is not valid"), no session, no user row.
- This flow caught the JIT provisioning bug above. Re-ran both flows green after the fix.
- Unit: 13 router tests (fail-closed resolution, client cache keying and config-rotation bust, state/CSRF/provider binding) plus the full auth suite, 470 passed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
