### PR TITLE
fix(ci): add dhi.io login to shared model-server build action + consolidate PR builds

### DIFF
--- a/.github/actions/build-model-server-image/action.yml
+++ b/.github/actions/build-model-server-image/action.yml
@@ -17,8 +17,21 @@ inputs:
   run-id:
     description: "GitHub run ID used in output image tag"
     required: true
+  tag-prefix:
+    description: "Output image tag prefix; the image is pushed as <runs-on-ecr-cache>:<tag-prefix>-<run-id>"
+    required: true
+  platforms:
+    description: "Target build platform(s), e.g. linux/arm64. Empty builds for the runner's native platform."
+    required: false
+    default: ""
   ecr-registry:
     description: "ECR registry host for the Docker Hub pull-through cache (the ECR_REGISTRY repo variable)"
+    required: true
+  docker-username:
+    description: "Docker Hub username (must have access to the DHI catalog on dhi.io)"
+    required: true
+  docker-token:
+    description: "Docker Hub token"
     required: true
 runs:
   using: "composite"
@@ -39,22 +52,32 @@ runs:
         echo "cache-suffix=${CACHE_SUFFIX}" >> "$GITHUB_OUTPUT"
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # ratchet:docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # ratchet:docker/setup-buildx-action@v4
 
     - name: Log in to ECR pull-through cache
       uses: ./.github/actions/login-ecr-pullthrough-cache
       with:
         ecr-registry: ${{ inputs.ecr-registry }}
 
+    # Dockerfile.model_server pulls its hardened Python base from dhi.io, authenticated
+    # with the same Docker account credentials (the account must have DHI catalog access).
+    - name: Login to Docker Hardened Images (dhi.io)
+      uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4
+      with:
+        registry: dhi.io
+        username: ${{ inputs.docker-username }}
+        password: ${{ inputs.docker-token }}
+
     - name: Build and push Model Server Docker image
-      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # ratchet:docker/build-push-action@v6
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # ratchet:docker/build-push-action@v6
       with:
         context: ./backend
         file: ./backend/Dockerfile.model_server
         push: true
+        platforms: ${{ inputs.platforms }}
         build-args: |
           BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
-        tags: ${{ inputs.runs-on-ecr-cache }}:nightly-llm-it-model-server-${{ inputs.run-id }}
+        tags: ${{ inputs.runs-on-ecr-cache }}:${{ inputs.tag-prefix }}-${{ inputs.run-id }}
         cache-from: |
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:model-server-cache-${{ inputs.github-sha }}
           type=registry,ref=${{ inputs.runs-on-ecr-cache }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }}

--- a/.github/workflows/pr-integration-tests.yml
+++ b/.github/workflows/pr-integration-tests.yml
@@ -147,55 +147,18 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Format branch name for cache
-        id: format-branch
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [ -n "${PR_NUMBER}" ]; then
-            CACHE_SUFFIX="${PR_NUMBER}"
-          else
-            # shellcheck disable=SC2001
-            CACHE_SUFFIX=$(echo "${REF_NAME}" | sed 's/[^A-Za-z0-9._-]/-/g')
-          fi
-          echo "cache-suffix=${CACHE_SUFFIX}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # ratchet:docker/setup-buildx-action@v4
-
-      - name: Log in to ECR pull-through cache
-        uses: ./.github/actions/login-ecr-pullthrough-cache
+      - name: Build model server image
+        uses: ./.github/actions/build-model-server-image
         with:
+          runs-on-ecr-cache: ${{ env.RUNS_ON_ECR_CACHE }}
+          ref-name: ${{ github.ref_name }}
+          pr-number: ${{ github.event.pull_request.number }}
+          github-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          run-id: ${{ github.run_id }}
+          tag-prefix: integration-test-model-server-test
           ecr-registry: ${{ vars.ECR_REGISTRY }}
-
-      # Dockerfile.model_server pulls its hardened Python base from dhi.io, authenticated
-      # with the same Docker account credentials (the account must have DHI catalog access).
-      - name: Login to Docker Hardened Images (dhi.io)
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4
-        with:
-          registry: dhi.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and push Model Server Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile.model_server
-          push: true
-          build-args: |
-            BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
-          tags: ${{ env.RUNS_ON_ECR_CACHE }}:integration-test-model-server-test-${{ github.run_id }}
-          cache-from: |
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ github.event.pull_request.head.sha || github.sha }}
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }}
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache
-            type=registry,ref=${{ env.BASE_IMAGE_REGISTRY }}/onyxdotapp/onyx-model-server:latest
-          cache-to: |
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ github.event.pull_request.head.sha || github.sha }},mode=max
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }},mode=max
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache,mode=max
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-token: ${{ secrets.DOCKER_TOKEN }}
 
   build-devcontainer-image:
     needs: changes

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -279,57 +279,19 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Format branch name for cache
-        id: format-branch
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [ -n "${PR_NUMBER}" ]; then
-            CACHE_SUFFIX="${PR_NUMBER}"
-          else
-            # shellcheck disable=SC2001
-            CACHE_SUFFIX=$(echo "${REF_NAME}" | sed 's/[^A-Za-z0-9._-]/-/g')
-          fi
-          echo "cache-suffix=${CACHE_SUFFIX}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # ratchet:docker/setup-buildx-action@v4
-
-      - name: Log in to ECR pull-through cache
-        uses: ./.github/actions/login-ecr-pullthrough-cache
+      - name: Build model server image
+        uses: ./.github/actions/build-model-server-image
         with:
-          ecr-registry: ${{ vars.ECR_REGISTRY }}
-
-      # backend/Dockerfile.model_server pulls its hardened Python base from dhi.io,
-      # authenticated with the same Docker account credentials (the account must
-      # have access to the DHI catalog).
-      - name: Login to Docker Hardened Images (dhi.io)
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4
-        with:
-          registry: dhi.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Build and push Model Server Docker image
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
-        with:
-          context: ./backend
-          file: ./backend/Dockerfile.model_server
+          runs-on-ecr-cache: ${{ env.RUNS_ON_ECR_CACHE }}
+          ref-name: ${{ github.ref_name }}
+          pr-number: ${{ github.event.pull_request.number }}
+          github-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          run-id: ${{ github.run_id }}
+          tag-prefix: playwright-test-model-server
           platforms: linux/arm64
-          tags: ${{ env.RUNS_ON_ECR_CACHE }}:playwright-test-model-server-${{ github.run_id }}
-          push: true
-          build-args: |
-            BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}
-          cache-from: |
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ github.event.pull_request.head.sha || github.sha }}
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }}
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache
-            type=registry,ref=${{ env.BASE_IMAGE_REGISTRY }}/onyxdotapp/onyx-model-server:latest
-          cache-to: |
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ github.event.pull_request.head.sha || github.sha }},mode=max
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }},mode=max
-            type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache,mode=max
+          ecr-registry: ${{ vars.ECR_REGISTRY }}
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-token: ${{ secrets.DOCKER_TOKEN }}
           no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   playwright-tests:

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -292,7 +292,6 @@ jobs:
           ecr-registry: ${{ vars.ECR_REGISTRY }}
           docker-username: ${{ secrets.DOCKER_USERNAME }}
           docker-token: ${{ secrets.DOCKER_TOKEN }}
-          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
 
   playwright-tests:
     needs: [build-web-image, build-backend-image, build-model-server-image]

--- a/.github/workflows/pr-python-model-tests.yml
+++ b/.github/workflows/pr-python-model-tests.yml
@@ -48,57 +48,23 @@ jobs:
             backend/requirements/default.txt
             backend/requirements/dev.txt
 
-      - name: Format branch name for cache
-        id: format-branch
-        env:
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [ -n "${PR_NUMBER}" ]; then
-            CACHE_SUFFIX="${PR_NUMBER}"
-          else
-            # shellcheck disable=SC2001
-            CACHE_SUFFIX=$(echo "${REF_NAME}" | sed 's/[^A-Za-z0-9._-]/-/g')
-          fi
-          echo "cache-suffix=${CACHE_SUFFIX}" >> $GITHUB_OUTPUT
-
-      - name: Log in to ECR pull-through cache
-        uses: ./.github/actions/login-ecr-pullthrough-cache
+      - name: Build model server image
+        uses: ./.github/actions/build-model-server-image
         with:
+          runs-on-ecr-cache: ${{ env.RUNS_ON_ECR_CACHE }}
+          ref-name: ${{ github.ref_name }}
+          pr-number: ${{ github.event.pull_request.number }}
+          github-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          run-id: ${{ github.run_id }}
+          tag-prefix: model-server
           ecr-registry: ${{ vars.ECR_REGISTRY }}
-
-      # Dockerfile.model_server pulls its hardened Python base from dhi.io, authenticated
-      # with the same Docker account credentials (the account must have DHI catalog access).
-      - name: Login to Docker Hardened Images (dhi.io)
-        uses: docker/login-action@c99871dec2022cc055c062a10cc1a1310835ceb4
-        with:
-          registry: dhi.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # ratchet:docker/setup-buildx-action@v4
-
-      - name: Build and load
-        uses: docker/bake-action@6614cfa25eff9a0b2b2697efb0b6159e7680d584 # ratchet:docker/bake-action@v7.2.0
-        env:
-          TAG: model-server-${{ github.run_id }}
-        with:
-          load: true
-          targets: model-server
-          set: |
-            model-server.cache-from=type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ github.event.pull_request.head.sha || github.sha }}
-            model-server.cache-from=type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }}
-            model-server.cache-from=type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache
-            model-server.cache-from=type=registry,ref=${{ env.BASE_IMAGE_REGISTRY }}/onyxdotapp/onyx-model-server:latest
-            model-server.cache-to=type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ github.event.pull_request.head.sha || github.sha }},mode=max
-            model-server.cache-to=type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache-${{ steps.format-branch.outputs.cache-suffix }},mode=max
-            model-server.cache-to=type=registry,ref=${{ env.RUNS_ON_ECR_CACHE }}:model-server-cache,mode=max
+          docker-username: ${{ secrets.DOCKER_USERNAME }}
+          docker-token: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Start Docker containers
         id: start_docker
         env:
