### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/build/test_workspace_hidden_entries.py
+++ b/backend/tests/unit/build/test_workspace_hidden_entries.py
@@ -1,0 +1,21 @@
+"""Workspace file-listing filter hides sandbox runtime artifacts."""
+
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+def _entry(name: str) -> FilesystemEntry:
+    return FilesystemEntry(name=name, path=f"/{name}", is_directory=False)
+
+
+@pytest.mark.parametrize("name", ["nextjs.log", "nextjs.pid"])
+def test_nextjs_runtime_files_are_hidden(name: str) -> None:
+    assert _is_hidden_workspace_entry(_entry(name)) is True
+
+
+def test_regular_files_are_not_hidden() -> None:
+    assert _is_hidden_workspace_entry(_entry("page.tsx")) is False


### PR DESCRIPTION
## What

Hide `nextjs.log` and `nextjs.pid` from the Craft sandbox file explorer (files tab).

## Why

The Next.js dev server writes `nextjs.log` and `nextjs.pid` to the session
root (`backend/onyx/server/features/build/sandbox/nextjs_dev.py`). Because they
live at the workspace root, they surfaced as listed files in the Craft file
explorer even though they are internal runtime artifacts, not user content.

## Change

- Add `nextjs.log` and `nextjs.pid` to the existing `HIDDEN_PATTERNS` set in
  `backend/onyx/server/features/build/session/manager.py`. This is the single,
  canonical filter applied by `_is_hidden_workspace_entry`, covering both the
  directory listing (`list_directory`) and folder-zip downloads
  (`_walk_sandbox_dir`) across the Docker and Kubernetes backends. No frontend
  change is needed — the backend listing is the source of truth.

## Verification

- Added `backend/tests/unit/build/test_workspace_hidden_entries.py` asserting
  both files are hidden and that a regular file is not. Tests pass.
- `ruff check` / `ruff format --check` clean on changed files.
- Existing `test_list_directory_filters_hidden_entries` uses subset assertions,
  so it is unaffected.

## Known minor items (for reviewer awareness, out of scope)

- Direct download by explicit path (`download_artifact`) does not consult
  `HIDDEN_PATTERNS`; these files remain fetchable if the exact path is known.
  This matches existing behavior (only `opencode.json` is hard-blocked there)
  and the goal here is hiding from the listing, not access control.
- The basename match hides these names at any depth, consistent with existing
  entries like `node_modules` / `.env`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide `nextjs.log` and `nextjs.pid` from the Craft sandbox file explorer and folder-zip downloads to keep runtime noise out of the workspace.

- **Bug Fixes**
  - Added `nextjs.log` and `nextjs.pid` to `HIDDEN_PATTERNS` in `backend/onyx/server/features/build/session/manager.py` so they are filtered in directory listings and zip exports.
  - Added unit tests in `backend/tests/unit/build/test_workspace_hidden_entries.py` to cover the new hidden entries.

<sup>Written for commit 6a61a8039a57aed08804039921e5a1fa62581a4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




- [x] Override Linear Check

<!-- linked internally -->
