### PR TITLE
fix(auth): only enforce password constraints during signup, not login

### DIFF
--- a/web/src/lib/auth/components.test.tsx
+++ b/web/src/lib/auth/components.test.tsx
@@ -197,6 +197,27 @@ describe("Email/Password Signup Workflow", () => {
     });
   });
 
+  test("rejects a password that fails signup constraints", async () => {
+    const user = setupUser();
+
+    render(<EmailPasswordForm label="create" />);
+
+    await user.type(
+      screen.getByPlaceholderText(/email@yourcompany.com/i),
+      "newuser@example.com"
+    );
+    await user.type(screen.getByTestId("password"), "weak");
+
+    // Signup enforces password policy — button must be disabled.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /create account/i })
+      ).toBeDisabled();
+    });
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   test("shows error toast when email already exists", async () => {
     const user = setupUser();
 

--- a/web/src/lib/auth/components.test.tsx
+++ b/web/src/lib/auth/components.test.tsx
@@ -91,6 +91,34 @@ describe("Email/Password Login Workflow", () => {
     expect(body.toString()).toContain("password=password123");
   });
 
+  test("submits with a password that would fail signup constraints", async () => {
+    const user = setupUser();
+
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    } as Response);
+
+    render(<EmailPasswordForm label="submit" />);
+
+    await user.type(
+      screen.getByPlaceholderText(/email@yourcompany.com/i),
+      "test@example.com"
+    );
+    await user.type(screen.getByTestId("password"), "weak");
+
+    // Login must not enforce password policy — button stays enabled.
+    expect(screen.getByRole("button", { name: /sign in/i })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/auth/login",
+        expect.anything()
+      );
+    });
+  });
+
   test("shows error toast when login fails", async () => {
     const user = setupUser();
 

--- a/web/src/lib/auth/components.tsx
+++ b/web/src/lib/auth/components.tsx
@@ -282,39 +282,43 @@ export function EmailPasswordForm({
   const { getCaptchaToken } = useCaptcha();
 
   const validationSchema = useMemo(() => {
-    const minLength = authTypeMetadata?.passwordMinLength ?? 0;
-    const maxLength = authTypeMetadata?.passwordMaxLength ?? Infinity;
+    let passwordSchema = Yup.string();
 
-    let passwordSchema = Yup.string().test(
-      "length",
-      `Password must be between ${minLength}–${maxLength} characters`,
-      (v) => passwordMeetsLengthRequirements(v ?? "", minLength, maxLength)
-    );
+    if (isSignup) {
+      const minLength = authTypeMetadata?.passwordMinLength ?? 0;
+      const maxLength = authTypeMetadata?.passwordMaxLength ?? Infinity;
 
-    if (authTypeMetadata?.passwordRequireUppercase)
       passwordSchema = passwordSchema.test(
-        "uppercase",
-        "Password must contain at least one uppercase letter",
-        (v) => passwordHasUppercase(v ?? "")
+        "length",
+        `Password must be between ${minLength}–${maxLength} characters`,
+        (v) => passwordMeetsLengthRequirements(v ?? "", minLength, maxLength)
       );
-    if (authTypeMetadata?.passwordRequireLowercase)
-      passwordSchema = passwordSchema.test(
-        "lowercase",
-        "Password must contain at least one lowercase letter",
-        (v) => passwordHasLowercase(v ?? "")
-      );
-    if (authTypeMetadata?.passwordRequireDigit)
-      passwordSchema = passwordSchema.test(
-        "digit",
-        "Password must contain at least one number",
-        (v) => passwordHasDigit(v ?? "")
-      );
-    if (authTypeMetadata?.passwordRequireSpecialChar)
-      passwordSchema = passwordSchema.test(
-        "special-char",
-        "Password must contain at least one special character",
-        (v) => passwordHasSpecialChar(v ?? "")
-      );
+
+      if (authTypeMetadata?.passwordRequireUppercase)
+        passwordSchema = passwordSchema.test(
+          "uppercase",
+          "Password must contain at least one uppercase letter",
+          (v) => passwordHasUppercase(v ?? "")
+        );
+      if (authTypeMetadata?.passwordRequireLowercase)
+        passwordSchema = passwordSchema.test(
+          "lowercase",
+          "Password must contain at least one lowercase letter",
+          (v) => passwordHasLowercase(v ?? "")
+        );
+      if (authTypeMetadata?.passwordRequireDigit)
+        passwordSchema = passwordSchema.test(
+          "digit",
+          "Password must contain at least one number",
+          (v) => passwordHasDigit(v ?? "")
+        );
+      if (authTypeMetadata?.passwordRequireSpecialChar)
+        passwordSchema = passwordSchema.test(
+          "special-char",
+          "Password must contain at least one special character",
+          (v) => passwordHasSpecialChar(v ?? "")
+        );
+    }
 
     return Yup.object().shape({
       email: Yup.string()
@@ -323,7 +327,7 @@ export function EmailPasswordForm({
         .transform((value: string) => value.toLowerCase()),
       password: passwordSchema.required(),
     });
-  }, [authTypeMetadata]);
+  }, [isSignup, authTypeMetadata]);
 
   const initialValues: FormValues = {
     email: defaultEmail?.toLowerCase() ?? "",

--- a/web/tests/e2e/auth/login.spec.ts
+++ b/web/tests/e2e/auth/login.spec.ts
@@ -68,6 +68,19 @@ test.describe("Login flow", () => {
     expect(me.ok()).toBe(false);
   });
 
+  test("Login button is enabled for a password that fails signup constraints", async ({
+    page,
+  }) => {
+    await page.goto("/auth/login");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("email").fill("test@example.com");
+    await page.getByTestId("password").fill("weak");
+
+    // Login must not enforce password policy — the submit button must remain enabled.
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeEnabled();
+  });
+
   test("Login fails with non-existent user", async ({ page }) => {
     await page.goto("/auth/login");
     await page.waitForLoadState("networkidle");

--- a/web/tests/e2e/auth/login.spec.ts
+++ b/web/tests/e2e/auth/login.spec.ts
@@ -81,6 +81,19 @@ test.describe("Login flow", () => {
     await expect(page.getByRole("button", { name: "Sign In" })).toBeEnabled();
   });
 
+  test("Login button is enabled for a password that meets signup constraints", async ({
+    page,
+  }) => {
+    await page.goto("/auth/login");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("email").fill("test@example.com");
+    await page.getByTestId("password").fill("ValidPassword123!");
+
+    // Compliant and non-compliant passwords must behave identically on login.
+    await expect(page.getByRole("button", { name: "Sign In" })).toBeEnabled();
+  });
+
   test("Login fails with non-existent user", async ({ page }) => {
     await page.goto("/auth/login");
     await page.waitForLoadState("networkidle");


### PR DESCRIPTION
## Description

`EmailPasswordForm` uses a single `validationSchema` for both login and signup modes. Before this fix, the Yup schema applied all password constraints (min/max length, uppercase, lowercase, digit, special char) from `AuthTypeMetadata` unconditionally — meaning a user whose existing password didn't meet the current policy would be blocked from logging in entirely.

The fix gates all constraint tests behind `isSignup`, so:
- **Login**: password field only requires a non-empty value.
- **Signup**: full constraint schema is built from `AuthTypeMetadata` as before.

Introduced in 59603a14684c1c3718bdcae15631084281b95956.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes login by scoping password policy to signup. Existing users can sign in even if their passwords don’t meet newer rules.

- **Bug Fixes**
  - Apply length/uppercase/lowercase/digit/special-char checks only when `isSignup` is true.
  - Login only requires a non-empty password; validation schema now memoized with `[isSignup, authTypeMetadata]`.
  - Tests: unit and E2E confirm login ignores policy (button enabled for both non-compliant and compliant passwords) and signup blocks weak passwords.

<sup>Written for commit ba7e75a1f18fc6c6c59b007abbf750afc230f024. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

