### PR TITLE
test(auth): live multi-provider OIDC login against mock-oauth2-server

### DIFF
--- a/.github/workflows/pr-external-dependency-unit-tests.yml
+++ b/.github/workflows/pr-external-dependency-unit-tests.yml
@@ -148,6 +148,21 @@ jobs:
           alembic upgrade head
           alembic heads --verbose
 
+      # A real OIDC server for the live multi-provider login test. Auth leg only.
+      # Fail if it never becomes ready, otherwise the live tests would silently skip.
+      - name: Start mock OIDC server
+        if: matrix.test-dir == 'auth'
+        run: |
+          docker run -d --name mock-oidc -p 8086:8080 \
+            ghcr.io/navikt/mock-oauth2-server:2.1.10
+          ready="http://localhost:8086/issuer-a/.well-known/openid-configuration"
+          for _ in $(seq 1 30); do
+            curl -sf "$ready" >/dev/null && break
+            sleep 1
+          done
+          curl -sf "$ready" >/dev/null \
+            || { echo "mock OIDC server never became ready"; exit 1; }
+
       - name: Run Tests for ${{ matrix.test-dir }}
         shell: script -q -e -c "bash --noprofile --norc -eo pipefail {0}"
         env:

--- a/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
+++ b/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
@@ -1,0 +1,196 @@
+"""Live-IdP coverage for the DB-backed multi-provider OIDC login: two providers
+on one instance complete the full authorization-code flow against a real OIDC
+server (discovery fetch, code exchange, userinfo, JIT user provisioning, session
+issuance), and the per-provider email-domain gate rejects a cross-domain login.
+
+Uses navikt/mock-oauth2-server, a real OIDC server whose per-login claims are
+set through its documented username+claims form post, so there is no HTML
+scraping. Requires it reachable at MOCK_OIDC_URL (default http://localhost:8086).
+The module skips when it is not.
+
+The login flow runs in a single async test driven by httpx.AsyncClient, so every
+request shares one event loop. A sync TestClient opens a fresh loop per request,
+which strands the async DB connection the callback pooled on the prior request's
+loop."""
+
+import json
+import os
+from collections.abc import Generator
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from httpx import ASGITransport
+from httpx import AsyncClient
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import cookie_transport
+from onyx.db.enums import SSOProviderType
+from onyx.db.models import SSOProvider
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.sso_provider import create_sso_provider
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.server import oidc_multi
+
+_MOCK_URL = os.environ.get("MOCK_OIDC_URL", "http://localhost:8086").rstrip("/")
+_STATE_SECRET = "live-idp-test-secret"
+_WEB_DOMAIN = "http://testserver"
+
+_PROVIDER_A = "mock-a"
+_PROVIDER_B = "mock-b"
+_ISSUER_A = "issuer-a"
+_ISSUER_B = "issuer-b"
+_USER_A = "user-a@companya.com"
+_USER_B = "user-b@companyb.com"
+# A companyb.com identity offered to provider A, which only allows companya.com.
+_EVE = "eve@companyb.com"
+_SESSION_COOKIE = cookie_transport.cookie_name
+
+_EMAILS = [_USER_A, _USER_B, _EVE]
+_NAMES = [_PROVIDER_A, _PROVIDER_B]
+
+
+def _mock_reachable() -> bool:
+    try:
+        httpx.get(
+            f"{_MOCK_URL}/{_ISSUER_A}/.well-known/openid-configuration", timeout=2
+        ).raise_for_status()
+        return True
+    except httpx.HTTPError:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _mock_reachable(), reason="requires navikt/mock-oauth2-server (MOCK_OIDC_URL)"
+)
+
+
+def _config_url(issuer: str) -> str:
+    return f"{_MOCK_URL}/{issuer}/.well-known/openid-configuration"
+
+
+def _cleanup_db(db_session: Session) -> None:
+    users = list(
+        db_session.query(User).filter(
+            User.email.in_(_EMAILS)  # ty: ignore[unresolved-attribute]
+        )
+    )
+    user_ids = [user.id for user in users]
+    if user_ids:
+        # user__user_group is ON DELETE NO ACTION, so clear the group links first.
+        # oauth_account is ON DELETE CASCADE, so the user delete removes it.
+        db_session.query(User__UserGroup).filter(
+            User__UserGroup.user_id.in_(user_ids)
+        ).delete(synchronize_session=False)
+        for user in users:
+            db_session.delete(user)
+    for provider in db_session.query(SSOProvider).filter(SSOProvider.name.in_(_NAMES)):
+        db_session.delete(provider)
+    db_session.commit()
+
+
+@pytest.fixture
+def providers(db_session: Session) -> Generator[None, None, None]:
+    _cleanup_db(db_session)
+    for name, issuer, domain in (
+        (_PROVIDER_A, _ISSUER_A, "companya.com"),
+        (_PROVIDER_B, _ISSUER_B, "companyb.com"),
+    ):
+        create_sso_provider(
+            db_session=db_session,
+            name=name,
+            display_name=f"Mock OIDC {name}",
+            provider_type=SSOProviderType.OIDC,
+            config={
+                "client_id": "onyx-live",
+                "client_secret": "onyx-live-secret",
+                "openid_config_url": _config_url(issuer),
+            },
+            allowed_email_domains=[domain],
+        )
+    yield
+    _cleanup_db(db_session)
+
+
+@pytest.fixture
+def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    monkeypatch.setattr(oidc_multi, "WEB_DOMAIN", _WEB_DOMAIN)
+    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _STATE_SECRET)
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(oidc_multi.router)
+    register_onyx_exception_handlers(fastapi_app)
+    return fastapi_app
+
+
+def _idp_login(authorization_url: str, email: str) -> str:
+    """Post the identity to the IdP's login form and return the callback redirect
+    location. The claims set what userinfo returns."""
+    claims = json.dumps({"sub": email, "email": email, "email_verified": True})
+    with httpx.Client(follow_redirects=False, timeout=10) as browser:
+        submit = browser.post(
+            authorization_url, data={"username": email, "claims": claims}
+        )
+    assert submit.status_code == 302, submit.text
+    return submit.headers["location"]
+
+
+async def _drive_login(
+    client: AsyncClient, provider: str, email: str
+) -> httpx.Response:
+    """Full authorization-code flow: authorize on the Onyx side (CSRF cookie lands
+    in the client jar), log in at the IdP, then follow the redirect back into the
+    Onyx callback."""
+    resp = await client.get(f"/auth/oidc/{provider}/authorize")
+    assert resp.status_code == 200, resp.text
+    location = _idp_login(resp.json()["authorization_url"], email)
+
+    prefix = f"{_WEB_DOMAIN}/api"
+    assert location.startswith(f"{prefix}/auth/oidc/{provider}/callback")
+    # The web proxy strips /api before requests reach FastAPI.
+    return await client.get(location.removeprefix(prefix))
+
+
+@pytest.mark.usefixtures("providers")
+def test_two_providers_resolve_to_distinct_issuers(app: FastAPI) -> None:
+    client = TestClient(app)
+    urls = {
+        name: client.get(f"/auth/oidc/{name}/authorize").json()["authorization_url"]
+        for name in _NAMES
+    }
+    assert f"/{_ISSUER_A}/" in urls[_PROVIDER_A]
+    assert f"/{_ISSUER_B}/" in urls[_PROVIDER_B]
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("providers")
+async def test_two_providers_live_login_and_domain_gate(
+    app: FastAPI, db_session: Session
+) -> None:
+    logins = ((_PROVIDER_A, _USER_A), (_PROVIDER_B, _USER_B))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
+        # Both providers log in end-to-end on the one instance.
+        for provider, email in logins:
+            resp = await _drive_login(client, provider, email)
+            assert resp.status_code == 302, resp.text
+            assert _SESSION_COOKIE in resp.headers.get("set-cookie", "")
+
+        # Provider A only allows companya.com, so a companyb.com identity is rejected.
+        blocked = await _drive_login(client, _PROVIDER_A, _EVE)
+        assert blocked.status_code == 400, blocked.text
+        assert _SESSION_COOKIE not in blocked.headers.get("set-cookie", "")
+
+    db_session.expire_all()
+    for provider, email in logins:
+        user = (
+            db_session.query(User)
+            .filter(User.email == email)  # ty: ignore[invalid-argument-type]
+            .one()
+        )
+        assert [oa.oauth_name for oa in user.oauth_accounts] == [provider]
+    eve_rows = db_session.query(User).filter(
+        User.email == _EVE  # ty: ignore[invalid-argument-type]
+    )
+    assert eve_rows.count() == 0

