### PR TITLE
fix: public root nodes (#12880) to release v4.2

### DIFF
--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -25,11 +25,15 @@ def _build_hierarchy_access_filter(
     """Build SQLAlchemy filter for hierarchy node access.
 
     A user can access a hierarchy node if any of the following are true:
+    - The node is the SOURCE root for its source (always visible as the tree root)
     - The node is marked as public (is_public=True)
     - The user's email is in the node's external_user_emails list
     - Any of the user's external group IDs overlap with the node's external_user_group_ids
     """
-    access_filters: list[ColumnElement[bool]] = [HierarchyNode.is_public.is_(True)]
+    access_filters: list[ColumnElement[bool]] = [
+        HierarchyNode.node_type == HierarchyNodeType.SOURCE,
+        HierarchyNode.is_public.is_(True),
+    ]
     if user_email:
         access_filters.append(any_(HierarchyNode.external_user_emails) == user_email)
     if external_group_ids:
@@ -47,23 +51,7 @@ def _get_accessible_hierarchy_nodes_for_source(
     user_email: str,
     external_group_ids: list[str],
 ) -> list[HierarchyNode]:
-    """
-    EE version: Returns hierarchy nodes filtered by user permissions.
-
-    A user can access a hierarchy node if any of the following are true:
-    - The node is marked as public (is_public=True)
-    - The user's email is in the node's external_user_emails list
-    - Any of the user's external group IDs overlap with the node's external_user_group_ids
-
-    Args:
-        db_session: SQLAlchemy session
-        source: Document source type
-        user_email: User's email for permission checking
-        external_group_ids: User's external group IDs for permission checking
-
-    Returns:
-        List of HierarchyNode objects the user has access to
-    """
+    """EE version: hierarchy nodes the user can access, always including the SOURCE root."""
     stmt = select(HierarchyNode).where(
         HierarchyNode.source == source,
         HierarchyNode.node_type != HierarchyNodeType.STUB,

--- a/backend/onyx/db/hierarchy.py
+++ b/backend/onyx/db/hierarchy.py
@@ -94,6 +94,14 @@ def ensure_source_node_exists(
     # Try to get existing SOURCE node first
     existing_node = get_source_hierarchy_node(db_session, source)
     if existing_node:
+        if (
+            not existing_node.is_public
+        ):  # fix for earlier bug where SOURCE nodes were not public
+            existing_node.is_public = True
+            if commit:
+                db_session.commit()
+            else:
+                db_session.flush()
         return existing_node
 
     # Create the SOURCE node
@@ -107,6 +115,7 @@ def ensure_source_node_exists(
         node_type=HierarchyNodeType.SOURCE,
         document_id=None,
         parent_id=None,  # SOURCE nodes have no parent
+        is_public=True,
     )
 
     db_session.add(source_node)

--- a/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
+++ b/backend/tests/external_dependency_unit/hierarchy/test_hierarchy_access_filter.py
@@ -14,6 +14,7 @@ from sqlalchemy.orm import Session
 from ee.onyx.db.hierarchy import _get_accessible_hierarchy_nodes_for_source
 from onyx.configs.constants import DocumentSource
 from onyx.db.enums import HierarchyNodeType
+from onyx.db.hierarchy import get_source_hierarchy_node
 from onyx.db.models import HierarchyNode
 
 
@@ -154,3 +155,39 @@ def test_combined_email_and_group(
     assert email_node.raw_node_id in result_ids
     assert group_node.raw_node_id in result_ids
     assert private_node.raw_node_id not in result_ids
+
+
+def test_source_node_always_accessible(
+    db_session: Session,
+) -> None:
+    """SOURCE roots are always returned, even when is_public is false."""
+    source_node = get_source_hierarchy_node(db_session, DocumentSource.SLACK)
+    assert source_node is not None
+    original_is_public = source_node.is_public
+    source_node.is_public = False
+
+    tag = uuid4().hex[:8]
+    private_child = HierarchyNode(
+        raw_node_id=f"private_child_{tag}",
+        display_name=f"Private Child {tag}",
+        source=DocumentSource.SLACK,
+        node_type=HierarchyNodeType.CHANNEL,
+        is_public=False,
+    )
+    db_session.add(private_child)
+    db_session.flush()
+
+    try:
+        results = _get_accessible_hierarchy_nodes_for_source(
+            db_session,
+            source=DocumentSource.SLACK,
+            user_email="",
+            external_group_ids=[],
+        )
+        result_ids = {n.id for n in results}
+        assert source_node.id in result_ids
+        assert private_child.id not in result_ids
+    finally:
+        source_node.is_public = original_is_public
+        db_session.delete(private_child)
+        db_session.commit()


### PR DESCRIPTION
Cherry-pick of commit 05fa6ffd8fde8386606fe58a560f9ed697629ab8 to release/v4.2 branch.

Original PR: #12880

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure SOURCE root hierarchy nodes are always visible and marked public, fixing cases where source roots were hidden. Private children remain correctly restricted.

- **Bug Fixes**
  - Include SOURCE roots in the access filter, regardless of `is_public`.
  - `ensure_source_node_exists` now sets `is_public=True` and fixes existing non-public SOURCE nodes.
  - Added a test to verify SOURCE roots are returned while private children are not.

<sup>Written for commit 0972bdc0fa8e38944f8a3b61d5ffe7eb43cc91e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12891?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

