### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/integration/tests/craft/test_file_ops_api.py
+++ b/backend/tests/integration/tests/craft/test_file_ops_api.py
@@ -286,7 +286,14 @@ def test_list_directory_filters_hidden_entries(
     session_id, sandbox_id = _create_session_with_sandbox(admin_user)
     manager = get_sandbox_manager()
 
-    hidden_names = {".venv/keep", "node_modules/keep", "opencode.json", ".env"}
+    hidden_names = {
+        ".venv/keep",
+        "node_modules/keep",
+        "opencode.json",
+        ".env",
+        "nextjs.log",
+        "nextjs.pid",
+    }
     visible_names = {"alpha.txt", "beta.txt"}
 
     for rel in hidden_names | visible_names:
@@ -303,6 +310,8 @@ def test_list_directory_filters_hidden_entries(
     assert "node_modules" not in names
     assert "opencode.json" not in names
     assert ".env" not in names
+    assert "nextjs.log" not in names
+    assert "nextjs.pid" not in names
     assert visible_names <= names
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize(
+    ("name", "is_directory", "expected_hidden"),
+    [
+        ("nextjs.log", False, True),
+        ("nextjs.pid", False, True),
+        (".env", False, True),
+        ("node_modules", True, True),
+        ("page.tsx", False, False),
+        ("outputs", True, False),
+    ],
+)
+def test_is_hidden_workspace_entry(
+    name: str, is_directory: bool, expected_hidden: bool
+) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=is_directory)
+    assert _is_hidden_workspace_entry(entry) is expected_hidden


### PR DESCRIPTION
## What & why

In the Onyx Craft sandbox Files tab, the Next.js dev server's runtime artifacts `nextjs.log` and `nextjs.pid` were showing up as listed files in the explorer. These are internal runtime files (written to the session root by the dev-server start script) and shouldn't be surfaced to users as workspace files.

This adds `nextjs.log` and `nextjs.pid` to the existing `HIDDEN_PATTERNS` set that the file listing already uses to filter out entries like `node_modules`, `.next`, and `opencode.json`. No new mechanism is introduced — it reuses the single canonical filter in `SessionManager` (`_is_hidden_workspace_entry`). Since neither filename starts with `.`, they were not caught by the existing dotfile rule.

The same set also drives the artifact-zip walker, so these runtime files are now correctly excluded from downloaded archives as well.

## How it was verified

- Added a focused unit test (`test_hidden_entries.py`) asserting `_is_hidden_workspace_entry` hides `nextjs.log`/`nextjs.pid` while keeping regular files visible. Confirmed it fails before the fix and passes after.
- Extended the existing integration filter test (`test_list_directory_filters_hidden_entries`) to cover both filenames.
- A regression review confirmed process management (pid/log read by direct shell path) and snapshot/restore are unaffected — only the file listing and zip walker consume the filter.

## Known minor items

None.

- [x] Override Linear Check
