### PR TITLE
feat(reindex-port): auto-pause failing units + operator Resume

### DIFF
--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -17,6 +17,7 @@ from collections.abc import MutableMapping
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
+from enum import Enum
 from typing import Any
 from uuid import UUID
 
@@ -808,17 +809,26 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
     return tasks_created
 
 
+class PortResumeResult(Enum):
+    NOT_PAUSED = "not_paused"  # nothing to resume (not paused / superseded / raced)
+    RESUMED = "resumed"  # fresh attempt minted AND dispatched now
+    DISPATCH_FAILED = "dispatch_failed"  # minted, but the immediate enqueue failed
+
+
 def resume_paused_port_unit(
     celery_app: Celery,
     tenant_id: str,
     cc_pair_id: int | None,
     port_user_id: UUID | None,
     search_settings_id: int,
-) -> bool:
+) -> PortResumeResult:
     """Operator Resume: mint a fresh attempt from the paused cursor and enqueue it now,
-    rather than waiting a TTL for the scheduler to notice the NOT_STARTED. Returns True if
-    a unit was resumed (False if it wasn't PAUSED / the target was superseded / a
-    concurrent resume won)."""
+    rather than waiting a TTL for the scheduler to notice the NOT_STARTED.
+
+    NOT_PAUSED if there was nothing to resume. DISPATCH_FAILED if the fresh attempt was
+    committed but the immediate enqueue failed (broker down) — the caller must NOT report
+    an immediate resume; the row is a committed NOT_STARTED that the scheduler re-enqueues
+    once its TTL lapses, so the resume isn't lost, just delayed. RESUMED otherwise."""
     scope: PortScope = "user_file" if port_user_id is not None else "connector"
     with get_session_with_current_tenant() as db_session:
         attempt = resume_paused_port_attempt(
@@ -828,17 +838,16 @@ def resume_paused_port_unit(
             search_settings_id=search_settings_id,
         )
         if attempt is None:
-            return False
+            return PortResumeResult.NOT_PAUSED
         attempt_id = attempt.id
     try:
         _enqueue_run_port_attempt(celery_app, attempt_id, tenant_id, scope)
     except Exception:
-        # The row is a committed NOT_STARTED; the scheduler re-enqueues it once its TTL
-        # lapses, so a broker hiccup here only delays the resume, it doesn't lose it.
         task_logger.exception(
             "resume_paused_port_unit: enqueue failed for PortAttempt %s", attempt_id
         )
-    return True
+        return PortResumeResult.DISPATCH_FAILED
+    return PortResumeResult.RESUMED
 
 
 @shared_task(

--- a/backend/onyx/background/celery/tasks/port/tasks.py
+++ b/backend/onyx/background/celery/tasks/port/tasks.py
@@ -31,6 +31,7 @@ from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import MAX_CONCURRENT_PORT_ATTEMPTS
 from onyx.configs.app_configs import MAX_CONCURRENT_USER_FILE_PORT_ATTEMPTS
+from onyx.configs.app_configs import MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
@@ -61,8 +62,10 @@ from onyx.db.port_attempt import mark_port_canceled
 from onyx.db.port_attempt import mark_port_failed
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.port_attempt import pause_port_attempt
 from onyx.db.port_attempt import port_backfill_has_pending_work
 from onyx.db.port_attempt import PortScope
+from onyx.db.port_attempt import resume_paused_port_attempt
 from onyx.db.port_attempt import touch_port_progress
 from onyx.db.port_orphan_candidate import cleanup_stale_port_orphan_candidates
 from onyx.db.port_orphan_candidate import clear_port_orphan_candidates
@@ -632,16 +635,47 @@ def _schedule_scope_attempts(
                         active.id,
                     )
             continue
+        latest = get_latest_port_attempt(
+            db_session, cc_pair_id, search_settings_id, port_user_id=port_user_id
+        )
+        # Auto-pause a unit stuck failing at the same cursor: after N consecutive
+        # same-cursor failures, park it PAUSED for the operator instead of retrying it
+        # forever. Evaluated before the cap gate so a cap-starved stuck unit still pauses
+        # (else the operator banner is late to surface the very units it most needs to).
+        if (
+            latest is not None
+            and latest.status == PortAttemptStatus.FAILED
+            and count_consecutive_failed_port_attempts_no_progress(
+                db_session, cc_pair_id, search_settings_id, port_user_id=port_user_id
+            )
+            >= MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE
+        ):
+            try:
+                if pause_port_attempt(db_session, latest.id):
+                    task_logger.warning(
+                        "check_for_port: auto-paused after %d consecutive failures "
+                        "(scope=%s cc_pair=%s user=%s)",
+                        MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE,
+                        scope,
+                        cc_pair_id,
+                        port_user_id,
+                    )
+            except Exception:
+                # One unit's pause failing (DB blip) must not abort the whole tick.
+                task_logger.exception(
+                    "check_for_port: auto-pause failed (scope=%s cc_pair=%s user=%s)",
+                    scope,
+                    cc_pair_id,
+                    port_user_id,
+                )
+            continue
         # At the concurrency cap: don't start new attempts (the remaining entities still
         # get recovery re-enqueues above next pass).
         if active_attempts >= cap:
             at_cap += 1
             continue
-        latest = get_latest_port_attempt(
-            db_session, cc_pair_id, search_settings_id, port_user_id=port_user_id
-        )
-        # SUCCESS -> backlog already ported; CANCELED -> operator stopped it. Only a
-        # FAILED (or no) attempt warrants a fresh run.
+        # SUCCESS -> already ported; CANCELED/PAUSED -> stopped. Only a FAILED (or no)
+        # attempt warrants a fresh run.
         if latest is not None and latest.status != PortAttemptStatus.FAILED:
             continue
         # Back off a port stuck failing at the same cursor (durable error) so it doesn't
@@ -772,6 +806,39 @@ def run_check_for_port(tenant_id: str, celery_app: Celery) -> int | None:
             lock_beat.release()
 
     return tasks_created
+
+
+def resume_paused_port_unit(
+    celery_app: Celery,
+    tenant_id: str,
+    cc_pair_id: int | None,
+    port_user_id: UUID | None,
+    search_settings_id: int,
+) -> bool:
+    """Operator Resume: mint a fresh attempt from the paused cursor and enqueue it now,
+    rather than waiting a TTL for the scheduler to notice the NOT_STARTED. Returns True if
+    a unit was resumed (False if it wasn't PAUSED / the target was superseded / a
+    concurrent resume won)."""
+    scope: PortScope = "user_file" if port_user_id is not None else "connector"
+    with get_session_with_current_tenant() as db_session:
+        attempt = resume_paused_port_attempt(
+            db_session,
+            cc_pair_id=cc_pair_id,
+            port_user_id=port_user_id,
+            search_settings_id=search_settings_id,
+        )
+        if attempt is None:
+            return False
+        attempt_id = attempt.id
+    try:
+        _enqueue_run_port_attempt(celery_app, attempt_id, tenant_id, scope)
+    except Exception:
+        # The row is a committed NOT_STARTED; the scheduler re-enqueues it once its TTL
+        # lapses, so a broker hiccup here only delays the resume, it doesn't lose it.
+        task_logger.exception(
+            "resume_paused_port_unit: enqueue failed for PortAttempt %s", attempt_id
+        )
+    return True
 
 
 @shared_task(

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -447,15 +447,24 @@ def _index_user_file_to_secondary(
     """Index one user file into the secondary (reindex-port target) index, re-embedding with
     its model. `index_to_secondary=True` makes the adapter skip the terminal side-effects the
     PRESENT pass already applied. Raises on an incomplete write; the caller owns the flag."""
-    embedder = DefaultIndexingEmbedder.from_db_search_settings(
-        search_settings=secondary,
-    )
-    document_indices = get_all_document_indices(
-        secondary,
-        None,
-        httpx_client=HttpxPool.get("vespa"),
-    )
     with get_session_with_current_tenant() as db_session:
+        # Callers resolve `secondary` in a separate, already-closed session, so it arrives
+        # detached. Re-bind before from_db_search_settings reads its cloud_provider-backed
+        # properties (api_key/api_url/api_version/deployment_name), which would otherwise
+        # lazy-load and raise DetachedInstanceError.
+        bound_secondary = db_session.get(SearchSettings, secondary.id)
+        if bound_secondary is None:
+            raise RuntimeError(
+                f"secondary search settings gone for user file {user_file_id}"
+            )
+        embedder = DefaultIndexingEmbedder.from_db_search_settings(
+            search_settings=bound_secondary,
+        )
+        document_indices = get_all_document_indices(
+            bound_secondary,
+            None,
+            httpx_client=HttpxPool.get("vespa"),
+        )
         adapter = UserFileIndexingAdapter(
             tenant_id=tenant_id,
             db_session=db_session,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -952,7 +952,8 @@ MAX_CONCURRENT_USER_FILE_PORT_ATTEMPTS = max(
     1, _non_negative_int_env("MAX_CONCURRENT_USER_FILE_PORT_ATTEMPTS", 1)
 )
 
-# MUST stay below _MAX_TRACKED_FAILED_RETRIES (db/port_attempt.py) or pause never fires.
+# Auto-pause a port unit after this many consecutive same-cursor failures. Any value works:
+# _MAX_TRACKED_FAILED_RETRIES (db/port_attempt.py) sizes its streak history to cover it.
 MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE = max(
     1, _non_negative_int_env("MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE", 5)
 )

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -19,6 +19,7 @@ from sqlalchemy import func
 from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy import update
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.db.connector_credential_pair import (
@@ -668,6 +669,77 @@ def pause_port_attempt(db_session: Session, port_attempt_id: int) -> bool:
         raise
 
 
+def resume_paused_port_attempt(
+    db_session: Session,
+    *,
+    cc_pair_id: int | None,
+    port_user_id: UUID | None,
+    search_settings_id: int,
+) -> PortAttempt | None:
+    """Operator Resume: if the scope's latest attempt is still PAUSED, mint a fresh
+    NOT_STARTED resuming from its cursor. The PAUSED row stays as history — it's a streak
+    barrier, so the resumed unit gets a fresh failure budget before it can re-pause.
+
+    Returns the new attempt, or None when there is nothing to resume: the latest isn't
+    PAUSED (a racing resume/supersede moved it), the FUTURE is no longer the port target, or
+    a concurrent resume already created the active attempt (active-unique IntegrityError).
+    Holds the row lock on the PAUSED row across the insert so concurrent resumes serialize
+    — whichever locks first wins; the other sees a newer latest under the lock and no-ops."""
+    # Local imports break the port_attempt <-> search_settings cycle (search_settings
+    # lazily imports this module).
+    from onyx.db.port_orphan_candidate import port_target_settings_id
+    from onyx.db.search_settings import get_current_search_settings
+    from onyx.db.search_settings import get_secondary_search_settings
+
+    _scope_where(cc_pair_id, port_user_id)
+    latest = get_latest_port_attempt(
+        db_session, cc_pair_id, search_settings_id, port_user_id=port_user_id
+    )
+    if latest is None or latest.status != PortAttemptStatus.PAUSED:
+        return None
+    try:
+        locked = _get_locked(db_session, latest.id)
+        # Re-read latest under the lock: a resume that raced in already minted a newer
+        # attempt (the active-unique index alone wouldn't catch it once that sibling was
+        # canceled, e.g. by connector deletion, in the commit->insert window).
+        current_latest = get_latest_port_attempt(
+            db_session, cc_pair_id, search_settings_id, port_user_id=port_user_id
+        )
+        if (
+            locked.status != PortAttemptStatus.PAUSED
+            or current_latest is None
+            or current_latest.id != locked.id
+        ):
+            db_session.rollback()
+            return None
+        # Refuse if this FUTURE is no longer the port target (superseded/promoted).
+        target_id = port_target_settings_id(
+            get_current_search_settings(db_session),
+            get_secondary_search_settings(db_session),
+        )
+        if target_id != search_settings_id:
+            db_session.rollback()
+            return None
+        fresh = PortAttempt(
+            cc_pair_id=cc_pair_id,
+            port_user_id=port_user_id,
+            search_settings_id=search_settings_id,
+            status=PortAttemptStatus.NOT_STARTED,
+            last_processed_doc_id=locked.last_processed_doc_id,
+            up_to_doc_id=locked.up_to_doc_id,
+        )
+        db_session.add(fresh)
+        db_session.commit()
+        return fresh
+    except IntegrityError:
+        # concurrent resume already minted the active attempt
+        db_session.rollback()
+        return None
+    except Exception:
+        db_session.rollback()
+        raise
+
+
 def request_port_cancel(db_session: Session, port_attempt_id: int) -> None:
     """Ask a port to stop so a waiter (connector deletion) can be the last writer.
     Under the row lock (serializes vs mark_port_in_progress):
@@ -701,11 +773,14 @@ def _mark_terminal(
 ) -> None:
     try:
         attempt = _get_locked(db_session, port_attempt_id)
-        if attempt.status.is_terminal():
-            # First terminal write wins: the row lock makes the watchdog-vs-task
-            # race deterministic, so a late SUCCESS can't clobber a watchdog FAILED.
+        if attempt.status.is_resting():
+            # First terminal write wins (the row lock makes the watchdog-vs-task race
+            # deterministic, so a late SUCCESS can't clobber a watchdog FAILED). PAUSED is
+            # resting too: a wedged worker that un-wedges after its attempt was auto-paused
+            # must NOT drive it back to SUCCESS/FAILED and silently unblock the swap — only
+            # an operator Resume may move a PAUSED row (by minting a fresh attempt).
             logger.debug(
-                "PortAttempt %s already terminal (%s); ignoring %s",
+                "PortAttempt %s already resting (%s); ignoring %s",
                 port_attempt_id,
                 attempt.status.value,
                 status.value,

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -244,13 +244,15 @@ class ReindexProgressCounts(BaseModel):
     in_progress: int
     completed: int
     failed: int
+    paused: int
 
 
 def get_reindex_progress_counts(
     db_session: Session, search_settings_id: int
 ) -> ReindexProgressCounts:
     """Bucket each in-scope entity (both scopes) by its latest PortAttempt. No attempt /
-    NOT_STARTED / CANCELED → waiting, so the bar never stalls above real remaining work."""
+    NOT_STARTED / CANCELED → waiting; an auto-paused unit is its own `paused` bucket.
+    Buckets partition `total`."""
     cc_pair_ids, user_ids = _reindex_port_scope(db_session, search_settings_id)
     total = len(cc_pair_ids) + len(user_ids)
 
@@ -263,32 +265,36 @@ def get_reindex_progress_counts(
     in_progress = sum(1 for s in statuses if s == PortAttemptStatus.IN_PROGRESS)
     completed = sum(1 for s in statuses if s == PortAttemptStatus.SUCCESS)
     failed = sum(1 for s in statuses if s == PortAttemptStatus.FAILED)
+    paused = sum(1 for s in statuses if s == PortAttemptStatus.PAUSED)
 
     return ReindexProgressCounts(
         total=total,
-        waiting=max(0, total - in_progress - completed - failed),
+        waiting=max(0, total - in_progress - completed - failed - paused),
         in_progress=in_progress,
         completed=completed,
         failed=failed,
+        paused=paused,
     )
 
 
 class ReindexErrorRow(BaseModel):
-    """A failed port unit for the error modal; exactly one of cc_pair_id / user_id set,
-    name = connector name or user email."""
+    """A port unit needing attention (FAILED or PAUSED) for the modal; exactly one of
+    cc_pair_id / user_id set, name = connector name or user email. `paused` = Resume-able."""
 
     scope: PortScope
     cc_pair_id: int | None
     user_id: UUID | None
     name: str
     error_msg: str | None
+    paused: bool
 
 
 def get_reindex_error_rows(
     db_session: Session, search_settings_id: int
 ) -> list[ReindexErrorRow]:
-    """In-scope entities (both scopes) whose latest port attempt is FAILED, with name +
-    error_msg. Same scope/latest-per-entity as get_reindex_progress_counts's `failed`."""
+    """In-scope entities (both scopes) whose latest port attempt is FAILED (auto-retrying)
+    or PAUSED (awaiting operator Resume), with name + error_msg. Same scope/latest-per-entity
+    as get_reindex_progress_counts's `failed` + `paused` buckets."""
     cc_pair_ids, user_ids = _reindex_port_scope(db_session, search_settings_id)
 
     rows: list[ReindexErrorRow] = []
@@ -316,7 +322,7 @@ def get_reindex_error_rows(
                 PortAttempt.id.desc(),
             )
         ):
-            if status == PortAttemptStatus.FAILED:
+            if status in (PortAttemptStatus.FAILED, PortAttemptStatus.PAUSED):
                 rows.append(
                     ReindexErrorRow(
                         scope="connector",
@@ -324,6 +330,7 @@ def get_reindex_error_rows(
                         user_id=None,
                         name=name,
                         error_msg=error_msg,
+                        paused=status == PortAttemptStatus.PAUSED,
                     )
                 )
 
@@ -348,7 +355,7 @@ def get_reindex_error_rows(
                 PortAttempt.id.desc(),
             )
         ):
-            if status == PortAttemptStatus.FAILED:
+            if status in (PortAttemptStatus.FAILED, PortAttemptStatus.PAUSED):
                 rows.append(
                     ReindexErrorRow(
                         scope="user_file",
@@ -356,6 +363,7 @@ def get_reindex_error_rows(
                         user_id=user_id,
                         name=email,
                         error_msg=error_msg,
+                        paused=status == PortAttemptStatus.PAUSED,
                     )
                 )
 

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -22,6 +22,7 @@ from sqlalchemy import update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.configs.app_configs import MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE
 from onyx.db.connector_credential_pair import (
     fetch_indexable_standard_connector_credential_pair_ids,
 )
@@ -57,9 +58,11 @@ def _scope_where(
 # (none / active / FAILED) is still pending work.
 _SETTLED_STATUSES = frozenset({PortAttemptStatus.SUCCESS, PortAttemptStatus.CANCELED})
 
-# Reads enough recent attempts to reach the streak where retry backoff caps (9 at
-# the current 30s base / 1h cap); 10 = small margin. Raise if that cap is raised.
-_MAX_TRACKED_FAILED_RETRIES = 10
+# How many recent attempts the same-cursor streak query reads. Must cover BOTH consumers
+# of that streak: retry backoff (caps ~9 at the 30s base / 1h cap) and the auto-pause gate
+# (fires at MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE). Taking the max means a pause
+# threshold above the backoff window still fires -- a fixed 10 would silently never pause.
+_MAX_TRACKED_FAILED_RETRIES = max(10, MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE)
 
 
 def _get_locked(db_session: Session, port_attempt_id: int) -> PortAttempt:

--- a/backend/onyx/db/swap_index.py
+++ b/backend/onyx/db/swap_index.py
@@ -218,6 +218,9 @@ def _port_swap_ready(
     for cc_pair in required_cc_pairs:
         if get_active_port_attempt(db_session, cc_pair.id, ss_id) is not None:
             return False
+        # Only a SUCCESS clears the gate; PAUSED (awaiting operator Resume), FAILED, or a
+        # missing latest all block. A paused unit thus holds the swap until it's resumed
+        # and succeeds.
         latest_port = get_latest_port_attempt(db_session, cc_pair.id, ss_id)
         if latest_port is None or not latest_port.status.is_successful():
             return False

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -322,7 +322,7 @@ def get_reindex_progress(
     target = _active_port_settings(db_session)
     if target is None:
         return ReindexProgressCounts(
-            total=0, waiting=0, in_progress=0, completed=0, failed=0
+            total=0, waiting=0, in_progress=0, completed=0, failed=0, paused=0
         )
     return get_reindex_progress_counts(db_session, target.id)
 

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -1,10 +1,15 @@
+from uuid import UUID
+
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import status
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.background.celery.tasks.port.tasks import resume_paused_port_unit
+from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.app_configs import DISABLE_INDEX_UPDATE_ON_SWAP
 from onyx.context.search.models import SavedSearchSettings
 from onyx.context.search.models import SearchSettingsCreationRequest
@@ -53,6 +58,7 @@ from onyx.server.utils_vector_db import require_vector_db
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import ALT_INDEX_SUFFIX
 from shared_configs.configs import MULTI_TENANT
+from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter(prefix="/search-settings")
 logger = setup_logger()
@@ -329,6 +335,47 @@ def get_reindex_errors(
     if target is None:
         return []
     return get_reindex_error_rows(db_session, target.id)
+
+
+class PortActionRequest(BaseModel):
+    """Resume one paused port unit — exactly one scope set."""
+
+    cc_pair_id: int | None = None
+    user_id: UUID | None = None
+
+
+class PortActionResponse(BaseModel):
+    ok: bool
+
+
+@router.post("/reindex/port/resume")
+def resume_paused_port(
+    request: PortActionRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> PortActionResponse:
+    if (request.cc_pair_id is None) == (request.user_id is None):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Exactly one of cc_pair_id / user_id must be set.",
+        )
+    target = _active_port_settings(db_session)
+    if target is None:
+        raise OnyxError(OnyxErrorCode.CONFLICT, "No reindex port is currently active.")
+    resumed = resume_paused_port_unit(
+        client_app,
+        get_current_tenant_id(),
+        request.cc_pair_id,
+        request.user_id,
+        target.id,
+    )
+    if not resumed:
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "That unit is not paused (it may have already been resumed or is still "
+            "retrying).",
+        )
+    return PortActionResponse(ok=True)
 
 
 @router.get("/get-all-search-settings")

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
+from onyx.background.celery.tasks.port.tasks import PortResumeResult
 from onyx.background.celery.tasks.port.tasks import resume_paused_port_unit
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.app_configs import DISABLE_INDEX_UPDATE_ON_SWAP
@@ -362,18 +363,27 @@ def resume_paused_port(
     target = _active_port_settings(db_session)
     if target is None:
         raise OnyxError(OnyxErrorCode.CONFLICT, "No reindex port is currently active.")
-    resumed = resume_paused_port_unit(
+    result = resume_paused_port_unit(
         client_app,
         get_current_tenant_id(),
         request.cc_pair_id,
         request.user_id,
         target.id,
     )
-    if not resumed:
+    if result is PortResumeResult.NOT_PAUSED:
         raise OnyxError(
             OnyxErrorCode.CONFLICT,
             "That unit is not paused (it may have already been resumed or is still "
             "retrying).",
+        )
+    if result is PortResumeResult.DISPATCH_FAILED:
+        # The unit WAS resumed (a fresh attempt is committed), but the task broker was
+        # unavailable so it wasn't dispatched now. Don't report an immediate resume — the
+        # scheduler re-enqueues it within a few minutes.
+        raise OnyxError(
+            OnyxErrorCode.SERVICE_UNAVAILABLE,
+            "The unit was resumed but could not be dispatched right now (the task queue is "
+            "unavailable). It will start automatically within a few minutes.",
         )
     return PortActionResponse(ok=True)
 

--- a/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
+++ b/backend/tests/external_dependency_unit/db/test_port_swap_criterion.py
@@ -36,17 +36,21 @@ from onyx.db.models import Document as DbDocument
 from onyx.db.models import DocumentByConnectorCredentialPair
 from onyx.db.models import PortAttempt
 from onyx.db.models import SearchSettings
+from onyx.db.models import User
 from onyx.db.port_attempt import cancel_active_port_attempts
 from onyx.db.port_attempt import create_port_attempt
 from onyx.db.port_attempt import get_active_port_attempt
 from onyx.db.port_attempt import mark_port_canceled
+from onyx.db.port_attempt import mark_port_failed
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.port_attempt import pause_port_attempt
 from onyx.db.port_attempt import request_port_cancel
 from onyx.db.swap_index import _port_swap_ready
 from onyx.db.swap_index import _required_cc_pairs_for_switchover
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.kg.models import KGStage
+from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
 from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair_and_future
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
@@ -112,6 +116,63 @@ def test_port_swap_blocks_on_active_port(
     attempt = create_port_attempt(db_session, cc_pair.id, future_id)
     mark_port_in_progress(db_session, attempt.id)  # active, not terminal
     assert _port_swap_ready(db_session, future_ss, [cc_pair], []) is False
+
+
+def _pause_unit(db_session: Session, cc_pair_id: int, ss_id: int) -> None:
+    """Park a connector unit at PAUSED (FAILED -> PAUSED) for the swap-gate tests."""
+    attempt = create_port_attempt(db_session, cc_pair_id, ss_id)
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_failed(db_session, attempt.id, error_msg="durable")
+    assert pause_port_attempt(db_session, attempt.id) is True
+
+
+def test_port_swap_paused_connector_blocks_until_success(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A PAUSED connector port blocks the swap (only SUCCESS clears the gate); once the
+    operator Resumes and the fresh attempt SUCCEEDs, the swap unblocks. Guards that PAUSED
+    is not mistaken for a settled/successful state."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+
+    _pause_unit(db_session, cc_pair.id, future_id)
+    assert _port_swap_ready(db_session, future_ss, [cc_pair], []) is False
+
+    # a Resume mints a fresh attempt that eventually SUCCEEDs -> latest is SUCCESS -> ready
+    _make_success_port(db_session, cc_pair.id, future_id)
+    db_session.expire_all()
+    assert _port_swap_ready(db_session, future_ss, [cc_pair], []) is True
+
+
+def test_port_swap_paused_user_blocks(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A PAUSED user port blocks the swap via all_user_scopes_ported (PAUSED isn't settled).
+    Pure regression guard for the user branch."""
+    _cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    user = create_test_user(db_session, "port_paused_user")
+    try:
+        attempt = create_port_attempt(db_session, None, future_id, port_user_id=user.id)
+        mark_port_in_progress(db_session, attempt.id)
+        mark_port_failed(db_session, attempt.id, error_msg="durable")
+        assert pause_port_attempt(db_session, attempt.id) is True
+
+        # no required connectors; the single required user is PAUSED -> blocked
+        assert _port_swap_ready(db_session, future_ss, [], [user.id]) is False
+    finally:
+        db_session.rollback()
+        db_session.query(PortAttempt).filter(
+            PortAttempt.port_user_id == user.id
+        ).delete(synchronize_session="fetch")
+        db_session.commit()
+        # delete the user via the ORM object (a User.id column-equality delete trips ty)
+        fresh_user = db_session.get(User, user.id)
+        if fresh_user is not None:
+            db_session.delete(fresh_user)
+            db_session.commit()
 
 
 def test_port_swap_blocks_on_pending_sync_backlog(

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -40,6 +40,7 @@ from onyx.background.celery.tasks.shared.tasks import (
 )
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.app_configs import MAX_CONCURRENT_PORT_ATTEMPTS
+from onyx.configs.app_configs import MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.context.search.models import SavedSearchSettings
@@ -84,6 +85,7 @@ from onyx.db.port_attempt import mark_port_succeeded
 from onyx.db.port_attempt import pause_port_attempt
 from onyx.db.port_attempt import port_backfill_has_pending_work
 from onyx.db.port_attempt import request_port_cancel
+from onyx.db.port_attempt import resume_paused_port_attempt
 from onyx.db.port_orphan_candidate import cleanup_stale_port_orphan_candidates
 from onyx.db.port_orphan_candidate import clear_port_orphan_candidates
 from onyx.db.port_orphan_candidate import delete_port_orphan_candidates_by_id
@@ -1982,3 +1984,245 @@ def test_commit_port_cursor_stops_on_paused(
     assert row.status == PortAttemptStatus.PAUSED
     assert row.last_processed_doc_id == "portdoc-003"  # cursor not advanced
     assert row.docs_ported == 3
+
+
+def _paused_unit(
+    db_session: Session, cc_pair_id: int, future_id: int, cursor: str | None
+) -> int:
+    """A unit parked at PAUSED (one FAILED at `cursor`, then auto-paused). Returns the
+    paused attempt id."""
+    attempt = create_port_attempt(
+        db_session, cc_pair_id, future_id, resume_from_doc_id=cursor
+    )
+    mark_port_in_progress(db_session, attempt.id)
+    mark_port_failed(db_session, attempt.id, error_msg="durable")
+    assert pause_port_attempt(db_session, attempt.id) is True
+    return attempt.id
+
+
+def test_check_for_port_auto_pauses_after_threshold(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A unit stuck failing at the same cursor auto-pauses once it hits the consecutive-
+    failure threshold: the latest FAILED flips to PAUSED and no fresh attempt is created."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    for _ in range(MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE):
+        _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+
+    # patch out the (global) user scope so `result` reflects only this cc_pair
+    with patch.object(port_task, "fetch_port_scope_user_ids", lambda *_: []):
+        result, celery_app = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 0  # paused, not retried -> nothing created/enqueued
+    celery_app.send_task.assert_not_called()
+    db_session.expire_all()
+    latest = get_latest_port_attempt(db_session, cc_pair.id, future_id)
+    assert latest is not None and latest.status == PortAttemptStatus.PAUSED
+    assert (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .count()
+        == 0
+    )
+
+
+def test_check_for_port_does_not_pause_below_threshold(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """One short of the threshold, the unit still RETRIES (fresh attempt), not pauses."""
+    cc_pair, future_id = cc_pair_and_future
+    future_ss = db_session.get(SearchSettings, future_id)
+    assert future_ss is not None
+    future_ss.use_port_flow = True
+    db_session.commit()
+
+    for _ in range(MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE - 1):
+        _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+    # clear the retry backoff so the tick acts this pass
+    latest = get_latest_port_attempt(db_session, cc_pair.id, future_id)
+    assert latest is not None
+    latest.time_completed = datetime.now(timezone.utc) - timedelta(
+        seconds=port_task._PORT_RETRY_BACKOFF_MAX_S + 1
+    )
+    db_session.commit()
+
+    with patch.object(port_task, "fetch_port_scope_user_ids", lambda *_: []):
+        result, _ = _run_check_for_port(cc_pair, future_id)
+
+    assert result == 1  # retried, not paused
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.PAUSED,
+        )
+        .count()
+        == 0
+    )
+    assert (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .count()
+        == 1
+    )
+
+
+def test_resume_paused_port_attempt_from_cursor_and_streak_reset(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Resume mints a fresh NOT_STARTED at the paused cursor; the PAUSED row is a streak
+    barrier, so the resumed unit gets a fresh failure budget (streak 0, then 1 after a
+    single re-failure -- not threshold+1)."""
+    cc_pair, future_id = cc_pair_and_future
+    _paused_unit(db_session, cc_pair.id, future_id, "doc-5")
+
+    with patch(
+        "onyx.db.port_orphan_candidate.port_target_settings_id", lambda *_: future_id
+    ):
+        resumed = resume_paused_port_attempt(
+            db_session,
+            cc_pair_id=cc_pair.id,
+            port_user_id=None,
+            search_settings_id=future_id,
+        )
+    assert resumed is not None
+    assert resumed.status == PortAttemptStatus.NOT_STARTED
+    assert resumed.last_processed_doc_id == "doc-5"  # resumes from the paused cursor
+    assert (
+        count_consecutive_failed_port_attempts_no_progress(
+            db_session, cc_pair.id, future_id
+        )
+        == 0
+    )
+
+    mark_port_in_progress(db_session, resumed.id)
+    mark_port_failed(db_session, resumed.id, error_msg="again")
+    # one fresh failure -> streak 1 (the PAUSED history row broke the prior run)
+    assert (
+        count_consecutive_failed_port_attempts_no_progress(
+            db_session, cc_pair.id, future_id
+        )
+        == 1
+    )
+
+
+def test_resume_refuses_when_not_current_target(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Resume no-ops if the FUTURE was superseded/promoted out from under it (the target
+    re-check), so it can't resurrect a unit against stale settings."""
+    cc_pair, future_id = cc_pair_and_future
+    _paused_unit(db_session, cc_pair.id, future_id, "doc-2")
+
+    with patch(
+        "onyx.db.port_orphan_candidate.port_target_settings_id",
+        lambda *_: future_id + 9999,
+    ):
+        assert (
+            resume_paused_port_attempt(
+                db_session,
+                cc_pair_id=cc_pair.id,
+                port_user_id=None,
+                search_settings_id=future_id,
+            )
+            is None
+        )
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .count()
+        == 0
+    )
+
+
+def test_resume_noop_when_not_paused(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Resume only acts on a PAUSED latest: a FAILED (still auto-retrying) unit yields no
+    new attempt."""
+    cc_pair, future_id = cc_pair_and_future
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+
+    assert (
+        resume_paused_port_attempt(
+            db_session,
+            cc_pair_id=cc_pair.id,
+            port_user_id=None,
+            search_settings_id=future_id,
+        )
+        is None
+    )
+
+
+def test_resume_twice_only_mints_one_attempt(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A second Resume is a no-op: the first mints a NOT_STARTED (now the latest), so the
+    second sees a non-PAUSED latest and creates nothing. Guards against a double-click /
+    two-admin duplicate attempt."""
+    cc_pair, future_id = cc_pair_and_future
+    _paused_unit(db_session, cc_pair.id, future_id, "doc-3")
+
+    with patch(
+        "onyx.db.port_orphan_candidate.port_target_settings_id", lambda *_: future_id
+    ):
+        first = resume_paused_port_attempt(
+            db_session,
+            cc_pair_id=cc_pair.id,
+            port_user_id=None,
+            search_settings_id=future_id,
+        )
+        assert first is not None
+        second = resume_paused_port_attempt(
+            db_session,
+            cc_pair_id=cc_pair.id,
+            port_user_id=None,
+            search_settings_id=future_id,
+        )
+    assert second is None
+    db_session.expire_all()
+    assert (
+        db_session.query(PortAttempt)
+        .filter(
+            PortAttempt.cc_pair_id == cc_pair.id,
+            PortAttempt.status == PortAttemptStatus.NOT_STARTED,
+        )
+        .count()
+        == 1
+    )
+
+
+def test_mark_terminal_refuses_paused_attempt(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A wedged worker that un-wedges after its attempt was auto-paused can't drive it
+    terminal: mark_port_succeeded / mark_port_failed no-op on a PAUSED (resting) row, so it
+    stays PAUSED and keeps blocking the swap until an operator Resume."""
+    cc_pair, future_id = cc_pair_and_future
+    paused_id = _paused_unit(db_session, cc_pair.id, future_id, "doc-7")
+
+    mark_port_succeeded(db_session, paused_id)  # wedged worker's late success
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, paused_id)
+    assert row is not None and row.status == PortAttemptStatus.PAUSED
+
+    mark_port_failed(db_session, paused_id, error_msg="late stall")
+    db_session.expire_all()
+    row = db_session.get(PortAttempt, paused_id)
+    assert row is not None and row.status == PortAttemptStatus.PAUSED

--- a/backend/tests/external_dependency_unit/db/test_reindex_port.py
+++ b/backend/tests/external_dependency_unit/db/test_reindex_port.py
@@ -2226,3 +2226,100 @@ def test_mark_terminal_refuses_paused_attempt(
     db_session.expire_all()
     row = db_session.get(PortAttempt, paused_id)
     assert row is not None and row.status == PortAttemptStatus.PAUSED
+
+
+def test_resume_paused_port_unit_dispatches_and_reports_resumed(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """The happy path: the orchestrator mints a fresh NOT_STARTED at the cursor, enqueues
+    it, and reports RESUMED."""
+    cc_pair, future_id = cc_pair_and_future
+    _paused_unit(db_session, cc_pair.id, future_id, "doc-4")
+
+    celery_app = MagicMock()
+    with patch(
+        "onyx.db.port_orphan_candidate.port_target_settings_id", lambda *_: future_id
+    ):
+        result = port_task.resume_paused_port_unit(
+            celery_app, get_current_tenant_id(), cc_pair.id, None, future_id
+        )
+
+    assert result is port_task.PortResumeResult.RESUMED
+    celery_app.send_task.assert_called_once()
+    db_session.expire_all()
+    latest = get_latest_port_attempt(db_session, cc_pair.id, future_id)
+    assert latest is not None
+    assert latest.status == PortAttemptStatus.NOT_STARTED
+    assert latest.last_processed_doc_id == "doc-4"
+
+
+def test_resume_paused_port_unit_reports_dispatch_failure(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """A broker enqueue failure is surfaced as DISPATCH_FAILED (not masked as success), so
+    the endpoint doesn't tell the operator a wedged unit resumed immediately. The minted
+    NOT_STARTED stays for the scheduler to re-enqueue within a TTL -- the resume isn't lost."""
+    cc_pair, future_id = cc_pair_and_future
+    _paused_unit(db_session, cc_pair.id, future_id, "doc-4")
+
+    celery_app = MagicMock()
+    celery_app.send_task.side_effect = RuntimeError("broker down")
+    with patch(
+        "onyx.db.port_orphan_candidate.port_target_settings_id", lambda *_: future_id
+    ):
+        result = port_task.resume_paused_port_unit(
+            celery_app, get_current_tenant_id(), cc_pair.id, None, future_id
+        )
+
+    assert result is port_task.PortResumeResult.DISPATCH_FAILED
+    db_session.expire_all()
+    latest = get_latest_port_attempt(db_session, cc_pair.id, future_id)
+    assert latest is not None
+    assert (
+        latest.status == PortAttemptStatus.NOT_STARTED
+    )  # committed; self-heals via TTL
+
+
+def test_resume_paused_port_unit_not_paused(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """Nothing to resume (latest is FAILED, not PAUSED) -> NOT_PAUSED, no enqueue."""
+    cc_pair, future_id = cc_pair_and_future
+    _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+
+    celery_app = MagicMock()
+    with patch(
+        "onyx.db.port_orphan_candidate.port_target_settings_id", lambda *_: future_id
+    ):
+        result = port_task.resume_paused_port_unit(
+            celery_app, get_current_tenant_id(), cc_pair.id, None, future_id
+        )
+
+    assert result is port_task.PortResumeResult.NOT_PAUSED
+    celery_app.send_task.assert_not_called()
+
+
+def test_tracked_retries_covers_pause_threshold() -> None:
+    """The streak history the pause gate reads must cover the configured pause threshold,
+    else a threshold above the old fixed cap (10) would silently never fire."""
+    assert (
+        port_attempt_db._MAX_TRACKED_FAILED_RETRIES
+        >= MAX_CONSECUTIVE_PORT_FAILURES_BEFORE_PAUSE
+    )
+
+
+def test_streak_counts_beyond_default_cap_when_limit_allows(
+    db_session: Session, cc_pair_and_future: tuple[ConnectorCredentialPair, int]
+) -> None:
+    """The same-cursor streak can exceed the default backoff window (10) when the tracked-
+    history limit covers it -- so a pause threshold > 10 actually reaches its trigger."""
+    cc_pair, future_id = cc_pair_and_future
+    with patch.object(port_attempt_db, "_MAX_TRACKED_FAILED_RETRIES", 12):
+        for _ in range(12):
+            _fail_port_at(db_session, cc_pair.id, future_id, "doc-1")
+        assert (
+            count_consecutive_failed_port_attempts_no_progress(
+                db_session, cc_pair.id, future_id
+            )
+            == 12
+        )

--- a/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
+++ b/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
@@ -29,6 +29,7 @@ from onyx.db.port_attempt import mark_port_canceled
 from onyx.db.port_attempt import mark_port_failed
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.port_attempt import pause_port_attempt
 from onyx.db.user_file import clear_user_file_reconcile_pending
 from onyx.db.user_file import count_user_files_reconcile_pending
 from onyx.db.user_file import fetch_port_scope_user_ids
@@ -315,6 +316,12 @@ def test_reindex_progress_counts_and_errors_both_scopes(
         mark_port_canceled(
             db_session, create_port_attempt(db_session, cc_canceled.id, ss.id).id
         )
+        cc_paused = make_cc_pair(db_session)  # auto-paused -> paused bucket
+        cc_paused_attempt = create_port_attempt(db_session, cc_paused.id, ss.id)
+        mark_port_failed(
+            db_session, cc_paused_attempt.id, error_msg="connector paused boom"
+        )
+        assert pause_port_attempt(db_session, cc_paused_attempt.id) is True
         cc_pairs = [
             cc_waiting,
             cc_no_attempt,
@@ -322,6 +329,7 @@ def test_reindex_progress_counts_and_errors_both_scopes(
             cc_completed,
             cc_failed,
             cc_canceled,
+            cc_paused,
         ]
 
         # Users (per-user scope; a COMPLETED file puts the user in scope).
@@ -342,36 +350,56 @@ def test_reindex_progress_counts_and_errors_both_scopes(
         )
         u_waiting = create_test_user(db_session, "reindexprog")
         _make_user_file(db_session, u_waiting.id)  # no attempt -> waiting
-        users = [u_completed, u_failed, u_waiting]
+        u_paused = create_test_user(db_session, "reindexprog")
+        _make_user_file(db_session, u_paused.id)
+        u_paused_attempt = create_port_attempt(
+            db_session, None, ss.id, port_user_id=u_paused.id
+        )
+        mark_port_failed(db_session, u_paused_attempt.id, error_msg="user paused boom")
+        assert pause_port_attempt(db_session, u_paused_attempt.id) is True
+        users = [u_completed, u_failed, u_waiting, u_paused]
 
         counts = get_reindex_progress_counts(db_session, ss.id)
         # Exact: only this fresh FUTURE's attempts contribute to these buckets.
         assert counts.in_progress == 1
         assert counts.completed == 2
         assert counts.failed == 2
+        assert counts.paused == 2
         assert (
-            counts.waiting + counts.in_progress + counts.completed + counts.failed
+            counts.waiting
+            + counts.in_progress
+            + counts.completed
+            + counts.failed
+            + counts.paused
             == counts.total
         )
-        assert counts.total >= 9
+        assert counts.total >= 11
         assert counts.waiting >= 4
 
         rows = get_reindex_error_rows(db_session, ss.id)
         by_key = {(r.scope, r.name): r for r in rows}
 
-        assert ("connector", cc_failed.name) in by_key
+        # FAILED rows: paused=False
         conn_row = by_key[("connector", cc_failed.name)]
         assert conn_row.cc_pair_id == cc_failed.id
         assert conn_row.user_id is None
         assert conn_row.error_msg == "connector boom"
+        assert conn_row.paused is False
 
-        assert ("user_file", u_failed.email) in by_key
         user_row = by_key[("user_file", u_failed.email)]
         assert user_row.user_id == u_failed.id
         assert user_row.cc_pair_id is None
         assert user_row.error_msg == "user boom"
+        assert user_row.paused is False
 
-        assert len(rows) == counts.failed == 2
+        # PAUSED rows: paused=True, error_msg kept
+        conn_paused_row = by_key[("connector", cc_paused.name)]
+        assert conn_paused_row.paused is True
+        assert conn_paused_row.error_msg == "connector paused boom"
+        user_paused_row = by_key[("user_file", u_paused.email)]
+        assert user_paused_row.paused is True
+
+        assert len(rows) == counts.failed + counts.paused == 4
     finally:
         db_session.rollback()
         db_session.query(SearchSettings).filter(SearchSettings.id == ss.id).delete(

--- a/web/src/lib/indexing/interfaces.ts
+++ b/web/src/lib/indexing/interfaces.ts
@@ -174,6 +174,7 @@ export interface ReindexProgress {
   in_progress: number;
   completed: number;
   failed: number;
+  paused: number;
 }
 
 /** Mirrors backend `ReindexErrorRow`; exactly one of cc_pair_id / user_id set. */
@@ -183,4 +184,5 @@ export interface ReindexErrorRow {
   user_id: string | null;
   name: string;
   error_msg: string | null;
+  paused: boolean;
 }

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -3,6 +3,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   EmbeddingModel,
   EmbeddingProviderName,
+  ReindexErrorRow,
   SavedSearchSettings,
   SwitchoverType,
 } from "@/lib/indexing/interfaces";
@@ -144,6 +145,33 @@ export async function cancelNewEmbedding(): Promise<Response> {
   return await fetch("/api/search-settings/cancel-new-embedding", {
     method: "POST",
   });
+}
+
+/**
+ * Resume a paused re-index unit from its cursor. Throws on a hard failure; a 503
+ * (resumed but the queue is down) is treated as success — the scheduler re-dispatches it.
+ */
+export async function resumePausedPort(
+  row: Pick<ReindexErrorRow, "cc_pair_id" | "user_id">
+): Promise<void> {
+  const response = await fetch("/api/search-settings/reindex/port/resume", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ cc_pair_id: row.cc_pair_id, user_id: row.user_id }),
+  });
+  if (response.status === 503) {
+    return;
+  }
+  if (!response.ok) {
+    let detail: string | undefined;
+    try {
+      detail = ((await response.json()) as { detail?: string }).detail;
+    } catch (e) {
+      // non-JSON error body (e.g. a 502 HTML page): log so the failure is traceable
+      console.error(`resumePausedPort failed (${response.status}):`, e);
+    }
+    throw new Error(detail ?? "Failed to resume the paused unit.");
+  }
 }
 
 interface SetNewSearchSettingsArgs {

--- a/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
@@ -149,9 +149,9 @@ export default function ReindexErrorsModal({
               Nothing needs attention.
             </Text>
           ) : (
-            // Modal.Body aligns children to the start; w-full stops the table
-            // shrinking to content and left-packing.
             <div className="w-full">
+              {/* Modal.Body aligns children to the start; w-full stops the
+                  table shrinking to content and left-packing. */}
               <Table
                 data={rows}
                 columns={COLUMNS}

--- a/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
@@ -1,31 +1,119 @@
+import { useState } from "react";
+import { mutate } from "swr";
 import Modal from "@/refresh-components/Modal";
-import { Table, createTableColumns, Text } from "@opal/components";
-import { SvgAlertCircle } from "@opal/icons";
+import { Button, createTableColumns, Table, Tag, Text } from "@opal/components";
+import { SvgAlertCircle, SvgPauseCircle, SvgPlayCircle } from "@opal/icons";
 import { useReindexErrors } from "@/lib/indexing/hooks";
+import { resumePausedPort } from "@/lib/indexing/svc";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import type { ReindexErrorRow } from "@/lib/indexing/interfaces";
+
+function ResumeButton({ row }: { row: ReindexErrorRow }) {
+  const [busy, setBusy] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  async function onResume() {
+    setBusy(true);
+    setErrorMsg(null);
+    try {
+      await resumePausedPort(row);
+    } catch (e) {
+      console.error("Failed to resume paused port unit:", e);
+      setErrorMsg(e instanceof Error ? e.message : "Failed to resume.");
+      setBusy(false);
+      return;
+    }
+    // Resumed (a 503 just means it starts within minutes): the unit is no longer
+    // paused/failed, so it drops off the list on refetch. Re-enable in case the
+    // refetch itself fails, so the button never stays stuck on "Resuming…".
+    setBusy(false);
+    void Promise.all([
+      mutate(SWR_KEYS.reindexProgress),
+      mutate(SWR_KEYS.reindexErrors),
+    ]);
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        variant="action"
+        prominence="secondary"
+        size="sm"
+        icon={SvgPlayCircle}
+        disabled={busy}
+        onClick={onResume}
+      >
+        {busy ? "Resuming…" : "Resume"}
+      </Button>
+      {errorMsg && (
+        <Text font="secondary-body" color="status-error-05">
+          {errorMsg}
+        </Text>
+      )}
+    </div>
+  );
+}
 
 const tc = createTableColumns<ReindexErrorRow>();
 const COLUMNS = [
   tc.column("scope", {
     header: "Type",
-    weight: 15,
-    cell: (value) => (value === "connector" ? "Connector" : "User Files"),
+    weight: 12,
+    cell: (value) => (
+      <Text font="secondary-body" color="text-04">
+        {value === "connector" ? "Connector" : "User Files"}
+      </Text>
+    ),
   }),
-  tc.column("name", { header: "Name", weight: 25 }),
+  tc.column("name", {
+    header: "Name",
+    weight: 22,
+    cell: (value) => (
+      <Text font="secondary-body" color="text-04">
+        {value}
+      </Text>
+    ),
+  }),
   tc.displayColumn({
     id: "entity_id",
     header: "ID",
-    width: { weight: 15 },
-    cell: (row) => row.cc_pair_id ?? row.user_id ?? "—",
+    width: { weight: 12 },
+    cell: (row) => (
+      <Text font="secondary-body" color="text-03" nowrap>
+        {row.cc_pair_id != null
+          ? String(row.cc_pair_id)
+          : row.user_id
+            ? row.user_id.slice(0, 8)
+            : "—"}
+      </Text>
+    ),
+  }),
+  tc.displayColumn({
+    id: "status",
+    header: "Status",
+    width: { weight: 12 },
+    cell: (row) =>
+      row.paused ? (
+        <Tag color="amber" icon={SvgPauseCircle} title="Paused" />
+      ) : (
+        <Tag color="red" icon={SvgAlertCircle} title="Failed" />
+      ),
   }),
   tc.column("error_msg", {
     header: "Error",
-    weight: 45,
+    weight: 30,
+    enableSorting: false,
     cell: (value) => (
       <Text font="secondary-body" color="text-03">
         {value ?? "Unknown error"}
       </Text>
     ),
+  }),
+  tc.displayColumn({
+    id: "actions",
+    header: "",
+    width: { weight: 12 },
+    cell: (row) => (row.paused ? <ResumeButton row={row} /> : null),
   }),
 ];
 
@@ -36,15 +124,15 @@ interface ReindexErrorsModalProps {
 export default function ReindexErrorsModal({
   onClose,
 }: ReindexErrorsModalProps) {
-  const { data: errors, isLoading, error } = useReindexErrors(true);
+  const { data: rows, isLoading, error } = useReindexErrors(true);
 
   return (
     <Modal open onOpenChange={onClose}>
-      <Modal.Content width="lg" height="sm">
+      <Modal.Content width="xl" height="sm">
         <Modal.Header
           icon={SvgAlertCircle}
-          title="Re-index Errors"
-          description="Connectors and user files whose latest re-index attempt failed."
+          title="Re-index Attention"
+          description="Connectors and user files whose latest re-index attempt failed (auto-retrying) or was paused (Resume to retry)."
           onClose={onClose}
         />
         <Modal.Body>
@@ -54,20 +142,24 @@ export default function ReindexErrorsModal({
             </Text>
           ) : error ? (
             <Text as="p" color="status-error-05">
-              Couldn&apos;t load re-index errors. Please try again.
+              Couldn&apos;t load re-index status. Please try again.
             </Text>
-          ) : !errors || errors.length === 0 ? (
+          ) : !rows || rows.length === 0 ? (
             <Text as="p" color="text-03">
-              No re-index errors.
+              Nothing needs attention.
             </Text>
           ) : (
-            <Table
-              data={errors}
-              columns={COLUMNS}
-              getRowId={(row) =>
-                `${row.scope}-${row.cc_pair_id ?? row.user_id}`
-              }
-            />
+            // Modal.Body aligns children to the start; w-full stops the table
+            // shrinking to content and left-packing.
+            <div className="w-full">
+              <Table
+                data={rows}
+                columns={COLUMNS}
+                getRowId={(row) =>
+                  `${row.scope}-${row.cc_pair_id ?? row.user_id}`
+                }
+              />
+            </div>
           )}
         </Modal.Body>
       </Modal.Content>

--- a/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
@@ -10,6 +10,7 @@ import {
   SvgClock,
   SvgExpand,
   SvgLoader,
+  SvgPauseCircle,
 } from "@opal/icons";
 import ReindexErrorsModal from "@/views/admin/IndexSettingsPage/ReindexErrorsModal";
 import { useReindexProgress } from "@/lib/indexing/hooks";
@@ -19,7 +20,14 @@ interface ReindexProgressBannerProps {
   onCancel: () => void;
 }
 
-const ZERO = { total: 0, waiting: 0, in_progress: 0, completed: 0, failed: 0 };
+const ZERO = {
+  total: 0,
+  waiting: 0,
+  in_progress: 0,
+  completed: 0,
+  failed: 0,
+  paused: 0,
+};
 
 // Stable identity so the spinner doesn't remount (and restart at 0°) each poll.
 const SpinningLoader: IconFunctionComponent = (props) => (
@@ -32,7 +40,8 @@ export default function ReindexProgressBanner({
 }: ReindexProgressBannerProps) {
   const [errorsOpen, setErrorsOpen] = useState(false);
   const { data } = useReindexProgress({ pollIntervalMs: 5000 });
-  const { total, waiting, in_progress, completed, failed } = data ?? ZERO;
+  const { total, waiting, in_progress, completed, failed, paused } =
+    data ?? ZERO;
 
   const description = markdown(
     `New embedding settings${
@@ -61,7 +70,7 @@ export default function ReindexProgressBanner({
                   <Tag color="purple" icon={SvgClock} title={String(waiting)} />
                   <Tag
                     color="blue"
-                    icon={SpinningLoader}
+                    icon={in_progress > 0 ? SpinningLoader : SvgLoader}
                     title={String(in_progress)}
                   />
                   <Tag
@@ -74,14 +83,19 @@ export default function ReindexProgressBanner({
                     icon={SvgAlertCircle}
                     title={String(failed)}
                   />
-                  {failed > 0 && (
+                  <Tag
+                    color="amber"
+                    icon={SvgPauseCircle}
+                    title={String(paused)}
+                  />
+                  {(failed > 0 || paused > 0) && (
                     <Button
                       icon={SvgExpand}
-                      variant="danger"
+                      variant={failed > 0 ? "danger" : "default"}
                       prominence="tertiary"
                       size="sm"
-                      tooltip="View re-index errors"
-                      aria-label="View re-index errors"
+                      tooltip="View units needing attention"
+                      aria-label="View units needing attention"
                       onClick={() => setErrorsOpen(true)}
                     />
                   )}

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -81,6 +81,7 @@ import {
   useConfiguredEmbeddingProviders,
   useCurrentEmbeddingModel,
   useCurrentSearchSettings,
+  useReindexProgress,
   useSecondarySearchSettings,
 } from "@/lib/indexing/hooks";
 import { useLlmDefaults } from "@/lib/languageModels/hooks";
@@ -631,7 +632,15 @@ export default function IndexSettingsPage() {
     settings.image_extraction_and_analysis_enabled ?? false;
 
   const { data: secondarySearchSettings } = useSecondarySearchSettings();
-  const isReindexing = !!secondarySearchSettings;
+  // INSTANT switchover swaps immediately — no secondary settings — and backfills on the
+  // current index. The reindex-progress endpoint still reports that active port target,
+  // so treat it as reindexing too; otherwise the banner never shows for INSTANT.
+  const { data: reindexProgress } = useReindexProgress({
+    pollIntervalMs: 5000,
+  });
+  const isPortBackfilling =
+    !secondarySearchSettings && (reindexProgress?.total ?? 0) > 0;
+  const isReindexing = !!secondarySearchSettings || isPortBackfilling;
 
   // When a migration finishes, the fast poll on the current settings stops in
   // the same render — revalidate once so the new model shows as current.
@@ -940,10 +949,15 @@ export default function IndexSettingsPage() {
                   </customModelModal.Provider>
 
                   {isReindexing ? (
-                    secondarySearchSettings?.use_port_flow ? (
-                      // Port-flow reindex → the new per-connector/user progress banner.
+                    secondarySearchSettings?.use_port_flow ||
+                    isPortBackfilling ? (
+                      // Port-flow reindex, or an INSTANT-switchover backfill (already
+                      // swapped, no secondary) → the per-connector/user progress banner.
                       <ReindexProgressBanner
-                        secondaryModelName={secondarySearchSettings?.model_name}
+                        secondaryModelName={
+                          secondarySearchSettings?.model_name ??
+                          searchSettings?.model_name
+                        }
                         onCancel={() => cancelReindexModal.toggle(true)}
                       />
                     ) : (


### PR DESCRIPTION
## Description

- Auto-pause a connector/user port unit after 5 consecutive same-cursor failures, so a durably-broken unit stops burning embedding spend on endless retries and surfaces to the operator instead
- Add an operator **Resume** endpoint that retries a paused unit from its saved cursor; a paused unit holds the reindex swap until it's resumed and succeeds (no silent skip)
- Harden the terminal-write guard so a wedged/stalled worker can't revive a paused unit to SUCCESS and unblock the swap without operator action

## How Has This Been Tested?

External-dependency unit tests: auto-pause at/below threshold, resume-from-cursor + streak reset, resume no-op races, the wedged-worker guard, and paused-blocks-swap (connector + user scope).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-pauses reindex port units (connector or user) after 5 same-cursor failures and adds an admin Resume to restart from the saved cursor. Paused units block the swap until they are resumed and succeed; the admin UI now shows paused vs failed and lets you Resume.

- **New Features**
  - Auto-pause after 5 consecutive same-cursor failures (configurable; works above the backoff cap), evaluated before the concurrency cap.
  - Admin endpoint POST `/search-settings/reindex/port/resume` to resume one paused unit (set exactly one of `cc_pair_id` or `user_id`). Progress includes a “paused” bucket; the Errors modal shows paused/failed items with a Resume button. The banner shows a paused count and supports INSTANT-switchover backfills.

- **Bug Fixes**
  - Swap gate requires SUCCESS; PAUSED, FAILED, or missing latest all block. Terminal writes to a PAUSED attempt are ignored (no silent unblocks).
  - Resume is race-safe and returns 503 if dispatching the fresh attempt fails; the attempt is still committed and will auto-start via the scheduler. Fixed a DetachedInstanceError when indexing user files to the secondary index by re-binding `SearchSettings` before use.

<sup>Written for commit 47dc2a7df1ca6f04769b6088beab5c0c98a5d73d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



