### PR TITLE
fix(llm): downgrade required tool_choice to auto for Qwen thinking models

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -572,19 +572,12 @@ class LitellmLLM(LLM):
             model = f"{model_provider}/{self.config.deployment_name or self.config.model_name}"
 
         # Tool choice
-        # Some models reject or silently drop reasoning when tool_choice is
-        # required, so fall back to AUTO and rely on the chat loop's fallback
-        # tool-call extraction to still enforce the tool:
-        #   - Claude will not use reasoning when tool_choice is required.
-        #   - Qwen (Alibaba) thinking models return a 400
-        #     "The tool_choice parameter does not support being set to required
-        #     or object in thinking mode".
-        # We intentionally match on model name rather than `is_reasoning` here:
-        # `model_is_reasoning_model` relies on the litellm/local registry, which
-        # lags behind newly released Qwen models (e.g. it returns False for
-        # qwen3.7-plus), so gating on it would miss exactly the thinking models
-        # that reject `required`. The downgrade is safe for non-thinking Qwen
-        # models since the chat loop still enforces the forced tool.
+        # Downgrade tool_choice=required to AUTO for models that mishandle it:
+        # Claude skips reasoning when it's set, and Qwen thinking models reject
+        # it with a 400. The chat loop's fallback tool-call extraction still
+        # enforces the forced tool. Matched by model name rather than
+        # `is_reasoning` because the litellm/local registry lags behind new
+        # Qwen releases (e.g. qwen3.7-plus).
         if (is_claude_model or is_qwen_model) and (
             tool_choice == ToolChoiceOptions.REQUIRED
         ):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -579,6 +579,12 @@ class LitellmLLM(LLM):
         #   - Qwen (Alibaba) thinking models return a 400
         #     "The tool_choice parameter does not support being set to required
         #     or object in thinking mode".
+        # We intentionally match on model name rather than `is_reasoning` here:
+        # `model_is_reasoning_model` relies on the litellm/local registry, which
+        # lags behind newly released Qwen models (e.g. it returns False for
+        # qwen3.7-plus), so gating on it would miss exactly the thinking models
+        # that reject `required`. The downgrade is safe for non-thinking Qwen
+        # models since the chat loop still enforces the forced tool.
         if (is_claude_model or is_qwen_model) and (
             tool_choice == ToolChoiceOptions.REQUIRED
         ):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -526,6 +526,7 @@ class LitellmLLM(LLM):
         # Flags that modify the final arguments
         #########################
         is_claude_model = "claude" in self.config.model_name.lower()
+        is_qwen_model = "qwen" in self.config.model_name.lower()
         is_reasoning = model_is_reasoning_model(
             self.config.model_name, self.config.model_provider
         )
@@ -571,9 +572,16 @@ class LitellmLLM(LLM):
             model = f"{model_provider}/{self.config.deployment_name or self.config.model_name}"
 
         # Tool choice
-        if is_claude_model and tool_choice == ToolChoiceOptions.REQUIRED:
-            # Claude models will not use reasoning if tool_choice is required
-            # let it choose tools automatically so reasoning can still be used
+        # Some models reject or silently drop reasoning when tool_choice is
+        # required, so fall back to AUTO and rely on the chat loop's fallback
+        # tool-call extraction to still enforce the tool:
+        #   - Claude will not use reasoning when tool_choice is required.
+        #   - Qwen (Alibaba) thinking models return a 400
+        #     "The tool_choice parameter does not support being set to required
+        #     or object in thinking mode".
+        if (is_claude_model or is_qwen_model) and (
+            tool_choice == ToolChoiceOptions.REQUIRED
+        ):
             tool_choice = ToolChoiceOptions.AUTO
 
         # If no tools are provided, tool_choice should be None

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -22,6 +22,7 @@ from onyx.llm.models import FunctionCall
 from onyx.llm.models import LanguageModelInput
 from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import ToolCall
+from onyx.llm.models import ToolChoiceOptions
 from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import _parse_anthropic_model_version
 from onyx.llm.multi_llm import LitellmLLM
