### PR TITLE
feat(opal): add Formik form field layer

### DIFF
--- a/web/lib/opal/src/components/form/CheckboxField.tsx
+++ b/web/lib/opal/src/components/form/CheckboxField.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useField } from "formik";
+import { Checkbox, type CheckboxProps } from "@opal/components";
+import { useOnChangeValue } from "./hooks";
+
+export interface CheckboxFieldProps extends Omit<CheckboxProps, "checked"> {
+  name: string;
+}
+
+export function CheckboxField({
+  name,
+  onCheckedChange,
+  ...props
+}: CheckboxFieldProps) {
+  const [field] = useField<boolean>({ name, type: "checkbox" });
+  const onChange = useOnChangeValue(name, onCheckedChange);
+
+  return (
+    <Checkbox checked={field.value} onCheckedChange={onChange} {...props} />
+  );
+}

--- a/web/lib/opal/src/components/form/FieldContext.tsx
+++ b/web/lib/opal/src/components/form/FieldContext.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { createContext, useContext } from "react";
+import { FieldContextType } from "./types";
+
+export const FieldContext = createContext<FieldContextType | undefined>(
+  undefined
+);
+
+export const useFieldContext = () => {
+  const context = useContext(FieldContext);
+  if (context === undefined) {
+    throw new Error(
+      "useFieldContext must be used within a FieldContext.Provider"
+    );
+  }
+  return context;
+};

--- a/web/lib/opal/src/components/form/FieldMessage.tsx
+++ b/web/lib/opal/src/components/form/FieldMessage.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import React from "react";
+import { cn } from "@opal/utils";
+import type { RichStr } from "@opal/types";
+import { Text } from "@opal/components";
+import {
+  SvgAlertCircle,
+  SvgCheckCircle,
+  SvgLoader,
+  SvgXOctagon,
+} from "@opal/icons";
+
+type MessageVariant =
+  | "error"
+  | "success"
+  | "loading"
+  | "warning"
+  | "info"
+  | "idle";
+
+const iconMap: Record<MessageVariant, React.ReactNode> = {
+  error: <SvgXOctagon className="h-3 w-3 stroke-status-error-05" />,
+  success: <SvgCheckCircle className="h-3 w-3 stroke-status-success-05" />,
+  loading: <SvgLoader className="h-3 w-3 stroke-text-02 animate-spin" />,
+  warning: <SvgAlertCircle className="h-3 w-3 stroke-status-warning-05" />,
+  info: <SvgAlertCircle className="h-3 w-3 stroke-text-03" />,
+  idle: null,
+};
+
+interface FieldMessageRootProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant: MessageVariant;
+  children: React.ReactNode;
+}
+
+function FieldMessageRoot({
+  variant,
+  className,
+  children,
+  ...props
+}: FieldMessageRootProps) {
+  const icon = iconMap[variant];
+
+  return (
+    <div
+      className={cn("flex flex-row items-center gap-x-0.5", className)}
+      {...props}
+    >
+      {icon !== null && (
+        <div className="w-4 h-4 flex items-center justify-center">{icon}</div>
+      )}
+      {children}
+    </div>
+  );
+}
+
+interface FieldMessageContentProps {
+  id?: string;
+  children: string | RichStr;
+}
+
+function FieldMessageContent({ id, children }: FieldMessageContentProps) {
+  return (
+    <Text as="p" id={id} color="text-03" font="secondary-body">
+      {children}
+    </Text>
+  );
+}
+
+export const FieldMessage = Object.assign(FieldMessageRoot, {
+  Content: FieldMessageContent,
+});

