### PR TITLE
feat(auth): multi-provider SSO login page + login-options endpoint

### DIFF
--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -5,6 +5,7 @@ import requests
 from fastapi import APIRouter
 from fastapi import HTTPException
 from fastapi import Response
+from fastapi.concurrency import run_in_threadpool
 
 from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
@@ -16,14 +17,48 @@ from onyx.configs.constants import DEV_VERSION_PATTERN
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.configs.constants import STABLE_VERSION_PATTERN
 from onyx.db.auth import get_user_count
+from onyx.db.engine.sql_engine import get_session_with_shared_schema
+from onyx.db.enums import SSOProviderType
+from onyx.db.sso_provider import fetch_sso_providers
 from onyx.server.manage.models import AllVersions
 from onyx.server.manage.models import AuthTypeResponse
 from onyx.server.manage.models import ContainerVersions
+from onyx.server.manage.models import SSOProviderOption
 from onyx.server.manage.models import VersionResponse
 from onyx.server.models import StatusResponse
 from onyx.server.security.store import get_security_settings
+from shared_configs.configs import MULTI_TENANT
 
 router = APIRouter()
+
+# GOOGLE_OAUTH and OIDC share the /auth/oidc router. SAML has its own. Keep in
+# sync with the router prefixes in oidc_multi.py and saml_multi.py.
+_SSO_AUTHORIZE_ROUTER = {
+    SSOProviderType.GOOGLE_OAUTH: "oidc",
+    SSOProviderType.OIDC: "oidc",
+    SSOProviderType.SAML: "saml",
+}
+
+
+def _fetch_sso_provider_options() -> list[SSOProviderOption]:
+    # Single-tenant only. /auth/type runs before any tenant context, so a
+    # multi-tenant lookup has no tenant to key on, and cloud does not use the
+    # provider table.
+    if MULTI_TENANT or AUTH_TYPE == AuthType.CLOUD:
+        return []
+    with get_session_with_shared_schema() as db_session:
+        return [
+            SSOProviderOption(
+                name=provider.name,
+                display_name=provider.display_name,
+                provider_type=provider.provider_type,
+                authorize_url=(
+                    f"/api/auth/{_SSO_AUTHORIZE_ROUTER[provider.provider_type]}"
+                    f"/{provider.name}/authorize"
+                ),
+            )
+            for provider in fetch_sso_providers(db_session, enabled_only=True)
+        ]
 
 
 @router.get("/health", tags=PUBLIC_API_TAGS)
@@ -56,6 +91,7 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
         password_min_length=get_security_settings().password_min_length,
         has_users=has_users,
         oauth_enabled=OAUTH_ENABLED,
