### PR TITLE
fix(llm): keep GPT- brand prefix in generated model display names

### DIFF
--- a/backend/onyx/llm/model_name_parser.py
+++ b/backend/onyx/llm/model_name_parser.py
@@ -135,6 +135,7 @@ def _generate_display_name_from_model(model_name: str) -> str:
         "gemini-2.5-pro-exp-03-25" → "Gemini 2.5 Pro"
         "claude-3-5-sonnet-20241022" → "Claude 3.5 Sonnet"
         "gpt-oss:120b" → "GPT-OSS 120B" (hyphenated exception)
+        "gpt-4o-mini" → "GPT-4o Mini" (GPT- brand prefix kept)
     """
     try:
         # Remove provider prefix if present
@@ -164,6 +165,13 @@ def _generate_display_name_from_model(model_name: str) -> str:
         # Remove version suffixes like -v1, -v2
         cleaned = re.sub(r"-v\d+$", "", cleaned)
 
+        # GPT models keep the "GPT-" brand prefix, with the hyphen bound to the
+        # version token (e.g., "gpt-4o-mini" → "GPT-4o Mini")
+        gpt_prefix = ""
+        if base_name_lower.startswith("gpt-"):
+            gpt_prefix = "GPT-"
+            cleaned = cleaned[len(gpt_prefix) :]
+
         # Convert separators to spaces
         cleaned = cleaned.replace("-", " ").replace("_", " ")
 
@@ -174,8 +182,11 @@ def _generate_display_name_from_model(model_name: str) -> str:
         # Title case each word, preserving version numbers
         words = cleaned.split()
         result_words = []
-        for word in words:
-            if word.isdigit() or re.match(r"^\d+\.?\d*$", word):
+        for i, word in enumerate(words):
+            if gpt_prefix and i == 0 and re.match(r"^\d", word):
+                # Version tokens like "4o" or "4.1" keep their casing after "GPT-"
+                result_words.append(word)
+            elif word.isdigit() or re.match(r"^\d+\.?\d*$", word):
                 # Keep numbers as-is
                 result_words.append(word)
             elif word.lower() in ("pro", "lite", "mini", "flash", "preview", "ultra"):
@@ -185,7 +196,7 @@ def _generate_display_name_from_model(model_name: str) -> str:
                 # Title case other words
                 result_words.append(word.title())
 
-        return " ".join(result_words) + size_suffix
+        return gpt_prefix + " ".join(result_words) + size_suffix
     except Exception:
         return model_name
 

--- a/backend/tests/unit/onyx/llm/test_model_name_parser.py
+++ b/backend/tests/unit/onyx/llm/test_model_name_parser.py
@@ -40,6 +40,14 @@ def test_direct_provider_inference() -> None:
     assert result.provider_display_name == "GPT (OpenAI)"
 
 
+def test_gpt_model_fallback_keeps_gpt_prefix() -> None:
+    """Unenriched GPT models keep the "GPT-" brand prefix in generated display names."""
+    result = parse_litellm_model_name("azure/gpt-4o-mini-custom")
+
+    assert result.display_name == "GPT-4o Mini Custom"
+    assert result.vendor == "openai"
+
+
 def test_unknown_model_fallback() -> None:
     """Test that unknown models get a cleaned-up display name."""
     result = parse_litellm_model_name("some-unknown-model-xyz")


### PR DESCRIPTION
## Description

Fallback display-name generation in `backend/onyx/llm/model_name_parser.py` title-cased everything, so unenriched GPT models rendered as "Gpt 4O Mini". Model names whose base name starts with `gpt-` now keep the uppercase `GPT-` brand prefix, with the hyphen bound to the version token and version casing preserved (so `4o` doesn't become `4O`).

Before → after (fallback path only; enriched models already got display names from enrichment and are unchanged):

- `gpt-4o-mini` — `Gpt 4O Mini` → `GPT-4o Mini`
- `gpt-4.1-nano` — `Gpt 4.1 Nano` → `GPT-4.1 Nano`
- `gpt-5-chat-latest` — `Gpt 5 Chat Latest` → `GPT-5 Chat Latest`
- `gpt-image-1` — `Gpt Image 1` → `GPT-Image 1`
- `azure/gpt-4o-mini-2024-07-18` — → `GPT-4o Mini`

The `gpt-oss` hyphenated exception still matches first (`GPT-OSS 120B`), and non-GPT names (`gemini-…`, `claude-…`, `chatgpt-…`, unknown models) are unchanged.

## How Has This Been Tested?

- Added `test_gpt_model_fallback_keeps_gpt_prefix` unit test covering an unenriched Azure GPT model name.
- `pytest backend/tests/unit/onyx/llm/ backend/tests/unit/onyx/server/manage/llm/` — 425 passed.
- Pre-commit hooks (ruff, ruff format, ty) pass on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fallback display-name generation to keep the uppercase "GPT-" brand prefix for `gpt-` models and preserve version casing (e.g., 4o, 4.1). Prevents outputs like "Gpt 4O Mini" and aligns unenriched GPT names with branding.

- **Bug Fixes**
  - For names starting with `gpt-`, keep "GPT-" and bind the hyphen to the first version token; preserve version casing. Examples: `gpt-4o-mini` → `GPT-4o Mini`, `gpt-4.1-nano` → `GPT-4.1 Nano`, `azure/gpt-4o-mini-2024-07-18` → `GPT-4o Mini`.
  - `gpt-oss` exception unchanged; non-GPT models unaffected; provider prefixes like `azure/` still removed. Added unit test `test_gpt_model_fallback_keeps_gpt_prefix`.

<sup>Written for commit 3b8351bb5950211812c39d03a6e0dc015312ec50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

