### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in sandbox file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize("name", ["nextjs.log", "nextjs.pid"])
+def test_nextjs_runtime_files_are_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is True
+
+
+@pytest.mark.parametrize("name", ["page.tsx", "README.md", "nextjs.config.ts"])
+def test_regular_files_are_not_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is False


### PR DESCRIPTION
### What

Hide the Next.js dev-server runtime files `nextjs.log` and `nextjs.pid` from the Craft sandbox **Files** tab (file explorer).

### Why

These two files are written at the session root by the dev-server start script (`nextjs_dev.py`). They are runtime artifacts (a live PID and the dev-server log) with no value to the user, but they were showing up as regular files in the explorer.

### How

Directory listings for the file explorer are filtered in a single place — `_is_hidden_workspace_entry()` in `backend/onyx/server/features/build/session/manager.py`, which hides names in `HIDDEN_PATTERNS` or starting with `.`. Since these filenames don't start with `.`, they were never hidden. The fix adds them to the existing `HIDDEN_PATTERNS` set, matching the set's existing literal-filename convention (`node_modules`, `.next`, `opencode.json`, ...).

The same filter also feeds the session-root zip/download walk, so the runtime files are consistently excluded there too (they were never part of snapshots, which only capture `outputs`/`attachments`).

### Verification

- Added a focused unit test (`test_hidden_entries.py`) asserting both files are hidden and lookalikes (e.g. `nextjs.config.ts`) stay visible.
- `pytest backend/tests/unit/onyx/server/features/build/session/` + `test_file_listing.py` → all green (92 passed).

### Known minor items

- The filenames `nextjs.log` / `nextjs.pid` are literal strings in several files (writers in `nextjs_dev.py`, stop scripts in the docker/k8s managers, and now this set). Centralizing them into shared constants is a reasonable pre-existing follow-up but out of scope here.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Next.js dev-server runtime files `nextjs.log` and `nextjs.pid` in the Craft sandbox Files tab and session-root downloads to remove transient noise from the file explorer.

- **Bug Fixes**
  - Added `nextjs.log` and `nextjs.pid` to `HIDDEN_PATTERNS` so they are filtered from directory listings and zips.
  - Added unit tests to confirm these files are hidden and similar files (e.g., `nextjs.config.ts`) remain visible.

<sup>Written for commit 3bf84ec2f7a13ec4c3ddb509ce9d3e7caf13e536. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12898?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

