### PR TITLE
feat(banner): admin System Announcement section in Appearance & Theming

### DIFF
--- a/backend/onyx/db/admin_banner.py
+++ b/backend/onyx/db/admin_banner.py
@@ -18,6 +18,8 @@ ADMIN_BANNER_KV_KEY = "admin_banner"
 class AdminBanner(BaseModel):
     title: str
     content: str | None
+    # Admin's choice to also show the announcement as a first-visit popup.
+    show_as_popup: bool = False
     # ISO-8601 timestamp of the last publish/edit.
     updated_at: str
 
@@ -30,10 +32,13 @@ def get_admin_banner() -> AdminBanner | None:
     return AdminBanner.model_validate(raw)
 
 
-def set_admin_banner(title: str, content: str | None) -> AdminBanner:
+def set_admin_banner(
+    title: str, content: str | None, show_as_popup: bool = False
+) -> AdminBanner:
     banner = AdminBanner(
         title=title,
         content=content,
+        show_as_popup=show_as_popup,
         updated_at=datetime.now(timezone.utc).isoformat(),
     )
     get_kv_store().store(ADMIN_BANNER_KV_KEY, banner.model_dump())

--- a/backend/onyx/server/features/admin_banner/api.py
+++ b/backend/onyx/server/features/admin_banner/api.py
@@ -24,6 +24,7 @@ MAX_CONTENT_LEN = 1000
 class AdminBannerUpdateRequest(BaseModel):
     title: str = Field(..., max_length=MAX_TITLE_LEN)
     content: str | None = Field(default=None, max_length=MAX_CONTENT_LEN)
+    show_as_popup: bool = False
 
 
 # Admin-only configuration of the single site-wide banner. Users receive it
@@ -52,7 +53,9 @@ def upsert_admin_banner(
             "Title must include non-whitespace characters",
         )
     content = (request.content or "").strip() or None
-    banner = set_admin_banner(title=title, content=content)
+    banner = set_admin_banner(
+        title=title, content=content, show_as_popup=request.show_as_popup
+    )
     # Clear existing rows so every user re-materializes the edited banner.
     delete_notifications_by_type(NotificationType.SYSTEM_ANNOUNCEMENT, db_session)
     return banner

--- a/backend/tests/external_dependency_unit/db/test_admin_banner_notification.py
+++ b/backend/tests/external_dependency_unit/db/test_admin_banner_notification.py
@@ -139,3 +139,21 @@ def test_delete_clears_banner_and_notifications(
     # A later read no longer re-creates it.
     ensure_system_announcement_notification(admin, db_session)
     assert _system_announcements(admin, db_session) == []
+
+
+def test_upsert_stores_show_as_popup(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    admin = create_test_user(db_session, "sys_announce_popup", role=UserRole.ADMIN)
+    admin_banner_api.upsert_admin_banner(
+        AdminBannerUpdateRequest(
+            title="Maintenance", content="Soon", show_as_popup=True
+        ),
+        admin,
+        db_session,
+    )
+
+    stored = get_admin_banner()
+    assert stored is not None
+    assert stored.show_as_popup is True

--- a/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
+++ b/web/src/app/ee/admin/theme/AppearanceThemeSettings.tsx
@@ -41,6 +41,8 @@ interface AppearanceThemeSettingsProps {
     custom_popup_header: number;
     custom_popup_content: number;
     consent_screen_prompt: number;
+    system_announcement_header: number;
+    system_announcement_content: number;
   };
 }
 
@@ -66,11 +68,16 @@ export const AppearanceThemeSettings = forwardRef<
   const noticeContentInputRef = useRef<HTMLTextAreaElement>(null);
   const consentPromptTextAreaRef = useRef<HTMLTextAreaElement>(null);
   const customHelpLinkUrlInputRef = useRef<HTMLInputElement>(null);
+  const systemAnnouncementHeaderInputRef = useRef<HTMLInputElement>(null);
+  const systemAnnouncementContentInputRef = useRef<HTMLTextAreaElement>(null);
   const prevShowFirstVisitNoticeRef = useRef<boolean>(
     Boolean(values.show_first_visit_notice)
   );
   const prevEnableConsentScreenRef = useRef<boolean>(
     Boolean(values.enable_consent_screen)
+  );
+  const prevSystemAnnouncementEnabledRef = useRef<boolean>(
+    Boolean(values.system_announcement_enabled)
   );
   const [focusedPreviewTarget, setFocusedPreviewTarget] =
     useState<PreviewHighlightTarget | null>(null);
@@ -107,6 +114,14 @@ export const AppearanceThemeSettings = forwardRef<
         { name: "custom_popup_content", ref: noticeContentInputRef },
         { name: "consent_screen_prompt", ref: consentPromptTextAreaRef },
         { name: "custom_help_link_url", ref: customHelpLinkUrlInputRef },
+        {
+          name: "system_announcement_header",
+          ref: systemAnnouncementHeaderInputRef,
+        },
+        {
+          name: "system_announcement_content",
+          ref: systemAnnouncementContentInputRef,
+        },
       ];
       for (const field of fieldRefs) {
         if (errors[field.name] && field.ref.current) {
@@ -149,6 +164,20 @@ export const AppearanceThemeSettings = forwardRef<
 
     prevEnableConsentScreenRef.current = next;
   }, [values.enable_consent_screen]);
