### PR TITLE
feat(opal): add IconContainer

### DIFF
--- a/web/lib/opal/src/components/icon-container/IconContainer.stories.tsx
+++ b/web/lib/opal/src/components/icon-container/IconContainer.stories.tsx
@@ -1,0 +1,71 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { IconContainer, type IconContainerSize } from "@opal/components";
+import { SvgSearch, SvgUser } from "@opal/icons";
+import { SvgSlack } from "@opal/logos";
+
+const meta: Meta<typeof IconContainer> = {
+  title: "opal/components/IconContainer",
+  component: IconContainer,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof IconContainer>;
+
+const SIZES: IconContainerSize[] = [
+  "secondary",
+  "main-ui",
+  "main-content",
+  "section",
+  "sub-headline",
+];
+
+export const Icon: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      {SIZES.map((size) => (
+        <IconContainer key={size} size={size} icon={SvgSearch} />
+      ))}
+    </div>
+  ),
+};
+
+export const Entity: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      {SIZES.map((size) => (
+        <IconContainer key={size} size={size} type="entity" icon={SvgSearch} />
+      ))}
+    </div>
+  ),
+};
+
+export const AvatarUser: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      {SIZES.map((size) => (
+        <IconContainer key={size} size={size} avatar="user" name="Taylor" />
+      ))}
+    </div>
+  ),
+};
+
+export const AvatarIcon: Story = {
+  render: () => (
+    <div className="flex items-center gap-2 rounded-08 bg-background-tint-02 p-2">
+      {SIZES.map((size) => (
+        <IconContainer key={size} size={size} avatar="icon" icon={SvgUser} />
+      ))}
+    </div>
+  ),
+};
+
+export const Logo: Story = {
+  render: () => (
+    <div className="flex items-center gap-2">
+      {SIZES.map((size) => (
+        <IconContainer key={size} size={size} icon={SvgSlack} />
+      ))}
+    </div>
+  ),
+};

--- a/web/lib/opal/src/components/icon-container/README.md
+++ b/web/lib/opal/src/components/icon-container/README.md
@@ -1,0 +1,32 @@
+# IconContainer
+
+**Import:** `import { IconContainer, type IconContainerProps } from "@opal/components";`
+
+Fixed-size icon slot, the Figma Icon Container. One primitive covers the bare glyph, the user avatar (dark circle with an initial), the icon-in-circle badge (light circle), and logo slots.
+
+## Props
+
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `size` | `IconContainerSize` | `"main-ui"` | Box keyed to the line-height scale: secondary 16, main-ui 20, main-content 24, section 28, sub-headline 32 |
+| `type` | `"default" \| "entity" \| "action"` | `"default"` | Reading prominence. `entity` renders `text-04` at every size, `action` emits `data-type="action"` as a styling hook and currently renders like `default` |
+| `icon` | `IconFunctionComponent` | — | Glyph for the bare content, or the circle's glyph with `avatar="icon"`. Logos from `@opal/logos` work here too |
+| `avatar` | `"user" \| "icon"` | — | Round avatar: `user` is the dark circle with the initial of `name`, `icon` is the light circle around `icon` |
+| `name` | `string` | — | Initial source for `avatar="user"` (first character after trim, uppercased, `?` fallback) |
+
+Glyph sizes follow the spec (12 at secondary, 16 at main-ui and main-content, 24 at section and sub-headline, with entity bumping main-ui to 18). The avatar circle fills the box up to 24px.
+
+## Usage
+
+```tsx
+// Bare glyph beside main-ui text
+<IconContainer icon={SvgSearch} />
+
+// User avatar
+<IconContainer size="section" avatar="user" name={user.displayName} />
+
+// Icon badge
+<IconContainer avatar="icon" icon={SvgSlack} />
+```
+
+Default glyph color ascends with the size preset (`text-02` at secondary, `text-03` at main-ui and main-content, `text-04` at section and sub-headline). Uploaded-image avatars are not in the Figma spec and are out of scope. The avatar renders an initial or an icon only.

