### PR TITLE
fix(celery): backport #12964 to release/v4.3 — model-server timeouts, hierarchy queue, bounded lock

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -140,6 +140,10 @@ from shared_configs.configs import USAGE_LIMITS_ENABLED
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from shared_configs.contextvars import INDEX_ATTEMPT_INFO_CONTEXTVAR
 
+# Bound for waiting on the shared cross-batch DB lock (see usage below).
+CROSS_BATCH_DB_LOCK_ACQUIRE_TIMEOUT_S = 300
+
+
 logger = setup_logger()
 
 # Heartbeat timeout: if no heartbeat received for 30 minutes, consider it dead.
@@ -1860,7 +1864,21 @@ def _docprocessing_task(
         # Time the lock-acquire wait (the contention signal); record it after
         # release (below) so the metric write doesn't extend this shared lock.
         lock_acquire_start = time.monotonic()
-        cross_batch_db_lock.acquire()
+        # Bounded acquire: the lock guards a short DB update (normal hold well
+        # under a second), but a holder killed mid-section (worker restart /
+        # OOM) leaves the key for its full CELERY_INDEXING_LOCK_TIMEOUT (3h15m).
+        # An unbounded acquire() then wedges every docprocessing thread across
+        # all workers until the fossil expires — observed in production. Fail
+        # the task instead; it redelivers and retries against a fresh lock.
+        if not cross_batch_db_lock.acquire(
+            blocking_timeout=CROSS_BATCH_DB_LOCK_ACQUIRE_TIMEOUT_S
+        ):
+            raise RuntimeError(
+                f"Could not acquire cross-batch DB lock for index attempt "
+                f"{index_attempt_id} within "
+                f"{CROSS_BATCH_DB_LOCK_ACQUIRE_TIMEOUT_S}s — likely a fossil "
+                f"lock from a killed worker; task will be retried."
+            )
         lock_acquire_ms = max(0, int((time.monotonic() - lock_acquire_start) * 1000))
         try:
             with get_session_with_current_tenant() as db_session:

--- a/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
@@ -21,6 +21,7 @@ from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
 from onyx.background.celery.apps.app_base import task_logger
+from onyx.background.celery.tasks.beat_schedule import BEAT_EXPIRES_DEFAULT
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import DANSWER_REDIS_FUNCTION_LOCK_PREFIX
 from onyx.configs.constants import DocumentSource
@@ -143,6 +144,10 @@ def _try_creating_hierarchy_fetching_task(
             queue=OnyxCeleryQueues.CONNECTOR_HIERARCHY_FETCHING,
             task_id=custom_task_id,
             priority=OnyxCeleryPriority.LOW,
+            # Unexpired fan-out tasks accumulate forever if consumption stalls
+            # (a deployment with no worker on this queue collected 67k+ of
+            # these); the hourly check re-enqueues anything still due.
+            expires=BEAT_EXPIRES_DEFAULT,
         )
 
         if not result:

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -58,8 +58,10 @@ from onyx.utils.timing import log_function_time
 from shared_configs.configs import API_BASED_EMBEDDING_TIMEOUT
 from shared_configs.configs import DOC_EMBEDDING_CONTEXT_SIZE
 from shared_configs.configs import INDEXING_ONLY
+from shared_configs.configs import MODEL_SERVER_CONNECT_TIMEOUT
 from shared_configs.configs import MODEL_SERVER_HOST
 from shared_configs.configs import MODEL_SERVER_PORT
+from shared_configs.configs import MODEL_SERVER_READ_TIMEOUT
 from shared_configs.configs import OPENAI_EMBEDDING_TIMEOUT
 from shared_configs.configs import SKIP_WARM_UP
 from shared_configs.configs import VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE
@@ -895,6 +897,7 @@ class EmbeddingModel:
                 endpoint,
                 headers=headers,
                 json=embed_request.model_dump(),
+                timeout=(MODEL_SERVER_CONNECT_TIMEOUT, MODEL_SERVER_READ_TIMEOUT),
             )
             # signify that this is a rate limit error
             if response.status_code == 429:
@@ -1300,7 +1303,9 @@ class RerankingModel:
                 )
 
                 response = requests.post(
-                    self.rerank_server_endpoint, json=rerank_request.model_dump()
+                    self.rerank_server_endpoint,
+                    json=rerank_request.model_dump(),
+                    timeout=(MODEL_SERVER_CONNECT_TIMEOUT, MODEL_SERVER_READ_TIMEOUT),
                 )
                 response.raise_for_status()
 
@@ -1338,7 +1343,9 @@ class QueryAnalysisModel:
             provider="model_server",
         ):
             response = requests.post(
-                self.intent_server_endpoint, json=intent_request.model_dump()
+                self.intent_server_endpoint,
+                json=intent_request.model_dump(),
+                timeout=(MODEL_SERVER_CONNECT_TIMEOUT, MODEL_SERVER_READ_TIMEOUT),
             )
             response.raise_for_status()
 

