### PR TITLE
feat(opal): auth layouts, InlineMarkdown lists, inputs topRight, Content success color

### DIFF
--- a/web/lib/opal/src/components/text/InlineMarkdown.tsx
+++ b/web/lib/opal/src/components/text/InlineMarkdown.tsx
@@ -19,12 +19,30 @@ const sanitizeSchema = {
   },
 };
 
-const ALLOWED_ELEMENTS = ["p", "br", "a", "strong", "em", "code", "del"];
+const ALLOWED_ELEMENTS = [
+  "p",
+  "br",
+  "a",
+  "strong",
+  "em",
+  "code",
+  "del",
+  "ul",
+  "ol",
+  "li",
+];
 
 const INLINE_COMPONENTS = {
   p: ({ children }: { children?: ReactNode }) => (
     <span className="block">{children}</span>
   ),
+  ul: ({ children }: { children?: ReactNode }) => (
+    <ul className="list-disc pl-3 space-y-0">{children}</ul>
+  ),
+  ol: ({ children }: { children?: ReactNode }) => (
+    <ol className="list-decimal pl-3">{children}</ol>
+  ),
+  li: ({ children }: { children?: ReactNode }) => <li>{children}</li>,
   a: ({ children, href }: { children?: ReactNode; href?: string }) => {
     if (!href) return <>{children}</>;
     // rehype-sanitize has already stripped unsafe hrefs — routing decision only.

--- a/web/lib/opal/src/layouts/auth/AuthLayouts.stories.tsx
+++ b/web/lib/opal/src/layouts/auth/AuthLayouts.stories.tsx
@@ -24,10 +24,10 @@ export const BasicLogin: Story = {
   render: () => (
     <AuthLayouts.Root>
       <AuthLayouts.Card
-        title="Welcome to Onyx"
-        description="Your open source AI platform for work"
+        title="Welcome back"
+        description="Sign in to your account"
         bottomPrompt={markdown(
-          "New to Onyx? [Create an Account](/auth/signup)"
+          "Don't have an account? [Create an Account](/auth/signup)"
         )}
       >
         <AuthLayouts.Fields>
@@ -44,10 +44,10 @@ export const WithSSOAndSeparator: Story = {
   render: () => (
     <AuthLayouts.Root>
       <AuthLayouts.Card
-        title="Welcome to Onyx"
-        description="Your open source AI platform for work"
+        title="Welcome back"
+        description="Sign in to your account"
         bottomPrompt={markdown(
-          "New to Onyx? [Create an Account](/auth/signup)"
+          "Don't have an account? [Create an Account](/auth/signup)"
         )}
       >
         <Button width="full">Continue with Google</Button>
@@ -67,7 +67,7 @@ export const Signup: Story = {
     <AuthLayouts.Root>
       <AuthLayouts.Card
         title="Create account"
-        description="Get started with Onyx"
+        description="Get started"
         bottomPrompt={markdown(
           "Already have an account? [Sign In](/auth/login)"
         )}

--- a/web/lib/opal/src/layouts/auth/AuthLayouts.stories.tsx
+++ b/web/lib/opal/src/layouts/auth/AuthLayouts.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import * as AuthLayouts from "@opal/layouts/auth/components";
+import { Button } from "@opal/components";
+import { markdown } from "@opal/utils";
+
+const meta: Meta = {
+  title: "Layouts/Auth",
+  tags: ["autodocs"],
+  parameters: { layout: "fullscreen" },
+};
+
+export default meta;
+type Story = StoryObj;
+
+const FieldPlaceholder = ({ label }: { label: string }) => (
+  <div className="flex flex-col gap-1">
+    <div className="h-4 w-12 rounded-04 bg-background-neutral-02" />
+    <div className="h-9 rounded-08 border border-border-02 bg-background-neutral-01" />
+    <span className="sr-only">{label}</span>
+  </div>
+);
+
+export const BasicLogin: Story = {
+  render: () => (
+    <AuthLayouts.Root>
+      <AuthLayouts.Card
+        title="Welcome to Onyx"
+        description="Your open source AI platform for work"
+        bottomPrompt={markdown(
+          "New to Onyx? [Create an Account](/auth/signup)"
+        )}
+      >
+        <AuthLayouts.Fields>
+          <FieldPlaceholder label="Email" />
+          <FieldPlaceholder label="Password" />
+        </AuthLayouts.Fields>
+        <AuthLayouts.Submit label="submit" />
+      </AuthLayouts.Card>
+    </AuthLayouts.Root>
+  ),
+};
+
+export const WithSSOAndSeparator: Story = {
+  render: () => (
+    <AuthLayouts.Root>
+      <AuthLayouts.Card
+        title="Welcome to Onyx"
+        description="Your open source AI platform for work"
+        bottomPrompt={markdown(
+          "New to Onyx? [Create an Account](/auth/signup)"
+        )}
+      >
+        <Button width="full">Continue with Google</Button>
+        <AuthLayouts.OrSeparator />
+        <AuthLayouts.Fields>
+          <FieldPlaceholder label="Email" />
+          <FieldPlaceholder label="Password" />
+        </AuthLayouts.Fields>
+        <AuthLayouts.Submit label="submit" />
+      </AuthLayouts.Card>
+    </AuthLayouts.Root>
+  ),
+};
+
+export const Signup: Story = {
+  render: () => (
+    <AuthLayouts.Root>
+      <AuthLayouts.Card
+        title="Create account"
+        description="Get started with Onyx"
+        bottomPrompt={markdown(
+          "Already have an account? [Sign In](/auth/login)"
+        )}
+      >
+        <AuthLayouts.Fields>
+          <FieldPlaceholder label="Email" />
+          <FieldPlaceholder label="Password" />
+        </AuthLayouts.Fields>
+        <AuthLayouts.Submit label="create" />
+      </AuthLayouts.Card>
+    </AuthLayouts.Root>
+  ),
+};
+
+export const ForgotPassword: Story = {
+  render: () => (
+    <AuthLayouts.Root>
+      <AuthLayouts.Card
+        title="Forgot Password"
+        description="Enter your email address and we'll send you a reset link."
+        bottomPrompt={markdown("[Back to Login](/auth/login)")}
+      >
+        <AuthLayouts.Fields>
+          <FieldPlaceholder label="Email" />
+        </AuthLayouts.Fields>
+        <AuthLayouts.Submit label="submit" />
+      </AuthLayouts.Card>
+    </AuthLayouts.Root>
+  ),
+};
+
+export const DisabledSubmit: Story = {
+  render: () => (
+    <AuthLayouts.Root>
+      <AuthLayouts.Card title="Sign in" description="Submitting…">
+        <AuthLayouts.Fields>
+          <FieldPlaceholder label="Email" />
+          <FieldPlaceholder label="Password" />
+        </AuthLayouts.Fields>
+        <AuthLayouts.Submit label="submit" disabled />
+      </AuthLayouts.Card>
+    </AuthLayouts.Root>
+  ),
+};

--- a/web/lib/opal/src/layouts/auth/AuthLayouts.stories.tsx
+++ b/web/lib/opal/src/layouts/auth/AuthLayouts.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import * as AuthLayouts from "@opal/layouts/auth/components";
 import { Button } from "@opal/components";
+import SvgSparkle from "@opal/icons/sparkle";
 import { markdown } from "@opal/utils";
 
 const meta: Meta = {
@@ -24,6 +25,7 @@ export const BasicLogin: Story = {
   render: () => (
     <AuthLayouts.Root>
       <AuthLayouts.Card
+        icon={SvgSparkle}
         title="Welcome back"
         description="Sign in to your account"
         bottomPrompt={markdown(
@@ -44,6 +46,7 @@ export const WithSSOAndSeparator: Story = {
   render: () => (
     <AuthLayouts.Root>
       <AuthLayouts.Card
+        icon={SvgSparkle}
         title="Welcome back"
         description="Sign in to your account"
         bottomPrompt={markdown(
@@ -66,6 +69,7 @@ export const Signup: Story = {
   render: () => (
     <AuthLayouts.Root>
       <AuthLayouts.Card
+        icon={SvgSparkle}
         title="Create account"
         description="Get started"
         bottomPrompt={markdown(
@@ -86,6 +90,7 @@ export const ForgotPassword: Story = {
   render: () => (
     <AuthLayouts.Root>
       <AuthLayouts.Card
+        icon={SvgSparkle}
         title="Forgot Password"
         description="Enter your email address and we'll send you a reset link."
         bottomPrompt={markdown("[Back to Login](/auth/login)")}
@@ -102,7 +107,11 @@ export const ForgotPassword: Story = {
 export const DisabledSubmit: Story = {
   render: () => (
     <AuthLayouts.Root>
-      <AuthLayouts.Card title="Sign in" description="Submitting…">
+      <AuthLayouts.Card
+        icon={SvgSparkle}
+        title="Sign in"
+        description="Submitting…"
+      >
         <AuthLayouts.Fields>
           <FieldPlaceholder label="Email" />
           <FieldPlaceholder label="Password" />

--- a/web/lib/opal/src/layouts/auth/README.md
+++ b/web/lib/opal/src/layouts/auth/README.md
@@ -15,16 +15,16 @@ No props — accepts `children` only.
 
 ### Card
 
-The main auth card. Renders the product logo (or a custom logo), a heading, an optional
-description, card content, and a bottom prompt rendered outside/below the card border.
+The main auth card. Renders an icon above a heading, optional description, card content, and
+an optional bottom prompt rendered outside/below the card border.
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
+| `icon` | `IconFunctionComponent` | **(required)** | Logo/icon rendered above the card heading |
 | `title` | `string \| RichStr` | **(required)** | Card heading |
 | `description` | `string \| RichStr` | — | Subtitle below the heading |
 | `children` | `ReactNode` | — | Card body (form, buttons, separators) |
 | `bottomPrompt` | `string \| RichStr` | — | Text/link below the card (e.g. "Already have an account?") |
-| `logoSrc` | `string \| null` | — | Custom logo URL; falls back to the default logo |
 
 ### OrSeparator
 
@@ -57,13 +57,14 @@ Full-width submit button. Thin wrapper around `Button` with `type="submit"` and 
 ```tsx
 import { AuthLayouts } from "@opal/layouts";
 import { markdown } from "@opal/utils";
+import { getAppLogo } from "@/lib/app/utils";
 
 <AuthLayouts.Root>
   <AuthLayouts.Card
+    icon={getAppLogo(logoSrc)}
     title="Welcome back"
     description="Sign in to your account"
     bottomPrompt={markdown("Don't have an account? [Create an Account](/auth/signup)")}
-    logoSrc={logoUrl}
   >
     <SignInButton authorizeUrl={authUrl} authType={AuthType.CLOUD} />
     <AuthLayouts.OrSeparator />

--- a/web/lib/opal/src/layouts/auth/README.md
+++ b/web/lib/opal/src/layouts/auth/README.md
@@ -1,0 +1,81 @@
+# Auth Layouts
+
+**Import:** `import { AuthLayouts } from "@opal/layouts";`
+
+Namespaced layout primitives for authentication pages. Provides a full-screen centering shell
+and a branded card with logo, title, description, form slots, and an optional bottom prompt.
+
+## Components
+
+### Root
+
+Full-screen centering wrapper. Wrap every auth page with this.
+
+No props — accepts `children` only.
+
+### Card
+
+The main auth card. Renders the Onyx logo (or a custom logo), a heading, an optional
+description, card content, and a bottom prompt rendered outside/below the card border.
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `title` | `string \| RichStr` | **(required)** | Card heading |
+| `description` | `string \| RichStr` | — | Subtitle below the heading |
+| `children` | `ReactNode` | — | Card body (form, buttons, separators) |
+| `bottomPrompt` | `string \| RichStr` | — | Text/link below the card (e.g. "Already have an account?") |
+| `logoSrc` | `string \| null` | — | Custom logo URL; falls back to the Onyx logo |
+
+### OrSeparator
+
+A centered "or" label flanked by two divider lines. Use between an SSO button and an
+email/password form.
+
+No props.
+
+### FormFields
+
+Flex-column container for form inputs with a consistent `0.75rem` gap between fields.
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `children` | `ReactNode` | — | Input field components |
+
+### Submit
+
+Full-width submit button. Thin wrapper around `Button` with `type="submit"` and `width="full"`.
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `children` | `string` | **(required)** | Button label |
+| `disabled` | `boolean` | `false` | Disabled state — pass `isSubmitting` from Formik |
+
+## Usage Example
+
+```tsx
+import { AuthLayouts } from "@opal/layouts";
+import { markdown } from "@opal/utils";
+
+<AuthLayouts.Root>
+  <AuthLayouts.Card
+    title="Welcome to Onyx"
+    description="Your open source AI platform for work"
+    bottomPrompt={markdown("New to Onyx? [Create an Account](/auth/signup)")}
+    logoSrc={logoUrl}
+  >
+    <SignInButton authorizeUrl={authUrl} authType={AuthType.CLOUD} />
+    <AuthLayouts.OrSeparator />
+    <Formik ...>
+      {({ isSubmitting }) => (
+        <Form className="flex flex-col gap-6">
+          <AuthLayouts.FormFields>
+            <TextFormField name="email" label="Email" type="email" />
+            <TextFormField name="password" label="Password" type="password" />
+          </AuthLayouts.FormFields>
+          <AuthLayouts.Submit disabled={isSubmitting}>Sign in</AuthLayouts.Submit>
+        </Form>
+      )}
+    </Formik>
+  </AuthLayouts.Card>
+</AuthLayouts.Root>
+```

--- a/web/lib/opal/src/layouts/auth/README.md
+++ b/web/lib/opal/src/layouts/auth/README.md
@@ -33,7 +33,7 @@ email/password form.
 
 No props.
 
-### FormFields
+### Fields
 
 Flex-column container for form inputs with a consistent `0.75rem` gap between fields.
 
@@ -47,8 +47,10 @@ Full-width submit button. Thin wrapper around `Button` with `type="submit"` and 
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `children` | `string` | **(required)** | Button label |
-| `disabled` | `boolean` | `false` | Disabled state — pass `isSubmitting` from Formik |
+| `label` | `SubmitLabel` | **(required)** | Button label key (`"sign-in"`, `"sign-up"`, etc.) |
+| `isSubmitting` | `boolean` | — | Disables + shows spinner while submitting |
+| `isValid` | `boolean` | — | When provided, disables if `false` |
+| `dirty` | `boolean` | — | When provided, disables if `false` |
 
 ## Usage Example
 
@@ -68,11 +70,11 @@ import { markdown } from "@opal/utils";
     <Formik ...>
       {({ isSubmitting }) => (
         <Form className="flex flex-col gap-6">
-          <AuthLayouts.FormFields>
+          <AuthLayouts.Fields>
             <TextFormField name="email" label="Email" type="email" />
             <TextFormField name="password" label="Password" type="password" />
-          </AuthLayouts.FormFields>
-          <AuthLayouts.Submit disabled={isSubmitting}>Sign in</AuthLayouts.Submit>
+          </AuthLayouts.Fields>
+          <AuthLayouts.Submit label="sign-in" isSubmitting={isSubmitting} isValid={isValid} dirty={dirty} />
         </Form>
       )}
     </Formik>

--- a/web/lib/opal/src/layouts/auth/README.md
+++ b/web/lib/opal/src/layouts/auth/README.md
@@ -15,7 +15,7 @@ No props — accepts `children` only.
 
 ### Card
 
-The main auth card. Renders the Onyx logo (or a custom logo), a heading, an optional
+The main auth card. Renders the product logo (or a custom logo), a heading, an optional
 description, card content, and a bottom prompt rendered outside/below the card border.
 
 | Prop | Type | Default | Description |
@@ -24,7 +24,7 @@ description, card content, and a bottom prompt rendered outside/below the card b
 | `description` | `string \| RichStr` | — | Subtitle below the heading |
 | `children` | `ReactNode` | — | Card body (form, buttons, separators) |
 | `bottomPrompt` | `string \| RichStr` | — | Text/link below the card (e.g. "Already have an account?") |
-| `logoSrc` | `string \| null` | — | Custom logo URL; falls back to the Onyx logo |
+| `logoSrc` | `string \| null` | — | Custom logo URL; falls back to the default logo |
 
 ### OrSeparator
 
@@ -60,9 +60,9 @@ import { markdown } from "@opal/utils";
 
 <AuthLayouts.Root>
   <AuthLayouts.Card
-    title="Welcome to Onyx"
-    description="Your open source AI platform for work"
-    bottomPrompt={markdown("New to Onyx? [Create an Account](/auth/signup)")}
+    title="Welcome back"
+    description="Sign in to your account"
+    bottomPrompt={markdown("Don't have an account? [Create an Account](/auth/signup)")}
     logoSrc={logoUrl}
   >
     <SignInButton authorizeUrl={authUrl} authType={AuthType.CLOUD} />

--- a/web/lib/opal/src/layouts/auth/README.md
+++ b/web/lib/opal/src/layouts/auth/README.md
@@ -68,13 +68,13 @@ import { markdown } from "@opal/utils";
     <SignInButton authorizeUrl={authUrl} authType={AuthType.CLOUD} />
     <AuthLayouts.OrSeparator />
     <Formik ...>
-      {({ isSubmitting }) => (
+      {({ isSubmitting, isValid, dirty }) => (
         <Form className="flex flex-col gap-6">
           <AuthLayouts.Fields>
             <TextFormField name="email" label="Email" type="email" />
             <TextFormField name="password" label="Password" type="password" />
           </AuthLayouts.Fields>
-          <AuthLayouts.Submit label="sign-in" isSubmitting={isSubmitting} isValid={isValid} dirty={dirty} />
+          <AuthLayouts.Submit label="submit" isSubmitting={isSubmitting} isValid={isValid} dirty={dirty} />
         </Form>
       )}
     </Formik>

--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -146,7 +146,7 @@ function Submit({ label, isSubmitting, isValid, dirty }: SubmitProps) {
     <Button
       type="submit"
       width="full"
-      disabled={isSubmitting || !isValid || !dirty}
+      disabled={Boolean(isSubmitting) || (isValid !== undefined && !isValid) || (dirty !== undefined && !dirty)}
       icon={isSubmitting ? SvgSimpleLoader : undefined}
       rightIcon={SvgArrowRightCircle}
     >

--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import "@opal/layouts/auth/styles.css";
+import {
+  Button,
+  Card as OpalCard,
+  EndOfList,
+  MessageCard,
+  Text,
+} from "@opal/components";
+import { Form } from "formik";
+import SvgArrowRightCircle from "@opal/icons/arrow-right-circle";
+import { Content } from "@opal/layouts";
+import { SvgOnyxLogo } from "@opal/logos";
+import type { RichStr } from "@opal/types";
+import { SvgSimpleLoader } from "@opal/icons";
+
+// ---------------------------------------------------------------------------
+// Root — screen-centering wrapper for auth pages
+// ---------------------------------------------------------------------------
+
+interface RootProps {
+  children: React.ReactNode;
+}
+
+function Root({ children }: RootProps) {
+  return <div className="opal-auth-root">{children}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Card — logo + header + content + optional bottom prompt
+// ---------------------------------------------------------------------------
+
+interface CardProps {
+  title: string | RichStr;
+  description?: string | RichStr;
+  children?: React.ReactNode;
+  bottomPrompt?: string | RichStr;
+  logoSrc?: string | null;
+}
+
+function Card({
+  title,
+  description,
+  children,
+  bottomPrompt,
+  logoSrc,
+}: CardProps) {
+  return (
+    <div className="opal-auth-card-outer">
+      <OpalCard padding="lg" rounding="lg" shadow="lg">
+        <div className="flex flex-col gap-6">
+          <div className="flex flex-col gap-3">
+            <div className="p-0.5">
+              {logoSrc ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  alt="Logo"
+                  src={logoSrc}
+                  className="rounded-full object-cover object-center"
+                  style={{ width: "3rem", height: "3rem" }}
+                />
+              ) : (
+                <SvgOnyxLogo size={48} />
+              )}
+            </div>
+            <Content
+              sizePreset="headline"
+              variant="heading"
+              title={title}
+              description={description}
+            />
+          </div>
+          <div className="flex flex-col gap-4">{children}</div>
+        </div>
+      </OpalCard>
+
+      {bottomPrompt && (
+        <div className="opal-auth-card-bottom-prompt">
+          <Text color="text-03" as="p">
+            {bottomPrompt}
+          </Text>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FormBody — Formik Form wrapper with standard auth-page layout classes
+// ---------------------------------------------------------------------------
+
+interface FormBodyProps {
+  children: React.ReactNode;
+}
+
+function FormBody({ children }: FormBodyProps) {
+  return (
+    <Form className="w-full flex flex-col items-stretch gap-4">{children}</Form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// OrSeparator — "or" label flanked by two divider lines
+// ---------------------------------------------------------------------------
+
+function OrSeparator() {
+  return <EndOfList title="or" />;
+}
+
+// ---------------------------------------------------------------------------
+// Fields — consistent-gap container for form inputs
+// ---------------------------------------------------------------------------
+
+interface FieldsProps {
+  children: React.ReactNode;
+}
+
+function Fields({ children }: FieldsProps) {
+  return <div className="opal-auth-fields">{children}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// Submit — full-width submit button
+// ---------------------------------------------------------------------------
+
+type SubmitLabel = "submit" | "create" | "join" | "reset" | "impersonate";
+
+interface SubmitProps {
+  label: SubmitLabel;
+  isSubmitting?: boolean;
+  isValid?: boolean;
+  dirty?: boolean;
+}
+
+const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
+  submit: "Sign In",
+  create: "Create Account",
+  join: "Join",
+  reset: "Reset Password",
+  impersonate: "Impersonate",
+};
+
+function Submit({ label, isSubmitting, isValid, dirty }: SubmitProps) {
+  return (
+    <Button
+      type="submit"
+      width="full"
+      disabled={isSubmitting || !isValid || !dirty}
+      icon={isSubmitting ? SvgSimpleLoader : undefined}
+      rightIcon={SvgArrowRightCircle}
+    >
+      {SUBMIT_LABEL_TEXT[label]}
+    </Button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Message — restrictive wrapper over MessageCard for auth pages
+// ---------------------------------------------------------------------------
+
+type MessageType = "default" | "warning" | "success";
+
+interface MessageProps {
+  messageType?: MessageType;
+  title: string | RichStr;
+  description: string | RichStr;
+}
+
+function Message({
+  messageType = "default",
+  title,
+  description,
+}: MessageProps) {
+  return (
+    <MessageCard
+      variant={messageType}
+      title={title}
+      description={description}
+    />
+  );
+}
+
+export {
+  Root,
+  type CardProps,
+  Card,
+  type FormBodyProps,
+  FormBody,
+  OrSeparator,
+  type FieldsProps,
+  Fields,
+  type SubmitLabel,
+  type SubmitProps,
+  Submit,
+  type MessageType,
+  type MessageProps,
+  Message,
+};

--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -11,8 +11,7 @@ import {
 import { Form } from "formik";
 import SvgArrowRightCircle from "@opal/icons/arrow-right-circle";
 import { Content } from "@opal/layouts";
-import { SvgOnyxLogo } from "@opal/logos";
-import type { RichStr } from "@opal/types";
+import type { IconFunctionComponent, RichStr } from "@opal/types";
 import { SvgSimpleLoader } from "@opal/icons";
 
 // ---------------------------------------------------------------------------
@@ -32,19 +31,19 @@ function Root({ children }: RootProps) {
 // ---------------------------------------------------------------------------
 
 interface CardProps {
+  icon: IconFunctionComponent;
   title: string | RichStr;
   description?: string | RichStr;
   children?: React.ReactNode;
   bottomPrompt?: string | RichStr;
-  logoSrc?: string | null;
 }
 
 function Card({
+  icon: Icon,
   title,
   description,
   children,
   bottomPrompt,
-  logoSrc,
 }: CardProps) {
   return (
     <div className="opal-auth-card-outer">
@@ -52,17 +51,7 @@ function Card({
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-3">
             <div className="p-0.5">
-              {logoSrc ? (
-                // eslint-disable-next-line @next/next/no-img-element
-                <img
-                  alt="Logo"
-                  src={logoSrc}
-                  className="rounded-full object-cover object-center"
-                  style={{ width: "3rem", height: "3rem" }}
-                />
-              ) : (
-                <SvgOnyxLogo size={48} />
-              )}
+              <Icon size={48} />
             </div>
             <Content
               sizePreset="headline"

--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -146,7 +146,11 @@ function Submit({ label, isSubmitting, isValid, dirty }: SubmitProps) {
     <Button
       type="submit"
       width="full"
-      disabled={Boolean(isSubmitting) || (isValid !== undefined && !isValid) || (dirty !== undefined && !dirty)}
+      disabled={
+        Boolean(isSubmitting) ||
+        (isValid !== undefined && !isValid) ||
+        (dirty !== undefined && !dirty)
+      }
       icon={isSubmitting ? SvgSimpleLoader : undefined}
       rightIcon={SvgArrowRightCircle}
     >

--- a/web/lib/opal/src/layouts/auth/styles.css
+++ b/web/lib/opal/src/layouts/auth/styles.css
@@ -1,0 +1,25 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   AuthLayouts
+
+   Full-screen centering shell and branded card for authentication pages.
+   --------------------------------------------------------------------------- */
+
+.opal-auth-root {
+  @apply flex min-h-screen items-center justify-center;
+}
+
+.opal-auth-card-outer {
+  @apply w-full flex flex-col gap-6;
+  max-width: var(--auth-container-width);
+}
+
+.opal-auth-card-bottom-prompt {
+  @apply text-center;
+}
+
+.opal-auth-fields {
+  @apply flex flex-col w-full;
+  gap: 0.75rem;
+}

--- a/web/lib/opal/src/layouts/content/styles.css
+++ b/web/lib/opal/src/layouts/content/styles.css
@@ -41,6 +41,12 @@
   color: var(--content-foreground);
 }
 
+[data-content-color="success"] {
+  --content-foreground: var(--text-04);
+  --content-foreground-icon: var(--status-success-05);
+  color: var(--content-foreground);
+}
+
 [data-content-color="danger"] {
   --content-foreground: var(--status-error-05);
   --content-foreground-icon: var(--status-error-05);

--- a/web/lib/opal/src/layouts/index.ts
+++ b/web/lib/opal/src/layouts/index.ts
@@ -68,3 +68,12 @@ export type {
 /* SidebarLayouts */
 export * as SidebarLayouts from "@opal/layouts/sidebar/components";
 export { type SidebarRootProps } from "@opal/layouts/sidebar/components";
+
+/* AuthLayouts */
+export * as AuthLayouts from "@opal/layouts/auth/components";
+export type {
+  CardProps as AuthCardProps,
+  FieldsProps as AuthFieldsProps,
+  SubmitProps as AuthSubmitProps,
+  SubmitLabel as AuthSubmitLabel,
+} from "@opal/layouts/auth/components";

--- a/web/lib/opal/src/layouts/inputs/components.tsx
+++ b/web/lib/opal/src/layouts/inputs/components.tsx
@@ -72,6 +72,8 @@ interface InputLayoutProps {
 
 interface VerticalProps extends InputLayoutProps {
   subDescription?: string | RichStr;
+  /** Optional text or markdown rendered at the top-right of the label row. */
+  topRight?: string | RichStr;
 }
 
 function Vertical({
@@ -80,6 +82,7 @@ function Vertical({
   ref,
   children,
   subDescription,
+  topRight,
   title,
   tag,
   description,
@@ -88,16 +91,37 @@ function Vertical({
   const fieldName =
     typeof withLabelProp === "string" ? withLabelProp : undefined;
 
+  const titleRow = topRight ? (
+    <ContentAction
+      title={title}
+      description={description}
+      suffix={suffix}
+      tag={tag}
+      sizePreset="main-ui"
+      variant="section"
+      width="full"
+      padding="fit"
+      rightChildren={
+        <Text font="secondary-body" color="text-03" as="p">
+          {topRight}
+        </Text>
+      }
+      center
+    />
+  ) : (
+    <Content
+      title={title}
+      description={description}
+      suffix={suffix}
+      tag={tag}
+      sizePreset="main-ui"
+      variant="section"
+    />
+  );
+
   const content = (
     <Section ref={ref} gap={0.25} alignItems="start">
-      <Content
-        title={title}
-        description={description}
-        suffix={suffix}
-        tag={tag}
-        sizePreset="main-ui"
-        variant="section"
-      />
+      {titleRow}
       {children}
       {fieldName && <FormikInputError name={fieldName} />}
       {subDescription && (

--- a/web/lib/opal/src/styles/sizes.css
+++ b/web/lib/opal/src/styles/sizes.css
@@ -25,6 +25,10 @@
 
   --chrome-header-height: 3.25rem;
 
+  --auth-container-width: 24rem;
+}
+
+:root {
   /* BLOCK — WIDTH */
   --block-width-tooltip-max: 15rem;
 

--- a/web/lib/opal/src/types.ts
+++ b/web/lib/opal/src/types.ts
@@ -150,6 +150,7 @@ export type BackgroundVariants = "none" | "light" | "heavy";
 export type ColorTypes =
   | "default"
   | "muted"
+  | "success"
   | "danger"
   | "warning"
   | "interactive";

--- a/web/src/lib/app/utils.tsx
+++ b/web/src/lib/app/utils.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { SvgOnyxLogo } from "@opal/logos";
+import type { IconFunctionComponent } from "@opal/types";
+
+function makeImgIcon(src: string): IconFunctionComponent {
+  return function AppLogoImg({ size = 48 }) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        alt="Logo"
+        src={src}
+        className="rounded-full object-cover object-center"
+        style={{ width: size, height: size }}
+      />
+    );
+  };
+}
+
+export function getAppLogo(logoSrc?: string | null): IconFunctionComponent {
+  if (logoSrc) return makeImgIcon(logoSrc);
+  return SvgOnyxLogo;
+}


### PR DESCRIPTION
## Description

Opal-only changes extracted from `feat/auth-refresh` so they can land on `main` first. `feat/auth-refresh` will then merge latest `main` to eliminate these as a diff.

**`AuthLayouts`** — new layout system for auth pages:
- `AuthLayouts.Card`, `Fields`, `Submit`, `FormBody`, `Message` sub-components
- Covers login, signup, forgot-password, reset-password, and join flows

**`InlineMarkdown`** — adds `ul` / `ol` / `li` renderer support

**`InputLayouts.Vertical`** — adds `topRight` prop for auxiliary controls (e.g. "Forgot password?" link inline with a field label)

**`Content` — `"success"` color mode** — green icon (`--status-success-05`) + neutral text (`--text-04`); used by the upcoming `PasswordCriterion` component to indicate a met password rule

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `AuthLayouts` for card-based auth pages and small UI upgrades across `InlineMarkdown`, inputs, and `Content`. Also fixes `AuthLayouts.Submit` disabled logic when `isValid`/`dirty` are not provided.

- New Features
  - `AuthLayouts`: `Root`, `Card` (now requires `icon`), `Fields`, `FormBody`, `OrSeparator`, `Submit`, `Message` for login, signup, forgot/reset, and join; supports `bottomPrompt`.
  - `InlineMarkdown`: renders `ul` / `ol` / `li`.
  - `InputLayouts.Vertical`: `topRight` prop for inline actions.
  - `Content`: new `"success"` color; `ColorTypes` extended. Exported from `@opal/layouts`; added Storybook/README and `--auth-container-width` CSS var.

- Bug Fixes
  - `AuthLayouts.Submit`: disabled state no longer forced when `isValid`/`dirty` are omitted.
  - README: corrected component names, `Submit` API, and usage example.

<sup>Written for commit b4fd9fd42793737b4a460ee763db69617b1a9f1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

