### PR TITLE
feat(connectors): add LumApps connector

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -263,6 +263,7 @@ class DocumentSource(str, Enum):
     BITBUCKET = "bitbucket"
     TESTRAIL = "testrail"
     BRAINTRUST = "braintrust"
+    LUMAPPS = "lumapps"
 
     # Special case just for integration tests
     MOCK_CONNECTOR = "mock_connector"
@@ -749,4 +750,5 @@ DocumentSourceDescription: dict[DocumentSource, str] = {
     DocumentSource.IMAP: "Email messages and threads",
     DocumentSource.TESTRAIL: "Test cases and QA management",
     DocumentSource.BRAINTRUST: "LLM eval experiments, datasets, and prompts",
+    DocumentSource.LUMAPPS: "Intranet pages, news, and content",
 }

--- a/backend/onyx/connectors/lumapps/client.py
+++ b/backend/onyx/connectors/lumapps/client.py
@@ -95,12 +95,8 @@ class OnyxLumApps:
             time.monotonic() + max(expires_in, 120) - _TOKEN_REFRESH_SKEW_SECONDS
         )
 
-    def _bearer(self, force_refresh: bool = False) -> str:
-        if (
-            force_refresh
-            or not self._token
-            or time.monotonic() >= self._token_expiry_monotonic
-        ):
+    def _bearer(self) -> str:
+        if not self._token or time.monotonic() >= self._token_expiry_monotonic:
             self._mint_token()
         assert self._token is not None
         return self._token
@@ -115,22 +111,37 @@ class OnyxLumApps:
         json_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         url = f"{self.base_url}{path}"
+        last_network_error: requests.RequestException | None = None
         for attempt in range(_MAX_RETRIES):
