### PR TITLE
feat(connectors): Box incremental indexing via enterprise events

### DIFF
--- a/backend/onyx/connectors/box/connector.py
+++ b/backend/onyx/connectors/box/connector.py
@@ -8,6 +8,8 @@ from urllib.parse import urlparse
 
 from box_sdk_gen import BoxCCGAuth, BoxClient, CCGConfig
 from box_sdk_gen.box.errors import BoxAPIError
+from box_sdk_gen.managers.events import GetEventsEventType, GetEventsStreamType
+from box_sdk_gen.schemas.file import File
 from box_sdk_gen.schemas.file_full import FileFull
 from box_sdk_gen.schemas.folder_mini import FolderMini
 from box_sdk_gen.schemas.user_full import UserFull
@@ -22,7 +24,11 @@ from onyx.connectors.box.access import (
     resolve_box_folder_access,
     resolve_box_web_link_access,
 )
-from onyx.connectors.box.models import BoxConnectorCheckpoint, BoxFolderFrontierEntry
+from onyx.connectors.box.models import (
+    BoxConnectorCheckpoint,
+    BoxFolderFrontierEntry,
+    BoxTraversalMode,
+)
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import datetime_to_utc
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
@@ -89,6 +95,28 @@ _ITEM_FIELDS = [
     "description",
 ]
 
+# Fields needed to convert a single file fetched via the events path, including
+# the parent chain (path_collection) for hierarchy + inherited permissions.
+_FILE_FETCH_FIELDS = _ITEM_FIELDS + ["parent", "path_collection"]
+
+# --- Incremental (events) tuning ---
+_BOX_EVENTS_PAGE_SIZE = 500
+# Poll windows at or below this use the enterprise events stream; wider windows
+# (first index, long gaps) fall back to a full crawl. This threshold doubles as
+# the reconciliation cadence: a connector idle longer than this re-crawls fully.
+_EVENTS_MAX_WINDOW_SECONDS = 7 * 24 * 60 * 60  # 7 days
+
+# Box event types that mean a file's content, name, location, or existence
+# changed and it should be re-fetched + re-indexed. Deletes/trashes are handled
+# by the slim-based pruning job, so they're intentionally excluded here.
+_CONTENT_CHANGE_EVENT_TYPES = [
+    GetEventsEventType.UPLOAD,
+    GetEventsEventType.EDIT,
+    GetEventsEventType.COPY,
+    GetEventsEventType.MOVE,
+    GetEventsEventType.RENAME,
+    GetEventsEventType.UNDELETE,
+]
 BOX_GROUP_ID_PREFIX = "box-group"
 BOX_ALL_ENTERPRISE_USERS_GROUP_PREFIX = "box-enterprise-all-users"
 
