### PR TITLE
feat(opal): add Calendar

### DIFF
--- a/web/bun.lock
+++ b/web/bun.lock
@@ -145,6 +145,7 @@
         "formik": "^2.0.0",
         "next": ">=14.0.0",
         "react": "^18.0.0 || ^19.0.0",
+        "react-day-picker": "^9.0.0",
         "react-dom": "^18.0.0 || ^19.0.0",
         "react-markdown": "^9.0.0",
         "rehype-sanitize": "^6.0.0",

--- a/web/lib/opal/package.json
+++ b/web/lib/opal/package.json
@@ -87,6 +87,7 @@
     "formik": "^2.0.0",
     "next": ">=14.0.0",
     "react": "^18.0.0 || ^19.0.0",
+    "react-day-picker": "^9.0.0",
     "react-dom": "^18.0.0 || ^19.0.0",
     "react-markdown": "^9.0.0",
     "rehype-sanitize": "^6.0.0",

--- a/web/lib/opal/src/components/calendar/Calendar.stories.tsx
+++ b/web/lib/opal/src/components/calendar/Calendar.stories.tsx
@@ -1,0 +1,72 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import type { DateRange } from "react-day-picker";
+import { Calendar } from "@opal/components";
+
+const meta: Meta<typeof Calendar> = {
+  title: "opal/components/Calendar",
+  component: Calendar,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof Calendar>;
+
+export const Single: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<Date | undefined>(
+      new Date(2025, 11, 16)
+    );
+    return (
+      <Calendar
+        mode="single"
+        selected={selected}
+        onSelect={setSelected}
+        defaultMonth={new Date(2025, 11)}
+      />
+    );
+  },
+};
+
+export const Range: Story = {
+  render: () => {
+    const [range, setRange] = useState<DateRange | undefined>({
+      from: new Date(2025, 11, 16),
+      to: new Date(2025, 11, 24),
+    });
+    return (
+      <Calendar
+        mode="range"
+        selected={range}
+        onSelect={setRange}
+        defaultMonth={new Date(2025, 11)}
+      />
+    );
+  },
+};
+
+export const DisabledFutureDates: Story = {
+  render: () => {
+    const [selected, setSelected] = useState<Date | undefined>(undefined);
+    const today = new Date();
+    return (
+      <Calendar
+        mode="single"
+        selected={selected}
+        onSelect={setSelected}
+        disabled={[{ after: today }]}
+        endMonth={today}
+      />
+    );
+  },
+};
+
+export const TwoMonths: Story = {
+  render: () => (
+    <Calendar
+      mode="single"
+      numberOfMonths={2}
+      defaultMonth={new Date(2025, 11)}
+    />
+  ),
+};

--- a/web/lib/opal/src/components/calendar/README.md
+++ b/web/lib/opal/src/components/calendar/README.md
@@ -1,0 +1,30 @@
+# Calendar
+
+**Import:** `import { Calendar } from "@opal/components";`
+
+Month grid on `react-day-picker`, the Figma `Date Picker`. Accepts the DayPicker selection modes (`single`, `multiple`, `range`), navigation props (`month`, `defaultMonth`, `startMonth`, `endMonth`, `numberOfMonths`), and `disabled` matchers. Opal owns all chrome: the styling and slot escape hatches (`className`/`classNames`, `style`/`styles`, `components`, `formatters`, `modifiersClassNames`, `modifiersStyles`, `showOutsideDays`) are stripped, and outside-month cells stay empty while keeping their 28px slot so week rows keep even spacing.
+
+```tsx
+<Calendar
+  mode="single"
+  selected={date}
+  onSelect={setDate}
+  disabled={[{ after: new Date() }]}
+/>
+```
+
+## Anatomy
+
+| Part | Spec |
+|---|---|
+| Month | 232px wide, caption row + weekday header + weeks |
+| Caption | Month label in `main-ui-action` / `text-04`, prev/next `internal` icon buttons top-right |
+| Weekday | 28px cell, `secondary-body` / `text-03` |
+| Day chip | 28px (`--height-line-h3-section`), `rounded-08`, `main-ui-mono` numeral in `text-04` |
+| Hover | `tint-02` fill with `border-02` outline |
+| Selected / range endpoints | `tint-inverted-03` chip with `text-inverted-05` numeral |
+| Range middle | `tint-02` band spanning the week, rounded at week edges |
+| Today | Underlined numeral |
+| Disabled | `text-01` numeral, not clickable |
+
+Requires the `react-day-picker` peer dependency.

