### PR TITLE
fix: canvas tests

### DIFF
--- a/backend/tests/daily/connectors/canvas/test_canvas_perm_sync_daily.py
+++ b/backend/tests/daily/connectors/canvas/test_canvas_perm_sync_daily.py
@@ -31,7 +31,7 @@ CANVAS_BASE_URL = "https://canvas.onyx.app"
 COURSE_A_NAME = "intro to python"
 COURSE_B_NAME = "introductory data structures"
 
-TEACHER_EMAILS = {"justin@onyx.app", "admin-test@onyx.app"}
+TEACHER_EMAILS = {"justin@onyx.app", "admin-test@onyx.app", "test_user_3@onyx-test.com"}
 STUDENT_1_EMAIL = "test_user_1@onyx-test.com"
 STUDENT_2_EMAIL = "test_user_2@onyx-test.com"
 COURSE_A_EMAILS = TEACHER_EMAILS | {STUDENT_1_EMAIL, STUDENT_2_EMAIL}


### PR DESCRIPTION
## Description

fix canvas connector tests

## How Has This Been Tested?

tested locally

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Canvas connector daily permission sync tests by adding the missing instructor email to `TEACHER_EMAILS`. This aligns the test with current fixture data and prevents false failures.

<sup>Written for commit 31a127ca6ec314b3e72b3b7959fd63b9d16ac000. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

