### PR TITLE
feat(opal): add Modal

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -138,6 +138,7 @@
         "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.0.0",
+        "@radix-ui/react-dialog": "^1.0.0",
         "@radix-ui/react-popover": "^1.0.0",
         "@radix-ui/react-separator": "^1.0.0",
         "@radix-ui/react-slot": "^1.0.0",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -78,6 +78,7 @@
     "@dnd-kit/modifiers": "^7.0.0 || ^8.0.0",
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.0.0",
+    "@radix-ui/react-dialog": "^1.0.0",
     "@radix-ui/react-popover": "^1.0.0",
     "@radix-ui/react-tabs": "^1.0.0",
     "@radix-ui/react-separator": "^1.0.0",

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -141,6 +141,16 @@ export {
   type PopoverMenuProps,
 } from "@opal/components/popover/components";
 
+/* Modal */
+export {
+  Modal,
+  BasicModalFooter,
+  type ModalContentProps,
+  type ModalHeaderProps,
+  type ModalBodyProps,
+  type BasicModalFooterProps,
+} from "@opal/components/modal/components";
+
 /* InputTypeIn */
 export {
   default as InputTypeIn,

--- a/web/lib/opal/src/components/modal/Modal.stories.tsx
+++ b/web/lib/opal/src/components/modal/Modal.stories.tsx
@@ -1,0 +1,118 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { BasicModalFooter, Button, Modal } from "@opal/components";
+import { SvgSettings, SvgTrash } from "@opal/icons";
+
+const meta: Meta<typeof Modal.Content> = {
+  title: "opal/components/Modal",
+  component: Modal.Content,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal.Content>;
+
+function ModalHarness({
+  children,
+  label = "Open modal",
+}: {
+  children: (close: () => void) => React.ReactNode;
+  label?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>{label}</Button>
+      <Modal open={open} onOpenChange={setOpen}>
+        {children(() => setOpen(false))}
+      </Modal>
+    </>
+  );
+}
+
+export const Default: Story = {
+  render: () => (
+    <ModalHarness>
+      {(close) => (
+        <Modal.Content width="md">
+          <Modal.Header
+            icon={SvgSettings}
+            title="Modal title"
+            description="Supporting description for the modal."
+            onClose={close}
+          />
+          <Modal.Body>Body content lives here.</Modal.Body>
+          <Modal.Footer>
+            <BasicModalFooter
+              cancel={
+                <Button prominence="secondary" onClick={close}>
+                  Cancel
+                </Button>
+              }
+              submit={<Button onClick={close}>Confirm</Button>}
+            />
+          </Modal.Footer>
+        </Modal.Content>
+      )}
+    </ModalHarness>
+  ),
+};
+
+export const MinimalHeader: Story = {
+  render: () => (
+    <ModalHarness label="Open preview modal">
+      {(close) => (
+        <Modal.Content width="sm">
+          <Modal.Header title="Preview" onClose={close} />
+          <Modal.Body twoTone={false}>
+            Minimal header variant without an icon.
+          </Modal.Body>
+        </Modal.Content>
+      )}
+    </ModalHarness>
+  ),
+};
+
+export const DangerFooter: Story = {
+  render: () => (
+    <ModalHarness label="Open delete modal">
+      {(close) => (
+        <Modal.Content width="sm">
+          <Modal.Header
+            icon={SvgTrash}
+            title="Delete item"
+            description="This cannot be undone."
+            onClose={close}
+          />
+          <Modal.Footer>
+            <BasicModalFooter
+              cancel={
+                <Button prominence="secondary" onClick={close}>
+                  Cancel
+                </Button>
+              }
+              submit={
+                <Button variant="danger" onClick={close}>
+                  Delete
+                </Button>
+              }
+            />
+          </Modal.Footer>
+        </Modal.Content>
+      )}
+    </ModalHarness>
+  ),
+};
+
+export const TopPosition: Story = {
+  render: () => (
+    <ModalHarness label="Open top-pinned modal">
+      {(close) => (
+        <Modal.Content width="md" position="top">
+          <Modal.Header title="Command palette position" onClose={close} />
+          <Modal.Body>Pinned near the top of the viewport.</Modal.Body>
+        </Modal.Content>
+      )}
+    </ModalHarness>
+  ),
+};

--- a/web/lib/opal/src/components/modal/README.md
+++ b/web/lib/opal/src/components/modal/README.md
@@ -1,0 +1,60 @@
+# Modal
+
+**Import:** `import { Modal, BasicModalFooter } from "@opal/components";`
+
+Radix Dialog compound, the Figma Modal. `Modal` is the Radix root (`open`, `onOpenChange`). `Modal.Content` renders the scrim, positioning, and the card. `Modal.Header`, `Modal.Body`, and `Modal.Footer` are the card's sections.
+
+```tsx
+<Modal open={open} onOpenChange={setOpen}>
+  <Modal.Content width="md">
+    <Modal.Header
+      icon={SvgSettings}
+      title="Modal title"
+      description="Supporting description."
+      onClose={() => setOpen(false)}
+    />
+    <Modal.Body>Content</Modal.Body>
+    <Modal.Footer>
+      <BasicModalFooter
+        cancel={<Button prominence="secondary">Cancel</Button>}
+        submit={<Button>Confirm</Button>}
+      />
+    </Modal.Footer>
+  </Modal.Content>
+</Modal>
+```
+
+## Modal.Content
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `width` | `"full" \| "xl" \| "lg" \| "md" \| "sm"` | `"xl"` | Card width (`80dvw`, 60rem, 50rem, 40rem, 30rem) |
+| `height` | `"fit" \| "sm" \| "lg" \| "full"` | `"fit"` | Card height and scroll behavior |
+| `position` | `"center" \| "top"` | `"center"` | `"top"` pins near the viewport top (command-menu position) |
+| `preventAccidentalClose` | `boolean` | `true` | After the user types in any text input, the first Escape/outside-click focuses the close button and the second closes |
+| `skipOverlay` | `boolean` | `false` | Omit the scrim |
+| `background` | `"default" \| "gray"` | `"default"` | Card background (`tint-00` or `tint-01`) |
+| `bottomSlot` | `ReactNode` | — | Rendered below the card, inside the dialog's focus scope |
+
+## Modal.Header
+
+| Prop | Type | Description |
+|---|---|---|
+| `icon`, `moreIcon1`, `moreIcon2` | `IconFunctionComponent` | Heading icons. Omitting `icon` gives the minimal (icon-less) variant |
+| `title` | `string \| RichStr` | Required |
+| `description` | `string \| RichStr` | Optional, also wired to `aria-describedby` |
+| `onClose` | `() => void` | Renders the close button |
+
+`children` render below the title stack (e.g. a search input).
+
+## Modal.Body
+
+`twoTone` (default `true`) gives the body the gray `tint-01` background separating it from header and footer. Scrolls when the card height caps.
+
+## Modal.Footer
+
+Right-aligned action row. `BasicModalFooter` adds the common layout: optional `left` slot plus right-aligned `cancel`/`submit`.
+
+## Deferred
+
+Container-relative centering (the app-side `useContainerCenter` behavior) and the remaining Figma header/footer content variants (Search, Card, Panel, Checkbox, Message) are follow-ups.

--- a/web/lib/opal/src/components/modal/README.md
+++ b/web/lib/opal/src/components/modal/README.md
@@ -55,6 +55,10 @@ Radix Dialog compound, the Figma Modal. `Modal` is the Radix root (`open`, `onOp
 
 Right-aligned action row. `BasicModalFooter` adds the common layout: optional `left` slot plus right-aligned `cancel`/`submit`.
 
+## Positioning
+
+When a `[data-main-container]` element is present (the content area beside the sidebar), the modal centers on it instead of the viewport, and falls back to viewport centering on medium screens or when the container is absent.
+
 ## Deferred
 
-Container-relative centering (the app-side `useContainerCenter` behavior) and the remaining Figma header/footer content variants (Search, Card, Panel, Checkbox, Message) are follow-ups.
+The remaining Figma header/footer content variants (Search, Card, Panel, Checkbox, Message) are follow-ups.

--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -204,14 +204,17 @@ const ModalContent = React.forwardRef<
       [preventAccidentalClose, hasAttemptedClose]
     );
 
-    const handleRef = (node: HTMLDivElement | null) => {
-      if (typeof ref === "function") {
-        ref(node);
-      } else if (ref) {
-        ref.current = node;
-      }
-      contentRef(node);
-    };
+    const handleRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+        contentRef(node);
+      },
+      [ref, contentRef]
+    );
 
     const isTop = position === "top";
 
@@ -228,7 +231,11 @@ const ModalContent = React.forwardRef<
       isTop ? "top-[72px]" : "-translate-y-1/2 top-1/2"
     );
 
+    // Internal handlers are defined after the props spread so callers cannot
+    // replace them. Each forwards to the caller's handler.
     const dialogEventHandlers = {
+      ...(!hasDescription && { "aria-describedby": undefined }),
+      ...props,
       onOpenAutoFocus: (e: Event) => {
         resetState();
         props.onOpenAutoFocus?.(e);
@@ -237,10 +244,22 @@ const ModalContent = React.forwardRef<
         resetState();
         props.onCloseAutoFocus?.(e);
       },
-      onEscapeKeyDown: handleInteractOutside,
-      onPointerDownOutside: handleInteractOutside,
-      ...(!hasDescription && { "aria-describedby": undefined }),
-      ...props,
+      onEscapeKeyDown: (e: KeyboardEvent) => {
+        handleInteractOutside(e);
+        props.onEscapeKeyDown?.(e);
+      },
+      onPointerDownOutside: (
+        e: Parameters<
+          NonNullable<
+            React.ComponentPropsWithoutRef<
+              typeof DialogPrimitive.Content
+            >["onPointerDownOutside"]
+          >
+        >[0]
+      ) => {
+        handleInteractOutside(e);
+        props.onPointerDownOutside?.(e);
+      },
     };
 
     const cardClasses = cn(

--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -1,0 +1,512 @@
+"use client";
+
+import React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { cn } from "@opal/utils";
+import type {
+  IconFunctionComponent,
+  RichStr,
+  WithoutStyles,
+} from "@opal/types";
+import { Button } from "@opal/components";
+import { Content, Section, type SectionProps } from "@opal/layouts";
+import { toPlainString } from "@opal/components/text/InlineMarkdown";
+import { SvgX } from "@opal/icons";
+
+// ---------------------------------------------------------------------------
+// Root + Overlay
+// ---------------------------------------------------------------------------
+
+const ModalRoot = DialogPrimitive.Root;
+
+const ModalOverlay = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Overlay>,
+  WithoutStyles<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>
+>(({ ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-modal-overlay bg-mask-03 backdrop-blur-03 pointer-events-none",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0"
+    )}
+    {...props}
+  />
+));
+ModalOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+// Shared by Content and Header: the close-button ref receives focus on a
+// guarded close attempt, and setHasDescription drives aria-describedby.
+interface ModalContextValue {
+  closeButtonRef: React.RefObject<HTMLDivElement | null>;
+  setHasDescription: (value: boolean) => void;
+}
+
+const ModalContext = React.createContext<ModalContextValue | null>(null);
+
+const useModalContext = () => {
+  const context = React.useContext(ModalContext);
+  if (!context) {
+    throw new Error("Modal compound components must be used within Modal");
+  }
+  return context;
+};
+
+const widthClasses = {
+  full: "w-[80dvw]",
+  xl: "w-240",
+  lg: "w-200",
+  md: "w-160",
+  sm: "w-120",
+};
+
+const heightClasses = {
+  fit: "h-fit",
+  sm: "max-h-120 overflow-y-auto",
+  lg: "max-h-[calc(100dvh-4rem)] overflow-y-auto",
+  full: "h-[80dvh] overflow-y-auto",
+};
+
+// ---------------------------------------------------------------------------
+// Content
+// ---------------------------------------------------------------------------
+
+interface ModalContentProps extends WithoutStyles<
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+> {
+  width?: keyof typeof widthClasses;
+  height?: keyof typeof heightClasses;
+
+  /**
+   * Vertical placement. `"center"` (default) centers in the viewport.
+   * `"top"` pins the modal near the top, the command-menu position.
+   */
+  position?: "center" | "top";
+
+  /**
+   * Two-stage close guard: once the user has typed into any text input in
+   * the modal, the first Escape/outside-click focuses the close button
+   * instead of closing, and the second closes.
+   */
+  preventAccidentalClose?: boolean;
+
+  skipOverlay?: boolean;
+
+  background?: "default" | "gray";
+
+  /**
+   * Content rendered below the modal card with 1rem separation. Stays inside
+   * DialogPrimitive.Content so focus management covers it.
+   */
+  bottomSlot?: React.ReactNode;
+}
+
+const ModalContent = React.forwardRef<
+  React.ComponentRef<typeof DialogPrimitive.Content>,
+  ModalContentProps
+>(
+  (
+    {
+      children,
+      width = "xl",
+      height = "fit",
+      position = "center",
+      preventAccidentalClose = true,
+      skipOverlay = false,
+      background = "default",
+      bottomSlot,
+      ...props
+    },
+    ref
+  ) => {
+    const closeButtonRef = React.useRef<HTMLDivElement>(null);
+    const [hasAttemptedClose, setHasAttemptedClose] = React.useState(false);
+    const [hasDescription, setHasDescription] = React.useState(false);
+    const hasUserTypedRef = React.useRef(false);
+
+    const resetState = React.useCallback(() => {
+      setHasAttemptedClose(false);
+      hasUserTypedRef.current = false;
+    }, []);
+
+    // Trusted input events on text fields mark the modal dirty for the
+    // accidental-close guard.
+    const handleInput = React.useCallback((e: Event) => {
+      if (hasUserTypedRef.current) return;
+      if (!e.isTrusted) return;
+
+      const target = e.target as HTMLElement;
+      if (
+        !(
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement
+        )
+      ) {
+        return;
+      }
+      if (
+        target.type === "hidden" ||
+        target.type === "submit" ||
+        target.type === "button" ||
+        target.type === "checkbox" ||
+        target.type === "radio"
+      ) {
+        return;
+      }
+      hasUserTypedRef.current = true;
+    }, []);
+
+    const containerNodeRef = React.useRef<HTMLDivElement | null>(null);
+
+    const contentRef = React.useCallback(
+      (node: HTMLDivElement | null) => {
+        if (containerNodeRef.current) {
+          containerNodeRef.current.removeEventListener(
+            "input",
+            handleInput,
+            true
+          );
+        }
+        if (node) {
+          node.addEventListener("input", handleInput, true);
+          containerNodeRef.current = node;
+        } else {
+          containerNodeRef.current = null;
+        }
+      },
+      [handleInput]
+    );
+
+    const handleInteractOutside = React.useCallback(
+      (e: Event) => {
+        if (!preventAccidentalClose) {
+          setHasAttemptedClose(false);
+          return;
+        }
+        if (hasUserTypedRef.current) {
+          if (!hasAttemptedClose) {
+            e.preventDefault();
+            setHasAttemptedClose(true);
+            setTimeout(() => {
+              closeButtonRef.current?.focus();
+            }, 0);
+          } else {
+            setHasAttemptedClose(false);
+          }
+        } else {
+          setHasAttemptedClose(false);
+        }
+      },
+      [preventAccidentalClose, hasAttemptedClose]
+    );
+
+    const handleRef = (node: HTMLDivElement | null) => {
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+      contentRef(node);
+    };
+
+    const isTop = position === "top";
+
+    const animationClasses = cn(
+      "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+      "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
+      !isTop &&
+        "data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:slide-out-to-top-1/2",
+      "duration-200"
+    );
+
+    const positionClasses = cn(
+      "fixed -translate-x-1/2 left-1/2",
+      isTop ? "top-[72px]" : "-translate-y-1/2 top-1/2"
+    );
+
+    const dialogEventHandlers = {
+      onOpenAutoFocus: (e: Event) => {
+        resetState();
+        props.onOpenAutoFocus?.(e);
+      },
+      onCloseAutoFocus: (e: Event) => {
+        resetState();
+        props.onCloseAutoFocus?.(e);
+      },
+      onEscapeKeyDown: handleInteractOutside,
+      onPointerDownOutside: handleInteractOutside,
+      ...(!hasDescription && { "aria-describedby": undefined }),
+      ...props,
+    };
+
+    const cardClasses = cn(
+      "overflow-hidden",
+      background === "gray" ? "bg-background-tint-01" : "bg-background-tint-00",
+      "border rounded-16 shadow-2xl",
+      "flex flex-col",
+      heightClasses[height]
+    );
+
+    return (
+      <ModalContext.Provider
+        value={{
+          closeButtonRef,
+          setHasDescription,
+        }}
+      >
+        <DialogPrimitive.Portal>
+          {!skipOverlay && <ModalOverlay />}
+          {bottomSlot ? (
+            <DialogPrimitive.Content
+              asChild
+              ref={handleRef}
+              {...dialogEventHandlers}
+            >
+              <div
+                className={cn(
+                  positionClasses,
+                  "z-modal",
+                  "flex flex-col gap-4 items-center",
+                  "max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)]",
+                  animationClasses,
+                  widthClasses[width]
+                )}
+              >
+                <div className={cn(cardClasses, "w-full min-h-0")}>
+                  {children}
+                </div>
+                <div className="w-full shrink-0">{bottomSlot}</div>
+              </div>
+            </DialogPrimitive.Content>
+          ) : (
+            <DialogPrimitive.Content
+              ref={handleRef}
+              className={cn(
+                positionClasses,
+                "overflow-hidden",
+                "z-modal",
+                background === "gray"
+                  ? "bg-background-tint-01"
+                  : "bg-background-tint-00",
+                "border rounded-16 shadow-2xl",
+                "flex flex-col",
+                "max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)]",
+                animationClasses,
+                widthClasses[width],
+                heightClasses[height]
+              )}
+              {...dialogEventHandlers}
+            >
+              {children}
+            </DialogPrimitive.Content>
+          )}
+        </DialogPrimitive.Portal>
+      </ModalContext.Provider>
+    );
+  }
+);
+ModalContent.displayName = DialogPrimitive.Content.displayName;
+
+// ---------------------------------------------------------------------------
+// Header
+// ---------------------------------------------------------------------------
+
+/**
+ * Header with icon, title, description, and close button (Figma
+ * Modal/Header). Omitting `icon` yields the icon-less minimal variant.
+ * `children` render below the title stack (e.g. a search input).
+ */
+interface ModalHeaderProps extends Omit<WithoutStyles<SectionProps>, "title"> {
+  icon?: IconFunctionComponent;
+  moreIcon1?: IconFunctionComponent;
+  moreIcon2?: IconFunctionComponent;
+  title: string | RichStr;
+  description?: string | RichStr;
+  onClose?: () => void;
+}
+
+const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
+  (
+    {
+      icon,
+      moreIcon1,
+      moreIcon2,
+      title,
+      description,
+      onClose,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const { closeButtonRef, setHasDescription } = useModalContext();
+
+    React.useLayoutEffect(() => {
+      setHasDescription(!!description);
+    }, [description, setHasDescription]);
+
+    const closeButton = onClose && (
+      <div
+        tabIndex={-1}
+        ref={closeButtonRef as React.RefObject<HTMLDivElement>}
+        className="outline-hidden"
+      >
+        <DialogPrimitive.Close asChild>
+          <Button
+            icon={SvgX}
+            prominence="tertiary"
+            size="sm"
+            onClick={onClose}
+          />
+        </DialogPrimitive.Close>
+      </div>
+    );
+
+    return (
+      <Section
+        ref={ref}
+        padding={0.5}
+        alignItems="start"
+        height="fit"
+        {...props}
+      >
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          alignItems="start"
+          gap={0}
+          padding={0.5}
+        >
+          <div className="relative w-full">
+            {/* Absolutely positioned per the Figma mocks: the close button
+               overlaps the content's top-right so the description keeps the
+               full width. */}
+            <div className="absolute top-0 right-0">{closeButton}</div>
+            <DialogPrimitive.Title asChild>
+              <div>
+                <Content
+                  icon={icon}
+                  moreIcon1={moreIcon1}
+                  moreIcon2={moreIcon2}
+                  title={title}
+                  description={description}
+                  sizePreset="section"
+                  variant="heading"
+                />
+                {description && (
+                  <DialogPrimitive.Description className="hidden">
+                    {toPlainString(description)}
+                  </DialogPrimitive.Description>
+                )}
+              </div>
+            </DialogPrimitive.Title>
+          </div>
+        </Section>
+        {children}
+      </Section>
+    );
+  }
+);
+ModalHeader.displayName = "ModalHeader";
+
+// ---------------------------------------------------------------------------
+// Body + Footer
+// ---------------------------------------------------------------------------
+
+interface ModalBodyProps extends WithoutStyles<SectionProps> {
+  /** Gray body background separating it from the header/footer. */
+  twoTone?: boolean;
+}
+
+const ModalBody = React.forwardRef<HTMLDivElement, ModalBodyProps>(
+  ({ twoTone = true, children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          twoTone && "bg-background-tint-01",
+          "flex-auto min-h-0 overflow-y-auto w-full"
+        )}
+      >
+        <Section
+          height="auto"
+          padding={1}
+          gap={1}
+          alignItems="start"
+          {...props}
+        >
+          {children}
+        </Section>
+      </div>
+    );
+  }
+);
+ModalBody.displayName = "ModalBody";
+
+const ModalFooter = React.forwardRef<
+  HTMLDivElement,
+  WithoutStyles<SectionProps>
+>(({ ...props }, ref) => {
+  return (
+    <Section
+      ref={ref}
+      flexDirection="row"
+      justifyContent="end"
+      gap={0.5}
+      padding={1}
+      height="fit"
+      {...props}
+    />
+  );
+});
+ModalFooter.displayName = "ModalFooter";
+
+/**
+ * Modal (Figma Modal): Radix Dialog compound. `Modal` is the Radix root
+ * (`open`/`onOpenChange`). Content renders the scrim, positioning, and
+ * card. Header/Body/Footer are the card's sections.
+ */
+const Modal = Object.assign(ModalRoot, {
+  Content: ModalContent,
+  Header: ModalHeader,
+  Body: ModalBody,
+  Footer: ModalFooter,
+});
+
+// ---------------------------------------------------------------------------
+// Common layouts
+// ---------------------------------------------------------------------------
+
+interface BasicModalFooterProps {
+  left?: React.ReactNode;
+  cancel?: React.ReactNode;
+  submit?: React.ReactNode;
+}
+
+/** Footer layout with an optional left slot and right-aligned cancel/submit. */
+function BasicModalFooter({ left, cancel, submit }: BasicModalFooterProps) {
+  return (
+    <>
+      {left && <Section alignItems="start">{left}</Section>}
+      {(cancel || submit) && (
+        <Section flexDirection="row" justifyContent="end" gap={0.5}>
+          {cancel}
+          {submit}
+        </Section>
+      )}
+    </>
+  );
+}
+
+export {
+  Modal,
+  BasicModalFooter,
+  type ModalContentProps,
+  type ModalHeaderProps,
+  type ModalBodyProps,
+  type BasicModalFooterProps,
+};

--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -12,6 +12,7 @@ import { Button } from "@opal/components";
 import { Content, Section, type SectionProps } from "@opal/layouts";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { SvgX } from "@opal/icons";
+import useContainerCenter from "@opal/hooks/useContainerCenter";
 
 // ---------------------------------------------------------------------------
 // Root + Overlay
@@ -216,6 +217,10 @@ const ModalContent = React.forwardRef<
       [ref, contentRef]
     );
 
+    // Center on [data-main-container] when present (the content area beside
+    // the sidebar) instead of the viewport.
+    const { centerX, centerY, hasContainerCenter } = useContainerCenter();
+
     const isTop = position === "top";
 
     const animationClasses = cn(
@@ -226,9 +231,29 @@ const ModalContent = React.forwardRef<
       "duration-200"
     );
 
+    const containerStyle: React.CSSProperties | undefined =
+      hasContainerCenter && !isTop
+        ? ({
+            left: centerX,
+            top: centerY,
+            "--tw-enter-translate-x": "-50%",
+            "--tw-exit-translate-x": "-50%",
+            "--tw-enter-translate-y": "-50%",
+            "--tw-exit-translate-y": "-50%",
+          } as React.CSSProperties)
+        : hasContainerCenter && isTop
+          ? ({
+              left: centerX,
+              "--tw-enter-translate-x": "-50%",
+              "--tw-exit-translate-x": "-50%",
+            } as React.CSSProperties)
+          : undefined;
+
     const positionClasses = cn(
-      "fixed -translate-x-1/2 left-1/2",
-      isTop ? "top-[72px]" : "-translate-y-1/2 top-1/2"
+      "fixed -translate-x-1/2",
+      isTop
+        ? cn("top-[72px]", !hasContainerCenter && "left-1/2")
+        : cn("-translate-y-1/2", !hasContainerCenter && "left-1/2 top-1/2")
     );
 
     // Internal handlers are defined after the props spread so callers cannot
@@ -286,6 +311,7 @@ const ModalContent = React.forwardRef<
               {...dialogEventHandlers}
             >
               <div
+                style={containerStyle}
                 className={cn(
                   positionClasses,
                   "z-modal",
@@ -304,6 +330,7 @@ const ModalContent = React.forwardRef<
           ) : (
             <DialogPrimitive.Content
               ref={handleRef}
+              style={containerStyle}
               className={cn(
                 positionClasses,
                 "overflow-hidden",

--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import "@opal/components/modal/styles.css";
+
 import React from "react";
 import * as DialogPrimitive from "@radix-ui/react-dialog";
-import { cn } from "@opal/utils";
 import type {
   IconFunctionComponent,
   RichStr,
+  SizeVariants,
   WithoutStyles,
 } from "@opal/types";
 import { Button } from "@opal/components";
@@ -20,21 +22,21 @@ import useContainerCenter from "@opal/hooks/useContainerCenter";
 
 const ModalRoot = DialogPrimitive.Root;
 
-const ModalOverlay = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Overlay>,
-  WithoutStyles<React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>>
->(({ ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      "fixed inset-0 z-modal-overlay bg-mask-03 backdrop-blur-03 pointer-events-none",
-      "data-[state=open]:animate-in data-[state=closed]:animate-out",
-      "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0"
-    )}
-    {...props}
-  />
-));
-ModalOverlay.displayName = DialogPrimitive.Overlay.displayName;
+interface ModalOverlayProps extends WithoutStyles<
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+> {
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Overlay>>;
+}
+
+function ModalOverlay({ ref, ...props }: ModalOverlayProps) {
+  return (
+    <DialogPrimitive.Overlay
+      ref={ref}
+      className="opal-modal-overlay"
+      {...props}
+    />
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Context
@@ -57,20 +59,8 @@ const useModalContext = () => {
   return context;
 };
 
-const widthClasses = {
-  full: "w-[80dvw]",
-  xl: "w-240",
-  lg: "w-200",
-  md: "w-160",
-  sm: "w-120",
-};
-
-const heightClasses = {
-  fit: "h-fit",
-  sm: "max-h-120 overflow-y-auto",
-  lg: "max-h-[calc(100dvh-4rem)] overflow-y-auto",
-  full: "h-[80dvh] overflow-y-auto",
-};
+type ModalWidth = Extract<SizeVariants, "sm" | "md" | "lg" | "xl" | "full">;
+type ModalHeight = Extract<SizeVariants, "fit" | "sm" | "lg" | "full">;
 
 // ---------------------------------------------------------------------------
 // Content
@@ -79,8 +69,10 @@ const heightClasses = {
 interface ModalContentProps extends WithoutStyles<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
 > {
-  width?: keyof typeof widthClasses;
-  height?: keyof typeof heightClasses;
+  ref?: React.Ref<React.ComponentRef<typeof DialogPrimitive.Content>>;
+
+  width?: ModalWidth;
+  height?: ModalHeight;
 
   /**
    * Vertical placement. `"center"` (default) centers in the viewport.
@@ -106,256 +98,219 @@ interface ModalContentProps extends WithoutStyles<
   bottomSlot?: React.ReactNode;
 }
 
-const ModalContent = React.forwardRef<
-  React.ComponentRef<typeof DialogPrimitive.Content>,
-  ModalContentProps
->(
-  (
-    {
-      children,
-      width = "xl",
-      height = "fit",
-      position = "center",
-      preventAccidentalClose = true,
-      skipOverlay = false,
-      background = "default",
-      bottomSlot,
-      ...props
+function ModalContent({
+  ref,
+  children,
+  width = "xl",
+  height = "fit",
+  position = "center",
+  preventAccidentalClose = true,
+  skipOverlay = false,
+  background = "default",
+  bottomSlot,
+  ...props
+}: ModalContentProps) {
+  const closeButtonRef = React.useRef<HTMLDivElement>(null);
+  const [hasAttemptedClose, setHasAttemptedClose] = React.useState(false);
+  const [hasDescription, setHasDescription] = React.useState(false);
+  const hasUserTypedRef = React.useRef(false);
+
+  const resetState = React.useCallback(() => {
+    setHasAttemptedClose(false);
+    hasUserTypedRef.current = false;
+  }, []);
+
+  // Trusted input events on text fields mark the modal dirty for the
+  // accidental-close guard.
+  const handleInput = React.useCallback((e: Event) => {
+    if (hasUserTypedRef.current) return;
+    if (!e.isTrusted) return;
+
+    const target = e.target as HTMLElement;
+    if (
+      !(
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement
+      )
+    ) {
+      return;
+    }
+    if (
+      target.type === "hidden" ||
+      target.type === "submit" ||
+      target.type === "button" ||
+      target.type === "checkbox" ||
+      target.type === "radio"
+    ) {
+      return;
+    }
+    hasUserTypedRef.current = true;
+  }, []);
+
+  const containerNodeRef = React.useRef<HTMLDivElement | null>(null);
+
+  const contentRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      if (containerNodeRef.current) {
+        containerNodeRef.current.removeEventListener(
+          "input",
+          handleInput,
+          true
+        );
+      }
+      if (node) {
+        node.addEventListener("input", handleInput, true);
+        containerNodeRef.current = node;
+      } else {
+        containerNodeRef.current = null;
+      }
     },
-    ref
-  ) => {
-    const closeButtonRef = React.useRef<HTMLDivElement>(null);
-    const [hasAttemptedClose, setHasAttemptedClose] = React.useState(false);
-    const [hasDescription, setHasDescription] = React.useState(false);
-    const hasUserTypedRef = React.useRef(false);
+    [handleInput]
+  );
 
-    const resetState = React.useCallback(() => {
-      setHasAttemptedClose(false);
-      hasUserTypedRef.current = false;
-    }, []);
-
-    // Trusted input events on text fields mark the modal dirty for the
-    // accidental-close guard.
-    const handleInput = React.useCallback((e: Event) => {
-      if (hasUserTypedRef.current) return;
-      if (!e.isTrusted) return;
-
-      const target = e.target as HTMLElement;
-      if (
-        !(
-          target instanceof HTMLInputElement ||
-          target instanceof HTMLTextAreaElement
-        )
-      ) {
+  const handleInteractOutside = React.useCallback(
+    (e: Event) => {
+      if (!preventAccidentalClose) {
+        setHasAttemptedClose(false);
         return;
       }
-      if (
-        target.type === "hidden" ||
-        target.type === "submit" ||
-        target.type === "button" ||
-        target.type === "checkbox" ||
-        target.type === "radio"
-      ) {
-        return;
-      }
-      hasUserTypedRef.current = true;
-    }, []);
-
-    const containerNodeRef = React.useRef<HTMLDivElement | null>(null);
-
-    const contentRef = React.useCallback(
-      (node: HTMLDivElement | null) => {
-        if (containerNodeRef.current) {
-          containerNodeRef.current.removeEventListener(
-            "input",
-            handleInput,
-            true
-          );
-        }
-        if (node) {
-          node.addEventListener("input", handleInput, true);
-          containerNodeRef.current = node;
-        } else {
-          containerNodeRef.current = null;
-        }
-      },
-      [handleInput]
-    );
-
-    const handleInteractOutside = React.useCallback(
-      (e: Event) => {
-        if (!preventAccidentalClose) {
-          setHasAttemptedClose(false);
-          return;
-        }
-        if (hasUserTypedRef.current) {
-          if (!hasAttemptedClose) {
-            e.preventDefault();
-            setHasAttemptedClose(true);
-            setTimeout(() => {
-              closeButtonRef.current?.focus();
-            }, 0);
-          } else {
-            setHasAttemptedClose(false);
-          }
+      if (hasUserTypedRef.current) {
+        if (!hasAttemptedClose) {
+          e.preventDefault();
+          setHasAttemptedClose(true);
+          setTimeout(() => {
+            closeButtonRef.current?.focus();
+          }, 0);
         } else {
           setHasAttemptedClose(false);
         }
-      },
-      [preventAccidentalClose, hasAttemptedClose]
-    );
+      } else {
+        setHasAttemptedClose(false);
+      }
+    },
+    [preventAccidentalClose, hasAttemptedClose]
+  );
 
-    const handleRef = React.useCallback(
-      (node: HTMLDivElement | null) => {
-        if (typeof ref === "function") {
-          ref(node);
-        } else if (ref) {
-          ref.current = node;
-        }
-        contentRef(node);
-      },
-      [ref, contentRef]
-    );
+  const handleRef = React.useCallback(
+    (node: HTMLDivElement | null) => {
+      if (typeof ref === "function") {
+        ref(node);
+      } else if (ref) {
+        ref.current = node;
+      }
+      contentRef(node);
+    },
+    [ref, contentRef]
+  );
 
-    // Center on [data-main-container] when present (the content area beside
-    // the sidebar) instead of the viewport.
-    const { centerX, centerY, hasContainerCenter } = useContainerCenter();
+  // Center on [data-main-container] when present (the content area beside
+  // the sidebar) instead of the viewport.
+  const { centerX, centerY, hasContainerCenter } = useContainerCenter();
 
-    const isTop = position === "top";
+  const isTop = position === "top";
 
-    const animationClasses = cn(
-      "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
-      "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95",
-      !isTop &&
-        "data-[state=open]:slide-in-from-top-1/2 data-[state=closed]:slide-out-to-top-1/2",
-      "duration-200"
-    );
-
-    const containerStyle: React.CSSProperties | undefined =
-      hasContainerCenter && !isTop
+  const containerStyle: React.CSSProperties | undefined =
+    hasContainerCenter && !isTop
+      ? ({
+          left: centerX,
+          top: centerY,
+          "--tw-enter-translate-x": "-50%",
+          "--tw-exit-translate-x": "-50%",
+          "--tw-enter-translate-y": "-50%",
+          "--tw-exit-translate-y": "-50%",
+        } as React.CSSProperties)
+      : hasContainerCenter && isTop
         ? ({
             left: centerX,
-            top: centerY,
             "--tw-enter-translate-x": "-50%",
             "--tw-exit-translate-x": "-50%",
-            "--tw-enter-translate-y": "-50%",
-            "--tw-exit-translate-y": "-50%",
           } as React.CSSProperties)
-        : hasContainerCenter && isTop
-          ? ({
-              left: centerX,
-              "--tw-enter-translate-x": "-50%",
-              "--tw-exit-translate-x": "-50%",
-            } as React.CSSProperties)
-          : undefined;
+        : undefined;
 
-    const positionClasses = cn(
-      "fixed -translate-x-1/2",
-      isTop
-        ? cn("top-[72px]", !hasContainerCenter && "left-1/2")
-        : cn("-translate-y-1/2", !hasContainerCenter && "left-1/2 top-1/2")
-    );
+  const positionerData = {
+    "data-position": position,
+    "data-width": width,
+    ...(!hasContainerCenter && { "data-viewport-centered": "" }),
+  };
 
-    // Internal handlers are defined after the props spread so callers cannot
-    // replace them. Each forwards to the caller's handler.
-    const dialogEventHandlers = {
-      ...(!hasDescription && { "aria-describedby": undefined }),
-      ...props,
-      onOpenAutoFocus: (e: Event) => {
-        resetState();
-        props.onOpenAutoFocus?.(e);
-      },
-      onCloseAutoFocus: (e: Event) => {
-        resetState();
-        props.onCloseAutoFocus?.(e);
-      },
-      onEscapeKeyDown: (e: KeyboardEvent) => {
-        handleInteractOutside(e);
-        props.onEscapeKeyDown?.(e);
-      },
-      onPointerDownOutside: (
-        e: Parameters<
-          NonNullable<
-            React.ComponentPropsWithoutRef<
-              typeof DialogPrimitive.Content
-            >["onPointerDownOutside"]
+  // Internal handlers are defined after the props spread so callers cannot
+  // replace them. Each forwards to the caller's handler.
+  const dialogEventHandlers = {
+    ...(!hasDescription && { "aria-describedby": undefined }),
+    ...props,
+    onOpenAutoFocus: (e: Event) => {
+      resetState();
+      props.onOpenAutoFocus?.(e);
+    },
+    onCloseAutoFocus: (e: Event) => {
+      resetState();
+      props.onCloseAutoFocus?.(e);
+    },
+    onEscapeKeyDown: (e: KeyboardEvent) => {
+      handleInteractOutside(e);
+      props.onEscapeKeyDown?.(e);
+    },
+    onPointerDownOutside: (
+      e: Parameters<
+        NonNullable<
+          React.ComponentPropsWithoutRef<
+            typeof DialogPrimitive.Content
+          >["onPointerDownOutside"]
+        >
+      >[0]
+    ) => {
+      handleInteractOutside(e);
+      props.onPointerDownOutside?.(e);
+    },
+  };
+
+  return (
+    <ModalContext.Provider
+      value={{
+        closeButtonRef,
+        setHasDescription,
+      }}
+    >
+      <DialogPrimitive.Portal>
+        {!skipOverlay && <ModalOverlay />}
+        {bottomSlot ? (
+          <DialogPrimitive.Content
+            asChild
+            ref={handleRef}
+            {...dialogEventHandlers}
           >
-        >[0]
-      ) => {
-        handleInteractOutside(e);
-        props.onPointerDownOutside?.(e);
-      },
-    };
-
-    const cardClasses = cn(
-      "overflow-hidden",
-      background === "gray" ? "bg-background-tint-01" : "bg-background-tint-00",
-      "border rounded-16 shadow-2xl",
-      "flex flex-col",
-      heightClasses[height]
-    );
-
-    return (
-      <ModalContext.Provider
-        value={{
-          closeButtonRef,
-          setHasDescription,
-        }}
-      >
-        <DialogPrimitive.Portal>
-          {!skipOverlay && <ModalOverlay />}
-          {bottomSlot ? (
-            <DialogPrimitive.Content
-              asChild
-              ref={handleRef}
-              {...dialogEventHandlers}
+            <div
+              style={containerStyle}
+              className="opal-modal-positioner opal-modal-stack"
+              {...positionerData}
             >
               <div
-                style={containerStyle}
-                className={cn(
-                  positionClasses,
-                  "z-modal",
-                  "flex flex-col gap-4 items-center",
-                  "max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)]",
-                  animationClasses,
-                  widthClasses[width]
-                )}
+                className="opal-modal-card"
+                data-height={height}
+                data-background={background}
               >
-                <div className={cn(cardClasses, "w-full min-h-0")}>
-                  {children}
-                </div>
-                <div className="w-full shrink-0">{bottomSlot}</div>
+                {children}
               </div>
-            </DialogPrimitive.Content>
-          ) : (
-            <DialogPrimitive.Content
-              ref={handleRef}
-              style={containerStyle}
-              className={cn(
-                positionClasses,
-                "overflow-hidden",
-                "z-modal",
-                background === "gray"
-                  ? "bg-background-tint-01"
-                  : "bg-background-tint-00",
-                "border rounded-16 shadow-2xl",
-                "flex flex-col",
-                "max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)]",
-                animationClasses,
-                widthClasses[width],
-                heightClasses[height]
-              )}
-              {...dialogEventHandlers}
-            >
-              {children}
-            </DialogPrimitive.Content>
-          )}
-        </DialogPrimitive.Portal>
-      </ModalContext.Provider>
-    );
-  }
-);
-ModalContent.displayName = DialogPrimitive.Content.displayName;
+              <div className="opal-modal-bottom-slot">{bottomSlot}</div>
+            </div>
+          </DialogPrimitive.Content>
+        ) : (
+          <DialogPrimitive.Content
+            ref={handleRef}
+            style={containerStyle}
+            className="opal-modal-positioner opal-modal-card"
+            data-height={height}
+            data-background={background}
+            {...positionerData}
+            {...dialogEventHandlers}
+          >
+            {children}
+          </DialogPrimitive.Content>
+        )}
+      </DialogPrimitive.Portal>
+    </ModalContext.Provider>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Header
@@ -367,6 +322,7 @@ ModalContent.displayName = DialogPrimitive.Content.displayName;
  * `children` render below the title stack (e.g. a search input).
  */
 interface ModalHeaderProps extends Omit<WithoutStyles<SectionProps>, "title"> {
+  ref?: React.Ref<HTMLDivElement>;
   icon?: IconFunctionComponent;
   moreIcon1?: IconFunctionComponent;
   moreIcon2?: IconFunctionComponent;
@@ -375,128 +331,105 @@ interface ModalHeaderProps extends Omit<WithoutStyles<SectionProps>, "title"> {
   onClose?: () => void;
 }
 
-const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
-  (
-    {
-      icon,
-      moreIcon1,
-      moreIcon2,
-      title,
-      description,
-      onClose,
-      children,
-      ...props
-    },
-    ref
-  ) => {
-    const { closeButtonRef, setHasDescription } = useModalContext();
+function ModalHeader({
+  ref,
+  icon,
+  moreIcon1,
+  moreIcon2,
+  title,
+  description,
+  onClose,
+  children,
+  ...props
+}: ModalHeaderProps) {
+  const { closeButtonRef, setHasDescription } = useModalContext();
 
-    React.useLayoutEffect(() => {
-      setHasDescription(!!description);
-    }, [description, setHasDescription]);
+  React.useLayoutEffect(() => {
+    setHasDescription(!!description);
+  }, [description, setHasDescription]);
 
-    const closeButton = onClose && (
-      <div
-        tabIndex={-1}
-        ref={closeButtonRef as React.RefObject<HTMLDivElement>}
-        className="outline-hidden"
-      >
-        <DialogPrimitive.Close asChild>
-          <Button
-            icon={SvgX}
-            prominence="tertiary"
-            size="sm"
-            onClick={onClose}
-          />
-        </DialogPrimitive.Close>
-      </div>
-    );
+  const closeButton = onClose && (
+    <div
+      tabIndex={-1}
+      ref={closeButtonRef as React.RefObject<HTMLDivElement>}
+      className="opal-modal-close-focus"
+    >
+      <DialogPrimitive.Close asChild>
+        <Button icon={SvgX} prominence="tertiary" size="sm" onClick={onClose} />
+      </DialogPrimitive.Close>
+    </div>
+  );
 
-    return (
+  return (
+    <Section ref={ref} padding={0.5} alignItems="start" height="fit" {...props}>
       <Section
-        ref={ref}
-        padding={0.5}
+        flexDirection="row"
+        justifyContent="between"
         alignItems="start"
-        height="fit"
-        {...props}
+        gap={0}
+        padding={0.5}
       >
-        <Section
-          flexDirection="row"
-          justifyContent="between"
-          alignItems="start"
-          gap={0}
-          padding={0.5}
-        >
-          <div className="relative w-full">
-            {/* Absolutely positioned per the Figma mocks: the close button
-               overlaps the content's top-right so the description keeps the
-               full width. */}
-            <div className="absolute top-0 right-0">{closeButton}</div>
-            <DialogPrimitive.Title asChild>
-              <div>
-                <Content
-                  icon={icon}
-                  moreIcon1={moreIcon1}
-                  moreIcon2={moreIcon2}
-                  title={title}
-                  description={description}
-                  sizePreset="section"
-                  variant="heading"
-                />
-                {description && (
-                  <DialogPrimitive.Description className="hidden">
-                    {toPlainString(description)}
-                  </DialogPrimitive.Description>
-                )}
-              </div>
-            </DialogPrimitive.Title>
-          </div>
-        </Section>
-        {children}
+        <div className="opal-modal-header-content">
+          <div className="opal-modal-header-close">{closeButton}</div>
+          <DialogPrimitive.Title asChild>
+            <div>
+              <Content
+                icon={icon}
+                moreIcon1={moreIcon1}
+                moreIcon2={moreIcon2}
+                title={title}
+                description={description}
+                sizePreset="section"
+                variant="heading"
+              />
+              {description && (
+                <DialogPrimitive.Description className="opal-modal-a11y-description">
+                  {toPlainString(description)}
+                </DialogPrimitive.Description>
+              )}
+            </div>
+          </DialogPrimitive.Title>
+        </div>
       </Section>
-    );
-  }
-);
-ModalHeader.displayName = "ModalHeader";
+      {children}
+    </Section>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Body + Footer
 // ---------------------------------------------------------------------------
 
 interface ModalBodyProps extends WithoutStyles<SectionProps> {
+  ref?: React.Ref<HTMLDivElement>;
   /** Gray body background separating it from the header/footer. */
   twoTone?: boolean;
 }
 
-const ModalBody = React.forwardRef<HTMLDivElement, ModalBodyProps>(
-  ({ twoTone = true, children, ...props }, ref) => {
-    return (
-      <div
-        ref={ref}
-        className={cn(
-          twoTone && "bg-background-tint-01",
-          "flex-auto min-h-0 overflow-y-auto w-full"
-        )}
-      >
-        <Section
-          height="auto"
-          padding={1}
-          gap={1}
-          alignItems="start"
-          {...props}
-        >
-          {children}
-        </Section>
-      </div>
-    );
-  }
-);
-ModalBody.displayName = "ModalBody";
+function ModalBody({
+  ref,
+  twoTone = true,
+  children,
+  ...props
+}: ModalBodyProps) {
+  return (
+    <div
+      ref={ref}
+      className="opal-modal-body"
+      {...(twoTone && { "data-two-tone": "" })}
+    >
+      <Section height="auto" padding={1} gap={1} alignItems="start" {...props}>
+        {children}
+      </Section>
+    </div>
+  );
+}
 
-const ModalFooter = React.forwardRef<
-  HTMLDivElement,
-  WithoutStyles<SectionProps>
->(({ ...props }, ref) => {
+interface ModalFooterProps extends WithoutStyles<SectionProps> {
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+function ModalFooter({ ref, ...props }: ModalFooterProps) {
   return (
     <Section
       ref={ref}
@@ -508,8 +441,7 @@ const ModalFooter = React.forwardRef<
       {...props}
     />
   );
-});
-ModalFooter.displayName = "ModalFooter";
+}
 
 /**
  * Modal (Figma Modal): Radix Dialog compound. `Modal` is the Radix root

--- a/web/lib/opal/src/components/modal/styles.css
+++ b/web/lib/opal/src/components/modal/styles.css
@@ -1,0 +1,124 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   Modal
+
+   Three layers share the chrome:
+   - .opal-modal-overlay: the scrim behind the card.
+   - .opal-modal-positioner: the fixed, centered (or top-pinned) frame that
+     carries width, the viewport clamp, and the open/close animations. When a
+     [data-main-container] center is in effect, the owner supplies left/top
+     inline and omits [data-viewport-centered].
+   - .opal-modal-card: the bordered card that carries background and height.
+
+   Without a bottom slot, one element wears positioner + card. With one, the
+   positioner wraps a .opal-modal-stack column of card + slot.
+   --------------------------------------------------------------------------- */
+
+.opal-modal-overlay {
+  @apply fixed inset-0 bg-mask-03 backdrop-blur-03 pointer-events-none;
+  z-index: var(--z-modal-overlay);
+}
+.opal-modal-overlay[data-state="open"] {
+  @apply animate-in fade-in-0;
+}
+.opal-modal-overlay[data-state="closed"] {
+  @apply animate-out fade-out-0;
+}
+
+.opal-modal-positioner {
+  @apply fixed -translate-x-1/2 duration-200;
+  @apply max-w-[calc(100dvw-2rem)] max-h-[calc(100dvh-2rem)];
+  z-index: var(--z-modal);
+}
+.opal-modal-positioner[data-state="open"] {
+  @apply animate-in fade-in-0 zoom-in-95;
+}
+.opal-modal-positioner[data-state="closed"] {
+  @apply animate-out fade-out-0 zoom-out-95;
+}
+.opal-modal-positioner[data-position="center"] {
+  @apply -translate-y-1/2;
+}
+.opal-modal-positioner[data-position="center"][data-state="open"] {
+  @apply slide-in-from-top-1/2;
+}
+.opal-modal-positioner[data-position="center"][data-state="closed"] {
+  @apply slide-out-to-top-1/2;
+}
+.opal-modal-positioner[data-position="center"][data-viewport-centered] {
+  @apply left-1/2 top-1/2;
+}
+.opal-modal-positioner[data-position="top"] {
+  @apply top-[72px];
+}
+.opal-modal-positioner[data-position="top"][data-viewport-centered] {
+  @apply left-1/2;
+}
+
+.opal-modal-positioner[data-width="sm"] {
+  @apply w-120;
+}
+.opal-modal-positioner[data-width="md"] {
+  @apply w-160;
+}
+.opal-modal-positioner[data-width="lg"] {
+  @apply w-200;
+}
+.opal-modal-positioner[data-width="xl"] {
+  @apply w-240;
+}
+.opal-modal-positioner[data-width="full"] {
+  @apply w-[80dvw];
+}
+
+.opal-modal-card {
+  @apply overflow-hidden bg-background-tint-00 border rounded-16 shadow-2xl flex flex-col;
+}
+.opal-modal-card[data-background="gray"] {
+  @apply bg-background-tint-01;
+}
+.opal-modal-card[data-height="fit"] {
+  @apply h-fit;
+}
+.opal-modal-card[data-height="sm"] {
+  @apply max-h-120 overflow-y-auto;
+}
+.opal-modal-card[data-height="lg"] {
+  @apply max-h-[calc(100dvh-4rem)] overflow-y-auto;
+}
+.opal-modal-card[data-height="full"] {
+  @apply h-[80dvh] overflow-y-auto;
+}
+
+.opal-modal-stack {
+  @apply flex flex-col gap-4 items-center;
+}
+.opal-modal-stack > .opal-modal-card {
+  @apply w-full min-h-0;
+}
+.opal-modal-bottom-slot {
+  @apply w-full shrink-0;
+}
+
+/* Header: the close button overlaps the content's top-right per the Figma
+   mocks, so the description keeps the full width. */
+.opal-modal-header-content {
+  @apply relative w-full;
+}
+.opal-modal-header-close {
+  @apply absolute top-0 right-0;
+}
+.opal-modal-close-focus {
+  @apply outline-hidden;
+}
+.opal-modal-a11y-description {
+  @apply hidden;
+}
+
+.opal-modal-body {
+  @apply flex-auto min-h-0 overflow-y-auto w-full;
+}
+.opal-modal-body[data-two-tone] {
+  @apply bg-background-tint-01;
+}

--- a/web/lib/opal/src/hooks/useContainerCenter.ts
+++ b/web/lib/opal/src/hooks/useContainerCenter.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { usePathname } from "next/navigation";
+import useScreenSize from "@opal/hooks/useScreenSize";
+
+const SELECTOR = "[data-main-container]";
+
+interface ContainerCenter {
+  centerX: number | null;
+  centerY: number | null;
+  hasContainerCenter: boolean;
+}
+
+const NULL_CENTER = { x: null, y: null } as const;
+
+function measure(el: HTMLElement): { x: number; y: number } | null {
+  if (!el.isConnected) return null;
+  const rect = el.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) return null;
+  return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+}
+
+/**
+ * Tracks the center point of the `[data-main-container]` element so that
+ * portaled overlays (modals, command menus) can center relative to the main
+ * content area rather than the full viewport.
+ *
+ * Returns `{ centerX, centerY, hasContainerCenter }`.
+ * When the container is not present (e.g. pages without `AppLayouts.Root`),
+ * both center values are `null` and `hasContainerCenter` is `false`, allowing
+ * callers to fall back to standard viewport centering.
+ *
+ * Uses a lazy `useState` initializer so the first render already has the
+ * correct values (no flash), and a `ResizeObserver` to stay reactive when
+ * the sidebar folds/unfolds. Re-subscribes on route changes because each
+ * page renders its own `AppLayouts.Root`, replacing the DOM element.
+ */
+export default function useContainerCenter(): ContainerCenter {
+  const pathname = usePathname();
+  const { isMediumScreen } = useScreenSize();
+  const [center, setCenter] = useState<{ x: number | null; y: number | null }>(
+    () => {
+      if (typeof document === "undefined") return NULL_CENTER;
+      const el = document.querySelector<HTMLElement>(SELECTOR);
+      if (!el) return NULL_CENTER;
+      const m = measure(el);
+      return m ?? NULL_CENTER;
+    }
+  );
+
+  useEffect(() => {
+    const container = document.querySelector<HTMLElement>(SELECTOR);
+    if (!container) {
+      setCenter(NULL_CENTER);
+      return;
+    }
+
+    const update = () => {
+      const m = measure(container);
+      setCenter(m ?? NULL_CENTER);
+    };
+
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [pathname]);
+
+  return {
+    centerX: isMediumScreen ? null : center.x,
+    centerY: isMediumScreen ? null : center.y,
+    hasContainerCenter: isMediumScreen
+      ? false
+      : center.x !== null && center.y !== null,
+  };
+}

--- a/web/lib/opal/src/styles/z-index.css
+++ b/web/lib/opal/src/styles/z-index.css
@@ -10,6 +10,11 @@
      over pinned columns without being obscured. */
   --z-settings-header: 11;
 
+  /* Modal scrim and card. Below popovers/tooltips so pickers opened from
+     inside a modal stack above it. */
+  --z-modal-overlay: 900;
+  --z-modal: 1000;
+
   /* Interactive overlays. Toasts sit below popovers so an open menu is
      never obscured by a passive notification. */
   --z-toast: 1100;
@@ -19,6 +24,12 @@
 
 .z-settings-header {
   z-index: var(--z-settings-header);
+}
+.z-modal-overlay {
+  z-index: var(--z-modal-overlay);
+}
+.z-modal {
+  z-index: var(--z-modal);
 }
 .z-toast {
   z-index: var(--z-toast);


### PR DESCRIPTION
## Description

Ports the `refresh-components` Modal (66 importers) into Opal — the library previously had no modal primitive (the biggest gap in the Opal audit: agent-wiki alone hand-rolls 11 scrims).

- Radix Dialog compound: `Modal` root, `Modal.Content` (scrim + positioning + card), `Modal.Header` / `Modal.Body` / `Modal.Footer`, plus the `BasicModalFooter` layout.
- Width/height presets, `center`/`top` positioning, `background`, `skipOverlay`, `bottomSlot`, and the two-stage accidental-close guard (typing arms it, first Escape focuses the close button).
- New `z-modal-overlay`/`z-modal` tokens in Opal's z-index.css matching the app's values, below popovers so pickers inside modals stack correctly.
- `@radix-ui/react-dialog` added to peerDependencies beside the other radix packages.

Deliberate divergences from the source: container-relative centering (`useContainerCenter`) is deferred (viewport-only), and the internal modal context is trimmed to the fields consumers read. Remaining Figma header/footer content variants (Search/Card/Panel, Checkbox/Message/Actions) are follow-ups.

## How Has This Been Tested?

Storybook stories for each variant (below), tsgo typecheck, and a live Playwright pass: open, full anatomy render, Escape close verified (dialog and overlay removed), re-verified after the handler-precedence fix.

Default (md, icon header, two-tone body, footer actions):

<img width="2400" height="1702" alt="image" src="https://github.com/user-attachments/assets/e8af8060-45d8-4837-99f6-c88311135dcc" />

Minimal header (no icon, preview variant):

<img width="2400" height="1702" alt="image" src="https://github.com/user-attachments/assets/b648721c-03bf-4b2d-9b8c-ab0981d66429" />

Danger footer:

<img width="2400" height="1702" alt="image" src="https://github.com/user-attachments/assets/b0072145-b0bf-45de-8596-316485e3ba8a" />

Top position (command-palette placement):

<img width="2400" height="1702" alt="image" src="https://github.com/user-attachments/assets/27806bb4-cdc1-4f68-b7f5-9ee7e89c3288" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check