### PR TITLE
feat(search): Toggles for source/time filter

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -120,6 +120,7 @@ from onyx.server.query_and_chat.streaming_models import CitationInfo
 from onyx.server.query_and_chat.streaming_models import heartbeat_packet
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
+from onyx.server.settings.store import load_settings
 from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.server.utils import get_json_line
 from onyx.tools.constants import FILE_READER_TOOL_ID
@@ -1089,6 +1090,9 @@ def _run_models(
     """
     n_models = len(setup.llms)
 
+    # Workspace toggle: infer source/time filters from the query (default on).
+    auto_detect_search_filters = load_settings().auto_detect_search_filters is not False
+
     merged_queue: queue.Queue[tuple[int, Packet | Exception | object]] = queue.Queue()
 
     state_containers: list[ChatStateContainer] = [
@@ -1221,6 +1225,7 @@ def _run_models(
                     enable_slack_search=_should_enable_slack_search(
                         setup.persona, setup.new_msg_req.internal_search_filters
                     ),
+                    auto_detect_filters=auto_detect_search_filters,
                 ),
                 custom_tool_config=CustomToolConfig(
                     chat_session_id=setup.chat_session.id,

--- a/backend/onyx/server/features/search/api.py
+++ b/backend/onyx/server/features/search/api.py
@@ -44,6 +44,7 @@ from onyx.server.features.search.models import SearchResponse
 from onyx.server.features.search.models import SearchResult
 from onyx.server.manage.llm.models import LLMProviderView
 from onyx.server.query_and_chat.placement import Placement
+from onyx.server.settings.store import load_settings
 from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.server.utils_vector_db import require_vector_db
 from onyx.tools.constants import SEARCH_TOOL_ID
@@ -167,6 +168,7 @@ def search(
         bypass_acl=False,
         slack_context=None,
         enable_slack_search=True,
+        auto_detect_filters=load_settings().auto_detect_search_filters is not False,
     )
 
     # 7. Run search

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -48,6 +48,7 @@ class Settings(BaseModel):
     deep_research_enabled: bool | None = None
     multi_model_chat_enabled: bool | None = True
     search_ui_enabled: bool | None = True
+    auto_detect_search_filters: bool | None = True
 
     # Whether EE features are unlocked for use.
     # Depends on license status: True when the user has a valid license

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -72,6 +72,7 @@ class SearchToolConfig(BaseModel):
     additional_context: str | None = None
     slack_context: SlackContext | None = None
     enable_slack_search: bool = True
+    auto_detect_filters: bool = True
 
 
 class FileReaderToolConfig(BaseModel):
@@ -207,6 +208,7 @@ def _construct_tools_impl(
             bypass_acl=config.bypass_acl,
             slack_context=config.slack_context,
             enable_slack_search=config.enable_slack_search,
+            auto_detect_filters=config.auto_detect_filters,
         )
 
     added_search_tool = False

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -282,6 +282,9 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         slack_context: SlackContext | None = None,
         # Whether to enable Slack federated search
         enable_slack_search: bool = True,
+        # Whether to infer source (and, once implemented, time) filters from the
+        # query. When False, only user/persona-selected filters are applied.
+        auto_detect_filters: bool = True,
     ) -> None:
         super().__init__(emitter=emitter)
 
@@ -295,6 +298,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         self.bypass_acl = bypass_acl
         self.slack_context = slack_context
         self.enable_slack_search = enable_slack_search
+        self.auto_detect_filters = auto_detect_filters
 
         self._search_cycles: list[SearchCycle] = []
         self._cached_expansion: tuple[str | None, list[str]] | None = None
@@ -596,7 +600,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         turn, since the conversation cannot introduce one mid-turn.
         """
         expand_queries = not skip_query_expansion
-        decide_scope = not self._scope_decision_settled
+        decide_scope = self.auto_detect_filters and not self._scope_decision_settled
 
         jobs: list[tuple[Callable, tuple]] = []
         scope_job_index: int | None = None

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -282,7 +282,7 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
         slack_context: SlackContext | None = None,
         # Whether to enable Slack federated search
         enable_slack_search: bool = True,
-        # Whether to infer source (and, once implemented, time) filters from the
+        # Whether to infer source and time filters from the
         # query. When False, only user/persona-selected filters are applied.
         auto_detect_filters: bool = True,
     ) -> None:

--- a/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
@@ -20,7 +20,10 @@ MODULE = "onyx.tools.tool_implementations.search.search_tool"
 ScopeDecision = list[DocumentSource] | None
 
 
