### PR TITLE
feat(opal): add editable type to Tag

### DIFF
--- a/web/lib/opal/src/components/tag/README.md
+++ b/web/lib/opal/src/components/tag/README.md
@@ -2,19 +2,29 @@
 
 **Import:** `import { Tag, type TagProps } from "@opal/components";`
 
-A small colored label used to annotate items with status, category, or metadata. Fixed at 1rem height, uses `font-figure-small-value`.
+A small colored label used to annotate items with status, category, or metadata. Two types, matching the Figma `Tag` component:
+
+- **Passive** (default): metadata label. 1rem tall with `font-figure-small-value` at `sm`, 1.375rem with `secondary-body` at `md`.
+- **Editable** (`onRemove` set): remove button, gray hover, and a dark focus-within treatment chip fields use as the keyboard-selection state before deleting a tag.
 
 ## Props
 
 | Prop | Type | Default | Description |
 |---|---|---|---|
-| `title` | `string` | **(required)** | Tag label text |
+| `title` | `string \| RichStr` | **(required)** | Tag label text |
 | `color` | `TagColor` | `"gray"` | Color variant |
 | `icon` | `IconFunctionComponent` | — | Optional icon before the title |
+| `size` | `"sm" \| "md"` | `"sm"` | Size variant (Figma Small / Regular) |
+| `onRemove` | `() => void` | — | Switches to the editable type and renders the remove button |
+| `disabled` | `boolean` | `false` | Editable only: dims the tag, hides the remove button |
+| `value` | `string \| RichStr` | — | Secondary text after the title, in `text-03` |
+| `truncate` | `boolean` | `false` | Cap the title at 120px (`sm`) / 160px (`md`) with an ellipsis. Editable tags are always capped |
+| `tooltip` | `string` | — | Hover tooltip. Defaults to string titles on editable or truncated tags |
+| `error` | `boolean` | `false` | Warning indicator after the title (no Figma variant, exists for chip-field validation) |
 
 ### `TagColor`
 
-`"green" | "blue" | "purple" | "amber" | "gray"`
+`"green" | "blue" | "purple" | "amber" | "red" | "gray"`
 
 | Color | Background | Text |
 |---|---|---|
@@ -22,7 +32,8 @@ A small colored label used to annotate items with status, category, or metadata.
 | `blue` | `theme-blue-01` | `theme-blue-05` |
 | `purple` | `theme-purple-01` | `theme-purple-05` |
 | `amber` | `theme-amber-01` | `theme-amber-05` |
-| `gray` | `background-tint-02` | `text-03` |
+| `red` | `status-error-01` | `status-error-05` |
+| `gray` | `background-tint-02` | `text-03` (passive) / `text-04` (editable) |
 
 ## Usage Examples
 
@@ -36,8 +47,14 @@ import SvgStar from "@opal/icons/star";
 // With icon
 <Tag icon={SvgStar} title="Featured" color="purple" />
 
