### PR TITLE
feat(metrics): MCP server/client metrics + DB-snapshot connector state gauges

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -140,6 +140,7 @@ from onyx.server.manage.voice.api import admin_router as voice_admin_router
 from onyx.server.manage.voice.user_api import router as voice_router
 from onyx.server.manage.voice.websocket_api import router as voice_websocket_router
 from onyx.server.manage.web_search.api import admin_router as web_search_admin_router
+from onyx.server.metrics.connector_state_metrics import register_connector_state_metrics
 from onyx.server.metrics.postgres_connection_pool import (
     setup_postgres_connection_pool_metrics,
 )
@@ -358,6 +359,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
     # Register pool metrics now that engines are created.
     # HTTP instrumentation is set up earlier in get_application() since it
     # adds middleware (which Starlette forbids after the app has started).
+    register_connector_state_metrics()
     setup_postgres_connection_pool_metrics(
         engines={
             "sync": SqlEngine.get_engine(),

--- a/backend/onyx/mcp_server/api.py
+++ b/backend/onyx/mcp_server/api.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.responses import Response
 from fastmcp import FastMCP
+from prometheus_fastapi_instrumentator import Instrumentator
 from starlette.datastructures import MutableHeaders
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.types import Receive
@@ -106,6 +107,8 @@ def create_mcp_fastapi_app() -> FastAPI:
             allow_methods=["*"],
             allow_headers=["*"],
         )
+
+    Instrumentator().instrument(app).expose(app)
 
     app.mount("/", _ensure_streamable_accept_header)
 

--- a/backend/onyx/mcp_server/auth.py
+++ b/backend/onyx/mcp_server/auth.py
@@ -4,12 +4,19 @@ from typing import Optional
 
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.auth import TokenVerifier
+from prometheus_client import Counter
 
 from onyx.mcp_server.utils import get_http_client
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
+
+MCP_SERVER_AUTH_TOTAL = Counter(
+    "onyx_mcp_server_auth_total",
+    "MCP server authentication attempts",
+    ["result"],  # success, rejected, error
+)
 
 
 class OnyxTokenVerifier(TokenVerifier):
@@ -23,6 +30,7 @@ class OnyxTokenVerifier(TokenVerifier):
                 headers={"Authorization": f"Bearer {token}"},
             )
         except Exception as exc:
+            MCP_SERVER_AUTH_TOTAL.labels(result="error").inc()
             logger.error(
                 "MCP server failed to reach API /me for authentication: %s",
                 exc,
@@ -31,12 +39,14 @@ class OnyxTokenVerifier(TokenVerifier):
             return None
 
         if response.status_code != 200:
+            MCP_SERVER_AUTH_TOTAL.labels(result="rejected").inc()
             logger.warning(
                 "API server rejected MCP auth token with status %s",
                 response.status_code,
             )
             return None
 
+        MCP_SERVER_AUTH_TOTAL.labels(result="success").inc()
         return AccessToken(
             token=token,
             client_id="mcp",

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -1,10 +1,13 @@
 """Search tools for MCP server - document and web search."""
 
+import time
 from datetime import datetime
 from typing import Any
 
 import httpx
 from fastmcp.server.auth.auth import AccessToken
+from prometheus_client import Counter
+from prometheus_client import Histogram
 from pydantic import BaseModel
 from pydantic import TypeAdapter
 from pydantic import ValidationError
@@ -25,6 +28,31 @@ from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
+
+# Operational metrics
+MCP_SERVER_TOOL_LATENCY = Histogram(
+    "onyx_mcp_server_tool_latency_seconds",
+    "MCP server tool execution latency",
+    ["tool"],
+    buckets=(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+MCP_SERVER_TOOL_TOTAL = Counter(
+    "onyx_mcp_server_tool_calls_total",
+    "MCP server tool calls",
+    ["tool", "status"],  # status: success, error
+)
+# Product metrics
+MCP_SERVER_SEARCH_RESULTS = Histogram(
+    "onyx_mcp_server_search_results_count",
+    "Number of results returned by MCP server search tools",
+    ["tool"],
+    buckets=(0, 1, 2, 5, 10, 20, 50),
+)
+MCP_SERVER_SEARCH_SOURCES = Counter(
+    "onyx_mcp_server_search_by_source_total",
+    "MCP server document searches broken down by requested source type",
+    ["source_type"],
+)
 
 
 async def _post_model(
@@ -127,6 +155,7 @@ async def search_indexed_documents(
     }
     ```
     """
+    _start = time.monotonic()
     logger.info(
         "Onyx MCP Server: document search: query='%s', sources=%s, document_sets=%s",
         query,
@@ -134,8 +163,14 @@ async def search_indexed_documents(
         document_set_names,
     )
 
-    # Normalize empty list inputs to None so the API treats them as "no filter"
-    # rather than "match zero".
+    # Track requested source types for product metrics
+    if source_types:
+        for src in source_types:
+            MCP_SERVER_SEARCH_SOURCES.labels(source_type=src.lower()).inc()
+
+    # Normalize empty list inputs to None so downstream filter construction is
+    # consistent — BaseFilters treats [] as "match zero" which differs from
+    # "no filter" (None).
     source_types = source_types or None
     document_set_names = document_set_names or None
 
@@ -202,11 +237,27 @@ async def search_indexed_documents(
         payload = SearchResponse.model_validate_json(response.content)
         results = [_to_mcp_dict(result) for result in payload.results]
 
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(
+            tool="search_indexed_documents", status="success"
+        ).inc()
+        MCP_SERVER_SEARCH_RESULTS.labels(tool="search_indexed_documents").observe(
+            len(results)
+        )
+
         logger.info(
             "Onyx MCP Server: Internal search returned %s results", len(results)
         )
         return {"results": results}
     except Exception as err:
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(
+            tool="search_indexed_documents", status="error"
+        ).inc()
         logger.error("Onyx MCP Server: Document search error: %s", err, exc_info=True)
         return _error_payload(f"Document search failed: {str(err)}")
 
@@ -231,6 +282,7 @@ async def search_web(
     }
     ```
     """
+    _start = time.monotonic()
     logger.info("Onyx MCP Server: Web search: query='%s', limit=%s", query, limit)
 
     access_token = require_access_token()
@@ -248,11 +300,24 @@ async def search_web(
                 "query": query,
             }
         payload = WebSearchToolResponse.model_validate_json(response.content)
+
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="success").inc()
+        MCP_SERVER_SEARCH_RESULTS.labels(tool="search_web").observe(
+            len(payload.results)
+        )
+
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
             "query": query,
         }
     except Exception as e:
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="error").inc()
         logger.error("Onyx MCP Server: Web search error: %s", e, exc_info=True)
         return {
             "error": f"Web search failed: {str(e)}",
@@ -281,6 +346,7 @@ async def open_urls(
     }
     ```
     """
+    _start = time.monotonic()
     logger.info("Onyx MCP Server: Open URL: fetching %s URLs", len(urls))
 
     access_token = require_access_token()
@@ -294,9 +360,19 @@ async def open_urls(
         if not response.is_success:
             return _error_payload(_extract_error_detail(response))
         payload = OpenUrlsToolResponse.model_validate_json(response.content)
+
+        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="success").inc()
+
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
         }
     except Exception as err:
+        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="error").inc()
         logger.error("Onyx MCP Server: URL fetch error: %s", err, exc_info=True)
         return _error_payload(f"URL fetch failed: {str(err)}")

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -55,6 +55,13 @@ MCP_SERVER_SEARCH_SOURCES = Counter(
 )
 
 
+def _record_tool_outcome(tool: str, start: float, status: str) -> None:
+    """Record latency + outcome for a tool call. Every return path of a tool
+    must go through this exactly once so failures aren't understated."""
+    MCP_SERVER_TOOL_LATENCY.labels(tool=tool).observe(time.monotonic() - start)
+    MCP_SERVER_TOOL_TOTAL.labels(tool=tool, status=status).inc()
+
+
 async def _post_model(
     url: str,
     body: BaseModel,
@@ -163,10 +170,16 @@ async def search_indexed_documents(
         document_set_names,
     )
 
-    # Track requested source types for product metrics
+    # Track requested source types for product metrics. Only canonical
+    # DocumentSource values become label values — arbitrary client strings
+    # would otherwise mint unbounded Prometheus series.
     if source_types:
         for src in source_types:
-            MCP_SERVER_SEARCH_SOURCES.labels(source_type=src.lower()).inc()
+            try:
+                canonical = DocumentSource(src.lower()).value
+            except ValueError:
+                canonical = "unknown"
+            MCP_SERVER_SEARCH_SOURCES.labels(source_type=canonical).inc()
 
     # Normalize empty list inputs to None so downstream filter construction is
     # consistent — BaseFilters treats [] as "match zero" which differs from
@@ -185,10 +198,12 @@ async def search_indexed_documents(
             err,
             exc_info=True,
         )
+        _record_tool_outcome("search_indexed_documents", _start, "error")
         return _error_payload(f"Failed to check indexed sources: {str(err)}")
 
     if not sources:
         logger.info("Onyx MCP Server: No indexed sources available for tenant")
+        _record_tool_outcome("search_indexed_documents", _start, "error")
         return _error_payload(
             "No document sources are indexed yet. Add connectors or upload data "
             "through Onyx before calling search_indexed_documents."
@@ -232,17 +247,13 @@ async def search_indexed_documents(
     try:
         response = await _post_model(endpoint, request, access_token)
         if not response.is_success:
+            _record_tool_outcome("search_indexed_documents", _start, "error")
             return _error_payload(_extract_error_detail(response))
 
         payload = SearchResponse.model_validate_json(response.content)
         results = [_to_mcp_dict(result) for result in payload.results]
 
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(
-            tool="search_indexed_documents", status="success"
-        ).inc()
+        _record_tool_outcome("search_indexed_documents", _start, "success")
         MCP_SERVER_SEARCH_RESULTS.labels(tool="search_indexed_documents").observe(
             len(results)
         )
@@ -252,12 +263,7 @@ async def search_indexed_documents(
         )
         return {"results": results}
     except Exception as err:
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(
-            tool="search_indexed_documents", status="error"
-        ).inc()
+        _record_tool_outcome("search_indexed_documents", _start, "error")
         logger.error("Onyx MCP Server: Document search error: %s", err, exc_info=True)
         return _error_payload(f"Document search failed: {str(err)}")
 
@@ -294,6 +300,7 @@ async def search_web(
             access_token,
         )
         if not response.is_success:
+            _record_tool_outcome("search_web", _start, "error")
             return {
                 "error": _extract_error_detail(response),
                 "results": [],
@@ -301,10 +308,7 @@ async def search_web(
             }
         payload = WebSearchToolResponse.model_validate_json(response.content)
 
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="success").inc()
+        _record_tool_outcome("search_web", _start, "success")
         MCP_SERVER_SEARCH_RESULTS.labels(tool="search_web").observe(
             len(payload.results)
         )
@@ -314,10 +318,7 @@ async def search_web(
             "query": query,
         }
     except Exception as e:
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="error").inc()
+        _record_tool_outcome("search_web", _start, "error")
         logger.error("Onyx MCP Server: Web search error: %s", e, exc_info=True)
         return {
             "error": f"Web search failed: {str(e)}",
@@ -358,21 +359,16 @@ async def open_urls(
             access_token,
         )
         if not response.is_success:
+            _record_tool_outcome("open_urls", _start, "error")
             return _error_payload(_extract_error_detail(response))
         payload = OpenUrlsToolResponse.model_validate_json(response.content)
 
-        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="success").inc()
+        _record_tool_outcome("open_urls", _start, "success")
 
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
         }
     except Exception as err:
-        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="error").inc()
+        _record_tool_outcome("open_urls", _start, "error")
         logger.error("Onyx MCP Server: URL fetch error: %s", err, exc_info=True)
         return _error_payload(f"URL fetch failed: {str(err)}")

--- a/backend/onyx/server/metrics/connector_state_metrics.py
+++ b/backend/onyx/server/metrics/connector_state_metrics.py
@@ -24,6 +24,9 @@ from prometheus_client.core import REGISTRY
 from prometheus_client.registry import Collector
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingMode
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
@@ -32,11 +35,12 @@ from shared_configs.configs import MULTI_TENANT
 
 logger = logging.getLogger(__name__)
 
-# One-hot label values; anything else is reported as UNKNOWN so a new enum
-# value can't silently create an unbounded label set.
-_VALID_CC_PAIR_STATUSES = ("ACTIVE", "PAUSED", "DELETING")
-_VALID_ACCESS_TYPES = ("PUBLIC", "PRIVATE", "SYNC")
-_VALID_INDEXING_MODES = ("SCHEDULED", "ON_DEMAND")
+# One-hot label values, derived from the source enums so every persisted
+# state gets its own series; anything outside them (bad data) collapses to
+# UNKNOWN instead of minting unbounded label values.
+_VALID_CC_PAIR_STATUSES = tuple(s.value for s in ConnectorCredentialPairStatus)
+_VALID_ACCESS_TYPES = tuple(a.value for a in AccessType)
+_VALID_INDEXING_MODES = tuple(m.value for m in IndexingMode)
 
 
 def _to_unix_ts(dt: datetime | None) -> int:

--- a/backend/onyx/server/metrics/connector_state_metrics.py
+++ b/backend/onyx/server/metrics/connector_state_metrics.py
@@ -1,0 +1,304 @@
+"""DB-snapshot connector state metrics.
+
+Complements connector_health_metrics.py: those are event-driven counters
+emitted from the celery workers, so they reset on worker restart and say
+nothing about connectors that haven't run since. This collector reads the
+current state straight from Postgres on each scrape, giving absolute truth
+for staleness alerting (e.g. "connector hasn't indexed successfully in N
+hours") regardless of process restarts.
+
+Registered on the API server (see main.py); one cheap query per scrape.
+Skipped in multi-tenant deployments — a scrape-time collector has no tenant
+context to enumerate.
+"""
+
+import logging
+from collections.abc import Iterator
+from datetime import datetime
+from datetime import timezone
+
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.core import InfoMetricFamily
+from prometheus_client.core import Metric
+from prometheus_client.core import REGISTRY
+from prometheus_client.registry import Collector
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import User
+from shared_configs.configs import MULTI_TENANT
+
+logger = logging.getLogger(__name__)
+
+# One-hot label values; anything else is reported as UNKNOWN so a new enum
+# value can't silently create an unbounded label set.
+_VALID_CC_PAIR_STATUSES = ("ACTIVE", "PAUSED", "DELETING")
+_VALID_ACCESS_TYPES = ("PUBLIC", "PRIVATE", "SYNC")
+_VALID_INDEXING_MODES = ("SCHEDULED", "ON_DEMAND")
+
+
+def _to_unix_ts(dt: datetime | None) -> int:
+    """Convert datetime to Unix timestamp, return 0 if None."""
+    if not dt:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp())
+
+
+def _enum_str(value: object, valid: tuple[str, ...]) -> str:
+    raw = getattr(value, "value", None) or getattr(value, "name", None) or str(value)
+    return raw if raw in valid else "UNKNOWN"
+
+
+class ConnectorStateMetricsCollector(Collector):
+    """Prometheus collector exposing per-cc-pair state gauges from the DB."""
+
+    def collect(self) -> Iterator[Metric]:
+        g_last_pruned = GaugeMetricFamily(
+            "onyx_connector_last_pruned_timestamp_seconds",
+            "Unix timestamp of the last successful prune operation (0 if never).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_last_perm_sync = GaugeMetricFamily(
+            "onyx_connector_last_perm_sync_timestamp_seconds",
+            "Unix timestamp of the last permission sync (0 if never).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_last_external_group_sync = GaugeMetricFamily(
+            "onyx_connector_last_external_group_sync_timestamp_seconds",
+            "Unix timestamp of the last external group sync (0 if never).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_cc_pair_status = GaugeMetricFamily(
+            "onyx_connector_status",
+            "Current connector credential pair status as one-hot encoding.",
+            labels=["cc_pair_id", "cc_pair_name", "source_type", "status"],
+        )
+        g_access_type = GaugeMetricFamily(
+            "onyx_connector_access_type",
+            "Access type of the connector as one-hot encoding.",
+            labels=["cc_pair_id", "cc_pair_name", "source_type", "access_type"],
+        )
+        g_indexing_trigger = GaugeMetricFamily(
+            "onyx_connector_indexing_trigger",
+            "Indexing trigger mode as one-hot encoding.",
+            labels=["cc_pair_id", "cc_pair_name", "source_type", "trigger_mode"],
+        )
+        g_auto_sync_enabled = GaugeMetricFamily(
+            "onyx_connector_auto_sync_enabled",
+            "Whether auto-sync is configured (1 = enabled, 0 = disabled).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_time_since_last_success = GaugeMetricFamily(
+            "onyx_connector_seconds_since_last_success",
+            "Seconds since the last successful indexing (0 if never indexed).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_time_since_last_prune = GaugeMetricFamily(
+            "onyx_connector_seconds_since_last_prune",
+            "Seconds since the last prune operation (0 if never pruned).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_total_connectors = GaugeMetricFamily(
+            "onyx_connectors_total",
+            "Total number of connector credential pairs by source type and status.",
+            labels=["source_type", "status"],
+        )
+        g_total_docs_by_source = GaugeMetricFamily(
+            "onyx_connector_docs_by_source_total",
+            "Total documents currently indexed across all connectors by source type.",
+            labels=["source_type"],
+        )
+        g_connector_info = InfoMetricFamily(
+            "onyx_connector",
+            "Metadata information about connector credential pairs.",
+            labels=["cc_pair_id"],
+        )
+
+        try:
+            with get_session_with_current_tenant() as db:
+                rows = (
+                    db.query(
+                        ConnectorCredentialPair.id,
+                        ConnectorCredentialPair.name,
+                        ConnectorCredentialPair.status,
+                        ConnectorCredentialPair.last_successful_index_time,
+                        ConnectorCredentialPair.last_pruned,
+                        ConnectorCredentialPair.last_time_perm_sync,
+                        ConnectorCredentialPair.last_time_external_group_sync,
+                        ConnectorCredentialPair.total_docs_indexed,
+                        ConnectorCredentialPair.access_type,
+                        ConnectorCredentialPair.indexing_trigger,
+                        ConnectorCredentialPair.auto_sync_options,
+                        Connector.source,
+                        Credential.id,
+                        Credential.name,
+                        User.email,  # ty: ignore[invalid-argument-type]
+                    )
+                    .join(ConnectorCredentialPair.connector)
+                    .join(ConnectorCredentialPair.credential)
+                    .outerjoin(ConnectorCredentialPair.creator)
+                    .filter(ConnectorCredentialPair.name != "DefaultCCPair")
+                    .all()
+                )
+
+            connector_counts: dict[tuple[str, str], int] = {}
+            docs_by_source: dict[str, int] = {}
+            current_time = datetime.now(timezone.utc)
+
+            for (
+                cc_pair_id,
+                cc_pair_name,
+                status,
+                last_successful_index_time,
+                last_pruned,
+                last_time_perm_sync,
+                last_time_external_group_sync,
+                total_docs_indexed,
+                access_type,
+                indexing_trigger,
+                auto_sync_options,
+                source,
+                credential_id,
+                credential_name,
+                creator_email,
+            ) in rows:
+                cc_pair_id_str = str(cc_pair_id)
+                cc_pair_name_str = cc_pair_name or ""
+                source_str = (
+                    getattr(source, "value", None)
+                    or getattr(source, "name", None)
+                    or str(source)
+                )
+                status_str = _enum_str(status, _VALID_CC_PAIR_STATUSES)
+                access_type_str = _enum_str(access_type, _VALID_ACCESS_TYPES)
+                indexing_trigger_str = (
+                    _enum_str(indexing_trigger, _VALID_INDEXING_MODES)
+                    if indexing_trigger
+                    else "NONE"
+                )
+
+                common_labels = [cc_pair_id_str, cc_pair_name_str, source_str]
+
+                g_last_pruned.add_metric(common_labels, float(_to_unix_ts(last_pruned)))
+                g_last_perm_sync.add_metric(
+                    common_labels, float(_to_unix_ts(last_time_perm_sync))
+                )
+                g_last_external_group_sync.add_metric(
+                    common_labels,
+                    float(_to_unix_ts(last_time_external_group_sync)),
+                )
+
+                for st in _VALID_CC_PAIR_STATUSES:
+                    g_cc_pair_status.add_metric(
+                        [*common_labels, st], 1.0 if st == status_str else 0.0
+                    )
+                for at in _VALID_ACCESS_TYPES:
+                    g_access_type.add_metric(
+                        [*common_labels, at], 1.0 if at == access_type_str else 0.0
+                    )
+                for mode in [*_VALID_INDEXING_MODES, "NONE"]:
+                    g_indexing_trigger.add_metric(
+                        [*common_labels, mode],
+                        1.0 if mode == indexing_trigger_str else 0.0,
+                    )
+
+                g_auto_sync_enabled.add_metric(
+                    common_labels, 1.0 if auto_sync_options else 0.0
+                )
+
+                if last_successful_index_time:
+                    seconds_since_success = (
+                        current_time
+                        - last_successful_index_time.replace(tzinfo=timezone.utc)
+                    ).total_seconds()
+                    g_time_since_last_success.add_metric(
+                        common_labels, max(0.0, seconds_since_success)
+                    )
+                else:
+                    g_time_since_last_success.add_metric(common_labels, 0.0)
+
+                if last_pruned:
+                    seconds_since_prune = (
+                        current_time - last_pruned.replace(tzinfo=timezone.utc)
+                    ).total_seconds()
+                    g_time_since_last_prune.add_metric(
+                        common_labels, max(0.0, seconds_since_prune)
+                    )
+                else:
+                    g_time_since_last_prune.add_metric(common_labels, 0.0)
+
+                g_connector_info.add_metric(
+                    [cc_pair_id_str],
+                    {
+                        "cc_pair_name": cc_pair_name_str,
+                        "source_type": source_str,
+                        "credential_id": str(credential_id),
+                        "credential_name": credential_name or "",
+                        "creator_email": creator_email or "unknown",
+                        "status": status_str,
+                        "access_type": access_type_str,
+                    },
+                )
+
+                connector_counts[(source_str, status_str)] = (
+                    connector_counts.get((source_str, status_str), 0) + 1
+                )
+                docs_by_source[source_str] = docs_by_source.get(source_str, 0) + (
+                    total_docs_indexed or 0
+                )
+
+            for (source_type, status_val), count in connector_counts.items():
+                g_total_connectors.add_metric([source_type, status_val], float(count))
+            for source_type, total_docs in docs_by_source.items():
+                g_total_docs_by_source.add_metric([source_type], float(total_docs))
+
+        except RuntimeError as e:
+            if "Engine not initialized" in str(e):
+                logger.warning(
+                    "Database engine not initialized yet, "
+                    "skipping connector state metrics collection"
+                )
+            else:
+                logger.error(
+                    "Error collecting connector state metrics: %s", e, exc_info=True
+                )
+        except Exception as e:
+            logger.error(
+                "Unexpected error collecting connector state metrics: %s",
+                e,
+                exc_info=True,
+            )
+
+        # Always yield metric families, even if empty.
+        yield g_last_pruned
+        yield g_last_perm_sync
+        yield g_last_external_group_sync
+        yield g_cc_pair_status
+        yield g_access_type
+        yield g_indexing_trigger
+        yield g_auto_sync_enabled
+        yield g_time_since_last_success
+        yield g_time_since_last_prune
+        yield g_total_connectors
+        yield g_total_docs_by_source
+        yield g_connector_info
+
+
+def register_connector_state_metrics() -> None:
+    """Register the connector state collector with the default registry."""
+    if MULTI_TENANT:
+        # A scrape-time collector has no tenant context; per-tenant state
+        # metrics need a different mechanism in cloud deployments.
+        logger.info(
+            "Multi-tenant deployment — skipping connector state metrics collector"
+        )
+        return
+    try:
+        REGISTRY.register(ConnectorStateMetricsCollector())
+        logger.info("Connector state metrics collector registered")
+    except ValueError:
+        logger.debug("Connector state metrics collector already registered")

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -1,7 +1,10 @@
 import json
+import time
 from typing import Any
 
 from mcp.client.auth import OAuthClientProvider
+from prometheus_client import Counter
+from prometheus_client import Histogram
 
 from onyx.chat.emitter import Emitter
 from onyx.db.enums import MCPAuthenticationType
@@ -20,6 +23,19 @@ from onyx.tools.tool_name import sanitize_tool_name
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# MCP client metrics (Onyx calling external MCP servers)
+MCP_CLIENT_TOOL_TOTAL = Counter(
+    "onyx_mcp_client_tool_calls_total",
+    "External MCP tool calls made by Onyx",
+    ["server_name", "tool_name", "status"],  # status: success, auth_error, error
+)
+MCP_CLIENT_TOOL_LATENCY = Histogram(
+    "onyx_mcp_client_tool_latency_seconds",
+    "External MCP tool call latency",
+    ["server_name", "tool_name"],
+    buckets=(0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
+)
 
 # Headers that cannot be overridden by user requests to prevent security issues
 # Host header is particularly critical - it can be used for Host Header Injection attacks
@@ -129,6 +145,8 @@ class MCPTool(Tool[None]):
         **llm_kwargs: Any,
     ) -> ToolResponse:
         """Execute the MCP tool by calling the MCP server"""
+        _start = time.monotonic()
+        _server = self.mcp_server.name
         try:
             # Build headers with proper precedence:
             # 1. Start with additional headers from API request (filled in first, excluding denylisted)
@@ -255,6 +273,12 @@ class MCPTool(Tool[None]):
                 auth=auth,
             )
 
+            MCP_CLIENT_TOOL_LATENCY.labels(
+                server_name=_server, tool_name=self._name
+            ).observe(time.monotonic() - _start)
+            MCP_CLIENT_TOOL_TOTAL.labels(
+                server_name=_server, tool_name=self._name, status="success"
+            ).inc()
             logger.info("MCP tool '%s' executed successfully", self._name)
 
             # Format the tool result for response
@@ -283,6 +307,9 @@ class MCPTool(Tool[None]):
             )
 
         except Exception as e:
+            MCP_CLIENT_TOOL_LATENCY.labels(
+                server_name=_server, tool_name=self._name
+            ).observe(time.monotonic() - _start)
             error_str = str(e).lower()
             logger.error("Failed to execute MCP tool '%s': %s", self._name, e)
 
@@ -305,6 +332,11 @@ class MCPTool(Tool[None]):
             )
 
             if is_auth_error:
+                MCP_CLIENT_TOOL_TOTAL.labels(
+                    server_name=_server,
+                    tool_name=self._name,
+                    status="auth_error",
+                ).inc()
                 auth_error_msg = (
                     f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
                     f"Please use the MCP dropdown in the chat bar to update your credentials "
@@ -312,6 +344,11 @@ class MCPTool(Tool[None]):
                 )
                 error_result = {"error": auth_error_msg}
             else:
+                MCP_CLIENT_TOOL_TOTAL.labels(
+                    server_name=_server,
+                    tool_name=self._name,
+                    status="error",
+                ).inc()
                 error_result = {"error": f"Tool execution failed: {str(e)}"}
 
             llm_facing_response = json.dumps(error_result)

--- a/backend/tests/unit/server/metrics/test_connector_state_metrics.py
+++ b/backend/tests/unit/server/metrics/test_connector_state_metrics.py
@@ -1,0 +1,60 @@
+"""Unit tests for the DB-snapshot connector state metrics collector."""
+
+from datetime import datetime
+from datetime import timezone
+
+import pytest
+
+import onyx.server.metrics.connector_state_metrics as csm
+from onyx.server.metrics.connector_state_metrics import _enum_str
+from onyx.server.metrics.connector_state_metrics import _to_unix_ts
+from onyx.server.metrics.connector_state_metrics import ConnectorStateMetricsCollector
+
+
+def test_to_unix_ts() -> None:
+    assert _to_unix_ts(None) == 0
+    aware = datetime(2026, 7, 11, 12, 0, 0, tzinfo=timezone.utc)
+    assert _to_unix_ts(aware) == int(aware.timestamp())
+    naive = datetime(2026, 7, 11, 12, 0, 0)
+    assert _to_unix_ts(naive) == int(aware.timestamp())  # naive treated as UTC
+
+
+def test_enum_str_guards_label_cardinality() -> None:
+    class _FakeEnum:
+        value = "ACTIVE"
+
+    assert _enum_str(_FakeEnum(), ("ACTIVE", "PAUSED")) == "ACTIVE"
+    # Unexpected values collapse to UNKNOWN instead of minting new label values.
+    assert _enum_str("SOMETHING_NEW", ("ACTIVE", "PAUSED")) == "UNKNOWN"
+
+
+def test_collect_yields_all_families_when_db_unavailable() -> None:
+    """A scrape must never crash the /metrics endpoint: with no DB engine the
+    collector logs and still yields every (empty) metric family."""
+    families = list(ConnectorStateMetricsCollector().collect())
+    names = {f.name for f in families}
+    assert len(families) == 12
+    assert "onyx_connector_seconds_since_last_success" in names
+    assert "onyx_connectors_total" in names
+    assert all(not f.samples for f in families)
+
+
+def test_register_skipped_in_multi_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    registered: list[object] = []
+    monkeypatch.setattr(csm, "MULTI_TENANT", True)
+    monkeypatch.setattr(csm.REGISTRY, "register", registered.append)
+
+    csm.register_connector_state_metrics()
+
+    assert registered == []
+
+
+def test_register_in_single_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    registered: list[object] = []
+    monkeypatch.setattr(csm, "MULTI_TENANT", False)
+    monkeypatch.setattr(csm.REGISTRY, "register", registered.append)
+
+    csm.register_connector_state_metrics()
+
+    assert len(registered) == 1
+    assert isinstance(registered[0], ConnectorStateMetricsCollector)


