### PR TITLE
feat(anthropic): add Fable 5 and Sonnet 5 to recommended models

### DIFF
--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,6 +1,6 @@
 {
-  "version": "1.4",
-  "updated_at": "2026-06-04T00:00:00Z",
+  "version": "1.5",
+  "updated_at": "2026-07-10T00:00:00Z",
   "providers": {
     "openai": {
       "default_model": "gpt-5.5",
@@ -14,6 +14,10 @@
       "default_model": "claude-opus-4-8",
       "additional_visible_models": [
         {
+          "name": "claude-fable-5",
+          "display_name": "Claude Fable 5"
+        },
+        {
           "name": "claude-opus-4-8",
           "display_name": "Claude Opus 4.8"
         },
@@ -24,6 +28,10 @@
         {
           "name": "claude-opus-4-6",
           "display_name": "Claude Opus 4.6"
+        },
+        {
+          "name": "claude-sonnet-5",
+          "display_name": "Claude Sonnet 5"
         },
         {
           "name": "claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

Adds two Anthropic models to the recommended/visible model list:

- **Claude Fable 5** (`claude-fable-5`)
- **Claude Sonnet 5** (`claude-sonnet-5`)

`default_model` is unchanged (`claude-opus-4-8`) — these are added as visible options, not promoted to default. Bumped the config `version` `1.4` → `1.5` (the auto-update sync path keys off the version to decide whether to re-process).

No other files need to change: `recommended-models.json` carries the `display_name`, and litellm already knows both IDs (available-model list + token/context metadata), while `multi_llm.py` routing is already version-aware for the Claude 5 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)