### PR TITLE
feat: open url tool lite mode

### DIFF
--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -572,6 +572,16 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                     sections=[], missing_document_ids=[]
                 )
                 crawled_sections, failed_web_fetches = crawled_result or ([], [])
+
+                if (
+                    timeout_occurred[0]
+                    and not indexed_result.sections
+                    and not crawled_sections
+                ):
+                    return ToolResponse(
+                        rich_response=None,
+                        llm_facing_response="The call to open_url timed out",
+                    )
             else:
                 url_requests, unresolved_urls = _resolve_urls_to_document_ids(
                     urls, db_session
@@ -612,6 +622,17 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                 )
                 crawled_sections, failed_web_fetches = crawled_result or ([], [])
 
+                # Before link-based fallback (retries index retrieval with no timeout).
+                if (
+                    timeout_occurred[0]
+                    and not indexed_result.sections
+                    and not crawled_sections
+                ):
+                    return ToolResponse(
+                        rich_response=None,
+                        llm_facing_response="The call to open_url timed out",
+                    )
+
                 # Last-resort: link-based lookup when doc-ID resolve + crawl both fail.
                 failed_web_fetches = self._fallback_link_lookup(
                     unresolved_urls=unresolved_urls,
@@ -620,16 +641,6 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                     indexed_result=indexed_result,
                     url_to_doc_id=url_to_doc_id,
                     filters=filters,
-                )
-
-            if (
-                timeout_occurred[0]
-                and not indexed_result.sections
-                and not crawled_sections
-            ):
-                return ToolResponse(
-                    rich_response=None,
-                    llm_facing_response="The call to open_url timed out",
                 )
 
             # Prefer indexed when available, else crawled

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -1,7 +1,6 @@
 import json
 from collections import defaultdict
 from typing import Any
-from typing import Callable
 
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
@@ -461,9 +460,10 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
     @override
     @classmethod
     def is_available(cls, db_session: Session) -> bool:  # noqa: ARG003
