### PR TITLE
ci(craft-k8s): scope the helm trigger to sandbox/craft chart paths

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -106,7 +106,17 @@ jobs:
               - 'backend/onyx/server/features/skill/**'
               - 'backend/onyx/skills/**'
               - 'backend/shared_configs/**'
-              - 'deployment/helm/**'
+              # Only the sandbox/craft-specific chart bits gate this lane. Generic
+              # chart changes (workers, deps, version bumps) are install-tested by
+              # the `Helm - Lint and Test Charts` lane (`ct install` into kind), so
+              # they don't need the full sandbox suite here.
+              - 'deployment/helm/charts/onyx/templates/sandbox-*'
+              - 'deployment/helm/charts/onyx/templates/sandbox-proxy/**'
+              - 'deployment/helm/charts/onyx/templates/network-policy-sandbox-*'
+              - 'deployment/helm/charts/onyx/templates/craft-*'
+              - 'deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks*'
+              - 'deployment/helm/charts/onyx/charts/code-interpreter-*'
+              - 'deployment/helm/charts/onyx/values-ci.yaml'
               - 'backend/tests/integration/tests/craft/*.py'
               - 'backend/tests/integration/tests/craft/k8s/**'
               - 'backend/tests/common/craft/**'


### PR DESCRIPTION
## Description

The **Craft Kubernetes Integration Tests** lane (`pr-craft-k8s-tests.yml`) gates on a `dorny/paths-filter`, but its helm entry was the broad `deployment/helm/**`. So *any* chart edit — a worker template tweak, a dependency bump, or just a chart version bump — triggered the full sandbox suite (a kind cluster + built images per test shard, ~40 min). Example: a backend PR that only added a Celery queue to the light worker and bumped the chart version ran the entire craft-k8s lane despite touching nothing craft-related.

This narrows the helm trigger to the **sandbox/craft-specific chart bits**:

```
- 'deployment/helm/charts/onyx/templates/sandbox-*'
- 'deployment/helm/charts/onyx/templates/sandbox-proxy/**'
- 'deployment/helm/charts/onyx/templates/network-policy-sandbox-*'
- 'deployment/helm/charts/onyx/templates/craft-*'
- 'deployment/helm/charts/onyx/templates/celery-worker-scheduled-tasks*'   # Craft scheduled-task executor
- 'deployment/helm/charts/onyx/charts/code-interpreter-*'                   # sandbox execution subchart
- 'deployment/helm/charts/onyx/values-ci.yaml'                             # values this lane installs with
```

### Why this is safe

Generic chart validity/install is **already covered elsewhere**: the `Helm - Lint and Test Charts` lane (`pr-helm-chart-testing.yml`) runs `ct lint` + `ct install` (a real `helm install` into a kind cluster) on any chart change. So a broken worker template or dependency bump is still caught pre-merge — just by the cheaper, chart-focused lane rather than the full sandbox suite.

The craft-k8s lane keeps firing for the chart pieces it uniquely exercises (sandbox proxy, sandbox pods/RBAC/network policies, the Craft scheduled-task worker, the code-interpreter subchart). `schedule` (nightly), `push` tags, and `workflow_dispatch` still default `craft_k8s=true` and run the full lane regardless, so nothing craft-related goes permanently unchecked.

### Trade-off (called out for review)

A craft-affecting change to a *shared, non-craft-named* template (e.g. a configmap the sandbox reads at runtime) would no longer trigger craft-k8s pre-merge on a PR — it'd be caught by the nightly run instead. If reviewers prefer, the path list can be widened. I erred toward the compose lane's philosophy (`pr-craft-compose-integration.yml` filters on specific craft-relevant deployment files, not a broad `deployment/**` glob).

## How Has This Been Tested?

- `actionlint` + `zizmor` (pre-commit) pass on the workflow.
- Verified the filter globs: the queue/chart-version PR's `Chart.yaml` and `celery-worker-light.yaml` no longer match (skip), while `sandbox-*`, `celery-worker-scheduled-tasks*`, and `code-interpreter-*` still match (trigger).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the Craft K8s tests to sandbox/craft-specific Helm paths so the suite runs only on relevant chart changes, reducing unnecessary 40‑minute CI runs.

- **Refactors**
  - Narrowed `dorny/paths-filter` from `deployment/helm/**` to: `templates/sandbox-*`, `templates/sandbox-proxy/**`, `templates/network-policy-sandbox-*`, `templates/craft-*`, `templates/celery-worker-scheduled-tasks*`, `charts/code-interpreter-*`, and `values-ci.yaml`.
  - Generic chart changes are still covered by the Helm chart testing workflow (`ct lint` + `ct install`).
  - Nightly, tag pushes, and manual runs still force the full suite (`craft_k8s=true`).

<sup>Written for commit 6cba16b5acad5cffc04c4adacb3edbde68df0219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

