### PR TITLE
feat(craft): admin Craft section with editable workspace instructions

### DIFF
--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -82,6 +82,7 @@ from onyx.server.documents.credential import router as credential_router
 from onyx.server.documents.document import router as document_router
 from onyx.server.documents.standard_oauth import router as standard_oauth_router
 from onyx.server.documents.targeted_reindex import router as targeted_reindex_router
+from onyx.server.features.build.api import admin_router as build_admin_router
 from onyx.server.features.build.api import router as build_router
 from onyx.server.features.build.webapp_proxy import public_build_router
 from onyx.server.features.default_assistant.api import (
@@ -529,6 +530,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, projects_router)
     include_router_with_global_prefix_prepended(application, public_build_router)
     include_router_with_global_prefix_prepended(application, build_router)
+    include_router_with_global_prefix_prepended(application, build_admin_router)
     include_router_with_global_prefix_prepended(application, image_generation_router)
     include_router_with_global_prefix_prepended(application, document_set_router)
     include_router_with_global_prefix_prepended(application, hierarchy_router)

--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -22,7 +22,7 @@ in the user's connected apps. Use all available resources to best accomplish the
 - Be autonomous when building. Act within the turn rather than stopping to ask.
 
 {{DISABLED_TOOLS_SECTION}}
-
+{{ORGANIZATION_INSTRUCTIONS_SECTION}}
 ## Environment
 
 Ephemeral VM with Python 3.11 and Node v22. A Python virtual environment is already on your

--- a/backend/onyx/server/features/build/api.py
+++ b/backend/onyx/server/features/build/api.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 from fastapi import Depends
+from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
@@ -10,6 +11,9 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.approvals.api import router as approvals_router
 from onyx.server.features.build.debug import router as debug_router
