### PR TITLE
fix(web): key model-selector selection by model configuration id

### DIFF
--- a/web/src/hooks/useMultiModelChat.ts
+++ b/web/src/hooks/useMultiModelChat.ts
@@ -7,7 +7,7 @@ import {
 } from "@/sections/model-selector/MultiModelSelector";
 import { LLMOverride } from "@/app/app/services/lib";
 import { LlmManager } from "@/lib/hooks";
-import { buildLlmOptions } from "@/lib/languageModels/options";
+import { buildLlmOptions, llmOptionKey } from "@/lib/languageModels/options";
 
 export interface UseMultiModelChatReturn {
   /** Currently selected models for multi-model comparison. */
@@ -56,16 +56,21 @@ export default function useMultiModelChat(
     if (llmOptions.length === 0) return null;
     const { currentLlm } = llmManager;
     if (!currentLlm.modelName) return null;
-    const match = llmOptions.find(
+    // Two providers can expose a model with the same name; prefer the one
+    // whose provider (instance) name matches the current descriptor.
+    const candidates = llmOptions.filter(
       (opt) =>
         opt.provider === currentLlm.provider &&
         opt.modelName === currentLlm.modelName
     );
+    const match =
+      candidates.find((opt) => opt.name === currentLlm.name) ?? candidates[0];
     if (!match) return null;
     return {
       name: match.name,
       provider: match.provider,
       modelName: match.modelName,
+      modelConfigurationId: match.modelConfigurationId ?? null,
       displayName: match.displayName,
     };
   }, [llmOptions, llmManager.currentLlm]);
@@ -92,12 +97,7 @@ export default function useMultiModelChat(
         const base =
           prev.length <= 1 && currentLlmModel ? [currentLlmModel] : prev;
         if (base.length >= MAX_MODELS) return base;
-        if (
-          base.some(
-            (m) =>
-              m.provider === model.provider && m.modelName === model.modelName
-          )
-        ) {
+        if (base.some((m) => llmOptionKey(m) === llmOptionKey(model))) {
           return base;
         }
         return [...base, model];
@@ -140,10 +140,7 @@ export default function useMultiModelChat(
         // Don't replace with a model that's already selected elsewhere
         if (
           prev.some(
-            (m, i) =>
-              i !== index &&
-              m.provider === model.provider &&
-              m.modelName === model.modelName
+            (m, i) => i !== index && llmOptionKey(m) === llmOptionKey(model)
           )
         ) {
           return prev;
@@ -178,6 +175,7 @@ export default function useMultiModelChat(
             name: match.name,
             provider: match.provider,
             modelName: match.modelName,
+            modelConfigurationId: match.modelConfigurationId ?? null,
             displayName: match.displayName,
           });
         }
@@ -204,6 +202,7 @@ export default function useMultiModelChat(
             name: match.name,
             provider: match.provider,
             modelName: match.modelName,
+            modelConfigurationId: match.modelConfigurationId ?? null,
             displayName: match.displayName,
           },
         ]);

--- a/web/src/hooks/useMultiModelChat.ts
+++ b/web/src/hooks/useMultiModelChat.ts
@@ -27,11 +27,14 @@ export interface UseMultiModelChatReturn {
   /**
    * Restore multi-model selection from model version strings (e.g. from chat history).
    * Matches against available llmOptions to reconstruct full SelectedModel objects.
+   * History stores only name strings, so when two providers expose a model with the
+   * same name this resolves to the first match.
    */
   restoreFromModelNames: (modelNames: string[]) => void;
   /**
    * Switch to a single model by name (after user picks a preferred response).
-   * Matches against llmOptions to find the full SelectedModel.
+   * Matches against llmOptions to find the full SelectedModel. Name-only, so
+   * same-named models across providers resolve to the first match.
    */
   selectSingleModel: (modelName: string) => void;
 }

--- a/web/src/lib/languageModels/options.test.ts
+++ b/web/src/lib/languageModels/options.test.ts
@@ -1,0 +1,73 @@
+import { buildLlmOptions, llmOptionKey } from "@/lib/languageModels/options";
+import type {
+  LLMProviderDescriptor,
+  ModelConfiguration,
+} from "@/lib/languageModels/types";
+
+function makeModelConfiguration(id: number, name: string): ModelConfiguration {
+  return {
+    id,
+    name,
+    is_visible: true,
+    max_input_tokens: null,
+    supports_image_input: false,
+    supports_reasoning: false,
+    effectiveDisplayName: name,
+  };
+}
+
+function makeProvider(
+  id: number,
+  name: string,
+  provider: string,
+  modelConfigurations: ModelConfiguration[]
+): LLMProviderDescriptor {
+  return {
+    id,
+    name,
+    provider,
+    provider_display_name: name,
+    model_configurations: modelConfigurations,
+  };
+}
+
+describe("llmOptionKey", () => {
+  it("gives distinct keys to same-named models from different providers", () => {
+    const providers = [
+      makeProvider(1, "OpenAI Main", "openai", [
+        makeModelConfiguration(11, "gpt-4o"),
+      ]),
+      makeProvider(2, "OpenAI Backup", "openai", [
+        makeModelConfiguration(22, "gpt-4o"),
+      ]),
+    ];
+
+    const keys = buildLlmOptions(providers).map(llmOptionKey);
+
+    expect(keys).toHaveLength(2);
+    expect(new Set(keys).size).toBe(2);
+  });
+
+  it("keys by model configuration id when present", () => {
+    expect(
+      llmOptionKey({
+        provider: "openai",
+        modelName: "gpt-4o",
+        modelConfigurationId: 11,
+      })
+    ).toBe("mc:11");
+  });
+
+  it("falls back to provider + model name without an id", () => {
+    expect(
+      llmOptionKey({
+        provider: "openai",
+        modelName: "gpt-4o",
+        modelConfigurationId: null,
+      })
+    ).toBe("openai:gpt-4o");
+    expect(llmOptionKey({ provider: "openai", modelName: "gpt-4o" })).toBe(
+      "openai:gpt-4o"
+    );
+  });
+});

--- a/web/src/lib/languageModels/options.ts
+++ b/web/src/lib/languageModels/options.ts
@@ -48,6 +48,26 @@ export const GLOBAL_DEFAULT_LLM_OPTION: LLMOption = {
 };
 
 // ---------------------------------------------------------------------------
+// llmOptionKey
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable identity key for a selectable model. Prefers the unique model
+ * configuration id; the provider + model name fallback can collide when two
+ * providers expose a model with the same name, so it is only used for
+ * options that were never persisted (no id).
+ */
+export function llmOptionKey(option: {
+  provider: string;
+  modelName: string;
+  modelConfigurationId?: number | null;
+}): string {
+  return option.modelConfigurationId != null
+    ? `mc:${option.modelConfigurationId}`
+    : `${option.provider}:${option.modelName}`;
+}
+
+// ---------------------------------------------------------------------------
 // buildLlmOptions
 // ---------------------------------------------------------------------------
 

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -17,6 +17,7 @@ import {
   LLMOption,
   buildLlmOptions,
   groupLlmOptions,
+  llmOptionKey,
 } from "@/lib/languageModels/options";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import {
@@ -131,10 +132,7 @@ export default function ModelSelectorContent({
       capabilities.length > 0 ? capabilities.join(", ") : undefined;
 
     return (
-      <Disabled
-        key={`${option.provider}:${option.modelName}`}
-        disabled={disabled}
-      >
+      <Disabled key={llmOptionKey(option)} disabled={disabled}>
         <LineItemButton
           selectVariant="select-heavy"
           state={selected ? "selected" : "empty"}

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -12,7 +12,11 @@ import {
 import { SvgPlusCircle, SvgX } from "@opal/icons";
 import { cn } from "@opal/utils";
 import { useSettings } from "@/lib/settings/hooks";
-import { LLMOption, buildLlmOptions } from "@/lib/languageModels/options";
+import {
+  LLMOption,
+  buildLlmOptions,
+  llmOptionKey,
+} from "@/lib/languageModels/options";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
 import ModelSelectorContent from "@/sections/model-selector/ModelSelectorContent";
 
@@ -22,6 +26,8 @@ export interface SelectedModel {
   name: string;
   provider: string;
   modelName: string;
+  /** Unique id of the model configuration; disambiguates same-named models across providers. */
+  modelConfigurationId: number | null;
   displayName: string;
 }
 
@@ -30,10 +36,6 @@ export interface MultiModelSelectorProps {
   onAdd: (model: SelectedModel) => void;
   onRemove: (index: number) => void;
   onReplace: (index: number, model: SelectedModel) => void;
-}
-
-function modelKey(provider: string, modelName: string): string {
-  return `${provider}:${modelName}`;
 }
 
 export default function MultiModelSelector({
@@ -70,16 +72,14 @@ export default function MultiModelSelector({
       : "Add Model";
 
   const selectedKeys = useMemo(
-    () => new Set(selectedModels.map((m) => modelKey(m.provider, m.modelName))),
+    () => new Set(selectedModels.map(llmOptionKey)),
     [selectedModels]
   );
 
   const otherSelectedKeys = useMemo(() => {
     if (replacingIndex === null) return new Set<string>();
     return new Set(
-      selectedModels
-        .filter((_, i) => i !== replacingIndex)
-        .map((m) => modelKey(m.provider, m.modelName))
+      selectedModels.filter((_, i) => i !== replacingIndex).map(llmOptionKey)
     );
   }, [selectedModels, replacingIndex]);
 
@@ -87,18 +87,18 @@ export default function MultiModelSelector({
     replacingIndex !== null
       ? (() => {
           const m = selectedModels[replacingIndex];
-          return m ? modelKey(m.provider, m.modelName) : null;
+          return m ? llmOptionKey(m) : null;
         })()
       : null;
 
   const isSelected = (option: LLMOption) => {
-    const key = modelKey(option.provider, option.modelName);
+    const key = llmOptionKey(option);
     if (replacingIndex !== null) return key === replacingKey;
     return selectedKeys.has(key);
   };
 
   const isDisabled = (option: LLMOption) => {
-    const key = modelKey(option.provider, option.modelName);
+    const key = llmOptionKey(option);
     if (replacingIndex !== null) return otherSelectedKeys.has(key);
     return !selectedKeys.has(key) && atMax;
   };
@@ -108,6 +108,7 @@ export default function MultiModelSelector({
       name: option.name,
       provider: option.provider,
       modelName: option.modelName,
+      modelConfigurationId: option.modelConfigurationId ?? null,
       displayName: option.displayName,
     };
 
@@ -118,9 +119,9 @@ export default function MultiModelSelector({
       return;
     }
 
-    const key = modelKey(option.provider, option.modelName);
+    const key = llmOptionKey(option);
     const existingIndex = selectedModels.findIndex(
-      (m) => modelKey(m.provider, m.modelName) === key
+      (m) => llmOptionKey(m) === key
     );
     if (existingIndex >= 0) {
       onRemove(existingIndex);
@@ -199,9 +200,7 @@ export default function MultiModelSelector({
                   return (
                     <div
                       key={
-                        isMultiModel
-                          ? modelKey(model.provider, model.modelName)
-                          : "single-model-pill"
+                        isMultiModel ? llmOptionKey(model) : "single-model-pill"
                       }
                       className="flex items-center"
                     >


### PR DESCRIPTION
## Description

In the chat model selector, when two LLM providers expose a model with the same name (e.g. two openai-type providers both serving `gpt-4o`, or two Ollama instances both serving `qwen3.5:0.8b`), both entries rendered as selected when only one was, and clicking one could add/remove the other:

- `MultiModelSelector` keyed selection identity on `provider type + model name`, which collides across provider instances of the same type. `isSelected`, `isDisabled`, and the add/remove toggle all misfired on the colliding key.
- `useMultiModelChat` resolved `currentLlm` to an option by `provider + modelName` only, so the selection could snap to the wrong provider's same-named model.

### Fix

- Add `llmOptionKey`, which keys on the unique `model_configuration_id` and only falls back to `provider:modelName` for options without an id, and use it for all selection identity in `MultiModelSelector` / `useMultiModelChat` (and as the render key in `ModelSelectorContent`).
- Carry `modelConfigurationId` on `SelectedModel`.
- When resolving the current LLM descriptor to an option, prefer the candidate whose provider (instance) name matches before falling back to the first provider-type/model-name match.

## How Has This Been Tested?

- Jest unit test (`options.test.ts`) locking the invariant that same-named models from different providers get distinct keys.
- Manually against a dev deployment with two ollama_chat providers both exposing `qwen3.5:0.8b`:
  - Opening the selector from the pill shows exactly one checkmark, on the instance actually selected.
  - Selecting the other provider's same-named model moves the checkmark to that instance (and the auto-expanded group follows).
  - In multi-model mode, the same-named model from each provider can be added side by side, and toggling one off removes only its own pill (previously it removed the other provider's pill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the chat model selector showing/toggling the wrong item when different providers expose the same model name. Selections now key off unique model configuration IDs so single and multi-model modes behave correctly.

- **Bug Fixes**
  - Added `llmOptionKey` that keys by `model_configuration_id` (fallback to `provider:modelName` only when no id).
  - Switched selection, disabled, toggle logic, and render keys to use `llmOptionKey` in `MultiModelSelector` and `ModelSelectorContent`.
  - Carried `modelConfigurationId` on `SelectedModel`; `useMultiModelChat` now prefers matching provider instance name when resolving the current LLM.
  - Documented that `restoreFromModelNames` and `selectSingleModel` are name-only and resolve same-named models to the first match.
  - Added unit tests to ensure same-named models from different providers get distinct keys.

<sup>Written for commit 1dfd7d6ab001b70282953ed3d895e92620569c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