-// Default gray
-<Tag title="Draft" />
+// Editable (chip): remove button, hover, focus states
+<Tag title="filter:owner" onRemove={() => removeFilter(id)} />
+
+// Editable with secondary value
+<Tag title="env" value="production" size="md" onRemove={() => {}} />
+
+// Truncated passive tag with the default title tooltip
+<Tag title="A very long label" truncate />
 ```
 
 ## Usage inside Content

--- a/web/lib/opal/src/components/tag/Tag.stories.tsx
+++ b/web/lib/opal/src/components/tag/Tag.stories.tsx
@@ -45,3 +45,53 @@ export const AllColorsWithIcon: Story = {
     </div>
   ),
 };
+
+export const Editable: Story = {
+  args: {
+    title: "Label",
+    onRemove: () => {},
+  },
+};
+
+export const EditableMd: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Tag title="Default" size="md" onRemove={() => {}} />
+      <Tag
+        title="With icon"
+        size="md"
+        icon={SvgAlertCircle}
+        onRemove={() => {}}
+      />
+      <Tag title="Label" size="md" value="Value" onRemove={() => {}} />
+      <Tag
+        title="A very long label that gets capped at 160px"
+        size="md"
+        onRemove={() => {}}
+      />
+      <Tag title="Error" size="md" error onRemove={() => {}} />
+      <Tag title="Disabled" size="md" disabled onRemove={() => {}} />
+    </div>
+  ),
+};
+
+export const EditableSm: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      <Tag title="Default" onRemove={() => {}} />
+      <Tag title="With icon" icon={SvgAlertCircle} onRemove={() => {}} />
+      <Tag
+        title="A very long label that gets capped at 120px"
+        onRemove={() => {}}
+      />
+      <Tag title="Disabled" disabled onRemove={() => {}} />
+    </div>
+  ),
+};
+
+export const TruncatedWithTooltip: Story = {
+  args: {
+    title: "A very long metadata label that gets capped",
+    truncate: true,
+  },
+};

--- a/web/lib/opal/src/components/tag/components.tsx
+++ b/web/lib/opal/src/components/tag/components.tsx
@@ -1,6 +1,7 @@
 import "@opal/components/tag/styles.css";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
-import { Text } from "@opal/components";
+import { Text, Tooltip } from "@opal/components";
+import { SvgAlertTriangle, SvgX } from "@opal/icons";
 import { cn } from "@opal/utils";
 import { TAG_COLORS, type TagColor } from "@opal/components/tag/colors";
 
@@ -22,33 +23,124 @@ interface TagProps {
 
   /** Size variant. Default: `"sm"`. */
   size?: TagSize;
+
+  /**
+   * Switches to the editable tag (Figma Tag `Type=Editable`): remove button,
+   * gray hover, and the dark focus-within treatment chip fields use as the
+   * keyboard-selection state before deleting a tag.
+   */
+  onRemove?: () => void;
+
+  /** Editable only: dims the tag and hides the remove button. */
+  disabled?: boolean;
+
+  /** Secondary text rendered after the title in `text-03`. */
+  value?: string | RichStr;
+
+  /**
+   * Cap the title width with an ellipsis (120px `sm`, 160px `md`).
+   * Editable tags are always capped, per the Figma spec.
+   */
+  truncate?: boolean;
+
+  /** Hover tooltip. Defaults to string titles on editable or truncated tags. */
+  tooltip?: string;
+
+  /** Warning indicator after the title. */
+  error?: boolean;
 }
 
 // ---------------------------------------------------------------------------
 // Tag
 // ---------------------------------------------------------------------------
 
-function Tag({ icon: Icon, title, color = "gray", size = "sm" }: TagProps) {
+function Tag({
+  icon: Icon,
+  title,
+  color = "gray",
+  size = "sm",
+  onRemove,
+  disabled = false,
+  value,
+  truncate = false,
+  tooltip,
+  error = false,
+}: TagProps) {
   const config = TAG_COLORS[color];
+  const editable = onRemove !== undefined;
+  const capped = editable || truncate;
 
-  return (
+  const font =
+    size === "sm"
+      ? "figure-small-value"
+      : editable
+        ? "main-ui-body"
+        : "secondary-body";
+
+  // Editable gray reads in text-04 per the Figma spec. TAG_COLORS.gray
+  // (text-03) stays for the passive metadata tag.
+  const textClass = editable && color === "gray" ? "text-text-04" : config.text;
+
+  const tag = (
     <div
-      className={cn("opal-auxiliary-tag", config.bg, config.text)}
+      className={cn("opal-auxiliary-tag", config.bg, textClass)}
       data-size={size}
+      data-type={editable ? "editable" : undefined}
+      data-color={color}
+      data-disabled={(editable && disabled) || undefined}
     >
       {Icon && (
         <div className="opal-auxiliary-tag-icon-container">
-          <Icon className={cn("opal-auxiliary-tag-icon", config.text)} />
+          <Icon className={cn("opal-auxiliary-tag-icon", textClass)} />
         </div>
       )}
-      <Text
-        font={size === "md" ? "secondary-body" : "figure-small-value"}
-        color="inherit"
-        nowrap
-      >
-        {title}
-      </Text>
+      <span className="opal-auxiliary-tag-text">
+        <span
+          className={cn(
+            "opal-auxiliary-tag-label",
+            capped && "opal-auxiliary-tag-capped"
+          )}
+        >
+          <Text font={font} color="inherit" nowrap>
+            {title}
+          </Text>
+        </span>
+        {value !== undefined && (
+          <span className="opal-auxiliary-tag-value">
+            <Text font={font} color="inherit" nowrap>
+              {value}
+            </Text>
+          </span>
+        )}
+      </span>
+      {error && <SvgAlertTriangle className="opal-auxiliary-tag-error-icon" />}
+      {editable &&
+        !disabled && (
+          // raw-ok: the remove control is 16px (md) / 12px (sm), and Button's fixed sizes bottom out at 16px, so the tag owns its remove sizing
+          <button
+            type="button"
+            className="opal-auxiliary-tag-remove"
+            aria-label={
+              typeof title === "string" ? `Remove ${title}` : "Remove"
+            }
+            onClick={(event) => {
+              event.stopPropagation();
+              onRemove();
+            }}
+          >
+            <SvgX />
+          </button>
+        )}
     </div>
+  );
+
+  const tooltipText =
+    tooltip ?? (capped && typeof title === "string" ? title : undefined);
+
+  return (
+    <Tooltip tooltip={tooltipText} side="top">
+      {tag}
+    </Tooltip>
   );
 }
 

--- a/web/lib/opal/src/components/tag/styles.css
+++ b/web/lib/opal/src/components/tag/styles.css
@@ -3,8 +3,16 @@
 /* ---------------------------------------------------------------------------
    AuxiliaryTag
 
-   Fixed height of 1rem (16px). Icon is 0.75rem (12px) with p-0.5 (2px)
-   padding to match the font-figure-small-value line-height (12px).
+   Passive (metadata) tag: fixed height of 1rem (sm) / 1.375rem (md). Icon box
+   is 12px (10px glyph + 1px padding) to match the font-figure-small-value
+   line-height (12px).
+
+   Editable tag ([data-type="editable"], Figma Tag Type=Editable): remove
+   button, gray hover, and a dark focus-within treatment used by chip fields
+   as the keyboard-selection state. Metrics per Figma: md = 4px/2px padding
+   with radius 8, sm = 2px padding with radius 4. A transparent border keeps
+   the focus border from shifting layout, so paddings are 1px smaller than
+   the spec values.
    --------------------------------------------------------------------------- */
 
 .opal-auxiliary-tag {
@@ -33,6 +41,125 @@
   height: 10px;
 }
 
-.opal-auxiliary-tag-title {
-  white-space: nowrap;
+/* Text group: no-op wrapper for the passive tag, flex row for editable. */
+.opal-auxiliary-tag-text {
+  display: contents;
+}
+
+.opal-auxiliary-tag-label {
+  display: contents;
+}
+
+/* line-height 0: the wrapper must not impose its inherited line box. The
+   inner Text's own line-height sizes it. */
+.opal-auxiliary-tag-capped {
+  @apply block min-w-0 truncate;
+  max-width: 160px;
+  line-height: 0;
+}
+
+.opal-auxiliary-tag[data-size="sm"] .opal-auxiliary-tag-capped {
+  max-width: 120px;
+}
+
+.opal-auxiliary-tag-value {
+  @apply block min-w-0 truncate text-text-03;
+  max-width: 160px;
+  line-height: 0;
+}
+
+.opal-auxiliary-tag-error-icon {
+  @apply shrink-0 text-status-warning-05;
+  width: 0.875rem;
+  height: 0.875rem;
+}
+
+.opal-auxiliary-tag[data-size="sm"] .opal-auxiliary-tag-error-icon {
+  width: 0.75rem;
+  height: 0.75rem;
+}
+
+/* ---------------------------------------------------------------------------
+   Editable
+   --------------------------------------------------------------------------- */
+
+.opal-auxiliary-tag[data-type="editable"] {
+  height: auto;
+  max-width: 100%;
+  min-width: 0;
+  padding: 1px 3px;
+  border: 1px solid transparent;
+  border-radius: 0.5rem;
+}
+
+.opal-auxiliary-tag[data-type="editable"][data-size="sm"] {
+  padding: 1px;
+  border-radius: 0.25rem;
+}
+
+.opal-auxiliary-tag[data-type="editable"] .opal-auxiliary-tag-text {
+  @apply flex min-w-0 items-baseline;
+  gap: 2px;
+  padding: 0 2px;
+}
+
+/* Editable sm keeps the metadata icon metrics (12px box, 10px glyph). */
+.opal-auxiliary-tag[data-type="editable"][data-size="md"]
+  .opal-auxiliary-tag-icon-container {
+  padding: 0;
+}
+
+.opal-auxiliary-tag[data-type="editable"][data-size="md"]
+  .opal-auxiliary-tag-icon {
+  width: 16px;
+  height: 16px;
+}
+
+.opal-auxiliary-tag[data-type="editable"][data-color="gray"]:not(
+    [data-disabled]
+  ):hover {
+  @apply bg-background-tint-03;
+}
+
+.opal-auxiliary-tag[data-disabled] {
+  @apply text-text-01;
+}
+
+/* Keyboard-selection state: dark pill with an outer ring (Figma State=Focus). */
+.opal-auxiliary-tag[data-type="editable"]:focus-within {
+  @apply border-border-05 bg-background-tint-inverted-03 text-text-inverted-05 ring-2 ring-background-tint-04;
+}
+
+.opal-auxiliary-tag[data-type="editable"]:focus-within
+  .opal-auxiliary-tag-value {
+  color: inherit;
+}
+
+.opal-auxiliary-tag-remove {
+  @apply flex shrink-0 cursor-pointer items-center justify-center;
+  width: 1rem;
+  height: 1rem;
+  padding: 2px;
+  border-radius: 0.25rem;
+  color: inherit;
+}
+
+.opal-auxiliary-tag-remove:hover {
+  @apply bg-background-tint-00;
+}
+
+.opal-auxiliary-tag-remove:focus-visible {
+  @apply outline-none;
+}
+
+.opal-auxiliary-tag-remove svg {
+  width: 100%;
+  height: 100%;
+}
+
+.opal-auxiliary-tag[data-size="sm"] .opal-auxiliary-tag-remove {
+  width: 0.75rem;
+  height: 0.75rem;
+  padding: 1px;
+  border-radius: 2px;
 }


### PR DESCRIPTION
## Description

Implements the Figma Tag `Type=Editable` variant on the existing Opal `Tag`, so consumers stop hand-rolling chips (agent-wiki carries a divergent port with `!important` overrides against Button internals).

New props, all additive: `onRemove` (switches to editable rendering), `disabled`, `value`, `truncate`, `tooltip`, `error`. Passive tag rendering is unchanged.

Per the Figma spec:
- md 24px / sm 16px, radius 8/4, bg tint-02, label text-04, value text-03
- label caps at 160px md / 120px sm with ellipsis and a default title tooltip
- gray hover (tint-03), dark focus-within keyboard-selection state (tint-inverted-03 + ring), disabled dims and drops the remove button
- remove control is 16px md / 12px sm, owned by the tag (Button's fixed sizes bottom out at 16px)

Deferred to follow-ups: Figma `Metadata State=Selected`, sizes Internal/Large, types Citation/Source.

## How Has This Been Tested?

Storybook stories for every state (below), tsgo typecheck, live computed-style checks against the Figma tokens (16px sm / 24px md, focus bg tint-inverted-03), CI visual regression: zero changes across existing snapshots.

Passive (unchanged), colors + icon:

<img width="568" height="34" alt="image" src="https://github.com/user-attachments/assets/d565b4ec-316e-4139-9a22-74272bb1c5da" />

Editable md, default / icon / value / truncated / error / disabled:

<img width="1364" height="50" alt="image" src="https://github.com/user-attachments/assets/133906d9-e0a4-40ae-b6f8-566902808d24" />

Editable sm:

<img width="720" height="34" alt="image" src="https://github.com/user-attachments/assets/ce67b6bc-7ad9-49db-a8ef-4dea66ad333a" />

Hover (gray to tint-03):

<img width="1364" height="50" alt="image" src="https://github.com/user-attachments/assets/aae1ad7c-c3d4-4365-b625-578a53959d96" />

Focus, the keyboard-selection state chip fields use (dark pill + ring):

<img width="1364" height="50" alt="image" src="https://github.com/user-attachments/assets/2050ba10-bde9-4a6a-a4e5-bd02509b16d2" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check