### PR TITLE
ci(dependabot): add Docker update entries for web and backend images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -68,3 +68,25 @@ updates:
     labels:
       - "dependabot:docker"
       - "dependabot:sandbox"
+  - package-ecosystem: "docker"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    assignees:
+      - "jmelahman"
+    labels:
+      - "dependabot:docker"
+  - package-ecosystem: "docker"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 1
+    assignees:
+      - "jmelahman"
+    labels:
+      - "dependabot:docker"


### PR DESCRIPTION
## Description

Adds `docker` package-ecosystem entries to `.github/dependabot.yml` for:

- `/web` — covers `web/Dockerfile`
- `/backend` — covers both `backend/Dockerfile` and `backend/Dockerfile.model_server` (Dependabot scans the directory for any file whose name contains "Dockerfile")

Both entries follow the existing conventions (weekly schedule, 7-day cooldown, `dependabot:docker` label) with `open-pull-requests-limit: 1`.

Notes:
- The `dhi.io` base images (web node bases, model server Python bases) come from an authenticated registry; without a `registries:` config + Dependabot secrets those `FROM` lines won't get update PRs. The Docker Hub images (`oven/bun`, `python:3.13-slim`) are covered as-is.
- The `ghcr.io/astral-sh/uv` pin is referenced via `COPY --from=`, which Dependabot doesn't parse, so it still needs manual bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Dependabot support for Docker base image updates in the web and backend builds by adding `docker` entries to the config.

- **Dependencies**
  - Add `docker` updates for `/web` and `/backend` (covers `web/Dockerfile`, `backend/Dockerfile`, `backend/Dockerfile.model_server`).
  - Weekly schedule with 7-day cooldown; max 1 open PR; assign `jmelahman`; label `dependabot:docker`.
  - Limits: private `dhi.io` bases need `registries:` + secrets to update; `COPY --from=ghcr.io/astral-sh/uv` is not parsed and must be bumped manually; Docker Hub images like `oven/bun` and `python:3.13-slim` will update.

<sup>Written for commit 499cb0d31e5e44172d9195c807010e56a3fd6391. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