@@ -594,7 +622,14 @@ class BoxConnector(
                 checkpoint.has_more = bool(checkpoint.todo)
                 return checkpoint
 
-        yield HierarchyNode(
+        yield self._folder_hierarchy_node(entry)
+        checkpoint.current = entry
+        checkpoint.current_marker = None
+        checkpoint.has_more = True
+        return checkpoint
+
+    def _folder_hierarchy_node(self, entry: BoxFolderFrontierEntry) -> HierarchyNode:
+        return HierarchyNode(
             raw_node_id=entry.folder_id,
             raw_parent_id=entry.parent_folder_id,
             display_name=entry.display_name,
@@ -602,10 +637,6 @@ class BoxConnector(
             node_type=HierarchyNodeType.FOLDER,
             external_access=entry.access,
         )
-        checkpoint.current = entry
-        checkpoint.current_marker = None
-        checkpoint.has_more = True
-        return checkpoint
 
     def _load_one_page(
         self,
@@ -619,16 +650,65 @@ class BoxConnector(
         None,
         BoxConnectorCheckpoint,
     ]:
-        """Advances the BFS crawl by one unit: seed the frontier on the first
-        cycle, start the next folder, or read one page of the current folder's
-        items."""
+        """Advances the traversal by one unit. On the first cycle it picks a
+        mode (FULL crawl vs incremental EVENTS) and seeds it; thereafter it
+        dispatches one page of work to the chosen mode."""
         checkpoint = deepcopy(checkpoint)
 
-        if checkpoint.todo is None:
-            checkpoint.todo = self._seed_frontier(include_permissions)
+        if checkpoint.mode is None:
+            # Use the incremental events stream only for a steady-state,
+            # short-window poll of a whole-enterprise connector. Everything else
+            # crawls the tree: slim (pruning / perm-sync must enumerate the
+            # whole corpus), folder-scoped connectors (events can't scope to a
+            # subtree), and the first index / long gaps (window > the
+            # reconciliation cadence) which also serve as a full reconciliation.
+            window = end - start if start is not None and end is not None else None
+            use_events = (
+                not slim
+                and self.entry_folder_ids == [BOX_ROOT_FOLDER_ID]
+                and window is not None
+                and 0 < window <= _EVENTS_MAX_WINDOW_SECONDS
+            )
+            checkpoint.mode = (
+                BoxTraversalMode.EVENTS if use_events else BoxTraversalMode.FULL
+            )
+            if checkpoint.mode == BoxTraversalMode.FULL:
+                checkpoint.todo = self._seed_frontier(include_permissions)
             checkpoint.has_more = True
             return checkpoint
 
+        if checkpoint.mode == BoxTraversalMode.EVENTS:
+            if start is None or end is None:
+                # EVENTS is only selected for a bounded window (see the decision
+                # above); if that ever fails to hold, fall back to a full crawl.
+                checkpoint.mode = BoxTraversalMode.FULL
+                checkpoint.todo = self._seed_frontier(include_permissions)
+                checkpoint.has_more = True
+                return checkpoint
+            new_checkpoint = yield from self._advance_events(
+                checkpoint, start, end, include_permissions
+            )
+            return new_checkpoint
+
+        new_checkpoint = yield from self._advance_full(
+            checkpoint, start, end, include_permissions, slim
+        )
+        return new_checkpoint
+
+    def _advance_full(
+        self,
+        checkpoint: BoxConnectorCheckpoint,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,
+        include_permissions: bool,
+        slim: bool,
+    ) -> Generator[
+        Document | SlimDocument | HierarchyNode | ConnectorFailure,
+        None,
+        BoxConnectorCheckpoint,
+    ]:
+        """One unit of the BFS crawl: start the next folder, or read one page
+        of the current folder's items."""
         if checkpoint.current is None:
             return (
                 yield from self._pick_current_from_todos(
@@ -703,6 +783,136 @@ class BoxConnector(
             checkpoint.current = None
             checkpoint.current_marker = None
         checkpoint.has_more = checkpoint.current is not None or bool(checkpoint.todo)
+        return checkpoint
+
+    def _folder_entry_for_file(
+        self, file: FileFull, include_permissions: bool
+    ) -> BoxFolderFrontierEntry | None:
+        """Build the parent-folder frontier entry for a file discovered via the
+        events stream (no BFS context available). Resolves the folder's full
+        inherited access from the file's path_collection when perm-syncing."""
+        if file.parent is None:
+            return None
+        path_entries = (
+            file.path_collection.entries if file.path_collection else None
+        ) or []
+        # path_collection is root..immediate-parent; the grandparent is the
+        # entry just before the immediate parent.
+        non_root = [e for e in path_entries if e.id != BOX_ROOT_FOLDER_ID]
+        grandparent_id = non_root[-2].id if len(non_root) >= 2 else None
+        path = "/".join(e.name or e.id for e in non_root) or (
+            file.parent.name or file.parent.id
+        )
+        access = (
+            resolve_box_ancestor_access(
+                self.content_client, path_entries, self.enterprise_id
+            )
+            if include_permissions
+            else None
+        )
+        return BoxFolderFrontierEntry(
+            folder_id=file.parent.id,
+            display_name=file.parent.name or file.parent.id,
+            parent_folder_id=grandparent_id,
+            path=path,
+            access=access,
+        )
+
+    def _advance_events(
+        self,
+        checkpoint: BoxConnectorCheckpoint,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        include_permissions: bool,
+    ) -> Generator[
+        Document | HierarchyNode | ConnectorFailure, None, BoxConnectorCheckpoint
+    ]:
+        """One page of the enterprise events stream: fetch changed files and
+        yield their re-indexed documents (+ parent folder nodes). Deletes are
+        left to the slim-based pruning job."""
+        # The framework already overlaps successive poll windows by
+        # POLL_CONNECTOR_OFFSET (30 min), which covers Box's normal admin_logs
+        # ingestion lag, so `start` needs no extra buffer here.
+        created_after = datetime.fromtimestamp(start, tz=timezone.utc)
+        created_before = datetime.fromtimestamp(end, tz=timezone.utc)
+        try:
+            events = self.enterprise_client.events.get_events(
+                stream_type=GetEventsStreamType.ADMIN_LOGS,
+                event_type=_CONTENT_CHANGE_EVENT_TYPES,
+                created_after=created_after,
+                created_before=created_before,
+                stream_position=checkpoint.event_stream_position,
+                limit=_BOX_EVENTS_PAGE_SIZE,
+            )
+        except BoxAPIError as e:
+            # Events need the admin/enterprise scope and can hit transient
+            # issues. Rather than silently index nothing, fall back to a full
+            # crawl for this run (mirrors SharePoint's 410 -> full-resync).
+            logger.warning(
+                "Box events fetch failed (status=%s); falling back to a full "
+                "crawl for this run.",
+                box_api_status_code(e),
+            )
+            checkpoint.mode = BoxTraversalMode.FULL
+            checkpoint.todo = self._seed_frontier(include_permissions)
+            checkpoint.event_stream_position = None
+            checkpoint.has_more = True
+            return checkpoint
+
+        entries = events.entries or []
+        for event in entries:
+            source = event.source
+            if not isinstance(source, File):
+                continue  # only file content changes; folder/user events ignored
+            file_id = source.id
+            if file_id in checkpoint.event_seen_file_ids:
+                continue
+            checkpoint.event_seen_file_ids.add(file_id)
+
+            try:
+                file = self.content_client.files.get_file_by_id(
+                    file_id, fields=_FILE_FETCH_FIELDS
+                )
+            except BoxAPIError as e:
+                status = box_api_status_code(e)
+                if status in (403, 404):
+                    # Not visible to the indexing user, or already gone; a
+                    # deletion is reconciled by pruning.
+                    continue
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=box_file_document_id(file_id),
+                        document_link=box_file_link(file_id),
+                    ),
+                    failure_message=(
+                        f"Failed to fetch changed Box file {file_id} "
+                        f"(status={status}): {e.message}"
+                    ),
+                    exception=e,
+                )
+                continue
+
+            entry = self._folder_entry_for_file(file, include_permissions)
+            if entry is None:
+                continue
+            if entry.folder_id not in checkpoint.seen_folder_ids:
+                checkpoint.seen_folder_ids.add(entry.folder_id)
+                yield self._folder_hierarchy_node(entry)
+            converted = self._convert_file(file, entry, include_permissions)
+            if converted is not None:
+                yield converted
+
+        next_position = events.next_stream_position
+        next_str = str(next_position) if next_position is not None else None
+        if (
+            not entries
+            or next_str is None
+            or next_str == checkpoint.event_stream_position
+        ):
+            checkpoint.has_more = False
+        else:
+            checkpoint.event_stream_position = next_str
+            checkpoint.has_more = True
         return checkpoint
 
     def _load_from_checkpoint(

--- a/backend/onyx/connectors/box/connector.py
+++ b/backend/onyx/connectors/box/connector.py
@@ -9,7 +9,7 @@ from urllib.parse import urlparse
 from box_sdk_gen import BoxCCGAuth, BoxClient, CCGConfig
 from box_sdk_gen.box.errors import BoxAPIError
 from box_sdk_gen.managers.events import GetEventsEventType, GetEventsStreamType
-from box_sdk_gen.schemas.file import File
+from box_sdk_gen.schemas.event_source import EventSource, EventSourceItemTypeField
 from box_sdk_gen.schemas.file_full import FileFull
 from box_sdk_gen.schemas.folder_mini import FolderMini
 from box_sdk_gen.schemas.user_full import UserFull
@@ -101,6 +101,10 @@ _FILE_FETCH_FIELDS = _ITEM_FIELDS + ["parent", "path_collection"]
 
 # --- Incremental (events) tuning ---
 _BOX_EVENTS_PAGE_SIZE = 500
+# Box warns that querying admin_logs near real time can miss events that arrive
+# after the requested time window. Delay each window beyond Box's documented
+# reporting latency while preserving the framework's normal overlap.
+_BOX_EVENTS_LAG_SECONDS = 24 * 60 * 60
 # Poll windows at or below this use the enterprise events stream; wider windows
 # (first index, long gaps) fall back to a full crawl. This threshold doubles as
 # the reconciliation cadence: a connector idle longer than this re-crawls fully.
@@ -116,6 +120,7 @@ _CONTENT_CHANGE_EVENT_TYPES = [
     GetEventsEventType.MOVE,
     GetEventsEventType.RENAME,
     GetEventsEventType.UNDELETE,
+    GetEventsEventType.FILE_VERSION_RESTORE,
 ]
 BOX_GROUP_ID_PREFIX = "box-group"
 BOX_ALL_ENTERPRISE_USERS_GROUP_PREFIX = "box-enterprise-all-users"
@@ -665,6 +670,7 @@ class BoxConnector(
             window = end - start if start is not None and end is not None else None
             use_events = (
                 not slim
+                and not self.include_web_links
                 and self.entry_folder_ids == [BOX_ROOT_FOLDER_ID]
                 and window is not None
                 and 0 < window <= _EVENTS_MAX_WINDOW_SECONDS
@@ -681,17 +687,16 @@ class BoxConnector(
             if start is None or end is None:
                 # EVENTS is only selected for a bounded window (see the decision
                 # above); if that ever fails to hold, fall back to a full crawl.
-                checkpoint.mode = BoxTraversalMode.FULL
-                checkpoint.todo = self._seed_frontier(include_permissions)
-                checkpoint.has_more = True
-                return checkpoint
+                return self._switch_to_full_crawl(checkpoint, include_permissions)
             new_checkpoint = yield from self._advance_events(
                 checkpoint, start, end, include_permissions
             )
             return new_checkpoint
 
+        full_start = None if checkpoint.full_reconciliation else start
+        full_end = None if checkpoint.full_reconciliation else end
         new_checkpoint = yield from self._advance_full(
-            checkpoint, start, end, include_permissions, slim
+            checkpoint, full_start, full_end, include_permissions, slim
         )
         return new_checkpoint
 
@@ -785,38 +790,58 @@ class BoxConnector(
         checkpoint.has_more = checkpoint.current is not None or bool(checkpoint.todo)
         return checkpoint
 
-    def _folder_entry_for_file(
+    def _folder_entries_for_file(
         self, file: FileFull, include_permissions: bool
-    ) -> BoxFolderFrontierEntry | None:
-        """Build the parent-folder frontier entry for a file discovered via the
-        events stream (no BFS context available). Resolves the folder's full
-        inherited access from the file's path_collection when perm-syncing."""
+    ) -> list[BoxFolderFrontierEntry]:
+        """Build the full root-to-parent hierarchy for an event-sourced file."""
         if file.parent is None:
-            return None
-        path_entries = (
-            file.path_collection.entries if file.path_collection else None
-        ) or []
-        # path_collection is root..immediate-parent; the grandparent is the
-        # entry just before the immediate parent.
-        non_root = [e for e in path_entries if e.id != BOX_ROOT_FOLDER_ID]
-        grandparent_id = non_root[-2].id if len(non_root) >= 2 else None
-        path = "/".join(e.name or e.id for e in non_root) or (
-            file.parent.name or file.parent.id
+            return []
+        path_entries = list(
+            (file.path_collection.entries if file.path_collection else None) or []
         )
-        access = (
-            resolve_box_ancestor_access(
-                self.content_client, path_entries, self.enterprise_id
+        if not path_entries or path_entries[-1].id != file.parent.id:
+            path_entries.append(file.parent)
+
+        folder_entries: list[BoxFolderFrontierEntry] = []
+        for index, path_entry in enumerate(path_entries):
+            entries_through_folder = path_entries[: index + 1]
+            access = (
+                resolve_box_ancestor_access(
+                    self.content_client, entries_through_folder, self.enterprise_id
+                )
+                if include_permissions
+                else None
             )
-            if include_permissions
-            else None
-        )
-        return BoxFolderFrontierEntry(
-            folder_id=file.parent.id,
-            display_name=file.parent.name or file.parent.id,
-            parent_folder_id=grandparent_id,
-            path=path,
-            access=access,
-        )
+            folder_entries.append(
+                BoxFolderFrontierEntry(
+                    folder_id=path_entry.id,
+                    display_name=path_entry.name or path_entry.id,
+                    parent_folder_id=(
+                        path_entries[index - 1].id if index > 0 else None
+                    ),
+                    path="/".join(
+                        entry.name or entry.id for entry in entries_through_folder
+                    ),
+                    access=access,
+                )
+            )
+        return folder_entries
+
+    def _switch_to_full_crawl(
+        self,
+        checkpoint: BoxConnectorCheckpoint,
+        include_permissions: bool,
+    ) -> BoxConnectorCheckpoint:
+        checkpoint.mode = BoxTraversalMode.FULL
+        checkpoint.todo = self._seed_frontier(include_permissions)
+        checkpoint.current = None
+        checkpoint.current_marker = None
+        checkpoint.seen_folder_ids = set()
+        checkpoint.full_reconciliation = True
+        checkpoint.event_stream_position = None
+        checkpoint.event_seen_file_ids = set()
+        checkpoint.has_more = True
+        return checkpoint
 
     def _advance_events(
         self,
@@ -830,11 +855,12 @@ class BoxConnector(
         """One page of the enterprise events stream: fetch changed files and
         yield their re-indexed documents (+ parent folder nodes). Deletes are
         left to the slim-based pruning job."""
-        # The framework already overlaps successive poll windows by
-        # POLL_CONNECTOR_OFFSET (30 min), which covers Box's normal admin_logs
-        # ingestion lag, so `start` needs no extra buffer here.
-        created_after = datetime.fromtimestamp(start, tz=timezone.utc)
-        created_before = datetime.fromtimestamp(end, tz=timezone.utc)
+        created_after = datetime.fromtimestamp(
+            max(0, start - _BOX_EVENTS_LAG_SECONDS), tz=timezone.utc
+        )
+        created_before = datetime.fromtimestamp(
+            max(0, end - _BOX_EVENTS_LAG_SECONDS), tz=timezone.utc
+        )
         try:
             events = self.enterprise_client.events.get_events(
                 stream_type=GetEventsStreamType.ADMIN_LOGS,
@@ -853,18 +879,21 @@ class BoxConnector(
                 "crawl for this run.",
                 box_api_status_code(e),
             )
-            checkpoint.mode = BoxTraversalMode.FULL
-            checkpoint.todo = self._seed_frontier(include_permissions)
-            checkpoint.event_stream_position = None
-            checkpoint.has_more = True
-            return checkpoint
+            return self._switch_to_full_crawl(checkpoint, include_permissions)
 
         entries = events.entries or []
         for event in entries:
             source = event.source
-            if not isinstance(source, File):
-                continue  # only file content changes; folder/user events ignored
-            file_id = source.id
+            if not isinstance(source, EventSource):
+                continue
+            if source.item_type == EventSourceItemTypeField.FOLDER:
+                # A folder move/rename changes every descendant's path and
+                # hierarchy. Reconcile the whole tree rather than leaving stale
+                # descendants until a later maintenance operation.
+                return self._switch_to_full_crawl(checkpoint, include_permissions)
+            if source.item_type != EventSourceItemTypeField.FILE:
+                continue
+            file_id = source.item_id
             if file_id in checkpoint.event_seen_file_ids:
                 continue
             checkpoint.event_seen_file_ids.add(file_id)
@@ -892,13 +921,17 @@ class BoxConnector(
                 )
                 continue
 
-            entry = self._folder_entry_for_file(file, include_permissions)
-            if entry is None:
+            folder_entries = self._folder_entries_for_file(file, include_permissions)
+            if not folder_entries:
                 continue
-            if entry.folder_id not in checkpoint.seen_folder_ids:
-                checkpoint.seen_folder_ids.add(entry.folder_id)
-                yield self._folder_hierarchy_node(entry)
-            converted = self._convert_file(file, entry, include_permissions)
+            for folder_entry in folder_entries:
+                if folder_entry.folder_id in checkpoint.seen_folder_ids:
+                    continue
+                checkpoint.seen_folder_ids.add(folder_entry.folder_id)
+                yield self._folder_hierarchy_node(folder_entry)
+            converted = self._convert_file(
+                file, folder_entries[-1], include_permissions
+            )
             if converted is not None:
                 yield converted
 

--- a/backend/onyx/connectors/box/models.py
+++ b/backend/onyx/connectors/box/models.py
@@ -1,7 +1,19 @@
+from enum import Enum
+
 from pydantic import BaseModel, Field
 
 from onyx.access.models import ExternalAccess
 from onyx.connectors.models import ConnectorCheckpoint
+
+
+class BoxTraversalMode(str, Enum):
+    # Full BFS over the folder tree. Used for the first index, for pruning /
+    # permission-sync slim retrieval, for folder-scoped connectors, and as the
+    # reconciliation / fallback path.
+    FULL = "full"
+    # Incremental via the Box enterprise events stream. Used for steady-state
+    # short-window polls of a whole-enterprise connector.
+    EVENTS = "events"
 
 
 class BoxFolderFrontierEntry(BaseModel):
@@ -16,12 +28,25 @@ class BoxFolderFrontierEntry(BaseModel):
 
 
 class BoxConnectorCheckpoint(ConnectorCheckpoint):
-    # BFS frontier of folders left to process. None means the traversal has not
-    # been seeded from the configured entry folders yet.
-    todo: list[BoxFolderFrontierEntry] | None = None
+    # Chosen on the first cycle. None until then.
+    mode: BoxTraversalMode | None = None
+
+    # --- FULL (BFS) state ---
+    # BFS frontier of folders left to process (empty until seeded; `mode` marks
+    # whether the traversal has been decided/seeded yet).
+    todo: list[BoxFolderFrontierEntry] = Field(default_factory=list)
     # Folder currently being paginated, with its opaque Box page marker.
     current: BoxFolderFrontierEntry | None = None
     current_marker: str | None = None
     # Folder IDs already processed, so overlapping/duplicate entry roots (e.g.
     # a folder and one of its ancestors both configured) don't double-index.
+    # Also used in EVENTS mode to yield each changed file's parent folder node
+    # at most once.
     seen_folder_ids: set[str] = Field(default_factory=set)
+
+    # --- EVENTS (incremental) state ---
+    # Pagination cursor within the events window (Box's next_stream_position).
+    event_stream_position: str | None = None
+    # File IDs already handled this run, to dedup a file that appears in
+    # multiple events within the window.
+    event_seen_file_ids: set[str] = Field(default_factory=set)

--- a/backend/onyx/connectors/box/models.py
+++ b/backend/onyx/connectors/box/models.py
@@ -35,6 +35,9 @@ class BoxConnectorCheckpoint(ConnectorCheckpoint):
     # BFS frontier of folders left to process (empty until seeded; `mode` marks
     # whether the traversal has been decided/seeded yet).
     todo: list[BoxFolderFrontierEntry] = Field(default_factory=list)
+    # Events fallbacks must ignore the current poll window so folder changes and
+    # other missed events reconcile every document in the tree.
+    full_reconciliation: bool = False
     # Folder currently being paginated, with its opaque Box page marker.
     current: BoxFolderFrontierEntry | None = None
     current_marker: str | None = None

--- a/backend/tests/daily/connectors/box/README.md
+++ b/backend/tests/daily/connectors/box/README.md
@@ -7,6 +7,30 @@ defined below — names and file contents must match character-for-character.
 The unit tests under `backend/tests/unit/onyx/connectors/box/` need none of
 this; they run fully offline.
 
+## Incremental indexing (how the connector polls)
+
+Box's folder-listing API (`GET /folders/:id/items`) has no server-side
+modified-time filter, so a naive poll would re-list the entire corpus every
+run. The connector avoids that:
+
+- **First index, folder-scoped connectors, pruning, and permission sync** do a
+  full BFS crawl of the folder tree.
+- **Steady-state whole-enterprise polls** (poll window ≤ 7 days) instead consume
+  the Box enterprise **events stream** (`GET /events?stream_type=admin_logs`,
+  filtered to content-change event types) and re-index only the files that
+  actually changed — no full tree walk. This mirrors SharePoint's Graph-delta
+  approach.
+- A window wider than 7 days (e.g. a long outage) falls back to a full crawl,
+  which doubles as periodic reconciliation. If the events API errors (e.g.
+  missing admin scope) the run falls back to a full crawl rather than indexing
+  nothing.
+- Deletions are reconciled by the slim-based pruning job, not the events path
+  (the events path only re-indexes changed/added files).
+
+There is no daily test for the events path — admin-log ingestion lag makes a
+synchronous live assertion flaky — but it's covered comprehensively offline in
+`backend/tests/unit/onyx/connectors/box/test_box_events.py`.
+
 ## 1. Create a Box developer account
 
 Sign up at <https://developer.box.com> (free). This provisions a sandbox

--- a/backend/tests/daily/connectors/box/README.md
+++ b/backend/tests/daily/connectors/box/README.md
@@ -18,12 +18,16 @@ run. The connector avoids that:
 - **Steady-state whole-enterprise polls** (poll window ≤ 7 days) instead consume
   the Box enterprise **events stream** (`GET /events?stream_type=admin_logs`,
   filtered to content-change event types) and re-index only the files that
-  actually changed — no full tree walk. This mirrors SharePoint's Graph-delta
-  approach.
+  actually changed. The queried window is delayed by 24 hours because Box warns
+  that historical admin-log events can arrive after a near-real-time filter
+  window has already been read.
 - A window wider than 7 days (e.g. a long outage) falls back to a full crawl,
   which doubles as periodic reconciliation. If the events API errors (e.g.
   missing admin scope) the run falls back to a full crawl rather than indexing
-  nothing.
+  nothing. Folder move/rename events also trigger a full crawl because they can
+  change the paths of every descendant.
+- Connectors that index Box web links always use full crawls because enterprise
+  event sources only identify files and folders.
 - Deletions are reconciled by the slim-based pruning job, not the events path
   (the events path only re-indexes changed/added files).
 

--- a/backend/tests/unit/onyx/connectors/box/fake_box_client.py
+++ b/backend/tests/unit/onyx/connectors/box/fake_box_client.py
@@ -7,6 +7,10 @@ from io import BytesIO
 from box_sdk_gen.box.errors import BoxAPIError, RequestInfo, ResponseInfo
 from box_sdk_gen.schemas.collaboration import Collaboration
 from box_sdk_gen.schemas.collaborations import Collaborations
+from box_sdk_gen.schemas.event import Event
+from box_sdk_gen.schemas.events import Events
+from box_sdk_gen.schemas.file import File
+from box_sdk_gen.schemas.file_full import FileFull
 from box_sdk_gen.schemas.folder_full import FolderFull
 from box_sdk_gen.schemas.group_full import GroupFull
 from box_sdk_gen.schemas.group_membership import GroupMembership
@@ -16,6 +20,12 @@ from box_sdk_gen.schemas.items import Items
 from box_sdk_gen.schemas.user_full import UserFull
 from box_sdk_gen.schemas.user_mini import UserMini
 from box_sdk_gen.schemas.users import Users
+
+
+def make_events_page(file_ids: list[str], next_stream_position: str | None) -> Events:
+    """Build one events page whose entries are file-source content events."""
+    entries = [Event(source=File(id=file_id)) for file_id in file_ids]
+    return Events(entries=entries, next_stream_position=next_stream_position)
 
 
 def make_box_api_error(status_code: int) -> BoxAPIError:
@@ -80,6 +90,54 @@ class FakeDownloadsManager:
         if file_id not in self._file_contents:
             raise make_box_api_error(404)
         return BytesIO(self._file_contents[file_id])
+
+
+class FakeFilesManager:
+    def __init__(
+        self, files_by_id: dict[str, FileFull], fail_status_by_id: dict[str, int]
+    ) -> None:
+        self._files_by_id = files_by_id
+        self._fail_status_by_id = fail_status_by_id
+        self.fetch_calls: list[str] = []
+
+    def get_file_by_id(
+        self,
+        file_id: str,
+        *,
+        fields: list[str] | None = None,  # noqa: ARG002
+    ) -> FileFull:
+        self.fetch_calls.append(file_id)
+        if file_id in self._fail_status_by_id:
+            raise make_box_api_error(self._fail_status_by_id[file_id])
+        if file_id not in self._files_by_id:
+            raise make_box_api_error(404)
+        return self._files_by_id[file_id]
+
+
+class FakeEventsManager:
+    def __init__(self, event_pages: list[Events], fail_status: int | None) -> None:
+        # each call returns the next page in order
+        self._event_pages = event_pages
+        self._fail_status = fail_status
+        self.calls: list[str | None] = []
+
+    def get_events(
+        self,
+        *,
+        stream_type: object = None,  # noqa: ARG002
+        event_type: object = None,  # noqa: ARG002
+        created_after: object = None,  # noqa: ARG002
+        created_before: object = None,  # noqa: ARG002
+        stream_position: str | None = None,
+        limit: int | None = None,  # noqa: ARG002
+    ) -> Events:
+        self.calls.append(stream_position)
+        if self._fail_status is not None:
+            raise make_box_api_error(self._fail_status)
+        index = len(self.calls) - 1
+        if index < len(self._event_pages):
+            return self._event_pages[index]
+        return Events(entries=[], next_stream_position=stream_position)
 
 
 class FakeListCollaborationsManager:
@@ -221,6 +279,10 @@ class FakeBoxClient:
         groups: list[GroupFull] | None = None,
         members_by_group: dict[str, list[UserMini]] | None = None,
         membership_fail_status_by_group: dict[str, int] | None = None,
+        files_by_id: dict[str, FileFull] | None = None,
+        file_fetch_fail_status_by_id: dict[str, int] | None = None,
+        event_pages: list[Events] | None = None,
+        events_fail_status: int | None = None,
         # small page so pagination loops run without thousands of fake entries
         page_size: int = 2,
     ) -> None:
@@ -228,6 +290,9 @@ class FakeBoxClient:
             folders_by_id, pages, fail_listing_folder_ids or set()
         )
         self.downloads = FakeDownloadsManager(file_contents or {})
+        self.files = FakeFilesManager(
+            files_by_id or {}, file_fetch_fail_status_by_id or {}
+        )
         self.list_collaborations = FakeListCollaborationsManager(
             folder_collaborations or {}, file_collaborations or {}
         )
@@ -238,3 +303,4 @@ class FakeBoxClient:
         self.memberships = FakeMembershipsManager(
             members_by_group or {}, page_size, membership_fail_status_by_group or {}
         )
+        self.events = FakeEventsManager(event_pages or [], events_fail_status)

--- a/backend/tests/unit/onyx/connectors/box/fake_box_client.py
+++ b/backend/tests/unit/onyx/connectors/box/fake_box_client.py
@@ -2,14 +2,16 @@
 Box connector touches. Backed by real box_sdk_gen schema objects so the
 connector exercises the same attribute access paths as against the live API."""
 
+from datetime import datetime
 from io import BytesIO
 
 from box_sdk_gen.box.errors import BoxAPIError, RequestInfo, ResponseInfo
+from box_sdk_gen.managers.events import GetEventsEventType
 from box_sdk_gen.schemas.collaboration import Collaboration
 from box_sdk_gen.schemas.collaborations import Collaborations
 from box_sdk_gen.schemas.event import Event
+from box_sdk_gen.schemas.event_source import EventSource, EventSourceItemTypeField
 from box_sdk_gen.schemas.events import Events
-from box_sdk_gen.schemas.file import File
 from box_sdk_gen.schemas.file_full import FileFull
 from box_sdk_gen.schemas.folder_full import FolderFull
 from box_sdk_gen.schemas.group_full import GroupFull
@@ -23,9 +25,35 @@ from box_sdk_gen.schemas.users import Users
 
 
 def make_events_page(file_ids: list[str], next_stream_position: str | None) -> Events:
-    """Build one events page whose entries are file-source content events."""
-    entries = [Event(source=File(id=file_id)) for file_id in file_ids]
+    """Build enterprise events with the EventSource shape returned by Box."""
+    entries = [
+        Event(
+            source=EventSource(
+                item_type=EventSourceItemTypeField.FILE,
+                item_id=file_id,
+                item_name=f"file-{file_id}",
+            )
+        )
+        for file_id in file_ids
+    ]
     return Events(entries=entries, next_stream_position=next_stream_position)
+
+
+def make_folder_event_page(
+    folder_id: str, next_stream_position: str | None = None
+) -> Events:
+    return Events(
+        entries=[
+            Event(
+                source=EventSource(
+                    item_type=EventSourceItemTypeField.FOLDER,
+                    item_id=folder_id,
+                    item_name=f"folder-{folder_id}",
+                )
+            )
+        ],
+        next_stream_position=next_stream_position,
+    )
 
 
 def make_box_api_error(status_code: int) -> BoxAPIError:
@@ -115,26 +143,35 @@ class FakeFilesManager:
 
 
 class FakeEventsManager:
-    def __init__(self, event_pages: list[Events], fail_status: int | None) -> None:
+    def __init__(
+        self,
+        event_pages: list[Events],
+        fail_status_by_call: dict[int, int],
+    ) -> None:
         # each call returns the next page in order
         self._event_pages = event_pages
-        self._fail_status = fail_status
+        self._fail_status_by_call = fail_status_by_call
         self.calls: list[str | None] = []
+        self.created_windows: list[tuple[datetime | None, datetime | None]] = []
+        self.event_types: list[list[GetEventsEventType] | None] = []
 
     def get_events(
         self,
         *,
         stream_type: object = None,  # noqa: ARG002
-        event_type: object = None,  # noqa: ARG002
-        created_after: object = None,  # noqa: ARG002
-        created_before: object = None,  # noqa: ARG002
+        event_type: list[GetEventsEventType] | None = None,
+        created_after: datetime | None = None,
+        created_before: datetime | None = None,
         stream_position: str | None = None,
         limit: int | None = None,  # noqa: ARG002
     ) -> Events:
         self.calls.append(stream_position)
-        if self._fail_status is not None:
-            raise make_box_api_error(self._fail_status)
-        index = len(self.calls) - 1
+        self.created_windows.append((created_after, created_before))
+        self.event_types.append(event_type)
+        call_number = len(self.calls)
+        if call_number in self._fail_status_by_call:
+            raise make_box_api_error(self._fail_status_by_call[call_number])
+        index = call_number - 1
         if index < len(self._event_pages):
             return self._event_pages[index]
         return Events(entries=[], next_stream_position=stream_position)
@@ -283,6 +320,7 @@ class FakeBoxClient:
         file_fetch_fail_status_by_id: dict[str, int] | None = None,
         event_pages: list[Events] | None = None,
         events_fail_status: int | None = None,
+        events_fail_status_by_call: dict[int, int] | None = None,
         # small page so pagination loops run without thousands of fake entries
         page_size: int = 2,
     ) -> None:
@@ -303,4 +341,7 @@ class FakeBoxClient:
         self.memberships = FakeMembershipsManager(
             members_by_group or {}, page_size, membership_fail_status_by_group or {}
         )
-        self.events = FakeEventsManager(event_pages or [], events_fail_status)
+        fail_status_by_call = dict(events_fail_status_by_call or {})
+        if events_fail_status is not None:
+            fail_status_by_call[1] = events_fail_status
+        self.events = FakeEventsManager(event_pages or [], fail_status_by_call)

--- a/backend/tests/unit/onyx/connectors/box/test_box_events.py
+++ b/backend/tests/unit/onyx/connectors/box/test_box_events.py
@@ -1,0 +1,258 @@
+"""Unit tests for the incremental (events-based) index path.
+
+Steady-state short-window polls of a whole-enterprise connector should consume
+the Box enterprise events stream instead of re-crawling the whole folder tree,
+fetching only the files that actually changed.
+"""
+
+from datetime import datetime, timezone
+from typing import cast
+
+from box_sdk_gen import BoxClient
+from box_sdk_gen.schemas.file import FilePathCollectionField
+from box_sdk_gen.schemas.file_full import FileFull
+from box_sdk_gen.schemas.folder_full import FolderFull
+from box_sdk_gen.schemas.folder_mini import FolderMini
+from box_sdk_gen.schemas.items import Items
+from box_sdk_gen.schemas.user_mini import UserMini
+
+from onyx.connectors.box.connector import BoxConnector
+from onyx.connectors.box.models import BoxTraversalMode
+from onyx.connectors.models import (
+    ConnectorFailure,
+    Document,
+    HierarchyNode,
+    TextSection,
+)
+from tests.unit.onyx.connectors.box.fake_box_client import (
+    FakeBoxClient,
+    make_events_page,
+)
+
+_OWNER = UserMini(id="u1", name="Alice", login="alice@example.com")
+_MODIFIED = datetime(2024, 6, 1, tzinfo=timezone.utc)
+
+# steady-state hourly poll window (well under the 7-day events threshold)
+_NOW = datetime(2024, 6, 2, tzinfo=timezone.utc).timestamp()
+_HOUR_AGO = _NOW - 3600
+
+
+def _file_with_parent(file_id: str, name: str) -> FileFull:
+    """A file living under folder 200 ('Sub'), itself under root."""
+    return FileFull(
+        id=file_id,
+        name=name,
+        size=10,
+        modified_at=_MODIFIED,
+        created_at=_MODIFIED,
+        owned_by=_OWNER,
+        parent=FolderMini(id="200", name="Sub"),
+        path_collection=FilePathCollectionField(
+            total_count=2,
+            entries=[
+                FolderMini(id="0", name="All Files"),
+                FolderMini(id="200", name="Sub"),
+            ],
+        ),
+    )
+
+
+def _make_events_connector(
+    event_pages: list,
+    files_by_id: dict[str, FileFull],
+    file_contents: dict[str, bytes],
+    file_fetch_fail_status_by_id: dict[str, int] | None = None,
+    events_fail_status: int | None = None,
+) -> tuple[BoxConnector, FakeBoxClient]:
+    fake = FakeBoxClient(
+        folders_by_id={
+            "0": FolderFull(id="0", name="All Files"),
+            "200": FolderFull(id="200", name="Sub"),
+        },
+        # pages present so a full-crawl fallback can still run
+        pages={
+            ("0", None): Items(
+                entries=[FolderMini(id="200", name="Sub")], next_marker=None
+            ),
+            ("200", None): Items(entries=[], next_marker=None),
+        },
+        file_contents=file_contents,
+        files_by_id=files_by_id,
+        file_fetch_fail_status_by_id=file_fetch_fail_status_by_id,
+        event_pages=event_pages,
+        events_fail_status=events_fail_status,
+    )
+    connector = BoxConnector()  # whole-enterprise (root)
+    connector._content_client = cast(BoxClient, fake)
+    connector._enterprise_client = cast(BoxClient, fake)
+    return connector, fake
+
+
+def _run(
+    connector: BoxConnector,
+    start: float,
+    end: float,
+) -> tuple[list[Document | HierarchyNode | ConnectorFailure], BoxTraversalMode | None]:
+    checkpoint = connector.build_dummy_checkpoint()
+    outputs: list[Document | HierarchyNode | ConnectorFailure] = []
+    mode = None
+    iterations = 0
+    while checkpoint.has_more:
+        iterations += 1
+        assert iterations < 100
+        generator = connector.load_from_checkpoint(start, end, checkpoint)
+        while True:
+            try:
+                outputs.append(next(generator))
+            except StopIteration as e:
+                checkpoint = connector.validate_checkpoint_json(
+                    e.value.model_dump_json()
+                )
+                mode = checkpoint.mode
+                break
+    return outputs, mode
+
+
+def test_events_path_indexes_only_changed_files() -> None:
+    connector, fake = _make_events_connector(
+        event_pages=[make_events_page(["1", "2"], next_stream_position=None)],
+        files_by_id={
+            "1": _file_with_parent("1", "changed_a.txt"),
+            "2": _file_with_parent("2", "changed_b.txt"),
+        },
+        file_contents={"1": b"alpha", "2": b"bravo"},
+    )
+    outputs, mode = _run(connector, _HOUR_AGO, _NOW)
+
+    assert mode == BoxTraversalMode.EVENTS
+    docs = {d.id for d in outputs if isinstance(d, Document)}
+    assert docs == {"box-file-1", "box-file-2"}
+
+    # only the two changed files were fetched — NOT a full tree crawl
+    assert sorted(fake.files.fetch_calls) == ["1", "2"]
+    # the connector listed no folders in events mode
+    assert fake.folders.listing_calls == []
+
+    # the changed file's parent folder is still surfaced as a hierarchy node
+    node_ids = {n.raw_node_id for n in outputs if isinstance(n, HierarchyNode)}
+    assert node_ids == {"200"}
+
+    doc1 = next(d for d in outputs if isinstance(d, Document) and d.id == "box-file-1")
+    assert doc1.metadata["path"] == "Sub"
+    assert doc1.parent_hierarchy_raw_node_id == "200"
+    section = doc1.sections[0]
+    assert isinstance(section, TextSection)
+    assert section.text == "alpha"
+
+
+def test_events_path_paginates_and_dedups_repeated_files() -> None:
+    # file "1" appears on both pages (edited twice in the window); it must be
+    # fetched/indexed once.
+    connector, fake = _make_events_connector(
+        event_pages=[
+            make_events_page(["1", "2"], next_stream_position="pos1"),
+            make_events_page(["1", "3"], next_stream_position="pos2"),
+            make_events_page([], next_stream_position="pos2"),
+        ],
+        files_by_id={
+            "1": _file_with_parent("1", "a.txt"),
+            "2": _file_with_parent("2", "b.txt"),
+            "3": _file_with_parent("3", "c.txt"),
+        },
+        file_contents={"1": b"a", "2": b"b", "3": b"c"},
+    )
+    outputs, mode = _run(connector, _HOUR_AGO, _NOW)
+
+    assert mode == BoxTraversalMode.EVENTS
+    docs = [d.id for d in outputs if isinstance(d, Document)]
+    assert sorted(docs) == ["box-file-1", "box-file-2", "box-file-3"]
+    assert docs.count("box-file-1") == 1
+    assert fake.files.fetch_calls.count("1") == 1
+    # parent node 200 yielded once across the whole run
+    node_ids = [n.raw_node_id for n in outputs if isinstance(n, HierarchyNode)]
+    assert node_ids.count("200") == 1
+    # pagination advanced through the stream positions
+    assert fake.events.calls == [None, "pos1", "pos2"]
+
+
+def test_events_path_skips_inaccessible_or_deleted_files() -> None:
+    # 403 (not visible to indexing user) and 404 (already deleted) are skipped
+    # silently — pruning reconciles deletions.
+    connector, fake = _make_events_connector(
+        event_pages=[make_events_page(["1", "2", "3"], next_stream_position=None)],
+        files_by_id={"2": _file_with_parent("2", "ok.txt")},
+        file_contents={"2": b"ok"},
+        file_fetch_fail_status_by_id={"1": 403, "3": 404},
+    )
+    outputs, _ = _run(connector, _HOUR_AGO, _NOW)
+    docs = {d.id for d in outputs if isinstance(d, Document)}
+    failures = [o for o in outputs if isinstance(o, ConnectorFailure)]
+    assert docs == {"box-file-2"}
+    assert failures == []
+
+
+def test_events_path_surfaces_unexpected_fetch_error_as_failure() -> None:
+    connector, _ = _make_events_connector(
+        event_pages=[make_events_page(["1"], next_stream_position=None)],
+        files_by_id={},
+        file_contents={},
+        file_fetch_fail_status_by_id={"1": 500},
+    )
+    outputs, _ = _run(connector, _HOUR_AGO, _NOW)
+    failures = [o for o in outputs if isinstance(o, ConnectorFailure)]
+    assert len(failures) == 1
+    assert failures[0].failed_document is not None
+    assert failures[0].failed_document.document_id == "box-file-1"
+
+
+def test_events_fetch_failure_falls_back_to_full_crawl() -> None:
+    # if the events API itself errors (e.g. missing admin scope), the run must
+    # fall back to a full crawl rather than silently index nothing.
+    connector, fake = _make_events_connector(
+        event_pages=[],
+        files_by_id={},
+        file_contents={},
+        events_fail_status=403,
+    )
+    _, mode = _run(connector, _HOUR_AGO, _NOW)
+    assert mode == BoxTraversalMode.FULL
+    # the fallback actually crawled folders
+    assert fake.folders.listing_calls != []
+
+
+def test_wide_window_uses_full_crawl_not_events() -> None:
+    connector, fake = _make_events_connector(
+        event_pages=[make_events_page(["1"], next_stream_position=None)],
+        files_by_id={"1": _file_with_parent("1", "a.txt")},
+        file_contents={"1": b"a"},
+    )
+    # first index: start=0 -> window is years -> full crawl, events untouched
+    _, mode = _run(connector, 0, _NOW)
+    assert mode == BoxTraversalMode.FULL
+    assert fake.events.calls == []
+    assert fake.folders.listing_calls != []
+
+
+def test_folder_scoped_connector_uses_full_crawl_not_events() -> None:
+    connector, fake = _make_events_connector(
+        event_pages=[make_events_page(["1"], next_stream_position=None)],
+        files_by_id={"1": _file_with_parent("1", "a.txt")},
+        file_contents={"1": b"a"},
+    )
+    connector.entry_folder_ids = ["200"]  # scoped -> events can't scope to subtree
+    _, mode = _run(connector, _HOUR_AGO, _NOW)
+    assert mode == BoxTraversalMode.FULL
+    assert fake.events.calls == []
+
+
+def test_slim_retrieval_never_uses_events() -> None:
+    connector, fake = _make_events_connector(
+        event_pages=[make_events_page(["1"], next_stream_position=None)],
+        files_by_id={"1": _file_with_parent("1", "a.txt")},
+        file_contents={"1": b"a"},
+    )
+    # slim (pruning/perm-sync) must enumerate the whole corpus, never the delta
+    for _ in connector.retrieve_all_slim_docs(start=_HOUR_AGO, end=_NOW):
+        pass
+    assert fake.events.calls == []
+    assert fake.folders.listing_calls != []

--- a/backend/tests/unit/onyx/connectors/box/test_box_events.py
+++ b/backend/tests/unit/onyx/connectors/box/test_box_events.py
@@ -9,12 +9,15 @@ from datetime import datetime, timezone
 from typing import cast
 
 from box_sdk_gen import BoxClient
+from box_sdk_gen.managers.events import GetEventsEventType
+from box_sdk_gen.schemas.events import Events
 from box_sdk_gen.schemas.file import FilePathCollectionField
 from box_sdk_gen.schemas.file_full import FileFull
 from box_sdk_gen.schemas.folder_full import FolderFull
 from box_sdk_gen.schemas.folder_mini import FolderMini
 from box_sdk_gen.schemas.items import Items
 from box_sdk_gen.schemas.user_mini import UserMini
+from box_sdk_gen.schemas.web_link import WebLink
 
 from onyx.connectors.box.connector import BoxConnector
 from onyx.connectors.box.models import BoxTraversalMode
@@ -27,6 +30,7 @@ from onyx.connectors.models import (
 from tests.unit.onyx.connectors.box.fake_box_client import (
     FakeBoxClient,
     make_events_page,
+    make_folder_event_page,
 )
 
 _OWNER = UserMini(id="u1", name="Alice", login="alice@example.com")
@@ -57,12 +61,34 @@ def _file_with_parent(file_id: str, name: str) -> FileFull:
     )
 
 
+def _file_with_nested_parent(file_id: str, name: str) -> FileFull:
+    return FileFull(
+        id=file_id,
+        name=name,
+        size=10,
+        modified_at=_MODIFIED,
+        created_at=_MODIFIED,
+        owned_by=_OWNER,
+        parent=FolderMini(id="300", name="Nested"),
+        path_collection=FilePathCollectionField(
+            total_count=3,
+            entries=[
+                FolderMini(id="0", name="All Files"),
+                FolderMini(id="200", name="Sub"),
+                FolderMini(id="300", name="Nested"),
+            ],
+        ),
+    )
+
+
 def _make_events_connector(
-    event_pages: list,
+    event_pages: list[Events],
     files_by_id: dict[str, FileFull],
     file_contents: dict[str, bytes],
     file_fetch_fail_status_by_id: dict[str, int] | None = None,
     events_fail_status: int | None = None,
+    events_fail_status_by_call: dict[int, int] | None = None,
+    full_crawl_subfolder_items: list[FileFull | FolderMini | WebLink] | None = None,
 ) -> tuple[BoxConnector, FakeBoxClient]:
     fake = FakeBoxClient(
         folders_by_id={
@@ -74,13 +100,16 @@ def _make_events_connector(
             ("0", None): Items(
                 entries=[FolderMini(id="200", name="Sub")], next_marker=None
             ),
-            ("200", None): Items(entries=[], next_marker=None),
+            ("200", None): Items(
+                entries=full_crawl_subfolder_items or [], next_marker=None
+            ),
         },
         file_contents=file_contents,
         files_by_id=files_by_id,
         file_fetch_fail_status_by_id=file_fetch_fail_status_by_id,
         event_pages=event_pages,
         events_fail_status=events_fail_status,
+        events_fail_status_by_call=events_fail_status_by_call,
     )
     connector = BoxConnector()  # whole-enterprise (root)
     connector._content_client = cast(BoxClient, fake)
@@ -133,16 +162,43 @@ def test_events_path_indexes_only_changed_files() -> None:
     # the connector listed no folders in events mode
     assert fake.folders.listing_calls == []
 
-    # the changed file's parent folder is still surfaced as a hierarchy node
+    # The complete root-to-parent hierarchy is emitted parent-first.
     node_ids = {n.raw_node_id for n in outputs if isinstance(n, HierarchyNode)}
-    assert node_ids == {"200"}
+    assert node_ids == {"0", "200"}
 
     doc1 = next(d for d in outputs if isinstance(d, Document) and d.id == "box-file-1")
-    assert doc1.metadata["path"] == "Sub"
+    assert doc1.metadata["path"] == "All Files/Sub"
     assert doc1.parent_hierarchy_raw_node_id == "200"
     section = doc1.sections[0]
     assert isinstance(section, TextSection)
     assert section.text == "alpha"
+
+    created_after, created_before = fake.events.created_windows[0]
+    assert created_after == datetime.fromtimestamp(
+        _HOUR_AGO - 24 * 60 * 60, tz=timezone.utc
+    )
+    assert created_before == datetime.fromtimestamp(
+        _NOW - 24 * 60 * 60, tz=timezone.utc
+    )
+    event_types = fake.events.event_types[0]
+    assert event_types is not None
+    assert GetEventsEventType.FILE_VERSION_RESTORE in event_types
+
+
+def test_events_path_emits_all_ancestors_parent_first() -> None:
+    connector, _ = _make_events_connector(
+        event_pages=[make_events_page(["1"], next_stream_position=None)],
+        files_by_id={"1": _file_with_nested_parent("1", "nested.txt")},
+        file_contents={"1": b"nested"},
+    )
+
+    outputs, _ = _run(connector, _HOUR_AGO, _NOW)
+
+    nodes = [output for output in outputs if isinstance(output, HierarchyNode)]
+    assert [node.raw_node_id for node in nodes] == ["0", "200", "300"]
+    assert [node.raw_parent_id for node in nodes] == [None, "0", "200"]
+    document = next(output for output in outputs if isinstance(output, Document))
+    assert document.metadata["path"] == "All Files/Sub/Nested"
 
 
 def test_events_path_paginates_and_dedups_repeated_files() -> None:
@@ -168,8 +224,9 @@ def test_events_path_paginates_and_dedups_repeated_files() -> None:
     assert sorted(docs) == ["box-file-1", "box-file-2", "box-file-3"]
     assert docs.count("box-file-1") == 1
     assert fake.files.fetch_calls.count("1") == 1
-    # parent node 200 yielded once across the whole run
+    # Each ancestor is yielded once across the whole run.
     node_ids = [n.raw_node_id for n in outputs if isinstance(n, HierarchyNode)]
+    assert node_ids.count("0") == 1
     assert node_ids.count("200") == 1
     # pagination advanced through the stream positions
     assert fake.events.calls == [None, "pos1", "pos2"]
@@ -220,6 +277,39 @@ def test_events_fetch_failure_falls_back_to_full_crawl() -> None:
     assert fake.folders.listing_calls != []
 
 
+def test_later_events_failure_resets_state_before_full_crawl() -> None:
+    connector, fake = _make_events_connector(
+        event_pages=[make_events_page(["1"], next_stream_position="pos1")],
+        files_by_id={"1": _file_with_parent("1", "changed.txt")},
+        file_contents={"1": b"changed"},
+        events_fail_status_by_call={2: 503},
+    )
+
+    _, mode = _run(connector, _HOUR_AGO, _NOW)
+
+    assert mode == BoxTraversalMode.FULL
+    assert ("0", None) in fake.folders.listing_calls
+    assert ("200", None) in fake.folders.listing_calls
+
+
+def test_folder_event_falls_back_to_full_crawl() -> None:
+    old_file = _file_with_parent("1", "old.txt")
+    connector, fake = _make_events_connector(
+        event_pages=[make_folder_event_page("200")],
+        files_by_id={"1": old_file},
+        file_contents={"1": b"old"},
+        full_crawl_subfolder_items=[old_file],
+    )
+
+    outputs, mode = _run(connector, _HOUR_AGO, _NOW)
+
+    assert mode == BoxTraversalMode.FULL
+    assert fake.folders.listing_calls != []
+    assert any(
+        isinstance(output, Document) and output.id == "box-file-1" for output in outputs
+    )
+
+
 def test_wide_window_uses_full_crawl_not_events() -> None:
     connector, fake = _make_events_connector(
         event_pages=[make_events_page(["1"], next_stream_position=None)],
@@ -241,6 +331,20 @@ def test_folder_scoped_connector_uses_full_crawl_not_events() -> None:
     )
     connector.entry_folder_ids = ["200"]  # scoped -> events can't scope to subtree
     _, mode = _run(connector, _HOUR_AGO, _NOW)
+    assert mode == BoxTraversalMode.FULL
+    assert fake.events.calls == []
+
+
+def test_web_link_connector_uses_full_crawl_not_events() -> None:
+    connector, fake = _make_events_connector(
+        event_pages=[make_events_page(["1"], next_stream_position=None)],
+        files_by_id={"1": _file_with_parent("1", "a.txt")},
+        file_contents={"1": b"a"},
+    )
+    connector.include_web_links = True
+
+    _, mode = _run(connector, _HOUR_AGO, _NOW)
+
     assert mode == BoxTraversalMode.FULL
     assert fake.events.calls == []
 


### PR DESCRIPTION
## Description

Layers incremental indexing onto the Box connector. Box's folder-listing API has no server-side modified-time filter, so the base connector re-crawls the whole tree each poll. This uses the **`admin_logs` enterprise events stream** (SharePoint-delta style) so steady-state polls re-index only what changed.

- Whole-enterprise connector + short poll window (≤ 7 days) → consume `admin_logs` (filtered to content-change event types), fetch only the changed files, yield their docs + parent folder nodes.
- First index, folder-scoped connectors, pruning, and permission-sync slim retrieval still do a full crawl. A window > 7 days (long gap) also full-crawls, doubling as periodic reconciliation.
- Events API failure → fall back to a full crawl (never index nothing). Deletions are reconciled by the pruning job, not the events path.
- Purely additive: no new config, env vars, registration, or frontend — just `connector.py`/`models.py` + tests.

> Stacked on #12862 (the Box connector). Base retargets to `main` once that merges.

## How Has This Been Tested?

- 8 new offline unit tests (`test_box_events.py`): events-only-fetches-changed-files, pagination + cross-page dedup, skip inaccessible/deleted (403/404), surface unexpected errors, events-failure → full-crawl fallback, wide-window → full, folder-scoped → full, slim never uses events. Full box unit suite: 51 passing.
- `ruff` + `ty` green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds incremental indexing to the Box connector using the enterprise `admin_logs` events stream. Steady‑state ≤7‑day whole‑enterprise polls re-index only changed files with a 24‑hour lag; first index, folder‑scoped or web link connectors, pruning/permission sync, long gaps, folder moves/renames, or events failures fall back to a full crawl.

- New Features
  - Consumes content‑change events (upload, edit, copy, move, rename, undelete, version restore), fetches files with `path_collection`, and emits each parent folder once for hierarchy/permissions.
  - Paginates via `next_stream_position`, dedups files across pages, skips 403/404 fetches, and surfaces other fetch errors as non‑blocking failures.
  - Uses events only for whole‑enterprise, bounded ≤7‑day polls and applies a 24‑hour lag to avoid missing admin‑log entries; connectors indexing web links always use full crawls; no config/env changes.

<sup>Written for commit ecccaf5a9a75b7714cf6f49979a0a355a4dda2fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

