### PR TITLE
fix(llm): omit sampling params and use adaptive thinking for claude-sonnet-5 (#12735) [v4.2]

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -88,6 +88,8 @@ _ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
     "claude-5-fable",
     "claude-mythos-5",
     "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
 )
 
 # Anthropic models that reject any non-default sampling parameter (temperature,
@@ -109,6 +111,8 @@ _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
     "claude-5-fable",
     "claude-mythos-5",
     "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-5-sonnet",
 )
 
 

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -442,6 +442,9 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-5-fable",
     "claude-mythos-5",
     "claude-5-mythos",
+    "claude-sonnet-5",
+    "claude-sonnet-5@20260203",
+    "claude-5-sonnet",
 ]
 
 
@@ -477,6 +480,8 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         "claude-5-fable",
         "claude-mythos-5",
         "claude-5-mythos",
+        "claude-sonnet-5",
+        "claude-5-sonnet",
     ],
 )
 @pytest.mark.parametrize(
@@ -524,6 +529,38 @@ def test_keeps_temperature_for_other_models(default_multi_llm: LitellmLLM) -> No
 
         kwargs = mock_completion.call_args.kwargs
         assert kwargs["temperature"] == 0.0
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "claude-sonnet-4-5",
+        "claude-sonnet-4-6",
+        "claude-3-5-sonnet-20241022",
+    ],
+)
+def test_keeps_temperature_for_older_sonnet_models(model_name: str) -> None:
+    # The no-sampling-params match is substring-based; make sure sonnet-5
+    # entries don't catch older sonnets, which still accept temperature.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name=model_name,
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name=model_name,
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "temperature" in kwargs
 
 
 @pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)


### PR DESCRIPTION
## Description

Cherry-pick of #12735 to the `release/v4.2` branch.

Claude Sonnet 5 rejects non-default sampling parameters (`temperature`/`top_p`/`top_k`) with a 400 and only supports the adaptive thinking API. This adds `claude-sonnet-5` / `claude-5-sonnet` to `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS` and `_ANTHROPIC_ADAPTIVE_THINKING_MODELS`, mirroring the earlier Opus 4.7/4.8 and Fable 5 fixes. Older Sonnets are unaffected.

Applied cleanly with no conflicts.

## How Has This Been Tested?

Covered by the parametrized unit tests in `backend/tests/unit/onyx/llm/test_multi_llm.py` (carried over in the cherry-pick).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent Anthropic 400 errors on Claude Sonnet 5 by omitting sampling parameters and using adaptive thinking. Adds support for `claude-sonnet-5` and `claude-5-sonnet`; older Sonnets are unchanged.

- **Bug Fixes**
  - Added `claude-sonnet-5` and `claude-5-sonnet` to `_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS` and `_ANTHROPIC_ADAPTIVE_THINKING_MODELS`.
  - Extended tests to cover both identifiers and a dated variant, and to confirm older Sonnet models keep `temperature`.

<sup>Written for commit d46007b3f6043fc1951929a021d8aff5a9afeb43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

