### PR TITLE
fix(open_url): resolve type-ambiguous Google Drive links to indexed docs

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -30,6 +30,9 @@ from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.google_drive.doc_conversion import (
+    _FALLBACK_BINARY_WEB_VIEW_LINK_TEMPLATE,
+)
+from onyx.connectors.google_drive.doc_conversion import (
     _FALLBACK_WEB_VIEW_LINK_TEMPLATES,
 )
 from onyx.connectors.google_drive.doc_conversion import build_slim_document
@@ -150,7 +153,7 @@ def _candidate_document_ids_from_file_id(file_id: str) -> list[str]:
         template.format(file_id)
         for template in _FALLBACK_WEB_VIEW_LINK_TEMPLATES.values()
     ]
-    uploaded_binary_link = f"https://drive.google.com/file/d/{file_id}/view"
+    uploaded_binary_link = _FALLBACK_BINARY_WEB_VIEW_LINK_TEMPLATE.format(file_id)
 
     candidates: list[str] = []
     for link in [*native_doc_links, uploaded_binary_link]:

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -12,8 +12,8 @@ from typing import Any
 from typing import cast
 from typing import Protocol
 from urllib.parse import parse_qs
+from urllib.parse import ParseResult
 from urllib.parse import urlparse
-from urllib.parse import urlunparse
 
 from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials as OAuthCredentials
@@ -29,10 +29,14 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.exceptions import CredentialExpiredError
 from onyx.connectors.exceptions import InsufficientPermissionsError
+from onyx.connectors.google_drive.doc_conversion import (
+    _FALLBACK_WEB_VIEW_LINK_TEMPLATES,
+)
 from onyx.connectors.google_drive.doc_conversion import build_slim_document
 from onyx.connectors.google_drive.doc_conversion import convert_drive_item_to_document
 from onyx.connectors.google_drive.doc_conversion import onyx_document_id_from_drive_file
 from onyx.connectors.google_drive.doc_conversion import PermissionSyncContext
+from onyx.connectors.google_drive.doc_conversion import WEB_VIEW_LINK_KEY
 from onyx.connectors.google_drive.file_retrieval import crawl_folders_for_files
 from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
 from onyx.connectors.google_drive.file_retrieval import get_all_files_for_oauth
@@ -118,6 +122,42 @@ def _extract_str_list_from_comma_str(string: str | None) -> list[str]:
 
 def _extract_ids_from_urls(urls: list[str]) -> list[str]:
     return [urlparse(url).path.strip("/").split("/")[-1] for url in urls]
