### PR TITLE
feat(opal): add InputDatePicker

### DIFF
--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -147,6 +147,12 @@ export {
   type InputTypeInProps,
 } from "@opal/components/inputs/input-type-in/components";
 
+/* InputDatePicker */
+export {
+  InputDatePicker,
+  type InputDatePickerProps,
+} from "@opal/components/inputs/input-date-picker/components";
+
 /* InputTags */
 export {
   InputTags,

--- a/web/lib/opal/src/components/inputs/input-date-picker/InputDatePicker.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-date-picker/InputDatePicker.stories.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { InputDatePicker } from "@opal/components";
+
+const meta: Meta<typeof InputDatePicker> = {
+  title: "opal/components/InputDatePicker",
+  component: InputDatePicker,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof InputDatePicker>;
+
+export const Default: Story = {
+  render: () => {
+    const [date, setDate] = useState<Date | null>(null);
+    return (
+      <div className="w-60">
+        <InputDatePicker value={date} onChange={setDate} />
+      </div>
+    );
+  },
+};
+
+export const Filled: Story = {
+  render: () => {
+    const [date, setDate] = useState<Date | null>(new Date(2025, 11, 16));
+    return (
+      <div className="w-60">
+        <InputDatePicker value={date} onChange={setDate} clearable />
+      </div>
+    );
+  },
+};
+
+export const PastOnly: Story = {
+  render: () => {
+    const [date, setDate] = useState<Date | null>(null);
+    return (
+      <div className="w-60">
+        <InputDatePicker value={date} onChange={setDate} maxDate={new Date()} />
+      </div>
+    );
+  },
+};
+
+export const BoundedRange: Story = {
+  render: () => {
+    const [date, setDate] = useState<Date | null>(null);
+    const today = new Date();
+    const weekAgo = new Date(today);
+    weekAgo.setDate(today.getDate() - 7);
+    const weekAhead = new Date(today);
+    weekAhead.setDate(today.getDate() + 7);
+    return (
+      <div className="w-60">
+        <InputDatePicker
+          value={date}
+          onChange={setDate}
+          minDate={weekAgo}
+          maxDate={weekAhead}
+        />
+      </div>
+    );
+  },
+};
+
+export const Error: Story = {
+  render: () => {
+    const [date, setDate] = useState<Date | null>(null);
+    return (
+      <div className="w-60">
+        <InputDatePicker value={date} onChange={setDate} error />
+      </div>
+    );
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div className="w-60">
+      <InputDatePicker
+        value={new Date(2025, 11, 16)}
+        onChange={() => undefined}
+        disabled
+      />
+    </div>
+  ),
+};

--- a/web/lib/opal/src/components/inputs/input-date-picker/README.md
+++ b/web/lib/opal/src/components/inputs/input-date-picker/README.md
@@ -1,0 +1,29 @@
+# InputDatePicker
+
+**Import:** `import { InputDatePicker } from "@opal/components";`
+
+Segmented date field on the shared `.opal-input` chrome, the Figma `Input/Date`. Mono `MM/DD/YYYY` segments accept typed input (auto-advance, backspace to the previous segment, commit on blur or Enter once the segments form a real in-range date), and the calendar action opens the Opal `Calendar` in a popover for click selection. Invalid or out-of-range typing reverts to the committed value.
+
+```tsx
+<InputDatePicker
+  value={date}
+  onChange={setDate}
+  maxDate={new Date()}
+  clearable
+/>
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `value` | `Date \| null` | — | Selected date (required, controlled) |
+| `onChange` | `(date: Date \| null) => void` | — | Fires on commit, `null` when cleared |
+| `error` | `boolean` | `false` | Error chrome on the field |
+| `disabled` | `boolean` | `false` | Disabled chrome, segments and calendar action inert, clear action hidden |
+| `clearable` | `boolean` | `false` | Shows a clear action while a value is set and the field is enabled |
+| `minDate` | `Date` | — | Earliest selectable day (inclusive) |
+| `maxDate` | `Date` | — | Latest selectable day (inclusive) |
+| `id` | `string` | — | Applied to the month segment for `<label htmlFor>` |
+
+Date ranges (the Figma `Range` variant) are not implemented yet. The `Calendar` beneath already supports `mode="range"`, so a range picker is an API addition here, not a new surface.

--- a/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import "@opal/components/inputs/shared.css";
+import "@opal/components/inputs/input-date-picker/styles.css";
+import React from "react";
+import type { InputVariants } from "@opal/types";
+import { Button, Calendar, Popover, Text } from "@opal/components";
+import { SvgCalendar, SvgX } from "@opal/icons";
+
+// ---------------------------------------------------------------------------
+// Segment helpers
+// ---------------------------------------------------------------------------
+
+interface Segments {
+  month: string;
+  day: string;
+  year: string;
+}
+
+const EMPTY_SEGMENTS: Segments = { month: "", day: "", year: "" };
+
+const SEGMENT_FIELDS = [
+  { part: "month", label: "Month", placeholder: "MM", maxLen: 2 },
+  { part: "day", label: "Day", placeholder: "DD", maxLen: 2 },
+  { part: "year", label: "Year", placeholder: "YYYY", maxLen: 4 },
+] as const;
+
+function toSegments(date: Date | null): Segments {
+  if (!date) return EMPTY_SEGMENTS;
+  return {
+    month: String(date.getMonth() + 1).padStart(2, "0"),
+    day: String(date.getDate()).padStart(2, "0"),
+    year: String(date.getFullYear()).padStart(4, "0"),
+  };
+}
+
+// Round-trip through Date to reject overflows like 02/31 (which Date would
+// silently roll into March).
+function parseSegments({ month, day, year }: Segments): Date | null {
+  if (!month || !day || !year) return null;
+  const m = Number(month);
+  const d = Number(day);
+  const y = Number(year);
+  const date = new Date(y, m - 1, d);
+  const valid =
+    date.getFullYear() === y &&
+    date.getMonth() === m - 1 &&
+    date.getDate() === d;
+  return valid ? date : null;
+}
+
+function startOfDay(date: Date): Date {
+  const normalized = new Date(date);
+  normalized.setHours(0, 0, 0, 0);
+  return normalized;
+}
+
+// ---------------------------------------------------------------------------
+// InputDatePicker
+// ---------------------------------------------------------------------------
+
+interface InputDatePickerProps {
+  /** Selected date, or null when empty. */
+  value: Date | null;
+
+  /** Fires with the committed date, or null when cleared. */
+  onChange: (date: Date | null) => void;
+
+  /** Error chrome. */
+  error?: boolean;
+  disabled?: boolean;
+
+  /** Shows a clear action while a value is set and the field is enabled. */
+  clearable?: boolean;
+
+  /** Earliest selectable day (inclusive). */
+  minDate?: Date;
+
+  /** Latest selectable day (inclusive). */
+  maxDate?: Date;
+
+  /** Applied to the month segment so a `<label htmlFor>` can target the field. */
+  id?: string;
+}
+
+/**
+ * InputDatePicker (Figma Input/Date): segmented MM/DD/YYYY field with a
+ * calendar action that opens the Opal Calendar in a popover. Typing commits
+ * on blur or Enter once the segments form a real in-range date. Picking in
+ * the calendar commits immediately.
+ */
+function InputDatePicker({
+  value,
+  onChange,
+  error,
+  disabled,
+  clearable,
+  minDate,
+  maxDate,
+  id,
+}: InputDatePickerProps) {
+  const variant: InputVariants = disabled
+    ? "disabled"
+    : error
+      ? "error"
+      : "primary";
+
+  const normalizedMin = minDate ? startOfDay(minDate) : undefined;
+  const normalizedMax = maxDate ? startOfDay(maxDate) : undefined;
+
+  const [segments, setSegments] = React.useState<Segments>(() =>
+    toSegments(value)
+  );
+  const [open, setOpen] = React.useState(false);
+
+  const monthRef = React.useRef<HTMLInputElement>(null);
+  const dayRef = React.useRef<HTMLInputElement>(null);
+  const yearRef = React.useRef<HTMLInputElement>(null);
+  const segmentRefs = { month: monthRef, day: dayRef, year: yearRef };
+
+  const valueTime = value ? value.getTime() : null;
+  React.useEffect(() => {
+    setSegments(toSegments(value));
+    // Key on the instant, not Date identity, so parent re-renders that
+    // recreate an equal Date don't clobber in-progress typing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [valueTime]);
+
+  function inRange(date: Date): boolean {
+    const t = startOfDay(date).getTime();
+    if (normalizedMin && t < normalizedMin.getTime()) return false;
+    if (normalizedMax && t > normalizedMax.getTime()) return false;
+    return true;
+  }
+
+  function commit(next: Segments) {
+    const parsed = parseSegments(next);
+    if (parsed && inRange(parsed)) {
+      // Day-granularity compare: a value carrying a time-of-day must not
+      // fire a midnight-normalizing onChange on an editless tab-through.
+      const sameDay =
+        value != null && parsed.getTime() === startOfDay(value).getTime();
+      if (!sameDay) onChange(parsed);
+      else setSegments(toSegments(value));
+    } else {
+      setSegments(toSegments(value));
+    }
+  }
+
+  function handleSegmentChange(
+    part: keyof Segments,
+    maxLen: number,
+    nextRef: React.RefObject<HTMLInputElement | null> | null
+  ) {
+    return (e: React.ChangeEvent<HTMLInputElement>) => {
+      const digits = e.target.value.replace(/\D/g, "").slice(0, maxLen);
+      setSegments((prev) => ({ ...prev, [part]: digits }));
+      if (digits.length === maxLen) nextRef?.current?.focus();
+    };
+  }
+
+  function handleSegmentKeyDown(
+    part: keyof Segments,
+    prevRef: React.RefObject<HTMLInputElement | null> | null
+  ) {
+    return (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        commit(segments);
+        return;
+      }
+      if (e.key === "Backspace" && segments[part] === "") {
+        prevRef?.current?.focus();
+        e.preventDefault();
+      }
+    };
+  }
+
+  // Commit when focus leaves the whole field, not on intra-field tabbing.
+  function handleRootBlur(e: React.FocusEvent<HTMLDivElement>) {
+    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    commit(segments);
+  }
+
+  function handleCalendarSelect(date: Date | undefined) {
+    if (!date) return;
+    onChange(date);
+    setOpen(false);
+  }
+
+  const segmentProps = {
+    className: "opal-input-date-picker-segment",
+    type: "text" as const,
+    inputMode: "numeric" as const,
+    autoComplete: "off",
+    disabled,
+  };
+
+  const separator = (
+    <Text font="main-ui-mono" color="text-02" aria-hidden>
+      /
+    </Text>
+  );
+
+  return (
+    <div className="opal-input-date-picker-root">
+      <Popover open={open} onOpenChange={setOpen}>
+        <div
+          className="opal-input opal-input-date-picker"
+          data-variant={variant}
+          role="group"
+          aria-label="Date"
+          onBlur={handleRootBlur}
+        >
+          <div className="opal-input-date-picker-content">
+            {SEGMENT_FIELDS.map((field, i) => (
+              <React.Fragment key={field.part}>
+                {i > 0 && separator}
+                {/* raw-ok: segmented numeric fields have no Opal input primitive; the field chrome is the surrounding .opal-input */}
+                <input
+                  {...segmentProps}
+                  ref={segmentRefs[field.part]}
+                  id={field.part === "month" ? id : undefined}
+                  aria-label={field.label}
+                  placeholder={field.placeholder}
+                  maxLength={field.maxLen}
+                  data-year={field.part === "year" ? true : undefined}
+                  value={segments[field.part]}
+                  onChange={handleSegmentChange(
+                    field.part,
+                    field.maxLen,
+                    i < SEGMENT_FIELDS.length - 1
+                      ? segmentRefs[SEGMENT_FIELDS[i + 1]!.part]
+                      : null
+                  )}
+                  onKeyDown={handleSegmentKeyDown(
+                    field.part,
+                    i > 0 ? segmentRefs[SEGMENT_FIELDS[i - 1]!.part] : null
+                  )}
+                />
+              </React.Fragment>
+            ))}
+          </div>
+
+          <div className="opal-input-date-picker-actions">
+            {clearable && value && !disabled && (
+              <Button
+                icon={SvgX}
+                prominence="internal"
+                size="sm"
+                tooltip="Clear"
+                onClick={() => onChange(null)}
+              />
+            )}
+            <Popover.Trigger asChild>
+              <Button
+                icon={SvgCalendar}
+                prominence="internal"
+                size="sm"
+                tooltip="Open calendar"
+                disabled={disabled}
+              />
+            </Popover.Trigger>
+          </div>
+        </div>
+
+        <Popover.Content align="end">
+          <Calendar
+            mode="single"
+            selected={value ?? undefined}
+            onSelect={handleCalendarSelect}
+            defaultMonth={value ?? normalizedMax ?? normalizedMin ?? undefined}
+            startMonth={normalizedMin}
+            endMonth={normalizedMax}
+            disabled={
+              normalizedMin || normalizedMax
+                ? [
+                    ...(normalizedMin ? [{ before: normalizedMin }] : []),
+                    ...(normalizedMax ? [{ after: normalizedMax }] : []),
+                  ]
+                : undefined
+            }
+          />
+        </Popover.Content>
+      </Popover>
+    </div>
+  );
+}
+
+export { InputDatePicker, type InputDatePickerProps };

--- a/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-date-picker/components.tsx
@@ -117,6 +117,7 @@ function InputDatePicker({
   const dayRef = React.useRef<HTMLInputElement>(null);
   const yearRef = React.useRef<HTMLInputElement>(null);
   const segmentRefs = { month: monthRef, day: dayRef, year: yearRef };
+  const popoverContentRef = React.useRef<HTMLDivElement>(null);
 
   const valueTime = value ? value.getTime() : null;
   React.useEffect(() => {
@@ -175,9 +176,13 @@ function InputDatePicker({
     };
   }
 
-  // Commit when focus leaves the whole field, not on intra-field tabbing.
+  // Commit when focus leaves the whole field. The calendar content is
+  // portaled, so containment is checked against it too or opening the
+  // popover would commit (or revert) a half-typed draft.
   function handleRootBlur(e: React.FocusEvent<HTMLDivElement>) {
-    if (e.currentTarget.contains(e.relatedTarget as Node)) return;
+    const next = e.relatedTarget as Node | null;
+    if (e.currentTarget.contains(next)) return;
+    if (next && popoverContentRef.current?.contains(next)) return;
     commit(segments);
   }
 
@@ -263,7 +268,7 @@ function InputDatePicker({
           </div>
         </div>
 
-        <Popover.Content align="end">
+        <Popover.Content ref={popoverContentRef} align="end">
           <Calendar
             mode="single"
             selected={value ?? undefined}

--- a/web/lib/opal/src/components/inputs/input-date-picker/styles.css
+++ b/web/lib/opal/src/components/inputs/input-date-picker/styles.css
@@ -1,0 +1,54 @@
+@reference "#reference.css";
+
+/* ---------------------------------------------------------------------------
+   InputDatePicker (Figma Input/Date)
+
+   The field reuses the shared .opal-input chrome. Inside it: mono MM/DD/YYYY
+   segments with text-02 separators and placeholders, then 24px internal
+   action buttons (clear, calendar). Segment inputs are chromeless, the box
+   around them is the field.
+   --------------------------------------------------------------------------- */
+
+.opal-input-date-picker-root {
+  @apply relative w-full;
+  min-width: var(--block-width-form-input-min);
+}
+
+.opal-input-date-picker {
+  @apply gap-1;
+}
+
+.opal-input-date-picker-content {
+  @apply flex min-h-6 flex-1 items-center p-0.5;
+}
+
+.opal-input-date-picker-segment {
+  @apply border-0 bg-transparent p-0 text-center font-main-ui-mono text-text-04 outline-hidden;
+  width: 2ch;
+}
+
+.opal-input-date-picker-segment[data-year] {
+  width: 4ch;
+}
+
+.opal-input-date-picker-segment::placeholder {
+  color: var(--text-02);
+}
+
+.opal-input-date-picker-segment:first-child {
+  @apply pl-0.5;
+}
+
+.opal-input-date-picker[data-variant="disabled"]
+  .opal-input-date-picker-segment {
+  @apply cursor-not-allowed text-text-01;
+}
+
+.opal-input-date-picker[data-variant="disabled"]
+  .opal-input-date-picker-segment::placeholder {
+  color: var(--text-01);
+}
+
+.opal-input-date-picker-actions {
+  @apply flex h-6 items-center justify-end;
+}

--- a/web/lib/opal/src/components/inputs/input-date-picker/styles.css
+++ b/web/lib/opal/src/components/inputs/input-date-picker/styles.css
@@ -24,11 +24,13 @@
 
 .opal-input-date-picker-segment {
   @apply border-0 bg-transparent p-0 text-center font-main-ui-mono text-text-04 outline-hidden;
-  width: 2ch;
+  /* ch is the "0" advance, but DM Mono digit ink is a hair wider, so an exact
+     Nch box clips the last digit. The +4px fits the ink for any digits. */
+  width: calc(2ch + 4px);
 }
 
 .opal-input-date-picker-segment[data-year] {
-  width: 4ch;
+  width: calc(4ch + 4px);
 }
 
 .opal-input-date-picker-segment::placeholder {


### PR DESCRIPTION
## Description

Ports the date picker into Opal (Figma `Input/Date`), stacked on #12886 (Calendar). Retargets to `main` once the parent merges.

- Segmented `MM/DD/YYYY` field (DM Mono) on the shared `.opal-input` chrome: auto-advance, backspace to the previous segment, commit on blur/Enter once the segments form a real in-range date, revert on invalid.
- Calendar action (24px internal button) opens the Opal `Calendar` in a `Popover`; picking commits immediately. Optional clear action.
- Figma is the spec: no year dropdown or Today button (refresh-source additions the design lacks). Range variant deferred (`Calendar` already supports `mode="range"`).
- Day-granularity commits: values carrying a time-of-day don't fire a midnight-normalizing `onChange` on tab-through.
- Noted drift: Figma `Input/Date` shows `border-02` at rest, the shared `.opal-input` chrome uses `border-01`. Kept the shared chrome for cross-input consistency; changing the rest border is a one-line `shared.css` follow-up if design confirms.

## How Has This Been Tested?

Storybook + Playwright probes: auto-advance and Enter commit verified via document.activeElement, typed 07/04/2026 steered the calendar month, picking a day committed and closed the popover, measured styles Figma-exact (36px field, DM Mono 14/20 segments, 24px internal actions).

**Placeholder:**
<img width="720" height="108" alt="date-default" src="https://github.com/user-attachments/assets/d8f416d5-7e5c-4037-974a-3517af2be933" />

**Filled + clear:**
<img width="720" height="108" alt="date-filled" src="https://github.com/user-attachments/assets/6319e0f6-9839-4f16-afc5-eb72bc628bfb" />


**Calendar open:**
<img width="2400" height="1702" alt="image" src="https://github.com/user-attachments/assets/5bbc223d-ece2-4ec7-967a-ecd227ba407f" />

**Disabled:**
<img width="720" height="108" alt="date-disabled" src="https://github.com/user-attachments/assets/81ed7554-8bae-4755-9a0c-f3c04d64bdfc" />

**Error:**
<img width="720" height="108" alt="date-error" src="https://github.com/user-attachments/assets/57992364-d7e1-46f7-b0a5-5d03c6d6ef60" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check