### PR TITLE
feat: canvas perm sync cleanup

### DIFF
--- a/backend/ee/onyx/external_permissions/canvas/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/canvas/doc_sync.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
-from typing import Any
 
+from ee.onyx.external_permissions.canvas.utils import credential_json
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsFunction
 from ee.onyx.external_permissions.perm_sync_types import FetchAllDocumentsIdsFunction
 from ee.onyx.external_permissions.utils import generic_doc_sync
@@ -13,14 +13,6 @@ from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 CANVAS_DOC_SYNC_TAG = "canvas_doc_sync"
 
 
-def _credential_json(cc_pair: ConnectorCredentialPair) -> dict[str, Any]:
-    return (
-        cc_pair.credential.credential_json.get_value(apply_mask=False)
-        if cc_pair.credential.credential_json
-        else {}
-    )
-
-
 def canvas_doc_sync(
     cc_pair: ConnectorCredentialPair,
     fetch_all_existing_docs_fn: FetchAllDocumentsFunction,  # noqa: ARG001
@@ -28,7 +20,7 @@ def canvas_doc_sync(
     callback: IndexingHeartbeatInterface | None = None,
 ) -> Generator[ElementExternalAccess, None, None]:
     canvas_connector = CanvasConnector(**cc_pair.connector.connector_specific_config)
-    canvas_connector.load_credentials(_credential_json(cc_pair))
+    canvas_connector.load_credentials(credential_json(cc_pair))
 
     yield from generic_doc_sync(
         cc_pair=cc_pair,

--- a/backend/ee/onyx/external_permissions/canvas/group_sync.py
+++ b/backend/ee/onyx/external_permissions/canvas/group_sync.py
@@ -1,8 +1,8 @@
 from collections.abc import Generator
-from typing import Any
 
 from ee.onyx.db.external_perm import ExternalUserGroup
 from ee.onyx.external_permissions.canvas.access import build_course_permission_context
+from ee.onyx.external_permissions.canvas.utils import credential_json
 from onyx.connectors.canvas.connector import canvas_all_users_group_id
 from onyx.connectors.canvas.connector import canvas_course_group_id
 from onyx.connectors.canvas.connector import canvas_group_group_id
@@ -13,14 +13,6 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-
-def _credential_json(cc_pair: ConnectorCredentialPair) -> dict[str, Any]:
-    return (
-        cc_pair.credential.credential_json.get_value(apply_mask=False)
-        if cc_pair.credential.credential_json
-        else {}
-    )
 
 
 def _fetch_account_user_emails(connector: CanvasConnector) -> set[str]:
@@ -50,25 +42,16 @@ def _fetch_canvas_group_emails(
     return user_emails
 
 
-def _referenced_canvas_group_ids(
+def _referenced_group_and_section_ids(
     connector: CanvasConnector,
     course_id: int,
-) -> set[int]:
+) -> tuple[set[int], set[int]]:
     group_ids: set[int] = set()
+    section_ids: set[int] = set()
     for assignment in connector._list_assignments(course_id):
         for override in assignment.overrides:
             if override.group_id is not None:
                 group_ids.add(override.group_id)
-    return group_ids
-
-
-def _referenced_section_ids(
-    connector: CanvasConnector,
-    course_id: int,
-) -> set[int]:
-    section_ids: set[int] = set()
-    for assignment in connector._list_assignments(course_id):
-        for override in assignment.overrides:
             if override.course_section_id is not None:
                 section_ids.add(override.course_section_id)
 
@@ -76,7 +59,7 @@ def _referenced_section_ids(
         for section in announcement.sections:
             section_ids.add(section.id)
 
-    return section_ids
+    return group_ids, section_ids
 
 
 def canvas_group_sync(
@@ -84,28 +67,28 @@ def canvas_group_sync(
     cc_pair: ConnectorCredentialPair,
 ) -> Generator[ExternalUserGroup, None, None]:
     connector = CanvasConnector(**cc_pair.connector.connector_specific_config)
-    connector.load_credentials(_credential_json(cc_pair))
+    connector.load_credentials(credential_json(cc_pair))
 
     should_emit_all_users = False
     for course in connector._list_courses():
         context = build_course_permission_context(connector.canvas_client, course.id)
-        course_emails = set(context.user_id_to_email.values())
+        course_user_emails = set(context.user_id_to_email.values())
         yield ExternalUserGroup(
             id=canvas_course_group_id(course.id),
-            user_emails=list(course_emails),
+            user_emails=list(course_user_emails),
         )
 
-        section_ids = set(context.section_id_to_emails) | _referenced_section_ids(
-            connector,
-            course.id,
+        group_ids, referenced_section_ids = _referenced_group_and_section_ids(
+            connector, course.id
         )
+        section_ids = set(context.section_id_to_emails) | referenced_section_ids
         for section_id in section_ids:
             yield ExternalUserGroup(
                 id=canvas_section_group_id(section_id),
                 user_emails=list(context.section_id_to_emails.get(section_id, set())),
             )
 
-        for group_id in _referenced_canvas_group_ids(connector, course.id):
+        for group_id in group_ids:
             yield ExternalUserGroup(
                 id=canvas_group_group_id(group_id),
                 user_emails=list(_fetch_canvas_group_emails(connector, group_id)),

--- a/backend/ee/onyx/external_permissions/canvas/utils.py
+++ b/backend/ee/onyx/external_permissions/canvas/utils.py
@@ -1,0 +1,11 @@
+from typing import Any
+
+from onyx.db.models import ConnectorCredentialPair
+
+
+def credential_json(cc_pair: ConnectorCredentialPair) -> dict[str, Any]:
+    return (
+        cc_pair.credential.credential_json.get_value(apply_mask=False)
+        if cc_pair.credential.credential_json
+        else {}
+    )

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -12,6 +12,9 @@ from ee.onyx.external_permissions.canvas.access import CanvasCoursePermissionCon
 from ee.onyx.external_permissions.canvas.access import get_announcement_permissions
 from ee.onyx.external_permissions.canvas.access import get_assignment_permissions
 from ee.onyx.external_permissions.canvas.access import get_page_permissions
+from ee.onyx.external_permissions.canvas.group_sync import (
+    _referenced_group_and_section_ids,
+)
 from onyx.access.models import ExternalAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.canvas.client import CanvasApiClient
@@ -1819,6 +1822,44 @@ class TestRetrieveAllSlimDocsPermSync:
         ):
             with pytest.raises(RuntimeError, match="permission lookup failed"):
                 list(connector.retrieve_all_slim_docs_perm_sync())
+
+
+class TestCanvasGroupSyncHelpers:
+    def test_referenced_ids_fetch_assignments_once(self) -> None:
+        connector = MagicMock(spec=CanvasConnector)
+        connector._list_assignments.return_value = [
+            CanvasAssignment(
+                id=20,
+                name="Group override",
+                html_url=f"{FAKE_BASE_URL}/courses/1/assignments/20",
+                course_id=1,
+                overrides=[CanvasAssignmentOverride(group_id=99)],
+            ),
+            CanvasAssignment(
+                id=21,
+                name="Section override",
+                html_url=f"{FAKE_BASE_URL}/courses/1/assignments/21",
+                course_id=1,
+                overrides=[CanvasAssignmentOverride(course_section_id=10)],
+            ),
+        ]
+        connector._list_announcements.return_value = [
+            CanvasAnnouncement(
+                id=30,
+                title="Section announcement",
+                html_url=f"{FAKE_BASE_URL}/courses/1/discussion_topics/30",
+                course_id=1,
+                is_section_specific=True,
+                sections=[CanvasAnnouncementSection(id=11)],
+            )
+        ]
+
+        group_ids, section_ids = _referenced_group_and_section_ids(connector, 1)
+
+        assert group_ids == {99}
+        assert section_ids == {10, 11}
+        connector._list_assignments.assert_called_once_with(1)
+        connector._list_announcements.assert_called_once_with(1)
 
 
 class TestCanvasPermissionMapping:


### PR DESCRIPTION
## Description

some cleanup from PR #12729 

## How Has This Been Tested?

tests from prev PR

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleaned up Canvas permission sync by extracting a shared credential helper and unifying group/section ID discovery to cut duplicate API calls and simplify code.

- **Refactors**
  - Add shared `credential_json` in `ee.onyx.external_permissions.canvas.utils` and use it in doc/group sync to load `CanvasConnector` credentials.
  - Replace separate helpers with `_referenced_group_and_section_ids` to collect group and section IDs in one pass; update group sync to emit memberships from it.
  - Add a unit test to ensure assignments and announcements are fetched exactly once.

<sup>Written for commit f0bab80e294d46ba90947d4864e9b71531680d4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

