### PR TITLE
feat(mcp): forward trusted chat context headers on tool calls

### DIFF
--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -452,8 +452,11 @@ def _construct_tools_impl(
 
             # Extract additional MCP headers from config
             additional_mcp_headers = None
-            if custom_tool_config and custom_tool_config.mcp_headers:
-                additional_mcp_headers = custom_tool_config.mcp_headers
+            mcp_chat_session_id = None
+            if custom_tool_config:
+                if custom_tool_config.mcp_headers:
+                    additional_mcp_headers = custom_tool_config.mcp_headers
+                mcp_chat_session_id = custom_tool_config.chat_session_id
 
             mcp_tool_cache[db_tool_model.mcp_server_id] = {}
             # Find the matching tool definition
@@ -471,6 +474,8 @@ def _construct_tools_impl(
                     user_id=str(user.id),
                     user_oauth_token=mcp_user_oauth_token,
                     additional_headers=additional_mcp_headers,
+                    chat_session_id=mcp_chat_session_id,
+                    persona_id=persona.id,
                 )
                 mcp_tool_cache[db_tool_model.mcp_server_id][saved_tool.id] = mcp_tool
 

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any
+from uuid import UUID
 
 from mcp.client.auth import OAuthClientProvider
 
@@ -21,11 +22,17 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# Trusted context headers set by Onyx (not the LLM or API caller).
+ONYX_CHAT_SESSION_ID_HEADER = "X-Onyx-Chat-Session-Id"
+ONYX_PERSONA_ID_HEADER = "X-Onyx-Persona-Id"
+
 # Headers that cannot be overridden by user requests to prevent security issues
 # Host header is particularly critical - it can be used for Host Header Injection attacks
 # to route requests to unintended internal servers
 DENYLISTED_MCP_HEADERS = {
     "host",  # Prevents Host Header Injection attacks
+    ONYX_CHAT_SESSION_ID_HEADER.lower(),
+    ONYX_PERSONA_ID_HEADER.lower(),
 }
 
 # TODO: for now we're fitting MCP tool responses into the CustomToolCallSummary class
@@ -65,6 +72,8 @@ class MCPTool(Tool[None]):
         user_id: str = "",
         user_oauth_token: str | None = None,
         additional_headers: dict[str, str] | None = None,
+        chat_session_id: UUID | None = None,
+        persona_id: int | None = None,
     ) -> None:
         super().__init__(emitter=emitter)
 
@@ -75,6 +84,8 @@ class MCPTool(Tool[None]):
         self._user_id = user_id
         self._user_oauth_token = user_oauth_token
         self._additional_headers = additional_headers or {}
+        self._chat_session_id = chat_session_id
+        self._persona_id = persona_id
 
         self._mcp_tool_name = tool_name
         self._name = tool_name  # NOTE: this may change in _disambiguate_mcp_tool_names
@@ -122,6 +133,14 @@ class MCPTool(Tool[None]):
             )
         )
 
