### PR TITLE
fix(web): fix connector loading overlay and credential edits

### DIFF
--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -201,9 +201,9 @@ function Main({ ccPairId }: { ccPairId: number }) {
   const handleStatusUpdate = async (
     newStatus: ConnectorCredentialPairStatus
   ) => {
-    setShowIsResolvingKickoffLoader(true); // Show fullscreen spinner
+    setShowIsResolvingKickoffLoader(true);
     await handleStatusChange(newStatus);
-    setShowIsResolvingKickoffLoader(false); // Hide fullscreen spinner
+    setShowIsResolvingKickoffLoader(false);
   };
 
   const triggerReIndex = async (fromBeginning: boolean) => {

--- a/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
+++ b/web/src/app/admin/connectors/[connector]/AddConnectorPage.tsx
@@ -54,13 +54,12 @@ import {
 } from "@/lib/connectors/oauth";
 import { CreateStdOAuthCredential } from "@/components/credentials/actions/CreateStdOAuthCredential";
 import { Spinner } from "@/components/Spinner";
-import { Button } from "@opal/components";
+import { Button, Tooltip } from "@opal/components";
 import { Section } from "@opal/layouts";
 import { deleteConnector } from "@/lib/connector";
 import ConnectorDocsLink from "@/components/admin/connectors/ConnectorDocsLink";
 import Text from "@/refresh-components/texts/Text";
 import { SvgKey, SvgAlertCircle } from "@opal/icons";
-import { Tooltip } from "@opal/components";
 import Link from "next/link";
 
 export interface AdvancedConfig {

--- a/web/src/components/Spinner.tsx
+++ b/web/src/components/Spinner.tsx
@@ -2,7 +2,7 @@ import "./spinner.css";
 
 export const Spinner = () => {
   return (
-    <div className="fixed top-0 left-0 z-50 w-screen h-screen bg-black bg-opacity-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-mask-03 backdrop-blur-03">
       <div className="loader ease-linear rounded-full border-8 border-t-8 border-background-200 h-8 w-8"></div>
     </div>
   );

--- a/web/src/components/credentials/CredentialSection.tsx
+++ b/web/src/components/credentials/CredentialSection.tsx
@@ -264,10 +264,11 @@ export default function CredentialSection({
               title="Edit Credential"
               onClose={closeEditingCredential}
             />
-            <Modal.Body>
+            <Modal.Body alignItems="stretch">
               <EditCredential
                 onUpdate={onUpdateCredential}
                 credential={editingCredential}
+                sourceType={sourceType}
                 onClose={closeEditingCredential}
               />
             </Modal.Body>

--- a/web/src/components/credentials/actions/EditCredential.tsx
+++ b/web/src/components/credentials/actions/EditCredential.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@opal/components";
 import { Text } from "@opal/components";
 
-import { FaNewspaper, FaTrash } from "react-icons/fa";
+import { FaNewspaper } from "react-icons/fa";
 import { TextFormField, TypedFileUploadFormField } from "@/components/Field";
 import { Form, Formik, FormikHelpers } from "formik";
 import { toast } from "@/hooks/useToast";
@@ -9,12 +9,19 @@ import {
   Credential,
   getDisplayNameForCredentialKey,
 } from "@/lib/connectors/credentials";
-import { createEditingValidationSchema, createInitialValues } from "../lib";
+import {
+  createEditingValidationSchema,
+  createInitialValues,
+  getEditableCredentialFields,
+} from "../lib";
 import { dictionaryType, formType } from "../types";
 import { isTypedFileField } from "@/lib/connectors/fileTypes";
 import { SvgTrash } from "@opal/icons";
+import type { ValidSources } from "@/lib/types";
+
 export interface EditCredentialProps {
   credential: Credential<dictionaryType>;
+  sourceType: ValidSources;
   onClose: () => void;
   onUpdate: (
     selectedCredentialId: Credential<any>,
@@ -25,13 +32,21 @@ export interface EditCredentialProps {
 
 export default function EditCredential({
   credential,
+  sourceType,
   onClose,
   onUpdate,
 }: EditCredentialProps) {
-  const validationSchema = createEditingValidationSchema(
-    credential.credential_json
+  const editableCredentialFields = getEditableCredentialFields(
+    credential,
+    sourceType
   );
-  const initialValues = createInitialValues(credential);
+  const validationSchema = createEditingValidationSchema(
+    editableCredentialFields
+  );
+  const initialValues = createInitialValues(
+    credential,
+    editableCredentialFields
+  );
 
   const handleSubmit = async (
     values: formType,
@@ -49,7 +64,7 @@ export default function EditCredential({
   };
 
   return (
-    <div className="flex flex-col gap-y-6">
+    <div className="flex w-full flex-col gap-y-6">
       <Text as="p">
         Ensure that you update to a credential with the proper permissions!
       </Text>
@@ -60,7 +75,7 @@ export default function EditCredential({
         onSubmit={handleSubmit}
       >
         {({ isSubmitting, resetForm }) => (
-          <Form>
+          <Form className="flex w-full flex-col gap-y-4">
             <TextFormField
               includeRevert
               name="name"
@@ -68,7 +83,7 @@ export default function EditCredential({
               label="Name (optional):"
             />
 
-            {Object.entries(credential.credential_json).map(([key, value]) =>
+            {Object.entries(editableCredentialFields).map(([key, value]) =>
               isTypedFileField(key) ? (
                 <TypedFileUploadFormField
                   key={key}
@@ -80,11 +95,12 @@ export default function EditCredential({
                   includeRevert
                   key={key}
                   name={key}
-                  placeholder={value as string}
+                  placeholder={value == null ? undefined : String(value)}
                   label={getDisplayNameForCredentialKey(key)}
                   type={
                     key.toLowerCase().includes("token") ||
-                    key.toLowerCase().includes("password")
+                    key.toLowerCase().includes("password") ||
+                    key.toLowerCase().includes("secret")
                       ? "password"
                       : "text"
                   }

--- a/web/src/components/credentials/lib.test.ts
+++ b/web/src/components/credentials/lib.test.ts
@@ -1,0 +1,65 @@
+import type { Credential } from "@/lib/connectors/credentials";
+import { ValidSources } from "@/lib/types";
+
+import { createInitialValues, getEditableCredentialFields } from "./lib";
+
+function buildCredential(
+  credential: Partial<Credential<Record<string, unknown>>>
+): Credential<Record<string, unknown>> {
+  return {
+    id: 1,
+    credential_json: {},
+    admin_public: true,
+    source: ValidSources.Jira,
+    user_id: null,
+    user_email: null,
+    time_created: "2026-01-01T00:00:00Z",
+    time_updated: "2026-01-01T00:00:00Z",
+    ...credential,
+  };
+}
+
+describe("credential edit helpers", () => {
+  it("includes optional template fields omitted from stored credential json", () => {
+    const credential = buildCredential({
+      credential_json: {
+        jira_api_token: "masked-token",
+      },
+      source: ValidSources.Jira,
+    });
+
+    const editableFields = getEditableCredentialFields(
+      credential,
+      ValidSources.Jira
+    );
+
+    expect(editableFields).toEqual({
+      jira_user_email: null,
+      jira_api_token: "masked-token",
+    });
+    expect(createInitialValues(credential, editableFields)).toMatchObject({
+      name: "",
+      jira_user_email: "",
+      jira_api_token: "",
+    });
+  });
+
+  it("uses fields from the stored auth method for multi-auth templates", () => {
+    const credential = buildCredential({
+      credential_json: {
+        authentication_method: "iam_role",
+      },
+      source: ValidSources.S3,
+    });
+
+    const editableFields = getEditableCredentialFields(
+      credential,
+      ValidSources.S3
+    );
+
+    expect(editableFields).toEqual({
+      authentication_method: "iam_role",
+      aws_role_arn: "",
+    });
+  });
+});

--- a/web/src/components/credentials/lib.ts
+++ b/web/src/components/credentials/lib.ts
@@ -3,8 +3,9 @@ import * as Yup from "yup";
 import { dictionaryType, formType } from "./types";
 import {
   Credential,
-  getDisplayNameForCredentialKey,
   CredentialTemplateWithAuth,
+  credentialTemplates,
+  getDisplayNameForCredentialKey,
 } from "@/lib/connectors/credentials";
 import { isTypedFileField } from "@/lib/connectors/fileTypes";
 
@@ -107,12 +108,72 @@ export function createEditingValidationSchema(json_values: dictionaryType) {
   return Yup.object().shape(schemaFields);
 }
 
-export function createInitialValues(credential: Credential<any>): formType {
+function getAuthMethodFieldsForCredential(
+  credentialJson: dictionaryType,
+  credentialTemplate: CredentialTemplateWithAuth<dictionaryType>
+): dictionaryType {
+  const authMethods = credentialTemplate.authMethods ?? [];
+  const storedAuthMethod =
+    typeof credentialJson.authentication_method === "string"
+      ? credentialJson.authentication_method
+      : undefined;
+  const selectedAuthMethod =
+    authMethods.find((method) => method.value === storedAuthMethod) ??
+    authMethods.find((method) =>
+      Object.keys(method.fields).some((fieldKey) => fieldKey in credentialJson)
+    ) ??
+    authMethods[0];
+
+  return {
+    authentication_method:
+      storedAuthMethod ??
+      selectedAuthMethod?.value ??
+      credentialTemplate.authentication_method ??
+      "",
+    ...selectedAuthMethod?.fields,
+  };
+}
+
+export function getEditableCredentialFields(
+  credential: Credential<any>,
+  sourceType: Credential<any>["source"] = credential.source
+): dictionaryType {
+  const credentialJson = credential.credential_json ?? {};
+  const credentialTemplate = credentialTemplates[sourceType] as
+    | dictionaryType
+    | null
+    | undefined;
+
+  if (!credentialTemplate) {
+    return credentialJson;
+  }
+
+  const templateWithAuth =
+    credentialTemplate as CredentialTemplateWithAuth<dictionaryType>;
+  const templateFields =
+    templateWithAuth.authMethods && templateWithAuth.authMethods.length > 1
+      ? getAuthMethodFieldsForCredential(credentialJson, templateWithAuth)
+      : Object.fromEntries(
+          Object.entries(credentialTemplate).filter(
+            ([key]) => key !== "authMethods"
+          )
+        );
+
+  return {
+    ...templateFields,
+    ...credentialJson,
+  };
+}
+
+export function createInitialValues(
+  credential: Credential<any>,
+  credentialFields: dictionaryType = credential.credential_json
+): formType {
   const initialValues: formType = {
     name: credential.name || "",
   };
 
-  for (const key in credential.credential_json) {
+  for (const key in credentialFields) {
     // Initialize TypedFile fields as null, other fields as empty strings
     if (isTypedFileField(key)) {
       initialValues[key] = null as any; // TypedFile fields start as null


### PR DESCRIPTION
## Description

Fixes connector and credential modal loading/editing issues:

- Updates the shared full-screen `Spinner` overlay to use app mask and backdrop blur tokens instead of legacy Tailwind opacity classes that were rendering as a black screen.
- Ensures edit credential forms render optional template fields even when those fields were omitted from the stored credential JSON.
- Lets edit credential modal content stretch to the modal body width.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the black-screen loading overlay and makes credential editing resilient to missing fields and multi-auth templates. Also lets the edit modal content use the full body width.

- **Bug Fixes**
  - Updated `Spinner` overlay to use `bg-mask-03` and `backdrop-blur-03` to avoid the black screen.
  - Edit Credential now merges the template with stored values, so optional fields show even if omitted, and multi-auth templates select the right fields automatically.
  - Treats fields containing “token”, “password”, or “secret” as password inputs.
  - Stretched edit modal content to the modal body width.
  - Added unit tests for editable field selection and initial values.

<sup>Written for commit de11b436384f19fac25eef157d00d0f9cf9228d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12879?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

