### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid from file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize("name", ["nextjs.log", "nextjs.pid"])
+def test_nextjs_dev_artifacts_are_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is True
+
+
+@pytest.mark.parametrize("name", ["page.tsx", "outputs", "README.md"])
+def test_regular_entries_are_not_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is False


### PR DESCRIPTION
## What

The Craft sandbox file explorer listed the Next.js dev-server artifacts `nextjs.log` and `nextjs.pid` at the workspace root. These are transient runtime files (a log stream and a PID file) written by the dev-server bootstrap, not user content, so they should not appear in the file tree.

## Why

`nextjs_dev.py` writes both files to the session root (`{session_path}/nextjs.log`, `{session_path}/nextjs.pid`), which is exactly the directory the file explorer lists at its root. Since neither name starts with `.` nor was in the ignore set, they passed through `_is_hidden_workspace_entry` and showed up in the UI.

## Change

Add `nextjs.log` and `nextjs.pid` to the existing `HIDDEN_PATTERNS` set in `session/manager.py`. This is the single canonical ignore list already used for `node_modules`, `.next`, etc. It is backend-agnostic (covers both Docker and Kubernetes list paths) and also excludes these files from the workspace zip/download path, which is desirable.

No frontend change is needed — the file explorer renders the backend listing verbatim.

## Verification

Added `test_hidden_entries.py` asserting both artifacts are now filtered while regular files are not. Full run:

- `pytest .../session/test_hidden_entries.py .../session/test_archive_walk.py .../sandbox/test_file_listing.py` → 10 passed
- `ruff check` on both changed files → clean

## Checklist

- [x] Override Linear Check
