### PR TITLE
fix: hide nextjs.log and nextjs.pid in Craft file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -87,6 +87,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_archive_walk.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_archive_walk.py
@@ -77,3 +77,28 @@ def test_archive_walk_skips_hidden_entries() -> None:
         "outputs/web",
         "outputs/web/app",
     ]
+
+
+def test_archive_walk_skips_nextjs_runtime_files() -> None:
+    sandbox_manager = StubSandboxManager()
+    sandbox_manager.list_directory_returns_by_path = {
+        "": [
+            FilesystemEntry(name="outputs", path="outputs", is_directory=True),
+            FilesystemEntry(name="nextjs.log", path="nextjs.log", is_directory=False),
+            FilesystemEntry(name="nextjs.pid", path="nextjs.pid", is_directory=False),
+        ],
+        "outputs": [
+            FilesystemEntry(
+                name="report.md", path="outputs/report.md", is_directory=False
+            ),
+        ],
+    }
+
+    files = _manager(sandbox_manager)._walk_sandbox_dir(
+        uuid4(),
+        uuid4(),
+        "",
+        arcname_for=lambda path: path,
+    )
+
+    assert files == [("outputs/report.md", "outputs/report.md")]


### PR DESCRIPTION
## What

Adds `nextjs.log` and `nextjs.pid` to the workspace file-listing ignore set so they no longer appear in the Craft sandbox **Files** tab.

## Why

The Next.js dev server writes `nextjs.log` and `nextjs.pid` to the session root (`nextjs_dev.py`). The file explorer lists the session root and only filters names in `HIDDEN_PATTERNS` (or dotfiles), so these two runtime artifacts were shown as user files. They are not deliverables and should be hidden, consistent with existing entries like `.next`, `node_modules`, and `opencode.json`.

## Change

- `backend/onyx/server/features/build/session/manager.py`: add `nextjs.log` and `nextjs.pid` to `HIDDEN_PATTERNS`. This single canonical filter (`_is_hidden_workspace_entry`) is reused by both the file explorer (`list_directory`) and the archive walker (`_walk_sandbox_dir`), so both surfaces exclude them.

## Verification

- Added unit test `test_archive_walk_skips_nextjs_runtime_files` (fails before the fix, passes after).
- `pytest tests/unit/onyx/server/features/build/session tests/unit/onyx/server/features/build/sandbox/test_file_listing.py` — 95 passed.
- `black --check` clean on both files.
- Confirmed the dev-server shutdown reads `nextjs.pid` directly by path (not via the listing), so hiding it does not affect process cleanup.

## Notes

- Match is exact-basename, consistent with existing `HIDDEN_PATTERNS` entries; a user file named exactly `nextjs.log`/`nextjs.pid` would also be hidden (same pre-existing semantics as `opencode.json`).


- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides Next.js runtime files (`nextjs.log`, `nextjs.pid`) in the Craft Files tab and archives so they don’t show up as user files.

- **Bug Fixes**
  - Added `nextjs.log` and `nextjs.pid` to `HIDDEN_PATTERNS` used by both file listing and archive walking.
  - Added unit test to verify these files are skipped.

<sup>Written for commit c72aeee3f50c6333802138188d0df3df0d3f54ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
