### PR TITLE
fix(web): render Nebius provider logo on its lime brand tile

### DIFF
--- a/web/lib/opal/src/logos/nebius.tsx
+++ b/web/lib/opal/src/logos/nebius.tsx
@@ -1,10 +1,10 @@
 import type { IconProps } from "@opal/types";
 
-// Nebius Token Factory mark — the lime rounded-square-with-plus glyph on the
-// brand's dark tile (its official lockup). The dark tile keeps the light lime
-// mark visible on light provider-card backgrounds, where a bare lime glyph
-// washes out. Colors are inlined (like the other brand logos) rather than a
-// Tailwind text-color class, so the mark renders regardless of theme.
+// Nebius Token Factory mark — the brand "N" glyph on the brand's lime tile
+// (its official light lockup, matching the admin mocks). The lime tile keeps
+// the mark legible on both light and dark provider-card backgrounds; colors are
+// inlined (like the other brand logos) rather than a Tailwind text-color class,
+// so the mark renders identically regardless of theme.
 const SvgNebius = ({ size, className, ...props }: IconProps) => (
   <svg
     width={size}
@@ -16,12 +16,15 @@ const SvgNebius = ({ size, className, ...props }: IconProps) => (
     {...props}
   >
     <title>Nebius TokenFactory</title>
-    <rect width="28" height="28" rx="6.5" fill="#0B0B0B" />
-    <path
-      transform="translate(4.2 4.2) scale(0.7) translate(-103 0)"
-      d="M124.041 0c3.842 0 6.958 3.16 6.958 7.06v13.88l-.009.364c-.186 3.73-3.226 6.696-6.949 6.696h-14.083l-.357-.01c-3.558-.183-6.412-3.077-6.592-6.686L103 20.94V7.06c0-3.9 3.115-7.06 6.958-7.06h14.083Zm-14.083.916c-3.324 0-6.042 2.738-6.042 6.144v13.88c0 3.405 2.718 6.144 6.042 6.144h14.083c3.324 0 6.042-2.738 6.042-6.144V7.06c0-3.3-2.551-5.971-5.732-6.135l-.31-.009h-14.083Zm5.244 4.78c.301 0 .544.244.544.544V8.63c0 .214.173.389.388.389h2.389c.301 0 .544.243.544.544v2.388a.39.39 0 0 0 .389.389h2.389c.301 0 .545.244.545.545v2.233a.546.546 0 0 1-.545.544h-2.389a.39.39 0 0 0-.389.389v2.389c0 .3-.243.543-.544.543h-2.389a.389.389 0 0 0-.388.39v2.388c0 .3-.243.543-.544.544h-2.233a.543.543 0 0 1-.544-.544v-2.234c0-.3.243-.544.544-.544h2.388a.389.389 0 0 0 .389-.388v-2.389c0-.3.243-.544.544-.544h2.39a.388.388 0 0 0 .387-.388v-2.544a.389.389 0 0 0-.387-.39h-2.39a.543.543 0 0 1-.544-.544V9.406a.389.389 0 0 0-.389-.388h-2.388a.543.543 0 0 1-.544-.544V6.24c0-.3.243-.544.544-.544h2.233Z"
-      fill="#E0FF4F"
-    />
+    <rect width="28" height="28" rx="6.5" fill="#E0FF4F" />
+    <g
+      transform="translate(6.5 6.5) scale(0.625)"
+      fill="#0B0B0B"
+      fillRule="evenodd"
+    >
+      <path d="M20 2.306v16.797s4-.242 4-4.815V2.306h-4zM4 22.001V5.204s-4 .242-4 4.816V22h4z" />
+      <path d="M16.318 16.51L11.286 4.94c-.824-1.872-2.168-2.926-4.077-2.926-1.908 0-3.211 1.54-3.211 3.19 0 0 2.405-.333 3.68 2.593l5.036 11.57c.821 1.87 2.168 2.926 4.075 2.926 1.905 0 3.211-1.541 3.211-3.19 0 0-2.406.333-3.682-2.594z" />
+    </g>
   </svg>
 );
 


### PR DESCRIPTION
## Description

The Nebius Token Factory provider logo used the brand's **dark** lockup (near-black `#0B0B0B` tile + lime `#E0FF4F` glyph). That near-black tile sinks into the dark-mode card background, and it doesn't match the admin-panel mocks, which use the brand's **light** lockup (lime tile + dark glyph).

This swaps the two fills so the mark renders as a lime `#E0FF4F` tile with a dark `#0B0B0B` glyph — the brand's official self-contained lockup, which stays legible on both light and dark provider cards. Kept fixed (not theme-swapped) to match the neighboring colored brand marks; the tile carries its own background so it reads in either theme.

## How Has This Been Tested?

- Rendered the SVG standalone and composited on a dark background — the lime tile + dark glyph reads clearly in both light and dark.
- Confirmed the mark matches the admin-panel design.
- Screenshots from the local app (light + dark) to follow.

<!-- screenshots -->
Before:
<img width="423" height="83" alt="Screenshot 2026-07-13 at 12 54 25 PM" src="https://github.com/user-attachments/assets/2f5685fd-8c23-4aa3-a462-e71665df281f" />

After:
<img width="425" height="83" alt="Screenshot 2026-07-13 at 12 54 39 PM" src="https://github.com/user-attachments/assets/2321be11-afca-4e23-846e-c04d38a7e61b" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the Nebius provider logo with the actual “N” mark on the brand’s light lockup: lime `#E0FF4F` tile with dark `#0B0B0B` glyph. This fixes the placeholder artwork and matches the admin mocks while staying readable in light and dark.

<sup>Written for commit 1492365a9fc04dd17da394e4aa05151b2b90307e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

