### PR TITLE
feat(opal): add modal context hooks

### DIFF
--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -157,6 +157,16 @@ export {
   type BasicModalFooterProps,
 } from "@opal/components/modal/components";
 
+/* ModalContext */
+export {
+  useCreateModal,
+  useModal,
+  useModalClose,
+  type ModalInterface,
+  type ModalCreationInterface,
+  type ModalProviderProps,
+} from "@opal/components/modal/context";
+
 /* InputTypeIn */
 export {
   default as InputTypeIn,

--- a/web/lib/opal/src/components/modal/context.tsx
+++ b/web/lib/opal/src/components/modal/context.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import React, { createContext, useContext, useState, useCallback } from "react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ModalProviderProps {
+  children?: React.ReactNode;
+}
+
+interface ModalInterface {
+  isOpen: boolean;
+  toggle: (state: boolean) => void;
+}
+
+interface ModalCreationInterface extends ModalInterface {
+  /** Mounts children only while open, with the modal state in context. */
+  Provider: React.FunctionComponent<ModalProviderProps>;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+const ModalContext = createContext<ModalInterface | null>(null);
+
+/**
+ * Owns one modal's open state. Render modal content inside the returned
+ * `Provider`: it mounts children only while open, and descendants reach the
+ * state via `useModal` / `useModalClose` without prop drilling.
+ */
+function useCreateModal(): ModalCreationInterface {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const toggle = useCallback((state: boolean) => {
+    setIsOpen(state);
+  }, []);
+
+  const Provider: React.FunctionComponent<ModalProviderProps> = useCallback(
+    ({ children }: ModalProviderProps) => {
+      if (!isOpen) return null;
+
+      return (
+        <ModalContext.Provider value={{ isOpen, toggle }}>
+          {children}
+        </ModalContext.Provider>
+      );
+    },
+    [isOpen, toggle]
+  );
+
+  return { isOpen, toggle, Provider };
+}
+
+/** Modal state from the nearest `useCreateModal` Provider. Throws outside one. */
+function useModal(): ModalInterface {
+  const context = useContext(ModalContext);
+
+  if (!context) {
+    throw new Error(
+      "useModal must be used within the `Provider` returned by `useCreateModal`"
+    );
+  }
+
+  return context;
+}
+
+/**
+ * Close-and-callback: closes the nearest modal then runs `onClose`. Outside
+ * a Provider it returns `onClose` as-is, so components work in both places.
+ */
+function useModalClose(onClose?: () => void): (() => void) | undefined {
+  const context = useContext(ModalContext);
+
+  return context
+    ? () => {
+        context.toggle(false);
+        onClose?.();
+      }
+    : onClose;
+}
+
+export {
+  useCreateModal,
+  useModal,
+  useModalClose,
+  type ModalInterface,
+  type ModalCreationInterface,
+  type ModalProviderProps,
+};


### PR DESCRIPTION
## Description

Ports `refresh-components/contexts/ModalContext` (44 importers) into Opal beside the Modal. Stacked on #12835 as part of the modal-ecosystem chain (Modal → ModalContext → ConfirmationModalLayout → the reworked migration #12840). Retarget to `main` after #12835 merges.

- `useCreateModal` owns one modal's open state and returns a `Provider` that mounts children only while open.
- `useModal` reads the nearest state (throws outside a Provider). `useModalClose` composes close-then-callback, passing `onClose` through unchanged outside a Provider so shared close buttons work in both placements.
- API matches the production source, so consumers migrate by import swap. One string fix: the `useModal` error names the real `Provider` member (the source referenced a nonexistent `Modal` field).

## How Has This Been Tested?

tsgo typecheck passes with the hooks exported through the barrel. Pure state hooks with no rendered surface of their own; consumer behavior is exercised when the migration PR at the end of the chain swaps the 44 importers.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check