### PR TITLE
fix(scim): return 409 not 500 on concurrent duplicate user create

### DIFF
--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -252,6 +252,17 @@ def _assign_default_groups_or_error(
     """
     try:
         assign_user_to_default_groups__no_commit(db_session, user, is_admin=is_admin)
+    except IntegrityError:
+        # A concurrent SCIM provisioning request (e.g. an IdP batch retry) already
+        # created this user; the duplicate INSERT is deferred and surfaces here via
+        # autoflush rather than at ``add_user``. This is an expected provisioning
+        # race, not a server error — surface a clean 409 like the create path does.
+        dal.rollback()
+        logger.info(
+            "SCIM user %s already exists (concurrent provisioning); returning 409",
+            email,
+        )
+        return _scim_error_response(409, f"User with email {email} already exists")
     except Exception:
         dal.rollback()
         logger.exception("Failed to assign SCIM user %s to default groups", email)

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -65,6 +65,7 @@ from onyx.db.models import UserRole
 from onyx.db.permissions import recompute_permissions_for_group__no_commit
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import assign_user_to_default_groups__no_commit
+from onyx.db.utils import is_unique_violation
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -245,26 +246,31 @@ def _assign_default_groups_or_error(
 ) -> ScimJSONResponse | None:
     """Assign *user* to the Basic/Admin default group, or return a SCIM error.
 
-    ``assign_user_to_default_groups__no_commit`` raises (e.g. ``RuntimeError``)
-    if the default group is missing, so failures are rolled back and surfaced
-    as a structured SCIM 500 instead of leaking a raw 500. Returns the error
-    response on failure, else ``None``.
+    Two distinct failure modes are handled:
+    - A concurrent provisioning request already committed the same user, so the
+      pending user INSERT is deferred and its ``ix_user_email`` unique violation
+      surfaces here via autoflush rather than at ``add_user``. That specific race
+      is expected — rolled back and surfaced as a clean 409, matching the
+      ``add_user`` fast-path.
+    - Any other failure (e.g. ``RuntimeError`` for a missing default group, or an
+      unrelated integrity error such as a FK violation) is rolled back and
+      surfaced as a structured SCIM 500 with a full traceback.
+
+    Returns the error response on failure, else ``None``.
     """
     try:
         assign_user_to_default_groups__no_commit(db_session, user, is_admin=is_admin)
-    except IntegrityError:
-        # A concurrent SCIM provisioning request (e.g. an IdP batch retry) already
-        # created this user; the duplicate INSERT is deferred and surfaces here via
-        # autoflush rather than at ``add_user``. This is an expected provisioning
-        # race, not a server error — surface a clean 409 like the create path does.
+    except Exception as e:
         dal.rollback()
-        logger.info(
-            "SCIM user %s already exists (concurrent provisioning); returning 409",
-            email,
-        )
-        return _scim_error_response(409, f"User with email {email} already exists")
-    except Exception:
-        dal.rollback()
+        # Only the duplicate-email race is an expected, benign 409. Every other
+        # failure — including non-email integrity errors — stays a 500 so real
+        # backend faults aren't masked as "already exists".
+        if isinstance(e, IntegrityError) and is_unique_violation(e, "ix_user_email"):
+            logger.info(
+                "SCIM user %s already exists (concurrent provisioning); returning 409",
+                email,
+            )
+            return _scim_error_response(409, f"User with email {email} already exists")
         logger.exception("Failed to assign SCIM user %s to default groups", email)
         return _scim_error_response(
             500, f"Failed to assign user {email} to default group"

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -446,6 +446,34 @@ class TestCreateUser:
         assert_scim_error(result, 409)
         mock_dal.rollback.assert_called_once()
 
+    @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_assign_default_groups_integrity_error_returns_409(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_assign: MagicMock,
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """A concurrent duplicate create can surface as an IntegrityError during
+        default-group assignment (deferred autoflush) rather than at ``add_user``.
+        It must return a clean 409, not a misleading 500."""
+        mock_dal.get_user_by_email.return_value = None
+        mock_assign.side_effect = IntegrityError("dup", {}, Exception())
+
+        result = create_user(
+            user_resource=make_scim_user(),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 409)
+        mock_dal.rollback.assert_called_once()
+        mock_dal.commit.assert_not_called()
+
     @patch("ee.onyx.server.scim.api._check_seat_availability")
     def test_seat_limit_returns_403(
         self,

--- a/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
+++ b/backend/tests/unit/onyx/server/scim/test_user_endpoints.py
@@ -446,20 +446,22 @@ class TestCreateUser:
         assert_scim_error(result, 409)
         mock_dal.rollback.assert_called_once()
 
+    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=True)
     @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
     @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
-    def test_assign_default_groups_integrity_error_returns_409(
+    def test_assign_default_groups_email_integrity_error_returns_409(
         self,
         mock_seats: MagicMock,  # noqa: ARG002
         mock_assign: MagicMock,
+        mock_is_unique: MagicMock,  # noqa: ARG002
         mock_db_session: MagicMock,
         mock_token: MagicMock,
         mock_dal: MagicMock,
         provider: ScimProvider,
     ) -> None:
-        """A concurrent duplicate create can surface as an IntegrityError during
-        default-group assignment (deferred autoflush) rather than at ``add_user``.
-        It must return a clean 409, not a misleading 500."""
+        """A concurrent duplicate create can surface as an ix_user_email
+        IntegrityError during default-group assignment (deferred autoflush)
+        rather than at ``add_user``. It must return a clean 409, not a 500."""
         mock_dal.get_user_by_email.return_value = None
         mock_assign.side_effect = IntegrityError("dup", {}, Exception())
 
@@ -471,6 +473,36 @@ class TestCreateUser:
         )
 
         assert_scim_error(result, 409)
+        mock_dal.rollback.assert_called_once()
+        mock_dal.commit.assert_not_called()
+
+    @patch("ee.onyx.server.scim.api.is_unique_violation", return_value=False)
+    @patch("ee.onyx.server.scim.api.assign_user_to_default_groups__no_commit")
+    @patch("ee.onyx.server.scim.api._check_seat_availability", return_value=None)
+    def test_assign_default_groups_other_integrity_error_returns_500(
+        self,
+        mock_seats: MagicMock,  # noqa: ARG002
+        mock_assign: MagicMock,
+        mock_is_unique: MagicMock,  # noqa: ARG002
+        mock_db_session: MagicMock,
+        mock_token: MagicMock,
+        mock_dal: MagicMock,
+        provider: ScimProvider,
+    ) -> None:
+        """An integrity error NOT from the ix_user_email unique constraint (e.g.
+        a FK/other-constraint fault) must stay a structured 500 so real backend
+        faults aren't masked as a benign 409 'already exists'."""
+        mock_dal.get_user_by_email.return_value = None
+        mock_assign.side_effect = IntegrityError("fk", {}, Exception())
+
+        result = create_user(
+            user_resource=make_scim_user(),
+            _token=mock_token,
+            provider=provider,
+            db_session=mock_db_session,
+        )
+
+        assert_scim_error(result, 500)
         mock_dal.rollback.assert_called_once()
         mock_dal.commit.assert_not_called()
 


### PR DESCRIPTION
## Description

Concurrent SCIM `POST /Users` requests for the **same email** (e.g. an IdP batch/retry sending the create twice near-simultaneously) can race on the case-sensitive `email` primary key. The create path already guards `add_user` with `except IntegrityError -> 409`, but the duplicate INSERT can be **deferred past `add_user` and surface via autoflush** inside the default-group query in `assign_user_to_default_groups__no_commit`.

At that point the broad `except Exception` in `_assign_default_groups_or_error` catches the `IntegrityError`, rolls back, **logs a full error-level traceback**, and returns a misleading **500 "Failed to assign user to default group"** — instead of the clean **409 "already exists"** the create path returns for the same race elsewhere.

This was observed in production: an IdP re-provisioning the same user produced repeated 500s + noisy `IntegrityError` tracebacks (`duplicate key value violates unique constraint "ix_user_email"`) originating from the group-assignment autoflush.

**Fix:** catch `IntegrityError` distinctly in `_assign_default_groups_or_error` and return a quiet 409. Genuine assignment failures (e.g. missing seeded default group -> `RuntimeError`) still return 500 with the traceback.

## How Has This Been Tested?

- New unit test `test_assign_default_groups_integrity_error_returns_409`: when `assign_user_to_default_groups__no_commit` raises `IntegrityError`, `create_user` returns 409, rolls back, and does not commit.
- Existing `test_promotion_default_group_failure_returns_500` (missing default group -> 500) still passes, confirming non-race errors are unaffected.
- Full SCIM user-endpoint unit suite: 73 passed.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return 409 Conflict instead of 500 when concurrent SCIM `POST /Users` requests create a duplicate user during default-group assignment, matching the create path and avoiding noisy tracebacks.

- **Bug Fixes**
  - Catch `IntegrityError` in `_assign_default_groups_or_error` and return 409 only for `ix_user_email` unique violations using `is_unique_violation`.
  - Keep 500 for other failures (e.g., missing default group or non-email integrity errors) with full traceback.
  - Add `test_assign_default_groups_email_integrity_error_returns_409` and `test_assign_default_groups_other_integrity_error_returns_500`; existing 500 path test still passes.

<sup>Written for commit 3de1b26bd1f8366cadd49ccc4fb44a21e04e30bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