+
+  useEffect(() => {
+    const prev = prevSystemAnnouncementEnabledRef.current;
+    const next = Boolean(values.system_announcement_enabled);
+
+    // When enabling the toggle, autofocus the "Notice Header" input.
+    if (!prev && next) {
+      requestAnimationFrame(() => {
+        systemAnnouncementHeaderInputRef.current?.focus();
+      });
+    }
+
+    prevSystemAnnouncementEnabledRef.current = next;
+  }, [values.system_announcement_enabled]);
 
   const handleLogoEdit = () => {
     fileInputRef.current?.click();
@@ -682,6 +711,126 @@ export const AppearanceThemeSettings = forwardRef<
                 />
               </FormField>
             )}
+          </>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-4 p-4 bg-background-tint-00 rounded-16">
+        <FormField state="idle" className="gap-0">
+          <div className="flex justify-between items-center">
+            <FormField.Label>System Announcement</FormField.Label>
+            <FormField.Control>
+              <Switch
+                aria-label="System Announcement"
+                data-label="system-announcement-toggle"
+                checked={values.system_announcement_enabled}
+                onCheckedChange={(checked) =>
+                  setFieldValue("system_announcement_enabled", checked)
+                }
+              />
+            </FormField.Control>
+          </div>
+          <FormField.Description>
+            Show a persistent system announcement that users can dismiss.
+          </FormField.Description>
+        </FormField>
+
+        {values.system_announcement_enabled && (
+          <>
+            <FormField
+              state={errors.system_announcement_header ? "error" : "idle"}
+            >
+              <FormField.Label
+                required
+                rightAction={
+                  <CharacterCount
+                    value={values.system_announcement_header}
+                    limit={charLimits.system_announcement_header}
+                  />
+                }
+              >
+                Notice Header
+              </FormField.Label>
+              <FormField.Control asChild>
+                <InputTypeIn
+                  ref={systemAnnouncementHeaderInputRef}
+                  data-label="system-announcement-header-input"
+                  clearButton
+                  placeholder="Add an announcement"
+                  variant={
+                    errors.system_announcement_header ? "error" : undefined
+                  }
+                  value={values.system_announcement_header}
+                  onChange={(e) =>
+                    setFieldValue("system_announcement_header", e.target.value)
+                  }
+                />
+              </FormField.Control>
+              <FormField.Message
+                messages={{
+                  error: errors.system_announcement_header as string,
+                }}
+              />
+            </FormField>
+
+            <FormField
+              state={errors.system_announcement_content ? "error" : "idle"}
+            >
+              <FormField.Label
+                required
+                rightAction={
+                  <CharacterCount
+                    value={values.system_announcement_content}
+                    limit={charLimits.system_announcement_content}
+                  />
+                }
+              >
+                Notice Content
+              </FormField.Label>
+              <FormField.Control asChild>
+                <InputTextArea
+                  ref={systemAnnouncementContentInputRef}
+                  data-label="system-announcement-content-textarea"
+                  rows={3}
+                  placeholder="Add markdown content"
+                  variant={
+                    errors.system_announcement_content ? "error" : undefined
+                  }
+                  value={values.system_announcement_content}
+                  onChange={(e) =>
+                    setFieldValue("system_announcement_content", e.target.value)
+                  }
+                />
+              </FormField.Control>
+              <FormField.Message
+                messages={{
+                  error: errors.system_announcement_content as string,
+                }}
+              />
+            </FormField>
+
+            <FormField state="idle" className="gap-0">
+              <div className="flex justify-between items-center">
+                <FormField.Label>Pop-up Notice at First Visit</FormField.Label>
+                <FormField.Control>
+                  <Switch
+                    aria-label="Pop-up Notice at First Visit"
+                    data-label="system-announcement-popup-toggle"
+                    checked={values.system_announcement_show_as_popup}
+                    onCheckedChange={(checked) =>
+                      setFieldValue(
+                        "system_announcement_show_as_popup",
+                        checked
+                      )
+                    }
+                  />
+                </FormField.Control>
+              </div>
+              <FormField.Description>
+                Also show this notice as a full-screen pop-up at first visit for
+                all users. Use with caution.
+              </FormField.Description>
+            </FormField>
           </>
         )}
       </div>