@@ -1776,6 +1777,78 @@ def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> Non
         assert "tool_choice" not in kwargs, (
             "tool_choice must not be sent to providers when no tools are provided"
         )
+
+
+_TOOL_CHOICE_DOWNGRADE_TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get the current weather for a location",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"],
+            },
+        },
+    }
+]
+
+
+@pytest.mark.parametrize(
+    "model_provider, model_name",
+    [
+        (LlmProviderNames.OPENROUTER, "qwen/qwen3.7-plus"),
+        (LlmProviderNames.ANTHROPIC, "claude-sonnet-5"),
+    ],
+)
+def test_required_tool_choice_downgraded_to_auto(
+    model_provider: str, model_name: str
+) -> None:
+    """Claude and Qwen thinking models reject/degrade required tool_choice, so
+    it must be sent to the provider as AUTO instead."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=model_provider,
+        model_name=model_name,
+        max_input_tokens=32000,
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Weather in NYC?")]
+        list(
+            llm.stream(
+                messages,
+                tools=_TOOL_CHOICE_DOWNGRADE_TOOLS,
+                tool_choice=ToolChoiceOptions.REQUIRED,
+            )
+        )
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["tool_choice"] == ToolChoiceOptions.AUTO
+
+
+def test_required_tool_choice_preserved_for_other_models(
+    default_multi_llm: LitellmLLM,
+) -> None:
+    """Models without the thinking-mode constraint must keep required."""
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Weather in NYC?")]
+        list(
+            default_multi_llm.stream(
+                messages,
+                tools=_TOOL_CHOICE_DOWNGRADE_TOOLS,
+                tool_choice=ToolChoiceOptions.REQUIRED,
+            )
+        )
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["tool_choice"] == ToolChoiceOptions.REQUIRED
 
 
 def test_bifrost_normalizes_api_base_in_model_kwargs() -> None:


### PR DESCRIPTION
## Description

Qwen (Alibaba) thinking models reject `tool_choice=required`, returning a 400:

> `<400> InternalError.Algo.InvalidParameter: The tool_choice parameter does not support being set to required or object in thinking mode`

<img width="2880" height="1920" alt="20260710_14h55m13s_grim" src="https://github.com/user-attachments/assets/f4db8a38-9bdf-4de0-be4d-7c52df1cb9a2" />

This surfaced on #12865, which promotes `qwen/qwen3.7-plus` in the OpenRouter recommended models, causing the `provider-chat-test` (openrouter) CI job to fail when it forces a tool call.

This extends the existing Claude carve-out in `LitellmLLM._completion`: when a Claude **or** Qwen model is called with `tool_choice=required`, we send `tool_choice=auto` to the provider instead. The chat loop's fallback tool-call extraction (`llm_loop.py`) still enforces that the forced tool is used, so behavior is preserved while avoiding the hard 400 (and, for Claude, preserving reasoning).

## How Has This Been Tested?

- New unit tests in `test_multi_llm.py`:
  - `test_required_tool_choice_downgraded_to_auto` — Qwen and Claude models downgrade `required` → `auto`.
  - `test_required_tool_choice_preserved_for_other_models` — other models keep `required`.
- Full `backend/tests/unit/onyx/llm/test_multi_llm.py` suite passes (109 tests).
- Covered end-to-end by the Recommended LLM Provider chat tests once #12865 rebases on this.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid 400s from Qwen thinking models by downgrading `tool_choice=required` to `auto` (also for Claude), while still enforcing the forced tool in the chat loop. This preserves reasoning and fixes CI failures when testing `qwen/qwen3.7-plus` via OpenRouter.

- **Bug Fixes**
  - In `LitellmLLM._completion`, send `tool_choice=auto` for Claude and Qwen when `required` is requested; other models keep `required`.
  - Behavior remains enforced via the chat loop’s fallback tool-call extraction.
  - Explain the intentional name-based Qwen check (not `is_reasoning`) due to registry lag so new thinking models are covered.
  - Add unit tests covering downgrade for Qwen/Claude and preservation for other models.

<sup>Written for commit c0258eaa6925c99a391bd6bb147f54a63aecc3b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