+from onyx.server.features.build.external_apps.api import (
+    admin_router as external_apps_admin_router,
+)
 from onyx.server.features.build.external_apps.api import router as external_apps_router
 from onyx.server.features.build.external_apps.oauth import (
     router as external_apps_oauth_router,
@@ -17,6 +21,9 @@ from onyx.server.features.build.external_apps.oauth import (
 from onyx.server.features.build.interactive_turns.api import router as turns_router
 from onyx.server.features.build.rate_limit import get_user_rate_limit_status
 from onyx.server.features.build.rate_limit import RateLimitResponse
+from onyx.server.features.build.sandbox.util.agent_instructions import (
+    AGENT_INSTRUCTIONS_TEMPLATE_PATH,
+)
 from onyx.server.features.build.scheduled_tasks.api import (
     router as scheduled_tasks_router,
 )
@@ -41,6 +48,29 @@ def require_onyx_craft_enabled(
 
 
 router = APIRouter(prefix="/build", dependencies=[Depends(require_onyx_craft_enabled)])
+
+# Admin-only Craft endpoints. Deliberately NOT behind the craft-enabled-for-user
+# gate: an admin configuring Craft may not have Craft enabled for themselves.
+admin_router = APIRouter(prefix="/build/admin")
+admin_router.include_router(external_apps_admin_router, tags=["build"])
+
+
+class BaseInstructionsResponse(BaseModel):
+    content: str
+
+
+@admin_router.get("/base-instructions")
+def get_base_instructions(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+) -> BaseInstructionsResponse:
+    """The base AGENTS.md template, so admins can see what their workspace
+    instructions are appended to. Dynamic sections appear as placeholders."""
+    if not AGENT_INSTRUCTIONS_TEMPLATE_PATH.exists():
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Base instructions not found")
+    return BaseInstructionsResponse(
+        content=AGENT_INSTRUCTIONS_TEMPLATE_PATH.read_text()
+    )
+
 
 router.include_router(sessions_router, tags=["build"])
 router.include_router(messages_router, tags=["build"])

--- a/backend/onyx/server/features/build/api.py
+++ b/backend/onyx/server/features/build/api.py
@@ -51,7 +51,11 @@ router = APIRouter(prefix="/build", dependencies=[Depends(require_onyx_craft_ena
 
 # Admin-only Craft endpoints. Deliberately NOT behind the craft-enabled-for-user
 # gate: an admin configuring Craft may not have Craft enabled for themselves.
-admin_router = APIRouter(prefix="/build/admin")
+# The router-level permission guard backstops every route added here.
+admin_router = APIRouter(
+    prefix="/build/admin",
+    dependencies=[Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS))],
+)
 admin_router.include_router(external_apps_admin_router, tags=["build"])
 
 

--- a/backend/onyx/server/features/build/api.py
+++ b/backend/onyx/server/features/build/api.py
@@ -1,6 +1,5 @@
 from fastapi import APIRouter
 from fastapi import Depends
-from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
@@ -19,6 +18,7 @@ from onyx.server.features.build.external_apps.oauth import (
     router as external_apps_oauth_router,
 )
 from onyx.server.features.build.interactive_turns.api import router as turns_router
+from onyx.server.features.build.models import BaseInstructionsResponse
 from onyx.server.features.build.rate_limit import get_user_rate_limit_status
 from onyx.server.features.build.rate_limit import RateLimitResponse
 from onyx.server.features.build.sandbox.util.agent_instructions import (
@@ -57,10 +57,6 @@ admin_router = APIRouter(
     dependencies=[Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS))],
 )
 admin_router.include_router(external_apps_admin_router, tags=["build"])
-
-
-class BaseInstructionsResponse(BaseModel):
-    content: str
 
 
 @admin_router.get("/base-instructions")

--- a/backend/onyx/server/features/build/api.py
+++ b/backend/onyx/server/features/build/api.py
@@ -51,7 +51,6 @@ router = APIRouter(prefix="/build", dependencies=[Depends(require_onyx_craft_ena
 
 # Admin-only Craft endpoints. Deliberately NOT behind the craft-enabled-for-user
 # gate: an admin configuring Craft may not have Craft enabled for themselves.
-# The router-level permission guard backstops every route added here.
 admin_router = APIRouter(
     prefix="/build/admin",
     dependencies=[Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS))],

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -65,6 +65,11 @@ from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter()
 
+# Admin-only app management. Mounted under the ungated /build/admin router so
+# admins without personal Craft access can still configure org apps; every
+# route enforces FULL_ADMIN_PANEL_ACCESS itself.
+admin_router = APIRouter()
+
 # Adapters for the structured custom-app form fields, which arrive as JSON
 # strings (multipart can't carry native lists/objects).
 _STR_LIST_ADAPTER = TypeAdapter(list[str])
@@ -142,7 +147,7 @@ def _to_user_response(
 # =============================================================================
 
 
-@router.post("/admin/apps/built-in")
+@admin_router.post("/apps/built-in")
 def create_built_in_external_app(
     request: CreateBuiltInExternalAppRequest,
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
@@ -191,7 +196,7 @@ def create_built_in_external_app(
     return _to_admin_response(app)
 
 
-@router.patch("/admin/apps/{external_app_id}")
+@admin_router.patch("/apps/{external_app_id}")
 def update_external_app_admin(
     external_app_id: int,
     request: UpdateExternalAppRequest,
@@ -244,7 +249,7 @@ def update_external_app_admin(
     return _to_admin_response(app)
 
 
-@router.post("/admin/apps/custom")
+@admin_router.post("/apps/custom")
 def create_custom_external_app(
     name: str = Form(...),
     description: str = Form(""),
@@ -322,7 +327,7 @@ def create_custom_external_app(
     return _to_admin_response(app)
 
 
-@router.put("/admin/apps/{external_app_id}/bundle")
+@admin_router.put("/apps/{external_app_id}/bundle")
 def replace_custom_app_bundle(
     external_app_id: int,
     bundle: UploadFile = File(...),
@@ -365,7 +370,7 @@ def replace_custom_app_bundle(
     return _to_admin_response(app)
 
 
-@router.get("/admin/apps")
+@admin_router.get("/apps")
 def list_external_apps_admin(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
@@ -375,7 +380,7 @@ def list_external_apps_admin(
     return [_to_admin_response(app) for app in apps]
 
 
-@router.get("/admin/apps/built-in/options")
+@admin_router.get("/apps/built-in/options")
 def list_built_in_external_apps(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> list[BuiltInExternalAppDescriptor]:
@@ -383,7 +388,7 @@ def list_built_in_external_apps(
     return fetch_available_built_in_apps()
 
 
-@router.delete("/admin/apps/{external_app_id}")
+@admin_router.delete("/apps/{external_app_id}")
 def delete_external_app_admin(
     external_app_id: int,
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -65,9 +65,6 @@ from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter()
 
-# Admin-only app management. Mounted under the ungated /build/admin router so
-# admins without personal Craft access can still configure org apps; every
-# route enforces FULL_ADMIN_PANEL_ACCESS itself.
 admin_router = APIRouter()
 
 # Adapters for the structured custom-app form fields, which arrive as JSON

--- a/backend/onyx/server/features/build/models.py
+++ b/backend/onyx/server/features/build/models.py
@@ -7,3 +7,7 @@ class UploadResponse(BaseModel):
     filename: str  # Sanitized filename
     path: str  # Relative path in sandbox (e.g., "attachments/doc.pdf")
     size_bytes: int  # File size in bytes
+
+
+class BaseInstructionsResponse(BaseModel):
+    content: str

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -137,6 +137,7 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
 )
+from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -1075,6 +1076,7 @@ class DockerSandboxManager(SandboxManager):
             nextjs_port=nextjs_port,
             disabled_tools=OPENCODE_DISABLED_TOOLS,
             user_name=user_name,
+            organization_instructions=load_settings().craft_instructions,
         )
         return agent_instructions.replace("'", "'\\''")
 

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -142,6 +142,7 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
 )
+from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -490,6 +491,7 @@ class KubernetesSandboxManager(SandboxManager):
             nextjs_port=nextjs_port,
             disabled_tools=disabled_tools,
             user_name=user_name,
+            organization_instructions=load_settings().craft_instructions,
         )
 
     def _create_sandbox_pod(

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -10,6 +10,12 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# Canonical location of the base AGENTS.md template (backend/onyx/server/
+# features/build/AGENTS.template.md).
+AGENT_INSTRUCTIONS_TEMPLATE_PATH = (
+    Path(__file__).parent.parent.parent / "AGENTS.template.md"
+)
+
 # Provider display name mapping
 PROVIDER_DISPLAY_NAMES = {
     "openai": "OpenAI",
@@ -102,6 +108,20 @@ def build_connectable_apps_list(apps: Iterable[ExternalApp]) -> str:
     return "\n".join(f"- **{slug}**: {desc}" for slug, desc in entries)
 
 
+def build_organization_instructions_section(instructions: str | None) -> str:
+    """Render the org-wide instructions admins set for Craft, or an empty
+    string when none are configured."""
+    if not instructions or not instructions.strip():
+        return ""
+    return (
+        "\n## Organization instructions\n\n"
+        "Your organization's admins set these workspace-wide instructions. "
+        "Follow them in every session; the Hard rules above still win on any "
+        "conflict.\n\n"
+        f"{instructions.strip()}\n"
+    )
+
+
 def generate_agent_instructions(
     template_path: Path,
     skills_section: str,
@@ -111,6 +131,7 @@ def generate_agent_instructions(
     nextjs_port: int | None = None,
     disabled_tools: list[str] | None = None,
     user_name: str | None = None,
+    organization_instructions: str | None = None,
 ) -> str:
     """Generate AGENTS.md content by populating the template with dynamic values.
 
@@ -123,6 +144,7 @@ def generate_agent_instructions(
         nextjs_port: Port for Next.js development server
         disabled_tools: List of disabled tools
         user_name: User's name for personalization
+        organization_instructions: Admin-set workspace-wide Craft instructions
 
     Returns:
         Generated AGENTS.md content with placeholders replaced
@@ -165,5 +187,11 @@ def generate_agent_instructions(
     content = content.replace("{{DISABLED_TOOLS_SECTION}}", disabled_tools_section)
     content = content.replace("{{AVAILABLE_SKILLS_SECTION}}", skills_section)
     content = content.replace("{{CONNECTABLE_APPS_LIST}}", connectable_apps_section)
+    # Last, so admin-authored text containing literal {{...}} tokens (e.g.
+    # copy-pasted from the base template) is never expanded.
+    content = content.replace(
+        "{{ORGANIZATION_INSTRUCTIONS_SECTION}}",
+        build_organization_instructions_section(organization_instructions),
+    )
 
     return content

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -10,8 +10,6 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Canonical location of the base AGENTS.md template (backend/onyx/server/
-# features/build/AGENTS.template.md).
 AGENT_INSTRUCTIONS_TEMPLATE_PATH = (
     Path(__file__).parent.parent.parent / "AGENTS.template.md"
 )
@@ -109,8 +107,6 @@ def build_connectable_apps_list(apps: Iterable[ExternalApp]) -> str:
 
 
 def build_organization_instructions_section(instructions: str | None) -> str:
-    """Render the org-wide instructions admins set for Craft, or an empty
-    string when none are configured."""
     if not instructions or not instructions.strip():
         return ""
     return (

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -85,7 +85,6 @@ def admin_put_settings(
     # older client) must not silently reset it to the pydantic default.
     if "craft_default_enabled" not in settings.model_fields_set:
         settings.craft_default_enabled = existing.craft_default_enabled
-    # Same preservation rule for the Craft workspace instructions.
     if "craft_instructions" not in settings.model_fields_set:
         settings.craft_instructions = existing.craft_instructions
     # Search Mode is Business+; Chat Retention is Enterprise-only.

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -85,6 +85,9 @@ def admin_put_settings(
     # older client) must not silently reset it to the pydantic default.
     if "craft_default_enabled" not in settings.model_fields_set:
         settings.craft_default_enabled = existing.craft_default_enabled
+    # Same preservation rule for the Craft workspace instructions.
+    if "craft_instructions" not in settings.model_fields_set:
+        settings.craft_instructions = existing.craft_instructions
     # Search Mode is Business+; Chat Retention is Enterprise-only.
     # Use the same error code (FEATURE_NOT_AVAILABLE / 402) the tier_gate
     # middleware uses, so the FE has one shape to handle for tier-rejected
@@ -146,6 +149,11 @@ def fetch_settings(
         apply_license_status_to_settings,
     )
     general_settings = apply_fn(general_settings)
+
+    # Workspace Craft instructions are admin-configured internal guidance;
+    # non-admins (and anonymous users) don't need them in the settings payload.
+    if not user or not is_user_admin(user):
+        general_settings.craft_instructions = None
 
     # Check if Onyx Craft is enabled for this user (used for server-side
     # redirects). The deployment gate and already-loaded settings are shared.

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -150,9 +150,9 @@ def fetch_settings(
     )
     general_settings = apply_fn(general_settings)
 
-    # Workspace Craft instructions are admin-configured internal guidance;
-    # non-admins (and anonymous users) don't need them in the settings payload.
-    if not user or not is_user_admin(user):
+    # Craft workspace instructions are visible to authenticated users (they
+    # appear in sandbox AGENTS.md anyway) but not to anonymous visitors.
+    if user is None:
         general_settings.craft_instructions = None
 
     # Check if Onyx Craft is enabled for this user (used for server-side

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -14,6 +14,8 @@ from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_VECTOR_DB = 200
 DEFAULT_FILE_TOKEN_COUNT_THRESHOLD_K_NO_VECTOR_DB = 10000
 
+CRAFT_INSTRUCTIONS_MAX_LENGTH = 4000
+
 
 class PageType(str, Enum):
     CHAT = "chat"
@@ -90,6 +92,12 @@ class Settings(BaseModel):
     # Workspace default for Craft access; per-user User.craft_enabled
     # overrides win. The deployment-level Craft gate still applies on top.
     craft_default_enabled: bool = True
+
+    # Workspace-wide instructions injected into every Craft agent's AGENTS.md
+    # as an "Organization instructions" section. Applies to new sessions only.
+    craft_instructions: str | None = Field(
+        default=None, max_length=CRAFT_INSTRUCTIONS_MAX_LENGTH
+    )
 
     # Seat usage - populated by license enforcement when seat limit is exceeded
     seat_count: int | None = None

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -94,7 +94,7 @@ class Settings(BaseModel):
     craft_default_enabled: bool = True
 
     # Workspace-wide instructions injected into every Craft agent's AGENTS.md
-    # as an "Organization instructions" section. Applies to new sessions only.
+    # as an "Organization instructions" section.
     craft_instructions: str | None = Field(
         default=None, max_length=CRAFT_INSTRUCTIONS_MAX_LENGTH
     )

--- a/backend/tests/integration/tests/permissions/test_admin_access.py
+++ b/backend/tests/integration/tests/permissions/test_admin_access.py
@@ -23,6 +23,7 @@ ADMIN_ACCESS_ENDPOINTS: list[tuple[str, str]] = [
     ("GET", "/manage/users/invited"),
     ("GET", "/manage/admin/valid-domains"),
     ("GET", "/manage/users/download"),
+    ("GET", "/build/admin/base-instructions"),
 ]
 
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
@@ -83,7 +83,6 @@ def test_generate_agent_instructions_injects_organization_instructions() -> None
 
     assert "## Organization instructions" in content
     assert "SENTINEL_ORG_RULE: always use the brand kit." in content
-    # Injected between the hard rules and the environment section.
     assert content.index("## Hard rules") < content.index(
         "## Organization instructions"
     )
@@ -94,7 +93,6 @@ def test_generate_agent_instructions_injects_organization_instructions() -> None
 
 
 def test_org_instructions_containing_template_tokens_stay_literal() -> None:
-    """Admin text copy-pasted from the base template must not be expanded."""
     content = agent_instructions.generate_agent_instructions(
         template_path=_template_path(),
         skills_section="SENTINEL_REAL_SKILLS",

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_agent_instructions.py
@@ -73,6 +73,54 @@ def test_generate_agent_instructions_omits_optional_sections_when_values_absent(
     assert _unresolved_placeholders(content) == set()
 
 
+def test_generate_agent_instructions_injects_organization_instructions() -> None:
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section="",
+        connectable_apps_section="",
+        organization_instructions="SENTINEL_ORG_RULE: always use the brand kit.",
+    )
+
+    assert "## Organization instructions" in content
+    assert "SENTINEL_ORG_RULE: always use the brand kit." in content
+    # Injected between the hard rules and the environment section.
+    assert content.index("## Hard rules") < content.index(
+        "## Organization instructions"
+    )
+    assert content.index("## Organization instructions") < content.index(
+        "## Environment"
+    )
+    assert _unresolved_placeholders(content) == set()
+
+
+def test_org_instructions_containing_template_tokens_stay_literal() -> None:
+    """Admin text copy-pasted from the base template must not be expanded."""
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section="SENTINEL_REAL_SKILLS",
+        connectable_apps_section="",
+        organization_instructions="Refer to {{AVAILABLE_SKILLS_SECTION}} above.",
+    )
+
+    assert "Refer to {{AVAILABLE_SKILLS_SECTION}} above." in content
+    assert "Refer to SENTINEL_REAL_SKILLS above." not in content
+
+
+@pytest.mark.parametrize("instructions", [None, "", "   \n  "])
+def test_generate_agent_instructions_omits_org_section_when_blank(
+    instructions: str | None,
+) -> None:
+    content = agent_instructions.generate_agent_instructions(
+        template_path=_template_path(),
+        skills_section="",
+        connectable_apps_section="",
+        organization_instructions=instructions,
+    )
+
+    assert "## Organization instructions" not in content
+    assert _unresolved_placeholders(content) == set()
+
+
 def test_build_connectable_apps_list_empty_renders_fallback() -> None:
     """No connectable apps → a fallback line, mirroring ``build_skills_section_
     from_data``'s "No skills available." (the template blurb stays either way)."""

--- a/backend/tests/unit/onyx/server/settings/test_admin_put_settings.py
+++ b/backend/tests/unit/onyx/server/settings/test_admin_put_settings.py
@@ -1,9 +1,3 @@
-"""Preservation semantics of admin_put_settings for craft_instructions.
-
-A PUT from an older client that omits the field must not wipe stored
-instructions; an explicit null must clear them.
-"""
-
 from typing import Any
 from unittest.mock import MagicMock
 

--- a/backend/tests/unit/onyx/server/settings/test_admin_put_settings.py
+++ b/backend/tests/unit/onyx/server/settings/test_admin_put_settings.py
@@ -1,0 +1,63 @@
+"""Preservation semantics of admin_put_settings for craft_instructions.
+
+A PUT from an older client that omits the field must not wipe stored
+instructions; an explicit null must clear them.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from onyx.server.settings import api as settings_api
+from onyx.server.settings.models import CRAFT_INSTRUCTIONS_MAX_LENGTH
+from onyx.server.settings.models import Settings
+
+
+def _put_settings(
+    payload: dict[str, Any],
+    existing: Settings,
+    monkeypatch: pytest.MonkeyPatch,
+) -> Settings:
+    stored: list[Settings] = []
+    monkeypatch.setattr(settings_api, "load_settings", lambda: existing)
+    monkeypatch.setattr(settings_api, "store_settings", stored.append)
+    monkeypatch.setattr(settings_api, "emit_audit_event", lambda *_a, **_k: None)
+    monkeypatch.setattr(settings_api.global_version, "is_ee_version", lambda: False)
+    settings_api.admin_put_settings(
+        Settings.model_validate(payload), current_user=MagicMock()
+    )
+    assert len(stored) == 1
+    return stored[0]
+
+
+def test_omitted_craft_instructions_is_preserved(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = Settings(craft_instructions="keep me")
+    result = _put_settings({}, existing, monkeypatch)
+    assert result.craft_instructions == "keep me"
+
+
+def test_explicit_null_clears_craft_instructions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = Settings(craft_instructions="old value")
+    result = _put_settings({"craft_instructions": None}, existing, monkeypatch)
+    assert result.craft_instructions is None
+
+
+def test_explicit_value_overwrites_craft_instructions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    existing = Settings(craft_instructions="old value")
+    result = _put_settings({"craft_instructions": "new value"}, existing, monkeypatch)
+    assert result.craft_instructions == "new value"
+
+
+def test_over_length_craft_instructions_rejected() -> None:
+    with pytest.raises(ValidationError):
+        Settings.model_validate(
+            {"craft_instructions": "x" * (CRAFT_INSTRUCTIONS_MAX_LENGTH + 1)}
+        )

--- a/web/src/app/admin/configuration/craft/page.tsx
+++ b/web/src/app/admin/configuration/craft/page.tsx
@@ -1,1 +1,7 @@
-export { default } from "@/views/admin/CraftPage";
+import { redirect } from "next/navigation";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+
+// Craft administration moved into its own sidebar section.
+export default function Page() {
+  redirect(ADMIN_ROUTES.CRAFT_ACCESS.path);
+}

--- a/web/src/app/admin/configuration/craft/page.tsx
+++ b/web/src/app/admin/configuration/craft/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
-// Craft administration moved into its own sidebar section.
 export default function Page() {
   redirect(ADMIN_ROUTES.CRAFT_ACCESS.path);
 }

--- a/web/src/app/admin/craft/access/page.tsx
+++ b/web/src/app/admin/craft/access/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/views/admin/CraftPage";

--- a/web/src/app/admin/craft/apps/page.tsx
+++ b/web/src/app/admin/craft/apps/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/views/admin/ExternalAppsPage";

--- a/web/src/app/admin/craft/instructions/page.tsx
+++ b/web/src/app/admin/craft/instructions/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "@/views/admin/CraftInstructionsPage";

--- a/web/src/app/craft/v1/apps/admin/page.tsx
+++ b/web/src/app/craft/v1/apps/admin/page.tsx
@@ -1,14 +1,7 @@
-"use client";
+import { redirect } from "next/navigation";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-
-// /craft/v1/apps/admin was the shipped admin apps page before management moved
-// to /craft/v1/apps/manage; redirect so bookmarks to the old path still work.
+// Old admin apps path; management now lives in the admin panel's Craft section.
 export default function ExternalAppsAdminRedirect() {
-  const router = useRouter();
-  useEffect(() => {
-    router.replace("/craft/v1/apps/manage");
-  }, [router]);
-  return null;
+  redirect(ADMIN_ROUTES.CRAFT_APPS.path);
 }

--- a/web/src/app/craft/v1/apps/admin/page.tsx
+++ b/web/src/app/craft/v1/apps/admin/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
-// Old admin apps path; management now lives in the admin panel's Craft section.
 export default function ExternalAppsAdminRedirect() {
   redirect(ADMIN_ROUTES.CRAFT_APPS.path);
 }

--- a/web/src/app/craft/v1/apps/manage/page.tsx
+++ b/web/src/app/craft/v1/apps/manage/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
-// Org app configuration moved to the admin panel's Craft section.
 export default function ManageAppsPage() {
   redirect(ADMIN_ROUTES.CRAFT_APPS.path);
 }

--- a/web/src/app/craft/v1/apps/manage/page.tsx
+++ b/web/src/app/craft/v1/apps/manage/page.tsx
@@ -1,10 +1,7 @@
-"use client";
+import { redirect } from "next/navigation";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
-import { useRouter } from "next/navigation";
-import ExternalAppsPage from "@/views/admin/ExternalAppsPage";
-
-// Admin-only org app configuration (gated server-side by CraftManageLayout).
+// Org app configuration moved to the admin panel's Craft section.
 export default function ManageAppsPage() {
-  const router = useRouter();
-  return <ExternalAppsPage onBack={() => router.push("/craft/v1/apps")} />;
+  redirect(ADMIN_ROUTES.CRAFT_APPS.path);
 }

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -22,8 +22,8 @@ import UserCredentialsModal from "@/app/craft/v1/apps/UserCredentialsModal";
 import { toast } from "@/hooks/useToast";
 import { useUser } from "@/providers/UserProvider";
 
-// The user's own app connections. Org-wide configuration lives at
-// /craft/v1/apps/manage (admin-only); admins get a shortcut button to it here.
+// The user's own app connections. Org-wide configuration lives in the admin
+// panel's Craft section; admins get a shortcut button to it here.
 export default function ExternalAppsPage() {
   const { isAdmin } = useUser();
   const [query, setQuery] = useState("");
@@ -44,15 +44,13 @@ export default function ExternalAppsPage() {
         description="Connect the tools Onyx Craft can use as context while it works."
         rightChildren={
           isAdmin ? (
-            <div className="flex items-center gap-2">
-              <Button
-                href="/craft/v1/apps/manage"
-                prominence="secondary"
-                icon={SvgSettings}
-              >
-                Manage apps
-              </Button>
-            </div>
+            <Button
+              href="/admin/craft/apps"
+              prominence="secondary"
+              icon={SvgSettings}
+            >
+              Manage apps
+            </Button>
           ) : undefined
         }
       >

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -20,6 +20,7 @@ import {
   SvgMcp,
   SvgOnyxOctagon,
   SvgPaintBrush,
+  SvgPlug,
   SvgProgressBars,
   SvgSearchMenu,
   SvgShield,
@@ -27,6 +28,7 @@ import {
   SvgThumbsUp,
   SvgUploadCloud,
   SvgUser,
+  SvgUserCheck,
   SvgUserKey,
   SvgUserSync,
   SvgUsers,
@@ -156,11 +158,23 @@ export const ADMIN_ROUTES = {
     title: "Code Interpreter",
     sidebarLabel: "Code Interpreter",
   },
-  CRAFT: {
-    path: "/admin/configuration/craft",
+  CRAFT_ACCESS: {
+    path: "/admin/craft/access",
+    icon: SvgUserCheck,
+    title: "Access",
+    sidebarLabel: "Access",
+  },
+  CRAFT_APPS: {
+    path: "/admin/craft/apps",
+    icon: SvgPlug,
+    title: "Apps",
+    sidebarLabel: "Apps",
+  },
+  CRAFT_INSTRUCTIONS: {
+    path: "/admin/craft/instructions",
     icon: SvgDevKit,
-    title: "Craft",
-    sidebarLabel: "Craft",
+    title: "Instructions",
+    sidebarLabel: "Instructions",
   },
   INDEX_SETTINGS: {
     path: "/admin/configuration/index-settings",

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -68,7 +68,7 @@ export interface Settings {
   craft_default_enabled?: boolean;
 
   // Workspace-wide instructions injected into every Craft agent's system
-  // prompt (AGENTS.md). Applies to new sessions only.
+  // prompt (AGENTS.md).
   craft_instructions?: string | null;
 
   // Dev/debug flag: when true, the Craft UI renders an "Opencode pod logs"

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -67,6 +67,10 @@ export interface Settings {
   // Workspace default for Craft access; per-user overrides win.
   craft_default_enabled?: boolean;
 
+  // Workspace-wide instructions injected into every Craft agent's system
+  // prompt (AGENTS.md). Applies to new sessions only.
+  craft_instructions?: string | null;
+
   // Dev/debug flag: when true, the Craft UI renders an "Opencode pod logs"
   // button that streams the user's sandbox pod logs in real time. Backed
   // by the ENABLE_OPENCODE_DEBUGGING env var on the server. Never set in

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -152,6 +152,7 @@ export const SWR_KEYS = {
   buildExternalApps: "/api/build/apps",
   buildExternalAppsAdmin: "/api/build/admin/apps",
   buildExternalAppsBuiltInOptions: "/api/build/admin/apps/built-in/options",
+  buildBaseInstructions: "/api/build/admin/base-instructions",
   buildSessionLiveApprovals: (sessionId: string) =>
     `/api/build/approvals/sessions/${sessionId}/live`,
 

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -27,6 +27,7 @@ import { markdown } from "@opal/utils";
 
 const SECTIONS = {
   UNLABELED: null,
+  CRAFT: "Craft",
   AGENTS_AND_ACTIONS: "Agents & Actions",
   DOCUMENTS_AND_KNOWLEDGE: "Documents & Knowledge",
   INTEGRATIONS: "Integrations",
@@ -83,9 +84,6 @@ function buildItems(
     add(SECTIONS.UNLABELED, ADMIN_ROUTES.IMAGE_GENERATION);
     add(SECTIONS.UNLABELED, ADMIN_ROUTES.VOICE);
     add(SECTIONS.UNLABELED, ADMIN_ROUTES.CODE_INTERPRETER);
-    if (settings?.onyx_craft_available === true) {
-      add(SECTIONS.UNLABELED, ADMIN_ROUTES.CRAFT);
-    }
     add(SECTIONS.UNLABELED, ADMIN_ROUTES.CHAT_PREFERENCES);
 
     if (!enableCloud && customAnalyticsEnabled) {
@@ -97,12 +95,19 @@ function buildItems(
     }
   }
 
-  // 2. Agents & Actions
+  // 2. Craft (admin only, deployment-gated)
+  if (!isCurator && settings?.onyx_craft_available === true) {
+    add(SECTIONS.CRAFT, ADMIN_ROUTES.CRAFT_ACCESS);
+    add(SECTIONS.CRAFT, ADMIN_ROUTES.CRAFT_APPS);
+    add(SECTIONS.CRAFT, ADMIN_ROUTES.CRAFT_INSTRUCTIONS);
+  }
+
+  // 3. Agents & Actions
   add(SECTIONS.AGENTS_AND_ACTIONS, ADMIN_ROUTES.AGENTS);
   add(SECTIONS.AGENTS_AND_ACTIONS, ADMIN_ROUTES.MCP_ACTIONS);
   add(SECTIONS.AGENTS_AND_ACTIONS, ADMIN_ROUTES.OPENAPI_ACTIONS);
 
-  // 3. Documents & Knowledge
+  // 4. Documents & Knowledge
   // Shown even in Lite mode; the pages themselves render a no-indexing notice.
   add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.INDEXING_STATUS);
   add(SECTIONS.DOCUMENTS_AND_KNOWLEDGE, ADMIN_ROUTES.ADD_CONNECTOR);
@@ -115,7 +120,7 @@ function buildItems(
     });
   }
 
-  // 4. Integrations (admin only)
+  // 5. Integrations (admin only)
   if (!isCurator) {
     addGated(SECTIONS.INTEGRATIONS, ADMIN_ROUTES.API_KEYS, Tier.BUSINESS);
     add(SECTIONS.INTEGRATIONS, ADMIN_ROUTES.SLACK_BOTS);
@@ -125,7 +130,7 @@ function buildItems(
     }
   }
 
-  // 5. Permissions
+  // 6. Permissions
   if (!isCurator) {
     add(SECTIONS.PERMISSIONS, ADMIN_ROUTES.USERS);
     addGated(SECTIONS.PERMISSIONS, ADMIN_ROUTES.GROUPS, Tier.BUSINESS);
@@ -134,7 +139,7 @@ function buildItems(
     add(SECTIONS.PERMISSIONS, ADMIN_ROUTES.GROUPS);
   }
 
-  // 6. Usage (admin only)
+  // 7. Usage (admin only)
   if (!isCurator) {
     // Tracing config is not supported on multi-tenant cloud.
     if (!enableCloud) {
@@ -150,7 +155,7 @@ function buildItems(
     }
   }
 
-  // 7. Organization (admin only)
+  // 8. Organization (admin only)
   if (!isCurator) {
     addGated(SECTIONS.ORGANIZATION, ADMIN_ROUTES.THEME, Tier.BUSINESS);
     add(SECTIONS.ORGANIZATION, ADMIN_ROUTES.SECURITY_HARDENING);

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -326,7 +326,7 @@ export default function AdminSidebar() {
         {!folded && <Divider paddingPerpendicular="sm" />}
         <SidebarTab
           icon={SvgX}
-          href="/app"
+          href={pathname?.startsWith("/admin/craft") ? "/craft/v1" : "/app"}
           variant="sidebar-light"
           folded={folded}
         >

--- a/web/src/views/admin/CraftInstructionsPage/index.tsx
+++ b/web/src/views/admin/CraftInstructionsPage/index.tsx
@@ -88,6 +88,7 @@ export default function CraftInstructionsPage() {
       toast.success("Craft instructions saved");
       return true;
     } catch (err) {
+      console.error("Failed to save Craft instructions", err);
       toast.error(
         err instanceof Error ? err.message : "Failed to save instructions"
       );

--- a/web/src/views/admin/CraftInstructionsPage/index.tsx
+++ b/web/src/views/admin/CraftInstructionsPage/index.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import useSWR, { mutate } from "swr";
+import { Button, Card, Text } from "@opal/components";
+import {
+  IllustrationContent,
+  InputVertical,
+  SettingsLayouts,
+} from "@opal/layouts";
+import { SvgArrowUpRight, SvgRefreshCw, SvgSimpleLoader } from "@opal/icons";
+import SvgNoResult from "@opal/illustrations/no-result";
+import { Section } from "@/layouts/general-layouts";
+import InputTextArea from "@/refresh-components/inputs/InputTextArea";
+import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
+import ConfirmationModalLayout from "@/refresh-components/layouts/ConfirmationModalLayout";
+import { toast } from "@/hooks/useToast";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+import { useSettings } from "@/lib/settings/hooks";
+import { toSettings } from "@/lib/settings/types";
+import { updateAdminSettings } from "@/lib/settings/svc";
+
+const MAX_INSTRUCTIONS_LENGTH = 4000;
+
+function BaseInstructionsPreview() {
+  const { data, error } = useSWR<{ content: string }>(
+    SWR_KEYS.buildBaseInstructions,
+    errorHandlingFetcher
+  );
+
+  if (error) {
+    return (
+      <Text font="secondary-body" color="text-03">
+        Failed to load the base instructions.
+      </Text>
+    );
+  }
+  if (!data) {
+    return (
+      <div className="flex justify-center py-4">
+        <SvgSimpleLoader className="h-5 w-5" />
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-lg border border-border-01 p-3 overflow-y-auto overflow-x-hidden bg-background-neutral-00 max-h-96">
+      <pre className="m-0 whitespace-pre-wrap wrap-break-word font-mono text-xs leading-5 text-text-04">
+        {data.content}
+      </pre>
+    </div>
+  );
+}
+
+export default function CraftInstructionsPage() {
+  const settings = useSettings();
+  const craftAvailable = settings?.onyx_craft_available === true;
+  const savedInstructions = settings?.craft_instructions ?? "";
+
+  const [draft, setDraft] = useState<string | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+
+  // null until the user edits — render the saved value until then.
+  const value = draft ?? savedInstructions;
+  const isDirty = value !== savedInstructions;
+
+  useEffect(() => {
+    if (!isDirty) return;
+    function warn(event: BeforeUnloadEvent) {
+      event.preventDefault();
+    }
+    window.addEventListener("beforeunload", warn);
+    return () => window.removeEventListener("beforeunload", warn);
+  }, [isDirty]);
+
+  async function save(instructions: string): Promise<boolean> {
+    if (!settings) return false;
+    setIsSaving(true);
+    try {
+      await updateAdminSettings({
+        ...toSettings(settings),
+        craft_instructions: instructions.trim() || null,
+      });
+      await mutate(SWR_KEYS.settings);
+      setDraft(null);
+      toast.success("Craft instructions saved");
+      return true;
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : "Failed to save instructions"
+      );
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const header = (
+    <SettingsLayouts.Header
+      icon={ADMIN_ROUTES.CRAFT_INSTRUCTIONS.icon}
+      title={ADMIN_ROUTES.CRAFT_INSTRUCTIONS.title}
+      description="Workspace-wide instructions every Craft agent follows, on top of Craft's built-in behavior."
+      rightChildren={
+        craftAvailable && !settings.isLoading && !settings.error ? (
+          <div className="flex items-start gap-2">
+            <Button
+              href="/craft"
+              prominence="secondary"
+              rightIcon={SvgArrowUpRight}
+            >
+              Try in Craft
+            </Button>
+            <Button disabled={!isDirty || isSaving} onClick={() => save(value)}>
+              {isSaving ? "Saving…" : "Save"}
+            </Button>
+          </div>
+        ) : undefined
+      }
+      divider
+    />
+  );
+
+  // useSettings returns a default object while loading (and on error), which
+  // lacks onyx_craft_available — don't misreport Craft as unavailable.
+  if (settings.isLoading || settings.error) {
+    return (
+      <SettingsLayouts.Root>
+        {header}
+        <SettingsLayouts.Body>
+          {settings.error ? (
+            <Text as="p" font="secondary-body" color="text-03">
+              Failed to load settings. Please try refreshing the page.
+            </Text>
+          ) : (
+            <div className="flex justify-center py-12">
+              <SvgSimpleLoader className="h-6 w-6" />
+            </div>
+          )}
+        </SettingsLayouts.Body>
+      </SettingsLayouts.Root>
+    );
+  }
+
+  if (!craftAvailable) {
+    return (
+      <SettingsLayouts.Root>
+        {header}
+        <SettingsLayouts.Body>
+          <IllustrationContent
+            illustration={SvgNoResult}
+            title="Craft isn't available on this deployment"
+            description="Craft is enabled per deployment by Onyx. Contact your Onyx representative to get access."
+          />
+        </SettingsLayouts.Body>
+      </SettingsLayouts.Root>
+    );
+  }
+
+  return (
+    <SettingsLayouts.Root>
+      {header}
+      <SettingsLayouts.Body>
+        <Card border="solid" rounding="lg">
+          <Section alignItems="stretch" gap={0.25}>
+            <InputVertical
+              title="Workspace instructions"
+              topRight={`${value.length.toLocaleString()} / ${MAX_INSTRUCTIONS_LENGTH.toLocaleString()}`}
+              withLabel
+            >
+              <InputTextArea
+                value={value}
+                onChange={(event) => setDraft(event.target.value)}
+                placeholder="e.g. Always follow our brand guidelines and prefer concise, formal copy."
+                rows={8}
+                autoResize
+                maxRows={24}
+                maxLength={MAX_INSTRUCTIONS_LENGTH}
+              />
+              <div className="w-full flex items-center justify-between gap-4">
+                <Text font="secondary-body" color="text-03">
+                  Changes apply when a session starts or is restored — they
+                  don&apos;t reach into sessions mid-run.
+                </Text>
+                {savedInstructions && (
+                  <Button
+                    icon={SvgRefreshCw}
+                    variant="danger"
+                    prominence="tertiary"
+                    size="sm"
+                    disabled={isSaving}
+                    onClick={() => setResetConfirmOpen(true)}
+                  >
+                    Reset to default
+                  </Button>
+                )}
+              </div>
+            </InputVertical>
+          </Section>
+        </Card>
+
+        <SimpleCollapsible defaultOpen={false}>
+          <SimpleCollapsible.Header
+            title="View base instructions"
+            description="The built-in prompt your instructions are appended to. Dynamic sections are filled in per session."
+          />
+          <SimpleCollapsible.Content>
+            <BaseInstructionsPreview />
+          </SimpleCollapsible.Content>
+        </SimpleCollapsible>
+      </SettingsLayouts.Body>
+
+      {resetConfirmOpen && (
+        <ConfirmationModalLayout
+          icon={ADMIN_ROUTES.CRAFT_INSTRUCTIONS.icon}
+          title="Reset Craft instructions?"
+          onClose={isSaving ? undefined : () => setResetConfirmOpen(false)}
+          submit={
+            <Button
+              variant="danger"
+              disabled={isSaving}
+              onClick={async () => {
+                if (await save("")) {
+                  setResetConfirmOpen(false);
+                }
+              }}
+            >
+              {isSaving ? "Resetting…" : "Reset"}
+            </Button>
+          }
+        >
+          New Craft sessions will run with only the built-in instructions. This
+          removes your workspace instructions for everyone.
+        </ConfirmationModalLayout>
+      )}
+    </SettingsLayouts.Root>
+  );
+}

--- a/web/src/views/admin/CraftPage/index.tsx
+++ b/web/src/views/admin/CraftPage/index.tsx
@@ -151,8 +151,8 @@ export default function CraftPage() {
 
   const header = (
     <SettingsLayouts.Header
-      icon={ADMIN_ROUTES.CRAFT.icon}
-      title={ADMIN_ROUTES.CRAFT.title}
+      icon={ADMIN_ROUTES.CRAFT_ACCESS.icon}
+      title={ADMIN_ROUTES.CRAFT_ACCESS.title}
       description="Control who can use Craft, Onyx's agentic app builder."
       divider
     />
@@ -269,7 +269,7 @@ export default function CraftPage() {
 
       {pendingDefault !== null && (
         <ConfirmationModalLayout
-          icon={ADMIN_ROUTES.CRAFT.icon}
+          icon={ADMIN_ROUTES.CRAFT_ACCESS.icon}
           title={
             pendingDefault
               ? "Enable Craft for all users?"

--- a/web/src/views/admin/ExternalAppsPage.tsx
+++ b/web/src/views/admin/ExternalAppsPage.tsx
@@ -7,7 +7,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { Button, Divider, Text } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
 import Card from "@/refresh-components/cards/Card";
-import { SvgArrowUpRight, SvgPlug, SvgPlus, SvgTrash } from "@opal/icons";
+import { SvgArrowLeft, SvgPlug, SvgPlus, SvgTrash } from "@opal/icons";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import {
   availableBuiltInDescriptors,
@@ -40,9 +40,9 @@ export default function ExternalAppsPage() {
           <Button
             href="/craft/v1/apps"
             prominence="secondary"
-            rightIcon={SvgArrowUpRight}
+            icon={SvgArrowLeft}
           >
-            Your apps in Craft
+            Back to Craft
           </Button>
         }
       />

--- a/web/src/views/admin/ExternalAppsPage.tsx
+++ b/web/src/views/admin/ExternalAppsPage.tsx
@@ -7,7 +7,8 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import { Button, Divider, Text } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
 import Card from "@/refresh-components/cards/Card";
-import { SvgArrowLeft, SvgPlug, SvgPlus, SvgTrash } from "@opal/icons";
+import { SvgArrowUpRight, SvgPlug, SvgPlus, SvgTrash } from "@opal/icons";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import {
   availableBuiltInDescriptors,
   BuiltInExternalAppDescriptor,
@@ -27,32 +28,22 @@ interface ModalState {
   existingApp: ExternalAppAdminResponse | null;
 }
 
-interface ExternalAppsPageProps {
-  onBack?: () => void;
-}
-
 // Admin External Apps management; members connect their own accounts on the Apps page.
-export default function ExternalAppsPage({
-  onBack,
-}: ExternalAppsPageProps = {}) {
+export default function ExternalAppsPage() {
   return (
     <SettingsLayouts.Root>
       <SettingsLayouts.Header
-        icon={SvgPlug}
-        title="External Apps"
+        icon={ADMIN_ROUTES.CRAFT_APPS.icon}
+        title={ADMIN_ROUTES.CRAFT_APPS.title}
         description="Connect third-party integrations so users in your org can authorize them with their personal accounts in Onyx Craft."
         rightChildren={
-          onBack ? (
-            <div className="flex items-center gap-2">
-              <Button
-                prominence="secondary"
-                icon={SvgArrowLeft}
-                onClick={onBack}
-              >
-                Back
-              </Button>
-            </div>
-          ) : undefined
+          <Button
+            href="/craft/v1/apps"
+            prominence="secondary"
+            rightIcon={SvgArrowUpRight}
+          >
+            Your apps in Craft
+          </Button>
         }
       />
       <SettingsLayouts.Body>


### PR DESCRIPTION
## Description

Gives Craft its own labeled **Craft** section in the admin sidebar and adds admin-editable workspace instructions for Craft agents.

**Admin IA**
- New sidebar section (admin-only, gated on `onyx_craft_available`) with three pages: **Access** (`/admin/craft/access`, the existing access controls), **Apps** (`/admin/craft/apps`, org app/skill management moved out of the Craft app), and **Instructions** (`/admin/craft/instructions`, new).
- Old routes redirect: `/admin/configuration/craft`, `/craft/v1/apps/manage`, `/craft/v1/apps/admin`. One-click round trip between the admin Apps page and the in-Craft user Apps page ("Manage apps" ↔ "Your apps in Craft").
- External-apps admin endpoints moved to the ungated `/build/admin` router (each already enforces `FULL_ADMIN_PANEL_ACCESS`) so admins **without personal Craft access** can still manage org apps. Final URLs are unchanged.

**Workspace instructions**
- New `craft_instructions` setting (4,000-char cap): admin-only writes via `PUT /admin/settings`, preserved when older clients omit the field, explicit `null` clears it, stripped from the `/settings` payload for non-admins.
- Injected into each session's rendered AGENTS.md as an `## Organization instructions` section (both Docker and K8s sandbox managers, including snapshot restore). Substitution runs last so admin text containing literal `{{...}}` template tokens is never expanded.
- New `GET /build/admin/base-instructions` endpoint so the editor can show the base prompt being appended to.
- Instructions editor: labeled textarea with live counter, explicit Save with dirty tracking + `beforeunload` guard, confirm-gated Reset to default, collapsible base-prompt view, "Try in Craft" shortcut.

## How Has This Been Tested?

<img width="1913" height="936" alt="Screenshot 2026-07-13 at 13 55 19" src="https://github.com/user-attachments/assets/a23bb994-feb0-42e3-a03f-9d515b5830c3" />

<img width="236" height="384" alt="Screenshot 2026-07-13 at 13 55 39" src="https://github.com/user-attachments/assets/30f3f9f9-5710-4955-86bd-6e3fb8c483b5" />

- Unit: `test_agent_instructions.py` (11 tests — injection position, blank omission, token-literalness) and new `test_admin_put_settings.py` (4 tests — omit-preserves / null-clears / value-overwrites / over-length rejected).
- Integration: `GET /build/admin/base-instructions` added to the `ADMIN_ACCESS_ENDPOINTS` authz matrix.
- Live browser verification of all three pages, redirects, save/reset/dirty flows, and the apps admin page after the router split.
- Multi-lens review (correctness, security, tests, regressions, frontend style); confirmed findings fixed. Shell-escaping of the admin text through the sandbox `printf` path and tenant resolution of `load_settings()` were explicitly verified.
- `mypy`, `tsgo`, `ruff`, `oxfmt` clean.

**Known minor items** (flagged in review, intentionally left):
- Curators navigating directly to `/admin/craft/*` URLs render pages whose fetches 403 (the sidebar hides the links from them; same class of behavior as before, but a server-side gate could be added).
- `CraftManageLayout` now only wraps a redirect page and could be deleted in a follow-up cleanup.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin Craft section with Access, Apps, and Instructions pages, plus workspace-wide instructions injected into every Craft agent’s prompt. This gives orgs consistent guardrails and lets admins manage apps without personal Craft access.

- **New Features**
  - Admin Craft section: `/admin/craft/access`, `/admin/craft/apps`, `/admin/craft/instructions`. Old routes redirect. Admin app endpoints live under `/build/admin` with a router‑level `FULL_ADMIN_PANEL_ACCESS` guard; one-click between the user Apps page and admin Apps (user “Manage apps” → admin; admin “Back to Craft” → user). The admin sidebar’s exit link is context-aware and returns to Craft when you’re in the Craft section.
  - Workspace instructions: new `craft_instructions` setting (max 4,000 chars) injected into AGENTS.md as “Organization instructions” (after Hard rules, before Environment). Literal `{{...}}` tokens are not expanded. Visible to authenticated users; admin-only writes. Omitted on PUT preserves value; `null` clears. `GET /build/admin/base-instructions` shows the base prompt. Editor has counter, Save with dirty guard, Reset to default, base‑prompt preview, “Try in Craft,” and error toasts.

- **Migration**
  - No API URL changes; admin apps endpoints remain under `/build/admin`. Redirects added from `/admin/configuration/craft`, `/craft/v1/apps/manage`, and `/craft/v1/apps/admin`.
  - Instructions apply to new or restored sessions only.

<sup>Written for commit 62fc67e37406ee628f240e765381be51f0f69b38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



