### PR TITLE
fix(craft): refresh files without clearing tree

### DIFF
--- a/web/src/app/craft/components/OutputPanel.tsx
+++ b/web/src/app/craft/components/OutputPanel.tsx
@@ -114,6 +114,7 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
   // Counters to force-reload previews
   const [previewRefreshKey, setPreviewRefreshKey] = useState(0);
   const [filePreviewRefreshKey, setFilePreviewRefreshKey] = useState(0);
+  const [filesRefreshing, setFilesRefreshing] = useState(false);
 
   // Determine which tab is visually active
   const isFilePreviewActive = activePanelTabId !== null;
@@ -351,7 +352,7 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
       // Web preview tab: remount the iframe
       setPreviewRefreshKey((k) => k + 1);
     } else if (activeOutputTab === "files" && session?.id) {
-      // Files tab: clear cache and re-fetch directory listing
+      // Files tab: revalidate the visible directory listings
       triggerFilesRefresh(session.id);
     }
   }, [isFilePreviewActive, activeOutputTab, session?.id, triggerFilesRefresh]);
@@ -584,6 +585,7 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
         onDownload={isMarkdownPreview ? handleDocxDownload : undefined}
         isDownloading={isExportingDocx}
         onRefresh={handleRefresh}
+        isRefreshing={activeOutputTab === "files" && filesRefreshing}
         sessionId={
           !isFilePreviewActive &&
           activeOutputTab === "preview" &&
@@ -626,8 +628,10 @@ const BuildOutputPanel = memo(({ isOpen }: BuildOutputPanelProps) => {
               ))}
             {activeOutputTab === "files" && (
               <FilesTab
+                key={session?.id ?? preProvisionedSessionId}
                 sessionId={session?.id ?? preProvisionedSessionId}
                 onFileClick={session ? handleFileClick : undefined}
+                onRefreshingChange={setFilesRefreshing}
                 isPreProvisioned={!session && !!preProvisionedSessionId}
                 isProvisioning={!session && isPreProvisioning}
               />

--- a/web/src/app/craft/components/output-panel/FilesTab.test.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.test.tsx
@@ -1,5 +1,11 @@
 import React from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { SWRConfig } from "swr";
 
 import FilesTab from "@/app/craft/components/output-panel/FilesTab";
@@ -157,5 +163,54 @@ describe("FilesTab", () => {
       expect(screen.getByText("newest.txt")).toBeInTheDocument();
       expect(screen.queryByText("stale.txt")).not.toBeInTheDocument();
     });
+  });
+
+  it("invalidates cached collapsed directories when refreshing", async () => {
+    const sessionId = "session-1";
+    const oldFile = file("old.txt", "outputs/old.txt");
+    const newFile = file("new.txt", "outputs/new.txt");
+
+    mockedFetchDirectoryListing.mockImplementation((_sessionId, path) => {
+      if (path === "") {
+        return Promise.resolve({ path: "", entries: [outputsDirectory] });
+      }
+      if (path === "outputs") {
+        return Promise.resolve({ path: "outputs", entries: [newFile] });
+      }
+      return Promise.resolve({ path: path ?? "", entries: [] });
+    });
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      filesTabState: {
+        expandedPaths: [],
+        scrollTop: 0,
+        directoryCache: { outputs: [oldFile] },
+      },
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <FilesTab sessionId={sessionId} />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("outputs")).toBeInTheDocument();
+
+    act(() => {
+      useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+    });
+
+    await waitFor(() =>
+      expect(
+        useBuildSessionStore.getState().sessions.get(sessionId)?.filesTabState
+          .directoryCache.outputs
+      ).toBeUndefined()
+    );
+
+    fireEvent.click(screen.getByText("outputs"));
+
+    expect(await screen.findByText("new.txt")).toBeInTheDocument();
+    expect(screen.queryByText("old.txt")).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/craft/components/output-panel/FilesTab.test.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.test.tsx
@@ -54,6 +54,7 @@ describe("FilesTab", () => {
     const sessionId = "session-1";
     const oldFile = file("old.txt", "outputs/old.txt");
     const newFile = file("new.txt", "outputs/new.txt");
+    const onRefreshingChange = jest.fn();
     let resolveRefreshedOutputs: (listing: DirectoryListing) => void = () => {};
     const refreshedOutputs = new Promise<DirectoryListing>((resolve) => {
       resolveRefreshedOutputs = resolve;
@@ -76,9 +77,12 @@ describe("FilesTab", () => {
     });
     useBuildSessionStore.getState().setCurrentSession(sessionId);
 
-    render(
+    const { unmount } = render(
       <SWRConfig value={{ provider: () => new Map() }}>
-        <FilesTab sessionId={sessionId} />
+        <FilesTab
+          sessionId={sessionId}
+          onRefreshingChange={onRefreshingChange}
+        />
       </SWRConfig>
     );
 
@@ -94,6 +98,7 @@ describe("FilesTab", () => {
         "outputs"
       )
     );
+    expect(onRefreshingChange).toHaveBeenCalledWith(true);
     expect(screen.getByText("old.txt")).toBeInTheDocument();
     expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
 
@@ -103,9 +108,25 @@ describe("FilesTab", () => {
 
     expect(await screen.findByText("new.txt")).toBeInTheDocument();
     expect(screen.queryByText("old.txt")).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(onRefreshingChange).toHaveBeenLastCalledWith(false)
+    );
+
+    unmount();
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <FilesTab sessionId={sessionId} />
+      </SWRConfig>
+    );
+    expect(await screen.findByText("new.txt")).toBeInTheDocument();
+    expect(
+      mockedFetchDirectoryListing.mock.calls.filter(
+        ([, path]) => path === "outputs"
+      )
+    ).toHaveLength(1);
   });
 
-  it("ignores an older directory response that finishes last", async () => {
+  it("coalesces overlapping refreshes into one trailing refresh", async () => {
     const sessionId = "session-1";
     const oldFile = file("old.txt", "outputs/old.txt");
     const staleFile = file("stale.txt", "outputs/stale.txt");
@@ -148,6 +169,18 @@ describe("FilesTab", () => {
 
     act(() => {
       useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+      useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+    });
+    await waitFor(() =>
+      expect(
+        useBuildSessionStore.getState().sessions.get(sessionId)
+          ?.filesNeedsRefresh
+      ).toBe(3)
+    );
+    expect(outputResolvers).toHaveLength(1);
+
+    act(() => {
+      outputResolvers[0]?.({ path: "outputs", entries: [staleFile] });
     });
     await waitFor(() => expect(outputResolvers).toHaveLength(2));
 
@@ -155,13 +188,94 @@ describe("FilesTab", () => {
       outputResolvers[1]?.({ path: "outputs", entries: [newestFile] });
     });
     expect(await screen.findByText("newest.txt")).toBeInTheDocument();
-
-    act(() => {
-      outputResolvers[0]?.({ path: "outputs", entries: [staleFile] });
-    });
     await waitFor(() => {
       expect(screen.getByText("newest.txt")).toBeInTheDocument();
       expect(screen.queryByText("stale.txt")).not.toBeInTheDocument();
+      expect(outputResolvers).toHaveLength(2);
+    });
+  });
+
+  it("refreshes expanded directories sequentially", async () => {
+    const sessionId = "session-1";
+    const oldFile = file("old.txt", "outputs/old.txt");
+    const newFile = file("new.txt", "outputs/new.txt");
+    const webDirectory: FileSystemEntry = {
+      name: "web",
+      path: "outputs/web",
+      is_directory: true,
+      size: null,
+      mime_type: null,
+    };
+    let resolveOutputs: (listing: DirectoryListing) => void = () => {};
+    let resolveWeb: (listing: DirectoryListing) => void = () => {};
+
+    mockedFetchDirectoryListing.mockImplementation((_sessionId, path) => {
+      if (path === "") {
+        return Promise.resolve({ path: "", entries: [outputsDirectory] });
+      }
+      if (path === "outputs") {
+        return new Promise<DirectoryListing>((resolve) => {
+          resolveOutputs = resolve;
+        });
+      }
+      if (path === "outputs/web") {
+        return new Promise<DirectoryListing>((resolve) => {
+          resolveWeb = resolve;
+        });
+      }
+      return Promise.resolve({ path: path ?? "", entries: [] });
+    });
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      filesTabState: {
+        expandedPaths: ["outputs", "outputs/web"],
+        scrollTop: 0,
+        directoryCache: {
+          outputs: [webDirectory, oldFile],
+          "outputs/web": [],
+        },
+      },
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <FilesTab sessionId={sessionId} />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("old.txt")).toBeInTheDocument();
+
+    act(() => {
+      useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+    });
+    await waitFor(() =>
+      expect(mockedFetchDirectoryListing).toHaveBeenCalledWith(
+        sessionId,
+        "outputs"
+      )
+    );
+    expect(mockedFetchDirectoryListing).not.toHaveBeenCalledWith(
+      sessionId,
+      "outputs/web"
+    );
+
+    act(() => {
+      resolveOutputs({ path: "outputs", entries: [webDirectory, newFile] });
+    });
+
+    expect(await screen.findByText("new.txt")).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(mockedFetchDirectoryListing).toHaveBeenCalledWith(
+        sessionId,
+        "outputs/web"
+      )
+    );
+
+    await act(async () => {
+      resolveWeb({ path: "outputs/web", entries: [] });
+      await Promise.resolve();
     });
   });
 

--- a/web/src/app/craft/components/output-panel/FilesTab.test.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.test.tsx
@@ -126,6 +126,66 @@ describe("FilesTab", () => {
     ).toHaveLength(1);
   });
 
+  it("retries a refresh interrupted by unmounting", async () => {
+    const sessionId = "session-1";
+    const oldFile = file("old.txt", "outputs/old.txt");
+    const staleFile = file("stale.txt", "outputs/stale.txt");
+    const newFile = file("new.txt", "outputs/new.txt");
+    const outputResolvers: Array<(listing: DirectoryListing) => void> = [];
+
+    mockedFetchDirectoryListing.mockImplementation((_sessionId, path) => {
+      if (path === "") {
+        return Promise.resolve({ path: "", entries: [outputsDirectory] });
+      }
+      if (path === "outputs") {
+        return new Promise<DirectoryListing>((resolve) => {
+          outputResolvers.push(resolve);
+        });
+      }
+      return Promise.resolve({ path: path ?? "", entries: [] });
+    });
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      filesTabState: {
+        expandedPaths: ["outputs"],
+        scrollTop: 0,
+        directoryCache: { outputs: [oldFile] },
+      },
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+
+    const { unmount } = render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <FilesTab sessionId={sessionId} />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("old.txt")).toBeInTheDocument();
+    act(() => {
+      useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+    });
+    await waitFor(() => expect(outputResolvers).toHaveLength(1));
+
+    unmount();
+    await act(async () => {
+      outputResolvers[0]?.({ path: "outputs", entries: [staleFile] });
+      await Promise.resolve();
+    });
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <FilesTab sessionId={sessionId} />
+      </SWRConfig>
+    );
+    await waitFor(() => expect(outputResolvers).toHaveLength(2));
+
+    act(() => {
+      outputResolvers[1]?.({ path: "outputs", entries: [newFile] });
+    });
+    expect(await screen.findByText("new.txt")).toBeInTheDocument();
+    expect(screen.queryByText("stale.txt")).not.toBeInTheDocument();
+  });
+
   it("coalesces overlapping refreshes into one trailing refresh", async () => {
     const sessionId = "session-1";
     const oldFile = file("old.txt", "outputs/old.txt");

--- a/web/src/app/craft/components/output-panel/FilesTab.test.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.test.tsx
@@ -1,0 +1,161 @@
+import React from "react";
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+
+import FilesTab from "@/app/craft/components/output-panel/FilesTab";
+import { useBuildSessionStore } from "@/app/craft/hooks/useBuildSessionStore";
+import { fetchDirectoryListing } from "@/app/craft/services/apiServices";
+import type {
+  DirectoryListing,
+  FileSystemEntry,
+} from "@/app/craft/types/streamingTypes";
+
+jest.mock("@/app/craft/services/apiServices", () => ({
+  ...jest.requireActual("@/app/craft/services/apiServices"),
+  fetchDirectoryListing: jest.fn(),
+}));
+
+const mockedFetchDirectoryListing = jest.mocked(fetchDirectoryListing);
+
+function file(name: string, path: string): FileSystemEntry {
+  return {
+    name,
+    path,
+    is_directory: false,
+    size: 10,
+    mime_type: "text/plain",
+  };
+}
+
+const outputsDirectory: FileSystemEntry = {
+  name: "outputs",
+  path: "outputs",
+  is_directory: true,
+  size: null,
+  mime_type: null,
+};
+
+describe("FilesTab", () => {
+  beforeEach(() => {
+    mockedFetchDirectoryListing.mockReset();
+    useBuildSessionStore.setState({
+      currentSessionId: null,
+      sessions: new Map(),
+    });
+  });
+
+  it("keeps expanded directory contents visible while refreshing", async () => {
+    const sessionId = "session-1";
+    const oldFile = file("old.txt", "outputs/old.txt");
+    const newFile = file("new.txt", "outputs/new.txt");
+    let resolveRefreshedOutputs: (listing: DirectoryListing) => void = () => {};
+    const refreshedOutputs = new Promise<DirectoryListing>((resolve) => {
+      resolveRefreshedOutputs = resolve;
+    });
+
+    mockedFetchDirectoryListing.mockImplementation((_sessionId, path) => {
+      if (path === "") {
+        return Promise.resolve({ path: "", entries: [outputsDirectory] });
+      }
+      if (path === "outputs") return refreshedOutputs;
+      return Promise.resolve({ path: path ?? "", entries: [] });
+    });
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      filesTabState: {
+        expandedPaths: ["outputs"],
+        scrollTop: 0,
+        directoryCache: { outputs: [oldFile] },
+      },
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <FilesTab sessionId={sessionId} />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("old.txt")).toBeInTheDocument();
+
+    act(() => {
+      useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+    });
+
+    await waitFor(() =>
+      expect(mockedFetchDirectoryListing).toHaveBeenCalledWith(
+        sessionId,
+        "outputs"
+      )
+    );
+    expect(screen.getByText("old.txt")).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+
+    act(() => {
+      resolveRefreshedOutputs({ path: "outputs", entries: [newFile] });
+    });
+
+    expect(await screen.findByText("new.txt")).toBeInTheDocument();
+    expect(screen.queryByText("old.txt")).not.toBeInTheDocument();
+  });
+
+  it("ignores an older directory response that finishes last", async () => {
+    const sessionId = "session-1";
+    const oldFile = file("old.txt", "outputs/old.txt");
+    const staleFile = file("stale.txt", "outputs/stale.txt");
+    const newestFile = file("newest.txt", "outputs/newest.txt");
+    const outputResolvers: Array<(listing: DirectoryListing) => void> = [];
+
+    mockedFetchDirectoryListing.mockImplementation((_sessionId, path) => {
+      if (path === "") {
+        return Promise.resolve({ path: "", entries: [outputsDirectory] });
+      }
+      if (path === "outputs") {
+        return new Promise<DirectoryListing>((resolve) => {
+          outputResolvers.push(resolve);
+        });
+      }
+      return Promise.resolve({ path: path ?? "", entries: [] });
+    });
+
+    useBuildSessionStore.getState().createSession(sessionId, {
+      filesTabState: {
+        expandedPaths: ["outputs"],
+        scrollTop: 0,
+        directoryCache: { outputs: [oldFile] },
+      },
+    });
+    useBuildSessionStore.getState().setCurrentSession(sessionId);
+
+    render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <FilesTab sessionId={sessionId} />
+      </SWRConfig>
+    );
+
+    expect(await screen.findByText("old.txt")).toBeInTheDocument();
+
+    act(() => {
+      useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+    });
+    await waitFor(() => expect(outputResolvers).toHaveLength(1));
+
+    act(() => {
+      useBuildSessionStore.getState().triggerFilesRefresh(sessionId);
+    });
+    await waitFor(() => expect(outputResolvers).toHaveLength(2));
+
+    act(() => {
+      outputResolvers[1]?.({ path: "outputs", entries: [newestFile] });
+    });
+    expect(await screen.findByText("newest.txt")).toBeInTheDocument();
+
+    act(() => {
+      outputResolvers[0]?.({ path: "outputs", entries: [staleFile] });
+    });
+    await waitFor(() => {
+      expect(screen.getByText("newest.txt")).toBeInTheDocument();
+      expect(screen.queryByText("stale.txt")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -45,6 +45,9 @@ export default function FilesTab({
   const updateFilesTabState = useBuildSessionStore(
     (state) => state.updateFilesTabState
   );
+  const mergeFilesTabDirectoryCache = useBuildSessionStore(
+    (state) => state.mergeFilesTabDirectoryCache
+  );
 
   // Local state for pre-provisioned mode (no persistence needed)
   const [localExpandedPaths, setLocalExpandedPaths] = useState<Set<string>>(
@@ -72,15 +75,13 @@ export default function FilesTab({
     () =>
       isPreProvisioned
         ? localDirectoryCache
-        : (new Map(Object.entries(filesTabState.directoryCache)) as Map<
-            string,
-            FileSystemEntry[]
-          >),
+        : new Map(Object.entries(filesTabState.directoryCache)),
     [isPreProvisioned, localDirectoryCache, filesTabState.directoryCache]
   );
 
   // Scroll container ref for position tracking
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const refreshGenerationRef = useRef(0);
 
   // Fetch root directory
   const {
@@ -99,33 +100,33 @@ export default function FilesTab({
   // Refresh files list when outputs/ directory changes
   const filesNeedsRefresh = useFilesNeedsRefresh();
 
-  // Snapshot of currently expanded paths — avoids putting both local and store
-  // versions in the dependency array (only one is used per mode).
-  const currentExpandedPaths = isPreProvisioned
-    ? Array.from(localExpandedPaths)
-    : filesTabState.expandedPaths;
+  const expandedPathsRef = useRef<string[]>([]);
+  useEffect(() => {
+    expandedPathsRef.current = isPreProvisioned
+      ? Array.from(localExpandedPaths)
+      : filesTabState.expandedPaths;
+  }, [isPreProvisioned, localExpandedPaths, filesTabState.expandedPaths]);
 
   useEffect(() => {
     if (filesNeedsRefresh > 0 && sessionId && mutate) {
-      // Clear directory cache to ensure all directories are refreshed
-      if (isPreProvisioned) {
-        setLocalDirectoryCache(new Map());
-      } else {
-        updateFilesTabState(sessionId, { directoryCache: {} });
-      }
-      // Refresh root directory listing
-      mutate();
+      const refreshGeneration = ++refreshGenerationRef.current;
+      const expandedPathsToRefresh = expandedPathsRef.current;
 
-      // Re-fetch all currently expanded subdirectories so they don't get
-      // stuck on "Loading..." after the cache was cleared
-      if (currentExpandedPaths.length > 0) {
-        Promise.allSettled(
-          currentExpandedPaths.map((p) => fetchDirectoryListing(sessionId, p))
+      // Keep the current tree visible while updated listings are fetched.
+      // Clearing the cache here makes every expanded directory briefly render
+      // as "Loading..." whenever an agent writes a file.
+      void mutate();
+
+      if (expandedPathsToRefresh.length > 0) {
+        void Promise.allSettled(
+          expandedPathsToRefresh.map((p) => fetchDirectoryListing(sessionId, p))
         ).then((settled) => {
+          if (refreshGeneration !== refreshGenerationRef.current) return;
+
           // Collect only the successful fetches into a path → entries map
           const fetched = new Map<string, FileSystemEntry[]>();
           settled.forEach((r, i) => {
-            const p = currentExpandedPaths[i];
+            const p = expandedPathsToRefresh[i];
             if (p && r.status === "fulfilled" && r.value) {
               fetched.set(p, r.value.entries);
             }
@@ -138,22 +139,25 @@ export default function FilesTab({
               return next;
             });
           } else {
-            const obj: Record<string, FileSystemEntry[]> = {};
+            const listings: Record<string, FileSystemEntry[]> = {};
             fetched.forEach((entries, p) => {
-              obj[p] = entries;
+              listings[p] = entries;
             });
-            updateFilesTabState(sessionId, { directoryCache: obj });
+            mergeFilesTabDirectoryCache(sessionId, listings);
           }
         });
       }
+
+      return () => {
+        refreshGenerationRef.current += 1;
+      };
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     filesNeedsRefresh,
     sessionId,
     mutate,
     isPreProvisioned,
-    updateFilesTabState,
+    mergeFilesTabDirectoryCache,
   ]);
 
   // Update cache when root listing changes
@@ -166,14 +170,10 @@ export default function FilesTab({
           return newCache;
         });
       } else {
-        const newCache = {
-          ...filesTabState.directoryCache,
-          "": rootListing.entries,
-        };
-        updateFilesTabState(sessionId, { directoryCache: newCache });
+        mergeFilesTabDirectoryCache(sessionId, { "": rootListing.entries });
       }
     }
-  }, [rootListing, sessionId, isPreProvisioned]);
+  }, [rootListing, sessionId, isPreProvisioned, mergeFilesTabDirectoryCache]);
 
   const toggleFolder = useCallback(
     async (path: string) => {

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -28,6 +28,7 @@ import { InlineFilePreview } from "@/app/craft/components/output-panel/FilePrevi
 interface FilesTabProps {
   sessionId: string | null;
   onFileClick?: (path: string, fileName: string) => void;
+  onRefreshingChange?: (isRefreshing: boolean) => void;
   /** True when showing pre-provisioned sandbox (read-only, no file clicks) */
   isPreProvisioned?: boolean;
   /** True when sandbox is still being provisioned */
@@ -37,6 +38,7 @@ interface FilesTabProps {
 export default function FilesTab({
   sessionId,
   onFileClick,
+  onRefreshingChange,
   isPreProvisioned = false,
   isProvisioning = false,
 }: FilesTabProps) {
@@ -84,7 +86,12 @@ export default function FilesTab({
 
   // Scroll container ref for position tracking
   const scrollContainerRef = useRef<HTMLDivElement>(null);
-  const refreshGenerationRef = useRef(0);
+  const isMountedRef = useRef(true);
+  const handledRefreshGenerationRef = useRef(
+    filesTabState.lastRefreshGeneration ?? 0
+  );
+  const refreshInFlightRef = useRef(false);
+  const refreshQueuedRef = useRef(false);
 
   // Fetch root directory
   const {
@@ -99,6 +106,19 @@ export default function FilesTab({
       dedupingInterval: 2000,
     }
   );
+  const mutateRootRef = useRef(mutate);
+  useEffect(() => {
+    mutateRootRef.current = mutate;
+  }, [mutate]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      refreshQueuedRef.current = false;
+      onRefreshingChange?.(false);
+    };
+  }, [onRefreshingChange]);
 
   // Refresh files list when outputs/ directory changes
   const filesNeedsRefresh = useFilesNeedsRefresh();
@@ -110,69 +130,94 @@ export default function FilesTab({
       : filesTabState.expandedPaths;
   }, [isPreProvisioned, localExpandedPaths, filesTabState.expandedPaths]);
 
-  useEffect(() => {
-    if (filesNeedsRefresh > 0 && sessionId && mutate) {
-      const refreshGeneration = ++refreshGenerationRef.current;
-      const expandedPathsToRefresh = expandedPathsRef.current;
-      const retainedPaths = new Set(["", ...expandedPathsToRefresh]);
+  const performFilesRefresh = useCallback(async () => {
+    if (!sessionId) return;
 
-      // Keep the current tree visible while updated listings are fetched.
-      // Clearing the cache here makes every expanded directory briefly render
-      // as "Loading..." whenever an agent writes a file.
+    const refreshSessionId = sessionId;
+    const expandedPathsToRefresh = [...expandedPathsRef.current];
+    const retainedPaths = new Set(["", ...expandedPathsToRefresh]);
+
+    // Retain visible listings during revalidation. Hidden listings are removed
+    // so a collapsed directory fetches fresh contents when it is reopened.
+    if (isPreProvisioned) {
+      setLocalDirectoryCache(
+        (prev) =>
+          new Map(Array.from(prev).filter(([path]) => retainedPaths.has(path)))
+      );
+    } else {
+      retainFilesTabDirectoryCache(refreshSessionId, retainedPaths);
+    }
+
+    // The sandbox filesystem transport stalls when multiple listings are in
+    // flight. Refresh serially while applying each result as it arrives.
+    await mutateRootRef.current().catch(() => undefined);
+    for (const path of expandedPathsToRefresh) {
+      const listing = await fetchDirectoryListing(refreshSessionId, path).catch(
+        () => null
+      );
+      if (!listing || !isMountedRef.current) continue;
+
       if (isPreProvisioned) {
-        setLocalDirectoryCache(
-          (prev) =>
-            new Map(
-              Array.from(prev).filter(([path]) => retainedPaths.has(path))
-            )
-        );
+        setLocalDirectoryCache((prev) => {
+          const next = new Map(prev);
+          next.set(path, listing.entries);
+          return next;
+        });
       } else {
-        retainFilesTabDirectoryCache(sessionId, retainedPaths);
-      }
-      void mutate();
-
-      if (expandedPathsToRefresh.length > 0) {
-        void Promise.allSettled(
-          expandedPathsToRefresh.map((p) => fetchDirectoryListing(sessionId, p))
-        ).then((settled) => {
-          if (refreshGeneration !== refreshGenerationRef.current) return;
-
-          // Collect only the successful fetches into a path → entries map
-          const fetched = new Map<string, FileSystemEntry[]>();
-          settled.forEach((r, i) => {
-            const p = expandedPathsToRefresh[i];
-            if (p && r.status === "fulfilled" && r.value) {
-              fetched.set(p, r.value.entries);
-            }
-          });
-
-          if (isPreProvisioned) {
-            setLocalDirectoryCache((prev) => {
-              const next = new Map(prev);
-              fetched.forEach((entries, p) => next.set(p, entries));
-              return next;
-            });
-          } else {
-            const listings: Record<string, FileSystemEntry[]> = {};
-            fetched.forEach((entries, p) => {
-              listings[p] = entries;
-            });
-            mergeFilesTabDirectoryCache(sessionId, listings);
-          }
+        mergeFilesTabDirectoryCache(refreshSessionId, {
+          [path]: listing.entries,
         });
       }
-
-      return () => {
-        refreshGenerationRef.current += 1;
-      };
     }
   }, [
-    filesNeedsRefresh,
     sessionId,
-    mutate,
     isPreProvisioned,
     mergeFilesTabDirectoryCache,
     retainFilesTabDirectoryCache,
+  ]);
+
+  const runRefreshQueue = useCallback(async () => {
+    if (refreshInFlightRef.current) {
+      refreshQueuedRef.current = true;
+      return;
+    }
+
+    refreshInFlightRef.current = true;
+    onRefreshingChange?.(true);
+    try {
+      do {
+        refreshQueuedRef.current = false;
+        await performFilesRefresh();
+      } while (refreshQueuedRef.current && isMountedRef.current);
+    } finally {
+      refreshInFlightRef.current = false;
+      if (isMountedRef.current) onRefreshingChange?.(false);
+    }
+  }, [performFilesRefresh, onRefreshingChange]);
+
+  useEffect(() => {
+    if (!sessionId || filesNeedsRefresh <= 0) return;
+
+    handledRefreshGenerationRef.current = Math.max(
+      handledRefreshGenerationRef.current,
+      filesTabState.lastRefreshGeneration ?? 0
+    );
+    if (filesNeedsRefresh <= handledRefreshGenerationRef.current) return;
+
+    handledRefreshGenerationRef.current = filesNeedsRefresh;
+    if (!isPreProvisioned) {
+      updateFilesTabState(sessionId, {
+        lastRefreshGeneration: filesNeedsRefresh,
+      });
+    }
+    void runRefreshQueue();
+  }, [
+    filesNeedsRefresh,
+    sessionId,
+    isPreProvisioned,
+    filesTabState.lastRefreshGeneration,
+    updateFilesTabState,
+    runRefreshQueue,
   ]);
 
   // Update cache when root listing changes
@@ -227,15 +272,9 @@ export default function FilesTab({
           if (!directoryCache.has(path)) {
             const listing = await fetchDirectoryListing(sessionId, path);
             if (listing) {
-              const newCache = {
-                ...filesTabState.directoryCache,
+              mergeFilesTabDirectoryCache(sessionId, {
                 [path]: listing.entries,
-              };
-              updateFilesTabState(sessionId, {
-                expandedPaths: Array.from(newExpanded),
-                directoryCache: newCache,
               });
-              return;
             }
           }
           updateFilesTabState(sessionId, {
@@ -251,8 +290,8 @@ export default function FilesTab({
       localDirectoryCache,
       expandedPaths,
       directoryCache,
-      filesTabState.directoryCache,
       updateFilesTabState,
+      mergeFilesTabDirectoryCache,
     ]
   );
 

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -189,11 +189,24 @@ export default function FilesTab({
         refreshQueuedRef.current = false;
         await performFilesRefresh();
       } while (refreshQueuedRef.current && isMountedRef.current);
+      if (isMountedRef.current && !isPreProvisioned && sessionId) {
+        updateFilesTabState(sessionId, {
+          lastRefreshGeneration: handledRefreshGenerationRef.current,
+        });
+      }
     } finally {
       refreshInFlightRef.current = false;
-      if (isMountedRef.current) onRefreshingChange?.(false);
+      if (isMountedRef.current) {
+        onRefreshingChange?.(false);
+      }
     }
-  }, [performFilesRefresh, onRefreshingChange]);
+  }, [
+    performFilesRefresh,
+    isPreProvisioned,
+    sessionId,
+    updateFilesTabState,
+    onRefreshingChange,
+  ]);
 
   useEffect(() => {
     if (!sessionId || filesNeedsRefresh <= 0) return;
@@ -205,18 +218,11 @@ export default function FilesTab({
     if (filesNeedsRefresh <= handledRefreshGenerationRef.current) return;
 
     handledRefreshGenerationRef.current = filesNeedsRefresh;
-    if (!isPreProvisioned) {
-      updateFilesTabState(sessionId, {
-        lastRefreshGeneration: filesNeedsRefresh,
-      });
-    }
     void runRefreshQueue();
   }, [
     filesNeedsRefresh,
     sessionId,
-    isPreProvisioned,
     filesTabState.lastRefreshGeneration,
-    updateFilesTabState,
     runRefreshQueue,
   ]);
 

--- a/web/src/app/craft/components/output-panel/FilesTab.tsx
+++ b/web/src/app/craft/components/output-panel/FilesTab.tsx
@@ -48,6 +48,9 @@ export default function FilesTab({
   const mergeFilesTabDirectoryCache = useBuildSessionStore(
     (state) => state.mergeFilesTabDirectoryCache
   );
+  const retainFilesTabDirectoryCache = useBuildSessionStore(
+    (state) => state.retainFilesTabDirectoryCache
+  );
 
   // Local state for pre-provisioned mode (no persistence needed)
   const [localExpandedPaths, setLocalExpandedPaths] = useState<Set<string>>(
@@ -111,10 +114,21 @@ export default function FilesTab({
     if (filesNeedsRefresh > 0 && sessionId && mutate) {
       const refreshGeneration = ++refreshGenerationRef.current;
       const expandedPathsToRefresh = expandedPathsRef.current;
+      const retainedPaths = new Set(["", ...expandedPathsToRefresh]);
 
       // Keep the current tree visible while updated listings are fetched.
       // Clearing the cache here makes every expanded directory briefly render
       // as "Loading..." whenever an agent writes a file.
+      if (isPreProvisioned) {
+        setLocalDirectoryCache(
+          (prev) =>
+            new Map(
+              Array.from(prev).filter(([path]) => retainedPaths.has(path))
+            )
+        );
+      } else {
+        retainFilesTabDirectoryCache(sessionId, retainedPaths);
+      }
       void mutate();
 
       if (expandedPathsToRefresh.length > 0) {
@@ -158,6 +172,7 @@ export default function FilesTab({
     mutate,
     isPreProvisioned,
     mergeFilesTabDirectoryCache,
+    retainFilesTabDirectoryCache,
   ]);
 
   // Update cache when root listing changes

--- a/web/src/app/craft/components/output-panel/UrlBar.test.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.test.tsx
@@ -18,6 +18,23 @@ describe("UrlBar", () => {
     (copyText as jest.Mock).mockResolvedValue(undefined);
   });
 
+  test("shows and disables a spinner while refreshing", () => {
+    const onRefresh = jest.fn();
+    render(
+      <UrlBar
+        displayUrl="sandbox://"
+        showNavigation
+        onRefresh={onRefresh}
+        isRefreshing
+      />
+    );
+
+    const refreshButton = screen.getByRole("button", { name: "Refresh" });
+    expect(refreshButton).toBeDisabled();
+    expect(refreshButton).toHaveAttribute("aria-busy", "true");
+    expect(refreshButton.querySelector("svg")).toHaveClass("animate-spin");
+  });
+
   test("contains long preview URLs inside the URL bar and copies them", async () => {
     const user = setupUser();
     const longPreviewUrl =

--- a/web/src/app/craft/components/output-panel/UrlBar.tsx
+++ b/web/src/app/craft/components/output-panel/UrlBar.tsx
@@ -40,6 +40,8 @@ export interface UrlBarProps {
   isDownloading?: boolean;
   /** Optional refresh callback — shows a refresh icon at the right edge of the URL pill */
   onRefresh?: () => void;
+  /** Whether the current view is refreshing. */
+  isRefreshing?: boolean;
   /** Session ID — when present with previewUrl, shows share button for webapp */
   sessionId?: string;
   /** Sharing scope for the webapp (used when sessionId + previewUrl) */
@@ -68,6 +70,7 @@ export default function UrlBar({
   onDownload,
   isDownloading = false,
   onRefresh,
+  isRefreshing = false,
   sessionId,
   sharingScope = "private",
   onScopeChange,
@@ -150,10 +153,19 @@ export default function UrlBar({
             {onRefresh && (
               <button
                 onClick={onRefresh}
-                className="p-1.5 rounded-full transition-colors hover:bg-background-tint-03 text-text-03"
+                disabled={isRefreshing}
+                className={cn(
+                  "p-1.5 rounded-full transition-colors text-text-03",
+                  isRefreshing ? "cursor-wait" : "hover:bg-background-tint-03"
+                )}
                 aria-label="Refresh"
+                aria-busy={isRefreshing}
               >
-                <SvgRevert size={14} className="-scale-x-100" />
+                {isRefreshing ? (
+                  <SpinningLoader size={14} />
+                ) : (
+                  <SvgRevert size={14} className="-scale-x-100" />
+                )}
               </button>
             )}
           </div>

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -8,6 +8,7 @@ import {
   Artifact,
   ArtifactType,
   BuildMessage,
+  FileSystemEntry,
   SessionHistoryItem,
   SessionOrigin,
   SessionStatus,
@@ -566,7 +567,7 @@ export interface FilesTabState {
   expandedPaths: string[];
   scrollTop: number;
   /** Cached directory listings by path - avoids refetch on tab switch */
-  directoryCache: Record<string, unknown[]>;
+  directoryCache: Record<string, FileSystemEntry[]>;
 }
 
 /** Tab history entry - can be a pinned tab or a transient panel tab */
@@ -783,6 +784,10 @@ interface BuildSessionStore {
   updateFilesTabState: (
     sessionId: string,
     updates: Partial<FilesTabState>
+  ) => void;
+  mergeFilesTabDirectoryCache: (
+    sessionId: string,
+    listings: Record<string, FileSystemEntry[]>
   ) => void;
 
   // Subagent Actions
@@ -2126,6 +2131,31 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const updatedSession: BuildSessionData = {
         ...session,
         filesTabState: { ...session.filesTabState, ...updates },
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  mergeFilesTabDirectoryCache: (
+    sessionId: string,
+    listings: Record<string, FileSystemEntry[]>
+  ) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+
+      const updatedSession: BuildSessionData = {
+        ...session,
+        filesTabState: {
+          ...session.filesTabState,
+          directoryCache: {
+            ...session.filesTabState.directoryCache,
+            ...listings,
+          },
+        },
         lastAccessed: new Date(),
       };
       const newSessions = new Map(state.sessions);

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -568,6 +568,8 @@ export interface FilesTabState {
   scrollTop: number;
   /** Cached directory listings by path - avoids refetch on tab switch */
   directoryCache: Record<string, FileSystemEntry[]>;
+  /** Last refresh generation accepted by the Files tab. */
+  lastRefreshGeneration?: number;
 }
 
 /** Tab history entry - can be a pinned tab or a transient panel tab */
@@ -888,7 +890,12 @@ const createInitialSessionData = (
   viewedSubagentSessionId: null,
   activeOutputTab: "preview",
   activePanelTabId: null,
-  filesTabState: { expandedPaths: [], scrollTop: 0, directoryCache: {} },
+  filesTabState: {
+    expandedPaths: [],
+    scrollTop: 0,
+    directoryCache: {},
+    lastRefreshGeneration: 0,
+  },
   tabHistory: {
     entries: [{ type: "pinned", tab: "preview" }],
     currentIndex: 0,
@@ -2176,11 +2183,15 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const session = state.sessions.get(sessionId);
       if (!session) return state;
 
-      const directoryCache = Object.fromEntries(
-        Object.entries(session.filesTabState.directoryCache).filter(([path]) =>
-          retainedPaths.has(path)
-        )
+      const cachedListings = Object.entries(
+        session.filesTabState.directoryCache
       );
+      const retainedListings = cachedListings.filter(([path]) =>
+        retainedPaths.has(path)
+      );
+      if (retainedListings.length === cachedListings.length) return state;
+
+      const directoryCache = Object.fromEntries(retainedListings);
       const updatedSession: BuildSessionData = {
         ...session,
         filesTabState: {
@@ -2608,6 +2619,7 @@ const EMPTY_FILES_TAB_STATE: FilesTabState = {
   expandedPaths: [],
   scrollTop: 0,
   directoryCache: {},
+  lastRefreshGeneration: 0,
 };
 const EMPTY_TAB_HISTORY: TabNavigationHistory = {
   entries: [],

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -789,6 +789,10 @@ interface BuildSessionStore {
     sessionId: string,
     listings: Record<string, FileSystemEntry[]>
   ) => void;
+  retainFilesTabDirectoryCache: (
+    sessionId: string,
+    retainedPaths: ReadonlySet<string>
+  ) => void;
 
   // Subagent Actions
   /** Swap the main column to show a subagent's transcript in place of the chat. */
@@ -2155,6 +2159,33 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
             ...session.filesTabState.directoryCache,
             ...listings,
           },
+        },
+        lastAccessed: new Date(),
+      };
+      const newSessions = new Map(state.sessions);
+      newSessions.set(sessionId, updatedSession);
+      return { sessions: newSessions };
+    });
+  },
+
+  retainFilesTabDirectoryCache: (
+    sessionId: string,
+    retainedPaths: ReadonlySet<string>
+  ) => {
+    set((state) => {
+      const session = state.sessions.get(sessionId);
+      if (!session) return state;
+
+      const directoryCache = Object.fromEntries(
+        Object.entries(session.filesTabState.directoryCache).filter(([path]) =>
+          retainedPaths.has(path)
+        )
+      );
+      const updatedSession: BuildSessionData = {
+        ...session,
+        filesTabState: {
+          ...session.filesTabState,
+          directoryCache,
         },
         lastAccessed: new Date(),
       };

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -568,7 +568,7 @@ export interface FilesTabState {
   scrollTop: number;
   /** Cached directory listings by path - avoids refetch on tab switch */
   directoryCache: Record<string, FileSystemEntry[]>;
-  /** Last refresh generation accepted by the Files tab. */
+  /** Last refresh generation completed by the Files tab. */
   lastRefreshGeneration?: number;
 }
 
@@ -1884,17 +1884,9 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
     const session = get().sessions.get(sessionId);
     if (session) {
       // Increment refresh counter to trigger files list refresh
-      // Using a counter ensures each write/edit triggers a new refresh
-      // Also collapse the attachments directory to show fresh state
-      const collapsedExpandedPaths = session.filesTabState.expandedPaths.filter(
-        (path) => path !== "attachments" && !path.startsWith("attachments/")
-      );
+      // Using a counter ensures each filesystem change triggers a new refresh
       get().updateSessionData(sessionId, {
         filesNeedsRefresh: (session.filesNeedsRefresh || 0) + 1,
-        filesTabState: {
-          ...session.filesTabState,
-          expandedPaths: collapsedExpandedPaths,
-        },
       });
     }
   },

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -135,6 +135,9 @@ describe("useBuildStreaming thinking packets", () => {
   });
 
   it("refreshes files only when an output write completes", async () => {
+    useBuildSessionStore.getState().updateFilesTabState(sessionId, {
+      expandedPaths: ["attachments", "attachments/reports"],
+    });
     jest
       .mocked(processSSEStream)
       .mockImplementationOnce(async (_response, onPacket) => {
@@ -160,6 +163,10 @@ describe("useBuildStreaming thinking packets", () => {
     const session = useBuildSessionStore.getState().sessions.get(sessionId);
     expect(session?.filesNeedsRefresh).toBe(1);
     expect(session?.webappNeedsRefresh).toBe(0);
+    expect(session?.filesTabState.expandedPaths).toEqual([
+      "attachments",
+      "attachments/reports",
+    ]);
   });
 
   it("refreshes both files and preview for a completed output web write", async () => {
@@ -219,6 +226,25 @@ describe("useBuildStreaming thinking packets", () => {
     expect(
       useBuildSessionStore.getState().sessions.get(sessionId)?.filesNeedsRefresh
     ).toBe(1);
+  });
+
+  it("does not reconcile files after a text-only turn", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({ type: "text_chunk", text: "Done." } as never);
+        onPacket({ type: "prompt_response" } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "explain the project");
+    });
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)?.filesNeedsRefresh
+    ).toBe(0);
   });
 
   it("seeds clickable subagent metadata from a task start packet", async () => {

--- a/web/src/app/craft/hooks/useBuildStreaming.test.tsx
+++ b/web/src/app/craft/hooks/useBuildStreaming.test.tsx
@@ -134,6 +134,93 @@ describe("useBuildStreaming thinking packets", () => {
     ).toBe(newerController);
   });
 
+  it("refreshes files only when an output write completes", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        for (const status of ["pending", "in_progress", "completed"] as const) {
+          onPacket({
+            type: "tool_call_progress",
+            tool_call_id: "write-output",
+            kind: "edit",
+            status,
+            raw_input: { filePath: "outputs/report.txt" },
+            raw_output: null,
+            _meta: { toolName: "write" },
+          } as never);
+        }
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "write a report");
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session?.filesNeedsRefresh).toBe(1);
+    expect(session?.webappNeedsRefresh).toBe(0);
+  });
+
+  it("refreshes both files and preview for a completed output web write", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_progress",
+          tool_call_id: "write-web-output",
+          kind: "edit",
+          status: "completed",
+          raw_input: {
+            filePath:
+              "/workspace/sessions/323d7ce1-ea1b-42a8-bc34-ca5d8b4d27a3/outputs/web/app/page.tsx",
+          },
+          raw_output: null,
+          _meta: { toolName: "write" },
+        } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(sessionId, "update the web app");
+    });
+
+    const session = useBuildSessionStore.getState().sessions.get(sessionId);
+    expect(session?.filesNeedsRefresh).toBe(1);
+    expect(session?.webappNeedsRefresh).toBe(1);
+  });
+
+  it("reconciles files when a turn completes", async () => {
+    jest
+      .mocked(processSSEStream)
+      .mockImplementationOnce(async (_response, onPacket) => {
+        onPacket({
+          type: "tool_call_progress",
+          tool_call_id: "mkdir-output",
+          kind: "execute",
+          status: "completed",
+          raw_input: { command: "mkdir -p outputs/report" },
+          raw_output: null,
+          _meta: { toolName: "bash" },
+        } as never);
+        onPacket({ type: "prompt_response" } as never);
+      });
+
+    const { result } = renderHook(() => useBuildStreaming());
+
+    await act(async () => {
+      await result.current.streamMessage(
+        sessionId,
+        "create a report directory"
+      );
+    });
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(sessionId)?.filesNeedsRefresh
+    ).toBe(1);
+  });
+
   it("seeds clickable subagent metadata from a task start packet", async () => {
     jest
       .mocked(processSSEStream)

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -266,6 +266,12 @@ export function useBuildStreaming() {
       const currentItems =
         useBuildSessionStore.getState().sessions.get(sessionId)?.streamItems ??
         [];
+      let needsTurnCompletionFileRefresh = currentItems.some(
+        (item) =>
+          item.type === "tool_call" &&
+          item.toolCall.kind === "execute" &&
+          item.toolCall.status === "completed"
+      );
       const lastCurrentItem = currentItems[currentItems.length - 1];
       if (lastCurrentItem?.type === "text") {
         accumulatedText = lastCurrentItem.content;
@@ -501,6 +507,9 @@ export function useBuildStreaming() {
           }
 
           case "tool_call_progress": {
+            if (parsed.status === "completed" && parsed.kind === "execute") {
+              needsTurnCompletionFileRefresh = true;
+            }
             if (
               parsed.status === "completed" &&
               parsed.kind === "edit" &&
@@ -651,9 +660,11 @@ export function useBuildStreaming() {
           }
 
           case "prompt_response": {
-            // Shell commands and scripts can mutate the workspace without
-            // emitting structured file paths. Reconcile once when the turn ends.
-            triggerFilesRefresh(sessionId);
+            if (needsTurnCompletionFileRefresh) {
+              // Shell commands and scripts can mutate the workspace without
+              // emitting structured file paths. Reconcile once when the turn ends.
+              triggerFilesRefresh(sessionId);
+            }
             finalizeStreaming();
             const isInterrupting = useBuildSessionStore
               .getState()

--- a/web/src/app/craft/hooks/useBuildStreaming.ts
+++ b/web/src/app/craft/hooks/useBuildStreaming.ts
@@ -239,34 +239,19 @@ export function useBuildStreaming() {
     (state) => state.appendSubagentThinkingChunk
   );
 
-  // ── Output file detector registry ──────────────────────────────────────
-  // Ordered by priority — first match wins.
-  // To add a new output type, add an entry here + a store action.
-  const OUTPUT_FILE_DETECTORS = useMemo(
-    () => [
-      {
-        match: (fp: string, k: string) =>
-          (k === "edit" || k === "write") &&
-          (fp.includes("/web/") || fp.startsWith("web/")),
-        onDetect: (sid: string) => triggerWebappRefresh(sid),
-      },
-      {
-        match: (fp: string, k: string) =>
-          (k === "edit" || k === "write") &&
-          fp.endsWith(".md") &&
-          (fp.includes("/outputs/") || fp.startsWith("outputs/")),
-        onDetect: (sid: string, fp: string) => {
-          openMarkdownPreview(sid, fp);
-          triggerFilesRefresh(sid);
-        },
-      },
-      {
-        match: (fp: string, k: string) =>
-          (k === "edit" || k === "write") &&
-          (fp.includes("/outputs/") || fp.startsWith("outputs/")),
-        onDetect: (sid: string) => triggerFilesRefresh(sid),
-      },
-    ],
+  const handleCompletedFileChange = useCallback(
+    (sid: string, filePath: string) => {
+      const isWebFile =
+        filePath.includes("/web/") || filePath.startsWith("web/");
+      const isOutputFile =
+        filePath.includes("/outputs/") || filePath.startsWith("outputs/");
+
+      if (isWebFile) triggerWebappRefresh(sid);
+      if (isOutputFile) {
+        if (filePath.endsWith(".md")) openMarkdownPreview(sid, filePath);
+        triggerFilesRefresh(sid);
+      }
+    },
     [triggerWebappRefresh, triggerFilesRefresh, openMarkdownPreview]
   );
 
@@ -516,6 +501,14 @@ export function useBuildStreaming() {
           }
 
           case "tool_call_progress": {
+            if (
+              parsed.status === "completed" &&
+              parsed.kind === "edit" &&
+              parsed.filePath
+            ) {
+              handleCompletedFileChange(sessionId, parsed.filePath);
+            }
+
             const subagentClass = classifySubagentEvent(parsed);
 
             // Child (subagent-internal) event: route to the subagent's own
@@ -532,14 +525,6 @@ export function useBuildStreaming() {
                 null,
                 ""
               );
-              if (parsed.filePath && parsed.kind) {
-                for (const detector of OUTPUT_FILE_DETECTORS) {
-                  if (detector.match(parsed.filePath, parsed.kind)) {
-                    detector.onDetect(sessionId, parsed.filePath);
-                    break;
-                  }
-                }
-              }
               break;
             }
 
@@ -631,14 +616,6 @@ export function useBuildStreaming() {
               }),
             });
 
-            if (parsed.filePath && parsed.kind) {
-              for (const detector of OUTPUT_FILE_DETECTORS) {
-                if (detector.match(parsed.filePath, parsed.kind)) {
-                  detector.onDetect(sessionId, parsed.filePath);
-                  break;
-                }
-              }
-            }
             break;
           }
 
@@ -674,6 +651,9 @@ export function useBuildStreaming() {
           }
 
           case "prompt_response": {
+            // Shell commands and scripts can mutate the workspace without
+            // emitting structured file paths. Reconcile once when the turn ends.
+            triggerFilesRefresh(sessionId);
             finalizeStreaming();
             const isInterrupting = useBuildSessionStore
               .getState()
@@ -805,7 +785,8 @@ export function useBuildStreaming() {
       upsertTodoListStreamItem,
       addArtifactToSession,
       appendMessageToSession,
-      OUTPUT_FILE_DETECTORS,
+      handleCompletedFileChange,
+      triggerFilesRefresh,
       globalMutate,
       recordSubagentToolCall,
       seedSubagentMeta,


### PR DESCRIPTION
## Description

Keeps the Craft Files tab current without clearing or flashing the visible tree while agents modify the workspace.

- Reconcile files after completed structured edits and once when a turn finishes, covering shell commands and directory creation that do not emit file paths.
- Keep root and expanded-directory listings visible while refreshed data is merged in place.
- Drop cached collapsed directories so reopening them fetches current contents.
- Serialize directory listings to avoid the sandbox transport's multi-request latency stall.
- Coalesce overlapping refresh triggers into one trailing pass and persist the handled generation across remounts.
- Show a spinner and disable the reload button while a refresh is running.
- Refresh the web preview independently when completed edits affect web output.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents flashing in the Craft Files tab by keeping the current tree visible and merging refreshed listings in place. Refreshes are queued, applied sequentially, survive unmounts, and show a spinner for better responsiveness.

- **Bug Fixes**
  - Retain root and expanded directories during refresh; update listings in the background.
  - Invalidate caches for collapsed folders; re-fetch on expand via `retainFilesTabDirectoryCache`.
  - Merge refreshed listings with `mergeFilesTabDirectoryCache` instead of clearing the tree.
  - Coalesce overlapping refreshes; refresh root then expanded paths sequentially; persist a handled generation (`lastRefreshGeneration`) to ignore stale responses and retry after unmount.
  - Surface refresh state to the URL bar (`isRefreshing`): show a spinner, set `aria-busy`, and disable the refresh button.
  - Stream handling: trigger file refresh only on completed writes, refresh the web preview for web writes, and reconcile once when a turn ends.
  - Tests cover non-flashing refreshes, ordered/coalesced updates, collapsed-cache invalidation, URL bar spinner, streaming-triggered refreshes, and retry after unmount.

<sup>Written for commit 2ff2b0871b8997042844ab3df4900fa02d4fc855. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

