### PR TITLE
feat(opal): make LinkButton external glyph optional

### DIFF
--- a/web/lib/opal/src/components/buttons/link-button/LinkButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/LinkButton.stories.tsx
@@ -25,6 +25,14 @@ export const ExternalLink: Story = {
   ),
 };
 
+export const InternalLink: Story = {
+  render: () => (
+    <LinkButton href="/admin/settings" external={false}>
+      Settings
+    </LinkButton>
+  ),
+};
+
 export const LongLabel: Story = {
   render: () => (
     <LinkButton href="https://docs.onyx.app" target="_blank">
@@ -37,7 +45,9 @@ export const LongLabel: Story = {
 
 export const AsButton: Story = {
   render: () => (
-    <LinkButton onClick={() => alert("clicked")}>Click me</LinkButton>
+    <LinkButton onClick={() => alert("clicked")} external={false}>
+      Click me
+    </LinkButton>
   ),
 };
 
@@ -53,7 +63,11 @@ export const DisabledLink: Story = {
 
 export const DisabledButton: Story = {
   render: () => (
-    <LinkButton onClick={() => alert("should not fire")} disabled>
+    <LinkButton
+      onClick={() => alert("should not fire")}
+      disabled
+      external={false}
+    >
       Disabled button
     </LinkButton>
   ),

--- a/web/lib/opal/src/components/buttons/link-button/README.md
+++ b/web/lib/opal/src/components/buttons/link-button/README.md
@@ -2,14 +2,14 @@
 
 **Import:** `import { LinkButton, type LinkButtonProps } from "@opal/components";`
 
-A compact, anchor-styled link with an underlined label and a trailing external-link glyph. Intended for **inline references** — "Pricing", "Docs", "Learn more" — not for interactive surfaces that need hover backgrounds or prominence tiers. Use [`Button`](../button/README.md) for those.
+A compact, anchor-styled link with an underlined label and an optional trailing external-link glyph. Intended for **inline references** — "Pricing", "Docs", "Learn more" — not for interactive surfaces that need hover backgrounds or prominence tiers. Use [`Button`](../button/README.md) for those.
 
 ## Architecture
 
 Deliberately **does not** use `Interactive.Stateless` / `Interactive.Container`. Those primitives come with height, rounding, padding, and a colour matrix designed for clickable surfaces — all wrong for an inline text link.
 
 The component renders a plain `<a>` (when given `href`) or `<button>` (when given `onClick`) with:
-- `inline-flex` so the label + icon track naturally next to surrounding prose
+- `inline-flex` so the label + optional icon track naturally next to surrounding prose
 - `text-text-03` that shifts to `text-text-05` on hover
 - `underline` on the label only (the icon stays non-underlined)
 - `data-disabled` driven opacity + `cursor-not-allowed` for the disabled state
@@ -22,6 +22,7 @@ The component renders a plain `<a>` (when given `href`) or `<button>` (when give
 | `href` | `string` | — | Destination URL. Renders the component as `<a>`. |
 | `target` | `string` | — | Anchor target (e.g. `"_blank"`). Adds `rel="noopener noreferrer"` automatically when `"_blank"`. |
 | `onClick` | `() => void` | — | Click handler. Without `href`, renders the component as `<button>`. |
+| `external` | `boolean` | `true` | Shows the trailing external-link glyph. Turn off for in-app links and link-styled actions. |
 | `disabled` | `boolean` | `false` | Applies disabled styling + suppresses navigation / clicks |
 | `tooltip` | `string \| RichStr` | — | Hover tooltip text. Pass `markdown(...)` for inline markdown. |
 | `tooltipSide` | `TooltipSide` | `"top"` | Tooltip placement |
@@ -38,11 +39,15 @@ import { LinkButton } from "@opal/components";
   Read the docs
 </LinkButton>
 
-// Internal link
-<LinkButton href="/admin/settings">Settings</LinkButton>
+// Internal link, no external glyph
+<LinkButton href="/admin/settings" external={false}>
+  Settings
+</LinkButton>
 
 // Button-mode (no href)
-<LinkButton onClick={openModal}>Learn more</LinkButton>
+<LinkButton onClick={openModal} external={false}>
+  Learn more
+</LinkButton>
 
 // Disabled
 <LinkButton href="/" disabled>

--- a/web/lib/opal/src/components/buttons/link-button/README.md
+++ b/web/lib/opal/src/components/buttons/link-button/README.md
@@ -2,7 +2,7 @@
 
 **Import:** `import { LinkButton, type LinkButtonProps } from "@opal/components";`
 
-A compact, anchor-styled link with an underlined label and an optional trailing external-link glyph. Intended for **inline references** — "Pricing", "Docs", "Learn more" — not for interactive surfaces that need hover backgrounds or prominence tiers. Use [`Button`](../button/README.md) for those.
+A compact, anchor-styled link with an underlined label and an optional trailing external-link glyph. Intended for **inline references** like "Pricing", "Docs", and "Learn more", not for interactive surfaces that need hover backgrounds or prominence tiers. Use [`Button`](../button/README.md) for those.
 
 ## Architecture
 

--- a/web/lib/opal/src/components/buttons/link-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/components.tsx
@@ -69,6 +69,10 @@ function LinkButton({
       <span className="opal-link-button-label font-secondary-body">
         {children}
       </span>
+      {/* The glyph is aria-hidden, so new-window behavior needs a spoken cue. */}
+      {target === "_blank" && (
+        <span className="sr-only">(opens in new tab)</span>
+      )}
       {external && <SvgExternalLink size={12} aria-hidden />}
     </>
   );

--- a/web/lib/opal/src/components/buttons/link-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/components.tsx
@@ -20,6 +20,13 @@ interface LinkButtonProps {
   /** Click handler. When provided without `href`, the component renders as a `<button>`. */
   onClick?: () => void;
 
+  /**
+   * Shows the trailing external-link glyph. Turn off for in-app links and
+   * link-styled actions.
+   * @default true
+   */
+  external?: boolean;
+
   /** Applies disabled styling + suppresses navigation/clicks. */
   disabled?: boolean;
 
@@ -35,8 +42,8 @@ interface LinkButtonProps {
 // ---------------------------------------------------------------------------
 
 /**
- * A bare, anchor-styled link with a trailing external-link glyph. Renders
- * as `<a>` when given `href`, or `<button>` when given `onClick`. Intended
+ * A bare, anchor-styled link with an optional trailing external-link glyph.
+ * Renders as `<a>` when given `href`, or `<button>` when given `onClick`. Intended
  * for inline references — "Pricing", "Docs", etc. — not for interactive
  * surfaces that need hover backgrounds or prominence tiers (use `Button`
  * for those).
@@ -44,7 +51,7 @@ interface LinkButtonProps {
  * Deliberately does NOT use `Interactive.Stateless` / `Interactive.Container`
  * — those come with height/rounding/padding and a colour matrix that are
  * wrong for an inline text link. Styling is kept to: underlined label,
- * small external-link icon, a subtle color shift on hover, and disabled
+ * optional external-link icon, a subtle color shift on hover, and disabled
  * opacity.
  */
 function LinkButton({
@@ -52,6 +59,7 @@ function LinkButton({
   href,
   target,
   onClick,
+  external = true,
   disabled,
   tooltip,
   tooltipSide = "top",
@@ -61,7 +69,7 @@ function LinkButton({
       <span className="opal-link-button-label font-secondary-body">
         {children}
       </span>
-      <SvgExternalLink size={12} />
+      {external && <SvgExternalLink size={12} />}
     </>
   );
 

--- a/web/lib/opal/src/components/buttons/link-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/link-button/components.tsx
@@ -69,7 +69,7 @@ function LinkButton({
       <span className="opal-link-button-label font-secondary-body">
         {children}
       </span>
-      {external && <SvgExternalLink size={12} />}
+      {external && <SvgExternalLink size={12} aria-hidden />}
     </>
   );
 

--- a/web/src/app/admin/billing/page.tsx
+++ b/web/src/app/admin/billing/page.tsx
@@ -75,7 +75,9 @@ function FooterLinks({
           <Text secondaryBody text03>
             Have a license key?
           </Text>
-          <LinkButton onClick={onActivateLicense}>{licenseText}</LinkButton>
+          <LinkButton onClick={onActivateLicense} external={false}>
+            {licenseText}
+          </LinkButton>
         </>
       )}
       <LinkButton href={billingHelpHref}>Billing Help</LinkButton>


### PR DESCRIPTION
## Description

Adds `external?: boolean` (default `true`) to the Opal `LinkButton`, controlling the trailing external-link glyph.

- Default `true` keeps every existing external-link call site rendering identically.
- `external={false}` is for in-app links and link-styled actions. Explicit prop, not `href`/`target` inference (mailto and router links would misclassify).
- Repo audit: the billing "Activate License Key" action was the only mislabeled site and now passes `external={false}`. The other five call sites are genuine external links.
- Stories and README updated so button-mode examples model the glyph-off pattern; new `InternalLink` story.

## How Has This Been Tested?

Storybook stories verified with Playwright DOM assertions (default and ExternalLink render the glyph, InternalLink and button-mode stories render label only).

**External (default):**
<img width="152" height="114" alt="image" src="https://github.com/user-attachments/assets/51b84e12-7604-4f23-88b4-4bca0af3ca78" />

**Internal (`external={false}`):**
<img width="160" height="114" alt="image" src="https://github.com/user-attachments/assets/ef67c272-fdd5-4e87-9557-4eeeac86c21d" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check