### PR TITLE
docs(agents): recommend playwright bootstrap admin credentials in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,8 +7,10 @@ This file provides guidance to AI agents when working with code in this reposito
 - Python deps live in a `uv`-managed virtualenv at `.venv` (repo root). If it doesn't exist yet, create it \
   with `uv sync --frozen`, then `source .venv/bin/activate`.
 - To make tests work, check the `.env` file at the root of the project to find an OpenAI key.
-- If using `playwright` to explore the frontend, you can usually log in with username `a@example.com` and password
-  `a`. The app can be accessed at `http://localhost:3000`.
+- If using `playwright` to explore the frontend, log in with username `admin_user@example.com` and password
+  `TestPassword123!` (the admin user created by the playwright global setup — see
+  `web/tests/e2e/constants.ts`). If it doesn't exist yet, register it via the signup page; the first user
+  registered automatically becomes admin. The app can be accessed at `http://localhost:3000`.
 - You should assume that all Onyx services are running. To verify, you can check the `backend/log` directory to
   make sure we see logs coming out from the relevant service.
 - To connect to the Postgres database, use: `docker exec -it onyx-relational_db-1 psql -U postgres -c "<SQL>"`


### PR DESCRIPTION
## Description

AGENTS.md previously told agents to log into the frontend with `a@example.com` / `a`. That guidance is broken:

1. The password `a` fails the default 8-character minimum, so the account can't even be registered as described.
2. The user is not created by the playwright pre-flight initialization, so it usually doesn't exist.

This updates the note to point at `admin_user@example.com` / `TestPassword123!` — the admin user that `web/tests/e2e/global-setup.ts` registers from `TEST_ADMIN_CREDENTIALS` in `web/tests/e2e/constants.ts` — and mentions that registering it via signup works too, since the first registered user automatically becomes admin.

## How Has This Been Tested?

Docs-only change; credentials verified against `web/tests/e2e/constants.ts` and `global-setup.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update AGENTS.md to point `playwright` users to the bootstrap admin credentials `admin_user@example.com` / `TestPassword123!`, replacing the broken `a@example.com` / `a` guidance. Notes these are created by the `playwright` global setup and that signing up also works since the first user becomes admin.

<sup>Written for commit f1e6a9d32a07d94f003212cec5302e80df5cc006. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

