### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -87,6 +87,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize("name", ["nextjs.log", "nextjs.pid"])
+def test_dev_server_runtime_files_are_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is True
+
+
+@pytest.mark.parametrize("name", ["page.tsx", "README.md", "app.log"])
+def test_regular_files_are_not_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is False


### PR DESCRIPTION
## Description

Hide the Next.js dev-server runtime files `nextjs.log` and `nextjs.pid` from the Craft sandbox file explorer.

In the Craft sandbox "Files" tab, `nextjs.log` and `nextjs.pid` were listed as regular workspace files. They are internal artifacts written to the session root by the dev-server start script (`nextjs_dev.py`), not user content, so they shouldn't appear in the explorer.

Fix: added both filenames to the existing `HIDDEN_PATTERNS` set in `session/manager.py` — the single canonical filter (`_is_hidden_workspace_entry`) already consumed by both the `/files` listing endpoint and the zip/download walk. This is the same mechanism that already hides `.DS_Store`, `opencode.json`, `node_modules`, etc.

`nextjs.pid` is read internally via a direct filesystem path in the sandbox start/stop scripts (`cat {session_path}/nextjs.pid`), never through the listing API, so hiding it from the explorer has no functional impact.

## How Has This Been Tested?

Added `test_hidden_workspace_entry.py` covering the two runtime files (hidden) plus regular files (not hidden). The full build-session unit suite passes (95 tests).

Known minor item: `HIDDEN_PATTERNS` matches by basename at any depth, so a user file literally named `nextjs.log`/`nextjs.pid` would also be hidden — consistent with the existing entries like `opencode.json`, and acceptable since these are platform-reserved runtime filenames.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