--- a/web/lib/opal/src/components/icon-container/README.md
+++ b/web/lib/opal/src/components/icon-container/README.md
@@ -10,9 +10,9 @@ Fixed-size icon slot, the Figma Icon Container. One primitive covers the bare gl
 |---|---|---|---|
 | `size` | `IconContainerSize` | `"main-ui"` | Box keyed to the line-height scale: secondary 16, main-ui 20, main-content 24, section 28, sub-headline 32 |
 | `type` | `"default" \| "entity" \| "action"` | `"default"` | Reading prominence. `entity` renders `text-04` at every size, `action` emits `data-type="action"` as a styling hook and currently renders like `default` |
-| `icon` | `IconFunctionComponent` | — | Glyph for the bare content, or the circle's glyph with `avatar="icon"`. Logos from `@opal/logos` work here too |
-| `avatar` | `"user" \| "icon"` | — | Round avatar: `user` is the dark circle with the initial of `name`, `icon` is the light circle around `icon` |
-| `name` | `string` | — | Initial source for `avatar="user"` (first character after trim, uppercased, `?` fallback) |
+| `icon` | `IconFunctionComponent` | — | Glyph for the bare content, required with `avatar="icon"`. Logos from `@opal/logos` work here too |
+| `avatar` | `"user" \| "icon"` | — | Round avatar: `user` is the dark circle with the initial of `name`, `icon` is the light circle around `icon`. The content union makes an avatar without its content a type error |
+| `name` | `string` | — | Required with `avatar="user"`: initial source (first character after trim, uppercased, `?` fallback for empty strings) |
 
 Glyph sizes follow the spec (12 at secondary, 16 at main-ui and main-content, 24 at section and sub-headline, with entity bumping main-ui to 18). The avatar circle fills the box up to 24px.
 

--- a/web/lib/opal/src/components/icon-container/components.tsx
+++ b/web/lib/opal/src/components/icon-container/components.tsx
@@ -15,7 +15,38 @@ type IconContainerSize =
 
 type IconContainerType = "default" | "entity" | "action";
 