-            force = attempt == 1  # re-mint once after a 401
-            response = self._session.request(
-                method,
-                url,
-                params=params,
-                json=json_body,
-                headers={
-                    "Authorization": f"Bearer {self._bearer(force_refresh=force)}",
-                    "Content-Type": "application/json",
-                    "Accept": "application/json",
-                },
-                timeout=self.timeout,
-            )
+            try:
+                response = self._session.request(
+                    method,
+                    url,
+                    params=params,
+                    json=json_body,
+                    headers={
+                        "Authorization": f"Bearer {self._bearer()}",
+                        "Content-Type": "application/json",
+                        "Accept": "application/json",
+                    },
+                    timeout=self.timeout,
+                )
+            except requests.RequestException as e:
+                # Connection resets / timeouts are as transient as a 5xx —
+                # back off and retry instead of aborting the indexing attempt.
+                last_network_error = e
+                delay = min(2.0**attempt, _MAX_BACKOFF_SECONDS)
+                logger.warning(
+                    "LumApps network error on %s (%s); retry %d in %.1fs",
+                    path,
+                    e,
+                    attempt + 1,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
             if response.status_code == 401 and attempt == 0:
-                self._token = None  # expired/invalid; retry forces a re-mint
+                self._token = None  # expired/invalid; next _bearer() re-mints
                 continue
             if response.status_code == 429 or response.status_code >= 500:
                 delay = _backoff_seconds(response, attempt)
@@ -146,7 +157,8 @@ class OnyxLumApps:
             if response.status_code != 200:
                 raise LumAppsClientError(response.status_code, response.text)
             return response.json()
-        raise LumAppsClientError(503, f"Exhausted retries calling {path}")
+        detail = f": {last_network_error}" if last_network_error else ""
+        raise LumAppsClientError(503, f"Exhausted retries calling {path}{detail}")
 
     # ---------------------------------------------------------------- methods
     def list_content(self, body: dict[str, Any]) -> dict[str, Any]:

--- a/backend/onyx/connectors/lumapps/client.py
+++ b/backend/onyx/connectors/lumapps/client.py
@@ -1,0 +1,163 @@
+import base64
+import time
+from typing import Any
+
+import requests
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# The documented public API lives under the legacy lumsites path on the customer cell.
+LEGACY_PREFIX = "/_ah/api/lumsites/v1"
+
+_MAX_RETRIES = 5
+_MAX_BACKOFF_SECONDS = 60.0
+_TOKEN_REFRESH_SKEW_SECONDS = 60  # mint a new token this long before it expires
+
+
+class LumAppsClientError(Exception):
+    def __init__(self, status_code: int, message: str) -> None:
+        super().__init__(f"LumApps API error {status_code}: {message}")
+        self.status_code = status_code
+        self.message = message
+
+
+def _backoff_seconds(response: requests.Response, attempt: int) -> float:
+    retry_after = response.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return min(max(float(retry_after), 1.0), _MAX_BACKOFF_SECONDS)
+        except ValueError:
+            pass
+    return min(2.0**attempt, _MAX_BACKOFF_SECONDS)
+
+
+class OnyxLumApps:
+    """Thin LumApps API client.
+
+    Auth (verified live): exchange the application id + api key (HTTP Basic) for a
+    short-lived JWT via ``application-token`` (``grant_type=client_credentials``,
+    on-behalf-of a service user), then call the data endpoints with just
+    ``Authorization: Bearer <jwt>`` — the token carries the organization, so no other
+    headers are required. The JWT (~1 h) is cached and re-minted before it expires.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        organization_id: str,
+        application_id: str,
+        api_key: str,
+        service_user: str,
+        timeout: int = 60,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.organization_id = organization_id
+        self.application_id = application_id
+        self.api_key = api_key
+        self.service_user = service_user
+        self.timeout = timeout
+        self._session = requests.Session()
+        self._token: str | None = None
+        self._token_expiry_monotonic: float = 0.0
+
+    # ------------------------------------------------------------------ auth
+    def _basic_header(self) -> str:
+        raw = f"{self.application_id}:{self.api_key}".encode()
+        return "Basic " + base64.b64encode(raw).decode()
+
+    def _mint_token(self) -> None:
+        url = (
+            f"{self.base_url}/v2/organizations/{self.organization_id}/application-token"
+        )
+        data: dict[str, str] = {"grant_type": "client_credentials"}
+        if "@" in (self.service_user or ""):
+            data["user_email"] = self.service_user
+        elif self.service_user:
+            data["user_id"] = self.service_user
+
+        response = self._session.post(
+            url,
+            headers={
+                "Authorization": self._basic_header(),
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            data=data,
+            timeout=self.timeout,
+        )
+        if response.status_code != 200:
+            raise LumAppsClientError(response.status_code, response.text)
+        body = response.json()
+        self._token = body["access_token"]
+        expires_in = int(body.get("expires_in", 3600))
+        self._token_expiry_monotonic = (
+            time.monotonic() + max(expires_in, 120) - _TOKEN_REFRESH_SKEW_SECONDS
+        )
+
+    def _bearer(self, force_refresh: bool = False) -> str:
+        if (
+            force_refresh
+            or not self._token
+            or time.monotonic() >= self._token_expiry_monotonic
+        ):
+            self._mint_token()
+        assert self._token is not None
+        return self._token
+
+    # --------------------------------------------------------------- request
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+        json_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        url = f"{self.base_url}{path}"
+        for attempt in range(_MAX_RETRIES):
+            force = attempt == 1  # re-mint once after a 401
+            response = self._session.request(
+                method,
+                url,
+                params=params,
+                json=json_body,
+                headers={
+                    "Authorization": f"Bearer {self._bearer(force_refresh=force)}",
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                timeout=self.timeout,
+            )
+            if response.status_code == 401 and attempt == 0:
+                self._token = None  # expired/invalid; retry forces a re-mint
+                continue
+            if response.status_code == 429 or response.status_code >= 500:
+                delay = _backoff_seconds(response, attempt)
+                logger.warning(
+                    "LumApps %s on %s; retry %d in %.1fs",
+                    response.status_code,
+                    path,
+                    attempt + 1,
+                    delay,
+                )
+                time.sleep(delay)
+                continue
+            if response.status_code != 200:
+                raise LumAppsClientError(response.status_code, response.text)
+            return response.json()
+        raise LumAppsClientError(503, f"Exhausted retries calling {path}")
+
+    # ---------------------------------------------------------------- methods
+    def list_content(self, body: dict[str, Any]) -> dict[str, Any]:
+        return self._request("POST", f"{LEGACY_PREFIX}/content/list", json_body=body)
+
+    def get_content(self, uid: str, lang: str) -> dict[str, Any]:
+        return self._request(
+            "GET", f"{LEGACY_PREFIX}/content/get", params={"uid": uid, "lang": lang}
+        )
+
+    def get_metadata(self, uid: str, lang: str) -> dict[str, Any]:
+        return self._request(
+            "GET", f"{LEGACY_PREFIX}/metadata/get", params={"uid": uid, "lang": lang}
+        )

--- a/backend/onyx/connectors/lumapps/connector.py
+++ b/backend/onyx/connectors/lumapps/connector.py
@@ -39,7 +39,10 @@ _CONTENT_FIELDS = (
     "updatedAt,publicationDate,metadata,instance,authorId,authorDetails(email),"
     "template,properties),cursor,more"
 )
-_SLIM_FIELDS = "items(id,status),cursor,more"
+# Must request every field the indexing path can use as the document id
+# (id with uid fallback) — anything indexed but missing from the slim set
+# would be wrongly pruned.
+_SLIM_FIELDS = "items(id,uid,status),cursor,more"
 _SLIM_PAGE_SIZE = 100
 
 # Only published content is ingested. The API-side `status` filter in
@@ -110,6 +113,14 @@ class LumAppsConnector(CheckpointedConnector[LumAppsCheckpoint], SlimConnector):
     def _get_client(self) -> OnyxLumApps:
         if self._client is not None:
             return self._client
+        # The client exchanges the application id + API key via HTTP Basic when
+        # minting tokens; over plain http those credentials would travel in
+        # cleartext. LumApps is SaaS-only, so https is always available.
+        if not self.base_url.lower().startswith("https://"):
+            raise ConnectorValidationError(
+                "LumApps base URL must use https:// (credentials are sent with "
+                "every token request)."
+            )
         if not (self._application_id and self._api_key and self._service_user):
             raise ConnectorMissingCredentialError("LumApps")
         self._client = OnyxLumApps(
@@ -198,8 +209,11 @@ class LumAppsConnector(CheckpointedConnector[LumAppsCheckpoint], SlimConnector):
             value_label = pick_lang(meta.get("name"), self.lang)
             family_id = str(meta.get("familyKey") or meta.get("parent") or "")
             family_name = self._family_name(family_id, client) if family_id else ""
+            # Non-Latin family names slugify to nothing; fall back to the stable
+            # family id so distinct families never collapse into one key.
+            fallback_key = f"metadata_{family_id}" if family_id else "metadata"
             self._label_map[metadata_id] = (
-                slugify_family_key(family_name),
+                slugify_family_key(family_name, fallback=fallback_key),
                 value_label,
             )
         return resolve_metadata_labels(metadata_ids, self._label_map)
@@ -313,10 +327,12 @@ class LumAppsConnector(CheckpointedConnector[LumAppsCheckpoint], SlimConnector):
                 )
             )
             items = response.get("items") or []
+            # Same id fallback as _content_to_document — a doc indexed under its
+            # uid must appear in the slim set or pruning would delete it.
             batch: list[SlimDocument | HierarchyNode] = [
-                SlimDocument(id=str(item.get("id")))
+                SlimDocument(id=str(item.get("id") or item.get("uid")))
                 for item in items
-                if item.get("id") and _is_live(item)
+                if (item.get("id") or item.get("uid")) and _is_live(item)
             ]
             if batch:
                 yield batch

--- a/backend/onyx/connectors/lumapps/connector.py
+++ b/backend/onyx/connectors/lumapps/connector.py
@@ -1,0 +1,327 @@
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+from onyx.configs.app_configs import INDEX_BATCH_SIZE
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.exceptions import ConnectorValidationError
+from onyx.connectors.exceptions import CredentialExpiredError
+from onyx.connectors.exceptions import InsufficientPermissionsError
+from onyx.connectors.interfaces import CheckpointedConnector
+from onyx.connectors.interfaces import CheckpointOutput
+from onyx.connectors.interfaces import GenerateSlimDocumentOutput
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
+from onyx.connectors.interfaces import SlimConnector
+from onyx.connectors.lumapps.client import LumAppsClientError
+from onyx.connectors.lumapps.client import OnyxLumApps
+from onyx.connectors.lumapps.models import LumAppsCheckpoint
+from onyx.connectors.lumapps.utils import extract_body_text
+from onyx.connectors.lumapps.utils import pick_lang
+from onyx.connectors.lumapps.utils import resolve_metadata_labels
+from onyx.connectors.lumapps.utils import slugify_family_key
+from onyx.connectors.models import BasicExpertInfo
+from onyx.connectors.models import ConnectorFailure
+from onyx.connectors.models import ConnectorMissingCredentialError
+from onyx.connectors.models import Document
+from onyx.connectors.models import DocumentFailure
+from onyx.connectors.models import HierarchyNode
+from onyx.connectors.models import SlimDocument
+from onyx.connectors.models import TextSection
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# Fields requested from content/list. Includes `template`/`properties` so the body is
+# returned inline (no per-item content/get / N+1).
+_CONTENT_FIELDS = (
+    "items(id,uid,type,customContentType,canonicalUrl,link,url,title,slug,status,"
+    "updatedAt,publicationDate,metadata,instance,authorId,authorDetails(email),"
+    "template,properties),cursor,more"
+)
+_SLIM_FIELDS = "items(id,status),cursor,more"
+_SLIM_PAGE_SIZE = 100
+
+# Only published content is ingested. The API-side `status` filter in
+# `_list_body` is not trusted on its own — enforce LIVE per item too, on both
+# the indexing and the pruning path (so content leaving LIVE gets pruned).
+_LIVE_STATUS = "LIVE"
+
+
+def _is_live(content: dict[str, Any]) -> bool:
+    return str(content.get("status") or "").upper() == _LIVE_STATUS
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+class LumAppsConnector(CheckpointedConnector[LumAppsCheckpoint], SlimConnector):
+    """Ingests LumApps content (pages/news/custom) into Onyx.
+
+    Carries over **all** LumApps metadata families as Onyx metadata
+    (``{family_key: [labels]}``), so whatever HR tags — country or otherwise — becomes a
+    filterable tag without any connector change.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        organization_id: str,
+        instance_ids: list[str] | None = None,
+        custom_content_types: list[str] | None = None,
+        lang: str = "en",
+        batch_size: int = INDEX_BATCH_SIZE,
+    ) -> None:
+        self.base_url = base_url
+        self.organization_id = organization_id
+        self.instance_ids = instance_ids or None
+        self.custom_content_types = custom_content_types or None
+        self.lang = lang or "en"
+        self.batch_size = min(batch_size, 100)  # LumApps maxResults cap
+
+        self._client: OnyxLumApps | None = None
+        self._application_id: str | None = None
+        self._api_key: str | None = None
+        self._service_user: str | None = None
+
+        # Lazy metadata-label resolution caches (kept on the instance, NOT the checkpoint).
+        self._label_map: dict[
+            str, tuple[str, str]
+        ] = {}  # value id -> (family_key, label)
+        self._family_name_cache: dict[str, str] = {}  # family id -> family name
+
+    # ---------------------------------------------------------------- credentials
+    def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
+        self._application_id = credentials["lumapps_application_id"]
+        self._api_key = credentials["lumapps_api_key"]
+        self._service_user = credentials["lumapps_service_user"]
+        self._client = None
+        return None
+
+    def _get_client(self) -> OnyxLumApps:
+        if self._client is not None:
+            return self._client
+        if not (self._application_id and self._api_key and self._service_user):
+            raise ConnectorMissingCredentialError("LumApps")
+        self._client = OnyxLumApps(
+            base_url=self.base_url,
+            organization_id=self.organization_id,
+            application_id=self._application_id,
+            api_key=self._api_key,
+            service_user=self._service_user,
+        )
+        return self._client
+
+    def validate_connector_settings(self) -> None:
+        client = self._get_client()
+        try:
+            client.list_content(self._list_body(max_results=1, fields="items(id),more"))
+        except LumAppsClientError as e:
+            if e.status_code == 401:
+                raise CredentialExpiredError(
+                    "LumApps credentials are invalid or expired."
+                )
+            if e.status_code == 403:
+                raise InsufficientPermissionsError(
+                    "The LumApps service user lacks permission to read content."
+                )
+            raise ConnectorValidationError(str(e))
+
+    # ----------------------------------------------------------------- checkpoint
+    def build_dummy_checkpoint(self) -> LumAppsCheckpoint:
+        return LumAppsCheckpoint(has_more=True, cursor=None)
+
+    def validate_checkpoint_json(self, checkpoint_json: str) -> LumAppsCheckpoint:
+        return LumAppsCheckpoint.model_validate_json(checkpoint_json)
+
+    # ---------------------------------------------------------------- list helper
+    def _list_body(
+        self,
+        cursor: str | None = None,
+        fields: str = _CONTENT_FIELDS,
+        max_results: int | None = None,
+    ) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "lang": [self.lang],
+            "status": ["LIVE"],
+            "sortOrder": ["-updatedAt"],
+            "maxResults": max_results or self.batch_size,
+            "fields": fields,
+        }
+        if self.instance_ids:
+            body["instanceId"] = self.instance_ids
+        if self.custom_content_types:
+            body["customContentType"] = self.custom_content_types
+        if cursor:
+            body["cursor"] = cursor
+        return body
+
+    # --------------------------------------------------------------- label resolve
+    def _family_name(self, family_id: str, client: OnyxLumApps) -> str:
+        if family_id in self._family_name_cache:
+            return self._family_name_cache[family_id]
+        name = ""
+        try:
+            name = pick_lang(
+                client.get_metadata(family_id, self.lang).get("name"), self.lang
+            )
+        except LumAppsClientError as e:
+            logger.warning(
+                "Could not resolve LumApps metadata family %s: %s", family_id, e
+            )
+        self._family_name_cache[family_id] = name
+        return name
+
+    def _resolve_labels(
+        self, metadata_ids: list[str], client: OnyxLumApps
+    ) -> dict[str, list[str]]:
+        for raw_id in metadata_ids:
+            metadata_id = str(raw_id)
+            if metadata_id in self._label_map:
+                continue
+            try:
+                meta = client.get_metadata(metadata_id, self.lang)
+            except LumAppsClientError as e:
+                logger.warning(
+                    "Could not resolve LumApps metadata id %s: %s", metadata_id, e
+                )
+                continue
+            value_label = pick_lang(meta.get("name"), self.lang)
+            family_id = str(meta.get("familyKey") or meta.get("parent") or "")
+            family_name = self._family_name(family_id, client) if family_id else ""
+            self._label_map[metadata_id] = (
+                slugify_family_key(family_name),
+                value_label,
+            )
+        return resolve_metadata_labels(metadata_ids, self._label_map)
+
+    # ---------------------------------------------------------------- to-document
+    def _content_to_document(
+        self, content: dict[str, Any], client: OnyxLumApps
+    ) -> Document:
+        content_id = str(content.get("id") or content.get("uid"))
+        title = pick_lang(content.get("title"), self.lang) or content_id
+        link = (
+            pick_lang(content.get("canonicalUrl"), self.lang)
+            or content.get("link")
+            or content.get("url")
+            or ""
+        )
+        body = extract_body_text(content.get("template"), self.lang)
+        if not body:
+            body = extract_body_text(content.get("properties"), self.lang)
+
+        metadata: dict[str, str | list[str]] = dict(
+            self._resolve_labels(content.get("metadata") or [], client)
+        )
+        if content.get("type"):
+            metadata["content_type"] = str(content["type"])
+        if content.get("customContentType"):
+            metadata["custom_content_type"] = str(content["customContentType"])
+
+        owners = []
+        author_email = (content.get("authorDetails") or {}).get("email")
+        if author_email:
+            owners = [BasicExpertInfo(email=author_email)]
+
+        return Document(
+            id=content_id,
+            sections=[TextSection(link=link, text=body)],
+            source=DocumentSource.LUMAPPS,
+            semantic_identifier=title,
+            doc_updated_at=_parse_dt(content.get("updatedAt"))
+            or _parse_dt(content.get("publicationDate")),
+            primary_owners=owners or None,
+            metadata=metadata,
+        )
+
+    # --------------------------------------------------------------- checkpointed
+    def load_from_checkpoint(
+        self,
+        start: SecondsSinceUnixEpoch,
+        end: SecondsSinceUnixEpoch,
+        checkpoint: LumAppsCheckpoint,
+    ) -> CheckpointOutput[LumAppsCheckpoint]:
+        client = self._get_client()
+        start_dt = datetime.fromtimestamp(start, tz=timezone.utc)
+        end_dt = datetime.fromtimestamp(end, tz=timezone.utc)
+
+        response = client.list_content(self._list_body(cursor=checkpoint.cursor))
+        items = response.get("items") or []
+        next_cursor = response.get("cursor") if response.get("more") else None
+
+        for content in items:
+            updated_at = _parse_dt(content.get("updatedAt"))
+            # content/list is sorted by -updatedAt, so once we cross below the poll
+            # window start there is nothing newer left → stop (incremental early-break).
+            if updated_at is not None and updated_at < start_dt:
+                return LumAppsCheckpoint(has_more=False, cursor=None)
+            # skip anything updated after the window end (newest-first ordering puts
+            # these at the top; a failed-attempt retry can use an earlier end).
+            if updated_at is not None and updated_at > end_dt:
+                continue
+            if not _is_live(content):
+                logger.debug(
+                    "Skipping non-LIVE LumApps content %s (status=%s)",
+                    content.get("id") or content.get("uid"),
+                    content.get("status"),
+                )
+                continue
+            content_id = str(content.get("id") or content.get("uid"))
+            try:
+                yield self._content_to_document(content, client)
+            except Exception as e:
+                logger.exception("Failed to convert LumApps content %s", content_id)
+                yield ConnectorFailure(
+                    failed_document=DocumentFailure(document_id=content_id),
+                    failure_message=str(e),
+                    exception=e,
+                )
+
+        if next_cursor:
+            return LumAppsCheckpoint(has_more=True, cursor=next_cursor)
+        return LumAppsCheckpoint(has_more=False, cursor=None)
+
+    # ----------------------------------------------------------------------- slim
+    def retrieve_all_slim_docs(
+        self,
+        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002 (full-state enum)
+        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        callback: IndexingHeartbeatInterface | None = None,
+    ) -> GenerateSlimDocumentOutput:
+        # Enumerate the SAME scope that indexing covers (LIVE content for the configured
+        # instances/content-types) so pruning never deletes validly-indexed docs.
+        # The client raises on any non-200, so a partial enumeration aborts (never a
+        # truncated set) — required for safe pruning.
+        client = self._get_client()
+        cursor: str | None = None
+        while True:
+            if callback and callback.should_stop():
+                return
+            response = client.list_content(
+                self._list_body(
+                    cursor=cursor, fields=_SLIM_FIELDS, max_results=_SLIM_PAGE_SIZE
+                )
+            )
+            items = response.get("items") or []
+            batch: list[SlimDocument | HierarchyNode] = [
+                SlimDocument(id=str(item.get("id")))
+                for item in items
+                if item.get("id") and _is_live(item)
+            ]
+            if batch:
+                yield batch
+            if callback:
+                callback.progress("lumapps_slim", len(batch))
+            cursor = response.get("cursor") if response.get("more") else None
+            if not cursor:
+                return

