### PR TITLE
fix(llm): Use read-write lock when sending calls

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1,13 +1,15 @@
 import copy
 import os
 import re
-import threading
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Any
 from typing import cast
 from typing import TYPE_CHECKING
 from typing import Union
+
+from readerwriterlock import rwlock
 
 from onyx.configs.app_configs import MOCK_LLM_RESPONSE
 from onyx.configs.app_configs import SEND_USER_METADATA_TO_LLM_PROVIDER
@@ -59,11 +61,14 @@ from onyx.llm.well_known_providers.constants import VERTEX_PROJECT_KWARG
 from onyx.utils.encryption import mask_env_value_for_logging
 from onyx.utils.encryption import mask_string
 from onyx.utils.logger import setup_logger
-from onyx.utils.timing import log_generator_function_time
 
 logger = setup_logger()
 
-_env_lock = threading.Lock()
+# Write-preferring reader-writer lock guarding os.environ during litellm calls.
+# Calls that inject custom_config env vars hold the write lock; all other calls
+# hold a read lock so they never observe injected secrets but still run
+# concurrently with each other.
+_env_rwlock = rwlock.RWLockWrite()
 
 if TYPE_CHECKING:
     from litellm import CustomStreamWrapper
@@ -1025,25 +1030,32 @@ class LitellmLLM(LLM):
 
 
 @contextmanager
-@log_generator_function_time()
 def temporary_env_and_lock(env_variables: dict[str, str]) -> Iterator[None]:
     """
-    Temporarily sets the environment variables to the given values.
-    _env_lock is held while the environment variables are set, so no concurrent
-    LLM call can observe them. Then cleans up the environment and releases the
-    lock.
+    Temporarily sets the environment variables to the given values while holding
+    the exclusive write side of _env_rwlock, so no concurrent LLM call can
+    observe them. Then cleans up the environment and releases the lock.
+
+    Calls without env_variables hold the shared read side instead: they run
+    concurrently with each other and only block while a writer has env vars
+    injected.
     """