--- a/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
+++ b/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
@@ -1,12 +1,14 @@
-"""Live-IdP coverage for the DB-backed multi-provider OIDC login: two providers
-on one instance complete the full authorization-code flow against a real OIDC
-server (discovery fetch, code exchange, userinfo, JIT user provisioning, session
-issuance), and the per-provider email-domain gate rejects a cross-domain login.
+"""Live-IdP coverage for the DB-backed multi-provider OIDC login against a real
+OIDC server: two providers on one instance complete the authorization-code flow
+(discovery fetch, code exchange, userinfo, JIT user provisioning, session
+issuance), the per-provider email-domain gate rejects a cross-domain login, an
+unverified email is rejected, and with auto-linking off a second provider does
+not attach to an existing account.
 
 Uses navikt/mock-oauth2-server, a real OIDC server whose per-login claims are
 set through its documented username+claims form post, so there is no HTML
 scraping. Requires it reachable at MOCK_OIDC_URL (default http://localhost:8086).
-The module skips when it is not.
+The suite skips when it is not.
 
 The login flow runs in a single async test driven by httpx.AsyncClient, so every
 request shares one event loop. A sync TestClient opens a fresh loop per request,
@@ -25,6 +27,7 @@ from httpx import ASGITransport
 from httpx import AsyncClient
 from sqlalchemy.orm import Session
 
+import onyx.db.engine.async_sql_engine as async_sql_engine
 from onyx.auth.users import cookie_transport
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
@@ -46,10 +49,18 @@ _USER_A = "user-a@companya.com"
 _USER_B = "user-b@companyb.com"
 # A companyb.com identity offered to provider A, which only allows companya.com.
 _EVE = "eve@companyb.com"
+
+# Two providers that allow the same domain, to exercise the no-auto-link path.
+_PROVIDER_C = "mock-c"
+_PROVIDER_D = "mock-d"
+_ISSUER_C = "issuer-c"
+_ISSUER_D = "issuer-d"
+_SHARED_USER = "shared@shared.com"
+
 _SESSION_COOKIE = cookie_transport.cookie_name
 
-_EMAILS = [_USER_A, _USER_B, _EVE]
-_NAMES = [_PROVIDER_A, _PROVIDER_B]
+_EMAILS = [_USER_A, _USER_B, _EVE, _SHARED_USER]
+_NAMES = [_PROVIDER_A, _PROVIDER_B, _PROVIDER_C, _PROVIDER_D]
 
 
 def _mock_reachable() -> bool:
@@ -58,13 +69,30 @@ def _mock_reachable() -> bool:
             f"{_MOCK_URL}/{_ISSUER_A}/.well-known/openid-configuration", timeout=2
         ).raise_for_status()
         return True