--- a/backend/onyx/connectors/lumapps/models.py
+++ b/backend/onyx/connectors/lumapps/models.py
@@ -1,0 +1,9 @@
+from onyx.connectors.models import ConnectorCheckpoint
+
+
+class LumAppsCheckpoint(ConnectorCheckpoint):
+    # Within-run pagination only. LumApps content/list returns an opaque (offset-based)
+    # `cursor` string; we resume from it within a single indexing run. Cross-run
+    # incrementality is driven by the framework poll window (`start`), not this field,
+    # because Onyx resets the checkpoint to a dummy after every successful run.
+    cursor: str | None = None

--- a/backend/onyx/connectors/lumapps/utils.py
+++ b/backend/onyx/connectors/lumapps/utils.py
@@ -1,0 +1,117 @@
+import re
+from typing import Any
+
+from bs4 import BeautifulSoup
+
+# Keys whose values hold renderable widget text inside a LumApps content template.
+_CONTENT_KEYS = {"html", "content", "longText", "text", "body", "value"}
+
+# A language-code key in a LumApps localized value: "en", "fr", "en-US", "pt_BR".
+_LANG_CODE_RE = re.compile(r"^[a-z]{2}(?:[-_][A-Za-z]{2,4})?$")
+
+
+def slugify_family_key(name: str) -> str:
+    """Turn a metadata family display name into a stable Onyx metadata key.
+
+    e.g. "News type" -> "news_type", "Country" -> "country".
+    """
+    cleaned = re.sub(r"[^a-z0-9]+", "_", (name or "").strip().lower()).strip("_")
+    return cleaned or "metadata"
+
+
+def pick_lang(value: Any, preferred_lang: str, fallback_lang: str = "en") -> str:
+    """Pick a string from a LumApps language-keyed dict (e.g. {"en": "...", "fr": "..."}).
+
+    Falls back to the preferred language, then English, then any non-empty value.
+    Plain strings are returned as-is.
+    """
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, dict) or not value:
+        return ""
+    for lang in (preferred_lang, fallback_lang):
+        if value.get(lang):
+            return str(value[lang])
+    for candidate in value.values():
+        if candidate:
+            return str(candidate)
+    return ""
+
+
+def _html_to_text(html: str) -> str:
+    if not html:
+        return ""
+    if "<" in html and ">" in html:
+        return BeautifulSoup(html, "html.parser").get_text(separator="\n").strip()
+    return html.strip()
+
+
+def _is_lang_dict(node: dict) -> bool:
+    # A LumApps localized value: language-code keys (en, fr, en-US) -> string values.
+    return bool(node) and all(
+        isinstance(k, str) and _LANG_CODE_RE.match(k) and isinstance(v, str)
+        for k, v in node.items()
+    )
+
+
+def extract_body_text(
+    template: Any, preferred_lang: str, fallback_lang: str = "en"
+) -> str:
+    """Best-effort extraction of human-readable body text from a LumApps template.
+
+    LumApps stores the body inside a structured template (components -> cells ->
+    widgets; rich-text/HTML widgets keep their text under ``properties`` in
+    content-ish, often language-keyed, fields). The exact widget schema varies, so we
+    walk the whole structure, harvest text only from content-ish keys, convert HTML to
+    text, de-duplicate, and join.
+    """
+    chunks: list[str] = []
+    seen: set[str] = set()
+
+    def add(raw: str) -> None:
+        text = _html_to_text(raw)
+        if text and text not in seen:
+            seen.add(text)
+            chunks.append(text)
+
+    def walk(node: Any, under_content_key: bool) -> None:
+        if isinstance(node, str):
+            if under_content_key:
+                add(node)
+        elif isinstance(node, dict):
+            if _is_lang_dict(node):
+                if under_content_key:
+                    add(pick_lang(node, preferred_lang, fallback_lang))
+                return
+            for key, value in node.items():
+                walk(value, under_content_key or key in _CONTENT_KEYS)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item, under_content_key)
+
+    walk(template, False)
+    return "\n\n".join(chunks).strip()
+
+
+def resolve_metadata_labels(
+    metadata_ids: list[str], label_map: dict[str, tuple[str, str]]
+) -> dict[str, list[str]]:
+    """Group resolved metadata values by family for ``Document.metadata``.
+
+    ``label_map`` maps a metadata value id -> ``(family_key, value_label)``. Returns
+    ``{family_key: [value labels...]}`` carrying **all** labels generically (no
+    country special-casing). Ids missing from ``label_map`` are skipped (the caller
+    logs them).
+    """
+    grouped: dict[str, list[str]] = {}
+    for metadata_id in metadata_ids or []:
+        entry = label_map.get(str(metadata_id))
+        if not entry:
+            continue
+        family_key, value_label = entry
+        if not family_key or not value_label:
+            continue
+        values = grouped.setdefault(family_key, [])
+        if value_label not in values:
+            values.append(value_label)
+    return grouped