### PR DESCRIPTION
## Description

Adds three groups of Prometheus metrics we run in production, filling observability gaps left between the existing suites (`connector_health_metrics`, `celery_task_metrics`, `opensearch_search`, …):

**MCP server** — the standalone MCP server currently exposes no metrics at all.
- `/metrics` on the MCP FastAPI app via `prometheus-fastapi-instrumentator` (same as the main API server).
- `onyx_mcp_server_auth_total{result}` — auth outcomes (success / rejected / error): the first thing to look at when clients report "no credentials".
- `onyx_mcp_server_tool_latency_seconds{tool}` / `onyx_mcp_server_tool_calls_total{tool,status}`.
- `onyx_mcp_server_search_results_count{tool}` and `onyx_mcp_server_search_by_source_total{source_type}` — result quality/product signals.

**MCP client** (`MCPTool.run`) — Onyx calling external MCP servers.
- `onyx_mcp_client_tool_calls_total{server_name,tool_name,status}` (success / auth_error / error) and `onyx_mcp_client_tool_latency_seconds{server_name,tool_name}` — makes flaky or slow third-party MCP servers visible instead of surfacing only as vague chat errors.

**Connector state collector** (`connector_state_metrics.py`, registered on the API server) — complements `connector_health_metrics.py`. Those are event-driven counters emitted from celery workers: they reset on worker restart and say nothing about connectors that haven't run since. This collector reads current state from Postgres on each scrape (one query), giving absolute truth for staleness alerting:
- `onyx_connector_last_{pruned,perm_sync,external_group_sync}_timestamp_seconds`
- `onyx_connector_seconds_since_last_{success,prune}` — direct alert signals ("connector X hasn't indexed in N hours")
- `onyx_connector_status` / `onyx_connector_access_type` / `onyx_connector_indexing_trigger` one-hots (values outside the known enums collapse to `UNKNOWN`, so label cardinality is bounded)
- `onyx_connectors_total{source_type,status}`, `onyx_connector_docs_by_source_total{source_type}`, and an `onyx_connector_info` metadata metric.

