### PR TITLE
fix(auth): stop /me from 500ing for service-account API key users

### DIFF
--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -1030,23 +1030,31 @@ def verify_user_logged_in(
             else oidc_expiry
         )
 
-    team_name = fetch_ee_implementation_or_noop(
-        "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
-    )(user.email)
-
+    team_name: str | None
     new_tenant: TenantSnapshot | None = None
     tenant_invitation: TenantSnapshot | None = None
 
-    if MULTI_TENANT:
-        if team_name != get_current_tenant_id():
-            user_count = fetch_ee_implementation_or_noop(
-                "onyx.server.tenants.user_mapping", "get_tenant_count", None
-            )(team_name)
-            new_tenant = TenantSnapshot(tenant_id=team_name, number_of_users=user_count)
-
-        tenant_invitation = fetch_ee_implementation_or_noop(
-            "onyx.server.tenants.user_mapping", "get_tenant_invitation", None
+    # Service-account (API key) emails are synthetic with no UserTenantMapping row,
+    # so get_tenant_id_for_email raises. An API key belongs only to its own tenant.
+    if MULTI_TENANT and user.account_type == AccountType.SERVICE_ACCOUNT:
+        team_name = tenant_id
+    else:
+        team_name = fetch_ee_implementation_or_noop(
+            "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
         )(user.email)
+
+        if MULTI_TENANT:
+            if team_name != tenant_id:
+                user_count = fetch_ee_implementation_or_noop(
+                    "onyx.server.tenants.user_mapping", "get_tenant_count", None
+                )(team_name)
+                new_tenant = TenantSnapshot(
+                    tenant_id=team_name, number_of_users=user_count
+                )
+
+            tenant_invitation = fetch_ee_implementation_or_noop(
+                "onyx.server.tenants.user_mapping", "get_tenant_invitation", None
+            )(user.email)
 
     super_users_list = cast(
         list[str],

--- a/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
+++ b/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
@@ -9,6 +9,7 @@ from onyx.db.enums import Permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.users import list_all_users_basic_info
+from onyx.server.manage.users import verify_user_logged_in
 from onyx.server.security.models import SecuritySettings
 from onyx.server.security.store import _build_env_defaults
 
@@ -109,3 +110,45 @@ def test_list_all_users_basic_info_allows_non_admin_when_flag_off(
 
     # BOT accounts are filtered out; human account is returned.
     assert [u.email for u in result] == ["human@example.com"]
+
+
+def test_me_service_account_skips_tenant_mapping_lookup() -> None:
+    """/me must not consult the tenant mapping for a multi-tenant service
+    account (its synthetic email has no UserTenantMapping row and the lookup
+    raises). team_name is the key's own tenant."""
+    user = _fake_user(
+        "API_KEY__key@abc123onyxapikey.ai",
+        account_type=AccountType.SERVICE_ACCOUNT,
+    )
+    user.oidc_expiry = None
+
+    with (
+        patch("onyx.server.manage.users.MULTI_TENANT", True),
+        patch(
+            "onyx.server.manage.users.get_current_tenant_id",
+            return_value="tenant_current",
+        ),
+        patch(
+            "onyx.server.manage.users.fetch_ee_implementation_or_noop",
+            side_effect=AssertionError(
+                "tenant mapping consulted for a service account"
+            ),
+        ),
+        patch(
+            "onyx.server.manage.users.fetch_versioned_implementation_with_fallback",
+            return_value=[],
+        ),
+        patch("onyx.server.manage.users.get_memories_for_user", return_value=[]),
+        patch(
+            "onyx.server.manage.users.get_security_settings",
+            return_value=_settings(user_directory_admin_only=False),
+        ),
+        patch("onyx.server.manage.users._get_token_created_at", return_value=None),
+        patch("onyx.server.manage.users.UserInfo") as mock_user_info,
+    ):
+        verify_user_logged_in(request=MagicMock(), user=user, db_session=MagicMock())
+
+    kwargs = mock_user_info.from_model.call_args.kwargs
+    assert kwargs["team_name"] == "tenant_current"
+    assert kwargs["tenant_info"].new_tenant is None
+    assert kwargs["tenant_info"].invitation is None


### PR DESCRIPTION
## Description

**Bug:** `cloud.onyx.app/mcp` rejects every valid Onyx API key with `401 invalid_token`.

**Why:** The MCP server authenticates by calling `/me` and treats any non-200 as auth failure. `/me` resolves a home tenant via `get_tenant_id_for_email(user.email)` for every authenticated user. In multi-tenant, API-key (service-account) users have a synthetic `@onyxapikey.ai` email with no `UserTenantMapping` row, so the lookup raises `UserNotExists`, which is unhandled and returns 500. Chat endpoints never call this path, so the same key works for chat.

**Fix:** In multi-tenant, skip the home-tenant/invitation lookup for service accounts and report the current tenant as `team_name`. An API key is tenant-bound, so this is exact. Single-tenant and CE paths are unchanged.

Confirmed in cloud logs: mcp-server `API server rejected MCP auth token with status 500` lines up with api-server tracebacks ending at `user_mapping.py get_tenant_id_for_email` for the reporting tenants.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check