### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "nextjs.log",
+        "nextjs.pid",
+        ".next",
+        "node_modules",
+        ".env",
+    ],
+)
+def test_runtime_artifacts_are_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is True
+
+
+@pytest.mark.parametrize("name", ["page.tsx", "outputs", "README.md"])
+def test_user_files_are_visible(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is False


### PR DESCRIPTION
## What

Add `nextjs.log` and `nextjs.pid` to the sandbox file-listing ignore set so they no longer appear in the Craft file explorer (or session ZIP downloads).

These files are runtime artifacts written to the session root by the Next.js dev-server bootstrap (`backend/onyx/server/features/build/sandbox/nextjs_dev.py`), not user deliverables, so they should be hidden like the other machine-generated entries.

## Why

They currently show up as top-level files in the file explorer because they are not in `HIDDEN_PATTERNS` and don't start with `.`. This is the same class of artifact as `.next`, `node_modules`, and `opencode.json`, which are already filtered.

## Change

- `backend/onyx/server/features/build/session/manager.py`: add `nextjs.log` and `nextjs.pid` to the existing `HIDDEN_PATTERNS` set. This single source of truth backs both `SessionManager.list_directory` (the `GET /{session_id}/files` endpoint) and the ZIP-archive walk, so the fix applies to both surfaces. No frontend change is needed — the client renders whatever the endpoint returns.

## Verification

Added `backend/tests/unit/onyx/server/features/build/session/test_hidden_entries.py` covering the `_is_hidden_workspace_entry` predicate. It fails on `main` for these two files and passes with the change; existing `test_archive_walk.py` still passes.

- [x] Override Linear Check