+        sso_providers=await run_in_threadpool(_fetch_sso_provider_options),
     )
 
 

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -41,10 +41,11 @@ _SSO_AUTHORIZE_ROUTER = {
 
 
 def _fetch_sso_provider_options() -> list[SSOProviderOption]:
-    # Single-tenant only. /auth/type runs before any tenant context, so a
-    # multi-tenant lookup has no tenant to key on, and cloud does not use the
-    # provider table.
-    if MULTI_TENANT or AUTH_TYPE == AuthType.CLOUD:
+    # Single-tenant BASIC only. /auth/type runs before any tenant context, so a
+    # multi-tenant lookup has no tenant to key on, and only a BASIC deployment
+    # renders the provider buttons (legacy oidc/saml auto-redirect to the one IdP
+    # and never consume this list), so the query is pure overhead elsewhere.
+    if MULTI_TENANT or AUTH_TYPE != AuthType.BASIC:
         return []
     with get_session_with_shared_schema() as db_session:
         return [
@@ -79,7 +80,10 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
     # Cache only after bootstrap; the first user flow depends on a live
     # has_users flag so avoid serving a stale redirect. no-store in that
     # case prevents an intermediate CDN with a default TTL from pinning
-    # has_users=false past the first signup.
+    # has_users=false past the first signup. sso_providers rides this cache
+    # too, so a disabled provider's button can linger up to 60s. Clicking it
+    # still fails closed (authorize resolves enabled_only), so this is a UX
+    # blip, not an access path. Reduce the window if that is too slow.
     response.headers["Cache-Control"] = (
         "public, max-age=60" if has_users else "no-store"
     )

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -14,6 +14,7 @@ from onyx.auth.schemas import UserRole
 from onyx.configs.constants import AuthType
 from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import DefaultAppMode
+from onyx.db.enums import SSOProviderType
 from onyx.db.enums import SupportedLanguage
 from onyx.db.enums import ThemePreference
 from onyx.db.memory import MAX_MEMORIES_PER_USER
@@ -50,6 +51,15 @@ class VersionResponse(BaseModel):
     backend_version: str
 
 
+class SSOProviderOption(BaseModel):
+    # No sensitive config. Allowed domains stay server-side so the public login
+    # page does not enumerate the participating companies' domains.
+    name: str
+    display_name: str
+    provider_type: SSOProviderType
+    authorize_url: str
+
+
 class AuthTypeResponse(BaseModel):
     auth_type: AuthType
     # specifies whether the current auth setup requires
@@ -60,6 +70,9 @@ class AuthTypeResponse(BaseModel):
     # whether there are any users in the system
     has_users: bool = True
     oauth_enabled: bool = False
+    # Enabled DB-backed SSO providers, one login button each. Empty on cloud and
+    # on instances with no provider rows, so the page falls back to auth_type.
+    sso_providers: list[SSOProviderOption] = []
 
 
 class UserSpecificAssistantPreference(BaseModel):

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -3,6 +3,7 @@
 import { AuthTypeMetadata } from "@/lib/auth/types";
 import LoginText from "@/app/auth/login/LoginText";
 import SignInButton from "@/app/auth/login/SignInButton";
+import ProviderSignInButton from "@/app/auth/login/ProviderSignInButton";
 import EmailPasswordForm from "./EmailPasswordForm";
 import { AuthType, NEXT_PUBLIC_FORGOT_PASSWORD_ENABLED } from "@/lib/constants";
 import { useSendAuthRequiredMessage } from "@/lib/extension/utils";
@@ -31,6 +32,8 @@ export default function LoginPage({
   // Honor any existing nextUrl; only default to new team flow for first users with no nextUrl
   const effectiveNextUrl =
     nextUrl ?? (isFirstUser ? "/app?new_team=true" : null);
+
+  const ssoProviders = authTypeMetadata?.ssoProviders ?? [];
 
   return (
     <div className="flex flex-col w-full justify-center">
@@ -82,6 +85,26 @@ export default function LoginPage({
       {authTypeMetadata?.authType === AuthType.BASIC && (
         <div className="flex flex-col w-full gap-6">
           <LoginText />
+          {ssoProviders.length > 0 && (
+            <>
+              <div className="flex flex-col w-full gap-4">
+                {ssoProviders.map((provider) => (
+                  <ProviderSignInButton
+                    key={provider.name}
+                    provider={provider}
+                    nextUrl={effectiveNextUrl}
+                  />
+                ))}
+              </div>
+              <div className="flex flex-row items-center w-full gap-2">
+                <div className="flex-1 border-t border-text-01" />
+                <Text as="p" text03 mainUiMuted>
+                  or
+                </Text>
+                <div className="flex-1 border-t border-text-01" />
+              </div>
+            </>
+          )}
           <EmailPasswordForm nextUrl={effectiveNextUrl} />
         </div>
       )}

--- a/web/src/app/auth/login/ProviderSignInButton.tsx
+++ b/web/src/app/auth/login/ProviderSignInButton.tsx
@@ -1,0 +1,80 @@
+/**
+ * ProviderSignInButton: one login button for a DB-backed SSO provider.
+ *
+ * /authorize returns JSON {authorization_url} rather than redirecting. For
+ * OIDC/Google it also sets the CSRF/PKCE cookies on that response, so the fetch
+ * must run in the browser (credentials included) to land those cookies on the
+ * client that completes the flow. A server component fetching it would land them
+ * on the wrong client. SAML sets no cookies but returns the same shape, so it
+ * takes the same path.
+ *
+ * Like SignInButton, this renders on the login page which is hit by headless
+ * SSR requests, so browser globals stay out of the render path and live only in
+ * the click handler.
+ */
+
+"use client";
+
+import { useState } from "react";
+import { Button } from "@opal/components";
+import { FcGoogle } from "react-icons/fc";
+import Text from "@/refresh-components/texts/Text";
+import { SSOProviderOption } from "@/lib/auth/types";
+
+interface ProviderSignInButtonProps {
+  provider: SSOProviderOption;
+  nextUrl: string | null;
+}
+
+export default function ProviderSignInButton({
+  provider,
+  nextUrl,
+}: ProviderSignInButtonProps) {
+  const [isRedirecting, setIsRedirecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isGoogle = provider.providerType === "GOOGLE_OAUTH";
+
+  async function handleClick() {
+    if (isRedirecting) return;
+    setIsRedirecting(true);
+    setError(null);
+    try {
+      const url = nextUrl
+        ? `${provider.authorizeUrl}?next=${encodeURIComponent(nextUrl)}`
+        : provider.authorizeUrl;
+      const res = await fetch(url, { credentials: "include" });
+      if (!res.ok) {
+        throw new Error(`Could not start sign-in (status ${res.status})`);
+      }
+      const data: { authorization_url?: string } = await res.json();
+      if (!data.authorization_url) {
+        throw new Error("Sign-in response was missing the authorization URL");
+      }
+      window.location.href = data.authorization_url;
+    } catch (exc) {
+      // Re-enable the button so the user can retry.
+      setError(exc instanceof Error ? exc.message : String(exc));
+      setIsRedirecting(false);
+    }
+  }
+
+  return (
+    <>
+      <Button
+        prominence={isGoogle ? "secondary" : "primary"}
+        width="full"
+        icon={isGoogle ? FcGoogle : undefined}
+        onClick={handleClick}
+        disabled={isRedirecting}
+      >
+        {provider.displayName}
+      </Button>
+      {error && (
+        <Text as="p" mainUiMuted className="text-status-error-05 mt-2">
+          {error}
+        </Text>
+      )}
+    </>
+  );
+}

--- a/web/src/lib/auth/svcSS.ts
+++ b/web/src/lib/auth/svcSS.ts
@@ -2,7 +2,7 @@ import { buildUrl, UrlBuilder } from "@/lib/utilsSS";
 import { AuthType, NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { User, UserRole } from "@/lib/types";
 import { getCurrentUserSS } from "@/lib/users/svcSS";
-import { AuthTypeMetadata } from "@/lib/auth/types";
+import { AuthTypeMetadata, SSOProviderType } from "@/lib/auth/types";
 
 export async function getAuthTypeMetadataSS(): Promise<AuthTypeMetadata> {
   const res = await fetch(buildUrl("/auth/type"));
@@ -17,6 +17,12 @@ export async function getAuthTypeMetadataSS(): Promise<AuthTypeMetadata> {
     password_min_length: number;
     has_users: boolean;
     oauth_enabled: boolean;
+    sso_providers?: {
+      name: string;
+      display_name: string;
+      provider_type: SSOProviderType;
+      authorize_url: string;
+    }[];
   } = await res.json();
 
   const authType: AuthType = NEXT_PUBLIC_CLOUD_ENABLED
@@ -33,6 +39,12 @@ export async function getAuthTypeMetadataSS(): Promise<AuthTypeMetadata> {
     passwordMinLength: data.password_min_length,
     hasUsers: data.has_users,
     oauthEnabled: data.oauth_enabled,
+    ssoProviders: (data.sso_providers ?? []).map((provider) => ({
+      name: provider.name,
+      displayName: provider.display_name,
+      providerType: provider.provider_type,
+      authorizeUrl: provider.authorize_url,
+    })),
   };
 }
 

--- a/web/src/lib/auth/svcSS.ts
+++ b/web/src/lib/auth/svcSS.ts
@@ -2,7 +2,8 @@ import { buildUrl, UrlBuilder } from "@/lib/utilsSS";
 import { AuthType, NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { User, UserRole } from "@/lib/types";
 import { getCurrentUserSS } from "@/lib/users/svcSS";
-import { AuthTypeMetadata, SSOProviderType } from "@/lib/auth/types";
+import { AuthTypeMetadata } from "@/lib/auth/types";
+import type { SSOProviderType } from "@/lib/auth/types";
 
 export async function getAuthTypeMetadataSS(): Promise<AuthTypeMetadata> {
   const res = await fetch(buildUrl("/auth/type"));

--- a/web/src/lib/auth/types.ts
+++ b/web/src/lib/auth/types.ts
@@ -1,5 +1,14 @@
 import { AuthType } from "@/lib/constants";
 
+export type SSOProviderType = "GOOGLE_OAUTH" | "OIDC" | "SAML";
+
+export interface SSOProviderOption {
+  name: string;
+  displayName: string;
+  providerType: SSOProviderType;
+  authorizeUrl: string;
+}
+
 export interface AuthTypeMetadata {
   authType: AuthType;
   autoRedirect: boolean;
@@ -8,4 +17,7 @@ export interface AuthTypeMetadata {
   passwordMinLength: number;
   hasUsers: boolean;
   oauthEnabled: boolean;
+  // DB-backed SSO providers, one login button each. Absent on the client-hook
+  // path that does not fetch them. The login page treats absent as none.
+  ssoProviders?: SSOProviderOption[];
 }


### PR DESCRIPTION
## Description

Multi-provider SSO login page plus the login-options endpoint (A-PR4), building on the merged DB-backed multi-provider OIDC auth (#12797).

- `/auth/type` now also returns the enabled SSO providers, labels only (name, display name, type, authorize URL). Allowed domains stay server-side so the public login page does not enumerate the participating companies' domains.
- The login page renders one button per provider above the password form. Each button fetches its per-provider authorize endpoint from the browser (so the CSRF/PKCE cookie lands on the right client) and then hands off to the IdP.
- Single-tenant only. Cloud and multi-tenant return no providers, so nothing changes for them. Legacy oidc/saml deployments keep their existing auto-redirect. Ships dark: an instance with no provider rows shows the plain password form.

## How Has This Been Tested?

Verified end-to-end in a real browser on a self-hosted (basic-auth) instance with two OIDC providers configured, and re-captured with Playwright.

Login page renders one button per provider, above the password form:

![Multi-provider login page](https://raw.githubusercontent.com/nmgarza5/onyx-wiki-assets/main/pr4-multi-provider-login.png)

Clicking a provider runs the full flow (authorize, IdP login, callback, JIT user, session) and lands authenticated in the app:


The backend authorization-code flow (two providers, per-provider domain gate, unverified-email rejection, no auto-link) is covered by the live-IdP test in #12824.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check