### PR TITLE
fix(agents): clear rejected file from agent editor upload state

### DIFF
--- a/web/src/providers/__tests__/ProjectsContext.test.tsx
+++ b/web/src/providers/__tests__/ProjectsContext.test.tsx
@@ -159,4 +159,40 @@ describe("ProjectsContext beginUpload size precheck", () => {
     expect(onSuccess).not.toHaveBeenCalled();
     expect(onFailure).toHaveBeenCalledWith([]);
   });
+
+  it("reports the optimistic temp id via onFailure when the server rejects a file", async () => {
+    const { result } = renderHook(() => useProjectsContext(), { wrapper });
+
+    const rejected = new File(["small"], "too-many-tokens.txt", {
+      type: "text/plain",
+    });
+    const onSuccess = jest.fn();
+    const onFailure = jest.fn();
+
+    mockUploadFiles.mockResolvedValue({
+      user_files: [],
+      rejected_files: [
+        { file_name: "too-many-tokens.txt", reason: "Exceeds token limit" },
+      ],
+    });
+
+    let optimisticFiles: ProjectFile[] = [];
+    await act(async () => {
+      optimisticFiles = await result.current.beginUpload(
+        [rejected],
+        null,
+        onSuccess,
+        onFailure
+      );
+    });
+
+    const tempId = optimisticFiles[0]?.temp_id;
+    expect(tempId).toBeTruthy();
+    expect(mockUploadFiles).toHaveBeenCalledTimes(1);
+    expect(mockToastWarning).toHaveBeenCalledTimes(1);
+    // AgentEditorPage relies on this callback firing with the failed temp id
+    // to strip the file from user_file_ids; otherwise the submit button stays
+    // disabled forever waiting on a phantom "uploading" file.
+    expect(onFailure).toHaveBeenCalledWith([tempId]);
+  });
 });

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -1099,6 +1099,13 @@ export default function AgentEditorPage({
           );
           selectedIds = replaced;
           setFieldValue("user_file_ids", replaced);
+        },
+        (failedTempIds) => {
+          // Drop optimistic ids for rejected files (e.g. size/token limit) so
+          // they don't linger as "uploading" and keep the submit button disabled.
+          const failed = new Set(failedTempIds);
+          selectedIds = selectedIds.filter((id) => !failed.has(id));
+          setFieldValue("user_file_ids", selectedIds);
         }
       );
       if (optimistic) {

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -552,6 +552,9 @@ export default function AgentEditorPage({
 
   const agentDraftStorageKey = draftKey("agent-editor", "new");
   const clearAgentDraftRef = useRef<(() => void) | null>(null);
+  // Tracks the latest user_file_ids so async upload callbacks reconcile against
+  // current form state rather than a stale snapshot from when the upload began.
+  const userFileIdsRef = useRef<string[]>([]);
 
   // Labels are edited in the Share Agent section and saved with the form
   const { labels: allLabels, createLabel } = useLabels();
@@ -1082,7 +1085,15 @@ export default function AgentEditorPage({
     const files = e.target.files;
     if (!files || files.length === 0) return;
     try {
-      let selectedIds = [...(currentFileIds || [])];
+      // Seed lazily from the latest form state on the first async callback so
+      // selections the user changed while the upload was in flight are kept.
+      // onFailure and onSuccess share this variable and both run in the same
+      // resolution, so their edits stay consistent with each other.
+      let workingIds: string[] | null = null;
+      const seed = () => {
+        if (workingIds === null) workingIds = [...userFileIdsRef.current];
+        return workingIds;
+      };
       const optimistic = await beginUpload(
         Array.from(files),
         null,
@@ -1094,24 +1105,23 @@ export default function AgentEditorPage({
               .filter((f) => f.temp_id)
               .map((f) => [f.temp_id as string, f.id])
           );
-          const replaced = (selectedIds || []).map(
-            (id: string) => tempToFinal.get(id) ?? id
-          );
-          selectedIds = replaced;
-          setFieldValue("user_file_ids", replaced);
+          workingIds = seed().map((id) => tempToFinal.get(id) ?? id);
+          setFieldValue("user_file_ids", workingIds);
         },
         (failedTempIds) => {
           // Drop optimistic ids for rejected files (e.g. size/token limit) so
           // they don't linger as "uploading" and keep the submit button disabled.
           const failed = new Set(failedTempIds);
-          selectedIds = selectedIds.filter((id) => !failed.has(id));
-          setFieldValue("user_file_ids", selectedIds);
+          workingIds = seed().filter((id) => !failed.has(id));
+          setFieldValue("user_file_ids", workingIds);
         }
       );
       if (optimistic) {
         const optimisticIds = optimistic.map((f) => f.id);
-        selectedIds = [...selectedIds, ...optimisticIds];
-        setFieldValue("user_file_ids", selectedIds);
+        setFieldValue("user_file_ids", [
+          ...(currentFileIds || []),
+          ...optimisticIds,
+        ]);
       }
     } catch (error) {
       console.error("Upload error:", error);
@@ -1151,6 +1161,9 @@ export default function AgentEditorPage({
           initialStatus={{ warnings: {} }}
         >
           {({ isSubmitting, isValid, dirty, values, setFieldValue }) => {
+            // Keep the ref in sync so async upload callbacks read current ids.
+            userFileIdsRef.current = values.user_file_ids;
+
             const fileStatusMap = new Map(
               allRecentFiles.map((f) => [f.id, f.status])
             );


### PR DESCRIPTION
## Description

Fixes a stuck **Create/Save** button in the agent editor when a knowledge-file upload is rejected by the server.

When a file uploaded under an agent's Knowledge section is rejected (e.g. it exceeds the size/token limit), the file disappears from the list but its optimistic `temp_` id was left behind in the form's `user_file_ids`. This kept `hasUploadingFiles` permanently true, disabling the submit button with a *"Please wait for files to finish uploading"* tooltip. Because the draft form auto-saves to `sessionStorage`, refreshing the same tab restored the broken state — while opening a new tab appeared to "fix" it (empty sessionStorage). Reported on v4.3.0.

**Root cause:** `beginUpload` already fires an `onFailure(failedTempIds)` callback on server rejection (and removes the optimistic file from `allRecentFiles`), but `handleUploadChange` in the agent editor never passed one — so the dead `temp_` id was never removed from `user_file_ids`.

**Fix:** Pass an `onFailure` handler to `beginUpload` that strips the failed `temp_` ids out of `user_file_ids`, mirroring the existing `onSuccess` path.

## How Has This Been Tested?

- Added a unit test in `ProjectsContext.test.tsx` covering the server-side `rejected_files` path (the reported trigger), asserting `beginUpload` fires `onFailure` with the rejected file's `temp_id`. The existing suite only covered the client-side size precheck. `4/4` passing.
- `tsc` / pre-commit TypeScript check pass.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stuck Create/Save button in the Agent Editor after a rejected Knowledge upload and prevents in-flight uploads from overwriting current file selections. Rejected uploads now clear their optimistic ids, and callbacks reconcile against the latest form state.

- **Bug Fixes**
  - Pass an onFailure handler to beginUpload to remove failed temp ids from user_file_ids, mirroring onSuccess.
  - Reconcile async onSuccess/onFailure against the latest user_file_ids via a ref, so user changes during upload aren’t clobbered.

- **Tests**
  - Adds a ProjectsContext test verifying onFailure receives the rejected file’s temp_id.

<sup>Written for commit d93697956e653f3b00ec651dd12662e5ff78988e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

