### PR TITLE
feat(opal): add InputTextArea

### DIFF
--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -166,6 +166,12 @@ export {
   type PasswordInputTypeInProps,
 } from "@opal/components/inputs/password-input-type-in/components";
 
+/* InputTextArea */
+export {
+  InputTextArea,
+  type InputTextAreaProps,
+} from "@opal/components/inputs/input-text-area/components";
+
 /* Spacer */
 export { Spacer, type SpacerProps } from "@opal/components/spacer/components";
 

--- a/web/lib/opal/src/components/inputs/input-text-area/InputTextArea.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-text-area/InputTextArea.stories.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { InputTextArea } from "@opal/components";
+
+const meta: Meta<typeof InputTextArea> = {
+  title: "opal/components/InputTextArea",
+  component: InputTextArea,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InputTextArea>;
+
+function ControlledInputTextArea(
+  props: Partial<React.ComponentProps<typeof InputTextArea>>
+) {
+  const [value, setValue] = useState("");
+  return (
+    <div className="w-96">
+      <InputTextArea
+        value={value}
+        onChange={(event) => setValue(event.target.value)}
+        placeholder="Enter a description…"
+        {...props}
+      />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  render: () => <ControlledInputTextArea />,
+};
+
+export const AutoResize: Story = {
+  render: () => <ControlledInputTextArea autoResize rows={2} maxRows={6} />,
+};
+
+export const Error: Story = {
+  render: () => <ControlledInputTextArea variant="error" />,
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="w-96">
+      <InputTextArea
+        variant="disabled"
+        value="Cannot edit"
+        onChange={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const ReadOnly: Story = {
+  render: () => (
+    <div className="w-96">
+      <InputTextArea
+        variant="readOnly"
+        value="Read-only value"
+        onChange={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const Internal: Story = {
+  render: () => <ControlledInputTextArea variant="internal" />,
+};

--- a/web/lib/opal/src/components/inputs/input-text-area/README.md
+++ b/web/lib/opal/src/components/inputs/input-text-area/README.md
@@ -1,0 +1,31 @@
+# InputTextArea
+
+**Import:** `import { InputTextArea, type InputTextAreaProps } from "@opal/components";`
+
+Multiline text field on the shared `.opal-input` chrome. Accepts standard textarea attributes except `disabled` (use `variant="disabled"`), `className`, and `style`.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `variant` | `InputVariants` | `"primary"` | Wrapper chrome variant |
+| `rows` | `number` | `4` | Initial rows, also the `autoResize` minimum |
+| `autoResize` | `boolean` | `false` | Grow with content between `rows` and `maxRows`, disables manual resizing |
+| `maxRows` | `number` | — | Row cap for `autoResize`, content beyond it scrolls |
+| `resizable` | `boolean` | `true` | Manual vertical resize handle, ignored with `autoResize` |
+| `rightSection` | `ReactNode` | — | Slot pinned to the top-right inside the field |
+
+## Usage
+
+```tsx
+<InputTextArea
+  value={value}
+  onChange={(event) => setValue(event.target.value)}
+  placeholder="Enter a description…"
+  autoResize
+  rows={2}
+  maxRows={8}
+/>
+```
+
+The Figma Input family has no dedicated textarea component.

--- a/web/lib/opal/src/components/inputs/input-text-area/README.md
+++ b/web/lib/opal/src/components/inputs/input-text-area/README.md
@@ -2,7 +2,7 @@
 
 **Import:** `import { InputTextArea, type InputTextAreaProps } from "@opal/components";`
 
-Multiline text field on the shared `.opal-input` chrome. Accepts standard textarea attributes except `disabled` (use `variant="disabled"`), `className`, and `style`.
+Multiline text field on the shared `.opal-input` chrome. Accepts standard textarea attributes except `disabled` and `readOnly` (use the matching `variant`), `className`, and `style`.
 
 ## Props
 

--- a/web/lib/opal/src/components/inputs/input-text-area/README.md
+++ b/web/lib/opal/src/components/inputs/input-text-area/README.md
@@ -9,7 +9,7 @@ Multiline text field on the shared `.opal-input` chrome. Accepts standard textar
 | Prop | Type | Default | Description |
 |---|---|---|---|
 | `variant` | `InputVariants` | `"primary"` | Wrapper chrome variant |
-| `rows` | `number` | `4` | Initial rows, also the `autoResize` minimum |
+| `rows` | `number` | `4` | Initial rows and the `autoResize` minimum. The field has a 48px min-height floor, so values below 2 rows render at the floor |
 | `autoResize` | `boolean` | `false` | Grow with content between `rows` and `maxRows`, disables manual resizing |
 | `maxRows` | `number` | — | Row cap for `autoResize`, content beyond it scrolls |
 | `resizable` | `boolean` | `true` | Manual vertical resize handle, ignored with `autoResize` |

--- a/web/lib/opal/src/components/inputs/input-text-area/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-text-area/components.tsx
@@ -101,6 +101,12 @@ function InputTextArea({
         )}
         rows={rows}
         {...props}
+        // After the spread so uncontrolled typing also resizes. The effect
+        // covers programmatic value changes.
+        onInput={(event) => {
+          adjustHeight();
+          props.onInput?.(event);
+        }}
       />
       {rightSection && (
         <div className="opal-input-textarea-right">{rightSection}</div>

--- a/web/lib/opal/src/components/inputs/input-text-area/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-text-area/components.tsx
@@ -13,7 +13,10 @@ import { cn, mergeRefs } from "@opal/utils";
 // ---------------------------------------------------------------------------
 
 interface InputTextAreaProps extends WithoutStyles<
-  Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "disabled">
+  Omit<
+    React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+    "disabled" | "readOnly"
+  >
 > {
   variant?: InputVariants;
 
@@ -43,7 +46,6 @@ interface InputTextAreaProps extends WithoutStyles<
 function InputTextArea({
   variant = "primary",
   rows = 4,
-  readOnly,
   autoResize = false,
   maxRows,
   resizable = true,
@@ -52,7 +54,7 @@ function InputTextArea({
   ...props
 }: InputTextAreaProps) {
   const disabled = variant === "disabled";
-  const isReadOnly = variant === "readOnly" || readOnly;
+  const isReadOnly = variant === "readOnly";
 
   const internalRef = React.useRef<HTMLTextAreaElement | null>(null);
   const cachedLineHeight = React.useRef<number | null>(null);

--- a/web/lib/opal/src/components/inputs/input-text-area/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-text-area/components.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import "@opal/components/inputs/shared.css";
+// The field reuses InputTypeIn's .opal-input-field base, color, and placeholder rules.
+import "@opal/components/inputs/input-type-in/styles.css";
+import "@opal/components/inputs/input-text-area/styles.css";
+import React from "react";
+import type { InputVariants, WithoutStyles } from "@opal/types";
+import { cn, mergeRefs } from "@opal/utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface InputTextAreaProps extends WithoutStyles<
+  Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "disabled">
+> {
+  variant?: InputVariants;
+
+  /**
+   * Grow with content between `rows` and `maxRows`. Disables manual
+   * resizing.
+   */
+  autoResize?: boolean;
+
+  /** Row cap for `autoResize`. Content beyond it scrolls. */
+  maxRows?: number;
+
+  /** Allow manual vertical resizing. Ignored when `autoResize` is set. */
+  resizable?: boolean;
+
+  /** Slot pinned to the top-right inside the field. */
+  rightSection?: React.ReactNode;
+
+  ref?: React.Ref<HTMLTextAreaElement>;
+}
+
+// ---------------------------------------------------------------------------
+// InputTextArea
+// ---------------------------------------------------------------------------
+
+/** Multiline text field on the `.opal-input` chrome. */
+function InputTextArea({
+  variant = "primary",
+  rows = 4,
+  readOnly,
+  autoResize = false,
+  maxRows,
+  resizable = true,
+  rightSection,
+  ref,
+  ...props
+}: InputTextAreaProps) {
+  const disabled = variant === "disabled";
+  const isReadOnly = variant === "readOnly" || readOnly;
+
+  const internalRef = React.useRef<HTMLTextAreaElement | null>(null);
+  const cachedLineHeight = React.useRef<number | null>(null);
+
+  const adjustHeight = React.useCallback(() => {
+    const textarea = internalRef.current;
+    if (!textarea || !autoResize) return;
+
+    if (cachedLineHeight.current === null) {
+      cachedLineHeight.current =
+        parseFloat(getComputedStyle(textarea).lineHeight) || 20;
+    }
+    const lineHeight = cachedLineHeight.current;
+
+    // Reset to auto so scrollHeight reflects the actual content.
+    textarea.style.height = "auto";
+    textarea.style.overflowY = "hidden";
+
+    const minHeight = rows * lineHeight;
+    const maxHeight = maxRows ? maxRows * lineHeight : Infinity;
+
+    const contentHeight = textarea.scrollHeight;
+    const clampedHeight = Math.min(
+      Math.max(contentHeight, minHeight),
+      maxHeight
+    );
+
+    textarea.style.height = `${clampedHeight}px`;
+    textarea.style.overflowY = contentHeight > maxHeight ? "auto" : "hidden";
+  }, [autoResize, rows, maxRows]);
+
+  React.useEffect(() => {
+    adjustHeight();
+  }, [adjustHeight, props.value]);
+
+  return (
+    <div className="opal-input opal-input-textarea" data-variant={variant}>
+      {/* raw-ok: Opal ships no textarea element, this component IS the library's textarea */}
+      <textarea
+        ref={mergeRefs(internalRef, ref)}
+        disabled={disabled}
+        readOnly={isReadOnly}
+        className={cn(
+          "opal-input-field opal-input-textarea-field",
+          autoResize || !resizable ? "resize-none" : "resize-y"
+        )}
+        rows={rows}
+        {...props}
+      />
+      {rightSection && (
+        <div className="opal-input-textarea-right">{rightSection}</div>
+      )}
+    </div>
+  );
+}
+
+export { InputTextArea, type InputTextAreaProps };

--- a/web/lib/opal/src/components/inputs/input-text-area/styles.css
+++ b/web/lib/opal/src/components/inputs/input-text-area/styles.css
@@ -1,0 +1,22 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   InputTextArea
+
+   Multiline field on the .opal-input chrome. Overrides the wrapper's
+   items-center so the field and the right slot align to the top, and
+   replaces the fixed single-line field height with row-driven auto height
+   plus a fixed min-height floor.
+   --------------------------------------------------------------------------- */
+
+.opal-input-textarea {
+  @apply items-start;
+}
+
+.opal-input-textarea-field {
+  @apply h-auto min-h-12 min-w-0 flex-1;
+}
+
+.opal-input-textarea-right {
+  @apply shrink-0 self-start;
+}


### PR DESCRIPTION
## Description

Ports the `refresh-components` InputTextArea (11 importers) onto the shared `.opal-input` chrome. Opal previously shipped no textarea.

- Variant-driven states via the shared `InputVariants` vocabulary, including `readOnly`; `disabled` is a variant, not a prop.
- `autoResize` grows between `rows` and `maxRows` (cached line-height measurement carried from the source), content beyond the cap scrolls; `resizable` toggles the manual handle.
- Top-right `rightSection` slot.
- The field reuses `.opal-input-field` base/color/placeholder rules, same pattern as InputTags (#12833).

Deliberate divergence from the source: the right slot drops the flush negative-margin offsets (the Opal chrome's padding differs, and InputTypeIn renders its right slot bare).

## How Has This Been Tested?

Storybook stories for each state (below), tsgo typecheck, and a live Playwright pass of autoResize: 2-row minimum rendered 52px, five lines grew the field to 124px with overflow hidden, nine lines capped at 144px (6 rows) with overflowY auto.

Default:

<img width="768" height="226" alt="image" src="https://github.com/user-attachments/assets/1ad910d6-48df-4129-8fad-4377d5412fa2" />

autoResize at the 6-row cap (scrollable):

<img width="768" height="314" alt="image" src="https://github.com/user-attachments/assets/5317b235-3d87-46a9-9baa-0fd166e0fd62" />

Error variant:

<img width="768" height="226" alt="image" src="https://github.com/user-attachments/assets/7fbe6c61-e009-49e2-a8f3-f4422e735a23" />

Disabled variant:

<img width="768" height="226" alt="image" src="https://github.com/user-attachments/assets/1363fb2f-4b0f-4b3d-af1a-494b0c0f4f25" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check