-def _make_tool(user_selected_filters: BaseFilters | None = None) -> SearchTool:
+def _make_tool(
+    user_selected_filters: BaseFilters | None = None,
+    auto_detect_filters: bool = True,
+) -> SearchTool:
     """Instantiate SearchTool with non-DB deps mocked; DB/LLM calls are patched in _run."""
     return SearchTool(
         tool_id=1,
@@ -32,6 +35,7 @@ def _make_tool(user_selected_filters: BaseFilters | None = None) -> SearchTool:
         user_selected_filters=user_selected_filters,
         project_id_filter=None,
         enable_slack_search=False,
+        auto_detect_filters=auto_detect_filters,
     )
 
 
@@ -301,3 +305,45 @@ def test_prior_cycles_accumulate_across_calls_for_the_walk() -> None:
     assert second_cycles[0].searched_sources == ["zendesk"]
     assert second_cycles[0].queries == ["ticket"]
     assert second_cycles[0].cycle_number == 1
+
+
+def test_auto_detect_disabled_skips_scope_decision() -> None:
+    """With auto-detect off, no scope decision runs and the search stays unscoped."""
+    tool = _make_tool(auto_detect_filters=False)
+    connected = [DocumentSource.ZENDESK, DocumentSource.CONFLUENCE]
+    decide_mock = MagicMock(return_value=[DocumentSource.ZENDESK])
+
+    mock_search_pipeline = _run(
+        tool, decide_mock=decide_mock, connected_sources=connected
+    )
+
+    decide_mock.assert_not_called()
+    assert _emitted_filter_sources(tool) == []
+    filters = _filters_passed_to_search(mock_search_pipeline)
+    assert filters, "search_pipeline was never called"
+    for applied in filters:
+        assert applied is None or applied.source_type is None
+
+
+def test_auto_detect_disabled_keeps_user_selected_filters() -> None:
+    """With auto-detect off, user/persona-selected filters are still applied."""
+    restriction = [DocumentSource.CONFLUENCE, DocumentSource.GITHUB]
+    tool = _make_tool(BaseFilters(source_type=restriction), auto_detect_filters=False)
+    decide_mock = MagicMock(return_value=[DocumentSource.CONFLUENCE])
+
+    mock_search_pipeline = _run(
+        tool,
+        decide_mock=decide_mock,
+        connected_sources=[
+            DocumentSource.CONFLUENCE,
+            DocumentSource.GITHUB,
+            DocumentSource.SLACK,
+        ],
+    )
+
+    decide_mock.assert_not_called()
+    filters = _filters_passed_to_search(mock_search_pipeline)
+    assert filters, "search_pipeline was never called"
+    for applied in filters:
+        assert applied is not None
+        assert applied.source_type == restriction

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -40,6 +40,7 @@ export interface Settings {
   deep_research_enabled?: boolean;
   multi_model_chat_enabled?: boolean;
   search_ui_enabled?: boolean;
+  auto_detect_search_filters?: boolean;
 
   // Image processing settings
   image_extraction_and_analysis_enabled?: boolean;

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -874,6 +874,18 @@ export default function ChatPreferencesPage() {
                 </InputHorizontal>
               </Disabled>
               <InputHorizontal
+                title="Auto-Detect Search Filters"
+                description="Automatically apply source and time filters inferred from the search query."
+                withLabel
+              >
+                <Switch
+                  checked={s.auto_detect_search_filters ?? true}
+                  onCheckedChange={(checked) => {
+                    void saveSettings({ auto_detect_search_filters: checked });
+                  }}
+                />
+              </InputHorizontal>
+              <InputHorizontal
                 title="Multi-Model Generation"
                 tag={{ title: "beta", color: "blue" }}
                 description="Allow multiple models to generate responses in parallel in chat."


### PR DESCRIPTION
## Description
Adds a toggle to enable and disable the source and time filter. Default on

<img width="1046" height="528" alt="Screenshot 2026-07-10 at 7 06 55 PM" src="https://github.com/user-attachments/assets/03ec32af-7813-4046-a262-64a9416114ba" />

Figma Reference:
https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=6979-40776&m=dev

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a workspace toggle to auto-detect source/time filters from queries across chat and the Search API. When off, inference is skipped and only user/persona-selected filters are applied.

- **New Features**
  - Added “Auto-Detect Search Filters” switch in Admin → Chat Preferences (default on).
  - New `auto_detect_search_filters` setting wired into chat processing and the Search API, plumbed to `SearchTool` as `auto_detect_filters`.
  - Scope inference now gated by the flag; off = no inferred source/time filters (respects user/persona filters).
  - Updated web `Settings` type and added unit tests verifying disabled behavior and preserving user-selected filters.

<sup>Written for commit acec421ef820411fa5a5d71f2e4f9ca2ca1f5b31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12897?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



