### PR TITLE
fix(craft): hide nextjs.log and nextjs.pid in sandbox file explorer

### DIFF
--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -95,6 +95,8 @@ HIDDEN_PATTERNS = {
     "opencode.json",
     ".env",
     ".gitignore",
+    "nextjs.log",
+    "nextjs.pid",
 }
 
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from onyx.server.features.build.sandbox.models import FilesystemEntry
+from onyx.server.features.build.session.manager import _is_hidden_workspace_entry
+
+
+@pytest.mark.parametrize("name", ["nextjs.log", "nextjs.pid"])
+def test_nextjs_runtime_files_are_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=False)
+    assert _is_hidden_workspace_entry(entry) is True
+
+
+@pytest.mark.parametrize("name", ["outputs", "AGENTS.md", "attachments"])
+def test_regular_entries_are_not_hidden(name: str) -> None:
+    entry = FilesystemEntry(name=name, path=name, is_directory=True)
+    assert _is_hidden_workspace_entry(entry) is False


### PR DESCRIPTION
## What

Hide the Next.js dev-server runtime files `nextjs.log` and `nextjs.pid` from the Craft sandbox file explorer ("files tab").

## Why

The Next.js dev server writes `nextjs.log` and `nextjs.pid` to the session workspace root, so they appear at the top level of the file explorer as siblings of `outputs/`, `attachments/`, etc. These are internal runtime artifacts and should not be listed as user files.

## How

Added both filenames to the existing `HIDDEN_PATTERNS` set in `backend/onyx/server/features/build/session/manager.py`. This set is the single choke point used by `_is_hidden_workspace_entry`, which filters both the file-explorer listing (`list_directory`) and directory zip/download (`_walk_sandbox_dir`). No new constant or helper was needed — this reuses the established filtering mechanism (`.git`, `node_modules`, `.next`, ...).

## Verification

Added `backend/tests/unit/onyx/server/features/build/session/test_hidden_workspace_entry.py`, which asserts `nextjs.log`/`nextjs.pid` are now hidden and that ordinary entries (`outputs`, `AGENTS.md`, `attachments`) still pass through. Tests fail before the fix and pass after. `ruff check` clean on both files.

## Known minor items

None.

- [x] Override Linear Check

<!-- ci: revalidate linear-check -->
