### PR TITLE
feat: add MiniMax LLM provider

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -27,6 +27,7 @@ class LlmProviderNames(str, Enum):
     LITELLM_PROXY = "litellm_proxy"
     BIFROST = "bifrost"
     OPENAI_COMPATIBLE = "openai_compatible"
+    MINIMAX = "minimax"
     NEBIUS_TOKENFACTORY = "nebius_tokenfactory"
 
     def __str__(self) -> str:
@@ -49,6 +50,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.LITELLM_PROXY,
     LlmProviderNames.BIFROST,
     LlmProviderNames.OPENAI_COMPATIBLE,
+    LlmProviderNames.MINIMAX,
     LlmProviderNames.NEBIUS_TOKENFACTORY,
 ]
 
@@ -69,6 +71,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.LITELLM_PROXY: "LiteLLM Proxy",
     LlmProviderNames.BIFROST: "Bifrost",
     LlmProviderNames.OPENAI_COMPATIBLE: "OpenAI-Compatible",
+    LlmProviderNames.MINIMAX: "MiniMax",
     LlmProviderNames.NEBIUS_TOKENFACTORY: "Nebius TokenFactory",
     "groq": "Groq",
     "anyscale": "Anyscale",

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -47,6 +47,7 @@ from onyx.llm.well_known_providers.constants import (
     AWS_SECRET_ACCESS_KEY_KWARG_ENV_VAR_FORMAT,
 )
 from onyx.llm.well_known_providers.constants import LM_STUDIO_API_KEY_CONFIG_KEY
+from onyx.llm.well_known_providers.constants import MINIMAX_API_BASE
 from onyx.llm.well_known_providers.constants import OLLAMA_API_KEY_CONFIG_KEY
 from onyx.llm.well_known_providers.constants import VERTEX_AUTH_METHOD_KWARG
 from onyx.llm.well_known_providers.constants import VERTEX_AUTH_METHOD_WORKLOAD_IDENTITY
@@ -425,6 +426,7 @@ class LitellmLLM(LLM):
         if model_provider in (
             LlmProviderNames.BIFROST,
             LlmProviderNames.OPENAI_COMPATIBLE,
+            LlmProviderNames.MINIMAX,
             LlmProviderNames.NEBIUS_TOKENFACTORY,
         ):
             self._custom_llm_provider = "openai"
@@ -433,6 +435,8 @@ class LitellmLLM(LLM):
             # placeholder to prevent LiteLLM from raising AuthenticationError.
             if not self._api_key:
                 model_kwargs.setdefault("api_key", "not-needed")
+            if self._api_base is None and model_provider == LlmProviderNames.MINIMAX:
+                self._api_base = MINIMAX_API_BASE
             if self._api_base is not None:
                 base = self._api_base.rstrip("/")
                 self._api_base = base if base.endswith("/v1") else f"{base}/v1"
