### PR TITLE
feat(web-connector): URL rewrite rules for stored document links

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -103,6 +103,10 @@ class ScrapeSessionContext:
         self.to_visit = to_visit
         self.url_rewrites = url_rewrites or {}
         self.visited_links: set[str] = set()
+        # Ids already emitted this run. Rewrite rules can map two fetched URLs
+        # onto the same storage id; only the first one wins (a duplicate id
+        # would overwrite the earlier document in the index).
+        self.emitted_doc_ids: set[str] = set()
         self.content_hashes: set[int] = set()
 
         self.at_least_one_doc: bool = False
@@ -734,6 +738,15 @@ class WebConnector(LoadConnector, SlimConnector):
                         continue
 
                     if result.doc:
+                        if result.doc.id in session_ctx.emitted_doc_ids:
+                            logger.warning(
+                                "Skipping %s: rewritten document id %s was "
+                                "already emitted by another URL this run",
+                                initial_url,
+                                result.doc.id,
+                            )
+                            continue
+                        session_ctx.emitted_doc_ids.add(result.doc.id)
                         batch.append(
                             SlimDocument(id=result.doc.id) if slim else result.doc
                         )

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -48,12 +48,42 @@ from shared_configs.configs import MULTI_TENANT
 logger = setup_logger()
 
 
+def _parse_url_rewrites(raw_rewrites: list[str]) -> dict[str, str]:
+    """Parse a list of "source_prefix -> target_prefix" strings into a dict."""
+    rewrites: dict[str, str] = {}
+    for entry in raw_rewrites:
+        if "->" not in entry:
+            logger.warning("Skipping invalid url_rewrite entry (no '->'): %s", entry)
+            continue
+        src, dst = entry.split("->", 1)
+        src, dst = src.strip(), dst.strip()
+        if src and dst:
+            rewrites[src] = dst
+        else:
+            logger.warning("Skipping empty url_rewrite entry: %s", entry)
+    return rewrites
+
+
+def _rewrite_url(url: str, rewrites: dict[str, str]) -> str:
+    """Apply URL prefix rewrites. First matching prefix wins."""
+    for src_prefix, dst_prefix in rewrites.items():
+        if url.startswith(src_prefix):
+            return url.replace(src_prefix, dst_prefix, 1)
+    return url
+
+
 class ScrapeSessionContext:
     """Session level context for scraping"""
 
-    def __init__(self, base_url: str, to_visit: list[str]):
+    def __init__(
+        self,
+        base_url: str,
+        to_visit: list[str],
+        url_rewrites: dict[str, str] | None = None,
+    ):
         self.base_url = base_url
         self.to_visit = to_visit
+        self.url_rewrites = url_rewrites or {}
         self.visited_links: set[str] = set()
         self.content_hashes: set[int] = set()
 
@@ -350,6 +380,7 @@ class WebConnector(LoadConnector, SlimConnector):
         mintlify_cleanup: bool = True,  # Mostly ok to apply to other websites as well
         batch_size: int = INDEX_BATCH_SIZE,
         scroll_before_scraping: bool = False,
+        url_rewrites: list[str] | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         self.mintlify_cleanup = mintlify_cleanup
@@ -357,6 +388,7 @@ class WebConnector(LoadConnector, SlimConnector):
         self.recursive = False
         self.scroll_before_scraping = scroll_before_scraping
         self.web_connector_type = web_connector_type
+        self.url_rewrites = _parse_url_rewrites(url_rewrites or [])
         if web_connector_type == WEB_CONNECTOR_VALID_SETTINGS.RECURSIVE.value:
             self.recursive = True
             self.to_visit_list = [_ensure_valid_url(base_url)]
@@ -412,6 +444,11 @@ class WebConnector(LoadConnector, SlimConnector):
 
         result = ScrapeResult()
 
+        # The URL used for the stored document (id, link, semantic id). Fetching
+        # still uses initial_url; only what gets persisted is rewritten. Slim
+        # docs must use the same rewritten id or pruning would delete the docs.
+        storage_url = _rewrite_url(initial_url, session_ctx.url_rewrites)
+
         # Handle cookies for the URL
         _handle_cookies(session_ctx.playwright_context, initial_url)
 
