### PR TITLE
fix(ttl): isolate + batch chat retention cleanup off the primary queue (#12928) [backport v4.3]

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -1,18 +1,54 @@
-from uuid import UUID
+import uuid
 
 from celery import shared_task
 from celery import Task
 
 from ee.onyx.background.celery_utils import should_perform_chat_ttl_check
 from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.configs.constants import CELERY_CHAT_TTL_DELETE_TASK_EXPIRES
+from onyx.configs.constants import CHAT_TTL_DELETE_BATCH_SIZE
+from onyx.configs.constants import OnyxCeleryPriority
+from onyx.configs.constants import OnyxCeleryQueues
 from onyx.configs.constants import OnyxCeleryTask
+from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.redis.redis_pool import get_redis_client
+from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# Extend the chain lease only if we still own it (marker value == our token).
+# Returns 1 when owned+extended, 0 otherwise. Prevents a task whose lease lapsed
+# (and whose chain a later beat has replaced) from extending someone else's lease.
+_REFRESH_IF_OWNED = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('expire', KEYS[1], ARGV[2])
+else
+    return 0
+end
+"""
+
+# Release the chain marker only if we still own it.
+_RELEASE_IF_OWNED = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+else
+    return 0
+end
+"""
+
+
+def _release_chain_if_owned(redis_client: TenantRedisClient, chain_token: str) -> None:
+    """Delete the chain marker only if ``chain_token`` still owns it."""
+    redis_client.eval(
+        _RELEASE_IF_OWNED,
+        [OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE],
+        [chain_token],
+    )
 
 
 @shared_task(
@@ -24,63 +60,138 @@ logger = setup_logger()
 )
 def perform_ttl_management_task(
     self: Task,
-    retention_limit_days: int,
+    retention_limit_days: float,
+    # Defaulted for rollout compatibility: a message enqueued by the pre-upgrade
+    # code carries no chain_token. An empty token never matches the marker, so
+    # such a message harmlessly no-ops below and the beat starts a fresh chain.
+    chain_token: str = "",
     *,
-    tenant_id: str,  # noqa: ARG001
+    tenant_id: str,
 ) -> None:
-    task_id = self.request.id
-    if not task_id:
-        raise RuntimeError("No task id defined for this task; cannot identify it")
+    """Delete the oldest batch of expired chat sessions, then chain the next task.
 
-    user_id: UUID | None = None
-    session_id: UUID | None = None
-    try:
-        with get_session_with_current_tenant() as db_session:
-            old_chat_sessions = get_chat_sessions_older_than(
-                retention_limit_days, db_session
-            )
+    Each run hard-deletes at most ``CHAT_TTL_DELETE_BATCH_SIZE`` of the *oldest*
+    expired sessions and exits, so it occupies a single light-worker thread for
+    only one short batch and interleaves with the other light-queue work. If a
+    full batch is deleted (more sessions likely remain) it enqueues the next task
+    with the same ``chain_token``; otherwise the chain is done and it releases the
+    in-flight marker so ``check_ttl_management_task`` can start a fresh chain.
 
-        for user_id, session_id in old_chat_sessions:
-            try:
-                with get_session_with_current_tenant() as db_session:
-                    delete_chat_session(
-                        user_id,
-                        session_id,
-                        db_session,
-                        include_deleted=True,
-                        hard_delete=True,
-                    )
-            except Exception:
-                logger.exception(
-                    "Failed to delete chat session user_id=%s session_id=%s, continuing with remaining sessions",
+    ``chain_token`` fences the chain: each run extends the lease only if it still
+    owns the marker, and stops if it doesn't. So if a slow batch outlives the
+    lease and the beat starts a replacement chain, the superseded task can neither
+    extend nor delete the new chain's marker — it just exits. Only one chain runs
+    per tenant at a time, so at most one light-worker thread does TTL work.
+
+    NOTE: every run re-selects the oldest sessions, so a session that repeatedly
+    fails to delete is retried on every run. If the oldest ``CHAT_TTL_DELETE_BATCH_SIZE``
+    sessions can never be deleted, the chain loops on them indefinitely (across
+    tasks) and never reaches newer sessions. This is an accepted trade-off for
+    keeping the task simple; each failure is logged.
+    """
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    # Extend our lease only if we still own the chain; if a replacement chain has
+    # taken over, stop — we're a superseded task and must not touch its marker.
+    owns_chain = redis_client.eval(
+        _REFRESH_IF_OWNED,
+        [OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE],
+        [chain_token, str(CELERY_CHAT_TTL_DELETE_TASK_EXPIRES)],
+    )
+    if not owns_chain:
+        return
+
+    with get_session_with_current_tenant() as db_session:
+        old_chat_sessions = get_chat_sessions_older_than(
+            retention_limit_days, db_session, limit=CHAT_TTL_DELETE_BATCH_SIZE
+        )
+
+    for user_id, session_id in old_chat_sessions:
+        try:
+            with get_session_with_current_tenant() as db_session:
+                delete_chat_session(
                     user_id,
                     session_id,
+                    db_session,
+                    include_deleted=True,
+                    hard_delete=True,
                 )
+        except Exception:
+            logger.exception(
+                "Failed to delete chat session user_id=%s session_id=%s, continuing with remaining sessions",
+                user_id,
+                session_id,
+            )
 
-    except Exception:
-        logger.exception(
-            "delete_chat_session exceptioned. user_id=%s session_id=%s",
-            user_id,
-            session_id,
-        )
-        raise
+    # A full batch means more expired sessions probably remain; continue the
+    # chain. Otherwise the backlog is drained — release the marker (if we own it).
+    if len(old_chat_sessions) == CHAT_TTL_DELETE_BATCH_SIZE:
+        try:
+            self.app.send_task(
+                OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
+                kwargs={
+                    "retention_limit_days": retention_limit_days,
+                    "chain_token": chain_token,
+                    "tenant_id": tenant_id,
+                },
+                queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+                priority=OnyxCeleryPriority.LOW,
+                expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+            )
+        except Exception:
+            _release_chain_if_owned(redis_client, chain_token)
+            raise
+    else:
+        _release_chain_if_owned(redis_client, chain_token)
 
 
 @shared_task(
     name=OnyxCeleryTask.CHECK_TTL_MANAGEMENT_TASK,
     ignore_result=True,
     soft_time_limit=JOB_TIMEOUT,
+    bind=True,
+    trail=False,
 )
-def check_ttl_management_task(*, tenant_id: str) -> None:
-    """Runs periodically to check if any ttl tasks should be run and adds them
-    to the queue"""
+def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
+    """Start a chat-retention cleanup chain if one isn't already running.
 
+    Deletion happens in ``perform_ttl_management_task``, which chains itself
+    batch-by-batch and holds a token-fenced in-flight marker for the whole chain.
+    This dispatcher claims that marker with a fresh token (``SET NX``); if it's
+    already held a chain is active, so we skip and don't stack a second one.
+    """
     settings = load_settings()
     retention_limit_days = settings.maximum_chat_retention_days
     with get_session_with_current_tenant() as db_session:
-        if should_perform_chat_ttl_check(retention_limit_days, db_session):
-            perform_ttl_management_task.apply_async(
-                kwargs=dict(
-                    retention_limit_days=retention_limit_days, tenant_id=tenant_id
-                ),
-            )
+        if not should_perform_chat_ttl_check(retention_limit_days, db_session):
+            return
+    if retention_limit_days is None:
+        return
+
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    chain_token = uuid.uuid4().hex
+    # Claim the chain. If the marker is already set, a chain is in flight (its
+    # active task may not be sitting in the queue), so don't start another.
+    if not redis_client.set(
+        OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
+        chain_token,
+        nx=True,
+        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+    ):
+        return
+
+    try:
+        self.app.send_task(
+            OnyxCeleryTask.PERFORM_TTL_MANAGEMENT_TASK,
+            kwargs={
+                "retention_limit_days": retention_limit_days,
+                "chain_token": chain_token,
+                "tenant_id": tenant_id,
+            },
+            queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+            priority=OnyxCeleryPriority.LOW,
+            expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+        )
+    except Exception:
+        # Roll back the claim so the next beat can start the chain.
+        _release_chain_if_owned(redis_client, chain_token)
+        raise

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -168,6 +168,7 @@ def _collect_queue_metrics(redis_celery: Redis) -> list[Metric]:
         "llm_model_update_queue_length": OnyxCeleryQueues.LLM_MODEL_UPDATE,
         "checkpoint_cleanup_queue_length": OnyxCeleryQueues.CHECKPOINT_CLEANUP,
         "index_attempt_cleanup_queue_length": OnyxCeleryQueues.INDEX_ATTEMPT_CLEANUP,
+        "chat_ttl_deletion_queue_length": OnyxCeleryQueues.CHAT_TTL_DELETION,
         "csv_generation_queue_length": OnyxCeleryQueues.CSV_GENERATION,
         "user_file_processing_queue_length": OnyxCeleryQueues.USER_FILE_PROCESSING,
         "user_file_project_sync_queue_length": OnyxCeleryQueues.USER_FILE_PROJECT_SYNC,

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -200,6 +200,15 @@ CELERY_USER_FILE_DELETE_TASK_EXPIRES = 60  # 1 minute (in seconds)
 # Max queue depth before the delete beat stops enqueuing more delete tasks.
 USER_FILE_DELETE_MAX_QUEUE_DEPTH = 500
 
+# Chat-retention (TTL) cleanup tuning. Each delete task removes the oldest
+# CHAT_TTL_DELETE_BATCH_SIZE expired sessions and chains the next task, so
+# deletion drains one batch at a time on the light queue and interleaves with
+# the other light-queue work instead of running as one long task.
+CHAT_TTL_DELETE_BATCH_SIZE = 100
+# How long a queued delete task is valid before workers discard it. Bounds queue
+# growth; if a task expires the beat starts a fresh chain on its next run.
+CELERY_CHAT_TTL_DELETE_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
+
 DANSWER_REDIS_FUNCTION_LOCK_PREFIX = "da_function_lock:"
 
 TMP_DRALPHA_PERSONA_NAME = "KG Beta"
@@ -434,6 +443,10 @@ class OnyxCeleryQueues:
     CONNECTOR_HIERARCHY_FETCHING = "connector_hierarchy_fetching"
     CSV_GENERATION = "csv_generation"
 
+    # Chat retention (TTL) hard-deletion queue, consumed by the light worker.
+    # Kept off the primary "celery" queue so cleanup never starves check_for_indexing.
+    CHAT_TTL_DELETION = "chat_ttl_deletion"
+
     # User file processing queue
     USER_FILE_PROCESSING = "user_file_processing"
     USER_FILE_PROJECT_SYNC = "user_file_project_sync"
@@ -475,6 +488,9 @@ class OnyxRedisLocks:
     SECURITY_SETTINGS = "da_lock:security_settings"
 
     MONITOR_BACKGROUND_PROCESSES_LOCK = "da_lock:monitor_background_processes"
+    # In-flight marker: set while a chat-TTL cleanup chain is active (spanning
+    # its chained tasks) so the beat won't start a second chain per tenant.
+    CHAT_TTL_CHAIN_ACTIVE = "da_lock:chat_ttl_chain_active"
     CHECK_AVAILABLE_TENANTS_LOCK = "da_lock:check_available_tenants"
     CLOUD_PRE_PROVISION_TENANT_LOCK = "da_lock:pre_provision_tenant"
 

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -370,7 +370,7 @@ def delete_chat_session(
 
 
 def get_chat_sessions_older_than(
-    days_old: int, db_session: Session
+    days_old: float, db_session: Session, limit: int | None = None
 ) -> list[tuple[UUID | None, UUID]]:
     """
     Retrieves chat sessions whose last activity is older than a specified number of days.
@@ -382,6 +382,9 @@ def get_chat_sessions_older_than(
     Args:
         days_old: The number of days to consider as "old".
         db_session: The database session.
+        limit: Optional cap on the number of sessions returned. When set, the
+            oldest sessions are returned first so callers can drain the backlog
+            in bounded batches without loading every matching row at once.
 
     Returns:
         A list of tuples, where each tuple contains the user_id (can be None) and the chat_session_id of an old chat session.
@@ -391,11 +394,16 @@ def get_chat_sessions_older_than(
     last_activity = func.coalesce(
         func.max(ChatMessage.time_sent), ChatSession.time_created
     )
-    old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
+    stmt = (
         select(ChatSession.user_id, ChatSession.id)
         .outerjoin(ChatMessage, ChatMessage.chat_session_id == ChatSession.id)
         .group_by(ChatSession.id, ChatSession.user_id)
         .having(last_activity < cutoff_time)
+    )
+    if limit is not None:
+        stmt = stmt.order_by(last_activity.asc()).limit(limit)
+    old_sessions: Sequence[Row[Tuple[UUID | None, UUID]]] = db_session.execute(
+        stmt
     ).fetchall()
 
     # convert old_sessions to a conventional list of tuples

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -44,7 +44,7 @@ stopasgroup=true
 [program:celery_worker_light]
 command=celery -A onyx.background.celery.versioned_apps.light worker
     --hostname=light@%%n
-    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration
+    -Q vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,chat_ttl_deletion
 stdout_logfile=/var/log/celery_worker_light.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/backend/tests/integration/tests/chat_retention/test_chat_retention.py
+++ b/backend/tests/integration/tests/chat_retention/test_chat_retention.py
@@ -1,5 +1,6 @@
 import os
 import time
+import uuid
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
@@ -7,13 +8,20 @@ from uuid import UUID
 
 import httpx
 import pytest
+from pytest import MonkeyPatch
 from sqlalchemy import update
+from sqlalchemy.orm import Session
 
+import ee.onyx.background.celery.tasks.ttl_management.tasks as ttl_tasks
+from onyx.configs.constants import CELERY_CHAT_TTL_DELETE_TASK_EXPIRES
+from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.chat import delete_chat_session
 from onyx.db.chat import get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import ChatMessage
 from onyx.db.models import ChatSession
+from onyx.redis.redis_pool import get_redis_client
+from shared_configs.contextvars import get_current_tenant_id
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.settings import SettingsManager
 from tests.integration.common_utils.test_models import DATestChatSession
@@ -178,3 +186,125 @@ def test_chat_retention_uses_last_message_time(
     assert _is_session_deleted(stale_session, admin_user), (
         "Session with no recent activity should be deleted"
     )
+
+
+def _make_old_session(
+    admin_user: DATestUser, description: str, days_old: int = 60
+) -> DATestChatSession:
+    """Create a chat session with a message, aged so TTL cleanup will select it."""
+    session = ChatSessionManager.create(
+        persona_id=0,
+        description=description,
+        user_performing_action=admin_user,
+    )
+    response = ChatSessionManager.send_message(
+        chat_session_id=session.id,
+        message="This session should be cleaned up",
+        user_performing_action=admin_user,
+    )
+    assert response.error is None, (
+        f"Chat response should not have an error: {response.error}"
+    )
+    _backdate_session(
+        session.id, created_days_ago=days_old, last_message_days_ago=days_old
+    )
+    return session
+
+
+def _run_perform_ttl(retention_days: int) -> None:
+    """Claim the chain marker with a fresh token, then run one perform task.
+
+    Mirrors how the beat starts a chain: perform only proceeds while it owns the
+    marker, so the token must be claimed before invoking it.
+    """
+    tenant_id = get_current_tenant_id()
+    token = uuid.uuid4().hex
+    get_redis_client(tenant_id=tenant_id).set(
+        OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
+        token,
+        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+    )
+    result = ttl_tasks.perform_ttl_management_task.apply(
+        kwargs=dict(
+            retention_limit_days=retention_days,
+            chain_token=token,
+            tenant_id=tenant_id,
+        ),
+    )
+    assert result.successful(), f"TTL task failed: {result.traceback}"
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Chat retention tests are enterprise only",
+)
+def test_perform_ttl_deletes_oldest_expired(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+) -> None:
+    """The worker hard-deletes the oldest batch of expired sessions."""
+
+    retention_days = 30
+    sessions = [_make_old_session(admin_user, f"Stale session {i}") for i in range(3)]
+
+    _run_perform_ttl(retention_days)
+
+    for session in sessions:
+        assert _is_session_deleted(session, admin_user), (
+            f"Session {session.id} should have been deleted by TTL cleanup"
+        )
+
+
+@pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Chat retention tests are enterprise only",
+)
+def test_perform_ttl_continues_past_failing_session(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    llm_provider: DATestLLMProvider,  # noqa: ARG001
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """One undeletable session must not block the rest of the batch.
+
+    The worker logs and continues past a failing delete, so every other expired
+    session is still removed and the task itself succeeds.
+    """
+
+    retention_days = 30
+    poison_session = _make_old_session(admin_user, "Undeletable session")
+    deletable_sessions = [
+        _make_old_session(admin_user, f"Deletable session {i}") for i in range(3)
+    ]
+
+    real_delete_chat_session = ttl_tasks.delete_chat_session
+
+    def _delete_or_fail(
+        user_id: UUID | None,
+        chat_session_id: UUID,
+        db_session: Session,
+        include_deleted: bool = False,
+        hard_delete: bool = False,
+    ) -> None:
+        if str(chat_session_id) == str(poison_session.id):
+            raise RuntimeError("Simulated delete failure")
+        real_delete_chat_session(
+            user_id,
+            chat_session_id,
+            db_session,
+            include_deleted=include_deleted,
+            hard_delete=hard_delete,
+        )
+
+    monkeypatch.setattr(ttl_tasks, "delete_chat_session", _delete_or_fail)
+
+    _run_perform_ttl(retention_days)
+
+    assert not _is_session_deleted(poison_session, admin_user), (
+        "The failing session should remain (retried on the next run)"
+    )
+    for session in deletable_sessions:
+        assert _is_session_deleted(session, admin_user), (
+            f"Session {session.id} should be deleted despite a failing session"
+        )

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.8
+version: 0.6.9
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,12 +16,11 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: security
-      description: Add an egress NetworkPolicy on the Craft sandbox pods restricting their egress to
-        the sandbox proxy (:8080) and kube-dns (:53) only. CNI-layer backstop to the in-pod iptables
-        in firewall-init.sh, so a sandbox that bypasses that iptables still cannot reach anything but
-        the proxy. DNS is allowed because sandbox-init resolves the proxy FQDN before its iptables
-        closes DNS.
+    - kind: added
+      description: Add the chat_ttl_deletion queue to the light celery worker so chat-retention
+        (TTL) cleanup runs off the primary "celery" queue and can no longer stall indexing. The
+        light worker consumes the new queue via its -Q list; a rollout is required for existing
+        deployments to pick it up.
 dependencies:
   - name: cloudnative-pg
     version: 0.26.0

--- a/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-light.yaml
@@ -73,7 +73,7 @@ spec:
               {{- end }}
               "--hostname=light@%n",
               "-Q",
-              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration",
+              "vespa_metadata_sync,connector_deletion,doc_permissions_upsert,checkpoint_cleanup,index_attempt_cleanup,opensearch_migration,chat_ttl_deletion",
             ]
           ports:
             - name: metrics


### PR DESCRIPTION
## Description

Backport of #12928 to `release/v4.3` (cherry-pick of squash commit `f6bf055`).

Chat-retention (TTL) cleanup ran on the primary `celery` queue and deleted every expired session in one unbounded task, so on a large backlog it pinned a primary worker thread and starved `check_for_indexing` (which then expired) — surfacing as `Discarding revoked task: check_for_indexing[...]` and silently stalled indexing. Cleanup now runs as a **token-fenced chain of oldest-100 batches** on a dedicated `chat_ttl_deletion` queue consumed by the light worker, so it interleaves with other light-queue work and never touches the indexing lane.

Cherry-pick was clean except `Chart.yaml`: resolved by bumping v4.3's chart **0.6.8 → 0.6.9** (instead of main's 0.6.11) and taking the `chat_ttl_deletion` changelog entry.

> **Deploy note:** the light celery worker must be restarted to pick up the new `chat_ttl_deletion` queue in its `-Q` list.

## How Has This Been Tested?

- `ty`, `ruff check`, `ruff format` pass against the v4.3 tree.
- Integration tests (`test_perform_ttl_*`) came across with the cherry-pick.
- Original PR #12928 is green on main (including the `tests/chat_retention` EE suite).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates chat-retention (TTL) cleanup from the primary `celery` queue and runs deletions in small batches to avoid starving indexing. Adds a token-fenced chain on a new `chat_ttl_deletion` light-worker queue so only one cleanup runs per tenant.

- **Bug Fixes**
  - Move TTL cleanup to `chat_ttl_deletion` consumed by the light worker to keep indexing clear.
  - Delete the oldest 100 expired sessions per task, chaining with a Redis token and a 1h task expiry to prevent overlaps and unbounded runs.
  - Continue past per-session delete failures; add `chat_ttl_deletion_queue_length` metric; DB query orders by last activity and supports a limit.

- **Migration**
  - Restart the light `celery` worker to pick up `chat_ttl_deletion` in its `-Q` list (Helm chart `version: 0.6.9` includes this).

<sup>Written for commit 89aad3857509e48a9089feff8ae86423fd2a77a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

