### PR TITLE
fix(ttl): isolate + batch chat retention cleanup off the primary queue

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -54,6 +54,11 @@ def perform_ttl_management_task(
         logger.info("Chat TTL cleanup already in progress; skipping this run.")
         return
 
+    # Sessions that failed to delete are excluded from subsequent batches so a
+    # few undeletable rows can't block the rest of the (oldest-first) backlog.
+    # Every fetched session is either deleted or added here, so the eligible set
+    # shrinks each iteration and the loop always terminates.
+    failed_session_ids: set[UUID] = set()
     user_id: UUID | None = None
     session_id: UUID | None = None
     try:
@@ -61,13 +66,15 @@ def perform_ttl_management_task(
             lock.reacquire()
             with get_session_with_current_tenant() as db_session:
                 old_chat_sessions = get_chat_sessions_older_than(
-                    retention_limit_days, db_session, limit=_TTL_DELETE_BATCH_SIZE
+                    retention_limit_days,
+                    db_session,
+                    limit=_TTL_DELETE_BATCH_SIZE,
+                    exclude_session_ids=failed_session_ids,
                 )
 
             if not old_chat_sessions:
                 break
 
-            deleted_count = 0
             for user_id, session_id in old_chat_sessions:
                 lock.reacquire()
                 try:
@@ -79,27 +86,20 @@ def perform_ttl_management_task(
                             include_deleted=True,
                             hard_delete=True,
                         )
-                    deleted_count += 1
                 except Exception:
                     logger.exception(
                         "Failed to delete chat session user_id=%s session_id=%s, continuing with remaining sessions",
                         user_id,
                         session_id,
                     )
+                    failed_session_ids.add(session_id)
 
-            # If a full batch was fetched but nothing could be deleted, the same
-            # rows would be re-fetched forever. Stop and let the next scheduled
-            # check retry rather than spin.
-            if deleted_count == 0:
-                logger.error(
-                    "Chat TTL cleanup made no progress on a full batch of %d sessions; stopping.",
-                    len(old_chat_sessions),
-                )
-                break
-
-            # A partial batch means we've reached the tail of the backlog.
-            if len(old_chat_sessions) < _TTL_DELETE_BATCH_SIZE:
-                break
+        if failed_session_ids:
+            logger.error(
+                "Chat TTL cleanup finished but %d session(s) could not be deleted; "
+                "they will be retried on the next scheduled run.",
+                len(failed_session_ids),
+            )
 
     except Exception:
         logger.exception(

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -1,13 +1,9 @@
 from celery import shared_task
 from celery import Task
-from redis.lock import Lock as RedisLock
 
 from ee.onyx.background.celery_utils import should_perform_chat_ttl_check
-from onyx.background.celery.celery_redis import celery_get_broker_client
-from onyx.background.celery.celery_redis import celery_get_queue_length
 from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.configs.constants import CELERY_CHAT_TTL_DELETE_TASK_EXPIRES
-from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CHAT_TTL_DELETE_BATCH_SIZE
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
@@ -34,7 +30,7 @@ def perform_ttl_management_task(
     self: Task,
     retention_limit_days: float,
     *,
-    tenant_id: str,  # noqa: ARG001
+    tenant_id: str,
 ) -> None:
     """Delete the oldest batch of expired chat sessions, then chain the next task.
 
@@ -42,9 +38,10 @@ def perform_ttl_management_task(
     expired sessions and exits, so it occupies a single light-worker thread for
     only one short batch and interleaves with the other light-queue work. If a
     full batch is deleted (more sessions likely remain) it enqueues the next task
-    to continue the chain. Only one task is ever in flight (``check_ttl_management_task``
-    starts a chain only when the queue is empty), so at most one light-worker
-    thread does TTL work at a time.
+    to continue the chain; otherwise the chain is done and it releases the
+    in-flight marker so ``check_ttl_management_task`` can start a fresh chain.
+    Only one chain runs per tenant at a time (guarded by the marker), so at most
+    one light-worker thread does TTL work at a time.
 
     NOTE: every run re-selects the oldest sessions, so a session that repeatedly
     fails to delete is retried on every run. If the oldest ``CHAT_TTL_DELETE_BATCH_SIZE``
@@ -52,13 +49,20 @@ def perform_ttl_management_task(
     tasks) and never reaches newer sessions. This is an accepted trade-off for
     keeping the task simple; each failure is logged.
     """
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    # Refresh the in-flight marker. The active batch isn't in the queue, so queue
+    # length can't be the guard; the marker spans the whole chain and keeps the
+    # beat from starting a second one.
+    redis_client.set(
+        OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
+        1,
+        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+    )
+
     with get_session_with_current_tenant() as db_session:
         old_chat_sessions = get_chat_sessions_older_than(
             retention_limit_days, db_session, limit=CHAT_TTL_DELETE_BATCH_SIZE
         )
-
-    if not old_chat_sessions:
-        return
 
     for user_id, session_id in old_chat_sessions:
         try:
@@ -77,18 +81,26 @@ def perform_ttl_management_task(
                 session_id,
             )
 
-    # A full batch means more expired sessions probably remain; continue the chain.
+    # A full batch means more expired sessions probably remain; continue the
+    # chain. Otherwise the backlog is drained — release the marker.
     if len(old_chat_sessions) == CHAT_TTL_DELETE_BATCH_SIZE:
-        self.app.send_task(
-            OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
-            kwargs={
-                "retention_limit_days": retention_limit_days,
-                "tenant_id": tenant_id,
-            },
-            queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
-            priority=OnyxCeleryPriority.LOW,
-            expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
-        )
+        try:
+            self.app.send_task(
+                OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
+                kwargs={
+                    "retention_limit_days": retention_limit_days,
+                    "tenant_id": tenant_id,
+                },
+                queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+                priority=OnyxCeleryPriority.LOW,
+                expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+            )
+        except Exception:
+            # Chain broke; release the marker so the beat can restart it.
+            redis_client.delete(OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE)
+            raise
+    else:
+        redis_client.delete(OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE)
 
 
 @shared_task(
@@ -102,8 +114,9 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
     """Start a chat-retention cleanup chain if one isn't already running.
 
     Deletion happens in ``perform_ttl_management_task``, which chains itself
-    batch-by-batch. This dispatcher only kicks off a new chain when the
-    ``chat_ttl_deletion`` queue is empty, so chains don't stack.
+    batch-by-batch and holds an in-flight marker for the whole chain. This
+    dispatcher claims that marker (``SET NX``); if it's already held a chain is
+    active, so we skip and don't stack a second one.
     """
     settings = load_settings()
     retention_limit_days = settings.maximum_chat_retention_days
@@ -114,19 +127,17 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
         return
 
     redis_client = get_redis_client(tenant_id=tenant_id)
-    lock: RedisLock = redis_client.lock(
-        OnyxRedisLocks.CHAT_TTL_MANAGEMENT_LOCK,
-        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
-    )
-    if not lock.acquire(blocking=False):
+    # Claim the chain. If the marker is already set, a chain is in flight (its
+    # active task may not be sitting in the queue), so don't start another.
+    if not redis_client.set(
+        OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
+        1,
+        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+        nx=True,
+    ):
         return
 
     try:
-        # A non-empty queue means a chain is already draining; don't start another.
-        r_celery = celery_get_broker_client(self.app)
-        if celery_get_queue_length(OnyxCeleryQueues.CHAT_TTL_DELETION, r_celery) > 0:
-            return
-
         self.app.send_task(
             OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
             kwargs={
@@ -137,6 +148,7 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
             priority=OnyxCeleryPriority.LOW,
             expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
         )
-    finally:
-        if lock.owned():
-            lock.release()
+    except Exception:
+        # Roll back the claim so the next beat can start the chain.
+        redis_client.delete(OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE)
+        raise

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -61,7 +61,10 @@ def _release_chain_if_owned(redis_client: TenantRedisClient, chain_token: str) -
 def perform_ttl_management_task(
     self: Task,
     retention_limit_days: float,
-    chain_token: str,
+    # Defaulted for rollout compatibility: a message enqueued by the pre-upgrade
+    # code carries no chain_token. An empty token never matches the marker, so
+    # such a message harmlessly no-ops below and the beat starts a fresh chain.
+    chain_token: str = "",
     *,
     tenant_id: str,
 ) -> None:

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -2,17 +2,27 @@ from uuid import UUID
 
 from celery import shared_task
 from celery import Task
+from redis.lock import Lock as RedisLock
 
 from ee.onyx.background.celery_utils import should_perform_chat_ttl_check
 from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
+from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.redis.redis_pool import get_redis_client
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# Chat sessions are hard-deleted one at a time, each in its own transaction. We
+# fetch and delete in bounded batches so a large backlog never loads every
+# matching row into memory at once and never occupies a worker thread for hours.
+_TTL_DELETE_BATCH_SIZE = 100
 
 
 @shared_task(
@@ -32,30 +42,64 @@ def perform_ttl_management_task(
     if not task_id:
         raise RuntimeError("No task id defined for this task; cannot identify it")
 
+    # A per-tenant lock ensures only one cleanup run drains the backlog at a
+    # time. Without it the hourly check would stack a new full run on top of any
+    # still-draining one, compounding queue congestion on large backlogs.
+    r = get_redis_client()
+    lock: RedisLock = r.lock(
+        OnyxRedisLocks.CHAT_TTL_MANAGEMENT_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
+    if not lock.acquire(blocking=False):
+        logger.info("Chat TTL cleanup already in progress; skipping this run.")
+        return
+
     user_id: UUID | None = None
     session_id: UUID | None = None
     try:
-        with get_session_with_current_tenant() as db_session:
-            old_chat_sessions = get_chat_sessions_older_than(
-                retention_limit_days, db_session
-            )
+        while True:
+            lock.reacquire()
+            with get_session_with_current_tenant() as db_session:
+                old_chat_sessions = get_chat_sessions_older_than(
+                    retention_limit_days, db_session, limit=_TTL_DELETE_BATCH_SIZE
+                )
 
-        for user_id, session_id in old_chat_sessions:
-            try:
-                with get_session_with_current_tenant() as db_session:
-                    delete_chat_session(
+            if not old_chat_sessions:
+                break
+
+            deleted_count = 0
+            for user_id, session_id in old_chat_sessions:
+                lock.reacquire()
+                try:
+                    with get_session_with_current_tenant() as db_session:
+                        delete_chat_session(
+                            user_id,
+                            session_id,
+                            db_session,
+                            include_deleted=True,
+                            hard_delete=True,
+                        )
+                    deleted_count += 1
+                except Exception:
+                    logger.exception(
+                        "Failed to delete chat session user_id=%s session_id=%s, continuing with remaining sessions",
                         user_id,
                         session_id,
-                        db_session,
-                        include_deleted=True,
-                        hard_delete=True,
                     )
-            except Exception:
-                logger.exception(
-                    "Failed to delete chat session user_id=%s session_id=%s, continuing with remaining sessions",
-                    user_id,
-                    session_id,
+
+            # If a full batch was fetched but nothing could be deleted, the same
+            # rows would be re-fetched forever. Stop and let the next scheduled
+            # check retry rather than spin.
+            if deleted_count == 0:
+                logger.error(
+                    "Chat TTL cleanup made no progress on a full batch of %d sessions; stopping.",
+                    len(old_chat_sessions),
                 )
+                break
+
+            # A partial batch means we've reached the tail of the backlog.
+            if len(old_chat_sessions) < _TTL_DELETE_BATCH_SIZE:
+                break
 
     except Exception:
         logger.exception(
@@ -64,6 +108,9 @@ def perform_ttl_management_task(
             session_id,
         )
         raise
+    finally:
+        if lock.owned():
+            lock.release()
 
 
 @shared_task(
@@ -83,4 +130,6 @@ def check_ttl_management_task(*, tenant_id: str) -> None:
                 kwargs=dict(
                     retention_limit_days=retention_limit_days, tenant_id=tenant_id
                 ),
+                queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+                expires=JOB_TIMEOUT,
             )

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -5,8 +5,14 @@ from celery import Task
 from redis.lock import Lock as RedisLock
 
 from ee.onyx.background.celery_utils import should_perform_chat_ttl_check
+from onyx.background.celery.celery_redis import celery_get_broker_client
+from onyx.background.celery.celery_redis import celery_get_queue_length
 from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.configs.constants import CELERY_CHAT_TTL_DELETE_TASK_EXPIRES
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
+from onyx.configs.constants import CHAT_TTL_DELETE_BATCH_SIZE
+from onyx.configs.constants import CHAT_TTL_DELETE_MAX_QUEUE_DEPTH
+from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
 from onyx.configs.constants import OnyxRedisLocks
@@ -14,124 +20,157 @@ from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Chat sessions are hard-deleted one at a time, each in its own transaction. We
-# fetch and delete in bounded batches so a large backlog never loads every
-# matching row into memory at once and never occupies a worker thread for hours.
-_TTL_DELETE_BATCH_SIZE = 100
+
+def _chat_ttl_queued_key(session_id: str | UUID) -> str:
+    return f"{OnyxRedisLocks.CHAT_TTL_QUEUED_PREFIX}:{session_id}"
 
 
 @shared_task(
     name=OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
     ignore_result=True,
     soft_time_limit=JOB_TIMEOUT,
-    bind=True,
     trail=False,
 )
 def perform_ttl_management_task(
-    self: Task,
-    retention_limit_days: int,
+    session_batch: list[tuple[str | None, str]],
     *,
-    tenant_id: str,  # noqa: ARG001
+    tenant_id: str,
 ) -> None:
-    task_id = self.request.id
-    if not task_id:
-        raise RuntimeError("No task id defined for this task; cannot identify it")
+    """Hard-delete one bounded batch of expired chat sessions, then exit.
 
-    # Only one cleanup run should drain the backlog at a time; without this the
-    # hourly check would stack a new full run on top of any still-draining one,
-    # compounding queue congestion on large backlogs. get_redis_client()
-    # tenant-prefixes the lock key, so this is per-tenant despite the constant
-    # name (same pattern as the other beat locks).
-    r = get_redis_client()
-    lock: RedisLock = r.lock(
-        OnyxRedisLocks.CHAT_TTL_MANAGEMENT_LOCK,
-        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
-    )
-    if not lock.acquire(blocking=False):
-        logger.info("Chat TTL cleanup already in progress; skipping this run.")
-        return
+    Each batch is an independent, short-lived task so the light worker can
+    interleave it with other light-queue work. Sessions are enqueued in batches
+    by ``check_ttl_management_task`` rather than drained in a single long task.
+    """
+    redis_client = get_redis_client(tenant_id=tenant_id)
 
-    # Sessions that failed to delete are excluded from subsequent batches so a
-    # few undeletable rows can't block the rest of the (oldest-first) backlog.
-    # Every fetched session is either deleted or added here, so the eligible set
-    # shrinks each iteration and the loop always terminates.
-    failed_session_ids: set[UUID] = set()
-    user_id: UUID | None = None
-    session_id: UUID | None = None
-    try:
-        while True:
-            lock.reacquire()
+    for user_id_raw, session_id_raw in session_batch:
+        session_id = UUID(session_id_raw)
+        user_id = UUID(user_id_raw) if user_id_raw else None
+
+        # Clear the queued guard up front so that if deletion fails and the
+        # session remains eligible, the dispatcher can re-enqueue it next cycle.
+        redis_client.delete(_chat_ttl_queued_key(session_id))
+        try:
             with get_session_with_current_tenant() as db_session:
-                old_chat_sessions = get_chat_sessions_older_than(
-                    retention_limit_days,
+                delete_chat_session(
+                    user_id,
+                    session_id,
                     db_session,
-                    limit=_TTL_DELETE_BATCH_SIZE,
-                    exclude_session_ids=failed_session_ids,
+                    include_deleted=True,
+                    hard_delete=True,
                 )
-
-            if not old_chat_sessions:
-                break
-
-            for user_id, session_id in old_chat_sessions:
-                lock.reacquire()
-                try:
-                    with get_session_with_current_tenant() as db_session:
-                        delete_chat_session(
-                            user_id,
-                            session_id,
-                            db_session,
-                            include_deleted=True,
-                            hard_delete=True,
-                        )
-                except Exception:
-                    logger.exception(
-                        "Failed to delete chat session user_id=%s session_id=%s, continuing with remaining sessions",
-                        user_id,
-                        session_id,
-                    )
-                    failed_session_ids.add(session_id)
-
-        if failed_session_ids:
-            logger.error(
-                "Chat TTL cleanup finished but %d session(s) could not be deleted; "
-                "they will be retried on the next scheduled run.",
-                len(failed_session_ids),
+        except Exception:
+            logger.exception(
+                "Failed to delete chat session user_id=%s session_id=%s, continuing with remaining sessions",
+                user_id,
+                session_id,
             )
-
-    except Exception:
-        logger.exception(
-            "delete_chat_session exceptioned. user_id=%s session_id=%s",
-            user_id,
-            session_id,
-        )
-        raise
-    finally:
-        if lock.owned():
-            lock.release()
 
 
 @shared_task(
     name=OnyxCeleryTask.CHECK_TTL_MANAGEMENT_TASK,
     ignore_result=True,
     soft_time_limit=JOB_TIMEOUT,
+    bind=True,
+    trail=False,
 )
-def check_ttl_management_task(*, tenant_id: str) -> None:
-    """Runs periodically to check if any ttl tasks should be run and adds them
-    to the queue"""
+def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
+    """Fan expired chat sessions out to the light queue in bounded batches.
 
+    Runs periodically. Instead of deleting the whole backlog in one task, it
+    enqueues ``CHAT_TTL_DELETE_BATCH_SIZE``-session batches so deletion
+    interleaves with other light-queue work. A per-tenant beat lock prevents
+    overlapping fan-out, queue-depth backpressure prevents unbounded growth, and
+    a per-session guard prevents re-enqueuing sessions already in flight.
+    """
     settings = load_settings()
     retention_limit_days = settings.maximum_chat_retention_days
     with get_session_with_current_tenant() as db_session:
-        if should_perform_chat_ttl_check(retention_limit_days, db_session):
-            perform_ttl_management_task.apply_async(
-                kwargs=dict(
-                    retention_limit_days=retention_limit_days, tenant_id=tenant_id
-                ),
-                queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
-                expires=JOB_TIMEOUT,
+        if not should_perform_chat_ttl_check(retention_limit_days, db_session):
+            return
+    if retention_limit_days is None:
+        return
+
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    lock: RedisLock = redis_client.lock(
+        OnyxRedisLocks.CHAT_TTL_MANAGEMENT_LOCK,
+        timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
+    )
+    # Only one fan-out per tenant should run at a time.
+    if not lock.acquire(blocking=False):
+        return
+
+    enqueued = 0
+    try:
+        # Backpressure: don't pile more batches on top of an already-deep queue.
+        # Must use the broker's Redis client — Celery queues live on a separate
+        # Redis DB with CELERY_SEPARATOR keys.
+        r_celery = celery_get_broker_client(self.app)
+        queue_len = celery_get_queue_length(
+            OnyxCeleryQueues.CHAT_TTL_DELETION, r_celery
+        )
+        if queue_len > CHAT_TTL_DELETE_MAX_QUEUE_DEPTH:
+            return
+
+        with get_session_with_current_tenant() as db_session:
+            old_chat_sessions = get_chat_sessions_older_than(
+                retention_limit_days,
+                db_session,
+                limit=CHAT_TTL_DELETE_MAX_QUEUE_DEPTH * CHAT_TTL_DELETE_BATCH_SIZE,
             )
+
+        batch: list[tuple[str | None, str]] = []
+        for user_id, session_id in old_chat_sessions:
+            # Skip sessions already queued (guard set) but not yet processed.
+            guard_set = redis_client.set(
+                _chat_ttl_queued_key(session_id),
+                1,
+                ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+                nx=True,
+            )
+            if not guard_set:
+                continue
+
+            batch.append((str(user_id) if user_id else None, str(session_id)))
+            if len(batch) >= CHAT_TTL_DELETE_BATCH_SIZE:
+                _enqueue_ttl_batch(self, redis_client, batch, tenant_id)
+                enqueued += len(batch)
+                batch = []
+
+        if batch:
+            _enqueue_ttl_batch(self, redis_client, batch, tenant_id)
+            enqueued += len(batch)
+    finally:
+        if lock.owned():
+            lock.release()
+
+    if enqueued:
+        logger.info("check_ttl_management_task enqueued %d session(s)", enqueued)
+
+
+def _enqueue_ttl_batch(
+    task: Task,
+    redis_client: TenantRedisClient,
+    batch: list[tuple[str | None, str]],
+    tenant_id: str,
+) -> None:
+    try:
+        task.app.send_task(
+            OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
+            kwargs={"session_batch": batch, "tenant_id": tenant_id},
+            queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+            priority=OnyxCeleryPriority.LOW,
+            expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+        )
+    except Exception:
+        # Roll back the guards so these sessions can be re-enqueued next cycle.
+        for _, session_id in batch:
+            redis_client.delete(_chat_ttl_queued_key(session_id))
+        raise

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -42,9 +42,11 @@ def perform_ttl_management_task(
     if not task_id:
         raise RuntimeError("No task id defined for this task; cannot identify it")
 
-    # A per-tenant lock ensures only one cleanup run drains the backlog at a
-    # time. Without it the hourly check would stack a new full run on top of any
-    # still-draining one, compounding queue congestion on large backlogs.
+    # Only one cleanup run should drain the backlog at a time; without this the
+    # hourly check would stack a new full run on top of any still-draining one,
+    # compounding queue congestion on large backlogs. get_redis_client()
+    # tenant-prefixes the lock key, so this is per-tenant despite the constant
+    # name (same pattern as the other beat locks).
     r = get_redis_client()
     lock: RedisLock = r.lock(
         OnyxRedisLocks.CHAT_TTL_MANAGEMENT_LOCK,

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -1,3 +1,5 @@
+import uuid
+
 from celery import shared_task
 from celery import Task
 
@@ -13,10 +15,40 @@ from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# Extend the chain lease only if we still own it (marker value == our token).
+# Returns 1 when owned+extended, 0 otherwise. Prevents a task whose lease lapsed
+# (and whose chain a later beat has replaced) from extending someone else's lease.
+_REFRESH_IF_OWNED = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('expire', KEYS[1], ARGV[2])
+else
+    return 0
+end
+"""
+
+# Release the chain marker only if we still own it.
+_RELEASE_IF_OWNED = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+else
+    return 0
+end
+"""
+
+
+def _release_chain_if_owned(redis_client: TenantRedisClient, chain_token: str) -> None:
+    """Delete the chain marker only if ``chain_token`` still owns it."""
+    redis_client.eval(
+        _RELEASE_IF_OWNED,
+        [OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE],
+        [chain_token],
+    )
 
 
 @shared_task(
@@ -29,6 +61,7 @@ logger = setup_logger()
 def perform_ttl_management_task(
     self: Task,
     retention_limit_days: float,
+    chain_token: str,
     *,
     tenant_id: str,
 ) -> None:
@@ -38,10 +71,14 @@ def perform_ttl_management_task(
     expired sessions and exits, so it occupies a single light-worker thread for
     only one short batch and interleaves with the other light-queue work. If a
     full batch is deleted (more sessions likely remain) it enqueues the next task
-    to continue the chain; otherwise the chain is done and it releases the
+    with the same ``chain_token``; otherwise the chain is done and it releases the
     in-flight marker so ``check_ttl_management_task`` can start a fresh chain.
-    Only one chain runs per tenant at a time (guarded by the marker), so at most
-    one light-worker thread does TTL work at a time.
+
+    ``chain_token`` fences the chain: each run extends the lease only if it still
+    owns the marker, and stops if it doesn't. So if a slow batch outlives the
+    lease and the beat starts a replacement chain, the superseded task can neither
+    extend nor delete the new chain's marker — it just exits. Only one chain runs
+    per tenant at a time, so at most one light-worker thread does TTL work.
 
     NOTE: every run re-selects the oldest sessions, so a session that repeatedly
     fails to delete is retried on every run. If the oldest ``CHAT_TTL_DELETE_BATCH_SIZE``
@@ -50,14 +87,15 @@ def perform_ttl_management_task(
     keeping the task simple; each failure is logged.
     """
     redis_client = get_redis_client(tenant_id=tenant_id)
-    # Refresh the in-flight marker. The active batch isn't in the queue, so queue
-    # length can't be the guard; the marker spans the whole chain and keeps the
-    # beat from starting a second one.
-    redis_client.set(
-        OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
-        1,
-        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+    # Extend our lease only if we still own the chain; if a replacement chain has
+    # taken over, stop — we're a superseded task and must not touch its marker.
+    owns_chain = redis_client.eval(
+        _REFRESH_IF_OWNED,
+        [OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE],
+        [chain_token, str(CELERY_CHAT_TTL_DELETE_TASK_EXPIRES)],
     )
+    if not owns_chain:
+        return
 
     with get_session_with_current_tenant() as db_session:
         old_chat_sessions = get_chat_sessions_older_than(
@@ -82,13 +120,14 @@ def perform_ttl_management_task(
             )
 
     # A full batch means more expired sessions probably remain; continue the
-    # chain. Otherwise the backlog is drained — release the marker.
+    # chain. Otherwise the backlog is drained — release the marker (if we own it).
     if len(old_chat_sessions) == CHAT_TTL_DELETE_BATCH_SIZE:
         try:
             self.app.send_task(
                 OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
                 kwargs={
                     "retention_limit_days": retention_limit_days,
+                    "chain_token": chain_token,
                     "tenant_id": tenant_id,
                 },
                 queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
@@ -96,11 +135,10 @@ def perform_ttl_management_task(
                 expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
             )
         except Exception:
-            # Chain broke; release the marker so the beat can restart it.
-            redis_client.delete(OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE)
+            _release_chain_if_owned(redis_client, chain_token)
             raise
     else:
-        redis_client.delete(OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE)
+        _release_chain_if_owned(redis_client, chain_token)
 
 
 @shared_task(
@@ -114,9 +152,9 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
     """Start a chat-retention cleanup chain if one isn't already running.
 
     Deletion happens in ``perform_ttl_management_task``, which chains itself
-    batch-by-batch and holds an in-flight marker for the whole chain. This
-    dispatcher claims that marker (``SET NX``); if it's already held a chain is
-    active, so we skip and don't stack a second one.
+    batch-by-batch and holds a token-fenced in-flight marker for the whole chain.
+    This dispatcher claims that marker with a fresh token (``SET NX``); if it's
+    already held a chain is active, so we skip and don't stack a second one.
     """
     settings = load_settings()
     retention_limit_days = settings.maximum_chat_retention_days
@@ -127,13 +165,14 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
         return
 
     redis_client = get_redis_client(tenant_id=tenant_id)
+    chain_token = uuid.uuid4().hex
     # Claim the chain. If the marker is already set, a chain is in flight (its
     # active task may not be sitting in the queue), so don't start another.
     if not redis_client.set(
         OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
-        1,
-        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+        chain_token,
         nx=True,
+        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
     ):
         return
 
@@ -142,6 +181,7 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
             OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
             kwargs={
                 "retention_limit_days": retention_limit_days,
+                "chain_token": chain_token,
                 "tenant_id": tenant_id,
             },
             queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
@@ -150,5 +190,5 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
         )
     except Exception:
         # Roll back the claim so the next beat can start the chain.
-        redis_client.delete(OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE)
+        _release_chain_if_owned(redis_client, chain_token)
         raise

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 from celery import shared_task
 from celery import Task
 from redis.lock import Lock as RedisLock
@@ -11,7 +9,6 @@ from onyx.configs.app_configs import JOB_TIMEOUT
 from onyx.configs.constants import CELERY_CHAT_TTL_DELETE_TASK_EXPIRES
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CHAT_TTL_DELETE_BATCH_SIZE
-from onyx.configs.constants import CHAT_TTL_DELETE_MAX_QUEUE_DEPTH
 from onyx.configs.constants import OnyxCeleryPriority
 from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
@@ -20,43 +17,50 @@ from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.redis.redis_pool import get_redis_client
-from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
 
-def _chat_ttl_queued_key(session_id: str | UUID) -> str:
-    return f"{OnyxRedisLocks.CHAT_TTL_QUEUED_PREFIX}:{session_id}"
-
-
 @shared_task(
     name=OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
     ignore_result=True,
     soft_time_limit=JOB_TIMEOUT,
+    bind=True,
     trail=False,
 )
 def perform_ttl_management_task(
-    session_batch: list[tuple[str | None, str]],
+    self: Task,
+    retention_limit_days: float,
     *,
-    tenant_id: str,
+    tenant_id: str,  # noqa: ARG001
 ) -> None:
-    """Hard-delete one bounded batch of expired chat sessions, then exit.
+    """Delete the oldest batch of expired chat sessions, then chain the next task.
 
-    Each batch is an independent, short-lived task so the light worker can
-    interleave it with other light-queue work. Sessions are enqueued in batches
-    by ``check_ttl_management_task`` rather than drained in a single long task.
+    Each run hard-deletes at most ``CHAT_TTL_DELETE_BATCH_SIZE`` of the *oldest*
+    expired sessions and exits, so it occupies a single light-worker thread for
+    only one short batch and interleaves with the other light-queue work. If a
+    full batch is deleted (more sessions likely remain) it enqueues the next task
+    to continue the chain. Only one task is ever in flight (``check_ttl_management_task``
+    starts a chain only when the queue is empty), so at most one light-worker
+    thread does TTL work at a time.
+
+    NOTE: every run re-selects the oldest sessions, so a session that repeatedly
+    fails to delete is retried on every run. If the oldest ``CHAT_TTL_DELETE_BATCH_SIZE``
+    sessions can never be deleted, the chain loops on them indefinitely (across
+    tasks) and never reaches newer sessions. This is an accepted trade-off for
+    keeping the task simple; each failure is logged.
     """
-    redis_client = get_redis_client(tenant_id=tenant_id)
+    with get_session_with_current_tenant() as db_session:
+        old_chat_sessions = get_chat_sessions_older_than(
+            retention_limit_days, db_session, limit=CHAT_TTL_DELETE_BATCH_SIZE
+        )
 
-    for user_id_raw, session_id_raw in session_batch:
-        session_id = UUID(session_id_raw)
-        user_id = UUID(user_id_raw) if user_id_raw else None
+    if not old_chat_sessions:
+        return
 
-        # Clear the queued guard up front so that if deletion fails and the
-        # session remains eligible, the dispatcher can re-enqueue it next cycle.
-        redis_client.delete(_chat_ttl_queued_key(session_id))
+    for user_id, session_id in old_chat_sessions:
         try:
             with get_session_with_current_tenant() as db_session:
                 delete_chat_session(
@@ -73,6 +77,19 @@ def perform_ttl_management_task(
                 session_id,
             )
 
+    # A full batch means more expired sessions probably remain; continue the chain.
+    if len(old_chat_sessions) == CHAT_TTL_DELETE_BATCH_SIZE:
+        self.app.send_task(
+            OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
+            kwargs={
+                "retention_limit_days": retention_limit_days,
+                "tenant_id": tenant_id,
+            },
+            queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+            priority=OnyxCeleryPriority.LOW,
+            expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+        )
+
 
 @shared_task(
     name=OnyxCeleryTask.CHECK_TTL_MANAGEMENT_TASK,
@@ -82,13 +99,11 @@ def perform_ttl_management_task(
     trail=False,
 )
 def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
-    """Fan expired chat sessions out to the light queue in bounded batches.
+    """Start a chat-retention cleanup chain if one isn't already running.
 
-    Runs periodically. Instead of deleting the whole backlog in one task, it
-    enqueues ``CHAT_TTL_DELETE_BATCH_SIZE``-session batches so deletion
-    interleaves with other light-queue work. A per-tenant beat lock prevents
-    overlapping fan-out, queue-depth backpressure prevents unbounded growth, and
-    a per-session guard prevents re-enqueuing sessions already in flight.
+    Deletion happens in ``perform_ttl_management_task``, which chains itself
+    batch-by-batch. This dispatcher only kicks off a new chain when the
+    ``chat_ttl_deletion`` queue is empty, so chains don't stack.
     """
     settings = load_settings()
     retention_limit_days = settings.maximum_chat_retention_days
@@ -103,74 +118,25 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
         OnyxRedisLocks.CHAT_TTL_MANAGEMENT_LOCK,
         timeout=CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
     )
-    # Only one fan-out per tenant should run at a time.
     if not lock.acquire(blocking=False):
         return
 
-    enqueued = 0
     try:
-        # Backpressure: don't pile more batches on top of an already-deep queue.
-        # Must use the broker's Redis client — Celery queues live on a separate
-        # Redis DB with CELERY_SEPARATOR keys.
+        # A non-empty queue means a chain is already draining; don't start another.
         r_celery = celery_get_broker_client(self.app)
-        queue_len = celery_get_queue_length(
-            OnyxCeleryQueues.CHAT_TTL_DELETION, r_celery
-        )
-        if queue_len > CHAT_TTL_DELETE_MAX_QUEUE_DEPTH:
+        if celery_get_queue_length(OnyxCeleryQueues.CHAT_TTL_DELETION, r_celery) > 0:
             return
 
-        with get_session_with_current_tenant() as db_session:
-            old_chat_sessions = get_chat_sessions_older_than(
-                retention_limit_days,
-                db_session,
-                limit=CHAT_TTL_DELETE_MAX_QUEUE_DEPTH * CHAT_TTL_DELETE_BATCH_SIZE,
-            )
-
-        batch: list[tuple[str | None, str]] = []
-        for user_id, session_id in old_chat_sessions:
-            # Skip sessions already queued (guard set) but not yet processed.
-            guard_set = redis_client.set(
-                _chat_ttl_queued_key(session_id),
-                1,
-                ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
-                nx=True,
-            )
-            if not guard_set:
-                continue
-
-            batch.append((str(user_id) if user_id else None, str(session_id)))
-            if len(batch) >= CHAT_TTL_DELETE_BATCH_SIZE:
-                _enqueue_ttl_batch(self, redis_client, batch, tenant_id)
-                enqueued += len(batch)
-                batch = []
-
-        if batch:
-            _enqueue_ttl_batch(self, redis_client, batch, tenant_id)
-            enqueued += len(batch)
-    finally:
-        if lock.owned():
-            lock.release()
-
-    if enqueued:
-        logger.info("check_ttl_management_task enqueued %d session(s)", enqueued)
-
-
-def _enqueue_ttl_batch(
-    task: Task,
-    redis_client: TenantRedisClient,
-    batch: list[tuple[str | None, str]],
-    tenant_id: str,
-) -> None:
-    try:
-        task.app.send_task(
+        self.app.send_task(
             OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
-            kwargs={"session_batch": batch, "tenant_id": tenant_id},
+            kwargs={
+                "retention_limit_days": retention_limit_days,
+                "tenant_id": tenant_id,
+            },
             queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
             priority=OnyxCeleryPriority.LOW,
             expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
         )
-    except Exception:
-        # Roll back the guards so these sessions can be re-enqueued next cycle.
-        for _, session_id in batch:
-            redis_client.delete(_chat_ttl_queued_key(session_id))
-        raise
+    finally:
+        if lock.owned():
+            lock.release()

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -169,6 +169,7 @@ def _collect_queue_metrics(redis_celery: Redis) -> list[Metric]:
         "llm_model_update_queue_length": OnyxCeleryQueues.LLM_MODEL_UPDATE,
         "checkpoint_cleanup_queue_length": OnyxCeleryQueues.CHECKPOINT_CLEANUP,
         "index_attempt_cleanup_queue_length": OnyxCeleryQueues.INDEX_ATTEMPT_CLEANUP,
+        "chat_ttl_deletion_queue_length": OnyxCeleryQueues.CHAT_TTL_DELETION,
         "csv_generation_queue_length": OnyxCeleryQueues.CSV_GENERATION,
         "user_file_processing_queue_length": OnyxCeleryQueues.USER_FILE_PROCESSING,
         "user_file_project_sync_queue_length": OnyxCeleryQueues.USER_FILE_PROJECT_SYNC,

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -435,6 +435,10 @@ class OnyxCeleryQueues:
     CONNECTOR_HIERARCHY_FETCHING = "connector_hierarchy_fetching"
     CSV_GENERATION = "csv_generation"
 
+    # Chat retention (TTL) hard-deletion queue. Kept off the primary "celery"
+    # queue so long backlog-cleanup runs never starve check_for_indexing.
+    CHAT_TTL_DELETION = "chat_ttl_deletion"
+
     # User file processing queue
     USER_FILE_PROCESSING = "user_file_processing"
     USER_FILE_PROJECT_SYNC = "user_file_project_sync"
@@ -481,6 +485,7 @@ class OnyxRedisLocks:
     SECURITY_SETTINGS = "da_lock:security_settings"
 
     MONITOR_BACKGROUND_PROCESSES_LOCK = "da_lock:monitor_background_processes"
+    CHAT_TTL_MANAGEMENT_LOCK = "da_lock:chat_ttl_management"
     CHECK_AVAILABLE_TENANTS_LOCK = "da_lock:check_available_tenants"
     CLOUD_PRE_PROVISION_TENANT_LOCK = "da_lock:pre_provision_tenant"
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -201,16 +201,13 @@ CELERY_DOCUMENT_SYNC_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
 # Max queue depth before the delete beat stops enqueuing more delete tasks.
 USER_FILE_DELETE_MAX_QUEUE_DEPTH = 500
 
-# Chat-retention (TTL) cleanup fan-out tuning. The beat dispatcher enqueues
-# bounded batches of expired chat sessions onto the light queue instead of
-# draining the whole backlog in one long task, so deletion interleaves with the
-# other light-queue work.
+# Chat-retention (TTL) cleanup tuning. Each delete task removes the oldest
+# CHAT_TTL_DELETE_BATCH_SIZE expired sessions and chains the next task, so
+# deletion drains one batch at a time on the light queue and interleaves with
+# the other light-queue work instead of running as one long task.
 CHAT_TTL_DELETE_BATCH_SIZE = 100
-# Max queue depth before the dispatcher stops enqueuing more delete batches.
-CHAT_TTL_DELETE_MAX_QUEUE_DEPTH = 50
-# How long a queued delete batch is valid before workers discard it. Long
-# enough to absorb queue wait; the per-session guard shares this TTL so a task
-# that expires unprocessed can be re-enqueued on a later cycle.
+# How long a queued delete task is valid before workers discard it. Bounds queue
+# growth; if a task expires the beat starts a fresh chain on its next run.
 CELERY_CHAT_TTL_DELETE_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
 
 DANSWER_REDIS_FUNCTION_LOCK_PREFIX = "da_function_lock:"
@@ -447,8 +444,8 @@ class OnyxCeleryQueues:
     CONNECTOR_HIERARCHY_FETCHING = "connector_hierarchy_fetching"
     CSV_GENERATION = "csv_generation"
 
-    # Chat retention (TTL) hard-deletion queue. Kept off the primary "celery"
-    # queue so long backlog-cleanup runs never starve check_for_indexing.
+    # Chat retention (TTL) hard-deletion queue, consumed by the light worker.
+    # Kept off the primary "celery" queue so cleanup never starves check_for_indexing.
     CHAT_TTL_DELETION = "chat_ttl_deletion"
 
     # User file processing queue
@@ -497,10 +494,8 @@ class OnyxRedisLocks:
     SECURITY_SETTINGS = "da_lock:security_settings"
 
     MONITOR_BACKGROUND_PROCESSES_LOCK = "da_lock:monitor_background_processes"
-    # Beat-dispatcher lock: only one chat-TTL fan-out runs per tenant at a time.
+    # Beat-dispatcher lock: only one chat-TTL chain is started per tenant at a time.
     CHAT_TTL_MANAGEMENT_LOCK = "da_lock:chat_ttl_management"
-    # Per-session queued guard so an in-flight session isn't re-enqueued.
-    CHAT_TTL_QUEUED_PREFIX = "da_lock:chat_ttl_queued"
     CHECK_AVAILABLE_TENANTS_LOCK = "da_lock:check_available_tenants"
     CLOUD_PRE_PROVISION_TENANT_LOCK = "da_lock:pre_provision_tenant"
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -201,6 +201,18 @@ CELERY_DOCUMENT_SYNC_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
 # Max queue depth before the delete beat stops enqueuing more delete tasks.
 USER_FILE_DELETE_MAX_QUEUE_DEPTH = 500
 
+# Chat-retention (TTL) cleanup fan-out tuning. The beat dispatcher enqueues
+# bounded batches of expired chat sessions onto the light queue instead of
+# draining the whole backlog in one long task, so deletion interleaves with the
+# other light-queue work.
+CHAT_TTL_DELETE_BATCH_SIZE = 100
+# Max queue depth before the dispatcher stops enqueuing more delete batches.
+CHAT_TTL_DELETE_MAX_QUEUE_DEPTH = 50
+# How long a queued delete batch is valid before workers discard it. Long
+# enough to absorb queue wait; the per-session guard shares this TTL so a task
+# that expires unprocessed can be re-enqueued on a later cycle.
+CELERY_CHAT_TTL_DELETE_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
+
 DANSWER_REDIS_FUNCTION_LOCK_PREFIX = "da_function_lock:"
 
 TMP_DRALPHA_PERSONA_NAME = "KG Beta"
@@ -485,7 +497,10 @@ class OnyxRedisLocks:
     SECURITY_SETTINGS = "da_lock:security_settings"
 
     MONITOR_BACKGROUND_PROCESSES_LOCK = "da_lock:monitor_background_processes"
+    # Beat-dispatcher lock: only one chat-TTL fan-out runs per tenant at a time.
     CHAT_TTL_MANAGEMENT_LOCK = "da_lock:chat_ttl_management"
+    # Per-session queued guard so an in-flight session isn't re-enqueued.
+    CHAT_TTL_QUEUED_PREFIX = "da_lock:chat_ttl_queued"
     CHECK_AVAILABLE_TENANTS_LOCK = "da_lock:check_available_tenants"
     CLOUD_PRE_PROVISION_TENANT_LOCK = "da_lock:pre_provision_tenant"
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -494,8 +494,9 @@ class OnyxRedisLocks:
     SECURITY_SETTINGS = "da_lock:security_settings"
 
     MONITOR_BACKGROUND_PROCESSES_LOCK = "da_lock:monitor_background_processes"
-    # Beat-dispatcher lock: only one chat-TTL chain is started per tenant at a time.
-    CHAT_TTL_MANAGEMENT_LOCK = "da_lock:chat_ttl_management"
+    # In-flight marker: set while a chat-TTL cleanup chain is active (spanning
+    # its chained tasks) so the beat won't start a second chain per tenant.
+    CHAT_TTL_CHAIN_ACTIVE = "da_lock:chat_ttl_chain_active"
     CHECK_AVAILABLE_TENANTS_LOCK = "da_lock:check_available_tenants"
     CLOUD_PRE_PROVISION_TENANT_LOCK = "da_lock:pre_provision_tenant"
 

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -370,7 +370,7 @@ def delete_chat_session(
 
 
 def get_chat_sessions_older_than(
-    days_old: int, db_session: Session
+    days_old: int, db_session: Session, limit: int | None = None
 ) -> list[tuple[UUID | None, UUID]]:
     """
     Retrieves chat sessions whose last activity is older than a specified number of days.
@@ -382,6 +382,9 @@ def get_chat_sessions_older_than(
     Args:
         days_old: The number of days to consider as "old".
         db_session: The database session.
+        limit: Optional cap on the number of sessions returned. When set, the
+            oldest sessions are returned first so callers can drain the backlog
+            in bounded batches without loading every matching row at once.
 
     Returns:
         A list of tuples, where each tuple contains the user_id (can be None) and the chat_session_id of an old chat session.
@@ -391,11 +394,16 @@ def get_chat_sessions_older_than(
     last_activity = func.coalesce(
         func.max(ChatMessage.time_sent), ChatSession.time_created
     )
-    old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
+    stmt = (
         select(ChatSession.user_id, ChatSession.id)
         .outerjoin(ChatMessage, ChatMessage.chat_session_id == ChatSession.id)
         .group_by(ChatSession.id, ChatSession.user_id)
         .having(last_activity < cutoff_time)
+    )
+    if limit is not None:
+        stmt = stmt.order_by(last_activity.asc()).limit(limit)
+    old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
+        stmt
     ).fetchall()
 
     # convert old_sessions to a conventional list of tuples

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
@@ -370,7 +371,10 @@ def delete_chat_session(
 
 
 def get_chat_sessions_older_than(
-    days_old: int, db_session: Session, limit: int | None = None
+    days_old: int,
+    db_session: Session,
+    limit: int | None = None,
+    exclude_session_ids: Collection[UUID] | None = None,
 ) -> list[tuple[UUID | None, UUID]]:
     """
     Retrieves chat sessions whose last activity is older than a specified number of days.
@@ -385,6 +389,9 @@ def get_chat_sessions_older_than(
         limit: Optional cap on the number of sessions returned. When set, the
             oldest sessions are returned first so callers can drain the backlog
             in bounded batches without loading every matching row at once.
+        exclude_session_ids: Session ids to skip. Callers draining in oldest-first
+            batches use this to advance past sessions that failed to delete so a
+            few undeletable rows don't block the rest of the backlog.
 
     Returns:
         A list of tuples, where each tuple contains the user_id (can be None) and the chat_session_id of an old chat session.
@@ -400,6 +407,8 @@ def get_chat_sessions_older_than(
         .group_by(ChatSession.id, ChatSession.user_id)
         .having(last_activity < cutoff_time)
     )
+    if exclude_session_ids:
+        stmt = stmt.where(ChatSession.id.notin_(exclude_session_ids))
     if limit is not None:
         stmt = stmt.order_by(last_activity.asc()).limit(limit)
     old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -1,4 +1,3 @@
-from collections.abc import Collection
 from collections.abc import Sequence
 from datetime import datetime
 from datetime import timedelta
@@ -371,10 +370,7 @@ def delete_chat_session(
 
 
 def get_chat_sessions_older_than(
-    days_old: int,
-    db_session: Session,
-    limit: int | None = None,
-    exclude_session_ids: Collection[UUID] | None = None,
+    days_old: float, db_session: Session, limit: int | None = None
 ) -> list[tuple[UUID | None, UUID]]:
     """
     Retrieves chat sessions whose last activity is older than a specified number of days.
@@ -389,9 +385,6 @@ def get_chat_sessions_older_than(
         limit: Optional cap on the number of sessions returned. When set, the
             oldest sessions are returned first so callers can drain the backlog
             in bounded batches without loading every matching row at once.
-        exclude_session_ids: Session ids to skip. Callers draining in oldest-first
-            batches use this to advance past sessions that failed to delete so a
-            few undeletable rows don't block the rest of the backlog.
 
     Returns:
         A list of tuples, where each tuple contains the user_id (can be None) and the chat_session_id of an old chat session.
@@ -407,8 +400,6 @@ def get_chat_sessions_older_than(
         .group_by(ChatSession.id, ChatSession.user_id)
         .having(last_activity < cutoff_time)
     )
-    if exclude_session_ids:
-        stmt = stmt.where(ChatSession.id.notin_(exclude_session_ids))
     if limit is not None:
         stmt = stmt.order_by(last_activity.asc()).limit(limit)
     old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -44,7 +44,7 @@ stopasgroup=true
 [program:celery_worker_light]
 command=celery -A onyx.background.celery.versioned_apps.light worker
     --hostname=light@%%n
-    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
+    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,chat_ttl_deletion
 stdout_logfile=/var/log/celery_worker_light.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -7,13 +7,16 @@ from uuid import UUID
 
 import httpx
 import pytest
+from pytest import MonkeyPatch
 from sqlalchemy import update
 
+import ee.onyx.background.celery.tasks.ttl_management.tasks as ttl_tasks
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
+from shared_configs.contextvars import get_current_tenant_id
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.settings import SettingsManager
 from tests.integration.common_utils.test_models import DATestChatSession
@@ -178,3 +181,59 @@ def test_chat_retention_uses_last_message_time(
     assert _is_session_deleted(stale_session, admin_user), (
         "Session with no recent activity should be deleted"
     )
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Chat retention tests are enterprise only",
+)
+def test_chat_retention_batched_deletion(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """The real TTL task drains a backlog spanning multiple batches.
+
+    Forces a small batch size so several sessions require more than one batch,
+    then runs the actual Celery task to verify the drain loop deletes every old
+    session and terminates.
+    """
+
+    retention_days = 30
+    settings = DATestSettings(maximum_chat_retention_days=retention_days)
+    SettingsManager.update_settings(settings, user_performing_action=admin_user)
+
+    monkeypatch.setattr(ttl_tasks, "_TTL_DELETE_BATCH_SIZE", 2)
+
+    old_sessions: list[DATestChatSession] = []
+    for i in range(5):
+        session = ChatSessionManager.create(
+            persona_id=0,
+            description=f"Stale session {i}",
+            user_performing_action=admin_user,
+        )
+        response = ChatSessionManager.send_message(
+            chat_session_id=session.id,
+            message="This session should be cleaned up",
+            user_performing_action=admin_user,
+        )
+        assert response.error is None, (
+            f"Chat response should not have an error: {response.error}"
+        )
+        _backdate_session(session.id, created_days_ago=60, last_message_days_ago=60)
+        old_sessions.append(session)
+
+    # Run the real task (eager) so the batched drain loop + Redis lock execute.
+    result = ttl_tasks.perform_ttl_management_task.apply(
+        kwargs=dict(
+            retention_limit_days=retention_days,
+            tenant_id=get_current_tenant_id(),
+        ),
+    )
+    assert result.successful(), f"TTL task failed: {result.traceback}"
+
+    for session in old_sessions:
+        assert _is_session_deleted(session, admin_user), (
+            f"Session {session.id} should have been deleted by batched cleanup"
+        )

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -9,6 +9,7 @@ import httpx
 import pytest
 from pytest import MonkeyPatch
 from sqlalchemy import update
+from sqlalchemy.orm import Session
 
 import ee.onyx.background.celery.tasks.ttl_management.tasks as ttl_tasks
 from onyx.db.chat import delete_chat_session
@@ -236,4 +237,95 @@ def test_chat_retention_batched_deletion(
     for session in old_sessions:
         assert _is_session_deleted(session, admin_user), (
             f"Session {session.id} should have been deleted by batched cleanup"
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Chat retention tests are enterprise only",
+)
+def test_chat_retention_skips_failing_session(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """A single undeletable session must not block the rest of the backlog.
+
+    The oldest session is made to fail deletion. Because cleanup runs oldest
+    first, a naive stop-on-no-progress guard would strand every newer session
+    behind it. The failed session should be skipped and all others deleted.
+    """
+
+    retention_days = 30
+    settings = DATestSettings(maximum_chat_retention_days=retention_days)
+    SettingsManager.update_settings(settings, user_performing_action=admin_user)
+
+    monkeypatch.setattr(ttl_tasks, "_TTL_DELETE_BATCH_SIZE", 2)
+
+    # Oldest session (largest last_message_days_ago) is fetched first.
+    poison_session = ChatSessionManager.create(
+        persona_id=0,
+        description="Undeletable oldest session",
+        user_performing_action=admin_user,
+    )
+    poison_response = ChatSessionManager.send_message(
+        chat_session_id=poison_session.id,
+        message="This session's deletion will fail",
+        user_performing_action=admin_user,
+    )
+    assert poison_response.error is None
+    _backdate_session(poison_session.id, created_days_ago=90, last_message_days_ago=90)
+
+    deletable_sessions: list[DATestChatSession] = []
+    for i in range(4):
+        session = ChatSessionManager.create(
+            persona_id=0,
+            description=f"Deletable session {i}",
+            user_performing_action=admin_user,
+        )
+        response = ChatSessionManager.send_message(
+            chat_session_id=session.id,
+            message="This session should be cleaned up",
+            user_performing_action=admin_user,
+        )
+        assert response.error is None
+        _backdate_session(session.id, created_days_ago=60, last_message_days_ago=60)
+        deletable_sessions.append(session)
+
+    real_delete_chat_session = ttl_tasks.delete_chat_session
+
+    def _delete_or_fail(
+        user_id: UUID | None,
+        chat_session_id: UUID,
+        db_session: Session,
+        include_deleted: bool = False,
+        hard_delete: bool = False,
+    ) -> None:
+        if str(chat_session_id) == str(poison_session.id):
+            raise RuntimeError("Simulated delete failure")
+        real_delete_chat_session(
+            user_id,
+            chat_session_id,
+            db_session,
+            include_deleted=include_deleted,
+            hard_delete=hard_delete,
+        )
+
+    monkeypatch.setattr(ttl_tasks, "delete_chat_session", _delete_or_fail)
+
+    result = ttl_tasks.perform_ttl_management_task.apply(
+        kwargs=dict(
+            retention_limit_days=retention_days,
+            tenant_id=get_current_tenant_id(),
+        ),
+    )
+    assert result.successful(), f"TTL task failed: {result.traceback}"
+
+    assert not _is_session_deleted(poison_session, admin_user), (
+        "The failing session should remain (retried on the next run)"
+    )
+    for session in deletable_sessions:
+        assert _is_session_deleted(session, admin_user), (
+            f"Session {session.id} should be deleted despite an older failing session"
         )

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -184,7 +184,10 @@ def test_chat_retention_uses_last_message_time(
     )
 
 
-def _make_session(admin_user: DATestUser, description: str) -> DATestChatSession:
+def _make_old_session(
+    admin_user: DATestUser, description: str, days_old: int = 60
+) -> DATestChatSession:
+    """Create a chat session with a message, aged so TTL cleanup will select it."""
     session = ChatSessionManager.create(
         persona_id=0,
         description=description,
@@ -198,6 +201,9 @@ def _make_session(admin_user: DATestUser, description: str) -> DATestChatSession
     assert response.error is None, (
         f"Chat response should not have an error: {response.error}"
     )
+    _backdate_session(
+        session.id, created_days_ago=days_old, last_message_days_ago=days_old
+    )
     return session
 
 
@@ -205,24 +211,26 @@ def _make_session(admin_user: DATestUser, description: str) -> DATestChatSession
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Chat retention tests are enterprise only",
 )
-def test_perform_ttl_deletes_batch(
+def test_perform_ttl_deletes_oldest_expired(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
 ) -> None:
-    """The batch worker hard-deletes every session in the batch it's given."""
+    """The worker hard-deletes the oldest batch of expired sessions."""
 
-    sessions = [_make_session(admin_user, f"Stale session {i}") for i in range(3)]
-    session_batch = [(str(admin_user.id), str(s.id)) for s in sessions]
+    retention_days = 30
+    sessions = [_make_old_session(admin_user, f"Stale session {i}") for i in range(3)]
 
     result = ttl_tasks.perform_ttl_management_task.apply(
-        kwargs=dict(session_batch=session_batch, tenant_id=get_current_tenant_id()),
+        kwargs=dict(
+            retention_limit_days=retention_days, tenant_id=get_current_tenant_id()
+        ),
     )
     assert result.successful(), f"TTL task failed: {result.traceback}"
 
     for session in sessions:
         assert _is_session_deleted(session, admin_user), (
-            f"Session {session.id} should have been deleted by the batch worker"
+            f"Session {session.id} should have been deleted by TTL cleanup"
         )
 
 
@@ -230,21 +238,22 @@ def test_perform_ttl_deletes_batch(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Chat retention tests are enterprise only",
 )
-def test_perform_ttl_skips_failing_session_in_batch(
+def test_perform_ttl_continues_past_failing_session(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """One undeletable session must not block the rest of its batch.
+    """One undeletable session must not block the rest of the batch.
 
-    The worker logs and continues past a failing delete, so every other session
-    in the same batch is still removed and the task itself succeeds.
+    The worker logs and continues past a failing delete, so every other expired
+    session is still removed and the task itself succeeds.
     """
 
-    poison_session = _make_session(admin_user, "Undeletable session")
+    retention_days = 30
+    poison_session = _make_old_session(admin_user, "Undeletable session")
     deletable_sessions = [
-        _make_session(admin_user, f"Deletable session {i}") for i in range(3)
+        _make_old_session(admin_user, f"Deletable session {i}") for i in range(3)
     ]
 
     real_delete_chat_session = ttl_tasks.delete_chat_session
@@ -268,28 +277,17 @@ def test_perform_ttl_skips_failing_session_in_batch(
 
     monkeypatch.setattr(ttl_tasks, "delete_chat_session", _delete_or_fail)
 
-    # Poison session first in the batch, to prove later sessions still delete.
-    session_batch = [(str(admin_user.id), str(poison_session.id))] + [
-        (str(admin_user.id), str(s.id)) for s in deletable_sessions
-    ]
-
     result = ttl_tasks.perform_ttl_management_task.apply(
-        kwargs=dict(session_batch=session_batch, tenant_id=get_current_tenant_id()),
+        kwargs=dict(
+            retention_limit_days=retention_days, tenant_id=get_current_tenant_id()
+        ),
     )
     assert result.successful(), f"TTL task failed: {result.traceback}"
-
-    assert not _is_session_deleted(poison_session, admin_user), (
-        "The failing session should remain (retried on the next cycle)"
-    )
-    for session in deletable_sessions:
-        assert _is_session_deleted(session, admin_user), (
-            f"Session {session.id} should be deleted despite a failing session in the batch"
-        )
 
     assert not _is_session_deleted(poison_session, admin_user), (
         "The failing session should remain (retried on the next run)"
     )
     for session in deletable_sessions:
         assert _is_session_deleted(session, admin_user), (
-            f"Session {session.id} should be deleted despite an older failing session"
+            f"Session {session.id} should be deleted despite a failing session"
         )

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -1,5 +1,6 @@
 import os
 import time
+import uuid
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -12,11 +13,14 @@ from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 import ee.onyx.background.celery.tasks.ttl_management.tasks as ttl_tasks
+from onyx.configs.constants import CELERY_CHAT_TTL_DELETE_TASK_EXPIRES
+from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
+from onyx.redis.redis_pool import get_redis_client
 from shared_configs.contextvars import get_current_tenant_id
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.settings import SettingsManager
@@ -207,6 +211,29 @@ def _make_old_session(
     return session
 
 
+def _run_perform_ttl(retention_days: int) -> None:
+    """Claim the chain marker with a fresh token, then run one perform task.
+
+    Mirrors how the beat starts a chain: perform only proceeds while it owns the
+    marker, so the token must be claimed before invoking it.
+    """
+    tenant_id = get_current_tenant_id()
+    token = uuid.uuid4().hex
+    get_redis_client(tenant_id=tenant_id).set(
+        OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
+        token,
+        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+    )
+    result = ttl_tasks.perform_ttl_management_task.apply(
+        kwargs=dict(
+            retention_limit_days=retention_days,
+            chain_token=token,
+            tenant_id=tenant_id,
+        ),
+    )
+    assert result.successful(), f"TTL task failed: {result.traceback}"
+
+
 @pytest.mark.skipif(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Chat retention tests are enterprise only",
@@ -221,12 +248,7 @@ def test_perform_ttl_deletes_oldest_expired(
     retention_days = 30
     sessions = [_make_old_session(admin_user, f"Stale session {i}") for i in range(3)]
 
-    result = ttl_tasks.perform_ttl_management_task.apply(
-        kwargs=dict(
-            retention_limit_days=retention_days, tenant_id=get_current_tenant_id()
-        ),
-    )
-    assert result.successful(), f"TTL task failed: {result.traceback}"
+    _run_perform_ttl(retention_days)
 
     for session in sessions:
         assert _is_session_deleted(session, admin_user), (
@@ -277,12 +299,7 @@ def test_perform_ttl_continues_past_failing_session(
 
     monkeypatch.setattr(ttl_tasks, "delete_chat_session", _delete_or_fail)
 
-    result = ttl_tasks.perform_ttl_management_task.apply(
-        kwargs=dict(
-            retention_limit_days=retention_days, tenant_id=get_current_tenant_id()
-        ),
-    )
-    assert result.successful(), f"TTL task failed: {result.traceback}"
+    _run_perform_ttl(retention_days)
 
     assert not _is_session_deleted(poison_session, admin_user), (
         "The failing session should remain (retried on the next run)"

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -184,59 +184,45 @@ def test_chat_retention_uses_last_message_time(
     )
 
 
+def _make_session(admin_user: DATestUser, description: str) -> DATestChatSession:
+    session = ChatSessionManager.create(
+        persona_id=0,
+        description=description,
+        user_performing_action=admin_user,
+    )
+    response = ChatSessionManager.send_message(
+        chat_session_id=session.id,
+        message="This session should be cleaned up",
+        user_performing_action=admin_user,
+    )
+    assert response.error is None, (
+        f"Chat response should not have an error: {response.error}"
+    )
+    return session
+
+
 @pytest.mark.skipif(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Chat retention tests are enterprise only",
 )
-def test_chat_retention_batched_deletion(
+def test_perform_ttl_deletes_batch(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
-    monkeypatch: MonkeyPatch,
 ) -> None:
-    """The real TTL task drains a backlog spanning multiple batches.
+    """The batch worker hard-deletes every session in the batch it's given."""
 
-    Forces a small batch size so several sessions require more than one batch,
-    then runs the actual Celery task to verify the drain loop deletes every old
-    session and terminates.
-    """
+    sessions = [_make_session(admin_user, f"Stale session {i}") for i in range(3)]
+    session_batch = [(str(admin_user.id), str(s.id)) for s in sessions]
 
-    retention_days = 30
-    settings = DATestSettings(maximum_chat_retention_days=retention_days)
-    SettingsManager.update_settings(settings, user_performing_action=admin_user)
-
-    monkeypatch.setattr(ttl_tasks, "_TTL_DELETE_BATCH_SIZE", 2)
-
-    old_sessions: list[DATestChatSession] = []
-    for i in range(5):
-        session = ChatSessionManager.create(
-            persona_id=0,
-            description=f"Stale session {i}",
-            user_performing_action=admin_user,
-        )
-        response = ChatSessionManager.send_message(
-            chat_session_id=session.id,
-            message="This session should be cleaned up",
-            user_performing_action=admin_user,
-        )
-        assert response.error is None, (
-            f"Chat response should not have an error: {response.error}"
-        )
-        _backdate_session(session.id, created_days_ago=60, last_message_days_ago=60)
-        old_sessions.append(session)
-
-    # Run the real task (eager) so the batched drain loop + Redis lock execute.
     result = ttl_tasks.perform_ttl_management_task.apply(
-        kwargs=dict(
-            retention_limit_days=retention_days,
-            tenant_id=get_current_tenant_id(),
-        ),
+        kwargs=dict(session_batch=session_batch, tenant_id=get_current_tenant_id()),
     )
     assert result.successful(), f"TTL task failed: {result.traceback}"
 
-    for session in old_sessions:
+    for session in sessions:
         assert _is_session_deleted(session, admin_user), (
-            f"Session {session.id} should have been deleted by batched cleanup"
+            f"Session {session.id} should have been deleted by the batch worker"
         )
 
 
@@ -244,54 +230,22 @@ def test_chat_retention_batched_deletion(
     os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
     reason="Chat retention tests are enterprise only",
 )
-def test_chat_retention_skips_failing_session(
+def test_perform_ttl_skips_failing_session_in_batch(
     reset: None,  # noqa: ARG001
     admin_user: DATestUser,
     llm_provider: DATestLLMProvider,  # noqa: ARG001
     monkeypatch: MonkeyPatch,
 ) -> None:
-    """A single undeletable session must not block the rest of the backlog.
+    """One undeletable session must not block the rest of its batch.
 
-    The oldest session is made to fail deletion. Because cleanup runs oldest
-    first, a naive stop-on-no-progress guard would strand every newer session
-    behind it. The failed session should be skipped and all others deleted.
+    The worker logs and continues past a failing delete, so every other session
+    in the same batch is still removed and the task itself succeeds.
     """
 
-    retention_days = 30
-    settings = DATestSettings(maximum_chat_retention_days=retention_days)
-    SettingsManager.update_settings(settings, user_performing_action=admin_user)
-
-    monkeypatch.setattr(ttl_tasks, "_TTL_DELETE_BATCH_SIZE", 2)
-
-    # Oldest session (largest last_message_days_ago) is fetched first.
-    poison_session = ChatSessionManager.create(
-        persona_id=0,
-        description="Undeletable oldest session",
-        user_performing_action=admin_user,
-    )
-    poison_response = ChatSessionManager.send_message(
-        chat_session_id=poison_session.id,
-        message="This session's deletion will fail",
-        user_performing_action=admin_user,
-    )
-    assert poison_response.error is None
-    _backdate_session(poison_session.id, created_days_ago=90, last_message_days_ago=90)
-
-    deletable_sessions: list[DATestChatSession] = []
-    for i in range(4):
-        session = ChatSessionManager.create(
-            persona_id=0,
-            description=f"Deletable session {i}",
-            user_performing_action=admin_user,
-        )
-        response = ChatSessionManager.send_message(
-            chat_session_id=session.id,
-            message="This session should be cleaned up",
-            user_performing_action=admin_user,
-        )
-        assert response.error is None
-        _backdate_session(session.id, created_days_ago=60, last_message_days_ago=60)
-        deletable_sessions.append(session)
+    poison_session = _make_session(admin_user, "Undeletable session")
+    deletable_sessions = [
+        _make_session(admin_user, f"Deletable session {i}") for i in range(3)
+    ]
 
     real_delete_chat_session = ttl_tasks.delete_chat_session
 
@@ -314,13 +268,23 @@ def test_chat_retention_skips_failing_session(
 
     monkeypatch.setattr(ttl_tasks, "delete_chat_session", _delete_or_fail)
 
+    # Poison session first in the batch, to prove later sessions still delete.
+    session_batch = [(str(admin_user.id), str(poison_session.id))] + [
+        (str(admin_user.id), str(s.id)) for s in deletable_sessions
+    ]
+
     result = ttl_tasks.perform_ttl_management_task.apply(
-        kwargs=dict(
-            retention_limit_days=retention_days,
-            tenant_id=get_current_tenant_id(),
-        ),
+        kwargs=dict(session_batch=session_batch, tenant_id=get_current_tenant_id()),
     )
     assert result.successful(), f"TTL task failed: {result.traceback}"
+
+    assert not _is_session_deleted(poison_session, admin_user), (
+        "The failing session should remain (retried on the next cycle)"
+    )
+    for session in deletable_sessions:
+        assert _is_session_deleted(session, admin_user), (
+            f"Session {session.id} should be deleted despite a failing session in the batch"
+        )
 
     assert not _is_session_deleted(poison_session, admin_user), (
         "The failing session should remain (retried on the next run)"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.10
+version: 0.6.11
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,13 +16,11 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: fixed
-      description: Support clusters running their own cluster-managed CloudNativePG operator.
-        New postgresqlOperator.enabled toggle (mirrors redisOperator.enabled) skips the bundled
-        CNPG operator and its CRDs while keeping the Cluster CR for the external operator to
-        reconcile; the CRDs move byte-for-byte into a condition-gated CRDs-only subchart
-        (onyx-cnpg-crds) with postgresql.installCRDs as an independent override. Default
-        behavior is unchanged; CRDs also no longer install when postgresql.enabled is false.
+    - kind: added
+      description: Add the chat_ttl_deletion queue to the light celery worker so chat-retention
+        (TTL) cleanup runs off the primary "celery" queue and can no longer stall indexing. The
+        light worker consumes the new queue via its -Q list; a rollout is required for existing
+        deployments to pick it up.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -73,7 +73,7 @@ spec:
               {{- end }}
               "--hostname=light@%n",
               "-Q",
-              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,chat_ttl_deletion",
             ]
           ports:
             - name: metrics


### PR DESCRIPTION
## Description

TTL chat-retention cleanup (`perform_ttl_management_task`) was enqueued on the default `celery` queue — the primary worker's only lane, shared with the recurring `check_for_indexing` beat task — and deleted every expired chat session in a single unbounded task (`get_chat_sessions_older_than` had no `LIMIT`).

On an instance with a large backlog (tens of thousands of sessions), one cleanup run pinned a primary worker thread for a long time. While it ran, `check_for_indexing` (every 15s) piled up behind it on the same queue and aged past its `expires` (`BEAT_EXPIRES_DEFAULT` = 15 min), so Celery dropped them — surfacing as `Discarding revoked task: check_for_indexing[...]` and silently stalled indexing. Flushing Redis cleared the backlog temporarily, then it recurred.

Separately, the `should_perform_chat_ttl_check` guard was ineffective (nothing ever called `register_task` for this task), so the hourly beat stacked a **new** full cleanup run on top of any still-draining one, compounding the congestion on large backlogs.

This PR:

- **Dedicated queue.** Routes `perform_ttl_management_task` to a new `chat_ttl_deletion` queue consumed by the **light** worker, and enqueues it with an `expires` (previously enqueued with none). Fully off the primary/indexing lane. Added to the light worker `-Q` in `supervisord.conf` and `celery-worker-light.yaml`.
- **Batched deletes.** `get_chat_sessions_older_than` gains an optional `limit` (oldest-first) and the task drains in bounded 100-row batches, so no run loads the whole backlog into memory or holds a thread indefinitely. The loop terminates on an empty or partial batch, and stops (with an error log) if a full batch makes zero progress, so it can't spin forever.
- **Single-run guard.** Wraps the run in a per-tenant Redis lock (reacquired per batch) so overlapping hourly runs can't stack.
- **Observability.** Reports `chat_ttl_deletion` queue depth in the monitoring task.

> **Deploy note:** the light celery worker must be restarted to pick up the new `chat_ttl_deletion` queue in its `-Q` list.

## How Has This Been Tested?

- Added `test_chat_retention_batched_deletion` (enterprise integration test) that forces a small batch size and runs the real task to verify a multi-batch backlog is fully drained and the loop terminates. Existing `test_chat_retention` cases are unchanged (the `get_chat_sessions_older_than` signature is backward compatible).
- `ruff check` + `ruff format --check` pass on all changed files.
- Full integration suite not run locally (requires a live enterprise deployment); relying on CI.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved chat TTL cleanup to a dedicated `chat_ttl_deletion` queue and run it in chained 100‑session batches so it won’t block the primary queue or stall `check_for_indexing`. Added a token‑fenced Redis lock and rolling‑upgrade safety to keep a single chain per tenant.

- **Bug Fixes**
  - Dispatcher (`check_ttl_management_task`): per‑tenant `SET NX` marker claimed with a token; starts a chain only when not set; enqueues the first task to `chat_ttl_deletion` with 1h `expires` and low priority.
  - Worker (`perform_ttl_management_task`): deletes the oldest batch and, if full, enqueues the next with the same token; extends/releases the marker only if still owned; continues past per‑session errors; defaults an empty `chain_token` to safely no‑op legacy messages.
  - `get_chat_sessions_older_than`: added `limit` (oldest‑first) and float `days_old`.
  - Monitoring: added `chat_ttl_deletion` queue length metric.
  - Tests: cover full‑batch deletion and skipping a failing session.

- **Migration**
  - Restart the light Celery worker to pick up `-Q chat_ttl_deletion` (Helm chart bumped to 0.6.11 to roll the worker).

<sup>Written for commit 7e8cc3d88146ac621bb023011490466047cb272a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

