### PR TITLE
feat(indexing): resume immediately on graceful worker shutdown

### DIFF
--- a/backend/onyx/background/celery/apps/docfetching.py
+++ b/backend/onyx/background/celery/apps/docfetching.py
@@ -9,8 +9,12 @@ from celery.signals import celeryd_init
 from celery.signals import worker_init
 from celery.signals import worker_ready
 from celery.signals import worker_shutdown
+from celery.signals import worker_shutting_down
 
 import onyx.background.celery.apps.app_base as app_base
+from onyx.background.celery.tasks.docfetching.worker_shutdown import (
+    signal_worker_shutting_down,
+)
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_DOCFETCHING_APP_NAME
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.metrics.celery_task_metrics import on_celery_task_postrun
@@ -117,6 +121,16 @@ def on_worker_init(sender: Worker, **kwargs: Any) -> None:
 def on_worker_ready(sender: Any, **kwargs: Any) -> None:
     start_metrics_server("docfetching")
     app_base.on_worker_ready(sender, **kwargs)
+
+
+@worker_shutting_down.connect
+def on_worker_shutting_down(**kwargs: Any) -> None:  # noqa: ARG001
+    # SIGTERM (deploy / scale-down). Flag it so the watchdog interrupts its
+    # in-flight attempt for a fast checkpoint resume, not the heartbeat timeout.
+    logger.info(
+        "worker_shutting_down received, flagging docfetching for graceful interrupt."
+    )
+    signal_worker_shutting_down()
 
 
 @worker_shutdown.connect

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -13,6 +13,9 @@ from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.memory_monitoring import emit_process_memory
 from onyx.background.celery.memory_monitoring import start_memory_observer
 from onyx.background.celery.memory_monitoring import stop_memory_observer
+from onyx.background.celery.tasks.docfetching.worker_shutdown import (
+    is_worker_shutting_down,
+)
 from onyx.background.celery.tasks.docprocessing.heartbeat import start_heartbeat
 from onyx.background.celery.tasks.docprocessing.heartbeat import stop_heartbeat
 from onyx.background.celery.tasks.docprocessing.tasks import ConnectorIndexingLogBuilder
@@ -35,6 +38,7 @@ from onyx.db.enums import IndexingStatus
 from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import mark_attempt_canceled
 from onyx.db.index_attempt import mark_attempt_failed
+from onyx.db.index_attempt import mark_attempt_interrupted
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector import RedisConnector
 from onyx.server.metrics.connector_health_metrics import on_index_attempt_status_change