-    except httpx.HTTPError:
+    except Exception:
         return False
 
 
-pytestmark = pytest.mark.skipif(
-    not _mock_reachable(), reason="requires navikt/mock-oauth2-server (MOCK_OIDC_URL)"
-)
+@pytest.fixture(autouse=True)
+def require_mock_oidc() -> None:
+    # Deferred to test time (not import/collection) so collecting the auth suite
+    # never makes a network call.
+    if not _mock_reachable():
+        pytest.skip("requires navikt/mock-oauth2-server (MOCK_OIDC_URL)")
+
+
+@pytest.fixture(autouse=True)
+def null_pool_async_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    # A pooled asyncpg connection is bound to the loop that created it, so the
+    # process async engine cannot be reused across the per-test event loops that
+    # pytest-asyncio creates. NullPool gives each request a fresh connection in
+    # the current loop, and rebuilding drops any engine bound to a dead loop.
+    monkeypatch.setattr(async_sql_engine, "POSTGRES_USE_NULL_POOL", True)
+    async_sql_engine._ASYNC_ENGINE = None
+    yield
+    async_sql_engine._ASYNC_ENGINE = None
 
 
 def _config_url(issuer: str) -> str:
@@ -91,25 +119,35 @@ def _cleanup_db(db_session: Session) -> None:
     db_session.commit()
 
 