-interface IconContainerProps {
+/**
+ * Content union: a bare glyph, the light circle around a required icon, or
+ * the dark circle with the required name's initial. Invalid combinations
+ * (an avatar circle without its content) are type errors.
+ */
+type IconContainerContentProps =
+  | {
+      avatar?: undefined;
+
+      /**
+       * Glyph for the bare icon content. Logo components from `@opal/logos`
+       * work here too.
+       */
+      icon?: IconFunctionComponent;
+      name?: never;
+    }
+  | {
+      /** Light circle around `icon`. */
+      avatar: "icon";
+      icon: IconFunctionComponent;
+      name?: never;
+    }
+  | {
+      /** Dark circle with the initial of `name`. */
+      avatar: "user";
+
+      /** Initial source (first character after trim, uppercased). */
+      name: string;
+      icon?: never;
+    };
+
+type IconContainerProps = IconContainerContentProps & {
   /** Size preset, keyed to the line-height scale of the matching text role. */
   size?: IconContainerSize;
 
@@ -25,22 +56,7 @@ interface IconContainerProps {
    * as a hook for interactive contexts.
    */
   type?: IconContainerType;
-
-  /**
-   * Glyph for the bare icon content, or the circle's glyph with
-   * `avatar="icon"`. Logo components from `@opal/logos` work here too.
-   */
-  icon?: IconFunctionComponent;
-
-  /**
-   * Renders the round avatar: `"user"` is the dark circle with the initial
-   * of `name`, `"icon"` is the light circle around `icon`.
-   */
-  avatar?: "user" | "icon";
-
-  /** Initial source for `avatar="user"`. */
-  name?: string;
-}
+};
 
 // ---------------------------------------------------------------------------
 // IconContainer

--- a/web/lib/opal/src/components/icon-container/components.tsx
+++ b/web/lib/opal/src/components/icon-container/components.tsx
@@ -1,0 +1,93 @@
+import "@opal/components/icon-container/styles.css";
+import type { IconFunctionComponent } from "@opal/types";
+import { Text } from "@opal/components";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type IconContainerSize =
+  | "secondary"
+  | "main-ui"
+  | "main-content"
+  | "section"
+  | "sub-headline";
+
+type IconContainerType = "default" | "entity" | "action";
+
+interface IconContainerProps {
+  /** Size preset, keyed to the line-height scale of the matching text role. */
+  size?: IconContainerSize;
+
+  /**
+   * Reading prominence: `"entity"` renders in `text-04` at every size.
+   * `"action"` has no styles of its own, it only emits `data-type="action"`
+   * as a hook for interactive contexts.
+   */
+  type?: IconContainerType;
+
+  /**
+   * Glyph for the bare icon content, or the circle's glyph with
+   * `avatar="icon"`. Logo components from `@opal/logos` work here too.
+   */
+  icon?: IconFunctionComponent;
+
+  /**
+   * Renders the round avatar: `"user"` is the dark circle with the initial
+   * of `name`, `"icon"` is the light circle around `icon`.
+   */
+  avatar?: "user" | "icon";
+
+  /** Initial source for `avatar="user"`. */
+  name?: string;
+}
+
+// ---------------------------------------------------------------------------
+// IconContainer
+// ---------------------------------------------------------------------------
+
+/**
+ * Fixed-size icon slot (Figma Icon Container): a bare glyph, or the round
+ * avatar holding a user initial or an icon. The one primitive behind
+ * avatars, icon-in-circle badges, and logo slots.
+ */
+function IconContainer({
+  size = "main-ui",
+  type = "default",
+  icon: Icon,
+  avatar,
+  name,
+}: IconContainerProps) {
+  const glyph = Icon ? <Icon className="opal-icon-container-glyph" /> : null;
+
+  let content: React.ReactNode = glyph;
+  if (avatar === "user") {
+    const initial = (name?.trim()[0] ?? "?").toUpperCase();
+    content = (
+      <div className="opal-icon-container-avatar opal-icon-container-avatar-user">
+        <Text font="secondary-action" color="text-inverted-05" nowrap>
+          {initial}
+        </Text>
+      </div>
+    );
+  } else if (avatar === "icon") {
+    content = (
+      <div className="opal-icon-container-avatar opal-icon-container-avatar-icon">
+        {glyph}
+      </div>
+    );
+  }
+
+  return (
+    <div className="opal-icon-container" data-size={size} data-type={type}>
+      {content}
+    </div>
+  );
+}
+
+export {
+  IconContainer,
+  type IconContainerProps,
+  type IconContainerSize,
+  type IconContainerType,
+};

--- a/web/lib/opal/src/components/icon-container/styles.css
+++ b/web/lib/opal/src/components/icon-container/styles.css
@@ -1,0 +1,96 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   IconContainer (Figma Icon Container)
+
+   Fixed square keyed to the line-height scale, centering a fixed-size glyph
+   or avatar circle. Glyph color rides on the container's text color so
+   stroke-current icons inherit it.
+   --------------------------------------------------------------------------- */
+
+.opal-icon-container {
+  @apply flex shrink-0 items-center justify-center;
+}
+
+.opal-icon-container[data-size="secondary"] {
+  @apply text-text-02;
+  width: 16px;
+  height: 16px;
+}
+
+.opal-icon-container[data-size="main-ui"] {
+  @apply text-text-03;
+  width: 20px;
+  height: 20px;
+}
+
+.opal-icon-container[data-size="main-content"] {
+  @apply text-text-03;
+  width: 24px;
+  height: 24px;
+}
+
+.opal-icon-container[data-size="section"] {
+  @apply text-text-04;
+  width: 28px;
+  height: 28px;
+}
+
+.opal-icon-container[data-size="sub-headline"] {
+  @apply text-text-04;
+  width: 32px;
+  height: 32px;
+}
+
+.opal-icon-container[data-type="entity"] {
+  @apply text-text-04;
+}
+
+.opal-icon-container-glyph {
+  width: 16px;
+  height: 16px;
+}
+
+.opal-icon-container[data-size="secondary"] .opal-icon-container-glyph {
+  width: 12px;
+  height: 12px;
+}
+
+/* Bare glyph only (direct child): the avatar glyph stays at the base size. */
+.opal-icon-container[data-size="section"] > .opal-icon-container-glyph,
+.opal-icon-container[data-size="sub-headline"] > .opal-icon-container-glyph {
+  width: 24px;
+  height: 24px;
+}
+
+/* Entity bumps the bare main-ui glyph to 18px per the Figma spec. */
+.opal-icon-container[data-type="entity"][data-size="main-ui"]
+  > .opal-icon-container-glyph {
+  width: 18px;
+  height: 18px;
+}
+
+/* Avatar circle: fills the box up to 24px. */
+.opal-icon-container-avatar {
+  @apply flex shrink-0 items-center justify-center overflow-clip rounded-full;
+  width: 24px;
+  height: 24px;
+}
+
+.opal-icon-container[data-size="secondary"] .opal-icon-container-avatar {
+  width: 16px;
+  height: 16px;
+}
+
+.opal-icon-container[data-size="main-ui"] .opal-icon-container-avatar {
+  width: 20px;
+  height: 20px;
+}
+
+.opal-icon-container-avatar-user {
+  @apply bg-background-neutral-inverted-00;
+}
+
+.opal-icon-container-avatar-icon {
+  @apply bg-background-neutral-00;
+}

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -75,6 +75,14 @@ export {
   type DividerProps,
 } from "@opal/components/divider/components";
 
+/* IconContainer */
+export {
+  IconContainer,
+  type IconContainerProps,
+  type IconContainerSize,
+  type IconContainerType,
+} from "@opal/components/icon-container/components";
+
 /* Card */
 export { Card, type CardProps } from "@opal/components/cards/card/components";
 


### PR DESCRIPTION
## Description

Fixed-size icon slot per the Figma Icon Container spec. One primitive covers the bare glyph, the dark user-avatar circle (derived initial), the light icon-circle badge, and logo slots. Consolidation target for the three onyx avatar components and agent-wiki's two avatar primitives plus inline circles.

- Five sizes keyed to the line-height scale (16/20/24/28/32), avatar circle fills the box up to 24px.
- Glyph matrix per the spec: 12/16/16/24/24, entity bumping main-ui to 18.
- Default color ascends with size (`text-02`/`text-03`/`text-04`), `entity` reads `text-04` everywhere, `action` emits `data-type="action"` as a styling hook.
- Every metric is ground truth from per-variant Figma pulls, no interpolation.

Uploaded-image avatars are not in the Figma spec and are out of scope.

## How Has This Been Tested?

Storybook stories for each content kind (below), tsgo typecheck, and live Playwright measurement of both matrices: boxes 16/20/24/28/32, bare glyphs 12/16/16/24/24 with computed colors matching text-02/03/03/04/04, avatar circles 16/20/24/24/24 with 16px glyphs inside. The avatar-glyph specificity bug the review caught is fixed and re-measured.

Bare glyphs across the five sizes (colors ascend text-02 to text-04):

<img width="304" height="66" alt="image" src="https://github.com/user-attachments/assets/71239db3-3c54-47b6-a057-2b95ae649de1" />

User avatars (initial derived from name, circle caps at 24px):

<img width="304" height="66" alt="image" src="https://github.com/user-attachments/assets/59ad5831-4352-4fe7-974f-90529ecc20c6" />

Icon badges:

<img width="336" height="98" alt="image" src="https://github.com/user-attachments/assets/5c8e00b3-4fbf-4ac8-9aaf-607733b4b4aa" />

Logos:

<img width="304" height="66" alt="image" src="https://github.com/user-attachments/assets/f81b3871-00fc-41bf-8704-e7b04e2e219f" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check