Design notes:
- The collector deliberately does **not** duplicate the worker metrics' names (`docs_indexed_total` / `last_success_timestamp_seconds` / `in_error_state`) — same-name series with different semantics from two processes would make dashboards lie.
- Registration is skipped when `MULTI_TENANT` is set: a scrape-time collector has no tenant context to enumerate, so cloud deployments are unaffected.
- A DB failure during scrape logs and yields empty families — `/metrics` never breaks.

## How Has This Been Tested?

- New unit tests (`test_connector_state_metrics.py`): all 12 families are yielded (empty) when the DB engine is unavailable, registration is skipped under `MULTI_TENANT` and performed otherwise, timestamp/enum helpers incl. the `UNKNOWN` cardinality guard.
- Full `tests/unit/server/metrics` (147) and `tests/unit/onyx/tools` suites pass; `ruff` / `ruff format` / `ty check` / lazy-import check clean.
- All three metric groups have been running in production in our Onyx fork; the MCP auth counter and the seconds-since-last-success gauges are the basis of our alerting.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus metrics for the MCP server and client, plus a DB-snapshot connector state collector, to close observability gaps and enable clear alerting on MCP auth issues and connector staleness. Tightens labels and records MCP tool metrics on every outcome.

- **New Features**
  - MCP server: exposes `/metrics` via `prometheus-fastapi-instrumentator`; adds `onyx_mcp_server_auth_total{result}`, `onyx_mcp_server_tool_latency_seconds`, `onyx_mcp_server_tool_calls_total{tool,status}`, `onyx_mcp_server_search_results_count`, and `onyx_mcp_server_search_by_source_total{source_type}`.
  - MCP client: `MCPTool.run` emits `onyx_mcp_client_tool_calls_total{server_name,tool_name,status}` and `onyx_mcp_client_tool_latency_seconds{server_name,tool_name}` to surface flaky or slow external MCP servers.
  - Connector state collector: scrape-time gauges from Postgres for last prune/perm-sync/group-sync timestamps, seconds-since-last-success/prune, one-hot status/access/trigger with bounded labels, totals by source/status, docs by source, and an `onyx_connector` info metric; skipped when `MULTI_TENANT`; on DB errors, families are yielded empty so `/metrics` stays healthy.

- **Bug Fixes**
  - One-hot label values for status/access/trigger now derive from enums so new values don’t collapse to UNKNOWN; MCP server tool metrics now record latency and status on every return path; requested source labels are bounded to canonical `DocumentSource` values with an `unknown` fallback.

<sup>Written for commit 3413a7409cedf239eb3311d2aab07f96fe2b1a56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12904?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