--- a/backend/onyx/connectors/lumapps/utils.py
+++ b/backend/onyx/connectors/lumapps/utils.py
@@ -10,13 +10,16 @@ _CONTENT_KEYS = {"html", "content", "longText", "text", "body", "value"}
 _LANG_CODE_RE = re.compile(r"^[a-z]{2}(?:[-_][A-Za-z]{2,4})?$")
 
 
-def slugify_family_key(name: str) -> str:
+def slugify_family_key(name: str, fallback: str = "metadata") -> str:
     """Turn a metadata family display name into a stable Onyx metadata key.
 
-    e.g. "News type" -> "news_type", "Country" -> "country".
+    e.g. "News type" -> "news_type", "Country" -> "country". Names with no
+    ASCII alphanumerics (e.g. non-Latin family names) slugify to nothing and
+    return ``fallback`` instead — callers pass a per-family fallback so
+    distinct families don't collapse into one key.
     """
     cleaned = re.sub(r"[^a-z0-9]+", "_", (name or "").strip().lower()).strip("_")
-    return cleaned or "metadata"
+    return cleaned or fallback
 
 
 def pick_lang(value: Any, preferred_lang: str, fallback_lang: str = "en") -> str:

--- a/backend/onyx/connectors/registry.py
+++ b/backend/onyx/connectors/registry.py
@@ -220,6 +220,10 @@ CONNECTOR_CLASS_MAP = {
         module_path="onyx.connectors.braintrust.connector",
         class_name="BraintrustConnector",
     ),