+def _create_provider(db_session: Session, name: str, issuer: str, domain: str) -> None:
+    create_sso_provider(
+        db_session=db_session,
+        name=name,
+        display_name=f"Mock OIDC {name}",
+        provider_type=SSOProviderType.OIDC,
+        config={
+            "client_id": "onyx-live",
+            "client_secret": "onyx-live-secret",
+            "openid_config_url": _config_url(issuer),
+        },
+        allowed_email_domains=[domain],
+    )
+
+
 @pytest.fixture
 def providers(db_session: Session) -> Generator[None, None, None]:
     _cleanup_db(db_session)
-    for name, issuer, domain in (
-        (_PROVIDER_A, _ISSUER_A, "companya.com"),
-        (_PROVIDER_B, _ISSUER_B, "companyb.com"),
-    ):
-        create_sso_provider(
-            db_session=db_session,
-            name=name,
-            display_name=f"Mock OIDC {name}",
-            provider_type=SSOProviderType.OIDC,
-            config={
-                "client_id": "onyx-live",
-                "client_secret": "onyx-live-secret",
-                "openid_config_url": _config_url(issuer),
-            },
-            allowed_email_domains=[domain],
-        )
+    _create_provider(db_session, _PROVIDER_A, _ISSUER_A, "companya.com")
+    _create_provider(db_session, _PROVIDER_B, _ISSUER_B, "companyb.com")
+    yield
+    _cleanup_db(db_session)
+
+
+@pytest.fixture
+def same_domain_providers(db_session: Session) -> Generator[None, None, None]:
+    _cleanup_db(db_session)
+    _create_provider(db_session, _PROVIDER_C, _ISSUER_C, "shared.com")
+    _create_provider(db_session, _PROVIDER_D, _ISSUER_D, "shared.com")
     yield
     _cleanup_db(db_session)
 
@@ -124,10 +162,12 @@ def app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     return fastapi_app
 
 
-def _idp_login(authorization_url: str, email: str) -> str:
+def _idp_login(authorization_url: str, email: str, email_verified: bool = True) -> str:
     """Post the identity to the IdP's login form and return the callback redirect
     location. The claims set what userinfo returns."""
