### PR TITLE
feat(reindex-port): paused reporting + Resume in the reindex banner

### DIFF
--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -447,15 +447,24 @@ def _index_user_file_to_secondary(
     """Index one user file into the secondary (reindex-port target) index, re-embedding with
     its model. `index_to_secondary=True` makes the adapter skip the terminal side-effects the
     PRESENT pass already applied. Raises on an incomplete write; the caller owns the flag."""
-    embedder = DefaultIndexingEmbedder.from_db_search_settings(
-        search_settings=secondary,
-    )
-    document_indices = get_all_document_indices(
-        secondary,
-        None,
-        httpx_client=HttpxPool.get("vespa"),
-    )
     with get_session_with_current_tenant() as db_session:
+        # Callers resolve `secondary` in a separate, already-closed session, so it arrives
+        # detached. Re-bind before from_db_search_settings reads its cloud_provider-backed
+        # properties (api_key/api_url/api_version/deployment_name), which would otherwise
+        # lazy-load and raise DetachedInstanceError.
+        bound_secondary = db_session.get(SearchSettings, secondary.id)
+        if bound_secondary is None:
+            raise RuntimeError(
+                f"secondary search settings gone for user file {user_file_id}"
+            )
+        embedder = DefaultIndexingEmbedder.from_db_search_settings(
+            search_settings=bound_secondary,
+        )
+        document_indices = get_all_document_indices(
+            bound_secondary,
+            None,
+            httpx_client=HttpxPool.get("vespa"),
+        )
         adapter = UserFileIndexingAdapter(
             tenant_id=tenant_id,
             db_session=db_session,

--- a/backend/onyx/db/port_attempt.py
+++ b/backend/onyx/db/port_attempt.py
@@ -244,13 +244,15 @@ class ReindexProgressCounts(BaseModel):
     in_progress: int
     completed: int
     failed: int
+    paused: int
 
 
 def get_reindex_progress_counts(
     db_session: Session, search_settings_id: int
 ) -> ReindexProgressCounts:
     """Bucket each in-scope entity (both scopes) by its latest PortAttempt. No attempt /
-    NOT_STARTED / CANCELED → waiting, so the bar never stalls above real remaining work."""
+    NOT_STARTED / CANCELED → waiting; an auto-paused unit is its own `paused` bucket.
+    Buckets partition `total`."""
     cc_pair_ids, user_ids = _reindex_port_scope(db_session, search_settings_id)
     total = len(cc_pair_ids) + len(user_ids)
 
@@ -263,32 +265,36 @@ def get_reindex_progress_counts(
     in_progress = sum(1 for s in statuses if s == PortAttemptStatus.IN_PROGRESS)
     completed = sum(1 for s in statuses if s == PortAttemptStatus.SUCCESS)
     failed = sum(1 for s in statuses if s == PortAttemptStatus.FAILED)
+    paused = sum(1 for s in statuses if s == PortAttemptStatus.PAUSED)
 
     return ReindexProgressCounts(
         total=total,
-        waiting=max(0, total - in_progress - completed - failed),
+        waiting=max(0, total - in_progress - completed - failed - paused),
         in_progress=in_progress,
         completed=completed,
         failed=failed,
+        paused=paused,
     )
 
 
 class ReindexErrorRow(BaseModel):
-    """A failed port unit for the error modal; exactly one of cc_pair_id / user_id set,
-    name = connector name or user email."""
+    """A port unit needing attention (FAILED or PAUSED) for the modal; exactly one of
+    cc_pair_id / user_id set, name = connector name or user email. `paused` = Resume-able."""
 
     scope: PortScope
     cc_pair_id: int | None
     user_id: UUID | None
     name: str
     error_msg: str | None
+    paused: bool
 
 
 def get_reindex_error_rows(
     db_session: Session, search_settings_id: int
 ) -> list[ReindexErrorRow]:
-    """In-scope entities (both scopes) whose latest port attempt is FAILED, with name +
-    error_msg. Same scope/latest-per-entity as get_reindex_progress_counts's `failed`."""
+    """In-scope entities (both scopes) whose latest port attempt is FAILED (auto-retrying)
+    or PAUSED (awaiting operator Resume), with name + error_msg. Same scope/latest-per-entity
+    as get_reindex_progress_counts's `failed` + `paused` buckets."""
     cc_pair_ids, user_ids = _reindex_port_scope(db_session, search_settings_id)
 
     rows: list[ReindexErrorRow] = []
@@ -316,7 +322,7 @@ def get_reindex_error_rows(
                 PortAttempt.id.desc(),
             )
         ):
-            if status == PortAttemptStatus.FAILED:
+            if status in (PortAttemptStatus.FAILED, PortAttemptStatus.PAUSED):
                 rows.append(
                     ReindexErrorRow(
                         scope="connector",
@@ -324,6 +330,7 @@ def get_reindex_error_rows(
                         user_id=None,
                         name=name,
                         error_msg=error_msg,
+                        paused=status == PortAttemptStatus.PAUSED,
                     )
                 )
 
@@ -348,7 +355,7 @@ def get_reindex_error_rows(
                 PortAttempt.id.desc(),
             )
         ):
-            if status == PortAttemptStatus.FAILED:
+            if status in (PortAttemptStatus.FAILED, PortAttemptStatus.PAUSED):
                 rows.append(
                     ReindexErrorRow(
                         scope="user_file",
@@ -356,6 +363,7 @@ def get_reindex_error_rows(
                         user_id=user_id,
                         name=email,
                         error_msg=error_msg,
+                        paused=status == PortAttemptStatus.PAUSED,
                     )
                 )
 

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -322,7 +322,7 @@ def get_reindex_progress(
     target = _active_port_settings(db_session)
     if target is None:
         return ReindexProgressCounts(
-            total=0, waiting=0, in_progress=0, completed=0, failed=0
+            total=0, waiting=0, in_progress=0, completed=0, failed=0, paused=0
         )
     return get_reindex_progress_counts(db_session, target.id)
 

--- a/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
+++ b/backend/tests/external_dependency_unit/db/test_userfile_port_scope.py
@@ -29,6 +29,7 @@ from onyx.db.port_attempt import mark_port_canceled
 from onyx.db.port_attempt import mark_port_failed
 from onyx.db.port_attempt import mark_port_in_progress
 from onyx.db.port_attempt import mark_port_succeeded
+from onyx.db.port_attempt import pause_port_attempt
 from onyx.db.user_file import clear_user_file_reconcile_pending
 from onyx.db.user_file import count_user_files_reconcile_pending
 from onyx.db.user_file import fetch_port_scope_user_ids
@@ -315,6 +316,12 @@ def test_reindex_progress_counts_and_errors_both_scopes(
         mark_port_canceled(
             db_session, create_port_attempt(db_session, cc_canceled.id, ss.id).id
         )
+        cc_paused = make_cc_pair(db_session)  # auto-paused -> paused bucket
+        cc_paused_attempt = create_port_attempt(db_session, cc_paused.id, ss.id)
+        mark_port_failed(
+            db_session, cc_paused_attempt.id, error_msg="connector paused boom"
+        )
+        assert pause_port_attempt(db_session, cc_paused_attempt.id) is True
         cc_pairs = [
             cc_waiting,
             cc_no_attempt,
@@ -322,6 +329,7 @@ def test_reindex_progress_counts_and_errors_both_scopes(
             cc_completed,
             cc_failed,
             cc_canceled,
+            cc_paused,
         ]
 
         # Users (per-user scope; a COMPLETED file puts the user in scope).
@@ -342,36 +350,56 @@ def test_reindex_progress_counts_and_errors_both_scopes(
         )
         u_waiting = create_test_user(db_session, "reindexprog")
         _make_user_file(db_session, u_waiting.id)  # no attempt -> waiting
-        users = [u_completed, u_failed, u_waiting]
+        u_paused = create_test_user(db_session, "reindexprog")
+        _make_user_file(db_session, u_paused.id)
+        u_paused_attempt = create_port_attempt(
+            db_session, None, ss.id, port_user_id=u_paused.id
+        )
+        mark_port_failed(db_session, u_paused_attempt.id, error_msg="user paused boom")
+        assert pause_port_attempt(db_session, u_paused_attempt.id) is True
+        users = [u_completed, u_failed, u_waiting, u_paused]
 
         counts = get_reindex_progress_counts(db_session, ss.id)
         # Exact: only this fresh FUTURE's attempts contribute to these buckets.
         assert counts.in_progress == 1
         assert counts.completed == 2
         assert counts.failed == 2
+        assert counts.paused == 2
         assert (
-            counts.waiting + counts.in_progress + counts.completed + counts.failed
+            counts.waiting
+            + counts.in_progress
+            + counts.completed
+            + counts.failed
+            + counts.paused
             == counts.total
         )
-        assert counts.total >= 9
+        assert counts.total >= 11
         assert counts.waiting >= 4
 
         rows = get_reindex_error_rows(db_session, ss.id)
         by_key = {(r.scope, r.name): r for r in rows}
 
-        assert ("connector", cc_failed.name) in by_key
+        # FAILED rows: paused=False
         conn_row = by_key[("connector", cc_failed.name)]
         assert conn_row.cc_pair_id == cc_failed.id
         assert conn_row.user_id is None
         assert conn_row.error_msg == "connector boom"
+        assert conn_row.paused is False
 
-        assert ("user_file", u_failed.email) in by_key
         user_row = by_key[("user_file", u_failed.email)]
         assert user_row.user_id == u_failed.id
         assert user_row.cc_pair_id is None
         assert user_row.error_msg == "user boom"
+        assert user_row.paused is False
 
-        assert len(rows) == counts.failed == 2
+        # PAUSED rows: paused=True, error_msg kept
+        conn_paused_row = by_key[("connector", cc_paused.name)]
+        assert conn_paused_row.paused is True
+        assert conn_paused_row.error_msg == "connector paused boom"
+        user_paused_row = by_key[("user_file", u_paused.email)]
+        assert user_paused_row.paused is True
+
+        assert len(rows) == counts.failed + counts.paused == 4
     finally:
         db_session.rollback()
         db_session.query(SearchSettings).filter(SearchSettings.id == ss.id).delete(

--- a/web/src/lib/indexing/interfaces.ts
+++ b/web/src/lib/indexing/interfaces.ts
@@ -174,6 +174,7 @@ export interface ReindexProgress {
   in_progress: number;
   completed: number;
   failed: number;
+  paused: number;
 }
 
 /** Mirrors backend `ReindexErrorRow`; exactly one of cc_pair_id / user_id set. */
@@ -183,4 +184,5 @@ export interface ReindexErrorRow {
   user_id: string | null;
   name: string;
   error_msg: string | null;
+  paused: boolean;
 }

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -3,6 +3,7 @@ import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   EmbeddingModel,
   EmbeddingProviderName,
+  ReindexErrorRow,
   SavedSearchSettings,
   SwitchoverType,
 } from "@/lib/indexing/interfaces";
@@ -144,6 +145,36 @@ export async function cancelNewEmbedding(): Promise<Response> {
   return await fetch("/api/search-settings/cancel-new-embedding", {
     method: "POST",
   });
+}
+
+export interface ResumePausedPortResult {
+  /** Resumed, but the queue was down (503) so it starts within minutes, not now. */
+  delayed: boolean;
+}
+
+/**
+ * Resume a paused re-index unit from its cursor. Throws on a hard failure; a 503 is
+ * treated as success-but-delayed (the scheduler re-dispatches it).
+ */
+export async function resumePausedPort(
+  row: Pick<ReindexErrorRow, "cc_pair_id" | "user_id">
+): Promise<ResumePausedPortResult> {
+  const response = await fetch("/api/search-settings/reindex/port/resume", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ cc_pair_id: row.cc_pair_id, user_id: row.user_id }),
+  });
+  if (response.status === 503) {
+    return { delayed: true };
+  }
+  if (!response.ok) {
+    const detail = await response
+      .json()
+      .then((body) => body?.detail as string | undefined)
+      .catch(() => undefined);
+    throw new Error(detail ?? "Failed to resume the paused unit.");
+  }
+  return { delayed: false };
 }
 
 interface SetNewSearchSettingsArgs {

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -163,10 +163,13 @@ export async function resumePausedPort(
     return;
   }
   if (!response.ok) {
-    const detail = await response
-      .json()
-      .then((body) => body?.detail as string | undefined)
-      .catch(() => undefined);
+    let detail: string | undefined;
+    try {
+      detail = ((await response.json()) as { detail?: string }).detail;
+    } catch (e) {
+      // non-JSON error body (e.g. a 502 HTML page): log so the failure is traceable
+      console.error(`resumePausedPort failed (${response.status}):`, e);
+    }
     throw new Error(detail ?? "Failed to resume the paused unit.");
   }
 }

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -147,25 +147,20 @@ export async function cancelNewEmbedding(): Promise<Response> {
   });
 }
 
