### PR TITLE
Fix MCP OAuth public PKCE registration

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -616,6 +616,7 @@ def make_oauth_provider(
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
             scope=REQUESTED_SCOPE,  # TODO: do we need to pass this in? maybe make configurable
+            token_endpoint_auth_method="none",
         ),
         storage=storage,
         redirect_handler=redirect_handler,

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -287,6 +287,11 @@ def test_make_oauth_provider_auto_discovery_leaves_metadata_unset() -> None:
     assert provider.context.token_expiry_time is None
 
 
+def test_make_oauth_provider_auto_discovery_requests_public_pkce_client() -> None:
+    provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+    assert provider.context.client_metadata.token_endpoint_auth_method == "none"
+
+
 def test_get_tokens_hydrates_expiry_and_invalidates_expired_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
# Description

## What

This PR updates MCP OAuth provider setup to explicitly register dynamically discovered OAuth clients as public PKCE clients.

Key changes:

- Adds `token_endpoint_auth_method="none"` to the `OAuthClientMetadata` used by `make_oauth_provider`.
- Adds a unit test asserting that auto-discovered MCP OAuth providers request public PKCE client registration.
- Validates that the Notion MCP OAuth flow can complete locally with this metadata set.

## Why

Some MCP OAuth providers require dynamic client registration metadata to explicitly declare that the client is public and does not authenticate at the token endpoint.

Without `token_endpoint_auth_method="none"`, providers may infer a confidential-client authentication method or reject a later PKCE token exchange as ambiguous. We observed this with Notion MCP OAuth, where token exchange failed with:

```text
invalid_request: Client must not use multiple authentication methods
```

This change aligns the registered client metadata with how the flow already behaves: Onyx is using a PKCE-style OAuth flow without a client secret in this path.

## How to Review

Primary file:

- `backend/onyx/server/features/mcp/api.py`

Test file:

- `backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py`

The main thing to verify is whether `make_oauth_provider` should always treat this auto-discovery path as a public PKCE client. Existing nearby logic already normalizes OAuth client information to `token_endpoint_auth_method="none"` when no client secret exists, so this change is intended to make dynamic registration consistent with that behavior.

## How Has This Been Tested

Tested locally with:

```bash
uv run pytest backend/tests/unit/onyx/server/features/mcp backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py -q
```

Result:

```text
59 passed
```

Also tested manually by running Onyx locally against a fresh database and completing the Notion MCP OAuth setup flow successfully.

## Risks / Impact

Risk is low for public PKCE-based MCP OAuth providers and should improve compatibility with stricter providers.

Potential compatibility consideration: if an auto-discovered MCP OAuth provider expects dynamic registration to create a confidential client with a client secret, this change would instead request public-client registration. However, this path does not provide a client secret today, so public PKCE registration is the behavior that best matches the current implementation.

No database migration or stored credential format change is required.

## Related

[MCP OAuth dynamic registration should explicitly support public PKCE clients
](https://github.com/onyx-dot-app/onyx/issues/12874)



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers auto-discovered MCP OAuth clients as public PKCE by setting `token_endpoint_auth_method="none"`, fixing token exchange failures (e.g., Notion) and aligning with our secretless flow.

- **Bug Fixes**
  - Set `token_endpoint_auth_method="none"` in the `make_oauth_provider` auto-discovery path so providers treat the client as public PKCE.
  - Added a unit test to assert public PKCE registration in auto-discovery.

<sup>Written for commit 3991a3d1a0b536e7e85a22a49735303523db85b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

