### PR TITLE
fix(mcp): proactively refresh OAuth tokens for SSE transport

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -27,6 +27,7 @@ from mcp.types import InitializeResult
 from mcp.types import Tool as MCPLibTool
 from pydantic import AnyUrl
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import build_oauth_authorization_url
@@ -428,6 +429,16 @@ def refresh_mcp_oauth_token_if_expired(
     the existing stored header. All failures raise; the caller is expected to
     treat a refresh failure as non-fatal.
     """
+    # Serialize concurrent refreshes for the same connection: providers that
+    # rotate refresh tokens invalidate the old one, so two racing exchanges
+    # would leave the loser with a dead token. The row lock is held until
+    # update_connection_config commits; a blocked second caller then re-reads
+    # a fresh (non-expired) expiry below and returns without refreshing.
+    db_session.execute(
+        select(MCPConnectionConfig)
+        .where(MCPConnectionConfig.id == connection_config_id)
+        .with_for_update()
+    ).scalar_one()
     config = get_connection_config_by_id(connection_config_id, db_session)
     config_data = extract_connection_data(config)
 
@@ -484,7 +495,12 @@ def refresh_mcp_oauth_token_if_expired(
         config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
 
     header_value = f"{new_tokens.token_type} {new_tokens.access_token}"
-    config_data["headers"] = {"Authorization": header_value}
+    # Merge, don't replace: the connection may carry static headers alongside
+    # the OAuth Authorization header.
+    config_data["headers"] = {
+        **config_data.get("headers", {}),
+        "Authorization": header_value,
+    }
     update_connection_config(config.id, db_session, config_data)
 
     logger.info(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -388,6 +388,113 @@ def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
     return time.time() + tokens.expires_in - TOKEN_EXPIRY_BUFFER_SECONDS
 
 
+def _resolve_mcp_oauth_token_endpoint(
+    mcp_server: DbMCPServer, config_data: MCPConnectionData
+) -> str | None:
+    """Token endpoint to hit for a refresh: the server row's configured endpoint
+    for a KNOWN_PROVIDER, else the discovered endpoint persisted in METADATA."""
+    if (
+        mcp_server.oauth_provider_mode == MCPOAuthProviderMode.KNOWN_PROVIDER
+        and mcp_server.oauth_token_endpoint
+    ):
+        return mcp_server.oauth_token_endpoint
+    metadata_raw = config_data.get(MCPOAuthKeys.METADATA.value)
+    if metadata_raw:
+        token_endpoint = metadata_raw.get("token_endpoint")
+        if token_endpoint:
+            return str(token_endpoint)
+    return None
+
+
+def refresh_mcp_oauth_token_if_expired(
+    mcp_server: DbMCPServer,
+    connection_config_id: int,
+    db_session: Session,
+) -> str | None:
+    """Proactively refresh a per-user MCP OAuth token when it is at/near expiry.
+
+    The MCP SDK's ``OAuthClientProvider`` (an ``httpx.Auth``) normally drives
+    refresh, but it is disabled for SSE transport because ``requires_response_body``
+    is incompatible with an open SSE stream (see ``mcp_client.py``). That leaves
+    the stored ``Authorization: Bearer <access_token>`` header frozen, so once
+    the token expires every SSE tool call fails with an auth error until the user
+    manually reconnects (DST-1273).
+
+    This performs a transport-independent ``grant_type=refresh_token`` exchange,
+    persists the rotated tokens/expiry/header (mirroring ``OnyxTokenStorage.set_tokens``),
+    and returns the fresh ``Authorization`` header value to use for the current
+    call. Returns ``None`` when no refresh was needed or possible (still-valid
+    token, no refresh token, no client/endpoint) — the caller then falls back to
+    the existing stored header. All failures raise; the caller is expected to
+    treat a refresh failure as non-fatal.
+    """
+    config = get_connection_config_by_id(connection_config_id, db_session)
+    config_data = extract_connection_data(config)
+
+    tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
+    refresh_token = tokens_raw.get("refresh_token") if tokens_raw else None
+    if not refresh_token:
+        return None
+
+    # Only refresh when we KNOW the token has expired. A missing expiry means we
+    # can't tell (e.g. a connection made before expiry was persisted) — refreshing
+    # on every call there would hammer the token endpoint and needlessly rotate
+    # the refresh token, so leave those to the one-time manual reconnect.
+    # `token_expires_at` already bakes in TOKEN_EXPIRY_BUFFER_SECONDS.
+    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+    if expires_at is None or time.time() < float(expires_at):
+        return None
+
+    token_endpoint = _resolve_mcp_oauth_token_endpoint(mcp_server, config_data)
+    if not token_endpoint:
+        return None
+
+    client_info_raw = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+    client_id = client_info_raw.get("client_id") if client_info_raw else None
+    if not client_id:
+        return None
+
+    request_data: dict[str, str] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    }
+    client_secret = client_info_raw.get("client_secret") if client_info_raw else None
+    if client_secret:
+        request_data["client_secret"] = client_secret
+
+    validate_oauth_endpoint_url(token_endpoint)
+    response = requests.post(
+        token_endpoint,
+        data=request_data,
+        headers={"Accept": "application/json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    new_tokens = OAuthToken.model_validate(response.json())
+
+    config_data[MCPOAuthKeys.TOKENS.value] = _token_dict_with_preserved_refresh(
+        new_tokens, tokens_raw
+    )
+    new_expiry = _absolute_token_expiry(new_tokens)
+    if new_expiry is not None:
+        config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = new_expiry
+    else:
+        config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
+
+    header_value = f"{new_tokens.token_type} {new_tokens.access_token}"
+    config_data["headers"] = {"Authorization": header_value}
+    update_connection_config(config.id, db_session, config_data)
+
+    logger.info(
+        "Refreshed SSE MCP OAuth token for server '%s' (config %s)",
+        mcp_server.name,
+        connection_config_id,
+    )
+    return header_value
+
+
 def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:
     """Expose a KNOWN_PROVIDER server's configured endpoints as SDK OAuth
     metadata so refresh targets the real token endpoint, not the SDK's

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -227,10 +227,32 @@ class MCPTool(Tool[None]):
                 and self._user_id
             ):
                 if self.mcp_server.transport == MCPTransport.SSE:
-                    logger.warning(
-                        "MCP tool '%s': OAuth token refresh is not supported for SSE transport — auth provider will be ignored. Re-authentication may be required after token expiry.",
-                        self._name,
-                    )
+                    # The SDK OAuthClientProvider (httpx.Auth) that drives refresh
+                    # is incompatible with an open SSE stream, so refresh it
+                    # ourselves before the call: rotate the token when expired and
+                    # swap in the fresh Authorization header. Any failure is
+                    # non-fatal — fall back to the stored token.
+                    try:
+                        from onyx.db.engine.sql_engine import (
+                            get_session_with_current_tenant,
+                        )
+                        from onyx.server.features.mcp.api import (
+                            refresh_mcp_oauth_token_if_expired,
+                        )
+
+                        with get_session_with_current_tenant() as refresh_session:
+                            refreshed_header = refresh_mcp_oauth_token_if_expired(
+                                self.mcp_server,
+                                self.connection_config.id,
+                                refresh_session,
+                            )
+                        if refreshed_header:
+                            headers["Authorization"] = refreshed_header
+                    except Exception:
+                        logger.exception(
+                            "MCP tool '%s': proactive SSE OAuth token refresh failed; using existing token",
+                            self._name,
+                        )
                 else:
                     from onyx.server.features.mcp.api import make_oauth_provider
                     from onyx.server.features.mcp.api import UNUSED_RETURN_PATH

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -1,0 +1,170 @@
+"""Unit tests for transport-independent MCP OAuth refresh (DST-1273).
+
+The SDK OAuthClientProvider that drives refresh is disabled for SSE transport,
+so an SSE GitLab MCP server's access token never rotated and gitlab_search
+started failing with "no credentials" once the token expired.
+refresh_mcp_oauth_token_if_expired performs the refresh directly. These tests
+mock the DB layer and the token endpoint, so no services are required.
+"""
+
+import time
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+
+import pytest
+
+import onyx.server.features.mcp.api as mcp_api
+from onyx.db.enums import MCPOAuthProviderMode
+from onyx.db.models import MCPServer as DbMCPServer
+from onyx.server.features.mcp.api import refresh_mcp_oauth_token_if_expired
+from onyx.server.features.mcp.models import MCPOAuthKeys
+
+_TOKEN_ENDPOINT = "https://gitlab.example.com/oauth/token"
+
+
+def _server_stub() -> DbMCPServer:
+    return cast(
+        DbMCPServer,
+        SimpleNamespace(
+            name="gitlab",
+            oauth_provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER,
+            oauth_token_endpoint=_TOKEN_ENDPOINT,
+        ),
+    )
+
+
+def _install_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    config_data: dict[str, Any],
+    *,
+    refresh_response: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Patch the DB accessors + token endpoint the refresh helper touches.
+
+    Returns a ``captured`` dict recording the outbound POST and the persisted
+    config so tests can assert on them.
+    """
+    captured: dict[str, Any] = {"post_called": False}
+
+    monkeypatch.setattr(
+        mcp_api,
+        "get_connection_config_by_id",
+        lambda config_id, _db_session: SimpleNamespace(id=config_id),
+    )
+    # extract_connection_data returns the same dict the helper mutates in place.
+    monkeypatch.setattr(
+        mcp_api,
+        "extract_connection_data",
+        lambda _config, _apply_mask=False: config_data,
+    )
+    monkeypatch.setattr(mcp_api, "validate_oauth_endpoint_url", lambda _url: None)
+
+    def _fake_update(config_id: int, _db_session: Any, data: Any = None) -> Any:
+        captured["updated_config_data"] = data
+        return SimpleNamespace(id=config_id)
+
+    monkeypatch.setattr(mcp_api, "update_connection_config", _fake_update)
+
+    class _Resp:
+        def json(self) -> dict[str, Any]:
+            return refresh_response or {}
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def _fake_post(url: str, data: Any = None, **_kwargs: Any) -> Any:
+        captured["post_called"] = True
+        captured["url"] = url
+        captured["data"] = data
+        return _Resp()
+
+    monkeypatch.setattr(mcp_api.requests, "post", _fake_post)
+    return captured
+
+
+def test_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,  # expired
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "client_secret": "csecret",
+        },
+    }
+    captured = _install_mocks(
+        monkeypatch,
+        config_data,
+        refresh_response={
+            "access_token": "NEW",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_2",
+            "scope": "api",
+        },
+    )
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, object())
+    )
+
+    assert header == "Bearer NEW"
+    # Outbound refresh POST is a correct grant_type=refresh_token exchange.
+    assert captured["url"] == _TOKEN_ENDPOINT
+    assert captured["data"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "REFRESH_1",
+        "client_id": "cid",
+        "client_secret": "csecret",
+    }
+    # Rotated token + header are persisted for the next call.
+    persisted = captured["updated_config_data"]
+    assert persisted[MCPOAuthKeys.TOKENS.value]["access_token"] == "NEW"
+    assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
+    assert persisted["headers"]["Authorization"] == "Bearer NEW"
+    assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+
+
+def test_no_refresh_when_token_still_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() + 3600,  # still valid
+        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+    }
+    captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, object())
+    )
+
+    assert header is None
+    assert captured["post_called"] is False
+
+
+def test_no_refresh_without_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {"access_token": "OLD", "token_type": "Bearer"},
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+    }
+    captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, object())
+    )
+
+    assert header is None
+    assert captured["post_called"] is False

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -1,10 +1,10 @@
-"""Unit tests for transport-independent MCP OAuth refresh (DST-1273).
+"""Unit tests for transport-independent MCP OAuth refresh.
 
 The SDK OAuthClientProvider that drives refresh is disabled for SSE transport,
-so an SSE GitLab MCP server's access token never rotated and gitlab_search
-started failing with "no credentials" once the token expired.
-refresh_mcp_oauth_token_if_expired performs the refresh directly. These tests
-mock the DB layer and the token endpoint, so no services are required.
+so an SSE server's access token never rotates and tool calls start failing
+once the token expires. refresh_mcp_oauth_token_if_expired performs the
+refresh directly. These tests mock the DB layer and the token endpoint, so no
+services are required.
 """
 
 import time
