### PR TITLE
fix(freshdesk): handle null due by (#10801) [backport v3.3]

### DIFF
--- a/backend/onyx/connectors/freshdesk/connector.py
+++ b/backend/onyx/connectors/freshdesk/connector.py
@@ -87,6 +87,20 @@ def _rate_limited_freshdesk_get(
     return rl_requests.get(url, auth=auth, params=params)
 
 
+def _parse_freshdesk_datetime(raw: str | None) -> datetime | None:
+    """Freshdesk timestamps are ISO-8601 with a trailing 'Z'.
+
+    The API documents that fields like ``due_by``/``fr_due_by`` may be returned
+    as ``null`` — see https://developers.freshdesk.com/api/. This is also
+    significantly more frequent on accounts created after 25 Aug 2025, where
+    the new SLA engine recalculates ``due_by`` for a few seconds after every
+    ticket update.
+    """
+    if not raw:
+        return None
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
 def _create_metadata_from_ticket(ticket: dict) -> dict:
     metadata: dict[str, str | list[str]] = {}
     # Combine all emails into a list so there are no repeated emails
@@ -137,8 +151,9 @@ def _create_metadata_from_ticket(ticket: dict) -> dict:
             status_number, "Unknown Status"
         )
 
-    due_by = datetime.fromisoformat(ticket["due_by"].replace("Z", "+00:00"))
-    metadata["overdue"] = str(datetime.now(timezone.utc) > due_by)
+    due_by = _parse_freshdesk_datetime(ticket.get("due_by"))
+    if due_by is not None:
+        metadata["overdue"] = str(datetime.now(timezone.utc) > due_by)
 
     return metadata
 
@@ -162,9 +177,7 @@ def _create_doc_from_ticket(ticket: dict, domain: str) -> Document:
         source=DocumentSource.FRESHDESK,
         semantic_identifier=ticket["subject"],
         metadata=metadata,
-        doc_updated_at=datetime.fromisoformat(
-            ticket["updated_at"].replace("Z", "+00:00")
-        ),
+        doc_updated_at=_parse_freshdesk_datetime(ticket.get("updated_at")),
     )
 
 

--- a/backend/tests/unit/onyx/connectors/freshdesk/test_freshdesk_due_by.py
+++ b/backend/tests/unit/onyx/connectors/freshdesk/test_freshdesk_due_by.py
@@ -1,0 +1,63 @@
+"""Unit tests for Freshdesk connector handling of nullable timestamp fields.
+
+Reproduces the production traceback:
+
+    File "/app/onyx/connectors/freshdesk/connector.py", line 131
+        due_by = datetime.fromisoformat(ticket["due_by"].replace("Z", "+00:00"))
+    AttributeError: 'NoneType' object has no attribute 'replace'
+
+The Freshdesk API explicitly documents ``due_by`` (and ``fr_due_by``) as
+nullable. This is dramatically more frequent on accounts created after
+25 Aug 2025, where the new SLA engine recalculates ``due_by`` for a few
+seconds after every ticket update — and our connector polls by
+``updated_since``, so it specifically targets the tickets most likely to be
+in that recalculation window.
+"""
+
+from typing import Any
+
+from onyx.connectors.freshdesk.connector import _create_doc_from_ticket
+from onyx.connectors.freshdesk.connector import _create_metadata_from_ticket
+
+
+def _ticket(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": 42,
+        "subject": "Website unresponsive",
+        "description_text": "Some details on the issue ...",
+        "status": 2,
+        "priority": 1,
+        "source": 2,
+        "due_by": "2024-01-15T11:30:00Z",
+        "updated_at": "2024-01-10T11:30:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestNullDueBy:
+    def test_metadata_omits_overdue_when_due_by_is_null(self) -> None:
+        metadata = _create_metadata_from_ticket(_ticket(due_by=None))
+        assert "overdue" not in metadata
+
+    def test_metadata_omits_overdue_when_due_by_is_missing(self) -> None:
+        ticket = _ticket()
+        del ticket["due_by"]
+        metadata = _create_metadata_from_ticket(ticket)
+        assert "overdue" not in metadata
+
+    def test_metadata_includes_overdue_when_due_by_is_present(self) -> None:
+        metadata = _create_metadata_from_ticket(_ticket(due_by="2024-01-15T11:30:00Z"))
+        # 2024-01-15 is in the past, so the ticket is overdue
+        assert metadata["overdue"] == "True"
+
+    def test_doc_creation_does_not_crash_on_null_due_by(self) -> None:
+        doc = _create_doc_from_ticket(_ticket(due_by=None), domain="example")
+        assert doc.semantic_identifier == "Website unresponsive"
+        assert "overdue" not in doc.metadata
+
+
+class TestNullUpdatedAt:
+    def test_doc_creation_does_not_crash_on_null_updated_at(self) -> None:
+        doc = _create_doc_from_ticket(_ticket(updated_at=None), domain="example")
+        assert doc.doc_updated_at is None


### PR DESCRIPTION
## Description

Backport of #10801 ("fix(freshdesk): handle null due by") to the `release/v3.3` branch.

The Freshdesk connector crashed with `AttributeError: 'NoneType' object has no attribute 'replace'` when the API returned a `null` `due_by` (or `updated_at`). The Freshdesk API documents these fields as nullable, and it is significantly more frequent on accounts created after 25 Aug 2025, where the new SLA engine recalculates `due_by` for a few seconds after every ticket update — exactly the tickets the connector's `updated_since` poll targets.

The fix introduces a `_parse_freshdesk_datetime()` helper that returns `None` instead of crashing, and skips the `overdue` metadata when `due_by` is absent. Connector-local change; no schema, migration, or API surface changes.

This is a clean cherry-pick of `caf662ac55` (already shipped in v4.0.0) — applied to `release/v3.3` with zero conflicts. Requested by a customer running v3.3.

## How Has This Been Tested?

- Cherry-picked `caf662ac55` onto `release/v3.3` with no conflicts.
- Includes the upstream unit test `test_freshdesk_due_by.py` (null / missing / present `due_by`, null `updated_at`); CI runs it against the v3.3 dependency set.
- Logic is byte-identical to the version already shipping and tested in v4.0.0.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backport to `release/v3.3` that prevents the Freshdesk connector from crashing when `due_by` or `updated_at` are null by safely parsing timestamps and skipping `overdue` when missing.

- **Bug Fixes**
  - Added `_parse_freshdesk_datetime()` to handle nullable ISO-8601 timestamps with trailing `Z`.
  - Set `overdue` only when `due_by` exists; `doc_updated_at` now accepts null.
  - Added unit tests for null/missing `due_by` and null `updated_at`.

<sup>Written for commit cd87e918314b4de89046a00510588e7797fafa55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

