### PR TITLE
feat(llm): add refresh-models support to OpenAI and Anthropic modals

### DIFF
--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -141,28 +141,38 @@ def is_obsolete_model(model_name: str, provider: str) -> bool:
     return False
 
 
+# TODO: remove these lists once we have a comprehensive model configuration page
+# The ideal flow should be: fetch all available models --> filter by type
+# --> allow user to modify filters and select models based on current context
+_OPENAI_NON_CHAT_MODEL_TERMS = {
+    "embed",
+    "audio",
+    "tts",
+    "whisper",
+    "dall-e",
+    "image",
+    "moderation",
+    "sora",
+    "container",
+    "realtime",
+    "transcribe",
+}
+_OPENAI_DEPRECATED_MODEL_TERMS = {"babbage", "davinci", "gpt-3.5", "gpt-4-"}
+_OPENAI_EXCLUDED_TERMS = _OPENAI_NON_CHAT_MODEL_TERMS | _OPENAI_DEPRECATED_MODEL_TERMS
+
+
+def is_openai_chat_model_id(model_id: str) -> bool:
+    """Whether an OpenAI model id looks like a usable chat-completion model
+    (i.e. not an embedding/audio/image/moderation or deprecated model)."""
+    model_lower = model_id.lower()
+    return not any(ex in model_lower for ex in _OPENAI_EXCLUDED_TERMS)
+
+
 def get_openai_model_names() -> list[str]:
     """Get OpenAI model names dynamically from litellm."""
     import re
 
     import litellm
-
-    # TODO: remove these lists once we have a comprehensive model configuration page
-    # The ideal flow should be: fetch all available models --> filter by type
-    # --> allow user to modify filters and select models based on current context
-    non_chat_model_terms = {
-        "embed",
-        "audio",
-        "tts",
-        "whisper",
-        "dall-e",
-        "image",
-        "moderation",
-        "sora",
-        "container",
-    }
-    deprecated_model_terms = {"babbage", "davinci", "gpt-3.5", "gpt-4-"}
-    excluded_terms = non_chat_model_terms | deprecated_model_terms
 
     # NOTE: We are explicitly excluding all "timestamped" models
     # because they are mostly just noise in the admin configuration panel
@@ -170,10 +180,7 @@ def get_openai_model_names() -> list[str]:
     date_pattern = re.compile(r"-\d{4}")
 
     def is_valid_model(model: str) -> bool:
