### PR TITLE
feat(llm): update OpenRouter and OpenAI recommended models

### DIFF
--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -1,22 +1,33 @@
 {
-  "version": "1.5",
+  "version": "1.7",
   "updated_at": "2026-07-10T00:00:00Z",
   "providers": {
     "openai": {
-      "default_model": "gpt-5.5",
+      "default_model": "gpt-5.6-sol",
       "additional_visible_models": [
-        { "name": "gpt-5.5" },
-        { "name": "gpt-5.4" },
-        { "name": "gpt-5.2" }
+        {
+          "name": "gpt-5.6-sol"
+        },
+        {
+          "name": "gpt-5.6-terra"
+        },
+        {
+          "name": "gpt-5.6-luna"
+        },
+        {
+          "name": "gpt-5.5"
+        },
+        {
+          "name": "gpt-5.4"
+        },
+        {
+          "name": "gpt-5.2"
+        }
       ]
     },
     "anthropic": {
       "default_model": "claude-opus-4-8",
       "additional_visible_models": [
-        {
-          "name": "claude-fable-5",
-          "display_name": "Claude Fable 5"
-        },
         {
           "name": "claude-opus-4-8",
           "display_name": "Claude Opus 4.8"
@@ -30,12 +41,12 @@
           "display_name": "Claude Opus 4.6"
         },
         {
-          "name": "claude-sonnet-5",
-          "display_name": "Claude Sonnet 5"
+          "name": "claude-fable-5",
+          "display_name": "Claude Fable 5"
         },
         {
-          "name": "claude-sonnet-4-6",
-          "display_name": "Claude Sonnet 4.6"
+          "name": "claude-sonnet-5",
+          "display_name": "Claude Sonnet 5"
         },
         {
           "name": "claude-haiku-4-5",
@@ -51,25 +62,25 @@
           "display_name": "Gemini 3.1 Pro"
         },
         {
-          "name": "gemini-3-flash-preview",
-          "display_name": "Gemini 3 Flash"
+          "name": "gemini-3.5-flash",
+          "display_name": "Gemini 3.5 Flash"
         }
       ]
     },
     "openrouter": {
-      "default_model": "z-ai/glm-5.1",
+      "default_model": "z-ai/glm-5.2",
       "additional_visible_models": [
         {
-          "name": "z-ai/glm-5.1",
-          "display_name": "GLM 5.1"
+          "name": "z-ai/glm-5.2",
+          "display_name": "GLM 5.2"
         },
         {
           "name": "deepseek/deepseek-v4-pro",
           "display_name": "DeepSeek V4 Pro"
         },
         {
-          "name": "qwen/qwen3.6-plus",
-          "display_name": "Qwen3.6 Plus"
+          "name": "qwen/qwen3.7-plus",
+          "display_name": "Qwen3.7 Plus"
         },
         {
           "name": "moonshotai/kimi-k2.6",


### PR DESCRIPTION
## Description

Updates the recommended models using https://github.com/onyx-dot-app/onyx/pull/12864

## How Has This Been Tested?

Captured by Recommended LLM Provider tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update recommended LLMs: set OpenAI default to `gpt-5.6-sol` and OpenRouter default to `z-ai/glm-5.2`. Also refresh visible model lists for Anthropic and Gemini.

- **New Features**
  - OpenAI: add `gpt-5.6-terra` and `gpt-5.6-luna`.
  - Gemini: switch Flash to `gemini-3.5-flash`.
  - OpenRouter: update Qwen to `qwen/qwen3.7-plus`.
  - Anthropic: include `claude-sonnet-5` and `claude-fable-5`.
  - Version: bump catalog to 1.7.

<sup>Written for commit af7071f41f059739e27342ed613f408cb7752f41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