-          IMAGE_TAG: model-server-${{ github.run_id }}
+          ONYX_MODEL_SERVER_IMAGE: ${{ env.RUNS_ON_ECR_CACHE }}:model-server-${{ github.run_id }}
         run: |
           cd deployment/docker_compose
           docker compose \

--- a/.github/workflows/reusable-nightly-llm-provider-chat.yml
+++ b/.github/workflows/reusable-nightly-llm-provider-chat.yml
@@ -76,6 +76,20 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b
+        with:
+          role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+          aws-region: us-east-2
+
+      - name: Get AWS Secrets
+        uses: aws-actions/aws-secretsmanager-get-secrets@2cb1a461cbd4865ac4299648312e4704c646cd53
+        with:
+          parse-json-secrets: false
+          secret-ids: |
+            DOCKER_USERNAME, test/docker-username
+            DOCKER_TOKEN, test/docker-token
+
       - name: Build model server image
         uses: ./.github/actions/build-model-server-image
         with:
@@ -84,7 +98,10 @@ jobs:
           pr-number: ${{ github.event.pull_request.number }}
           github-sha: ${{ github.sha }}
           run-id: ${{ github.run_id }}
+          tag-prefix: nightly-llm-it-model-server
           ecr-registry: ${{ vars.ECR_REGISTRY }}
+          docker-username: ${{ env.DOCKER_USERNAME }}
+          docker-token: ${{ env.DOCKER_TOKEN }}
 
   build-devcontainer-image:
     runs-on:


### PR DESCRIPTION
## Problem

The nightly **Model Server Tests** build ([run 29089573969](https://github.com/onyx-dot-app/onyx/actions/runs/29089573969/job/86351424595)) failed with:

```
#2 ERROR: failed to authorize: failed to fetch anonymous token: ... https://dhi.io/token?... 401 Unauthorized
FROM dhi.io/python:3.13-debian13@sha256:... AS final
```

`b21ea7f2f1` added the `dhi.io` (Docker Hardened Image) login to the **four inline** model-server build workflows, but the nightly build (`build-model-server-image` job in `reusable-nightly-llm-provider-chat.yml`) builds through the shared `./.github/actions/build-model-server-image` composite action, which was never given the login. It therefore pulled the `dhi.io/python` base anonymously and 401'd.

## Fix

- Add the `dhi.io` login (+ `docker-username` / `docker-token` inputs) to the composite action, and fetch the Docker creds in the nightly build job (via AWS Secrets Manager, matching the sibling job).

## Consolidation

To stop this class of drift recurring, the three PR-side model-server builds now go through the composite action instead of duplicating the `buildx → ECR login → dhi.io login → build` sequence:

| Workflow | Change |
|---|---|
| `pr-integration-tests.yml` | inline steps → composite (`tag-prefix: integration-test-model-server-test`) |
| `pr-playwright-tests.yml` | inline steps → composite (`+ platforms: linux/arm64`) |
| `pr-python-model-tests.yml` | `docker/bake-action` (load) → composite; image is now pushed to the ECR cache and consumed via `ONYX_MODEL_SERVER_IMAGE`, like the other flows |

Composite action updates:
- New `tag-prefix` input parameterizes the output tag (`…:<tag-prefix>-<run-id>`); optional `platforms` input (native by default).
- Pins aligned to the repo standard (`setup-buildx-action` v4, `build-push-action` `f9f3042`, `login-action` `c99871dec`) so migrated workflows keep their existing action versions.

**Out of scope (intentionally left inline):** `deployment.yml`'s release build (multi-arch push to real registries + signing) and the separate web-image `dhi.io` login in `pr-playwright-tests.yml`.

## Testing

Composite-action wiring has no local validation path — verification is a CI run of the three migrated workflows plus the nightly build job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes nightly Model Server builds by adding authenticated `dhi.io` login to the shared build action and consolidating PR builds onto the composite to prevent drift. Also removes a stray `no-cache` input from the Playwright workflow.

- **Bug Fixes**
  - Add `dhi.io` login to `./.github/actions/build-model-server-image` with `docker-username`/`docker-token`.
  - Nightly workflow pulls Docker creds from AWS Secrets Manager via `aws-actions/configure-aws-credentials` and `aws-actions/aws-secretsmanager-get-secrets`.
  - Base image `dhi.io/python` now pulls with auth; resolves 401 failures.
  - Remove orphaned `no-cache` input from the Playwright model-server build to fix actionlint failure.

- **Refactors**
  - Route `pr-integration-tests.yml`, `pr-playwright-tests.yml` (adds `platforms: linux/arm64`), and `pr-python-model-tests.yml` through the composite; Python model tests now push to ECR cache and consume via `ONYX_MODEL_SERVER_IMAGE`.
  - Composite adds `tag-prefix` input for `<tag-prefix>-<run-id>` tags and an optional `platforms` input.
  - Align pins: `docker/setup-buildx-action` v4, `docker/build-push-action` `f9f3042`, `docker/login-action` `c99871dec`.

<sup>Written for commit 0fcd60393c8dd6234b31292e9d232a9bacf7ef06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

