### PR TITLE
Fix MCP OAuth public PKCE registration (#12875) [backport v4.3]

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -616,6 +616,7 @@ def make_oauth_provider(
             grant_types=["authorization_code", "refresh_token"],
             response_types=["code"],
             scope=REQUESTED_SCOPE,  # TODO: do we need to pass this in? maybe make configurable
+            token_endpoint_auth_method="none",
         ),
         storage=storage,
         redirect_handler=redirect_handler,

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -287,6 +287,11 @@ def test_make_oauth_provider_auto_discovery_leaves_metadata_unset() -> None:
     assert provider.context.token_expiry_time is None
 
 
+def test_make_oauth_provider_auto_discovery_requests_public_pkce_client() -> None:
+    provider = _build_provider(MCPOAuthProviderMode.AUTO_DISCOVERY)
+    assert provider.context.client_metadata.token_endpoint_auth_method == "none"
+
+
 def test_get_tokens_hydrates_expiry_and_invalidates_expired_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Description

Backport of #12875 to `release/v4.3`.

Fixes MCP OAuth registration for public PKCE clients by setting `token_endpoint_auth_method="none"` on the dynamic client registration request in `make_oauth_provider`. Without this, public clients (which have no client secret) were registered as confidential, breaking the PKCE authorization-code flow.

Clean cherry-pick of the squash commit `99ace22` — no conflicts.

## How Has This Been Tested?

Existing unit test `backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py` updated in the original PR asserts the `token_endpoint_auth_method` is now emitted; it applied cleanly on this branch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix MCP OAuth registration for public PKCE clients by sending token_endpoint_auth_method="none" during dynamic client registration. This prevents public clients from being treated as confidential and restores the PKCE authorization-code flow on release/v4.3.

<sup>Written for commit bc9833b7b806c17d07e5d9673ac726b9e957389e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12877?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