@@ -494,6 +498,46 @@ def docfetching_proxy_task(
 
             time.monotonic()
 
+            # Worker shutting down (SIGTERM). Mark the attempt INTERRUPTED before
+            # terminating so the subprocess can't write a competing status, then
+            # stop it. A fresh attempt resumes from checkpoint on the next beat.
+            if is_worker_shutting_down():
+                result.status = (
+                    IndexingWatchdogTerminalStatus.TERMINATED_BY_WORKER_SHUTDOWN
+                )
+                try:
+                    with get_session_with_current_tenant() as db_session:
+                        attempt = get_index_attempt(db_session, index_attempt_id)
+                        if attempt and not attempt.status.is_terminal():
+                            mark_attempt_interrupted(
+                                index_attempt_id,
+                                db_session,
+                                "Indexing worker shutting down (deploy or "
+                                "autoscaling). The attempt resumes automatically "
+                                "from the last checkpoint.",
+                            )
+                except Exception:
+                    task_logger.exception(
+                        log_builder.build(
+                            "Indexing watchdog - transient exception marking index "
+                            "attempt as interrupted on worker shutdown"
+                        )
+                    )
+                try:
+                    job.terminate_and_wait(
+                        CELERY_INDEXING_WATCHDOG_SIGTERM_GRACE_SECONDS
+                    )
+                except Exception:
+                    task_logger.exception(
+                        log_builder.build(
+                            "Indexing watchdog - exception while terminating "
+                            "subprocess on worker shutdown"
+                        )
+                    )
+                if job.process is not None:
+                    result.exit_code = job.process.exitcode
+                break
+
             # if the job is done, clean up and break
             if job.done():
                 try:
@@ -741,6 +785,10 @@ def docfetching_proxy_task(
         # successful completion in the spawned process before we noticed). The
         # subprocess has been killed in the watchdog loop above; no further DB
         # writes are needed here.
+        pass
+    elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_WORKER_SHUTDOWN:
+        # already marked INTERRUPTED in the loop (best-effort). The heartbeat
+        # watchdog is the fallback if that write failed, so nothing to do here.
         pass
     elif result.status == IndexingWatchdogTerminalStatus.TERMINATED_BY_MEMORY_LIMIT:
         # subprocess already terminated in the watchdog loop. Re-mark in case the

--- a/backend/onyx/background/celery/tasks/docfetching/worker_shutdown.py
+++ b/backend/onyx/background/celery/tasks/docfetching/worker_shutdown.py
@@ -1,0 +1,19 @@
+"""Process-global flag that the docfetching worker is shutting down.
+
+The ``worker_shutting_down`` handler sets it on SIGTERM. The indexing watchdog
+polls it and interrupts its in-flight attempt for a fast checkpoint resume instead
+of the heartbeat timeout. Both run in the same process (handler on the main thread,
+watchdog on a pool thread), so a plain ``threading.Event`` is the right carrier.
+"""
+
+import threading
+
+_worker_shutting_down = threading.Event()
+
+
+def signal_worker_shutting_down() -> None:
+    _worker_shutting_down.set()
+
+
+def is_worker_shutting_down() -> bool:
+    return _worker_shutting_down.is_set()

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -85,6 +85,7 @@ from onyx.db.index_attempt import get_stale_not_started_index_attempts
 from onyx.db.index_attempt import IndexAttemptError
 from onyx.db.index_attempt import mark_attempt_canceled
 from onyx.db.index_attempt import mark_attempt_failed
+from onyx.db.index_attempt import mark_attempt_interrupted
 from onyx.db.index_attempt import mark_attempt_partially_succeeded
 from onyx.db.index_attempt import mark_attempt_succeeded
 from onyx.db.index_attempt_metrics import IndexAttemptStage
@@ -308,34 +309,49 @@ def validate_active_indexing_attempts(
                         f"no pending or in-flight batches — all batches failed or lost"
                     )
             else:
-                # total_batches is None: docfetching is still running but the
-                # worker process died. The heartbeat thread runs independently
-                # of rate limiting, so a stale heartbeat here means a real crash.
+                # total_batches is None: docfetching still running, but the
+                # heartbeat thread (independent of the fetch loop) went stale, which
+                # means the worker process is gone, not merely slow.
                 failure_reason = (
-                    f"No heartbeat received for {heartbeat_timeout_seconds} seconds"
+                    "Indexing was interrupted before completing (the worker was "
+                    "stopped, e.g. by a deploy or autoscaling event). It resumes "
+                    "automatically from the last checkpoint."
                 )
 
             task_logger.warning(
-                f"Invalidating attempt {fresh_attempt.id}: "
-                f"last_heartbeat_time={last_check_time} "
-                f"cutoff_time={cutoff_time} "
-                f"counter={current_counter}"
+                "Invalidating attempt %s: last_heartbeat_time=%s cutoff_time=%s counter=%s",
+                fresh_attempt.id,
+                last_check_time,
+                cutoff_time,
+                current_counter,
             )
 
+            # Mid-fetch death is a resumable interruption, not a failure, so it
+            # doesn't trip the auto-pause. Post-fetch stalls are real failures.
+            interrupted = fresh_attempt.total_batches is None
             try:
-                mark_attempt_failed(
-                    fresh_attempt.id,
-                    db_session,
-                    failure_reason=failure_reason,
-                )
+                if interrupted:
+                    mark_attempt_interrupted(
+                        fresh_attempt.id,
+                        db_session,
+                        reason=failure_reason,
+                    )
+                else:
+                    mark_attempt_failed(
+                        fresh_attempt.id,
+                        db_session,
+                        failure_reason=failure_reason,
+                    )
 
-                task_logger.error(
-                    f"Marked attempt {fresh_attempt.id} as failed due to heartbeat timeout"
+                task_logger.info(
+                    "Finalized stale attempt %s as %s",
+                    fresh_attempt.id,
+                    "interrupted" if interrupted else "failed",
                 )
 
             except Exception:
                 task_logger.exception(
-                    f"Failed to mark attempt {fresh_attempt.id} as failed due to heartbeat timeout"
+                    "Failed to finalize stale attempt %s", fresh_attempt.id
                 )
 
         # Separately handle NOT_STARTED attempts. Their heartbeat_counter never
@@ -426,7 +442,7 @@ def monitor_indexing_attempt_progress(
         db_session, attempt.connector_credential_pair_id
     )
     if not cc_pair:
-        task_logger.warning(f"CC pair not found for attempt {attempt.id}")
+        task_logger.warning("CC pair not found for attempt %s", attempt.id)
         return
 
     # Check if the CC Pair should be moved to INITIAL_INDEXING
@@ -460,7 +476,7 @@ def monitor_indexing_attempt_progress(
         )
 
     if coordination_status.cancellation_requested:
-        task_logger.info(f"Indexing attempt {attempt.id} has been cancelled")
+        task_logger.info("Indexing attempt %s has been cancelled", attempt.id)
         mark_attempt_canceled(attempt.id, db_session)
         return
 
@@ -1162,7 +1178,7 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                 try:
                     monitor_indexing_attempt_progress(attempt, tenant_id, db_session)
                 except Exception:
-                    task_logger.exception(f"Error monitoring attempt {attempt.id}")
+                    task_logger.exception("Error monitoring attempt %s", attempt.id)
 
                 lock_beat.reacquire()
 
@@ -1713,7 +1729,7 @@ def _docprocessing_task(
             IndexAttemptStage.BATCH_LOAD, index_attempt_id, batch_load_ms
         )
         if not documents:
-            task_logger.error(f"No documents found for batch {batch_num}")
+            task_logger.error("No documents found for batch %s", batch_num)
             return
 
         # FIX: Monitor memory after loading documents
@@ -1857,7 +1873,7 @@ def _docprocessing_task(
                     usage_db_session.commit()
             except Exception as e:
                 # Log but don't fail indexing if usage tracking fails
-                task_logger.warning(f"Failed to track chunk indexing usage: {e}")
+                task_logger.warning("Failed to track chunk indexing usage: %s", e)
 
         # Update batch completion and document counts atomically using database coordination
 

--- a/backend/onyx/background/celery/tasks/models.py
+++ b/backend/onyx/background/celery/tasks/models.py
@@ -59,6 +59,10 @@ class IndexingWatchdogTerminalStatus(str, Enum):
     # logically. The DB row already reflects the real outcome, so we don't touch it.
     TERMINATED_BY_ATTEMPT_FINALIZED = "terminated_by_attempt_finalized"
 
+    # worker got SIGTERM (deploy / scale-down). The watchdog stops its subprocess
+    # and marks the attempt INTERRUPTED for a fast checkpoint resume.
+    TERMINATED_BY_WORKER_SHUTDOWN = "terminated_by_worker_shutdown"
+
     # NOTE: this may actually be the same as SIGKILL, but parsed differently by python
     # consolidate once we know more
     OUT_OF_MEMORY = "out_of_memory"

--- a/backend/onyx/background/indexing/checkpointing_utils.py
+++ b/backend/onyx/background/indexing/checkpointing_utils.py
@@ -14,7 +14,6 @@ from onyx.db.engine.time_utils import get_db_current_time
 from onyx.db.index_attempt import get_index_attempt
 from onyx.db.index_attempt import get_recent_completed_attempts_for_cc_pair
 from onyx.db.models import IndexAttempt
-from onyx.db.models import IndexingStatus
 from onyx.file_store.file_store import get_default_file_store
 from onyx.utils.logger import setup_logger
 from onyx.utils.object_size_check import deep_getsizeof
@@ -111,12 +110,7 @@ def get_latest_valid_checkpoint(
         if (
             candidate.poll_range_start == window_start
             and candidate.poll_range_end == window_end
-            and (
-                candidate.status == IndexingStatus.FAILED
-                # if the background job was killed (and thus the attempt was canceled)
-                # we still want to use the checkpoint so that we can pick up where we left off
-                or candidate.status == IndexingStatus.CANCELED
-            )
+            and candidate.status.should_reuse_checkpoint()
             and candidate.checkpoint_pointer is not None
             # NOTE: There are a couple connectors that may make progress but not have
             # any "total_docs_indexed". E.g. they are going through

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -507,17 +507,14 @@ def connector_document_extraction(
             None,
         )
 
-        # if the last attempt failed, try and use the same window. This is necessary
-        # to ensure correctness with checkpointing. If we don't do this, things like
-        # new slack channels could be missed (since existing slack channels are
-        # cached as part of the checkpoint).
+        # if the last attempt didn't complete cleanly, reuse the same window. This
+        # is necessary to ensure correctness with checkpointing. If we don't do this,
+        # things like new slack channels could be missed (since existing slack
+        # channels are cached as part of the checkpoint).
         if (
             most_recent_attempt
             and most_recent_attempt.poll_range_end
-            and (
-                most_recent_attempt.status == IndexingStatus.FAILED
-                or most_recent_attempt.status == IndexingStatus.CANCELED
-            )
+            and most_recent_attempt.status.should_reuse_checkpoint()
         ):
             window_end = most_recent_attempt.poll_range_end
         else:
@@ -912,14 +909,12 @@ def connector_document_extraction(
 
         else:
             with get_session_with_current_tenant() as db_session_temp:
-                # don't overwrite attempts that are already failed/canceled for another reason
+                # don't overwrite an attempt already in a terminal state for
+                # another reason (e.g. INTERRUPTED by a worker shutdown)
                 index_attempt = get_index_attempt(db_session_temp, index_attempt_id)
-                if index_attempt and index_attempt.status in [
-                    IndexingStatus.CANCELED,
-                    IndexingStatus.FAILED,
-                ]:
+                if index_attempt and index_attempt.status.is_terminal():
                     logger.info(
-                        "Attempt %s is already failed/canceled, skipping marking as failed.",
+                        "Attempt %s is already terminal, skipping marking as failed.",
                         index_attempt_id,
                     )
                     raise e

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -40,6 +40,9 @@ class IndexingStatus(str, PyEnum):
     IN_PROGRESS = "in_progress"
     SUCCESS = "success"
     CANCELED = "canceled"
+    # Worker stopped mid-run by infrastructure (deploy / autoscaling), not a real
+    # error or a user. Terminal but resumable, and not counted as a failure.
+    INTERRUPTED = "interrupted"
     FAILED = "failed"
     COMPLETED_WITH_ERRORS = "completed_with_errors"
 
@@ -48,9 +51,20 @@ class IndexingStatus(str, PyEnum):
             IndexingStatus.SUCCESS,
             IndexingStatus.COMPLETED_WITH_ERRORS,
             IndexingStatus.CANCELED,
+            IndexingStatus.INTERRUPTED,
             IndexingStatus.FAILED,
         }
         return self in terminal_states
+
+    def should_reuse_checkpoint(self) -> bool:
+        # Terminal states where the crawl stopped before finishing, so the next
+        # attempt continues from the saved checkpoint and poll window instead of
+        # restarting. SUCCESS / COMPLETED_WITH_ERRORS finished, so they start fresh.
+        return self in {
+            IndexingStatus.FAILED,
+            IndexingStatus.CANCELED,
+            IndexingStatus.INTERRUPTED,
+        }
 
     def is_successful(self) -> bool:
         return (

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -478,6 +478,51 @@ def mark_attempt_failed(
         raise
 
 
+def mark_attempt_interrupted(
+    index_attempt_id: int,
+    db_session: Session,
+    reason: str = "Unknown",
+) -> None:
+    """Terminal-but-resumable: worker stopped mid-run by infrastructure, not by an
+    error. Distinct from FAILED (so it doesn't trip the repeated-error auto-pause)
+    and from CANCELED (so the UI doesn't imply a user did it)."""
+    try:
+        attempt = db_session.execute(
+            select(IndexAttempt)
+            .where(IndexAttempt.id == index_attempt_id)
+            .with_for_update()
+        ).scalar_one()
+
+        if not attempt.time_started:
+            attempt.time_started = datetime.now(timezone.utc)
+        attempt.status = IndexingStatus.INTERRUPTED
+        attempt.error_msg = reason
+        attempt.celery_task_id = None
+        db_session.commit()
+
+        optional_telemetry(
+            record_type=RecordType.INDEX_ATTEMPT_STATUS,
+            data={
+                "index_attempt_id": index_attempt_id,
+                "status": IndexingStatus.INTERRUPTED.value,
+                "cc_pair_id": attempt.connector_credential_pair_id,
+            },
+        )
+        # Stale counter keys left by a failed cleanup() are harmless: the monitor
+        # skips attempts that are already in a terminal state before reading Redis.
+        try:
+            RedisDocprocessing(index_attempt_id, get_redis_client()).cleanup()
+        except Exception:
+            logger.debug(
+                "Failed to clean up docprocessing counters for attempt %s",
+                index_attempt_id,
+                exc_info=True,
+            )
+    except Exception:
+        db_session.rollback()
+        raise
+
+
 def update_docs_indexed(
     db_session: Session,
     index_attempt_id: int,

--- a/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_worker_shutdown.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_docfetching_worker_shutdown.py
@@ -1,0 +1,24 @@
+"""Guards the graceful-shutdown wiring: the process-global signal the
+worker_shutting_down handler sets and the indexing watchdog polls, plus the
+existence of the watchdog terminal-status constant the shutdown branch keys off.
+"""
+
+from onyx.background.celery.tasks.docfetching import worker_shutdown
+from onyx.background.celery.tasks.models import IndexingWatchdogTerminalStatus
+
+
+def test_worker_shutdown_signal_round_trips() -> None:
+    worker_shutdown._worker_shutting_down.clear()
+    try:
+        assert worker_shutdown.is_worker_shutting_down() is False
+        worker_shutdown.signal_worker_shutting_down()
+        assert worker_shutdown.is_worker_shutting_down() is True
+    finally:
+        worker_shutdown._worker_shutting_down.clear()
+
+
+def test_worker_shutdown_terminal_status_exists() -> None:
+    assert (
+        IndexingWatchdogTerminalStatus.TERMINATED_BY_WORKER_SHUTDOWN.value
+        == "terminated_by_worker_shutdown"
+    )

--- a/backend/tests/unit/onyx/background/celery/tasks/test_indexing_interrupted.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_indexing_interrupted.py
@@ -1,0 +1,67 @@
+"""Guards the INTERRUPTED reclassification: an attempt stopped mid-run by
+infrastructure (deploy / autoscaling) must not count as a failure, so it never
+trips the repeated-error auto-pause, while genuine consecutive FAILED still does.
+"""
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.background.celery.tasks.docprocessing.utils import is_in_repeated_error_state
+from onyx.background.celery.tasks.docprocessing.utils import (
+    NUM_REPEAT_ERRORS_BEFORE_REPEATED_ERROR_STATE,
+)
+from onyx.db.enums import IndexingStatus
+
+_UTILS = "onyx.background.celery.tasks.docprocessing.utils"
+
+
+def _attempt(status: IndexingStatus) -> MagicMock:
+    attempt = MagicMock()
+    attempt.status = status
+    return attempt
+
+
+def _cc_pair(refresh_freq: int | None = 3600) -> MagicMock:
+    cc_pair = MagicMock()
+    cc_pair.id = 1
+    cc_pair.connector.refresh_freq = refresh_freq
+    return cc_pair
+
+
+def test_interrupted_is_terminal_but_not_a_failure() -> None:
+    assert IndexingStatus.INTERRUPTED.is_terminal() is True
+    assert IndexingStatus.INTERRUPTED.is_successful() is False
+    assert IndexingStatus.INTERRUPTED != IndexingStatus.FAILED
+
+
+@patch(f"{_UTILS}.get_recent_attempts_for_cc_pair")
+def test_consecutive_failed_is_repeated_error(mock_recent: MagicMock) -> None:
+    mock_recent.return_value = [
+        _attempt(IndexingStatus.FAILED)
+        for _ in range(NUM_REPEAT_ERRORS_BEFORE_REPEATED_ERROR_STATE)
+    ]
+    assert (
+        is_in_repeated_error_state(
+            _cc_pair(), search_settings_id=1, db_session=MagicMock()
+        )
+        is True
+    )
+
+
+@patch(f"{_UTILS}.get_recent_attempts_for_cc_pair")
+def test_interrupted_breaks_the_failed_streak(mock_recent: MagicMock) -> None:
+    # A single infra interruption anywhere in the recent window keeps the
+    # connector out of the repeated-error state, so a deploy/scale-down burst
+    # never auto-pauses it.
+    attempts = [
+        _attempt(IndexingStatus.FAILED)
+        for _ in range(NUM_REPEAT_ERRORS_BEFORE_REPEATED_ERROR_STATE - 1)
+    ]
+    attempts.append(_attempt(IndexingStatus.INTERRUPTED))
+    mock_recent.return_value = attempts
+    assert (
+        is_in_repeated_error_state(
+            _cc_pair(), search_settings_id=1, db_session=MagicMock()
+        )
+        is False
+    )

--- a/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-docfetching.yaml
@@ -34,6 +34,8 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      # Grace for the watchdog to interrupt its in-flight attempt before SIGKILL.
+      terminationGracePeriodSeconds: {{ .Values.celery_worker_docfetching.terminationGracePeriodSeconds }}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1022,6 +1022,9 @@ mcpServer:
 celery_worker_docfetching:
   extraEnv: []
   replicaCount: 1
+  # Grace for the watchdog to mark its in-flight attempt INTERRUPTED and stop its
+  # subprocess on SIGTERM. Must exceed the watchdog poll interval + subprocess grace.
+  terminationGracePeriodSeconds: 60
   # Per-worker log level override. Empty (default) means use the global
   # LOG_LEVEL env var. Set to INFO/DEBUG/WARNING/etc. to override LOG_LEVEL for
   # this worker only — this becomes `--loglevel=<value>` on the celery worker

--- a/web/src/app/admin/indexing/status/FilterComponent.tsx
+++ b/web/src/app/admin/indexing/status/FilterComponent.tsx
@@ -201,6 +201,14 @@ export const FilterComponent = forwardRef<
                 Failed
               </DropdownMenuCheckboxItem>
               <DropdownMenuCheckboxItem
+                checked={selectedStatuses.includes("interrupted")}
+                onCheckedChange={() => handleStatusChange("interrupted")}
+                className="flex items-center justify-between"
+                onSelect={(e) => e.preventDefault()}
+              >
+                Interrupted
+              </DropdownMenuCheckboxItem>
+              <DropdownMenuCheckboxItem
                 checked={selectedStatuses.includes("in_progress")}
                 onCheckedChange={() => handleStatusChange("in_progress")}
                 className="flex items-center justify-between"

--- a/web/src/components/Status.tsx
+++ b/web/src/components/Status.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ReactNode } from "react";
 import { ValidStatuses } from "@/lib/types";
 import { Badge } from "@/components/ui/badge";
 import { timeAgo } from "@opal/time";
@@ -16,6 +17,22 @@ import {
 } from "@/app/admin/connector/[ccPairId]/types";
 import { Tooltip } from "@opal/components";
 
+// Wrap a status badge in a hover tooltip carrying its error/reason text, or
+// return the bare badge when there is no message.
+function badgeWithErrorTooltip(
+  icon: ReactNode,
+  errorMsg?: string | null
+): ReactNode {
+  if (!errorMsg) {
+    return icon;
+  }
+  return (
+    <Tooltip tooltip={errorMsg}>
+      <div className="cursor-pointer">{icon}</div>
+    </Tooltip>
+  );
+}
+
 export function IndexAttemptStatus({
   status,
   errorMsg,
@@ -26,20 +43,12 @@ export function IndexAttemptStatus({
   let badge;
 
   if (status === "failed") {
-    const icon = (
+    badge = badgeWithErrorTooltip(
       <Badge variant="destructive" icon={FiAlertTriangle}>
         Failed
-      </Badge>
+      </Badge>,
+      errorMsg
     );
-    if (errorMsg) {
-      badge = (
-        <Tooltip tooltip={errorMsg}>
-          <div className="cursor-pointer">{icon}</div>
-        </Tooltip>
-      );
-    } else {
-      badge = icon;
-    }
   } else if (status === "completed_with_errors") {
     badge = (
       <Badge variant="secondary" icon={FiAlertTriangle}>
@@ -69,6 +78,15 @@ export function IndexAttemptStatus({
       <Badge variant="canceled" icon={FiClock}>
         Canceled
       </Badge>
+    );
+  } else if (status === "interrupted") {
+    // Stopped by infrastructure (deploy / autoscaling), not an error, so it
+    // resumes automatically. Neutral badge with the reason on hover, never red.
+    badge = badgeWithErrorTooltip(
+      <Badge variant="canceled" icon={FiClock}>
+        Interrupted
+      </Badge>,
+      errorMsg
     );
   } else if (status === "invalid") {
     badge = (

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -173,6 +173,7 @@ export type ValidStatuses =
   | "success"
   | "completed_with_errors"
   | "canceled"
+  | "interrupted"
   | "failed"
   | "in_progress"
   | "not_started";


### PR DESCRIPTION
## Description

Base is `nikg/indexing-interrupted-status` (#12954), so this diff is only the graceful-shutdown commit.

**Why:** #12954 makes a killed docfetching worker resumable, but a hard kill is only noticed by the beat heartbeat validator up to 1800s later. This closes that gap for the graceful case.

**Fix:** on SIGTERM (rolling deploy / KEDA scale-down) a `worker_shutting_down` handler sets a process-global flag. The indexing watchdog polls it, marks its in-flight attempt INTERRUPTED (best-effort), and stops its subprocess before SIGKILL. A fresh attempt resumes from checkpoint on the next beat (~15s) instead of after ~1800s.

- new `TERMINATED_BY_WORKER_SHUTDOWN` watchdog status (set explicitly, no exit-code mapping)
- `terminationGracePeriodSeconds: 60` on the docfetching Deployment so the watchdog has time to mark and stop
- `acks_late` unchanged, so no broker redelivery. Recovery is still the beat re-create path, just faster.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