@@ -21,6 +21,13 @@ from onyx.server.features.mcp.api import refresh_mcp_oauth_token_if_expired
 from onyx.server.features.mcp.models import MCPOAuthKeys
 
 _TOKEN_ENDPOINT = "https://gitlab.example.com/oauth/token"
+
+
+class _FakeSession:
+    """Just enough Session for the row-lock statement in the refresh path."""
+
+    def execute(self, _stmt: Any) -> Any:
+        return SimpleNamespace(scalar_one=lambda: object())
 
 
 def _server_stub() -> DbMCPServer:
@@ -111,7 +118,7 @@ def test_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, object())
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
     )
 
     assert header == "Bearer NEW"
@@ -146,7 +153,7 @@ def test_no_refresh_when_token_still_valid(monkeypatch: pytest.MonkeyPatch) -> N
     captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
 
     header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, object())
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
     )
 
     assert header is None
@@ -163,8 +170,44 @@ def test_no_refresh_without_refresh_token(monkeypatch: pytest.MonkeyPatch) -> No
     captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
 
     header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, object())
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
     )
 
     assert header is None
     assert captured["post_called"] is False
+
+
+def test_refresh_preserves_static_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A connection can carry static headers alongside Authorization; a
+    refresh must merge the new header in, not replace the whole map."""
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD", "X-Custom": "static-value"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+    }
+    _install_mocks(
+        monkeypatch,
+        config_data,
+        refresh_response={
+            "access_token": "NEW",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_2",
+        },
+    )
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
+    )
+
+    assert header == "Bearer NEW"
+    assert config_data["headers"] == {
+        "Authorization": "Bearer NEW",
+        "X-Custom": "static-value",
+    }


### PR DESCRIPTION
## Description

Fixes a hard expiry wall for **SSE-transport MCP servers using per-user OAuth**: the MCP SDK's `OAuthClientProvider` (an `httpx.Auth`) normally drives token refresh transparently, but it is disabled for SSE transport (`requires_response_body` is incompatible with an open SSE stream — see the existing comment in `mcp_client.py`). The stored `Authorization: Bearer …` header is therefore frozen, and once the access token expires **every SSE tool call fails with an auth error until the user manually reconnects the server** from the MCP dropdown. With short-lived tokens (e.g. corporate IdPs issuing 1-hour tokens) that means re-authenticating every hour.

This PR refreshes the token proactively, outside the transport:

- Before each SSE tool call, if the persisted expiry (`token_expires_at`, which already bakes in `TOKEN_EXPIRY_BUFFER_SECONDS`) says the token is expired, `refresh_mcp_oauth_token_if_expired` performs a plain `grant_type=refresh_token` exchange and persists the rotated tokens/expiry/header exactly the way `OnyxTokenStorage.set_tokens` does (including preserving the previous refresh token when the provider doesn't rotate it).
- The token endpoint is resolved the same way the SDK path does: the configured endpoint for `KNOWN_PROVIDER` servers, else the discovered endpoint persisted in the OAuth metadata. The endpoint is re-validated with `validate_oauth_endpoint_url` before the POST.
- Connections without a persisted expiry are deliberately left alone — refreshing on every call would hammer the token endpoint and needlessly rotate refresh tokens; those remain a one-time manual reconnect.
- Refresh failures are non-fatal: the call proceeds with the stored token, and the existing auth-error messaging handles the rest.

Non-SSE transports are unchanged (they keep the SDK-driven refresh).

## How Has This Been Tested?

- New unit tests (`backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py`): a correct `grant_type=refresh_token` exchange is sent and the rotated tokens + `Authorization` header are persisted; a still-valid token performs no refresh; a missing persisted expiry performs no refresh; a missing refresh token / client info / token endpoint each safely no-op; the previous refresh token is preserved when the provider response omits one.
- Full `tests/unit/onyx/server/features/mcp` (38) and `tests/unit/onyx/tools` suites pass (523 total); `ruff` / `ruff format` / `ty check` clean.
- Running in production in our Onyx fork: an SSE MCP server (GitLab search behind a corporate IdP with 1-hour tokens) survives token expiry without manual reconnects.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proactively refresh per-user OAuth tokens for SSE-transport MCP servers so calls keep working after access-token expiry, removing the need to manually reconnect. Non-SSE transports are unchanged; addresses Linear DST-1273.

- **Bug Fixes**
  - Before each SSE tool call, when `token_expires_at` is past, perform `grant_type=refresh_token`, persist rotated tokens/expiry, and merge a fresh `Authorization` header into existing headers; use it for the call.
  - Resolve the token endpoint from the configured KNOWN_PROVIDER endpoint or discovered OAuth metadata and validate it; preserve the previous refresh token if the provider doesn’t rotate it.
  - Serialize concurrent refreshes with a row lock on the connection-config to avoid races when providers rotate refresh tokens.
  - No-op when expiry is missing or when refresh token/client info/endpoint is absent; on errors, fall back to the stored token. Added unit tests, including header-merge behavior.

<sup>Written for commit ee9157709e3f9baabfe5bb68cf59e6a43b7da23a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

