### PR TITLE
feat(opal): add InputSelect

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -139,6 +139,7 @@
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.0.0",
         "@radix-ui/react-popover": "^1.0.0",
+        "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-separator": "^1.0.0",
         "@radix-ui/react-slot": "^1.0.0",
         "@radix-ui/react-tabs": "^1.0.0",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -79,6 +79,7 @@
     "@dnd-kit/sortable": "^8.0.0",
     "@dnd-kit/utilities": "^3.0.0",
     "@radix-ui/react-popover": "^1.0.0",
+    "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-tabs": "^1.0.0",
     "@radix-ui/react-separator": "^1.0.0",
     "@radix-ui/react-slot": "^1.0.0",

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -159,6 +159,7 @@ export {
   type InputSelectRootProps,
   type InputSelectTriggerProps,
   type InputSelectItemProps,
+  type InputSelectSearchProps,
 } from "@opal/components/inputs/input-select/components";
 
 /* InputTags */

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -153,6 +153,14 @@ export {
   type InputDatePickerProps,
 } from "@opal/components/inputs/input-date-picker/components";
 
+/* InputSelect */
+export {
+  InputSelect,
+  type InputSelectRootProps,
+  type InputSelectTriggerProps,
+  type InputSelectItemProps,
+} from "@opal/components/inputs/input-select/components";
+
 /* InputTags */
 export {
   InputTags,

--- a/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
@@ -103,3 +103,51 @@ export const Disabled: Story = {
     </div>
   ),
 };
+
+const AGENTS = [
+  "General Assistant",
+  "Search Copilot",
+  "Sales Researcher",
+  "Support Triage",
+  "Code Reviewer",
+  "Data Analyst",
+  "Meeting Notetaker",
+  "Onboarding Guide",
+];
+
+function SearchableHarness() {
+  const [value, setValue] = useState("");
+  const [query, setQuery] = useState("");
+  const filtered = AGENTS.filter((name) =>
+    name.toLowerCase().includes(query.toLowerCase())
+  );
+  return (
+    <div className="w-72">
+      <InputSelect
+        value={value}
+        onValueChange={setValue}
+        onOpenChange={(open) => {
+          if (open) setQuery("");
+        }}
+      >
+        <InputSelect.Trigger placeholder="Select an agent" />
+        <InputSelect.Content>
+          <InputSelect.Search
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search agents..."
+          />
+          {filtered.map((name) => (
+            <InputSelect.Item key={name} value={name}>
+              {name}
+            </InputSelect.Item>
+          ))}
+        </InputSelect.Content>
+      </InputSelect>
+    </div>
+  );
+}
+
+export const Searchable: Story = {
+  render: () => <SearchableHarness />,
+};

--- a/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { InputSelect } from "@opal/components";
+import { SvgCloud, SvgCpu, SvgSparkle } from "@opal/icons";
+
+const meta: Meta<typeof InputSelect> = {
+  title: "opal/components/InputSelect",
+  component: InputSelect,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InputSelect>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="w-72">
+      <InputSelect defaultValue="fast">
+        <InputSelect.Trigger placeholder="Pick a tier" />
+        <InputSelect.Content>
+          <InputSelect.Item value="fast" icon={SvgSparkle}>
+            Fast
+          </InputSelect.Item>
+          <InputSelect.Item
+            value="balanced"
+            icon={SvgCpu}
+            description="Good default"
+          >
+            Balanced
+          </InputSelect.Item>
+          <InputSelect.Item value="thorough" icon={SvgCloud}>
+            Thorough
+          </InputSelect.Item>
+        </InputSelect.Content>
+      </InputSelect>
+    </div>
+  ),
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | undefined>(undefined);
+    return (
+      <div className="w-72">
+        <InputSelect value={value} onValueChange={setValue}>
+          <InputSelect.Trigger placeholder="Select a region" />
+          <InputSelect.Content>
+            <InputSelect.Item value="us">United States</InputSelect.Item>
+            <InputSelect.Item value="eu">European Union</InputSelect.Item>
+            <InputSelect.Item value="apac">Asia Pacific</InputSelect.Item>
+          </InputSelect.Content>
+        </InputSelect>
+      </div>
+    );
+  },
+};
+
+export const Groups: Story = {
+  render: () => (
+    <div className="w-72">
+      <InputSelect>
+        <InputSelect.Trigger placeholder="Choose a model" />
+        <InputSelect.Content>
+          <InputSelect.Group>
+            <InputSelect.Label>OpenAI</InputSelect.Label>
+            <InputSelect.Item value="gpt-mini">GPT-5 Mini</InputSelect.Item>
+            <InputSelect.Item value="gpt">GPT-5</InputSelect.Item>
+          </InputSelect.Group>
+          <InputSelect.Separator />
+          <InputSelect.Group>
+            <InputSelect.Label>Anthropic</InputSelect.Label>
+            <InputSelect.Item value="haiku">Claude Haiku</InputSelect.Item>
+            <InputSelect.Item value="opus">Claude Opus</InputSelect.Item>
+          </InputSelect.Group>
+        </InputSelect.Content>
+      </InputSelect>
+    </div>
+  ),
+};
+
+export const Error: Story = {
+  render: () => (
+    <div className="w-72">
+      <InputSelect error>
+        <InputSelect.Trigger placeholder="Required field" />
+        <InputSelect.Content>
+          <InputSelect.Item value="x">Option</InputSelect.Item>
+        </InputSelect.Content>
+      </InputSelect>
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="w-72">
+      <InputSelect disabled defaultValue="x">
+        <InputSelect.Trigger />
+        <InputSelect.Content>
+          <InputSelect.Item value="x">Locked option</InputSelect.Item>
+        </InputSelect.Content>
+      </InputSelect>
+    </div>
+  ),
+};

