### PR TITLE
feat(gitlab): clone-based code indexing with incremental sync and glob filtering

### DIFF
--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -285,9 +285,12 @@ def _convert_file_to_document(
     )
     logger.debug("Generated file ID: %s", file_id)
 
-    # Use last commit date if available, otherwise current time - ensure UTC
-    doc_updated_at = _ensure_utc_datetime(last_commit_date)
-    logger.debug("Document updated_at: %s", doc_updated_at)
+    # Leave doc_updated_at unset when no reliable commit date is available —
+    # the indexing pipeline's content hash then governs change detection. A
+    # fabricated now() timestamp would mark every doc as updated on each run.
+    doc_updated_at = (
+        _ensure_utc_datetime(last_commit_date) if last_commit_date else None
+    )
 
     # Create and return a Document object
     doc = Document(
@@ -345,25 +348,16 @@ def _should_exclude_by_glob(path: str, exclude_patterns: list[str]) -> bool:
     return _matches_any_glob(path, exclude_patterns)
 
 
-def _get_file_last_commit_date(repo: git.Repo, file_path: str) -> datetime:
-    """Get the last commit date for a specific file."""
-    logger.debug("Getting last commit date for file: %s", file_path)
+def _get_file_last_commit_date(repo: git.Repo, file_path: str) -> datetime | None:
+    """Get the last commit date for a specific file (None when unavailable)."""
     try:
         commits = list(repo.iter_commits(paths=file_path, max_count=1))
         if commits:
-            commit_date = commits[0].committed_datetime
-            # Ensure timezone info is present and convert to UTC
-            commit_date = _ensure_utc_datetime(commit_date)
-            logger.debug("Last commit date for '%s': %s", file_path, commit_date)
-            return commit_date
-        else:
-            logger.debug("No commits found for file: %s", file_path)
+            return _ensure_utc_datetime(commits[0].committed_datetime)
+        logger.debug("No commits found for file: %s", file_path)
     except Exception as e:
         logger.warning("Could not get commit date for %s: %s", file_path, e)
-
-    fallback_date = datetime.now(timezone.utc)
-    logger.debug("Using fallback date for '%s': %s", file_path, fallback_date)
-    return fallback_date
+    return None
 
 
 class GitlabConnector(LoadConnector, PollConnector):
@@ -585,13 +579,34 @@ class GitlabConnector(LoadConnector, PollConnector):
                     dirs.remove(".git")
                     logger.debug("Skipped .git directory")
                 for file in files:
-                    yield Path(root) / file
+                    file_path = Path(root) / file
+                    if self._is_safe_repo_file(file_path):
+                        yield file_path
             return
 
         for rel_path in candidate_rel_paths:
             file_path = self.repo_path / rel_path
-            if file_path.is_file():
+            if self._is_safe_repo_file(file_path):
                 yield file_path
+
+    def _is_safe_repo_file(self, file_path: Path) -> bool:
+        """Reject symlinks and anything resolving outside the checkout.
+
+        A repository-controlled symlink (e.g. ``secret -> /etc/passwd``) must
+        not let indexing read and publish files from the host filesystem.
+        """
+        if self.repo_path is None:
+            return False
+        if file_path.is_symlink() or not file_path.is_file():
+            return False
+        try:
+            file_path.resolve().relative_to(self.repo_path.resolve())
+        except ValueError:
+            logger.warning(
+                "Skipping %s: resolves outside the repository checkout", file_path
+            )
+            return False
+        return True
 
     def _get_filtered_files(
         self, candidate_rel_paths: set[str] | None = None
@@ -773,12 +788,17 @@ class GitlabConnector(LoadConnector, PollConnector):
 
             code_doc_batch: list[Document | HierarchyNode] = []
 
+            # On a shallow full clone (clone_depth set) the truncated history
+            # attributes every file to the boundary commit — skip the per-file
+            # lookup and let content hashing govern change detection instead.
+            history_is_reliable = changed_rel_paths is not None or not self.clone_depth
+
             for file_path in file_batch:
                 try:
                     # Get last commit date for the file
                     relative_path = str(file_path.relative_to(self.repo_path))
                     last_commit_date = None
-                    if self.git_repo:
+                    if self.git_repo and history_is_reliable:
                         last_commit_date = _get_file_last_commit_date(
                             self.git_repo, relative_path
                         )

--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -1,12 +1,15 @@
 import fnmatch
 import itertools
-from collections import deque
+import os
+import shutil
+import tempfile
 from collections.abc import Iterable, Iterator
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Any, TypeVar
 
+import git
 import gitlab
-import pytz
 from gitlab.v4.objects import Project
 
 from onyx.configs.app_configs import (
@@ -36,34 +39,113 @@ T = TypeVar("T")
 
 logger = setup_logger()
 
-# List of directories/Files to exclude
+# List of directories/Files to exclude by default
 exclude_patterns = [
     "logs",
     ".github/",
     ".gitlab/",
     ".pre-commit-config.yaml",
+    ".git/",
+    "__pycache__/",
+    "*.pyc",
+    "*.pyo",
+    "*.pyd",
+    ".DS_Store",
+    "Thumbs.db",
+    "node_modules/",
+    ".vscode/",
+    ".idea/",
+    "*.log",
+    "*.tmp",
+    "*.temp",
 ]
 
+# Default glob patterns matched against repo files when code-file indexing is
+# enabled. Patterns without a "/" match the basename anywhere in the tree (e.g.
+# "*.py", "Makefile"); patterns with a "/" match the full relative path (e.g.
+# "src/*.py"). Users can override this list from the connector configuration
+# (see ``code_file_patterns``). Unlike a plain extension list, glob patterns also
+# match extensionless files such as ``Makefile`` and ``Dockerfile``.
+DEFAULT_CODE_FILE_PATTERNS = [
+    "*.py",
+    "*.js",
+    "*.ts",
+    "*.java",
+    "*.cpp",
+    "*.c",
+    "*.h",
+    "*.hpp",
+    "*.cs",
+    "*.php",
+    "*.rb",
+    "*.go",
+    "*.rs",
+    "*.kt",
+    "*.scala",
+    "*.swift",
+    "*.m",
+    "*.mm",
+    "*.r",
+    "*.sql",
+    "*.html",
+    "*.htm",
+    "*.css",
+    "*.scss",
+    "*.sass",
+    "*.less",
+    "*.xml",
+    "*.json",
+    "*.yaml",
+    "*.yml",
+    "*.toml",
+    "*.ini",
+    "*.cfg",
+    "*.config",
+    "*.md",
+    "*.rst",
+    "*.txt",
+    "*.sh",
+    "*.bash",
+    "*.ps1",
+    "*.bat",
+    "*.cmd",
+    "*.bazel",
+    "Makefile",
+    "Dockerfile",
+]
 
-def _batch_gitlab_objects(git_objs: Iterable[T], batch_size: int) -> Iterator[list[T]]:
-    it = iter(git_objs)
-    while True:
-        batch = list(itertools.islice(it, batch_size))
-        if not batch:
-            break
-        yield batch
+# Anything before this cutoff is treated as a "from the beginning" full index.
+# Onyx passes a poll window starting at the unix epoch (1970) for the very first
+# index attempt (or when re-indexing from scratch), so a real incremental poll
+# window will always start well after this date.
+_FULL_INDEX_START_CUTOFF = datetime(2005, 1, 1, tzinfo=timezone.utc)
 
 
-def get_author(author: Any) -> BasicExpertInfo:
-    # GitLab masks the `name` field as "****" for blocked users and as an
-    # anti-scraping measure on free-tier public projects. Fall back to
-    # `username` so we surface a usable identifier instead.
-    name = author.get("name")
-    if not name or name == "****":
-        name = author.get("username")
-    return BasicExpertInfo(
-        display_name=name,
-    )
+def _normalize_patterns(patterns: Iterable[str]) -> list[str]:
+    """Normalize user-supplied glob patterns.
+
+    Strips whitespace, drops empties and duplicates, and rewrites the legacy
+    regex "match everything" pattern (``.*``) to its glob equivalent (``*``) so
+    that connectors created before the glob migration keep matching all files.
+    """
+    normalized: list[str] = []
+    for pattern in patterns:
+        cleaned = pattern.strip()
+        if not cleaned:
+            continue
+        if cleaned == ".*":
+            cleaned = "*"
+        if cleaned not in normalized:
+            normalized.append(cleaned)
+    return normalized
+
+
+def _extension_to_glob(extension: str) -> str:
+    """Convert a legacy bare extension (e.g. ``.py`` or ``py``) to a glob."""
+    cleaned = extension.strip()
+    if not cleaned:
+        return ""
+    return f"*{cleaned}" if cleaned.startswith(".") else f"*.{cleaned}"
 
 
 def _gitlab_datetime_to_utc(value: Any) -> datetime | None:
@@ -79,6 +161,46 @@ def _gitlab_datetime_to_utc(value: Any) -> datetime | None:
     if isinstance(value, datetime):
         return datetime_to_utc(value)
     return time_str_to_utc(value)
+
+
+def _ensure_utc_datetime(dt: datetime | None) -> datetime:
+    """Ensure datetime has UTC timezone information (None -> now)."""
+    if dt is None:
+        return datetime.now(timezone.utc)
+
+    if dt.tzinfo is None:
+        # If no timezone info, assume UTC
+        return dt.replace(tzinfo=timezone.utc)
+
+    # If timezone info exists, convert to UTC
+    return dt.astimezone(timezone.utc)
+
+
+def _batch_gitlab_objects(git_objs: Iterable[T], batch_size: int) -> Iterator[list[T]]:
+    """Batch GitLab objects into chunks."""
+    logger.debug("Starting to batch objects with batch size: %s", batch_size)
+    it = iter(git_objs)
+    batch_count = 0
+    while True:
+        batch = list(itertools.islice(it, batch_size))
+        if not batch:
+            logger.debug("Finished batching. Total batches created: %s", batch_count)
+            break
+        batch_count += 1
+        logger.debug("Created batch #%s with %s objects", batch_count, len(batch))
+        yield batch
+
+
+def get_author(author: Any) -> BasicExpertInfo:
+    # GitLab masks the `name` field as "****" for blocked users and as an
+    # anti-scraping measure on free-tier public projects. Fall back to
+    # `username` so we surface a usable identifier instead.
+    name = author.get("name") if author else None
+    if not name or name == "****":
+        name = author.get("username") if author else None
+    return BasicExpertInfo(
+        display_name=name,
+    )
 
 
 def _convert_merge_request_to_document(mr: Any) -> Document:
@@ -111,46 +233,142 @@ def _convert_issue_to_document(issue: Any) -> Document:
     return doc
 
 
-def _convert_code_to_document(
-    project: Project, file: Any, url: str, projectName: str, projectOwner: str
+def _convert_file_to_document(
+    file_path: Path,
+    repo_path: Path,
+    project_url: str,
+    project_name: str,
+    project_owner: str,
+    default_branch: str,
+    last_commit_date: datetime | None = None,
 ) -> Document:
-    # Dynamically get the default branch from the project object
-    default_branch = project.default_branch
+    """Convert a file to Document."""
+    logger.debug("Converting file to document: %s", file_path)
 
-    # Fetch the file content using the correct branch
-    file_content_obj = project.files.get(
-        file_path=file["path"],
-        ref=default_branch,  # Use the default branch
-    )
     try:
-        file_content = file_content_obj.decode().decode("utf-8")
+        # Read file content
+        logger.debug("Attempting to read file content with UTF-8 encoding")
+        with open(file_path, "r", encoding="utf-8") as f:
+            file_content = f.read()
+        logger.debug(
+            "Successfully read file content (%s characters)", len(file_content)
+        )
     except UnicodeDecodeError:
-        file_content = file_content_obj.decode().decode("latin-1")
+        logger.warning("UTF-8 decode failed for %s, trying latin-1", file_path)
+        try:
+            with open(file_path, "r", encoding="latin-1") as f:
+                file_content = f.read()
+            logger.debug(
+                "Successfully read file content with latin-1 (%s characters)",
+                len(file_content),
+            )
+        except Exception as e:
+            logger.error("Could not read file %s with latin-1: %s", file_path, e)
+            file_content = f"[Could not read file content: {e}]"
+    except Exception as e:
+        logger.error("Could not read file %s: %s", file_path, e)
+        file_content = f"[Could not read file content: {e}]"
 
-    # Construct the file URL dynamically using the default branch
-    file_url = (
-        f"{url}/{projectOwner}/{projectName}/-/blob/{default_branch}/{file['path']}"
+    # Get relative path from repo root
+    relative_path = file_path.relative_to(repo_path)
+    logger.debug("File relative path: %s", relative_path)
+
+    # Construct the file URL
+    file_url = f"{project_url}/{project_owner}/{project_name}/-/blob/{default_branch}/{relative_path}".replace(
+        "\\\\", "\\"
     )
+    logger.debug("Constructed file URL: %s", file_url)
+
+    # Generate unique ID using file path
+    file_id = f"{project_url}/{project_owner}/{project_name}/blob/{default_branch}/{relative_path}".replace(
+        "\\\\", "\\"
+    )
+    logger.debug("Generated file ID: %s", file_id)
+
+    # Use last commit date if available, otherwise current time - ensure UTC
+    doc_updated_at = _ensure_utc_datetime(last_commit_date)
+    logger.debug("Document updated_at: %s", doc_updated_at)
 
     # Create and return a Document object
     doc = Document(
-        id=file["id"],
+        id=file_id,
         sections=[TextSection(link=file_url, text=file_content)],
         source=DocumentSource.GITLAB,
-        semantic_identifier=file["name"],
-        doc_updated_at=datetime.now().replace(tzinfo=timezone.utc),
-        primary_owners=[],  # Add owners if needed
-        metadata={"type": "CodeFile"},
+        semantic_identifier=str(relative_path),
+        doc_updated_at=doc_updated_at,
+        primary_owners=[],  # Could be enhanced to include git blame info
+        metadata={"type": "CodeFile", "file_extension": file_path.suffix},
     )
+    logger.debug("Successfully converted file document: %s", doc.semantic_identifier)
     return doc
 
 
-def _should_exclude(path: str) -> bool:
+def _should_exclude_by_patterns(path: str, patterns: list[str]) -> bool:
     """Check if a path matches any of the exclude patterns."""
-    return any(fnmatch.fnmatch(path, pattern) for pattern in exclude_patterns)
+    for pattern in patterns:
+        if fnmatch.fnmatch(path, pattern):
+            logger.debug("Path '%s' excluded by pattern '%s'", path, pattern)
+            return True
+    return False
+
+
+def _matches_glob(path: str, pattern: str) -> bool:
+    """Match a repo-relative path against a single glob pattern.
+
+    Patterns without a ``/`` match the file's basename anywhere in the tree
+    (e.g. ``*.py``, ``Makefile``); patterns containing a ``/`` match the full
+    relative path (e.g. ``src/*.py``, ``docs/**``).
+    """
+    pattern = pattern.strip()
+    if not pattern:
+        return False
+    if "/" in pattern:
+        return fnmatch.fnmatch(path, pattern)
+    return fnmatch.fnmatch(Path(path).name, pattern)
+
+
+def _matches_any_glob(path: str, patterns: list[str]) -> bool:
+    return any(_matches_glob(path, pattern) for pattern in patterns)
+
+
+def _should_include_by_glob(path: str, include_patterns: list[str]) -> bool:
+    """Include the path if it matches any include glob (empty = include all)."""
+    if not include_patterns:
+        return True
+    return _matches_any_glob(path, include_patterns)
+
+
+def _should_exclude_by_glob(path: str, exclude_patterns: list[str]) -> bool:
+    """Exclude the path if it matches any exclude glob (empty = exclude none)."""
+    if not exclude_patterns:
+        return False
+    return _matches_any_glob(path, exclude_patterns)
+
+
+def _get_file_last_commit_date(repo: git.Repo, file_path: str) -> datetime:
+    """Get the last commit date for a specific file."""
+    logger.debug("Getting last commit date for file: %s", file_path)
+    try:
+        commits = list(repo.iter_commits(paths=file_path, max_count=1))
+        if commits:
+            commit_date = commits[0].committed_datetime
+            # Ensure timezone info is present and convert to UTC
+            commit_date = _ensure_utc_datetime(commit_date)
+            logger.debug("Last commit date for '%s': %s", file_path, commit_date)
+            return commit_date
+        else:
+            logger.debug("No commits found for file: %s", file_path)
+    except Exception as e:
+        logger.warning("Could not get commit date for %s: %s", file_path, e)
+
+    fallback_date = datetime.now(timezone.utc)
+    logger.debug("Using fallback date for '%s': %s", file_path, fallback_date)
+    return fallback_date
 
 
 class GitlabConnector(LoadConnector, PollConnector):
+    """Enhanced GitLab connector that clones entire repository and indexes with glob filtering."""
+
     def __init__(
         self,
         project_owner: str,
@@ -160,7 +378,38 @@ class GitlabConnector(LoadConnector, PollConnector):
         include_mrs: bool = True,
         include_issues: bool = True,
         include_code_files: bool = GITLAB_CONNECTOR_INCLUDE_CODE_FILES,
+        include_path_patterns: list[str] | None = None,
+        exclude_path_patterns: list[str] | None = None,
+        clone_depth: int | None = None,  # None for a full clone
+        branch: str | None = None,  # None for the default branch
+        code_file_patterns: list[str] | None = None,  # None for defaults
+        # Deprecated: previously a list of bare extensions (e.g. ".py"). Still
+        # accepted so connectors created before the glob migration keep working;
+        # the extensions are converted to equivalent globs ("*.py").
+        code_file_extensions: list[str] | None = None,
     ) -> None:
+        include_path_patterns = _normalize_patterns(include_path_patterns or [])
+        exclude_path_patterns = _normalize_patterns(exclude_path_patterns or [])
+
+        logger.info(
+            "Initializing GitlabConnector for %s/%s", project_owner, project_name
+        )
+        logger.debug(
+            "Configuration - batch_size: %s, state_filter: %s", batch_size, state_filter
+        )
+        logger.debug(
+            "Include options - MRs: %s, Issues: %s, Code files: %s",
+            include_mrs,
+            include_issues,
+            include_code_files,
+        )
+        logger.debug(
+            "Filter patterns - Include: %s, Exclude: %s",
+            include_path_patterns,
+            exclude_path_patterns,
+        )
+        logger.debug("Clone options - Depth: %s, Branch: %s", clone_depth, branch)
+
         self.project_owner = project_owner
         self.project_name = project_name
         self.batch_size = batch_size
@@ -168,105 +417,655 @@ class GitlabConnector(LoadConnector, PollConnector):
         self.include_mrs = include_mrs
         self.include_issues = include_issues
         self.include_code_files = include_code_files
+        self.include_path_patterns = include_path_patterns
+        self.exclude_path_patterns = exclude_path_patterns
+        self.clone_depth = clone_depth
+        self.branch = branch
+        if code_file_patterns:
+            self.code_file_patterns = _normalize_patterns(code_file_patterns)
+        elif code_file_extensions:
+            # Back-compat: convert legacy bare extensions to globs.
+            self.code_file_patterns = _normalize_patterns(
+                [_extension_to_glob(ext) for ext in code_file_extensions]
+            )
+        else:
+            self.code_file_patterns = list(DEFAULT_CODE_FILE_PATTERNS)
+        logger.debug("Code file patterns: %s", self.code_file_patterns)
         self.gitlab_client: gitlab.Gitlab | None = None
+        self.repo_path: Path | None = None
+        self.git_repo: git.Repo | None = None
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
-        self.gitlab_client = gitlab.Gitlab(
-            credentials["gitlab_url"], private_token=credentials["gitlab_access_token"]
-        )
+        """Load GitLab credentials."""
+        logger.info("Loading GitLab credentials")
+        gitlab_url = credentials.get("gitlab_url", "Unknown")
+        logger.debug("GitLab URL: %s", gitlab_url)
+        self.gitlab_url = gitlab_url.rstrip("/")
+
+        try:
+            self.gitlab_client = gitlab.Gitlab(
+                credentials["gitlab_url"],
+                private_token=credentials["gitlab_access_token"],
+            )
+            # Test the connection
+            self.gitlab_client.auth()
+            logger.info("Successfully authenticated with GitLab")
+        except Exception as e:
+            logger.error("Failed to authenticate with GitLab: %s", e)
+            raise
+
         return None
 
-    def _fetch_from_gitlab(
-        self, start: datetime | None = None, end: datetime | None = None
-    ) -> GenerateDocumentsOutput:
-        if self.gitlab_client is None:
-            raise ConnectorMissingCredentialError("Gitlab")
-        project: Project = self.gitlab_client.projects.get(
-            f"{self.project_owner}/{self.project_name}"
+    def _clone_repository(self, since: datetime | None = None) -> Path:
+        """Clone the repository to a temporary directory.
+
+        When ``since`` is provided we perform an incremental sync, so we clone
+        with ``--shallow-since`` to fetch just enough history to diff the current
+        HEAD against the state that was indexed during the previous sync. When it
+        is ``None`` (full index) we honor ``clone_depth`` instead, which can be a
+        shallow ``depth=1`` snapshot since we index every file in the tree.
+        """
+        logger.info(
+            "Starting repository clone process for %s/%s",
+            self.project_owner,
+            self.project_name,
         )
 
-        # Fetch code files
-        if self.include_code_files:
-            # Fetching using BFS as project.report_tree with recursion causing slow load
-            queue = deque([""])  # Start with the root directory
-            while queue:
-                current_path = queue.popleft()
-                files = project.repository_tree(path=current_path, all=True)
-                for file_batch in _batch_gitlab_objects(files, self.batch_size):
-                    code_doc_batch: list[Document | HierarchyNode] = []
-                    for file in file_batch:
-                        if _should_exclude(file["path"]):
-                            continue
+        if self.gitlab_client is None:
+            logger.error("GitLab client not initialized")
+            raise ConnectorMissingCredentialError("Gitlab")
 
-                        if file["type"] == "blob":
-                            code_doc_batch.append(
-                                _convert_code_to_document(
-                                    project,
-                                    file,
-                                    self.gitlab_client.url,
-                                    self.project_name,
-                                    self.project_owner,
-                                )
-                            )
-                        elif file["type"] == "tree":
-                            queue.append(file["path"])
+        try:
+            logger.debug("Fetching project information from GitLab API")
+            project: Project = self.gitlab_client.projects.get(
+                f"{self.project_owner}/{self.project_name}"
+            )
+            logger.info("Found project: %s (ID: %s)", project.name, project.id)
+        except Exception as e:
+            logger.error("Failed to fetch project information: %s", e)
+            raise
 
-                    if code_doc_batch:
-                        yield code_doc_batch
+        # Create temporary directory
+        temp_dir = tempfile.mkdtemp(prefix=f"gitlab_repo_{self.project_name}_")
+        repo_path = Path(temp_dir)
+        logger.info("Created temporary directory: %s", repo_path)
 
-        if self.include_mrs:
+        try:
+            # Get clone URL with token
+            clone_url = project.http_url_to_repo
+            logger.debug("Original clone URL: %s", clone_url)
+
+            if self.gitlab_client.private_token:
+                # Insert token into URL for authentication
+                clone_url = clone_url.replace(
+                    "://", f"://oauth2:{self.gitlab_client.private_token}@"
+                )
+                logger.debug("Added authentication token to clone URL")
+
+            # Clone repository
+            clone_kwargs: dict[str, Any] = {
+                "url": clone_url,
+                "to_path": str(repo_path),
+            }
+            multi_options: list[str] = []
+
+            if since is not None:
+                # Fetch history back to (just before) the previous sync so we can
+                # diff against it. Subtract a day of slack to make sure the
+                # boundary commit that predates the window is included.
+                shallow_since = (since - timedelta(days=1)).strftime(
+                    "%Y-%m-%dT%H:%M:%S"
+                )
+                multi_options.append(f"--shallow-since={shallow_since}")
+                logger.debug(
+                    "Incremental clone using --shallow-since=%s", shallow_since
+                )
+            elif self.clone_depth:
+                clone_kwargs["depth"] = self.clone_depth
+                logger.debug("Using shallow clone with depth: %s", self.clone_depth)
+
+            if self.branch:
+                clone_kwargs["branch"] = self.branch
+                logger.debug("Cloning specific branch: %s", self.branch)
+
+            if multi_options:
+                clone_kwargs["multi_options"] = multi_options
+
+            logger.info("Starting git clone operation...")
+            self.git_repo = git.Repo.clone_from(**clone_kwargs)
+
+            # Log repository information
+            active_branch = self.git_repo.active_branch.name
+            commit_count = sum(1 for _ in self.git_repo.iter_commits())
+            logger.info(
+                "Successfully cloned repository - Active branch: %s, Commits: %s",
+                active_branch,
+                commit_count,
+            )
+
+            return repo_path
+
+        except Exception:
+            logger.exception("Failed to clone repository")
+            # Clean up on failure
+            shutil.rmtree(repo_path, ignore_errors=True)
+            raise
+
+    def _cleanup_repository(self) -> None:
+        """Clean up cloned repository."""
+        if self.repo_path and self.repo_path.exists():
+            logger.info("Cleaning up repository at %s", self.repo_path)
+            try:
+                shutil.rmtree(self.repo_path, ignore_errors=True)
+                logger.debug("Repository cleanup completed successfully")
+            except Exception as e:
+                logger.warning("Error during repository cleanup: %s", e)
+            finally:
+                self.repo_path = None
+                self.git_repo = None
+        else:
+            logger.debug("No repository to clean up")
+
+    def _iter_candidate_files(
+        self, candidate_rel_paths: set[str] | None
+    ) -> Iterator[Path]:
+        """Yield repository files to consider for indexing.
+
+        For a full index (``candidate_rel_paths is None``) we walk the whole
+        working tree. For an incremental sync we only look at the supplied set of
+        changed relative paths (skipping any that no longer exist on disk).
+        """
+        if not self.repo_path:
+            return
+
+        if candidate_rel_paths is None:
+            for root, dirs, files in os.walk(self.repo_path):
+                # Skip .git directory
+                if ".git" in dirs:
+                    dirs.remove(".git")
+                    logger.debug("Skipped .git directory")
+                for file in files:
+                    yield Path(root) / file
+            return
+
+        for rel_path in candidate_rel_paths:
+            file_path = self.repo_path / rel_path
+            if file_path.is_file():
+                yield file_path
+
+    def _get_filtered_files(
+        self, candidate_rel_paths: set[str] | None = None
+    ) -> list[Path]:
+        """Get list of files that match the filtering criteria.
+
+        ``candidate_rel_paths`` restricts the scan to a specific set of changed
+        files for incremental syncs; ``None`` scans the entire repository.
+        """
+        logger.info("Starting file filtering process")
+
+        if not self.repo_path:
+            logger.warning("Repository path not available")
+            return []
+
+        all_files = []
+        total_files_scanned = 0
+        excluded_by_default = 0
+        excluded_by_glob = 0
+        excluded_by_include_filter = 0
+        excluded_not_code = 0
+
+        # Walk through all candidate files in the repository
+        logger.debug("Scanning files in repository: %s", self.repo_path)
+        for file_path in self._iter_candidate_files(candidate_rel_paths):
+            total_files_scanned += 1
+            relative_path = str(file_path.relative_to(self.repo_path))
+
+            # Apply default exclude patterns
+            if _should_exclude_by_patterns(relative_path, exclude_patterns):
+                excluded_by_default += 1
+                continue
+
+            # Apply glob exclude patterns
+            if _should_exclude_by_glob(relative_path, self.exclude_path_patterns):
+                excluded_by_glob += 1
+                continue
+
+            # Apply glob include patterns
+            if not _should_include_by_glob(relative_path, self.include_path_patterns):
+                excluded_by_include_filter += 1
+                continue
+
+            # Check if it's a code file (matches a code-file glob pattern)
+            if self.include_code_files and not _matches_any_glob(
+                relative_path, self.code_file_patterns
+            ):
+                excluded_not_code += 1
+                continue
+
+            all_files.append(file_path)
+            logger.debug("Included file: %s", relative_path)
+
+        # Log filtering statistics
+        logger.info("File filtering completed:")
+        logger.info("  Total files scanned: %s", total_files_scanned)
+        logger.info("  Excluded by default patterns: %s", excluded_by_default)
+        logger.info("  Excluded by glob patterns: %s", excluded_by_glob)
+        logger.info("  Excluded by include filter: %s", excluded_by_include_filter)
+        logger.info("  Excluded (not code files): %s", excluded_not_code)
+        logger.info("  Final files included: %s", len(all_files))
+
+        return all_files
+
+    def _get_changed_paths_since(self, start: datetime) -> set[str] | None:
+        """Compute repository paths changed since the previous successful sync.
+
+        Returns a set of repo-relative paths that were added/modified/renamed in
+        commits after ``start`` (deletions are excluded — they are handled by
+        pruning, not indexing). Returns ``None`` when no commit predates
+        ``start`` (i.e. the whole history is newer than the window), signalling
+        the caller to fall back to a full index.
+        """
+        if not self.git_repo:
+            logger.warning(
+                "Git repo not available for diff; falling back to full index"
+            )
+            return None
+
+        start_utc = _ensure_utc_datetime(start)
+        # git rev-list --until expects the committer's local representation; an
+        # ISO-8601 string with offset is unambiguous and accepted by git.
+        until_str = start_utc.strftime("%Y-%m-%dT%H:%M:%S%z")
+
+        try:
+            base_commit = next(
+                iter(self.git_repo.iter_commits("HEAD", until=until_str, max_count=1)),
+                None,
+            )
+        except Exception as e:
+            logger.warning(
+                "Could not determine base commit for diff: %s. Full index.", e
+            )
+            return None
+
+        if base_commit is None:
+            logger.info(
+                "No commit found at or before the previous sync window; "
+                "performing a full index."
+            )
+            return None
+
+        logger.info(
+            "Computing diff from base commit %s (committed %s) to HEAD",
+            base_commit.hexsha[:12],
+            base_commit.committed_datetime.isoformat(),
+        )
+        try:
+            # --diff-filter=d excludes deletions; name-only gives changed paths.
+            diff_output = self.git_repo.git.diff(
+                "--name-only", "--diff-filter=d", f"{base_commit.hexsha}..HEAD"
+            )
+        except Exception as e:
+            logger.warning("git diff failed: %s. Falling back to full index.", e)
+            return None
+
+        changed_paths = {
+            line.strip() for line in diff_output.splitlines() if line.strip()
+        }
+        logger.info("Detected %s changed file(s) since last sync", len(changed_paths))
+        return changed_paths
+
+    def _fetch_code_files(
+        self, changed_rel_paths: set[str] | None = None
+    ) -> GenerateDocumentsOutput:
+        """Fetch and convert code files to documents.
+
+        ``changed_rel_paths`` restricts processing to the given set of changed
+        files for incremental syncs; ``None`` processes the entire repository.
+        """
+        logger.info("Starting code files fetch process")
+
+        if not self.include_code_files:
+            logger.info("Code files inclusion disabled, skipping")
+            return
+
+        if not self.repo_path:
+            logger.error("Repository path not available for code files processing")
+            return
+
+        if changed_rel_paths is not None and not changed_rel_paths:
+            logger.info("No files changed since last sync; nothing to re-index")
+            return
+
+        if self.gitlab_client is None:
+            raise ConnectorMissingCredentialError("Gitlab")
+
+        filtered_files = self._get_filtered_files(changed_rel_paths)
+
+        if not filtered_files:
+            logger.warning("No files found matching filter criteria")
+            return
+
+        # Get project info for URL construction
+        try:
+            project: Project = self.gitlab_client.projects.get(
+                f"{self.project_owner}/{self.project_name}"
+            )
+            default_branch = self.branch or project.default_branch
+            logger.info("Using branch '%s' for URL construction", default_branch)
+        except Exception as e:
+            logger.error("Failed to get project information: %s", e)
+            raise
+
+        # Process files in batches
+        logger.info(
+            "Processing %s files in batches of %s", len(filtered_files), self.batch_size
+        )
+        batch_count = 0
+        total_documents = 0
+
+        for file_batch in _batch_gitlab_objects(filtered_files, self.batch_size):
+            batch_count += 1
+            logger.info(
+                "Processing code file batch #%s (%s files)",
+                batch_count,
+                len(file_batch),
+            )
+
+            code_doc_batch: list[Document | HierarchyNode] = []
+
+            for file_path in file_batch:
+                try:
+                    # Get last commit date for the file
+                    relative_path = str(file_path.relative_to(self.repo_path))
+                    last_commit_date = None
+                    if self.git_repo:
+                        last_commit_date = _get_file_last_commit_date(
+                            self.git_repo, relative_path
+                        )
+
+                    doc = _convert_file_to_document(
+                        file_path=file_path,
+                        repo_path=self.repo_path,
+                        project_url=self.gitlab_url,
+                        project_name=self.project_name,
+                        project_owner=self.project_owner,
+                        default_branch=default_branch,
+                        last_commit_date=last_commit_date,
+                    )
+                    code_doc_batch.append(doc)
+                    total_documents += 1
+
+                except Exception as e:
+                    logger.error("Error processing file %s: %s", file_path, e)
+                    continue
+
+            if code_doc_batch:
+                logger.info(
+                    "Yielding batch #%s with %s code documents",
+                    batch_count,
+                    len(code_doc_batch),
+                )
+                yield code_doc_batch
+
+        logger.info(
+            "Code files processing completed. Total documents: %s", total_documents
+        )
+
+    def _fetch_merge_requests(
+        self, start: datetime | None = None, end: datetime | None = None
+    ) -> GenerateDocumentsOutput:
+        """Fetch merge requests."""
+        logger.info("Starting merge requests fetch process")
+
+        if not self.include_mrs:
+            logger.info("Merge requests inclusion disabled, skipping")
+            return
+
+        if self.gitlab_client is None:
+            raise ConnectorMissingCredentialError("Gitlab")
+
+        if start:
+            logger.info("Fetching MRs updated after: %s", start)
+        if end:
+            logger.info("Fetching MRs updated before: %s", end)
+
+        try:
+            project: Project = self.gitlab_client.projects.get(
+                f"{self.project_owner}/{self.project_name}"
+            )
+            logger.debug(
+                "Fetching merge requests with state filter: %s", self.state_filter
+            )
+        except Exception as e:
+            logger.error("Failed to get project for MRs: %s", e)
+            raise
+
+        try:
             merge_requests = project.mergerequests.list(
                 state=self.state_filter,
                 order_by="updated_at",
                 sort="desc",
                 iterator=True,
             )
+            logger.debug("Successfully initialized merge requests iterator")
+        except Exception as e:
+            logger.error("Failed to get merge requests list: %s", e)
+            raise
 
-            for mr_batch in _batch_gitlab_objects(merge_requests, self.batch_size):
-                mr_doc_batch: list[Document | HierarchyNode] = []
-                for mr in mr_batch:
-                    mr.updated_at = datetime.strptime(
-                        mr.updated_at, "%Y-%m-%dT%H:%M:%S.%f%z"
-                    )
-                    if start is not None and mr.updated_at < start.replace(
-                        tzinfo=pytz.UTC
-                    ):
-                        yield mr_doc_batch
-                        return
-                    if end is not None and mr.updated_at > end.replace(tzinfo=pytz.UTC):
-                        continue
+        batch_count = 0
+        total_mrs = 0
+
+        for mr_batch in _batch_gitlab_objects(merge_requests, self.batch_size):
+            batch_count += 1
+            logger.info("Processing MR batch #%s (%s MRs)", batch_count, len(mr_batch))
+
+            mr_doc_batch: list[Document | HierarchyNode] = []
+            for mr in mr_batch:
+                try:
+                    updated_at = _gitlab_datetime_to_utc(mr.updated_at)
+
+                    # Time filtering
+                    if updated_at is not None and start is not None:
+                        start_utc = _ensure_utc_datetime(start)
+                        if updated_at < start_utc:
+                            logger.debug(
+                                "MR %s is older than start time, stopping", mr.title
+                            )
+                            if mr_doc_batch:
+                                yield mr_doc_batch
+                            return
+                    if updated_at is not None and end is not None:
+                        end_utc = _ensure_utc_datetime(end)
+                        if updated_at > end_utc:
+                            logger.debug(
+                                "MR %s is newer than end time, skipping", mr.title
+                            )
+                            continue
+
                     mr_doc_batch.append(_convert_merge_request_to_document(mr))
+                    total_mrs += 1
+
+                except Exception as e:
+                    logger.error(
+                        "Error processing MR %s: %s", getattr(mr, "title", "Unknown"), e
+                    )
+                    continue
+
+            if mr_doc_batch:
+                logger.info(
+                    "Yielding MR batch #%s with %s documents",
+                    batch_count,
+                    len(mr_doc_batch),
+                )
                 yield mr_doc_batch
 
-        if self.include_issues:
-            issues = project.issues.list(state=self.state_filter, iterator=True)
+        logger.info("Merge requests processing completed. Total MRs: %s", total_mrs)
 
-            for issue_batch in _batch_gitlab_objects(issues, self.batch_size):
-                issue_doc_batch: list[Document | HierarchyNode] = []
-                for issue in issue_batch:
-                    issue.updated_at = datetime.strptime(
-                        issue.updated_at, "%Y-%m-%dT%H:%M:%S.%f%z"
-                    )
-                    if start is not None:
-                        start = start.replace(tzinfo=pytz.UTC)
-                        if issue.updated_at < start:
-                            yield issue_doc_batch
+    def _fetch_issues(
+        self, start: datetime | None = None, end: datetime | None = None
+    ) -> GenerateDocumentsOutput:
+        """Fetch issues."""
+        logger.info("Starting issues fetch process")
+
+        if not self.include_issues:
+            logger.info("Issues inclusion disabled, skipping")
+            return
+
+        if self.gitlab_client is None:
+            raise ConnectorMissingCredentialError("Gitlab")
+
+        if start:
+            logger.info("Fetching issues updated after: %s", start)
+        if end:
+            logger.info("Fetching issues updated before: %s", end)
+
+        try:
+            project: Project = self.gitlab_client.projects.get(
+                f"{self.project_owner}/{self.project_name}"
+            )
+            logger.debug("Fetching issues with state filter: %s", self.state_filter)
+        except Exception as e:
+            logger.error("Failed to get project for issues: %s", e)
+            raise
+
+        try:
+            issues = project.issues.list(state=self.state_filter, iterator=True)
+            logger.debug("Successfully initialized issues iterator")
+        except Exception as e:
+            logger.error("Failed to get issues list: %s", e)
+            raise
+
+        batch_count = 0
+        total_issues = 0
+
+        for issue_batch in _batch_gitlab_objects(issues, self.batch_size):
+            batch_count += 1
+            logger.info(
+                "Processing issue batch #%s (%s issues)", batch_count, len(issue_batch)
+            )
+
+            issue_doc_batch: list[Document | HierarchyNode] = []
+            for issue in issue_batch:
+                try:
+                    updated_at = _gitlab_datetime_to_utc(issue.updated_at)
+
+                    # Time filtering
+                    if updated_at is not None and start is not None:
+                        start_utc = _ensure_utc_datetime(start)
+                        if updated_at < start_utc:
+                            logger.debug(
+                                "Issue %s is older than start time, stopping",
+                                issue.title,
+                            )
+                            if issue_doc_batch:
+                                yield issue_doc_batch
                             return
-                    if end is not None:
-                        end = end.replace(tzinfo=pytz.UTC)
-                        if issue.updated_at > end:
+                    if updated_at is not None and end is not None:
+                        end_utc = _ensure_utc_datetime(end)
+                        if updated_at > end_utc:
+                            logger.debug(
+                                "Issue %s is newer than end time, skipping", issue.title
+                            )
                             continue
+
                     issue_doc_batch.append(_convert_issue_to_document(issue))
+                    total_issues += 1
+
+                except Exception as e:
+                    logger.error(
+                        "Error processing issue %s: %s",
+                        getattr(issue, "title", "Unknown"),
+                        e,
+                    )
+                    continue
+
+            if issue_doc_batch:
+                logger.info(
+                    "Yielding issue batch #%s with %s documents",
+                    batch_count,
+                    len(issue_doc_batch),
+                )
                 yield issue_doc_batch
 
+        logger.info("Issues processing completed. Total issues: %s", total_issues)
+
+    def _fetch_from_gitlab(
+        self, start: datetime | None = None, end: datetime | None = None
+    ) -> GenerateDocumentsOutput:
+        """Main method to fetch data from GitLab."""
+        logger.info("Starting GitLab data fetch process")
+
+        if self.gitlab_client is None:
+            logger.error("GitLab client not initialized")
+            raise ConnectorMissingCredentialError("Gitlab")
+
+        # Log the fetch parameters
+        if start:
+            logger.info("Fetch start time: %s", start)
+        if end:
+            logger.info("Fetch end time: %s", end)
+
+        # A poll window starting at (or before) the cutoff means Onyx is asking
+        # for a full index (first attempt / re-index from scratch), so we index
+        # every file. Otherwise we only re-index files changed since `start`.
+        is_full_index = (
+            start is None or _ensure_utc_datetime(start) <= _FULL_INDEX_START_CUTOFF
+        )
+
+        try:
+            # Clone repository if including code files
+            if self.include_code_files:
+                logger.info("Code files inclusion enabled, starting repository clone")
+                self.repo_path = self._clone_repository(
+                    since=None if is_full_index else start
+                )
+
+                if is_full_index or start is None:
+                    logger.info("Performing full index of code files")
+                    changed_rel_paths: set[str] | None = None
+                else:
+                    logger.info("Performing incremental (diff-based) code file sync")
+                    changed_rel_paths = self._get_changed_paths_since(start)
+
+                # Yield code file documents
+                logger.info("Processing code files")
+                yield from self._fetch_code_files(changed_rel_paths)
+            else:
+                logger.info("Code files inclusion disabled, skipping repository clone")
+
+            # Fetch merge requests
+            logger.info("Processing merge requests")
+            yield from self._fetch_merge_requests(start, end)
+
+            # Fetch issues
+            logger.info("Processing issues")
+            yield from self._fetch_issues(start, end)
+
+            logger.info("GitLab data fetch process completed successfully")
+
+        except Exception:
+            logger.exception("Error during GitLab data fetch")
+            raise
+        finally:
+            # Always cleanup cloned repository
+            logger.info("Starting cleanup process")
+            self._cleanup_repository()
+
     def load_from_state(self) -> GenerateDocumentsOutput:
+        """Load all documents from GitLab."""
+        logger.info("Starting full load from GitLab (load_from_state)")
         return self._fetch_from_gitlab()
 
     def poll_source(
         self, start: SecondsSinceUnixEpoch, end: SecondsSinceUnixEpoch
     ) -> GenerateDocumentsOutput:
+        """Poll GitLab for updates within time range."""
+        logger.info("Starting GitLab polling (poll_source) from %s to %s", start, end)
         start_datetime = datetime.fromtimestamp(start, tz=timezone.utc)
         end_datetime = datetime.fromtimestamp(end, tz=timezone.utc)
+        logger.info(
+            "Converted to datetime range: %s to %s", start_datetime, end_datetime
+        )
         return self._fetch_from_gitlab(start_datetime, end_datetime)
 
 
@@ -274,16 +1073,19 @@ if __name__ == "__main__":
     import os
 
     connector = GitlabConnector(
-        # gitlab_url="https://gitlab.com/api/v4",
         project_owner=os.environ["PROJECT_OWNER"],
         project_name=os.environ["PROJECT_NAME"],
         batch_size=10,
         state_filter="all",
         include_mrs=True,
         include_issues=True,
-        include_code_files=GITLAB_CONNECTOR_INCLUDE_CODE_FILES,
+        include_code_files=True,
+        code_file_patterns=["*.py", "*.js", "*.ts", "*.md", "Makefile"],
+        include_path_patterns=["src/*", "backend/*", "docs/*"],
+        exclude_path_patterns=["*_test.py", "*.tmp", "temp/*"],
+        clone_depth=1,
+        branch="main",
     )
-
     connector.load_credentials(
         {
             "gitlab_access_token": os.environ["GITLAB_ACCESS_TOKEN"],

--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -162,6 +162,9 @@ def update_connector_specific_config_fields(
 
     The dict is reassigned (rather than mutated in place) so SQLAlchemy detects
     the change on the JSON column. Returns ``None`` if the connector is missing.
+
+    Does NOT commit — the caller owns the transaction, so the config change can
+    be committed atomically with related updates (e.g. a re-index trigger).
     """
     connector = fetch_connector_by_id(connector_id, db_session)
     if connector is None:
@@ -171,7 +174,7 @@ def update_connector_specific_config_fields(
     new_config.update(config_updates)
     connector.connector_specific_config = new_config
 
-    db_session.commit()
+    db_session.flush()
     return connector
 
 

--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timezone
+from typing import Any
 
 from sqlalchemy import and_, exists, func, select
 from sqlalchemy.orm import Session, aliased
@@ -147,6 +148,28 @@ def update_connector(
         if connector_data.prune_freq is not None
         else DEFAULT_PRUNING_FREQ
     )
+
+    db_session.commit()
+    return connector
+
+
+def update_connector_specific_config_fields(
+    connector_id: int,
+    config_updates: dict[str, Any],
+    db_session: Session,
+) -> Connector | None:
+    """Merge a partial set of fields into a connector's connector_specific_config.
+
+    The dict is reassigned (rather than mutated in place) so SQLAlchemy detects
+    the change on the JSON column. Returns ``None`` if the connector is missing.
+    """
+    connector = fetch_connector_by_id(connector_id, db_session)
+    if connector is None:
+        return None
+
+    new_config = dict(connector.connector_specific_config or {})
+    new_config.update(config_updates)
+    connector.connector_specific_config = new_config
 
     db_session.commit()
     return connector

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -22,7 +22,11 @@ from onyx.connectors.exceptions import ValidationError
 from onyx.connectors.factory import identify_connector_class, validate_ccpair_for_user
 from onyx.connectors.interfaces import Resolver
 from onyx.connectors.models import InputType
-from onyx.db.connector import delete_connector
+from onyx.db.connector import (
+    delete_connector,
+    mark_ccpair_with_indexing_trigger,
+    update_connector_specific_config_fields,
+)
 from onyx.db.connector_credential_pair import (
     add_credential_to_connector,
     get_connector_credential_pair_for_user,
@@ -36,6 +40,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import (
     AccessType,
     ConnectorCredentialPairStatus,
+    IndexingMode,
     IndexingStatus,
     Permission,
     PermissionSyncStatus,
@@ -65,6 +70,7 @@ from onyx.redis.redis_connector_utils import get_deletion_attempt_snapshot
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.documents.models import (
+    CCConnectorConfigUpdateRequest,
     CCPairFullInfo,
     CCPairSyncAttemptsResponse,
     CCPropertyUpdateRequest,
@@ -601,6 +607,64 @@ def update_cc_pair_property(
         )
 
     return StatusResponse(success=True, message=msg, data=cc_pair_id)
+
+
+# Connector config keys that may be edited in-place after a connector is created.
+# Editing other keys (e.g. project_owner) could orphan already-indexed documents,
+# so we keep the allowlist scoped to filtering options.
+EDITABLE_CONNECTOR_CONFIG_KEYS = {
+    "include_code_files",
+    "code_file_patterns",
+    "include_path_patterns",
+    "exclude_path_patterns",
+}
+
+
+@router.put("/admin/cc-pair/{cc_pair_id}/connector-config")
+def update_cc_pair_connector_config(
+    cc_pair_id: int,
+    update_request: CCConnectorConfigUpdateRequest,
+    user: User = Depends(current_curator_or_admin_user),
+    db_session: Session = Depends(get_session),
+) -> StatusResponse[int]:
+    cc_pair = get_connector_credential_pair_from_id_for_user(
+        cc_pair_id=cc_pair_id,
+        db_session=db_session,
+        user=user,
+        get_editable=True,
+    )
+    if not cc_pair:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "CC Pair not found for current user's permissions",
+        )
+
+    invalid_keys = (
+        set(update_request.connector_specific_config) - EDITABLE_CONNECTOR_CONFIG_KEYS
+    )
+    if invalid_keys:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"These connector config keys cannot be edited: {sorted(invalid_keys)}",
+        )
+
+    updated_connector = update_connector_specific_config_fields(
+        connector_id=cc_pair.connector.id,
+        config_updates=update_request.connector_specific_config,
+        db_session=db_session,
+    )
+    if updated_connector is None:
+        raise OnyxError(OnyxErrorCode.CONNECTOR_NOT_FOUND, "Connector not found")
+
+    # The new filter only applies repo-wide after a fresh re-index; an incremental
+    # sync would otherwise only pick up files that change after this edit.
+    mark_ccpair_with_indexing_trigger(cc_pair_id, IndexingMode.REINDEX, db_session)
+
+    return StatusResponse(
+        success=True,
+        message="Connector configuration updated successfully",
+        data=cc_pair_id,
+    )
 
 
 @router.get("/admin/cc-pair/{cc_pair_id}/last_pruned")

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -70,7 +70,6 @@ from onyx.redis.redis_connector_utils import get_deletion_attempt_snapshot
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.server.documents.models import (
-    CCConnectorConfigUpdateRequest,
     CCPairFullInfo,
     CCPairSyncAttemptsResponse,
     CCPropertyUpdateRequest,
@@ -80,6 +79,7 @@ from onyx.server.documents.models import (
     DocPermissionSyncAttemptSnapshot,
     DocumentSyncStatus,
     ExternalGroupSyncAttemptSnapshot,
+    GitlabFilterConfigUpdateRequest,
     IndexAttemptSnapshot,
     IndexAttemptStageMetricSnapshot,
     IndexAttemptStageMetricsResponse,
@@ -609,21 +609,10 @@ def update_cc_pair_property(
     return StatusResponse(success=True, message=msg, data=cc_pair_id)
 
 
-# Connector config keys that may be edited in-place after a connector is created.
-# Editing other keys (e.g. project_owner) could orphan already-indexed documents,
-# so we keep the allowlist scoped to filtering options.
-EDITABLE_CONNECTOR_CONFIG_KEYS = {
-    "include_code_files",
-    "code_file_patterns",
-    "include_path_patterns",
-    "exclude_path_patterns",
-}
-
-
 @router.put("/admin/cc-pair/{cc_pair_id}/connector-config")
 def update_cc_pair_connector_config(
     cc_pair_id: int,
-    update_request: CCConnectorConfigUpdateRequest,
+    update_request: GitlabFilterConfigUpdateRequest,
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> StatusResponse[int]:
@@ -639,25 +628,30 @@ def update_cc_pair_connector_config(
             "CC Pair not found for current user's permissions",
         )
 
-    invalid_keys = (
-        set(update_request.connector_specific_config) - EDITABLE_CONNECTOR_CONFIG_KEYS
-    )
-    if invalid_keys:
+    # The request schema carries GitLab-only filtering keys; writing them onto
+    # another connector type would break its next indexing run (the factory
+    # expands connector_specific_config into the connector constructor).
+    if cc_pair.connector.source != DocumentSource.GITLAB:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"These connector config keys cannot be edited: {sorted(invalid_keys)}",
+            "Connector config editing is only supported for GitLab connectors",
         )
+
+    config_updates = update_request.model_dump(exclude_none=True)
+    if not config_updates:
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "No config fields provided")
 
     updated_connector = update_connector_specific_config_fields(
         connector_id=cc_pair.connector.id,
-        config_updates=update_request.connector_specific_config,
+        config_updates=config_updates,
         db_session=db_session,
     )
     if updated_connector is None:
         raise OnyxError(OnyxErrorCode.CONNECTOR_NOT_FOUND, "Connector not found")
 
     # The new filter only applies repo-wide after a fresh re-index; an incremental
-    # sync would otherwise only pick up files that change after this edit.
+    # sync would otherwise only pick up files that change after this edit. The
+    # config update above is only flushed, so this commit lands both atomically.
     mark_ccpair_with_indexing_trigger(cc_pair_id, IndexingMode.REINDEX, db_session)
 
     return StatusResponse(

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -736,6 +736,12 @@ class CCPropertyUpdateRequest(BaseModel):
     value: str
 
 
+class CCConnectorConfigUpdateRequest(BaseModel):
+    # Partial set of connector_specific_config keys to merge into the connector's
+    # existing configuration. Only an allowlisted set of keys may be updated.
+    connector_specific_config: dict[str, Any]
+
+
 """Connectors Models"""
 
 

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -736,10 +736,19 @@ class CCPropertyUpdateRequest(BaseModel):
     value: str
 
 
-class CCConnectorConfigUpdateRequest(BaseModel):
-    # Partial set of connector_specific_config keys to merge into the connector's
-    # existing configuration. Only an allowlisted set of keys may be updated.
-    connector_specific_config: dict[str, Any]
+class GitlabFilterConfigUpdateRequest(BaseModel):
+    """Partial update of the GitLab connector's file-filtering options.
+
+    The schema doubles as the allowlist: only filtering keys can be edited
+    in-place. Identity keys (e.g. project_owner) stay immutable — changing
+    them would orphan already-indexed documents. ``None`` means "leave the
+    stored value untouched".
+    """
+
+    include_code_files: bool | None = None
+    code_file_patterns: list[str] | None = None
+    include_path_patterns: list[str] | None = None
+    exclude_path_patterns: list[str] | None = None
 
 
 """Connectors Models"""

--- a/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_incremental.py
+++ b/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_incremental.py
@@ -1,0 +1,192 @@
+"""Unit tests for the GitLab connector's incremental (diff-based) code-file logic
+and its glob-based file filtering.
+
+These exercise the local-git diff computation against a throwaway repository, so
+they only depend on a local ``git`` binary (no GitLab API / Onyx services).
+"""
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+import git
+import pytest
+
+from onyx.connectors.gitlab.connector import (
+    DEFAULT_CODE_FILE_PATTERNS,
+    GitlabConnector,
+    _matches_glob,
+    _normalize_patterns,
+)
+
+
+def _commit_file(
+    repo: git.Repo, repo_path: Path, rel_path: str, content: str, when: datetime
+) -> None:
+    file_path = repo_path / rel_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content)
+    repo.index.add([rel_path])
+    date_str = when.strftime("%Y-%m-%dT%H:%M:%S")
+    repo.index.commit(
+        f"add {rel_path}",
+        author_date=date_str,
+        commit_date=date_str,
+    )
+
+
+@pytest.fixture
+def gitlab_connector() -> GitlabConnector:
+    # No credentials needed: the diff/filter methods only use repo_path/git_repo.
+    return GitlabConnector(
+        project_owner="owner",
+        project_name="repo",
+        include_code_files=True,
+    )
+
+
+@pytest.fixture
+def local_repo(tmp_path: Path) -> tuple[git.Repo, Path]:
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    repo = git.Repo.init(repo_path)
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Test")
+        cw.set_value("user", "email", "test@example.com")
+
+    # An extensionless code file (no Path.suffix) — only matched by globs.
+    _commit_file(
+        repo, repo_path, "Makefile", "all:\n\techo hi", datetime(2020, 1, 1, 10, 0, 0)
+    )
+    _commit_file(
+        repo, repo_path, "old.py", "print('old')", datetime(2020, 1, 1, 12, 0, 0)
+    )
+    _commit_file(
+        repo, repo_path, "new.py", "print('new')", datetime(2024, 6, 1, 12, 0, 0)
+    )
+    _commit_file(
+        repo, repo_path, "data.bin", "not-code", datetime(2024, 6, 2, 12, 0, 0)
+    )
+    return repo, repo_path
+
+
+def test_normalize_patterns_strips_dedups_and_migrates_legacy() -> None:
+    # Whitespace stripped, empties + duplicates dropped, order preserved, and the
+    # legacy regex "match all" (".*") rewritten to its glob equivalent ("*").
+    assert _normalize_patterns([" *.py ", "*.py", "", "Makefile", ".*"]) == [
+        "*.py",
+        "Makefile",
+        "*",
+    ]
+
+
+def test_matches_glob_basename_vs_path() -> None:
+    # No-slash patterns match the basename anywhere in the tree.
+    assert _matches_glob("src/a/b/foo.py", "*.py")
+    assert _matches_glob("Makefile", "Makefile")
+    assert _matches_glob("build/Makefile", "Makefile")
+    # Slash patterns match against the full relative path.
+    assert _matches_glob("src/foo.py", "src/*.py")
+    assert not _matches_glob("lib/foo.py", "src/*.py")
+
+
+def test_default_patterns_used_when_unset() -> None:
+    connector = GitlabConnector(project_owner="o", project_name="n")
+    assert connector.code_file_patterns == list(DEFAULT_CODE_FILE_PATTERNS)
+    # Makefile / Dockerfile are extensionless but covered by the defaults.
+    assert "Makefile" in connector.code_file_patterns
+    assert "Dockerfile" in connector.code_file_patterns
+
+
+def test_custom_patterns_override_defaults() -> None:
+    connector = GitlabConnector(
+        project_owner="o", project_name="n", code_file_patterns=["*.go", "Dockerfile"]
+    )
+    assert connector.code_file_patterns == ["*.go", "Dockerfile"]
+
+
+def test_legacy_code_file_extensions_converted_to_globs() -> None:
+    # Connectors created before the glob migration store bare extensions; the
+    # deprecated kwarg must still be accepted (no TypeError) and converted.
+    connector = GitlabConnector(
+        project_owner="o", project_name="n", code_file_extensions=[".py", "ts"]
+    )
+    assert connector.code_file_patterns == ["*.py", "*.ts"]
+
+
+def test_changed_paths_since_returns_only_recent_changes(
+    gitlab_connector: GitlabConnector, local_repo: tuple[git.Repo, Path]
+) -> None:
+    repo, repo_path = local_repo
+    gitlab_connector.git_repo = repo
+    gitlab_connector.repo_path = repo_path
+
+    # A window starting in 2022 should only pick up the 2024 commits.
+    start = datetime(2022, 1, 1, tzinfo=timezone.utc)
+    changed = gitlab_connector._get_changed_paths_since(start)
+
+    assert changed == {"new.py", "data.bin"}
+
+
+def test_changed_paths_since_full_index_when_no_prior_commit(
+    gitlab_connector: GitlabConnector, local_repo: tuple[git.Repo, Path]
+) -> None:
+    repo, repo_path = local_repo
+    gitlab_connector.git_repo = repo
+    gitlab_connector.repo_path = repo_path
+
+    # The window predates the whole repo history -> signal a full index (None).
+    start = datetime(2000, 1, 1, tzinfo=timezone.utc)
+    assert gitlab_connector._get_changed_paths_since(start) is None
+
+
+def test_changed_paths_since_empty_when_nothing_changed(
+    gitlab_connector: GitlabConnector, local_repo: tuple[git.Repo, Path]
+) -> None:
+    repo, repo_path = local_repo
+    gitlab_connector.git_repo = repo
+    gitlab_connector.repo_path = repo_path
+
+    # A window after the last commit -> no changes to re-index.
+    start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    assert gitlab_connector._get_changed_paths_since(start) == set()
+
+
+def test_get_filtered_files_matches_extensionless_code_files(
+    gitlab_connector: GitlabConnector, local_repo: tuple[git.Repo, Path]
+) -> None:
+    _, repo_path = local_repo
+    gitlab_connector.repo_path = repo_path
+
+    # Makefile (no extension) is now indexed via glob; data.bin is not a code file.
+    filtered = sorted(
+        p.name
+        for p in gitlab_connector._get_filtered_files(
+            {"new.py", "data.bin", "Makefile"}
+        )
+    )
+    assert filtered == ["Makefile", "new.py"]
+
+
+def test_get_filtered_files_full_scan_indexes_all_code_files(
+    gitlab_connector: GitlabConnector, local_repo: tuple[git.Repo, Path]
+) -> None:
+    _, repo_path = local_repo
+    gitlab_connector.repo_path = repo_path
+
+    filtered = sorted(p.name for p in gitlab_connector._get_filtered_files(None))
+    assert filtered == ["Makefile", "new.py", "old.py"]
+
+
+def test_exclude_glob_patterns_take_effect(local_repo: tuple[git.Repo, Path]) -> None:
+    _, repo_path = local_repo
+    connector = GitlabConnector(
+        project_owner="o",
+        project_name="n",
+        include_code_files=True,
+        exclude_path_patterns=["*.py"],
+    )
+    connector.repo_path = repo_path
+
+    # Excluding *.py leaves only the Makefile from the code files.
+    filtered = sorted(p.name for p in connector._get_filtered_files(None))
+    assert filtered == ["Makefile"]

--- a/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_incremental.py
+++ b/backend/tests/unit/onyx/connectors/gitlab/test_gitlab_incremental.py
@@ -190,3 +190,29 @@ def test_exclude_glob_patterns_take_effect(local_repo: tuple[git.Repo, Path]) ->
     # Excluding *.py leaves only the Makefile from the code files.
     filtered = sorted(p.name for p in connector._get_filtered_files(None))
     assert filtered == ["Makefile"]
+
+
+def test_symlinks_are_never_indexed(
+    gitlab_connector: GitlabConnector, tmp_path: Path
+) -> None:
+    """A repo-controlled symlink must not leak files outside the checkout
+    (e.g. secret.py -> /etc/hostname) into the index."""
+    repo_path = tmp_path / "repo"
+    repo_path.mkdir()
+    git.Repo.init(repo_path)
+    (repo_path / "real.py").write_text("print('ok')")
+
+    outside = tmp_path / "outside.py"
+    outside.write_text("host secret")
+    (repo_path / "leak.py").symlink_to(outside)
+
+    gitlab_connector.repo_path = repo_path
+
+    full_scan = sorted(p.name for p in gitlab_connector._get_filtered_files(None))
+    assert full_scan == ["real.py"]
+
+    # Incremental candidate paths go through the same guard.
+    candidates = sorted(
+        p.name for p in gitlab_connector._get_filtered_files({"real.py", "leak.py"})
+    )
+    assert candidates == ["real.py"]

--- a/web/src/app/admin/connector/[ccPairId]/EditGitlabFileTypesModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/EditGitlabFileTypesModal.tsx
@@ -1,0 +1,116 @@
+import { Formik, Form } from "formik";
+import { Button, Modal } from "@opal/components";
+import { Disabled } from "@opal/core";
+import { SvgEdit } from "@opal/icons";
+import { BooleanFormField, TextArrayField } from "@/components/Field";
+import { toast } from "@opal/layouts";
+import { updateConnectorConnectorConfig } from "@/lib/connector";
+import { DEFAULT_GITLAB_CODE_FILE_PATTERNS } from "@/lib/connectors/connectors";
+
+interface GitlabFileTypesFormValues {
+  include_code_files: boolean;
+  code_file_patterns: string[];
+}
+
+interface EditGitlabFileTypesModalProps {
+  ccPairId: number;
+  initialIncludeCodeFiles: boolean;
+  initialCodeFilePatterns: string[];
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function EditGitlabFileTypesModal({
+  ccPairId,
+  initialIncludeCodeFiles,
+  initialCodeFilePatterns,
+  onClose,
+  onSaved,
+}: EditGitlabFileTypesModalProps) {
+  const initialValues: GitlabFileTypesFormValues = {
+    include_code_files: initialIncludeCodeFiles,
+    code_file_patterns: initialCodeFilePatterns,
+  };
+
+  const handleSubmit = async (values: GitlabFileTypesFormValues) => {
+    const normalizedPatterns = values.code_file_patterns
+      .map((pattern) => pattern.trim())
+      .filter((pattern) => pattern.length > 0);
+
+    const response = await updateConnectorConnectorConfig(ccPairId, {
+      include_code_files: values.include_code_files,
+      code_file_patterns: normalizedPatterns,
+    });
+
+    if (!response.ok) {
+      toast.error(`Failed to update file types: ${await response.text()}`);
+      return;
+    }
+
+    toast.success(
+      "File type settings updated. A re-index has been scheduled so the new filter applies to the whole repository."
+    );
+    onSaved();
+    onClose();
+  };
+
+  return (
+    <Modal open onOpenChange={onClose}>
+      <Modal.Content width="sm">
+        <Modal.Header
+          icon={SvgEdit}
+          title="Edit Indexed File Types"
+          onClose={onClose}
+        />
+        <Modal.Body>
+          <Formik initialValues={initialValues} onSubmit={handleSubmit}>
+            {({ isSubmitting, values, setFieldValue }) => (
+              <Form className="w-full">
+                <BooleanFormField
+                  name="include_code_files"
+                  label="Include code files"
+                  subtext="Clone the repository and index its files. Subsequent syncs only re-index files changed since the last sync."
+                />
+
+                {values.include_code_files && (
+                  <div className="pt-4">
+                    <TextArrayField
+                      name="code_file_patterns"
+                      label="Code File Patterns"
+                      subtext="Glob patterns for files to index. Patterns without a '/' match the filename anywhere (e.g. *.py, Makefile, Dockerfile); patterns with a '/' match the path (e.g. src/*.py). Leave empty to use the built-in defaults, or click 'Use defaults' to start from the built-in list."
+                      placeholder="*.py"
+                      values={values}
+                    />
+                    <div className="pt-2">
+                      <Button
+                        type="button"
+                        prominence="tertiary"
+                        size="sm"
+                        onClick={() =>
+                          setFieldValue(
+                            "code_file_patterns",
+                            DEFAULT_GITLAB_CODE_FILE_PATTERNS
+                          )
+                        }
+                      >
+                        Use defaults
+                      </Button>
+                    </div>
+                  </div>
+                )}
+
+                <Modal.Footer>
+                  <Disabled disabled={isSubmitting}>
+                    <Button type="submit">
+                      {isSubmitting ? "Updating..." : "Save file types"}
+                    </Button>
+                  </Disabled>
+                </Modal.Footer>
+              </Form>
+            )}
+          </Formik>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/app/admin/connector/[ccPairId]/EditGitlabFileTypesModal.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/EditGitlabFileTypesModal.tsx
@@ -37,10 +37,29 @@ export default function EditGitlabFileTypesModal({
       .map((pattern) => pattern.trim())
       .filter((pattern) => pattern.length > 0);
 
-    const response = await updateConnectorConnectorConfig(ccPairId, {
-      include_code_files: values.include_code_files,
-      code_file_patterns: normalizedPatterns,
-    });
+    // Only write fields the user actually changed. A connector created
+    // before these options existed may omit include_code_files and rely on
+    // the backend's env default — persisting an untouched checkbox would
+    // silently override that default.
+    const configUpdates: Record<string, unknown> = {};
+    if (values.include_code_files !== initialIncludeCodeFiles) {
+      configUpdates.include_code_files = values.include_code_files;
+    }
+    if (
+      JSON.stringify(normalizedPatterns) !==
+      JSON.stringify(initialCodeFilePatterns)
+    ) {
+      configUpdates.code_file_patterns = normalizedPatterns;
+    }
+    if (Object.keys(configUpdates).length === 0) {
+      onClose();
+      return;
+    }
+
+    const response = await updateConnectorConnectorConfig(
+      ccPairId,
+      configUpdates
+    );
 
     if (!response.ok) {
       toast.error(`Failed to update file types: ${await response.text()}`);

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -741,17 +741,18 @@ function Main({ ccPairId }: { ccPairId: number }) {
               />
 
               {/* Edit which file types are indexed (GitLab) */}
-              {ccPair.connector.source === ValidSources.GitLab && (
-                <div className="mt-4 flex justify-end">
-                  <Button
-                    prominence="secondary"
-                    icon={SvgSettings}
-                    onClick={() => setEditingGitlabFileTypes(true)}
-                  >
-                    Edit indexed file types
-                  </Button>
-                </div>
-              )}
+              {ccPair.connector.source === ValidSources.GitLab &&
+                ccPair.is_editable_for_current_user && (
+                  <div className="mt-4 flex justify-end">
+                    <Button
+                      prominence="secondary"
+                      icon={SvgSettings}
+                      onClick={() => setEditingGitlabFileTypes(true)}
+                    >
+                      Edit indexed file types
+                    </Button>
+                  </div>
+                )}
 
               {/* Inline file management for file connectors */}
               {canManageInlineFileConnectorFiles && (

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -50,6 +50,7 @@ import {
   RefreshCwIcon,
 } from "lucide-react";
 import IndexAttemptErrorsModal from "./IndexAttemptErrorsModal";
+import EditGitlabFileTypesModal from "./EditGitlabFileTypesModal";
 import usePaginatedFetch from "@/hooks/usePaginatedFetch";
 import { IndexAttemptSnapshot } from "@/lib/types";
 import { Spinner } from "@/components/Spinner";
@@ -66,7 +67,7 @@ import { useStatusChange } from "./useStatusChange";
 import { useReIndexModal } from "./ReIndexModal";
 import { Button } from "@opal/components";
 import { SvgSettings } from "@opal/icons";
-import { UserRole } from "@/lib/types";
+import { UserRole, ValidSources } from "@/lib/types";
 import { useUser } from "@/providers/UserProvider";
 import { resolveAllErrorsForCCPair } from "@/lib/targeted_reindex";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -152,6 +153,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false);
   const [editingRefreshFrequency, setEditingRefreshFrequency] = useState(false);
   const [editingPruningFrequency, setEditingPruningFrequency] = useState(false);
+  const [editingGitlabFileTypes, setEditingGitlabFileTypes] = useState(false);
   const [showIndexAttemptErrors, setShowIndexAttemptErrors] = useState(false);
 
   const [showIsResolvingKickoffLoader, setShowIsResolvingKickoffLoader] =
@@ -414,6 +416,22 @@ function Main({ ccPairId }: { ccPairId: number }) {
           validationSchema={PruneFrequencySchema}
           onSubmit={handlePruningSubmit}
           onClose={() => setEditingPruningFrequency(false)}
+        />
+      )}
+
+      {editingGitlabFileTypes && (
+        <EditGitlabFileTypesModal
+          ccPairId={ccPairId}
+          initialIncludeCodeFiles={Boolean(
+            (ccPair.connector.connector_specific_config as any)
+              ?.include_code_files
+          )}
+          initialCodeFilePatterns={
+            ((ccPair.connector.connector_specific_config as any)
+              ?.code_file_patterns as string[]) ?? []
+          }
+          onClose={() => setEditingGitlabFileTypes(false)}
+          onSaved={() => mutate(buildCCPairInfoUrl(ccPairId))}
         />
       )}
 
@@ -721,6 +739,19 @@ function Main({ ccPairId }: { ccPairId: number }) {
                   ccPair.connector.source
                 )}
               />
+
+              {/* Edit which file types are indexed (GitLab) */}
+              {ccPair.connector.source === ValidSources.GitLab && (
+                <div className="mt-4 flex justify-end">
+                  <Button
+                    prominence="secondary"
+                    icon={SvgSettings}
+                    onClick={() => setEditingGitlabFileTypes(true)}
+                  >
+                    Edit indexed file types
+                  </Button>
+                </div>
+              )}
 
               {/* Inline file management for file connectors */}
               {canManageInlineFileConnectorFiles && (

--- a/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/ListInput.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/ConnectorInput/ListInput.tsx
@@ -1,27 +1,47 @@
 import React from "react";
 import { TextArrayField } from "@/components/Field";
 import { useFormikContext } from "formik";
+import { Button } from "@opal/components";
 
 interface ListInputProps {
   name: string;
   label: string | ((credential: any) => string);
   description: string | ((credential: any) => string);
+  defaultValues?: string[];
 }
 
-const ListInput: React.FC<ListInputProps> = ({ name, label, description }) => {
-  const { values } = useFormikContext<any>();
+const ListInput: React.FC<ListInputProps> = ({
+  name,
+  label,
+  description,
+  defaultValues,
+}) => {
+  const { values, setFieldValue } = useFormikContext<any>();
+  const resolvedLabel = typeof label === "function" ? label(null) : label;
   return (
-    <TextArrayField
-      name={name}
-      label={typeof label === "function" ? label(null) : label}
-      values={values}
-      subtext={
-        typeof description === "function" ? description(null) : description
-      }
-      placeholder={`Enter ${
-        typeof label === "function" ? label(null) : label.toLowerCase()
-      }`}
-    />
+    <div>
+      <TextArrayField
+        name={name}
+        label={resolvedLabel}
+        values={values}
+        subtext={
+          typeof description === "function" ? description(null) : description
+        }
+        placeholder={`Enter ${resolvedLabel.toLowerCase()}`}
+      />
+      {defaultValues && defaultValues.length > 0 && (
+        <div className="pt-2">
+          <Button
+            type="button"
+            prominence="tertiary"
+            size="sm"
+            onClick={() => setFieldValue(name, defaultValues)}
+          >
+            Use defaults
+          </Button>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
+++ b/web/src/app/admin/connectors/[connector]/pages/FieldRendering.tsx
@@ -176,7 +176,12 @@ export const RenderField: FC<RenderFieldProps> = ({
           description={description}
         />
       ) : field.type === "list" ? (
-        <ListInput name={field.name} label={label} description={description} />
+        <ListInput
+          name={field.name}
+          label={label}
+          description={description}
+          defaultValues={field.defaultValues}
+        />
       ) : field.type === "select" ? (
         <SelectInput
           name={field.name}

--- a/web/src/lib/connector.ts
+++ b/web/src/lib/connector.ts
@@ -73,6 +73,21 @@ export async function updateConnectorCredentialPairProperty(
   });
 }
 
+export async function updateConnectorConnectorConfig(
+  ccPairId: number,
+  configUpdates: Record<string, unknown>
+): Promise<Response> {
+  return fetch(`/api/manage/admin/cc-pair/${ccPairId}/connector-config`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      connector_specific_config: configUpdates,
+    }),
+  });
+}
+
 export async function updateConnector<T>(
   connector: Connector<T>
 ): Promise<Connector<T>> {

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -436,8 +436,10 @@ export const connectorConfigs: Record<
         type: "text",
         name: "branch",
         label: "Branch",
-        description: "Specific branch to clone (e.g., main).",
-        default: "main",
+        optional: true,
+        description:
+          "Specific branch to clone (e.g., main). Leave empty to use the project's default branch.",
+        default: "",
       },
     ],
   },

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -62,7 +62,22 @@ export interface ListOption extends Option {
   type: "list";
   default?: string[];
   transform?: (values: string[]) => string[];
+  // When provided, a "Use defaults" button is shown that populates the list
+  // with these values (lets users reveal/edit otherwise-hidden defaults).
+  defaultValues?: string[];
 }
+
+// Mirrors DEFAULT_CODE_FILE_PATTERNS in
+// backend/onyx/connectors/gitlab/connector.py — keep the two in sync.
+// prettier-ignore
+export const DEFAULT_GITLAB_CODE_FILE_PATTERNS: string[] = [
+  "*.py", "*.js", "*.ts", "*.java", "*.cpp", "*.c", "*.h", "*.hpp", "*.cs",
+  "*.php", "*.rb", "*.go", "*.rs", "*.kt", "*.scala", "*.swift", "*.m",
+  "*.mm", "*.r", "*.sql", "*.html", "*.htm", "*.css", "*.scss", "*.sass",
+  "*.less", "*.xml", "*.json", "*.yaml", "*.yml", "*.toml", "*.ini", "*.cfg",
+  "*.config", "*.md", "*.rst", "*.txt", "*.sh", "*.bash", "*.ps1", "*.bat",
+  "*.cmd", "*.bazel", "Makefile", "Dockerfile",
+];
 
 export interface TextOption extends Option {
   type: "text";
@@ -375,6 +390,54 @@ export const connectorConfigs: Record<
         name: "include_issues",
         description: "Index issues from repositories",
         default: true,
+      },
+      {
+        type: "checkbox",
+        query: "Include code files?",
+        label: "Include Code Files",
+        name: "include_code_files",
+        description:
+          "Clone the repository and index its files. Subsequent syncs only re-index files changed since the last sync.",
+        default: false,
+      },
+      {
+        type: "list",
+        name: "code_file_patterns",
+        label: "Code File Patterns",
+        description:
+          "Glob patterns for files to index when 'Include Code Files' is enabled. Patterns without a '/' match the filename anywhere (e.g. *.py, Makefile, Dockerfile); patterns with a '/' match the path (e.g. src/*.py). Leave empty to use the built-in defaults, or click 'Use defaults' to start from the built-in list.",
+        default: [],
+        defaultValues: DEFAULT_GITLAB_CODE_FILE_PATTERNS,
+      },
+      {
+        type: "list",
+        name: "include_path_patterns",
+        label: "Include Path Patterns",
+        description:
+          "Glob patterns for paths to include (e.g. src/**, docs/*). Leave empty to include all paths.",
+        default: [],
+      },
+      {
+        type: "list",
+        name: "exclude_path_patterns",
+        label: "Exclude Path Patterns",
+        description:
+          "Glob patterns for paths to exclude (e.g. *_test.py, vendor/**).",
+        default: [],
+      },
+      {
+        type: "number",
+        name: "clone_depth",
+        label: "Clone Depth",
+        description: "Git clone depth (e.g., 1 for shallow clone).",
+        default: 1,
+      },
+      {
+        type: "text",
+        name: "branch",
+        label: "Branch",
+        description: "Specific branch to clone (e.g., main).",
+        default: "main",
       },
     ],
   },
@@ -2081,6 +2144,12 @@ export interface GitlabConfig {
   project_name: string;
   include_mrs: boolean;
   include_issues: boolean;
+  include_code_files?: boolean;
+  code_file_patterns?: string[];
+  include_path_patterns?: string[];
+  exclude_path_patterns?: string[];
+  clone_depth?: number;
+  branch?: string;
 }
 
 export interface LumAppsConfig {


### PR DESCRIPTION
## Description

Rewrites the GitLab connector's **code-file indexing** and makes the file filters **editable after creation**. MR/issue indexing is untouched (keeps `_gitlab_datetime_to_utc` and `doc_created_at`; `include_mrs`/`include_issues` defaults unchanged).

**Clone-based indexing instead of per-file API fetches.** The current implementation walks `repository_tree` and calls `project.files.get` for every file (N+1 API calls, easily rate-limited on large repos), and stamps every document with `doc_updated_at=datetime.now()`. This PR clones the repo once (honoring new `clone_depth` / `branch` options) and reads files from disk, with `doc_updated_at` taken from each file's real last-commit date.

**Incremental sync.** Poll windows clone with `--shallow-since` and re-index **only files changed since the previous sync** (`git diff --name-only --diff-filter=d` against the boundary commit). A window starting at/before 2005 is treated as "index from scratch" (Onyx signals a first/full index with an epoch start). If no boundary commit can be resolved, it safely falls back to a full index.

**Glob-based file selection.** `code_file_patterns` (defaults cover common code/docs extensions *plus extensionless files like `Makefile`/`Dockerfile`*, which the old extension list could never match), and `include_path_patterns` / `exclude_path_patterns` for path scoping. Legacy `code_file_extensions` configs are auto-converted to equivalent globs, and the legacy `.*` regex is rewritten to `*`, so existing connectors keep working unchanged.

**Editable filters after creation.** New allowlisted `PUT /admin/cc-pair/{id}/connector-config` endpoint (only filter keys may be edited — identity keys like `project_owner` stay immutable to avoid orphaning documents) + an "Edit indexed file types" modal on the connector status page. Saving triggers a re-index so the new filter applies repo-wide, not just to files that change later. Also adds a generic "Use defaults" button for list fields (`defaultValues` on `ListOption`) so users can reveal and edit the built-in pattern list.

**⚠️ Behavior note for maintainers:** code-file document ids change from the git **blob SHA** to a stable path-based id. Blob-SHA ids produce a *new* document on every file edit while the old one lingers (the connector has no pruning), and identical files share one id across the repo. With path-based ids a changed file updates in place. Code files indexed under old blob-SHA ids will remain until the connector is re-created — happy to add a migration note or docs wording wherever you prefer.

## How Has This Been Tested?

- New unit tests (`backend/tests/unit/onyx/connectors/gitlab/test_gitlab_incremental.py`, 11 tests): full-index vs incremental window detection, changed-path computation against a real temporary git repo (boundary commit resolution, deletion filtering, fallback-to-full when history is too new), glob matching (basename vs path patterns, extensionless files), legacy extension/`.*` migration, and candidate-file restriction.
- Full `tests/unit/onyx/connectors` suite passes (840 passed).
- `ruff` / `ruff format` / `ty check` / lazy-import check clean; web `tsgo --noEmit`, `oxlint`, `oxfmt` clean.
- This connector (same code) has been indexing large internal GitLab repos in production in our Onyx fork for months, including incremental re-syncs and post-creation filter edits.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches GitLab code-file indexing to a single repo clone with incremental sync and glob-based filters you can edit after setup. This removes N+1 API calls, uses real commit times when available, keeps documents stable with path-based IDs, and ignores symlinks that resolve outside the repo.

- **New Features**
  - Clone once and read files from disk; supports `clone_depth` and optional `branch` (empty uses the project’s default); file `doc_updated_at` uses the last commit time when history is present and stays unset on shallow full clones (content hash drives updates).
  - Incremental sync re-indexes only files changed since the previous run; windows starting at/before 2005 trigger a full index; safely falls back to full when the boundary commit can’t be resolved.
  - Glob-based selection via `code_file_patterns`, plus `include_path_patterns`/`exclude_path_patterns`; defaults cover common code, docs, and extensionless files. Legacy `code_file_extensions` are auto-converted to globs and `.*` is rewritten to `*`.
  - Filters editable post-creation via `PUT /admin/cc-pair/{id}/connector-config` and the “Edit indexed file types” modal; the modal submits only changed fields and skips the update if nothing changed; a “Use defaults” button is available for list fields. Saving schedules a repo-wide re-index.
  - Code-file document IDs move from blob SHA to path-based IDs so changes update in place; previously indexed SHA-based docs are not auto-pruned.

- **Bug Fixes**
  - Skip symlinks and any path that resolves outside the checkout for both full scans and incremental candidates to prevent leaking host files.
  - Hardened config endpoint with a typed allowlist, rejects non-GitLab connectors, and commits the config update and re-index trigger atomically.
  - “Edit indexed file types” is shown only to users who can edit the connector.

<sup>Written for commit a6016b1fe08d86b95e37e2498ea1d9c42e0cd754. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

