### PR TITLE
refactor(llm): split LiteLLM model-map lookups out of llm/utils

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -40,7 +40,7 @@ from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
 from onyx.llm.interfaces import ToolChoiceOptions
-from onyx.llm.utils import is_true_openai_model
+from onyx.llm.model_capabilities import is_true_openai_model
 from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER
 from onyx.prompts.chat_prompts import OPEN_URL_REMINDER
 from onyx.prompts.prompt_utils import substitute_user_placeholders

--- a/backend/onyx/db/image_generation.py
+++ b/backend/onyx/db/image_generation.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from onyx.db.models import ImageGenerationConfig
 from onyx.db.models import LLMProvider
 from onyx.db.models import ModelConfiguration
-from onyx.llm.utils import get_max_input_tokens
+from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -32,8 +32,8 @@ from onyx.deep_research.utils import check_special_tool_calls
 from onyx.deep_research.utils import create_think_tool_token_processor
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.model_capabilities import model_is_reasoning_model
 from onyx.llm.models import ToolChoiceOptions
-from onyx.llm.utils import model_is_reasoning_model
 from onyx.prompts.deep_research.orchestration_layer import CLARIFICATION_PROMPT
 from onyx.prompts.deep_research.orchestration_layer import FINAL_REPORT_PROMPT
 from onyx.prompts.deep_research.orchestration_layer import FIRST_CYCLE_REMINDER