-        """OpenURLTool is always available.
-        In standard deployments, it uses the vector DB for indexed retrieval and falls back to link-based lookup.
-        In lite deployments, it uses the link-based lookup only.
+        """Always available via the web content provider / built-in crawler.
+
+        Full deployments also try indexed retrieval (+ link-based fallback).
+        Lite (DISABLE_VECTOR_DB) is crawl-only.
         """
         return True
 
@@ -544,52 +544,8 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
         )
 
         with get_session_with_current_tenant() as db_session:
-            # Resolve URLs to document IDs for indexed retrieval
-            # Handles both raw URLs and already-normalized document IDs
-            functions_with_args: list[tuple[Callable, tuple[Any, ...]]] = [
-                (
-                    lambda: self._fetch_web_content(
-                        urls, override_kwargs.url_snippet_map
-                    ),
-                    tuple(),
-                )
-            ]
             url_to_doc_id: dict[str, str] = {}
-            if DISABLE_VECTOR_DB:
-                functions_with_args.append((lambda: None, tuple()))
-                unresolved_urls: list[str] = []
-                filters = None
-            else:
-                url_requests, unresolved_urls = _resolve_urls_to_document_ids(
-                    urls, db_session
-                )
-
-                all_requests = _dedupe_document_requests(url_requests)
-
-                # Create mapping from URL to document_id for result merging
-                for request in url_requests:
-                    if request.original_url:
-                        url_to_doc_id[request.original_url] = request.document_id
-
-                # Build filters before parallel execution (session-safe)
-                filters = self._build_index_filters(db_session)
-
-                # Create wrapper function for parallel execution
-                # Filters are already built, so we just need to pass them
-                def _retrieve_indexed_with_filters(
-                    requests: list[IndexedDocumentRequest],
-                ) -> IndexedRetrievalResult:
-                    """Wrapper for parallel execution with pre-built filters."""
-                    return self._retrieve_indexed_documents_with_filters(
-                        requests, filters
-                    )
-
-                functions_with_args.append(
-                    (lambda: _retrieve_indexed_with_filters(all_requests), tuple())
-                )
-
-            # Track if timeout occurred for error reporting
-            timeout_occurred = [False]  # Using list for mutability in closure
+            timeout_occurred = [False]
 
             def _timeout_handler(
                 index: int,  # noqa: ARG001
@@ -599,24 +555,73 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                 timeout_occurred[0] = True
                 return None
 
-            # Run indexed retrieval and crawling in parallel for all URLs
-            # This allows us to compare results and pick the best representation
-            # Note: allow_failures=True ensures we get partial results even if one
-            # task times out or fails - the other task's results will still be used
-            crawled_result, indexed_result = run_functions_tuples_in_parallel(
-                functions_with_args,
-                allow_failures=True,
-                timeout=OPEN_URL_TIMEOUT_SECONDS,
-                timeout_callback=_timeout_handler,
-            )
+            if DISABLE_VECTOR_DB:
+                # Crawl-only: no indexed retrieval / link-based fallback without a vector DB.
+                crawled_result = run_functions_tuples_in_parallel(
+                    [
+                        (
+                            self._fetch_web_content,
+                            (urls, override_kwargs.url_snippet_map),
+                        )
+                    ],
+                    allow_failures=True,
+                    timeout=OPEN_URL_TIMEOUT_SECONDS,
+                    timeout_callback=_timeout_handler,
+                )[0]
+                indexed_result = IndexedRetrievalResult(
+                    sections=[], missing_document_ids=[]
+                )
+                crawled_sections, failed_web_fetches = crawled_result or ([], [])
+            else:
+                url_requests, unresolved_urls = _resolve_urls_to_document_ids(
+                    urls, db_session
+                )
 
-            indexed_result = indexed_result or IndexedRetrievalResult(
-                sections=[], missing_document_ids=[]
-            )
-            crawled_sections, failed_web_fetches = crawled_result or ([], [])
+                all_requests = _dedupe_document_requests(url_requests)
 
-            # If timeout occurred and we have no successful results from either path,
-            # return a timeout-specific error message
+                for request in url_requests:
+                    if request.original_url:
+                        url_to_doc_id[request.original_url] = request.document_id
+
+                # Build filters before parallel execution (session-safe)
+                filters = self._build_index_filters(db_session)
+
+                def _retrieve_indexed_with_filters(
+                    requests: list[IndexedDocumentRequest],
+                ) -> IndexedRetrievalResult:
+                    return self._retrieve_indexed_documents_with_filters(
+                        requests, filters
+                    )
+
+                # Indexed + crawl in parallel; allow_failures keeps partial results.
+                indexed_result, crawled_result = run_functions_tuples_in_parallel(
+                    [
+                        (_retrieve_indexed_with_filters, (all_requests,)),
+                        (
+                            self._fetch_web_content,
+                            (urls, override_kwargs.url_snippet_map),
+                        ),
+                    ],
+                    allow_failures=True,
+                    timeout=OPEN_URL_TIMEOUT_SECONDS,
+                    timeout_callback=_timeout_handler,
+                )
+
+                indexed_result = indexed_result or IndexedRetrievalResult(
+                    sections=[], missing_document_ids=[]
+                )
+                crawled_sections, failed_web_fetches = crawled_result or ([], [])
+
+                # Last-resort: link-based lookup when doc-ID resolve + crawl both fail.
+                failed_web_fetches = self._fallback_link_lookup(
+                    unresolved_urls=unresolved_urls,
+                    failed_web_fetches=failed_web_fetches,
+                    db_session=db_session,
+                    indexed_result=indexed_result,
+                    url_to_doc_id=url_to_doc_id,
+                    filters=filters,
+                )
+
             if (
                 timeout_occurred[0]
                 and not indexed_result.sections
@@ -627,20 +632,7 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                     llm_facing_response="The call to open_url timed out",
                 )
 
-            if not DISABLE_VECTOR_DB:
-                assert filters is not None  # type checking only
-                # Last-resort: attempt link-based lookup for URLs that failed both
-                # document-ID resolution and crawling.
-                failed_web_fetches = self._fallback_link_lookup(
-                    unresolved_urls=unresolved_urls,
-                    failed_web_fetches=failed_web_fetches,
-                    db_session=db_session,
-                    indexed_result=indexed_result,
-                    url_to_doc_id=url_to_doc_id,
-                    filters=filters,
-                )
-
-            # Merge results: prefer indexed when available, fallback to crawled
+            # Prefer indexed when available, else crawled
             inference_sections = self._merge_indexed_and_crawled_results(
                 indexed_result.sections,
                 crawled_sections,

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -1,12 +1,14 @@
 import json
 from collections import defaultdict
 from typing import Any
+from typing import Callable
 
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from onyx.chat.emitter import Emitter
+from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.context.search.models import IndexFilters
 from onyx.context.search.models import InferenceSection
 from onyx.context.search.models import SearchDocsResponse
@@ -459,19 +461,10 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
     @override
     @classmethod
     def is_available(cls, db_session: Session) -> bool:  # noqa: ARG003
-        """OpenURLTool is available unless the vector DB is disabled.
-
-        The tool uses id_based_retrieval to match URLs to indexed documents,
-        which requires a vector database. When DISABLE_VECTOR_DB is set, the
-        tool is disabled entirely.
+        """OpenURLTool is always available.
+        In standard deployments, it uses the vector DB for indexed retrieval and falls back to link-based lookup.
+        In lite deployments, it uses the link-based lookup only.
         """