@@ -428,10 +465,10 @@ class WebConnector(LoadConnector, SlimConnector):
         if is_pdf:
             if slim:
                 result.doc = Document(
-                    id=initial_url,
+                    id=storage_url,
                     sections=[],
                     source=DocumentSource.WEB,
-                    semantic_identifier=initial_url,
+                    semantic_identifier=storage_url,
                     metadata={},
                 )
                 return result
@@ -449,11 +486,11 @@ class WebConnector(LoadConnector, SlimConnector):
             # re-indexing. The content hash is the authoritative change signal for
             # web docs (see DocumentBase.content_hash).
             result.doc = Document(
-                id=initial_url,
-                sections=[TextSection(link=initial_url, text=page_text)],
+                id=storage_url,
+                sections=[TextSection(link=storage_url, text=page_text)],
                 source=DocumentSource.WEB,
-                semantic_identifier=initial_url.rstrip("/").split("/")[-1]
-                or initial_url,
+                semantic_identifier=storage_url.rstrip("/").split("/")[-1]
+                or storage_url,
                 metadata=metadata,
             )
 
@@ -561,10 +598,10 @@ class WebConnector(LoadConnector, SlimConnector):
 
             if slim:
                 result.doc = Document(
-                    id=initial_url,
+                    id=storage_url,
                     sections=[],
                     source=DocumentSource.WEB,
-                    semantic_identifier=initial_url,
+                    semantic_identifier=storage_url,
                     metadata={},
                 )
                 return result
@@ -607,10 +644,10 @@ class WebConnector(LoadConnector, SlimConnector):
             # branch above. The HTTP Last-Modified header is an unreliable change
             # signal for web content, so we rely on the content hash for dedup.
             result.doc = Document(
-                id=initial_url,
-                sections=[TextSection(link=initial_url, text=parsed_html.cleaned_text)],
+                id=storage_url,
+                sections=[TextSection(link=storage_url, text=parsed_html.cleaned_text)],
                 source=DocumentSource.WEB,
-                semantic_identifier=parsed_html.title or initial_url,
+                semantic_identifier=parsed_html.title or storage_url,
                 metadata={},
             )
         finally:
@@ -632,7 +669,9 @@ class WebConnector(LoadConnector, SlimConnector):
         base_url = self.to_visit_list[0]  # For the recursive case
         check_internet_connection(base_url)  # make sure we can connect to the base url
 
-        session_ctx = ScrapeSessionContext(base_url, self.to_visit_list)
+        session_ctx = ScrapeSessionContext(
+            base_url, self.to_visit_list, self.url_rewrites
+        )
         session_ctx.initialize()
 
         batch: list[Document | SlimDocument | HierarchyNode] = []

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -48,14 +48,32 @@ from shared_configs.configs import MULTI_TENANT
 logger = setup_logger()
 
 
-def _parse_url_rewrites(raw_rewrites: list[str]) -> dict[str, str]:
-    """Parse a list of "source_prefix -> target_prefix" strings into a dict."""
+def _parse_url_rewrites(
+    raw_rewrites: list[list[str] | str],
+) -> dict[str, str]:
+    """Parse URL rewrite rules into a {source_prefix: target_prefix} dict.
+
+    The admin form submits [source, target] pairs; "source -> target" strings
+    are also accepted for configs written by hand against the API.
+    """
     rewrites: dict[str, str] = {}
     for entry in raw_rewrites:
-        if "->" not in entry:
-            logger.warning("Skipping invalid url_rewrite entry (no '->'): %s", entry)
+        if isinstance(entry, str):
+            if "->" not in entry:
+                logger.warning(
+                    "Skipping invalid url_rewrite entry (no '->'): %s", entry
+                )
+                continue
+            src, dst = entry.split("->", 1)
+        elif (
+            isinstance(entry, list)
+            and len(entry) == 2
+            and all(isinstance(part, str) for part in entry)
+        ):
+            src, dst = entry
+        else:
+            logger.warning("Skipping malformed url_rewrite entry: %s", entry)
             continue
-        src, dst = entry.split("->", 1)
         src, dst = src.strip(), dst.strip()
         if src and dst:
             rewrites[src] = dst
@@ -380,7 +398,7 @@ class WebConnector(LoadConnector, SlimConnector):
         mintlify_cleanup: bool = True,  # Mostly ok to apply to other websites as well
         batch_size: int = INDEX_BATCH_SIZE,
         scroll_before_scraping: bool = False,
-        url_rewrites: list[str] | None = None,
+        url_rewrites: list[list[str] | str] | None = None,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
         self.mintlify_cleanup = mintlify_cleanup