--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -1,0 +1,460 @@
+"""Capability and token-limit lookups backed by the LiteLLM model map.
+
+This module is deliberately lightweight to import: no DB / SQLAlchemy
+dependencies, and `litellm` itself is only imported lazily at call time.
+Keep it that way — API schema modules (e.g. `onyx.server.manage.llm.models`)
+import from here at module scope.
+
+Helpers that layer DB or `LLMProviderView` lookups on top of these live in
+`onyx.llm.utils`.
+"""
+
+import copy
+import re
+import threading
+import time
+from functools import lru_cache
+from typing import Any
+from typing import cast
+
+from onyx.configs.model_configs import GEN_AI_MAX_TOKENS
+from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+from onyx.configs.model_configs import GEN_AI_NUM_RESERVED_OUTPUT_TOKENS
+from onyx.llm.constants import BEDROCK_MODEL_TOKEN_LIMITS
+from onyx.llm.constants import LlmProviderNames
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+_TWELVE_LABS_PEGASUS_MODEL_NAMES = [
+    "us.twelvelabs.pegasus-1-2-v1:0",
+    "us.twelvelabs.pegasus-1-2-v1",
+    "twelvelabs/us.twelvelabs.pegasus-1-2-v1:0",
+    "twelvelabs/us.twelvelabs.pegasus-1-2-v1",
+]
+_TWELVE_LABS_PEGASUS_OUTPUT_TOKENS = max(512, GEN_AI_MODEL_FALLBACK_MAX_TOKENS // 4)
+CUSTOM_LITELLM_MODEL_OVERRIDES: dict[str, dict[str, Any]] = {
+    model_name: {
+        "max_input_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+        "max_output_tokens": _TWELVE_LABS_PEGASUS_OUTPUT_TOKENS,
+        "max_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+        "supports_reasoning": False,
+        "supports_vision": False,
+    }
+    for model_name in _TWELVE_LABS_PEGASUS_MODEL_NAMES
+}
+
+
+@lru_cache(maxsize=1)  # the copy.deepcopy is expensive, so we cache the result
+def get_model_map() -> dict:
+    import litellm
+
+    DIVIDER = "/"
+
+    original_map = cast(dict[str, dict], litellm.model_cost)
+    starting_map = copy.deepcopy(original_map)
+    for key in original_map:
+        if DIVIDER in key:
+            truncated_key = key.split(DIVIDER)[-1]
+            # make sure not to overwrite an original key
+            if truncated_key in original_map:
+                continue
+
+            # if there are multiple possible matches, choose the most "detailed"
+            # one as a heuristic. "detailed" = the description of the model
+            # has the most filled out fields.
+            existing_truncated_value = starting_map.get(truncated_key)
+            potential_truncated_value = original_map[key]
+            if not existing_truncated_value or len(potential_truncated_value) > len(
+                existing_truncated_value
+            ):
+                starting_map[truncated_key] = potential_truncated_value
+
+    for model_name, model_metadata in CUSTOM_LITELLM_MODEL_OVERRIDES.items():
+        if model_name in starting_map:
+            continue
+        starting_map[model_name] = copy.deepcopy(model_metadata)
+
+    # NOTE: outside of the explicit CUSTOM_LITELLM_MODEL_OVERRIDES,
+    # we avoid hard-coding additional models here. Ollama, for example,
+    # allows the user to specify their desired max context window, and it's
+    # unlikely to be standard across users even for the same model
+    # (it heavily depends on their hardware). For those cases, we rely on
+    # GEN_AI_MODEL_FALLBACK_MAX_TOKENS to cover this.
+    # for model_name in [
+    #     "llama3.2",
+    #     "llama3.2:1b",
+    #     "llama3.2:3b",
+    #     "llama3.2:11b",
+    #     "llama3.2:90b",
+    # ]:
+    #     starting_map[f"ollama/{model_name}"] = {
+    #         "max_tokens": 128000,
+    #         "max_input_tokens": 128000,
+    #         "max_output_tokens": 128000,
+    #     }
+
+    return starting_map
+
+
+def _strip_extra_provider_from_model_name(model_name: str) -> str:
+    return model_name.split("/")[1] if "/" in model_name else model_name
+
+
+def _strip_colon_from_model_name(model_name: str) -> str:
+    return ":".join(model_name.split(":")[:-1]) if ":" in model_name else model_name
+
+
+def find_model_obj(model_map: dict, provider: str, model_name: str) -> dict | None:
+    stripped_model_name = _strip_extra_provider_from_model_name(model_name)
+
+    model_names = [
+        model_name,
+        _strip_extra_provider_from_model_name(model_name),
+        # Remove leading extra provider. Usually for cases where user has a
+        # customer model proxy which appends another prefix
+        # remove :XXXX from the end, if present. Needed for ollama.
+        _strip_colon_from_model_name(model_name),
+        _strip_colon_from_model_name(stripped_model_name),
+    ]
+
+    # Filter out None values and deduplicate model names
+    filtered_model_names = [name for name in model_names if name]
+
+    # First try all model names with provider prefix
+    for model_name in filtered_model_names:
+        model_obj = model_map.get(f"{provider}/{model_name}")
+        if model_obj:
+            return model_obj
+
+    # Then try all model names without provider prefix
+    for model_name in filtered_model_names:
+        model_obj = model_map.get(model_name)
+        if model_obj:
+            return model_obj
+
+    return None
+
+
+def llm_max_input_tokens(
+    model_map: dict,
+    model_name: str,
+    model_provider: str,
+) -> int:
+    """Best effort attempt to get the max input tokens for the LLM."""
+    if GEN_AI_MAX_TOKENS:
+        # This is an override, so always return this
+        logger.info("Using override GEN_AI_MAX_TOKENS: %s", GEN_AI_MAX_TOKENS)
+        return GEN_AI_MAX_TOKENS
+
+    model_obj = find_model_obj(
+        model_map,
+        model_provider,
+        model_name,
+    )
+    if not model_obj:
+        logger.warning(
+            "Model '%s' not found in LiteLLM. Falling back to %s tokens.",
+            model_name,
+            GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+        )
+        return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+
+    max_input_tokens = model_obj.get("max_input_tokens")
+    if max_input_tokens is not None:
+        return max_input_tokens
+
+    max_tokens = model_obj.get("max_tokens")
+    if max_tokens is not None:
+        return max_tokens
+
+    logger.warning(
+        "No max tokens found for '%s'. Falling back to %s tokens.",
+        model_name,
+        GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+    )
+    return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+
+
+def get_llm_max_output_tokens(
+    model_map: dict,
+    model_name: str,
+    model_provider: str,
+) -> int:
+    """Best effort attempt to get the max output tokens for the LLM."""
+    default_output_tokens = int(GEN_AI_MODEL_FALLBACK_MAX_TOKENS)
+
+    model_obj = model_map.get(f"{model_provider}/{model_name}")
+    if not model_obj:
+        model_obj = model_map.get(model_name)
+
+    if not model_obj:
+        logger.warning(
+            "Model '%s' not found in LiteLLM. Falling back to %s output tokens.",
+            model_name,
+            default_output_tokens,
+        )
+        return default_output_tokens
+
+    max_output_tokens = model_obj.get("max_output_tokens")
+    if max_output_tokens is not None:
+        return max_output_tokens
+
+    # Fallback to a fraction of max_tokens if max_output_tokens is not specified
+    max_tokens = model_obj.get("max_tokens")
+    if max_tokens is not None:
+        return int(max_tokens * 0.1)
+
+    logger.warning(
+        "No max output tokens found for '%s'. Falling back to %s output tokens.",
+        model_name,
+        default_output_tokens,
+    )
+    return default_output_tokens
+
+
+def get_max_input_tokens(
+    model_name: str,
+    model_provider: str,
+    output_tokens: int = GEN_AI_NUM_RESERVED_OUTPUT_TOKENS,
+) -> int:
+    # NOTE: we previously used `litellm.get_max_tokens()`, but despite the name, this actually
+    # returns the max OUTPUT tokens. Under the hood, this uses the `litellm.model_cost` dict,
+    # and there is no other interface to get what we want. This should be okay though, since the
+    # `model_cost` dict is a named public interface:
+    # https://litellm.vercel.app/docs/completion/token_usage#7-model_cost
+    # model_map is  litellm.model_cost
+    litellm_model_map = get_model_map()
+
+    input_toks = (
+        llm_max_input_tokens(
+            model_name=model_name,
+            model_provider=model_provider,
+            model_map=litellm_model_map,
+        )
+        - output_tokens
+    )
+
+    if input_toks <= 0:
+        return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+
+    return input_toks
+
+
+def get_bedrock_token_limit(model_id: str) -> int:
+    """Look up token limit for a Bedrock model.
+
+    AWS Bedrock API doesn't expose token limits directly. This function
+    attempts to determine the limit from multiple sources.
+
+    Lookup order:
+    1. Parse from model ID suffix (e.g., ":200k" → 200000)
+    2. Check LiteLLM's model_cost dictionary
+    3. Fall back to our hardcoded BEDROCK_MODEL_TOKEN_LIMITS mapping
+    4. Default to 32000 if not found anywhere
+    """
+    model_id_lower = model_id.lower()
+
+    # 1. Try to parse context length from model ID suffix
+    # Format: "model-name:version:NNNk" where NNN is the context length in thousands
+    # Examples: ":200k", ":128k", ":1000k", ":8k", ":4k"
+    context_match = re.search(r":(\d+)k\b", model_id_lower)
+    if context_match:
+        return int(context_match.group(1)) * 1000
+
+    # 2. Check LiteLLM's model_cost dictionary
+    try:
+        model_map = get_model_map()
+        # Try with bedrock/ prefix first, then without
+        for key in [f"bedrock/{model_id}", model_id]:
+            if key in model_map:
+                model_info = model_map[key]
+                max_input_tokens = model_info.get("max_input_tokens")
+                if max_input_tokens is not None:
+                    return max_input_tokens
+                max_tokens = model_info.get("max_tokens")
+                if max_tokens is not None:
+                    return max_tokens
+    except Exception:
+        pass  # Fall through to mapping
+
+    # 3. Try our hardcoded mapping (longest match first)
+    for pattern, limit in sorted(
+        BEDROCK_MODEL_TOKEN_LIMITS.items(), key=lambda x: -len(x[0])
+    ):
+        if pattern in model_id_lower:
+            return limit
+
+    # 4. Default fallback
+    return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+
+
+def litellm_thinks_model_supports_image_input(
+    model_name: str, model_provider: str
+) -> bool:
+    """Generally should call `model_supports_image_input` unless you already know that
+    `model_supports_image_input` from the DB is not set OR you need to avoid the performance
+    hit of querying the DB."""
+    try:
+        model_obj = find_model_obj(get_model_map(), model_provider, model_name)
+        if not model_obj:
+            logger.warning(
+                "No litellm entry found for %s/%s, this model may or may not support image input.",
+                model_provider,
+                model_name,
+            )
+            return False
+        # The or False here is because sometimes the dict contains the key but the value is None
+        return model_obj.get("supports_vision", False) or False
+    except Exception:
+        logger.exception(
+            "Failed to get model object for %s/%s", model_provider, model_name
+        )
+        return False
+
+
+_REASONING_PROBE_FAILURE_TTL_SECONDS = 300
+
+# keyed per (tenant, model): tenants can define the same custom model name for
+# different models, so probe results must never cross tenant boundaries.
+# (result, expires_at): None expiry = permanent probe result (static metadata);
+# float = failure placeholder that re-probes once the TTL passes
+_LITELLM_SUPPORTS_REASONING_CACHE: dict[str, tuple[bool, float | None]] = {}
+
+# per-(tenant, model) locks so concurrent cold misses probe once; a single
+# shared lock would serialize unrelated models behind one slow host
+_REASONING_PROBE_LOCKS: dict[str, threading.Lock] = {}
+_REASONING_PROBE_LOCKS_GUARD = threading.Lock()
+
+
+def _reasoning_cache_key(full_model_name: str) -> str:
+    return f"{get_current_tenant_id()}:{full_model_name}"
+
+
+def _cached_reasoning_result(cache_key: str) -> bool | None:
+    entry = _LITELLM_SUPPORTS_REASONING_CACHE.get(cache_key)
+    if entry is None:
+        return None
+    result, expires_at = entry
+    if expires_at is None or time.monotonic() < expires_at:
+        return result
+    return None
+
+
+def _litellm_supports_reasoning(full_model_name: str) -> bool:
+    """Single-flight, process-lifetime, tenant-scoped cache around
+    litellm.supports_reasoning, which can fetch model info over the network
+    (e.g. Ollama hosts). Successful probes cache permanently; failures cache as
+    False with a short TTL so an unreachable host isn't probed per-request but
+    recovers without a restart (a stuck False silently downgrades reasoning
+    models)."""
+    cache_key = _reasoning_cache_key(full_model_name)
+    cached = _cached_reasoning_result(cache_key)
+    if cached is not None:
+        return cached
+
+    with _REASONING_PROBE_LOCKS_GUARD:
+        key_lock = _REASONING_PROBE_LOCKS.setdefault(cache_key, threading.Lock())
+
+    with key_lock:
+        cached = _cached_reasoning_result(cache_key)
+        if cached is not None:
+            return cached
+
+        import litellm
+
+        expires_at = None
+        try:
+            result = bool(litellm.supports_reasoning(model=full_model_name))
+        except Exception:
+            logger.exception(
+                "Failed to check if %s supports reasoning", full_model_name
+            )
+            result = False
+            expires_at = time.monotonic() + _REASONING_PROBE_FAILURE_TTL_SECONDS
+        _LITELLM_SUPPORTS_REASONING_CACHE[cache_key] = (result, expires_at)
+        return result
+
+
+def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
+    model_map = get_model_map()
+    try:
+        model_obj = find_model_obj(
+            model_map,
+            model_provider,
+            model_name,
+        )
+        if model_obj and "supports_reasoning" in model_obj:
+            reasoning = model_obj["supports_reasoning"]
+            if reasoning is not None:
+                return reasoning
+            logger.error(
+                "Cannot find reasoning for name=%s and provider=%s",
+                model_name,
+                model_provider,
+            )
+
+        # Fallback for newer models missing from the local model map
+        full_model_name = (
+            f"{model_provider}/{model_name}"
+            if model_provider not in model_name
+            else model_name
+        )
+        return _litellm_supports_reasoning(full_model_name)
+
+    except Exception:
+        logger.exception(
+            "Failed to get model object for %s/%s", model_provider, model_name
+        )
+        return False
+
+
+def is_true_openai_model(model_provider: str, model_name: str) -> bool:
+    """
+    Determines if a model is a true OpenAI model or just using OpenAI-compatible API.
+
+    LiteLLM uses the "openai" provider for any OpenAI-compatible server (e.g. vLLM, LiteLLM proxy),
+    but this function checks if the model is actually from OpenAI's model registry.
+
+    This function is used primarily to determine if we should use the responses API.
+    OpenAI models from OpenAI and Azure should use responses.
+    """
+
+    if model_provider not in {
+        LlmProviderNames.OPENAI,
+        LlmProviderNames.LITELLM_PROXY,
+        LlmProviderNames.AZURE,
+    }:
+        return False
+
+    model_map = get_model_map()
+
+    def _check_if_model_name_is_openai_provider(model_name: str) -> bool:
+        if model_name not in model_map:
+            return False
+        return model_map[model_name].get("litellm_provider") == LlmProviderNames.OPENAI
+
+    try:
+        # Check if any model exists in litellm's registry with openai prefix
+        # If it's registered as "openai/model-name", it's a real OpenAI model
+        if f"{LlmProviderNames.OPENAI}/{model_name}" in model_map:
+            return True
+
+        if _check_if_model_name_is_openai_provider(model_name):
+            return True
+
+        if model_name.startswith(f"{LlmProviderNames.AZURE}/"):
+            model_name_with_azure_removed = "/".join(model_name.split("/")[1:])
+            if _check_if_model_name_is_openai_provider(model_name_with_azure_removed):
+                return True
+
+        return False
+
+    except Exception:
+        logger.exception(
+            "Failed to determine if %s/%s is a true OpenAI model",
+            model_provider,
+            model_name,
+        )
+        return False

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -25,6 +25,8 @@ from onyx.llm.interfaces import LLMConfig
 from onyx.llm.interfaces import LLMUserIdentity
 from onyx.llm.interfaces import ReasoningEffort
 from onyx.llm.interfaces import ToolChoiceOptions
+from onyx.llm.model_capabilities import is_true_openai_model
+from onyx.llm.model_capabilities import model_is_reasoning_model
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.model_response import ModelResponseStream
 from onyx.llm.model_response import Usage
@@ -33,8 +35,6 @@ from onyx.llm.models import ANTHROPIC_REASONING_EFFORT_BUDGET
 from onyx.llm.models import OPENAI_REASONING_EFFORT
 from onyx.llm.request_context import get_llm_mock_response
 from onyx.llm.utils import build_litellm_passthrough_kwargs
-from onyx.llm.utils import is_true_openai_model
-from onyx.llm.utils import model_is_reasoning_model
 from onyx.llm.well_known_providers.constants import AWS_ACCESS_KEY_ID_KWARG
 from onyx.llm.well_known_providers.constants import (
     AWS_ACCESS_KEY_ID_KWARG_ENV_VAR_FORMAT,

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -1,12 +1,8 @@
 import copy
 import re
-import threading
-import time
 from collections.abc import Callable
 from collections.abc import Iterable
-from functools import lru_cache
 from typing import Any
-from typing import cast
 from typing import TYPE_CHECKING
 
 from sqlalchemy import select
@@ -16,23 +12,20 @@ from onyx.configs.app_configs import MAX_TOKENS_FOR_FULL_INCLUSION
 from onyx.configs.app_configs import SEND_USER_METADATA_TO_LLM_PROVIDER
 from onyx.configs.app_configs import USE_CHUNK_SUMMARY
 from onyx.configs.app_configs import USE_DOCUMENT_SUMMARY
-from onyx.configs.model_configs import GEN_AI_MAX_TOKENS
-from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
-from onyx.configs.model_configs import GEN_AI_NUM_RESERVED_OUTPUT_TOKENS
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.models import LLMProvider
 from onyx.db.models import ModelConfiguration
-from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.model_capabilities import get_max_input_tokens
+from onyx.llm.model_capabilities import litellm_thinks_model_supports_image_input
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.models import UserMessage
 from onyx.prompts.contextual_retrieval import CONTEXTUAL_RAG_TOKEN_ESTIMATE
 from onyx.prompts.contextual_retrieval import DOCUMENT_SUMMARY_TOKEN_ESTIMATE
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import DOC_EMBEDDING_CONTEXT_SIZE
-from shared_configs.contextvars import get_current_tenant_id
 
 if TYPE_CHECKING:
     from onyx.server.manage.llm.models import LLMProviderView
@@ -44,23 +37,6 @@ MAX_CONTEXT_TOKENS = 100
 ONE_MILLION = 1_000_000
 CHUNKS_PER_DOC_ESTIMATE = 5
 MAX_LITELLM_USER_ID_LENGTH = 64
-_TWELVE_LABS_PEGASUS_MODEL_NAMES = [
-    "us.twelvelabs.pegasus-1-2-v1:0",
-    "us.twelvelabs.pegasus-1-2-v1",
-    "twelvelabs/us.twelvelabs.pegasus-1-2-v1:0",
-    "twelvelabs/us.twelvelabs.pegasus-1-2-v1",
-]
-_TWELVE_LABS_PEGASUS_OUTPUT_TOKENS = max(512, GEN_AI_MODEL_FALLBACK_MAX_TOKENS // 4)
-CUSTOM_LITELLM_MODEL_OVERRIDES: dict[str, dict[str, Any]] = {
-    model_name: {
-        "max_input_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
-        "max_output_tokens": _TWELVE_LABS_PEGASUS_OUTPUT_TOKENS,
-        "max_tokens": GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
-        "supports_reasoning": False,
-        "supports_vision": False,
-    }
-    for model_name in _TWELVE_LABS_PEGASUS_MODEL_NAMES
-}
 
 
 def truncate_litellm_user_id(user_id: str) -> str:
@@ -448,97 +424,6 @@ def test_llm(llm: LLM) -> str | None:
     return error_msg
 
 
-@lru_cache(maxsize=1)  # the copy.deepcopy is expensive, so we cache the result
-def get_model_map() -> dict:
-    import litellm
-
-    DIVIDER = "/"
-
-    original_map = cast(dict[str, dict], litellm.model_cost)
-    starting_map = copy.deepcopy(original_map)
-    for key in original_map:
-        if DIVIDER in key:
-            truncated_key = key.split(DIVIDER)[-1]
-            # make sure not to overwrite an original key
-            if truncated_key in original_map:
-                continue
-
-            # if there are multiple possible matches, choose the most "detailed"
-            # one as a heuristic. "detailed" = the description of the model
-            # has the most filled out fields.
-            existing_truncated_value = starting_map.get(truncated_key)
-            potential_truncated_value = original_map[key]
-            if not existing_truncated_value or len(potential_truncated_value) > len(
-                existing_truncated_value
-            ):
-                starting_map[truncated_key] = potential_truncated_value
-
-    for model_name, model_metadata in CUSTOM_LITELLM_MODEL_OVERRIDES.items():
-        if model_name in starting_map:
-            continue
-        starting_map[model_name] = copy.deepcopy(model_metadata)
-
-    # NOTE: outside of the explicit CUSTOM_LITELLM_MODEL_OVERRIDES,
-    # we avoid hard-coding additional models here. Ollama, for example,
-    # allows the user to specify their desired max context window, and it's
-    # unlikely to be standard across users even for the same model
-    # (it heavily depends on their hardware). For those cases, we rely on
-    # GEN_AI_MODEL_FALLBACK_MAX_TOKENS to cover this.
-    # for model_name in [
-    #     "llama3.2",
-    #     "llama3.2:1b",
-    #     "llama3.2:3b",
-    #     "llama3.2:11b",
-    #     "llama3.2:90b",
-    # ]:
-    #     starting_map[f"ollama/{model_name}"] = {
-    #         "max_tokens": 128000,
-    #         "max_input_tokens": 128000,
-    #         "max_output_tokens": 128000,
-    #     }
-
-    return starting_map
-
-
-def _strip_extra_provider_from_model_name(model_name: str) -> str:
-    return model_name.split("/")[1] if "/" in model_name else model_name
-
-
-def _strip_colon_from_model_name(model_name: str) -> str:
-    return ":".join(model_name.split(":")[:-1]) if ":" in model_name else model_name
-
-
-def find_model_obj(model_map: dict, provider: str, model_name: str) -> dict | None:
-    stripped_model_name = _strip_extra_provider_from_model_name(model_name)
-
-    model_names = [
-        model_name,
-        _strip_extra_provider_from_model_name(model_name),
-        # Remove leading extra provider. Usually for cases where user has a
-        # customer model proxy which appends another prefix
-        # remove :XXXX from the end, if present. Needed for ollama.
-        _strip_colon_from_model_name(model_name),
-        _strip_colon_from_model_name(stripped_model_name),
-    ]
-
-    # Filter out None values and deduplicate model names
-    filtered_model_names = [name for name in model_names if name]
-
-    # First try all model names with provider prefix
-    for model_name in filtered_model_names:
-        model_obj = model_map.get(f"{provider}/{model_name}")
-        if model_obj:
-            return model_obj
-
-    # Then try all model names without provider prefix
-    for model_name in filtered_model_names:
-        model_obj = model_map.get(model_name)
-        if model_obj:
-            return model_obj
-
-    return None
-
-
 def get_llm_contextual_cost(
     llm: LLM,
 ) -> float:
@@ -615,111 +500,6 @@ def get_llm_contextual_cost(
     return usd_per_prompt + usd_per_completion
 
 
-def llm_max_input_tokens(
-    model_map: dict,
-    model_name: str,
-    model_provider: str,
-) -> int:
-    """Best effort attempt to get the max input tokens for the LLM."""
-    if GEN_AI_MAX_TOKENS:
-        # This is an override, so always return this
-        logger.info("Using override GEN_AI_MAX_TOKENS: %s", GEN_AI_MAX_TOKENS)
-        return GEN_AI_MAX_TOKENS
-
-    model_obj = find_model_obj(
-        model_map,
-        model_provider,
-        model_name,
-    )
-    if not model_obj:
-        logger.warning(
-            "Model '%s' not found in LiteLLM. Falling back to %s tokens.",
-            model_name,
-            GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
-        )
-        return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
-
-    max_input_tokens = model_obj.get("max_input_tokens")
-    if max_input_tokens is not None:
-        return max_input_tokens
-
-    max_tokens = model_obj.get("max_tokens")
-    if max_tokens is not None:
-        return max_tokens
-
-    logger.warning(
-        "No max tokens found for '%s'. Falling back to %s tokens.",
-        model_name,
-        GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
-    )
-    return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
-
-
-def get_llm_max_output_tokens(
-    model_map: dict,
-    model_name: str,
-    model_provider: str,
-) -> int:
-    """Best effort attempt to get the max output tokens for the LLM."""
-    default_output_tokens = int(GEN_AI_MODEL_FALLBACK_MAX_TOKENS)
-
-    model_obj = model_map.get(f"{model_provider}/{model_name}")
-    if not model_obj:
-        model_obj = model_map.get(model_name)
-
-    if not model_obj:
-        logger.warning(
-            "Model '%s' not found in LiteLLM. Falling back to %s output tokens.",
-            model_name,
-            default_output_tokens,
-        )
-        return default_output_tokens
-
-    max_output_tokens = model_obj.get("max_output_tokens")
-    if max_output_tokens is not None:
-        return max_output_tokens
-
-    # Fallback to a fraction of max_tokens if max_output_tokens is not specified
-    max_tokens = model_obj.get("max_tokens")
-    if max_tokens is not None:
-        return int(max_tokens * 0.1)
-
-    logger.warning(
-        "No max output tokens found for '%s'. Falling back to %s output tokens.",
-        model_name,
-        default_output_tokens,
-    )
-    return default_output_tokens
-
-
-def get_max_input_tokens(
-    model_name: str,
-    model_provider: str,
-    output_tokens: int = GEN_AI_NUM_RESERVED_OUTPUT_TOKENS,
-) -> int:
-    # NOTE: we previously used `litellm.get_max_tokens()`, but despite the name, this actually
-    # returns the max OUTPUT tokens. Under the hood, this uses the `litellm.model_cost` dict,
-    # and there is no other interface to get what we want. This should be okay though, since the
-    # `model_cost` dict is a named public interface:
-    # https://litellm.vercel.app/docs/completion/token_usage#7-model_cost
-    # model_map is  litellm.model_cost
-    litellm_model_map = get_model_map()
-
-    input_toks = (
-        llm_max_input_tokens(
-            model_name=model_name,
-            model_provider=model_provider,
-            model_map=litellm_model_map,
-        )
-        - output_tokens
-    )
-
-    if input_toks <= 0:
-        return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
-
-    return input_toks
-
-
 def get_max_input_tokens_from_llm_provider(
     llm_provider: "LLMProviderView",
     model_name: str,
@@ -749,56 +529,6 @@ def get_max_input_tokens_from_llm_provider(
             model_name=model_name,
         )
     )
-
-
-def get_bedrock_token_limit(model_id: str) -> int:
-    """Look up token limit for a Bedrock model.
-
-    AWS Bedrock API doesn't expose token limits directly. This function
-    attempts to determine the limit from multiple sources.
-
-    Lookup order:
-    1. Parse from model ID suffix (e.g., ":200k" → 200000)
-    2. Check LiteLLM's model_cost dictionary
-    3. Fall back to our hardcoded BEDROCK_MODEL_TOKEN_LIMITS mapping
-    4. Default to 32000 if not found anywhere
-    """
-    from onyx.llm.constants import BEDROCK_MODEL_TOKEN_LIMITS
-
-    model_id_lower = model_id.lower()
-
-    # 1. Try to parse context length from model ID suffix
-    # Format: "model-name:version:NNNk" where NNN is the context length in thousands
-    # Examples: ":200k", ":128k", ":1000k", ":8k", ":4k"
-    context_match = re.search(r":(\d+)k\b", model_id_lower)
-    if context_match:
-        return int(context_match.group(1)) * 1000
-
-    # 2. Check LiteLLM's model_cost dictionary
-    try:
-        model_map = get_model_map()
-        # Try with bedrock/ prefix first, then without
-        for key in [f"bedrock/{model_id}", model_id]:
-            if key in model_map:
-                model_info = model_map[key]
-                max_input_tokens = model_info.get("max_input_tokens")
-                if max_input_tokens is not None:
-                    return max_input_tokens
-                max_tokens = model_info.get("max_tokens")
-                if max_tokens is not None:
-                    return max_tokens
-    except Exception:
-        pass  # Fall through to mapping
-
-    # 3. Try our hardcoded mapping (longest match first)
-    for pattern, limit in sorted(
-        BEDROCK_MODEL_TOKEN_LIMITS.items(), key=lambda x: -len(x[0])
-    ):
-        if pattern in model_id_lower:
-            return limit
-
-    # 4. Default fallback
-    return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 
 
 def model_supports_image_input(model_name: str, model_provider: str) -> bool:
@@ -831,176 +561,6 @@ def model_supports_image_input(model_name: str, model_provider: str) -> bool:
 
     # Fallback to looking up the model in the litellm model_cost dict
     return litellm_thinks_model_supports_image_input(model_name, model_provider)
-
-
-def litellm_thinks_model_supports_image_input(
-    model_name: str, model_provider: str
-) -> bool:
-    """Generally should call `model_supports_image_input` unless you already know that
-    `model_supports_image_input` from the DB is not set OR you need to avoid the performance
-    hit of querying the DB."""
-    try:
-        model_obj = find_model_obj(get_model_map(), model_provider, model_name)
-        if not model_obj:
-            logger.warning(
-                "No litellm entry found for %s/%s, this model may or may not support image input.",
-                model_provider,
-                model_name,
-            )
-            return False
-        # The or False here is because sometimes the dict contains the key but the value is None
-        return model_obj.get("supports_vision", False) or False
-    except Exception:
-        logger.exception(
-            "Failed to get model object for %s/%s", model_provider, model_name
-        )
-        return False
-
-
-_REASONING_PROBE_FAILURE_TTL_SECONDS = 300
-
-# keyed per (tenant, model): tenants can define the same custom model name for
-# different models, so probe results must never cross tenant boundaries.
-# (result, expires_at): None expiry = permanent probe result (static metadata);
-# float = failure placeholder that re-probes once the TTL passes
-_LITELLM_SUPPORTS_REASONING_CACHE: dict[str, tuple[bool, float | None]] = {}
-
-# per-(tenant, model) locks so concurrent cold misses probe once; a single
-# shared lock would serialize unrelated models behind one slow host
-_REASONING_PROBE_LOCKS: dict[str, threading.Lock] = {}
-_REASONING_PROBE_LOCKS_GUARD = threading.Lock()
-
-
-def _reasoning_cache_key(full_model_name: str) -> str:
-    return f"{get_current_tenant_id()}:{full_model_name}"
-
-
-def _cached_reasoning_result(cache_key: str) -> bool | None:
-    entry = _LITELLM_SUPPORTS_REASONING_CACHE.get(cache_key)
-    if entry is None:
-        return None
-    result, expires_at = entry
-    if expires_at is None or time.monotonic() < expires_at:
-        return result
-    return None
-
-
-def _litellm_supports_reasoning(full_model_name: str) -> bool:
-    """Single-flight, process-lifetime, tenant-scoped cache around
-    litellm.supports_reasoning, which can fetch model info over the network
-    (e.g. Ollama hosts). Successful probes cache permanently; failures cache as
-    False with a short TTL so an unreachable host isn't probed per-request but
-    recovers without a restart (a stuck False silently downgrades reasoning
-    models)."""
-    cache_key = _reasoning_cache_key(full_model_name)
-    cached = _cached_reasoning_result(cache_key)
-    if cached is not None:
-        return cached
-
-    with _REASONING_PROBE_LOCKS_GUARD:
-        key_lock = _REASONING_PROBE_LOCKS.setdefault(cache_key, threading.Lock())
-
-    with key_lock:
-        cached = _cached_reasoning_result(cache_key)
-        if cached is not None:
-            return cached
-
-        import litellm
-
-        expires_at = None
-        try:
-            result = bool(litellm.supports_reasoning(model=full_model_name))
-        except Exception:
-            logger.exception(
-                "Failed to check if %s supports reasoning", full_model_name
-            )
-            result = False
-            expires_at = time.monotonic() + _REASONING_PROBE_FAILURE_TTL_SECONDS
-        _LITELLM_SUPPORTS_REASONING_CACHE[cache_key] = (result, expires_at)
-        return result
-
-
-def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
-    model_map = get_model_map()
-    try:
-        model_obj = find_model_obj(
-            model_map,
-            model_provider,
-            model_name,
-        )
-        if model_obj and "supports_reasoning" in model_obj:
-            reasoning = model_obj["supports_reasoning"]
-            if reasoning is not None:
-                return reasoning
-            logger.error(
-                "Cannot find reasoning for name=%s and provider=%s",
-                model_name,
-                model_provider,
-            )
-
-        # Fallback for newer models missing from the local model map
-        full_model_name = (
-            f"{model_provider}/{model_name}"
-            if model_provider not in model_name
-            else model_name
-        )
-        return _litellm_supports_reasoning(full_model_name)
-
-    except Exception:
-        logger.exception(
-            "Failed to get model object for %s/%s", model_provider, model_name
-        )
-        return False
-
-
-def is_true_openai_model(model_provider: str, model_name: str) -> bool:
-    """
-    Determines if a model is a true OpenAI model or just using OpenAI-compatible API.
-
-    LiteLLM uses the "openai" provider for any OpenAI-compatible server (e.g. vLLM, LiteLLM proxy),
-    but this function checks if the model is actually from OpenAI's model registry.
-
-    This function is used primarily to determine if we should use the responses API.
-    OpenAI models from OpenAI and Azure should use responses.
-    """
-
-    if model_provider not in {
-        LlmProviderNames.OPENAI,
-        LlmProviderNames.LITELLM_PROXY,
-        LlmProviderNames.AZURE,
-    }:
-        return False
-
-    model_map = get_model_map()
-
-    def _check_if_model_name_is_openai_provider(model_name: str) -> bool:
-        if model_name not in model_map:
-            return False
-        return model_map[model_name].get("litellm_provider") == LlmProviderNames.OPENAI
-
-    try:
-        # Check if any model exists in litellm's registry with openai prefix
-        # If it's registered as "openai/model-name", it's a real OpenAI model
-        if f"{LlmProviderNames.OPENAI}/{model_name}" in model_map:
-            return True
-
-        if _check_if_model_name_is_openai_provider(model_name):
-            return True
-
-        if model_name.startswith(f"{LlmProviderNames.AZURE}/"):
-            model_name_with_azure_removed = "/".join(model_name.split("/")[1:])
-            if _check_if_model_name_is_openai_provider(model_name_with_azure_removed):
-                return True
-
-        return False
-
-    except Exception:
-        logger.exception(
-            "Failed to determine if %s/%s is a true OpenAI model",
-            model_provider,
-            model_name,
-        )
-        return False
 
 
 def model_needs_formatting_reenabled(model_name: str) -> bool:

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -6,7 +6,7 @@ import time
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.constants import PROVIDER_DISPLAY_NAMES
 from onyx.llm.constants import WELL_KNOWN_PROVIDER_NAMES
-from onyx.llm.utils import get_max_input_tokens
+from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.llm.well_known_providers.auto_update_service import (

--- a/backend/onyx/server/manage/image_generation/api.py
+++ b/backend/onyx/server/manage/image_generation/api.py
@@ -20,7 +20,7 @@ from onyx.image_gen.exceptions import ImageProviderCredentialsError
 from onyx.image_gen.factory import get_image_generation_provider
 from onyx.image_gen.factory import validate_credentials
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
-from onyx.llm.utils import get_max_input_tokens
+from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.server.manage.image_generation.models import ImageGenerationConfigCreate
 from onyx.server.manage.image_generation.models import ImageGenerationConfigUpdate
 from onyx.server.manage.image_generation.models import ImageGenerationConfigView

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -50,10 +50,10 @@ from onyx.llm.constants import WELL_KNOWN_PROVIDER_NAMES
 from onyx.llm.factory import get_default_llm
 from onyx.llm.factory import get_llm
 from onyx.llm.factory import get_max_input_tokens_from_llm_provider
-from onyx.llm.utils import get_bedrock_token_limit
+from onyx.llm.model_capabilities import get_bedrock_token_limit
+from onyx.llm.model_capabilities import litellm_thinks_model_supports_image_input
 from onyx.llm.utils import get_llm_contextual_cost
 from onyx.llm.utils import is_sensitive_custom_config_key
-from onyx.llm.utils import litellm_thinks_model_supports_image_input
 from onyx.llm.utils import test_llm
 from onyx.llm.well_known_providers.auto_update_service import (
     fetch_llm_recommendations_from_github,

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -11,9 +11,9 @@ from pydantic import Field
 from pydantic import field_validator
 
 from onyx.db.enums import LLMModelFlowType
-from onyx.llm.utils import get_max_input_tokens
-from onyx.llm.utils import litellm_thinks_model_supports_image_input
-from onyx.llm.utils import model_is_reasoning_model
+from onyx.llm.model_capabilities import get_max_input_tokens
+from onyx.llm.model_capabilities import litellm_thinks_model_supports_image_input
+from onyx.llm.model_capabilities import model_is_reasoning_model
 from onyx.server.manage.llm.utils import DYNAMIC_LLM_PROVIDERS
 from onyx.server.manage.llm.utils import extract_vendor_from_model_name
 from onyx.server.manage.llm.utils import filter_model_configurations

--- a/backend/onyx/tools/fake_tools/coding_agent.py
+++ b/backend/onyx/tools/fake_tools/coding_agent.py
@@ -23,9 +23,9 @@ from onyx.deep_research.dr_mock_tools import THINK_TOOL_RESPONSE_TOKEN_COUNT
 from onyx.deep_research.utils import create_think_tool_token_processor
 from onyx.llm.interfaces import LLM
 from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.model_capabilities import model_is_reasoning_model
 from onyx.llm.models import ReasoningEffort
 from onyx.llm.models import ToolChoiceOptions
-from onyx.llm.utils import model_is_reasoning_model
 from onyx.prompts.coding_agent.coding_agent import CODING_AGENT_FINAL_ANSWER_PROMPT
 from onyx.prompts.coding_agent.coding_agent import CODING_AGENT_PROMPT
 from onyx.prompts.coding_agent.coding_agent import CODING_AGENT_PROMPT_REASONING

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -730,7 +730,7 @@ if __name__ == "__main__":
     from onyx.db.persona import get_default_behavior_persona
     from onyx.llm.factory import get_default_llm
     from onyx.llm.factory import get_llm_token_counter
-    from onyx.llm.utils import model_is_reasoning_model
+    from onyx.llm.model_capabilities import model_is_reasoning_model
     from onyx.server.query_and_chat.placement import Placement
     from onyx.tools.models import ToolCallKickoff
     from onyx.tools.tool_constructor import construct_tools

--- a/backend/onyx/tools/utils.py
+++ b/backend/onyx/tools/utils.py
@@ -9,8 +9,8 @@ from onyx.db.connector import check_connectors_exist
 from onyx.db.document import check_docs_exist
 from onyx.db.models import LLMProvider
 from onyx.llm.constants import LlmProviderNames
-from onyx.llm.utils import find_model_obj
-from onyx.llm.utils import get_model_map
+from onyx.llm.model_capabilities import find_model_obj
+from onyx.llm.model_capabilities import get_model_map
 from onyx.tools.interface import Tool
 
 

--- a/backend/tests/integration/tests/llm_provider/test_llm_provider.py
+++ b/backend/tests/integration/tests/llm_provider/test_llm_provider.py
@@ -5,10 +5,10 @@ import httpx
 import pytest
 
 from onyx.llm.constants import LlmProviderNames
+from onyx.llm.model_capabilities import get_max_input_tokens
+from onyx.llm.model_capabilities import litellm_thinks_model_supports_image_input
+from onyx.llm.model_capabilities import model_is_reasoning_model
 from onyx.llm.model_name_parser import parse_litellm_model_name
-from onyx.llm.utils import get_max_input_tokens
-from onyx.llm.utils import litellm_thinks_model_supports_image_input
-from onyx.llm.utils import model_is_reasoning_model
 from onyx.llm.well_known_providers.llm_provider_options import (
     fetch_default_model_for_provider,
 )

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -29,10 +29,10 @@ from onyx.indexing.indexing_pipeline import filter_documents
 from onyx.indexing.indexing_pipeline import get_docs_to_update
 from onyx.indexing.indexing_pipeline import process_image_sections
 from onyx.llm.constants import LlmProviderNames
+from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.llm.model_response import Choice
 from onyx.llm.model_response import Message
 from onyx.llm.model_response import ModelResponse
-from onyx.llm.utils import get_max_input_tokens
 
 
 def create_test_document(
@@ -165,7 +165,7 @@ def test_filter_documents_empty_batch() -> None:
     assert len(failures) == 0
 
 
-@patch("onyx.llm.utils.GEN_AI_MAX_TOKENS", 4096)
+@patch("onyx.llm.model_capabilities.GEN_AI_MAX_TOKENS", 4096)
 @pytest.mark.parametrize("enable_contextual_rag", [True, False])
 def test_contextual_rag(
     embedder: DefaultIndexingEmbedder, enable_contextual_rag: bool

--- a/backend/tests/unit/onyx/llm/test_bedrock_token_limit.py
+++ b/backend/tests/unit/onyx/llm/test_bedrock_token_limit.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import patch
 
-from onyx.llm.utils import get_bedrock_token_limit
+from onyx.llm.model_capabilities import get_bedrock_token_limit
 
 
 class TestGetBedrockTokenLimit:
@@ -33,28 +33,34 @@ class TestGetBedrockTokenLimit:
         mock_model_map = {
             "bedrock/anthropic.claude-3-5-sonnet": {"max_input_tokens": 200000}
         }
-        with patch("onyx.llm.utils.get_model_map", return_value=mock_model_map):
+        with patch(
+            "onyx.llm.model_capabilities.get_model_map", return_value=mock_model_map
+        ):
             result = get_bedrock_token_limit("anthropic.claude-3-5-sonnet")
             assert result == 200000
 
     def test_litellm_lookup_without_prefix(self) -> None:
         """Test LiteLLM lookup works without bedrock/ prefix."""
         mock_model_map = {"anthropic.claude-3-sonnet": {"max_input_tokens": 200000}}
-        with patch("onyx.llm.utils.get_model_map", return_value=mock_model_map):
+        with patch(
+            "onyx.llm.model_capabilities.get_model_map", return_value=mock_model_map
+        ):
             result = get_bedrock_token_limit("anthropic.claude-3-sonnet")
             assert result == 200000
 
     def test_litellm_max_tokens_fallback(self) -> None:
         """Test fallback to max_tokens when max_input_tokens not present."""
         mock_model_map = {"bedrock/some-model": {"max_tokens": 32000}}
-        with patch("onyx.llm.utils.get_model_map", return_value=mock_model_map):
+        with patch(
+            "onyx.llm.model_capabilities.get_model_map", return_value=mock_model_map
+        ):
             result = get_bedrock_token_limit("some-model")
             assert result == 32000
 
     def test_hardcoded_mapping_claude_3_5(self) -> None:
         """Test hardcoded mapping for Claude 3.5 models."""
         # Mock empty LiteLLM to force mapping lookup
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit(
                 "anthropic.claude-3-5-sonnet-20241022-v2:0"
             )
@@ -62,38 +68,38 @@ class TestGetBedrockTokenLimit:
 
     def test_hardcoded_mapping_llama3_3(self) -> None:
         """Test hardcoded mapping for Llama 3.3 models (128K context)."""
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit("meta.llama3-3-70b-instruct-v1:0")
             assert result == 128000
 
     def test_hardcoded_mapping_llama3_70b(self) -> None:
         """Test hardcoded mapping for Llama 3 70B (8K context)."""
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit("meta.llama3-70b-instruct-v1:0")
             assert result == 8000
 
     def test_hardcoded_mapping_nova_pro(self) -> None:
         """Test hardcoded mapping for Nova Pro."""
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit("amazon.nova-pro-v1:0")
             assert result == 300000
 
     def test_hardcoded_mapping_mistral_large(self) -> None:
         """Test hardcoded mapping for Mistral Large."""
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit("mistral.mistral-large-2407-v1:0")
             assert result == 128000
 
     def test_default_fallback_unknown_model(self) -> None:
         """Test default fallback for unknown models."""
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit("unknown.model-v1:0")
             # Should fall back to GEN_AI_MODEL_FALLBACK_MAX_TOKENS (32000)
             assert result == 32000
 
     def test_cross_region_model_id(self) -> None:
         """Test cross-region model ID (us.anthropic.claude-...)."""
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit(
                 "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
             )
@@ -101,14 +107,16 @@ class TestGetBedrockTokenLimit:
 
     def test_case_insensitive_matching(self) -> None:
         """Test that matching is case-insensitive."""
-        with patch("onyx.llm.utils.get_model_map", return_value={}):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
             result = get_bedrock_token_limit("ANTHROPIC.CLAUDE-3-5-SONNET")
             assert result == 200000
 
     def test_suffix_takes_priority_over_litellm(self) -> None:
         """Test that :NNNk suffix takes priority over LiteLLM."""
         mock_model_map = {"bedrock/model": {"max_input_tokens": 50000}}
-        with patch("onyx.llm.utils.get_model_map", return_value=mock_model_map):
+        with patch(
+            "onyx.llm.model_capabilities.get_model_map", return_value=mock_model_map
+        ):
             # The :100k suffix should be used, not the LiteLLM value
             result = get_bedrock_token_limit("model:100k")
             assert result == 100000
@@ -116,7 +124,8 @@ class TestGetBedrockTokenLimit:
     def test_litellm_exception_falls_through(self) -> None:
         """Test that LiteLLM exceptions fall through to mapping."""
         with patch(
-            "onyx.llm.utils.get_model_map", side_effect=Exception("LiteLLM error")
+            "onyx.llm.model_capabilities.get_model_map",
+            side_effect=Exception("LiteLLM error"),
         ):
             # Should still work via hardcoded mapping
             result = get_bedrock_token_limit("anthropic.claude-3-5-sonnet")

--- a/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
+++ b/backend/tests/unit/onyx/llm/test_model_is_reasoning.py
@@ -1,8 +1,8 @@
 import litellm
 import pytest
 
-from onyx.llm import utils
-from onyx.llm.utils import model_is_reasoning_model
+from onyx.llm import model_capabilities
+from onyx.llm.model_capabilities import model_is_reasoning_model
 
 
 def test_model_is_reasoning_model() -> None:
@@ -47,7 +47,7 @@ def test_litellm_fallback_is_memoized(monkeypatch: pytest.MonkeyPatch) -> None:
         return True
 
     monkeypatch.setattr(litellm, "supports_reasoning", fake_supports_reasoning)
-    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+    monkeypatch.setattr(model_capabilities, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
 
     assert model_is_reasoning_model("not-in-map-model", "fakeprov") is True
     assert model_is_reasoning_model("not-in-map-model", "fakeprov") is True
@@ -71,8 +71,8 @@ def test_litellm_fallback_failure_cached_with_ttl(
 
     fake_now = 1000.0
     monkeypatch.setattr(litellm, "supports_reasoning", flaky_supports_reasoning)
-    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
-    monkeypatch.setattr(utils.time, "monotonic", lambda: fake_now)
+    monkeypatch.setattr(model_capabilities, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+    monkeypatch.setattr(model_capabilities.time, "monotonic", lambda: fake_now)
 
     # failure cached: second call within TTL does not re-probe
     assert model_is_reasoning_model("unreachable-model", "fakeprov") is False
@@ -80,7 +80,7 @@ def test_litellm_fallback_failure_cached_with_ttl(
     assert len(calls) == 1
 
     # past the TTL, a recovered host is re-probed and the result is permanent
-    fake_now += utils._REASONING_PROBE_FAILURE_TTL_SECONDS + 1
+    fake_now += model_capabilities._REASONING_PROBE_FAILURE_TTL_SECONDS + 1
     should_raise = False
     assert model_is_reasoning_model("unreachable-model", "fakeprov") is True
     assert model_is_reasoning_model("unreachable-model", "fakeprov") is True
@@ -101,8 +101,8 @@ def test_concurrent_cold_misses_probe_once(monkeypatch: pytest.MonkeyPatch) -> N
         return True
 
     monkeypatch.setattr(litellm, "supports_reasoning", slow_supports_reasoning)
-    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
-    monkeypatch.setattr(utils, "_REASONING_PROBE_LOCKS", {})
+    monkeypatch.setattr(model_capabilities, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+    monkeypatch.setattr(model_capabilities, "_REASONING_PROBE_LOCKS", {})
 
     results: list[bool] = []
     threads = [
@@ -135,9 +135,11 @@ def test_probe_results_are_tenant_scoped(monkeypatch: pytest.MonkeyPatch) -> Non
         return answers[current_tenant]
 
     monkeypatch.setattr(litellm, "supports_reasoning", per_tenant_supports_reasoning)
-    monkeypatch.setattr(utils, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
-    monkeypatch.setattr(utils, "_REASONING_PROBE_LOCKS", {})
-    monkeypatch.setattr(utils, "get_current_tenant_id", lambda: current_tenant)
+    monkeypatch.setattr(model_capabilities, "_LITELLM_SUPPORTS_REASONING_CACHE", {})
+    monkeypatch.setattr(model_capabilities, "_REASONING_PROBE_LOCKS", {})
+    monkeypatch.setattr(
+        model_capabilities, "get_current_tenant_id", lambda: current_tenant
+    )
 
     assert model_is_reasoning_model("shared-name-model", "fakeprov") is True
 

--- a/backend/tests/unit/onyx/llm/test_model_map.py
+++ b/backend/tests/unit/onyx/llm/test_model_map.py
@@ -4,9 +4,9 @@ import litellm
 
 from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
 from onyx.llm.constants import LlmProviderNames
-from onyx.llm.utils import find_model_obj
-from onyx.llm.utils import get_model_map
-from onyx.llm.utils import model_is_reasoning_model
+from onyx.llm.model_capabilities import find_model_obj
+from onyx.llm.model_capabilities import get_model_map
+from onyx.llm.model_capabilities import model_is_reasoning_model
 
 
 def test_partial_match_in_model_map() -> None:

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -15,6 +15,7 @@ import onyx.llm.models
 from onyx.configs.app_configs import MOCK_LLM_RESPONSE
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLMUserIdentity
+from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.model_response import ModelResponseStream
 from onyx.llm.models import AssistantMessage
@@ -27,7 +28,6 @@ from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import _parse_anthropic_model_version
 from onyx.llm.multi_llm import LitellmLLM
 from onyx.llm.multi_llm import temporary_env_and_lock
-from onyx.llm.utils import get_max_input_tokens
 
 VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG = [
     "claude-opus-4-5@20251101",

--- a/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
+++ b/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
@@ -1,12 +1,12 @@
-"""Tests for the token-limit lookup helpers in `onyx.llm.utils`:
+"""Tests for the token-limit lookup helpers in `onyx.llm.model_capabilities`:
 `llm_max_input_tokens`, `get_llm_max_output_tokens`, and `get_max_input_tokens`."""
 
 from unittest.mock import patch
 
 from onyx.configs.model_configs import GEN_AI_MODEL_FALLBACK_MAX_TOKENS
-from onyx.llm.utils import get_llm_max_output_tokens
-from onyx.llm.utils import get_max_input_tokens
-from onyx.llm.utils import llm_max_input_tokens
+from onyx.llm.model_capabilities import get_llm_max_output_tokens
+from onyx.llm.model_capabilities import get_max_input_tokens
+from onyx.llm.model_capabilities import llm_max_input_tokens
 
 
 class TestLlmMaxInputTokens:
@@ -89,7 +89,7 @@ class TestLlmMaxInputTokens:
 
     def test_override_env_var_wins(self) -> None:
         model_map = {"openai/gpt-4o": {"max_input_tokens": 128000}}
-        with patch("onyx.llm.utils.GEN_AI_MAX_TOKENS", 5000):
+        with patch("onyx.llm.model_capabilities.GEN_AI_MAX_TOKENS", 5000):
             assert (
                 llm_max_input_tokens(
                     model_map=model_map,
@@ -174,7 +174,7 @@ class TestGetLlmMaxOutputTokens:
 class TestGetMaxInputTokens:
     def test_subtracts_reserved_output_tokens(self) -> None:
         model_map = {"openai/gpt-4o": {"max_input_tokens": 128000}}
-        with patch("onyx.llm.utils.get_model_map", return_value=model_map):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
             assert (
                 get_max_input_tokens(
                     model_name="gpt-4o",
@@ -186,7 +186,7 @@ class TestGetMaxInputTokens:
 
     def test_non_positive_budget_falls_back(self) -> None:
         model_map = {"tiny/model": {"max_input_tokens": 100}}
-        with patch("onyx.llm.utils.get_model_map", return_value=model_map):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
             assert (
                 get_max_input_tokens(
                     model_name="model",
@@ -205,7 +205,7 @@ class TestGetMaxInputTokens:
                 "max_tokens": None,
             }
         }
-        with patch("onyx.llm.utils.get_model_map", return_value=model_map):
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value=model_map):
             result = get_max_input_tokens(
                 model_name="gpt-oss:20b-cloud",
                 model_provider="ollama_chat",

--- a/backend/tests/unit/onyx/llm/test_true_openai_model.py
+++ b/backend/tests/unit/onyx/llm/test_true_openai_model.py
@@ -1,6 +1,6 @@
 from onyx.llm.constants import LlmProviderNames
-from onyx.llm.utils import get_model_map
-from onyx.llm.utils import is_true_openai_model
+from onyx.llm.model_capabilities import get_model_map
+from onyx.llm.model_capabilities import is_true_openai_model
 
 
 class TestIsTrueOpenAIModel:


### PR DESCRIPTION
## Description

`onyx/llm/utils.py` imports `sqlalchemy` and the full `onyx.db.models` ORM registry at module scope, so the pure-Pydantic schema module `onyx/server/manage/llm/models.py` pulled the ORM in at import time just to call capability lookups (`get_max_input_tokens`, `litellm_thinks_model_supports_image_input`, `model_is_reasoning_model`). The two modules also formed an import cycle, held apart only by a `TYPE_CHECKING` back-import.

This PR moves the whole LiteLLM model-map family into a new, import-light `onyx/llm/model_capabilities.py`:

- `get_model_map` (+ `CUSTOM_LITELLM_MODEL_OVERRIDES`), `find_model_obj` and its name-strip helpers
- token-limit lookups: `llm_max_input_tokens`, `get_llm_max_output_tokens`, `get_max_input_tokens`, `get_bedrock_token_limit`
- capability checks: `litellm_thinks_model_supports_image_input`, `model_is_reasoning_model` (+ the tenant-scoped reasoning-probe cache), `is_true_openai_model`

The new module has no DB/SQLAlchemy imports, and `litellm` remains lazily imported at call time. Function bodies are moved verbatim. The DB-backed `model_supports_image_input` and view-typed `get_max_input_tokens_from_llm_provider` stay in `llm/utils.py` and call into the new module.

Result:

```
>>> import onyx.server.manage.llm.models
sqlalchemy loaded: False
litellm loaded: False
onyx.db.models loaded: False
```

and the `models.py ⇄ llm/utils.py` cycle is gone (`models.py` no longer imports `llm/utils.py` at all).

## How Has This Been Tested?

- `pytest tests/unit/onyx/llm tests/unit/onyx/server/manage/llm tests/unit/onyx/indexing/test_indexing_pipeline.py tests/unit/onyx/db/test_llm_sync.py tests/unit/onyx/server/features/build/session/test_get_all_build_mode_llm_configs.py` — 509 passed (mock patch targets updated to the new module path)
- `pre-commit` (ruff, ruff format, ty, lazy-import check) passes on all changed files
- Import-weight check above + full `import onyx.main` smoke test

## Backporting (check the box to trigger backporting)

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split LiteLLM model-map and capability lookups into a new import‑light module to remove DB import side effects and break the `models.py` ⇄ `llm/utils.py` cycle. This speeds up schema imports and keeps capability checks reusable without loading the ORM.

- **Refactors**
  - Added `onyx/llm/model_capabilities.py` with no DB imports; `litellm` stays lazily imported.
  - Moved model‑map and capability helpers (token limits incl. Bedrock lookup, vision/reasoning checks, `is_true_openai_model`) into the new module.
  - Kept DB-backed `model_supports_image_input` and `get_max_input_tokens_from_llm_provider` in `llm/utils.py`, now delegating to the new module.
  - Updated call sites and tests to import from `onyx.llm.model_capabilities`.
  - Importing `onyx.server.manage.llm.models` no longer loads `sqlalchemy`, `litellm`, or `onyx.db.models`.

- **Migration**
  - Update imports to `onyx.llm.model_capabilities` for: `get_model_map`, `find_model_obj`, `get_max_input_tokens`, `get_llm_max_output_tokens`, `llm_max_input_tokens`, `get_bedrock_token_limit`, `litellm_thinks_model_supports_image_input`, `model_is_reasoning_model`, `is_true_openai_model`.

<sup>Written for commit e35e3eb97c39c0eb93978059e2834984fbf414c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

