### PR TITLE
ci(llm): run provider chat tests on recommended-models.json changes

### DIFF
--- a/.github/workflows/pr-recommended-models-chat-test.yml
+++ b/.github/workflows/pr-recommended-models-chat-test.yml
@@ -1,0 +1,107 @@
+# Verifies that every model in recommended-models.json works end-to-end (LLM
+# provider creation + a real chat with tool calling) before the change merges.
+# Production deployments fetch that JSON live from `main` (AUTO_LLM_CONFIG_URL),
+# so a broken recommended model reaches all deployments as soon as it lands.
+#
+# Reuses the nightly provider chat pipeline, but with model lists derived from
+# recommended-models.json instead of the NIGHTLY_LLM_* repo vars. `strict: false`
+# lets providers absent from the JSON (bedrock, azure, ollama_chat) skip cleanly;
+# genuine per-model chat failures still fail the run regardless of strict. The
+# trade-off is that a covered provider whose credentials fail to resolve also
+# skips (green) — pytest runs with -rs, so skips are visible in the job log.
+#
+# Fork PRs are skipped: secrets (the AWS OIDC role) are unavailable there, and
+# recommended-model bumps come from maintainers.
+#
+# Keep this a NON-required status check: it calls real provider APIs (flaky,
+# costs money), and the top-level `paths:` filter is only safe for non-required
+# checks (see the trigger comment in pr-integration-tests.yml).
+name: Recommended LLM Models Chat Tests
+concurrency:
+  group: Recommended-LLM-Models-Chat-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/onyx/llm/well_known_providers/recommended-models.json"
+      - ".github/workflows/pr-recommended-models-chat-test.yml"
+      - ".github/workflows/reusable-nightly-llm-provider-chat.yml"
+      - ".github/actions/run-nightly-provider-chat-test/**"
+      - "backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py"
+
+permissions:
+  contents: read
+
+jobs:
+  derive-models:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    outputs:
+      openai_models: ${{ steps.derive.outputs.openai_models }}
+      anthropic_models: ${{ steps.derive.outputs.anthropic_models }}
+      vertex_ai_models: ${{ steps.derive.outputs.vertex_ai_models }}
+      openrouter_models: ${{ steps.derive.outputs.openrouter_models }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Derive model lists from recommended-models.json
+        id: derive
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          RECOMMENDED_MODELS_FILE="backend/onyx/llm/well_known_providers/recommended-models.json"
+
+          # default_model + additional_visible_models names, deduped, comma-joined.
+          # A missing provider key yields "" → clean pytest.skip under strict=false.
+          derive() {
+            jq -r --arg p "$1" '
+              (.providers[$p] // {})
+              | ([.default_model // empty] + [(.additional_visible_models // [])[].name])
+              | map(select(type == "string" and length > 0))
+              | unique
+              | join(",")
+            ' "$RECOMMENDED_MODELS_FILE"
+          }
+
+          OPENAI_MODELS=$(derive openai)
+          ANTHROPIC_MODELS=$(derive anthropic)
+          VERTEX_AI_MODELS=$(derive vertex_ai)
+          OPENROUTER_MODELS=$(derive openrouter)
+
+          {
+            echo "openai_models=${OPENAI_MODELS}"
+            echo "anthropic_models=${ANTHROPIC_MODELS}"
+            echo "vertex_ai_models=${VERTEX_AI_MODELS}"
+            echo "openrouter_models=${OPENROUTER_MODELS}"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Recommended models under test"
+            echo ""
+            echo "- \`openai\`: ${OPENAI_MODELS:-_none_}"
+            echo "- \`anthropic\`: ${ANTHROPIC_MODELS:-_none_}"
+            echo "- \`vertex_ai\`: ${VERTEX_AI_MODELS:-_none_}"
+            echo "- \`openrouter\`: ${OPENROUTER_MODELS:-_none_}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  provider-chat-test:
+    needs: [derive-models]
+    uses: ./.github/workflows/reusable-nightly-llm-provider-chat.yml
+    secrets:
+      AWS_OIDC_ROLE_ARN: ${{ secrets.AWS_OIDC_ROLE_ARN }}
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      openai_models: ${{ needs.derive-models.outputs.openai_models }}
+      anthropic_models: ${{ needs.derive-models.outputs.anthropic_models }}
+      vertex_ai_models: ${{ needs.derive-models.outputs.vertex_ai_models }}
+      openrouter_models: ${{ needs.derive-models.outputs.openrouter_models }}
+      strict: false

--- a/.github/workflows/pr-recommended-models-chat-test.yml
+++ b/.github/workflows/pr-recommended-models-chat-test.yml
@@ -1,21 +1,11 @@
-# Verifies that every model in recommended-models.json works end-to-end (LLM
-# provider creation + a real chat with tool calling) before the change merges.
-# Production deployments fetch that JSON live from `main` (AUTO_LLM_CONFIG_URL),
-# so a broken recommended model reaches all deployments as soon as it lands.
+# Pre-merge check that every model in recommended-models.json works end-to-end,
+# via the nightly provider chat pipeline. Production deployments fetch that JSON
+# live from `main` (AUTO_LLM_CONFIG_URL), so broken recommendations ship immediately.
 #
-# Reuses the nightly provider chat pipeline, but with model lists derived from
-# recommended-models.json instead of the NIGHTLY_LLM_* repo vars. `strict: false`
-# lets providers absent from the JSON (bedrock, azure, ollama_chat) skip cleanly;
-# genuine per-model chat failures still fail the run regardless of strict. The
-# trade-off is that a covered provider whose credentials fail to resolve also
-# skips (green) — pytest runs with -rs, so skips are visible in the job log.
-#
-# Fork PRs are skipped: secrets (the AWS OIDC role) are unavailable there, and
-# recommended-model bumps come from maintainers.
-#
-# Keep this a NON-required status check: it calls real provider APIs (flaky,
-# costs money), and the top-level `paths:` filter is only safe for non-required
-# checks (see the trigger comment in pr-integration-tests.yml).
+# `strict: false` lets providers absent from the JSON skip cleanly; genuine chat
+# failures still fail the run. Fork PRs skip (no OIDC secrets). Keep this a
+# non-required status check: it calls real provider APIs, and the top-level
+# `paths:` filter is only safe for non-required checks (see pr-integration-tests.yml).
 name: Recommended LLM Models Chat Tests
 concurrency:
   group: Recommended-LLM-Models-Chat-${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
## Description

`backend/onyx/llm/well_known_providers/recommended-models.json` is fetched live from `main` by production deployments (`AUTO_LLM_CONFIG_URL`), so a broken or unsupported recommended model reaches every deployment as soon as it merges — and nothing verified those models end-to-end before merge. The nightly provider chat tests only cover the manually maintained `NIGHTLY_LLM_*` repo vars, which can drift from the JSON.

This adds `.github/workflows/pr-recommended-models-chat-test.yml`, a PR check that runs whenever `recommended-models.json` (or the test pipeline around it) changes:

- A lightweight `derive-models` job extracts each provider's `default_model` + `additional_visible_models` from the JSON with `jq`, dedupes, and exposes comma-separated lists as job outputs (also echoed to the job summary).
- Those lists feed the existing `reusable-nightly-llm-provider-chat.yml` with `strict: false`: openai / anthropic / vertex_ai / openrouter run real provider-creation + chat-with-tool-calling tests, while providers absent from the JSON (bedrock, azure, ollama_chat) skip cleanly. Genuine per-model chat failures fail the run regardless of strict.
- Fork PRs are skipped (no OIDC secrets there); recommended-model bumps come from maintainers.
- This should stay a **non-required** status check — it calls real provider APIs, and the top-level `paths:` filter is only safe for non-required checks.

The nightly workflow, reusable workflow, composite action, and integration test are all unchanged.

## How Has This Been Tested?

- `jq` extraction verified locally against the current JSON: `openai → gpt-5.2,gpt-5.4,gpt-5.5`, `anthropic → claude-haiku-4-5,claude-opus-4-6,claude-opus-4-7,claude-opus-4-8,claude-sonnet-4-6`, `vertex_ai → gemini-3-flash-preview,gemini-3.1-pro-preview`, `openrouter → deepseek/deepseek-v4-pro,moonshotai/kimi-k2.6,qwen/qwen3.6-plus,z-ai/glm-5.1`; a provider missing from the JSON (bedrock) yields `""` → clean skip.
- `pre-commit` passes on the new file (actionlint, zizmor, Check YAML, ripsecrets).
- The workflow lists itself in its `paths:` filter, so it triggers on this very PR — the run here demonstrates the check end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a PR workflow that runs provider chat tests for every model in `backend/onyx/llm/well_known_providers/recommended-models.json` to catch broken recommendations before merge. Reuses the nightly provider chat pipeline with per-provider model lists derived from the JSON.

- **New Features**
  - Derives per-provider lists (`default_model` + `additional_visible_models`) via `jq`; tests `openai`, `anthropic`, `vertex_ai`, and `openrouter`.
  - Runs with `strict: false` so providers missing from the JSON skip; real chat failures still fail.
  - Skips fork PRs (no OIDC); remains a non-required check; triggers on changes to the JSON and related workflows/tests.

<sup>Written for commit cf5f60bbcb6626549fe74b1443bfad3492866bf0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

