### PR TITLE
feat(llm): add Portkey as a built-in LLM provider (3 API modes)

### DIFF
--- a/backend/onyx/llm/api_surfaces.py
+++ b/backend/onyx/llm/api_surfaces.py
@@ -1,0 +1,79 @@
+"""Wire protocols ("API surfaces") that provider endpoints speak.
+
+Routing a call depends on the surface rather than the provider: which LiteLLM
+provider to impersonate, whether the base URL is coerced to end in `/v1`, and
+how the model name is addressed. Gateways make this explicit — one gateway can
+expose several surfaces, and the admin picks one. Keeping the mapping here lets
+`multi_llm` branch on the surface alone, so a new provider is a table entry
+rather than another conditional in the call path.
+"""
+
+from enum import Enum
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.well_known_providers.constants import (
+    PORTKEY_API_MODE_CHAT_COMPLETIONS,
+    PORTKEY_API_MODE_CONFIG_KEY,
+    PORTKEY_API_MODE_MESSAGES,
+    PORTKEY_API_MODE_RESPONSES,
+    PORTKEY_DEFAULT_API_MODE,
+)
+
+
+class LlmApiSurface(str, Enum):
+    """The wire protocol a provider's endpoint speaks."""
+
+    # POST {base}/v1/chat/completions, model sent bare.
+    OPENAI_CHAT_COMPLETIONS = "openai_chat_completions"
+    # POST {base}/v1/responses, via LiteLLM's completions->responses bridge
+    # (a `responses/` model-name prefix).
+    OPENAI_RESPONSES = "openai_responses"
+    # POST {base}/v1/messages. LiteLLM appends the path, so the base stays bare.
+    ANTHROPIC_MESSAGES = "anthropic_messages"
+
+
+# Surfaces reached by impersonating LiteLLM's `openai` provider. These share the
+# `/v1` base coercion and the placeholder-api-key workaround.
+OPENAI_COMPATIBLE_SURFACES = frozenset(
+    {LlmApiSurface.OPENAI_CHAT_COMPLETIONS, LlmApiSurface.OPENAI_RESPONSES}
+)
+
+# Providers that always speak a single surface.
+_STATIC_SURFACES: dict[str, LlmApiSurface] = {
+    LlmProviderNames.BIFROST: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
+    LlmProviderNames.OPENAI_COMPATIBLE: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
+    LlmProviderNames.NEBIUS_TOKENFACTORY: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
+}
+
+# Providers whose surface the admin selects, keyed by the custom_config entry
+# holding the choice: {provider: (config_key, {stored value: surface}, default)}.
+_SELECTABLE_SURFACES: dict[str, tuple[str, dict[str, LlmApiSurface], str]] = {
+    LlmProviderNames.PORTKEY: (
+        PORTKEY_API_MODE_CONFIG_KEY,
+        {
+            PORTKEY_API_MODE_CHAT_COMPLETIONS: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
+            PORTKEY_API_MODE_RESPONSES: LlmApiSurface.OPENAI_RESPONSES,
+            PORTKEY_API_MODE_MESSAGES: LlmApiSurface.ANTHROPIC_MESSAGES,
+        },
+        PORTKEY_DEFAULT_API_MODE,
+    ),
+}
+
+# custom_config keys that only select a surface. They drive routing but are UI
+# form state, never credentials, so they are exempt from environment injection.
+SURFACE_SELECTION_CONFIG_KEYS: frozenset[str] = frozenset(
+    config_key for config_key, _, _ in _SELECTABLE_SURFACES.values()
+)
+
+
+def resolve_api_surface(
+    model_provider: str, custom_config: dict[str, str] | None
+) -> LlmApiSurface | None:
+    """The surface this provider speaks, or None when it is reached through
+    LiteLLM's own provider integration (Bedrock, Vertex, native Anthropic, ...)."""
+    selectable = _SELECTABLE_SURFACES.get(model_provider)
+    if selectable is not None:
+        config_key, by_value, default = selectable
+        chosen = (custom_config or {}).get(config_key) or default
+        return by_value.get(chosen, by_value[default])
+    return _STATIC_SURFACES.get(model_provider)

--- a/backend/onyx/llm/api_surfaces.py
+++ b/backend/onyx/llm/api_surfaces.py
@@ -1,11 +1,8 @@
 """Wire protocols ("API surfaces") that provider endpoints speak.
 
-Routing a call depends on the surface rather than the provider: which LiteLLM
-provider to impersonate, whether the base URL is coerced to end in `/v1`, and
-how the model name is addressed. Gateways make this explicit — one gateway can
-expose several surfaces, and the admin picks one. Keeping the mapping here lets
-`multi_llm` branch on the surface alone, so a new provider is a table entry
-rather than another conditional in the call path.
+Routing depends on the surface rather than the provider: which LiteLLM provider
+to impersonate, whether to coerce the base URL to `/v1`, and how to address the
+model. A gateway can expose several surfaces, with the admin picking one.
 """
 
 from enum import Enum