--- a/web/src/app/ee/admin/theme/page.tsx
+++ b/web/src/app/ee/admin/theme/page.tsx
@@ -13,8 +13,10 @@ import { toast } from "@/hooks/useToast";
 import { Formik, Form } from "formik";
 import * as Yup from "yup";
 import { EnterpriseSettings } from "@/lib/settings/types";
-import { mutate } from "swr";
+import useSWR, { mutate } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { AdminBanner } from "@/lib/banner/interfaces";
 
 const route = ADMIN_ROUTES.THEME;
 
@@ -26,6 +28,8 @@ const CHAR_LIMITS = {
   custom_popup_header: 100,
   custom_popup_content: 500,
   consent_screen_prompt: 200,
+  system_announcement_header: 100,
+  system_announcement_content: 1000,
 };
 
 export default function ThemePage() {
@@ -34,6 +38,16 @@ export default function ThemePage() {
   const [selectedLogo, setSelectedLogo] = useState<File | null>(null);
   const [logoVersion, setLogoVersion] = useState(0);
   const appearanceSettingsRef = useRef<AppearanceThemeSettingsRef>(null);
+  // The banner seeds Formik initialValues once, so the form renders only after
+  // this fetch settles (a failed fetch counts as "no banner"). Background
+  // revalidation stays off, and only our own post-save mutate refreshes it.
+  const { data: adminBanner, error: adminBannerError } =
+    useSWR<AdminBanner | null>(SWR_KEYS.adminBanner, errorHandlingFetcher, {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+    });
+  const bannerLoaded = adminBanner !== undefined || Boolean(adminBannerError);
+  const currentBanner = adminBanner ?? null;
 
   async function updateEnterpriseSettings(
     newValues: EnterpriseSettings
@@ -56,6 +70,20 @@ export default function ThemePage() {
       alert(`Failed to update settings. ${errorMsg}`);
       return false;
     }
+  }
+
+  async function mutateAdminBanner(
+    init: RequestInit,
+    failMessage: string
+  ): Promise<boolean> {
+    const response = await fetch("/api/admin/banner", init);
+    if (!response.ok) {
+      const errorMsg = (await response.json()).detail;
+      toast.error(`${failMessage} ${errorMsg}`);
+      return false;
+    }
+    await mutate(SWR_KEYS.adminBanner);
+    return true;
   }
 
   const validationSchema = Yup.object().shape({
@@ -141,7 +169,33 @@ export default function ThemePage() {
           ),
       }),
     hide_onyx_branding: Yup.boolean().nullable(),
+    system_announcement_enabled: Yup.boolean().nullable(),
+    system_announcement_header: Yup.string()
+      .trim()
+      .max(
+        CHAR_LIMITS.system_announcement_header,
+        `Maximum ${CHAR_LIMITS.system_announcement_header} characters`
+      )
+      .when("system_announcement_enabled", {
+        is: true,
+        then: (schema) => schema.required("Notice Header is required"),
+        otherwise: (schema) => schema.nullable(),
+      }),
+    system_announcement_content: Yup.string()
+      .trim()
+      .max(
+        CHAR_LIMITS.system_announcement_content,
+        `Maximum ${CHAR_LIMITS.system_announcement_content} characters`
+      )
+      .when("system_announcement_enabled", {
+        is: true,
+        then: (schema) => schema.required("Notice Content is required"),
+        otherwise: (schema) => schema.nullable(),
+      }),
+    system_announcement_show_as_popup: Yup.boolean().nullable(),
   });
