### PR TITLE
chore: [Running GitHub actions for #12875]

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -616,6 +616,7 @@ def make_oauth_provider(
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
             scope=REQUESTED_SCOPE,  # TODO: do we need to pass this in? maybe make configurable
+            token_endpoint_auth_method="none",
         ),
         storage=storage,
         redirect_handler=redirect_handler,

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -287,6 +287,11 @@ def test_make_oauth_provider_auto_discovery_leaves_metadata_unset() -> None:
     assert provider.context.token_expiry_time is None
 
 
+def test_make_oauth_provider_auto_discovery_requests_public_pkce_client() -> None:
+    provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+    assert provider.context.client_metadata.token_endpoint_auth_method == "none"
+
+
 def test_get_tokens_hydrates_expiry_and_invalidates_expired_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
This PR runs GitHub Actions CI for #12875.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP OAuth auto-discovery to register as a public PKCE client by setting token_endpoint_auth_method to "none", preventing auth failures with providers that require public clients. Adds a unit test to lock in this behavior.

<sup>Written for commit 3991a3d1a0b536e7e85a22a49735303523db85b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

