### PR TITLE
fix(slack): enforce bot agent access before answering (#12894) to release v4.3

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -184,6 +184,7 @@ def handle_generate_answer_button(
             client=client.web_client,
             channel=channel_id,
             logger=logger,
+            db_session=db_session,
             feedback_reminder_id=None,
         )
 

--- a/backend/onyx/onyxbot/slack/handlers/handle_message.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_message.py
@@ -452,6 +452,7 @@ def handle_message(
             client=client,
             channel=channel,
             logger=logger,
+            db_session=db_session,
             feedback_reminder_id=feedback_reminder_id,
         )
         return issue_with_regular_answer

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -5,6 +5,7 @@ from typing import Optional
 from typing import TypeVar
 
 from slack_sdk import WebClient
+from sqlalchemy.orm import Session
 
 from onyx.auth.users import get_anonymous_user
 from onyx.chat.models import ChatBasicResponse
@@ -18,7 +19,6 @@ from onyx.configs.onyxbot_configs import ONYX_BOT_NUM_RETRIES
 from onyx.configs.onyxbot_configs import ONYX_BOT_REACT_EMOJI
 from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import Tag
-from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import SlackChannelConfig
 from onyx.db.models import User
 from onyx.db.persona import get_persona_by_id
@@ -41,6 +41,8 @@ from onyx.utils.retry_wrapper import retry_builder
 srl = SlackRateLimiter()
 
 RT = TypeVar("RT")  # return type
+
+SLACK_PERSONA_ACCESS_DENIED_MESSAGE = "You don't have access to the Agent that the bot is configured with in this channel."
 
 
 def resolve_channel_references(
@@ -140,6 +142,7 @@ def handle_regular_answer(
     client: WebClient,
     channel: str,
     logger: OnyxLoggingAdapter,
+    db_session: Session,
     feedback_reminder_id: str | None,
     num_retries: int = ONYX_BOT_NUM_RETRIES,
     should_respond_with_error_msgs: bool = ONYX_BOT_DISPLAY_ERROR_MSGS,
@@ -167,9 +170,7 @@ def handle_regular_answer(
     # to public docs.
 
     if message_info.email:
-        with get_session_with_current_tenant() as db_session:
-            found_user = get_user_by_email(message_info.email, db_session)
-            user = found_user if found_user else get_anonymous_user()
+        user = get_user_by_email(message_info.email, db_session) or get_anonymous_user()
     else:
         user = get_anonymous_user()
 
@@ -184,22 +185,78 @@ def handle_regular_answer(
         else receiver_ids
     )
 
-    document_set_names: list[str] | None = None
     # If no persona is specified, use the default search based persona
     # This way slack flow always has a persona
-    persona = slack_channel_config.persona
-    if not persona:
+    persona_id = slack_channel_config.persona_id
+    if persona_id is None:
         logger.warning("No persona found for channel config, using default persona")
-        with get_session_with_current_tenant() as db_session:
-            persona = get_persona_by_id(DEFAULT_PERSONA_ID, user, db_session)
-            document_set_names = [
-                document_set.name for document_set in persona.document_sets
-            ]
+        persona_id = DEFAULT_PERSONA_ID
     else:
-        logger.info("Using persona %s for channel config", persona.name)
-        document_set_names = [
-            document_set.name for document_set in persona.document_sets
-        ]
+        persona_name = (
+            slack_channel_config.persona.name
+            if slack_channel_config.persona
+            else persona_id
+        )
+        logger.info("Using persona %s for channel config", persona_name)
+
+    # Load the persona through the user's read-access filter.
+    # ValueError means the user does not have access to this persona
+    try:
+        persona = get_persona_by_id(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+            is_for_edit=False,
+        )
+    except ValueError:
+        logger.info(
+            "Skipping Slack answer: user cannot access persona %s",
+            persona_id,
+        )
+
+        if not message_info.is_bot_dm and message_info.sender_id:
+            access_denied_receiver_ids = [message_info.sender_id]
+        else:
+            access_denied_receiver_ids = None
+            if not message_info.is_bot_dm:
+                logger.warning(
+                    "Unable to send ephemeral Slack persona access denial: missing Slack sender ID"
+                )
+
+        try:
+            respond_in_thread_or_channel(
+                client=client,
+                channel=channel,
+                receiver_ids=access_denied_receiver_ids,
+                text=SLACK_PERSONA_ACCESS_DENIED_MESSAGE,
+                thread_ts=target_thread_ts,
+                send_as_ephemeral=access_denied_receiver_ids is not None,
+            )
+        except Exception:
+            logger.exception("Unable to send Slack persona access denial")
+
+        if feedback_reminder_id and message_info.sender_id:
+            try:
+                client.chat_deleteScheduledMessage(
+                    channel=message_info.sender_id,
+                    scheduled_message_id=feedback_reminder_id,
+                )
+            except Exception:
+                logger.exception(
+                    "Unable to delete scheduled feedback reminder after Slack persona access denial"
+                )
+
+        if not is_slash_command:
+            update_emote_react(
+                emoji=ONYX_BOT_REACT_EMOJI,
+                channel=message_info.channel_to_respond,
+                message_ts=message_info.msg_to_respond,
+                remove=True,
+                client=client,
+            )
+        return False
+
+    document_set_names = [document_set.name for document_set in persona.document_sets]
 
     user_message = messages[-1]
     history_messages = messages[:-1]

--- a/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
+++ b/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
@@ -1,13 +1,27 @@
 """Tests for Slack channel reference resolution and tag filtering
 in handle_regular_answer.py."""
 
+from collections.abc import Callable
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
+import pytest
 from slack_sdk.errors import SlackApiError
 
+from onyx.chat.models import ChatBasicResponse
 from onyx.context.search.models import Tag
 from onyx.onyxbot.slack.constants import SLACK_CHANNEL_REF_PATTERN
+from onyx.onyxbot.slack.handlers.handle_regular_answer import handle_regular_answer
 from onyx.onyxbot.slack.handlers.handle_regular_answer import resolve_channel_references
+from onyx.onyxbot.slack.handlers.handle_regular_answer import (
+    SLACK_PERSONA_ACCESS_DENIED_MESSAGE,
+)
+from onyx.onyxbot.slack.models import ChannelType
+from onyx.onyxbot.slack.models import SlackContext
+from onyx.onyxbot.slack.models import SlackMessageInfo
+from onyx.onyxbot.slack.models import ThreadMessage
+
+_HANDLE_REGULAR_ANSWER = "onyx.onyxbot.slack.handlers.handle_regular_answer"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -40,6 +54,115 @@ def _mock_client_with_channels(
 
 def _mock_logger() -> MagicMock:
     return MagicMock()
+
+
+def _make_slack_message_info(
+    channel_type: ChannelType,
+    is_slash_command: bool = False,
+    is_bot_dm: bool = False,
+    sender_id: str | None = "U123",
+) -> SlackMessageInfo:
+    message_ts = None if is_slash_command else "111.222"
+    return SlackMessageInfo(
+        thread_messages=[ThreadMessage(message="answer this?", sender="User")],
+        channel_to_respond="C123",
+        msg_to_respond=message_ts,
+        thread_to_respond=message_ts,
+        sender_id=sender_id,
+        email="user@test.com",
+        bypass_filters=True,
+        is_slash_command=is_slash_command,
+        is_bot_dm=is_bot_dm,
+        slack_context=SlackContext(
+            channel_type=channel_type,
+            channel_id="C123",
+            user_id="U123",
+            message_ts=message_ts,
+        ),
+    )
+
+
+def _identity_decorator(
+    *_args: object, **_kwargs: object
+) -> Callable[[Callable[..., object]], Callable[..., object]]:
+    def _decorate(func: Callable[..., object]) -> Callable[..., object]:
+        return func
+
+    return _decorate
+
+
+def _make_slack_channel_config(
+    is_ephemeral: bool = False,
+) -> MagicMock:
+    persona = MagicMock()
+    persona.id = 123
+    persona.name = "Scoped Agent"
+    persona.document_sets = []
+
+    slack_channel_config = MagicMock()
+    slack_channel_config.persona = persona
+    slack_channel_config.persona_id = persona.id
+    slack_channel_config.channel_config = {"is_ephemeral": is_ephemeral}
+    return slack_channel_config
+
+
+def _assert_access_denied_response(
+    message_info: SlackMessageInfo,
+    slack_channel_config: MagicMock,
+    expected_receiver_ids: list[str] | None,
+    expected_thread_ts: str | None,
+    expected_send_as_ephemeral: bool,
+    expect_reaction_removal: bool,
+) -> None:
+    user = MagicMock()
+    client = MagicMock()
+    db_session = MagicMock()
+    logger = _mock_logger()
+
+    with (
+        patch(f"{_HANDLE_REGULAR_ANSWER}.get_user_by_email", return_value=user),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.get_persona_by_id",
+            side_effect=ValueError("persona access denied"),
+        ) as mock_get_persona_by_id,
+        patch(f"{_HANDLE_REGULAR_ANSWER}.respond_in_thread_or_channel") as mock_respond,
+        patch(f"{_HANDLE_REGULAR_ANSWER}.update_emote_react") as mock_update_react,
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.handle_stream_message_objects"
+        ) as mock_handle_stream_message_objects,
+    ):
+        result = handle_regular_answer(
+            message_info=message_info,
+            slack_channel_config=slack_channel_config,
+            receiver_ids=None,
+            client=client,
+            channel="C123",
+            logger=logger,
+            db_session=db_session,
+            feedback_reminder_id=None,
+            should_respond_with_error_msgs=False,
+        )
+
+    assert result is False
+    mock_get_persona_by_id.assert_called_once_with(
+        persona_id=slack_channel_config.persona_id,
+        user=user,
+        db_session=db_session,
+        is_for_edit=False,
+    )
+    mock_respond.assert_called_once_with(
+        client=client,
+        channel="C123",
+        receiver_ids=expected_receiver_ids,
+        text=SLACK_PERSONA_ACCESS_DENIED_MESSAGE,
+        thread_ts=expected_thread_ts,
+        send_as_ephemeral=expected_send_as_ephemeral,
+    )
+    if expect_reaction_removal:
+        assert mock_update_react.call_args.kwargs["remove"] is True
+    else:
+        mock_update_react.assert_not_called()
+    mock_handle_stream_message_objects.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -201,3 +324,233 @@ class TestResolveChannelReferences:
         assert "#eng-infra" in message
         assert "#random" in message
         assert len(tags) == 2
+
+
+@pytest.mark.parametrize(
+    (
+        "channel_type",
+        "is_ephemeral",
+        "is_slash_command",
+        "is_bot_dm",
+        "expected_receiver_ids",
+        "expected_thread_ts",
+        "expected_send_as_ephemeral",
+        "expect_reaction_removal",
+    ),
+    [
+        pytest.param(
+            ChannelType.PUBLIC_CHANNEL,
+            False,
+            False,
+            False,
+            ["U123"],
+            "111.222",
+            True,
+            True,
+            id="public-channel",
+        ),
+        pytest.param(
+            ChannelType.PRIVATE_CHANNEL,
+            False,
+            False,
+            False,
+            ["U123"],
+            "111.222",
+            True,
+            True,
+            id="private-channel",
+        ),
+        pytest.param(
+            ChannelType.PRIVATE_CHANNEL,
+            True,
+            False,
+            False,
+            ["U123"],
+            None,
+            True,
+            True,
+            id="configured-ephemeral",
+        ),
+        pytest.param(
+            ChannelType.PUBLIC_CHANNEL,
+            False,
+            True,
+            False,
+            ["U123"],
+            None,
+            True,
+            False,
+            id="slash-command",
+        ),
+        pytest.param(
+            ChannelType.IM,
+            False,
+            False,
+            True,
+            None,
+            "111.222",
+            False,
+            True,
+            id="dm",
+        ),
+    ],
+)
+def test_persona_access_denied_response(
+    channel_type: ChannelType,
+    is_ephemeral: bool,
+    is_slash_command: bool,
+    is_bot_dm: bool,
+    expected_receiver_ids: list[str] | None,
+    expected_thread_ts: str | None,
+    expected_send_as_ephemeral: bool,
+    expect_reaction_removal: bool,
+) -> None:
+    _assert_access_denied_response(
+        message_info=_make_slack_message_info(
+            channel_type=channel_type,
+            is_slash_command=is_slash_command,
+            is_bot_dm=is_bot_dm,
+        ),
+        slack_channel_config=_make_slack_channel_config(is_ephemeral=is_ephemeral),
+        expected_receiver_ids=expected_receiver_ids,
+        expected_thread_ts=expected_thread_ts,
+        expected_send_as_ephemeral=expected_send_as_ephemeral,
+        expect_reaction_removal=expect_reaction_removal,
+    )
+
+
+def test_persona_access_denied_without_sender_falls_back_to_channel_message() -> None:
+    _assert_access_denied_response(
+        message_info=_make_slack_message_info(
+            channel_type=ChannelType.PUBLIC_CHANNEL,
+            sender_id=None,
+        ),
+        slack_channel_config=_make_slack_channel_config(),
+        expected_receiver_ids=None,
+        expected_thread_ts="111.222",
+        expected_send_as_ephemeral=False,
+        expect_reaction_removal=True,
+    )
+
+
+def test_configured_persona_missing_uses_configured_id_for_denial() -> None:
+    slack_channel_config = _make_slack_channel_config()
+    slack_channel_config.persona = None
+    slack_channel_config.persona_id = 456
+
+    _assert_access_denied_response(
+        message_info=_make_slack_message_info(ChannelType.PUBLIC_CHANNEL),
+        slack_channel_config=slack_channel_config,
+        expected_receiver_ids=["U123"],
+        expected_thread_ts="111.222",
+        expected_send_as_ephemeral=True,
+        expect_reaction_removal=True,
+    )
+
+
+def test_persona_access_denied_cancels_feedback_reminder() -> None:
+    client = MagicMock()
+    db_session = MagicMock()
+
+    with (
+        patch(f"{_HANDLE_REGULAR_ANSWER}.get_user_by_email", return_value=MagicMock()),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.get_persona_by_id",
+            side_effect=ValueError("persona access denied"),
+        ),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.respond_in_thread_or_channel"),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.update_emote_react"),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.handle_stream_message_objects"),
+    ):
+        result = handle_regular_answer(
+            message_info=_make_slack_message_info(ChannelType.PUBLIC_CHANNEL),
+            slack_channel_config=_make_slack_channel_config(),
+            receiver_ids=None,
+            client=client,
+            channel="C123",
+            logger=_mock_logger(),
+            db_session=db_session,
+            feedback_reminder_id="scheduled-reminder",
+            should_respond_with_error_msgs=False,
+        )
+
+    assert result is False
+    client.chat_deleteScheduledMessage.assert_called_once_with(
+        channel="U123",
+        scheduled_message_id="scheduled-reminder",
+    )
+
+
+def test_private_channel_non_ephemeral_generates_after_persona_access_check() -> None:
+    user = MagicMock()
+    anonymous_user = MagicMock()
+    client = MagicMock()
+    db_session = MagicMock()
+    logger = _mock_logger()
+
+    with (
+        patch(f"{_HANDLE_REGULAR_ANSWER}.get_user_by_email", return_value=user),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.get_anonymous_user", return_value=anonymous_user
+        ),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.get_persona_by_id",
+            return_value=_make_slack_channel_config().persona,
+        ) as mock_get_persona_by_id,
+        patch(f"{_HANDLE_REGULAR_ANSWER}.rate_limits", side_effect=_identity_decorator),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.retry_builder", side_effect=_identity_decorator
+        ),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.get_channel_name_from_id",
+            return_value=("private-channel", False),
+        ),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.gather_stream",
+            return_value=ChatBasicResponse(
+                answer="answer",
+                answer_citationless="answer",
+                top_documents=[],
+                error_msg=None,
+                message_id=1,
+                citation_info=[],
+            ),
+        ),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.build_slack_response_blocks",
+            return_value=[],
+        ),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.handle_stream_message_objects",
+            return_value=iter(()),
+        ) as mock_handle_stream_message_objects,
+        patch(f"{_HANDLE_REGULAR_ANSWER}.respond_in_thread_or_channel") as mock_respond,
+        patch(f"{_HANDLE_REGULAR_ANSWER}.update_emote_react") as mock_update_react,
+    ):
+        result = handle_regular_answer(
+            message_info=_make_slack_message_info(ChannelType.PRIVATE_CHANNEL),
+            slack_channel_config=_make_slack_channel_config(),
+            receiver_ids=None,
+            client=client,
+            channel="C123",
+            logger=logger,
+            db_session=db_session,
+            feedback_reminder_id=None,
+        )
+
+    assert result is False
+    mock_get_persona_by_id.assert_called_once_with(
+        persona_id=123,
+        user=user,
+        db_session=db_session,
+        is_for_edit=False,
+    )
+
+    stream_call_kwargs = mock_handle_stream_message_objects.call_args.kwargs
+    assert stream_call_kwargs["user"] is anonymous_user
+    assert stream_call_kwargs["new_msg_req"].chat_session_info.persona_id == 123
+
+    mock_respond.assert_called_once()
+    assert mock_respond.call_args.kwargs["receiver_ids"] is None
+    mock_update_react.assert_called_once()
+    assert mock_update_react.call_args.kwargs["remove"] is True


### PR DESCRIPTION
Cherry-pick of commit 417cb04 to release/v4.3 branch.

Original PR: #12894

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces Slack bot agent access before generating answers. If the user can’t access the channel’s configured persona, the bot stops and sends a clear access-denied notice.

- **Bug Fixes**
  - Validate persona access via `get_persona_by_id` with the requester’s user; deny on failure and don’t generate an answer.
  - Send an access-denied message (ephemeral to sender in channels; fallback to channel if sender ID is missing; non-ephemeral in DMs).
  - Remove the thinking reaction and cancel any scheduled feedback reminder when denying.
  - Resolve persona by `persona_id` (use default when missing) and pass `db_session` through `handle_message`/`handle_buttons` into `handle_regular_answer`.
  - Add unit tests for public/private channels, ephemeral configs, slash commands, and DMs.

<sup>Written for commit 448b9739a12ac85d1ae1fc2939064ece8d3c6d6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

