### PR TITLE
fix(web): textarea resize utilities overridden by unlayered global CSS

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -182,10 +182,14 @@
 
 /* TEXTAREA */
 
-textarea {
-  resize: vertical;
-  scrollbar-width: thin;
-  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+/* In `base` so utility classes (e.g. `resize-none`) can override; an
+   unlayered rule would beat every layered Tailwind utility. */
+@layer base {
+  textarea {
+    resize: vertical;
+    scrollbar-width: thin;
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+  }
 }
 
 .nextjs-portal {

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -410,7 +410,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
                       onChange={(event) =>
                         setInstructionsMarkdown(event.target.value)
                       }
-                      className="min-h-[34rem] border-0"
+                      className="border-0"
                       placeholder="Write the skill instructions."
                       variant={fieldsLocked ? "disabled" : "internal"}
                     />


### PR DESCRIPTION
## Description

Two related fixes for textarea resizing, found via the skill editor page:

1. `globals.css` had an unlayered `textarea { resize: vertical; }` rule. Unlayered CSS beats cascade layers, so it silently overrode Tailwind's `resize-none`/`resize-y` utilities on every textarea in the app — e.g. the skill editor's description field (`autoResize`) showed a native drag handle it was never supposed to have, and the next keystroke snapped it back to content height. Moved the rule into `@layer base` so utilities apply again. This also restores intended non-resizability at the other `resize-none` call sites (message edit box, rename input, paste tile popover, standard-answer filter).

2. The skill editor's instructions `InputTextArea` passed `min-h-[34rem]` in `className`, which lands on the component's wrapper div (the visible card), not the inner textarea. Dragging the resize handle up shrank the textarea but the card stayed pinned at 34rem, masking the text. Removed the min-height; initial size still comes from `rows={22}` and the wrapper's `h-fit` now tracks the textarea both ways.

## How Has This Been Tested?

- Verified in the running app that `resize-none` computes to `resize: none` (previously `vertical`), `resize-y` still works, and bare textareas keep the `vertical` default.
- Manually exercised the skill edit page: instructions card now shrinks/grows with the drag handle; description field no longer shows a handle and auto-sizes as intended.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix textarea resizing across the app by layering the global textarea rule and removing an unnecessary min-height in the Skill Editor. Restores Tailwind utility control and prevents the instructions card from staying pinned when the textarea is resized.

- **Bug Fixes**
  - Moved `textarea` styles in `globals.css` into `@layer base` so `resize-none` and `resize-y` work again; `autoResize` fields no longer show a native handle.
  - Removed `min-h-[34rem]` from the Skill Editor instructions `InputTextArea` wrapper so the card grows and shrinks with the textarea.

<sup>Written for commit 71e3f3b95aad637ab821e21004d378ac378d2c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