--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -745,7 +745,9 @@ class WebConnector(LoadConnector, SlimConnector):
                                 initial_url,
                                 result.doc.id,
                             )
-                            continue
+                            # Skip-and-move-on, not a transient failure: don't
+                            # burn the remaining retries re-scraping this URL.
+                            break
                         session_ctx.emitted_doc_ids.add(result.doc.id)
                         batch.append(
                             SlimDocument(id=result.doc.id) if slim else result.doc

--- a/backend/tests/unit/onyx/connectors/web/test_url_rewrites.py
+++ b/backend/tests/unit/onyx/connectors/web/test_url_rewrites.py
@@ -7,7 +7,22 @@ from onyx.connectors.web.connector import (
 )
 
 
-def test_parse_url_rewrites() -> None:
+def test_parse_url_rewrites_pairs() -> None:
+    """The admin form submits [source, target] pairs."""
+    parsed = _parse_url_rewrites(
+        [
+            ["https://mirror.internal", "https://docs.example.com"],
+            ["http://a", "http://b"],
+        ]
+    )
+    assert parsed == {
+        "https://mirror.internal": "https://docs.example.com",
+        "http://a": "http://b",
+    }
+
+
+def test_parse_url_rewrites_arrow_strings() -> None:
+    """Hand-written API configs may use "source -> target" strings."""
     parsed = _parse_url_rewrites(
         [
             "https://mirror.internal -> https://docs.example.com",
@@ -26,7 +41,9 @@ def test_parse_url_rewrites_skips_invalid_entries() -> None:
             "no-arrow-here",  # no separator
             " -> https://target.only",  # empty source
             "https://source.only -> ",  # empty target
-            "https://ok -> https://fine",
+            ["https://one.element"],  # not a pair
+            ["", "https://empty.source"],  # empty pair source
+            ["https://ok", "https://fine"],
         ]
     )
     assert parsed == {"https://ok": "https://fine"}
@@ -66,7 +83,7 @@ def test_web_connector_parses_url_rewrites() -> None:
     connector = WebConnector(
         base_url="https://mirror.internal/docs",
         web_connector_type="single",
-        url_rewrites=["https://mirror.internal -> https://docs.example.com"],
+        url_rewrites=[["https://mirror.internal", "https://docs.example.com"]],
     )
     assert connector.url_rewrites == {
         "https://mirror.internal": "https://docs.example.com"

--- a/backend/tests/unit/onyx/connectors/web/test_url_rewrites.py
+++ b/backend/tests/unit/onyx/connectors/web/test_url_rewrites.py
@@ -1,0 +1,81 @@
+"""Unit tests for the web connector's URL rewrite helpers (pure functions)."""
+
+from onyx.connectors.web.connector import (
+    WebConnector,
+    _parse_url_rewrites,
+    _rewrite_url,
+)
+
+
+def test_parse_url_rewrites() -> None:
+    parsed = _parse_url_rewrites(
+        [
+            "https://mirror.internal -> https://docs.example.com",
+            "http://a -> http://b",
+        ]
+    )
+    assert parsed == {
+        "https://mirror.internal": "https://docs.example.com",
+        "http://a": "http://b",
+    }
+
+
+def test_parse_url_rewrites_skips_invalid_entries() -> None:
+    parsed = _parse_url_rewrites(
+        [
+            "no-arrow-here",  # no separator
+            " -> https://target.only",  # empty source
+            "https://source.only -> ",  # empty target
+            "https://ok -> https://fine",
+        ]
+    )
+    assert parsed == {"https://ok": "https://fine"}
+
+
+def test_rewrite_url_first_matching_prefix_wins() -> None:
+    rewrites = {
+        "https://mirror.internal/docs": "https://docs.example.com",
+        "https://mirror.internal": "https://www.example.com",
+    }
+    assert (
+        _rewrite_url("https://mirror.internal/docs/page", rewrites)
+        == "https://docs.example.com/page"
+    )
+    assert (
+        _rewrite_url("https://mirror.internal/blog", rewrites)
+        == "https://www.example.com/blog"
+    )
+
+
+def test_rewrite_url_replaces_prefix_only_once() -> None:
+    rewrites = {"https://a": "https://b"}
+    # Only the leading prefix is replaced, not later occurrences in the path.
+    assert (
+        _rewrite_url("https://a/redirect?to=https://a", rewrites)
+        == "https://b/redirect?to=https://a"
+    )
+
+
+def test_rewrite_url_no_match_returns_unchanged() -> None:
+    assert _rewrite_url("https://other.example.com/x", {"https://a": "https://b"}) == (
+        "https://other.example.com/x"
+    )
+
+
+def test_web_connector_parses_url_rewrites() -> None:
+    connector = WebConnector(
+        base_url="https://mirror.internal/docs",
+        web_connector_type="single",
+        url_rewrites=["https://mirror.internal -> https://docs.example.com"],
+    )
+    assert connector.url_rewrites == {
+        "https://mirror.internal": "https://docs.example.com"
+    }
+
+
+def test_web_connector_defaults_to_no_rewrites() -> None:
+    connector = WebConnector(
+        base_url="https://docs.example.com",
+        web_connector_type="single",
+    )
+    assert connector.url_rewrites == {}

--- a/backend/tests/unit/onyx/connectors/web/test_url_rewrites.py
+++ b/backend/tests/unit/onyx/connectors/web/test_url_rewrites.py
@@ -1,6 +1,11 @@
-"""Unit tests for the web connector's URL rewrite helpers (pure functions)."""
+"""Unit tests for the web connector's URL rewrite helpers."""
 
+from unittest.mock import patch
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import Document, TextSection
 from onyx.connectors.web.connector import (
+    ScrapeResult,
     WebConnector,
     _parse_url_rewrites,
     _rewrite_url,
@@ -96,3 +101,49 @@ def test_web_connector_defaults_to_no_rewrites() -> None:
         web_connector_type="single",
     )
     assert connector.url_rewrites == {}
+
+
+def test_colliding_rewritten_ids_emit_only_first_document() -> None:
+    """Two fetched URLs can rewrite to the same storage id (e.g. crawling a
+    mirror and the canonical site); only the first document may be emitted or
+    the later one would overwrite it in the index."""
+    connector = WebConnector(
+        base_url="https://mirror.internal/page",
+        web_connector_type="single",
+        url_rewrites=[["https://mirror.internal", "https://docs.example.com"]],
+    )
+    connector.to_visit_list = [
+        "https://mirror.internal/page",
+        "https://docs.example.com/page",
+    ]
+
+    def _fake_scrape(
+        index: int,  # noqa: ARG001
+        initial_url: str,  # noqa: ARG001
+        session_ctx: object,  # noqa: ARG001
+        slim: bool = False,  # noqa: ARG001
+    ) -> ScrapeResult:
+        result = ScrapeResult()
+        result.doc = Document(
+            id="https://docs.example.com/page",
+            sections=[TextSection(link="https://docs.example.com/page", text="x")],
+            source=DocumentSource.WEB,
+            semantic_identifier="page",
+            metadata={},
+        )
+        return result
+
+    with (
+        patch(
+            "onyx.connectors.web.connector.ScrapeSessionContext.initialize",
+        ),
+        patch("onyx.connectors.web.connector.check_internet_connection"),
+        patch("onyx.connectors.web.connector.protected_url_check"),
+        patch.object(WebConnector, "_do_scrape", side_effect=_fake_scrape),
+    ):
+        docs = [doc for batch in connector.load_from_state() for doc in batch]
+
+    assert [doc.id for doc in docs if isinstance(doc, Document)] == [
+        "https://docs.example.com/page"
+    ]
+    assert len(docs) == 1

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/StringPairListInput.tsx
@@ -1,0 +1,105 @@
+import React from "react";
+import { ArrayHelpers, ErrorMessage, Field, FieldArray } from "formik";
+import { useFormikContext } from "formik";
+import { FiX } from "react-icons/fi";
+import { Button } from "@opal/components";
+import { SvgPlusCircle } from "@opal/icons";
+import { Label, SubLabel } from "@/components/Field";
+
+interface StringPairListInputProps {
+  name: string;
+  label: string;
+  description?: string;
+  leftLabel: string;
+  rightLabel: string;
+  leftPlaceholder?: string;
+  rightPlaceholder?: string;
+}
+
+const FIELD_CLASSES = `
+  border
+  border-border
+  bg-background
+  rounded
+  w-full
+  py-2
+  px-3
+  disabled:cursor-not-allowed
+`;
+
+/** A list of [left, right] string pairs rendered as two side-by-side inputs
+ * per row (e.g. URL rewrite rules: source prefix -> replacement prefix). */
+const StringPairListInput: React.FC<StringPairListInputProps> = ({
+  name,
+  label,
+  description,
+  leftLabel,
+  rightLabel,
+  leftPlaceholder,
+  rightPlaceholder,
+}) => {
+  const { values } = useFormikContext<Record<string, any>>();
+  const pairs: [string, string][] = values[name] || [];
+
+  return (
+    <div className="mb-4">
+      <Label>{label}</Label>
+      {description && <SubLabel>{description}</SubLabel>}
+
+      <FieldArray
+        name={name}
+        render={(arrayHelpers: ArrayHelpers) => (
+          <div>
+            {pairs.length > 0 && (
+              <div className="flex mt-2 text-sm text-text-500">
+                <div className="w-full mr-2">{leftLabel}</div>
+                <div className="w-full">{rightLabel}</div>
+                <div className="w-10 shrink-0" />
+              </div>
+            )}
+            {pairs.map((_, index) => (
+              <div key={index} className="mt-2">
+                <div className="flex items-center">
+                  <Field
+                    name={`${name}.${index}.0`}
+                    className={`${FIELD_CLASSES} mr-2`}
+                    autoComplete="off"
+                    placeholder={leftPlaceholder}
+                  />
+                  <Field
+                    name={`${name}.${index}.1`}
+                    className={FIELD_CLASSES}
+                    autoComplete="off"
+                    placeholder={rightPlaceholder}
+                  />
+                  <FiX
+                    className="w-10 h-10 shrink-0 cursor-pointer hover:bg-background-neutral-02 rounded-sm p-2"
+                    onClick={() => arrayHelpers.remove(index)}
+                  />
+                </div>
+                <ErrorMessage
+                  name={`${name}.${index}`}
+                  component="div"
+                  className="text-action-danger-05 text-sm mt-1"
+                />
+              </div>
+            ))}
+
+            <div className="mt-2">
+              <Button
+                icon={SvgPlusCircle}
+                prominence="secondary"
+                onClick={() => arrayHelpers.push(["", ""])}
+                type="button"
+              >
+                Add New
+              </Button>
+            </div>
+          </div>
+        )}
+      />
+    </div>
+  );
+};
+
+export default StringPairListInput;

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -4,6 +4,7 @@ import SelectInput from "./ConnectorInput/SelectInput";
 import NumberInput from "./ConnectorInput/NumberInput";
 import { TextFormField, MultiSelectField } from "@/components/Field";
 import ListInput from "./ConnectorInput/ListInput";
+import StringPairListInput from "./ConnectorInput/StringPairListInput";
 import FileInput from "./ConnectorInput/FileInput";
 import { ConfigurableSources } from "@/lib/types";
 import { Credential } from "@/lib/connectors/credentials";
@@ -177,6 +178,16 @@ export const RenderField: FC<RenderFieldProps> = ({
         />
       ) : field.type === "list" ? (
         <ListInput name={field.name} label={label} description={description} />
+      ) : field.type === "string_pair_list" ? (
+        <StringPairListInput
+          name={field.name}
+          label={label}
+          description={description}
+          leftLabel={field.leftLabel}
+          rightLabel={field.rightLabel}
+          leftPlaceholder={field.leftPlaceholder}
+          rightPlaceholder={field.rightPlaceholder}
+        />
       ) : field.type === "select" ? (
         <SelectInput
           name={field.name}

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -178,6 +178,18 @@ export const connectorConfigs: Record<
         name: "scroll_before_scraping",
         optional: true,
       },
+      {
+        type: "list",
+        query: "Enter URL rewrite rules:",
+        label: "URL Rewrites",
+        name: "url_rewrites",
+        optional: true,
+        description:
+          'Rewrite document URLs before storing. Each entry: "https://source-prefix -> https://target-prefix". ' +
+          "Useful when crawling through an internal mirror while storing the canonical public links, " +
+          "for example: https://internal-mirror.example.com -> https://docs.example.com",
+        default: [],
+      },
     ],
     overrideDefaultFreq: 60 * 60 * 24,
   },
@@ -2066,6 +2078,7 @@ export interface ConnectorSnapshot {
 export interface WebConfig {
   base_url: string;
   web_connector_type?: "recursive" | "single" | "sitemap";
+  url_rewrites?: string[];
 }
 
 export interface GithubConfig {

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -64,6 +64,15 @@ export interface ListOption extends Option {
   transform?: (values: string[]) => string[];
 }
 
+export interface StringPairListOption extends Option {
+  type: "string_pair_list";
+  default?: [string, string][];
+  leftLabel: string;
+  rightLabel: string;
+  leftPlaceholder?: string;
+  rightPlaceholder?: string;
+}
+
 export interface TextOption extends Option {
   type: "text";
   default?: string;
@@ -118,6 +127,7 @@ export interface ConnectionConfiguration {
   values: (
     | BooleanOption
     | ListOption
+    | StringPairListOption
     | TextOption
     | NumberOption
     | SelectOption
@@ -128,6 +138,7 @@ export interface ConnectionConfiguration {
   advanced_values: (
     | BooleanOption
     | ListOption
+    | StringPairListOption
     | TextOption
     | NumberOption
     | SelectOption
@@ -179,15 +190,19 @@ export const connectorConfigs: Record<
         optional: true,
       },
       {
-        type: "list",
+        type: "string_pair_list",
         query: "Enter URL rewrite rules:",
         label: "URL Rewrites",
         name: "url_rewrites",
         optional: true,
         description:
-          'Rewrite document URLs before storing. Each entry: "https://source-prefix -> https://target-prefix". ' +
-          "Useful when crawling through an internal mirror while storing the canonical public links, " +
-          "for example: https://internal-mirror.example.com -> https://docs.example.com",
+          "Rewrite document URLs before storing. Useful when crawling through an internal " +
+          "mirror while storing the canonical public links, for example " +
+          "https://internal-mirror.example.com \u2192 https://docs.example.com",
+        leftLabel: "Source URL prefix",
+        rightLabel: "Replacement prefix",
+        leftPlaceholder: "https://internal-mirror.example.com",
+        rightPlaceholder: "https://docs.example.com",
         default: [],
       },
     ],
@@ -2078,7 +2093,7 @@ export interface ConnectorSnapshot {
 export interface WebConfig {
   base_url: string;
   web_connector_type?: "recursive" | "single" | "sitemap";
-  url_rewrites?: string[];
+  url_rewrites?: [string, string][];
 }
 
 export interface GithubConfig {


### PR DESCRIPTION
## Description

Adds an optional **URL Rewrites** setting to the web connector: a list of `[source_prefix, target_prefix]` rules applied to the URL a document is **stored** under (document id, section link, semantic identifier). Fetching still uses the original URL — only what gets persisted is rewritten.

The admin form renders each rule as two side-by-side fields (source prefix / replacement prefix) via a new reusable `string_pair_list` option type + `StringPairListInput` component; `"source -> target"` strings are also accepted by the backend for configs written by hand against the API.

**Use case:** crawling a site through an internal mirror, a staging host, or a pre-rendering proxy while storing the canonical public links — so citations in chat point users at the real site instead of the mirror. We run this in production to index docs sites that are only reachable from inside our network through a mirror host.

Behavior details:

- First matching prefix wins; only the **leading** prefix is replaced (a URL that merely *contains* the source prefix later in its path/query is untouched).
- Slim documents get the same rewritten id as indexed documents, so pruning enumeration stays consistent with what indexing stored — no false pruning.
- Invalid rules (malformed entries, empty source/target) are skipped with a warning; the field is optional and defaults to no rewrites, so existing connectors are unaffected.

Backend: `_parse_url_rewrites` / `_rewrite_url` helpers + `url_rewrites` connector param threaded through `ScrapeSessionContext`. Frontend: new `string_pair_list` option type rendered by `StringPairListInput` (two inputs per row, add/remove), used by the web connector form (`url_rewrites` in `WebConfig`).

## How Has This Been Tested?

- New unit tests (`backend/tests/unit/onyx/connectors/web/test_url_rewrites.py`): pair and arrow-string parsing incl. invalid-entry skipping, first-match-wins ordering, leading-prefix-only replacement, no-match passthrough, and connector wiring/defaults. Full `tests/unit/onyx/connectors/web` suite passes (20).
- `ruff` / `ruff format` / `ty check` clean; web `tsgo --noEmit`, `oxlint`, `oxfmt` clean.
- The same feature has been running in production in our Onyx fork: mirrored crawls store canonical public URLs and re-syncs/pruning behave correctly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check