-        from onyx.configs.app_configs import DISABLE_VECTOR_DB
-
-        if DISABLE_VECTOR_DB:
-            return False
-
-        # The tool can use either a configured provider or the built-in crawler,
-        # so it's always available when the vector DB is present
         return True
 
     def tool_definition(self) -> dict:
@@ -553,28 +546,47 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
         with get_session_with_current_tenant() as db_session:
             # Resolve URLs to document IDs for indexed retrieval
             # Handles both raw URLs and already-normalized document IDs
-            url_requests, unresolved_urls = _resolve_urls_to_document_ids(
-                urls, db_session
-            )
-
-            all_requests = _dedupe_document_requests(url_requests)
-
-            # Create mapping from URL to document_id for result merging
+            functions_with_args: list[tuple[Callable, tuple[Any, ...]]] = [
+                (
+                    lambda: self._fetch_web_content(
+                        urls, override_kwargs.url_snippet_map
+                    ),
+                    tuple(),
+                )
+            ]
             url_to_doc_id: dict[str, str] = {}
-            for request in url_requests:
-                if request.original_url:
-                    url_to_doc_id[request.original_url] = request.document_id
+            if DISABLE_VECTOR_DB:
+                functions_with_args.append((lambda: None, tuple()))
+                unresolved_urls: list[str] = []
+                filters = None
+            else:
+                url_requests, unresolved_urls = _resolve_urls_to_document_ids(
+                    urls, db_session
+                )
 
-            # Build filters before parallel execution (session-safe)
-            filters = self._build_index_filters(db_session)
+                all_requests = _dedupe_document_requests(url_requests)
 
-            # Create wrapper function for parallel execution
-            # Filters are already built, so we just need to pass them
-            def _retrieve_indexed_with_filters(
-                requests: list[IndexedDocumentRequest],
-            ) -> IndexedRetrievalResult:
-                """Wrapper for parallel execution with pre-built filters."""
-                return self._retrieve_indexed_documents_with_filters(requests, filters)
+                # Create mapping from URL to document_id for result merging
+                for request in url_requests:
+                    if request.original_url:
+                        url_to_doc_id[request.original_url] = request.document_id
+
+                # Build filters before parallel execution (session-safe)
+                filters = self._build_index_filters(db_session)
+
+                # Create wrapper function for parallel execution
+                # Filters are already built, so we just need to pass them
+                def _retrieve_indexed_with_filters(
+                    requests: list[IndexedDocumentRequest],
+                ) -> IndexedRetrievalResult:
+                    """Wrapper for parallel execution with pre-built filters."""
+                    return self._retrieve_indexed_documents_with_filters(
+                        requests, filters
+                    )
+
+                functions_with_args.append(
+                    (lambda: _retrieve_indexed_with_filters(all_requests), tuple())
+                )
 
             # Track if timeout occurred for error reporting
             timeout_occurred = [False]  # Using list for mutability in closure
@@ -591,11 +603,8 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
             # This allows us to compare results and pick the best representation
             # Note: allow_failures=True ensures we get partial results even if one
             # task times out or fails - the other task's results will still be used