+    def _context_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self._chat_session_id is not None:
+            headers[ONYX_CHAT_SESSION_ID_HEADER] = str(self._chat_session_id)
+        if self._persona_id is not None:
+            headers[ONYX_PERSONA_ID_HEADER] = str(self._persona_id)
+        return headers
+
     def run(
         self,
         placement: Placement,
@@ -132,8 +151,9 @@ class MCPTool(Tool[None]):
         try:
             # Build headers with proper precedence:
             # 1. Start with additional headers from API request (filled in first, excluding denylisted)
-            # 2. Override with connection config headers (from DB) - these take precedence
+            # 2. Override with connection config headers (from DB)
             # 3. Override Authorization header with OAuth token if present
+            # 4. Trusted chat context from Onyx (session/persona) — always wins
             headers: dict[str, str] = {}
 
             # Priority 1: Additional headers from API request (filled in first)
@@ -167,6 +187,9 @@ class MCPTool(Tool[None]):
             # Priority 3: For pass-through OAuth, use the user's login OAuth token
             if self._user_oauth_token:
                 headers["Authorization"] = f"Bearer {self._user_oauth_token}"
+
+            # Priority 4: Trusted chat context from Onyx — always wins over caller/config
+            headers.update(self._context_headers())
 
             # Check if this is an authentication issue before making the call
             is_passthrough_oauth = (

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -13,6 +13,7 @@ a JSON-Schema-valid `parameters` dict with a `properties` key.
 from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
+from uuid import UUID
 
 import pytest
 
@@ -23,6 +24,8 @@ from onyx.tools.models import ToolResponse
 from onyx.tools.tool_constructor import _disambiguate_mcp_tool_names
 from onyx.tools.tool_implementations.mcp.mcp_tool import _normalize_parameters_schema
 from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+from onyx.tools.tool_implementations.mcp.mcp_tool import ONYX_CHAT_SESSION_ID_HEADER
+from onyx.tools.tool_implementations.mcp.mcp_tool import ONYX_PERSONA_ID_HEADER
 
 
 class TestNormalizeParametersSchema:
@@ -121,6 +124,9 @@ def _make_tool(
     input_schema: dict,
     tool_name: str = "aws___list_regions",
     server_name: str = "aws-knowledge",
+    chat_session_id: UUID | None = None,
+    persona_id: int | None = None,
+    additional_headers: dict[str, str] | None = None,
 ) -> MCPTool:
     mcp_server = MagicMock()
     mcp_server.name = server_name
@@ -134,6 +140,9 @@ def _make_tool(
         tool_name=tool_name,
         tool_description="List AWS regions",
         tool_definition=input_schema,
+        chat_session_id=chat_session_id,
+        persona_id=persona_id,
+        additional_headers=additional_headers,
     )
 
 
@@ -230,6 +239,48 @@ class TestMCPToolLLMNames:
 
         mock_call_mcp_tool.assert_called_once()
         assert mock_call_mcp_tool.call_args.args[1] == "shared"
+
+
+class TestMCPToolContextHeaders:
+    def test_forwards_chat_session_and_persona_headers(self) -> None:
+        session_id = UUID("3f2a1b4c-5d6e-7f89-a0b1-c2d3e4f56789")
+        tool = _make_tool(
+            {"type": "object"},
+            chat_session_id=session_id,
+            persona_id=237,
+        )
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            return_value={"ok": True},
+        ) as mock_call_mcp_tool:
+            tool.run(Placement(turn_index=0))
+
+        headers = mock_call_mcp_tool.call_args.kwargs["connection_headers"]
+        assert headers[ONYX_CHAT_SESSION_ID_HEADER] == str(session_id)
+        assert headers[ONYX_PERSONA_ID_HEADER] == "237"
+
+    def test_context_headers_override_spoofed_mcp_headers(self) -> None:
+        session_id = UUID("3f2a1b4c-5d6e-7f89-a0b1-c2d3e4f56789")
+        tool = _make_tool(
+            {"type": "object"},
+            chat_session_id=session_id,
+            persona_id=42,
+            additional_headers={
+                ONYX_CHAT_SESSION_ID_HEADER: "spoofed-session",
+                ONYX_PERSONA_ID_HEADER: "999",
+            },
+        )
+
+        with patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            return_value={"ok": True},
+        ) as mock_call_mcp_tool:
+            tool.run(Placement(turn_index=0))
+
+        headers = mock_call_mcp_tool.call_args.kwargs["connection_headers"]
+        assert headers[ONYX_CHAT_SESSION_ID_HEADER] == str(session_id)
+        assert headers[ONYX_PERSONA_ID_HEADER] == "42"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Forward `X-Onyx-Chat-Session-Id` and `X-Onyx-Persona-Id` on MCP tool invocations from chat, mirroring OpenAPI `CHAT_SESSION_ID` behavior
- Pass `chat_session_id` and `persona.id` from `tool_constructor` into `MCPTool`
- Denylist context headers in `mcp_headers` so API callers cannot spoof trusted session/persona context

## Motivation
MCP tools had no server-side way to receive the current chat session id. OpenAPI Actions already support a `CHAT_SESSION_ID` placeholder; MCP callers need the same trusted context for workflows that compile or act on the current conversation without the model supplying session metadata.

## Test plan
- [x] `pytest tests/unit/onyx/tools/test_mcp_tool_schema.py::TestMCPToolContextHeaders -xv`
- [x] `pytest tests/unit/onyx/tools/test_mcp_tool_schema.py -xv`
- [x] `ty check` on changed files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Forward trusted chat context to MCP tool calls from chat. Tools now receive the current session and persona, mirroring OpenAPI `CHAT_SESSION_ID`, and callers cannot spoof them.

- **New Features**
  - Set `X-Onyx-Chat-Session-Id` and `X-Onyx-Persona-Id` on MCP requests server-side.
  - Pass `chat_session_id` and `persona.id` from `tool_constructor` into `MCPTool`.
  - Denylist context headers in `mcp_headers`; trusted context always overrides caller/config headers.
  - Added unit tests for forwarding and spoof override.

<sup>Written for commit bca55c869fead8eb4553ec02f83daa605335543d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