@@ -554,6 +558,7 @@ class LitellmLLM(LLM):
         is_openai_compatible_proxy = self._model_provider in (
             LlmProviderNames.BIFROST,
             LlmProviderNames.OPENAI_COMPATIBLE,
+            LlmProviderNames.MINIMAX,
             LlmProviderNames.NEBIUS_TOKENFACTORY,
         )
         model_provider = (

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -51,15 +51,30 @@ _TWELVE_LABS_PEGASUS_MODEL_NAMES = [
     "twelvelabs/us.twelvelabs.pegasus-1-2-v1",
 ]
 _TWELVE_LABS_PEGASUS_OUTPUT_TOKENS = max(512, GEN_AI_MODEL_FALLBACK_MAX_TOKENS // 4)
+_MINIMAX_M3_MODEL_NAMES = ["MiniMax-M3", "minimax/MiniMax-M3"]
 CUSTOM_LITELLM_MODEL_OVERRIDES: dict[str, dict[str, Any]] = {
-    model_name: {
-        "max_input_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
-        "max_output_tokens": _TWELVE_LABS_PEGASUS_OUTPUT_TOKENS,
-        "max_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
-        "supports_reasoning": False,
-        "supports_vision": False,
-    }
-    for model_name in _TWELVE_LABS_PEGASUS_MODEL_NAMES
+    **{
+        model_name: {
+            "input_cost_per_token": 0.6 / ONE_MILLION,
+            "output_cost_per_token": 2.4 / ONE_MILLION,
+            "cache_read_input_token_cost": 0.12 / ONE_MILLION,
+            "max_input_tokens": ONE_MILLION,
+            "max_tokens": ONE_MILLION,
+            "supports_reasoning": False,
+            "supports_vision": False,
+        }
+        for model_name in _MINIMAX_M3_MODEL_NAMES
+    },
+    **{
+        model_name: {
+            "max_input_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+            "max_output_tokens": _TWELVE_LABS_PEGASUS_OUTPUT_TOKENS,
+            "max_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+            "supports_reasoning": False,
+            "supports_vision": False,
+        }
+        for model_name in _TWELVE_LABS_PEGASUS_MODEL_NAMES
+    },
 }
 
 

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -17,6 +17,9 @@ BIFROST_PROVIDER_NAME = "bifrost"
 
 OPENAI_COMPATIBLE_PROVIDER_NAME = "openai_compatible"
 
+MINIMAX_PROVIDER_NAME = "minimax"
+MINIMAX_API_BASE = "https://api.minimax.io/v1"
+
 NEBIUS_TOKENFACTORY_PROVIDER_NAME = "nebius_tokenfactory"
 
 # Providers that use optional Bearer auth from custom_config

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -18,6 +18,7 @@ from onyx.llm.well_known_providers.constants import BEDROCK_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import BIFROST_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import LITELLM_PROXY_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import LM_STUDIO_PROVIDER_NAME
+from onyx.llm.well_known_providers.constants import MINIMAX_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import NEBIUS_TOKENFACTORY_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OLLAMA_PROVIDER_NAME
 from onyx.llm.well_known_providers.constants import OPENAI_COMPATIBLE_PROVIDER_NAME
@@ -54,6 +55,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
         LITELLM_PROXY_PROVIDER_NAME: [],  # Dynamic - fetched from LiteLLM proxy API
         BIFROST_PROVIDER_NAME: [],  # Dynamic - fetched from Bifrost API
         OPENAI_COMPATIBLE_PROVIDER_NAME: [],  # Dynamic - fetched from OpenAI-compatible API
+        MINIMAX_PROVIDER_NAME: ["MiniMax-M3"],
         NEBIUS_TOKENFACTORY_PROVIDER_NAME: [],  # Dynamic - fetched from /v1/models
     }
 
@@ -349,6 +351,7 @@ def get_provider_display_name(provider_name: str) -> str:
         OPENROUTER_PROVIDER_NAME: "OpenRouter",
         LITELLM_PROXY_PROVIDER_NAME: "LiteLLM Proxy",
         OPENAI_COMPATIBLE_PROVIDER_NAME: "OpenAI-Compatible",
+        MINIMAX_PROVIDER_NAME: "MiniMax",
         NEBIUS_TOKENFACTORY_PROVIDER_NAME: "Nebius TokenFactory",
     }
 

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -68,6 +68,15 @@
           "display_name": "Kimi K2.6"
         }
       ]
+    },
+    "minimax": {
+      "default_model": "MiniMax-M3",
+      "additional_visible_models": [
+        {
+          "name": "MiniMax-M3",
+          "display_name": "MiniMax M3"
+        }
+      ]
     }
   }
 }

--- a/backend/tests/unit/onyx/llm/test_model_map.py
+++ b/backend/tests/unit/onyx/llm/test_model_map.py
@@ -132,3 +132,19 @@ def test_twelvelabs_pegasus_override_present() -> None:
         assert model_obj["supports_reasoning"] is False
     finally:
         get_model_map.cache_clear()