+    DocumentSource.LUMAPPS: ConnectorMapping(
+        module_path="onyx.connectors.lumapps.connector",
+        class_name="LumAppsConnector",
+    ),
     # just for integration tests
     DocumentSource.MOCK_CONNECTOR: ConnectorMapping(
         module_path="onyx.connectors.mock_connector.connector",

--- a/backend/onyx/onyxbot/slack/icons.py
+++ b/backend/onyx/onyxbot/slack/icons.py
@@ -60,6 +60,8 @@ _SOURCE_IMAGE_FILENAMES: Mapping[DocumentSource, str] = {
     DocumentSource.BITBUCKET: "Bitbucket.png",
     DocumentSource.TESTRAIL: "Testrail.png",
     DocumentSource.BRAINTRUST: "Braintrust.png",
+    # LumApps ships only as an inline SVG in web; no PNG asset exists
+    DocumentSource.LUMAPPS: _DEFAULT_SOURCE_IMAGE_FILENAME,
     DocumentSource.MOCK_CONNECTOR: _DEFAULT_SOURCE_IMAGE_FILENAME,
     DocumentSource.USER_FILE: _DEFAULT_SOURCE_IMAGE_FILENAME,
     DocumentSource.CRAFT_FILE: _DEFAULT_SOURCE_IMAGE_FILENAME,

--- a/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_client.py
+++ b/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_client.py
@@ -1,0 +1,105 @@
+"""Unit tests for the LumApps client's retry/auth behavior (mocked HTTP)."""
+
+import time
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests
+
+from onyx.connectors.lumapps.client import LumAppsClientError
+from onyx.connectors.lumapps.client import OnyxLumApps
+
+
+def _client_with_token() -> tuple[OnyxLumApps, MagicMock]:
+    client = OnyxLumApps(
+        base_url="https://example.cell.lumapps.com",
+        organization_id="org-1",
+        application_id="app",
+        api_key="key",
+        service_user="svc@example.com",
+    )
+    client._token = "cached-token"
+    client._token_expiry_monotonic = time.monotonic() + 3600
+    session = MagicMock()
+    client._session = session
+    return client, session
+
+
+def _response(status_code: int, body: dict[str, Any] | None = None) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = {}
+    response.json.return_value = body if body is not None else {}
+    response.text = "error-body"
+    return response
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "onyx.connectors.lumapps.client.time.sleep", lambda _seconds: None
+    )
+
+
+def test_network_errors_are_retried() -> None:
+    """Connection resets / timeouts back off and retry like a 5xx instead of
+    aborting the indexing attempt."""
+    client, session = _client_with_token()
+    session.request.side_effect = [
+        requests.ConnectionError("reset by peer"),
+        requests.Timeout("timed out"),
+        _response(200, {"items": [], "more": False}),
+    ]
+
+    assert client.list_content({}) == {"items": [], "more": False}
+    assert session.request.call_count == 3
+
+
+def test_exhausted_network_errors_raise_client_error() -> None:
+    """After all retries fail, the network error surfaces as LumAppsClientError
+    so callers (validation included) can translate it."""
+    client, session = _client_with_token()
+    session.request.side_effect = requests.ConnectionError("down")
+
+    with pytest.raises(LumAppsClientError) as exc_info:
+        client.list_content({})
+    assert exc_info.value.status_code == 503
+    assert "down" in exc_info.value.message
+
+
+def test_429_retry_does_not_remint_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Rate-limit/server-error retries must reuse the cached token; only a 401
+    invalidates it."""
+    client, session = _client_with_token()
+    mint_mock = MagicMock()
+    monkeypatch.setattr(client, "_mint_token", mint_mock)
+    session.request.side_effect = [
+        _response(429),
+        _response(200, {"items": [], "more": False}),
+    ]
+
+    assert client.list_content({}) == {"items": [], "more": False}
+    mint_mock.assert_not_called()
+
+
+def test_401_invalidates_token_and_remints_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client, session = _client_with_token()
+
+    def _mint() -> None:
+        client._token = "fresh-token"
+        client._token_expiry_monotonic = time.monotonic() + 3600
+
+    mint_mock = MagicMock(side_effect=_mint)
+    monkeypatch.setattr(client, "_mint_token", mint_mock)
+    session.request.side_effect = [
+        _response(401),
+        _response(200, {"items": [], "more": False}),
+    ]
+
+    assert client.list_content({}) == {"items": [], "more": False}
+    mint_mock.assert_called_once()
+    sent_auth = session.request.call_args_list[1].kwargs["headers"]["Authorization"]
+    assert sent_auth == "Bearer fresh-token"

--- a/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_connector.py
+++ b/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_connector.py
@@ -1,0 +1,83 @@
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+from onyx.connectors.lumapps.connector import LumAppsConnector
+from onyx.connectors.models import Document
+from onyx.connectors.models import SlimDocument
+
+
+def _make_connector(list_response: dict[str, Any]) -> LumAppsConnector:
+    connector = LumAppsConnector(
+        base_url="https://example.cell.lumapps.com",
+        organization_id="org-1",
+    )
+    client = MagicMock()
+    client.list_content.return_value = list_response
+    connector._client = client
+    return connector
+
+
+def _item(content_id: str, status: str, updated_at: str) -> dict[str, Any]:
+    return {
+        "id": content_id,
+        "status": status,
+        "title": f"Title {content_id}",
+        "updatedAt": updated_at,
+        "template": None,
+        "properties": None,
+        "metadata": [],
+    }
+
+
+def test_load_from_checkpoint_yields_only_live_content() -> None:
+    """Non-LIVE items must be skipped even if the API-side status filter
+    fails to apply (defense in depth)."""
+    connector = _make_connector(
+        {
+            "items": [
+                _item("live-1", "LIVE", "2026-07-01T12:00:00Z"),
+                _item("draft-1", "DRAFT", "2026-07-01T11:00:00Z"),
+                _item("archive-1", "ARCHIVE", "2026-07-01T10:00:00Z"),
+                _item("live-2", "live", "2026-07-01T09:00:00Z"),  # case-insensitive
+            ],
+            "more": False,
+        }
+    )
+
+    start = datetime(2026, 7, 1, tzinfo=timezone.utc).timestamp()
+    end = datetime(2026, 7, 2, tzinfo=timezone.utc).timestamp()
+    results = list(
+        connector.load_from_checkpoint(start, end, connector.build_dummy_checkpoint())
+    )
+
+    docs = [r for r in results if isinstance(r, Document)]
+    assert [d.id for d in docs] == ["live-1", "live-2"]
+
+
+def test_slim_docs_exclude_non_live_content() -> None:
+    """Pruning enumeration must exclude non-LIVE items so content leaving
+    LIVE gets pruned from the index."""
+    connector = _make_connector(
+        {
+            "items": [
+                {"id": "live-1", "status": "LIVE"},
+                {"id": "draft-1", "status": "DRAFT"},
+                {"id": "no-status"},
+            ],
+            "more": False,
+        }
+    )
+
+    batches = list(connector.retrieve_all_slim_docs())
+
+    assert len(batches) == 1
+    assert [doc.id for doc in batches[0] if isinstance(doc, SlimDocument)] == ["live-1"]
+    assert all(isinstance(doc, SlimDocument) for doc in batches[0])
+
+
+def test_list_body_requests_live_status_from_api() -> None:
+    """The API-side filter stays in place alongside the in-code check."""
+    connector = _make_connector({"items": [], "more": False})
+    assert connector._list_body()["status"] == ["LIVE"]

--- a/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_connector.py
+++ b/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_connector.py
@@ -3,6 +3,9 @@ from datetime import timezone
 from typing import Any
 from unittest.mock import MagicMock
 
+import pytest
+
+from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.lumapps.connector import LumAppsConnector
 from onyx.connectors.models import Document
 from onyx.connectors.models import SlimDocument
@@ -75,6 +78,45 @@ def test_slim_docs_exclude_non_live_content() -> None:
     assert len(batches) == 1
     assert [doc.id for doc in batches[0] if isinstance(doc, SlimDocument)] == ["live-1"]
     assert all(isinstance(doc, SlimDocument) for doc in batches[0])
+
+
+def test_slim_docs_use_uid_fallback_like_indexing() -> None:
+    """An item with only a uid is indexed under that uid, so the slim set must
+    carry it too — otherwise pruning would delete a live document."""
+    connector = _make_connector(
+        {
+            "items": [
+                {"id": "live-1", "status": "LIVE"},
+                {"uid": "uid-only-1", "status": "LIVE"},
+            ],
+            "more": False,
+        }
+    )
+
+    batches = list(connector.retrieve_all_slim_docs())
+
+    assert [doc.id for doc in batches[0] if isinstance(doc, SlimDocument)] == [
+        "live-1",
+        "uid-only-1",
+    ]
+
+
+def test_http_base_url_is_rejected() -> None:
+    """The client sends credentials on every token request; plain http would
+    leak them in transit."""
+    connector = LumAppsConnector(
+        base_url="http://example.cell.lumapps.com",
+        organization_id="org-1",
+    )
+    connector.load_credentials(
+        {
+            "lumapps_application_id": "app",
+            "lumapps_api_key": "key",
+            "lumapps_service_user": "svc@example.com",
+        }
+    )
+    with pytest.raises(ConnectorValidationError, match="https"):
+        connector.validate_connector_settings()
 
 
 def test_list_body_requests_live_status_from_api() -> None:

--- a/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_utils.py
+++ b/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_utils.py
@@ -13,6 +13,17 @@ def test_slugify_family_key() -> None:
     assert slugify_family_key("") == "metadata"
 
 
+def test_slugify_family_key_non_latin_uses_fallback() -> None:
+    """Fully non-Latin names slugify to nothing; the per-family fallback keeps
+    distinct families from collapsing into one key."""
+    assert slugify_family_key("Страна", fallback="metadata_123") == "metadata_123"
+    assert slugify_family_key("部門", fallback="metadata_456") == "metadata_456"
+    # distinct families -> distinct keys
+    assert slugify_family_key("Страна", fallback="metadata_1") != slugify_family_key(
+        "Отдел", fallback="metadata_2"
+    )
+
+
 def test_pick_lang() -> None:
     val = {"en": "Hello", "fr": "Bonjour"}
     assert pick_lang(val, "fr") == "Bonjour"

--- a/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_utils.py
+++ b/backend/tests/unit/onyx/connectors/lumapps/test_lumapps_utils.py
@@ -1,0 +1,81 @@
+"""Unit tests for the LumApps connector's pure helpers (no API / services)."""
+
+from onyx.connectors.lumapps.utils import extract_body_text
+from onyx.connectors.lumapps.utils import pick_lang
+from onyx.connectors.lumapps.utils import resolve_metadata_labels
+from onyx.connectors.lumapps.utils import slugify_family_key
+
+
+def test_slugify_family_key() -> None:
+    assert slugify_family_key("News type") == "news_type"
+    assert slugify_family_key("Country") == "country"
+    assert slugify_family_key("  Départements / Teams  ") == "d_partements_teams"
+    assert slugify_family_key("") == "metadata"
+
+
+def test_pick_lang() -> None:
+    val = {"en": "Hello", "fr": "Bonjour"}
+    assert pick_lang(val, "fr") == "Bonjour"
+    assert pick_lang(val, "de") == "Hello"  # fallback to en
+    assert pick_lang({"de": "Hallo"}, "fr") == "Hallo"  # any available
+    assert pick_lang("plain", "en") == "plain"
+    assert pick_lang({}, "en") == ""
+
+
+def test_extract_body_text_walks_template_widgets() -> None:
+    template = {
+        "components": [
+            {
+                "cells": [
+                    {
+                        "widgets": [
+                            {
+                                "widgetType": "html",
+                                "properties": {
+                                    "content": {
+                                        "en": "<p>Hello <b>world</b></p>",
+                                        "fr": "<p>Bonjour</p>",
+                                    }
+                                },
+                            },
+                            {
+                                "widgetType": "title",
+                                "properties": {"text": "Section A"},
+                            },
+                            # non-content keys are ignored
+                            {"properties": {"styleId": "abc-123", "color": "#fff"}},
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    body = extract_body_text(template, preferred_lang="en")
+    assert "Hello" in body and "world" in body
+    assert "Section A" in body
+    assert "abc-123" not in body  # style ids are not harvested
+    assert "<p>" not in body  # HTML stripped
+    # preferred language is chosen
+    assert "Bonjour" not in body
+
+
+def test_extract_body_text_empty() -> None:
+    assert extract_body_text(None, "en") == ""
+    assert extract_body_text({}, "en") == ""
+
+
+def test_resolve_metadata_labels_groups_by_family() -> None:
+    label_map = {
+        "1": ("news_type", "General News"),
+        "2": ("departments", "HR"),
+        "3": ("departments", "HR"),  # duplicate value
+        "4": ("country", "Germany"),
+    }
+    out = resolve_metadata_labels(["1", "2", "3", "4", "999"], label_map)
+    assert out == {
+        "news_type": ["General News"],
+        "departments": ["HR"],  # de-duplicated
+        "country": ["Germany"],
+    }
+    # unknown ids (999) are skipped
+    assert resolve_metadata_labels([], label_map) == {}

--- a/web/lib/opal/src/logos/index.ts
+++ b/web/lib/opal/src/logos/index.ts
@@ -51,6 +51,7 @@ export { default as SvgLinear } from "@opal/logos/linear";
 export { default as SvgLitellm } from "@opal/logos/litellm";
 export { default as SvgLmStudio } from "@opal/logos/lm-studio";
 export { default as SvgLoopio } from "@opal/logos/loopio";
+export { default as SvgLumapps } from "@opal/logos/lumapps";
 export { default as SvgMediawiki } from "@opal/logos/mediawiki";
 export { default as SvgMicrosoft } from "@opal/logos/microsoft";
 export { default as SvgMistral } from "@opal/logos/mistral";

--- a/web/lib/opal/src/logos/lumapps.tsx
+++ b/web/lib/opal/src/logos/lumapps.tsx
@@ -1,0 +1,21 @@
+import type { IconProps } from "@opal/types";
+
+// LumApps brand mark (the isometric-cube glyph). Square viewBox so it renders
+// cleanly in connector tiles; `currentColor` lets it adapt to light/dark.
+const SvgLumapps = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 -0.22 28.33 28.33"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M6.197 0L0 3.54V10.623L4.869 13.437V6.31L11.017 2.781L6.197 0ZM7.97 18.666V24.323L14.167 27.886L20.364 24.323V18.666L14.167 22.223L7.97 18.666ZM7.97 8.146V15.229L14.167 18.769L20.364 15.229V8.146L14.167 4.606L7.97 8.146ZM17.318 2.783L23.461 6.306V13.434L28.33 10.62V3.54L22.13 0L17.318 2.783Z"
+      fill="currentColor"
+    />
+  </svg>
+);
+
+export default SvgLumapps;

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -181,6 +181,53 @@ export const connectorConfigs: Record<
     ],
     overrideDefaultFreq: 60 * 60 * 24,
   },
+  lumapps: {
+    description: "Configure LumApps connector",
+    values: [
+      {
+        type: "text",
+        label: "API Base URL (cell host)",
+        name: "base_url",
+        optional: false,
+        description:
+          "Your LumApps cell/API host, e.g. https://go-cell-005.api.lumapps.com (not the docs site api.lumapps.com).",
+      },
+      {
+        type: "text",
+        label: "Organization ID",
+        name: "organization_id",
+        optional: false,
+        description: "Your LumApps organization id (numeric).",
+      },
+    ],
+    advanced_values: [
+      {
+        type: "list",
+        label: "Instance (site) IDs",
+        name: "instance_ids",
+        optional: true,
+        description:
+          "Restrict indexing to specific instance/site IDs. Leave empty to index all content visible to the service user.",
+      },
+      {
+        type: "list",
+        label: "Custom Content Type IDs",
+        name: "custom_content_types",
+        optional: true,
+        description:
+          "Restrict to specific custom content type IDs. Leave empty to index all content types.",
+      },
+      {
+        type: "text",
+        label: "Language",
+        name: "lang",
+        optional: true,
+        default: "en",
+        description:
+          "Language used for content title/body and metadata labels (ISO 639-1, e.g. en, fr).",
+      },
+    ],
+  },
   github: {
     description: "Configure GitHub connector",
     values: [
@@ -1994,6 +2041,14 @@ export interface GitlabConfig {
   project_name: string;
   include_mrs: boolean;
   include_issues: boolean;
+}
+
+export interface LumAppsConfig {
+  base_url: string;
+  organization_id: string;
+  instance_ids?: string[];
+  custom_content_types?: string[];
+  lang?: string;
 }
 
 export interface BitbucketConfig {

--- a/web/src/lib/connectors/credentials.ts
+++ b/web/src/lib/connectors/credentials.ts
@@ -57,6 +57,12 @@ export interface GitlabCredentialJson {
   gitlab_access_token: string;
 }
 
+export interface LumAppsCredentialJson {
+  lumapps_application_id: string;
+  lumapps_api_key: string;
+  lumapps_service_user: string;
+}
+
 export interface BitbucketCredentialJson {
   bitbucket_email: string;
   bitbucket_api_token: string;
@@ -292,6 +298,11 @@ export const credentialTemplates: Record<ValidSources, any> = {
     gitlab_url: "",
     gitlab_access_token: "",
   } as GitlabCredentialJson,
+  lumapps: {
+    lumapps_application_id: "",
+    lumapps_api_key: "",
+    lumapps_service_user: "",
+  } as LumAppsCredentialJson,
   bitbucket: {
     bitbucket_email: "",
     bitbucket_api_token: "",
@@ -502,6 +513,11 @@ export const credentialTemplates: Record<ValidSources, any> = {
 export const credentialDisplayNames: Record<string, string> = {
   // Github
   github_access_token: "GitHub Access Token",
+
+  // LumApps
+  lumapps_application_id: "LumApps Application ID",
+  lumapps_api_key: "LumApps API Key",
+  lumapps_service_user: "Service User Email (to index on behalf of)",
 
   // Gitlab
   gitlab_url: "GitLab URL",

--- a/web/src/lib/sources.ts
+++ b/web/src/lib/sources.ts
@@ -40,6 +40,7 @@ import {
   SvgJira,
   SvgLinear,
   SvgLoopio,
+  SvgLumapps,
   SvgMediawiki,
   SvgNotion,
   SvgOracle,
@@ -103,6 +104,11 @@ export const SOURCE_METADATA_MAP: SourceMap = {
     docs: `${DOCS_ADMINS_PATH}/connectors/official/confluence`,
     oauthSupported: true,
     isPopular: true,
+  },
+  lumapps: {
+    icon: SvgLumapps,
+    displayName: "LumApps",
+    category: SourceCategory.Wiki,
   },
   sharepoint: {
     icon: SvgSharepoint,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -599,6 +599,7 @@ export enum ValidSources {
   Bitbucket = "bitbucket",
   TestRail = "testrail",
   Braintrust = "braintrust",
+  Lumapps = "lumapps",
 
   // Craft-specific sources
   CraftFile = "craft_file",


### PR DESCRIPTION
## Description

Adds a **LumApps** connector (LumApps is a widely-used enterprise intranet / employee-experience platform). It ingests published intranet content — pages, news, and custom content types — into Onyx.

Highlights:

- **Checkpointed, incremental indexing**: polls `content/list` sorted by `-updatedAt` and breaks early once items fall below the poll window, so recurring syncs only touch changed content. The opaque LumApps cursor is kept in the checkpoint for within-run pagination only.
- **LIVE-only ingestion, enforced on both paths**: the API-side `status` filter is not trusted on its own — each item is re-checked on the indexing *and* the pruning path, so content that leaves `LIVE` (drafts, archived, expired) gets pruned.
- **Generic metadata-label ingestion**: all LumApps metadata families are carried over as Onyx metadata (`{family_key: [labels]}`), resolved lazily with per-run caches. Whatever taxonomy an organization uses (country, department, topic, …) becomes filterable tags without connector changes.
- **Safe pruning**: `retrieve_all_slim_docs` enumerates exactly the scope indexing covers, and the client raises on any non-200, so pruning never acts on a truncated enumeration.
- **No new dependencies** — plain `requests` + `beautifulsoup4`.

Config: cell/API base URL + organization id (required); instance ids, custom content type ids, and language as advanced options. Credentials: application id, API key, and a service user email to index on behalf of.

This connector has been running in production on our self-hosted Onyx deployment.

## How Has This Been Tested?

- Unit tests: `backend/tests/unit/onyx/connectors/lumapps/` — pure helpers (language picking, template body extraction, metadata-label resolution) and connector behavior (pagination/checkpointing, LIVE filtering, document conversion) with a mocked HTTP client. All pass, along with the full `tests/unit/onyx/connectors` suite (837 passed).
- `ruff` / `ruff format` / `ty check` / lazy-import check clean; web `tsgo --noEmit`, `oxlint`, and `oxfmt` clean.
- Indexing, incremental re-sync, and pruning verified against a real LumApps tenant on our production deployment (fork of Onyx v4.2.2/v4.3.2, same connector code).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a checkpointed LumApps connector to ingest published intranet pages, news, and custom content into Onyx with incremental sync and safe pruning. Includes UI config, credentials, and icon so teams can set it up in the app.

- **New Features**
  - Incremental indexing via `content/list` sorted by `-updatedAt`, with an early stop once items fall below the poll window; the cursor is used only within a run.
  - LIVE-only ingestion enforced per item on indexing and pruning, so drafts/archived/expired content is skipped and removed.
  - Generic metadata ingestion: all families become `{family_key: [labels]}`, with a stable fallback for non‑Latin family names (`metadata_<family_id>`); resolved via per-run caches.
  - Slim retrieval enumerates the same scope as indexing, uses the same id-or-uid fallback as indexing, and aborts on non-200 to prevent partial pruning.
  - JWT auth using application ID + API key on behalf of a service user, with token refresh and resilient retries (network errors and 5xx/429 backoff; 401 re-mints token, others reuse it). Non-https `base_url` is rejected.

- **Migration**
  - In Sources, add a new LumApps connector with `base_url` (https cell API host) and `organization_id`.
  - Add credentials: `lumapps_application_id`, `lumapps_api_key`, `lumapps_service_user`.
  - Optional: restrict to `instance_ids`, `custom_content_types`, and set `lang` (default `en`).

<sup>Written for commit 4242ce694e4397cbe3e1d496c295726e3e003ca3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12899?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

