### PR TITLE
fix(notifications): Fix wrongly resolved ee notification module 

### DIFF
--- a/backend/onyx/server/features/notifications/api.py
+++ b/backend/onyx/server/features/notifications/api.py
@@ -65,7 +65,7 @@ def _ensure_license_expiry_notification(user: User, db_session: Session) -> None
     task. No-op on non-EE builds (and for non-admins / no active warning)."""
     try:
         fetch_ee_implementation_or_noop(
-            "ee.onyx.utils.license_notifications",
+            "onyx.utils.license_notifications",
             "ensure_license_expiry_notification_for_user",
         )(user, db_session)
     except Exception:


### PR DESCRIPTION
## Description
Currently, we see something like this in the logs:

```
DEBUG:    07/09/2026 09:51:05 AM      variable_functionality.py   93: [API:2SnPMSyv] Fetching versioned implementation for ee.onyx.utils.license_notifications.ensure_license_expiry_notification_for_user
  WARNING:  07/09/2026 09:51:05 AM      variable_functionality.py  100: [API:2SnPMSyv] Failed to fetch versioned implementation for ee.ee.onyx.utils.license_notifications.ensure_license_expiry_notification_for_user: No module named 'ee.ee'
  ERROR:    07/09/2026 09:51:05 AM      variable_functionality.py  195: [API:2SnPMSyv] Failed to fetch implementation for ee.onyx.utils.license_notifications.ensure_license_expiry_notification_for_user: No module named 'ee.ee'
  ERROR:    07/09/2026 09:51:05 AM                         api.py   72: [API:2SnPMSyv] Failed to ensure license expiry notification on read
  Traceback (most recent call last):
    File "/Users/durban/onyx/backend/onyx/server/features/notifications/api.py", line 67, in _ensure_license_expiry_notification
      fetch_ee_implementation_or_noop(
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
          "ee.onyx.utils.license_notifications",
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
          "ensure_license_expiry_notification_for_user",
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      )(user, db_session)
```

The root cause of this is we fetch 'ee.onyx.utils.license_notifications'. The fetch_ee_implementation_or_noop also prepends an 'ee.' so we end up in a case of 'ee.ee.onyx.utils.license_notifications' which does nto exist.

This removes that first ee fetch so we fetch appropriately

## How Has This Been Tested?
Manual

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix EE notification module resolution by passing `onyx.utils.license_notifications` to `fetch_ee_implementation_or_noop` instead of an EE-prefixed path. This prevents `ee.ee` import errors and lets `ensure_license_expiry_notification_for_user` run correctly in EE builds (no-op otherwise).

<sup>Written for commit 1249e0dde3c28791d63c2f2e22ae38f16c6d56ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