-        model_lower = model.lower()
-        return not any(
-            ex in model_lower for ex in excluded_terms
-        ) and not date_pattern.search(model)
+        return is_openai_chat_model_id(model) and not date_pattern.search(model)
 
     return sorted(
         (

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -50,9 +50,11 @@ from onyx.llm.factory import (
 )
 from onyx.llm.model_capabilities import (
     get_bedrock_token_limit,
+    get_max_input_tokens,
     litellm_thinks_model_supports_image_input,
     model_is_reasoning_model,
 )
+from onyx.llm.model_name_parser import parse_litellm_model_name
 from onyx.llm.utils import (
     get_llm_contextual_cost,
     is_sensitive_custom_config_key,
@@ -72,8 +74,12 @@ from onyx.llm.well_known_providers.constants import (
 from onyx.llm.well_known_providers.llm_provider_options import (
     WellKnownLLMProviderDescriptor,
     fetch_available_well_known_llms,
+    is_obsolete_model,
+    is_openai_chat_model_id,
 )
 from onyx.server.manage.llm.models import (
+    AnthropicFinalModelResponse,
+    AnthropicModelsRequest,
     BedrockFinalModelResponse,
     BedrockModelsRequest,
     BifrostFinalModelResponse,
@@ -98,6 +104,8 @@ from onyx.server.manage.llm.models import (
     OllamaModelsRequest,
     OpenAICompatibleFinalModelResponse,
     OpenAICompatibleModelsRequest,
+    OpenAIFinalModelResponse,
+    OpenAIModelsRequest,
     OpenRouterFinalModelResponse,
     OpenRouterModelDetails,
     OpenRouterModelsRequest,
@@ -117,6 +125,7 @@ from onyx.server.manage.llm.utils import (
     is_embedding_model,
     is_reasoning_model,
     is_valid_bedrock_model,
+    should_filter_as_dated_duplicate,
     strip_openrouter_vendor_prefix,
 )
 from onyx.utils.audit import (
@@ -2145,3 +2154,272 @@ def _get_openai_compatible_server_response(
         source_name="OpenAI-Compatible",
         api_key=api_key,
     )
+
+
+_OPENAI_MODELS_URL = "https://api.openai.com/v1/models"
+
+_ANTHROPIC_MODELS_URL = "https://api.anthropic.com/v1/models"
+_ANTHROPIC_API_VERSION = "2023-06-01"
+_ANTHROPIC_MODELS_PAGE_LIMIT = 1000
+_ANTHROPIC_MODELS_MAX_PAGES = 5
+
+
+@admin_router.post("/openai/available-models")
+def get_openai_available_models(
+    request: OpenAIModelsRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[OpenAIFinalModelResponse]:
+    """Fetch available models from OpenAI's /v1/models endpoint.
+
+    The listing API only returns model ids, so display names and capability
+    flags are derived from litellm metadata.
+    """
+    api_key = _resolve_api_key(request.api_key, request.provider_id, None, db_session)
+
+    response_json = _get_openai_compatible_models_response(
+        url=_OPENAI_MODELS_URL,
+        source_name="OpenAI",
+        api_key=api_key,
+    )
+
+    data = response_json.get("data", [])
+    if not isinstance(data, list) or len(data) == 0:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No models found from OpenAI",
+        )
+
+    all_model_ids = {
+        item.get("id") for item in data if isinstance(item, dict) and item.get("id")
+    }
+
+    results: list[OpenAIFinalModelResponse] = []
+    for item in data:
+        try:
+            model_id = item.get("id", "")
+            if not model_id:
+                continue
+
+            # Skip non-chat (embedding/audio/image/moderation) and deprecated models
+            if not is_openai_chat_model_id(model_id):
+                continue
+            if is_embedding_model(model_id):
+                continue
+            if is_obsolete_model(model_id, LlmProviderNames.OPENAI):
+                continue
+            # Skip dated variants when the undated base model is also present;
+            # the provider read path filters these out anyway.
+            if should_filter_as_dated_duplicate(model_id, all_model_ids):
+                continue
+
+            display_name = parse_litellm_model_name(f"openai/{model_id}").display_name
+
+            results.append(
+                OpenAIFinalModelResponse(
+                    name=model_id,
+                    display_name=display_name,
+                    max_input_tokens=get_max_input_tokens(
+                        model_name=model_id,
+                        model_provider=LlmProviderNames.OPENAI,
+                    ),
+                    supports_image_input=litellm_thinks_model_supports_image_input(
+                        model_id, LlmProviderNames.OPENAI
+                    ),
+                    supports_reasoning=(
+                        model_is_reasoning_model(model_id, LlmProviderNames.OPENAI)
+                        or is_reasoning_model(model_id, display_name)
+                    ),
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to parse OpenAI model entry",
+                extra={"error": str(e), "item": str(item)[:1000]},
+            )
+
+    if not results:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No compatible models found from OpenAI",
+        )
+
+    sorted_results = sorted(results, key=lambda m: m.name.lower())
+
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
+        _sync_fetched_models(
+            db_session=db_session,
+            provider_id=request.provider_id,
+            models=[
+                SyncModelEntry(
+                    name=r.name,
+                    display_name=r.display_name,
+                    max_input_tokens=r.max_input_tokens,
+                    supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
+                )
+                for r in sorted_results
+            ],
+            source_label="OpenAI",
+        )
+
+    return sorted_results
+
+
+def _get_anthropic_models_response(api_key: str | None) -> list[dict]:
+    """Fetch all model entries from Anthropic's paginated /v1/models endpoint."""
+    headers = {
+        "x-api-key": api_key or "",
+        "anthropic-version": _ANTHROPIC_API_VERSION,
+    }
+
+    entries: list[dict] = []
+    after_id: str | None = None
+    try:
+        for _ in range(_ANTHROPIC_MODELS_MAX_PAGES):
+            params: dict[str, Any] = {"limit": _ANTHROPIC_MODELS_PAGE_LIMIT}
+            if after_id:
+                params["after_id"] = after_id
+
+            response = httpx.get(
+                _ANTHROPIC_MODELS_URL, headers=headers, params=params, timeout=10.0
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+            data = payload.get("data", [])
+            if isinstance(data, list):
+                entries.extend(entry for entry in data if isinstance(entry, dict))
+
+            after_id = payload.get("last_id")
+            if not payload.get("has_more") or not after_id:
+                break
+
+        return entries
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 401:
+            raise OnyxError(
+                OnyxErrorCode.VALIDATION_ERROR,
+                "Authentication failed: invalid or missing API key for Anthropic.",
+            )
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"Failed to fetch Anthropic models: {e}",
+        )
+    except httpx.RequestError as e:
+        logger.warning(
+            "Could not reach Anthropic models endpoint",
+            extra={"error": str(e)},
+            exc_info=True,
+        )
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            f"Could not reach Anthropic. Check that api.anthropic.com is reachable "
+            f"from Onyx ({type(e).__name__}).",
+        )
+    except ValueError as e:
+        logger.warning(
+            "Received invalid model response from Anthropic",
+            extra={"error": str(e)},
+            exc_info=True,
+        )
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"Failed to fetch Anthropic models: {e}",
+        )
+
+
+@admin_router.post("/anthropic/available-models")
+def get_anthropic_available_models(
+    request: AnthropicModelsRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[AnthropicFinalModelResponse]:
+    """Fetch available models from Anthropic's /v1/models endpoint.
+
+    The listing API returns ids and display names; capability flags are
+    derived from litellm metadata.
+    """
+    api_key = _resolve_api_key(request.api_key, request.provider_id, None, db_session)
+
+    data = _get_anthropic_models_response(api_key)
+    if len(data) == 0:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No models found from Anthropic",
+        )
+
+    all_model_ids = {
+        item_id for item in data if isinstance(item_id := item.get("id"), str)
+    }
+
+    results: list[AnthropicFinalModelResponse] = []
+    for item in data:
+        try:
+            model_id = item.get("id", "")
+            if not model_id:
+                continue
+
+            if is_obsolete_model(model_id, LlmProviderNames.ANTHROPIC):
+                continue
+            # Skip dated variants when the undated base model is also present;
+            # the provider read path filters these out anyway.
+            if should_filter_as_dated_duplicate(model_id, all_model_ids):
+                continue
+
+            display_name = (
+                item.get("display_name")
+                or parse_litellm_model_name(f"anthropic/{model_id}").display_name
+            )
+
+            results.append(
+                AnthropicFinalModelResponse(
+                    name=model_id,
+                    display_name=display_name,
+                    max_input_tokens=get_max_input_tokens(
+                        model_name=model_id,
+                        model_provider=LlmProviderNames.ANTHROPIC,
+                    ),
+                    supports_image_input=litellm_thinks_model_supports_image_input(
+                        model_id, LlmProviderNames.ANTHROPIC
+                    ),
+                    supports_reasoning=(
+                        model_is_reasoning_model(model_id, LlmProviderNames.ANTHROPIC)
+                        or is_reasoning_model(model_id, display_name)
+                    ),
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to parse Anthropic model entry",
+                extra={"error": str(e), "item": str(item)[:1000]},
+            )
+
+    if not results:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No compatible models found from Anthropic",
+        )
+
+    sorted_results = sorted(results, key=lambda m: m.name.lower())
+
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
+        _sync_fetched_models(
+            db_session=db_session,
+            provider_id=request.provider_id,
+            models=[
+                SyncModelEntry(
+                    name=r.name,
+                    display_name=r.display_name,
+                    max_input_tokens=r.max_input_tokens,
+                    supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
+                )
+                for r in sorted_results
+            ],
+            source_label="Anthropic",
+        )
+
+    return sorted_results

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -50,7 +50,6 @@ from onyx.llm.factory import (
 )
 from onyx.llm.model_capabilities import (
     get_bedrock_token_limit,
-    get_max_input_tokens,
     litellm_thinks_model_supports_image_input,
     model_is_reasoning_model,
 )
@@ -2219,10 +2218,10 @@ def get_openai_available_models(
                 OpenAIFinalModelResponse(
                     name=model_id,
                     display_name=display_name,
-                    max_input_tokens=get_max_input_tokens(
-                        model_name=model_id,
-                        model_provider=LlmProviderNames.OPENAI,
-                    ),
+                    # OpenAI's /v1/models response does not include context
+                    # length; leave None so runtime resolves it via litellm
+                    # (self-heals for models litellm doesn't know yet).
+                    max_input_tokens=None,
                     supports_image_input=litellm_thinks_model_supports_image_input(
                         model_id, LlmProviderNames.OPENAI
                     ),
@@ -2377,10 +2376,10 @@ def get_anthropic_available_models(
                 AnthropicFinalModelResponse(
                     name=model_id,
                     display_name=display_name,
-                    max_input_tokens=get_max_input_tokens(
-                        model_name=model_id,
-                        model_provider=LlmProviderNames.ANTHROPIC,
-                    ),
+                    # Anthropic's /v1/models response does not include context
+                    # length; leave None so runtime resolves it via litellm
+                    # (self-heals for models litellm doesn't know yet).
+                    max_input_tokens=None,
                     supports_image_input=litellm_thinks_model_supports_image_input(
                         model_id, LlmProviderNames.ANTHROPIC
                     ),

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -459,6 +459,36 @@ class OpenRouterFinalModelResponse(BaseModel):
     supports_image_input: bool
 
 
+# OpenAI dynamic models fetch
+class OpenAIModelsRequest(BaseModel):
+    api_key: str
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
+
+
+class OpenAIFinalModelResponse(BaseModel):
+    name: str  # Model ID (e.g., "gpt-4o")
+    display_name: str  # Derived via the litellm model-name parser
+    max_input_tokens: int
+    supports_image_input: bool
+    supports_reasoning: bool
+
+
+# Anthropic dynamic models fetch
+class AnthropicModelsRequest(BaseModel):
+    api_key: str
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
+
+
+class AnthropicFinalModelResponse(BaseModel):
+    name: str  # Model ID (e.g., "claude-sonnet-4-5")
+    display_name: str  # Human-readable name from the Anthropic API
+    max_input_tokens: int
+    supports_image_input: bool
+    supports_reasoning: bool
+
+
 # LM Studio dynamic models fetch
 class LMStudioModelsRequest(BaseModel):
     api_base: str

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -469,7 +469,8 @@ class OpenAIModelsRequest(BaseModel):
 class OpenAIFinalModelResponse(BaseModel):
     name: str  # Model ID (e.g., "gpt-4o")
     display_name: str  # Derived via the litellm model-name parser
-    max_input_tokens: int
+    # Not in the /v1/models response; None defers to runtime litellm lookup
+    max_input_tokens: int | None
     supports_image_input: bool
     supports_reasoning: bool
 
@@ -484,7 +485,8 @@ class AnthropicModelsRequest(BaseModel):
 class AnthropicFinalModelResponse(BaseModel):
     name: str  # Model ID (e.g., "claude-sonnet-4-5")
     display_name: str  # Human-readable name from the Anthropic API
-    max_input_tokens: int
+    # Not in the /v1/models response; None defers to runtime litellm lookup
+    max_input_tokens: int | None
     supports_image_input: bool
     supports_reasoning: bool
 

--- a/backend/tests/external_dependency_unit/llm/test_llm_models_fetch.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_models_fetch.py
@@ -1,15 +1,27 @@
-"""External dependency unit tests for the OpenAI/Anthropic available-models endpoints.
+"""External dependency unit tests for the dynamic available-models endpoints.
 
-These tests hit the real OpenAI and Anthropic ``/v1/models`` endpoints, exercising
-the ``/admin/llm/openai/available-models`` and ``/admin/llm/anthropic/available-models``
-admin handlers end-to-end (minus auth — handlers are invoked directly with a mocked
-user since auth is a separate concern already covered elsewhere).
+These tests hit real provider APIs, exercising the
+``/admin/llm/{provider}/available-models`` admin handlers end-to-end (minus
+auth — handlers are invoked directly with a mocked user since auth is a
+separate concern already covered elsewhere). Their job is drift detection:
+catching new model categories that leak through our filters, response-shape
+changes, and pagination breakage that the mocked unit suite
+(``tests/unit/onyx/server/manage/llm/test_fetch_models_api.py``) can't see.
 
-OpenAI tests resolve their key via the shared ``@pytest.mark.secrets``
-infrastructure (env var / ``.vscode/.env`` locally, AWS Secrets Manager in CI).
-Anthropic has no ``TestSecret`` member yet, so its live tests are gated on the
-``ANTHROPIC_API_KEY`` env var and skip when absent; migrate them to
-``@pytest.mark.secrets`` if that secret is ever added.
+Credentials per provider:
+
+- **OpenAI / Bedrock**: keys resolve via the shared ``@pytest.mark.secrets``
+  infrastructure (env var / ``.vscode/.env`` locally, AWS Secrets Manager in CI).
+- **Anthropic**: no ``TestSecret`` member yet, so its live tests are gated on
+  the ``ANTHROPIC_API_KEY`` env var and skip when absent; migrate them to
+  ``@pytest.mark.secrets`` if that secret is ever added.
+- **OpenRouter / OpenAI-compatible**: OpenRouter's ``/api/v1/models`` endpoint
+  is public, so these run keyless. The generic OpenAI-compatible handler is
+  pointed at OpenRouter as a stable, real OpenAI-compatible server.
+
+Endpoints for self-hosted services (Ollama, LM Studio, Bifrost, LiteLLM proxy,
+Nebius) have no hosted catalog to drift against and are covered by the mocked
+unit suite only.
 """
 
 import os
@@ -20,21 +32,33 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.db.llm import fetch_existing_llm_provider
-from onyx.db.llm import remove_llm_provider
-from onyx.db.llm import upsert_llm_provider
+from onyx.db.llm import (
+    fetch_existing_llm_provider,
+    remove_llm_provider,
+    upsert_llm_provider,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.constants import LlmProviderNames
-from onyx.server.manage.llm.api import _mask_string
-from onyx.server.manage.llm.api import get_anthropic_available_models
-from onyx.server.manage.llm.api import get_openai_available_models
-from onyx.server.manage.llm.models import AnthropicModelsRequest
-from onyx.server.manage.llm.models import LLMProviderUpsertRequest
-from onyx.server.manage.llm.models import LLMProviderView
-from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
-from onyx.server.manage.llm.models import OpenAIModelsRequest
-from onyx.server.manage.llm.utils import extract_base_model_name
+from onyx.server.manage.llm.api import (
+    _mask_string,
+    get_anthropic_available_models,
+    get_bedrock_available_models,
+    get_openai_available_models,
+    get_openai_compatible_server_available_models,
+    get_openrouter_available_models,
+)
+from onyx.server.manage.llm.models import (
+    AnthropicModelsRequest,
+    BedrockModelsRequest,
+    LLMProviderUpsertRequest,
+    LLMProviderView,
+    ModelConfigurationUpsertRequest,
+    OpenAICompatibleModelsRequest,
+    OpenAIModelsRequest,
+    OpenRouterModelsRequest,
+)
+from onyx.server.manage.llm.utils import NON_LLM_PATTERNS, extract_base_model_name
 from tests.utils.secret_names import TestSecret
 
 pytestmark = pytest.mark.nightly
@@ -43,6 +67,11 @@ _ANTHROPIC_KEY_AVAILABLE = bool(os.environ.get("ANTHROPIC_API_KEY"))
 
 _BOGUS_OPENAI_KEY = "sk-not-a-real-openai-key-aaaaaaaaaaaaaaaaaaaaaaaa"
 _BOGUS_ANTHROPIC_KEY = "sk-ant-not-a-real-key-aaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+_OPENROUTER_API_BASE = "https://openrouter.ai/api/v1"
+
+# Same region as test_bedrock.py — where the test bearer token is provisioned.
+_BEDROCK_REGION = "us-west-2"
 
 # Categories that should never leak through the OpenAI filter.
 _OPENAI_EXCLUDED_SUBSTRINGS = (
@@ -232,3 +261,171 @@ def test_anthropic_auth_failure(db_session: Session) -> None:
 
     assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
     assert "Anthropic" in exc_info.value.detail
+
+
+# --------------------------- Bedrock ---------------------------------
+
+
+def _make_bedrock_provider(
+    db_session: Session, name: str, bearer_token: str
+) -> LLMProviderView:
+    return upsert_llm_provider(
+        LLMProviderUpsertRequest(
+            name=name,
+            provider=LlmProviderNames.BEDROCK,
+            custom_config={
+                "AWS_REGION_NAME": _BEDROCK_REGION,
+                "AWS_BEARER_TOKEN_BEDROCK": bearer_token,
+            },
+            model_configurations=[
+                ModelConfigurationUpsertRequest(
+                    name="anthropic.claude-3-5-sonnet-20241022-v2:0",
+                    is_visible=True,
+                    supports_image_input=True,
+                )
+            ],
+        ),
+        db_session=db_session,
+    )
+
+
+@pytest.fixture
+def bedrock_provider_name(db_session: Session) -> Generator[str, None, None]:
+    name = f"test-bedrock-fetch-{uuid4().hex[:8]}"
+    yield name
+    db_session.rollback()
+    _cleanup_provider(db_session, name)
+
+
+@pytest.mark.secrets(TestSecret.BEDROCK_API_KEY)
+def test_bedrock_happy_path(
+    db_session: Session, test_secrets: dict[TestSecret, str]
+) -> None:
+    """List real Bedrock foundation models via bearer token and verify the shape."""
+    request = BedrockModelsRequest(
+        aws_region_name=_BEDROCK_REGION,
+        aws_bearer_token_bedrock=test_secrets[TestSecret.BEDROCK_API_KEY],
+    )
+
+    results = get_bedrock_available_models(request, MagicMock(), db_session)
+
+    assert len(results) > 0, "Expected at least one model from Bedrock"
+    assert any("anthropic." in r.name for r in results), (
+        f"Expected at least one Anthropic model in {_BEDROCK_REGION}"
+    )
+
+    names = [r.name for r in results]
+    assert names == sorted(names, reverse=True), (
+        "Bedrock results should be sorted descending by model id"
+    )
+
+    for r in results:
+        lower = r.name.lower()
+        for pattern in NON_LLM_PATTERNS:
+            assert pattern not in lower, f"Non-LLM model leaked through: {r.name}"
+        assert r.display_name, f"display_name should be non-empty for {r.name}"
+        assert r.max_input_tokens > 0
+
+
+@pytest.mark.secrets(TestSecret.BEDROCK_API_KEY)
+def test_bedrock_db_sync_when_provider_id_provided(
+    db_session: Session,
+    bedrock_provider_name: str,
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """When provider_id is given, fetched models should be persisted to the DB."""
+    token = test_secrets[TestSecret.BEDROCK_API_KEY]
+    provider = _make_bedrock_provider(db_session, bedrock_provider_name, token)
+
+    request = BedrockModelsRequest(
+        aws_region_name=_BEDROCK_REGION,
+        aws_bearer_token_bedrock=token,
+        provider_id=provider.id,
+    )
+    results = get_bedrock_available_models(request, MagicMock(), db_session)
+    assert len(results) > 0
+
+    db_session.expire_all()
+    persisted = fetch_existing_llm_provider(
+        name=bedrock_provider_name, db_session=db_session
+    )
+    assert persisted is not None
+
+    persisted_names = {mc.name for mc in persisted.model_configurations}
+    fetched_names = {r.name for r in results}
+    # All fetched names should be persisted; the seed model should still
+    # exist (sync is additive — it does not drop pre-existing entries).
+    assert fetched_names.issubset(persisted_names)
+    assert "anthropic.claude-3-5-sonnet-20241022-v2:0" in persisted_names
+
+
+# --------------------------- OpenRouter ------------------------------
+
+
+def test_openrouter_happy_path(db_session: Session) -> None:
+    """Hit the real (public) OpenRouter /models endpoint and verify the shape.
+
+    OpenRouter's models endpoint requires no auth; an empty api_key means the
+    handler sends no Authorization header, so this runs keyless. If this ever
+    starts failing with an auth error, OpenRouter has started enforcing keys —
+    add an OPENROUTER_API_KEY TestSecret and gate the test on it.
+    """
+    request = OpenRouterModelsRequest(api_base=_OPENROUTER_API_BASE, api_key="")
+
+    results = get_openrouter_available_models(request, MagicMock(), db_session)
+
+    assert len(results) > 0, "Expected at least one model from OpenRouter"
+    assert any(r.name.startswith("openai/") for r in results)
+    assert any(r.name.startswith("anthropic/") for r in results)
+
+    names = [r.name for r in results]
+    assert names == sorted(names, key=str.lower), "Results should be sorted by name"
+
+    for r in results:
+        assert "embedding" not in r.name.lower(), (
+            f"Embedding model leaked through: {r.name}"
+        )
+        assert r.display_name, f"display_name should be non-empty for {r.name}"
+        assert r.max_input_tokens is None or r.max_input_tokens > 0, (
+            "context_length of 0 should be normalized to None"
+        )
+        # Vendor prefixes are stripped from display names ("OpenAI: GPT-4o" → "GPT-4o")
+        if r.name.startswith("openai/"):
+            assert not r.display_name.lower().startswith("openai:"), (
+                f"Vendor prefix not stripped from display name: {r.display_name}"
+            )
+
+
+# ----------------------- OpenAI-compatible ---------------------------
+
+
+def test_openai_compatible_happy_path_against_openrouter(db_session: Session) -> None:
+    """Run the generic OpenAI-compatible handler against a real live server.
+
+    OpenRouter's public /api/v1/models endpoint doubles as a stable, real
+    OpenAI-compatible server — this exercises URL construction (api_base
+    already ending in /v1) and response parsing without needing any secret.
+    """
+    request = OpenAICompatibleModelsRequest(api_base=_OPENROUTER_API_BASE)
+
+    results = get_openai_compatible_server_available_models(
+        request, MagicMock(), db_session
+    )
+
+    assert len(results) > 0, "Expected at least one model"
+
+    names = [r.name for r in results]
+    assert names == sorted(names, key=str.lower), "Results should be sorted by name"
+
+    for r in results:
+        assert "embedding" not in r.name.lower(), (
+            f"Embedding model leaked through: {r.name}"
+        )
+        assert r.display_name, f"display_name should be non-empty for {r.name}"
+
+    assert any(r.max_input_tokens for r in results), (
+        "OpenRouter reports context_length; expected it mapped to max_input_tokens"
+    )
+    assert any(r.supports_reasoning for r in results), (
+        "Expected at least one reasoning-capable model (o-series / deepseek-r1)"
+    )

--- a/backend/tests/external_dependency_unit/llm/test_llm_models_fetch.py
+++ b/backend/tests/external_dependency_unit/llm/test_llm_models_fetch.py
@@ -1,0 +1,234 @@
+"""External dependency unit tests for the OpenAI/Anthropic available-models endpoints.
+
+These tests hit the real OpenAI and Anthropic ``/v1/models`` endpoints, exercising
+the ``/admin/llm/openai/available-models`` and ``/admin/llm/anthropic/available-models``
+admin handlers end-to-end (minus auth — handlers are invoked directly with a mocked
+user since auth is a separate concern already covered elsewhere).
+
+OpenAI tests resolve their key via the shared ``@pytest.mark.secrets``
+infrastructure (env var / ``.vscode/.env`` locally, AWS Secrets Manager in CI).
+Anthropic has no ``TestSecret`` member yet, so its live tests are gated on the
+``ANTHROPIC_API_KEY`` env var and skip when absent; migrate them to
+``@pytest.mark.secrets`` if that secret is ever added.
+"""
+
+import os
+from collections.abc import Generator
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.llm import fetch_existing_llm_provider
+from onyx.db.llm import remove_llm_provider
+from onyx.db.llm import upsert_llm_provider
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.llm.constants import LlmProviderNames
+from onyx.server.manage.llm.api import _mask_string
+from onyx.server.manage.llm.api import get_anthropic_available_models
+from onyx.server.manage.llm.api import get_openai_available_models
+from onyx.server.manage.llm.models import AnthropicModelsRequest
+from onyx.server.manage.llm.models import LLMProviderUpsertRequest
+from onyx.server.manage.llm.models import LLMProviderView
+from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
+from onyx.server.manage.llm.models import OpenAIModelsRequest
+from onyx.server.manage.llm.utils import extract_base_model_name
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.nightly
+
+_ANTHROPIC_KEY_AVAILABLE = bool(os.environ.get("ANTHROPIC_API_KEY"))
+
+_BOGUS_OPENAI_KEY = "sk-not-a-real-openai-key-aaaaaaaaaaaaaaaaaaaaaaaa"
+_BOGUS_ANTHROPIC_KEY = "sk-ant-not-a-real-key-aaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+# Categories that should never leak through the OpenAI filter.
+_OPENAI_EXCLUDED_SUBSTRINGS = (
+    "embed",
+    "audio",
+    "tts",
+    "whisper",
+    "dall-e",
+    "moderation",
+    "sora",
+    "realtime",
+    "transcribe",
+)
+
+
+def _make_openai_provider(
+    db_session: Session, name: str, api_key: str
+) -> LLMProviderView:
+    return upsert_llm_provider(
+        LLMProviderUpsertRequest(
+            name=name,
+            provider=LlmProviderNames.OPENAI,
+            api_key=api_key,
+            api_key_changed=True,
+            model_configurations=[
+                ModelConfigurationUpsertRequest(
+                    name="gpt-4o", is_visible=True, supports_image_input=True
+                )
+            ],
+        ),
+        db_session=db_session,
+    )
+
+
+def _cleanup_provider(db_session: Session, name: str) -> None:
+    provider = fetch_existing_llm_provider(name=name, db_session=db_session)
+    if provider:
+        remove_llm_provider(db_session, provider.id)
+
+
+@pytest.fixture
+def openai_provider_name(db_session: Session) -> Generator[str, None, None]:
+    name = f"test-openai-fetch-{uuid4().hex[:8]}"
+    yield name
+    db_session.rollback()
+    _cleanup_provider(db_session, name)
+
+
+# --------------------------- OpenAI ---------------------------------
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_openai_happy_path(
+    db_session: Session, test_secrets: dict[TestSecret, str]
+) -> None:
+    """Hit the real OpenAI /v1/models endpoint and verify the result shape."""
+    request = OpenAIModelsRequest(api_key=test_secrets[TestSecret.OPENAI_API_KEY])
+
+    results = get_openai_available_models(request, MagicMock(), db_session)
+
+    assert len(results) > 0, "Expected at least one model from OpenAI"
+    assert any(r.name.startswith("gpt-") for r in results), (
+        "Expected at least one gpt- model"
+    )
+
+    names = [r.name for r in results]
+    assert names == sorted(names, key=str.lower), "Results should be sorted by name"
+
+    name_set = set(names)
+    for r in results:
+        lower = r.name.lower()
+        for excluded in _OPENAI_EXCLUDED_SUBSTRINGS:
+            assert excluded not in lower, (
+                f"Excluded category '{excluded}' leaked through for model {r.name}"
+            )
+        # Dated snapshots are only kept when no undated base model exists.
+        base = extract_base_model_name(r.name)
+        assert not (base and base in name_set), (
+            f"Dated duplicate leaked through: {r.name}"
+        )
+        assert r.display_name, "display_name should be non-empty"
+        assert r.max_input_tokens is None, (
+            "OpenAI handler should leave max_input_tokens=None and rely on "
+            "runtime litellm fallback"
+        )
+
+    assert any(r.supports_reasoning for r in results), (
+        "Expected at least one reasoning-capable model (o-series / gpt-5)"
+    )
+
+
+def test_openai_auth_failure(db_session: Session) -> None:
+    """Bogus key should raise OnyxError(VALIDATION_ERROR)."""
+    request = OpenAIModelsRequest(api_key=_BOGUS_OPENAI_KEY)
+
+    with pytest.raises(OnyxError) as exc_info:
+        get_openai_available_models(request, MagicMock(), db_session)
+
+    assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+    assert "OpenAI" in exc_info.value.detail
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_openai_db_sync_when_provider_id_provided(
+    db_session: Session,
+    openai_provider_name: str,
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """When provider_id is given, fetched models should be persisted to the DB."""
+    real_key = test_secrets[TestSecret.OPENAI_API_KEY]
+    provider = _make_openai_provider(db_session, openai_provider_name, real_key)
+
+    request = OpenAIModelsRequest(api_key=real_key, provider_id=provider.id)
+    results = get_openai_available_models(request, MagicMock(), db_session)
+    assert len(results) > 0
+
+    db_session.expire_all()
+    persisted = fetch_existing_llm_provider(
+        name=openai_provider_name, db_session=db_session
+    )
+    assert persisted is not None
+
+    persisted_names = {mc.name for mc in persisted.model_configurations}
+    fetched_names = {r.name for r in results}
+    # All fetched names should be persisted; the original gpt-4o should still
+    # exist (sync is additive — it does not drop pre-existing entries).
+    assert fetched_names.issubset(persisted_names)
+    assert "gpt-4o" in persisted_names
+
+
+@pytest.mark.secrets(TestSecret.OPENAI_API_KEY)
+def test_openai_masked_api_key_resolves(
+    db_session: Session,
+    openai_provider_name: str,
+    test_secrets: dict[TestSecret, str],
+) -> None:
+    """Submitting the masked form of a stored key should still succeed."""
+    real_key = test_secrets[TestSecret.OPENAI_API_KEY]
+    provider = _make_openai_provider(db_session, openai_provider_name, real_key)
+
+    masked = _mask_string(real_key)
+    assert masked != real_key, "Mask should differ from raw key"
+
+    request = OpenAIModelsRequest(api_key=masked, provider_id=provider.id)
+    results = get_openai_available_models(request, MagicMock(), db_session)
+    assert len(results) > 0
+
+
+# --------------------------- Anthropic ------------------------------
+
+
+@pytest.mark.skipif(
+    not _ANTHROPIC_KEY_AVAILABLE, reason="ANTHROPIC_API_KEY not set in environment"
+)
+def test_anthropic_happy_path(db_session: Session) -> None:
+    """Hit the real Anthropic /v1/models endpoint and verify the result shape."""
+    request = AnthropicModelsRequest(api_key=os.environ["ANTHROPIC_API_KEY"])
+
+    results = get_anthropic_available_models(request, MagicMock(), db_session)
+
+    assert len(results) > 0, "Expected at least one model from Anthropic"
+    assert any(r.name.startswith("claude-") for r in results), (
+        "Expected at least one claude- model"
+    )
+
+    for r in results:
+        lower = r.name.lower()
+        assert "claude-2" not in lower and "claude-instant" not in lower, (
+            f"Obsolete model leaked through: {r.name}"
+        )
+        assert r.display_name, f"display_name should be non-empty for {r.name}"
+        assert r.max_input_tokens is None, (
+            "Anthropic handler should leave max_input_tokens=None and rely on "
+            "runtime litellm fallback"
+        )
+
+    names = [r.name for r in results]
+    assert names == sorted(names, key=str.lower), "Results should be sorted by name"
+
+
+def test_anthropic_auth_failure(db_session: Session) -> None:
+    """Bogus key should raise OnyxError(VALIDATION_ERROR)."""
+    request = AnthropicModelsRequest(api_key=_BOGUS_ANTHROPIC_KEY)
+
+    with pytest.raises(OnyxError) as exc_info:
+        get_anthropic_available_models(request, MagicMock(), db_session)
+
+    assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+    assert "Anthropic" in exc_info.value.detail

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -15,6 +15,8 @@ import pytest
 from onyx.db.enums import LLMModelFlowType
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.manage.llm.models import (
+    AnthropicFinalModelResponse,
+    AnthropicModelsRequest,
     BedrockModelsRequest,
     BifrostFinalModelResponse,
     BifrostModelsRequest,
@@ -25,6 +27,8 @@ from onyx.server.manage.llm.models import (
     OllamaFinalModelResponse,
     OllamaModelsRequest,
     OpenAICompatibleModelsRequest,
+    OpenAIFinalModelResponse,
+    OpenAIModelsRequest,
     OpenRouterFinalModelResponse,
     OpenRouterModelsRequest,
 )
@@ -477,6 +481,482 @@ class TestGetOpenRouterAvailableModels:
             # No DB operations should happen
             mock_session.execute.assert_not_called()
             mock_session.commit.assert_not_called()
+
+
+class TestGetOpenAIAvailableModels:
+    """Tests for the OpenAI model fetch endpoint."""
+
+    @pytest.fixture
+    def mock_openai_response(self) -> dict:
+        """Mock response from OpenAI /v1/models endpoint."""
+        return {
+            "object": "list",
+            "data": [
+                {"id": "gpt-4o", "object": "model", "owned_by": "openai"},
+                {"id": "o1", "object": "model", "owned_by": "openai"},
+                # Dated duplicate of gpt-4o — should be filtered
+                {"id": "gpt-4o-2024-08-06", "object": "model", "owned_by": "openai"},
+                # Dated model WITHOUT an undated base — should be kept
+                {
+                    "id": "gpt-6-preview-2030-01-01",
+                    "object": "model",
+                    "owned_by": "openai",
+                },
+                # Non-chat models — should all be filtered
+                {"id": "text-embedding-3-small", "object": "model"},
+                {"id": "whisper-1", "object": "model"},
+                {"id": "dall-e-3", "object": "model"},
+                {"id": "tts-1", "object": "model"},
+                {"id": "omni-moderation-latest", "object": "model"},
+                {"id": "gpt-4o-realtime-preview", "object": "model"},
+                {"id": "gpt-4o-transcribe", "object": "model"},
+                # Deprecated — should be filtered
+                {"id": "gpt-3.5-turbo", "object": "model"},
+            ],
+        }
+
+    def test_returns_model_list(self, mock_openai_response: dict) -> None:
+        """Only chat-capable models survive, sorted, with parser display names."""
+        from onyx.server.manage.llm.api import get_openai_available_models
+
+        mock_session = MagicMock()
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_openai_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = OpenAIModelsRequest(api_key="test-key")
+            results = get_openai_available_models(request, MagicMock(), mock_session)
+
+            assert all(isinstance(r, OpenAIFinalModelResponse) for r in results)
+            assert [r.name for r in results] == [
+                "gpt-4o",
+                "gpt-6-preview-2030-01-01",
+                "o1",
+            ]
+            gpt_4o = next(r for r in results if r.name == "gpt-4o")
+            assert gpt_4o.display_name == "GPT-4o"
+
+    def test_filters_non_chat_and_dated_models(
+        self, mock_openai_response: dict
+    ) -> None:
+        """Embedding/audio/image/moderation, deprecated, and dated-duplicate
+        model ids are excluded; dated ids without an undated base survive."""
+        from onyx.server.manage.llm.api import get_openai_available_models
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_openai_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = OpenAIModelsRequest(api_key="test-key")
+            results = get_openai_available_models(request, MagicMock(), MagicMock())
+
+            names = {r.name for r in results}
+            assert "text-embedding-3-small" not in names
+            assert "whisper-1" not in names
+            assert "dall-e-3" not in names
+            assert "tts-1" not in names
+            assert "omni-moderation-latest" not in names
+            assert "gpt-4o-realtime-preview" not in names
+            assert "gpt-4o-transcribe" not in names
+            assert "gpt-3.5-turbo" not in names
+            # Dated duplicate filtered because "gpt-4o" is present
+            assert "gpt-4o-2024-08-06" not in names
+            # Dated id with no undated base is kept
+            assert "gpt-6-preview-2030-01-01" in names
+
+    def test_infers_capability_flags(self, mock_openai_response: dict) -> None:
+        """Vision/reasoning flags and token limits come from litellm metadata."""
+        from onyx.server.manage.llm.api import get_openai_available_models
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_openai_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = OpenAIModelsRequest(api_key="test-key")
+            results = get_openai_available_models(request, MagicMock(), MagicMock())
+
+            gpt_4o = next(r for r in results if r.name == "gpt-4o")
+            o1 = next(r for r in results if r.name == "o1")
+
+            assert gpt_4o.supports_image_input is True
+            assert gpt_4o.supports_reasoning is False
+            assert o1.supports_reasoning is True
+            assert gpt_4o.max_input_tokens > 0
+
+    def test_syncs_to_db_when_provider_id_specified(
+        self, mock_openai_response: dict
+    ) -> None:
+        """Test that models are synced to DB when provider_id is given."""
+        from onyx.server.manage.llm.api import get_openai_available_models
+
+        mock_session = MagicMock()
+        mock_provider = MagicMock()
+        mock_provider.id = 1
+        mock_provider.model_configurations = []
+
+        with (
+            patch("onyx.server.manage.llm.api.httpx.get") as mock_get,
+            patch(
+                "onyx.db.llm.fetch_existing_llm_provider_by_id",
+                return_value=mock_provider,
+            ),
+        ):
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_openai_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = OpenAIModelsRequest(api_key="test-key", provider_id=1)
+            get_openai_available_models(request, MagicMock(), mock_session)
+
+            assert mock_session.execute.called
+            mock_session.commit.assert_called_once()
+
+    def test_no_sync_when_provider_id_not_specified(
+        self, mock_openai_response: dict
+    ) -> None:
+        """Test that models are NOT synced when provider_id is None."""
+        from onyx.server.manage.llm.api import get_openai_available_models
+
+        mock_session = MagicMock()
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_openai_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = OpenAIModelsRequest(api_key="test-key")
+            get_openai_available_models(request, MagicMock(), mock_session)
+
+            mock_session.execute.assert_not_called()
+            mock_session.commit.assert_not_called()
+
+    def test_auth_failure_returns_400(self) -> None:
+        """A 401 from OpenAI maps to a validation error, not a gateway fault."""
+        from onyx.error_handling.error_codes import OnyxErrorCode
+        from onyx.server.manage.llm.api import get_openai_available_models
+
+        error_response = httpx.Response(
+            status_code=401,
+            request=httpx.Request("GET", "https://api.openai.com/v1/models"),
+        )
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "401 Unauthorized",
+                request=error_response.request,
+                response=error_response,
+            )
+            mock_get.return_value = mock_response
+
+            request = OpenAIModelsRequest(api_key="bad-key")
+            with pytest.raises(OnyxError) as exc_info:
+                get_openai_available_models(request, MagicMock(), MagicMock())
+
+        assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+        assert exc_info.value.status_code == 400
+
+    def test_request_failure_is_logged_and_returns_400(self) -> None:
+        """A request-layer failure is logged and returns 400 (client misconfig)."""
+        from onyx.error_handling.error_codes import OnyxErrorCode
+        from onyx.server.manage.llm.api import get_openai_available_models
+
+        with (
+            patch("onyx.server.manage.llm.api.httpx.get") as mock_get,
+            patch("onyx.server.manage.llm.api.logger.warning") as mock_warning,
+        ):
+            mock_get.side_effect = httpx.ConnectError(
+                "Connection refused", request=MagicMock()
+            )
+
+            request = OpenAIModelsRequest(api_key="test-key")
+            with pytest.raises(OnyxError) as exc_info:
+                get_openai_available_models(request, MagicMock(), MagicMock())
+
+            mock_warning.assert_called_once()
+
+        assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+        assert exc_info.value.status_code == 400
+
+
+class TestGetAnthropicAvailableModels:
+    """Tests for the Anthropic model fetch endpoint."""
+
+    @pytest.fixture
+    def mock_anthropic_response(self) -> dict:
+        """Mock response from Anthropic /v1/models endpoint."""
+        return {
+            "data": [
+                {
+                    "type": "model",
+                    "id": "claude-sonnet-4-5-20250929",
+                    "display_name": "Claude Sonnet 4.5",
+                    "created_at": "2025-09-29T00:00:00Z",
+                },
+                {
+                    "type": "model",
+                    "id": "claude-3-5-haiku-20241022",
+                    "display_name": "Claude Haiku 3.5",
+                    "created_at": "2024-10-22T00:00:00Z",
+                },
+                {
+                    "type": "model",
+                    "id": "claude-2.1",
+                    "display_name": "Claude 2.1",
+                    "created_at": "2023-11-21T00:00:00Z",
+                },
+                {
+                    "type": "model",
+                    "id": "claude-instant-1.2",
+                    "display_name": "Claude Instant 1.2",
+                    "created_at": "2023-08-09T00:00:00Z",
+                },
+            ],
+            "first_id": "claude-sonnet-4-5-20250929",
+            "last_id": "claude-instant-1.2",
+            "has_more": False,
+        }
+
+    def test_returns_model_list_with_api_display_names(
+        self, mock_anthropic_response: dict
+    ) -> None:
+        """Display names come verbatim from the Anthropic API response."""
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        mock_session = MagicMock()
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_anthropic_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = AnthropicModelsRequest(api_key="test-key")
+            results = get_anthropic_available_models(request, MagicMock(), mock_session)
+
+            assert all(isinstance(r, AnthropicFinalModelResponse) for r in results)
+            assert [r.name for r in results] == [
+                "claude-3-5-haiku-20241022",
+                "claude-sonnet-4-5-20250929",
+            ]
+            # The API's display_name is used verbatim (differs from the litellm
+            # parser's "Claude 3.5 Haiku" ordering)
+            haiku = next(r for r in results if "haiku" in r.name)
+            assert haiku.display_name == "Claude Haiku 3.5"
+
+    def test_filters_obsolete_models(self, mock_anthropic_response: dict) -> None:
+        """claude-2 / claude-instant generations are excluded."""
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_anthropic_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = AnthropicModelsRequest(api_key="test-key")
+            results = get_anthropic_available_models(request, MagicMock(), MagicMock())
+
+            names = {r.name for r in results}
+            assert "claude-2.1" not in names
+            assert "claude-instant-1.2" not in names
+
+    def test_paginates_through_has_more(self) -> None:
+        """Pagination follows has_more/last_id and merges all pages."""
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        page_one = {
+            "data": [
+                {
+                    "type": "model",
+                    "id": "claude-sonnet-4-5-20250929",
+                    "display_name": "Claude Sonnet 4.5",
+                }
+            ],
+            "last_id": "claude-sonnet-4-5-20250929",
+            "has_more": True,
+        }
+        page_two = {
+            "data": [
+                {
+                    "type": "model",
+                    "id": "claude-3-5-haiku-20241022",
+                    "display_name": "Claude Haiku 3.5",
+                }
+            ],
+            "last_id": "claude-3-5-haiku-20241022",
+            "has_more": False,
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            responses = []
+            for page in (page_one, page_two):
+                mock_response = MagicMock()
+                mock_response.json.return_value = page
+                mock_response.raise_for_status = MagicMock()
+                responses.append(mock_response)
+            mock_get.side_effect = responses
+
+            request = AnthropicModelsRequest(api_key="test-key")
+            results = get_anthropic_available_models(request, MagicMock(), MagicMock())
+
+            assert mock_get.call_count == 2
+            first_params = mock_get.call_args_list[0].kwargs["params"]
+            second_params = mock_get.call_args_list[1].kwargs["params"]
+            assert "after_id" not in first_params
+            assert second_params["after_id"] == "claude-sonnet-4-5-20250929"
+
+            assert {r.name for r in results} == {
+                "claude-sonnet-4-5-20250929",
+                "claude-3-5-haiku-20241022",
+            }
+
+    def test_infers_capability_flags(self) -> None:
+        """Vision/reasoning flags come from litellm metadata."""
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        response_payload = {
+            "data": [
+                {
+                    "type": "model",
+                    "id": "claude-3-7-sonnet-20250219",
+                    "display_name": "Claude Sonnet 3.7",
+                },
+                {
+                    "type": "model",
+                    "id": "claude-3-5-haiku-20241022",
+                    "display_name": "Claude Haiku 3.5",
+                },
+            ],
+            "has_more": False,
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response_payload
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = AnthropicModelsRequest(api_key="test-key")
+            results = get_anthropic_available_models(request, MagicMock(), MagicMock())
+
+            sonnet = next(r for r in results if "3-7-sonnet" in r.name)
+            haiku = next(r for r in results if "haiku" in r.name)
+
+            # From litellm metadata
+            assert sonnet.supports_image_input is True
+            assert sonnet.supports_reasoning is True
+            assert sonnet.max_input_tokens > 0
+            # Haiku 3.5 has no litellm entry; without cost-map data the
+            # flags default to False (admins can flip them in the UI)
+            assert haiku.supports_image_input is False
+            assert haiku.supports_reasoning is False
+
+    def test_syncs_to_db_when_provider_id_specified(
+        self, mock_anthropic_response: dict
+    ) -> None:
+        """Test that models are synced to DB when provider_id is given."""
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        mock_session = MagicMock()
+        mock_provider = MagicMock()
+        mock_provider.id = 1
+        mock_provider.model_configurations = []
+
+        with (
+            patch("onyx.server.manage.llm.api.httpx.get") as mock_get,
+            patch(
+                "onyx.db.llm.fetch_existing_llm_provider_by_id",
+                return_value=mock_provider,
+            ),
+        ):
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_anthropic_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = AnthropicModelsRequest(api_key="test-key", provider_id=1)
+            get_anthropic_available_models(request, MagicMock(), mock_session)
+
+            assert mock_session.execute.called
+            mock_session.commit.assert_called_once()
+
+    def test_no_sync_when_provider_id_not_specified(
+        self, mock_anthropic_response: dict
+    ) -> None:
+        """Test that models are NOT synced when provider_id is None."""
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        mock_session = MagicMock()
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = mock_anthropic_response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = AnthropicModelsRequest(api_key="test-key")
+            get_anthropic_available_models(request, MagicMock(), mock_session)
+
+            mock_session.execute.assert_not_called()
+            mock_session.commit.assert_not_called()
+
+    def test_auth_failure_returns_400(self) -> None:
+        """A 401 from Anthropic maps to a validation error, not a gateway fault."""
+        from onyx.error_handling.error_codes import OnyxErrorCode
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        error_response = httpx.Response(
+            status_code=401,
+            request=httpx.Request("GET", "https://api.anthropic.com/v1/models"),
+        )
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "401 Unauthorized",
+                request=error_response.request,
+                response=error_response,
+            )
+            mock_get.return_value = mock_response
+
+            request = AnthropicModelsRequest(api_key="bad-key")
+            with pytest.raises(OnyxError) as exc_info:
+                get_anthropic_available_models(request, MagicMock(), MagicMock())
+
+        assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+        assert exc_info.value.status_code == 400
+
+    def test_request_failure_is_logged_and_returns_400(self) -> None:
+        """A request-layer failure is logged and returns 400 (client misconfig)."""
+        from onyx.error_handling.error_codes import OnyxErrorCode
+        from onyx.server.manage.llm.api import get_anthropic_available_models
+
+        with (
+            patch("onyx.server.manage.llm.api.httpx.get") as mock_get,
+            patch("onyx.server.manage.llm.api.logger.warning") as mock_warning,
+        ):
+            mock_get.side_effect = httpx.ConnectError(
+                "Connection refused", request=MagicMock()
+            )
+
+            request = AnthropicModelsRequest(api_key="test-key")
+            with pytest.raises(OnyxError) as exc_info:
+                get_anthropic_available_models(request, MagicMock(), MagicMock())
+
+            mock_warning.assert_called_once()
+
+        assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
+        assert exc_info.value.status_code == 400
 
 
 class TestGetLMStudioAvailableModels:

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -588,7 +588,8 @@ class TestGetOpenAIAvailableModels:
             assert gpt_4o.supports_image_input is True
             assert gpt_4o.supports_reasoning is False
             assert o1.supports_reasoning is True
-            assert gpt_4o.max_input_tokens > 0
+            # Context length deferred to runtime litellm lookup
+            assert gpt_4o.max_input_tokens is None
 
     def test_syncs_to_db_when_provider_id_specified(
         self, mock_openai_response: dict
@@ -855,7 +856,8 @@ class TestGetAnthropicAvailableModels:
             # From litellm metadata
             assert sonnet.supports_image_input is True
             assert sonnet.supports_reasoning is True
-            assert sonnet.max_input_tokens > 0
+            # Context length deferred to runtime litellm lookup
+            assert sonnet.max_input_tokens is None
             # Haiku 3.5 has no litellm entry; without cost-map data the
             # flags default to False (admins can flip them in the UI)
             assert haiku.supports_image_input is False

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -28,6 +28,10 @@ import {
   type BifrostFetchParams,
   type OpenAICompatibleFetchParams,
   type OpenAICompatibleModelResponse,
+  type OpenAIFetchParams,
+  type OpenAIModelResponse,
+  type AnthropicFetchParams,
+  type AnthropicModelResponse,
   type NebiusTokenfactoryFetchParams,
   type NebiusTokenfactoryModelResponse,
 } from "@/lib/languageModels/types";
@@ -280,6 +284,116 @@ export const fetchOpenRouterModels = async (
       max_input_tokens: modelData.max_input_tokens,
       supports_image_input: modelData.supports_image_input,
       supports_reasoning: false,
+      effectiveDisplayName: modelData.display_name || modelData.name,
+    }));
+
+    return { models };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return { models: [], error: errorMessage };
+  }
+};
+
+/**
+ * Fetches the current model list from OpenAI's /v1/models endpoint.
+ */
+export const fetchOpenAIModels = async (
+  params: OpenAIFetchParams
+): Promise<{ models: ModelConfiguration[]; error?: string }> => {
+  if (!params.api_key) {
+    return { models: [], error: "API Key is required" };
+  }
+
+  try {
+    const response = await fetch("/api/admin/llm/openai/available-models", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        api_key: params.api_key,
+        provider_id: params.provider_id,
+      }),
+    });
+
+    if (!response.ok) {
+      let errorMessage = "Failed to fetch models";
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.detail || errorData.message || errorMessage;
+      } catch (jsonError) {
+        console.warn(
+          "Failed to parse OpenAI model fetch error response",
+          jsonError
+        );
+      }
+      return { models: [], error: errorMessage };
+    }
+
+    const data: OpenAIModelResponse[] = await response.json();
+    const models: ModelConfiguration[] = data.map((modelData) => ({
+      name: modelData.name,
+      display_name: modelData.display_name,
+      is_visible: true,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+      supports_reasoning: modelData.supports_reasoning,
+      effectiveDisplayName: modelData.display_name || modelData.name,
+    }));
+
+    return { models };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return { models: [], error: errorMessage };
+  }
+};
+
+/**
+ * Fetches the current model list from Anthropic's /v1/models endpoint.
+ */
+export const fetchAnthropicModels = async (
+  params: AnthropicFetchParams
+): Promise<{ models: ModelConfiguration[]; error?: string }> => {
+  if (!params.api_key) {
+    return { models: [], error: "API Key is required" };
+  }
+
+  try {
+    const response = await fetch("/api/admin/llm/anthropic/available-models", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        api_key: params.api_key,
+        provider_id: params.provider_id,
+      }),
+    });
+
+    if (!response.ok) {
+      let errorMessage = "Failed to fetch models";
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.detail || errorData.message || errorMessage;
+      } catch (jsonError) {
+        console.warn(
+          "Failed to parse Anthropic model fetch error response",
+          jsonError
+        );
+      }
+      return { models: [], error: errorMessage };
+    }
+
+    const data: AnthropicModelResponse[] = await response.json();
+    const models: ModelConfiguration[] = data.map((modelData) => ({
+      name: modelData.name,
+      display_name: modelData.display_name,
+      is_visible: true,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+      supports_reasoning: modelData.supports_reasoning,
       effectiveDisplayName: modelData.display_name || modelData.name,
     }));
 
@@ -573,6 +687,16 @@ export const fetchModels = async (
     case LLMProviderName.OPENROUTER:
       return fetchOpenRouterModels({
         api_base: formValues.api_base,
+        api_key: formValues.api_key,
+        provider_id: formValues.id,
+      });
+    case LLMProviderName.OPENAI:
+      return fetchOpenAIModels({
+        api_key: formValues.api_key,
+        provider_id: formValues.id,
+      });
+    case LLMProviderName.ANTHROPIC:
+      return fetchAnthropicModels({
         api_key: formValues.api_key,
         provider_id: formValues.id,
       });

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -242,7 +242,7 @@ export interface OpenAIFetchParams {
 export interface OpenAIModelResponse {
   name: string;
   display_name: string;
-  max_input_tokens: number;
+  max_input_tokens: number | null;
   supports_image_input: boolean;
   supports_reasoning: boolean;
 }
@@ -255,7 +255,7 @@ export interface AnthropicFetchParams {
 export interface AnthropicModelResponse {
   name: string;
   display_name: string;
-  max_input_tokens: number;
+  max_input_tokens: number | null;
   supports_image_input: boolean;
   supports_reasoning: boolean;
 }

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -234,6 +234,32 @@ export interface NebiusTokenfactoryModelResponse {
   supported_features: string[];
 }
 
+export interface OpenAIFetchParams {
+  api_key?: string;
+  provider_id?: number;
+}
+
+export interface OpenAIModelResponse {
+  name: string;
+  display_name: string;
+  max_input_tokens: number;
+  supports_image_input: boolean;
+  supports_reasoning: boolean;
+}
+
+export interface AnthropicFetchParams {
+  api_key?: string;
+  provider_id?: number;
+}
+
+export interface AnthropicModelResponse {
+  name: string;
+  display_name: string;
+  max_input_tokens: number;
+  supports_image_input: boolean;
+  supports_reasoning: boolean;
+}
+
 export interface VertexAIFetchParams {
   model_configurations?: ModelConfiguration[];
 }
@@ -253,5 +279,7 @@ export type FetchModelsParams =
   | LiteLLMProxyFetchParams
   | BifrostFetchParams
   | OpenAICompatibleFetchParams
+  | OpenAIFetchParams
+  | AnthropicFetchParams
   | VertexAIFetchParams
   | LMStudioFetchParams;

--- a/web/src/sections/modals/languageModels/AnthropicModal.tsx
+++ b/web/src/sections/modals/languageModels/AnthropicModal.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useSWRConfig } from "swr";
+import { useFormikContext } from "formik";
 import {
   LLMProviderFormProps,
   LLMProviderName,
+  LLMProviderView,
 } from "@/lib/languageModels/types";
+import { fetchAnthropicModels } from "@/lib/languageModels/svc";
 import {
   useInitialValues,
   buildValidationSchema,
+  BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -20,6 +25,63 @@ import {
 } from "@/sections/modals/languageModels/shared";
 import { InputDivider, toast } from "@opal/layouts";
 import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+
+interface AnthropicModalInternalsProps {
+  existingLlmProvider: LLMProviderView | undefined;
+  isOnboarding: boolean;
+}
+
+function AnthropicModalInternals({
+  existingLlmProvider,
+  isOnboarding,
+}: AnthropicModalInternalsProps) {
+  const formikProps = useFormikContext<BaseLLMFormValues>();
+
+  const isFetchDisabled = !formikProps.values.api_key;
+
+  const handleFetchModels = async () => {
+    const { models: fetched, error } = await fetchAnthropicModels({
+      api_key: formikProps.values.api_key,
+      provider_id: existingLlmProvider?.id ?? undefined,
+    });
+    if (error) {
+      throw new Error(error);
+    }
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        fetched,
+        formikProps.values.model_configurations
+      )
+    );
+  };
+
+  return (
+    <>
+      <APIKeyField providerName="Anthropic" />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <DisplayNameField />
+        </>
+      )}
+
+      <InputDivider />
+      <ModelSelectionField
+        shouldShowAutoUpdateToggle={true}
+        onRefetch={isFetchDisabled ? undefined : handleFetchModels}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <ModelAccessField />
+        </>
+      )}
+    </>
+  );
+}
 
 export default function AnthropicModal({
   variant = "llm-configuration",
@@ -81,24 +143,10 @@ export default function AnthropicModal({
         });
       }}
     >
-      <APIKeyField providerName="Anthropic" />
-
-      {!isOnboarding && (
-        <>
-          <InputDivider />
-          <DisplayNameField />
-        </>
-      )}
-
-      <InputDivider />
-      <ModelSelectionField shouldShowAutoUpdateToggle={true} />
-
-      {!isOnboarding && (
-        <>
-          <InputDivider />
-          <ModelAccessField />
-        </>
-      )}
+      <AnthropicModalInternals
+        existingLlmProvider={existingLlmProvider}
+        isOnboarding={isOnboarding}
+      />
     </ModalWrapper>
   );
 }

--- a/web/src/sections/modals/languageModels/OpenAIModal.tsx
+++ b/web/src/sections/modals/languageModels/OpenAIModal.tsx
@@ -1,13 +1,18 @@
 "use client";
 
 import { useSWRConfig } from "swr";
+import { useFormikContext } from "formik";
 import {
   LLMProviderFormProps,
   LLMProviderName,
+  LLMProviderView,
 } from "@/lib/languageModels/types";
+import { fetchOpenAIModels } from "@/lib/languageModels/svc";
 import {
   useInitialValues,
   buildValidationSchema,
+  BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
 } from "@/sections/modals/languageModels/utils";
 import { submitProvider } from "@/sections/modals/languageModels/svc";
 import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
@@ -20,6 +25,63 @@ import {
 } from "@/sections/modals/languageModels/shared";
 import { InputDivider, toast } from "@opal/layouts";
 import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+
+interface OpenAIModalInternalsProps {
+  existingLlmProvider: LLMProviderView | undefined;
+  isOnboarding: boolean;
+}
+
+function OpenAIModalInternals({
+  existingLlmProvider,
+  isOnboarding,
+}: OpenAIModalInternalsProps) {
+  const formikProps = useFormikContext<BaseLLMFormValues>();
+
+  const isFetchDisabled = !formikProps.values.api_key;
+
+  const handleFetchModels = async () => {
+    const { models: fetched, error } = await fetchOpenAIModels({
+      api_key: formikProps.values.api_key,
+      provider_id: existingLlmProvider?.id ?? undefined,
+    });
+    if (error) {
+      throw new Error(error);
+    }
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        fetched,
+        formikProps.values.model_configurations
+      )
+    );
+  };
+
+  return (
+    <>
+      <APIKeyField providerName="OpenAI" />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <DisplayNameField />
+        </>
+      )}
+
+      <InputDivider />
+      <ModelSelectionField
+        shouldShowAutoUpdateToggle={true}
+        onRefetch={isFetchDisabled ? undefined : handleFetchModels}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <ModelAccessField />
+        </>
+      )}
+    </>
+  );
+}
 
 export default function OpenAIModal({
   variant = "llm-configuration",
@@ -81,24 +143,10 @@ export default function OpenAIModal({
         });
       }}
     >
-      <APIKeyField providerName="OpenAI" />
-
-      {!isOnboarding && (
-        <>
-          <InputDivider />
-          <DisplayNameField />
-        </>
-      )}
-
-      <InputDivider />
-      <ModelSelectionField shouldShowAutoUpdateToggle={true} />
-
-      {!isOnboarding && (
-        <>
-          <InputDivider />
-          <ModelAccessField />
-        </>
-      )}
+      <OpenAIModalInternals
+        existingLlmProvider={existingLlmProvider}
+        isOnboarding={isOnboarding}
+      />
     </ModalWrapper>
   );
 }


### PR DESCRIPTION
## Summary

The OpenAI and Anthropic provider config modals showed only litellm's static model lists, so newly released models didn't appear until a litellm dependency bump. This adds the same refresh-models button that OpenRouter/Ollama/Bifrost/etc. already have, backed by two new endpoints that live-fetch each provider's current model list.

Supersedes #10736 (same design, rebuilt on the current `languageModels/` layout and `provider_id`-based key resolution/sync), and ports its live-API test suite and its `max_input_tokens=None` deferral.

**Backend**
- `POST /admin/llm/openai/available-models` — fetches `https://api.openai.com/v1/models` via the existing OpenAI-compatible helper (`_get_openai_compatible_models_response`), filters non-chat ids (embeddings/audio/image/moderation/realtime/transcribe), deprecated ids, and dated variants whose undated base is also present (matching what `filter_model_configurations` does on the read path), and derives display names via `parse_litellm_model_name` plus vision/reasoning flags from litellm metadata.
- `POST /admin/llm/anthropic/available-models` — fetches `https://api.anthropic.com/v1/models` (with `limit=1000` + `has_more`/`last_id` pagination), filters obsolete generations via `is_obsolete_model`, and uses the API's `display_name` verbatim.
- `max_input_tokens` is left `None` (neither listing API returns context length) so runtime resolves it via litellm — self-healing for models litellm doesn't know yet.
- Both reuse `_resolve_api_key` (masked-key handling on edit) and `_sync_fetched_models` (persists newly discovered models as `is_visible=False` when editing an existing provider).
- Extracted the OpenAI chat-model predicate out of `get_openai_model_names()` into `is_openai_chat_model_id()` so the static list and the live endpoint share one exclusion list (extended with `realtime`/`transcribe`).

**Frontend**
- New `fetchOpenAIModels` / `fetchAnthropicModels` svc functions + types, plus dispatcher cases in the generic `fetchModels`.
- Both modals restructured to the `OpenRouterModal` shape (an `...Internals` child inside the Formik tree) so they can wire `onRefetch` into `ModelSelectionField`; the refresh button appears once an API key is entered.

## Test plan

- [x] New unit tests: `TestGetOpenAIAvailableModels` and `TestGetAnthropicAvailableModels` in `test_fetch_models_api.py` (filtering, dated-duplicate handling, capability flags from real litellm data, Anthropic pagination, DB sync gating, 401/request-failure error mapping) — 64/64 pass in the file, 439 pass across `tests/unit/onyx/llm` + `tests/unit/onyx/server/manage/llm`.
- [x] Live-API external-dependency tests (`tests/external_dependency_unit/llm/test_llm_models_fetch.py`, ported from #10736, marked `nightly`): both endpoints against the real provider APIs — result shape/filtering, DB sync, masked-key round-trip, bogus-key auth failure. OpenAI uses the shared `@pytest.mark.secrets` infra; Anthropic skips until a `TestSecret.ANTHROPIC_API_KEY` exists. The two keyless auth-failure tests pass against the live APIs in this environment.
- [x] Extended the same live suite to the other hosted-catalog fetch endpoints: Bedrock happy path + DB sync (via `TestSecret.BEDROCK_API_KEY` bearer token, needs a nightly run to confirm the token's IAM allows `ListFoundationModels`), plus keyless OpenRouter and OpenAI-compatible happy paths against OpenRouter's public `/api/v1/models` — both keyless tests pass live in this environment. Self-hosted providers (Ollama, LM Studio, Bifrost, LiteLLM proxy, Nebius) stay mocked-unit-only since there's no hosted catalog to drift against.
- [x] `ty`, `ruff`, `oxlint`, `oxfmt` pre-commit hooks pass on changed files (web `tsc` failures are the pre-existing branch baseline — identical 494 errors with and without this change).
- [x] Live check via Playwright against the dev stack: refresh button hidden until a key is entered, appears next to "Select All", click hits the new endpoint through the frontend proxy, and an invalid key surfaces the "Authentication failed" toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
