### PR TITLE
feat(opal): add logout variant and onClick to AuthLayouts.Submit

### DIFF
--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -115,13 +115,20 @@ function Fields({ children }: FieldsProps) {
 // Submit — full-width submit button
 // ---------------------------------------------------------------------------
 
-type SubmitLabel = "submit" | "create" | "join" | "reset" | "impersonate";
+type SubmitLabel =
+  | "submit"
+  | "create"
+  | "join"
+  | "reset"
+  | "impersonate"
+  | "logout";
 
 interface SubmitProps {
   label: SubmitLabel;
   isSubmitting?: boolean;
   isValid?: boolean;
   dirty?: boolean;
+  onClick?: () => void;
 }
 
 const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
@@ -130,13 +137,15 @@ const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
   join: "Join",
   reset: "Reset Password",
   impersonate: "Impersonate",
+  logout: "Sign Out",
 };
 
-function Submit({ label, isSubmitting, isValid, dirty }: SubmitProps) {
+function Submit({ label, isSubmitting, isValid, dirty, onClick }: SubmitProps) {
   return (
     <Button
-      type="submit"
+      type={onClick ? "button" : "submit"}
       width="full"
+      onClick={onClick}
       disabled={
         Boolean(isSubmitting) ||
         (isValid !== undefined && !isValid) ||

--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -129,7 +129,6 @@ interface SubmitProps {
   isValid?: boolean;
   dirty?: boolean;
   onClick?: () => void;
-  type?: "submit" | "button";
 }
 
 const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
@@ -141,17 +140,10 @@ const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
   logout: "Sign Out",
 };
 
-function Submit({
-  label,
-  isSubmitting,
-  isValid,
-  dirty,
-  onClick,
-  type = "submit",
-}: SubmitProps) {
+function Submit({ label, isSubmitting, isValid, dirty, onClick }: SubmitProps) {
   return (
     <Button
-      type={type}
+      type="submit"
       width="full"
       onClick={onClick}
       disabled={

--- a/web/lib/opal/src/layouts/auth/components.tsx
+++ b/web/lib/opal/src/layouts/auth/components.tsx
@@ -129,6 +129,7 @@ interface SubmitProps {
   isValid?: boolean;
   dirty?: boolean;
   onClick?: () => void;
+  type?: "submit" | "button";
 }
 
 const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
@@ -140,10 +141,17 @@ const SUBMIT_LABEL_TEXT: Record<SubmitLabel, string> = {
   logout: "Sign Out",
 };
 
-function Submit({ label, isSubmitting, isValid, dirty, onClick }: SubmitProps) {
+function Submit({
+  label,
+  isSubmitting,
+  isValid,
+  dirty,
+  onClick,
+  type = "submit",
+}: SubmitProps) {
   return (
     <Button
-      type={onClick ? "button" : "submit"}
+      type={type}
       width="full"
       onClick={onClick}
       disabled={


### PR DESCRIPTION
## Description

Adds a `"logout"` label variant to `AuthLayouts.Submit`:

- Renders as `"Sign Out"` text
- Uses `prominence="secondary"` so it's visually distinct from primary form actions
- Accepts an optional `onClick` prop; when provided, `type` is set to `"button"` to prevent accidental form submission

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `logout` label to `AuthLayouts.Submit` that renders “Sign Out” with secondary prominence. Adds an optional `onClick`; the button is always `type="submit"` (no `type` prop), and `onClick` still fires—if there’s no parent form, submit is a no‑op.

<sup>Written for commit 542d19c148776ddcf311fef08ef497176c942ba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