--- a/web/lib/opal/src/components/form/Form.stories.tsx
+++ b/web/lib/opal/src/components/form/Form.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Formik, Form } from "formik";
+import {
+  FormField,
+  FormikField,
+  InputTypeIn,
+  InputTypeInField,
+  CheckboxField,
+  LabeledCheckboxField,
+  SwitchField,
+} from "@opal/components";
+
+const meta: Meta = {
+  title: "opal/components/Form",
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj;
+
+// Presentational FormField, driven directly by the `state` prop with no Formik.
+function FieldPreview({ state }: { state: "idle" | "success" | "error" }) {
+  return (
+    <FormField state={state} required className="w-80">
+      <FormField.Label required>Email</FormField.Label>
+      <FormField.Description>
+        {"We only use this to send account notifications."}
+      </FormField.Description>
+      <FormField.Control>
+        <InputTypeIn
+          placeholder="you@example.com"
+          value={state === "idle" ? "" : "ada@onyx.app"}
+          onChange={() => {}}
+        />
+      </FormField.Control>
+      <FormField.Message
+        messages={{
+          error: "Enter a valid email address.",
+          success: "Looks good.",
+          idle: "",
+        }}
+      />
+    </FormField>
+  );
+}
+
+export const Idle: Story = {
+  render: () => <FieldPreview state="idle" />,
+};
+
+export const Error: Story = {
+  render: () => <FieldPreview state="error" />,
+};
+
+export const Success: Story = {
+  render: () => <FieldPreview state="success" />,
+};
+
+// Full Formik integration. FormikField wires validation state into FormField,
+// and InputTypeInField binds the input to formik. Blur the field to validate.
+export const FormikIntegration: Story = {
+  render: () => (
+    <Formik
+      initialValues={{ email: "" }}
+      validate={(values) =>
+        values.email.includes("@") ? {} : { email: "Enter a valid email." }
+      }
+      onSubmit={() => {}}
+    >
+      <Form className="w-80">
+        <FormikField
+          name="email"
+          render={(_field, _helper, meta, state) => (
+            <FormField state={state} required>
+              <FormField.Label required>Email</FormField.Label>
+              <FormField.Control>
+                <InputTypeInField name="email" placeholder="you@example.com" />
+              </FormField.Control>
+              <FormField.Message
+                messages={{ error: meta.error ?? "", idle: "" }}
+              />
+            </FormField>
+          )}
+        />
+      </Form>
+    </Formik>
+  ),
+};
+
+export const Toggles: Story = {
+  render: () => (
+    <Formik
+      initialValues={{ terms: false, notify: true, beta: false }}
+      onSubmit={() => {}}
+    >
+      <Form className="flex flex-col gap-y-4 w-80">
+        <div className="flex items-center gap-x-2">
+          <CheckboxField name="terms" />
+          <span className="font-secondary-body text-text-04">
+            {"I accept the terms"}
+          </span>
+        </div>
+        <LabeledCheckboxField
+          name="notify"
+          label="Email notifications"
+          sublabel="Get notified when a document changes."
+        />
+        <div className="flex items-center justify-between">
+          <span className="font-main-ui-action text-text-04">
+            {"Enable beta features"}
+          </span>
+          <SwitchField name="beta" />
+        </div>
+      </Form>
+    </Formik>
+  ),
+};

--- a/web/lib/opal/src/components/form/FormField.tsx
+++ b/web/lib/opal/src/components/form/FormField.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import React, { useId, useMemo } from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cn } from "@opal/utils";
+import { Text } from "@opal/components";
+import { FieldContext, useFieldContext } from "./FieldContext";
+import { FieldMessage } from "./FieldMessage";
+import {
+  ControlProps,
+  DescriptionProps,
+  FieldContextType,
+  FormFieldRootProps,
+  LabelProps,
+  MessageProps,
+  APIMessageProps,
+} from "./types";
+
+export function FormFieldRoot({
+  id,
+  name,
+  state = "idle",
+  required,
+  className,
+  children,
+  ...props
+}: FormFieldRootProps) {
+  const reactId = useId();
+  const baseId = id ?? `field_${reactId}`;
+
+  const describedByIds = useMemo(
+    () => [`${baseId}-desc`, `${baseId}-msg`, `${baseId}-api-msg`],
+    [baseId]
+  );
+
+  const contextValue: FieldContextType = {
+    baseId,
+    name,
+    required,
+    state,
+    describedByIds,
+  };
+
+  return (
+    <FieldContext.Provider value={contextValue}>
+      <div
+        id={baseId}
+        className={cn("flex flex-col gap-y-1", className)}
+        {...props}
+      >
+        {children}
+      </div>
+    </FieldContext.Provider>
+  );
+}
+
+export function FormFieldLabel({
+  leftIcon,
+  rightIcon,
+  optional,
+  required,
+  rightAction,
+  className,
+  children,
+  ...props
+}: LabelProps) {
+  const { baseId } = useFieldContext();
+  return (
+    <label
+      id={`${baseId}-label`}
+      htmlFor={`${baseId}-control`}
+      className={cn(
+        "ml-0.5 text-text-04 font-main-ui-action flex flex-row items-center gap-1",
+        className
+      )}
+      {...props}
+    >
+      {leftIcon && <span className="flex items-center">{leftIcon}</span>}
+      {children}
+      {required ? (
+        <Text as="p" color="text-03" font="main-ui-muted">
+          {"(Required)"}
+        </Text>
+      ) : optional ? (
+        <Text as="p" color="text-03" font="main-ui-muted">
+          {"(Optional)"}
+        </Text>
+      ) : null}
+      {rightIcon && <span className="flex items-center">{rightIcon}</span>}
+      {rightAction && (
+        <span className="ml-auto flex items-center">{rightAction}</span>
+      )}
+    </label>
+  );
+}
+
+export function FormFieldControl({ asChild, children }: ControlProps) {
+  const { baseId, state, describedByIds, required } = useFieldContext();
+
+  const ariaAttributes = {
+    id: `${baseId}-control`,
+    "aria-invalid": state === "error",
+    "aria-describedby": describedByIds?.join(" "),
+    "aria-required": required,
+  };
+
+  if (asChild) {
+    return <Slot {...ariaAttributes}>{children}</Slot>;
+  }
+
+  if (React.isValidElement(children)) {
+    // Child props win, matching the asChild Slot branch: a child's own id
+    // takes precedence over the injected control id.
+    return React.cloneElement(children, {
+      ...ariaAttributes,
+      ...(children.props as any),
+    });
+  }
+
+  return <>{children}</>;
+}
+
+export function FormFieldDescription({ id, children }: DescriptionProps) {
+  const { baseId } = useFieldContext();
+  if (!children) return null;
+  return (
+    <Text
+      as="p"
+      id={id ?? `${baseId}-desc`}
+      color="text-03"
+      font="secondary-body"
+    >
+      {children}
+    </Text>
+  );
+}
+
+export function FormFieldMessage({ className, messages }: MessageProps) {
+  const { baseId, state } = useFieldContext();
+  let tempState = state;
+  let content = messages?.[tempState];
+  // Success with no explicit message falls back to the idle message.
+  if (tempState === "success" && !content) {
+    tempState = "idle";
+    content = messages?.idle;
+  }
+  return content ? (
+    <FieldMessage variant={tempState} className={className}>
+      <FieldMessage.Content id={`${baseId}-msg`}>
+        {content}
+      </FieldMessage.Content>
+    </FieldMessage>
+  ) : null;
+}
+
+export function FormAPIFieldMessage({
+  className,
+  messages,
+  state = "loading",
+}: APIMessageProps) {
+  const { baseId } = useFieldContext();
+  const content = messages?.[state];
+  return content ? (
+    <FieldMessage variant={state} className={className}>
+      <FieldMessage.Content id={`${baseId}-api-msg`}>
+        {content}
+      </FieldMessage.Content>
+    </FieldMessage>
+  ) : null;
+}
+
+export const FormField = Object.assign(FormFieldRoot, {
+  Label: FormFieldLabel,
+  Control: FormFieldControl,
+  Description: FormFieldDescription,
+  Message: FormFieldMessage,
+  APIMessage: FormAPIFieldMessage,
+});