+
+
+def _extract_drive_file_id(parsed: ParseResult) -> str | None:
+    """Extract the file id from a Drive/Docs URL.
+
+    Covers `?id=<id>`, `/d/<id>/...`, and the multi-account `/u/<N>/d/<id>/...` form.
+    """
+    id_query_param = parse_qs(parsed.query).get("id", [None])[0]
+    if id_query_param:
+        return id_query_param
+
+    path_parts = parsed.path.split("/")
+    for i, part in enumerate(path_parts):
+        if part == "d" and i + 1 < len(path_parts):
+            return path_parts[i + 1]
+    return None
+
+
+def _candidate_document_ids_from_file_id(file_id: str) -> list[str]:
+    """Every canonical Document.id a Drive file id could have been indexed under.
+
+    A file id is globally unique, so at most one of the native Doc/Sheet/Slide forms
+    and the uploaded-binary form is ever indexed; the caller matches whichever exists.
+    """
+    native_doc_links = [
+        template.format(file_id)
+        for template in _FALLBACK_WEB_VIEW_LINK_TEMPLATES.values()
+    ]
+    uploaded_binary_link = f"https://drive.google.com/file/d/{file_id}/view"
+
+    candidates: list[str] = []
+    for link in [*native_doc_links, uploaded_binary_link]:
+        doc_id = onyx_document_id_from_drive_file({WEB_VIEW_LINK_KEY: link}).rstrip("/")
+        if doc_id not in candidates:
+            candidates.append(doc_id)
+    return candidates
 
 
 def _clean_requested_drive_ids(
@@ -343,10 +383,12 @@ class GoogleDriveConnector(
     @classmethod
     @override
     def normalize_url(cls, url: str) -> NormalizationResult:
-        """Normalize a Google Drive URL to match the canonical Document.id format.
+        """Normalize a Google Drive URL to candidate Document.id values.
 
-        Reuses the connector's existing document ID creation logic from
-        onyx_document_id_from_drive_file.
+        The pasted URL often doesn't encode the file's type, so the canonical
+        Document.id could take any of several forms; emit them all as candidates and
+        let resolution match whichever is indexed. `normalized_url` is a single best
+        guess for callers that don't consult the candidate list.
         """
         parsed = urlparse(url)
         netloc = parsed.netloc.lower()
@@ -357,36 +399,21 @@ class GoogleDriveConnector(
         ):
             return NormalizationResult(normalized_url=None, use_default=False)
 
-        # Handle ?id= query parameter case
-        query_params = parse_qs(parsed.query)
-        doc_id = query_params.get("id", [None])[0]
-        if doc_id:
-            scheme = parsed.scheme or "https"
-            netloc = "drive.google.com"
-            path = f"/file/d/{doc_id}"
-            params = ""
-            query = ""
-            fragment = ""
-            normalized = urlunparse(
-                (scheme, netloc, path, params, query, fragment)
-            ).rstrip("/")
-            return NormalizationResult(normalized_url=normalized, use_default=False)
-
-        # Extract file ID and use connector's function
-        path_parts = parsed.path.split("/")
-        file_id = None
-        for i, part in enumerate(path_parts):
-            if part == "d" and i + 1 < len(path_parts):
-                file_id = path_parts[i + 1]
-                break
-
+        file_id = _extract_drive_file_id(parsed)
         if not file_id:
             return NormalizationResult(normalized_url=None, use_default=False)
 
-        # Create minimal file object for connector function
-        file_obj = {"webViewLink": url, "id": file_id}
-        normalized = onyx_document_id_from_drive_file(file_obj).rstrip("/")
-        return NormalizationResult(normalized_url=normalized, use_default=False)
+        # Best guess: keep the pasted URL's type if it has one; a ?id= link has none.
+        if parse_qs(parsed.query).get("id"):
+            normalized = f"https://drive.google.com/file/d/{file_id}"
+        else:
+            normalized = onyx_document_id_from_drive_file(
+                {WEB_VIEW_LINK_KEY: url, "id": file_id}
+            ).rstrip("/")
+        return NormalizationResult(
+            normalized_url=normalized,
+            candidate_document_ids=_candidate_document_ids_from_file_id(file_id),
+        )
 
     # TODO: ensure returned new_creds_dict is actually persisted when this is called?
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, str] | None:

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -408,7 +408,13 @@ class GoogleDriveConnector(
 
         # Best guess: keep the pasted URL's type if it has one; a ?id= link has none.
         if parse_qs(parsed.query).get("id"):
-            normalized = f"https://drive.google.com/file/d/{file_id}"
+            normalized = onyx_document_id_from_drive_file(
+                {
+                    WEB_VIEW_LINK_KEY: _FALLBACK_BINARY_WEB_VIEW_LINK_TEMPLATE.format(
+                        file_id
+                    )
+                }
+            ).rstrip("/")
         else:
             normalized = onyx_document_id_from_drive_file(
                 {WEB_VIEW_LINK_KEY: url, "id": file_id}

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -209,6 +209,8 @@ _FALLBACK_WEB_VIEW_LINK_TEMPLATES = {
     GDriveMimeType.SPREADSHEET.value: "https://docs.google.com/spreadsheets/d/{}/view",
     GDriveMimeType.PPT.value: "https://docs.google.com/presentation/d/{}/view",
 }
+# Fallback template for non-native (uploaded binary) Drive files.
+_FALLBACK_BINARY_WEB_VIEW_LINK_TEMPLATE = "https://drive.google.com/file/d/{}/view"
 
 MAX_RETRIEVER_EMAILS = 20
 CHUNK_SIZE_BUFFER = 64  # extra bytes past the limit to read
@@ -244,7 +246,7 @@ def onyx_document_id_from_drive_file(file: GoogleDriveFileType) -> str:
         mime_type = file.get("mimeType", "")
         template = _FALLBACK_WEB_VIEW_LINK_TEMPLATES.get(mime_type)
         if template is None:
-            link = f"https://drive.google.com/file/d/{file_id}/view"
+            link = _FALLBACK_BINARY_WEB_VIEW_LINK_TEMPLATE.format(file_id)
         else:
             link = template.format(file_id)
         logger.debug(

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -8,6 +8,7 @@ from typing import TypeAlias
 from typing import TypeVar
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import ConnectorCheckpoint
@@ -34,10 +35,14 @@ class NormalizationResult(BaseModel):
     Attributes:
         normalized_url: The normalized URL string, or None if normalization failed
         use_default: If True, fall back to default normalizer. If False, return None.
+        candidate_document_ids: Additional canonical Document.id values a single URL
+            may map to (e.g. a Google Drive file id whose type isn't encoded in the
+            pasted URL). Resolution matches whichever candidate exists in the index.
     """
 
     normalized_url: str | None
     use_default: bool = False
+    candidate_document_ids: list[str] = Field(default_factory=list)
 
 
 class BaseConnector(abc.ABC, Generic[CT]):

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -35,7 +35,9 @@ from onyx.tools.tool_implementations.open_url.models import WebContentProvider
 from onyx.tools.tool_implementations.open_url.url_normalization import (
     _default_url_normalizer,
 )
-from onyx.tools.tool_implementations.open_url.url_normalization import normalize_url
+from onyx.tools.tool_implementations.open_url.url_normalization import (
+    normalize_url_candidates,
+)
 from onyx.tools.tool_implementations.open_url.utils import (
     filter_web_contents_with_no_title_or_content,
 )
@@ -233,21 +235,18 @@ def _resolve_urls_to_document_ids(
     normalized_map: dict[str, set[str]] = {}
 
     for url in urls:
-        # Use connector-owned normalization (reuses connector's own logic)
-        normalized = normalize_url(url)
+        # A single URL may map to several candidate document IDs; match whichever is indexed.
+        candidates = normalize_url_candidates(url)
 
-        if normalized:
-            # Some connectors (e.g. Notion) normalize to a non-URL canonical document
-            # identifier (e.g. a UUID) rather than a URL. In those cases, we should
-            # treat the normalized value as a document_id directly.
-            if normalized.startswith(("http://", "https://")):
-                # Get URL variants (with/without trailing slash) for database lookup
-                variants = _url_lookup_variants(normalized)
-                # Defensive fallback: if variant generation fails, still try the
-                # normalized URL itself.
-                normalized_map[url] = variants or {normalized}
-            else:
-                normalized_map[url] = {normalized}
+        if candidates:
+            variants: set[str] = set()
+            for candidate in candidates:
+                if candidate.startswith(("http://", "https://")):
+                    variants |= _url_lookup_variants(candidate) or {candidate}
+                else:
+                    # Non-URL canonical id (e.g. a Notion UUID); use it directly.
+                    variants.add(candidate)
+            normalized_map[url] = variants
         else:
             # No normalizer found - could be a non-URL document ID (e.g., FILE_CONNECTOR__...)
             if url and not url.startswith(("http://", "https://")):

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -232,31 +232,35 @@ def _resolve_urls_to_document_ids(
     """
     matches: list[IndexedDocumentRequest] = []
     unresolved: list[str] = []
-    normalized_map: dict[str, set[str]] = {}
+    # Ordered by connector-defined candidate priority; the first indexed variant wins.
+    normalized_map: dict[str, list[str]] = {}
 
     for url in urls:
         # A single URL may map to several candidate document IDs; match whichever is indexed.
         candidates = normalize_url_candidates(url)
 
         if candidates:
-            variants: set[str] = set()
+            variants: list[str] = []
             for candidate in candidates:
                 if candidate.startswith(("http://", "https://")):
-                    variants |= _url_lookup_variants(candidate) or {candidate}
+                    candidate_variants = list(_url_lookup_variants(candidate)) or [
+                        candidate
+                    ]
                 else:
                     # Non-URL canonical id (e.g. a Notion UUID); use it directly.
-                    variants.add(candidate)
+                    candidate_variants = [candidate]
+                variants.extend(v for v in candidate_variants if v not in variants)
             normalized_map[url] = variants
         else:
             # No normalizer found - could be a non-URL document ID (e.g., FILE_CONNECTOR__...)
             if url and not url.startswith(("http://", "https://")):
                 # Likely a document ID, use it directly
-                normalized_map[url] = {url}
+                normalized_map[url] = [url]
             else:
                 # Try generic normalization as fallback
-                variants = _url_lookup_variants(url)
-                if variants:
-                    normalized_map[url] = variants
+                fallback_variants = list(_url_lookup_variants(url))
+                if fallback_variants:
+                    normalized_map[url] = fallback_variants
                 else:
                     unresolved.append(url)
 

--- a/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
+++ b/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
@@ -64,6 +64,46 @@ def normalize_url(url: str, source_type: DocumentSource | None = None) -> str | 
     return _default_url_normalizer(url)
 
 
+def normalize_url_candidates(
+    url: str, source_type: DocumentSource | None = None
+) -> list[str]:
+    """Return all candidate canonical Document.id values for a URL.
+
+    A single URL may map to more than one possible Document.id (e.g. a Google Drive
+    file id whose type isn't encoded in the pasted URL). Resolution matches whichever
+    candidate exists in the index. Falls back to the default normalizer's single value
+    when a connector doesn't provide candidates.
+    """
+    if source_type is None:
+        source_type = _detect_source_type(url)
+
+    if source_type:
+        try:
+            connector_class = identify_connector_class(source_type)
+            result = connector_class.normalize_url(url)
+
+            if result.use_default:
+                default = _default_url_normalizer(url)
+                return [default] if default else []
+
+            candidates: list[str] = []
+            if result.normalized_url:
+                candidates.append(result.normalized_url)
+            for candidate in result.candidate_document_ids:
+                if candidate not in candidates:
+                    candidates.append(candidate)
+            return candidates
+        except Exception as exc:
+            logger.debug(
+                "Failed to normalize URL candidates for source %s: %s. Using default normalizer.",
+                source_type,
+                exc,
+            )
+
+    default = _default_url_normalizer(url)
+    return [default] if default else []
+
+
 def _detect_source_type(url: str) -> DocumentSource | None:
     """Detect DocumentSource from URL patterns (simple heuristic)."""
     parsed = urlparse(url)

--- a/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
+++ b/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
@@ -1,0 +1,78 @@
+"""External dependency tests for open_url URL -> Document.id resolution.
+
+Uses real Postgres because the resolution under test (_resolve_urls_to_document_ids)
+matches candidate URLs against actual `Document.id` rows via `filter_existing_document_ids`.
+The bug this guards: a Google Doc indexed under the `docs.google.com/document/d/<id>`
+form must still be found when the user pastes the type-ambiguous
+`drive.google.com/file/d/<id>` form.
+"""
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.models import Document as DBDocument
+from onyx.kg.models import KGStage
+from onyx.tools.tool_implementations.open_url.open_url_tool import (
+    _resolve_urls_to_document_ids,
+)
+
+
+@pytest.fixture
+def doc_cleanup(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[list[str], None, None]:
+    created: list[str] = []
+    try:
+        yield created
+    finally:
+        if created:
+            db_session.query(DBDocument).filter(DBDocument.id.in_(created)).delete(
+                synchronize_session="fetch"
+            )
+            db_session.commit()
+
+
+def _seed_doc(db_session: Session, tracker: list[str], doc_id: str) -> None:
+    doc = DBDocument(
+        id=doc_id,
+        semantic_id=f"semantic-{doc_id}",
+        kg_stage=KGStage.NOT_STARTED,
+    )
+    db_session.add(doc)
+    db_session.commit()
+    tracker.append(doc_id)
+
+
+def test_file_d_url_resolves_to_indexed_native_doc(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """A pasted drive.google.com/file/d/<id> URL resolves to a doc indexed under
+    the docs.google.com/document/d/<id> form."""
+    file_id = uuid4().hex
+    indexed_id = f"https://docs.google.com/document/d/{file_id}"
+    _seed_doc(db_session, doc_cleanup, indexed_id)
+
+    pasted = f"https://drive.google.com/file/d/{file_id}/view"
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == indexed_id
+    assert matches[0].original_url == pasted
+
+
+def test_unindexed_file_id_is_unresolved(
+    db_session: Session,
+    doc_cleanup: list[str],  # noqa: ARG001
+) -> None:
+    """A file id that isn't in the index resolves to nothing (falls back to crawl)."""
+    pasted = f"https://drive.google.com/file/d/{uuid4().hex}/view"
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert matches == []
+    assert unresolved == [pasted]

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
@@ -8,6 +8,55 @@ from onyx.tools.tool_implementations.open_url.url_normalization import (
     _detect_source_type,
 )
 from onyx.tools.tool_implementations.open_url.url_normalization import normalize_url
+from onyx.tools.tool_implementations.open_url.url_normalization import (
+    normalize_url_candidates,
+)
+
+# A native Google Doc is indexed under the docs.google.com/document/d form regardless
+# of the URL shape the user pastes, so every form must offer it as a candidate.
+_GDRIVE_ID = "1RXOtmTndA5HXj-V5HoEF0gJaHb8Dc_ivSpb3Xcm1qzU"
+_GDRIVE_DOC_ID = f"https://docs.google.com/document/d/{_GDRIVE_ID}"
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # type-ambiguous file/d form (the reported bug)
+        f"https://drive.google.com/file/d/{_GDRIVE_ID}",
+        f"https://drive.google.com/file/d/{_GDRIVE_ID}/view",
+        # multi-account /u/N/ form
+        f"https://docs.google.com/document/u/0/d/{_GDRIVE_ID}/edit",
+        # ?id= share form
+        f"https://drive.google.com/open?id={_GDRIVE_ID}",
+        # already-canonical native doc form
+        f"{_GDRIVE_DOC_ID}/edit?usp=sharing",
+    ],
+)
+def test_google_drive_candidates_include_native_doc_form(url: str) -> None:
+    """Every Drive URL form must yield the native-doc canonical id as a candidate."""
+    candidates = normalize_url_candidates(url, source_type=DocumentSource.GOOGLE_DRIVE)
+    assert _GDRIVE_DOC_ID in candidates
+
+
+def test_google_drive_candidates_cover_all_type_forms() -> None:
+    """A type-ambiguous file/d URL should offer doc, sheet, slide, and file forms."""
+    candidates = normalize_url_candidates(
+        f"https://drive.google.com/file/d/{_GDRIVE_ID}",
+        source_type=DocumentSource.GOOGLE_DRIVE,
+    )
+    assert set(candidates) >= {
+        _GDRIVE_DOC_ID,
+        f"https://docs.google.com/spreadsheets/d/{_GDRIVE_ID}",
+        f"https://docs.google.com/presentation/d/{_GDRIVE_ID}",
+        f"https://drive.google.com/file/d/{_GDRIVE_ID}",
+    }
+
+
+def test_non_drive_candidates_fall_back_to_single_value() -> None:
+    """Non-connector URLs return just the default-normalized value."""
+    assert normalize_url_candidates("https://example.com/some/page?a=1#x") == [
+        "https://example.com/some/page"
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
A pasted drive.google.com/file/d/<id> link for a native Google Doc did not match its indexed Document.id (docs.google.com/document/d/<id>), so open_url fell back to crawling the doc from the web instead of returning the indexed copy.

Google Drive normalization now emits every plausible canonical Document.id for a file id (native doc/sheet/slide plus the uploaded-binary form) and the open_url resolver matches whichever one is indexed. Also handles the multi-account /u/<N>/ and ?id= URL forms.


## How Has This Been Tested?
Manual + Tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `open_url` for Google Drive so type-ambiguous links resolve to the indexed canonical `Document.id` instead of falling back to web crawling. Handles `/u/<N>/` and `?id=` forms, and resolves the first indexed candidate.

- **Bug Fixes**
  - Google Drive normalizer now emits a best-guess `normalized_url` plus `candidate_document_ids`; `open_url` switches to `normalize_url_candidates` and picks the first indexed variant.
  - Parses `?id=`, `/d/<id>`, and `/u/<N>/d/<id>`; generates doc/sheet/slide and uploaded-file candidates; maps `drive.google.com/file/d/<id>` to the indexed `docs.google.com/*/d/<id>`.
  - Added unit tests for candidate coverage and an external DB-backed test that resolves a pasted `file/d` URL to an indexed native doc and verifies fallback when unindexed.

<sup>Written for commit e362a3e9f79aabe045b1943b67c204540ac9a8b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

