### PR TITLE
fix(auth): sync in-memory oidc_expiry after OAuth refresh [v4.3]

### DIFF
--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -259,6 +259,7 @@ async def refresh_oauth_token(
                     await user_manager.user_db.update(
                         user, {"oidc_expiry": oidc_expiry}
                     )
+                    user.oidc_expiry = oidc_expiry
 
             # Update the OAuth account
             await user_manager.user_db.update_oauth_account(  # ty: ignore[invalid-argument-type]


### PR DESCRIPTION
## Description

Backport of #12760 to `release/v4.3`.

`refresh_oauth_token` was writing the refreshed `oidc_expiry` to the DB but not updating the in-memory `user` object. `double_check_user` then read the stale (already-expired) value and returned 403 immediately after a successful refresh, causing EE users to see the "You have been logged out" modal every ~15 minutes.

Fix: add `user.oidc_expiry = oidc_expiry` after the DB write — one line, mirrors the pattern `_sync_jwt_oidc_expiry` already uses.

## How Has This Been Tested?

Covered by the original PR (#12760).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the in-memory `oidc_expiry` with the refreshed OAuth value so `double_check_user` reads the correct expiry and no longer returns 403 right after refresh. This removes the periodic "You have been logged out" modal EE users saw roughly every 15 minutes.

<sup>Written for commit 5e3a224ebb5fe2352a5c4436bf3ed2299c573069. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

