### PR TITLE
fix(web): fix loading overlay css

### DIFF
--- a/web/src/components/Spinner.tsx
+++ b/web/src/components/Spinner.tsx
@@ -2,7 +2,7 @@ import "./spinner.css";
 
 export const Spinner = () => {
   return (
-    <div className="fixed top-0 left-0 z-50 w-screen h-screen bg-black bg-opacity-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-modal flex items-center justify-center bg-mask-03 backdrop-blur-03">
       <div className="loader ease-linear rounded-full border-8 border-t-8 border-background-200 h-8 w-8"></div>
     </div>
   );


### PR DESCRIPTION
## Description

- Updates the shared full-screen spinner overlay to use the app mask and backdrop-blur tokens instead of the legacy black opacity utility.
- Fixes the black full-page background seen while creating or pausing connectors.
- Keeps the intended full-screen loading state intact.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
