### PR TITLE
fix(craft): update image-generation skill description

### DIFF
--- a/backend/alembic/versions/bd38e2a494ff_update_image_generation_skill_.py
+++ b/backend/alembic/versions/bd38e2a494ff_update_image_generation_skill_.py
@@ -1,0 +1,48 @@
+"""update image generation skill description
+
+Revision ID: bd38e2a494ff
+Revises: c7d1f0a4b8e2
+Create Date: 2026-07-14 01:40:41.362266
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "bd38e2a494ff"
+down_revision = "c7d1f0a4b8e2"
+branch_labels = None
+depends_on = None
+
+
+_BUILT_IN_SKILL_ID = "image-generation"
+
+_OLD_DESCRIPTION = "Generate images using nano banana."
+
+_NEW_DESCRIPTION = (
+    "Generate or edit images with onyx-cli using the image generation provider "
+    "configured in Onyx. An admin has to set up a provider at "
+    "/admin/configuration/image-generation before you can use this skill."
+)
+
+_skill_table = sa.table(
+    "skill",
+    sa.column("description", sa.Text),
+    sa.column("built_in_skill_id", sa.String),
+)
+
+
+def _set_description(description: str) -> None:
+    op.get_bind().execute(
+        sa.update(_skill_table)
+        .where(_skill_table.c.built_in_skill_id == _BUILT_IN_SKILL_ID)
+        .values(description=description)
+    )
+
+
+def upgrade() -> None:
+    _set_description(_NEW_DESCRIPTION)
+
+
+def downgrade() -> None:
+    _set_description(_OLD_DESCRIPTION)

--- a/backend/alembic/versions/bd38e2a494ff_update_image_generation_skill_.py
+++ b/backend/alembic/versions/bd38e2a494ff_update_image_generation_skill_.py
@@ -27,6 +27,7 @@ _NEW_DESCRIPTION = (
 
 _skill_table = sa.table(
     "skill",
+    sa.column("slug", sa.String),
     sa.column("description", sa.Text),
     sa.column("built_in_skill_id", sa.String),
 )
@@ -35,6 +36,7 @@ _skill_table = sa.table(
 def _set_description(description: str) -> None:
     op.get_bind().execute(
         sa.update(_skill_table)
+        .where(_skill_table.c.slug == _BUILT_IN_SKILL_ID)
         .where(_skill_table.c.built_in_skill_id == _BUILT_IN_SKILL_ID)
         .values(description=description)
     )

--- a/backend/alembic/versions/bd38e2a494ff_update_image_generation_skill_.py
+++ b/backend/alembic/versions/bd38e2a494ff_update_image_generation_skill_.py
@@ -21,8 +21,7 @@ _OLD_DESCRIPTION = "Generate images using nano banana."
 
 _NEW_DESCRIPTION = (
     "Generate or edit images with onyx-cli using the image generation provider "
-    "configured in Onyx. An admin has to set up a provider at "
-    "/admin/configuration/image-generation before you can use this skill."
+    "configured in Onyx."
 )
 
 _skill_table = sa.table(


### PR DESCRIPTION
## What

Updates the seeded `description` for the built-in `image-generation` Craft skill. The row was seeded with `"Generate images using nano banana."`, which no longer reflects how the skill works: it runs via `onyx-cli` against whichever image generation provider an admin has configured in Onyx.

New description:

> Generate or edit images with onyx-cli using the image generation provider configured in Onyx. An admin has to set up a provider at /admin/configuration/image-generation before you can use this skill.

## Why

The built-in `skill.description` column is the sole source of truth surfaced to users (sandbox `AGENTS.md` skills list, the skills list/detail/preview APIs). Built-in rows are owned by Alembic migrations, so the fix is a new migration that updates that row, matching the pattern established by the original seed migration `7f5b159041be`.

## How it was verified

- Confirmed the stale value originates from the seed migration and that the DB column (not the on-disk `SKILL.md` frontmatter) is what reaches users.
- Confirmed the new migration is the single Alembic head (`down_revision = c7d1f0a4b8e2`).
- Exercised the migration's `upgrade()`/`downgrade()` against a bound connection: only the `image-generation` built-in row changes, custom rows (`built_in_skill_id IS NULL`) are untouched, and `downgrade()` restores the exact prior value.
- `ruff format` + `ruff check` clean; existing skill unit tests pass.

## Known minor items

- The UPDATE does not assert a rowcount; a missing seed row is a silent no-op (intended, keeps the migration idempotent).

Linear: https://linear.app/onyx-app/issue/ENG-4285/update-image-generation-skill-description

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the built-in `image-generation` Craft skill description so it reflects running via `onyx-cli` using the image provider configured in Onyx. Adds a targeted migration to keep user-facing guidance accurate (ENG-4285).

- **Migration**
  - Updates only the canonical built-in `image-generation` row by matching `slug` and `built_in_skill_id`; custom skills are untouched; no-op if the seed row is missing.
  - Sets the new text to describe `onyx-cli` using the configured provider; downgrade restores the old text.

<sup>Written for commit 84158d943d1e127057b556bb6c24412eec04e095. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12978?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

