### PR TITLE
feat(opal): add InputTags

### DIFF
--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -64,6 +64,7 @@ export {
 export {
   Tag,
   TAG_COLORS,
+  TAG_REMOVE_CLASS,
   type TagProps,
   type TagColor,
 } from "@opal/components/tag/components";

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -132,6 +132,13 @@ export {
   type InputTypeInProps,
 } from "@opal/components/inputs/input-type-in/components";
 
+/* InputTags */
+export {
+  InputTags,
+  type InputTagsProps,
+  type TagItem,
+} from "@opal/components/inputs/input-tags/components";
+
 /* Spacer */
 export { Spacer, type SpacerProps } from "@opal/components/spacer/components";
 

--- a/web/lib/opal/src/components/inputs/input-tags/InputTags.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/InputTags.stories.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { InputTags, type TagItem } from "@opal/components";
+import { SvgTag } from "@opal/icons";
+
+const meta: Meta<typeof InputTags> = {
+  title: "opal/components/InputTags",
+  component: InputTags,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InputTags>;
+
+function ControlledInputTags(
+  props: Partial<React.ComponentProps<typeof InputTags>>
+) {
+  const [tags, setTags] = useState<TagItem[]>([
+    { id: "1", label: "Tag" },
+    { id: "2", label: "2" },
+  ]);
+  const [value, setValue] = useState("");
+
+  return (
+    <div className="w-80">
+      <InputTags
+        tags={tags}
+        onRemoveTag={(id) => setTags((prev) => prev.filter((t) => t.id !== id))}
+        onAdd={(label) => {
+          setTags((prev) => [...prev, { id: crypto.randomUUID(), label }]);
+          setValue("");
+        }}
+        value={value}
+        onChange={setValue}
+        placeholder="Add a tag…"
+        {...props}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ControlledInputTags />,
+};
+
+export const WithIcon: Story = {
+  render: () => <ControlledInputTags icon={SvgTag} />,
+};
+
+export const WithClear: Story = {
+  render: () => <ControlledInputTags onClear={() => {}} />,
+};
+
+export const WithError: Story = {
+  render: () => {
+    const tags: TagItem[] = [
+      { id: "1", label: "valid" },
+      { id: "2", label: "not-an-email", error: true },
+    ];
+    return (
+      <div className="w-80">
+        <InputTags
+          tags={tags}
+          onRemoveTag={() => {}}
+          onAdd={() => {}}
+          value=""
+          onChange={() => {}}
+          placeholder="Add an email…"
+        />
+      </div>
+    );
+  },
+};
+
+export const Subtle: Story = {
+  render: () => <ControlledInputTags variant="internal" />,
+};
+
+export const Disabled: Story = {
+  render: () => <ControlledInputTags disabled />,
+};

--- a/web/lib/opal/src/components/inputs/input-tags/README.md
+++ b/web/lib/opal/src/components/inputs/input-tags/README.md
@@ -1,0 +1,51 @@
+# InputTags
+
+**Import:** `import { InputTags, type InputTagsProps, type TagItem } from "@opal/components";`
+
+Chips-in-input, the Figma `Input/Tags` component: editable `Tag`s rendered inline with a text input on the `.opal-input` chrome.
+
+Interaction model:
+
+- Enter adds the trimmed input text via `onAdd`.
+- Backspace on an empty input arms the last tag (its dark keyboard-selection state).
+- Backspace or Delete on an armed tag removes it and focus returns to the input. Enter and Space also activate the armed remove button.
+- Clicking the field focuses the input.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `tags` | `TagItem[]` | **(required)** | Tags rendered before the input |
+| `onRemoveTag` | `(id: string) => void` | **(required)** | Remove handler |
+| `onAdd` | `(value: string) => void` | **(required)** | Called with trimmed text on Enter (no-op when empty) |
+| `value` | `string` | **(required)** | Controlled input text |
+| `onChange` | `(value: string) => void` | **(required)** | Input change handler |
+| `placeholder` | `string` | — | Input placeholder |
+| `variant` | `"primary" \| "internal" \| "error"` | `"primary"` | Wrapper chrome. `"internal"` is the borderless Figma `Style=Subtle` look |
+| `disabled` | `boolean` | `false` | Dims the field, disables input, hides remove and clear buttons |
+| `icon` | `IconFunctionComponent` | — | Leading icon (24px container) |
+| `onClear` | `() => void` | — | Renders the clear action button |
+
+### `TagItem`
+
+`TagItem` is `{ id: string; label: string; error?: boolean }`. `error` shows the warning indicator on that tag.
+
+## Usage
+
+```tsx
+import { InputTags, type TagItem } from "@opal/components";
+
+const [tags, setTags] = useState<TagItem[]>([]);
+const [draft, setDraft] = useState("");
+
+<InputTags
+  tags={tags}
+  onRemoveTag={(id) => setTags(tags.filter((t) => t.id !== id))}
+  onAdd={(label) => setTags([...tags, { id: crypto.randomUUID(), label }])}
+  value={draft}
+  onChange={setDraft}
+  placeholder="Add a tag…"
+/>
+```
+
+Deferred from the Figma spec: the `resizable` corner handle and the extra `action` button slot.

--- a/web/lib/opal/src/components/inputs/input-tags/README.md
+++ b/web/lib/opal/src/components/inputs/input-tags/README.md
@@ -41,7 +41,10 @@ const [draft, setDraft] = useState("");
 <InputTags
   tags={tags}
   onRemoveTag={(id) => setTags(tags.filter((t) => t.id !== id))}
-  onAdd={(label) => setTags([...tags, { id: crypto.randomUUID(), label }])}
+  onAdd={(label) => {
+    setTags([...tags, { id: crypto.randomUUID(), label }]);
+    setDraft("");
+  }}
   value={draft}
   onChange={setDraft}
   placeholder="Add a tag…"

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -6,7 +6,7 @@ import "@opal/components/inputs/input-type-in/styles.css";
 import "@opal/components/inputs/input-tags/styles.css";
 import { useRef } from "react";
 import type { IconFunctionComponent } from "@opal/types";
-import { Button, Tag } from "@opal/components";
+import { Button, Tag, TAG_REMOVE_CLASS } from "@opal/components";
 import { SvgX } from "@opal/icons";
 
 // ---------------------------------------------------------------------------
@@ -56,10 +56,6 @@ interface InputTagsProps {
 // ---------------------------------------------------------------------------
 // InputTags
 // ---------------------------------------------------------------------------
-
-// Tag renders its remove control with this class. InputTags reaches into it
-// to drive the armed-tag keyboard flow (arm the last tag, delete an armed one).
-const TAG_REMOVE_CLASS = "opal-auxiliary-tag-remove";
 
 /**
  * Chips-in-input (Figma `Input/Tags`): editable Tags inline with a text

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -79,6 +79,9 @@ function InputTags({
   const inputRef = useRef<HTMLInputElement>(null);
 
   function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    // During IME composition, Enter confirms the candidate and Backspace
+    // edits the composition. Neither may add or arm tags.
+    if (event.nativeEvent.isComposing) return;
     if (event.key === "Enter") {
       event.preventDefault();
       event.stopPropagation();

--- a/web/lib/opal/src/components/inputs/input-tags/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-tags/components.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+import "@opal/components/inputs/shared.css";
+// The inner field reuses InputTypeIn's .opal-input-field styling.
+import "@opal/components/inputs/input-type-in/styles.css";
+import "@opal/components/inputs/input-tags/styles.css";
+import { useRef } from "react";
+import type { IconFunctionComponent } from "@opal/types";
+import { Button, Tag } from "@opal/components";
+import { SvgX } from "@opal/icons";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface TagItem {
+  id: string;
+  label: string;
+
+  /** Shows the warning indicator on the tag. */
+  error?: boolean;
+}
+
+interface InputTagsProps {
+  /** Tags rendered before the text input. */
+  tags: TagItem[];
+
+  onRemoveTag: (id: string) => void;
+
+  /** Called with the trimmed input text on Enter (no-op when empty). */
+  onAdd: (value: string) => void;
+
+  /** Controlled input text. */
+  value: string;
+
+  onChange: (value: string) => void;
+
+  placeholder?: string;
+
+  /**
+   * Wrapper chrome variant. `"internal"` is the borderless Figma
+   * `Style=Subtle` look.
+   */
+  variant?: "primary" | "internal" | "error";
+
+  /** Dims the field, disables the input, hides the remove and clear buttons. */
+  disabled?: boolean;
+
+  /** Leading icon. */
+  icon?: IconFunctionComponent;
+
+  /** Renders the clear action button (Figma `Clear`). */
+  onClear?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// InputTags
+// ---------------------------------------------------------------------------
+
+// Tag renders its remove control with this class. InputTags reaches into it
+// to drive the armed-tag keyboard flow (arm the last tag, delete an armed one).
+const TAG_REMOVE_CLASS = "opal-auxiliary-tag-remove";
+
+/**
+ * Chips-in-input (Figma `Input/Tags`): editable Tags inline with a text
+ * input. Enter adds the trimmed text. Backspace on an empty input arms the
+ * last tag (its dark keyboard-selection state), and Backspace or Delete on
+ * an armed tag removes it and returns focus to the input.
+ */
+function InputTags({
+  tags,
+  onRemoveTag,
+  onAdd,
+  value,
+  onChange,
+  placeholder,
+  variant = "primary",
+  disabled = false,
+  icon: Icon,
+  onClear,
+}: InputTagsProps) {
+  const rootRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function handleInputKeyDown(event: React.KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      event.stopPropagation();
+      const trimmed = value.trim();
+      if (trimmed) onAdd(trimmed);
+      return;
+    }
+    if (event.key === "Backspace" && value === "" && tags.length > 0) {
+      event.preventDefault();
+      const removes = rootRef.current?.querySelectorAll<HTMLButtonElement>(
+        `.${TAG_REMOVE_CLASS}`
+      );
+      removes?.[removes.length - 1]?.focus();
+    }
+  }
+
+  // Backspace/Delete on an armed remove button deletes its tag. Enter and
+  // Space already work as native button activation.
+  function handleRootKeyDown(event: React.KeyboardEvent<HTMLDivElement>) {
+    if (event.key !== "Backspace" && event.key !== "Delete") return;
+    const target = event.target as HTMLElement;
+    if (!target.classList.contains(TAG_REMOVE_CLASS)) return;
+    event.preventDefault();
+    target.click();
+  }
+
+  return (
+    <div
+      ref={rootRef}
+      className="opal-input opal-input-tags"
+      data-variant={disabled ? "disabled" : variant}
+      onKeyDown={handleRootKeyDown}
+      onClick={() => inputRef.current?.focus()}
+    >
+      {Icon && (
+        <div className="opal-input-tags-icon-container">
+          <Icon className="opal-input-tags-icon" />
+        </div>
+      )}
+      <div className="opal-input-tags-tags">
+        {tags.map((tag) => (
+          <Tag
+            key={tag.id}
+            size="md"
+            title={tag.label}
+            error={tag.error}
+            disabled={disabled}
+            onRemove={() => {
+              onRemoveTag(tag.id);
+              inputRef.current?.focus();
+            }}
+          />
+        ))}
+        {/* raw-ok: nesting InputTypeIn double-pads the composite chrome, so the inner field reuses InputTypeIn's .opal-input-field styling directly */}
+        <input
+          ref={inputRef}
+          type="text"
+          className="opal-input-field opal-input-tags-field"
+          disabled={disabled}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={handleInputKeyDown}
+          placeholder={placeholder}
+        />
+      </div>
+      {onClear !== undefined && !disabled && (
+        <Button
+          prominence="internal"
+          icon={SvgX}
+          size="xs"
+          tooltip="Clear"
+          onClick={(event) => {
+            event.stopPropagation();
+            onClear();
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export { InputTags, type InputTagsProps, type TagItem };

--- a/web/lib/opal/src/components/inputs/input-tags/styles.css
+++ b/web/lib/opal/src/components/inputs/input-tags/styles.css
@@ -1,0 +1,43 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   InputTags (Figma Input/Tags)
+
+   Chips-in-input built on the .opal-input chrome and the editable Tag.
+   Overrides the wrapper's justify-between/items-center: wrapped tag rows
+   must pack from the top-left.
+   --------------------------------------------------------------------------- */
+
+.opal-input-tags {
+  @apply cursor-text items-start justify-start;
+  gap: 4px;
+  min-width: 160px;
+}
+
+.opal-input-tags[data-variant="disabled"] {
+  cursor: not-allowed;
+}
+
+.opal-input-tags-icon-container {
+  @apply flex shrink-0 items-center justify-center;
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+}
+
+.opal-input-tags-icon {
+  @apply text-text-04;
+  width: 100%;
+  height: 100%;
+}
+
+.opal-input-tags-tags {
+  @apply flex min-w-0 flex-1 flex-wrap content-center items-center;
+  gap: 4px;
+  min-height: 24px;
+}
+
+.opal-input-tags-field {
+  @apply h-auto w-auto min-w-20 flex-1;
+  padding: 2px 4px;
+}

--- a/web/lib/opal/src/components/tag/components.tsx
+++ b/web/lib/opal/src/components/tag/components.tsx
@@ -54,6 +54,10 @@ interface TagProps {
 // Tag
 // ---------------------------------------------------------------------------
 
+// Class of the editable tag's remove control. Exported so composites (chip
+// fields) can target it for keyboard flows without a fragile string copy.
+const TAG_REMOVE_CLASS = "opal-auxiliary-tag-remove";
+
 function Tag({
   icon: Icon,
   title,
@@ -119,7 +123,7 @@ function Tag({
           // raw-ok: the remove control is 16px (md) / 12px (sm), and Button's fixed sizes bottom out at 16px, so the tag owns its remove sizing
           <button
             type="button"
-            className="opal-auxiliary-tag-remove"
+            className={TAG_REMOVE_CLASS}
             aria-label={
               typeof title === "string" ? `Remove ${title}` : "Remove"
             }
@@ -144,5 +148,5 @@ function Tag({
   );
 }
 
-export { Tag, type TagProps, type TagSize };
+export { Tag, TAG_REMOVE_CLASS, type TagProps, type TagSize };
 export { TAG_COLORS, type TagColor } from "@opal/components/tag/colors";


### PR DESCRIPTION
## Description

Chips-in-input per the Figma `Input/Tags` spec, built on the editable `Tag` (#12826) and the shared `.opal-input` chrome. Replaces the pattern behind `refresh-components` `InputChipField` (5 importers) and the agent-wiki port.

- Enter adds the trimmed input text. Backspace on an empty input arms the last tag (the Tag focus state from #12826), Backspace/Delete on an armed tag removes it and refocuses the input.
- Leading icon, clear action (internal Button), per-tag `error` indicator, borderless `internal` variant (Figma `Style=Subtle`), disabled.
- The `.opal-input` `justify-between`/`items-center` overrides live in the component's own stylesheet, so the shared chrome is untouched.

Deferred from the Figma spec: the `resizable` corner handle and the extra `action` slot.

## How Has This Been Tested?

Storybook stories for every state (below), tsgo typecheck, and a live Playwright run of the full keyboard chain: Enter added a tag, first Backspace armed the last tag (computed bg = tint-inverted-03), second Backspace removed it and refocused the input.

Default:

<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/0eba16d9-a7c3-462e-b96a-b961d3db097f" />

Leading icon:

<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/d05afd78-6070-4956-b579-552a290c871a" />

Clear action:

<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/4d2f2f3e-a4ef-4e9b-8132-b1cc8ecefe7d" />

Error tag:

<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/43f3a519-49ed-4ec7-ac31-c80c205cef12" />

Subtle (internal) variant:

<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/f3f2c873-426f-43c7-a375-c39d90f16677" />

Disabled:

<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/9be35291-1c23-42e7-ba67-cc0d666e787f" />

Armed tag after Backspace on empty input (second Backspace deletes it):

<img width="640" height="82" alt="image" src="https://github.com/user-attachments/assets/ed766dc4-5128-4ace-b26f-9d785b14b1cf" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check