-    if env_variables:
-        masked_env = {
-            key: mask_env_value_for_logging(key, value)
-            for key, value in env_variables.items()
-        }
-        logger.info(
-            "temporary_env_and_lock setting custom_config env var(s): %s",
-            masked_env,
-        )
-    with _env_lock:
-        logger.debug("Acquired lock in temporary_env_and_lock")
+    if not env_variables:
+        with _env_rwlock.gen_rlock():
+            yield
+        return
+
+    masked_env = {
+        key: mask_env_value_for_logging(key, value)
+        for key, value in env_variables.items()
+    }
+    logger.info(
+        "temporary_env_and_lock setting custom_config env var(s): %s",
+        masked_env,
+    )
+    start_time = time.monotonic()
+    with _env_rwlock.gen_wlock():
+        logger.debug("Acquired env write lock in temporary_env_and_lock")
         # Store original values (None if key didn't exist)
         original_values: dict[str, str | None] = {
             key: os.environ.get(key) for key in env_variables
@@ -1058,4 +1070,7 @@ def temporary_env_and_lock(env_variables: dict[str, str]) -> Iterator[None]:
                 else:
                     os.environ[key] = original_value  # Restore original value
 
-    logger.debug("Released lock in temporary_env_and_lock")
+    logger.info(
+        "temporary_env_and_lock write section took %.3f seconds",
+        time.monotonic() - start_time,
+    )

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -2545,6 +2545,9 @@ rapidfuzz==3.14.5 \
     --hash=sha256:f4c1bca487a17fe4226b4ffb2d30e799d2b274d692cffa76bd0746f56235fca3 \
     --hash=sha256:feedf219672eef83ea6be6f3bb093bba396a8560fc75be85ba225f082903df0a
     # via unstructured
+readerwriterlock==1.0.9 \
+    --hash=sha256:8c4b704e60d15991462081a27ef46762fea49b478aa4426644f2146754759ca7 \
+    --hash=sha256:b7c4cc003435d7a8ff15b312b0a62a88d9800ba6164af88991f87f8b748f9bea
 redis==5.0.8 \
     --hash=sha256:0c5b10d387568dfe0698c6fad6615750c24170e548ca2deac10c649d463e9870 \
     --hash=sha256:56134ee08ea909106090934adc36f65c9bcbbaecea5b21ba704ba6fb561f8eb4
@@ -3032,6 +3035,7 @@ typing-extensions==4.15.0 \
     #   pygithub
     #   python-docx
     #   python-oxmsg
+    #   readerwriterlock
     #   simple-salesforce
     #   sqlalchemy
     #   stripe

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -26,6 +26,7 @@ from onyx.llm.models import ToolChoiceOptions
 from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import _parse_anthropic_model_version
 from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.multi_llm import temporary_env_and_lock
 from onyx.llm.utils import get_max_input_tokens
 
 VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG = [
@@ -1192,8 +1193,9 @@ def test_multithreaded_custom_config_isolation(
     """Verify the env lock prevents concurrent LLM calls from seeing each other's custom_config.
 
     Two LitellmLLM instances with different custom_config dicts call invoke/stream
-    concurrently. The _env_lock in temporary_env_and_lock serializes their access so
-    each call only ever sees its own env vars—never the other's.
+    concurrently. Both hold the exclusive write side of the env rwlock in
+    temporary_env_and_lock, which serializes their access so each call only ever
+    sees its own env vars—never the other's.
     """
     # Ensure these keys start unset
     monkeypatch.delenv("SHARED_KEY", raising=False)
@@ -1312,12 +1314,12 @@ def test_multithreaded_custom_config_isolation(
 
 
 def test_multithreaded_invoke_without_custom_config_does_not_inject_env() -> None:
-    """invoke() without custom_config holds _env_lock but injects no env vars.
+    """invoke() without custom_config takes the shared read lock but injects no env vars.
 
-    Every call goes through temporary_env_and_lock (so it holds the shared
-    _env_lock during its litellm call and can't observe a concurrent
+    Every call goes through temporary_env_and_lock (so it participates in the
+    env rwlock during its litellm call and can't observe a concurrent
     custom_config call's injected secrets). Calls without custom_config pass an
-    empty mapping, so they take the lock but never mutate os.environ.
+    empty mapping, so they take the read lock but never mutate os.environ.
     """
     from onyx.llm import multi_llm as multi_llm_module
 
@@ -1403,6 +1405,84 @@ def test_multithreaded_invoke_without_custom_config_does_not_inject_env() -> Non
     assert mock_env_lock.call_count == 2
     for call in mock_env_lock.call_args_list:
         assert call.args[0] == {}
+
+
+def test_invokes_without_custom_config_run_concurrently() -> None:
+    """Calls without custom_config must not serialize each other.
+
+    They take the shared read side of the env rwlock, so two concurrent
+    invoke() calls run their litellm completions in parallel. Pins the fix for
+    the regression where a global mutex serialized every LLM call in the
+    process (parallel secondary-flow calls ran one at a time).
+    """
+    model_provider = LlmProviderNames.OPENAI
+    model_name = "gpt-3.5-turbo"
+
+    def build_llm(api_key: str) -> LitellmLLM:
+        return LitellmLLM(
+            api_key=api_key,
+            timeout=30,
+            model_provider=model_provider,
+            model_name=model_name,
+            max_input_tokens=get_max_input_tokens(
+                model_provider=model_provider,
+                model_name=model_name,
+            ),
+        )
+
+    llm_a = build_llm("key_a")
+    llm_b = build_llm("key_b")
+
+    mock_stream_chunks = [
+        litellm.ModelResponse(
+            id="chatcmpl-123",
+            choices=[
+                litellm.Choices(
+                    delta=_create_delta(role="assistant", content="Hi"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            model=model_name,
+        ),
+    ]
+
+    a_inside = threading.Event()
+    b_inside = threading.Event()
+
+    def fake_completion(**kwargs: Any) -> list[litellm.ModelResponse]:
+        # Each call waits for the other to also be inside its completion. If
+        # readers were serialized by an exclusive lock, the first call would
+        # time out here because the second could never enter.
+        api_key = kwargs.get("api_key", "")
+        mine, other = (
+            (a_inside, b_inside) if api_key == "key_a" else (b_inside, a_inside)
+        )
+        mine.set()
+        assert other.wait(timeout=5), (
+            "Concurrent no-custom-config calls were serialized by the env lock"
+        )
+        return mock_stream_chunks
+
+    errors: list[Exception] = []
+
+    def run_llm(llm: LitellmLLM) -> None:
+        try:
+            llm.invoke([UserMessage(content="Hi")])
+        except Exception as e:
+            errors.append(e)
+
+    with patch("litellm.completion", side_effect=fake_completion):
+        t_a = threading.Thread(target=run_llm, args=(llm_a,))
+        t_b = threading.Thread(target=run_llm, args=(llm_b,))
+
+        t_a.start()
+        t_b.start()
+        t_a.join(timeout=10)
+        t_b.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert a_inside.is_set() and b_inside.is_set()
 
 
 def test_keyless_reader_cannot_observe_writer_injected_secret(
@@ -1529,6 +1609,244 @@ def test_keyless_reader_cannot_observe_writer_injected_secret(
     # Env fully restored after the writer finished.
     assert os.environ.get("AWS_SECRET_ACCESS_KEY") is None
     assert os.environ.get("AWS_ACCESS_KEY_ID") is None
+
+
+# ---- Tests for temporary_env_and_lock reader/writer permutations ----
+#
+# These exercise the env rwlock directly (no LitellmLLM plumbing) so each
+# reader/writer interleaving is pinned explicitly:
+#   - reader || reader: concurrent
+#   - reader -> writer: writer waits for active readers to drain
+#   - writer -> reader: reader waits for the writer (covered here and by
+#     test_keyless_reader_cannot_observe_writer_injected_secret above)
+#   - reader -> writer -> reader: a reader arriving behind a queued writer
+#     waits for that writer (write preference), then sees a clean env
+#   - writer || writer: mutually exclusive
+#   - exceptions: lock released and env restored on both paths
+
+_ENV_LOCK_TEST_KEY = "ENV_RWLOCK_TEST_KEY"
+
+
+def test_env_lock_many_readers_hold_concurrently() -> None:
+    """All readers must be inside the lock at the same time."""
+    num_readers = 4
+    barrier = threading.Barrier(num_readers)
+    errors: list[Exception] = []
+
+    def reader() -> None:
+        try:
+            with temporary_env_and_lock({}):
+                # Completes only if every reader is inside simultaneously; an
+                # exclusive lock would leave the first reader stuck here until
+                # the barrier times out and breaks.
+                barrier.wait(timeout=5)
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=reader) for _ in range(num_readers)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+
+
+def test_env_lock_writer_waits_for_active_reader(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A writer must block until in-flight readers finish, and readers never
+    observe the writer's env vars."""
+    monkeypatch.delenv(_ENV_LOCK_TEST_KEY, raising=False)
+
+    reader_inside = threading.Event()
+    release_reader = threading.Event()
+    writer_inside = threading.Event()
+    errors: list[Exception] = []
+
+    def reader() -> None:
+        try:
+            with temporary_env_and_lock({}):
+                reader_inside.set()
+                assert release_reader.wait(timeout=5), "reader never released"
+                # Writer is queued but must not have injected env yet.
+                assert os.environ.get(_ENV_LOCK_TEST_KEY) is None
+        except Exception as e:
+            errors.append(e)
+
+    def writer() -> None:
+        try:
+            with temporary_env_and_lock({_ENV_LOCK_TEST_KEY: "writer_value"}):
+                writer_inside.set()
+                assert os.environ.get(_ENV_LOCK_TEST_KEY) == "writer_value"
+        except Exception as e:
+            errors.append(e)
+
+    reader_thread = threading.Thread(target=reader)
+    reader_thread.start()
+    assert reader_inside.wait(timeout=5), "reader never entered"
+
+    writer_thread = threading.Thread(target=writer)
+    writer_thread.start()
+
+    # Writer must stay blocked while the read lock is held.
+    assert not writer_inside.wait(timeout=0.3), (
+        "writer entered while a reader held the lock"
+    )
+
+    release_reader.set()
+    reader_thread.join(timeout=10)
+    writer_thread.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert writer_inside.is_set(), "writer never entered after readers drained"
+    assert os.environ.get(_ENV_LOCK_TEST_KEY) is None
+
+
+def test_env_lock_read_write_read_sequencing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """reader1 -> writer -> reader2: a reader arriving while a writer is queued
+    must wait behind it (write preference, so writers can't starve), and once
+    the writer finishes the late reader sees a clean environment."""
+    monkeypatch.delenv(_ENV_LOCK_TEST_KEY, raising=False)
+
+    r1_inside = threading.Event()
+    release_r1 = threading.Event()
+    writer_inside = threading.Event()
+    release_writer = threading.Event()
+    r2_inside = threading.Event()
+    order: list[str] = []
+    order_lock = threading.Lock()
+    errors: list[Exception] = []
+
+    def record(label: str) -> None:
+        with order_lock:
+            order.append(label)
+
+    def reader1() -> None:
+        try:
+            with temporary_env_and_lock({}):
+                record("r1")
+                r1_inside.set()
+                assert release_r1.wait(timeout=5), "r1 never released"
+        except Exception as e:
+            errors.append(e)
+
+    def writer() -> None:
+        try:
+            with temporary_env_and_lock({_ENV_LOCK_TEST_KEY: "writer_value"}):
+                record("w")
+                writer_inside.set()
+                assert os.environ.get(_ENV_LOCK_TEST_KEY) == "writer_value"
+                assert release_writer.wait(timeout=5), "writer never released"
+        except Exception as e:
+            errors.append(e)
+
+    def reader2() -> None:
+        try:
+            with temporary_env_and_lock({}):
+                record("r2")
+                r2_inside.set()
+                # Writer restored the env before releasing the lock.
+                assert os.environ.get(_ENV_LOCK_TEST_KEY) is None
+        except Exception as e:
+            errors.append(e)
+
+    r1_thread = threading.Thread(target=reader1)
+    r1_thread.start()
+    assert r1_inside.wait(timeout=5), "r1 never entered"
+
+    writer_thread = threading.Thread(target=writer)
+    writer_thread.start()
+    # Let the writer reach the blocked wlock acquisition before r2 arrives.
+    assert not writer_inside.wait(timeout=0.3), "writer entered while r1 held the lock"
+
+    r2_thread = threading.Thread(target=reader2)
+    r2_thread.start()
+    # r2 arrived after the writer queued, so it must wait behind the writer.
+    assert not r2_inside.wait(timeout=0.3), (
+        "late reader jumped ahead of a queued writer"
+    )
+
+    release_r1.set()
+    assert writer_inside.wait(timeout=5), "writer never entered after r1 exited"
+    # While the writer holds the lock, r2 must still be blocked.
+    assert not r2_inside.wait(timeout=0.3), "reader entered during write section"
+
+    release_writer.set()
+    assert r2_inside.wait(timeout=5), "r2 never entered after the writer exited"
+
+    r1_thread.join(timeout=10)
+    writer_thread.join(timeout=10)
+    r2_thread.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert order == ["r1", "w", "r2"]
+    assert os.environ.get(_ENV_LOCK_TEST_KEY) is None
+
+
+def test_env_lock_writers_are_mutually_exclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent writers serialize; each sees only its own env value and the
+    environment is fully restored afterwards."""
+    monkeypatch.delenv(_ENV_LOCK_TEST_KEY, raising=False)
+
+    active = 0
+    max_active = 0
+    counter_lock = threading.Lock()
+    errors: list[Exception] = []
+
+    def writer(value: str) -> None:
+        nonlocal active, max_active
+        try:
+            with temporary_env_and_lock({_ENV_LOCK_TEST_KEY: value}):
+                with counter_lock:
+                    active += 1
+                    max_active = max(max_active, active)
+                assert os.environ.get(_ENV_LOCK_TEST_KEY) == value
+                time.sleep(0.05)
+                assert os.environ.get(_ENV_LOCK_TEST_KEY) == value
+                with counter_lock:
+                    active -= 1
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(f"value_{i}",)) for i in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert max_active == 1, "two writers held the lock at once"
+    assert os.environ.get(_ENV_LOCK_TEST_KEY) is None
+
+
+def test_env_lock_released_and_env_restored_on_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception inside either section releases the lock and, for writers,
+    restores the pre-existing env value."""
+    monkeypatch.setenv(_ENV_LOCK_TEST_KEY, "original")
+
+    with pytest.raises(RuntimeError, match="writer boom"):
+        with temporary_env_and_lock({_ENV_LOCK_TEST_KEY: "writer_value"}):
+            assert os.environ.get(_ENV_LOCK_TEST_KEY) == "writer_value"
+            raise RuntimeError("writer boom")
+    assert os.environ.get(_ENV_LOCK_TEST_KEY) == "original"
+
+    with pytest.raises(RuntimeError, match="reader boom"):
+        with temporary_env_and_lock({}):
+            raise RuntimeError("reader boom")
+
+    # Lock is still usable in both modes afterwards.
+    with temporary_env_and_lock({_ENV_LOCK_TEST_KEY: "writer_value_2"}):
+        assert os.environ.get(_ENV_LOCK_TEST_KEY) == "writer_value_2"
+    assert os.environ.get(_ENV_LOCK_TEST_KEY) == "original"
+    with temporary_env_and_lock({}):
+        assert os.environ.get(_ENV_LOCK_TEST_KEY) == "original"
 
 
 # ---- Tests for Bedrock tool content stripping ----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ backend = [
     "pypdfium2==5.9.0",
     "python-dotenv==1.2.2",
     "pywikibot==11.4.2",
+    "readerwriterlock==1.0.9",
     "redis==5.0.8",
     "requests==2.33.0",
     "requests-oauthlib==2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -4047,7 +4047,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4058,7 +4058,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4085,9 +4085,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4098,7 +4098,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4290,6 +4290,7 @@ backend = [
     { name = "python3-saml" },
     { name = "pywikibot" },
     { name = "rapidfuzz" },
+    { name = "readerwriterlock" },
     { name = "redis" },
     { name = "requests" },
     { name = "requests-oauthlib" },
@@ -4460,6 +4461,7 @@ backend = [
     { name = "python3-saml", specifier = "==1.15.0" },
     { name = "pywikibot", specifier = "==11.4.2" },
     { name = "rapidfuzz", specifier = "==3.14.5" },
+    { name = "readerwriterlock", specifier = "==1.0.9" },
     { name = "redis", specifier = "==5.0.8" },
     { name = "requests", specifier = "==2.33.0" },
     { name = "requests-oauthlib", specifier = "==2.0.0" },
@@ -4898,7 +4900,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6083,6 +6085,18 @@ wheels = [
 ]
 
 [[package]]
+name = "readerwriterlock"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/b9/6b7c390440ec23bf5fdf33e76d6c3b697a788b983c11cb2739d6541835d6/readerwriterlock-1.0.9.tar.gz", hash = "sha256:b7c4cc003435d7a8ff15b312b0a62a88d9800ba6164af88991f87f8b748f9bea", size = 16595, upload-time = "2021-09-06T03:41:21.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/5a/2f2e7fc026d5e64b5408aa3fbe0296a6407b8481196cae4daacacb3a3ae0/readerwriterlock-1.0.9-py3-none-any.whl", hash = "sha256:8c4b704e60d15991462081a27ef46762fea49b478aa4426644f2146754759ca7", size = 9999, upload-time = "2021-09-06T03:41:19.435Z" },
+]
+
+[[package]]
 name = "redis"
 version = "5.0.8"
 source = { registry = "https://pypi.org/simple" }
@@ -6491,8 +6505,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Description
Replaces a straight lock with a read-write lock.
This means that while the env is not being used, we send requests in parallel. When the env wants to be used, we want for all the reads to finish. We then lock while the env is being used. When it is then freed, we can continue sending more requests

## How Has This Been Tested?
Tests + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the global env mutex with a write-preferring read–write lock to let LLM calls without custom_config run in parallel while keeping env injection safe. This removes a serialization bottleneck and prevents env leakage between requests.

- **Bug Fixes**
  - Guard `os.environ` with a write-preferring RW lock during litellm calls.
  - Readers (no custom_config) run concurrently; writers (with custom_config) are isolated and wait for active readers.
  - Added unit tests covering reader/writer interleavings, concurrency for no-config calls, isolation, and exception safety.

- **Dependencies**
  - Added `readerwriterlock==1.0.9` to `backend` (requirements, `pyproject.toml`, and lockfiles).

<sup>Written for commit 0191368d1fc030d5a190b26ea3b78e71c2c152d2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12979?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