@@ -21,32 +18,25 @@ from onyx.llm.well_known_providers.constants import (
 
 
 class LlmApiSurface(str, Enum):
-    """The wire protocol a provider's endpoint speaks."""
-
-    # POST {base}/v1/chat/completions, model sent bare.
     OPENAI_CHAT_COMPLETIONS = "openai_chat_completions"
-    # POST {base}/v1/responses, via LiteLLM's completions->responses bridge
-    # (a `responses/` model-name prefix).
+    # Reached via LiteLLM's completions->responses bridge (a `responses/` prefix).
     OPENAI_RESPONSES = "openai_responses"
-    # POST {base}/v1/messages. LiteLLM appends the path, so the base stays bare.
+    # LiteLLM appends /v1/messages to the base, so the base must stay bare.
     ANTHROPIC_MESSAGES = "anthropic_messages"
 
 
-# Surfaces reached by impersonating LiteLLM's `openai` provider. These share the
-# `/v1` base coercion and the placeholder-api-key workaround.
+# Share the `/v1` base coercion and the placeholder-api-key workaround.
 OPENAI_COMPATIBLE_SURFACES = frozenset(
     {LlmApiSurface.OPENAI_CHAT_COMPLETIONS, LlmApiSurface.OPENAI_RESPONSES}
 )
 
-# Providers that always speak a single surface.
 _STATIC_SURFACES: dict[str, LlmApiSurface] = {
     LlmProviderNames.BIFROST: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
     LlmProviderNames.OPENAI_COMPATIBLE: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
     LlmProviderNames.NEBIUS_TOKENFACTORY: LlmApiSurface.OPENAI_CHAT_COMPLETIONS,
 }
 
-# Providers whose surface the admin selects, keyed by the custom_config entry
-# holding the choice: {provider: (config_key, {stored value: surface}, default)}.
+# Admin-selected surfaces: {provider: (config_key, {stored value: surface}, default)}
 _SELECTABLE_SURFACES: dict[str, tuple[str, dict[str, LlmApiSurface], str]] = {
     LlmProviderNames.PORTKEY: (
         PORTKEY_API_MODE_CONFIG_KEY,
@@ -59,8 +49,7 @@ _SELECTABLE_SURFACES: dict[str, tuple[str, dict[str, LlmApiSurface], str]] = {
     ),
 }
 
-# custom_config keys that only select a surface. They drive routing but are UI
-# form state, never credentials, so they are exempt from environment injection.
+# UI form state, not credentials — exempt from environment injection.
 SURFACE_SELECTION_CONFIG_KEYS: frozenset[str] = frozenset(
     config_key for config_key, _, _ in _SELECTABLE_SURFACES.values()
 )
@@ -69,8 +58,8 @@ SURFACE_SELECTION_CONFIG_KEYS: frozenset[str] = frozenset(
 def resolve_api_surface(
     model_provider: str, custom_config: dict[str, str] | None
 ) -> LlmApiSurface | None:
-    """The surface this provider speaks, or None when it is reached through
-    LiteLLM's own provider integration (Bedrock, Vertex, native Anthropic, ...)."""
+    """None when the provider is reached through LiteLLM's own integration
+    (Bedrock, Vertex, native Anthropic, ...)."""
     selectable = _SELECTABLE_SURFACES.get(model_provider)
     if selectable is not None:
         config_key, by_value, default = selectable

--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -28,6 +28,7 @@ class LlmProviderNames(str, Enum):
     BIFROST = "bifrost"
     OPENAI_COMPATIBLE = "openai_compatible"
     NEBIUS_TOKENFACTORY = "nebius_tokenfactory"
+    PORTKEY = "portkey"
 
     def __str__(self) -> str:
         """Needed so things like:
@@ -50,6 +51,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.BIFROST,
     LlmProviderNames.OPENAI_COMPATIBLE,
     LlmProviderNames.NEBIUS_TOKENFACTORY,
+    LlmProviderNames.PORTKEY,
 ]
 
 
@@ -70,6 +72,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.BIFROST: "Bifrost",
     LlmProviderNames.OPENAI_COMPATIBLE: "OpenAI-Compatible",
     LlmProviderNames.NEBIUS_TOKENFACTORY: "Nebius TokenFactory",
+    LlmProviderNames.PORTKEY: "Portkey",
     "groq": "Groq",
     "anyscale": "Anyscale",
     "deepseek": "DeepSeek",
@@ -162,6 +165,7 @@ AGGREGATOR_PROVIDERS: set[str] = {
     LlmProviderNames.BIFROST,
     LlmProviderNames.OPENAI_COMPATIBLE,
     LlmProviderNames.NEBIUS_TOKENFACTORY,
+    LlmProviderNames.PORTKEY,
 }
 
 # Dynamic providers fetch models directly from source APIs (not LiteLLM).

--- a/backend/onyx/llm/custom_config_mapping.py
+++ b/backend/onyx/llm/custom_config_mapping.py
@@ -61,7 +61,7 @@ _PROVIDER_CUSTOM_CONFIG_KWARGS: dict[str, dict[str, str]] = {
 }
 
 # UI form state stored in custom_config; exempt from validation, env injection, and drop warnings.
-UI_ONLY_CONFIG_KEYS = frozenset({"BEDROCK_AUTH_METHOD"})
+UI_ONLY_CONFIG_KEYS = frozenset({"BEDROCK_AUTH_METHOD", "portkey_api_mode"})
 
 
 class CustomConfigMapping(BaseModel):

--- a/backend/onyx/llm/custom_config_mapping.py
+++ b/backend/onyx/llm/custom_config_mapping.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from onyx.llm.api_surfaces import SURFACE_SELECTION_CONFIG_KEYS
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.well_known_providers.constants import (
     AWS_ACCESS_KEY_ID_KWARG,
@@ -61,7 +62,7 @@ _PROVIDER_CUSTOM_CONFIG_KWARGS: dict[str, dict[str, str]] = {
 }
 
 # UI form state stored in custom_config; exempt from validation, env injection, and drop warnings.
-UI_ONLY_CONFIG_KEYS = frozenset({"BEDROCK_AUTH_METHOD", "portkey_api_mode"})
+UI_ONLY_CONFIG_KEYS = frozenset({"BEDROCK_AUTH_METHOD"}) | SURFACE_SELECTION_CONFIG_KEYS
 
 
 class CustomConfigMapping(BaseModel):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -418,9 +418,6 @@ class LitellmLLM(LLM):
         self._max_input_tokens = max_input_tokens
         self._custom_config = custom_config
 
-        # The wire protocol this provider's endpoint speaks, when it is reached
-        # through a generic surface rather than LiteLLM's own integration. For
-        # gateways exposing several surfaces this reflects the admin's choice.
         self._api_surface = resolve_api_surface(model_provider, custom_config)
 
         # Create a dictionary for model-specific arguments if it's None
@@ -465,9 +462,6 @@ class LitellmLLM(LLM):
         ):
             model_kwargs[VERTEX_LOCATION_KWARG] = "global"
 
-        # OpenAI-compatible surfaces (proxies, gateways, self-hosted servers)
-        # send model names directly to the endpoint, so we impersonate LiteLLM's
-        # openai provider against the server's base URL with /v1 appended.
         if self._api_surface in OPENAI_COMPATIBLE_SURFACES:
             self._custom_llm_provider = "openai"
             # LiteLLM's OpenAI client requires an api_key to be set.
@@ -480,8 +474,7 @@ class LitellmLLM(LLM):
                 self._api_base = base if base.endswith("/v1") else f"{base}/v1"
                 model_kwargs["api_base"] = self._api_base
         elif self._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES:
-            # LiteLLM appends /v1/messages to the base itself, so it must stay
-            # bare — coercing it to /v1 here would produce /v1/v1/messages.
+            # Base stays bare; LiteLLM appends /v1/messages itself.
             self._custom_llm_provider = "anthropic"
             if self._api_base is not None:
                 self._api_base = self._api_base.rstrip("/")
@@ -651,8 +644,6 @@ class LitellmLLM(LLM):
             # Drives LiteLLM's completions -> responses bridge.
             model = f"responses/{model_bare}"
         elif self._api_surface is not None:
-            # Generic surfaces set custom_llm_provider explicitly and expect the
-            # model name sent directly to the endpoint, with no provider prefix.
             model = model_bare
         else:
             model = f"{model_provider}/{model_bare}"

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -51,8 +51,8 @@ from onyx.llm.well_known_providers.constants import (
     PORTKEY_API_MODE_MESSAGES,
     PORTKEY_API_MODE_RESPONSES,
     PORTKEY_DEFAULT_API_MODE,
+    VERTEX_LOCATION_KWARG,
 )
-from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
 from onyx.tracing.llm_utils import record_llm_request_params
 from onyx.utils.encryption import mask_env_value_for_logging, mask_string
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -45,6 +45,13 @@ from onyx.llm.models import (
 )
 from onyx.llm.request_context import get_llm_mock_response
 from onyx.llm.utils import build_litellm_passthrough_kwargs
+from onyx.llm.well_known_providers.constants import (
+    PORTKEY_API_MODE_CHAT_COMPLETIONS,
+    PORTKEY_API_MODE_CONFIG_KEY,
+    PORTKEY_API_MODE_MESSAGES,
+    PORTKEY_API_MODE_RESPONSES,
+    PORTKEY_DEFAULT_API_MODE,
+)
 from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
 from onyx.tracing.llm_utils import record_llm_request_params
 from onyx.utils.encryption import mask_env_value_for_logging, mask_string
@@ -413,6 +420,15 @@ class LitellmLLM(LLM):
         self._max_input_tokens = max_input_tokens
         self._custom_config = custom_config
 
+        # Portkey is a single provider that can target three API surfaces; the
+        # selected one is persisted in custom_config. The key is registered in
+        # UI_ONLY_CONFIG_KEYS, so it is never injected into the environment.
+        self._portkey_api_mode: str | None = None
+        if model_provider == LlmProviderNames.PORTKEY:
+            self._portkey_api_mode = (custom_config or {}).get(
+                PORTKEY_API_MODE_CONFIG_KEY, PORTKEY_DEFAULT_API_MODE
+            )
+
         # Create a dictionary for model-specific arguments if it's None
         model_kwargs = model_kwargs or {}
 
@@ -458,10 +474,22 @@ class LitellmLLM(LLM):
         # Bifrost and OpenAI-compatible: OpenAI-compatible proxies that send
         # model names directly to the endpoint. We route through LiteLLM's
         # openai provider with the server's base URL, and ensure /v1 is appended.
-        if model_provider in (
-            LlmProviderNames.BIFROST,
-            LlmProviderNames.OPENAI_COMPATIBLE,
-            LlmProviderNames.NEBIUS_TOKENFACTORY,
+        # Portkey's Chat Completions and Responses surfaces are OpenAI-compatible,
+        # so they take this same path (the responses/ model prefix is applied in
+        # _completion). Portkey's Messages surface is Anthropic-compatible and is
+        # handled in the branch below.
+        portkey_openai_compat = model_provider == LlmProviderNames.PORTKEY and (
+            self._portkey_api_mode
+            in (PORTKEY_API_MODE_CHAT_COMPLETIONS, PORTKEY_API_MODE_RESPONSES)
+        )
+        if (
+            model_provider
+            in (
+                LlmProviderNames.BIFROST,
+                LlmProviderNames.OPENAI_COMPATIBLE,
+                LlmProviderNames.NEBIUS_TOKENFACTORY,
+            )
+            or portkey_openai_compat
         ):
             self._custom_llm_provider = "openai"
             # LiteLLM's OpenAI client requires an api_key to be set.
@@ -473,6 +501,16 @@ class LitellmLLM(LLM):
                 base = self._api_base.rstrip("/")
                 self._api_base = base if base.endswith("/v1") else f"{base}/v1"
                 model_kwargs["api_base"] = self._api_base
+        elif (
+            model_provider == LlmProviderNames.PORTKEY
+            and self._portkey_api_mode == PORTKEY_API_MODE_MESSAGES
+        ):
+            # Portkey Messages API is Anthropic-compatible. Route through
+            # LiteLLM's anthropic provider with the bare Portkey base — LiteLLM
+            # appends /v1/messages itself, so we must NOT coerce the base to /v1.
+            self._custom_llm_provider = "anthropic"
+            if self._api_base is not None:
+                self._api_base = self._api_base.rstrip("/")
 
         # This is needed for Ollama to do proper function calling
         if model_provider == LlmProviderNames.OLLAMA_CHAT and api_base is not None:
@@ -608,10 +646,22 @@ class LitellmLLM(LLM):
         optional_kwargs: dict[str, Any] = {}
 
         # Model name
-        is_openai_compatible_proxy = self._model_provider in (
-            LlmProviderNames.BIFROST,
-            LlmProviderNames.OPENAI_COMPATIBLE,
-            LlmProviderNames.NEBIUS_TOKENFACTORY,
+        is_portkey = self._model_provider == LlmProviderNames.PORTKEY
+        # Portkey's Chat Completions and Responses surfaces route like the other
+        # OpenAI-compatible proxies (custom_llm_provider="openai"); its Messages
+        # surface routes through the anthropic provider instead.
+        portkey_openai_compat = is_portkey and self._portkey_api_mode in (
+            PORTKEY_API_MODE_CHAT_COMPLETIONS,
+            PORTKEY_API_MODE_RESPONSES,
+        )
+        is_openai_compatible_proxy = (
+            self._model_provider
+            in (
+                LlmProviderNames.BIFROST,
+                LlmProviderNames.OPENAI_COMPATIBLE,
+                LlmProviderNames.NEBIUS_TOKENFACTORY,
+            )
+            or portkey_openai_compat
         )
         model_provider = (
             f"{self.config.model_provider}/responses"
@@ -637,14 +687,24 @@ class LitellmLLM(LLM):
         ):
             _log_azure_responses_api_version_override(self._api_base, api_version)
             api_version = None
-        if is_openai_compatible_proxy:
+
+        model_bare = self.config.deployment_name or self.config.model_name
+        if is_portkey:
+            # custom_llm_provider is already set (openai for chat/responses,
+            # anthropic for messages), so the model is sent bare — with the
+            # responses/ bridge prefix only in Responses mode.
+            if self._portkey_api_mode == PORTKEY_API_MODE_RESPONSES:
+                model = f"responses/{model_bare}"
+            else:
+                model = model_bare
+        elif is_openai_compatible_proxy:
             # OpenAI-compatible proxies (Bifrost, generic OpenAI-compatible
             # servers) expect model names sent directly to their endpoint.
             # We use custom_llm_provider="openai" so LiteLLM doesn't try
             # to route based on the provider prefix.
-            model = self.config.deployment_name or self.config.model_name
+            model = model_bare
         else:
-            model = f"{model_provider}/{self.config.deployment_name or self.config.model_name}"
+            model = f"{model_provider}/{model_bare}"
 
         # Tool choice
         # Downgrade tool_choice=required to AUTO for models that mishandle it:

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -18,6 +18,11 @@ from onyx.configs.chat_configs import (
     LLM_SOCKET_READ_TIMEOUT,
 )
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE, LITELLM_EXTRA_BODY
+from onyx.llm.api_surfaces import (
+    OPENAI_COMPATIBLE_SURFACES,
+    LlmApiSurface,
+    resolve_api_surface,
+)
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.cost import compute_cost_cents
 from onyx.llm.custom_config_mapping import (
@@ -45,14 +50,7 @@ from onyx.llm.models import (
 )
 from onyx.llm.request_context import get_llm_mock_response
 from onyx.llm.utils import build_litellm_passthrough_kwargs
-from onyx.llm.well_known_providers.constants import (
-    PORTKEY_API_MODE_CHAT_COMPLETIONS,
-    PORTKEY_API_MODE_CONFIG_KEY,
-    PORTKEY_API_MODE_MESSAGES,
-    PORTKEY_API_MODE_RESPONSES,
-    PORTKEY_DEFAULT_API_MODE,
-    VERTEX_LOCATION_KWARG,
-)
+from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
 from onyx.tracing.llm_utils import record_llm_request_params
 from onyx.utils.encryption import mask_env_value_for_logging, mask_string
 from onyx.utils.logger import setup_logger
@@ -420,14 +418,10 @@ class LitellmLLM(LLM):
         self._max_input_tokens = max_input_tokens
         self._custom_config = custom_config
 
-        # Portkey is a single provider that can target three API surfaces; the
-        # selected one is persisted in custom_config. The key is registered in
-        # UI_ONLY_CONFIG_KEYS, so it is never injected into the environment.
-        self._portkey_api_mode: str | None = None
-        if model_provider == LlmProviderNames.PORTKEY:
-            self._portkey_api_mode = (custom_config or {}).get(
-                PORTKEY_API_MODE_CONFIG_KEY, PORTKEY_DEFAULT_API_MODE
-            )
+        # The wire protocol this provider's endpoint speaks, when it is reached
+        # through a generic surface rather than LiteLLM's own integration. For
+        # gateways exposing several surfaces this reflects the admin's choice.
+        self._api_surface = resolve_api_surface(model_provider, custom_config)
 
         # Create a dictionary for model-specific arguments if it's None
         model_kwargs = model_kwargs or {}
@@ -471,26 +465,10 @@ class LitellmLLM(LLM):
         ):
             model_kwargs[VERTEX_LOCATION_KWARG] = "global"
 
-        # Bifrost and OpenAI-compatible: OpenAI-compatible proxies that send
-        # model names directly to the endpoint. We route through LiteLLM's
-        # openai provider with the server's base URL, and ensure /v1 is appended.
-        # Portkey's Chat Completions and Responses surfaces are OpenAI-compatible,
-        # so they take this same path (the responses/ model prefix is applied in
-        # _completion). Portkey's Messages surface is Anthropic-compatible and is
-        # handled in the branch below.
-        portkey_openai_compat = model_provider == LlmProviderNames.PORTKEY and (
-            self._portkey_api_mode
-            in (PORTKEY_API_MODE_CHAT_COMPLETIONS, PORTKEY_API_MODE_RESPONSES)
-        )
-        if (
-            model_provider
-            in (
-                LlmProviderNames.BIFROST,
-                LlmProviderNames.OPENAI_COMPATIBLE,
-                LlmProviderNames.NEBIUS_TOKENFACTORY,
-            )
-            or portkey_openai_compat
-        ):
+        # OpenAI-compatible surfaces (proxies, gateways, self-hosted servers)
+        # send model names directly to the endpoint, so we impersonate LiteLLM's
+        # openai provider against the server's base URL with /v1 appended.
+        if self._api_surface in OPENAI_COMPATIBLE_SURFACES:
             self._custom_llm_provider = "openai"
             # LiteLLM's OpenAI client requires an api_key to be set.
             # Many OpenAI-compatible servers don't need auth, so supply a
@@ -501,13 +479,9 @@ class LitellmLLM(LLM):
                 base = self._api_base.rstrip("/")
                 self._api_base = base if base.endswith("/v1") else f"{base}/v1"
                 model_kwargs["api_base"] = self._api_base
-        elif (
-            model_provider == LlmProviderNames.PORTKEY
-            and self._portkey_api_mode == PORTKEY_API_MODE_MESSAGES
-        ):
-            # Portkey Messages API is Anthropic-compatible. Route through
-            # LiteLLM's anthropic provider with the bare Portkey base — LiteLLM
-            # appends /v1/messages itself, so we must NOT coerce the base to /v1.
+        elif self._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES:
+            # LiteLLM appends /v1/messages to the base itself, so it must stay
+            # bare — coercing it to /v1 here would produce /v1/v1/messages.
             self._custom_llm_provider = "anthropic"
             if self._api_base is not None:
                 self._api_base = self._api_base.rstrip("/")
@@ -646,23 +620,7 @@ class LitellmLLM(LLM):
         optional_kwargs: dict[str, Any] = {}
 
         # Model name
-        is_portkey = self._model_provider == LlmProviderNames.PORTKEY
-        # Portkey's Chat Completions and Responses surfaces route like the other
-        # OpenAI-compatible proxies (custom_llm_provider="openai"); its Messages
-        # surface routes through the anthropic provider instead.
-        portkey_openai_compat = is_portkey and self._portkey_api_mode in (
-            PORTKEY_API_MODE_CHAT_COMPLETIONS,
-            PORTKEY_API_MODE_RESPONSES,
-        )
-        is_openai_compatible_proxy = (
-            self._model_provider
-            in (
-                LlmProviderNames.BIFROST,
-                LlmProviderNames.OPENAI_COMPATIBLE,
-                LlmProviderNames.NEBIUS_TOKENFACTORY,
-            )
-            or portkey_openai_compat
-        )
+        is_openai_compatible_proxy = self._api_surface in OPENAI_COMPATIBLE_SURFACES
         model_provider = (
             f"{self.config.model_provider}/responses"
             if is_openai_model  # Uses litellm's completions -> responses bridge
@@ -689,19 +647,12 @@ class LitellmLLM(LLM):
             api_version = None
 
         model_bare = self.config.deployment_name or self.config.model_name
-        if is_portkey:
-            # custom_llm_provider is already set (openai for chat/responses,
-            # anthropic for messages), so the model is sent bare — with the
-            # responses/ bridge prefix only in Responses mode.
-            if self._portkey_api_mode == PORTKEY_API_MODE_RESPONSES:
-                model = f"responses/{model_bare}"
-            else:
-                model = model_bare
-        elif is_openai_compatible_proxy:
-            # OpenAI-compatible proxies (Bifrost, generic OpenAI-compatible
-            # servers) expect model names sent directly to their endpoint.
-            # We use custom_llm_provider="openai" so LiteLLM doesn't try
-            # to route based on the provider prefix.
+        if self._api_surface is LlmApiSurface.OPENAI_RESPONSES:
+            # Drives LiteLLM's completions -> responses bridge.
+            model = f"responses/{model_bare}"
+        elif self._api_surface is not None:
+            # Generic surfaces set custom_llm_provider explicitly and expect the
+            # model name sent directly to the endpoint, with no provider prefix.
             model = model_bare
         else:
             model = f"{model_provider}/{model_bare}"

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -19,16 +19,12 @@ OPENAI_COMPATIBLE_PROVIDER_NAME = "openai_compatible"
 NEBIUS_TOKENFACTORY_PROVIDER_NAME = "nebius_tokenfactory"
 
 PORTKEY_PROVIDER_NAME = "portkey"
-# custom_config key that records which Portkey API surface a provider targets.
+# Which API surface a Portkey provider targets; stored in custom_config.
 PORTKEY_API_MODE_CONFIG_KEY = "portkey_api_mode"
-# OpenAI-compatible Chat Completions surface (default). Base ends in /v1.
 PORTKEY_API_MODE_CHAT_COMPLETIONS = "chat_completions"
-# OpenAI-compatible Responses surface. Base ends in /v1; model gets a responses/ prefix.
 PORTKEY_API_MODE_RESPONSES = "responses"
-# Anthropic-compatible Messages surface. Base stays bare; litellm appends /v1/messages.
 PORTKEY_API_MODE_MESSAGES = "messages"
 PORTKEY_DEFAULT_API_MODE = PORTKEY_API_MODE_CHAT_COMPLETIONS
-# Base URLs differ by surface: OpenAI-compat modes use /v1, Messages uses the bare host.
 PORTKEY_DEFAULT_API_BASE_OPENAI = "https://api.portkey.ai/v1"
 PORTKEY_DEFAULT_API_BASE_ANTHROPIC = "https://api.portkey.ai"
 

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -18,6 +18,20 @@ OPENAI_COMPATIBLE_PROVIDER_NAME = "openai_compatible"
 
 NEBIUS_TOKENFACTORY_PROVIDER_NAME = "nebius_tokenfactory"
 
+PORTKEY_PROVIDER_NAME = "portkey"
+# custom_config key that records which Portkey API surface a provider targets.
+PORTKEY_API_MODE_CONFIG_KEY = "portkey_api_mode"
+# OpenAI-compatible Chat Completions surface (default). Base ends in /v1.
+PORTKEY_API_MODE_CHAT_COMPLETIONS = "chat_completions"
+# OpenAI-compatible Responses surface. Base ends in /v1; model gets a responses/ prefix.
+PORTKEY_API_MODE_RESPONSES = "responses"
+# Anthropic-compatible Messages surface. Base stays bare; litellm appends /v1/messages.
+PORTKEY_API_MODE_MESSAGES = "messages"
+PORTKEY_DEFAULT_API_MODE = PORTKEY_API_MODE_CHAT_COMPLETIONS
+# Base URLs differ by surface: OpenAI-compat modes use /v1, Messages uses the bare host.
+PORTKEY_DEFAULT_API_BASE_OPENAI = "https://api.portkey.ai/v1"
+PORTKEY_DEFAULT_API_BASE_ANTHROPIC = "https://api.portkey.ai"
+
 # Providers that use optional Bearer auth from custom_config
 PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING: dict[str, str] = {
     LlmProviderNames.LM_STUDIO: LM_STUDIO_API_KEY_CONFIG_KEY,

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -26,6 +26,7 @@ from onyx.llm.well_known_providers.constants import (
     OPENAI_COMPATIBLE_PROVIDER_NAME,
     OPENAI_PROVIDER_NAME,
     OPENROUTER_PROVIDER_NAME,
+    PORTKEY_PROVIDER_NAME,
     VERTEXAI_PROVIDER_NAME,
 )
 from onyx.llm.well_known_providers.models import WellKnownLLMProviderDescriptor
@@ -59,6 +60,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
         BIFROST_PROVIDER_NAME: [],  # Dynamic - fetched from Bifrost API
         OPENAI_COMPATIBLE_PROVIDER_NAME: [],  # Dynamic - fetched from OpenAI-compatible API
         NEBIUS_TOKENFACTORY_PROVIDER_NAME: [],  # Dynamic - fetched from /v1/models
+        PORTKEY_PROVIDER_NAME: [],  # Dynamic - fetched from the Portkey gateway
     }
 
 
@@ -354,6 +356,7 @@ def get_provider_display_name(provider_name: str) -> str:
         LITELLM_PROXY_PROVIDER_NAME: "LiteLLM Proxy",
         OPENAI_COMPATIBLE_PROVIDER_NAME: "OpenAI-Compatible",
         NEBIUS_TOKENFACTORY_PROVIDER_NAME: "Nebius TokenFactory",
+        PORTKEY_PROVIDER_NAME: "Portkey",
     }
 
     if provider_name in _ONYX_PROVIDER_DISPLAY_NAMES:

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -2209,8 +2209,15 @@ def get_portkey_available_models(
                     name=model_id,
                     display_name=model_name,
                     max_input_tokens=model.get("context_length"),
-                    supports_image_input=infer_vision_support(model_id),
-                    supports_reasoning=is_reasoning_model(model_id, model_name),
+                    supports_image_input=litellm_thinks_model_supports_image_input(
+                        model_id, LlmProviderNames.PORTKEY
+                    ),
+                    # Reasoning support from the LiteLLM cost map, with the
+                    # substring heuristic covering models LiteLLM doesn't know
+                    supports_reasoning=model_is_reasoning_model(
+                        model_id, LlmProviderNames.PORTKEY
+                    )
+                    or is_reasoning_model(model_id, model_name),
                 )
             )
         except Exception as e:

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -101,6 +101,8 @@ from onyx.server.manage.llm.models import (
     OpenRouterFinalModelResponse,
     OpenRouterModelDetails,
     OpenRouterModelsRequest,
+    PortkeyFinalModelResponse,
+    PortkeyModelsRequest,
     SyncModelEntry,
     TestLLMRequest,
     VisionProviderResponse,
@@ -2145,3 +2147,102 @@ def _get_openai_compatible_server_response(
         source_name="OpenAI-Compatible",
         api_key=api_key,
     )
+
+
+def _get_portkey_models_response(api_base: str, api_key: str | None = None) -> dict:
+    """Fetch models from a Portkey gateway's /v1/models endpoint.
+
+    Portkey exposes the same OpenAI-shaped /v1/models listing regardless of the
+    selected inference surface (Chat Completions, Responses, or Messages), so the
+    base may arrive as either `https://api.portkey.ai/v1` or `https://api.portkey.ai`.
+    """
+    cleaned_api_base = api_base.strip().rstrip("/")
+    if cleaned_api_base.endswith("/v1"):
+        url = f"{cleaned_api_base}/models"
+    else:
+        url = f"{cleaned_api_base}/v1/models"
+
+    return _get_openai_compatible_models_response(
+        url=url,
+        source_name="Portkey",
+        api_key=api_key,
+    )
+
+
+@admin_router.post("/portkey/available-models")
+def get_portkey_available_models(
+    request: PortkeyModelsRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[PortkeyFinalModelResponse]:
+    """Fetch available models from a Portkey gateway's /v1/models endpoint."""
+    api_key = _resolve_api_key(
+        request.api_key, request.provider_id, request.api_base, db_session
+    )
+
+    response_json = _get_portkey_models_response(
+        api_base=request.api_base, api_key=api_key
+    )
+
+    models = response_json.get("data", [])
+    if not isinstance(models, list) or len(models) == 0:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No models found from your Portkey gateway",
+        )
+
+    results: list[PortkeyFinalModelResponse] = []
+    for model in models:
+        try:
+            model_id = model.get("id", "")
+            model_name = model.get("name", model_id)
+
+            if not model_id:
+                continue
+
+            # Skip embedding models
+            if is_embedding_model(model_id):
+                continue
+
+            results.append(
+                PortkeyFinalModelResponse(
+                    name=model_id,
+                    display_name=model_name,
+                    max_input_tokens=model.get("context_length"),
+                    supports_image_input=infer_vision_support(model_id),
+                    supports_reasoning=is_reasoning_model(model_id, model_name),
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to parse Portkey model entry",
+                extra={"error": str(e), "item": str(model)[:1000]},
+            )
+
+    if not results:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No compatible models found from your Portkey gateway",
+        )
+
+    sorted_results = sorted(results, key=lambda m: m.name.lower())
+
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
+        _sync_fetched_models(
+            db_session=db_session,
+            provider_id=request.provider_id,
+            models=[
+                SyncModelEntry(
+                    name=r.name,
+                    display_name=r.display_name,
+                    max_input_tokens=r.max_input_tokens,
+                    supports_image_input=r.supports_image_input,
+                    supports_reasoning=r.supports_reasoning,
+                )
+                for r in sorted_results
+            ],
+            source_label="Portkey",
+        )
+
+    return sorted_results

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -659,3 +659,22 @@ class OpenAICompatibleFinalModelResponse(BaseModel):
     max_input_tokens: int | None
     supports_image_input: bool
     supports_reasoning: bool
+
+
+# Portkey dynamic models fetch
+class PortkeyModelsRequest(BaseModel):
+    api_base: str
+    api_key: str | None = None
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
+    # Selected Portkey API surface (chat_completions | responses | messages).
+    # The model-listing endpoint is the same across surfaces; carried for clarity.
+    api_mode: str | None = None
+
+
+class PortkeyFinalModelResponse(BaseModel):
+    name: str  # Model ID (e.g. "gpt-4o", "claude-sonnet-5")
+    display_name: str  # Human-readable name from API
+    max_input_tokens: int | None
+    supports_image_input: bool
+    supports_reasoning: bool

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -667,9 +667,6 @@ class PortkeyModelsRequest(BaseModel):
     api_key: str | None = None
     # Existing provider id; resolves the stored key and syncs fetched models on edit
     provider_id: int | None = None
-    # Selected Portkey API surface (chat_completions | responses | messages).
-    # The model-listing endpoint is the same across surfaces; carried for clarity.
-    api_mode: str | None = None
 
 
 class PortkeyFinalModelResponse(BaseModel):

--- a/backend/tests/unit/onyx/llm/test_portkey_routing.py
+++ b/backend/tests/unit/onyx/llm/test_portkey_routing.py
@@ -1,0 +1,107 @@
+"""Unit tests for Portkey's three API-mode routing in LitellmLLM.
+
+Portkey is a single provider that can target three API surfaces, selected via a
+`portkey_api_mode` value persisted in custom_config. The routing differences are
+entirely: custom_llm_provider, the model= string, and whether the base is coerced
+to end in /v1. These tests lock that mapping down.
+"""
+
+from unittest.mock import patch
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import LanguageModelInput
+from onyx.llm.models import UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.well_known_providers.constants import PORTKEY_API_MODE_CONFIG_KEY
+
+
+def _make_portkey_llm(
+    mode: str | None,
+    api_base: str,
+    model_name: str = "gpt-4o",
+) -> LitellmLLM:
+    custom_config = {PORTKEY_API_MODE_CONFIG_KEY: mode} if mode is not None else None
+    return LitellmLLM(
+        api_key="pk-test-key",
+        timeout=30,
+        model_provider=LlmProviderNames.PORTKEY,
+        model_name=model_name,
+        max_input_tokens=128_000,
+        api_base=api_base,
+        custom_config=custom_config,
+    )
+
+
+def _completion_kwargs(llm: LitellmLLM) -> dict:
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+        return dict(mock_completion.call_args.kwargs)
+
+
+def test_chat_completions_mode_routes_via_openai_with_v1_base() -> None:
+    llm = _make_portkey_llm("chat_completions", "https://api.portkey.ai/v1")
+    assert llm._custom_llm_provider == "openai"
+    assert llm._api_base == "https://api.portkey.ai/v1"
+
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["base_url"] == "https://api.portkey.ai/v1"
+    # OpenAI-compatible proxies send a bare model name.
+    assert kwargs["model"] == "gpt-4o"
+
+
+def test_chat_completions_mode_coerces_bare_base_to_v1() -> None:
+    llm = _make_portkey_llm("chat_completions", "https://api.portkey.ai")
+    assert llm._api_base == "https://api.portkey.ai/v1"
+
+
+def test_default_mode_is_chat_completions() -> None:
+    # No portkey_api_mode in custom_config -> defaults to chat completions.
+    llm = _make_portkey_llm(None, "https://api.portkey.ai/v1")
+    assert llm._portkey_api_mode == "chat_completions"
+    assert llm._custom_llm_provider == "openai"
+
+
+def test_responses_mode_prefixes_model_and_keeps_v1_base() -> None:
+    llm = _make_portkey_llm("responses", "https://api.portkey.ai/v1")
+    assert llm._custom_llm_provider == "openai"
+    assert llm._api_base == "https://api.portkey.ai/v1"
+
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["custom_llm_provider"] == "openai"
+    assert kwargs["base_url"] == "https://api.portkey.ai/v1"
+    # Responses mode drives litellm's completions->responses bridge via the prefix.
+    assert kwargs["model"] == "responses/gpt-4o"
+
+
+def test_messages_mode_routes_via_anthropic_with_bare_base() -> None:
+    llm = _make_portkey_llm(
+        "messages", "https://api.portkey.ai", model_name="claude-sonnet-5"
+    )
+    assert llm._custom_llm_provider == "anthropic"
+    # Messages mode must NOT be coerced to /v1 — litellm appends /v1/messages.
+    assert llm._api_base == "https://api.portkey.ai"
+
+    kwargs = _completion_kwargs(llm)
+    assert kwargs["custom_llm_provider"] == "anthropic"
+    assert kwargs["base_url"] == "https://api.portkey.ai"
+    # Anthropic path uses a bare model name (no responses/ or provider prefix).
+    assert kwargs["model"] == "claude-sonnet-5"
+
+
+def test_messages_mode_strips_trailing_slash_but_keeps_bare_host() -> None:
+    llm = _make_portkey_llm(
+        "messages", "https://api.portkey.ai/", model_name="claude-sonnet-5"
+    )
+    assert llm._api_base == "https://api.portkey.ai"
+
+
+def test_api_mode_is_popped_from_custom_config() -> None:
+    # The mode must not leak into os.environ via temporary_env_and_lock, so it is
+    # stripped from _custom_config after being read.
+    llm = _make_portkey_llm("messages", "https://api.portkey.ai")
+    assert llm._custom_config is not None
+    assert PORTKEY_API_MODE_CONFIG_KEY not in llm._custom_config
+    assert llm._portkey_api_mode == "messages"

--- a/backend/tests/unit/onyx/llm/test_portkey_routing.py
+++ b/backend/tests/unit/onyx/llm/test_portkey_routing.py
@@ -9,8 +9,8 @@ to end in /v1. These tests lock that mapping down.
 from unittest.mock import patch
 
 from onyx.llm.constants import LlmProviderNames
-from onyx.llm.models import LanguageModelInput
-from onyx.llm.models import UserMessage
+from onyx.llm.custom_config_mapping import UI_ONLY_CONFIG_KEYS
+from onyx.llm.models import LanguageModelInput, UserMessage
 from onyx.llm.multi_llm import LitellmLLM
 from onyx.llm.well_known_providers.constants import PORTKEY_API_MODE_CONFIG_KEY
 
@@ -98,10 +98,10 @@ def test_messages_mode_strips_trailing_slash_but_keeps_bare_host() -> None:
     assert llm._api_base == "https://api.portkey.ai"
 
 
-def test_api_mode_is_popped_from_custom_config() -> None:
-    # The mode must not leak into os.environ via temporary_env_and_lock, so it is
-    # stripped from _custom_config after being read.
+def test_api_mode_is_never_injected_into_environment() -> None:
+    # The mode is UI-only form state: it must be readable for routing but must
+    # never reach os.environ via temporary_env_and_lock at call time.
     llm = _make_portkey_llm("messages", "https://api.portkey.ai")
-    assert llm._custom_config is not None
-    assert PORTKEY_API_MODE_CONFIG_KEY not in llm._custom_config
     assert llm._portkey_api_mode == "messages"
+    assert PORTKEY_API_MODE_CONFIG_KEY in UI_ONLY_CONFIG_KEYS
+    assert PORTKEY_API_MODE_CONFIG_KEY not in llm._env_only_custom_config

--- a/backend/tests/unit/onyx/llm/test_portkey_routing.py
+++ b/backend/tests/unit/onyx/llm/test_portkey_routing.py
@@ -8,6 +8,7 @@ to end in /v1. These tests lock that mapping down.
 
 from unittest.mock import patch
 
+from onyx.llm.api_surfaces import LlmApiSurface
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.custom_config_mapping import UI_ONLY_CONFIG_KEYS
 from onyx.llm.models import LanguageModelInput, UserMessage
@@ -60,7 +61,7 @@ def test_chat_completions_mode_coerces_bare_base_to_v1() -> None:
 def test_default_mode_is_chat_completions() -> None:
     # No portkey_api_mode in custom_config -> defaults to chat completions.
     llm = _make_portkey_llm(None, "https://api.portkey.ai/v1")
-    assert llm._portkey_api_mode == "chat_completions"
+    assert llm._api_surface is LlmApiSurface.OPENAI_CHAT_COMPLETIONS
     assert llm._custom_llm_provider == "openai"
 
 
@@ -102,6 +103,6 @@ def test_api_mode_is_never_injected_into_environment() -> None:
     # The mode is UI-only form state: it must be readable for routing but must
     # never reach os.environ via temporary_env_and_lock at call time.
     llm = _make_portkey_llm("messages", "https://api.portkey.ai")
-    assert llm._portkey_api_mode == "messages"
+    assert llm._api_surface is LlmApiSurface.ANTHROPIC_MESSAGES
     assert PORTKEY_API_MODE_CONFIG_KEY in UI_ONLY_CONFIG_KEYS
     assert PORTKEY_API_MODE_CONFIG_KEY not in llm._env_only_custom_config

--- a/backend/tests/unit/onyx/server/manage/llm/test_portkey_models.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_portkey_models.py
@@ -1,0 +1,86 @@
+"""Tests for the Portkey model fetcher.
+
+Verifies the mapping from Portkey's OpenAI-shaped /v1/models response to Onyx
+model configs: embedding models dropped, context length mapped, id-less entries
+skipped, and results sorted by name.
+"""
+
+from typing import cast
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from onyx.db.models import User
+from onyx.server.manage.llm.api import get_portkey_available_models
+from onyx.server.manage.llm.models import PortkeyModelsRequest
+
+# Trimmed OpenAI-shaped /v1/models payload with a chat model, another chat model,
+# an embedding model (must be dropped), and an id-less entry (must be skipped).
+_SAMPLE = {
+    "object": "list",
+    "data": [
+        {"id": "gpt-4o", "name": "GPT-4o", "context_length": 128000},
+        {"id": "claude-sonnet-5", "name": "Claude Sonnet 5", "context_length": 200000},
+        {"id": "text-embedding-3-large", "name": "Embedding", "context_length": 8191},
+        {"id": "", "name": "no id"},
+    ],
+}
+
+
+def _fetch(api_base: str = "https://api.portkey.ai/v1") -> dict:
+    with (
+        patch("onyx.server.manage.llm.api._resolve_api_key", return_value="pk-key"),
+        patch(
+            "onyx.server.manage.llm.api._get_portkey_models_response",
+            return_value=_SAMPLE,
+        ),
+    ):
+        results = get_portkey_available_models(
+            request=PortkeyModelsRequest(
+                api_base=api_base,
+                api_key="pk-key",
+                provider_id=None,  # skip DB sync
+            ),
+            _=cast(User, None),
+            db_session=cast(Session, None),
+        )
+    return {r.name: r for r in results}
+
+
+def test_embedding_and_idless_entries_dropped() -> None:
+    by_name = _fetch()
+    assert "text-embedding-3-large" not in by_name
+    # Only the two chat models remain (embedding + id-less entry dropped).
+    assert set(by_name) == {"gpt-4o", "claude-sonnet-5"}
+
+
+def test_context_length_mapped() -> None:
+    by_name = _fetch()
+    assert by_name["gpt-4o"].max_input_tokens == 128000
+    assert by_name["claude-sonnet-5"].max_input_tokens == 200000
+
+
+def test_display_name_from_payload() -> None:
+    assert _fetch()["gpt-4o"].display_name == "GPT-4o"
+
+
+def test_results_sorted_by_name() -> None:
+    with (
+        patch("onyx.server.manage.llm.api._resolve_api_key", return_value="pk-key"),
+        patch(
+            "onyx.server.manage.llm.api._get_portkey_models_response",
+            return_value=_SAMPLE,
+        ),
+    ):
+        results = get_portkey_available_models(
+            request=PortkeyModelsRequest(api_base="https://api.portkey.ai/v1"),
+            _=cast(User, None),
+            db_session=cast(Session, None),
+        )
+    assert [r.name for r in results] == ["claude-sonnet-5", "gpt-4o"]
+
+
+def test_messages_mode_bare_base_still_fetches() -> None:
+    # Messages mode passes the bare host; the fetcher still resolves /v1/models.
+    by_name = _fetch(api_base="https://api.portkey.ai")
+    assert set(by_name) == {"gpt-4o", "claude-sonnet-5"}

--- a/web/lib/opal/src/logos/index.ts
+++ b/web/lib/opal/src/logos/index.ts
@@ -74,6 +74,7 @@ export { default as SvgOracle } from "@opal/logos/oracle";
 export { default as SvgOutline } from "@opal/logos/outline";
 export { default as SvgOutlook } from "@opal/logos/outlook";
 export { default as SvgPerplexity } from "@opal/logos/perplexity";
+export { default as SvgPortkey } from "@opal/logos/portkey";
 export { default as SvgProductboard } from "@opal/logos/productboard";
 export { default as SvgQwen } from "@opal/logos/qwen";
 export { default as SvgSalesforce } from "@opal/logos/salesforce";

--- a/web/lib/opal/src/logos/portkey.tsx
+++ b/web/lib/opal/src/logos/portkey.tsx
@@ -1,0 +1,32 @@
+import type { IconProps } from "@opal/types";
+
+// PLACEHOLDER Portkey mark — pending the official brand SVG. Drawn monochrome
+// via var(--text-05) so it adapts to the theme; replace the <path> below with
+// the official Portkey artwork (inlined, self-contained) when available.
+const SvgPortkey = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <title>Portkey</title>
+    <path
+      d="M12 2.5 20.5 7v10L12 21.5 3.5 17V7L12 2.5Z"
+      stroke="var(--text-05)"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+    />
+    <path
+      d="m10 8.5 4 3.5-4 3.5"
+      stroke="var(--text-05)"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export default SvgPortkey;

--- a/web/lib/opal/src/logos/portkey.tsx
+++ b/web/lib/opal/src/logos/portkey.tsx
@@ -1,9 +1,7 @@
 import React from "react";
 import type { IconProps } from "@opal/types";
 
-// Portkey brand mark — the hexagon-with-chevron glyph in the brand's blue→red
-// gradient. The gradient id is generated per-instance so multiple renders on a
-// page don't collide.
+// Gradient id is per-instance so repeated renders don't collide.
 const SvgPortkey = ({ size, ...props }: IconProps) => {
   const gradientId = React.useId();
   return (

--- a/web/lib/opal/src/logos/portkey.tsx
+++ b/web/lib/opal/src/logos/portkey.tsx
@@ -1,32 +1,40 @@
+import React from "react";
 import type { IconProps } from "@opal/types";
 
-// PLACEHOLDER Portkey mark — pending the official brand SVG. Drawn monochrome
-// via var(--text-05) so it adapts to the theme; replace the <path> below with
-// the official Portkey artwork (inlined, self-contained) when available.
-const SvgPortkey = ({ size, ...props }: IconProps) => (
-  <svg
-    width={size}
-    height={size}
-    viewBox="0 0 24 24"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    {...props}
-  >
-    <title>Portkey</title>
-    <path
-      d="M12 2.5 20.5 7v10L12 21.5 3.5 17V7L12 2.5Z"
-      stroke="var(--text-05)"
-      strokeWidth="1.5"
-      strokeLinejoin="round"
-    />
-    <path
-      d="m10 8.5 4 3.5-4 3.5"
-      stroke="var(--text-05)"
-      strokeWidth="1.5"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-  </svg>
-);
+// Portkey brand mark — the hexagon-with-chevron glyph in the brand's blue→red
+// gradient. The gradient id is generated per-instance so multiple renders on a
+// page don't collide.
+const SvgPortkey = ({ size, ...props }: IconProps) => {
+  const gradientId = React.useId();
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 23 22"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <title>Portkey</title>
+      <path
+        d="M13.9178 0C15.8042 0 17.5382 1.01984 18.482 2.66087L21.4324 7.78973L21.4766 7.86809C22.3901 9.51965 22.3798 11.5412 21.4436 13.1848L18.4857 18.3761C17.5447 20.0279 15.8046 21.0561 13.9102 21.0561H8.19466C6.28675 21.0561 4.53612 20.0135 3.60014 18.343L0.691857 13.1518C-0.234191 11.499 -0.230504 9.47169 0.702307 7.82278L3.60386 2.69393C4.54275 1.03426 6.28701 5.1045e-06 8.18708 0H13.9178ZM8.18708 2.62239C7.24383 2.62239 6.36067 3.13559 5.87882 3.98736L2.97728 9.11621C2.49663 9.9659 2.49456 11.0151 2.9717 11.8669L5.88083 17.0591L5.90359 17.0992C6.38891 17.9326 7.26233 18.4336 8.19466 18.4336H13.9102C14.8507 18.4336 15.7317 17.9236 16.2145 17.076L19.1716 11.8847C19.6619 11.024 19.6597 9.95788 19.166 9.09944L16.2165 3.96975C15.7323 3.12792 14.8544 2.62239 13.9178 2.62239H8.18708ZM11.4337 5.44396C11.9783 4.99224 12.7859 5.05637 13.2528 5.59349L16.465 9.28869L16.4934 9.32221C17.0823 10.0321 17.0728 11.068 16.465 11.7674L13.2528 15.4626C12.7859 15.9997 11.9783 16.0639 11.4337 15.6121L11.4079 15.5902C10.8633 15.1144 10.8069 14.2857 11.2814 13.7399L14.0736 10.528L11.2814 7.31617C10.8069 6.77034 10.8633 5.94159 11.4079 5.46584L11.4337 5.44396Z"
+        fill={`url(#${gradientId})`}
+      />
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="-11.8055"
+          y1="5.70269"
+          x2="24.7895"
+          y2="26.7015"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop offset="0.173094" stopColor="#00A3FF" />
+          <stop offset="0.899073" stopColor="#FF0F00" />
+        </linearGradient>
+      </defs>
+    </svg>
+  );
+};
 
 export default SvgPortkey;

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -17,6 +17,7 @@ import {
   SvgQwen,
   SvgGoogle,
   SvgNebius,
+  SvgPortkey,
 } from "@opal/logos";
 import { ZAIIcon } from "@/components/icons/icons";
 import {
@@ -37,6 +38,7 @@ import LiteLLMProxyModal from "@/sections/modals/languageModels/LiteLLMProxyModa
 import BifrostModal from "@/sections/modals/languageModels/BifrostModal";
 import OpenAICompatibleModal from "@/sections/modals/languageModels/OpenAICompatibleModal";
 import NebiusTokenfactoryModal from "@/sections/modals/languageModels/NebiusTokenfactoryModal";
+import PortkeyModal from "@/sections/modals/languageModels/PortkeyModal";
 
 // ─── Text (LLM) providers ────────────────────────────────────────────────────
 
@@ -126,6 +128,12 @@ const PROVIDERS: Record<string, ProviderEntry> = {
     companyName: "Nebius",
     Modal: NebiusTokenfactoryModal,
   },
+  [LLMProviderName.PORTKEY]: {
+    icon: SvgPortkey,
+    productName: "Portkey",
+    companyName: "Portkey",
+    Modal: PortkeyModal,
+  },
   [LLMProviderName.CUSTOM]: {
     icon: SvgServer,
     productName: "Custom Models",
@@ -184,6 +192,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   LLMProviderName.BIFROST,
   LLMProviderName.OPENAI_COMPATIBLE,
   LLMProviderName.NEBIUS_TOKENFACTORY,
+  LLMProviderName.PORTKEY,
   LLMProviderName.VERTEX_AI,
 ]);
 
@@ -201,6 +210,7 @@ const MODEL_ICON_MAP: Record<string, IconFunctionComponent> = {
   [LLMProviderName.BIFROST]: SvgBifrost,
   [LLMProviderName.OPENAI_COMPATIBLE]: SvgPlug,
   [LLMProviderName.NEBIUS_TOKENFACTORY]: SvgNebius,
+  [LLMProviderName.PORTKEY]: SvgPortkey,
 
   amazon: SvgAws,
   gpt: SvgOpenai,

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -30,6 +30,8 @@ import {
   type OpenAICompatibleModelResponse,
   type NebiusTokenfactoryFetchParams,
   type NebiusTokenfactoryModelResponse,
+  type PortkeyFetchParams,
+  type PortkeyModelResponse,
 } from "@/lib/languageModels/types";
 
 /**
@@ -604,6 +606,13 @@ export const fetchModels = async (
         provider_id: formValues.id,
         signal,
       });
+    case LLMProviderName.PORTKEY:
+      return fetchPortkeyModels({
+        api_base: formValues.api_base,
+        api_key: formValues.api_key,
+        provider_id: formValues.id,
+        signal,
+      });
     default:
       return { models: [], error: `Unknown provider: ${providerName}` };
   }
@@ -665,6 +674,65 @@ export const fetchNebiusTokenfactoryModels = async (
       country_code: modelData.country_code,
       requests_per_minute: modelData.requests_per_minute,
       supported_features: modelData.supported_features,
+      effectiveDisplayName: modelData.display_name || modelData.name,
+    }));
+
+    return { models };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return { models: [], error: errorMessage };
+  }
+};
+
+/**
+ * Fetches models from a Portkey gateway (/v1/models). The listing endpoint is
+ * the same across Portkey's Chat Completions, Responses, and Messages surfaces.
+ */
+export const fetchPortkeyModels = async (
+  params: PortkeyFetchParams
+): Promise<{ models: ModelConfiguration[]; error?: string }> => {
+  const apiBase = params.api_base;
+  if (!apiBase) {
+    return { models: [], error: "API Base is required" };
+  }
+
+  try {
+    const response = await fetch("/api/admin/llm/portkey/available-models", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        api_base: apiBase,
+        api_key: params.api_key,
+        provider_id: params.provider_id,
+      }),
+      signal: params.signal,
+    });
+
+    if (!response.ok) {
+      let errorMessage = "Failed to fetch models";
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.detail || errorData.message || errorMessage;
+      } catch (jsonError) {
+        console.warn(
+          "Failed to parse Portkey model fetch error response",
+          jsonError
+        );
+      }
+      return { models: [], error: errorMessage };
+    }
+
+    const data: PortkeyModelResponse[] = await response.json();
+    const models: ModelConfiguration[] = data.map((modelData) => ({
+      name: modelData.name,
+      display_name: modelData.display_name,
+      is_visible: true,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+      supports_reasoning: modelData.supports_reasoning,
       effectiveDisplayName: modelData.display_name || modelData.name,
     }));
 

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -685,10 +685,7 @@ export const fetchNebiusTokenfactoryModels = async (
   }
 };
 
-/**
- * Fetches models from a Portkey gateway (/v1/models). The listing endpoint is
- * the same across Portkey's Chat Completions, Responses, and Messages surfaces.
- */
+/** Fetches models from a Portkey gateway; same endpoint for every API surface. */
 export const fetchPortkeyModels = async (
   params: PortkeyFetchParams
 ): Promise<{ models: ModelConfiguration[]; error?: string }> => {

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -56,8 +56,13 @@ export enum LLMProviderName {
   BIFROST = "bifrost",
   OPENAI_COMPATIBLE = "openai_compatible",
   NEBIUS_TOKENFACTORY = "nebius_tokenfactory",
+  PORTKEY = "portkey",
   CUSTOM = "custom",
 }
+
+// Which Portkey API surface a provider targets. Persisted in custom_config
+// under `portkey_api_mode`.
+export type PortkeyApiMode = "chat_completions" | "responses" | "messages";
 
 export interface SimpleKnownModel {
   name: string;
@@ -243,6 +248,21 @@ export interface NebiusTokenfactoryModelResponse {
   country_code: string | null;
   requests_per_minute: number | null;
   supported_features: string[];
+}
+
+export interface PortkeyFetchParams {
+  api_base?: string;
+  api_key?: string;
+  provider_id?: number;
+  signal?: AbortSignal;
+}
+
+export interface PortkeyModelResponse {
+  name: string;
+  display_name: string;
+  max_input_tokens: number | null;
+  supports_image_input: boolean;
+  supports_reasoning: boolean;
 }
 
 export interface VertexAIFetchParams {

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -60,8 +60,6 @@ export enum LLMProviderName {
   CUSTOM = "custom",
 }
 
-// Which Portkey API surface a provider targets. Persisted in custom_config
-// under `portkey_api_mode`.
 export type PortkeyApiMode = "chat_completions" | "responses" | "messages";
 
 export interface SimpleKnownModel {

--- a/web/src/sections/modals/languageModels/PortkeyModal.tsx
+++ b/web/src/sections/modals/languageModels/PortkeyModal.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { markdown } from "@opal/utils";
+import { useSWRConfig } from "swr";
+import { useFormikContext } from "formik";
+import { InputDivider } from "@opal/layouts";
+import { Tabs, Text, Button } from "@opal/components";
+import {
+  LLMProviderFormProps,
+  LLMProviderName,
+  LLMProviderView,
+  PortkeyApiMode,
+} from "@/lib/languageModels/types";
+import { fetchPortkeyModels } from "@/lib/languageModels/svc";
+import {
+  useInitialValues,
+  buildValidationSchema,
+  BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
+} from "@/sections/modals/languageModels/utils";
+import { submitProvider } from "@/sections/modals/languageModels/svc";
+import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
+import {
+  APIBaseField,
+  APIKeyField,
+  ModelSelectionField,
+  DisplayNameField,
+  ModelAccessField,
+  ModalWrapper,
+} from "@/sections/modals/languageModels/shared";
+import { toast } from "@/hooks/useToast";
+import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+
+// The two OpenAI-compatible surfaces (Chat Completions, Responses) hit /v1; the
+// Anthropic-compatible Messages surface uses the bare host (LiteLLM appends
+// /v1/messages).
+const DEFAULT_API_BASE_OPENAI = "https://api.portkey.ai/v1";
+const DEFAULT_API_BASE_ANTHROPIC = "https://api.portkey.ai";
+const DEFAULT_API_MODE: PortkeyApiMode = "chat_completions";
+const PORTKEY_API_MODE_KEY = "portkey_api_mode";
+const DEFAULT_DISPLAY_NAME = "Portkey Gateway";
+
+// Bases we consider "not customized" — switching modes replaces one of these
+// with the new mode's default, but leaves a user-entered self-hosted base alone.
+const KNOWN_DEFAULT_BASES = new Set<string>([
+  DEFAULT_API_BASE_OPENAI,
+  DEFAULT_API_BASE_ANTHROPIC,
+  "",
+]);
+
+function defaultBaseForMode(mode: PortkeyApiMode): string {
+  return mode === "messages"
+    ? DEFAULT_API_BASE_ANTHROPIC
+    : DEFAULT_API_BASE_OPENAI;
+}
+
+const API_MODE_TABS: {
+  value: PortkeyApiMode;
+  title: string;
+  subtitle: string;
+}[] = [
+  {
+    value: "chat_completions",
+    title: "Chat Completions API",
+    subtitle: "OpenAI-compatible",
+  },
+  { value: "responses", title: "Responses API", subtitle: "OpenAI-compatible" },
+  { value: "messages", title: "Messages API", subtitle: "Anthropic-compatible" },
+];
+
+interface PortkeyModalValues extends BaseLLMFormValues {
+  api_key: string;
+  api_base: string;
+}
+
+interface PortkeyModalInternalsProps {
+  existingLlmProvider: LLMProviderView | undefined;
+  isOnboarding: boolean;
+}
+
+function PortkeyModalInternals({
+  existingLlmProvider,
+  isOnboarding,
+}: PortkeyModalInternalsProps) {
+  const formikProps = useFormikContext<PortkeyModalValues>();
+  const { setFieldValue, values } = formikProps;
+
+  const mode =
+    (values.custom_config?.[PORTKEY_API_MODE_KEY] as PortkeyApiMode | undefined) ??
+    DEFAULT_API_MODE;
+  const modeDefaultBase = defaultBaseForMode(mode);
+  const isFetchDisabled = !values.api_base;
+  const isBaseDefault = values.api_base === modeDefaultBase;
+
+  const handleModeChange = (next: PortkeyApiMode) => {
+    setFieldValue("custom_config", { [PORTKEY_API_MODE_KEY]: next });
+    // Only swap the base URL if the user hasn't entered a custom (self-hosted) one.
+    if (KNOWN_DEFAULT_BASES.has(values.api_base)) {
+      setFieldValue("api_base", defaultBaseForMode(next));
+    }
+  };
+
+  const handleFetchModels = async () => {
+    const { models, error } = await fetchPortkeyModels({
+      api_base: values.api_base,
+      api_key: values.api_key || undefined,
+      provider_id: existingLlmProvider?.id ?? undefined,
+    });
+    if (error) {
+      throw new Error(error);
+    }
+    setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(models, values.model_configurations)
+    );
+  };
+
+  // When editing a saved provider the models load from the DB; refetch once on
+  // open so the picker matches the "add" view. Best-effort — ignore errors so
+  // the modal still works if the gateway is unreachable.
+  const autoRefetched = useRef(false);
+  useEffect(() => {
+    if (autoRefetched.current || !existingLlmProvider?.id) return;
+    if (!values.api_base) return;
+    autoRefetched.current = true;
+    fetchPortkeyModels({
+      api_base: values.api_base,
+      api_key: values.api_key || undefined,
+      provider_id: existingLlmProvider.id,
+    })
+      .then(({ models }) => {
+        if (models.length > 0) {
+          setFieldValue(
+            "model_configurations",
+            mergeFetchedModelConfigurations(models, values.model_configurations)
+          );
+        }
+      })
+      .catch(() => undefined);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <>
+      <Tabs
+        value={mode}
+        onValueChange={(next) => handleModeChange(next as PortkeyApiMode)}
+      >
+        <Tabs.List>
+          {API_MODE_TABS.map((tab) => (
+            <Tabs.Trigger key={tab.value} value={tab.value}>
+              <div className="flex flex-col items-start">
+                <Text font="main-ui-action" color="inherit">
+                  {tab.title}
+                </Text>
+                <Text font="secondary-body" color="text-03">
+                  {tab.subtitle}
+                </Text>
+              </div>
+            </Tabs.Trigger>
+          ))}
+        </Tabs.List>
+      </Tabs>
+
+      <APIBaseField
+        subDescription="Use Portkey's base URL or paste your self-hosted gateway base URL."
+        placeholder={modeDefaultBase}
+      />
+      {!isBaseDefault && (
+        <Button
+          prominence="tertiary"
+          size="xs"
+          onClick={() => setFieldValue("api_base", modeDefaultBase)}
+        >
+          Restore default
+        </Button>
+      )}
+
+      <APIKeyField
+        subDescription={markdown(
+          "Paste your API key from [Portkey](https://portkey.ai/) to load the available models."
+        )}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <DisplayNameField />
+        </>
+      )}
+
+      <InputDivider />
+      <ModelSelectionField
+        shouldShowAutoUpdateToggle={false}
+        onRefetch={isFetchDisabled ? undefined : handleFetchModels}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <ModelAccessField />
+        </>
+      )}
+    </>
+  );
+}
+
+export default function PortkeyModal({
+  variant = "llm-configuration",
+  existingLlmProvider,
+  shouldMarkAsDefault,
+  onOpenChange,
+  onSuccess,
+  analyticsSource,
+}: LLMProviderFormProps) {
+  const isOnboarding = variant === "onboarding";
+  const { mutate } = useSWRConfig();
+
+  const onClose = () => onOpenChange?.(false);
+
+  const initialValues: PortkeyModalValues = useInitialValues(
+    isOnboarding,
+    LLMProviderName.PORTKEY,
+    existingLlmProvider
+  ) as PortkeyModalValues;
+
+  // The selected API mode round-trips through custom_config. useInitialValues
+  // does not populate custom_config, so seed it here (mirroring CustomModal) so
+  // submitProvider's custom_config_changed diff is accurate.
+  const initialMode =
+    (existingLlmProvider?.custom_config?.[PORTKEY_API_MODE_KEY] as
+      | PortkeyApiMode
+      | undefined) ?? DEFAULT_API_MODE;
+  initialValues.custom_config = { [PORTKEY_API_MODE_KEY]: initialMode };
+
+  if (!initialValues.api_base) {
+    initialValues.api_base = defaultBaseForMode(initialMode);
+  }
+  if (!isOnboarding && !initialValues.name) {
+    initialValues.name = DEFAULT_DISPLAY_NAME;
+  }
+
+  const validationSchema = buildValidationSchema(isOnboarding, {
+    apiBase: true,
+    apiKey: true,
+  });
+
+  return (
+    <ModalWrapper
+      providerName={LLMProviderName.PORTKEY}
+      llmProvider={existingLlmProvider}
+      onClose={onClose}
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={async (values, { setSubmitting, setStatus }) => {
+        await submitProvider({
+          analyticsSource:
+            analyticsSource ??
+            (isOnboarding
+              ? LLMProviderConfiguredSource.CHAT_ONBOARDING
+              : LLMProviderConfiguredSource.ADMIN_PAGE),
+          providerName: LLMProviderName.PORTKEY,
+          values,
+          initialValues,
+          existingLlmProvider,
+          shouldMarkAsDefault,
+          setStatus,
+          setSubmitting,
+          onClose,
+          onSuccess: async () => {
+            if (onSuccess) {
+              await onSuccess();
+            } else {
+              await refreshLlmProviderCaches(mutate);
+              toast.success(
+                existingLlmProvider
+                  ? "Provider updated successfully!"
+                  : "Provider enabled successfully!"
+              );
+            }
+          },
+        });
+      }}
+    >
+      <PortkeyModalInternals
+        existingLlmProvider={existingLlmProvider}
+        isOnboarding={isOnboarding}
+      />
+    </ModalWrapper>
+  );
+}

--- a/web/src/sections/modals/languageModels/PortkeyModal.tsx
+++ b/web/src/sections/modals/languageModels/PortkeyModal.tsx
@@ -6,6 +6,7 @@ import { useSWRConfig } from "swr";
 import { useFormikContext } from "formik";
 import { InputDivider } from "@opal/layouts";
 import { Tabs, Text, Button } from "@opal/components";
+import { SvgHistory } from "@opal/icons";
 import {
   LLMProviderFormProps,
   LLMProviderName,
@@ -165,21 +166,24 @@ function PortkeyModalInternals({
 
       <APIBaseField
         subDescription="Use Portkey's base URL or paste your self-hosted gateway base URL."
-        placeholder={modeDefaultBase}
+        placeholder="Your Portkey gateway base URL"
+        rightChildren={
+          isBaseDefault ? undefined : (
+            <Button
+              icon={SvgHistory}
+              prominence="tertiary"
+              size="xs"
+              tooltip="Restore Default"
+              aria-label="Restore default API base URL"
+              onClick={() => setFieldValue("api_base", modeDefaultBase)}
+            />
+          )
+        }
       />
-      {!isBaseDefault && (
-        <Button
-          prominence="tertiary"
-          size="xs"
-          onClick={() => setFieldValue("api_base", modeDefaultBase)}
-        >
-          Restore default
-        </Button>
-      )}
 
       <APIKeyField
         subDescription={markdown(
-          "Paste your API key from [Portkey](https://portkey.ai/) to load the available models."
+          "Paste your API key from [Portkey](https://portkey.ai/) to access your models."
         )}
       />
 
@@ -194,6 +198,7 @@ function PortkeyModalInternals({
       <ModelSelectionField
         shouldShowAutoUpdateToggle={false}
         onRefetch={isFetchDisabled ? undefined : handleFetchModels}
+        emptyMessage="No models available. Provide a valid base URL and key."
       />
 
       {!isOnboarding && (
@@ -251,6 +256,7 @@ export default function PortkeyModal({
       providerName={LLMProviderName.PORTKEY}
       llmProvider={existingLlmProvider}
       onClose={onClose}
+      description="Connect to your Portkey gateway and set up compatible models."
       initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={async (values, { setSubmitting, setStatus }) => {

--- a/web/src/sections/modals/languageModels/PortkeyModal.tsx
+++ b/web/src/sections/modals/languageModels/PortkeyModal.tsx
@@ -32,17 +32,13 @@ import {
 } from "@/sections/modals/languageModels/shared";
 import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
 
-// The two OpenAI-compatible surfaces (Chat Completions, Responses) hit /v1; the
-// Anthropic-compatible Messages surface uses the bare host (LiteLLM appends
-// /v1/messages).
 const DEFAULT_API_BASE_OPENAI = "https://api.portkey.ai/v1";
 const DEFAULT_API_BASE_ANTHROPIC = "https://api.portkey.ai";
 const DEFAULT_API_MODE: PortkeyApiMode = "chat_completions";
 const PORTKEY_API_MODE_KEY = "portkey_api_mode";
 const DEFAULT_DISPLAY_NAME = "Portkey Gateway";
 
-// Bases we consider "not customized" — switching modes replaces one of these
-// with the new mode's default, but leaves a user-entered self-hosted base alone.
+// Switching modes replaces these, but leaves a self-hosted base alone.
 const KNOWN_DEFAULT_BASES = new Set<string>([
   DEFAULT_API_BASE_OPENAI,
   DEFAULT_API_BASE_ANTHROPIC,
@@ -100,7 +96,6 @@ function PortkeyModalInternals({
 
   const handleModeChange = (next: PortkeyApiMode) => {
     setFieldValue("custom_config", { [PORTKEY_API_MODE_KEY]: next });
-    // Only swap the base URL if the user hasn't entered a custom (self-hosted) one.
     if (KNOWN_DEFAULT_BASES.has(values.api_base)) {
       setFieldValue("api_base", defaultBaseForMode(next));
     }
@@ -121,9 +116,7 @@ function PortkeyModalInternals({
     );
   };
 
-  // When editing a saved provider the models load from the DB; refetch once on
-  // open so the picker matches the "add" view. Best-effort — ignore errors so
-  // the modal still works if the gateway is unreachable.
+  // Refetch once on open so an edit's picker matches the "add" view.
   const autoRefetched = useRef(false);
   useEffect(() => {
     if (autoRefetched.current || !existingLlmProvider?.id) return;
@@ -234,9 +227,8 @@ export default function PortkeyModal({
     existingLlmProvider
   ) as PortkeyModalValues;
 
-  // The selected API mode round-trips through custom_config. useInitialValues
-  // does not populate custom_config, so seed it here (mirroring CustomModal) so
-  // submitProvider's custom_config_changed diff is accurate.
+  // useInitialValues drops custom_config, so seed it for submitProvider's
+  // custom_config_changed diff (mirrors CustomModal).
   const initialMode =
     (existingLlmProvider?.custom_config?.[PORTKEY_API_MODE_KEY] as
       | PortkeyApiMode

--- a/web/src/sections/modals/languageModels/PortkeyModal.tsx
+++ b/web/src/sections/modals/languageModels/PortkeyModal.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from "react";
 import { markdown } from "@opal/utils";
 import { useSWRConfig } from "swr";
 import { useFormikContext } from "formik";
-import { InputDivider } from "@opal/layouts";
+import { InputDivider, toast } from "@opal/layouts";
 import { Tabs, Text, Button } from "@opal/components";
 import { SvgHistory } from "@opal/icons";
 import {
@@ -30,7 +30,6 @@ import {
   ModelAccessField,
   ModalWrapper,
 } from "@/sections/modals/languageModels/shared";
-import { toast } from "@/hooks/useToast";
 import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
 
 // The two OpenAI-compatible surfaces (Chat Completions, Responses) hit /v1; the
@@ -67,7 +66,11 @@ const API_MODE_TABS: {
     subtitle: "OpenAI-compatible",
   },
   { value: "responses", title: "Responses API", subtitle: "OpenAI-compatible" },
-  { value: "messages", title: "Messages API", subtitle: "Anthropic-compatible" },
+  {
+    value: "messages",
+    title: "Messages API",
+    subtitle: "Anthropic-compatible",
+  },
 ];
 
 interface PortkeyModalValues extends BaseLLMFormValues {
@@ -88,8 +91,9 @@ function PortkeyModalInternals({
   const { setFieldValue, values } = formikProps;
 
   const mode =
-    (values.custom_config?.[PORTKEY_API_MODE_KEY] as PortkeyApiMode | undefined) ??
-    DEFAULT_API_MODE;
+    (values.custom_config?.[PORTKEY_API_MODE_KEY] as
+      | PortkeyApiMode
+      | undefined) ?? DEFAULT_API_MODE;
   const modeDefaultBase = defaultBaseForMode(mode);
   const isFetchDisabled = !values.api_base;
   const isBaseDefault = values.api_base === modeDefaultBase;

--- a/web/src/sections/modals/languageModels/shared.tsx
+++ b/web/src/sections/modals/languageModels/shared.tsx
@@ -130,11 +130,14 @@ export interface APIBaseFieldProps {
   optional?: boolean;
   subDescription?: string | RichStr;
   placeholder?: string;
+  /** Rendered inside the input on the right (e.g. a restore-default control). */
+  rightChildren?: React.ReactNode;
 }
 export function APIBaseField({
   optional = false,
   subDescription,
   placeholder = "https://",
+  rightChildren,
 }: APIBaseFieldProps) {
   return (
     <InputPadder>
@@ -144,7 +147,11 @@ export function APIBaseField({
         subDescription={subDescription}
         suffix={optional ? "optional" : undefined}
       >
-        <InputTypeInField name="api_base" placeholder={placeholder} />
+        <InputTypeInField
+          name="api_base"
+          placeholder={placeholder}
+          rightChildren={rightChildren}
+        />
       </InputVertical>
     </InputPadder>
   );
@@ -570,11 +577,14 @@ export interface ModelSelectionFieldProps {
   onRefetch?: (signal: AbortSignal) => Promise<void> | void;
   /** Called when the user adds a custom model by name. Enables the "Add Model" input. */
   onAddModel?: (modelName: string) => void;
+  /** Overrides the empty-state copy shown when no models are loaded. */
+  emptyMessage?: string;
 }
 export function ModelSelectionField({
   shouldShowAutoUpdateToggle,
   onRefetch,
   onAddModel,
+  emptyMessage,
 }: ModelSelectionFieldProps) {
   const formikProps = useFormikContext<BaseLLMFormValues>();
   const [newModelName, setNewModelName] = useState("");
@@ -664,7 +674,10 @@ export function ModelSelectionField({
         </InputHorizontal>
 
         {models.length === 0 ? (
-          <EmptyMessageCard title="No models available." padding="sm" />
+          <EmptyMessageCard
+            title={emptyMessage ?? "No models available."}
+            padding="sm"
+          />
         ) : (
           <Section gap={0.25} alignItems="stretch">
             {(() => {

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -73,6 +73,7 @@ const PROVIDER_GROUPS: ProviderGroup[] = [
     providerNames: [
       LLMProviderName.OPENROUTER,
       LLMProviderName.LITELLM_PROXY,
+      LLMProviderName.PORTKEY,
       LLMProviderName.NEBIUS_TOKENFACTORY,
       LLMProviderName.BIFROST,
     ],


### PR DESCRIPTION
## Description

Adds **Portkey** (an LLM gateway/router) as a first-class built-in provider on the admin **Language Models** page, in the **Gateways & Routers** group, matching the "Set up Portkey" design.

The setup modal exposes a **3-way API-mode toggle**, each routed differently through LiteLLM. There is no `portkey/` LiteLLM provider prefix, so Portkey rides existing paths:

| Mode | Wire format | Default base URL | LiteLLM routing |
|------|-------------|------------------|-----------------|
| **Chat Completions** (default) | OpenAI-compatible | `https://api.portkey.ai/v1` | `custom_llm_provider="openai"`, bare model → `/v1/chat/completions` |
| **Responses** | OpenAI-compatible | `https://api.portkey.ai/v1` | `custom_llm_provider="openai"`, `responses/`-prefixed model → `/v1/responses` |
| **Messages** | Anthropic-compatible | `https://api.portkey.ai` | `custom_llm_provider="anthropic"`, bare base (LiteLLM appends `/v1/messages`) |

The selected mode is persisted in `custom_config` as `portkey_api_mode` and registered in `UI_ONLY_CONFIG_KEYS`, so it drives routing but is never injected into the environment at call time.

Verified against the installed **litellm 1.85.1**: all three modes route through the single existing `litellm.completion()` call site — no new LiteLLM plumbing. Notably, Responses is *not* a separate API call; it's the same completion call with a `responses/` model prefix (LiteLLM's completions→responses bridge).

### Backend
- Register `portkey` as a well-known provider (enum, well-known list, display name, aggregator, dynamic models).
- `multi_llm.py`: per-mode routing — the one behavioral change. Reads `portkey_api_mode` and selects `custom_llm_provider`, the `model=` string, and whether the base is `/v1`-coerced (yes for the OpenAI surfaces, **no** for Messages).
- New `POST /admin/llm/portkey/available-models` + `PortkeyModelsRequest` / `PortkeyFinalModelResponse`. Reuses the OpenAI-compatible `/v1/models` fetch (Portkey serves the same listing on both the `/v1` and bare hosts, so it works for all three modes), resolves the stored key by `provider_id` on edit, filters embeddings, flags reasoning/vision, sorts, and syncs to the provider.

### Frontend
- `PortkeyModal` built on the Nebius template, matched to the design: Opal `Tabs` mode toggle (title + subtitle per tab), per-mode default base URL with an in-field **Restore Default** control, masked API key, optional display name ("Portkey Gateway"), dynamic model fetch, and access control.
- `custom_config` round-trip for `portkey_api_mode` (mirrors `CustomModal`; deliberately kept out of `CUSTOM_CONFIG_OVERRIDES` so edits always reopen in `PortkeyModal`).
- Official Portkey brand logo, inlined with a per-instance gradient id.
- Two additive, backwards-compatible props on shared fields: `APIBaseField.rightChildren` (hosts Restore Default) and `ModelSelectionField.emptyMessage`. Both default to today's behavior for every other provider.

## How Has This Been Tested?

- **Unit — 12 passing.** `test_portkey_routing.py` locks the per-mode mapping (`custom_llm_provider` / `model=` / `/v1` coercion) and asserts the mode never reaches env injection. `test_portkey_models.py` covers the fetch route's parse/filter/sort.
- `tsc --noEmit` clean; `ruff check` + `ruff format` clean.
- Booted the API server against this branch: the app starts and `POST /admin/llm/portkey/available-models` is registered and auth-gated.
- **Not yet done:** live end-to-end calls against a real Portkey gateway (needs a Portkey API key), and a visual pass of the modal in a running app.

## Known follow-ups (not blocking)

- If a given Portkey deployment doesn't expose `/v1/models`, the modal supports manual model entry as a fallback.
- `DisplayNameField`'s shared helper text reads "Used to identify this provider in the app." where the mock says "Use to…"; left alone since that string is shared across all provider modals.

## Screenshots

<img width="889" height="815" alt="Screenshot 2026-07-27 at 11 25 19 AM" src="https://github.com/user-attachments/assets/9ec1460f-aeda-4c28-a345-9c231f91ac8e" />
<img width="923" height="800" alt="Screenshot 2026-07-27 at 11 25 48 AM" src="https://github.com/user-attachments/assets/54c046e4-7f90-436b-b42b-6267a3ca24f1" />

## Mocks
https://www.figma.com/design/sNcHyrXBLtTFDK0ijjMnSk/Admin-Panel?node-id=6963-329047&t=ndozUBIDjit7p9Kk-0

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check