### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_list_directory.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_list_directory.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import SessionManager
+from tests.common.craft.stubs import StubSandboxManager
+
+
+def _manager(sandbox_manager: StubSandboxManager) -> SessionManager:
+    manager = SessionManager.__new__(SessionManager)
+    manager._sandbox_manager = sandbox_manager
+    sandbox = SimpleNamespace(id=uuid4())
+    manager._resolve_owned_session_and_sandbox = (  # type: ignore[method-assign]
+        lambda *_: (SimpleNamespace(), sandbox)
+    )
+    return manager
+
+
+def test_list_directory_hides_nextjs_dev_server_artifacts() -> None:
+    sandbox_manager = StubSandboxManager()
+    sandbox_manager.list_directory_returns = [
+        FilesystemEntry(name="outputs", path="outputs", is_directory=True),
+        FilesystemEntry(name="AGENTS.md", path="AGENTS.md", is_directory=False),
+        FilesystemEntry(name="nextjs.log", path="nextjs.log", is_directory=False),
+        FilesystemEntry(name="nextjs.pid", path="nextjs.pid", is_directory=False),
+    ]
+
+    listing = _manager(sandbox_manager).list_directory(uuid4(), uuid4(), "")
+
+    assert listing is not None
+    assert [entry.name for entry in listing.entries] == ["outputs", "AGENTS.md"]


### PR DESCRIPTION
## What

In the Craft sandbox **files** tab, the transient Next.js dev-server artifacts `nextjs.log` and `nextjs.pid` (written to the session root by the dev-server start script) were shown as regular files. This adds them to the existing `HIDDEN_PATTERNS` ignore set so they no longer appear in the file explorer.

## Why

These files are internal dev-server bookkeeping (redirected stdout/stderr and the server PID), not user deliverables, so they shouldn't be surfaced in the file explorer.

## How it works

`SessionManager.list_directory` filters listings through `_is_hidden_workspace_entry`, which excludes any name in `HIDDEN_PATTERNS`. Adding the two filenames there is a single-point fix reusing the existing pattern — no new abstraction, no frontend change (the frontend just renders backend output). The same predicate is also used by the archive/zip download walk, so these artifacts are consistently excluded from downloads too.

## Verification

- Added `test_list_directory_hides_nextjs_dev_server_artifacts`, which reproduces the bug (fails before the fix, passes after) by asserting the two artifacts are filtered from a root listing.
- `pytest tests/unit/onyx/server/features/build/session/` — 91 passed.
- `ruff check` — clean.

## Linear

- [x] Override Linear Check