### PR TITLE
fix: skip user reminder after tool response for strict tool ordering

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -633,6 +633,34 @@ def select_reminder_text(
     )
 
 
+def build_post_cycle_reminder(
+    *,
+    reminder_message_text: str | None,
+    simple_chat_history: list[ChatMessageSimple],
+    token_counter: Callable[[str], int],
+) -> ChatMessageSimple | None:
+    """Build the USER_REMINDER to append after a tool cycle, if any.
+
+    A USER_REMINDER is translated into a user-role message. Placing it directly
+    after a tool response yields a user-after-tool sequence that providers
+    enforcing strict tool-message ordering (e.g. the native Mistral protocol)
+    reject before inference. When the last message is a tool result, no reminder
+    is attached for the continuation cycle.
+    """
+    if not reminder_message_text:
+        return None
+    if (
+        simple_chat_history
+        and simple_chat_history[-1].message_type == MessageType.TOOL_CALL_RESPONSE
+    ):
+        return None
+    return ChatMessageSimple(
+        message=reminder_message_text,
+        token_count=token_counter(reminder_message_text),
+        message_type=MessageType.USER_REMINDER,
+    )
+
+
 def run_llm_loop(
     emitter: Emitter,
     state_container: ChatStateContainer,
@@ -829,14 +857,10 @@ def run_llm_loop(
                 include_file_reminder=code_interpreter_file_generated,
             )
 
-            reminder_msg = (
-                ChatMessageSimple(
-                    message=reminder_message_text,
-                    token_count=token_counter(reminder_message_text),
-                    message_type=MessageType.USER_REMINDER,
-                )
-                if reminder_message_text
-                else None
+            reminder_msg = build_post_cycle_reminder(
+                reminder_message_text=reminder_message_text,
+                simple_chat_history=simple_chat_history,
+                token_counter=token_counter,
             )
 
             tool_token_budget = compute_all_tool_tokens(final_tools, token_counter)

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -6,6 +6,7 @@ from unittest.mock import Mock
 import pytest
 
 from onyx.chat.llm_loop import _build_empty_llm_response_error
+from onyx.chat.llm_loop import build_post_cycle_reminder
 from onyx.chat.llm_loop import _try_fallback_tool_extraction
 from onyx.chat.llm_loop import construct_message_history
 from onyx.chat.llm_loop import EmptyLLMResponseError
@@ -1343,3 +1344,49 @@ class TestSelectReminderText:
             ran_image_gen=True, just_ran_web_search=True, has_open_url_tool=True
         )
         assert result == IMAGE_GEN_REMINDER
+
+
+class TestBuildPostCycleReminder:
+    """Tests for build_post_cycle_reminder, which must not place a user-role
+    reminder directly after a tool response (invalid for strict tool-message
+    ordering, e.g. the native Mistral protocol)."""
+
+    @staticmethod
+    def _token_counter(text: str) -> int:
+        return max(1, len(text) // 4)
+
+    def test_no_reminder_when_last_message_is_tool_response(self) -> None:
+        history = [
+            create_message("Search the web for X", MessageType.USER, 5),
+            create_assistant_with_tool_call("call_1", "web_search", 5),
+            create_tool_response("call_1", "results", 5),
+        ]
+        result = build_post_cycle_reminder(
+            reminder_message_text="Remember to cite your sources.",
+            simple_chat_history=history,
+            token_counter=self._token_counter,
+        )
+        assert result is None
+
+    def test_reminder_added_when_last_message_is_not_tool_response(self) -> None:
+        history = [
+            create_message("Hello", MessageType.USER, 5),
+            create_message("Hi there!", MessageType.ASSISTANT, 5),
+        ]
+        result = build_post_cycle_reminder(
+            reminder_message_text="Remember to cite your sources.",
+            simple_chat_history=history,
+            token_counter=self._token_counter,
+        )
+        assert result is not None
+        assert result.message_type == MessageType.USER_REMINDER
+        assert result.message == "Remember to cite your sources."
+
+    def test_no_reminder_when_text_is_empty(self) -> None:
+        history = [create_message("Hello", MessageType.USER, 5)]
+        result = build_post_cycle_reminder(
+            reminder_message_text=None,
+            simple_chat_history=history,
+            token_counter=self._token_counter,
+        )
+        assert result is None


### PR DESCRIPTION
## Summary

After a tool call, `run_llm_loop` appended a `USER_REMINDER` to the continuation cycle. `USER_REMINDER` is translated into a `user`-role message, so the request ended up as:

```
assistant (tool_calls)
tool (tool result)
user (USER_REMINDER)
```

Providers that enforce strict tool-message ordering (the native Mistral protocol via `mistral_common`) reject a `user` message immediately after a `tool` message, failing the request before inference:

```
mistral_common.exceptions.InvalidMessageStructureException:
Unexpected role 'user' after role 'tool'
```

This blocks web search and any tool/MCP flow on Mistral models after the first tool call.

Fixes #12503
/claim #12503

## Changes

- `backend/onyx/chat/llm_loop.py`: extract the reminder construction into a small pure helper `build_post_cycle_reminder`, and skip the reminder for the continuation cycle when the last message is a `TOOL_CALL_RESPONSE`.
- `backend/tests/unit/onyx/chat/test_llm_loop.py`: add unit tests for the helper.

## Testing

- `pytest backend/tests/unit/onyx/chat/test_llm_loop.py` — **44 passed**.
- The suppression test was confirmed to fail without the tool-response guard, so it guards the actual regression.
- New tests cover: history ending in a tool response (no reminder), history not ending in a tool response (reminder present, typed `USER_REMINDER`), and empty reminder text.

## Notes

This follows the minimal fix validated in the issue. One trade-off worth flagging for reviewers: the reminder text can include the citation and open_url nudges (`select_reminder_text`), so suppressing it on a post-tool cycle also drops those nudges for permissive providers on that specific cycle. That keeps the change small and provider-agnostic; if preferred, a follow-up could preserve the nudge for permissive providers by attaching it in a position that does not create a `user`-after-`tool` sequence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip adding the `USER_REMINDER` after a tool response to keep message order valid for strict providers (Mistral via `mistral_common`). This prevents user-after-tool errors and restores web search and other tool/MCP flows on Mistral models after the first tool call.

- **Bug Fixes**
  - Added `build_post_cycle_reminder` to only append a reminder when the last message is not a `TOOL_CALL_RESPONSE`; includes unit tests for both paths.

<sup>Written for commit f4568d2eebebe3457d969450fb4a064fdcc6cc99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/12995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

