### PR TITLE
fix: public root nodes

### DIFF
--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -27,11 +27,15 @@ def _build_hierarchy_access_filter(
     """Build SQLAlchemy filter for hierarchy node access.
 
     A user can access a hierarchy node if any of the following are true:
+    - The node is the SOURCE root for its source (always visible as the tree root)
     - The node is marked as public (is_public=True)
     - The user's email is in the node's external_user_emails list
     - Any of the user's external group IDs overlap with the node's external_user_group_ids
     """
-    access_filters: list[ColumnElement[bool]] = [HierarchyNode.is_public.is_(True)]
+    access_filters: list[ColumnElement[bool]] = [
+        HierarchyNode.node_type == HierarchyNodeType.SOURCE,
+        HierarchyNode.is_public.is_(True),
+    ]
     if user_email:
         access_filters.append(any_(HierarchyNode.external_user_emails) == user_email)
     if external_group_ids:
@@ -49,23 +53,7 @@ def _get_accessible_hierarchy_nodes_for_source(
     user_email: str,
     external_group_ids: list[str],
 ) -> list[HierarchyNode]:
-    """
-    EE version: Returns hierarchy nodes filtered by user permissions.
-
-    A user can access a hierarchy node if any of the following are true:
-    - The node is marked as public (is_public=True)
-    - The user's email is in the node's external_user_emails list
-    - Any of the user's external group IDs overlap with the node's external_user_group_ids
-
-    Args:
-        db_session: SQLAlchemy session
-        source: Document source type
-        user_email: User's email for permission checking
-        external_group_ids: User's external group IDs for permission checking
-
-    Returns:
-        List of HierarchyNode objects the user has access to
-    """
+    """EE version: hierarchy nodes the user can access, always including the SOURCE root."""
     stmt = select(HierarchyNode).where(
         HierarchyNode.source == source,
         HierarchyNode.node_type != HierarchyNodeType.STUB,

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -107,6 +107,7 @@ def ensure_source_node_exists(
         node_type=HierarchyNodeType.SOURCE,
         document_id=None,
         parent_id=None,  # SOURCE nodes have no parent
+        is_public=True,
     )
 
     db_session.add(source_node)

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -94,6 +94,14 @@ def ensure_source_node_exists(
     # Try to get existing SOURCE node first
     existing_node = get_source_hierarchy_node(db_session, source)
     if existing_node:
+        if (
+            not existing_node.is_public
+        ):  # fix for earlier bug where SOURCE nodes were not public
+            existing_node.is_public = True
+            if commit:
+                db_session.commit()
+            else:
+                db_session.flush()
         return existing_node
 
     # Create the SOURCE node

--- a/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from ee.onyx.db.hierarchy import _get_accessible_hierarchy_nodes_for_source
 from onyx.configs.constants import DocumentSource
 from onyx.db.enums import HierarchyNodeType
+from onyx.db.hierarchy import get_source_hierarchy_node
 from onyx.db.models import HierarchyNode
 
 
@@ -154,3 +155,39 @@ def test_combined_email_and_group(
     assert email_node.raw_node_id in result_ids
     assert group_node.raw_node_id in result_ids
     assert private_node.raw_node_id not in result_ids
+
+
+def test_source_node_always_accessible(
+    db_session: Session,
+) -> None:
+    """SOURCE roots are always returned, even when is_public is false."""
+    source_node = get_source_hierarchy_node(db_session, DocumentSource.SLACK)
+    assert source_node is not None
+    original_is_public = source_node.is_public
+    source_node.is_public = False
+
+    tag = uuid4().hex[:8]
+    private_child = HierarchyNode(
+        raw_node_id=f"private_child_{tag}",
+        display_name=f"Private Child {tag}",
+        source=DocumentSource.SLACK,
+        node_type=HierarchyNodeType.CHANNEL,
+        is_public=False,
+    )
+    db_session.add(private_child)
+    db_session.flush()
+
+    try:
+        results = _get_accessible_hierarchy_nodes_for_source(
+            db_session,
+            source=DocumentSource.SLACK,
+            user_email="",
+            external_group_ids=[],
+        )
+        result_ids = {n.id for n in results}
+        assert source_node.id in result_ids
+        assert private_child.id not in result_ids
+    finally:
+        source_node.is_public = original_is_public
+        db_session.delete(private_child)
+        db_session.commit()


### PR DESCRIPTION
## Description

new source type hierarchy nodes should always be public, and should always be retrievable. This shouldn't have been an issue for any existing connector types as all these nodes (for every existing source in the codebase) were seeded as public in the migration, but this will cover the case of a new connector type being added after the migration.

## How Has This Been Tested?

added test

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure SOURCE root hierarchy nodes are always public and always returned by access checks, preventing hidden roots for new connector types. Also backfills existing non-public SOURCE nodes and adds a test to lock this in.

- **Bug Fixes**
  - Include SOURCE nodes unconditionally in the access filter.
  - Set SOURCE nodes to is_public=True in ensure_source_node_exists and upgrade existing non-public nodes.
  - Added unit test to confirm SOURCE root is accessible while private children remain hidden.

<sup>Written for commit ea44a8a0a6355578c33688840df5038c047f830a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

