### PR TITLE
feat(userfile-port): new-file dual-write + reconcile swap gate

### DIFF
--- a/backend/alembic/versions/f0ff4d3e69ac_rename_user_file_secondary_only_sync_.py
+++ b/backend/alembic/versions/f0ff4d3e69ac_rename_user_file_secondary_only_sync_.py
@@ -1,0 +1,41 @@
+"""rename user_file secondary_only_sync_pending to secondary_reconcile_pending
+
+Revision ID: f0ff4d3e69ac
+Revises: e3e324f5d32c
+Create Date: 2026-07-09 15:32:03.179317
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "f0ff4d3e69ac"
+down_revision = "e3e324f5d32c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # The user-file flag covers content too (not just an ACL "sync"), so name it for the
+    # reconcile. RENAME COLUMN carries the partial index predicate; rename the index to match.
+    # Metadata-only renames — no rewrite, no CONCURRENTLY.
+    op.execute(
+        "ALTER TABLE user_file "
+        "RENAME COLUMN secondary_only_sync_pending TO secondary_reconcile_pending"
+    )
+    op.execute(
+        "ALTER INDEX ix_user_file_secondary_only_sync_pending "
+        "RENAME TO ix_user_file_secondary_reconcile_pending"
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "ALTER INDEX ix_user_file_secondary_reconcile_pending "
+        "RENAME TO ix_user_file_secondary_only_sync_pending"
+    )
+    op.execute(
+        "ALTER TABLE user_file "
+        "RENAME COLUMN secondary_reconcile_pending TO secondary_only_sync_pending"
+    )

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -39,12 +39,15 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import UserFileStatus
+from onyx.db.models import SearchSettings
 from onyx.db.models import UserFile
 from onyx.db.port_attempt import port_backfill_has_pending_work
 from onyx.db.port_orphan_candidate import record_port_orphan_candidates_for_user_file
+from onyx.db.search_settings import active_secondary_port_target
 from onyx.db.search_settings import get_active_search_settings
 from onyx.db.search_settings import get_active_search_settings_list
 from onyx.db.user_file import fetch_user_files_with_access_relationships
+from onyx.db.user_file import mark_user_file_reconcile_pending
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
 from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
@@ -321,6 +324,46 @@ def _process_user_file_without_vector_db(
     )
 
 
+def _load_user_file_documents(
+    user_file_id: str,
+    file_id: str,
+    file_name: str | None,
+    tenant_id: str,
+) -> tuple[list[Document], list[str]]:
+    """Parse a user file's blob into indexable Documents (id/source stamped), plus the ids of
+    any CSVs staged for tabular sections — the caller reaps them after indexing reads them. A
+    load failure reaps its own staged files before re-raising (the caller gets no id list)."""
+    connector = LocalFileConnector(
+        file_locations=[file_id],
+        file_names=[file_name] if file_name else None,
+    )
+    connector.load_credentials({})
+
+    # User files aren't attempt-scoped, so the docfetching staging reapers don't cover them.
+    staging_callback, staged_csv_ids = build_tracking_raw_file_callback(
+        metadata={"user_file_id": str(user_file_id), "tenant_id": tenant_id}
+    )
+    connector.set_raw_file_callback(staging_callback)
+
+    documents: list[Document] = []
+    try:
+        for batch in connector.load_from_state():
+            documents.extend(
+                [doc for doc in batch if not isinstance(doc, HierarchyNode)]
+            )
+    except Exception:
+        delete_files_best_effort(
+            staged_csv_ids,
+            context=f"user-file load-failure staging cleanup uf={user_file_id}",
+        )
+        raise
+
+    for document in documents:
+        document.id = str(user_file_id)
+        document.source = DocumentSource.USER_FILE
+    return documents, staged_csv_ids
+
+
 def _process_user_file_with_indexing(
     user_file_id: str,
     documents: list[Document],
@@ -392,6 +435,131 @@ def _process_user_file_with_indexing(
                 db_session.commit()
         raise RuntimeError(f"Indexing pipeline failed for user file {user_file_id}")
 
+    _dual_write_new_file_to_secondary(user_file_id, documents, tenant_id)
+
+
+def _index_user_file_to_secondary(
+    user_file_id: str,
+    documents: list[Document],
+    secondary: SearchSettings,
+    tenant_id: str,
+) -> None:
+    """Index one user file into the secondary (reindex-port target) index, re-embedding with
+    its model. `index_to_secondary=True` makes the adapter skip the terminal side-effects the
+    PRESENT pass already applied. Raises on an incomplete write; the caller owns the flag."""
+    embedder = DefaultIndexingEmbedder.from_db_search_settings(
+        search_settings=secondary,
+    )
+    document_indices = get_all_document_indices(
+        secondary,
+        None,
+        httpx_client=HttpxPool.get("vespa"),
+    )
+    with get_session_with_current_tenant() as db_session:
+        adapter = UserFileIndexingAdapter(
+            tenant_id=tenant_id,
+            db_session=db_session,
+        )
+        result = run_indexing_pipeline(
+            embedder=embedder,
+            document_indices=document_indices,
+            ignore_time_skip=True,
+            # skip the content_hash gate, else the PRESENT run's hash no-ops this write
+            index_to_secondary=True,
+            db_session=db_session,
+            tenant_id=tenant_id,
+            document_batch=documents,
+            request_id=None,
+            adapter=adapter,
+        )
+    if (
+        result.failures
+        or result.total_docs != len(documents)
+        or result.total_chunks == 0
+    ):
+        raise RuntimeError(
+            f"secondary index write incomplete for user file {user_file_id}: {result}"
+        )
+
+
+def _dual_write_new_file_to_secondary(
+    user_file_id: str, documents: list[Document], tenant_id: str
+) -> None:
+    """During a reindex-port, also index a freshly-processed file into the secondary target so
+    it isn't missing at swap. Target resolved fresh (catches a file crossing kickoff). Isolated:
+    a failure only flags the file for the reconciler, never touching live status."""
+    with get_session_with_current_tenant() as db_session:
+        secondary = active_secondary_port_target(db_session)
+    if secondary is None:
+        return
+    try:
+        _index_user_file_to_secondary(user_file_id, documents, secondary, tenant_id)
+    except Exception as e:
+        task_logger.exception(
+            f"_dual_write_new_file_to_secondary - failed id={user_file_id}; "
+            f"flagging for reconcile - {e.__class__.__name__}"
+        )
+        with get_session_with_current_tenant() as db_session:
+            mark_user_file_reconcile_pending(db_session, _as_uuid(user_file_id))
+
+
+def _supply_user_file_to_secondary(user_file_id: str, tenant_id: str) -> bool:
+    """The reconciler's 404 fallback: (re)supply a user file's content to the secondary target
+    when a metadata update() found it missing. Returns True if the content landed (flag can
+    clear), False to keep the flag — no target (INSTANT self-heals via the port) or the write
+    failed (retried next scan)."""
+    with get_session_with_current_tenant() as db_session:
+        secondary = active_secondary_port_target(db_session)
+        user_file = db_session.get(UserFile, _as_uuid(user_file_id))
+        file_id = user_file.file_id if user_file is not None else None
+        file_name = user_file.name if user_file is not None else None
+    if secondary is None or file_id is None:
+        return False
+
+    # Fully isolated: any failure keeps the flag and never propagates into the sync task.
+    # The loader self-reaps on a load failure, so staged_csv_ids stays empty there.
+    staged_csv_ids: list[str] = []
+    try:
+        documents, staged_csv_ids = _load_user_file_documents(
+            user_file_id, file_id, file_name, tenant_id
+        )
+        _index_user_file_to_secondary(user_file_id, documents, secondary, tenant_id)
+        return True
+    except Exception as e:
+        task_logger.exception(
+            f"_supply_user_file_to_secondary - failed id={user_file_id} "
+            f"- {e.__class__.__name__}"
+        )
+        return False
+    finally:
+        delete_files_best_effort(
+            staged_csv_ids,
+            context=f"user-file secondary supply staging cleanup uf={user_file_id}",
+        )
+
+
+def _sync_metadata_and_reconcile_secondary(
+    retry_indices: list[RetryDocumentIndex],
+    update_request: MetadataUpdateRequest,
+    user_file_id: str,
+    tenant_id: str,
+) -> bool:
+    """Apply the metadata update to every index; if the secondary is still porting and lacks
+    the doc, supply its content instead. Returns whether the secondary now matches PRESENT."""
+    secondary_missing = False
+    for retry_index in retry_indices:
+        try:
+            retry_index.update([update_request])
+        except SecondaryIndexDocumentMissingError:
+            task_logger.debug(
+                f"user_file={user_file_id} missing from a still-porting index; "
+                "supplying content."
+            )
+            secondary_missing = True
+    if not secondary_missing:
+        return True
+    return _supply_user_file_to_secondary(user_file_id, tenant_id)
+
 
 def process_user_file_impl(
     *, user_file_id: str, tenant_id: str, redis_locking: bool
@@ -444,42 +612,27 @@ def process_user_file_impl(
             file_name = uf.name
         # DB connection returned to pool here; file I/O and indexing run without it.
 
-        connector = LocalFileConnector(
-            file_locations=[file_id],
-            file_names=[file_name] if file_name else None,
-        )
-        connector.load_credentials({})
-
-        # User files aren't attempt-scoped, so the docfetching staging reapers
-        # don't cover them. Track CSVs staged for tabular sections and reap them
-        # ourselves once indexing (which reads them) has run.
-        staging_callback, staged_csv_ids = build_tracking_raw_file_callback(
-            metadata={"user_file_id": str(user_file_id), "tenant_id": tenant_id}
-        )
-        connector.set_raw_file_callback(staging_callback)
-
         try:
-            for batch in connector.load_from_state():
-                documents.extend(
-                    [doc for doc in batch if not isinstance(doc, HierarchyNode)]
+            documents, staged_csv_ids = _load_user_file_documents(
+                user_file_id, file_id, file_name, tenant_id
+            )
+            try:
+                if DISABLE_VECTOR_DB:
+                    _process_user_file_without_vector_db(
+                        user_file_id=user_file_id,
+                        documents=documents,
+                    )
+                else:
+                    _process_user_file_with_indexing(
+                        user_file_id=user_file_id,
+                        documents=documents,
+                        tenant_id=tenant_id,
+                    )
+            finally:
+                delete_files_best_effort(
+                    staged_csv_ids,
+                    context=f"user-file tabular staging cleanup uf={user_file_id}",
                 )
-
-            for document in documents:
-                document.id = str(user_file_id)
-                document.source = DocumentSource.USER_FILE
-
-            if DISABLE_VECTOR_DB:
-                _process_user_file_without_vector_db(
-                    user_file_id=user_file_id,
-                    documents=documents,
-                )
-            else:
-                _process_user_file_with_indexing(
-                    user_file_id=user_file_id,
-                    documents=documents,
-                    tenant_id=tenant_id,
-                )
-
         except Exception as e:
             task_logger.exception(
                 f"process_user_file_impl - Error processing file id={user_file_id} - {e.__class__.__name__}"
@@ -494,11 +647,6 @@ def process_user_file_impl(
                     db_session.add(current_user_file)
                     db_session.commit()
             return
-        finally:
-            delete_files_best_effort(
-                staged_csv_ids,
-                context=f"user-file tabular staging cleanup uf={user_file_id}",
-            )
 
         elapsed = time.monotonic() - start
         task_logger.info(
@@ -812,8 +960,8 @@ def check_for_user_file_project_sync(self: Task, *, tenant_id: str) -> None:
                             sa.or_(
                                 UserFile.needs_project_sync.is_(True),
                                 UserFile.needs_persona_sync.is_(True),
-                                # re-enqueue port-deferred files so the drain retries
-                                UserFile.secondary_only_sync_pending.is_(True),
+                                # re-enqueue un-reconciled files so the reconciler retries
+                                UserFile.secondary_reconcile_pending.is_(True),
                             ),
                             UserFile.status == UserFileStatus.COMPLETED,
                         )
@@ -928,10 +1076,10 @@ def project_sync_user_file_impl(
                 chunk_count = user_file.chunk_count
                 access_map = build_access_for_user_files([user_file])
                 access = access_map.get(file_id_str)
-        # DB connection returned to pool here; Vespa HTTP calls run without it.
+        # DB connection returned to pool here; index update calls run without it.
 
-        # Phase 2: Vespa HTTP calls (no DB session held)
-        port_index_missing = False
+        # Phase 2: index update calls (no DB session held)
+        secondary_consistent = True
         if not skip_vespa:
             update_request = MetadataUpdateRequest(
                 document_ids=[file_id_str],
@@ -942,16 +1090,9 @@ def project_sync_user_file_impl(
                 project_ids=set(project_ids),
                 persona_ids=set(persona_ids),
             )
-            for retry_document_index in retry_document_indices:
-                try:
-                    retry_document_index.update([update_request])
-                except SecondaryIndexDocumentMissingError:
-                    # Not yet ported to FUTURE (or the INSTANT-promoted primary): defer
-                    # via the flag. The port supplies content; a later scan lands the ACL.
-                    task_logger.debug(
-                        f"user_file={file_id_str} not in a still-porting index; deferring sync."
-                    )
-                    port_index_missing = True
+            secondary_consistent = _sync_metadata_and_reconcile_secondary(
+                retry_document_indices, update_request, user_file_id, tenant_id
+            )
 
         task_logger.info(f"project_sync_user_file_impl - User file id={user_file_id}")
 
@@ -964,10 +1105,11 @@ def project_sync_user_file_impl(
                 user_file.last_project_sync_at = datetime.datetime.now(
                     datetime.timezone.utc
                 )
-                # Defer only a portable (COMPLETED) file — a non-portable one is never
-                # ported, so its flag would never drain (leave it synced instead).
-                user_file.secondary_only_sync_pending = (
-                    port_index_missing and user_file.status == UserFileStatus.COMPLETED
+                # Flag only a portable (COMPLETED) file — a non-portable one is never ported,
+                # so its flag would never reconcile (leave it clear instead).
+                user_file.secondary_reconcile_pending = (
+                    not secondary_consistent
+                    and user_file.status == UserFileStatus.COMPLETED
                 )
                 db_session.add(user_file)
                 db_session.commit()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5207,9 +5207,10 @@ class UserFile(Base):
     needs_persona_sync: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False
     )
-    # reindex port: FUTURE stale/missing for this file (content and/or ACL); the
-    # swap waits on it. Mirrors Document.secondary_only_sync_pending.
-    secondary_only_sync_pending: Mapped[bool] = mapped_column(
+    # reindex-port dirty bit: the secondary index is stale/missing for this file (content
+    # and/or ACL). The reconciler drains it; the swap waits on it. (Document has an ACL-only
+    # analog, secondary_only_sync_pending — this one is broader, hence "reconcile".)
+    secondary_reconcile_pending: Mapped[bool] = mapped_column(
         Boolean, nullable=False, default=False, server_default=text("false")
     )
     last_project_sync_at: Mapped[datetime.datetime | None] = mapped_column(
@@ -5232,9 +5233,9 @@ class UserFile(Base):
 
     __table_args__ = (
         Index(
-            "ix_user_file_secondary_only_sync_pending",
+            "ix_user_file_secondary_reconcile_pending",
             "id",
-            postgresql_where=text("secondary_only_sync_pending IS TRUE"),
+            postgresql_where=text("secondary_reconcile_pending IS TRUE"),
         ),
         # back the port scheduler's per-user cursor scan + COMPLETED enumeration
         Index("ix_user_file_user_status_id", "user_id", "status", "id"),

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -196,8 +196,8 @@ def _user_file_port_has_pending_work(
     — the row-aware form reintroduces the fixed cap-predicate stall. Users have no
     paused concept, so the set is switchover-agnostic.
 
-    Deliberately NOT gated on secondary_only_sync_pending: that flag is drained by the
-    sync path (which writes the promoted index from blob/DB, never the source), so it
+    Deliberately NOT gated on secondary_reconcile_pending: that flag is drained by the
+    reconciler (which writes the promoted index from blob/DB, never the source), so it
     must not pin the source — it gates the non-INSTANT swap instead (_port_swap_ready).
     """
     portable_users = set(fetch_port_scope_user_ids(db_session))

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -179,6 +179,16 @@ def get_search_settings_by_id(
     return db_session.get(SearchSettings, search_settings_id)
 
 
+def active_secondary_port_target(db_session: Session) -> SearchSettings | None:
+    """The secondary index a reindex-port is populating (the dual-write target), or None.
+    Pure — never unpins a drained INSTANT source (unlike _resolve_port_target_settings).
+    None after an INSTANT swap: FUTURE was promoted to current, so the live pass covers it."""
+    secondary = get_secondary_search_settings(db_session)
+    if secondary is not None and secondary.use_port_flow:
+        return secondary
+    return None
+
+
 def get_active_search_settings(db_session: Session) -> ActiveSearchSettings:
     """Returns active search settings. Secondary search settings may be None."""
 

--- a/backend/onyx/db/swap_index.py
+++ b/backend/onyx/db/swap_index.py
@@ -32,6 +32,7 @@ from onyx.db.port_attempt import get_latest_port_attempt
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.search_settings import update_search_settings_status
+from onyx.db.user_file import any_user_file_reconcile_pending_for_users
 from onyx.db.user_file import fetch_port_scope_user_ids
 from onyx.document_index.factory import get_all_document_indices
 from onyx.key_value_store.factory import get_kv_store
@@ -224,11 +225,12 @@ def _port_swap_ready(
     if not all_user_scopes_ported(db_session, ss_id, required_user_ids):
         return False
 
-    # No user-file secondary-pending gate here yet. The metadata sync only update()s
-    # FUTURE — it can't create a doc the port never copied (a file uploaded after the
-    # user's port settled, or whose id is beyond the attempt's snapshot bound). Such a
-    # file would set secondary_only_sync_pending forever, so gating on it would deadlock
-    # the swap. Gate on it only once new user files are also dual-written to FUTURE.
+    # Hold the swap until every user file's FUTURE copy reconciles. Safe only because new files
+    # dual-write to FUTURE and the reconciler supplies content on a 404, so every flag drains
+    # (an update()-only drain would pin a never-copied file forever and deadlock).
+    if any_user_file_reconcile_pending_for_users(db_session, required_user_ids):
+        return False
+
     return (
         count_secondary_only_sync_pending_documents_for_cc_pairs(
             db_session, [cc_pair.id for cc_pair in required_cc_pairs]

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -242,38 +242,59 @@ def user_file_port_scope_active(db_session: Session, user_id: UUID) -> bool:
     return db_session.get(User, user_id) is not None
 
 
-def mark_user_file_secondary_pending(db_session: Session, user_file_id: UUID) -> None:
+def mark_user_file_reconcile_pending(db_session: Session, user_file_id: UUID) -> None:
     """Flag FUTURE as stale/missing for this file (deferred ACL or missing content).
-    Owned by the sync path, never the port. Mirrors mark_document_synced_secondary_pending."""
+    Owned by the sync/index path, never the port."""
     db_session.execute(
         update(UserFile)
         .where(UserFile.id == user_file_id)
-        .values(secondary_only_sync_pending=True)
+        .values(secondary_reconcile_pending=True)
     )
     db_session.commit()
 
 
-def clear_user_file_secondary_pending(db_session: Session, user_file_id: UUID) -> None:
-    """Clear the flag once FUTURE matches PRESENT. Owned by the sync-path drain."""
+def clear_user_file_reconcile_pending(db_session: Session, user_file_id: UUID) -> None:
+    """Clear the flag once FUTURE matches PRESENT. Owned by the reconciler."""
     db_session.execute(
         update(UserFile)
         .where(UserFile.id == user_file_id)
-        .values(secondary_only_sync_pending=False)
+        .values(secondary_reconcile_pending=False)
     )
     db_session.commit()
 
 
-def count_user_files_secondary_pending(db_session: Session) -> int:
-    """Count of user files whose deferred FUTURE sync hasn't drained (swap progress)."""
+def count_user_files_reconcile_pending(db_session: Session) -> int:
+    """Count of user files whose FUTURE copy hasn't reconciled yet (swap progress)."""
     return db_session.execute(
-        select(func.count()).where(UserFile.secondary_only_sync_pending.is_(True))
+        select(func.count()).where(UserFile.secondary_reconcile_pending.is_(True))
     ).scalar_one()
 
 
-def any_user_file_secondary_pending(db_session: Session) -> bool:
-    """EXISTS over the deferred set — the swap gate's cheap check (partial index)."""
+def any_user_file_reconcile_pending(db_session: Session) -> bool:
+    """EXISTS over the un-reconciled set — the swap gate's cheap check (partial index)."""
     return bool(
         db_session.scalar(
-            select(exists().where(UserFile.secondary_only_sync_pending.is_(True)))
+            select(exists().where(UserFile.secondary_reconcile_pending.is_(True)))
+        )
+    )
+
+
+def any_user_file_reconcile_pending_for_users(
+    db_session: Session, user_ids: list[UUID]
+) -> bool:
+    """Swap-gate check: any un-reconciled COMPLETED file among the port's users? Scoped to
+    required_user_ids like the connector flag's required_cc_pairs. COMPLETED-only because only
+    those are drainable — a flag stuck on a non-COMPLETED row must not wedge the swap."""
+    if not user_ids:
+        return False
+    return bool(
+        db_session.scalar(
+            select(
+                exists().where(
+                    UserFile.user_id.in_(user_ids),
+                    UserFile.status == UserFileStatus.COMPLETED,
+                    UserFile.secondary_reconcile_pending.is_(True),
+                )
+            )
         )
     )

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -270,15 +270,6 @@ def count_user_files_reconcile_pending(db_session: Session) -> int:
     ).scalar_one()
 
 
-def any_user_file_reconcile_pending(db_session: Session) -> bool:
-    """EXISTS over the un-reconciled set — the swap gate's cheap check (partial index)."""
-    return bool(
-        db_session.scalar(
-            select(exists().where(UserFile.secondary_reconcile_pending.is_(True)))
-        )
-    )
-
-
 def any_user_file_reconcile_pending_for_users(
     db_session: Session, user_ids: list[UUID]
 ) -> bool:

--- a/backend/onyx/indexing/adapters/document_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/document_indexing_adapter.py
@@ -205,6 +205,7 @@ class DocumentIndexingBatchAdapter(IndexingBatchAdapter):
         filtered_documents: list[Document],
         enrichment: ChunkEnrichmentContext,
         db_session: Session,
+        index_to_secondary: bool,  # noqa: ARG002
     ) -> None:
         """Finalize DB updates, store plaintext, and mark docs as indexed."""
         updatable_ids = [doc.id for doc in context.updatable_docs]

--- a/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
@@ -245,8 +245,13 @@ class UserFileIndexingAdapter:
         filtered_documents: list[Document],  # noqa: ARG002
         enrichment: ChunkEnrichmentContext,
         db_session: Session,
+        index_to_secondary: bool,
     ) -> None:
         assert isinstance(enrichment, UserFileChunkEnricher)
+        if index_to_secondary:
+            # Secondary (reindex-port) write: chunks are written; the PRESENT pass owns the
+            # terminal side-effects (status/chunk_count/plaintext/notifications) — leave them.
+            return
         user_file_ids = [doc.id for doc in context.updatable_docs]
 
         user_files = (

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -1458,6 +1458,7 @@ def index_doc_batch(
                     filtered_documents=filtered_documents,
                     enrichment=enricher,
                     db_session=db_session,
+                    index_to_secondary=index_to_secondary,
                 )
 
             # Persist content hash only for documents confirmed written to the

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -293,4 +293,5 @@ class IndexingBatchAdapter(Protocol):
         filtered_documents: list[Document],
         enrichment: ChunkEnrichmentContext,
         db_session: Session,
+        index_to_secondary: bool,
     ) -> None: ...

--- a/backend/tests/external_dependency_unit/celery/test_persona_file_sync.py
+++ b/backend/tests/external_dependency_unit/celery/test_persona_file_sync.py
@@ -19,6 +19,7 @@ since we only need to verify the arguments passed to update_single.
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from contextlib import ExitStack
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -27,6 +28,13 @@ from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
+from onyx.access.models import DocumentAccess
+from onyx.background.celery.tasks.user_file_processing.tasks import (
+    _process_user_file_with_indexing,
+)
+from onyx.background.celery.tasks.user_file_processing.tasks import (
+    _supply_user_file_to_secondary,
+)
 from onyx.background.celery.tasks.user_file_processing.tasks import (
     check_for_user_file_project_sync,
 )
@@ -44,9 +52,13 @@ from onyx.db.models import UserFile
 from onyx.db.persona import upsert_persona
 from onyx.document_index.interfaces_new import MetadataUpdateRequest
 from onyx.document_index.interfaces_new import SecondaryIndexDocumentMissingError
+from onyx.indexing.adapters.user_file_indexing_adapter import UserFileChunkEnricher
+from onyx.indexing.adapters.user_file_indexing_adapter import UserFileIndexingAdapter
+from onyx.indexing.indexing_pipeline import IndexingPipelineResult
 from onyx.redis.redis_pool import get_redis_client
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.indexing_helpers import make_doc
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -224,7 +236,7 @@ class TestCheckSweepIncludesPersonaSync:
         drain can retry the FUTURE update — else the flag stays stuck and blocks the swap."""
         user = create_test_user(db_session, "secpend_sweep")
         uf = _create_completed_user_file(db_session, user)
-        uf.secondary_only_sync_pending = True
+        uf.secondary_reconcile_pending = True
         db_session.commit()
 
         mock_app = MagicMock()
@@ -257,6 +269,29 @@ _PATCH_HTTPX_INIT = (
 _PATCH_DISABLE_VDB = (
     "onyx.background.celery.tasks.user_file_processing.tasks.DISABLE_VECTOR_DB"
 )
+_PATCH_ACTIVE_SECONDARY = "onyx.background.celery.tasks.user_file_processing.tasks.active_secondary_port_target"
+_PATCH_SUPPLY = "onyx.background.celery.tasks.user_file_processing.tasks._supply_user_file_to_secondary"
+_PATCH_INDEX_SECONDARY = "onyx.background.celery.tasks.user_file_processing.tasks._index_user_file_to_secondary"
+_PATCH_LOAD_DOCS = (
+    "onyx.background.celery.tasks.user_file_processing.tasks._load_user_file_documents"
+)
+_PATCH_GET_SETTINGS_LIST = "onyx.background.celery.tasks.user_file_processing.tasks.get_active_search_settings_list"
+_PATCH_EMBEDDER = (
+    "onyx.background.celery.tasks.user_file_processing.tasks.DefaultIndexingEmbedder"
+)
+_PATCH_RUN_PIPELINE = (
+    "onyx.background.celery.tasks.user_file_processing.tasks.run_indexing_pipeline"
+)
+
+
+def _purge_user_files(db_session: Session, user: User) -> None:
+    """Drop a test's COMPLETED user files so they don't pollute the tenant-global
+    port-scope helpers other suites read."""
+    db_session.rollback()
+    db_session.query(UserFile).filter(UserFile.user_id == user.id).delete(
+        synchronize_session="fetch"
+    )
+    db_session.commit()
 
 
 class TestSyncTaskWritesPersonaIds:
@@ -567,8 +602,15 @@ class TestUpsertPersonaMarksSyncFlag:
 # ---------------------------------------------------------------------------
 
 
-def _run_sync(uf_id: str, mock_doc_index: MagicMock, secondary: Any) -> None:
-    """Run the sync task with the index mocked and the secondary target configured."""
+def _run_sync(
+    uf_id: str,
+    mock_doc_index: MagicMock,
+    secondary: Any,
+    port_target: Any = None,
+    supply: MagicMock | None = None,
+) -> None:
+    """Run the sync task with the index mocked. `active_secondary_port_target` is patched
+    (default None) so the 404 fallback is deterministic; pass `supply` to stub the fallback."""
     mock_search_settings = MagicMock()
     mock_search_settings.primary = MagicMock()
     mock_search_settings.primary.port_backfill_source_id = None
@@ -577,12 +619,19 @@ def _run_sync(uf_id: str, mock_doc_index: MagicMock, secondary: Any) -> None:
     redis_client = get_redis_client(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     redis_client.delete(user_file_project_sync_lock_key(uf_id))
 
-    with (
+    patches: list[Any] = [
         patch(_PATCH_DISABLE_VDB, False),
         patch(_PATCH_HTTPX_INIT),
         patch(_PATCH_GET_SETTINGS, return_value=mock_search_settings),
         patch(_PATCH_GET_INDICES, return_value=[mock_doc_index]),
-    ):
+        patch(_PATCH_ACTIVE_SECONDARY, return_value=port_target),
+    ]
+    if supply is not None:
+        patches.append(patch(_PATCH_SUPPLY, supply))
+
+    with ExitStack() as stack:
+        for p in patches:
+            stack.enter_context(p)
         process_single_user_file_project_sync.run(
             user_file_id=uf_id,
             tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
@@ -610,7 +659,7 @@ class TestSecondaryDeferAndDrain:
         _run_sync(str(uf.id), mock_doc_index, secondary=MagicMock())
 
         db_session.refresh(uf)
-        assert uf.secondary_only_sync_pending is True
+        assert uf.secondary_reconcile_pending is True
         assert uf.needs_project_sync is False
 
     def test_drain_clears_flag_on_success(
@@ -621,14 +670,14 @@ class TestSecondaryDeferAndDrain:
         """Once the port has copied the file, the update succeeds and the flag clears."""
         user = create_test_user(db_session, "defer_drain")
         uf = _create_completed_user_file(db_session, user)
-        uf.secondary_only_sync_pending = True
+        uf.secondary_reconcile_pending = True
         db_session.commit()
 
         mock_doc_index = MagicMock()  # update() succeeds
         _run_sync(str(uf.id), mock_doc_index, secondary=MagicMock())
 
         db_session.refresh(uf)
-        assert uf.secondary_only_sync_pending is False
+        assert uf.secondary_reconcile_pending is False
 
     def test_no_secondary_drain_clears_flag(
         self,
@@ -639,14 +688,14 @@ class TestSecondaryDeferAndDrain:
         and clears the flag — else it stays stuck forever (no secondary to reach)."""
         user = create_test_user(db_session, "defer_nosec")
         uf = _create_completed_user_file(db_session, user)
-        uf.secondary_only_sync_pending = True
+        uf.secondary_reconcile_pending = True
         db_session.commit()
 
         mock_doc_index = MagicMock()
         _run_sync(str(uf.id), mock_doc_index, secondary=None)
 
         db_session.refresh(uf)
-        assert uf.secondary_only_sync_pending is False
+        assert uf.secondary_reconcile_pending is False
 
     def test_non_portable_file_not_flagged(
         self,
@@ -668,4 +717,258 @@ class TestSecondaryDeferAndDrain:
         _run_sync(str(uf.id), mock_doc_index, secondary=MagicMock())
 
         db_session.refresh(uf)
-        assert uf.secondary_only_sync_pending is False
+        assert uf.secondary_reconcile_pending is False
+
+    def test_drain_dual_write_supplies_content_and_clears_flag(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """PR4 404 fallback: update() finds FUTURE missing the content, so the drain
+        dual-writes it. A successful dual-write clears the flag now (no wait on the port)."""
+        user = create_test_user(db_session, "drain_dw_ok")
+        uf = _create_completed_user_file(db_session, user, needs_project_sync=True)
+        try:
+            mock_doc_index = MagicMock()
+            mock_doc_index.update.side_effect = SecondaryIndexDocumentMissingError(
+                [str(uf.id)]
+            )
+            supply = MagicMock(return_value=True)
+
+            _run_sync(
+                str(uf.id),
+                mock_doc_index,
+                secondary=MagicMock(),
+                port_target=MagicMock(),
+                supply=supply,
+            )
+
+            supply.assert_called_once_with(
+                str(uf.id), POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+            )
+            db_session.refresh(uf)
+            assert uf.secondary_reconcile_pending is False
+        finally:
+            _purge_user_files(db_session, user)
+
+
+class TestDualWriteFallbackHelper:
+    """_supply_user_file_to_secondary: resolve target, supply content, isolate."""
+
+    def test_no_target_returns_false_without_writing(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """No active port target (e.g. after an INSTANT swap) — the fallback is a no-op that
+        keeps the flag; the file self-heals via the port instead."""
+        user = create_test_user(db_session, "fb_notarget")
+        uf = _create_completed_user_file(db_session, user)
+        try:
+            index_secondary = MagicMock()
+            with (
+                patch(_PATCH_ACTIVE_SECONDARY, return_value=None),
+                patch(_PATCH_INDEX_SECONDARY, index_secondary),
+            ):
+                result = _supply_user_file_to_secondary(
+                    str(uf.id), POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
+            assert result is False
+            index_secondary.assert_not_called()
+        finally:
+            _purge_user_files(db_session, user)
+
+    def test_supplies_content_returns_true(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """With a target and a loadable blob, the fallback re-indexes into FUTURE (threading
+        the resolved target through) and reports success so the flag can clear."""
+        user = create_test_user(db_session, "fb_ok")
+        uf = _create_completed_user_file(db_session, user)
+        try:
+            target = MagicMock()
+            index_secondary = MagicMock()
+            with (
+                patch(_PATCH_ACTIVE_SECONDARY, return_value=target),
+                patch(_PATCH_LOAD_DOCS, return_value=([make_doc(str(uf.id))], [])),
+                patch(_PATCH_INDEX_SECONDARY, index_secondary),
+            ):
+                result = _supply_user_file_to_secondary(
+                    str(uf.id), POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
+            assert result is True
+            index_secondary.assert_called_once()
+            assert index_secondary.call_args.args[2] is target
+        finally:
+            _purge_user_files(db_session, user)
+
+    def test_write_failure_is_isolated_returns_false(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """A FUTURE write failure never propagates into the sync task — it just returns False
+        so the flag stays set for a retry."""
+        user = create_test_user(db_session, "fb_fail")
+        uf = _create_completed_user_file(db_session, user)
+        try:
+            with (
+                patch(_PATCH_ACTIVE_SECONDARY, return_value=MagicMock()),
+                patch(_PATCH_LOAD_DOCS, return_value=([make_doc(str(uf.id))], [])),
+                patch(_PATCH_INDEX_SECONDARY, side_effect=RuntimeError("future down")),
+            ):
+                result = _supply_user_file_to_secondary(
+                    str(uf.id), POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+                )
+            assert result is False
+        finally:
+            _purge_user_files(db_session, user)
+
+
+def _run_index_pass(uf_id: str, port_target: Any, index_secondary: MagicMock) -> None:
+    """Drive _process_user_file_with_indexing with the PRESENT pass fully mocked, so only
+    the FUTURE dual-write orchestration is exercised."""
+    present_result = IndexingPipelineResult(
+        new_docs=1, total_docs=1, total_chunks=3, failures=[]
+    )
+    current = MagicMock()
+    current.status.is_current.return_value = True
+
+    with (
+        patch(_PATCH_HTTPX_INIT),
+        patch(_PATCH_GET_SETTINGS_LIST, return_value=[current]),
+        patch(_PATCH_EMBEDDER),
+        patch(_PATCH_GET_INDICES, return_value=[MagicMock()]),
+        patch(_PATCH_RUN_PIPELINE, return_value=present_result),
+        patch(_PATCH_ACTIVE_SECONDARY, return_value=port_target),
+        patch(_PATCH_INDEX_SECONDARY, index_secondary),
+    ):
+        _process_user_file_with_indexing(
+            uf_id, [make_doc(uf_id)], POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+        )
+
+
+class TestIndexTimeDualWrite:
+    """_process_user_file_with_indexing runs a FUTURE pass during a port, isolated from
+    live status."""
+
+    def test_dual_write_runs_when_target_present(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """A target exists -> after the PRESENT pass the file is also indexed into FUTURE,
+        with the resolved target threaded through."""
+        user = create_test_user(db_session, "idx_dw")
+        uf = _create_completed_user_file(db_session, user)
+        try:
+            target = MagicMock()
+            index_secondary = MagicMock()
+            _run_index_pass(
+                str(uf.id), port_target=target, index_secondary=index_secondary
+            )
+            index_secondary.assert_called_once()
+            assert index_secondary.call_args.args[0] == str(uf.id)
+            assert index_secondary.call_args.args[2] is target
+        finally:
+            _purge_user_files(db_session, user)
+
+    def test_no_dual_write_when_no_target(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """No port in progress -> no FUTURE pass (the common, non-reindex case)."""
+        user = create_test_user(db_session, "idx_notgt")
+        uf = _create_completed_user_file(db_session, user)
+        try:
+            index_secondary = MagicMock()
+            _run_index_pass(
+                str(uf.id), port_target=None, index_secondary=index_secondary
+            )
+            index_secondary.assert_not_called()
+        finally:
+            _purge_user_files(db_session, user)
+
+    def test_dual_write_failure_flags_and_keeps_status(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """H1: a FUTURE-pass failure flags the file for the drain and must NOT flip live
+        status — the PRESENT write already succeeded."""
+        user = create_test_user(db_session, "idx_fail")
+        uf = _create_completed_user_file(db_session, user)
+        try:
+            index_secondary = MagicMock(side_effect=RuntimeError("future down"))
+            _run_index_pass(
+                str(uf.id), port_target=MagicMock(), index_secondary=index_secondary
+            )
+            db_session.refresh(uf)
+            assert uf.secondary_reconcile_pending is True
+            assert uf.status == UserFileStatus.COMPLETED
+        finally:
+            _purge_user_files(db_session, user)
+
+
+class TestSecondaryPassSkipsTerminalSideEffects:
+    """A secondary (index_to_secondary) post_index must not re-apply the PRESENT pass's
+    terminal side-effects."""
+
+    def test_secondary_post_index_is_noop(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        """post_index with index_to_secondary=True leaves status and chunk_count untouched (a
+        primary pass would set COMPLETED + the enrichment chunk count)."""
+        user = create_test_user(db_session, "secondary_pass")
+        uf = UserFile(
+            id=uuid4(),
+            user_id=user.id,
+            file_id=f"fp_{uuid4().hex[:8]}",
+            name=f"{uuid4().hex[:8]}.txt",
+            file_type="text/plain",
+            status=UserFileStatus.INDEXING,
+            chunk_count=99,
+        )
+        db_session.add(uf)
+        db_session.commit()
+        db_session.refresh(uf)
+        try:
+            enricher = UserFileChunkEnricher(
+                user_file_id_to_access={},
+                user_file_id_to_project_ids={},
+                user_file_id_to_persona_ids={},
+                doc_id_to_previous_chunk_cnt={},
+                doc_id_to_new_chunk_cnt={str(uf.id): 0},
+                user_file_id_to_raw_text={},
+                user_file_id_to_token_count={},
+                no_access=DocumentAccess.build(
+                    user_emails=[],
+                    user_groups=[],
+                    external_user_emails=[],
+                    external_user_group_ids=[],
+                    is_public=False,
+                ),
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+            )
+            adapter = UserFileIndexingAdapter(
+                tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+                db_session=db_session,
+            )
+            adapter.post_index(
+                context=MagicMock(),
+                updatable_chunk_data=[],
+                filtered_documents=[],
+                enrichment=enricher,
+                db_session=db_session,
+                index_to_secondary=True,
+            )
+            db_session.refresh(uf)
+            assert uf.status == UserFileStatus.INDEXING
+            assert uf.chunk_count == 99
+        finally:
+            _purge_user_files(db_session, user)

--- a/backend/tests/external_dependency_unit/db/test_userfile_port_execution.py
+++ b/backend/tests/external_dependency_unit/db/test_userfile_port_execution.py
@@ -287,13 +287,38 @@ def test_swap_gate_not_deadlocked_by_canceled_user(
     assert _user_file_port_has_pending_work(db_session, future_ss_id) is False
 
 
-def test_swap_not_blocked_by_undrainable_secondary_pending_flag(
+def test_swap_gate_blocks_on_secondary_pending_then_releases(
     db_session: Session, future_ss_id: int, port_user: User
 ) -> None:
-    """The swap must NOT gate on secondary_only_sync_pending while the metadata sync only
-    update()s FUTURE: a file the port never copies (uploaded after its port settled, or
-    beyond the snapshot bound) would flag forever and deadlock. Gating waits until new
-    user files are also dual-written to FUTURE."""
+    """Now that every flag is drainable (dual-write + 404 fallback), the swap gate holds while
+    a user's secondary_reconcile_pending is set and releases once it clears."""
+    future_ss = db_session.get(SearchSettings, future_ss_id)
+    assert future_ss is not None
+    uf = _make_user_file(db_session, port_user.id)
+    attempt = create_port_attempt(
+        db_session, None, future_ss_id, port_user_id=port_user.id
+    )
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_succeeded(db_session, attempt.id)
+    assert all_user_scopes_ported(db_session, future_ss_id, [port_user.id]) is True
+
+    uf.secondary_reconcile_pending = True
+    db_session.commit()
+    # flag set -> swap blocked
+    assert _port_swap_ready(db_session, future_ss, [], [port_user.id]) is False
+
+    uf.secondary_reconcile_pending = False
+    db_session.commit()
+    # flag drained -> swap ready
+    assert _port_swap_ready(db_session, future_ss, [], [port_user.id]) is True
+
+
+def test_swap_gate_ignores_reconcile_flag_on_non_completed_file(
+    db_session: Session, future_ss_id: int, port_user: User
+) -> None:
+    """A reconcile flag stuck on a non-COMPLETED file is undrainable (the reconciler only
+    flags / re-enqueues COMPLETED files), so the gate must ignore it — else a delete racing
+    the mark, or a FAILED file, wedges the swap with no drain path."""
     future_ss = db_session.get(SearchSettings, future_ss_id)
     assert future_ss is not None
     uf = _make_user_file(db_session, port_user.id)
@@ -303,10 +328,14 @@ def test_swap_not_blocked_by_undrainable_secondary_pending_flag(
     mark_port_in_progress(db_session, attempt.id)
     mark_port_succeeded(db_session, attempt.id)
 
-    uf.secondary_only_sync_pending = True
+    uf.secondary_reconcile_pending = True
     db_session.commit()
-    assert all_user_scopes_ported(db_session, future_ss_id, [port_user.id]) is True
-    # flag set, yet the swap is ready — no deadlock
+    # COMPLETED + flag -> blocks
+    assert _port_swap_ready(db_session, future_ss, [], [port_user.id]) is False
+
+    uf.status = UserFileStatus.FAILED
+    db_session.commit()
+    # same flag, now on a FAILED (undrainable) row -> gate ignores it
     assert _port_swap_ready(db_session, future_ss, [], [port_user.id]) is True
 
 

--- a/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
+++ b/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
@@ -2,7 +2,7 @@
 
 Covers the scope-polymorphic PortAttempt (exactly-one CHECK, the NULL-distinct
 user-branch active-unique index), the user-file enumeration/survival helpers the port
-scheduler will consume, and the secondary_only_sync_pending flag lifecycle. All dark
+scheduler will consume, and the secondary_reconcile_pending flag lifecycle. All dark
 until PR2 wires the port itself — these assert only the storage/read/write primitives.
 """
 
@@ -25,14 +25,14 @@ from onyx.db.port_attempt import get_active_port_attempt
 from onyx.db.port_attempt import get_latest_port_attempt
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
-from onyx.db.user_file import any_user_file_secondary_pending
-from onyx.db.user_file import clear_user_file_secondary_pending
-from onyx.db.user_file import count_user_files_secondary_pending
+from onyx.db.user_file import any_user_file_reconcile_pending
+from onyx.db.user_file import clear_user_file_reconcile_pending
+from onyx.db.user_file import count_user_files_reconcile_pending
 from onyx.db.user_file import fetch_port_scope_user_ids
 from onyx.db.user_file import filter_existing_user_file_ids
 from onyx.db.user_file import get_max_user_file_id_for_user
 from onyx.db.user_file import get_user_file_ids_for_user_batch
-from onyx.db.user_file import mark_user_file_secondary_pending
+from onyx.db.user_file import mark_user_file_reconcile_pending
 from onyx.db.user_file import user_file_port_scope_active
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
@@ -263,17 +263,17 @@ def test_secondary_pending_flag_round_trip(
     db_session: Session, port_user: User
 ) -> None:
     uf = _make_user_file(db_session, port_user.id)
-    baseline = count_user_files_secondary_pending(db_session)
+    baseline = count_user_files_reconcile_pending(db_session)
 
-    mark_user_file_secondary_pending(db_session, uf.id)
+    mark_user_file_reconcile_pending(db_session, uf.id)
     db_session.expire_all()
     marked = db_session.get(UserFile, uf.id)
-    assert marked is not None and marked.secondary_only_sync_pending is True
-    assert any_user_file_secondary_pending(db_session) is True
-    assert count_user_files_secondary_pending(db_session) == baseline + 1
+    assert marked is not None and marked.secondary_reconcile_pending is True
+    assert any_user_file_reconcile_pending(db_session) is True
+    assert count_user_files_reconcile_pending(db_session) == baseline + 1
 
-    clear_user_file_secondary_pending(db_session, uf.id)
+    clear_user_file_reconcile_pending(db_session, uf.id)
     db_session.expire_all()
     cleared = db_session.get(UserFile, uf.id)
-    assert cleared is not None and cleared.secondary_only_sync_pending is False
-    assert count_user_files_secondary_pending(db_session) == baseline
+    assert cleared is not None and cleared.secondary_reconcile_pending is False
+    assert count_user_files_reconcile_pending(db_session) == baseline

--- a/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
+++ b/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
@@ -25,7 +25,6 @@ from onyx.db.port_attempt import get_active_port_attempt
 from onyx.db.port_attempt import get_latest_port_attempt
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
-from onyx.db.user_file import any_user_file_reconcile_pending
 from onyx.db.user_file import clear_user_file_reconcile_pending
 from onyx.db.user_file import count_user_files_reconcile_pending
 from onyx.db.user_file import fetch_port_scope_user_ids
@@ -269,7 +268,6 @@ def test_secondary_pending_flag_round_trip(
     db_session.expire_all()
     marked = db_session.get(UserFile, uf.id)
     assert marked is not None and marked.secondary_reconcile_pending is True
-    assert any_user_file_reconcile_pending(db_session) is True
     assert count_user_files_reconcile_pending(db_session) == baseline + 1
 
     clear_user_file_reconcile_pending(db_session, uf.id)


### PR DESCRIPTION
## Description

- Dual-write newly-indexed/edited user files into the FUTURE (secondary) index during a reindex-port, so it's complete at swap — a failure only flags the file for reconcile and never touches live status, and the metadata-sync drain supplies missing content on a 404 (so a file the backlog copy can't reach still lands).
- Re-add the swap gate on the reconcile flag, scoped to the port's COMPLETED users (mirrors the connector flag's `required_cc_pairs` scoping) — so a flag outside this switchover, or stuck on a non-COMPLETED/undrainable row, can't wedge the swap.
- Carry the "secondary pass" signal through the `IndexingBatchAdapter.post_index` interface (`index_to_secondary`) instead of a per-adapter flag, so the FUTURE write skips the once-only terminal side-effects (status/plaintext/notifications).
- Rename `UserFile.secondary_only_sync_pending` → `secondary_reconcile_pending` (a content-and-ACL FUTURE-dirty bit, broader than the `Document` ACL-only analog); additive rename migration.

## How Has This Been Tested?

External-dependency-unit tests: index-time dual-write fires only with an active target and a failure flags the file while keeping it COMPLETED; the drain's 404 fallback supplies content and clears the flag; the secondary-pass adapter skips terminal side-effects; the swap gate blocks on a set flag, releases when it clears, and ignores a flag on a non-COMPLETED file. Existing persona-sync + port-execution suites updated for the rename/restructure.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dual-write newly indexed or edited user files to the `FUTURE` index during a reindex port, and hold the swap on a drainable reconcile flag so files aren’t missing at swap and swaps can’t deadlock. Adds a 404 fallback that supplies missing content to `FUTURE`, and renames the flag to `secondary_reconcile_pending`.

- New Features
  - Dual-write to `FUTURE` at index time; failures only set `secondary_reconcile_pending` and never touch live status.
  - Metadata sync now reconciles: on `SecondaryIndexDocumentMissingError`, it supplies content to `FUTURE` and clears the flag when successful.
  - Swap gate restored: waits on reconcile flags only for the port’s COMPLETED users, and ignores flags on non-COMPLETED rows.
  - Adapter API: thread `index_to_secondary` through `post_index`; the secondary pass skips terminal side-effects (status/chunk_count/plaintext/notifications).
  - Removed unused `any_user_file_reconcile_pending` helper.

- Migration
  - Rename `UserFile.secondary_only_sync_pending` → `secondary_reconcile_pending` (and its partial index). Run the Alembic migration; no data rewrite needed.

<sup>Written for commit 6f34bc882a8c9b5d366b670faa6265f6932b612a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



