### PR TITLE
feat(mobile): chat message/streaming polish, agent timeline, file management

### DIFF
--- a/mobile/AGENTS.md
+++ b/mobile/AGENTS.md
@@ -96,3 +96,7 @@ Web is different: web uses **Tailwind's default step scale**, where `p-6` = step
   `mobile/src/chat/` (NOT shared) by decision — see `docs/mobile-chat/05-pr-roadmap.md` (PR 2 Decision).
 - Editing the shared package requires rebuilding its `dist` (`bun run build` in `web/lib/shared`); the
   mobile `file:` dep consumes `dist`. Web jest resolves it from `src` via a `moduleNameMapper`.
+- Mobile's `preinstall` hook builds `web/lib/shared`'s `dist` (a git-ignored artifact) **before** bun
+  links the `file:` dep, so a fresh `bun install` can't hit an unresolved `@onyx-ai/shared/dist`. It
+  must be `preinstall`, not `postinstall`: bun's link farm only includes `dist` if it exists at link
+  time. Active token/source edits still hot-rebuild via `bun run dev` in `web/lib/shared`.

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -68,6 +68,7 @@
     "typescript": "~6.0.3"
   },
   "scripts": {
+    "preinstall": "cd ../web/lib/shared && bun install && bun run build",
     "start": "expo start --port 8082",
     "ios": "expo start --ios --port 8082",
     "android": "expo start --android --port 8082",

--- a/mobile/src/api/chat/stream.ts
+++ b/mobile/src/api/chat/stream.ts
@@ -6,7 +6,11 @@ import { getBaseUrl } from "@/api/config";
 import { getToken } from "@/api/auth/tokenStore";
 import { createNdjsonBuffer } from "@/chat/ndjson";
 import { FileDescriptor } from "@/chat/interfaces";
-import { MessageResponseIDInfo, Packet } from "@/chat/streamingModels";
+import {
+  MessageResponseIDInfo,
+  Packet,
+  StreamingError,
+} from "@/chat/streamingModels";
 
 type ExpoResponse = Awaited<ReturnType<typeof expoFetch>>;
 
@@ -32,7 +36,7 @@ export class StreamHttpError extends Error {
 }
 
 // The wire mixes wrapped packets ({placement, obj}) with root control objects; discriminate by field, not `type`.
-export type StreamEvent = Packet | MessageResponseIDInfo;
+export type StreamEvent = Packet | MessageResponseIDInfo | StreamingError;
 
 export function isPacket(event: StreamEvent): event is Packet {
   return "obj" in event && "placement" in event;
@@ -42,6 +46,14 @@ export function isMessageIdInfo(
   event: StreamEvent,
 ): event is MessageResponseIDInfo {
   return "user_message_id" in event;
+}
+
+// Root-level backend error (StreamingError): a top-level `error` string, not a wrapped packet.
+// Matches web's `Object.hasOwn(packet, "error") && packet.error != null` check.
+export function isStreamError(event: StreamEvent): event is StreamingError {
+  return (
+    "error" in event && typeof (event as StreamingError).error === "string"
+  );
 }
 
 // Heartbeats come wrapped or at root; drop both.

--- a/mobile/src/api/chat/stream.ts
+++ b/mobile/src/api/chat/stream.ts
@@ -48,8 +48,7 @@ export function isMessageIdInfo(
   return "user_message_id" in event;
 }
 
-// Root-level backend error (StreamingError): a top-level `error` string, not a wrapped packet.
-// Matches web's `Object.hasOwn(packet, "error") && packet.error != null` check.
+// Root-level StreamingError: a top-level `error` string, not a wrapped packet (mirrors web's error check).
 export function isStreamError(event: StreamEvent): event is StreamingError {
   return (
     "error" in event && typeof (event as StreamingError).error === "string"

--- a/mobile/src/app/(app)/sources/[id].tsx
+++ b/mobile/src/app/(app)/sources/[id].tsx
@@ -1,0 +1,98 @@
+import { useMemo, useState } from "react";
+import { ScrollView, View } from "react-native";
+import { SafeAreaView } from "react-native-safe-area-context";
+import { router, useLocalSearchParams } from "expo-router";
+
+import { useProjectDetails } from "@/api/chat/projects";
+import { useProjectFiles } from "@/hooks/useProjectFiles";
+import { useRecentFiles } from "@/hooks/useRecentFiles";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/text";
+import { FilePickerSheet } from "@/components/chat/FilePickerSheet";
+import { ProjectFileList } from "@/components/chat/ProjectFileList";
+import SvgChevronLeft from "@/icons/chevron-left";
+import SvgPlus from "@/icons/plus";
+
+// Full-screen project-sources manager, opened from the project panel's "View sources" row. Lives
+// off the /chat and /projects prefixes so deriveFocus returns null and the ChatSurface overlay
+// hides. Owns the add ("+") button + file picker; the panel is now just an entry point.
+export default function SourcesScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const parsed = Number(id);
+  const projectId = id != null && Number.isFinite(parsed) ? parsed : null;
+
+  const { data: details, isLoading } = useProjectDetails(projectId);
+  const { files, addDocuments, addImages, linkRecent, removeFile } =
+    useProjectFiles(projectId, details?.files);
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const { data: recentFiles = [], isLoading: isLoadingRecent } =
+    useRecentFiles(pickerOpen);
+  const linkableRecent = useMemo(() => {
+    const existing = new Set(files.map((file) => file.id));
+    return recentFiles.filter((file) => !existing.has(file.id));
+  }, [files, recentFiles]);
+
+  return (
+    <SafeAreaView edges={["top"]} className="flex-1 bg-background-neutral-00">
+      <View className="flex-row items-center gap-8 px-12 py-8">
+        <Button
+          icon={SvgChevronLeft}
+          prominence="tertiary"
+          size="sm"
+          accessibilityLabel="Back"
+          onPress={() => router.back()}
+        />
+        <Text font="heading-h3" color="text-05" className="flex-1">
+          Sources
+        </Text>
+        <Button
+          icon={SvgPlus}
+          prominence="primary"
+          size="sm"
+          accessibilityLabel="Add files"
+          disabled={projectId == null}
+          onPress={() => setPickerOpen(true)}
+        />
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="gap-12 px-16 pb-24 pt-4"
+        keyboardShouldPersistTaps="handled"
+      >
+        <Text font="secondary-body" color="text-02">
+          Chats in this project can access these files.
+        </Text>
+
+        {isLoading && !details ? (
+          <View className="items-center py-24">
+            <Spinner size={20} />
+          </View>
+        ) : files.length === 0 ? (
+          <View className="justify-center rounded-12 border border-dashed border-border-01 px-12 py-24">
+            <Text font="secondary-body" color="text-02" className="text-center">
+              No files in this project yet. Tap + to add.
+            </Text>
+          </View>
+        ) : (
+          <ProjectFileList
+            files={files}
+            onRemove={(fileId) => void removeFile(fileId)}
+          />
+        )}
+      </ScrollView>
+
+      <FilePickerSheet
+        visible={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onUploadDocuments={() => void addDocuments()}
+        onUploadPhotos={() => void addImages()}
+        recentFiles={linkableRecent}
+        onPickRecent={(fileId) => void linkRecent(fileId)}
+        isLoadingRecent={isLoadingRecent}
+      />
+    </SafeAreaView>
+  );
+}

--- a/mobile/src/app/(app)/sources/[id].tsx
+++ b/mobile/src/app/(app)/sources/[id].tsx
@@ -14,9 +14,7 @@ import { ProjectFileList } from "@/components/chat/ProjectFileList";
 import SvgChevronLeft from "@/icons/chevron-left";
 import SvgPlus from "@/icons/plus";
 
-// Full-screen project-sources manager, opened from the project panel's "View sources" row. Lives
-// off the /chat and /projects prefixes so deriveFocus returns null and the ChatSurface overlay
-// hides. Owns the add ("+") button + file picker; the panel is now just an entry point.
+// Lives off the /chat and /projects prefixes so deriveFocus returns null and the ChatSurface overlay hides.
 export default function SourcesScreen() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const parsed = Number(id);

--- a/mobile/src/chat/__tests__/errorHelpers.test.ts
+++ b/mobile/src/chat/__tests__/errorHelpers.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { getErrorTitle } from "@/chat/errorHelpers";
+
+describe("getErrorTitle", () => {
+  it("maps known error codes to friendly titles", () => {
+    expect(getErrorTitle("RATE_LIMIT")).toBe("Rate Limit Exceeded");
+    expect(getErrorTitle("AUTH_ERROR")).toBe("Authentication Error");
+    expect(getErrorTitle("SERVICE_UNAVAILABLE")).toBe("Service Unavailable");
+  });
+
+  it("falls back to 'Error' for unknown, null, or missing codes", () => {
+    expect(getErrorTitle(undefined)).toBe("Error");
+    expect(getErrorTitle(null)).toBe("Error");
+    expect(getErrorTitle("SOMETHING_UNMAPPED")).toBe("Error");
+  });
+});

--- a/mobile/src/chat/chatHistory.ts
+++ b/mobile/src/chat/chatHistory.ts
@@ -1,6 +1,4 @@
-// Builds the message tree from a loaded session. Ported from web's
-// processRawChatHistory; minimal Message (no rich types). `packets` align to
-// assistant messages by ordinal — one list per assistant turn, in order.
+// `packets` align to assistant messages by ordinal — one list per assistant turn, in order.
 
 import { BackendMessage, Message, MessageType } from "./interfaces";
 import { MessageTreeState } from "./messageTree";
@@ -22,10 +20,10 @@ export function processRawChatHistory(
     }
 
     const message: Message = {
-      // loaded messages reuse message_id as nodeId (only uniqueness matters)
+      // reuse message_id as nodeId — only uniqueness matters
       nodeId: messageInfo.message_id,
       messageId: messageInfo.message_id,
-      // errored turns carry the error text in `error`; render that in the error box (web parity)
+      // errored turns carry text in `error`; render it as the message (web parity)
       message: messageInfo.error ?? messageInfo.message,
       type: messageInfo.error
         ? "error"

--- a/mobile/src/chat/chatHistory.ts
+++ b/mobile/src/chat/chatHistory.ts
@@ -25,7 +25,8 @@ export function processRawChatHistory(
       // loaded messages reuse message_id as nodeId (only uniqueness matters)
       nodeId: messageInfo.message_id,
       messageId: messageInfo.message_id,
-      message: messageInfo.message,
+      // errored turns carry the error text in `error`; render that in the error box (web parity)
+      message: messageInfo.error ?? messageInfo.message,
       type: messageInfo.error
         ? "error"
         : (messageInfo.message_type as MessageType),

--- a/mobile/src/chat/errorHelpers.ts
+++ b/mobile/src/chat/errorHelpers.ts
@@ -1,6 +1,4 @@
-// Human-readable title for a backend StreamingError.error_code. Ported verbatim from web's
-// message/errorHelpers.tsx getErrorTitle. Mobile shows a single alert icon rather than web's
-// per-code icon set (getErrorIcon), so only the title map is ported.
+// Mobile shows one alert icon, so web's per-code getErrorIcon is not ported — only this title map.
 export function getErrorTitle(errorCode?: string | null): string {
   switch (errorCode) {
     case "RATE_LIMIT":

--- a/mobile/src/chat/errorHelpers.ts
+++ b/mobile/src/chat/errorHelpers.ts
@@ -1,0 +1,37 @@
+// Human-readable title for a backend StreamingError.error_code. Ported verbatim from web's
+// message/errorHelpers.tsx getErrorTitle. Mobile shows a single alert icon rather than web's
+// per-code icon set (getErrorIcon), so only the title map is ported.
+export function getErrorTitle(errorCode?: string | null): string {
+  switch (errorCode) {
+    case "RATE_LIMIT":
+      return "Rate Limit Exceeded";
+    case "AUTH_ERROR":
+      return "Authentication Error";
+    case "PERMISSION_DENIED":
+      return "Permission Denied";
+    case "CONTEXT_TOO_LONG":
+      return "Message Too Long";
+    case "TOOL_CALL_FAILED":
+      return "Tool Error";
+    case "CONNECTION_ERROR":
+      return "Connection Error";
+    case "SERVICE_UNAVAILABLE":
+      return "Service Unavailable";
+    case "INIT_FAILED":
+      return "Initialization Error";
+    case "VALIDATION_ERROR":
+      return "Validation Error";
+    case "BUDGET_EXCEEDED":
+      return "Budget Exceeded";
+    case "CONTENT_POLICY":
+      return "Content Policy Violation";
+    case "BAD_REQUEST":
+      return "Invalid Request";
+    case "NOT_FOUND":
+      return "Resource Not Found";
+    case "API_ERROR":
+      return "API Error";
+    default:
+      return "Error";
+  }
+}

--- a/mobile/src/chat/interfaces.ts
+++ b/mobile/src/chat/interfaces.ts
@@ -1,11 +1,7 @@
-// Minimal core chat types. Rich fields (documents/citations/multi-model) are
-// added in their own phases.
-
 import { Packet } from "./streamingModels";
 
 export type MessageType = "user" | "assistant" | "system" | "error";
 
-// web also has "toolBuilding"; omitted until tools land.
 export type ChatState = "input" | "loading" | "streaming" | "uploading";
 
 export enum ChatFileType {
@@ -35,11 +31,11 @@ export interface Message {
   message: string;
   files: FileDescriptor[];
   packets: Packet[];
-  // Set on an errored turn (type === "error"): backend StreamingError.error_code, for the box title.
+  // Backend StreamingError.error_code on an errored turn; titles the error box.
   errorCode?: string | null;
 }
 
-// One row of a loaded session snapshot (GET get-chat-session); minimal subset.
+// Subset of a loaded session-snapshot row (GET get-chat-session).
 export interface BackendMessage {
   message_id: number;
   message_type: string;
@@ -51,7 +47,7 @@ export interface BackendMessage {
   error: string | null;
 }
 
-// Session snapshot for hydration; `packets` is indexed by assistant-message ordinal.
+// `packets` is indexed by assistant-message ordinal.
 export interface BackendChatSession {
   chat_session_id: string;
   description: string;

--- a/mobile/src/chat/interfaces.ts
+++ b/mobile/src/chat/interfaces.ts
@@ -35,6 +35,8 @@ export interface Message {
   message: string;
   files: FileDescriptor[];
   packets: Packet[];
+  // Set on an errored turn (type === "error"): backend StreamingError.error_code, for the box title.
+  errorCode?: string | null;
 }
 
 // One row of a loaded session snapshot (GET get-chat-session); minimal subset.

--- a/mobile/src/chat/streamingModels.ts
+++ b/mobile/src/chat/streamingModels.ts
@@ -84,3 +84,14 @@ export interface MessageResponseIDInfo {
   user_message_id: number | null;
   reserved_assistant_message_id: number;
 }
+
+// Root-level error object (backend `StreamingError`), NOT wrapped in Packet.obj —
+// so it is discriminated by the top-level `error` string, not `obj.type`. Dropping
+// it silently is what leaves the assistant turn stuck on the "…" placeholder.
+export interface StreamingError {
+  error: string;
+  stack_trace?: string | null;
+  error_code?: string | null;
+  is_retryable?: boolean;
+  details?: Record<string, unknown> | null;
+}

--- a/mobile/src/chat/streamingModels.ts
+++ b/mobile/src/chat/streamingModels.ts
@@ -1,5 +1,4 @@
-// Minimal core streaming-packet contracts (NDJSON wire shapes). Rich packet
-// types are added in their own phases.
+// Core streaming-packet contracts (NDJSON wire shapes).
 
 interface BaseObj {
   type: string;
@@ -75,19 +74,16 @@ export interface Packet {
   obj: ObjTypes;
 }
 
-// Root object (not wrapped in Packet.obj). The wire does NOT carry `type` here
-// (the backend emits only the two id fields), so consumers must discriminate it
-// by field presence (e.g. "user_message_id" in obj), never by `obj.type`. The
-// optional `type` is kept only as a readable tag.
+// Root object (not wrapped in Packet.obj); wire omits `type`, so discriminate by
+// field presence (`"user_message_id" in obj`), never `obj.type`.
 export interface MessageResponseIDInfo {
   type?: "message_id_info";
   user_message_id: number | null;
   reserved_assistant_message_id: number;
 }
 
-// Root-level error object (backend `StreamingError`), NOT wrapped in Packet.obj —
-// so it is discriminated by the top-level `error` string, not `obj.type`. Dropping
-// it silently is what leaves the assistant turn stuck on the "…" placeholder.
+// Root-level error (backend `StreamingError`), not wrapped in Packet.obj — discriminate
+// by top-level `error`, not `obj.type`. Dropping it silently leaves the turn stuck on "…".
 export interface StreamingError {
   error: string;
   stack_trace?: string | null;

--- a/mobile/src/components/chat/AgentTimeline.tsx
+++ b/mobile/src/components/chat/AgentTimeline.tsx
@@ -1,0 +1,141 @@
+// Simple port of web's AgentTimeline (web/src/app/app/message/messageComponents/timeline). The
+// assistant message is a vertical stack: this timeline — the agent avatar in a 36px rail plus a
+// status header — sits above the answer text. Web-faithful minus the rich step content: the
+// reasoning/tool STEP rows are scaffolded (rail dot + 1px connector + label) but fed no data yet,
+// since the mobile stream doesn't parse reasoning/tool packets. The loading state mirrors web's
+// shimmering "Thinking…" label (web uses a CSS gradient sweep; RN approximates it with an opacity
+// pulse on the reanimated UI thread).
+import { useEffect } from "react";
+import { View } from "react-native";
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
+
+import { AgentAvatar } from "@/components/avatars/AgentAvatar";
+import { Icon } from "@/components/ui/icon";
+import { Text } from "@/components/ui/text";
+import { MinimalAgent } from "@/chat/agents";
+import { cn } from "@/lib/utils";
+import type { IconFunctionComponent } from "@/icons/types";
+
+// web timeline rail width (--timeline-rail-width = 2.25rem = 36px) and header avatar size (24).
+const RAIL = "w-36";
+const AVATAR_SIZE = 24;
+
+export type TimelineStepStatus = "running" | "done" | "error";
+
+export interface TimelineStepData {
+  key: string;
+  label: string;
+  status: TimelineStepStatus;
+  // Tool/step icon when available; falls back to a status-colored dot.
+  icon?: IconFunctionComponent;
+}
+
+interface AgentTimelineProps {
+  agent: MinimalAgent | null;
+  // web's EMPTY state: the run has begun but no answer content has arrived → shimmer "Thinking…".
+  isLoading: boolean;
+  // Reasoning/tool steps; empty until the mobile stream parses those packets (kept as a seam).
+  steps?: TimelineStepData[];
+}
+
+export function AgentTimeline({
+  agent,
+  isLoading,
+  steps = [],
+}: AgentTimelineProps) {
+  return (
+    <View>
+      {/* Header row (web TimelineHeaderRow): avatar centered in the rail + status label beside it. */}
+      <View className="h-36 flex-row items-center">
+        <View className={cn("h-36 items-center justify-center", RAIL)}>
+          {agent ? <AgentAvatar agent={agent} size={AVATAR_SIZE} /> : null}
+        </View>
+        {isLoading ? <ThinkingLabel /> : null}
+      </View>
+
+      {steps.map((step, index) => (
+        <TimelineStep
+          key={step.key}
+          step={step}
+          isFirst={index === 0}
+          isLast={index === steps.length - 1}
+        />
+      ))}
+    </View>
+  );
+}
+
+// web `.shimmer-text` gradient sweep → an opacity breathe (no masked-gradient dep for the simple port).
+function ThinkingLabel() {
+  const opacity = useSharedValue(0.5);
+  useEffect(() => {
+    opacity.value = withRepeat(
+      withTiming(1, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+      -1,
+      true,
+    );
+  }, [opacity]);
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }));
+  return (
+    <Animated.View style={animatedStyle}>
+      <Text font="main-ui-action" color="text-03">
+        Thinking…
+      </Text>
+    </Animated.View>
+  );
+}
+
+// One reasoning/tool step: web TimelineRow (rail = 1px connector + a 12px icon/dot) + a muted label.
+function TimelineStep({
+  step,
+  isFirst,
+  isLast,
+}: {
+  step: TimelineStepData;
+  isFirst: boolean;
+  isLast: boolean;
+}) {
+  const isError = step.status === "error";
+  return (
+    <View className="flex-row">
+      <View className={cn("items-center", RAIL)}>
+        {/* connector above (web `bg-border-01`, `w-px`); hidden on the first step */}
+        <View
+          className={cn("h-8 w-[1px] bg-border-01", isFirst && "opacity-0")}
+        />
+        {step.icon ? (
+          <Icon
+            as={step.icon}
+            size={12}
+            className={isError ? "text-status-error-05" : "text-text-02"}
+          />
+        ) : (
+          <View
+            className={cn(
+              "h-8 w-8 rounded-full",
+              isError ? "bg-status-error-05" : "bg-text-04",
+            )}
+          />
+        )}
+        {/* connector below (flex-1); hidden on the last step */}
+        <View
+          className={cn("w-[1px] flex-1 bg-border-01", isLast && "opacity-0")}
+        />
+      </View>
+      <View className="flex-1 py-4">
+        <Text
+          font="main-ui-muted"
+          color={isError ? "status-error-05" : "text-04"}
+        >
+          {step.label}
+        </Text>
+      </View>
+    </View>
+  );
+}

--- a/mobile/src/components/chat/AgentTimeline.tsx
+++ b/mobile/src/components/chat/AgentTimeline.tsx
@@ -1,10 +1,5 @@
-// Simple port of web's AgentTimeline (web/src/app/app/message/messageComponents/timeline). The
-// assistant message is a vertical stack: this timeline — the agent avatar in a 36px rail plus a
-// status header — sits above the answer text. Web-faithful minus the rich step content: the
-// reasoning/tool STEP rows are scaffolded (rail dot + 1px connector + label) but fed no data yet,
-// since the mobile stream doesn't parse reasoning/tool packets. The loading state mirrors web's
-// shimmering "Thinking…" label (web uses a CSS gradient sweep; RN approximates it with an opacity
-// pulse on the reanimated UI thread).
+// Port of web's AgentTimeline (web/src/app/app/message/messageComponents/timeline): the agent
+// avatar in a 36px rail plus a status header, sitting above the answer text.
 import { useEffect } from "react";
 import { View } from "react-native";
 import Animated, {
@@ -22,7 +17,7 @@ import { MinimalAgent } from "@/chat/agents";
 import { cn } from "@/lib/utils";
 import type { IconFunctionComponent } from "@/icons/types";
 
-// web timeline rail width (--timeline-rail-width = 2.25rem = 36px) and header avatar size (24).
+// Mirrors web's --timeline-rail-width (36px); on mobile w-36 = 36px.
 const RAIL = "w-36";
 const AVATAR_SIZE = 24;
 
@@ -32,15 +27,14 @@ export interface TimelineStepData {
   key: string;
   label: string;
   status: TimelineStepStatus;
-  // Tool/step icon when available; falls back to a status-colored dot.
   icon?: IconFunctionComponent;
 }
 
 interface AgentTimelineProps {
   agent: MinimalAgent | null;
-  // web's EMPTY state: the run has begun but no answer content has arrived → shimmer "Thinking…".
+  // EMPTY state (web): run started but no answer content yet → shimmer "Thinking…".
   isLoading: boolean;
-  // Reasoning/tool steps; empty until the mobile stream parses those packets (kept as a seam).
+  // Empty until the mobile stream parses reasoning/tool packets (seam).
   steps?: TimelineStepData[];
 }
 
@@ -51,7 +45,6 @@ export function AgentTimeline({
 }: AgentTimelineProps) {
   return (
     <View>
-      {/* Header row (web TimelineHeaderRow): avatar centered in the rail + status label beside it. */}
       <View className="h-36 flex-row items-center">
         <View className={cn("h-36 items-center justify-center", RAIL)}>
           {agent ? <AgentAvatar agent={agent} size={AVATAR_SIZE} /> : null}
@@ -71,7 +64,7 @@ export function AgentTimeline({
   );
 }
 
-// web `.shimmer-text` gradient sweep → an opacity breathe (no masked-gradient dep for the simple port).
+// Approximates web's .shimmer-text gradient sweep with an opacity pulse (no masked-gradient dep).
 function ThinkingLabel() {
   const opacity = useSharedValue(0.5);
   useEffect(() => {
@@ -91,7 +84,6 @@ function ThinkingLabel() {
   );
 }
 
-// One reasoning/tool step: web TimelineRow (rail = 1px connector + a 12px icon/dot) + a muted label.
 function TimelineStep({
   step,
   isFirst,
@@ -105,7 +97,6 @@ function TimelineStep({
   return (
     <View className="flex-row">
       <View className={cn("items-center", RAIL)}>
-        {/* connector above (web `bg-border-01`, `w-px`); hidden on the first step */}
         <View
           className={cn("h-8 w-[1px] bg-border-01", isFirst && "opacity-0")}
         />
@@ -123,7 +114,6 @@ function TimelineStep({
             )}
           />
         )}
-        {/* connector below (flex-1); hidden on the last step */}
         <View
           className={cn("w-[1px] flex-1 bg-border-01", isLast && "opacity-0")}
         />

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -182,7 +182,11 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
           exiting={FadeOut.duration(TRANSITION_MS)}
           className="flex-1"
         >
-          <MessageList key={sessionId ?? "new"} messages={messages} />
+          <MessageList
+            key={sessionId ?? "new"}
+            messages={messages}
+            agent={liveAgent}
+          />
         </Animated.View>
       )}
     </ChatScreen>

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -182,7 +182,7 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
           exiting={FadeOut.duration(TRANSITION_MS)}
           className="flex-1"
         >
-          <MessageList messages={messages} />
+          <MessageList key={sessionId ?? "new"} messages={messages} />
         </Animated.View>
       )}
     </ChatScreen>

--- a/mobile/src/components/chat/ChatSurface.tsx
+++ b/mobile/src/components/chat/ChatSurface.tsx
@@ -25,9 +25,8 @@ import { useComposerDraft } from "@/hooks/useComposerDraft";
 
 const TRANSITION_MS = 150;
 
-// Persistent chat surface: one absolute overlay mounted in (app)/_layout, morphed in place
-// by route → focus so the header/composer never remount. null on non-chat routes (the Stack
-// screen shows through).
+// Persistent overlay mounted in (app)/_layout: morphed in place by route→focus so
+// header/composer never remount; null on non-chat routes (the Stack shows through).
 export function ChatSurface() {
   const pathname = usePathname();
   const focus = deriveFocus(pathname);
@@ -39,8 +38,8 @@ export function ChatSurface() {
   );
 }
 
-// Never keyed/remounted across new↔chat↔project — only `focus` changes, so the
-// chrome/composer persist and the body cross-fades.
+// Never remounted across new↔chat↔project — only `focus` changes, so chrome/composer
+// persist and the body cross-fades.
 function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   const sessionId = focus.kind === "chat" ? focus.sessionId : null;
   const projectId = focus.kind === "project" ? focus.projectId : null;
@@ -57,8 +56,8 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
 
   // Landing: agent from the route param. Existing session: its creation-time persona wins.
   const parsedAgentId = agentIdParam != null ? Number(agentIdParam) : NaN;
-  // Only a real agent id (non-negative integer) is honored; a bogus deep-link param
-  // (Infinity, float, negative) falls back to the default persona.
+  // Only a non-negative integer id is honored; a bogus deep-link param (Infinity/float/negative)
+  // falls back to the default persona.
   const selectedAgentId =
     Number.isInteger(parsedAgentId) && parsedAgentId >= 0
       ? parsedAgentId
@@ -78,8 +77,8 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
   // re-attaches to an in-flight run when opened cold
   useChatSessionController(sessionId);
 
-  // Per-conversation composer draft (text + attachments), keyed so navigation restores it and it
-  // can't leak across the persistent composer. Lives in ComposerDraftContext above the surface.
+  // Per-conversation draft, keyed so navigation restores it and it can't leak across the
+  // persistent composer.
   const draft = useComposerDraft(`${sessionId ?? "new"}:${projectId ?? ""}`);
 
   const { data: details, isLoading } = useProjectDetails(projectId);
@@ -94,8 +93,8 @@ function ChatSurfaceContent({ focus }: { focus: ChatFocus }) {
         : UNNAMED_CHAT
       : undefined;
 
-  // Cleared only on an accepted send (submit's onAccepted). Gate on hasBlockingFiles so a
-  // still-uploading file can't be sent; a starter keeps the text (consumeAttachments), a send clears both.
+  // Gate on hasBlockingFiles so a still-uploading file can't be sent; a starter keeps the text
+  // (consumeAttachments), a send clears both.
   const sendWithAttachments = (message?: string) => {
     if (draft.hasBlockingFiles) return;
     submit(

--- a/mobile/src/components/chat/FileCard.tsx
+++ b/mobile/src/components/chat/FileCard.tsx
@@ -20,7 +20,7 @@ import SvgX from "@/icons/x";
 
 const IMAGE_SIZE = 64;
 
-// web `shadow-xs` on the remove control.
+// Mirrors web `shadow-xs` on the remove control.
 const REMOVE_SHADOW = {
   shadowColor: "#000000",
   shadowOffset: { width: 0, height: 1 },
@@ -39,13 +39,8 @@ function isImage(file: ProjectFile): boolean {
   return file.chat_file_type === ChatFileType.IMAGE || isImageName(file.name);
 }
 
-// The single file-display card (mirrors web's FileCard), used by the composer strip, a
-// sent message's attachments, and the project panel. Images render as a square thumbnail;
-// everything else — and any failed upload — as a bordered pill. Removable once the upload
-// lands (matches web); a file stuck INDEXING/FAILED stays removable so the user can unblock
-// send.
-// Memoized so it skips the composer strip's per-keystroke re-renders. Progress is read from the
-// store by this card's own atomic selector, so a tick re-renders only this card.
+// Memoized + atomic progress selector so a store tick re-renders only this card, not the whole
+// composer strip. Stays removable while INDEXING/FAILED so the user can unblock send.
 export const FileCard = memo(function FileCard({
   file,
   onRemove,
@@ -69,9 +64,7 @@ export const FileCard = memo(function FileCard({
           )}
         </View>
         {canRemove ? (
-          // Web parity (FileCard `Removable`): a small rounded-square at the top-left, inverted
-          // fill + muted X + a subtle shadow. Web reveals it on hover; touch has no hover, so it
-          // stays visible.
+          // Web reveals this on hover; touch has no hover, so it stays visible.
           <Pressable
             onPress={() => onRemove(file.id)}
             hitSlop={8}

--- a/mobile/src/components/chat/FileCard.tsx
+++ b/mobile/src/components/chat/FileCard.tsx
@@ -1,8 +1,9 @@
 import { memo } from "react";
-import { ActivityIndicator, Pressable, View } from "react-native";
+import { Pressable, View } from "react-native";
 
 import { AttachmentImage } from "@/components/chat/AttachmentImage";
 import { Icon } from "@/components/ui/icon";
+import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
 import {
   isProcessingStatus,
@@ -18,6 +19,15 @@ import SvgFileText from "@/icons/file-text";
 import SvgX from "@/icons/x";
 
 const IMAGE_SIZE = 64;
+
+// web `shadow-xs` on the remove control.
+const REMOVE_SHADOW = {
+  shadowColor: "#000000",
+  shadowOffset: { width: 0, height: 1 },
+  shadowOpacity: 0.06,
+  shadowRadius: 2,
+  elevation: 1,
+} as const;
 
 interface FileCardProps {
   file: ProjectFile;
@@ -53,21 +63,27 @@ export const FileCard = memo(function FileCard({
           style={{ width: IMAGE_SIZE, height: IMAGE_SIZE }}
         >
           {uploading ? (
-            <ActivityIndicator size="small" />
+            <Spinner size={20} />
           ) : (
             <AttachmentImage fileId={file.file_id} size={IMAGE_SIZE} />
           )}
         </View>
         {canRemove ? (
+          // Web parity (FileCard `Removable`): a small rounded-square at the top-left, inverted
+          // fill + muted X + a subtle shadow. Web reveals it on hover; touch has no hover, so it
+          // stays visible.
           <Pressable
             onPress={() => onRemove(file.id)}
             hitSlop={8}
             accessibilityRole="button"
             accessibilityLabel={`Remove ${file.name}`}
-            style={{ top: -6, right: -6 }}
-            className="bg-background-inverted-05 absolute h-20 w-20 items-center justify-center rounded-full border border-border-01"
+            style={[
+              { top: -8, left: -8, width: 16, height: 16, zIndex: 10 },
+              REMOVE_SHADOW,
+            ]}
+            className="absolute items-center justify-center rounded-04 border border-border-01 bg-background-neutral-inverted-01"
           >
-            <Icon as={SvgX} size={12} className="text-text-inverted-05" />
+            <Icon as={SvgX} size={12} className="text-text-inverted-03" />
           </Pressable>
         ) : null}
       </View>
@@ -85,7 +101,7 @@ export const FileCard = memo(function FileCard({
       )}
     >
       {processing ? (
-        <ActivityIndicator size="small" />
+        <Spinner size={16} />
       ) : (
         <Icon
           as={failed ? SvgAlertCircle : SvgFileText}

--- a/mobile/src/components/chat/FilePickerSheet.tsx
+++ b/mobile/src/components/chat/FilePickerSheet.tsx
@@ -29,8 +29,7 @@ interface FilePickerSheetProps {
   isLoadingRecent: boolean;
 }
 
-// Add-files chooser (mirrors web's FilePickerPopover). Web uses a hover popover;
-// mobile uses a bottom sheet.
+// Mirrors web's FilePickerPopover, as a bottom sheet instead of a hover popover.
 export function FilePickerSheet({
   visible,
   onClose,
@@ -42,9 +41,8 @@ export function FilePickerSheet({
 }: FilePickerSheetProps) {
   const insets = useSafeAreaInsets();
 
-  // iOS drops a picker presented while this Modal is still dismissing ("presentation in progress"),
-  // so a chosen action is deferred to onDismiss (after the sheet is gone). Android has no such
-  // conflict (and no onDismiss), so it runs immediately.
+  // iOS drops a picker presented while this Modal is still dismissing, so defer the action to
+  // onDismiss (after the sheet is gone); Android has no such conflict and runs immediately.
   const pendingRef = useRef<(() => void) | null>(null);
   const choose = (action: () => void) => {
     onClose();

--- a/mobile/src/components/chat/FilePickerSheet.tsx
+++ b/mobile/src/components/chat/FilePickerSheet.tsx
@@ -1,15 +1,11 @@
-import {
-  ActivityIndicator,
-  Modal,
-  Pressable,
-  ScrollView,
-  View,
-} from "react-native";
+import { useRef } from "react";
+import { Modal, Platform, Pressable, ScrollView, View } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 import { Button } from "@/components/ui/button";
 import { LineItemButton } from "@/components/ui/line-item-button";
 import { Separator } from "@/components/ui/separator";
+import { Spinner } from "@/components/ui/spinner";
 import { Text } from "@/components/ui/text";
 import {
   UserFileStatus,
@@ -17,9 +13,9 @@ import {
   type ProjectFile,
 } from "@/chat/contracts/projects";
 import { extensionOf, isImageName } from "@/lib/files";
-import SvgFileSmall from "@/icons/file-small";
 import SvgFileText from "@/icons/file-text";
-import SvgImageSmall from "@/icons/image-small";
+import SvgImage from "@/icons/image";
+import SvgUploadSquare from "@/icons/upload-square";
 import SvgX from "@/icons/x";
 
 interface FilePickerSheetProps {
@@ -46,12 +42,27 @@ export function FilePickerSheet({
 }: FilePickerSheetProps) {
   const insets = useSafeAreaInsets();
 
+  // iOS drops a picker presented while this Modal is still dismissing ("presentation in progress"),
+  // so a chosen action is deferred to onDismiss (after the sheet is gone). Android has no such
+  // conflict (and no onDismiss), so it runs immediately.
+  const pendingRef = useRef<(() => void) | null>(null);
+  const choose = (action: () => void) => {
+    onClose();
+    if (Platform.OS === "ios") pendingRef.current = action;
+    else action();
+  };
+
   return (
     <Modal
       visible={visible}
       transparent
       animationType="slide"
       onRequestClose={onClose}
+      onDismiss={() => {
+        const action = pendingRef.current;
+        pendingRef.current = null;
+        action?.();
+      }}
       statusBarTranslucent
     >
       <Pressable
@@ -78,20 +89,20 @@ export function FilePickerSheet({
           </View>
 
           <LineItemButton
-            icon={SvgFileSmall}
+            icon={SvgUploadSquare}
             title="Upload from device"
             description="Documents, text, PDFs"
             sizePreset="main-ui"
             variant="section"
-            onPress={onUploadDocuments}
+            onPress={() => choose(onUploadDocuments)}
           />
           <LineItemButton
-            icon={SvgImageSmall}
+            icon={SvgImage}
             title="Choose photos"
             description="From your photo library"
             sizePreset="main-ui"
             variant="section"
-            onPress={onUploadPhotos}
+            onPress={() => choose(onUploadPhotos)}
           />
 
           <View className="py-8">
@@ -103,8 +114,8 @@ export function FilePickerSheet({
           </Text>
 
           {isLoadingRecent && recentFiles.length === 0 ? (
-            <View className="py-16">
-              <ActivityIndicator size="small" />
+            <View className="items-center py-16">
+              <Spinner size={20} />
             </View>
           ) : recentFiles.length === 0 ? (
             <View className="px-8 py-12">
@@ -125,12 +136,8 @@ export function FilePickerSheet({
                 return (
                   <LineItemButton
                     key={file.id}
-                    leading={
-                      processing ? (
-                        <ActivityIndicator size="small" />
-                      ) : undefined
-                    }
-                    icon={isImageName(file.name) ? SvgImageSmall : SvgFileText}
+                    leading={processing ? <Spinner size={16} /> : undefined}
+                    icon={isImageName(file.name) ? SvgImage : SvgFileText}
                     title={file.name}
                     description={
                       uploading
@@ -143,7 +150,7 @@ export function FilePickerSheet({
                     sizePreset="main-ui"
                     variant="section"
                     disabled={uploading}
-                    onPress={() => onPickRecent(file.id)}
+                    onPress={() => choose(() => onPickRecent(file.id))}
                   />
                 );
               })}

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -16,12 +16,11 @@ import SvgArrowUp from "@/icons/arrow-up";
 import SvgPaperclip from "@/icons/paperclip";
 import SvgStop from "@/icons/stop";
 
-// Auto-grow bounds (web parity: input `min-h-[44px]`, scrolls once it fills). We let the native
-// multiline TextInput size itself between these — never a JS-computed fixed height — so the caret
-// can't escape the frame (the old fixed-height approach let a fast double-Enter paint the caret
+// Fixed input height: Enter inserts a newline that scrolls *inside* the field instead of growing
+// the composer. Clamped via native min===max sizing — never a JS-computed height — so the caret
+// can't escape the frame (a content-driven fixed height let a fast double-Enter paint the caret
 // behind the toolbar).
-const INPUT_MIN_HEIGHT = 44;
-const INPUT_MAX_HEIGHT = 160;
+const INPUT_HEIGHT = 44;
 
 // web `shadow-box-01` (tokens/shadow.json): `0px 2px 12px 0px var(--shadow-02)` + a tight
 // `0px 0px 4px 1px` layer; `--shadow-02` = 10% black in both light & dark. RN renders one layer,
@@ -73,9 +72,6 @@ export function InputBar({
 
   const hasFiles = attachments.files.length > 0;
   const hasFailed = attachments.files.some(isFailedFile);
-  const blockingMessage = hasFailed
-    ? "Remove the failed attachment to send."
-    : "Attaching files…";
 
   return (
     <View
@@ -110,22 +106,24 @@ export function InputBar({
           multiline
           className="px-12 pb-8 pt-12 text-text-04"
           style={[
-            textPresets["main-content-body"] as TextStyle,
+            textPresets["main-ui-body"] as TextStyle,
             {
-              minHeight: INPUT_MIN_HEIGHT,
-              maxHeight: INPUT_MAX_HEIGHT,
+              minHeight: INPUT_HEIGHT,
+              maxHeight: INPUT_HEIGHT,
               textAlignVertical: "top",
             },
           ]}
         />
 
-        {attachments.hasBlockingFiles ? (
+        {/* Only surface the actionable failed-attachment hint; an in-progress upload shows its
+            spinner on the chip, so no "Attaching files…" line. */}
+        {hasFailed ? (
           <Text
             font="secondary-body"
-            color={hasFailed ? "status-error-05" : "text-02"}
+            color="status-error-05"
             className="px-12 pb-4"
           >
-            {blockingMessage}
+            Remove the failed attachment to send.
           </Text>
         ) : null}
 
@@ -165,17 +163,12 @@ export function InputBar({
       <FilePickerSheet
         visible={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        onUploadDocuments={() => {
-          setPickerOpen(false);
-          void attachments.addDocuments();
-        }}
-        onUploadPhotos={() => {
-          setPickerOpen(false);
-          void attachments.addImages();
-        }}
+        // The sheet closes itself (choose→onClose) and defers the action past the modal dismiss,
+        // so these are just the actions — no setPickerOpen here.
+        onUploadDocuments={() => void attachments.addDocuments()}
+        onUploadPhotos={() => void attachments.addImages()}
         recentFiles={linkableRecent}
         onPickRecent={(fileId) => {
-          setPickerOpen(false);
           const file = linkableRecent.find((item) => item.id === fileId);
           if (file) attachments.addRecent(file);
         }}

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -16,15 +16,12 @@ import SvgArrowUp from "@/icons/arrow-up";
 import SvgPaperclip from "@/icons/paperclip";
 import SvgStop from "@/icons/stop";
 
-// Fixed input height: Enter inserts a newline that scrolls *inside* the field instead of growing
-// the composer. Clamped via native min===max sizing — never a JS-computed height — so the caret
-// can't escape the frame (a content-driven fixed height let a fast double-Enter paint the caret
-// behind the toolbar).
+// Fixed height via native min===max sizing, never a JS-computed height: a content-driven height
+// let a fast double-Enter paint the caret behind the toolbar.
 const INPUT_HEIGHT = 44;
 
-// web `shadow-box-01` (tokens/shadow.json): `0px 2px 12px 0px var(--shadow-02)` + a tight
-// `0px 0px 4px 1px` layer; `--shadow-02` = 10% black in both light & dark. RN renders one layer,
-// so we mirror the primary blur; Android uses `elevation`.
+// Mirrors web `shadow-box-01` (tokens/shadow.json); RN renders one layer so we keep the primary
+// blur, Android uses `elevation`.
 const SHADOW_BOX_01 = {
   shadowColor: "#000000",
   shadowOffset: { width: 0, height: 2 },
@@ -42,11 +39,6 @@ interface InputBarProps {
   attachments: UseComposerDraft;
 }
 
-// Web-parity composer (mirrors web's Base/AppInputBar): a shadowed, borderless rounded card holding
-// an attachment chip strip, an auto-growing multi-line input, and a bottom toolbar with the attach
-// control (left) and stop/send (right). The left group is a slot — actions popover, model selector,
-// deep research, mic, etc. drop in beside the paperclip as those features land. ChatScreen's
-// KeyboardStickyView lifts the whole thing over the keyboard.
 export function InputBar({
   value,
   onChangeText,
@@ -62,7 +54,6 @@ export function InputBar({
   const canSend =
     value.trim().length > 0 && !isBusy && !attachments.hasBlockingFiles;
 
-  // Recent library files (fetched only while the picker is open), minus what's already attached.
   const { data: recentFiles = [], isLoading: isLoadingRecent } =
     useRecentFiles(pickerOpen);
   const linkableRecent = useMemo(() => {
@@ -78,9 +69,8 @@ export function InputBar({
       className="bg-background-neutral-00 px-12 pt-8"
       style={{ paddingBottom: insets.bottom }}
     >
-      {/* Borderless-with-shadow on web; RN also keeps a hairline border — in dark mode the card and
-          the page behind it are both near-black, where the black shadow is invisible, so the border
-          guarantees the card reads in both themes. The shadow supplies the light-mode depth. */}
+      {/* Hairline border (web is borderless): in dark mode card and page are both near-black and the
+          shadow is invisible, so the border guarantees the card reads. */}
       <View
         className="rounded-16 border border-border-01 bg-background-neutral-00"
         style={SHADOW_BOX_01}
@@ -115,8 +105,7 @@ export function InputBar({
           ]}
         />
 
-        {/* Only surface the actionable failed-attachment hint; an in-progress upload shows its
-            spinner on the chip, so no "Attaching files…" line. */}
+        {/* Only the actionable failed hint; in-progress uploads show a spinner on the chip. */}
         {hasFailed ? (
           <Text
             font="secondary-body"
@@ -128,7 +117,6 @@ export function InputBar({
         ) : null}
 
         <View className="min-h-40 flex-row items-center justify-between p-4">
-          {/* Left group — attach today; actions popover / model / deep research mount here later. */}
           <View className="flex-row items-center gap-8">
             <Button
               prominence="tertiary"
@@ -163,8 +151,7 @@ export function InputBar({
       <FilePickerSheet
         visible={pickerOpen}
         onClose={() => setPickerOpen(false)}
-        // The sheet closes itself (choose→onClose) and defers the action past the modal dismiss,
-        // so these are just the actions — no setPickerOpen here.
+        // Sheet closes itself (choose→onClose) and defers the action past dismiss — no setPickerOpen here.
         onUploadDocuments={() => void attachments.addDocuments()}
         onUploadPhotos={() => void attachments.addImages()}
         recentFiles={linkableRecent}

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -16,9 +16,23 @@ import SvgArrowUp from "@/icons/arrow-up";
 import SvgPaperclip from "@/icons/paperclip";
 import SvgStop from "@/icons/stop";
 
-// Auto-grow bounds: one line → ~5 lines, then the field scrolls internally.
-const INPUT_MIN_HEIGHT = 24;
-const INPUT_MAX_HEIGHT = 120;
+// Auto-grow bounds (web parity: input `min-h-[44px]`, scrolls once it fills). We let the native
+// multiline TextInput size itself between these — never a JS-computed fixed height — so the caret
+// can't escape the frame (the old fixed-height approach let a fast double-Enter paint the caret
+// behind the toolbar).
+const INPUT_MIN_HEIGHT = 44;
+const INPUT_MAX_HEIGHT = 160;
+
+// web `shadow-box-01` (tokens/shadow.json): `0px 2px 12px 0px var(--shadow-02)` + a tight
+// `0px 0px 4px 1px` layer; `--shadow-02` = 10% black in both light & dark. RN renders one layer,
+// so we mirror the primary blur; Android uses `elevation`.
+const SHADOW_BOX_01 = {
+  shadowColor: "#000000",
+  shadowOffset: { width: 0, height: 2 },
+  shadowOpacity: 0.1,
+  shadowRadius: 12,
+  elevation: 4,
+} as const;
 
 interface InputBarProps {
   value: string;
@@ -29,10 +43,11 @@ interface InputBarProps {
   attachments: UseComposerDraft;
 }
 
-// Web-parity composer (mirrors web's AppInputBar shape): a rounded container holding an
-// attachment chip strip, an auto-growing multi-line input, and a control row with the
-// attach button (left) and send/stop (right). ChatScreen's KeyboardStickyView lifts it
-// over the keyboard.
+// Web-parity composer (mirrors web's Base/AppInputBar): a shadowed, borderless rounded card holding
+// an attachment chip strip, an auto-growing multi-line input, and a bottom toolbar with the attach
+// control (left) and stop/send (right). The left group is a slot — actions popover, model selector,
+// deep research, mic, etc. drop in beside the paperclip as those features land. ChatScreen's
+// KeyboardStickyView lifts the whole thing over the keyboard.
 export function InputBar({
   value,
   onChangeText,
@@ -43,7 +58,6 @@ export function InputBar({
 }: InputBarProps) {
   const insets = useSafeAreaInsets();
   const [pickerOpen, setPickerOpen] = useState(false);
-  const [inputHeight, setInputHeight] = useState(INPUT_MIN_HEIGHT);
 
   const isBusy = chatState === "loading" || chatState === "streaming";
   const canSend =
@@ -57,24 +71,27 @@ export function InputBar({
     return recentFiles.filter((file) => !attachedIds.has(file.id));
   }, [attachments.files, recentFiles]);
 
+  const hasFiles = attachments.files.length > 0;
   const hasFailed = attachments.files.some(isFailedFile);
   const blockingMessage = hasFailed
     ? "Remove the failed attachment to send."
     : "Attaching files…";
-
-  const clampedHeight = Math.min(
-    Math.max(inputHeight, INPUT_MIN_HEIGHT),
-    INPUT_MAX_HEIGHT,
-  );
 
   return (
     <View
       className="bg-background-neutral-00 px-16 pt-8"
       style={{ paddingBottom: insets.bottom + 8 }}
     >
-      <View className="rounded-16 border border-border-01 bg-background-neutral-00 pt-8">
-        {attachments.files.length > 0 ? (
-          <View className="flex-row flex-wrap gap-8 px-12 pb-8">
+      {/* Borderless-with-shadow on web; RN also keeps a hairline border — in dark mode the card and
+          the page behind it are both near-black, where the black shadow is invisible, so the border
+          guarantees the card reads in both themes. The shadow supplies the light-mode depth. */}
+      <View
+        className="rounded-16 border border-border-01 bg-background-neutral-00"
+        style={SHADOW_BOX_01}
+      >
+        {hasFiles ? (
+          // gap-8 (wider than web's 4px): mobile file chips are larger touch targets.
+          <View className="flex-row flex-wrap gap-8 px-12 pt-12">
             {attachments.files.map((file) => (
               <FileCard
                 key={file.id}
@@ -91,14 +108,14 @@ export function InputBar({
           placeholder="Message Onyx…"
           placeholderClassName="text-text-02"
           multiline
-          onContentSizeChange={(event) =>
-            setInputHeight(event.nativeEvent.contentSize.height)
-          }
-          scrollEnabled={inputHeight > INPUT_MAX_HEIGHT}
-          className="px-16 text-text-04"
+          className="px-12 pb-8 pt-12 text-text-04"
           style={[
             textPresets["main-content-body"] as TextStyle,
-            { height: clampedHeight, textAlignVertical: "top" },
+            {
+              minHeight: INPUT_MIN_HEIGHT,
+              maxHeight: INPUT_MAX_HEIGHT,
+              textAlignVertical: "top",
+            },
           ]}
         />
 
@@ -106,37 +123,42 @@ export function InputBar({
           <Text
             font="secondary-body"
             color={hasFailed ? "status-error-05" : "text-02"}
-            className="px-16 pt-4"
+            className="px-12 pb-4"
           >
             {blockingMessage}
           </Text>
         ) : null}
 
-        <View className="flex-row items-center justify-between px-8 pb-8 pt-4">
-          <Button
-            prominence="tertiary"
-            size="sm"
-            icon={SvgPaperclip}
-            accessibilityLabel="Attach files"
-            onPress={() => setPickerOpen(true)}
-          />
-          {isBusy ? (
+        <View className="min-h-40 flex-row items-center justify-between p-4">
+          {/* Left group — attach today; actions popover / model / deep research mount here later. */}
+          <View className="flex-row items-center gap-8">
             <Button
               prominence="tertiary"
-              icon={SvgStop}
-              accessibilityLabel="Stop"
-              onPress={onStop}
-              className="rounded-12 border border-border-02"
+              icon={SvgPaperclip}
+              accessibilityLabel="Attach files"
+              onPress={() => setPickerOpen(true)}
             />
-          ) : (
-            <Button
-              prominence="primary"
-              icon={SvgArrowUp}
-              accessibilityLabel="Send"
-              onPress={onSend}
-              disabled={!canSend}
-            />
-          )}
+          </View>
+
+          <View className="flex-row items-center gap-4">
+            {isBusy ? (
+              <Button
+                prominence="tertiary"
+                icon={SvgStop}
+                accessibilityLabel="Stop"
+                onPress={onStop}
+                className="rounded-12 border-[1.5px] border-border-02"
+              />
+            ) : (
+              <Button
+                prominence="primary"
+                icon={SvgArrowUp}
+                accessibilityLabel="Send"
+                onPress={onSend}
+                disabled={!canSend}
+              />
+            )}
+          </View>
         </View>
       </View>
 

--- a/mobile/src/components/chat/InputBar.tsx
+++ b/mobile/src/components/chat/InputBar.tsx
@@ -79,8 +79,8 @@ export function InputBar({
 
   return (
     <View
-      className="bg-background-neutral-00 px-16 pt-8"
-      style={{ paddingBottom: insets.bottom + 8 }}
+      className="bg-background-neutral-00 px-12 pt-8"
+      style={{ paddingBottom: insets.bottom }}
     >
       {/* Borderless-with-shadow on web; RN also keeps a hairline border — in dark mode the card and
           the page behind it are both near-black, where the black shadow is invisible, so the border

--- a/mobile/src/components/chat/MessageList.tsx
+++ b/mobile/src/components/chat/MessageList.tsx
@@ -13,12 +13,15 @@ import {
 import { FlashList, FlashListRef } from "@shopify/flash-list";
 
 import { Message } from "@/chat/interfaces";
+import { MinimalAgent } from "@/chat/agents";
 import { MessageRow } from "@/components/chat/MessageRow";
 import { Icon } from "@/components/ui/icon";
 import SvgChevronDown from "@/icons/chevron-down";
 
 interface MessageListProps {
   messages: Message[];
+  // session agent, for the assistant-message avatar
+  agent: MinimalAgent | null;
 }
 
 // Newest turn this far below the viewport → treat as "scrolled up" and reveal the button (web: 32px).
@@ -32,18 +35,19 @@ const FAB_SHADOW = {
   elevation: 4,
 } as const;
 
-function renderItem({ item }: { item: Message }) {
-  return <MessageRow node={item} />;
-}
-
 function keyExtractor(item: Message): string {
   return String(item.nodeId);
 }
 
-export function MessageList({ messages }: MessageListProps) {
+export function MessageList({ messages, agent }: MessageListProps) {
   const listRef = useRef<FlashListRef<Message>>(null);
   const didInitialScroll = useRef(false);
   const [showScrollButton, setShowScrollButton] = useState(false);
+
+  const renderItem = useCallback(
+    ({ item }: { item: Message }) => <MessageRow node={item} agent={agent} />,
+    [agent],
+  );
 
   // Opening an existing chat lands on the newest turn (web's session-load scroll-to-bottom). A
   // short/new chat is already fully visible, so this is a no-op that leaves the first turn at top.

--- a/mobile/src/components/chat/MessageList.tsx
+++ b/mobile/src/components/chat/MessageList.tsx
@@ -1,13 +1,36 @@
-// FlashList v2 chat pattern: non-inverted + maintainVisibleContentPosition/startRenderingFromBottom keeps
-// the view pinned to the bottom while streaming. Pagination lands in PR 4.
-import { FlashList } from "@shopify/flash-list";
+// FlashList v2 chat pattern, top-anchored to mirror web: a new/short conversation reads top→down
+// (startRenderingFromBottom off), MVCP.autoscrollToBottomThreshold keeps the view pinned to the
+// latest turn while streaming *only when the user is already near the bottom*, opening an existing
+// chat jumps to the newest turn (web scrolls to bottom on session load), and a floating chevron
+// returns there after the user scrolls up.
+import { useCallback, useRef, useState } from "react";
+import {
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+  Pressable,
+  View,
+} from "react-native";
+import { FlashList, FlashListRef } from "@shopify/flash-list";
 
 import { Message } from "@/chat/interfaces";
 import { MessageRow } from "@/components/chat/MessageRow";
+import { Icon } from "@/components/ui/icon";
+import SvgChevronDown from "@/icons/chevron-down";
 
 interface MessageListProps {
   messages: Message[];
 }
+
+// Newest turn this far below the viewport → treat as "scrolled up" and reveal the button (web: 32px).
+const AT_BOTTOM_THRESHOLD_PX = 48;
+
+const FAB_SHADOW = {
+  shadowColor: "#000000",
+  shadowOffset: { width: 0, height: 2 },
+  shadowOpacity: 0.12,
+  shadowRadius: 8,
+  elevation: 4,
+} as const;
 
 function renderItem({ item }: { item: Message }) {
   return <MessageRow node={item} />;
@@ -18,16 +41,63 @@ function keyExtractor(item: Message): string {
 }
 
 export function MessageList({ messages }: MessageListProps) {
+  const listRef = useRef<FlashListRef<Message>>(null);
+  const didInitialScroll = useRef(false);
+  const [showScrollButton, setShowScrollButton] = useState(false);
+
+  // Opening an existing chat lands on the newest turn (web's session-load scroll-to-bottom). A
+  // short/new chat is already fully visible, so this is a no-op that leaves the first turn at top.
+  // Reset per session by keying this list on sessionId (see ChatSurface).
+  const handleLoad = useCallback(() => {
+    if (didInitialScroll.current) return;
+    didInitialScroll.current = true;
+    listRef.current?.scrollToEnd({ animated: false });
+  }, []);
+
+  const handleScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const distanceFromBottom =
+        contentSize.height - (contentOffset.y + layoutMeasurement.height);
+      setShowScrollButton(distanceFromBottom > AT_BOTTOM_THRESHOLD_PX);
+    },
+    [],
+  );
+
+  const scrollToBottom = useCallback(() => {
+    listRef.current?.scrollToEnd({ animated: true });
+  }, []);
+
   return (
-    <FlashList
-      data={messages}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      maintainVisibleContentPosition={{
-        startRenderingFromBottom: true,
-        autoscrollToBottomThreshold: 0.2,
-      }}
-      contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 8 }}
-    />
+    <View className="flex-1">
+      <FlashList
+        ref={listRef}
+        data={messages}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        onLoad={handleLoad}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
+        maintainVisibleContentPosition={{ autoscrollToBottomThreshold: 0.2 }}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 8 }}
+      />
+      {showScrollButton ? (
+        <View
+          pointerEvents="box-none"
+          className="absolute inset-x-0 bottom-16 items-center"
+        >
+          <Pressable
+            onPress={scrollToBottom}
+            accessibilityRole="button"
+            accessibilityLabel="Scroll to bottom"
+            style={FAB_SHADOW}
+            className="h-36 w-36 items-center justify-center rounded-full border border-border-01 bg-background-neutral-00 active:bg-background-tint-02"
+          >
+            <Icon as={SvgChevronDown} size={20} className="text-text-03" />
+          </Pressable>
+        </View>
+      ) : null}
+    </View>
   );
 }

--- a/mobile/src/components/chat/MessageList.tsx
+++ b/mobile/src/components/chat/MessageList.tsx
@@ -1,8 +1,6 @@
-// FlashList v2 chat pattern, top-anchored to mirror web: a new/short conversation reads top→down
-// (startRenderingFromBottom off), MVCP.autoscrollToBottomThreshold keeps the view pinned to the
-// latest turn while streaming *only when the user is already near the bottom*, opening an existing
-// chat jumps to the newest turn (web scrolls to bottom on session load), and a floating chevron
-// returns there after the user scrolls up.
+// Top-anchored FlashList mirroring web: short chats read top→down; MVCP autoscroll pins to the
+// latest turn while streaming only when the user is near the bottom; a floating chevron returns
+// after scrolling up.
 import { useCallback, useRef, useState } from "react";
 import {
   NativeScrollEvent,
@@ -20,11 +18,11 @@ import SvgChevronDown from "@/icons/chevron-down";
 
 interface MessageListProps {
   messages: Message[];
-  // session agent, for the assistant-message avatar
+  // for the assistant-message avatar
   agent: MinimalAgent | null;
 }
 
-// Newest turn this far below the viewport → treat as "scrolled up" and reveal the button (web: 32px).
+// Newest turn this far below viewport → "scrolled up", reveal the button (web uses 32px).
 const AT_BOTTOM_THRESHOLD_PX = 48;
 
 const FAB_SHADOW = {
@@ -49,9 +47,8 @@ export function MessageList({ messages, agent }: MessageListProps) {
     [agent],
   );
 
-  // Opening an existing chat lands on the newest turn (web's session-load scroll-to-bottom). A
-  // short/new chat is already fully visible, so this is a no-op that leaves the first turn at top.
-  // Reset per session by keying this list on sessionId (see ChatSurface).
+  // Land on newest turn when opening a chat (web's session-load scroll-to-bottom); no-op for short
+  // chats. Reset per session by keying this list on sessionId (see ChatSurface).
   const handleLoad = useCallback(() => {
     if (didInitialScroll.current) return;
     didInitialScroll.current = true;

--- a/mobile/src/components/chat/MessageRow.tsx
+++ b/mobile/src/components/chat/MessageRow.tsx
@@ -4,9 +4,12 @@ import { memo } from "react";
 import { View } from "react-native";
 
 import { Message } from "@/chat/interfaces";
+import { getErrorTitle } from "@/chat/errorHelpers";
 import { fileDescriptorToDisplayFile } from "@/chat/fileDescriptors";
 import { FileCard } from "@/components/chat/FileCard";
+import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
+import SvgAlertCircle from "@/icons/alert-circle";
 import { usePacketDisplay } from "@/hooks/usePacketDisplay";
 
 function UserMessage({ node }: { node: Message }) {
@@ -21,7 +24,8 @@ function UserMessage({ node }: { node: Message }) {
         </View>
       ) : null}
       {node.message.length > 0 ? (
-        <View className="max-w-[85%] rounded-16 bg-background-tint-02 px-16 py-12">
+        // Web parity (HumanMessage): tint bubble, px-3/py-2, asymmetric corners (square bottom-right).
+        <View className="max-w-[85%] rounded-t-16 rounded-bl-16 bg-background-tint-02 px-12 py-8">
           <Text font="main-content-body" color="text-05">
             {node.message}
           </Text>
@@ -31,12 +35,26 @@ function UserMessage({ node }: { node: Message }) {
   );
 }
 
-function ErrorMessage({ message }: { message: string }) {
+// Web parity: the ErrorBanner (red Alert "broken" box) — code-derived title + the raw error text.
+// Mobile port shows one alert icon (web varies it by code) and no stack-trace/regenerate yet.
+function ErrorMessage({ node }: { node: Message }) {
   return (
     <View className="py-6">
-      <Text font="main-content-body" color="status-error-05">
-        {message || "Something went wrong. Please try again."}
-      </Text>
+      <View className="flex-row gap-8 rounded-12 border border-status-error-05 bg-status-error-01 px-12 py-12">
+        <Icon
+          as={SvgAlertCircle}
+          size={16}
+          className="mt-2 text-status-error-05"
+        />
+        <View className="flex-1 gap-4">
+          <Text font="main-ui-action" color="status-error-05">
+            {getErrorTitle(node.errorCode)}
+          </Text>
+          <Text font="main-ui-body" color="status-error-05">
+            {node.message || "An error occurred. Please try again."}
+          </Text>
+        </View>
+      </View>
     </View>
   );
 }
@@ -61,7 +79,7 @@ function AssistantMessage({ node }: { node: Message }) {
 
 function MessageRowComponent({ node }: { node: Message }) {
   if (node.type === "user") return <UserMessage node={node} />;
-  if (node.type === "error") return <ErrorMessage message={node.message} />;
+  if (node.type === "error") return <ErrorMessage node={node} />;
   return <AssistantMessage node={node} />;
 }
 
@@ -72,6 +90,7 @@ export const MessageRow = memo(
     prev.node.type === next.node.type &&
     prev.node.message === next.node.message &&
     prev.node.messageId === next.node.messageId &&
+    prev.node.errorCode === next.node.errorCode &&
     prev.node.packets.length === next.node.packets.length &&
     // user rows render attachment chips from node.files; re-render if that array is replaced
     prev.node.files === next.node.files,

--- a/mobile/src/components/chat/MessageRow.tsx
+++ b/mobile/src/components/chat/MessageRow.tsx
@@ -4,8 +4,10 @@ import { memo } from "react";
 import { View } from "react-native";
 
 import { Message } from "@/chat/interfaces";
+import { MinimalAgent } from "@/chat/agents";
 import { getErrorTitle } from "@/chat/errorHelpers";
 import { fileDescriptorToDisplayFile } from "@/chat/fileDescriptors";
+import { AgentTimeline } from "@/components/chat/AgentTimeline";
 import { FileCard } from "@/components/chat/FileCard";
 import { Icon } from "@/components/ui/icon";
 import { Text } from "@/components/ui/text";
@@ -26,7 +28,9 @@ function UserMessage({ node }: { node: Message }) {
       {node.message.length > 0 ? (
         // Web parity (HumanMessage): tint bubble, px-3/py-2, asymmetric corners (square bottom-right).
         <View className="max-w-[85%] rounded-t-16 rounded-bl-16 bg-background-tint-02 px-12 py-8">
-          <Text font="main-content-body" color="text-05">
+          {/* main-ui-body (14px): deliberate reduction from web's main-content-body (16px) — 16px
+              reads oversized on a phone. Assistant markdown (StreamingMarkdown) matches. */}
+          <Text font="main-ui-body" color="text-05">
             {node.message}
           </Text>
         </View>
@@ -59,28 +63,43 @@ function ErrorMessage({ node }: { node: Message }) {
   );
 }
 
-function AssistantMessage({ node }: { node: Message }) {
+function AssistantMessage({
+  node,
+  agent,
+}: {
+  node: Message;
+  agent: MinimalAgent | null;
+}) {
   const { renderer, packets, isComplete } = usePacketDisplay(node);
   const Renderer = renderer?.Component;
+  const hasContent = Renderer != null && packets.length > 0;
 
+  // Web AgentMessage: vertical stack of the timeline (avatar + status) then the answer. The timeline
+  // owns the "Thinking…" loader, so the bare "…" placeholder is gone.
   return (
-    <View className="py-6">
-      {Renderer && packets.length > 0 ? (
-        <Renderer packets={packets} isComplete={isComplete} />
-      ) : (
-        // no content yet — thinking placeholder
-        <Text font="main-content-muted" color="text-03">
-          …
-        </Text>
-      )}
+    <View className="gap-12 py-6">
+      <AgentTimeline agent={agent} isLoading={!hasContent && !isComplete} />
+      {hasContent ? (
+        // web AgentMessage answer wrapper is px-3 (12px) — inset so the text lines up under the
+        // avatar rail instead of sticking out to its left.
+        <View className="px-12">
+          <Renderer packets={packets} isComplete={isComplete} />
+        </View>
+      ) : null}
     </View>
   );
 }
 
-function MessageRowComponent({ node }: { node: Message }) {
+function MessageRowComponent({
+  node,
+  agent,
+}: {
+  node: Message;
+  agent: MinimalAgent | null;
+}) {
   if (node.type === "user") return <UserMessage node={node} />;
   if (node.type === "error") return <ErrorMessage node={node} />;
-  return <AssistantMessage node={node} />;
+  return <AssistantMessage node={node} agent={agent} />;
 }
 
 export const MessageRow = memo(
@@ -93,5 +112,7 @@ export const MessageRow = memo(
     prev.node.errorCode === next.node.errorCode &&
     prev.node.packets.length === next.node.packets.length &&
     // user rows render attachment chips from node.files; re-render if that array is replaced
-    prev.node.files === next.node.files,
+    prev.node.files === next.node.files &&
+    // assistant rows show the agent avatar; re-render if the session's agent resolves/changes
+    prev.agent === next.agent,
 );

--- a/mobile/src/components/chat/MessageRow.tsx
+++ b/mobile/src/components/chat/MessageRow.tsx
@@ -1,5 +1,4 @@
-// Memoized on packetCount (not array identity): a row re-renders only when its own packets grow, so
-// streaming one message doesn't re-render the list.
+// Memoized on packet count, not array identity: a row re-renders only when its own packets grow.
 import { memo } from "react";
 import { View } from "react-native";
 
@@ -26,10 +25,9 @@ function UserMessage({ node }: { node: Message }) {
         </View>
       ) : null}
       {node.message.length > 0 ? (
-        // Web parity (HumanMessage): tint bubble, px-3/py-2, asymmetric corners (square bottom-right).
+        // Web parity: HumanMessage bubble with asymmetric corners (square bottom-right).
         <View className="max-w-[85%] rounded-t-16 rounded-bl-16 bg-background-tint-02 px-12 py-8">
-          {/* main-ui-body (14px): deliberate reduction from web's main-content-body (16px) — 16px
-              reads oversized on a phone. Assistant markdown (StreamingMarkdown) matches. */}
+          {/* 14px body: deliberate reduction from web's 16px, which reads oversized on a phone. */}
           <Text font="main-ui-body" color="text-05">
             {node.message}
           </Text>
@@ -39,8 +37,7 @@ function UserMessage({ node }: { node: Message }) {
   );
 }
 
-// Web parity: the ErrorBanner (red Alert "broken" box) — code-derived title + the raw error text.
-// Mobile port shows one alert icon (web varies it by code) and no stack-trace/regenerate yet.
+// Web parity: ErrorBanner — code-derived title + raw error. Single alert icon; no regenerate yet.
 function ErrorMessage({ node }: { node: Message }) {
   return (
     <View className="py-6">
@@ -74,14 +71,12 @@ function AssistantMessage({
   const Renderer = renderer?.Component;
   const hasContent = Renderer != null && packets.length > 0;
 
-  // Web AgentMessage: vertical stack of the timeline (avatar + status) then the answer. The timeline
-  // owns the "Thinking…" loader, so the bare "…" placeholder is gone.
+  // Web AgentMessage: timeline (avatar + status) above the answer; the timeline owns the loader.
   return (
     <View className="gap-12 py-6">
       <AgentTimeline agent={agent} isLoading={!hasContent && !isComplete} />
       {hasContent ? (
-        // web AgentMessage answer wrapper is px-3 (12px) — inset so the text lines up under the
-        // avatar rail instead of sticking out to its left.
+        // Inset (px-12) aligns the answer under the avatar rail, matching web's px-3.
         <View className="px-12">
           <Renderer packets={packets} isComplete={isComplete} />
         </View>
@@ -111,8 +106,8 @@ export const MessageRow = memo(
     prev.node.messageId === next.node.messageId &&
     prev.node.errorCode === next.node.errorCode &&
     prev.node.packets.length === next.node.packets.length &&
-    // user rows render attachment chips from node.files; re-render if that array is replaced
+    // user attachment chips: re-render if the files array is replaced
     prev.node.files === next.node.files &&
-    // assistant rows show the agent avatar; re-render if the session's agent resolves/changes
+    // assistant avatar: re-render if the session's agent changes
     prev.agent === next.agent,
 );

--- a/mobile/src/components/chat/ProjectContextPanel.tsx
+++ b/mobile/src/components/chat/ProjectContextPanel.tsx
@@ -1,16 +1,13 @@
-import { useCallback, useMemo, useState } from "react";
-import { ActivityIndicator, View } from "react-native";
+import { View } from "react-native";
+import { router } from "expo-router";
 
-import { useRecentFiles } from "@/hooks/useRecentFiles";
-import { Button } from "@/components/ui/button";
-import { Content, ContentAction } from "@/components/ui/content";
-import { Text } from "@/components/ui/text";
+import { Content } from "@/components/ui/content";
+import { Icon } from "@/components/ui/icon";
+import { LineItemButton } from "@/components/ui/line-item-button";
 import { Separator } from "@/components/ui/separator";
-import { FileCard } from "@/components/chat/FileCard";
-import { FilePickerSheet } from "@/components/chat/FilePickerSheet";
-import { useProjectFiles } from "@/hooks/useProjectFiles";
+import { Text } from "@/components/ui/text";
+import SvgChevronRight from "@/icons/chevron-right";
 import SvgFolder from "@/icons/folder";
-import SvgPlus from "@/icons/plus";
 import type { ProjectDetails } from "@/chat/contracts/projects";
 
 interface ProjectContextPanelProps {
@@ -19,34 +16,15 @@ interface ProjectContextPanelProps {
   isLoading: boolean;
 }
 
-// Project detail + file management (mirrors web's ProjectContextPanel).
+// Project overview. A "View sources" row shows the file count and opens the dedicated
+// /sources/[id] screen, which owns all file management.
 export function ProjectContextPanel({
   projectId,
   details,
-  isLoading,
 }: ProjectContextPanelProps) {
   const project = details?.project;
   const instructions = project?.instructions?.trim();
-  const loadingDetails = isLoading && !details;
-
-  const [pickerOpen, setPickerOpen] = useState(false);
-  const { files, addDocuments, addImages, linkRecent, removeFile } =
-    useProjectFiles(projectId, details?.files);
-
-  const onRemoveFile = useCallback(
-    (id: string) => {
-      void removeFile(id);
-    },
-    [removeFile],
-  );
-
-  // Recent library files, fetched only while the picker is open.
-  const { data: recentFiles = [], isLoading: isLoadingRecent } =
-    useRecentFiles(pickerOpen);
-  const linkableRecent = useMemo(() => {
-    const existingIds = new Set(files.map((file) => file.id));
-    return recentFiles.filter((file) => !existingIds.has(file.id));
-  }, [files, recentFiles]);
+  const fileCount = details?.files?.length ?? 0;
 
   return (
     <View className="gap-24">
@@ -62,58 +40,28 @@ export function ProjectContextPanel({
         descriptionMaxLines={4}
       />
 
-      <View className="gap-8">
-        <ContentAction
-          sizePreset="main-ui"
-          variant="section"
-          title="Files"
-          description="Chats in this project can access these files."
-          rightChildren={
-            <Button
-              icon={SvgPlus}
-              prominence="secondary"
-              size="sm"
-              accessibilityLabel="Add files"
-              disabled={projectId == null || loadingDetails}
-              onPress={() => setPickerOpen(true)}
-            />
-          }
-        />
-
-        {loadingDetails ? (
-          <ActivityIndicator size="small" />
-        ) : files.length === 0 ? (
-          <View className="justify-center rounded-12 border border-dashed border-border-01 px-12 py-12">
-            <Text font="secondary-body" color="text-02">
-              No files in this project yet.
+      <LineItemButton
+        icon={SvgFolder}
+        title="View sources"
+        sizePreset="main-ui"
+        variant="section"
+        center
+        disabled={projectId == null}
+        onPress={() =>
+          projectId != null &&
+          router.navigate({
+            pathname: "/sources/[id]",
+            params: { id: String(projectId) },
+          })
+        }
+        rightChildren={
+          <View className="flex-row items-center gap-4">
+            <Text font="secondary-body" color="text-03">
+              {fileCount} {fileCount === 1 ? "file" : "files"}
             </Text>
+            <Icon as={SvgChevronRight} size={16} className="text-text-03" />
           </View>
-        ) : (
-          <View className="flex-row flex-wrap gap-8">
-            {files.map((file) => (
-              <FileCard key={file.id} file={file} onRemove={onRemoveFile} />
-            ))}
-          </View>
-        )}
-      </View>
-
-      <FilePickerSheet
-        visible={pickerOpen}
-        onClose={() => setPickerOpen(false)}
-        onUploadDocuments={() => {
-          setPickerOpen(false);
-          void addDocuments();
-        }}
-        onUploadPhotos={() => {
-          setPickerOpen(false);
-          void addImages();
-        }}
-        recentFiles={linkableRecent}
-        onPickRecent={(fileId) => {
-          setPickerOpen(false);
-          void linkRecent(fileId);
-        }}
-        isLoadingRecent={isLoadingRecent}
+        }
       />
     </View>
   );

--- a/mobile/src/components/chat/ProjectContextPanel.tsx
+++ b/mobile/src/components/chat/ProjectContextPanel.tsx
@@ -16,8 +16,7 @@ interface ProjectContextPanelProps {
   isLoading: boolean;
 }
 
-// Project overview. A "View sources" row shows the file count and opens the dedicated
-// /sources/[id] screen, which owns all file management.
+// File management lives on the dedicated /sources/[id] screen, not here.
 export function ProjectContextPanel({
   projectId,
   details,

--- a/mobile/src/components/chat/ProjectFileList.tsx
+++ b/mobile/src/components/chat/ProjectFileList.tsx
@@ -22,8 +22,7 @@ interface ProjectFileListProps {
   onRemove: (id: string) => void;
 }
 
-// Project files as a grouped, hairline-divided list (icon box + name + type + remove) — the
-// mobile-appropriate shape for a vertical document list, vs the composer's chip-style FileCard.
+// Vertical document-list shape, deliberately distinct from the composer's chip-style FileCard.
 export function ProjectFileList({ files, onRemove }: ProjectFileListProps) {
   return (
     <View className="overflow-hidden rounded-12 border border-border-01">

--- a/mobile/src/components/chat/ProjectFileList.tsx
+++ b/mobile/src/components/chat/ProjectFileList.tsx
@@ -1,0 +1,114 @@
+import { memo } from "react";
+import { Pressable, View } from "react-native";
+
+import { Icon } from "@/components/ui/icon";
+import { Separator } from "@/components/ui/separator";
+import { Spinner } from "@/components/ui/spinner";
+import { Text } from "@/components/ui/text";
+import {
+  isProcessingStatus,
+  UserFileStatus,
+  type ProjectFile,
+} from "@/chat/contracts/projects";
+import { extensionOf, isFailedFile, isImageName } from "@/lib/files";
+import { cn } from "@/lib/utils";
+import SvgAlertCircle from "@/icons/alert-circle";
+import SvgFileText from "@/icons/file-text";
+import SvgImage from "@/icons/image";
+import SvgX from "@/icons/x";
+
+interface ProjectFileListProps {
+  files: ProjectFile[];
+  onRemove: (id: string) => void;
+}
+
+// Project files as a grouped, hairline-divided list (icon box + name + type + remove) — the
+// mobile-appropriate shape for a vertical document list, vs the composer's chip-style FileCard.
+export function ProjectFileList({ files, onRemove }: ProjectFileListProps) {
+  return (
+    <View className="overflow-hidden rounded-12 border border-border-01">
+      {files.map((file, index) => (
+        <View key={file.id}>
+          {index > 0 ? <Separator /> : null}
+          <ProjectFileRow file={file} onRemove={onRemove} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const ProjectFileRow = memo(function ProjectFileRow({
+  file,
+  onRemove,
+}: {
+  file: ProjectFile;
+  onRemove: (id: string) => void;
+}) {
+  const failed = isFailedFile(file);
+  const uploading =
+    String(file.status).toUpperCase() === UserFileStatus.UPLOADING;
+  const processing = isProcessingStatus(file.status);
+  const label = failed
+    ? "Upload failed"
+    : uploading
+      ? "Uploading…"
+      : processing
+        ? "Processing…"
+        : extensionOf(file.name).toUpperCase() || "File";
+
+  return (
+    <View className="flex-row items-center gap-12 px-12 py-8">
+      <View
+        style={{ width: 36, height: 36 }}
+        className={cn(
+          "items-center justify-center rounded-08",
+          failed ? "bg-status-error-01" : "bg-background-tint-01",
+        )}
+      >
+        {uploading || processing ? (
+          <Spinner size={16} />
+        ) : (
+          <Icon
+            as={
+              failed
+                ? SvgAlertCircle
+                : isImageName(file.name)
+                  ? SvgImage
+                  : SvgFileText
+            }
+            size={16}
+            className={failed ? "text-status-error-05" : "text-text-02"}
+          />
+        )}
+      </View>
+
+      <View className="min-w-0 flex-1">
+        <Text
+          font="main-ui-body"
+          color={failed ? "status-error-05" : "text-04"}
+          numberOfLines={1}
+        >
+          {file.name}
+        </Text>
+        <Text
+          font="secondary-body"
+          color={failed ? "status-error-05" : "text-02"}
+          numberOfLines={1}
+        >
+          {label}
+        </Text>
+      </View>
+
+      <Pressable
+        onPress={() => onRemove(file.id)}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`Remove ${file.name}`}
+        className="p-4"
+        style={({ pressed }) => (pressed ? { opacity: 0.6 } : undefined)}
+      >
+        <Icon as={SvgX} size={16} className="text-text-03" />
+      </Pressable>
+    </View>
+  );
+});

--- a/mobile/src/components/chat/StreamingMarkdown.tsx
+++ b/mobile/src/components/chat/StreamingMarkdown.tsx
@@ -1,6 +1,4 @@
-// streamdown wraps enriched-markdown (worklet parsing), which needs concrete style values, not NativeWind
-// classes — so resolve Onyx tokens from the shared vars/presets here. Swapping the markdown lib touches
-// only this file.
+// enriched-markdown needs concrete style values, not NativeWind classes — resolve Onyx tokens here.
 import { useMemo } from "react";
 import { useColorScheme } from "react-native";
 import { StreamdownText } from "react-native-streamdown";
@@ -12,17 +10,14 @@ interface StreamingMarkdownProps {
   isStreaming: boolean;
 }
 
-// main-ui-body (14px): deliberate reduction from web's main-content-body (16px) — 16px reads
-// oversized on a phone. The user bubble (MessageRow) matches. Headings/code keep fixed px sizes.
+// 14px body: deliberate reduction from web's 16px, which reads oversized on a phone.
 const BODY = textPresets["main-ui-body"];
 const MONO = textPresets["main-content-mono"];
 
-// Markdown element styles as concrete values (enriched-markdown takes literals, not NativeWind
-// classes): Onyx tokens on a 14px body base; heading/code sizes are fixed pixels.
 function buildMarkdownStyle(scheme: "light" | "dark"): MarkdownStyle {
   const vars = scheme === "dark" ? varsDark : varsLight;
   const color = (token: string): string => vars[token] ?? "#000000";
-  // Fenced code has no Onyx token; use the Atom One base color (one flat color — no per-token highlighting).
+  // Fenced code has no Onyx token; use Atom One's flat base color (no per-token highlighting).
   const codeBaseColor = scheme === "dark" ? "#e2e6eb" : "#383a42";
   return {
     paragraph: {
@@ -30,7 +25,7 @@ function buildMarkdownStyle(scheme: "light" | "dark"): MarkdownStyle {
       fontFamily: BODY.fontFamily,
       fontSize: BODY.fontSize,
       lineHeight: BODY.lineHeight,
-      // marginTop 0: RN doesn't collapse margins, so 0 top + 8 bottom gives an even 8px rhythm.
+      // RN doesn't collapse margins: 0 top + 8 bottom gives an even 8px rhythm.
       marginTop: 0,
       marginBottom: 8,
     },
@@ -62,7 +57,7 @@ function buildMarkdownStyle(scheme: "light" | "dark"): MarkdownStyle {
       marginBottom: 10,
     },
     strong: { color: color("--text-05"), fontWeight: "bold" },
-    // No color: italics inherit their block color (paragraph/list text-05, blockquote text-04).
+    // No color: italics inherit block color (paragraph/list text-05, blockquote text-04).
     em: { fontStyle: "italic" },
     link: { color: color("--action-link-05"), underline: true },
     list: {

--- a/mobile/src/components/chat/StreamingMarkdown.tsx
+++ b/mobile/src/components/chat/StreamingMarkdown.tsx
@@ -12,11 +12,13 @@ interface StreamingMarkdownProps {
   isStreaming: boolean;
 }
 
-const BODY = textPresets["main-content-body"];
+// main-ui-body (14px): deliberate reduction from web's main-content-body (16px) — 16px reads
+// oversized on a phone. The user bubble (MessageRow) matches. Headings/code keep fixed px sizes.
+const BODY = textPresets["main-ui-body"];
 const MONO = textPresets["main-content-mono"];
 
 // Markdown element styles as concrete values (enriched-markdown takes literals, not NativeWind
-// classes): Onyx tokens on a 16px body base; heading/code sizes are fixed pixels.
+// classes): Onyx tokens on a 14px body base; heading/code sizes are fixed pixels.
 function buildMarkdownStyle(scheme: "light" | "dark"): MarkdownStyle {
   const vars = scheme === "dark" ? varsDark : varsLight;
   const color = (token: string): string => vars[token] ?? "#000000";

--- a/mobile/src/components/chat/__tests__/FilePickerSheet.test.tsx
+++ b/mobile/src/components/chat/__tests__/FilePickerSheet.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest } from "@jest/globals";
 import { fireEvent, render, screen } from "@testing-library/react-native";
+import { Modal } from "react-native";
 
 import { FilePickerSheet } from "@/components/chat/FilePickerSheet";
 import { makeProjectFile } from "@/chat/__tests__/fixtures";
@@ -11,6 +12,12 @@ jest.mock("react-native-safe-area-context", () => ({
 
 function recent(id: string, name: string): ProjectFile {
   return makeProjectFile({ id, name, file_id: id });
+}
+
+// A chosen action is deferred past the sheet's modal dismiss (iOS presentation-conflict guard),
+// so a tap only fires the callback once the modal reports it has dismissed.
+function fireDismiss() {
+  fireEvent(screen.UNSAFE_getByType(Modal), "dismiss");
 }
 
 function renderSheet(
@@ -31,13 +38,15 @@ function renderSheet(
 }
 
 describe("FilePickerSheet", () => {
-  it("offers the two device-upload actions", () => {
+  it("offers the two device-upload actions (after the sheet dismisses)", () => {
     const props = renderSheet();
 
     fireEvent.press(screen.getByText("Upload from device"));
+    fireDismiss();
     expect(props.onUploadDocuments).toHaveBeenCalledTimes(1);
 
     fireEvent.press(screen.getByText("Choose photos"));
+    fireDismiss();
     expect(props.onUploadPhotos).toHaveBeenCalledTimes(1);
   });
 
@@ -48,6 +57,7 @@ describe("FilePickerSheet", () => {
 
     expect(screen.getByText("notes.txt")).toBeTruthy();
     fireEvent.press(screen.getByText("chart.png"));
+    fireDismiss();
     expect(props.onPickRecent).toHaveBeenCalledWith("f2");
   });
 
@@ -77,12 +87,13 @@ describe("FilePickerSheet", () => {
     expect(screen.getByText("Uploading…")).toBeTruthy();
     expect(screen.getByText("Indexing…")).toBeTruthy();
 
-    // No server id yet → not pickable.
+    // No server id yet → disabled, nothing to defer.
     fireEvent.press(screen.getByText("uploading.pdf"));
     expect(props.onPickRecent).not.toHaveBeenCalled();
 
     // Indexing (has a server id) → pickable.
     fireEvent.press(screen.getByText("indexing.pdf"));
+    fireDismiss();
     expect(props.onPickRecent).toHaveBeenCalledWith("idx");
   });
 });

--- a/mobile/src/components/chat/__tests__/FilePickerSheet.test.tsx
+++ b/mobile/src/components/chat/__tests__/FilePickerSheet.test.tsx
@@ -14,8 +14,7 @@ function recent(id: string, name: string): ProjectFile {
   return makeProjectFile({ id, name, file_id: id });
 }
 
-// A chosen action is deferred past the sheet's modal dismiss (iOS presentation-conflict guard),
-// so a tap only fires the callback once the modal reports it has dismissed.
+// Chosen action fires only after the modal reports dismissal (iOS presentation-conflict guard).
 function fireDismiss() {
   fireEvent(screen.UNSAFE_getByType(Modal), "dismiss");
 }

--- a/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
+++ b/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
@@ -24,7 +24,9 @@ function accumulateContent(packets: Packet[]): string {
       packet.obj.type === PacketType.MESSAGE_START ||
       packet.obj.type === PacketType.MESSAGE_DELTA
     ) {
-      content += (packet.obj as MessageStart | MessageDelta).content;
+      // `?? ""`: a message_start packet can arrive with no `content`; without the guard the
+      // template appends the literal string "undefined" before the first delta.
+      content += (packet.obj as MessageStart | MessageDelta).content ?? "";
     }
   }
   return content;

--- a/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
+++ b/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
@@ -1,4 +1,7 @@
-// MESSAGE_START/DELTA content concatenated into one markdown string.
+// MESSAGE_START/DELTA content concatenated into one markdown string, then revealed at a steady
+// pace (useTypewriter) so a fast/bursty response still animates in like other AI chat apps.
+import { useMemo, useState } from "react";
+
 import {
   MessageDelta,
   MessageStart,
@@ -6,6 +9,7 @@ import {
   PacketType,
 } from "@/chat/streamingModels";
 import { StreamingMarkdown } from "@/components/chat/StreamingMarkdown";
+import { useTypewriter } from "@/hooks/useTypewriter";
 
 import type { MessageRenderer, MessageRendererProps } from "./registry";
 
@@ -33,8 +37,12 @@ function accumulateContent(packets: Packet[]): string {
 }
 
 function MessageText({ packets, isComplete }: MessageRendererProps) {
-  const content = accumulateContent(packets);
-  return <StreamingMarkdown content={content} isStreaming={!isComplete} />;
+  // Stable between packet flushes so the typewriter target only grows when content actually does.
+  const content = useMemo(() => accumulateContent(packets), [packets]);
+  // Captured once at mount: animate live messages; a hydrated/historical one mounts complete → snap.
+  const [animate] = useState(() => !isComplete);
+  const { displayed } = useTypewriter(content, animate, isComplete);
+  return <StreamingMarkdown content={displayed} isStreaming={!isComplete} />;
 }
 
 export const MessageTextRenderer: MessageRenderer = {

--- a/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
+++ b/mobile/src/components/chat/renderers/MessageTextRenderer.tsx
@@ -1,5 +1,4 @@
-// MESSAGE_START/DELTA content concatenated into one markdown string, then revealed at a steady
-// pace (useTypewriter) so a fast/bursty response still animates in like other AI chat apps.
+// Reveals concatenated stream content at a steady pace (useTypewriter) so bursty responses still animate in.
 import { useMemo, useState } from "react";
 
 import {
@@ -28,8 +27,7 @@ function accumulateContent(packets: Packet[]): string {
       packet.obj.type === PacketType.MESSAGE_START ||
       packet.obj.type === PacketType.MESSAGE_DELTA
     ) {
-      // `?? ""`: a message_start packet can arrive with no `content`; without the guard the
-      // template appends the literal string "undefined" before the first delta.
+      // message_start can arrive with no content; guard prevents appending literal "undefined".
       content += (packet.obj as MessageStart | MessageDelta).content ?? "";
     }
   }
@@ -37,9 +35,9 @@ function accumulateContent(packets: Packet[]): string {
 }
 
 function MessageText({ packets, isComplete }: MessageRendererProps) {
-  // Stable between packet flushes so the typewriter target only grows when content actually does.
+  // Stable across packet flushes so the typewriter target grows only when content does.
   const content = useMemo(() => accumulateContent(packets), [packets]);
-  // Captured once at mount: animate live messages; a hydrated/historical one mounts complete → snap.
+  // Captured once at mount: live messages animate; historical ones mount complete and snap.
   const [animate] = useState(() => !isComplete);
   const { displayed } = useTypewriter(content, animate, isComplete);
   return <StreamingMarkdown content={displayed} isStreaming={!isComplete} />;

--- a/mobile/src/components/sidebar/Sidebar.tsx
+++ b/mobile/src/components/sidebar/Sidebar.tsx
@@ -110,7 +110,7 @@ function SidebarHeader({ logo, children }: SidebarHeaderProps) {
   return (
     <View className="gap-4 pb-2">
       {logoEl != null && (
-        <View className="flex-row items-start justify-between px-2 pt-3">
+        <View className="flex-row items-start justify-between px-8 pt-3">
           {logoEl}
           <Button
             prominence="internal"
@@ -120,7 +120,7 @@ function SidebarHeader({ logo, children }: SidebarHeaderProps) {
           />
         </View>
       )}
-      {children != null && <View className="px-2">{children}</View>}
+      {children != null && <View className="px-8">{children}</View>}
     </View>
   );
 }
@@ -133,7 +133,7 @@ interface SidebarBodyProps {
 function SidebarBody({ children }: SidebarBodyProps) {
   return (
     <ScrollView className="min-h-0 flex-1" showsVerticalScrollIndicator={false}>
-      <View className="gap-2 px-2 pb-8">{children}</View>
+      <View className="gap-2 px-8 pb-8">{children}</View>
     </ScrollView>
   );
 }
@@ -143,7 +143,7 @@ interface SidebarFooterProps {
 }
 
 function SidebarFooter({ children }: SidebarFooterProps) {
-  return <View className="px-2 pt-4">{children}</View>;
+  return <View className="px-8 pt-4">{children}</View>;
 }
 
 interface SidebarSectionProps {

--- a/mobile/src/components/sidebar/Sidebar.tsx
+++ b/mobile/src/components/sidebar/Sidebar.tsx
@@ -30,13 +30,13 @@ function SidebarRoot({ children }: SidebarRootProps) {
   const { folded, setFolded } = useSidebar();
   const insets = useSafeAreaInsets();
 
-  // Derived from `folded` so the slide stays state-driven (no effect mutation): 1 = open, 0 = closed.
+  // State-driven so the slide needs no effect mutation; 1 = open, 0 = closed.
   const progress = useDerivedValue(
     () => withTiming(folded ? 0 : 1, { duration: SIDEBAR_ANIM_MS }),
     [folded],
   );
 
-  // Live swipe offset, mutated only in the Pan worklet; layers on `progress` for 1:1 finger tracking.
+  // Live swipe offset (Pan worklet only); layers on progress for 1:1 finger tracking.
   const drag = useSharedValue(0);
 
   const columnStyle = useAnimatedStyle(() => {
@@ -51,7 +51,7 @@ function SidebarRoot({ children }: SidebarRootProps) {
 
   const close = React.useCallback(() => setFolded(true), [setFolded]);
 
-  // Swipe-left-to-close; `activeOffsetX` gates to horizontal so vertical scroll falls through to Body.
+  // activeOffsetX gates to horizontal so vertical scroll falls through to Body.
   const pan = Gesture.Pan()
     .activeOffsetX([-15, 15])
     .onUpdate((e) => {
@@ -70,7 +70,7 @@ function SidebarRoot({ children }: SidebarRootProps) {
         pointerEvents={folded ? "none" : "auto"}
         className="absolute inset-0 z-50"
       >
-        {/* Tap-to-close backdrop. Web's ~1px backdrop-blur is dropped — no mobile token. */}
+        {/* Web's ~1px backdrop-blur is dropped — no mobile token. */}
         <Animated.View style={backdropStyle} className="absolute inset-0">
           <Pressable className="flex-1 bg-mask-03" onPress={close} />
         </Animated.View>

--- a/mobile/src/components/ui/spinner.tsx
+++ b/mobile/src/components/ui/spinner.tsx
@@ -6,13 +6,12 @@ import SvgLoader from "@/icons/loader";
 
 interface SpinnerProps {
   size?: number;
-  // Onyx text-color class for the arc (default muted). e.g. "text-text-03", "text-status-error-05".
+  // Onyx text-color class for the arc, e.g. "text-status-error-05".
   className?: string;
 }
 
-// Design-system loader — web's SvgLoader (a 3/4-circle arc) + animate-spin, ported to RN. Uses the
-// RN Animated driver (native transform) rather than a platform ActivityIndicator so on-screen
-// spinners match the rest of the icon set. RN Animated (not reanimated) keeps it jest-safe.
+// RN Animated native transform (not ActivityIndicator) so spinners match the icon set;
+// Animated (not reanimated) keeps it jest-safe.
 export function Spinner({
   size = 16,
   className = "text-text-03",

--- a/mobile/src/components/ui/spinner.tsx
+++ b/mobile/src/components/ui/spinner.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useMemo } from "react";
+import { Animated, Easing } from "react-native";
+
+import { Icon } from "@/components/ui/icon";
+import SvgLoader from "@/icons/loader";
+
+interface SpinnerProps {
+  size?: number;
+  // Onyx text-color class for the arc (default muted). e.g. "text-text-03", "text-status-error-05".
+  className?: string;
+}
+
+// Design-system loader — web's SvgLoader (a 3/4-circle arc) + animate-spin, ported to RN. Uses the
+// RN Animated driver (native transform) rather than a platform ActivityIndicator so on-screen
+// spinners match the rest of the icon set. RN Animated (not reanimated) keeps it jest-safe.
+export function Spinner({
+  size = 16,
+  className = "text-text-03",
+}: SpinnerProps) {
+  const rotation = useMemo(() => new Animated.Value(0), []);
+
+  useEffect(() => {
+    const animation = Animated.loop(
+      Animated.timing(rotation, {
+        toValue: 1,
+        duration: 800,
+        easing: Easing.linear,
+        useNativeDriver: true,
+      }),
+    );
+    animation.start();
+    return () => animation.stop();
+  }, [rotation]);
+
+  const rotate = rotation.interpolate({
+    inputRange: [0, 1],
+    outputRange: ["0deg", "360deg"],
+  });
+
+  return (
+    <Animated.View style={{ transform: [{ rotate }] }}>
+      <Icon as={SvgLoader} size={size} className={className} />
+    </Animated.View>
+  );
+}

--- a/mobile/src/hooks/__tests__/useChatController.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatController.test.tsx
@@ -25,7 +25,7 @@ jest.mock("@/state/session", () => ({
   useSession: (selector: (s: { serverUrl: string | null }) => unknown) =>
     selector({ serverUrl: "https://example.test" }),
 }));
-// Mock the transport; re-implement the trivial discriminators so we don't pull in expo/fetch.
+// Re-implement the trivial discriminators inline so we don't pull in expo/fetch.
 jest.mock("@/api/chat/stream", () => ({
   streamChatMessage: jest.fn(),
   isPacket: (event: { obj?: unknown; placement?: unknown }) =>
@@ -312,8 +312,7 @@ describe("useChatController", () => {
       })(),
     );
 
-    // The hook stays bound to null; after create+navigate the store owns the new session, so drive
-    // and inspect it there (mirrors stop() aborting once the screen has navigated to the new id).
+    // Hook stays null-bound; after create the store owns the new session, so drive and inspect it there.
     const { result } = renderHook(() => useChatController(null), { wrapper });
     await act(async () => {
       await result.current.submit("first message");
@@ -410,7 +409,6 @@ describe("useChatController", () => {
     });
 
     expect(createSessionMock).toHaveBeenCalledWith(0, 7);
-    // From a project we navigate (push), not replace, so Back returns to it.
     expect(router.navigate).toHaveBeenCalledWith({
       pathname: "/chat/[id]",
       params: { id: "proj-session" },
@@ -439,7 +437,6 @@ describe("useChatController", () => {
   it("stop aborts the stream and stops the backend run", async () => {
     useChatSessionStore.getState().ensureSession("s1");
     stopSessionMock.mockResolvedValue();
-    // Keeps streaming until the controller's signal is aborted.
     streamMock.mockImplementation((_body, signal) =>
       (async function* () {
         yield startPacket("Hello");

--- a/mobile/src/hooks/__tests__/useChatController.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatController.test.tsx
@@ -32,6 +32,8 @@ jest.mock("@/api/chat/stream", () => ({
     "obj" in event && "placement" in event,
   isMessageIdInfo: (event: { user_message_id?: unknown }) =>
     "user_message_id" in event,
+  isStreamError: (event: { error?: unknown }) =>
+    "error" in event && typeof event.error === "string",
 }));
 jest.mock("@/api/chat/sessions", () => ({
   createChatSession: jest.fn(),
@@ -78,6 +80,9 @@ const idInfo = {
   user_message_id: 10,
   reserved_assistant_message_id: 11,
 } as StreamEvent;
+function streamError(error: string, errorCode?: string): StreamEvent {
+  return { error, error_code: errorCode ?? null } as unknown as StreamEvent;
+}
 
 async function* scripted(events: StreamEvent[]): AsyncGenerator<StreamEvent> {
   for (const event of events) yield event;
@@ -143,6 +148,62 @@ describe("useChatController", () => {
       (body as unknown as { parent_message_id: number | null })
         .parent_message_id,
     ).toBeNull();
+  });
+
+  it("surfaces a mid-stream backend error as an error node (no stuck placeholder)", async () => {
+    useChatSessionStore.getState().ensureSession("s1");
+    streamMock.mockReturnValue(
+      scripted([
+        startPacket("Partial "),
+        streamError("The model exploded.", "RATE_LIMIT"),
+      ]),
+    );
+
+    const { result } = renderHook(() => useChatController("s1"), { wrapper });
+    await act(async () => {
+      await result.current.submit("hi");
+    });
+
+    await waitFor(() => expect(result.current.chatState).toBe("input"));
+
+    const messages = result.current.messages;
+    expect(messages.map((m) => m.type)).toEqual(["user", "error"]);
+    expect(messages[1]!.message).toBe("The model exploded.");
+    expect(messages[1]!.errorCode).toBe("RATE_LIMIT");
+  });
+
+  it("surfaces a bare backend error that arrives before any content", async () => {
+    useChatSessionStore.getState().ensureSession("s1");
+    streamMock.mockReturnValue(scripted([streamError("Boom.")]));
+
+    const { result } = renderHook(() => useChatController("s1"), { wrapper });
+    await act(async () => {
+      await result.current.submit("hi");
+    });
+
+    await waitFor(() => expect(result.current.chatState).toBe("input"));
+    const messages = result.current.messages;
+    expect(messages.map((m) => m.type)).toEqual(["user", "error"]);
+    expect(messages[1]!.message).toBe("Boom.");
+  });
+
+  it("does not auto-name a new session whose first run errors", async () => {
+    createSessionMock.mockResolvedValue("err-session");
+    streamMock.mockReturnValue(scripted([streamError("nope")]));
+
+    const { result } = renderHook(() => useChatController(null), { wrapper });
+    await act(async () => {
+      await result.current.submit("first message");
+    });
+
+    await waitFor(() =>
+      expect(
+        useChatSessionStore.getState().sessions.get("err-session")?.chatState,
+      ).toBe("input"),
+    );
+    // Give any stray naming timer a chance to fire before asserting it never did.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(renameSessionMock).not.toHaveBeenCalled();
   });
 
   it("threads attachment descriptors into the send body and the optimistic user node", async () => {

--- a/mobile/src/hooks/__tests__/useChatSessionController.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatSessionController.test.tsx
@@ -31,6 +31,8 @@ jest.mock("@/api/chat/stream", () => ({
     "obj" in event && "placement" in event,
   isHeartbeat: (event: { obj?: { type?: string }; type?: string }) =>
     event?.obj?.type === "chat_heartbeat" || event?.type === "chat_heartbeat",
+  isStreamError: (event: { error?: unknown }) =>
+    "error" in event && typeof event.error === "string",
   StreamHttpError: class StreamHttpError extends Error {
     status: number;
     constructor(message: string, status: number) {
@@ -71,6 +73,9 @@ function endPacket(): StreamEvent {
     placement: { turn_index: 0 },
     obj: { type: PacketType.MESSAGE_END },
   } as StreamEvent;
+}
+function streamError(error: string, errorCode?: string): StreamEvent {
+  return { error, error_code: errorCode ?? null } as unknown as StreamEvent;
 }
 
 // A persisted session snapshot's `packets` are typed as Packet[][] (not StreamEvent).
@@ -261,6 +266,31 @@ describe("useChatSessionController", () => {
 
     act(() => releaseTail());
     await waitFor(() => expect(getSessionMock).toHaveBeenCalled());
+  });
+
+  it("surfaces an errored resumed run even when the settle-refetch fails", async () => {
+    seedLiveSession(2);
+    resumeMock.mockReturnValue(
+      scripted([streamError("resume boom", "SERVICE_UNAVAILABLE")]),
+    );
+    // Settle fetch fails → the in-stream error patch must survive (no stuck "…" placeholder).
+    getSessionMock.mockRejectedValue(new Error("offline"));
+
+    renderHook(() => useChatSessionController("s1"), { wrapper });
+
+    await waitFor(() => {
+      const node = getMessageByMessageId(
+        useChatSessionStore.getState().sessions.get("s1")!.messageTree,
+        2,
+      );
+      expect(node?.type).toBe("error");
+    });
+    const node = getMessageByMessageId(
+      useChatSessionStore.getState().sessions.get("s1")!.messageTree,
+      2,
+    );
+    expect(node?.message).toBe("resume boom");
+    expect(node?.errorCode).toBe("SERVICE_UNAVAILABLE");
   });
 
   it("stops writing to a session the user has navigated away from", async () => {

--- a/mobile/src/hooks/__tests__/useChatSessionController.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatSessionController.test.tsx
@@ -183,7 +183,6 @@ describe("useChatSessionController", () => {
     renderHook(() => useChatSessionController("s1"), { wrapper });
 
     expect(resumeMock).toHaveBeenCalledWith("s1", 0, expect.anything());
-    // After the run ends we refetch and settle from the persisted snapshot.
     await waitFor(() => expect(getSessionMock).toHaveBeenCalledWith("s1"));
     await waitFor(() => expect(assistantText("s1", 2)).toBe("final answer"));
     await waitFor(() =>
@@ -363,7 +362,6 @@ describe("useChatSessionController", () => {
 
     renderHook(() => useChatSessionController("s1"), { wrapper });
 
-    // Resume streamed, then began the settle-refetch.
     await waitFor(() => expect(assistantText("s1", 2)).toBe("resumed"));
     await waitFor(() => expect(getSessionMock).toHaveBeenCalled());
 

--- a/mobile/src/hooks/useChatController.ts
+++ b/mobile/src/hooks/useChatController.ts
@@ -1,5 +1,5 @@
-// Send → stream → ~50ms batched flush → stop, plus hydration. runChatStream is module-scope so the stream
-// keeps writing by sessionId after the landing screen unmounts navigating into /chat/[id].
+// runChatStream is module-scope so the stream keeps writing by sessionId after the landing screen
+// unmounts navigating into /chat/[id].
 import { useCallback, useEffect, useMemo, useRef } from "react";
 import { router } from "expo-router";
 import { QueryClient, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -113,8 +113,7 @@ async function runChatStream(
         continue;
       }
       if (isStreamError(event)) {
-        // Backend errored mid-stream (root-level StreamingError). Convert the assistant turn to
-        // an error node — as web does — instead of leaving it stuck on the "…" placeholder.
+        // Backend errored mid-stream: convert the assistant turn to an error node instead of leaving the "…" placeholder stuck.
         hadError = true;
         pending = [];
         if (flushTimer) {
@@ -163,9 +162,8 @@ async function runChatStream(
 export interface ChatController {
   messages: ReturnType<typeof getLatestMessageChain>;
   chatState: ChatState;
-  // `text` is the message to send (the composer text now lives in ComposerDraftContext, not
-  // here). `onAccepted` fires once, past every early return and before the session-create await,
-  // so the caller can clear the draft optimistically yet only on a committed send.
+  // `onAccepted` fires once, past every early return and before the session-create await, so the
+  // caller can clear the draft optimistically yet only on a committed send.
   submit: (
     text: string,
     files?: FileDescriptor[],
@@ -175,9 +173,8 @@ export interface ChatController {
   isHydrating: boolean;
 }
 
-// `personaId` is the agent to bind when this send creates a new session (ignored for an
-// existing session, whose persona is fixed at creation). `projectId` scopes a new chat to
-// a project.
+// `personaId` binds the agent only when this send creates a new session (ignored for an existing
+// session). `projectId` scopes a new chat to a project.
 export function useChatController(
   sessionId: string | null,
   personaId: number = DEFAULT_AGENT_ID,

--- a/mobile/src/hooks/useChatController.ts
+++ b/mobile/src/hooks/useChatController.ts
@@ -14,6 +14,7 @@ import {
 import {
   isMessageIdInfo,
   isPacket,
+  isStreamError,
   SendMessageBody,
   streamChatMessage,
 } from "@/api/chat/stream";
@@ -110,6 +111,22 @@ async function runChatStream(
           messageId: event.reserved_assistant_message_id,
         });
         continue;
+      }
+      if (isStreamError(event)) {
+        // Backend errored mid-stream (root-level StreamingError). Convert the assistant turn to
+        // an error node — as web does — instead of leaving it stuck on the "…" placeholder.
+        hadError = true;
+        pending = [];
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
+        store.getState().patchNode(sessionId, agentNodeId, {
+          type: "error",
+          message: event.error,
+          errorCode: event.error_code ?? null,
+        });
+        break;
       }
       if (isPacket(event)) {
         if (!sawStreaming) {

--- a/mobile/src/hooks/useChatController.ts
+++ b/mobile/src/hooks/useChatController.ts
@@ -115,6 +115,11 @@ async function runChatStream(
       if (isStreamError(event)) {
         // Backend errored mid-stream: convert the assistant turn to an error node instead of leaving the "…" placeholder stuck.
         hadError = true;
+        console.warn("chat stream returned a backend error", {
+          sessionId,
+          errorCode: event.error_code ?? null,
+          error: event.error,
+        });
         pending = [];
         if (flushTimer) {
           clearTimeout(flushTimer);

--- a/mobile/src/hooks/useChatSessionController.ts
+++ b/mobile/src/hooks/useChatSessionController.ts
@@ -96,8 +96,7 @@ async function runResumeStream(
       0,
       controller.signal,
     )) {
-      // re-check focus/abort on every event (heartbeats included) so navigate-away unwinds during
-      // quiet phases; heartbeats carry no content, so they aren't rendered
+      // re-check focus/abort on every event (heartbeats included) so navigate-away unwinds during quiet phases
       if (!stillCurrent()) break;
       if (isStreamError(event)) {
         // Errored run: show it immediately rather than waiting on (or getting stuck if it fails)

--- a/mobile/src/hooks/useChatSessionController.ts
+++ b/mobile/src/hooks/useChatSessionController.ts
@@ -14,6 +14,7 @@ import { getChatSession } from "@/api/chat/sessions";
 import {
   isHeartbeat,
   isPacket,
+  isStreamError,
   resumeChatMessage,
   StreamHttpError,
 } from "@/api/chat/stream";
@@ -98,6 +99,21 @@ async function runResumeStream(
       // re-check focus/abort on every event (heartbeats included) so navigate-away unwinds during
       // quiet phases; heartbeats carry no content, so they aren't rendered
       if (!stillCurrent()) break;
+      if (isStreamError(event)) {
+        // Errored run: show it immediately rather than waiting on (or getting stuck if it fails)
+        // the snapshot settle below. Matches the live-send path in useChatController.
+        pending = [];
+        if (flushTimer) {
+          clearTimeout(flushTimer);
+          flushTimer = null;
+        }
+        store.getState().patchNode(sessionId, nodeId, {
+          type: "error",
+          message: event.error,
+          errorCode: event.error_code ?? null,
+        });
+        break;
+      }
       if (isPacket(event) && !isHeartbeat(event)) {
         pending.push(event);
         scheduleFlush();

--- a/mobile/src/hooks/useChatSessionController.ts
+++ b/mobile/src/hooks/useChatSessionController.ts
@@ -101,6 +101,11 @@ async function runResumeStream(
       if (isStreamError(event)) {
         // Errored run: show it immediately rather than waiting on (or getting stuck if it fails)
         // the snapshot settle below. Matches the live-send path in useChatController.
+        console.warn("resume-stream received a backend error", {
+          sessionId,
+          errorCode: event.error_code ?? null,
+          error: event.error,
+        });
         pending = [];
         if (flushTimer) {
           clearTimeout(flushTimer);

--- a/mobile/src/hooks/useComposerDraft.ts
+++ b/mobile/src/hooks/useComposerDraft.ts
@@ -97,11 +97,16 @@ export function useComposerDraft(draftKey: string): UseComposerDraft {
 
   const removeFile = useCallback(
     (id: string) => {
-      ctxRemoveFile(draftKey, id);
+      // A chip renders with file.id — a tempId before reconcile, its SERVER id after. The draft is
+      // keyed by clientId (tempId), so resolve back through the store's server→client index (a
+      // no-op for an already-client id), else a completed upload can't be removed.
+      const store = useUserFileStore.getState();
+      const clientId = store.serverIdToClientId[id] ?? id;
+      ctxRemoveFile(draftKey, clientId);
       // Only hard-delete an upload this draft owns (the store gates on task target); a shared or
       // recent-attached record is just de-referenced above.
-      if (useUserFileStore.getState().tasksById[id]?.status === "uploading") {
-        upload.remove(id, target);
+      if (store.tasksById[clientId]?.status === "uploading") {
+        upload.remove(clientId, target);
       }
     },
     [ctxRemoveFile, draftKey, upload, target],

--- a/mobile/src/hooks/useComposerDraft.ts
+++ b/mobile/src/hooks/useComposerDraft.ts
@@ -33,8 +33,8 @@ export interface UseComposerDraft {
   consumeAttachments: () => void; // accepted starter send: clear attachments, keep text
 }
 
-// The composer draft lens: the sole ComposerDraftContext consumer, composed with the userFileStore
-// engine (text/refs from the context, file records from the store, uploads via useUpload).
+// Sole ComposerDraftContext consumer: text/refs from context, file records from the store,
+// uploads via useUpload.
 export function useComposerDraft(draftKey: string): UseComposerDraft {
   const ctx = useContext(ComposerDraftContext);
   if (!ctx) {

--- a/mobile/src/hooks/useProjectFiles.ts
+++ b/mobile/src/hooks/useProjectFiles.ts
@@ -21,7 +21,7 @@ import {
 } from "@/state/userFileStore";
 
 export interface UseProjectFiles {
-  // In-flight uploads first, then the committed files (resolved to their live store records).
+  // In-flight uploads first, then committed files as live store records.
   files: ProjectFile[];
   addDocuments: () => Promise<void>;
   addImages: () => Promise<void>;
@@ -29,9 +29,8 @@ export interface UseProjectFiles {
   removeFile: (fileId: string) => Promise<void>;
 }
 
-// Project file panel. The store owns file DATA; this lens owns the project's membership: renders each
-// committed file (from useProjectDetails) as its live store record (fresh status from the poll), with
-// in-flight uploads prepended.
+// Store owns file data; this hook owns project membership — committed files rendered as their live
+// store records (fresh poll status), with in-flight uploads prepended.
 export function useProjectFiles(
   projectId: number | null,
   committedFiles: ProjectFile[] | null | undefined,
@@ -45,8 +44,7 @@ export function useProjectFiles(
     [projectId],
   );
 
-  // Seed the store from the committed list (records + identity index) and clear this project's
-  // finished uploads (once committed, so they can't resurrect as phantom optimistic rows).
+  // Seed the store from the committed list; clears finished uploads so they can't resurrect as phantom optimistic rows.
   const upsert = useUserFileStore((state) => state.upsert);
   useEffect(() => {
     if (projectId != null && committedFiles) {
@@ -114,6 +112,13 @@ export function useProjectFiles(
   const removeFile = useCallback(
     async (fileId: string) => {
       if (projectId == null) return;
+      // An in-flight upload is keyed by a client temp id and isn't on the server yet — cancel it
+      // locally; unlinking would send the temp id to the server (4xx) and leave the chip stuck.
+      const store = useUserFileStore.getState();
+      if (store.tasksById[fileId]?.status === "uploading") {
+        store.removeFile(fileId, { kind: "project", projectId });
+        return;
+      }
       try {
         await unlinkFileFromProject(projectId, fileId);
         await invalidateProject();

--- a/mobile/src/hooks/useTypewriter.ts
+++ b/mobile/src/hooks/useTypewriter.ts
@@ -1,0 +1,166 @@
+// Paced character reveal for the streaming "typewriter" feel — ported from web's
+// hooks/useTypewriter.ts. Decouples what's shown from how fast/bursty tokens actually arrive:
+// reveals `target` a few chars per frame so a fast or chunked response still animates in. Pure
+// React + requestAnimationFrame; the only platform swap from web is AppState (RN) in place of
+// document.visibilitychange for the return-to-foreground snap.
+import { useEffect, useMemo, useRef, useState } from "react";
+import { AppState } from "react-native";
+
+// Mid-stream reveal rate, in chars per 60fps frame. 3 ≈ 180 cps.
+const CHARS_PER_FRAME = 3;
+// Once the stream is finished, the rate becomes adaptive so a long backlog drains within
+// ~CATCHUP_FRAMES frames — bursty rendering after the final packet is fine (the user is reading
+// along, not watching new content arrive).
+const CATCHUP_FRAMES = 30;
+
+export interface UseTypewriterResult {
+  displayed: string;
+  // True while the post-finish adaptive drain is running (callers can pause auto-scroll).
+  isDraining: boolean;
+}
+
+/**
+ * Reveals `target` one chunk at a time on each animation frame. When `enabled` is false
+ * (historical messages) it snaps to full on mount. The rAF loop pauses once caught up and resumes
+ * when `target` grows. `streamFinished` lets it drain a bursty backlog faster once the backend is
+ * done, so callers gating on "fully displayed" don't sit on a long tail.
+ */
+export function useTypewriter(
+  target: string,
+  enabled: boolean,
+  streamFinished: boolean = false,
+): UseTypewriterResult {
+  // Latest inputs mirrored so the long-lived rAF loop reads them without restarting. Synced in an
+  // effect (not written during render) to satisfy react-hooks/refs; a one-frame lag is invisible.
+  const targetRef = useRef(target);
+  const enabledRef = useRef(enabled);
+  const streamFinishedRef = useRef(streamFinished);
+  useEffect(() => {
+    targetRef.current = target;
+    enabledRef.current = enabled;
+    streamFinishedRef.current = streamFinished;
+  });
+
+  // Captured once when the post-finish drain begins so the per-frame step stays constant instead
+  // of decaying with the shrinking backlog (dividing the current backlog each tick overshoots).
+  const drainStepRef = useRef<number | null>(null);
+
+  const [isDraining, setIsDraining] = useState(false);
+  const isDrainingRef = useRef(false);
+
+  const [displayedLength, setDisplayedLength] = useState<number>(
+    enabled ? 0 : target.length,
+  );
+  const displayedLengthRef = useRef(displayedLength);
+
+  // Clamp (not reset) on target shrink — preserves already-revealed chars across cancel/regenerate.
+  const prevTargetLengthRef = useRef(target.length);
+  useEffect(() => {
+    if (target.length < prevTargetLengthRef.current) {
+      const clamped = Math.min(displayedLengthRef.current, target.length);
+      displayedLengthRef.current = clamped;
+      setDisplayedLength(clamped);
+    }
+    prevTargetLengthRef.current = target.length;
+  }, [target.length]);
+
+  // Self-scheduling rAF loop; pauses when caught up so idle/historical messages don't run forever.
+  const rafIdRef = useRef<number | null>(null);
+  const runningRef = useRef(false);
+  const startLoopRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    const tick = () => {
+      const targetLen = targetRef.current.length;
+      const prev = displayedLengthRef.current;
+      if (prev >= targetLen) {
+        runningRef.current = false;
+        rafIdRef.current = null;
+        if (isDrainingRef.current) {
+          isDrainingRef.current = false;
+          setIsDraining(false);
+        }
+        return;
+      }
+      let charsThisFrame: number;
+      if (streamFinishedRef.current) {
+        if (drainStepRef.current === null) {
+          const initialBacklog = targetLen - prev;
+          drainStepRef.current = Math.max(
+            CHARS_PER_FRAME,
+            Math.ceil(initialBacklog / CATCHUP_FRAMES),
+          );
+          if (!isDrainingRef.current) {
+            isDrainingRef.current = true;
+            setIsDraining(true);
+          }
+        }
+        charsThisFrame = drainStepRef.current;
+      } else {
+        charsThisFrame = CHARS_PER_FRAME;
+      }
+      const next = Math.min(prev + charsThisFrame, targetLen);
+      displayedLengthRef.current = next;
+      setDisplayedLength(next);
+      rafIdRef.current = requestAnimationFrame(tick);
+    };
+
+    const start = () => {
+      if (runningRef.current) return;
+      // Animation disabled — snap to full and stay idle (history/hydrated messages).
+      if (!enabledRef.current) {
+        const targetLen = targetRef.current.length;
+        if (displayedLengthRef.current !== targetLen) {
+          displayedLengthRef.current = targetLen;
+          setDisplayedLength(targetLen);
+        }
+        return;
+      }
+      runningRef.current = true;
+      rafIdRef.current = requestAnimationFrame(tick);
+    };
+
+    startLoopRef.current = start;
+
+    if (targetRef.current.length > displayedLengthRef.current) {
+      start();
+    }
+
+    return () => {
+      runningRef.current = false;
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current);
+        rafIdRef.current = null;
+      }
+      startLoopRef.current = null;
+    };
+  }, []);
+
+  // Restart the loop when target grows past what's currently displayed.
+  useEffect(() => {
+    if (target.length > displayedLength && startLoopRef.current) {
+      startLoopRef.current();
+    }
+  }, [target.length, displayedLength]);
+
+  // Returning to the foreground snaps to full so the user sees the whole response immediately.
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (state) => {
+      if (state === "active") {
+        const targetLen = targetRef.current.length;
+        if (displayedLengthRef.current < targetLen) {
+          displayedLengthRef.current = targetLen;
+          setDisplayedLength(targetLen);
+        }
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
+  const displayed = useMemo(
+    () => target.slice(0, Math.min(displayedLength, target.length)),
+    [target, displayedLength],
+  );
+
+  return { displayed, isDraining };
+}

--- a/mobile/src/hooks/useTypewriter.ts
+++ b/mobile/src/hooks/useTypewriter.ts
@@ -1,29 +1,25 @@
-// Paced character reveal for the streaming "typewriter" feel — ported from web's
-// hooks/useTypewriter.ts. Decouples what's shown from how fast/bursty tokens actually arrive:
-// reveals `target` a few chars per frame so a fast or chunked response still animates in. Pure
-// React + requestAnimationFrame; the only platform swap from web is AppState (RN) in place of
+// Paced "typewriter" reveal: decouples what's shown from how bursty tokens actually arrive by
+// revealing `target` a few chars per frame. Platform swap from web: AppState (RN) replaces
 // document.visibilitychange for the return-to-foreground snap.
 import { useEffect, useMemo, useRef, useState } from "react";
 import { AppState } from "react-native";
 
 // Mid-stream reveal rate, in chars per 60fps frame. 3 ≈ 180 cps.
 const CHARS_PER_FRAME = 3;
-// Once the stream is finished, the rate becomes adaptive so a long backlog drains within
-// ~CATCHUP_FRAMES frames — bursty rendering after the final packet is fine (the user is reading
-// along, not watching new content arrive).
+// Once the stream finishes the rate goes adaptive to drain a long backlog within ~CATCHUP_FRAMES
+// frames — bursty rendering after the final packet is fine (user is reading, not watching new content).
 const CATCHUP_FRAMES = 30;
 
 export interface UseTypewriterResult {
   displayed: string;
-  // True while the post-finish adaptive drain is running (callers can pause auto-scroll).
+  // True while the post-finish adaptive drain runs (callers can pause auto-scroll).
   isDraining: boolean;
 }
 
 /**
- * Reveals `target` one chunk at a time on each animation frame. When `enabled` is false
- * (historical messages) it snaps to full on mount. The rAF loop pauses once caught up and resumes
- * when `target` grows. `streamFinished` lets it drain a bursty backlog faster once the backend is
- * done, so callers gating on "fully displayed" don't sit on a long tail.
+ * Reveals `target` a chunk per animation frame; `enabled=false` snaps to full (historical messages).
+ * The loop pauses when caught up and resumes when `target` grows. `streamFinished` drains a bursty
+ * backlog faster so callers gating on "fully displayed" don't sit on a long tail.
  */
 export function useTypewriter(
   target: string,
@@ -41,8 +37,8 @@ export function useTypewriter(
     streamFinishedRef.current = streamFinished;
   });
 
-  // Captured once when the post-finish drain begins so the per-frame step stays constant instead
-  // of decaying with the shrinking backlog (dividing the current backlog each tick overshoots).
+  // Captured once when the drain begins so the step stays constant instead of decaying with the
+  // shrinking backlog (re-dividing the backlog each tick overshoots).
   const drainStepRef = useRef<number | null>(null);
 
   const [isDraining, setIsDraining] = useState(false);
@@ -136,14 +132,13 @@ export function useTypewriter(
     };
   }, []);
 
-  // Restart the loop when target grows past what's currently displayed.
   useEffect(() => {
     if (target.length > displayedLength && startLoopRef.current) {
       startLoopRef.current();
     }
   }, [target.length, displayedLength]);
 
-  // Returning to the foreground snaps to full so the user sees the whole response immediately.
+  // Returning to foreground snaps to full so the user sees the whole response immediately.
   useEffect(() => {
     const sub = AppState.addEventListener("change", (state) => {
       if (state === "active") {

--- a/mobile/src/hooks/useUpload.ts
+++ b/mobile/src/hooks/useUpload.ts
@@ -67,7 +67,18 @@ export function useUpload(): UseUpload {
               setUploadCancel(tempId, handle.cancel);
               const result = await handle.result;
               if (result.user_files.length > 0) {
-                store.reconcile(result.user_files, epoch);
+                // The backend echoes temp_id only when its file-key (`size|name` from the received
+                // multipart) matches ours — mobile picks routinely differ (image URIs are UUIDs,
+                // size can be absent), so temp_id comes back null and reconcile can't match. This
+                // upload is 1:1 (one asset → one request), so the returned file IS this record's:
+                // stamp our known tempId when the server didn't echo one.
+                store.reconcile(
+                  result.user_files.map((file) => ({
+                    ...file,
+                    temp_id: file.temp_id ?? tempId,
+                  })),
+                  epoch,
+                );
               }
               if (result.rejected_files.length > 0) {
                 store.removeFile(tempId, target);

--- a/mobile/src/hooks/useUpload.ts
+++ b/mobile/src/hooks/useUpload.ts
@@ -18,10 +18,9 @@ import {
 } from "@/state/userFileStore";
 
 export interface UseUpload {
-  // Returns optimistic clientIds synchronously (chips render now); the transfer runs in the
-  // background. Upload errors surface as toasts. A project upload refetches project-details.
+  // Returns optimistic clientIds synchronously; the transfer runs in the background, errors toast.
   upload: (assets: NormalizedAsset[], target: UploadTarget) => string[];
-  // Pick, then upload — surfacing a picker error as a toast. The one place picker-error routing lives.
+  // Pick then upload; the one place picker-error-to-toast routing lives.
   pickAndUpload: (
     pick: () => Promise<NormalizedAsset[]>,
     target: UploadTarget,
@@ -31,7 +30,6 @@ export interface UseUpload {
   remove: (clientId: string, target: UploadTarget) => void;
 }
 
-// The only place upload logic lives; the engine store owns files + tasks + reconcile.
 export function useUpload(): UseUpload {
   const queryClient = useQueryClient();
   const serverUrl = useSession((state) => state.serverUrl);
@@ -67,11 +65,9 @@ export function useUpload(): UseUpload {
               setUploadCancel(tempId, handle.cancel);
               const result = await handle.result;
               if (result.user_files.length > 0) {
-                // The backend echoes temp_id only when its file-key (`size|name` from the received
-                // multipart) matches ours — mobile picks routinely differ (image URIs are UUIDs,
-                // size can be absent), so temp_id comes back null and reconcile can't match. This
-                // upload is 1:1 (one asset → one request), so the returned file IS this record's:
-                // stamp our known tempId when the server didn't echo one.
+                // Backend echoes temp_id only when its `size|name` file-key matches ours, but
+                // mobile picks routinely differ so it comes back null. Upload is 1:1, so the
+                // returned file is this record's — stamp our tempId when the server didn't echo one.
                 store.reconcile(
                   result.user_files.map((file) => ({
                     ...file,
@@ -87,8 +83,8 @@ export function useUpload(): UseUpload {
                 );
               }
             } catch {
-              // Absent task = the user already removed this attachment, aborting the transfer
-              // (which rejects here). Intentional cancel, not a failure — don't toast.
+              // Absent task = user already removed this attachment, aborting the transfer (rejects
+              // here). Intentional cancel, not a failure — don't toast.
               if (useUserFileStore.getState().tasksById[tempId] == null) return;
               store.removeFile(tempId, target);
               uploadRejections.push(`${asset.name} could not be uploaded`);
@@ -96,8 +92,8 @@ export function useUpload(): UseUpload {
           }),
         );
 
-        // Project: the committed list renders from the store, hydrated by the project-details
-        // refetch. The optimistic record stays (deduped against the committed list) — no hand-off.
+        // Committed list renders from the store, hydrated by this refetch; the optimistic record
+        // stays (deduped against the committed list) — no hand-off.
         if (target.kind === "project") {
           try {
             await queryClient.invalidateQueries({

--- a/mobile/src/icons/chevron-down.tsx
+++ b/mobile/src/icons/chevron-down.tsx
@@ -1,0 +1,19 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgChevronDown = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <Path d="M4 6L8 10L12 6" strokeLinecap="round" strokeLinejoin="round" />
+  </Svg>
+);
+
+export default SvgChevronDown;

--- a/mobile/src/icons/chevron-left.tsx
+++ b/mobile/src/icons/chevron-left.tsx
@@ -1,0 +1,19 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgChevronLeft = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <Path d="M10 12L6 8L10 4" strokeLinecap="round" strokeLinejoin="round" />
+  </Svg>
+);
+
+export default SvgChevronLeft;

--- a/mobile/src/icons/chevron-right.tsx
+++ b/mobile/src/icons/chevron-right.tsx
@@ -1,0 +1,19 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgChevronRight = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <Path d="M6 12L10 8L6 4" strokeLinecap="round" strokeLinejoin="round" />
+  </Svg>
+);
+
+export default SvgChevronRight;

--- a/mobile/src/icons/image.tsx
+++ b/mobile/src/icons/image.tsx
@@ -1,0 +1,22 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgImage = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <Path
+      d="M11 14L6.06066 9.06072C5.47487 8.47498 4.52513 8.47498 3.93934 9.06072L2 11M2 3.49998C2 2.67156 2.67157 2 3.5 2H12.5C13.3285 2 14 2.67156 14 3.49998V12.4999C14 13.3283 13.3285 13.9998 12.5 13.9998H3.5C2.67157 13.9998 2 13.3283 2 12.4999V3.49998ZM9.875 7.62492C10.7034 7.62492 11.375 6.95338 11.375 6.12494C11.375 5.29653 10.7034 4.62496 9.875 4.62496C9.04655 4.62496 8.375 5.29653 8.375 6.12494C8.375 6.95338 9.04655 7.62492 9.875 7.62492Z"
+      strokeLinecap="round"
+    />
+  </Svg>
+);
+
+export default SvgImage;

--- a/mobile/src/icons/loader.tsx
+++ b/mobile/src/icons/loader.tsx
@@ -1,0 +1,23 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgLoader = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 15 15"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <Path
+      d="M7.41667 14.0833C3.73477 14.0833 0.75 11.0986 0.75 7.41667C0.75 3.73477 3.73477 0.75 7.41667 0.75C11.0986 0.75 14.0833 3.73477 14.0833 7.41667"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+export default SvgLoader;

--- a/mobile/src/icons/upload-square.tsx
+++ b/mobile/src/icons/upload-square.tsx
@@ -1,0 +1,23 @@
+import Svg, { Path } from "react-native-svg";
+
+import type { IconProps } from "@/icons/types";
+
+const SvgUploadSquare = ({ size = 16, ...props }: IconProps) => (
+  <Svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    {...props}
+  >
+    <Path
+      d="M11 14H12.6667C13.3929 14 14 13.3929 14 12.6667V3.33333C14 2.60711 13.3929 2 12.6667 2H3.33333C2.60711 2 2 2.60711 2 3.33333V12.6667C2 13.3929 2.60711 14 3.33333 14H5M10.6666 8.16667L7.99998 5.5M7.99998 5.5L5.33331 8.16667M7.99998 5.5V14"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </Svg>
+);
+
+export default SvgUploadSquare;


### PR DESCRIPTION
## Description

- Surface mid-stream errors as an error banner instead of leaving the assistant reply stuck on "…".
- Add a typewriter reveal plus an agent avatar / "Thinking…" timeline so assistant replies feel like they stream.
- Improve message-list scrolling: anchor the first message to the top, auto-scroll while streaming, and add a floating scroll-to-bottom button.
- Refine the composer: smaller text, tighter padding, and Enter inserts a newline without growing the input.
- Align file cards and the add-files picker to the design system (new `Spinner`, web-matched remove button, correct icons) and fix uploads that got stuck spinning or couldn't be removed.
- Move project file management into a dedicated full-screen Sources screen, reached from a "View sources" row in the project panel.
- Build the shared design-token package before linking on a fresh `bun install` (preinstall hook), preventing the NativeWind theme resolution crash.

## How Has This Been Tested?

- `typecheck`, `lint`, and `jest` (283 tests) pass; changes verified live in the iOS simulator.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the mobile chat experience: replies stream with a typewriter and agent timeline, scrolling/composer feel tighter, file management moves to a full-screen Sources screen, and the build is hardened to avoid the NativeWind theme crash.

- **New Features**
  - Agent timeline with avatar and a "Thinking…" shimmer; typewriter reveal for assistant text.
  - Message list: top-anchored reading, auto-scroll when near bottom, and a floating scroll-to-bottom button.
  - Composer: fixed-height input (Enter adds a newline that scrolls inside), smaller text, tighter padding, clear stop/send toolbar.
  - File management: new full-screen `/sources/[id]` with grouped `ProjectFileList`; project panel now shows a “View sources” row. File cards/picker match the design system, reuse `Spinner`, and use correct icons.

- **Bug Fixes**
  - Mid-stream backend errors now render as an error banner with a friendly title and are logged with safe metadata (no stuck "…" replies).
  - Unstuck uploads and removals: reconcile missing server `temp_id`, map server→client ids on remove, cancel in-flight project uploads locally on remove, and defer iOS picker actions until the sheet fully dismisses.
  - Build stability: added `preinstall` to build `../web/lib/shared` before linking, preventing the NativeWind theme resolution crash on fresh `bun install`.
  - Minor UI tweaks: consistent spinners and sidebar padding.

<sup>Written for commit dafcbe6bbe57b98093b2c1e76e1914922a82b3ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

