### PR TITLE
fix(web): restore standard height for connector wizard text inputs

### DIFF
--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -244,7 +244,6 @@ export const RenderField: FC<RenderFieldProps> = ({
             label={label}
             name={field.name}
             isTextArea={false}
-            defaultHeight={"h-15"}
             disabled={disabled}
             onChange={(e) => setFieldValue(field.name, e.target.value)}
           />

--- a/web/tests/e2e/admin/connector/ConnectorSetupPage.ts
+++ b/web/tests/e2e/admin/connector/ConnectorSetupPage.ts
@@ -1,0 +1,66 @@
+/**
+ * Page Object Model for the add-connector wizard
+ * (`/admin/connectors/<source>?step=1`).
+ *
+ * The wizard renders every connector's configuration form through the shared
+ * `RenderField`/`TextFormField` machinery, so text fields are addressable by
+ * their config `name` (exposed as `data-testid`) and select fields by their
+ * native `<select name=...>` element.
+ */
+
+import { expect, type Locator, type Page } from "@playwright/test";
+import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+
+export class ConnectorSetupPage {
+  readonly page: Page;
+  readonly source: string;
+  readonly pageTitle: Locator;
+  readonly connectorNameInput: Locator;
+  readonly createConnectorButton: Locator;
+
+  constructor(page: Page, source: string) {
+    this.page = page;
+    this.source = source;
+    this.pageTitle = page.locator('[aria-label="admin-page-title"]');
+    this.connectorNameInput = page.getByTestId("name");
+    this.createConnectorButton = page.getByRole("button", {
+      name: "Create Connector",
+    });
+  }
+
+  /** A single-line text field from the connector config, by its config name. */
+  textField(fieldName: string): Locator {
+    return this.page.getByTestId(fieldName);
+  }
+
+  /** A select field from the connector config, by its config name. */
+  selectField(fieldName: string): Locator {
+    return this.page.locator(`select[name="${fieldName}"]`);
+  }
+
+  /**
+   * Navigate straight to the configuration step of the wizard. Connectors
+   * without a credential step (e.g. web) render their form here.
+   */
+  async goto() {
+    await this.page.goto(`/admin/connectors/${this.source}?step=1`);
+    await expect(this.pageTitle).toBeVisible({ timeout: 10_000 });
+  }
+
+  /**
+   * Submit the form and wait for the post-creation redirect to the connector
+   * status page. Creation validates the config server-side (up to ~10s in the
+   * UI), so allow a generous timeout.
+   */
+  async submitAndWaitForCreation() {
+    await this.createConnectorButton.click();
+    await this.page.waitForURL("**/admin/indexing/status**", {
+      timeout: 30_000,
+    });
+  }
+
+  /** Capture a full-page visual snapshot of the wizard. */
+  async expectScreenshot(name: string) {
+    await expectScreenshot(this.page, { name });
+  }
+}

--- a/web/tests/e2e/admin/connector/IndexingStatusPage.ts
+++ b/web/tests/e2e/admin/connector/IndexingStatusPage.ts
@@ -33,6 +33,17 @@ export class IndexingStatusPage {
   }
 
   /**
+   * The row for an individual connector, located by its exact name. Only
+   * visible once its source group has been expanded.
+   */
+  connectorRow(connectorName: string): Locator {
+    return this.page
+      .getByRole("row")
+      .filter({ hasText: connectorName })
+      .first();
+  }
+
+  /**
    * Wait for a source group to render so we don't snapshot the loading
    * skeleton, then settle the network before any screenshot.
    */
@@ -41,6 +52,32 @@ export class IndexingStatusPage {
       timeout: 15_000,
     });
     await this.page.waitForLoadState("networkidle");
+  }
+
+  /**
+   * Expand a collapsed source group so its connector rows are visible.
+   */
+  async expandSourceGroup(displayName: string) {
+    await this.waitForSourceGroup(displayName);
+    await this.sourceGroup(displayName).click();
+  }
+
+  /**
+   * Click a connector row and wait for the connector detail page
+   * (`/admin/connector/<ccPairId>`). Returns the ccPairId from the URL.
+   */
+  async openConnector(connectorName: string): Promise<number> {
+    await this.connectorRow(connectorName).click();
+    await this.page.waitForURL(/\/admin\/connector\/\d+/, {
+      timeout: 15_000,
+    });
+    const match = this.page.url().match(/\/admin\/connector\/(\d+)/);
+    if (!match) {
+      throw new Error(
+        `Expected a connector detail URL, got: ${this.page.url()}`
+      );
+    }
+    return Number(match[1]);
   }
 
   /**

--- a/web/tests/e2e/admin/connector/web_connector_setup.spec.ts
+++ b/web/tests/e2e/admin/connector/web_connector_setup.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "@playwright/test";
+import { OnyxApiClient } from "@tests/e2e/utils/onyxApiClient";
+import { ConnectorSetupPage } from "@tests/e2e/admin/connector/ConnectorSetupPage";
+import { IndexingStatusPage } from "@tests/e2e/admin/connector/IndexingStatusPage";
+
+/**
+ * Full UI workflow for configuring a web connector: fill in the wizard,
+ * create the connector, and verify it lands on the status page and its
+ * detail page reflects the configuration.
+ *
+ * The connector is paused via the API immediately after creation so
+ * background workers don't actually crawl the site, and deleted in
+ * `afterEach` (looked up by name so cleanup also runs if the test fails
+ * mid-way after creation).
+ */
+const DOCS_URL = "https://docs.onyx.app";
+
+test.describe("Web connector setup", () => {
+  let connectorName: string;
+  let ccPairId: number | null = null;
+
+  test.beforeEach(() => {
+    connectorName = `Web Connector E2E ${Date.now()}`;
+  });
+
+  test.afterEach(async ({ page }) => {
+    const apiClient = new OnyxApiClient(page.request);
+    try {
+      const idToDelete =
+        ccPairId ?? (await apiClient.findCCPairByName("web", connectorName));
+      ccPairId = null;
+      if (idToDelete === null) return;
+
+      // Deletion requires the connector to be paused first.
+      await apiClient.pauseConnector(idToDelete);
+      await apiClient.deleteCCPair(idToDelete);
+    } catch (error) {
+      console.warn(`Failed to clean up connector "${connectorName}": ${error}`);
+    }
+  });
+
+  test("configures a web connector through the wizard", async ({ page }) => {
+    const setupPage = new ConnectorSetupPage(page, "web");
+    await setupPage.goto();
+
+    await setupPage.connectorNameInput.fill(connectorName);
+    await setupPage.textField("base_url").fill(DOCS_URL);
+    await setupPage.selectField("web_connector_type").selectOption("recursive");
+
+    await setupPage.submitAndWaitForCreation();
+
+    // Pause via the API as soon as the connector exists so background
+    // workers don't start crawling the site while the test finishes.
+    const apiClient = new OnyxApiClient(page.request);
+    ccPairId = await apiClient.findCCPairByName("web", connectorName);
+    expect(ccPairId).not.toBeNull();
+    await apiClient.pauseConnector(ccPairId!);
+
+    // The new connector is listed under the (collapsed) Web source group.
+    const statusPage = new IndexingStatusPage(page);
+    await statusPage.expandSourceGroup("Web");
+    await expect(statusPage.connectorRow(connectorName)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Clicking the row opens the detail page for the same cc-pair, which
+    // shows the configured base URL.
+    const openedCcPairId = await statusPage.openConnector(connectorName);
+    expect(openedCcPairId).toBe(ccPairId);
+    await expect(page.getByText(connectorName).first()).toBeVisible();
+    await expect(page.getByText(DOCS_URL).first()).toBeVisible();
+  });
+});

--- a/web/tests/e2e/admin/connector/web_connector_setup_visual.spec.ts
+++ b/web/tests/e2e/admin/connector/web_connector_setup_visual.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
-import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+import { ConnectorSetupPage } from "@tests/e2e/admin/connector/ConnectorSetupPage";
 
 /**
  * Visual-regression coverage for the web connector setup wizard
@@ -20,16 +20,12 @@ for (const theme of THEMES) {
   test(`web connector setup wizard – ${theme} mode`, async ({ page }) => {
     await setThemeBeforeNavigation(page, theme);
 
-    await page.goto("/admin/connectors/web?step=1");
+    const setupPage = new ConnectorSetupPage(page, "web");
+    await setupPage.goto();
 
-    await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible({
-      timeout: 10000,
-    });
-    await expect(page.getByTestId("base_url")).toBeVisible();
+    await expect(setupPage.textField("base_url")).toBeVisible();
     await page.waitForLoadState("networkidle");
 
-    await expectScreenshot(page, {
-      name: `admin-${theme}-connectors--web--step-1`,
-    });
+    await setupPage.expectScreenshot(`admin-${theme}-connectors--web--step-1`);
   });
 }

--- a/web/tests/e2e/admin/connector/web_connector_setup_visual.spec.ts
+++ b/web/tests/e2e/admin/connector/web_connector_setup_visual.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+import { THEMES, setThemeBeforeNavigation } from "@tests/e2e/utils/theme";
+import { expectScreenshot } from "@tests/e2e/utils/visualRegression";
+
+/**
+ * Visual-regression coverage for the web connector setup wizard
+ * (`/admin/connectors/web?step=1`).
+ *
+ * The admin-pages sweep (`admin_pages.spec.ts`) only visits pages linked from
+ * the sidebar, so per-connector wizard pages are not covered by it. This page
+ * renders the shared `RenderField`/`TextFormField` machinery used by every
+ * connector's setup form, so a regression here (e.g. the Base URL input
+ * rendering at the wrong height) affects all connectors.
+ *
+ * The page is a static form with no dependence on connectors created by other
+ * specs, so it can safely run in the parallel `admin` project. Auth comes from
+ * the project's `storageState`.
+ */
+for (const theme of THEMES) {
+  test(`web connector setup wizard – ${theme} mode`, async ({ page }) => {
+    await setThemeBeforeNavigation(page, theme);
+
+    await page.goto("/admin/connectors/web?step=1");
+
+    await expect(page.locator('[aria-label="admin-page-title"]')).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByTestId("base_url")).toBeVisible();
+    await page.waitForLoadState("networkidle");
+
+    await expectScreenshot(page, {
+      name: `admin-${theme}-connectors--web--step-1`,
+    });
+  });
+}

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -65,6 +65,7 @@ export interface CreateAgentOptions {
  *
  * **Connectors:**
  * - `createFileConnector(name)` - Creates a file connector with mock credentials
+ * - `findCCPairByName(source, name)` - Looks up a connector-credential pair ID by source + name
  * - `deleteCCPair(ccPairId)` - Deletes a connector-credential pair (with polling until complete)
  *
  * **Document Sets:**
@@ -344,6 +345,40 @@ export class OnyxApiClient {
 
     await this.handleResponse(response, "Failed to pause connector");
     this.log(`Paused connector CC Pair ID: ${ccPairId}`);
+  }
+
+  /**
+   * Finds a connector-credential pair by source and exact connector name.
+   * Useful for cleaning up connectors created through the UI, where the test
+   * never sees the ccPairId directly.
+   *
+   * @param source - The connector source (e.g. "web", "file")
+   * @param name - The exact connector name to match
+   * @returns The ccPairId, or null if no connector with that name exists
+   */
+  async findCCPairByName(source: string, name: string): Promise<number | null> {
+    const response = await this.post(
+      "/manage/admin/connector/indexing-status",
+      {
+        source,
+        name_filter: name,
+        get_all_connectors: true,
+      }
+    );
+
+    const sourceGroups = await this.handleResponse<
+      { indexing_statuses: { cc_pair_id: number; name: string }[] }[]
+    >(response, "Failed to fetch connector indexing status");
+
+    for (const group of sourceGroups) {
+      const match = group.indexing_statuses.find(
+        (status) => status.name === name
+      );
+      if (match) {
+        return match.cc_pair_id;
+      }
+    }
+    return null;
   }
 
   /**


### PR DESCRIPTION
## Description

The Base URL input on the Web connector setup wizard (`/admin/connectors/web?step=1`) rendered 50% taller (60px) than every other input (40px).

Root cause: `FieldRendering.tsx` passed `defaultHeight="h-15"` to `TextFormField` for all single-line text fields in the connector wizard. When that line was written the project was on Tailwind v3, where `h-15` isn't a real class — it was silently ignored and inputs rendered at the base `h-10` (40px). The Tailwind v4 upgrade made `h-15` a valid dynamic spacing utility (3.75rem = 60px), which started overriding `h-10` and inflated every single-line text input in every connector's setup form.

### Changes

- **Fix**: drop the `defaultHeight` override (the only call site in the app) so wizard inputs use the standard `h-10` height.
- **Visual regression test**: `web_connector_setup_visual.spec.ts` screenshots the wizard in light/dark via the shared `expectScreenshot` harness.
- **Full workflow e2e test**: `web_connector_setup.spec.ts` configures a web connector end-to-end through the UI — fills the wizard (name, base URL `https://docs.onyx.app`, recursive scrape method), creates the connector, verifies it appears under the Web source group on the status page, and opens its detail page to confirm the configured base URL. The connector is paused via the API immediately after creation so background workers don't crawl the site, and deleted in `afterEach` (looked up by name, so cleanup also runs on mid-test failures).
- **Page objects**: new `ConnectorSetupPage` POM for the add-connector wizard (visual spec refactored onto it); `IndexingStatusPage` extended with source-group expansion and row → detail-page navigation; `OnyxApiClient` gains `findCCPairByName`.

## How Has This Been Tested?

- Measured the `base_url` input bounding box in the running app: 60px before, 40px after; screenshot-compared the page.
- All three specs pass locally against the full stack (API server + web server + all Celery workers), including repeat runs; connector cleanup confirmed via deletion polling and a final DB check showing no leaked cc-pairs.
- Visual spec also verified in `VISUAL_REGRESSION=true` assert mode — baselines are deterministic across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)