### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/integration/tests/craft/test_file_ops_api.py
+++ b/backend/tests/integration/tests/craft/test_file_ops_api.py
@@ -286,7 +286,14 @@ def test_list_directory_filters_hidden_entries(
     session_id, sandbox_id = _create_session_with_sandbox(admin_user)
     manager = get_sandbox_manager()
 
-    hidden_names = {".venv/keep", "node_modules/keep", "opencode.json", ".env"}
+    hidden_names = {
+        ".venv/keep",
+        "node_modules/keep",
+        "opencode.json",
+        ".env",
+        "nextjs.log",
+        "nextjs.pid",
+    }
     visible_names = {"alpha.txt", "beta.txt"}
 
     for rel in hidden_names | visible_names:
@@ -303,6 +310,8 @@ def test_list_directory_filters_hidden_entries(
     assert "node_modules" not in names
     assert "opencode.json" not in names
     assert ".env" not in names
+    assert "nextjs.log" not in names
+    assert "nextjs.pid" not in names
     assert visible_names <= names
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "nextjs.log",
+        "nextjs.pid",
+        "node_modules",
+        "opencode.json",
+        ".env",
+        ".git",
+    ],
+)
+def test_hidden_entries_are_filtered(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is True
+
+
+@pytest.mark.parametrize(
+    "name", ["page.tsx", "README.md", "outputs", "nextjs.log.bak", "mynextjs.pid"]
+)
+def test_visible_entries_are_kept(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is False


### PR DESCRIPTION
## What & why

In the Onyx Craft sandbox **Files** tab, the dev-server runtime artifacts `nextjs.log` and `nextjs.pid` were showing up in the file explorer. These are internal Next.js dev-server files (stdout log + PID) written to the session workspace root, not user deliverables, so they should be hidden from the listing.

## Change

Add `nextjs.log` and `nextjs.pid` to the existing `HIDDEN_PATTERNS` set in `backend/onyx/server/features/build/session/manager.py`. This is the single, canonical filter (`_is_hidden_workspace_entry`) already used to hide entries like `node_modules`, `opencode.json`, and `.env` from both the directory listing and download zips. No frontend change is needed — the file explorer does no name-based filtering of its own.

## Verification

- New unit test `backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py` covers the predicate (positive: `nextjs.log`/`nextjs.pid`; negative: exact-match semantics so `nextjs.log.bak`/`mynextjs.pid` stay visible). Fails before the change, passes after.
- Extended the existing integration test `test_list_directory_filters_hidden_entries` to assert both files are filtered.
- `ruff check` and `ruff format --check` pass.

## Notes

- Filtering is by basename, consistent with the existing entries; the files remain on disk and the sandbox lifecycle scripts still read `nextjs.pid` by absolute path, so process management is unaffected.
- This declutters the listing only (it is not an access-control change), matching the pre-existing behavior of the other hidden entries.

---

- [x] Override Linear Check
