### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/integration/tests/craft/test_file_ops_api.py
+++ b/backend/tests/integration/tests/craft/test_file_ops_api.py
@@ -286,7 +286,14 @@ def test_list_directory_filters_hidden_entries(
     session_id, sandbox_id = _create_session_with_sandbox(admin_user)
     manager = get_sandbox_manager()
 
-    hidden_names = {".venv/keep", "node_modules/keep", "opencode.json", ".env"}
+    hidden_names = {
+        ".venv/keep",
+        "node_modules/keep",
+        "opencode.json",
+        ".env",
+        "nextjs.log",
+        "nextjs.pid",
+    }
     visible_names = {"alpha.txt", "beta.txt"}
 
     for rel in hidden_names | visible_names:
@@ -303,6 +310,8 @@ def test_list_directory_filters_hidden_entries(
     assert "node_modules" not in names
     assert "opencode.json" not in names
     assert ".env" not in names
+    assert "nextjs.log" not in names
+    assert "nextjs.pid" not in names
     assert visible_names <= names
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize("name", ["nextjs.log", "nextjs.pid"])
+def test_dev_server_runtime_files_are_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is True
+
+
+def test_regular_files_are_not_hidden() -> None:
+    entry = FilesystemEntry(name="page.tsx", path="page.tsx", is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is False


### PR DESCRIPTION
## What
The Craft sandbox Files tab lists `nextjs.log` and `nextjs.pid` as visible files. These are runtime artifacts written by the Next.js dev server (see `sandbox/nextjs_dev.py`) into the session workspace root and should not appear as user-facing files.

## Change
Add `nextjs.log` and `nextjs.pid` to the canonical `HIDDEN_PATTERNS` set in `backend/onyx/server/features/build/session/manager.py`. This set is the single source of truth consulted by `_is_hidden_workspace_entry`, which filters both the directory listing that powers the Files tab and the zip/archive walk. No frontend change is required — the Files tab renders exactly what the API returns and does no filtering of its own.

## Verification
- Added a unit test (`test_hidden_workspace_entry.py`) asserting both files are hidden and that normal files are not. It fails before the change and passes after.
- Extended the existing integration test `test_list_directory_filters_hidden_entries` to cover both filenames.
- `pytest` (unit), `ruff check`, and `ruff format --check` all pass on the touched files.

## Known minor items
None.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide Next.js dev server files `nextjs.log` and `nextjs.pid` in the Craft sandbox Files tab and archive downloads. Added both to the session manager’s `HIDDEN_PATTERNS`, so API listings and zips exclude them; updated unit and integration tests.

<sup>Written for commit f244b01ec0b5d46094fed8dcddbc8d128ba4d29f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

- [x] Override Linear Check

## CI note
The `build-image (sandbox)` job (and the dependent `craft-compose`/`craft-k8s` required jobs) fails on an unrelated base-image issue: the pinned `chromium-common` Debian version no longer resolves. This is independent of this data-only change.
