### PR TITLE
feat(web): group LLM providers into labeled sections

### DIFF
--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -40,25 +40,53 @@ function providerDisplayName(provider: LLMProviderView): string {
 }
 
 // ============================================================================
-// Provider form mapping (keyed by provider name from the API)
+// Provider grouping (keyed by provider name from the API)
 // ============================================================================
 
-// Static list of well-known providers rendered in the "Add Provider" grid.
-// Must match the backend's WELL_KNOWN_PROVIDER_NAMES (minus any that lack a
-// dedicated modal). Order here controls display order.
-const PROVIDER_DISPLAY_ORDER: string[] = [
-  LLMProviderName.OPENAI,
-  LLMProviderName.ANTHROPIC,
-  LLMProviderName.VERTEX_AI,
-  LLMProviderName.BEDROCK,
-  LLMProviderName.AZURE,
-  LLMProviderName.LITELLM_PROXY,
-  LLMProviderName.OLLAMA_CHAT,
-  LLMProviderName.OPENROUTER,
-  LLMProviderName.LM_STUDIO,
-  LLMProviderName.BIFROST,
-  LLMProviderName.OPENAI_COMPATIBLE,
-  LLMProviderName.NEBIUS_TOKENFACTORY,
+// The "Add Provider" area is split into labeled groups. Provider names must
+// match the backend's WELL_KNOWN_PROVIDER_NAMES (minus any that lack a
+// dedicated modal); order within each group controls display order.
+interface ProviderGroup {
+  title: string;
+  description?: string;
+  // Emphasized (main-content) header vs. a lighter secondary sub-header.
+  emphasis?: boolean;
+  providerNames: string[];
+  // Append the custom-provider card to this group.
+  includeCustom?: boolean;
+}
+
+const PROVIDER_GROUPS: ProviderGroup[] = [
+  {
+    title: "Add Provider",
+    description: "Onyx supports both popular providers and self-hosted models.",
+    emphasis: true,
+    providerNames: [
+      LLMProviderName.OPENAI,
+      LLMProviderName.ANTHROPIC,
+      LLMProviderName.VERTEX_AI,
+      LLMProviderName.BEDROCK,
+      LLMProviderName.AZURE,
+    ],
+  },
+  {
+    title: "Gateways & Routers",
+    providerNames: [
+      LLMProviderName.OPENROUTER,
+      LLMProviderName.LITELLM_PROXY,
+      LLMProviderName.NEBIUS_TOKENFACTORY,
+      LLMProviderName.BIFROST,
+    ],
+  },
+  {
+    title: "Self-hosted & Custom",
+    providerNames: [
+      LLMProviderName.OLLAMA_CHAT,
+      LLMProviderName.LM_STUDIO,
+      LLMProviderName.OPENAI_COMPATIBLE,
+    ],
+    includeCustom: true,
+  },
 ];
 
 // ============================================================================
@@ -441,32 +469,45 @@ export default function LanguageModelsPage() {
           />
         )}
 
-        {/* ── Add Provider (always visible) ── */}
+        {/* ── Add Provider groups (always visible) ── */}
         <Disabled disabled={isConfigurationDisabled}>
-          <GeneralLayouts.Section
-            gap={0.75}
-            height="fit"
-            alignItems="stretch"
-            justifyContent="start"
-          >
-            <Content
-              title="Add Provider"
-              description="Onyx supports both popular providers and self-hosted models."
-              sizePreset="main-content"
-              variant="section"
-            />
+          <div className="flex flex-col gap-8">
+            {PROVIDER_GROUPS.map((group) => (
+              <GeneralLayouts.Section
+                key={group.title}
+                gap={0.75}
+                height="fit"
+                alignItems="stretch"
+                justifyContent="start"
+              >
+                {group.emphasis ? (
+                  <Content
+                    title={group.title}
+                    description={group.description}
+                    sizePreset="main-content"
+                    variant="section"
+                  />
+                ) : (
+                  <Text font="main-ui-action" color="text-03">
+                    {group.title}
+                  </Text>
+                )}
 
-            <div className="grid grid-cols-2 gap-2">
-              {PROVIDER_DISPLAY_ORDER.map((name) => (
-                <NewProviderCard
-                  key={name}
-                  providerName={name}
-                  isFirstProvider={isFirstProvider}
-                />
-              ))}
-              <NewCustomProviderCard isFirstProvider={isFirstProvider} />
-            </div>
-          </GeneralLayouts.Section>
+                <div className="grid grid-cols-2 gap-2">
+                  {group.providerNames.map((name) => (
+                    <NewProviderCard
+                      key={name}
+                      providerName={name}
+                      isFirstProvider={isFirstProvider}
+                    />
+                  ))}
+                  {group.includeCustom && (
+                    <NewCustomProviderCard isFirstProvider={isFirstProvider} />
+                  )}
+                </div>
+              </GeneralLayouts.Section>
+            ))}
+          </div>
         </Disabled>
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>


### PR DESCRIPTION
## Description

The admin **Language Models (LLM)** page rendered every provider in a single flat "Add Provider" grid. This groups them into three labeled sections matching the admin design:

- **Add Provider** — first-party model APIs (OpenAI, Anthropic, Vertex AI, Bedrock, Azure)
- **Gateways & Routers** — OpenRouter, LiteLLM Proxy, Nebius Token Factory, Bifrost
- **Self-hosted & Custom** — Ollama, LM Studio, OpenAI-compatible, and the custom-provider card

Driven by a small `PROVIDER_GROUPS` config; the emphasized "Add Provider" header stays `main-content` while the two sub-group headers use the lighter `secondary` preset. Purely presentational — no change to which providers are offered or how they're configured.

**Note:** the design also shows a **Portkey** card under Gateways & Routers, but Portkey isn't implemented in the codebase yet (no provider enum / metadata / modal). It's intentionally left out of this presentational change and would need its own provider-integration PR.

## How Has This Been Tested?

- `tsc --noEmit` passes clean.
- Verified locally against the design — three grouped sections render with the correct providers and header hierarchy.
- Screenshots to follow.



<!-- screenshots -->
<img width="919" height="1162" alt="Screenshot 2026-07-13 at 1 46 16 PM" src="https://github.com/user-attachments/assets/ba8492a4-5d04-49a5-98be-c231fdb73353" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grouped LLM providers on the admin Language Models page into three labeled sections to match the design and make selection clearer. Purely presentational; no changes to available providers or configuration flows.

- **New Features**
  - Split into three groups: Add Provider (OpenAI, Anthropic, Vertex AI, Bedrock, Azure), Gateways & Routers (OpenRouter, LiteLLM Proxy, Nebius Token Factory, Bifrost), Self-hosted & Custom (Ollama, LM Studio, OpenAI-compatible + custom card).
  - Driven by a small `PROVIDER_GROUPS` config; the main group uses emphasized headers, sub-groups use the Main UI/Action font at Text/03 per the design.
  - Portkey is not included yet because its provider integration doesn’t exist.

<sup>Written for commit 8d8c3a2905cf66e3bf4fc7d986626cf99c942e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12953?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