-            indexed_result, crawled_result = run_functions_tuples_in_parallel(
-                [
-                    (_retrieve_indexed_with_filters, (all_requests,)),
-                    (self._fetch_web_content, (urls, override_kwargs.url_snippet_map)),
-                ],
+            crawled_result, indexed_result = run_functions_tuples_in_parallel(
+                functions_with_args,
                 allow_failures=True,
                 timeout=OPEN_URL_TIMEOUT_SECONDS,
                 timeout_callback=_timeout_handler,
@@ -618,16 +627,18 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                     llm_facing_response="The call to open_url timed out",
                 )
 
-            # Last-resort: attempt link-based lookup for URLs that failed both
-            # document-ID resolution and crawling.
-            failed_web_fetches = self._fallback_link_lookup(
-                unresolved_urls=unresolved_urls,
-                failed_web_fetches=failed_web_fetches,
-                db_session=db_session,
-                indexed_result=indexed_result,
-                url_to_doc_id=url_to_doc_id,
-                filters=filters,
-            )
+            if not DISABLE_VECTOR_DB:
+                assert filters is not None  # type checking only
+                # Last-resort: attempt link-based lookup for URLs that failed both
+                # document-ID resolution and crawling.
+                failed_web_fetches = self._fallback_link_lookup(
+                    unresolved_urls=unresolved_urls,
+                    failed_web_fetches=failed_web_fetches,
+                    db_session=db_session,
+                    indexed_result=indexed_result,
+                    url_to_doc_id=url_to_doc_id,
+                    filters=filters,
+                )
 
             # Merge results: prefer indexed when available, fallback to crawled
             inference_sections = self._merge_indexed_and_crawled_results(

--- a/backend/tests/unit/onyx/tools/test_construct_tools_no_vectordb.py
+++ b/backend/tests/unit/onyx/tools/test_construct_tools_no_vectordb.py
@@ -2,7 +2,7 @@
 
 Verifies that:
 - SearchTool.is_available() returns False when vector DB is disabled
-- OpenURLTool.is_available() returns False when vector DB is disabled
+- OpenURLTool.is_available() returns True when vector DB is disabled (crawl-only)
 - The force-add SearchTool block is suppressed when DISABLE_VECTOR_DB
 - FileReaderTool.is_available() returns True when vector DB is disabled
 """
@@ -14,6 +14,7 @@ from onyx.tools.tool_implementations.file_reader.file_reader_tool import FileRea
 
 APP_CONFIGS_MODULE = "onyx.configs.app_configs"
 FILE_READER_MODULE = "onyx.tools.tool_implementations.file_reader.file_reader_tool"
+OPEN_URL_MODULE = "onyx.tools.tool_implementations.open_url.open_url_tool"
 
 
 # ------------------------------------------------------------------
@@ -55,13 +56,13 @@ class TestSearchToolAvailability:
 
 
 class TestOpenURLToolAvailability:
-    @patch(f"{APP_CONFIGS_MODULE}.DISABLE_VECTOR_DB", True)
-    def test_unavailable_when_vector_db_disabled(self) -> None:
+    @patch(f"{OPEN_URL_MODULE}.DISABLE_VECTOR_DB", True)
+    def test_available_when_vector_db_disabled(self) -> None:
         from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 
-        assert OpenURLTool.is_available(MagicMock()) is False
+        assert OpenURLTool.is_available(MagicMock()) is True
 
-    @patch(f"{APP_CONFIGS_MODULE}.DISABLE_VECTOR_DB", False)
+    @patch(f"{OPEN_URL_MODULE}.DISABLE_VECTOR_DB", False)
     def test_available_when_vector_db_enabled(self) -> None:
         from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 

--- a/backend/tests/unit/onyx/tools/test_no_vectordb.py
+++ b/backend/tests/unit/onyx/tools/test_no_vectordb.py
@@ -1,7 +1,7 @@
 """Tests for tool availability when DISABLE_VECTOR_DB is True.
 
-Verifies that SearchTool and OpenURLTool report themselves as unavailable
-when the vector DB is disabled, and that FileReaderTool remains available.
+Verifies that SearchTool is unavailable, OpenURLTool stays available
+(crawl-only), and FileReaderTool remains available.
 """
 
 from unittest.mock import MagicMock
@@ -38,16 +38,21 @@ def test_search_tool_available_when_vector_db_enabled(
 
 
 # ------------------------------------------------------------------
-# OpenURLTool
+# OpenURLTool — crawl-only when vector DB is disabled
 # ------------------------------------------------------------------
 
 
-@patch("onyx.configs.app_configs.DISABLE_VECTOR_DB", True)
-def test_open_url_tool_unavailable_when_vector_db_disabled() -> None:
-    from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
+@pytest.mark.parametrize("vector_db_disabled", [True, False])
+def test_open_url_tool_available(vector_db_disabled: bool) -> None:
+    # Patch where it's used — module imports DISABLE_VECTOR_DB by value.
+    with patch(
+        "onyx.tools.tool_implementations.open_url.open_url_tool.DISABLE_VECTOR_DB",
+        vector_db_disabled,
+    ):
+        from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 
-    db_session = MagicMock(spec=Session)
-    assert OpenURLTool.is_available(db_session) is False
+        db_session = MagicMock(spec=Session)
+        assert OpenURLTool.is_available(db_session) is True
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Description

Allow use of the open url tool in lite mode

## How Has This Been Tested?

tested in UI, tests updated

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the `open_url` tool in lite deployments when the vector DB is disabled. The tool is now always available; lite uses web fetch only, while standard mode keeps indexed retrieval + crawl.

- **New Features**
  - `is_available` always returns true; no longer gated by `DISABLE_VECTOR_DB`.
  - Conditional run path: lite is crawl-only; standard runs indexed retrieval and web fetch in parallel.
  - Link-based DB fallback runs only when the vector DB is enabled; results prefer indexed when available.

<sup>Written for commit 4c42f147ecb3354b7e58201fb33314e2f619404e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