+
+
+def test_minimax_m3_override_present() -> None:
+    get_model_map.cache_clear()
+    try:
+        model_map = get_model_map()
+        model_obj = find_model_obj(model_map, LlmProviderNames.MINIMAX, "MiniMax-M3")
+        assert model_obj is not None
+        assert model_obj["max_input_tokens"] == 1_000_000
+        assert model_obj["max_tokens"] == 1_000_000
+        assert model_obj["input_cost_per_token"] == 0.6 / 1_000_000
+        assert model_obj["output_cost_per_token"] == 2.4 / 1_000_000
+        assert model_obj["cache_read_input_token_cost"] == 0.12 / 1_000_000
+        assert model_obj["supports_reasoning"] is False
+    finally:
+        get_model_map.cache_clear()

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -36,6 +36,7 @@ import LMStudioModal from "@/sections/modals/languageModels/LMStudioModal";
 import LiteLLMProxyModal from "@/sections/modals/languageModels/LiteLLMProxyModal";
 import BifrostModal from "@/sections/modals/languageModels/BifrostModal";
 import OpenAICompatibleModal from "@/sections/modals/languageModels/OpenAICompatibleModal";
+import MiniMaxModal from "@/sections/modals/languageModels/MiniMaxModal";
 import NebiusTokenfactoryModal from "@/sections/modals/languageModels/NebiusTokenfactoryModal";
 
 // ─── Text (LLM) providers ────────────────────────────────────────────────────
@@ -120,6 +121,12 @@ const PROVIDERS: Record<string, ProviderEntry> = {
     companyName: "OpenAI-Compatible",
     Modal: OpenAICompatibleModal,
   },