+
+  if (!bannerLoaded) return null;
 
   return (
     <Formik
@@ -166,6 +220,11 @@ export default function ThemePage() {
         custom_help_link_label:
           enterpriseSettings?.custom_help_link_label || "",
         hide_onyx_branding: enterpriseSettings?.hide_onyx_branding || false,
+        system_announcement_enabled: !!currentBanner,
+        system_announcement_header: currentBanner?.title || "",
+        system_announcement_content: currentBanner?.content || "",
+        system_announcement_show_as_popup:
+          currentBanner?.show_as_popup || false,
       }}
       validationSchema={validationSchema}
       validateOnChange={false}
@@ -215,9 +274,44 @@ export default function ThemePage() {
           hide_onyx_branding: values.hide_onyx_branding ?? null,
         });
 
-        // Important: after a successful save, reset Formik's "baseline" so
-        // dirty comparisons reflect the newly-saved values.
-        if (success) {
+        // Only touch the banner after the settings save succeeds, and only when
+        // its own fields changed, so an unrelated edit does not re-publish it.
+        const trimmedHeader = values.system_announcement_header.trim();
+        const trimmedContent =
+          values.system_announcement_content.trim() || null;
+        const bannerChanged =
+          values.system_announcement_enabled !== !!currentBanner ||
+          trimmedHeader !== (currentBanner?.title ?? "") ||
+          trimmedContent !== (currentBanner?.content ?? null) ||
+          values.system_announcement_show_as_popup !==
+            (currentBanner?.show_as_popup ?? false);
+
+        let bannerOk = true;
+        if (success && bannerChanged) {
+          if (values.system_announcement_enabled) {
+            bannerOk = await mutateAdminBanner(
+              {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                  title: trimmedHeader,
+                  content: trimmedContent,
+                  show_as_popup: values.system_announcement_show_as_popup,
+                }),
+              },
+              "Failed to save announcement."
+            );
+          } else if (currentBanner) {
+            bannerOk = await mutateAdminBanner(
+              { method: "DELETE" },
+              "Failed to clear announcement."
+            );
+          }
+        }
+
+        // After a successful save, reset Formik's baseline so dirty comparisons
+        // reflect the newly-saved values.
+        if (success && bannerOk) {
           formikHelpers.resetForm({ values });
           if (logoUploaded) {
             setLogoVersion((v) => v + 1);

--- a/web/src/lib/banner/interfaces.ts
+++ b/web/src/lib/banner/interfaces.ts
@@ -1,0 +1,6 @@
+export interface AdminBanner {
+  title: string;
+  content: string | null;
+  show_as_popup: boolean;
+  updated_at: string;
+}

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -177,6 +177,9 @@ export const SWR_KEYS = {
   // ── Prompt shortcuts ──────────────────────────────────────────────────────
   promptShortcuts: "/api/input_prompt",
 
+  // ── Admin Banner ──────────────────────────────────────────────────────────
+  adminBanner: "/api/admin/banner",
+
   // ── License & Billing ─────────────────────────────────────────────────────
   license: "/api/license",
   billingInformationCloud: "/api/tenants/billing-information",


### PR DESCRIPTION
## Description

Adds the "System Announcement" section to the Appearance & Theming admin page, authoring the KV-backed banner from #12369.

Admins get an enable toggle, Notice Header (<=100), Notice Content markdown (<=1000), and a pop-up-at-first-visit toggle. The section mirrors the existing first-visit-notice block. The page loads the current banner via SWR and, on Apply Changes, PUTs or DELETEs /api/admin/banner alongside the enterprise-settings save, only when the banner fields actually changed.

Backend adds show_as_popup to the AdminBanner model and PUT so the popup toggle round-trips. Rendering the popup to all users is a follow-up.

Base is #12369.

## How Has This Been Tested?

6 external-dependency unit tests in test_admin_banner_notification.py. Local checks: ruff, black, ty, tsgo, and oxlint all clean.
<img width="1904" height="1538" alt="image" src="https://github.com/user-attachments/assets/e168a3a5-60bc-4e15-93ee-eb5619a89f71" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
