### PR TITLE
fix(backend): rollback connector creation on validation failure

### DIFF
--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -9,6 +9,7 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
 from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import ValidationError
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.interfaces import CheckpointedConnector
 from onyx.connectors.interfaces import CredentialsConnector
@@ -185,15 +186,15 @@ def validate_ccpair_for_user(
             connector_specific_config=connector.connector_specific_config,
             credential=credential,
         )
-    except ConnectorValidationError as e:
-        raise e
+        runnable_connector.validate_connector_settings()
+        if access_type == AccessType.SYNC:
+            runnable_connector.validate_perm_sync()
+    except ValidationError:
+        raise
     except Exception as e:
         if enforce_creation:
             raise ConnectorValidationError(str(e))
         else:
             return False
 
-    runnable_connector.validate_connector_settings()
-    if access_type == AccessType.SYNC:
-        runnable_connector.validate_perm_sync()
     return True

--- a/backend/tests/unit/onyx/connectors/test_connector_factory.py
+++ b/backend/tests/unit/onyx/connectors/test_connector_factory.py
@@ -7,6 +7,7 @@ Unit tests for lazy loading connector factory to validate:
 """
 
 import importlib
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 from unittest.mock import Mock
 from unittest.mock import patch
@@ -14,15 +15,19 @@ from unittest.mock import patch
 import pytest
 
 from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import UnexpectedValidationError
 from onyx.connectors.factory import _connector_cache
 from onyx.connectors.factory import _load_connector_class
 from onyx.connectors.factory import ConnectorMissingException
 from onyx.connectors.factory import identify_connector_class
 from onyx.connectors.factory import instantiate_connector
+from onyx.connectors.factory import validate_ccpair_for_user
 from onyx.connectors.interfaces import BaseConnector
 from onyx.connectors.models import InputType
 from onyx.connectors.registry import CONNECTOR_CLASS_MAP
 from onyx.connectors.registry import ConnectorMapping
+from onyx.db.enums import AccessType
 
 
 class TestConnectorMappingValidation:
@@ -268,3 +273,105 @@ class TestInstantiateConnectorIntegration:
         # But the class should have been loaded into cache
         assert DocumentSource.WEB in _connector_cache
         assert _connector_cache[DocumentSource.WEB].__name__ == "WebConnector"
+
+
+class TestValidateCCPairForUser:
+    def test_validate_settings_error_raises_connector_validation_error(self) -> None:
+        runnable_connector = MagicMock()
+        runnable_connector.validate_connector_settings.side_effect = RuntimeError(
+            "SSL verification failed"
+        )
+
+        with (
+            patch(
+                "onyx.connectors.factory.fetch_connector_by_id",
+                return_value=SimpleNamespace(
+                    source=DocumentSource.DISCORD,
+                    input_type=InputType.POLL,
+                    connector_specific_config={},
+                ),
+            ),
+            patch(
+                "onyx.connectors.factory.fetch_credential_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.factory.instantiate_connector",
+                return_value=runnable_connector,
+            ),
+            pytest.raises(ConnectorValidationError) as exc_info,
+        ):
+            validate_ccpair_for_user(
+                connector_id=1,
+                credential_id=2,
+                access_type=AccessType.PUBLIC,
+                db_session=MagicMock(),
+            )
+
+        assert "SSL verification failed" in str(exc_info.value)
+
+    def test_validate_settings_error_returns_false_without_enforcing(self) -> None:
+        runnable_connector = MagicMock()
+        runnable_connector.validate_connector_settings.side_effect = RuntimeError(
+            "SSL verification failed"
+        )
+
+        with (
+            patch(
+                "onyx.connectors.factory.fetch_connector_by_id",
+                return_value=SimpleNamespace(
+                    source=DocumentSource.DISCORD,
+                    input_type=InputType.POLL,
+                    connector_specific_config={},
+                ),
+            ),
+            patch(
+                "onyx.connectors.factory.fetch_credential_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.factory.instantiate_connector",
+                return_value=runnable_connector,
+            ),
+        ):
+            valid = validate_ccpair_for_user(
+                connector_id=1,
+                credential_id=2,
+                access_type=AccessType.PUBLIC,
+                db_session=MagicMock(),
+                enforce_creation=False,
+            )
+
+        assert valid is False
+
+    def test_validate_settings_preserves_validation_error_type(self) -> None:
+        runnable_connector = MagicMock()
+        runnable_connector.validate_connector_settings.side_effect = (
+            UnexpectedValidationError("unexpected validation failure")
+        )
+
+        with (
+            patch(
+                "onyx.connectors.factory.fetch_connector_by_id",
+                return_value=SimpleNamespace(
+                    source=DocumentSource.DISCORD,
+                    input_type=InputType.POLL,
+                    connector_specific_config={},
+                ),
+            ),
+            patch(
+                "onyx.connectors.factory.fetch_credential_by_id",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "onyx.connectors.factory.instantiate_connector",
+                return_value=runnable_connector,
+            ),
+            pytest.raises(UnexpectedValidationError),
+        ):
+            validate_ccpair_for_user(
+                connector_id=1,
+                credential_id=2,
+                access_type=AccessType.PUBLIC,
+                db_session=MagicMock(),
+            )


### PR DESCRIPTION
## Description

- Wrap raw connector validation failures from `validate_connector_settings()` and permission-sync validation as `ConnectorValidationError` during creation validation.
- Preserve existing `ValidationError` subclasses so typed validation failures keep their semantics.
- Lets the existing connector-only rollback path in credential association delete the newly-created connector when validation fails before a connector credential pair is created.
- Adds unit coverage for raw validation failures, non-enforcing validation, and preserving typed validation errors.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures connector creation rolls back on validation failure by surfacing basic validation errors as `ConnectorValidationError`. Prevents orphan connectors when `validate_connector_settings()` or permission-sync validation fails.

- **Bug Fixes**
  - Run `validate_connector_settings()` and `validate_perm_sync()` inside the guarded block in `validate_ccpair_for_user`; wrap unexpected exceptions as `ConnectorValidationError` when `enforce_creation=True`, or return False. This triggers the existing connector-only rollback before a credential pair exists.
  - Preserve `ValidationError` subclasses (e.g., `UnexpectedValidationError`) so typed failures keep their semantics.
  - Add unit tests for raw failures, non-enforcing behavior, and typed error preservation.

<sup>Written for commit 7d43473a3f54e532b0e84922b9fe1b0319c424f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

