### PR TITLE
refactor(craft): use shared modal for sandbox sleep notice

### DIFF
--- a/web/src/app/craft/components/SandboxAsleepNotice.test.tsx
+++ b/web/src/app/craft/components/SandboxAsleepNotice.test.tsx
@@ -118,13 +118,18 @@ describe("SandboxAsleepNotice", () => {
     expect(screen.getByText(TITLE)).toBeInTheDocument();
   });
 
-  it("dismisses on backdrop click", () => {
+  it("dismisses on backdrop click", async () => {
     seedSession(SESSION_A, sandbox());
-    const { container } = render(<SandboxAsleepNotice />);
+    render(<SandboxAsleepNotice />);
 
-    const backdrop = container.firstElementChild?.firstElementChild;
-    expect(backdrop).not.toBeNull();
-    fireEvent.click(backdrop as Element);
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+    fireEvent.pointerDown(document.body, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    });
 
     expect(screen.queryByText(TITLE)).toBeNull();
     expect(loadSession).not.toHaveBeenCalled();

--- a/web/src/app/craft/components/SandboxAsleepNotice.test.tsx
+++ b/web/src/app/craft/components/SandboxAsleepNotice.test.tsx
@@ -81,6 +81,9 @@ describe("SandboxAsleepNotice", () => {
     expect(
       screen.getByRole("button", { name: "Wake sandbox" })
     ).toBeInTheDocument();
+    screen.getAllByRole("button").forEach((button) => {
+      expect(button).toHaveAccessibleName();
+    });
   });
 
   it("hides the modal on dismiss without waking", () => {

--- a/web/src/app/craft/components/SandboxAsleepNotice.tsx
+++ b/web/src/app/craft/components/SandboxAsleepNotice.tsx
@@ -46,7 +46,6 @@ export default function SandboxAsleepNotice() {
           icon={SvgMoon}
           title="Your sandbox fell asleep"
           description="It went to sleep after a period of inactivity — your work is saved. Wake it to keep going."
-          onClose={() => setDismissed(true)}
         />
         <Modal.Footer justifyContent="center">
           <Button

--- a/web/src/app/craft/components/SandboxAsleepNotice.tsx
+++ b/web/src/app/craft/components/SandboxAsleepNotice.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { Button, Text } from "@opal/components";
+import { Button } from "@opal/components";
+import { SvgMoon } from "@opal/icons";
 import {
   useSession,
   useSessionId,
   useBuildSessionStore,
 } from "@/app/craft/hooks/useBuildSessionStore";
 import { useSandboxSleepWatcher } from "@/app/craft/hooks/useSandboxSleepWatcher";
+import Modal from "@/refresh-components/Modal";
 
 // Waking is always user-initiated — never automatic — so we don't keep pods
 // alive forever and defeat idle reaping.
@@ -38,41 +40,27 @@ export default function SandboxAsleepNotice() {
   };
 
   return (
-    <div className="fixed inset-0 z-1400 flex items-center justify-center">
-      <div
-        className="absolute inset-0 bg-black/50 backdrop-blur-xs"
-        onClick={() => setDismissed(true)}
-      />
-
-      <div className="relative z-10 w-full max-w-xl mx-4 bg-background-tint-01 rounded-16 shadow-lg border border-border-01">
-        <div className="p-6 flex flex-col gap-6">
-          <div className="flex items-center justify-center">
-            <Text font="heading-h2" color="text-05">
-              Your sandbox fell asleep
-            </Text>
-          </div>
-
-          <div className="flex justify-center text-center">
-            <Text font="main-ui-body" color="text-04">
-              It went to sleep after a period of inactivity — your work is
-              saved. Wake it to keep going.
-            </Text>
-          </div>
-
-          <div className="flex items-center justify-center gap-3">
-            <Button
-              variant="default"
-              prominence="tertiary"
-              onClick={() => setDismissed(true)}
-            >
-              Dismiss
-            </Button>
-            <Button variant="default" prominence="primary" onClick={handleWake}>
-              Wake sandbox
-            </Button>
-          </div>
-        </div>
-      </div>
-    </div>
+    <Modal open onOpenChange={(open) => !open && setDismissed(true)}>
+      <Modal.Content width="sm" preventAccidentalClose={false}>
+        <Modal.Header
+          icon={SvgMoon}
+          title="Your sandbox fell asleep"
+          description="It went to sleep after a period of inactivity — your work is saved. Wake it to keep going."
+          onClose={() => setDismissed(true)}
+        />
+        <Modal.Footer justifyContent="center">
+          <Button
+            variant="default"
+            prominence="tertiary"
+            onClick={() => setDismissed(true)}
+          >
+            Dismiss
+          </Button>
+          <Button variant="default" prominence="primary" onClick={handleWake}>
+            Wake sandbox
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
   );
 }

--- a/web/src/app/craft/components/SandboxStatusIndicator.tsx
+++ b/web/src/app/craft/components/SandboxStatusIndicator.tsx
@@ -31,7 +31,7 @@ const STATUS_CONFIG = {
   restoring: {
     color: "bg-status-warning-05",
     pulse: true,
-    label: "Waking sandbox...",
+    label: "Restoring session...",
   },
   terminated: {
     color: "bg-status-error-05",


### PR DESCRIPTION
## Description

Refactor `SandboxAsleepNotice` to use the shared `Modal` component and Opal modal layout patterns instead of maintaining a custom backdrop and dialog implementation.

This brings the notice in line with the rest of the codebase and delegates backdrop dismissal, Escape handling, focus management, accessibility semantics, and layering to the shared modal primitive. The existing dismiss, wake, and session-switch behavior remains unchanged, and the backdrop test now exercises the portal-based modal interaction.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `SandboxAsleepNotice` to use the shared `Modal` for consistent a11y and behavior. Also clarifies the restore status copy to improve feedback.

- **Refactors**
  - Replace custom overlay with `Modal` (`Modal.Content`, `Modal.Header`, `Modal.Footer`) and Opal modal layout.
  - Add `SvgMoon` icon; keep Dismiss/Wake actions using `@opal/components`; import icons from `@opal/icons`.
  - Update test to use portal-based backdrop dismissal via document pointerDown and async tick.

- **Bug Fixes**
  - Change restore status label to "Restoring session..." in the status indicator.
  - Remove unlabeled control in the sleep notice to meet a11y; all buttons now have accessible names.

<sup>Written for commit 642ebad67afcc6f706e0822d7a04fb4299f9cd60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