-export interface ResumePausedPortResult {
-  /** Resumed, but the queue was down (503) so it starts within minutes, not now. */
-  delayed: boolean;
-}
-
 /**
- * Resume a paused re-index unit from its cursor. Throws on a hard failure; a 503 is
- * treated as success-but-delayed (the scheduler re-dispatches it).
+ * Resume a paused re-index unit from its cursor. Throws on a hard failure; a 503
+ * (resumed but the queue is down) is treated as success — the scheduler re-dispatches it.
  */
 export async function resumePausedPort(
   row: Pick<ReindexErrorRow, "cc_pair_id" | "user_id">
-): Promise<ResumePausedPortResult> {
+): Promise<void> {
   const response = await fetch("/api/search-settings/reindex/port/resume", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ cc_pair_id: row.cc_pair_id, user_id: row.user_id }),
   });
   if (response.status === 503) {
-    return { delayed: true };
+    return;
   }
   if (!response.ok) {
     const detail = await response
@@ -174,7 +169,6 @@ export async function resumePausedPort(
       .catch(() => undefined);
     throw new Error(detail ?? "Failed to resume the paused unit.");
   }
-  return { delayed: false };
 }
 
 interface SetNewSearchSettingsArgs {

--- a/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
@@ -1,31 +1,127 @@
+import { useState } from "react";
+import { mutate } from "swr";
 import Modal from "@/refresh-components/Modal";
-import { Table, createTableColumns, Text } from "@opal/components";
-import { SvgAlertCircle } from "@opal/icons";
+import { Button, createTableColumns, Table, Tag, Text } from "@opal/components";
+import { SvgAlertCircle, SvgPauseCircle, SvgPlayCircle } from "@opal/icons";
 import { useReindexErrors } from "@/lib/indexing/hooks";
+import { resumePausedPort } from "@/lib/indexing/svc";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import type { ReindexErrorRow } from "@/lib/indexing/interfaces";
+
+function ResumeButton({ row }: { row: ReindexErrorRow }) {
+  const [busy, setBusy] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [delayed, setDelayed] = useState(false);
+
+  async function onResume() {
+    setBusy(true);
+    setErrorMsg(null);
+    let result;
+    try {
+      result = await resumePausedPort(row);
+    } catch (e) {
+      setErrorMsg(e instanceof Error ? e.message : "Failed to resume.");
+      setBusy(false);
+      return;
+    }
+    if (result.delayed) {
+      // resumed but the queue was down (503); the poll clears the row once it starts
+      setDelayed(true);
+      return;
+    }
+    // fire-and-forget: a refetch failure is harmless, the banner polls anyway
+    void Promise.all([
+      mutate(SWR_KEYS.reindexProgress),
+      mutate(SWR_KEYS.reindexErrors),
+    ]);
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <Button
+        variant="action"
+        prominence="secondary"
+        size="sm"
+        icon={SvgPlayCircle}
+        disabled={busy}
+        onClick={onResume}
+      >
+        {busy ? "Resuming…" : "Resume"}
+      </Button>
+      {errorMsg && (
+        <Text font="secondary-body" color="status-error-05">
+          {errorMsg}
+        </Text>
+      )}
+      {delayed && (
+        <Text font="secondary-body" color="text-03">
+          Queued — it will start shortly.
+        </Text>
+      )}
+    </div>
+  );
+}
 
 const tc = createTableColumns<ReindexErrorRow>();
 const COLUMNS = [
   tc.column("scope", {
     header: "Type",
-    weight: 15,
-    cell: (value) => (value === "connector" ? "Connector" : "User Files"),
+    weight: 12,
+    cell: (value) => (
+      <Text font="secondary-body" color="text-04">
+        {value === "connector" ? "Connector" : "User Files"}
+      </Text>
+    ),
   }),
-  tc.column("name", { header: "Name", weight: 25 }),
+  tc.column("name", {
+    header: "Name",
+    weight: 22,
+    cell: (value) => (
+      <Text font="secondary-body" color="text-04">
+        {value}
+      </Text>
+    ),
+  }),
   tc.displayColumn({
     id: "entity_id",
     header: "ID",
-    width: { weight: 15 },
-    cell: (row) => row.cc_pair_id ?? row.user_id ?? "—",
+    width: { weight: 12 },
+    cell: (row) => (
+      <Text font="secondary-body" color="text-03" nowrap>
+        {row.cc_pair_id != null
+          ? String(row.cc_pair_id)
+          : row.user_id
+            ? row.user_id.slice(0, 8)
+            : "—"}
+      </Text>
+    ),
+  }),
+  tc.displayColumn({
+    id: "status",
+    header: "Status",
+    width: { weight: 12 },
+    cell: (row) =>
+      row.paused ? (
+        <Tag color="amber" icon={SvgPauseCircle} title="Paused" />
+      ) : (
+        <Tag color="red" icon={SvgAlertCircle} title="Failed" />
+      ),
   }),
   tc.column("error_msg", {
     header: "Error",
-    weight: 45,
+    weight: 30,
+    enableSorting: false,
     cell: (value) => (
       <Text font="secondary-body" color="text-03">
         {value ?? "Unknown error"}
       </Text>
     ),
+  }),
+  tc.displayColumn({
+    id: "actions",
+    header: "",
+    width: { weight: 12 },
+    cell: (row) => (row.paused ? <ResumeButton row={row} /> : null),
   }),
 ];
 
@@ -36,15 +132,15 @@ interface ReindexErrorsModalProps {
 export default function ReindexErrorsModal({
   onClose,
 }: ReindexErrorsModalProps) {
-  const { data: errors, isLoading, error } = useReindexErrors(true);
+  const { data: rows, isLoading, error } = useReindexErrors(true);
 
   return (
     <Modal open onOpenChange={onClose}>
-      <Modal.Content width="lg" height="sm">
+      <Modal.Content width="xl" height="sm">
         <Modal.Header
           icon={SvgAlertCircle}
-          title="Re-index Errors"
-          description="Connectors and user files whose latest re-index attempt failed."
+          title="Re-index Attention"
+          description="Connectors and user files whose latest re-index attempt failed (auto-retrying) or was paused (Resume to retry)."
           onClose={onClose}
         />
         <Modal.Body>
@@ -54,20 +150,24 @@ export default function ReindexErrorsModal({
             </Text>
           ) : error ? (
             <Text as="p" color="status-error-05">
-              Couldn&apos;t load re-index errors. Please try again.
+              Couldn&apos;t load re-index status. Please try again.
             </Text>
-          ) : !errors || errors.length === 0 ? (
+          ) : !rows || rows.length === 0 ? (
             <Text as="p" color="text-03">
-              No re-index errors.
+              Nothing needs attention.
             </Text>
           ) : (
-            <Table
-              data={errors}
-              columns={COLUMNS}
-              getRowId={(row) =>
-                `${row.scope}-${row.cc_pair_id ?? row.user_id}`
-              }
-            />
+            // Modal.Body aligns children to the start; w-full stops the table
+            // shrinking to content and left-packing.
+            <div className="w-full">
+              <Table
+                data={rows}
+                columns={COLUMNS}
+                getRowId={(row) =>
+                  `${row.scope}-${row.cc_pair_id ?? row.user_id}`
+                }
+              />
+            </div>
           )}
         </Modal.Body>
       </Modal.Content>

--- a/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
@@ -11,25 +11,21 @@ import type { ReindexErrorRow } from "@/lib/indexing/interfaces";
 function ResumeButton({ row }: { row: ReindexErrorRow }) {
   const [busy, setBusy] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
-  const [delayed, setDelayed] = useState(false);
 
   async function onResume() {
     setBusy(true);
     setErrorMsg(null);
-    let result;
     try {
-      result = await resumePausedPort(row);
+      await resumePausedPort(row);
     } catch (e) {
       setErrorMsg(e instanceof Error ? e.message : "Failed to resume.");
       setBusy(false);
       return;
     }
-    if (result.delayed) {
-      // resumed but the queue was down (503); the poll clears the row once it starts
-      setDelayed(true);
-      return;
-    }
-    // fire-and-forget: a refetch failure is harmless, the banner polls anyway
+    // Resumed (a 503 just means it starts within minutes): the unit is no longer
+    // paused/failed, so it drops off the list on refetch. Re-enable in case the
+    // refetch itself fails, so the button never stays stuck on "Resuming…".
+    setBusy(false);
     void Promise.all([
       mutate(SWR_KEYS.reindexProgress),
       mutate(SWR_KEYS.reindexErrors),
@@ -51,11 +47,6 @@ function ResumeButton({ row }: { row: ReindexErrorRow }) {
       {errorMsg && (
         <Text font="secondary-body" color="status-error-05">
           {errorMsg}
-        </Text>
-      )}
-      {delayed && (
-        <Text font="secondary-body" color="text-03">
-          Queued — it will start shortly.
         </Text>
       )}
     </div>

--- a/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexErrorsModal.tsx
@@ -18,6 +18,7 @@ function ResumeButton({ row }: { row: ReindexErrorRow }) {
     try {
       await resumePausedPort(row);
     } catch (e) {
+      console.error("Failed to resume paused port unit:", e);
       setErrorMsg(e instanceof Error ? e.message : "Failed to resume.");
       setBusy(false);
       return;

--- a/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
@@ -70,7 +70,7 @@ export default function ReindexProgressBanner({
                   <Tag color="purple" icon={SvgClock} title={String(waiting)} />
                   <Tag
                     color="blue"
-                    icon={SpinningLoader}
+                    icon={in_progress > 0 ? SpinningLoader : SvgLoader}
                     title={String(in_progress)}
                   />
                   <Tag

--- a/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
+++ b/web/src/views/admin/IndexSettingsPage/ReindexProgressBanner.tsx
@@ -10,6 +10,7 @@ import {
   SvgClock,
   SvgExpand,
   SvgLoader,
+  SvgPauseCircle,
 } from "@opal/icons";
 import ReindexErrorsModal from "@/views/admin/IndexSettingsPage/ReindexErrorsModal";
 import { useReindexProgress } from "@/lib/indexing/hooks";
@@ -19,7 +20,14 @@ interface ReindexProgressBannerProps {
   onCancel: () => void;
 }
 
-const ZERO = { total: 0, waiting: 0, in_progress: 0, completed: 0, failed: 0 };
+const ZERO = {
+  total: 0,
+  waiting: 0,
+  in_progress: 0,
+  completed: 0,
+  failed: 0,
+  paused: 0,
+};
 
 // Stable identity so the spinner doesn't remount (and restart at 0°) each poll.
 const SpinningLoader: IconFunctionComponent = (props) => (
@@ -32,7 +40,8 @@ export default function ReindexProgressBanner({
 }: ReindexProgressBannerProps) {
   const [errorsOpen, setErrorsOpen] = useState(false);
   const { data } = useReindexProgress({ pollIntervalMs: 5000 });
-  const { total, waiting, in_progress, completed, failed } = data ?? ZERO;
+  const { total, waiting, in_progress, completed, failed, paused } =
+    data ?? ZERO;
 
   const description = markdown(
     `New embedding settings${
@@ -74,14 +83,19 @@ export default function ReindexProgressBanner({
                     icon={SvgAlertCircle}
                     title={String(failed)}
                   />
-                  {failed > 0 && (
+                  <Tag
+                    color="amber"
+                    icon={SvgPauseCircle}
+                    title={String(paused)}
+                  />
+                  {(failed > 0 || paused > 0) && (
                     <Button
                       icon={SvgExpand}
-                      variant="danger"
+                      variant={failed > 0 ? "danger" : "default"}
                       prominence="tertiary"
                       size="sm"
-                      tooltip="View re-index errors"
-                      aria-label="View re-index errors"
+                      tooltip="View units needing attention"
+                      aria-label="View units needing attention"
                       onClick={() => setErrorsOpen(true)}
                     />
                   )}

--- a/web/src/views/admin/IndexSettingsPage/index.tsx
+++ b/web/src/views/admin/IndexSettingsPage/index.tsx
@@ -81,6 +81,7 @@ import {
   useConfiguredEmbeddingProviders,
   useCurrentEmbeddingModel,
   useCurrentSearchSettings,
+  useReindexProgress,
   useSecondarySearchSettings,
 } from "@/lib/indexing/hooks";
 import { useLlmDefaults } from "@/lib/languageModels/hooks";
@@ -631,7 +632,15 @@ export default function IndexSettingsPage() {
     settings.image_extraction_and_analysis_enabled ?? false;
 
   const { data: secondarySearchSettings } = useSecondarySearchSettings();
-  const isReindexing = !!secondarySearchSettings;
+  // INSTANT switchover swaps immediately — no secondary settings — and backfills on the
+  // current index. The reindex-progress endpoint still reports that active port target,
+  // so treat it as reindexing too; otherwise the banner never shows for INSTANT.
+  const { data: reindexProgress } = useReindexProgress({
+    pollIntervalMs: 5000,
+  });
+  const isPortBackfilling =
+    !secondarySearchSettings && (reindexProgress?.total ?? 0) > 0;
+  const isReindexing = !!secondarySearchSettings || isPortBackfilling;
 
   // When a migration finishes, the fast poll on the current settings stops in
   // the same render — revalidate once so the new model shows as current.
@@ -940,10 +949,15 @@ export default function IndexSettingsPage() {
                   </customModelModal.Provider>
 
                   {isReindexing ? (
-                    secondarySearchSettings?.use_port_flow ? (
-                      // Port-flow reindex → the new per-connector/user progress banner.
+                    secondarySearchSettings?.use_port_flow ||
+                    isPortBackfilling ? (
+                      // Port-flow reindex, or an INSTANT-switchover backfill (already
+                      // swapped, no secondary) → the per-connector/user progress banner.
                       <ReindexProgressBanner
-                        secondaryModelName={secondarySearchSettings?.model_name}
+                        secondaryModelName={
+                          secondarySearchSettings?.model_name ??
+                          searchSettings?.model_name
+                        }
                         onCancel={() => cancelReindexModal.toggle(true)}
                       />
                     ) : (


### PR DESCRIPTION
## Description

- Add a distinct **Paused** count to the re-index progress banner — its own bucket, not folded into failed or waiting
- Add a **Re-index Attention** modal listing failed and paused connectors/user files, with a **Resume** action on paused rows
- Resume retries a paused unit from where it stopped; a queue-down retry is reported as "starting shortly" rather than a failure
<img width="957" height="1210" alt="Screenshot 2026-07-14 at 9 57 29 AM" src="https://github.com/user-attachments/assets/1f1bf965-1d9c-4640-b688-4b68961351ce" />
<img width="1003" height="1227" alt="Screenshot 2026-07-14 at 9 57 36 AM" src="https://github.com/user-attachments/assets/fec065c1-2dec-4588-92a3-5850366689db" />

## How Has This Been Tested?

External-dependency unit tests (paused progress bucket + attention rows across both scopes); manually verified the banner and modal in the admin UI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Paused bucket to re-index progress and a “Re-index Attention” modal with a Resume action, so admins can see paused units and safely restart them. The banner now tracks paused units, and shows during INSTANT backfill as well; resuming treats 503 as queued and refreshes progress/errors so rows drop off once scheduled.

- **New Features**
  - Progress counts include `paused`; `waiting` excludes paused. Banner shows an amber Paused tag and the attention button when failed or paused > 0. Appears during INSTANT switchover backfills too.
  - “Re-index Attention” modal lists Failed and Paused with status tags; Paused rows include Resume. Backend/Frontend types add `paused`; new `resumePausedPort` API.
  - Resume restarts a paused unit from its cursor; 503 is treated as success (queued).

- **Bug Fixes**
  - Resume button no longer stays stuck; refetches progress and errors after success (including 503). Client logs resume failures and JSON parse errors.
  - Fixed `DetachedInstanceError` by rebinding search settings in the user-file indexing task.

<sup>Written for commit d5e32539678090414bdbc3cf947007653b630adc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



