### PR TITLE
fix(auth): raise `OnyxError` when email is unconfigured in auth hooks

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1219,7 +1219,14 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             async_return_default_schema,
         )(email=user.email)
 
-        send_forgot_password_email(user.email, tenant_id=tenant_id, token=token)
+        try:
+            send_forgot_password_email(user.email, tenant_id=tenant_id, token=token)
+        except Exception as e:
+            logger.error("Failed to send password reset email to %s: %s", user.email, e)
+            raise OnyxError(
+                OnyxErrorCode.SERVICE_UNAVAILABLE,
+                "Failed to send the password reset email.",
+            ) from e
 
         emit_audit_event(
             AuditAction.PASSWORD_FORGOT,
@@ -1262,9 +1269,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             "Verification requested for user %s. Verification token: %s", user.id, token
         )
         user_count = await get_user_count()
-        send_user_verification_email(
-            user.email, token, new_organization=user_count == 1
-        )
+        try:
+            send_user_verification_email(
+                user.email, token, new_organization=user_count == 1
+            )
+        except Exception as e:
+            logger.error("Failed to send verification email to %s: %s", user.email, e)
+            raise OnyxError(
+                OnyxErrorCode.SERVICE_UNAVAILABLE,
+                "Failed to send the verification email.",
+            ) from e
 
         emit_audit_event(
             AuditAction.EMAIL_VERIFY,

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1209,8 +1209,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             logger.error(
                 "Email is not configured. Please configure email in the admin panel"
             )
-            raise HTTPException(
-                status.HTTP_500_INTERNAL_SERVER_ERROR,
+            raise OnyxError(
+                OnyxErrorCode.SERVICE_UNAVAILABLE,
                 "Your admin has not enabled this feature.",
             )
         tenant_id = await fetch_ee_implementation_or_noop(
@@ -1244,6 +1244,15 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         token: str,
         request: Optional[Request] = None,  # noqa: ARG002
     ) -> None:
+        if not EMAIL_CONFIGURED:
+            logger.error(
+                "Email is not configured. Please configure email in the admin panel"
+            )
+            raise OnyxError(
+                OnyxErrorCode.SERVICE_UNAVAILABLE,
+                "Your admin has not enabled this feature.",
+            )
+
         verify_email_domain(
             user.email,
             valid_email_domains=get_security_settings().valid_email_domains,

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1211,7 +1211,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             )
             raise OnyxError(
                 OnyxErrorCode.SERVICE_UNAVAILABLE,
-                "Your admin has not enabled this feature.",
+                "Email sending has not been configured for this deployment.",
             )
         tenant_id = await fetch_ee_implementation_or_noop(
             "onyx.server.tenants.provisioning",
@@ -1250,7 +1250,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             )
             raise OnyxError(
                 OnyxErrorCode.SERVICE_UNAVAILABLE,
-                "Your admin has not enabled this feature.",
+                "Email sending has not been configured for this deployment.",
             )
 
         verify_email_domain(

--- a/backend/tests/unit/onyx/auth/test_auth_audit_events.py
+++ b/backend/tests/unit/onyx/auth/test_auth_audit_events.py
@@ -95,6 +95,7 @@ async def test_on_after_forgot_password_emits_event(
 @patch("onyx.auth.users.get_user_count", new_callable=AsyncMock)
 @patch("onyx.auth.users.get_security_settings")
 @patch("onyx.auth.users.verify_email_domain")
+@patch("onyx.auth.users.EMAIL_CONFIGURED", True)
 async def test_on_after_request_verify_emits_event(
     _mock_verify_domain: MagicMock,
     mock_settings: MagicMock,


### PR DESCRIPTION
## Description

Two fastapi-users hooks had broken error handling for email failures:

- **`on_after_forgot_password`**: raised `HTTPException` directly, violating the `OnyxError` convention. Also had no error handling around the actual send call — a transport failure (SMTP down, bad credentials, etc.) would propagate as a generic `"Internal Server Error"`.
- **`on_after_request_verify`**: had no `EMAIL_CONFIGURED` guard at all. A `ValueError` from `send_email` propagated uncaught, and like the above, any transport failure also surfaced as a generic `"Internal Server Error"`.

Both hooks now:
1. Check `EMAIL_CONFIGURED` upfront and raise `OnyxError(SERVICE_UNAVAILABLE, "Email sending has not been configured for this deployment.")` if email is unconfigured.
2. Wrap the send call in try/except and raise `OnyxError(SERVICE_UNAVAILABLE, "Failed to send the password reset / verification email.")` if the transport itself fails, preserving the original exception as `__cause__` for server-side traceability.

Other email call sites (`send_user_email_invite`, `license_notifications`, `connector.py`) already handle unconfigured email appropriately at their layer and are unchanged.

## How Has This Been Tested?

- Updated `test_on_after_request_verify_emits_event` to mock `EMAIL_CONFIGURED=True` (the existing `on_after_forgot_password` test already did this; the verify test was missing it and would now fail without the patch).
- All 5 tests in `backend/tests/unit/onyx/auth/test_auth_audit_events.py` pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check