--- a/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
@@ -116,7 +116,7 @@ const AGENTS = [
 ];
 
 function SearchableHarness() {
-  const [value, setValue] = useState("");
+  const [value, setValue] = useState<string | undefined>(undefined);
   const [query, setQuery] = useState("");
   const filtered = AGENTS.filter((name) =>
     name.toLowerCase().includes(query.toLowerCase())

--- a/web/lib/opal/src/components/inputs/input-select/README.md
+++ b/web/lib/opal/src/components/inputs/input-select/README.md
@@ -1,0 +1,34 @@
+# InputSelect
+
+**Import:** `import { InputSelect } from "@opal/components";`
+
+Styled dropdown on Radix Select, the Figma `Input/Select`. Compound component: the root owns value state (controlled or uncontrolled), `Trigger` renders the `.opal-input` chrome with the selected item's icon and label (truncating with a tooltip when clipped), `Content` is the popper matching the trigger width, `Item`s render as `ContentAction` rows with Radix driving highlight and selection.
+
+```tsx
+<InputSelect value={value} onValueChange={setValue} error={touched && !value}>
+  <InputSelect.Trigger placeholder="Choose a model" />
+  <InputSelect.Content>
+    <InputSelect.Group>
+      <InputSelect.Label>OpenAI</InputSelect.Label>
+      <InputSelect.Item value="gpt" icon={SvgCpu} description="Default">
+        GPT-5
+      </InputSelect.Item>
+    </InputSelect.Group>
+    <InputSelect.Separator />
+    <InputSelect.Item value="opus">Claude Opus</InputSelect.Item>
+  </InputSelect.Content>
+</InputSelect>
+```
+
+## Parts
+
+| Part | Key props | Notes |
+|---|---|---|
+| `InputSelect` | Radix Root props + `error`, `disabled` | `error`/`disabled` drive the trigger chrome variant |
+| `.Trigger` | `placeholder`, `rightSection` | Custom `children` replace the selected-item display |
+| `.Content` | Radix Content props | Popper, trigger-width, 18rem max height with scroll |
+| `.Item` | `value`, `children`, `icon`, `description`, `wrapDescription` | The selected item's icon and label mirror into the trigger |
+| `.Group` / `.Label` | Radix props | Uppercase group label |
+| `.Separator` | `paddingParallel`, `paddingPerpendicular` | Opal `Divider` |
+
+Requires the `@radix-ui/react-select` peer dependency. The selected row uses the `select-heavy` selected tokens (`action-link-01` background with the interactive foreground vars), and keyboard/hover highlight comes from Radix's `data-highlighted`.

--- a/web/lib/opal/src/components/inputs/input-select/README.md
+++ b/web/lib/opal/src/components/inputs/input-select/README.md
@@ -4,6 +4,23 @@
 
 Styled dropdown on Radix Select, the Figma `Input/Select`. Compound component: the root owns value state (controlled or uncontrolled), `Trigger` renders the `.opal-input` chrome with the selected item's icon and label (truncating with a tooltip when clipped), `Content` is the popper matching the trigger width, `Item`s render as `ContentAction` rows with Radix driving highlight and selection.
 
+For filterable lists, render `Search` as the first child of `Content`. It is a sticky query row: the consumer owns the query state and renders only the matching `Item`s. The row keeps printable keys in its input (Radix typeahead never fires), focuses itself when the menu opens, hands focus to the option list on ArrowDown (Radix then drives highlight and Enter), and lets Escape close the menu. Clear the query in `onOpenChange` so each open starts unfiltered.
+
+```tsx
+<InputSelect.Content>
+  <InputSelect.Search
+    value={query}
+    onChange={(e) => setQuery(e.target.value)}
+    placeholder="Search agents..."
+  />
+  {filtered.map((a) => (
+    <InputSelect.Item key={a.id} value={String(a.id)}>
+      {a.name}
+    </InputSelect.Item>
+  ))}
+</InputSelect.Content>
+```
+
 ```tsx
 <InputSelect value={value} onValueChange={setValue} error={touched && !value}>
   <InputSelect.Trigger placeholder="Choose a model" />

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -496,7 +496,16 @@ function InputSelectSearch({
       className="opal-input-select-search"
       // Mousedown must not reach Content, whose preventDefault would kill
       // caret placement and text selection in the input.
-      onMouseDown={(e) => e.stopPropagation()}
+      onMouseDown={(e) => {
+        e.stopPropagation();
+        // Keep focus in the input when the clear (×) button is clicked, so
+        // typing resumes immediately. Its action fires on click, which
+        // preventDefault on mousedown does not suppress.
+        if ((e.target as HTMLElement).closest("button")) {
+          e.preventDefault();
+          inputRef.current?.focus();
+        }
+      }}
       onKeyDown={(e) => {
         if (e.key === "ArrowDown") {
           e.preventDefault();

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -12,7 +12,7 @@ import type {
   RichStr,
   WithoutStyles,
 } from "@opal/types";
-import { Divider, Text, Tooltip } from "@opal/components";
+import { Divider, InputTypeIn, Text, Tooltip } from "@opal/components";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { ContentAction } from "@opal/layouts";
 import { SvgChevronDownSmall } from "@opal/icons";
@@ -450,13 +450,87 @@ function InputSelectSeparator({
 }
 
 // ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+interface InputSelectSearchProps {
+  /** Controlled query. The consumer filters its own Items from it. */
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+}
+
+/**
+ * Sticky search row at the top of Content for filterable selects. The
+ * consumer owns the query and renders only the Items that match. The row
+ * owns focus and keyboard isolation: printable keys stay in the input so
+ * Radix's item typeahead never fires, and ArrowDown hands focus to the
+ * option list where Radix drives highlight and Enter natively.
+ */
+function InputSelectSearch({
+  value,
+  onChange,
+  placeholder = "Search...",
+}: InputSelectSearchProps) {
+  const rowRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Focus a frame after mount, past Radix's own open autofocus in the
+  // normal path, so typing searches immediately instead of jumping the
+  // highlight via typeahead.
+  React.useEffect(() => {
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  function focusFirstOption() {
+    const listbox = rowRef.current?.closest('[role="listbox"]');
+    listbox
+      ?.querySelector<HTMLElement>('[role="option"]:not([data-disabled])')
+      ?.focus();
+  }
+
+  return (
+    <div
+      ref={rowRef}
+      className="opal-input-select-search"
+      // Mousedown must not reach Content, whose preventDefault would kill
+      // caret placement and text selection in the input.
+      onMouseDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          e.stopPropagation();
+          focusFirstOption();
+          return;
+        }
+        // Keep keys out of Radix's item typeahead. Escape still closes the
+        // menu: Radix listens at document capture, ahead of this handler.
+        e.stopPropagation();
+      }}
+    >
+      <InputTypeIn
+        ref={inputRef}
+        variant="internal"
+        searchIcon
+        clearButton
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
 /**
  * InputSelect (Figma Input/Select): styled dropdown on Radix Select.
  * Compound: Trigger opens the popper Content, Items are Radix options
- * rendered as ContentAction rows, Group/Label/Separator organize them.
+ * rendered as ContentAction rows, Group/Label/Separator organize them, and
+ * Search makes the list filterable.
  */
 const InputSelect = Object.assign(InputSelectRoot, {
   Trigger: InputSelectTrigger,
@@ -465,6 +539,7 @@ const InputSelect = Object.assign(InputSelectRoot, {
   Group: InputSelectGroup,
   Label: InputSelectLabel,
   Separator: InputSelectSeparator,
+  Search: InputSelectSearch,
 });
 
 export {
@@ -472,4 +547,5 @@ export {
   type InputSelectRootProps,
   type InputSelectTriggerProps,
   type InputSelectItemProps,
+  type InputSelectSearchProps,
 };

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -1,0 +1,455 @@
+"use client";
+
+import "@opal/components/inputs/shared.css";
+import "@opal/components/inputs/input-select/styles.css";
+import React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { cn } from "@opal/utils";
+import type {
+  IconFunctionComponent,
+  InputVariants,
+  PaddingVariants,
+  RichStr,
+  WithoutStyles,
+} from "@opal/types";
+import { Divider, Text, Tooltip } from "@opal/components";
+import { toPlainString } from "@opal/components/text/InlineMarkdown";
+import { ContentAction } from "@opal/layouts";
+import { SvgChevronDownSmall } from "@opal/icons";
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+interface SelectedItemDisplay {
+  childrenRef: React.MutableRefObject<string | RichStr>;
+  iconRef: React.MutableRefObject<IconFunctionComponent | undefined>;
+}
+
+interface InputSelectContextValue {
+  variant: InputVariants;
+  currentValue?: string;
+  disabled?: boolean;
+  selectedItemDisplay: SelectedItemDisplay | null;
+  setSelectedItemDisplay: (display: SelectedItemDisplay | null) => void;
+}
+
+const InputSelectContext = React.createContext<InputSelectContextValue | null>(
+  null
+);
+
+const useInputSelectContext = () => {
+  const context = React.useContext(InputSelectContext);
+  if (!context) {
+    throw new Error(
+      "InputSelect compound components must be used within InputSelect"
+    );
+  }
+  return context;
+};
+
+// ---------------------------------------------------------------------------
+// TruncatedDisplay
+// ---------------------------------------------------------------------------
+
+/**
+ * Single-line trigger display that shows a hover tooltip only when the text
+ * is actually truncated, measured against a hidden untruncated twin.
+ */
+function TruncatedDisplay({
+  children,
+  dimmed = false,
+}: {
+  children: string | RichStr;
+  dimmed?: boolean;
+}) {
+  const [isTruncated, setIsTruncated] = React.useState(false);
+  const visibleRef = React.useRef<HTMLDivElement>(null);
+  const hiddenRef = React.useRef<HTMLDivElement>(null);
+
+  React.useLayoutEffect(() => {
+    function checkTruncation() {
+      if (visibleRef.current && hiddenRef.current) {
+        setIsTruncated(
+          hiddenRef.current.offsetWidth > visibleRef.current.offsetWidth
+        );
+      }
+    }
+
+    // Defer a tick so initial layout settles before measuring.
+    const timeoutId = setTimeout(checkTruncation, 0);
+    window.addEventListener("resize", checkTruncation);
+    return () => {
+      clearTimeout(timeoutId);
+      window.removeEventListener("resize", checkTruncation);
+    };
+  }, [children]);
+
+  const text = (
+    <Text color={dimmed ? "text-01" : "text-04"} nowrap>
+      {children}
+    </Text>
+  );
+
+  return (
+    <Tooltip
+      tooltip={isTruncated ? toPlainString(children) : undefined}
+      side="top"
+    >
+      <div className="relative min-w-0 flex-1">
+        <div ref={visibleRef} className="overflow-hidden truncate">
+          {text}
+        </div>
+        <div
+          ref={hiddenRef}
+          aria-hidden
+          className="pointer-events-none invisible absolute left-0 top-0 whitespace-nowrap"
+        >
+          {text}
+        </div>
+      </div>
+    </Tooltip>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+interface InputSelectRootProps extends WithoutStyles<
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Root>
+> {
+  /** Error chrome on the trigger. */
+  error?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+function InputSelectRoot({
+  disabled,
+  error,
+  value,
+  defaultValue,
+  onValueChange,
+  children,
+  ref,
+  ...props
+}: InputSelectRootProps) {
+  const variant: InputVariants = disabled
+    ? "disabled"
+    : error
+      ? "error"
+      : "primary";
+
+  // Mirrors the value in both modes so Item selection state and the trigger
+  // display work without Radix internals.
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = React.useState<string | undefined>(
+    defaultValue
+  );
+  const currentValue = isControlled ? value : internalValue;
+
+  React.useEffect(() => {
+    if (isControlled) return;
+    setInternalValue(defaultValue);
+  }, [defaultValue, isControlled]);
+
+  const handleValueChange = React.useCallback(
+    (nextValue: string) => {
+      onValueChange?.(nextValue);
+
+      if (isControlled) return;
+      setInternalValue(nextValue);
+    },
+    [isControlled, onValueChange]
+  );
+
+  // Only the selected Item registers its display, read by the Trigger through refs.
+  const [selectedItemDisplay, setSelectedItemDisplay] =
+    React.useState<SelectedItemDisplay | null>(null);
+
+  React.useEffect(() => {
+    if (!currentValue) setSelectedItemDisplay(null);
+  }, [currentValue]);
+
+  const contextValue = React.useMemo<InputSelectContextValue>(
+    () => ({
+      variant,
+      currentValue,
+      disabled,
+      selectedItemDisplay,
+      setSelectedItemDisplay,
+    }),
+    [variant, currentValue, disabled, selectedItemDisplay]
+  );
+
+  return (
+    <div className="opal-input-select-root">
+      <InputSelectContext.Provider value={contextValue}>
+        <SelectPrimitive.Root
+          {...(isControlled ? { value: currentValue } : { defaultValue })}
+          onValueChange={handleValueChange}
+          disabled={disabled}
+          {...props}
+        >
+          <div ref={ref} className="w-full">
+            {children}
+          </div>
+        </SelectPrimitive.Root>
+      </InputSelectContext.Provider>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Trigger
+// ---------------------------------------------------------------------------
+
+interface InputSelectTriggerProps extends WithoutStyles<
+  React.ComponentProps<typeof SelectPrimitive.Trigger>
+> {
+  /** Shown when no value is selected. Falsy values fall back to "Select an option". */
+  placeholder?: React.ReactNode;
+
+  /** Slot before the chevron. */
+  rightSection?: React.ReactNode;
+}
+
+function InputSelectTrigger({
+  placeholder,
+  rightSection,
+  children,
+  ref,
+  ...props
+}: InputSelectTriggerProps) {
+  const { variant, selectedItemDisplay } = useInputSelectContext();
+
+  // Read every render, the refs already hold the latest children/icon.
+  let displayContent: React.ReactNode;
+
+  if (!selectedItemDisplay) {
+    const effectivePlaceholder = placeholder || "Select an option";
+    displayContent =
+      typeof effectivePlaceholder === "string" ? (
+        <Text as="p" color="text-03">
+          {effectivePlaceholder}
+        </Text>
+      ) : (
+        effectivePlaceholder
+      );
+  } else {
+    const Icon = selectedItemDisplay.iconRef.current;
+    displayContent = (
+      <div className="flex w-full flex-1 flex-row items-center gap-2">
+        {Icon && <Icon className="opal-input-select-icon" />}
+        <TruncatedDisplay dimmed={variant === "disabled"}>
+          {selectedItemDisplay.childrenRef.current}
+        </TruncatedDisplay>
+      </div>
+    );
+  }
+
+  return (
+    <SelectPrimitive.Trigger
+      ref={ref}
+      className="opal-input opal-input-select-trigger"
+      data-variant={variant}
+      {...props}
+    >
+      {/* text-left counters the button element's centered default. */}
+      <div className="flex w-full flex-row items-center justify-between gap-1 p-0.5 text-left">
+        {children ?? displayContent}
+
+        <div className="flex flex-row items-center gap-1">
+          {rightSection}
+
+          <SelectPrimitive.Icon asChild>
+            <SvgChevronDownSmall className="opal-input-select-icon opal-input-select-chevron" />
+          </SelectPrimitive.Icon>
+        </div>
+      </div>
+    </SelectPrimitive.Trigger>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Content
+// ---------------------------------------------------------------------------
+
+function InputSelectContent({
+  children,
+  ref,
+  ...props
+}: WithoutStyles<React.ComponentProps<typeof SelectPrimitive.Content>>) {
+  return (
+    <SelectPrimitive.Portal>
+      <SelectPrimitive.Content
+        ref={ref}
+        className={cn(
+          "opal-input-select-content",
+          "data-[state=open]:animate-in data-[state=closed]:animate-out",
+          "data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0",
+          "data-[state=open]:zoom-in-95 data-[state=closed]:zoom-out-95"
+        )}
+        sideOffset={4}
+        position="popper"
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+        }}
+        {...props}
+      >
+        <SelectPrimitive.Viewport className="flex flex-col gap-1">
+          {children}
+        </SelectPrimitive.Viewport>
+      </SelectPrimitive.Content>
+    </SelectPrimitive.Portal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Item
+// ---------------------------------------------------------------------------
+
+interface InputSelectItemProps {
+  /** Unique option value. */
+  value: string;
+
+  /** Option label. */
+  children: string | RichStr;
+
+  icon?: IconFunctionComponent;
+  description?: string | RichStr;
+
+  /** Let the description wrap instead of truncating to one line. */
+  wrapDescription?: boolean;
+
+  ref?: React.Ref<React.ComponentRef<typeof SelectPrimitive.Item>>;
+}
+
+function InputSelectItem({
+  value,
+  children,
+  description,
+  wrapDescription,
+  icon,
+  ref,
+}: InputSelectItemProps) {
+  const { currentValue, setSelectedItemDisplay } = useInputSelectContext();
+  const isSelected = value === currentValue;
+
+  // Refs so the trigger reads current children/icon without re-registration.
+  const childrenRef = React.useRef<string | RichStr>(children);
+  const iconRef = React.useRef(icon);
+  childrenRef.current = children;
+  iconRef.current = icon;
+
+  React.useEffect(() => {
+    if (!isSelected) return;
+    setSelectedItemDisplay({ childrenRef, iconRef });
+
+    return () => setSelectedItemDisplay(null);
+  }, [isSelected]);
+
+  return (
+    <SelectPrimitive.Item
+      ref={ref}
+      value={value}
+      className="opal-input-select-item"
+    >
+      {/* Hidden ItemText feeds Radix's typeahead and the native select fallback. */}
+      <span className="hidden">
+        <SelectPrimitive.ItemText>
+          {toPlainString(children)}
+        </SelectPrimitive.ItemText>
+      </span>
+
+      {/* Pure layout row: Radix owns highlight and selection state, styled
+          via the item's data attributes. */}
+      <div className="w-full p-2">
+        <ContentAction
+          sizePreset="main-ui"
+          variant="section"
+          color="interactive"
+          icon={icon}
+          title={children}
+          titleMaxLines={1}
+          description={description}
+          descriptionMaxLines={wrapDescription ? undefined : 1}
+          padding="fit"
+          width="full"
+        />
+      </div>
+    </SelectPrimitive.Item>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Group + Label + Separator
+// ---------------------------------------------------------------------------
+
+function InputSelectGroup({
+  ref,
+  ...props
+}: WithoutStyles<React.ComponentProps<typeof SelectPrimitive.Group>>) {
+  return <SelectPrimitive.Group ref={ref} {...props} />;
+}
+
+function InputSelectLabel({
+  children,
+  ref,
+  ...props
+}: WithoutStyles<React.ComponentProps<typeof SelectPrimitive.Label>>) {
+  return (
+    <SelectPrimitive.Label
+      ref={ref}
+      className="opal-input-select-label"
+      {...props}
+    >
+      {children}
+    </SelectPrimitive.Label>
+  );
+}
+
+interface InputSelectSeparatorProps {
+  paddingParallel?: PaddingVariants;
+  paddingPerpendicular?: PaddingVariants;
+}
+
+function InputSelectSeparator({
+  paddingParallel,
+  paddingPerpendicular,
+}: InputSelectSeparatorProps) {
+  return (
+    <Divider
+      paddingParallel={paddingParallel}
+      paddingPerpendicular={paddingPerpendicular}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exports
+// ---------------------------------------------------------------------------
+
+/**
+ * InputSelect (Figma Input/Select): styled dropdown on Radix Select.
+ * Compound: Trigger opens the popper Content, Items are Radix options
+ * rendered as ContentAction rows, Group/Label/Separator organize them.
+ */
+const InputSelect = Object.assign(InputSelectRoot, {
+  Trigger: InputSelectTrigger,
+  Content: InputSelectContent,
+  Item: InputSelectItem,
+  Group: InputSelectGroup,
+  Label: InputSelectLabel,
+  Separator: InputSelectSeparator,
+});
+
+export {
+  InputSelect,
+  type InputSelectRootProps,
+  type InputSelectTriggerProps,
+  type InputSelectItemProps,
+};

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -345,7 +345,10 @@ function InputSelectItem({
   childrenRef.current = children;
   iconRef.current = icon;
 
-  React.useEffect(() => {
+  // Layout effect so the trigger never paints the placeholder on first
+  // render when a value is already selected. Radix mounts closed Content
+  // into a detached fragment, so this runs even while the menu is closed.
+  React.useLayoutEffect(() => {
     if (!isSelected) return;
     setSelectedItemDisplay({ childrenRef, iconRef });
 

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -223,22 +223,13 @@ function InputSelectTrigger({
   ref,
   ...props
 }: InputSelectTriggerProps) {
-  const { variant, selectedItemDisplay } = useInputSelectContext();
+  const { variant, currentValue, selectedItemDisplay } =
+    useInputSelectContext();
 
   // Read every render, the refs already hold the latest children/icon.
   let displayContent: React.ReactNode;
 
-  if (!selectedItemDisplay) {
-    const effectivePlaceholder = placeholder || "Select an option";
-    displayContent =
-      typeof effectivePlaceholder === "string" ? (
-        <Text as="p" color="text-03">
-          {effectivePlaceholder}
-        </Text>
-      ) : (
-        effectivePlaceholder
-      );
-  } else {
+  if (selectedItemDisplay) {
     const Icon = selectedItemDisplay.iconRef.current;
     displayContent = (
       <div className="flex w-full flex-1 flex-row items-center gap-2">
@@ -248,6 +239,27 @@ function InputSelectTrigger({
         </TruncatedDisplay>
       </div>
     );
+  } else if (currentValue) {
+    // Radix mirrors the selected ItemText here, so a preselected value never
+    // shows the placeholder even before the Item's registration effect runs.
+    displayContent = (
+      <SelectPrimitive.Value
+        className={cn(
+          "truncate font-main-ui-body",
+          variant === "disabled" ? "text-text-01" : "text-text-04"
+        )}
+      />
+    );
+  } else {
+    const effectivePlaceholder = placeholder || "Select an option";
+    displayContent =
+      typeof effectivePlaceholder === "string" ? (
+        <Text as="p" color="text-03">
+          {effectivePlaceholder}
+        </Text>
+      ) : (
+        effectivePlaceholder
+      );
   }
 
   return (

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -351,7 +351,8 @@ function InputSelectItem({
   const { currentValue, setSelectedItemDisplay } = useInputSelectContext();
   const isSelected = value === currentValue;
 
-  // Refs so the trigger reads current children/icon without re-registration.
+  // Refs keep the trigger reading the latest children/icon between
+  // registrations.
   const childrenRef = React.useRef<string | RichStr>(children);
   const iconRef = React.useRef(icon);
   childrenRef.current = children;
@@ -360,12 +361,16 @@ function InputSelectItem({
   // Layout effect so the trigger never paints the placeholder on first
   // render when a value is already selected. Radix mounts closed Content
   // into a detached fragment, so this runs even while the menu is closed.
+  // Keyed on the rendered content (plain-text key, since RichStr identity
+  // churns per render) so the trigger mirror re-renders when the selected
+  // option's label or icon changes without a value change.
+  const childrenKey = toPlainString(children);
   React.useLayoutEffect(() => {
     if (!isSelected) return;
     setSelectedItemDisplay({ childrenRef, iconRef });
 
     return () => setSelectedItemDisplay(null);
-  }, [isSelected]);
+  }, [isSelected, childrenKey, icon]);
 
   return (
     <SelectPrimitive.Item

--- a/web/lib/opal/src/components/inputs/input-select/styles.css
+++ b/web/lib/opal/src/components/inputs/input-select/styles.css
@@ -1,0 +1,71 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   InputSelect (Figma Input/Select)
+
+   Trigger on the .opal-input chrome plus an open-state border. Items are
+   pure layout rows: Radix owns interaction, so highlight and selection are
+   styled from its data attributes, with the selected row using the
+   select-heavy tokens (action-link bg, interactive foreground vars).
+   --------------------------------------------------------------------------- */
+
+.opal-input-select-root {
+  @apply relative w-full;
+  min-width: var(--block-width-form-input-min);
+}
+
+.opal-input-select-trigger {
+  @apply cursor-pointer focus:outline-hidden;
+}
+
+.opal-input-select-trigger[data-variant="primary"][data-state="open"] {
+  border-color: var(--border-05);
+}
+
+.opal-input-select-trigger[data-variant="disabled"] {
+  cursor: not-allowed;
+}
+
+.opal-input-select-icon {
+  @apply size-4 shrink-0 text-text-03;
+}
+
+.opal-input-select-trigger[data-variant="disabled"] .opal-input-select-icon {
+  @apply text-text-01;
+}
+
+.opal-input-select-chevron {
+  @apply transition-transform;
+}
+
+.opal-input-select-trigger[data-state="open"] .opal-input-select-chevron {
+  rotate: 180deg;
+}
+
+.opal-input-select-content {
+  @apply z-popover max-h-72 overflow-auto rounded-12 border bg-background-neutral-00 p-1;
+  width: var(--radix-select-trigger-width);
+}
+
+/* The rows sit outside any .interactive ancestor (portaled), so the item
+   provides the base foreground vars ContentAction's interactive color reads. */
+.opal-input-select-item {
+  @apply rounded-08 outline-hidden focus:outline-hidden;
+  color: var(--interactive-foreground);
+  --interactive-foreground: var(--text-04);
+  --interactive-foreground-icon: var(--text-03);
+}
+
+.opal-input-select-item[data-highlighted] {
+  @apply bg-background-tint-02;
+}
+
+.opal-input-select-item[data-state="checked"] {
+  background-color: var(--action-link-01);
+  --interactive-foreground: var(--action-link-05);
+  --interactive-foreground-icon: var(--action-link-05);
+}
+
+.opal-input-select-label {
+  @apply px-2 py-1.5 text-xs font-medium uppercase tracking-wide text-text-03;
+}

--- a/web/lib/opal/src/components/inputs/input-select/styles.css
+++ b/web/lib/opal/src/components/inputs/input-select/styles.css
@@ -1,4 +1,6 @@
 @reference "#reference.css";
+/* Shared Interactive timing tokens + registered foreground @property vars. */
+@import "../../core/interactive/shared.css";
 
 /* ---------------------------------------------------------------------------
    InputSelect (Figma Input/Select)
@@ -48,12 +50,20 @@
 }
 
 /* The rows sit outside any .interactive ancestor (portaled), so the item
-   provides the base foreground vars ContentAction's interactive color reads. */
+   provides the base foreground vars ContentAction's interactive color reads,
+   plus the shared Interactive timing so highlight animates like every other
+   select surface. Deliberately not a nested Interactive (see header). */
 .opal-input-select-item {
-  @apply rounded-08 outline-hidden focus:outline-hidden;
+  @apply cursor-pointer rounded-08 outline-hidden select-none focus:outline-hidden;
   color: var(--interactive-foreground);
   --interactive-foreground: var(--text-04);
   --interactive-foreground-icon: var(--text-03);
+  transition:
+    background-color var(--interactive-duration) var(--interactive-easing),
+    --interactive-foreground var(--interactive-duration)
+      var(--interactive-easing),
+    --interactive-foreground-icon var(--interactive-duration)
+      var(--interactive-easing);
 }
 
 .opal-input-select-item[data-highlighted] {

--- a/web/lib/opal/src/components/inputs/input-select/styles.css
+++ b/web/lib/opal/src/components/inputs/input-select/styles.css
@@ -1,6 +1,6 @@
 @reference "#reference.css";
 /* Shared Interactive timing tokens + registered foreground @property vars. */
-@import "../../core/interactive/shared.css";
+@import "../../../core/interactive/shared.css";
 
 /* ---------------------------------------------------------------------------
    InputSelect (Figma Input/Select)

--- a/web/lib/opal/src/components/inputs/input-select/styles.css
+++ b/web/lib/opal/src/components/inputs/input-select/styles.css
@@ -49,6 +49,12 @@
   width: var(--radix-select-trigger-width);
 }
 
+/* Full-bleed over the content's p-1 (negative margins) so scrolling items
+   pass behind a solid, bordered row pinned to the scrollport top. */
+.opal-input-select-search {
+  @apply sticky -top-1 z-1 -mx-1 -mt-1 mb-1 border-b bg-background-neutral-00 p-1;
+}
+
 /* The rows sit outside any .interactive ancestor (portaled), so the item
    provides the base foreground vars ContentAction's interactive color reads,
    plus the shared Interactive timing so highlight animates like every other


### PR DESCRIPTION
## Description

Ports `refresh-components/inputs/InputSelect` into Opal (Figma `Input/Select`).

- Compound API on Radix Select: root (controlled/uncontrolled value), `Trigger`, `Content`, `Item`, `Group`, `Label`, `Separator`.
- Trigger uses the shared `.opal-input` chrome; selected item's icon/label mirror into it, truncating with a tooltip when clipped.
- Items render as `ContentAction` rows. Radix data attributes drive highlight/selection; the selected row uses the select-heavy tokens (`action-link-01` bg, `action-link-05` foreground).
- `Search` compound slot (folded in from #13020): a sticky query row for filterable selects. The consumer owns the query and renders matching Items; printable keys never trigger Radix typeahead, the row autofocuses on open, ArrowDown hands focus to the option list (Radix drives highlight/Enter), Escape closes via Radix's document-capture listener, and mousedown is isolated from Content's preventDefault so caret placement and text selection work in the input.
- Fixes from the source carried over or cleaned up: dead `onClick` prop dropped (Radix `Item` has no `onSelect`; zero call sites), `wrapDescription` kept for import-swap parity, base interactive-foreground vars set on items so portaled rows don't render transparent icons.
- Adds `@radix-ui/react-select` to Opal peerDependencies. Stories + README included.

## How Has This Been Tested?

Storybook stories verified live with computed-style assertions (selected row `action-link-05`, non-selected icons `text-03`, disabled dimmed to `text-01`, truncation tooltip).

**Open (selected + hover states):**
<img width="2400" height="1814" alt="image" src="https://github.com/user-attachments/assets/bc9af9bd-99ce-4ab7-a4cd-d54a0b8027fe" />

**Groups + separator:**
<img width="2400" height="1814" alt="image" src="https://github.com/user-attachments/assets/f61ea2a5-0095-4553-8065-2ddea58e9c46" />

**Error:**
<img width="2400" height="1814" alt="image" src="https://github.com/user-attachments/assets/ca5693f8-5712-4370-8cc1-3bc3a2a32f85" />

**Disabled:**
<img width="2400" height="1814" alt="image" src="https://github.com/user-attachments/assets/6b22e3a4-042a-4e41-a90b-78733c29d940" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