--- a/backend/shared_configs/configs.py
+++ b/backend/shared_configs/configs.py
@@ -91,6 +91,16 @@ JSON_LOGGING = LOG_FORMAT == "json"
 # allow us to specify a custom timeout
 API_BASED_EMBEDDING_TIMEOUT = int(os.environ.get("API_BASED_EMBEDDING_TIMEOUT", "600"))
 
+# Timeouts for requests to the self-hosted model server (embedding / rerank /
+# intent). The connect timeout fails fast on an unreachable server; the read
+# timeout bounds silent hangs — without one, a model-server pod restarting
+# mid-request leaves the calling worker thread blocked forever inside
+# requests.post (observed wedging every docprocessing thread for hours during
+# an upgrade). Reads are generous because CPU embedding of large batches can
+# legitimately take minutes.
+MODEL_SERVER_CONNECT_TIMEOUT = int(os.environ.get("MODEL_SERVER_CONNECT_TIMEOUT", "30"))
+MODEL_SERVER_READ_TIMEOUT = int(os.environ.get("MODEL_SERVER_READ_TIMEOUT", "600"))
+
 # Local batch size for VertexAI embedding models currently calibrated for item size of 512 tokens
 # NOTE: increasing this value may lead to API errors due to token limit exhaustion per call.
 VERTEXAI_EMBEDDING_LOCAL_BATCH_SIZE = int(

--- a/backend/supervisord.conf
+++ b/backend/supervisord.conf
@@ -55,7 +55,7 @@ stopasgroup=true
 [program:celery_worker_heavy]
 command=celery -A onyx.background.celery.versioned_apps.heavy worker
     --hostname=heavy@%%n
-    -Q connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox
+    -Q connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox,connector_hierarchy_fetching
 stdout_logfile=/var/log/celery_worker_heavy.log
 stdout_logfile_maxbytes=16MB
 redirect_stderr=true

--- a/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-worker-heavy.yaml
@@ -73,7 +73,7 @@ spec:
               {{- end }}
               "--hostname=heavy@%n",
               "-Q",
-              "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox",
+              "connector_pruning,connector_doc_permissions_sync,connector_external_group_sync,csv_generation,sandbox,connector_hierarchy_fetching",
             ]
           ports:
             - name: metrics


### PR DESCRIPTION
## Description

Manual backport of #12964 (squash `f81a2618623d`) after the auto-cherry-pick failed. Carries all four incident fixes for the next v4.3.x tag:

1. **Model-server `requests.post` timeouts** (embed/rerank/intent) — the no-timeout call that silently wedged every docprocessing thread when a model-server pod rolled mid-request
2. **Bounded `cross_batch_db_lock.acquire()`** (300s) — the second-act convoy: a holder killed mid-critical-section previously wedged all replacement threads for the fossil lock's full 3h15m TTL
3. **`connector_hierarchy_fetching` consumer** added to the heavy worker (supervisord + chart template) — the queue never had one in any deployment mode; long-lived brokers hold fossilized backlogs (67.9k tasks observed)
4. **`expires` on the hierarchy fan-out tasks** — closes the unbounded-growth hole

Conflict resolution: `backend/scripts/env_inventory_baseline.txt` dropped — the env-drift gate tooling is main-only (post-branch-cut), so the baseline doesn't exist here. The Chart.yaml bump also intentionally doesn't carry over (release branch chart is at 0.6.9; chart releases cut from main, where 0.6.12 landed).

## How Has This Been Tested?

Same verification as #12964 (root-caused live on the affected deployment; thread dumps; pre-commit clean on main). On this branch: py-compile clean on all touched modules; key changes grep-verified present.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports four Celery stability fixes to v4.3 to stop docprocessing hangs and prevent hierarchy task backlogs. Adds model-server request timeouts, bounds a shared DB lock, wires the missing `connector_hierarchy_fetching` queue, and sets task expiry.

- **Bug Fixes**
  - Added connect/read timeouts to model-server `requests.post` (embed/rerank/intent) via `MODEL_SERVER_CONNECT_TIMEOUT` and `MODEL_SERVER_READ_TIMEOUT` (defaults 30s/600s).
  - Bounded `cross_batch_db_lock.acquire()` to 300s; fail fast and retry instead of hanging behind a fossil lock.
  - Wired a consumer for `connector_hierarchy_fetching` in the heavy worker (supervisord + Helm) so enqueued tasks are processed.
  - Set `expires` (`BEAT_EXPIRES_DEFAULT`) on hierarchy fan-out tasks to stop unbounded growth if consumption stalls.

<sup>Written for commit 7aae11ebadaf09f39f57fd992acfccb6ff146d73. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