-    claims = json.dumps({"sub": email, "email": email, "email_verified": True})
+    claims = json.dumps(
+        {"sub": email, "email": email, "email_verified": email_verified}
+    )
     with httpx.Client(follow_redirects=False, timeout=10) as browser:
         submit = browser.post(
             authorization_url, data={"username": email, "claims": claims}
@@ -137,14 +177,14 @@ def _idp_login(authorization_url: str, email: str) -> str:
 
 
 async def _drive_login(
-    client: AsyncClient, provider: str, email: str
+    client: AsyncClient, provider: str, email: str, email_verified: bool = True
 ) -> httpx.Response:
     """Full authorization-code flow: authorize on the Onyx side (CSRF cookie lands
     in the client jar), log in at the IdP, then follow the redirect back into the
     Onyx callback."""
     resp = await client.get(f"/auth/oidc/{provider}/authorize")
     assert resp.status_code == 200, resp.text
-    location = _idp_login(resp.json()["authorization_url"], email)
+    location = _idp_login(resp.json()["authorization_url"], email, email_verified)
 
     prefix = f"{_WEB_DOMAIN}/api"
     assert location.startswith(f"{prefix}/auth/oidc/{provider}/callback")
@@ -152,12 +192,20 @@ async def _drive_login(
     return await client.get(location.removeprefix(prefix))
 
 
+def _user_by_email(db_session: Session, email: str) -> User:
+    return (
+        db_session.query(User)
+        .filter(User.email == email)  # ty: ignore[invalid-argument-type]
+        .one()
+    )
+
+
 @pytest.mark.usefixtures("providers")
 def test_two_providers_resolve_to_distinct_issuers(app: FastAPI) -> None:
     client = TestClient(app)
     urls = {
         name: client.get(f"/auth/oidc/{name}/authorize").json()["authorization_url"]
-        for name in _NAMES
+        for name in (_PROVIDER_A, _PROVIDER_B)
     }
     assert f"/{_ISSUER_A}/" in urls[_PROVIDER_A]
     assert f"/{_ISSUER_B}/" in urls[_PROVIDER_B]
@@ -175,22 +223,57 @@ async def test_two_providers_live_login_and_domain_gate(
         for provider, email in logins:
             resp = await _drive_login(client, provider, email)
             assert resp.status_code == 302, resp.text
-            assert _SESSION_COOKIE in resp.headers.get("set-cookie", "")
+            assert _SESSION_COOKIE in resp.cookies
 
         # Provider A only allows companya.com, so a companyb.com identity is rejected.
         blocked = await _drive_login(client, _PROVIDER_A, _EVE)
         assert blocked.status_code == 400, blocked.text
-        assert _SESSION_COOKIE not in blocked.headers.get("set-cookie", "")
+        assert _SESSION_COOKIE not in blocked.cookies
 
     db_session.expire_all()
     for provider, email in logins:
-        user = (
-            db_session.query(User)
-            .filter(User.email == email)  # ty: ignore[invalid-argument-type]
-            .one()
-        )
-        assert [oa.oauth_name for oa in user.oauth_accounts] == [provider]
+        assert [
+            oa.oauth_name for oa in _user_by_email(db_session, email).oauth_accounts
+        ] == [provider]
     eve_rows = db_session.query(User).filter(
         User.email == _EVE  # ty: ignore[invalid-argument-type]
     )
     assert eve_rows.count() == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("providers")
+async def test_unverified_email_is_rejected(app: FastAPI, db_session: Session) -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
+        resp = await _drive_login(client, _PROVIDER_A, _USER_A, email_verified=False)
+        assert resp.status_code == 400, resp.text
+        assert _SESSION_COOKIE not in resp.cookies
+
+    db_session.expire_all()
+    rows = db_session.query(User).filter(
+        User.email == _USER_A  # ty: ignore[invalid-argument-type]
+    )
+    assert rows.count() == 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("same_domain_providers")
+async def test_second_provider_does_not_link_existing_account(
+    app: FastAPI, db_session: Session
+) -> None:
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url=_WEB_DOMAIN) as client:
+        first = await _drive_login(client, _PROVIDER_C, _SHARED_USER)
+        assert first.status_code == 302, first.text
+        assert _SESSION_COOKIE in first.cookies
+
+        # Auto-linking is off, so the same email through a second provider is
+        # rejected rather than attached to the existing account.
+        second = await _drive_login(client, _PROVIDER_D, _SHARED_USER)
+        assert second.status_code == 400, second.text
+        assert _SESSION_COOKIE not in second.cookies
+
+    db_session.expire_all()
+    user = _user_by_email(db_session, _SHARED_USER)
+    assert [oa.oauth_name for oa in user.oauth_accounts] == [_PROVIDER_C]


### PR DESCRIPTION
## Description

Live-IdP integration test for the merged multi-provider OIDC login (#12797). Proves the thing the feature is for: two SSO providers on one instance.

- Runs the full authorization-code flow against a real `navikt/mock-oauth2-server` (discovery fetch, code exchange, userinfo, JIT user provisioning, session issuance), no HTML scraping. Per-login claims come from the server's documented username+claims form post.
- Two providers (two issuers) log in end-to-end and land as distinct users with the right per-provider `oauth_name`. A `companyb.com` identity offered to the `companya.com`-gated provider is rejected (400) and never persisted.
- The login flow is one async test on a single event loop. A sync TestClient opens a fresh loop per request, which strands the async DB connection the callback pools.
- CI: the mock server runs only on the `auth` matrix leg, and the step fails if it never becomes ready so the live tests can't silently skip.

Unit coverage for the router already lives in `test_oidc_multi.py`; this is the live-interop layer.

## How Has This Been Tested?

Both tests pass locally against a real mock-oauth2-server, twice, and skip cleanly when it is absent.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check