--- a/web/lib/opal/src/components/form/FormField.tsx
+++ b/web/lib/opal/src/components/form/FormField.tsx
@@ -109,11 +109,10 @@ export function FormFieldControl({ asChild, children }: ControlProps) {
   }
 
   if (React.isValidElement(children)) {
-    // Child props win, matching the asChild Slot branch: a child's own id
-    // takes precedence over the injected control id.
+    // Injected wiring wins so the control's id matches the label's htmlFor.
     return React.cloneElement(children, {
-      ...ariaAttributes,
       ...(children.props as any),
+      ...ariaAttributes,
     });
   }
 

--- a/web/lib/opal/src/components/form/FormField.tsx
+++ b/web/lib/opal/src/components/form/FormField.tsx
@@ -137,15 +137,12 @@ export function FormFieldDescription({ id, children }: DescriptionProps) {
 
 export function FormFieldMessage({ className, messages }: MessageProps) {
   const { baseId, state } = useFieldContext();
-  let tempState = state;
-  let content = messages?.[tempState];
   // Success with no explicit message falls back to the idle message.
-  if (tempState === "success" && !content) {
-    tempState = "idle";
-    content = messages?.idle;
-  }
+  const effectiveState =
+    state === "success" && !messages?.[state] ? "idle" : state;
+  const content = messages?.[effectiveState];
   return content ? (
-    <FieldMessage variant={tempState} className={className}>
+    <FieldMessage variant={effectiveState} className={className}>
       <FieldMessage.Content id={`${baseId}-msg`}>
         {content}
       </FieldMessage.Content>

--- a/web/lib/opal/src/components/form/FormikField.tsx
+++ b/web/lib/opal/src/components/form/FormikField.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import {
+  useField,
+  FieldInputProps,
+  FieldHelperProps,
+  FieldMetaProps,
+} from "formik";
+import { FormFieldState } from "./types";
+import React, { useMemo, memo } from "react";
+
+export type FormikFieldProps<T = any> = {
+  name: string;
+  render: (
+    field: FieldInputProps<T>,
+    helper: FieldHelperProps<T>,
+    meta: FieldMetaProps<T>,
+    status: FormFieldState
+  ) => React.ReactElement;
+};
+
+function FormikFieldComponent<T>({ name, render }: FormikFieldProps<T>) {
+  const [field, meta, helper] = useField<T>(name);
+
+  const state = useMemo(
+    (): FormFieldState =>
+      meta.touched ? (meta.error ? "error" : "success") : "idle",
+    [meta.touched, meta.error]
+  );
+
+  return render(field, helper, meta, state);
+}
+
+export const FormikField = memo(
+  FormikFieldComponent
+) as typeof FormikFieldComponent;

--- a/web/lib/opal/src/components/form/InputTypeInField.tsx
+++ b/web/lib/opal/src/components/form/InputTypeInField.tsx
@@ -10,6 +10,7 @@ export interface InputTypeInFieldProps extends Omit<InputTypeInProps, "value"> {
 
 export function InputTypeInField({
   name,
+  id,
   onChange: onChangeProp,
   onBlur: onBlurProp,
   ...inputProps
@@ -24,7 +25,7 @@ export function InputTypeInField({
   return (
     <InputTypeIn
       {...inputProps}
-      id={name}
+      id={id ?? name}
       name={name}
       value={field.value ?? ""}
       onChange={onChange}

--- a/web/lib/opal/src/components/form/InputTypeInField.tsx
+++ b/web/lib/opal/src/components/form/InputTypeInField.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useField } from "formik";
+import { InputTypeIn, type InputTypeInProps } from "@opal/components";
+import { useOnChangeEvent, useOnBlurEvent } from "./hooks";
+
+export interface InputTypeInFieldProps extends Omit<InputTypeInProps, "value"> {
+  name: string;
+}
+
+export function InputTypeInField({
+  name,
+  onChange: onChangeProp,
+  onBlur: onBlurProp,
+  ...inputProps
+}: InputTypeInFieldProps) {
+  const [field, meta] = useField(name);
+  const onChange = useOnChangeEvent(name, onChangeProp);
+  const onBlur = useOnBlurEvent(name, onBlurProp);
+  const hasError = meta.touched && meta.error;
+  const isNonEditable =
+    inputProps.variant === "disabled" || inputProps.variant === "readOnly";
+
+  return (
+    <InputTypeIn
+      {...inputProps}
+      id={name}
+      name={name}
+      value={field.value ?? ""}
+      onChange={onChange}
+      onBlur={onBlur}
+      variant={
+        isNonEditable
+          ? inputProps.variant
+          : hasError
+            ? "error"
+            : inputProps.variant
+      }
+    />
+  );
+}

--- a/web/lib/opal/src/components/form/InputTypeInField.tsx
+++ b/web/lib/opal/src/components/form/InputTypeInField.tsx
@@ -29,13 +29,7 @@ export function InputTypeInField({
       value={field.value ?? ""}
       onChange={onChange}
       onBlur={onBlur}
-      variant={
-        isNonEditable
-          ? inputProps.variant
-          : hasError
-            ? "error"
-            : inputProps.variant
-      }
+      variant={!isNonEditable && hasError ? "error" : inputProps.variant}
     />
   );
 }

--- a/web/lib/opal/src/components/form/LabeledCheckboxField.tsx
+++ b/web/lib/opal/src/components/form/LabeledCheckboxField.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useField } from "formik";
+import { Checkbox, Text, Tooltip } from "@opal/components";
+
+export interface LabeledCheckboxFieldProps {
+  name: string;
+  label: string;
+  sublabel?: string;
+  tooltip?: string;
+  disabled?: boolean;
+  onChange?: (checked: boolean) => void;
+}
+
+export function LabeledCheckboxField({
+  name,
+  label,
+  sublabel,
+  tooltip,
+  disabled,
+  onChange,
+}: LabeledCheckboxFieldProps) {
+  const [field, , helpers] = useField<boolean>({ name, type: "checkbox" });
+  const labelId = `${name}-label`;
+
+  function handleChange(checked: boolean) {
+    helpers.setValue(checked);
+    onChange?.(checked);
+  }
+
+  return (
+    <Tooltip tooltip={tooltip} side="top" sideOffset={25}>
+      <div className="flex w-fit items-start gap-x-2">
+        <Checkbox
+          id={name}
+          aria-labelledby={labelId}
+          checked={field.value}
+          onCheckedChange={handleChange}
+          disabled={disabled}
+        />
+        <label
+          id={labelId}
+          htmlFor={name}
+          className="flex flex-col cursor-pointer"
+        >
+          <Text font="main-ui-action" color="text-04">
+            {label}
+          </Text>
+          {sublabel && (
+            <Text as="p" font="secondary-body" color="text-03">
+              {sublabel}
+            </Text>
+          )}
+        </label>
+      </div>
+    </Tooltip>
+  );
+}

--- a/web/lib/opal/src/components/form/README.md
+++ b/web/lib/opal/src/components/form/README.md
@@ -1,0 +1,84 @@
+# Form
+
+**Import:** `import { FormField, FormikField, FieldMessage, InputTypeInField } from "@opal/components";`
+
+The form field layer: the presentational `FormField` chrome (label, description, control slot, validation message) plus a thin [Formik](https://formik.org) binding layer (`FormikField`, the `Field` wrappers, and the `useOn*` hooks).
+
+`FormField` is state-driven and has no dependency on Formik. `FormikField` and the `*Field` wrappers are the glue that maps Formik state onto it, so `FormField` stays usable with any form library or with plain React state.
+
+## Pieces
+
+| Export | Role |
+|---|---|
+| `FormField` | Compound presentational field: `Root` + `Label` + `Description` + `Control` + `Message` + `APIMessage` |
+| `FieldMessage` | Standalone inline message row (icon + text) used by `FormField.Message` |
+| `FormikField` | Render-prop that reads a Formik field and derives its `idle \| success \| error` state |
+| `useFieldContext` | Reads the `FormField` context (`baseId`, `state`, `describedByIds`, …) from a descendant |
+| `InputTypeInField` | `InputTypeIn` bound to a Formik field (mirrors error state, forwards `onChange`/`onBlur`) |
+| `CheckboxField` | `Checkbox` bound to a Formik boolean field |
+| `LabeledCheckboxField` | `Checkbox` with a label, optional sublabel, and optional tooltip |
+| `SwitchField` | `Switch` bound to a Formik boolean field |
+| `useOnChangeEvent` / `useOnChangeValue` / `useOnBlurEvent` | Formik event adapters for building custom `Field` wrappers |
+
+## FormField
+
+`FormField` derives ARIA wiring (`aria-invalid`, `aria-describedby`, `aria-required`, matched `id`s) from a single `state`. Drive `state` yourself, or let `FormikField` supply it.
+
+```tsx
+import { FormField, InputTypeIn } from "@opal/components";
+
+<FormField state="error" required>
+  <FormField.Label required>Email</FormField.Label>
+  <FormField.Description>We only use this for account notifications.</FormField.Description>
+  <FormField.Control>
+    <InputTypeIn placeholder="you@example.com" value={value} onChange={onChange} />
+  </FormField.Control>
+  <FormField.Message messages={{ error: "Enter a valid email.", idle: "" }} />
+</FormField>
+```
+
+- **`FormField.Control`** injects the ARIA attributes onto its single child via `cloneElement` (or Radix `Slot` when `asChild`).
+- **`FormField.Message`** picks the message for the current `state` from `messages`. `success` with no message falls back to the `idle` message.
+- **`FormField.APIMessage`** is the async variant, keyed on `idle | success | error | loading` for server-driven feedback.
+
+## Formik binding
+
+`FormikField` reads a field by `name` and passes `(field, helper, meta, state)` to its render prop, where `state` is `meta.touched ? (meta.error ? "error" : "success") : "idle"`.
+
+```tsx
+import { Formik, Form } from "formik";
+import { FormField, FormikField, InputTypeInField } from "@opal/components";
+
+<Formik initialValues={{ email: "" }} validate={validate} onSubmit={onSubmit}>
+  <Form>
+    <FormikField
+      name="email"
+      render={(_field, _helper, meta, state) => (
+        <FormField state={state} required>
+          <FormField.Label required>Email</FormField.Label>
+          <FormField.Control>
+            <InputTypeInField name="email" placeholder="you@example.com" />
+          </FormField.Control>
+          <FormField.Message messages={{ error: meta.error ?? "", idle: "" }} />
+        </FormField>
+      )}
+    />
+  </Form>
+</Formik>
+```
+
+### Building your own Field wrapper
+
+The `useOn*` hooks adapt a control's callbacks to Formik without re-reading the whole field:
+
+- `useOnChangeEvent(name, onChange?)`: for native event controls (calls `field.onChange`).
+- `useOnChangeValue(name, onChange?)`: for value controls (calls `setValue` + `setTouched(true)`).
+- `useOnBlurEvent(name, onBlur?)`: marks the field touched on blur.
+
+```tsx
+function MyField({ name, ...props }: { name: string }) {
+  const [field] = useField<string>(name);
+  const onChange = useOnChangeValue<string>(name);
+  return <MyControl value={field.value} onChange={onChange} {...props} />;
+}
+```

--- a/web/lib/opal/src/components/form/SwitchField.tsx
+++ b/web/lib/opal/src/components/form/SwitchField.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useField } from "formik";
+import { Switch, type SwitchProps } from "@opal/components";
+import { useOnChangeValue } from "./hooks";
+
+export interface SwitchFieldProps extends Omit<SwitchProps, "checked"> {
+  name: string;
+}
+
+export function SwitchField({
+  name,
+  onCheckedChange,
+  ...props
+}: SwitchFieldProps) {
+  const [field] = useField<boolean>({ name, type: "checkbox" });
+  const onChange = useOnChangeValue(name, onCheckedChange);
+
+  return (
+    <Switch
+      id={name}
+      name={name}
+      checked={field.value}
+      onCheckedChange={onChange}
+      {...props}
+    />
+  );
+}

--- a/web/lib/opal/src/components/form/hooks.ts
+++ b/web/lib/opal/src/components/form/hooks.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useCallback } from "react";
+import { useField } from "formik";
+
+export function useOnChangeEvent<T = any>(
+  name: string,
+  f?: (event: T) => void
+) {
+  const [field] = useField<T>(name);
+  return useCallback(
+    (event: T) => {
+      field.onChange(event);
+      f?.(event);
+    },
+    [field, f]
+  );
+}
+
+export function useOnChangeValue<T = any>(
+  name: string,
+  f?: (value: T) => void
+) {
+  const [, , helpers] = useField<T>(name);
+  return useCallback(
+    (value: T) => {
+      helpers.setValue(value);
+      helpers.setTouched(true);
+      f?.(value);
+    },
+    [helpers, f]
+  );
+}
+
+export function useOnBlurEvent<T = any>(name: string, f?: (event: T) => void) {
+  const [field] = useField<T>(name);
+  return useCallback(
+    (event: T) => {
+      f?.(event);
+      field.onBlur(event);
+    },
+    [field, f]
+  );
+}

--- a/web/lib/opal/src/components/form/types.ts
+++ b/web/lib/opal/src/components/form/types.ts
@@ -1,0 +1,54 @@
+import type React from "react";
+import type { RichStr } from "@opal/types";
+
+export type FormFieldState = "idle" | "success" | "error";
+export type APIFormFieldState = FormFieldState | "loading";
+
+export interface FieldContextType {
+  baseId: string;
+  name?: string;
+  required?: boolean;
+  state: FormFieldState;
+  describedByIds: string[];
+}
+
+export type FormFieldRootProps = React.HTMLAttributes<HTMLDivElement> & {
+  name?: string;
+  state?: FormFieldState;
+  required?: boolean;
+  id?: string;
+};
+
+export type LabelProps = React.HTMLAttributes<HTMLLabelElement> & {
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  optional?: boolean;
+  required?: boolean;
+  rightAction?: React.ReactNode;
+};
+
+export type ControlProps = React.PropsWithChildren<{
+  asChild?: boolean;
+}>;
+
+export type DescriptionProps = {
+  id?: string;
+  children?: string | RichStr;
+};
+
+export type MessageByState = Partial<Record<FormFieldState, string | RichStr>>;
+export type APIMessageByState = Partial<
+  Record<FormFieldState | "loading", string | RichStr>
+>;
+
+export type MessageProps = {
+  className?: string;
+  messages?: MessageByState;
+  render?: (state: FormFieldState) => React.ReactNode;
+};
+
+export type APIMessageProps = {
+  className?: string;
+  state?: APIFormFieldState;
+  messages?: APIMessageByState;
+};

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -171,3 +171,51 @@ export {
   EndOfList,
   type EndOfListProps,
 } from "@opal/components/end-of-list/components";
+
+/* Form */
+export {
+  FieldContext,
+  useFieldContext,
+} from "@opal/components/form/FieldContext";
+export {
+  FormikField,
+  type FormikFieldProps,
+} from "@opal/components/form/FormikField";
+export { FormField } from "@opal/components/form/FormField";
+export { FieldMessage } from "@opal/components/form/FieldMessage";
+export {
+  useOnChangeEvent,
+  useOnChangeValue,
+  useOnBlurEvent,
+} from "@opal/components/form/hooks";
+export type {
+  FormFieldState,
+  APIFormFieldState,
+  FieldContextType,
+  FormFieldRootProps,
+  LabelProps,
+  ControlProps,
+  DescriptionProps,
+  MessageByState,
+  APIMessageByState,
+  MessageProps,
+  APIMessageProps,
+} from "@opal/components/form/types";
+
+/* FormField wrappers */
+export {
+  InputTypeInField,
+  type InputTypeInFieldProps,
+} from "@opal/components/form/InputTypeInField";
+export {
+  CheckboxField,
+  type CheckboxFieldProps,
+} from "@opal/components/form/CheckboxField";
+export {
+  LabeledCheckboxField,
+  type LabeledCheckboxFieldProps,
+} from "@opal/components/form/LabeledCheckboxField";
+export {
+  SwitchField,
+  type SwitchFieldProps,
+} from "@opal/components/form/SwitchField";


### PR DESCRIPTION
## Description

Ports the app's Formik field layer into Opal at `lib/opal/src/components/form/` so agent-wiki and other consumers can build forms directly on Opal. Additive only, the app copies are untouched.

Pieces:
- `FormField`: presentational compound (Label, Description, Control, Message, APIMessage) driven by an `idle | success | error` state.
- `FieldMessage`: inline icon+text validation row.
- `FormikField`: render-prop that maps Formik field state onto `FormField`.
- Field wrappers: `InputTypeInField`, `CheckboxField`, `LabeledCheckboxField`, `SwitchField`, plus the `useOnChange*`/`useOnBlur` Formik hooks.

Notes:
- Legacy boolean-flag `Text` translated to Opal `Text` (`color`/`font` props).
- Message/description text retyped `string | RichStr` for Opal markdown support.
- `LabeledCheckboxField` cleaned vs source: single `onCheckedChange` with label delegation, dropped the dead `peer-disabled` classes.

## How Has This Been Tested?

Verified in Storybook (real Chrome) via `Form.stories.tsx`.

**Error state (label, required indicator, description, error message)**
<img width="640" height="200" alt="image" src="https://github.com/user-attachments/assets/dadaa291-0a94-412a-a591-59d182db76b3" />

**Success state**
<img width="640" height="200" alt="image" src="https://github.com/user-attachments/assets/cb931109-cd02-4a29-8fa7-8588bf38659b" />

**Toggles: CheckboxField, LabeledCheckboxField (with sublabel), SwitchField**
<img width="640" height="208" alt="image" src="https://github.com/user-attachments/assets/18343adb-5f08-4ed9-877e-206738d91454" />

**Live Formik validation (invalid input + blur flips the field to error)**
<img width="640" height="160" alt="image" src="https://github.com/user-attachments/assets/010d6e40-31cb-4b0d-8611-e7a0878f9086" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check