+  [LLMProviderName.MINIMAX]: {
+    icon: SvgPlug,
+    productName: "MiniMax",
+    companyName: "MiniMax",
+    Modal: MiniMaxModal,
+  },
   [LLMProviderName.NEBIUS_TOKENFACTORY]: {
     icon: SvgNebius,
     productName: "Nebius TokenFactory",
@@ -200,6 +207,7 @@ const MODEL_ICON_MAP: Record<string, IconFunctionComponent> = {
   [LLMProviderName.LITELLM_PROXY]: SvgLitellm,
   [LLMProviderName.BIFROST]: SvgBifrost,
   [LLMProviderName.OPENAI_COMPATIBLE]: SvgPlug,
+  [LLMProviderName.MINIMAX]: SvgPlug,
   [LLMProviderName.NEBIUS_TOKENFACTORY]: SvgNebius,
 
   amazon: SvgAws,

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -43,6 +43,7 @@ export enum LLMProviderName {
   LITELLM_PROXY = "litellm_proxy",
   BIFROST = "bifrost",
   OPENAI_COMPATIBLE = "openai_compatible",
+  MINIMAX = "minimax",
   NEBIUS_TOKENFACTORY = "nebius_tokenfactory",
   CUSTOM = "custom",
 }

--- a/web/src/sections/modals/languageModels/MiniMaxModal.tsx
+++ b/web/src/sections/modals/languageModels/MiniMaxModal.tsx
@@ -1,0 +1,15 @@
+import { LLMProviderFormProps, LLMProviderName } from "@/lib/languageModels/types";
+import { OpenAICompatibleModal } from "@/sections/modals/languageModels/OpenAICompatibleModal";
+
+const MINIMAX_API_BASE = "https://api.minimax.io/v1";
+
+export default function MiniMaxModal(props: LLMProviderFormProps) {
+  return (
+    <OpenAICompatibleModal
+      {...props}
+      providerName={LLMProviderName.MINIMAX}
+      defaultApiBase={MINIMAX_API_BASE}
+      description="Connect to MiniMax models through MiniMax's OpenAI-compatible endpoint."
+    />
+  );
+}

--- a/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenAICompatibleModal.tsx
@@ -102,13 +102,22 @@ function OpenAICompatibleModalInternals({
   );
 }
 
-export default function OpenAICompatibleModal({
+interface OpenAICompatibleModalProps extends LLMProviderFormProps {
+  providerName?: LLMProviderName;
+  defaultApiBase?: string;
+  description?: string;
+}
+
+export function OpenAICompatibleModal({
   variant = "llm-configuration",
   existingLlmProvider,
   shouldMarkAsDefault,
   onOpenChange,
   onSuccess,
-}: LLMProviderFormProps) {
+  providerName = LLMProviderName.OPENAI_COMPATIBLE,
+  defaultApiBase,
+  description = "Connect from other cloud or self-hosted models via OpenAI-compatible endpoints.",
+}: OpenAICompatibleModalProps) {
   const isOnboarding = variant === "onboarding";
   const { mutate } = useSWRConfig();
 
@@ -116,9 +125,13 @@ export default function OpenAICompatibleModal({
 
   const initialValues = useInitialValues(
     isOnboarding,
-    LLMProviderName.OPENAI_COMPATIBLE,
+    providerName,
     existingLlmProvider
   ) as OpenAICompatibleModalValues;
+
+  if (!initialValues.api_base && defaultApiBase) {
+    initialValues.api_base = defaultApiBase;
+  }
 
   const validationSchema = buildValidationSchema(isOnboarding, {
     apiBase: true,
@@ -126,18 +139,18 @@ export default function OpenAICompatibleModal({
 
   return (
     <ModalWrapper
-      providerName={LLMProviderName.OPENAI_COMPATIBLE}
+      providerName={providerName}
       llmProvider={existingLlmProvider}
       onClose={onClose}
       initialValues={initialValues}
-      description="Connect from other cloud or self-hosted models via OpenAI-compatible endpoints."
+      description={description}
       validationSchema={validationSchema}
       onSubmit={async (values, { setSubmitting, setStatus }) => {
         await submitProvider({
           analyticsSource: isOnboarding
             ? LLMProviderConfiguredSource.CHAT_ONBOARDING
             : LLMProviderConfiguredSource.ADMIN_PAGE,
-          providerName: LLMProviderName.OPENAI_COMPATIBLE,
+          providerName,
           values,
           initialValues,
           existingLlmProvider,
@@ -167,3 +180,5 @@ export default function OpenAICompatibleModal({
     </ModalWrapper>
   );
 }
+
+export default OpenAICompatibleModal;

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -58,6 +58,7 @@ const PROVIDER_DISPLAY_ORDER: string[] = [
   LLMProviderName.LM_STUDIO,
   LLMProviderName.BIFROST,
   LLMProviderName.OPENAI_COMPATIBLE,
+  LLMProviderName.MINIMAX,
   LLMProviderName.NEBIUS_TOKENFACTORY,
 ];
 


### PR DESCRIPTION
## Summary
- Register MiniMax as a well-known LLM provider across backend and admin UI registries.
- Add MiniMax-M3 defaults, context/pricing metadata, and an OpenAI-compatible setup flow with MiniMax's default API base.
- Cover the MiniMax-M3 model override in the existing model map unit tests.

## Test plan
- [x] Validate recommended-models.json parses as JSON
- [x] Run changed-file secret scan
- [x] Run git diff --check
- [x] Run Python AST syntax check for changed backend Python files
- [ ] Run pytest backend/tests/unit/onyx/llm/test_model_map.py -q (blocked: system Python has no pytest installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add MiniMax as a first-class LLM provider with an OpenAI-compatible setup and built-in support for the `MiniMax-M3` model, including pricing and 1M token context. This enables quick MiniMax configuration in the admin UI with a dedicated modal and sensible defaults.

- **New Features**
  - Backend: added `minimax` provider enum, display name, and default API base (`https://api.minimax.io/v1`); treated as OpenAI-compatible for routing.
  - Model metadata: added overrides for `MiniMax-M3` (1,000,000 max tokens, pricing, cache read cost).
  - Recommendations: added `minimax` with default model `MiniMax-M3`.
  - Admin UI: added `MiniMax` provider with `MiniMaxModal` using the OpenAI-compatible flow; updated provider list and icons.

- **Refactors**
  - Generalized `OpenAICompatibleModal` to accept `providerName`, `defaultApiBase`, and `description`; reused for `MiniMax`.
  - Added unit test to validate the `MiniMax-M3` model overrides.

<sup>Written for commit d690b9fcb69068c3b0a7514186a0878119eeabd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