--- a/web/lib/opal/src/components/calendar/components.tsx
+++ b/web/lib/opal/src/components/calendar/components.tsx
@@ -55,6 +55,9 @@ function NextMonthButton({
 function Calendar(props: CalendarProps) {
   return (
     <DayPicker
+      // Spread first so the Opal-owned chrome below wins even against
+      // untyped callers that smuggle in classNames/components.
+      {...props}
       classNames={{
         root: "opal-calendar",
         months: "opal-calendar-months",
@@ -78,7 +81,6 @@ function Calendar(props: CalendarProps) {
         range_end: "opal-calendar-cell--range-end",
       }}
       components={{ PreviousMonthButton, NextMonthButton }}
-      {...props}
     />
   );
 }

--- a/web/lib/opal/src/components/calendar/components.tsx
+++ b/web/lib/opal/src/components/calendar/components.tsx
@@ -56,8 +56,15 @@ function Calendar(props: CalendarProps) {
   return (
     <DayPicker
       // Spread first so the Opal-owned chrome below wins even against
-      // untyped callers that smuggle in stripped props.
+      // untyped callers that smuggle in stripped props. Every key in the
+      // CalendarProps omit list is re-pinned here so none survive the spread.
       {...props}
+      className={undefined}
+      style={undefined}
+      styles={undefined}
+      formatters={undefined}
+      modifiersClassNames={undefined}
+      modifiersStyles={undefined}
       // Outside days render as empty fixed-width cells, never as numerals.
       showOutsideDays={false}
       classNames={{

--- a/web/lib/opal/src/components/calendar/components.tsx
+++ b/web/lib/opal/src/components/calendar/components.tsx
@@ -56,8 +56,10 @@ function Calendar(props: CalendarProps) {
   return (
     <DayPicker
       // Spread first so the Opal-owned chrome below wins even against
-      // untyped callers that smuggle in classNames/components.
+      // untyped callers that smuggle in stripped props.
       {...props}
+      // Outside days render as empty fixed-width cells, never as numerals.
+      showOutsideDays={false}
       classNames={{
         root: "opal-calendar",
         months: "opal-calendar-months",

--- a/web/lib/opal/src/components/calendar/components.tsx
+++ b/web/lib/opal/src/components/calendar/components.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import "@opal/components/calendar/styles.css";
+import React from "react";
+import { DayPicker } from "react-day-picker";
+import { Button } from "@opal/components";
+import { SvgChevronLeft, SvgChevronRight } from "@opal/icons";
+
+// Omit must distribute over DayPicker's per-mode props union, or the
+// mode/selected/onSelect discrimination collapses.
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+type CalendarProps = DistributiveOmit<
+  React.ComponentProps<typeof DayPicker>,
+  | "className"
+  | "style"
+  | "classNames"
+  | "styles"
+  | "components"
+  | "formatters"
+  | "modifiersClassNames"
+  | "modifiersStyles"
+  | "showOutsideDays"
+>;
+
+type NavButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement>;
+
+function PreviousMonthButton({
+  className: _className,
+  children: _children,
+  ...props
+}: NavButtonProps) {
+  return (
+    <Button icon={SvgChevronLeft} prominence="internal" size="sm" {...props} />
+  );
+}
+
+function NextMonthButton({
+  className: _className,
+  children: _children,
+  ...props
+}: NavButtonProps) {
+  return (
+    <Button icon={SvgChevronRight} prominence="internal" size="sm" {...props} />
+  );
+}
+
+/**
+ * Calendar (Figma Date Picker): month grid on react-day-picker.
+ * Supports the DayPicker selection modes (single/multiple/range). Opal owns
+ * all chrome, so the styling escape hatches are stripped from the props.
+ */
+function Calendar(props: CalendarProps) {
+  return (
+    <DayPicker
+      classNames={{
+        root: "opal-calendar",
+        months: "opal-calendar-months",
+        month: "opal-calendar-month",
+        nav: "opal-calendar-nav",
+        month_caption: "opal-calendar-caption",
+        caption_label: "opal-calendar-caption-label",
+        month_grid: "opal-calendar-grid",
+        weekdays: "opal-calendar-weekdays",
+        weekday: "opal-calendar-weekday",
+        weeks: "opal-calendar-weeks",
+        week: "opal-calendar-week",
+        day: "opal-calendar-cell",
+        day_button: "opal-calendar-day",
+        today: "opal-calendar-cell--today",
+        disabled: "opal-calendar-cell--disabled",
+        focused: "opal-calendar-cell--focused",
+        selected: "opal-calendar-cell--selected",
+        range_start: "opal-calendar-cell--range-start",
+        range_middle: "opal-calendar-cell--range-middle",
+        range_end: "opal-calendar-cell--range-end",
+      }}
+      components={{ PreviousMonthButton, NextMonthButton }}
+      {...props}
+    />
+  );
+}
+
+export { Calendar, type CalendarProps };

--- a/web/lib/opal/src/components/calendar/styles.css
+++ b/web/lib/opal/src/components/calendar/styles.css
@@ -14,7 +14,7 @@
 }
 
 .opal-calendar-months {
-  @apply relative flex flex-row;
+  @apply relative flex flex-row gap-4;
 }
 
 .opal-calendar-month {

--- a/web/lib/opal/src/components/calendar/styles.css
+++ b/web/lib/opal/src/components/calendar/styles.css
@@ -1,0 +1,122 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   Calendar (Figma Date Picker)
+
+   232px-per-month grid. Day chips are 28px (h3-section) mono-numeral buttons
+   with rounded-08. Selection uses the inverted tint chip, ranges paint a
+   tint-02 band across the week, and today is underlined. react-day-picker
+   owns interaction and marks state through the modifier classes.
+   --------------------------------------------------------------------------- */
+
+.opal-calendar {
+  @apply w-fit p-1;
+}
+
+.opal-calendar-months {
+  @apply relative flex flex-row;
+}
+
+.opal-calendar-month {
+  @apply flex flex-col gap-1;
+  width: 14.5rem;
+}
+
+.opal-calendar-nav {
+  @apply absolute right-0 top-0 flex items-center gap-2.5 p-0.5;
+}
+
+.opal-calendar-caption {
+  @apply flex h-7 items-center p-1 pr-20;
+}
+
+.opal-calendar-caption-label {
+  @apply font-main-ui-action text-text-04;
+}
+
+.opal-calendar-grid {
+  @apply w-full border-collapse;
+}
+
+.opal-calendar-weekdays,
+.opal-calendar-week {
+  @apply flex w-full items-center justify-between;
+}
+
+.opal-calendar-weeks {
+  @apply flex w-full flex-col gap-1;
+}
+
+.opal-calendar-weekday {
+  @apply flex items-center justify-center font-secondary-body text-text-03;
+  width: var(--height-line-h3-section);
+  height: var(--height-line-h3-section);
+}
+
+/* Fixed cell width keeps week spacing even when an outside or nav-boundary
+   day renders as an empty cell (react-day-picker hides its button). */
+.opal-calendar-cell {
+  @apply relative flex items-center justify-center p-0;
+  width: var(--height-line-h3-section);
+  height: var(--height-line-h3-section);
+}
+
+.opal-calendar-day {
+  @apply relative z-1 flex cursor-pointer items-center justify-center rounded-08 border border-transparent p-0.5 font-main-ui-mono text-text-04 outline-hidden;
+  width: var(--height-line-h3-section);
+  height: var(--height-line-h3-section);
+}
+
+.opal-calendar-day:hover {
+  @apply border-border-02 bg-background-tint-02;
+}
+
+.opal-calendar-cell--focused .opal-calendar-day {
+  @apply border-border-05;
+}
+
+.opal-calendar-cell--today .opal-calendar-day {
+  @apply underline underline-offset-2;
+}
+
+/* All selected days share the inverted chip except range middles, which keep
+   the plain numeral on the band. */
+.opal-calendar-cell--selected:not(.opal-calendar-cell--range-middle)
+  .opal-calendar-day {
+  @apply border-transparent text-text-inverted-05;
+  background-color: var(--background-tint-inverted-03);
+}
+
+/* The band bridges the 6px justify-between gaps with 3px overhangs on each
+   neighbor-facing side. Week edges stay flush and rounded. */
+.opal-calendar-cell--range-start::before,
+.opal-calendar-cell--range-middle::before,
+.opal-calendar-cell--range-end::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: -3px;
+  right: -3px;
+  background-color: var(--background-tint-02);
+}
+
+.opal-calendar-cell--range-start::before,
+.opal-calendar-cell--range-middle:first-child::before,
+.opal-calendar-cell--range-end:first-child::before {
+  left: 0;
+  border-top-left-radius: var(--radius-08);
+  border-bottom-left-radius: var(--radius-08);
+}
+
+.opal-calendar-cell--range-end::before,
+.opal-calendar-cell--range-middle:last-child::before,
+.opal-calendar-cell--range-start:last-child::before {
+  right: 0;
+  border-top-right-radius: var(--radius-08);
+  border-bottom-right-radius: var(--radius-08);
+}
+
+.opal-calendar-cell--disabled .opal-calendar-day {
+  @apply pointer-events-none cursor-default border-transparent bg-transparent text-text-01;
+}

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -103,6 +103,12 @@ export {
   type PaginationSize,
 } from "@opal/components/pagination/components";
 
+/* Calendar */
+export {
+  Calendar,
+  type CalendarProps,
+} from "@opal/components/calendar/components";
+
 /* Checkbox */
 export {
   Checkbox,


### PR DESCRIPTION
## Description

Ports the calendar into Opal (Figma `Date Picker`), replacing the shadcn-derived `refresh-components/Calendar` for Opal consumers.

- Wraps `react-day-picker` v9: Opal owns all chrome via a flat `classNames` map, styling/slot escape hatches are stripped from the props (distributive `Omit` keeps the per-mode union intact).
- Figma-exact: 232px month, 28px `DM Mono` day chips (`rounded-08`), selected = `tint-inverted-03` chip, range = `tint-02` band bridging the week gaps with rounded week edges, today underlined, disabled `text-01`.
- Nav uses Opal `Button` (internal/sm) via the `PreviousMonthButton`/`NextMonthButton` slots — no button-in-button nesting, and RDP's default day button keeps library-owned focus management.
- Fixed 28px cells keep week spacing stable when outside or nav-boundary days render empty.
- Adds `react-day-picker` to Opal peerDependencies. Stories + README included.

## How Has This Been Tested?

Storybook stories verified with Playwright computed-style assertions against the Figma spec (caption 14/20 SemiBold `text-04`, day chips 28px DM Mono `text-04`, selected `tint-inverted-03`, band `tint-02`, disabled `text-01`, empty boundary cells hold their 28px slot).

**Single (selected + today):**
<img width="480" height="450" alt="image" src="https://github.com/user-attachments/assets/059b9ac8-cdb6-42fb-9b18-0930a8e39755" />

**Range:**
<img width="480" height="450" alt="image" src="https://github.com/user-attachments/assets/e6ebbf45-e7ab-44b4-ab81-5aacf4bcfbea" />

**Disabled future dates:**
<img width="480" height="450" alt="image" src="https://github.com/user-attachments/assets/2554dee8-18b1-41da-9628-d1b0d02af909" />

**Two months:**
<img width="944" height="450" alt="image" src="https://github.com/user-attachments/assets/46d2fb62-990d-470f-b9b2-3dd01d6c286e" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check