### PR TITLE
feat(auth): IdP directory-profile enrichment (modified mirror of #12905)

### DIFF
--- a/backend/onyx/auth/oauth_claims_capture.py
+++ b/backend/onyx/auth/oauth_claims_capture.py
@@ -270,18 +270,21 @@ def _resolve_profile(email: str) -> dict[str, tuple[str, str]]:
         return {}
     resolved: dict[str, tuple[str, str]] = {}
     for placeholder_key, label, default_aliases in _PROFILE_FIELDS:
-        for alias in _claim_aliases(placeholder_key, default_aliases):
-            value = next(
-                (
-                    source[alias]
-                    for source in sources
-                    if isinstance(source.get(alias), str) and source[alias].strip()
-                ),
-                None,
-            )
-            if value is not None:
-                resolved[placeholder_key] = (label, value.strip())
-                break
+        aliases = _claim_aliases(placeholder_key, default_aliases)
+        # Sources outer, aliases inner: a higher-priority source must win even
+        # when it uses a lower-priority alias for the same concept (e.g. a
+        # directory `division` beats a userinfo `department`).
+        value = next(
+            (
+                source[alias]
+                for source in sources
+                for alias in aliases
+                if isinstance(source.get(alias), str) and source[alias].strip()
+            ),
+            None,
+        )
+        if value is not None:
+            resolved[placeholder_key] = (label, value.strip())
     return resolved
 
 

--- a/backend/onyx/auth/oauth_claims_capture.py
+++ b/backend/onyx/auth/oauth_claims_capture.py
@@ -1,0 +1,341 @@
+"""Capture the OIDC/OAuth claims received at login and derive a directory
+profile from them.
+
+The IdP sends user information in the id_token and on the userinfo endpoint,
+but the login flow only consumes ``sub`` and ``email`` — everything else is
+discarded. When ``IDP_PROFILE_ENRICHMENT_ENABLED`` is set, this module
+snapshots the full claim set into Redis at login time and derives a
+"directory profile" (country, department, job title, ...) from it, which is
+then used to (a) enrich the chat system prompt and (b) resolve
+author-controlled ``{{user.<key>}}`` placeholders in agent prompts.
+
+Profile fields are resolved through a provider-agnostic claim map: each field
+has an ordered list of claim aliases checked against three sources in
+precedence order — the provider directory API (Microsoft Graph for Entra ID),
+the OIDC userinfo response, then the raw id_token claims. Okta/Keycloak/Google
+deployments therefore work out of the box for whatever claims they release,
+and the map can be extended per-deployment via ``IDP_PROFILE_CLAIM_MAP``.
+
+Capture is strictly best-effort: any failure is logged and swallowed so the
+login flow can never break because of it. No tokens are persisted — only
+claims and token metadata (key names, scope, expiry).
+"""
+
+import json
+from datetime import datetime
+from datetime import timezone
+from typing import Any
+
+import httpx
+import jwt
+
+from onyx.configs.app_configs import IDP_PROFILE_CLAIM_MAP
+from onyx.configs.app_configs import IDP_PROFILE_ENRICHMENT_ENABLED
+from onyx.redis.redis_pool import get_async_redis_connection
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
+
+logger = setup_logger()
+
+_OAUTH_CLAIMS_KEY_PREFIX = "oauth_login_claims"
+# Long enough that an admin can log in and inspect at leisure; short enough
+# that stale directory data doesn't linger forever.
+_OAUTH_CLAIMS_TTL_SECONDS = 60 * 60 * 24 * 30
+
+# Entra ID hosts its OIDC userinfo endpoint on Microsoft Graph; when we see
+# that host we can also query the Graph profile, which carries directory
+# fields the id_token/userinfo never include (country, usageLocation, ...).
+_MS_GRAPH_HOST = "graph.microsoft.com"
+_MS_GRAPH_ME_URL = "https://graph.microsoft.com/v1.0/me"
+# usageLocation is the most reliably populated location field in corporate
+# tenants (required for license assignment); `country` is the profile field.
+_MS_GRAPH_SELECT_FIELDS = (
+    "country,usageLocation,city,state,officeLocation,"
+    "department,jobTitle,companyName,preferredLanguage"
+)
+
+
+def _oauth_claims_key(tenant_id: str, email: str) -> str:
+    return f"{_OAUTH_CLAIMS_KEY_PREFIX}:{tenant_id}:{email.lower()}"
+
+
+def _decode_id_token_claims(raw_id_token: str) -> dict[str, Any]:
+    # Display-only decode: the token was just received directly from the
+    # IdP's token endpoint over TLS, so skipping signature verification is
+    # safe here — we never make authorization decisions from this data.
+    return jwt.decode(
+        raw_id_token,
+        options={"verify_signature": False, "verify_aud": False, "verify_exp": False},
+    )
+
+
+async def _fetch_userinfo(
+    userinfo_endpoint: str, access_token: str
+) -> dict[str, Any] | None:
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.get(
+            userinfo_endpoint,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        if response.status_code >= 400:
+            logger.warning(
+                "OAuth claims capture: userinfo endpoint returned %s",
+                response.status_code,
+            )
+            return None
+        data = response.json()
+        return data if isinstance(data, dict) else None
+
+
+async def _fetch_ms_graph_profile(access_token: str) -> dict[str, Any]:
+    """Fetch directory profile fields (incl. country/usageLocation) from
+    Microsoft Graph. Returns an ``{"error": ...}`` dict on failure so the
+    admin page can show WHY the data is missing (typically the token lacks
+    the User.Read scope — add it via OIDC_SCOPE_OVERRIDE)."""
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.get(
+            _MS_GRAPH_ME_URL,
+            params={"$select": _MS_GRAPH_SELECT_FIELDS},
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        if response.status_code >= 400:
+            return {
+                "error": (
+                    f"Graph /me returned HTTP {response.status_code}. "
+                    "The access token likely lacks the User.Read scope — "
+                    "add it to OIDC_SCOPE_OVERRIDE and log in again."
+                )
+            }
+        data = response.json()
+        if not isinstance(data, dict):
+            return {"error": "Graph /me returned a non-object response"}
+        data.pop("@odata.context", None)
+        return data
+
+
+async def capture_oauth_login_claims(
+    oauth_client: Any,
+    email: str,
+    token: dict[str, Any],
+) -> None:
+    """Snapshot the claims the IdP sent for this login into Redis.
+
+    ``oauth_client`` is the httpx_oauth client used for the login (its
+    ``openid_configuration`` — present on OpenID clients — supplies the
+    userinfo endpoint). No-op unless IDP_PROFILE_ENRICHMENT_ENABLED.
+    Never raises.
+    """
+    if not IDP_PROFILE_ENRICHMENT_ENABLED:
+        return
+    try:
+        id_token_claims: dict[str, Any] = {}
+        raw_id_token = token.get("id_token")
+        if raw_id_token:
+            try:
+                id_token_claims = _decode_id_token_claims(raw_id_token)
+            except Exception as e:
+                logger.warning("OAuth claims capture: id_token decode failed: %s", e)
+
+        userinfo: dict[str, Any] | None = None
+        openid_configuration = getattr(oauth_client, "openid_configuration", None)
+        userinfo_endpoint = (
+            openid_configuration.get("userinfo_endpoint")
+            if isinstance(openid_configuration, dict)
+            else None
+        )
+        access_token = token.get("access_token")
+        if userinfo_endpoint and access_token:
+            try:
+                userinfo = await _fetch_userinfo(userinfo_endpoint, access_token)
+            except Exception as e:
+                logger.warning("OAuth claims capture: userinfo fetch failed: %s", e)
+
+        # Entra ID: also pull the Graph directory profile — country and
+        # usageLocation live there, not in the id_token/userinfo (unless the
+        # `ctry` optional claim is configured on the app registration). Other
+        # providers release directory data directly in userinfo/id_token.
+        directory_profile: dict[str, Any] | None = None
+        directory_source: str | None = None
+        if access_token and userinfo_endpoint and _MS_GRAPH_HOST in userinfo_endpoint:
+            try:
+                directory_profile = await _fetch_ms_graph_profile(access_token)
+                directory_source = "ms_graph"
+            except Exception as e:
+                logger.warning("OAuth claims capture: Graph fetch failed: %s", e)
+
+        snapshot = {
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+            "oauth_name": getattr(oauth_client, "name", "unknown"),
+            "email": email,
+            "id_token_claims": id_token_claims,
+            "userinfo": userinfo or {},
+            "directory_profile": directory_profile,
+            "directory_source": directory_source,
+            "token_meta": {
+                # Which fields the token response contained — values omitted.
+                "keys": sorted(token.keys()),
+                "scope": token.get("scope"),
+                "token_type": token.get("token_type"),
+                "expires_at": token.get("expires_at"),
+                "has_refresh_token": bool(token.get("refresh_token")),
+                "has_id_token": bool(raw_id_token),
+            },
+        }
+
+        redis = await get_async_redis_connection()
+        await redis.set(
+            _oauth_claims_key(get_current_tenant_id(), email),
+            json.dumps(snapshot, default=str),
+            ex=_OAUTH_CLAIMS_TTL_SECONDS,
+        )
+    except Exception:
+        logger.warning(
+            "OAuth claims capture failed for %s (login unaffected)",
+            email,
+            exc_info=True,
+        )
+
+
+# Profile field definitions: (placeholder_key, human-readable label, ordered
+# claim aliases). Aliases are checked against each captured source in
+# precedence order (directory API -> userinfo -> id_token claims); the first
+# non-empty string wins. Aliases cover Microsoft Graph names plus the common
+# OIDC/Okta/Keycloak claim names for the same concept, and can be extended
+# per-deployment via IDP_PROFILE_CLAIM_MAP. This is the single source of truth
+# for the derived views (prompt labels vs. placeholder keys) so they can never
+# drift.
+_PROFILE_FIELDS: list[tuple[str, str, tuple[str, ...]]] = [
+    ("country", "Country", ("country", "ctry")),
+    ("usage_location", "Usage location (ISO code)", ("usageLocation",)),
+    ("city", "City", ("city", "l", "locality")),
+    ("state", "State", ("state", "region")),
+    ("office_location", "Office location", ("officeLocation", "office")),
+    ("department", "Department", ("department", "division")),
+    ("job_title", "Job title", ("jobTitle", "title")),
+    ("company_name", "Company", ("companyName", "organization", "org")),
+    ("preferred_language", "Preferred language", ("preferredLanguage", "locale")),
+    ("timezone", "Timezone", ("zoneinfo", "timezone")),
+]
+
+# The `{{user.<key>}}` placeholder keys sourced from the IdP directory profile.
+# Basic identity keys (email/name/role) are added by the substitution layer.
+IDP_PLACEHOLDER_KEYS: frozenset[str] = frozenset(
+    placeholder_key for placeholder_key, _, _ in _PROFILE_FIELDS
+)
+
+
+def _claim_aliases(placeholder_key: str, defaults: tuple[str, ...]) -> tuple[str, ...]:
+    """Deployment-configured aliases (IDP_PROFILE_CLAIM_MAP) take precedence
+    over the built-in ones; the built-ins remain as a fallback."""
+    override = IDP_PROFILE_CLAIM_MAP.get(placeholder_key)
+    if not override:
+        return defaults
+    return tuple(override) + tuple(a for a in defaults if a not in override)
+
+
+def _load_profile_sources(email: str) -> list[dict[str, Any]]:
+    """Read the captured login snapshot and return the claim sources to
+    resolve profile fields against, in precedence order.
+
+    Must use the RAW client — the capture writes via the raw async connection,
+    and the tenant-prefixing TenantRedisClient would look up a different key
+    (the tenant id is already part of ``_oauth_claims_key``). Best-effort: the
+    chat pipeline that consumes this must treat the profile as optional."""
+    from onyx.redis.redis_pool import get_raw_redis_client
+
+    redis = get_raw_redis_client()
+    raw = redis.get(_oauth_claims_key(get_current_tenant_id(), email))
+    if not isinstance(raw, (str, bytes)):
+        return []
+    snapshot = json.loads(raw)
+
+    sources: list[dict[str, Any]] = []
+    directory_profile = snapshot.get("directory_profile")
+    if isinstance(directory_profile, dict) and "error" not in directory_profile:
+        sources.append(directory_profile)
+    userinfo = snapshot.get("userinfo")
+    if isinstance(userinfo, dict):
+        sources.append(userinfo)
+    id_token_claims = snapshot.get("id_token_claims")
+    if isinstance(id_token_claims, dict):
+        sources.append(id_token_claims)
+    return sources
+
+
+def _resolve_profile(email: str) -> dict[str, tuple[str, str]]:
+    """Resolve the directory profile for ``email`` from the captured claim
+    sources. Returns ``{placeholder_key: (label, value)}`` in field order."""
+    sources = _load_profile_sources(email)
+    if not sources:
+        return {}
+    resolved: dict[str, tuple[str, str]] = {}
+    for placeholder_key, label, default_aliases in _PROFILE_FIELDS:
+        for alias in _claim_aliases(placeholder_key, default_aliases):
+            value = next(
+                (
+                    source[alias]
+                    for source in sources
+                    if isinstance(source.get(alias), str) and source[alias].strip()
+                ),
+                None,
+            )
+            if value is not None:
+                resolved[placeholder_key] = (label, value.strip())
+                break
+    return resolved
+
+
+def get_idp_profile_fields(email: str) -> dict[str, str]:
+    """Directory profile of the user (country, department, ...) from the last
+    captured login snapshot, as ordered ``{label: value}`` pairs for the auto
+    "Organization Profile" prompt block. Best-effort: returns ``{}`` when the
+    feature is disabled, nothing is captured, or Redis is unavailable —
+    callers must treat the profile as optional."""
+    if not IDP_PROFILE_ENRICHMENT_ENABLED:
+        return {}
+    try:
+        return {label: value for label, value in _resolve_profile(email).values()}
+    except Exception:
+        logger.warning(
+            "Failed to load IdP profile for %s (prompt continues without it)",
+            email,
+            exc_info=True,
+        )
+        return {}
+
+
+def get_idp_profile_placeholder_values(email: str) -> dict[str, str]:
+    """Directory profile of the user keyed by ``{{user.<key>}}`` placeholder
+    key (snake_case, e.g. ``department``/``job_title``/``city``) for
+    author-controlled placeholder substitution in agent prompts. Only
+    populated fields are included. Best-effort: returns ``{}`` when the
+    feature is disabled, nothing is captured, or Redis is unavailable —
+    callers must treat it as optional."""
+    if not IDP_PROFILE_ENRICHMENT_ENABLED:
+        return {}
+    try:
+        return {
+            placeholder_key: value
+            for placeholder_key, (_, value) in _resolve_profile(email).items()
+        }
+    except Exception:
+        logger.warning(
+            "Failed to load IdP placeholder values for %s "
+            "(prompt continues without them)",
+            email,
+            exc_info=True,
+        )
+        return {}
+
+
+async def get_captured_oauth_claims(email: str) -> dict[str, Any] | None:
+    """Return the last captured claims snapshot for ``email``, or None."""
+    redis = await get_async_redis_connection()
+    raw = await redis.get(_oauth_claims_key(get_current_tenant_id(), email))
+    if not raw:
+        return None
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        return None

--- a/backend/onyx/auth/oauth_claims_capture.py
+++ b/backend/onyx/auth/oauth_claims_capture.py
@@ -21,6 +21,7 @@ login flow can never break because of it. No tokens are persisted — only
 claims and token metadata (key names, scope, expiry).
 """
 
+import asyncio
 import json
 from datetime import datetime
 from datetime import timezone
@@ -41,6 +42,12 @@ _OAUTH_CLAIMS_KEY_PREFIX = "oauth_login_claims"
 # Long enough that an admin can log in and inspect at leisure; short enough
 # that stale directory data doesn't linger forever.
 _OAUTH_CLAIMS_TTL_SECONDS = 60 * 60 * 24 * 30
+
+# Hard ceiling on the whole best-effort capture. It runs inline in the login
+# flow, so a slow userinfo/Graph endpoint or an unreachable Redis must never
+# hold the login open indefinitely. Capture is refreshed on every login, so
+# dropping one is harmless.
+_OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS = 10
 
 # Entra ID hosts its OIDC userinfo endpoint on Microsoft Graph; when we see
 # that host we can also query the Graph profile, which carries directory
@@ -123,10 +130,27 @@ async def capture_oauth_login_claims(
     ``oauth_client`` is the httpx_oauth client used for the login (its
     ``openid_configuration`` — present on OpenID clients — supplies the
     userinfo endpoint). No-op unless IDP_PROFILE_ENRICHMENT_ENABLED.
-    Never raises.
+    Never raises, and never holds the login open past
+    _OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS.
     """
     if not IDP_PROFILE_ENRICHMENT_ENABLED:
         return
+    try:
+        await asyncio.wait_for(
+            _capture_oauth_login_claims(oauth_client, email, token),
+            timeout=_OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "OAuth claims capture timed out for %s (login unaffected)", email
+        )
+
+
+async def _capture_oauth_login_claims(
+    oauth_client: Any,
+    email: str,
+    token: dict[str, Any],
+) -> None:
     try:
         id_token_claims: dict[str, Any] = {}
         raw_id_token = token.get("id_token")

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -87,6 +87,7 @@ from onyx.auth.jwt import verify_jwt_token
 from onyx.auth.mobile_sso.sso_completion import apply_mobile_state
 from onyx.auth.mobile_sso.sso_completion import complete_mobile_sso
 from onyx.auth.mobile_sso.sso_completion import is_mobile_sso
+from onyx.auth.oauth_claims_capture import capture_oauth_login_claims
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.schemas import AuthBackend
 from onyx.auth.schemas import UserCreate
@@ -2366,6 +2367,11 @@ async def complete_login_flow(
             OnyxErrorCode.VALIDATION_ERROR,
             ErrorCode.OAUTH_NOT_AVAILABLE_EMAIL,
         )
+
+    # Snapshot the raw IdP claims for directory-profile enrichment and the
+    # admin "OAuth Test" page. Best-effort — never raises, no-op unless
+    # IDP_PROFILE_ENRICHMENT_ENABLED.
+    await capture_oauth_login_claims(oauth_client, account_email, token)
 
     next_url = sanitize_next_url(state_data.get("next_url"))
     referral_source = state_data.get("referral_source", None)

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -43,6 +43,7 @@ from onyx.llm.interfaces import ToolChoiceOptions
 from onyx.llm.utils import is_true_openai_model
 from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER
 from onyx.prompts.chat_prompts import OPEN_URL_REMINDER
+from onyx.prompts.prompt_utils import substitute_user_placeholders
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
@@ -735,6 +736,32 @@ def run_llm_loop(
         system_prompt = None
         custom_agent_prompt_msg = None
 
+        # Resolve author-controlled `{{user.<key>}}` placeholders in the
+        # agent's prompts against the current user's directory profile (+
+        # basic identity) once, before the cycle loop — so every branch below
+        # and every token count sees the final text. Never mutate the shared
+        # `persona`.
+        placeholder_values = (
+            user_memory_context.user_info.placeholder_values
+            if user_memory_context
+            else {}
+        )
+        custom_agent_prompt = (
+            substitute_user_placeholders(custom_agent_prompt, placeholder_values)
+            if custom_agent_prompt
+            else custom_agent_prompt
+        )
+        persona_system_prompt = (
+            substitute_user_placeholders(persona.system_prompt, placeholder_values)
+            if persona and persona.system_prompt
+            else None
+        )
+        persona_task_prompt = (
+            substitute_user_placeholders(persona.task_prompt, placeholder_values)
+            if persona and persona.task_prompt
+            else None
+        )
+
         reasoning_cycles = 0
         for llm_cycle_count in range(MAX_LLM_CYCLES):
             # Handling tool calls based on cycle count and past cycle conditions
@@ -761,11 +788,11 @@ def run_llm_loop(
                 # Handles the case where user has checked off the "Replace base system prompt" checkbox
                 system_prompt = (
                     ChatMessageSimple(
-                        message=persona.system_prompt,
-                        token_count=token_counter(persona.system_prompt),
+                        message=persona_system_prompt,
+                        token_count=token_counter(persona_system_prompt),
                         message_type=MessageType.SYSTEM,
                     )
-                    if persona.system_prompt
+                    if persona_system_prompt
                     else None
                 )
                 custom_agent_prompt_msg = None
@@ -821,9 +848,7 @@ def run_llm_loop(
                 just_ran_web_search=just_ran_web_search,
                 has_open_url_tool=has_open_url_tool,
                 out_of_cycles=out_of_cycles,
-                persona_task_prompt=(
-                    persona.task_prompt if persona and persona.task_prompt else None
-                ),
+                persona_task_prompt=persona_task_prompt,
                 include_citation_reminder=should_cite_documents
                 or always_cite_documents,
                 include_file_reminder=code_interpreter_file_generated,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -107,6 +107,7 @@ from onyx.llm.request_context import reset_llm_mock_response
 from onyx.llm.request_context import set_llm_mock_response
 from onyx.llm.utils import litellm_exception_to_error_msg
 from onyx.onyxbot.slack.models import SlackContext
+from onyx.prompts.prompt_utils import substitute_user_placeholders
 from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
 from onyx.server.query_and_chat.models import AUTO_PLACE_AFTER_LATEST_MESSAGE
 from onyx.server.query_and_chat.models import MessageResponseIDInfo
@@ -822,8 +823,12 @@ def build_chat_turn(
     )
 
     # ── Token reservation ────────────────────────────────────────────────────
-    max_reserved_system_prompt_tokens_str = (persona.system_prompt or "") + (
-        custom_agent_prompt or ""
+    # Reserve against the placeholder-substituted text — the same final form
+    # run_llm_loop sends to the model — so long directory values can't
+    # invalidate the reservation.
+    max_reserved_system_prompt_tokens_str = substitute_user_placeholders(
+        (persona.system_prompt or "") + (custom_agent_prompt or ""),
+        user_memory_context.user_info.placeholder_values,
     )
     reserved_token_count = calculate_reserved_tokens(
         db_session=db_session,

--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -27,6 +27,7 @@ from onyx.prompts.tool_prompts import TOOL_SECTION_HEADER
 from onyx.prompts.tool_prompts import WEB_SEARCH_GUIDANCE
 from onyx.prompts.tool_prompts import WEB_SEARCH_SITE_DISABLED_GUIDANCE
 from onyx.prompts.user_info import BASIC_INFORMATION_PROMPT
+from onyx.prompts.user_info import ORGANIZATION_PROFILE_PROMPT
 from onyx.prompts.user_info import TEAM_INFORMATION_PROMPT
 from onyx.prompts.user_info import USER_INFORMATION_HEADER
 from onyx.prompts.user_info import USER_MEMORIES_PROMPT
@@ -163,6 +164,17 @@ def _build_user_information_section(
                     user_name=ctx.user_info.name or "",
                     user_email=ctx.user_info.email or "",
                     user_role=role_line,
+                )
+            )
+
+        if ctx.user_info.organization_profile:
+            formatted_profile = "\n".join(
+                f"- {label}: {value}"
+                for label, value in ctx.user_info.organization_profile.items()
+            )
+            sections.append(
+                ORGANIZATION_PROFILE_PROMPT.format(
+                    organization_profile=formatted_profile
                 )
             )
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -294,7 +294,13 @@ if _IDP_PROFILE_CLAIM_MAP_RAW:
                 if isinstance(aliases, list)
             }
     except json.JSONDecodeError:
-        pass
+        # Import-time, so plain logging: a silently ignored map would make the
+        # misconfiguration invisible (placeholders just stay empty).
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "IDP_PROFILE_CLAIM_MAP is not valid JSON — ignoring it"
+        )
 
 # Applicable for SAML Auth
 SAML_CONF_DIR = os.environ.get("SAML_CONF_DIR") or "/app/onyx/configs/saml_config"

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -269,6 +269,33 @@ if _OIDC_SCOPE_OVERRIDE:
 # backwards compatibility for existing OIDC deployments.
 OIDC_PKCE_ENABLED = os.environ.get("OIDC_PKCE_ENABLED", "").lower() == "true"
 
+# Opt-in: capture IdP claims at OAuth login and enrich the chat experience
+# with the user's directory profile (country, department, job title, ...) —
+# an "Organization Profile" block in the system prompt plus `{{user.<key>}}`
+# placeholders in agent prompts. Off by default: it sends directory data to
+# the configured LLM, which deployments must consciously opt into.
+IDP_PROFILE_ENRICHMENT_ENABLED = (
+    os.environ.get("IDP_PROFILE_ENRICHMENT_ENABLED", "").lower() == "true"
+)
+
+# Optional per-deployment claim-alias overrides for the directory profile,
+# as JSON mapping placeholder key -> ordered claim-name list, e.g.
+# '{"department": ["dept", "division"], "country": ["c"]}'. Configured
+# aliases are checked before the built-in ones.
+IDP_PROFILE_CLAIM_MAP: dict[str, list[str]] = {}
+_IDP_PROFILE_CLAIM_MAP_RAW = os.environ.get("IDP_PROFILE_CLAIM_MAP")
+if _IDP_PROFILE_CLAIM_MAP_RAW:
+    try:
+        _parsed_claim_map = json.loads(_IDP_PROFILE_CLAIM_MAP_RAW)
+        if isinstance(_parsed_claim_map, dict):
+            IDP_PROFILE_CLAIM_MAP = {
+                str(key): [str(alias) for alias in aliases]
+                for key, aliases in _parsed_claim_map.items()
+                if isinstance(aliases, list)
+            }
+    except json.JSONDecodeError:
+        pass
+
 # Applicable for SAML Auth
 SAML_CONF_DIR = os.environ.get("SAML_CONF_DIR") or "/app/onyx/configs/saml_config"
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -14,6 +14,7 @@ from onyx.file_processing.enums import HtmlBasedConnectorTransformLinksStrategy
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_SYSTEM_PROMPT
 from onyx.prompts.image_analysis import DEFAULT_IMAGE_SUMMARIZATION_USER_PROMPT
 from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()
 
@@ -274,8 +275,13 @@ OIDC_PKCE_ENABLED = os.environ.get("OIDC_PKCE_ENABLED", "").lower() == "true"
 # an "Organization Profile" block in the system prompt plus `{{user.<key>}}`
 # placeholders in agent prompts. Off by default: it sends directory data to
 # the configured LLM, which deployments must consciously opt into.
+# Forced off under multi-tenancy: claims are captured in the unauthenticated
+# OAuth callback, where the tenant is not yet resolved, so the snapshot would be
+# written under the default tenant id and never read back. Single-tenant only
+# until per-tenant capture lands.
 IDP_PROFILE_ENRICHMENT_ENABLED = (
     os.environ.get("IDP_PROFILE_ENRICHMENT_ENABLED", "").lower() == "true"
+    and not MULTI_TENANT
 )
 
 # Optional per-deployment claim-alias overrides for the directory profile,

--- a/backend/onyx/db/memory.py
+++ b/backend/onyx/db/memory.py
@@ -2,9 +2,12 @@ from uuid import UUID
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
+from pydantic import Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.auth.oauth_claims_capture import get_idp_profile_fields
+from onyx.auth.oauth_claims_capture import get_idp_profile_placeholder_values
 from onyx.db.engine.sql_engine import get_session_with_current_tenant_if_none
 from onyx.db.models import Memory
 from onyx.db.models import User
@@ -16,12 +19,22 @@ class UserInfo(BaseModel):
     name: str | None = None
     role: str | None = None
     email: str | None = None
+    # Directory profile from the IdP login snapshot (country, department, ...)
+    # as ordered {label: value} pairs. Fork feature: lets the model give
+    # location/role-aware answers (e.g. country-specific HR policies).
+    organization_profile: dict[str, str] = Field(default_factory=dict)
+    # Same directory profile plus basic identity, keyed by snake_case
+    # `{{user.<key>}}` placeholder key (e.g. department/job_title/city/email),
+    # for author-controlled placeholder substitution in agent prompts.
+    placeholder_values: dict[str, str] = Field(default_factory=dict)
 
     def to_dict(self) -> dict:
         return {
             "name": self.name,
             "role": self.role,
             "email": self.email,
+            "organization_profile": self.organization_profile,
+            "placeholder_values": self.placeholder_values,
         }
 
 
@@ -51,6 +64,8 @@ class UserMemoryContext(BaseModel):
             result.append(f"User's role: {self.user_info.role}")
         if self.user_info.email:
             result.append(f"User's email: {self.user_info.email}")
+        for label, value in self.user_info.organization_profile.items():
+            result.append(f"User's {label.lower()}: {value}")
         if self.user_preferences:
             result.append(f"User preferences: {self.user_preferences}")
         result.extend(self.memories)
@@ -58,10 +73,23 @@ class UserMemoryContext(BaseModel):
 
 
 def get_memories(user: User, db_session: Session) -> UserMemoryContext:
+    # `{{user.<key>}}` placeholder values: IdP directory profile plus basic
+    # identity. Identity keys use setdefault so a directory field never gets
+    # clobbered (they don't overlap today, but keeps precedence explicit).
+    placeholder_values = get_idp_profile_placeholder_values(user.email)
+    if user.email:
+        placeholder_values.setdefault("email", user.email)
+    if user.personal_name:
+        placeholder_values.setdefault("name", user.personal_name)
+    if user.personal_role:
+        placeholder_values.setdefault("role", user.personal_role)
+
     user_info = UserInfo(
         name=user.personal_name,
         role=user.personal_role,
         email=user.email,
+        organization_profile=get_idp_profile_fields(user.email),
+        placeholder_values=placeholder_values,
     )
 
     user_preferences = None

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -129,6 +129,7 @@ from onyx.server.manage.image_generation.api import (
 )
 from onyx.server.manage.llm.api import admin_router as llm_admin_router
 from onyx.server.manage.llm.api import basic_router as llm_router
+from onyx.server.manage.oauth_test import router as oauth_test_admin_router
 from onyx.server.manage.opensearch_migration.api import (
     admin_router as opensearch_migration_admin_router,
 )
@@ -519,6 +520,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, query_router)
     include_router_with_global_prefix_prepended(application, document_router)
     include_router_with_global_prefix_prepended(application, user_router)
+    include_router_with_global_prefix_prepended(application, oauth_test_admin_router)
     include_router_with_global_prefix_prepended(application, admin_query_router)
     include_router_with_global_prefix_prepended(application, admin_router)
     include_router_with_global_prefix_prepended(application, connector_router)

--- a/backend/onyx/prompts/prompt_utils.py
+++ b/backend/onyx/prompts/prompt_utils.py
@@ -1,8 +1,10 @@
+import re
 from datetime import datetime
 from typing import cast
 
 from langchain_core.messages import BaseMessage
 
+from onyx.auth.oauth_claims_capture import IDP_PLACEHOLDER_KEYS
 from onyx.configs.constants import DocumentSource
 from onyx.prompts.chat_prompts import ADDITIONAL_INFO
 from onyx.prompts.chat_prompts import CITATION_GUIDANCE_REPLACEMENT_PAT
@@ -136,6 +138,45 @@ def handle_onyx_date_awareness(
         )
 
     return prompt_str
+
+
+# Basic identity placeholder keys, sourced from the user record rather than the
+# IdP directory profile. Combined with the IdP-derived keys to form the full
+# catalog of author-usable `{{user.<key>}}` placeholders.
+_IDENTITY_PLACEHOLDER_KEYS: frozenset[str] = frozenset({"email", "name", "role"})
+
+# Full allow-list of recognized `{{user.<key>}}` placeholder keys. A key in this
+# set always resolves (to its value, or "" when unavailable) so a non-Entra user
+# never leaks a raw placeholder to the LLM; an unknown key (e.g. a typo) is left
+# literal so the agent author notices it.
+USER_PLACEHOLDER_KEYS: frozenset[str] = (
+    IDP_PLACEHOLDER_KEYS | _IDENTITY_PLACEHOLDER_KEYS
+)
+
+# Matches `{{user.<key>}}` with optional inner whitespace, e.g. `{{ user.city }}`.
+# Deliberately a literal-tag regex (not str.format) so user prompts full of
+# `{...}` (JSON, code, LaTeX) are never touched and can never raise.
+_USER_PLACEHOLDER_RE = re.compile(r"\{\{\s*user\.([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}")
+
+
+def substitute_user_placeholders(
+    prompt_str: str, placeholder_values: dict[str, str]
+) -> str:
+    """Replace `{{user.<key>}}` placeholders in ``prompt_str`` with the current
+    user's attribute values (Entra directory profile + basic identity).
+
+    - Recognized key (in ``USER_PLACEHOLDER_KEYS``) -> its value, or "" when the
+      user has no captured value for it (avoids leaking the raw token).
+    - Unrecognized key -> left untouched so the author can spot the mistake.
+    """
+
+    def _replace(match: re.Match[str]) -> str:
+        key = match.group(1)
+        if key in USER_PLACEHOLDER_KEYS:
+            return placeholder_values.get(key, "")
+        return match.group(0)
+
+    return _USER_PLACEHOLDER_RE.sub(_replace, prompt_str)
 
 
 def get_company_context() -> str | None:

--- a/backend/onyx/prompts/user_info.py
+++ b/backend/onyx/prompts/user_info.py
@@ -12,6 +12,13 @@ USER_ROLE_PROMPT = """
 User role: {user_role}
 """.lstrip()
 
+# Organization profile comes from the company identity provider (directory).
+ORGANIZATION_PROFILE_PROMPT = """
+## Organization Profile
+Directory information about the user from the company identity provider. Rely on it when the answer depends on the user's location or position (e.g. country-specific HR policies, office specifics):
+{organization_profile}
+""".lstrip()
+
 # Team information should be a paragraph style description of the user's team.
 TEAM_INFORMATION_PROMPT = """
 ## Team Information

--- a/backend/onyx/server/manage/oauth_test.py
+++ b/backend/onyx/server/manage/oauth_test.py
@@ -1,0 +1,70 @@
+"""Admin "OAuth Test" API.
+
+Exposes the claims snapshot captured at OAuth/OIDC login time (see
+onyx/auth/oauth_claims_capture.py) so admins can inspect which user fields
+the IdP actually releases about a user, and debug the directory-profile
+enrichment. To refresh the snapshot the admin simply goes through the login
+flow again.
+"""
+
+from typing import Any
+
+from fastapi import APIRouter
+from fastapi import Depends
+from pydantic import BaseModel
+
+from onyx.auth.oauth_claims_capture import get_captured_oauth_claims
+from onyx.auth.oauth_claims_capture import get_idp_profile_fields
+from onyx.auth.users import current_curator_or_admin_user
+from onyx.configs.app_configs import IDP_PROFILE_ENRICHMENT_ENABLED
+from onyx.db.models import User
+
+router = APIRouter(prefix="/admin/oauth-test")
+
+
+class OAuthClaimsSnapshot(BaseModel):
+    found: bool
+    email: str
+    enrichment_enabled: bool = IDP_PROFILE_ENRICHMENT_ENABLED
+    captured_at: str | None = None
+    oauth_name: str | None = None
+    id_token_claims: dict[str, Any] | None = None
+    userinfo: dict[str, Any] | None = None
+    # Directory profile fetched from the provider API (e.g. Microsoft Graph
+    # for Entra ID); None when the provider has no directory API integration.
+    directory_profile: dict[str, Any] | None = None
+    directory_source: str | None = None
+    # The resolved profile actually used for prompt enrichment / placeholders
+    # (claim-mapped across all captured sources), as {label: value}.
+    resolved_profile: dict[str, str] | None = None
+    token_meta: dict[str, Any] | None = None
+
+
+@router.get("/claims")
+async def get_oauth_login_claims(
+    email: str | None = None,
+    user: User = Depends(current_curator_or_admin_user),
+) -> OAuthClaimsSnapshot:
+    """Last captured IdP claims for the given user (defaults to the caller).
+
+    Claims are captured on every OAuth/OIDC login (when
+    IDP_PROFILE_ENRICHMENT_ENABLED); if nothing is found the user has not
+    logged in through the IdP since capture was enabled.
+    """
+    target_email = email or user.email
+    snapshot = await get_captured_oauth_claims(target_email)
+    if snapshot is None:
+        return OAuthClaimsSnapshot(found=False, email=target_email)
+
+    return OAuthClaimsSnapshot(
+        found=True,
+        email=snapshot.get("email", target_email),
+        captured_at=snapshot.get("captured_at"),
+        oauth_name=snapshot.get("oauth_name"),
+        id_token_claims=snapshot.get("id_token_claims") or {},
+        userinfo=snapshot.get("userinfo") or {},
+        directory_profile=snapshot.get("directory_profile"),
+        directory_source=snapshot.get("directory_source"),
+        resolved_profile=get_idp_profile_fields(target_email),
+        token_meta=snapshot.get("token_meta") or {},
+    )

--- a/backend/onyx/server/manage/oauth_test.py
+++ b/backend/onyx/server/manage/oauth_test.py
@@ -15,9 +15,12 @@ from pydantic import BaseModel
 
 from onyx.auth.oauth_claims_capture import get_captured_oauth_claims
 from onyx.auth.oauth_claims_capture import get_idp_profile_fields
+from onyx.auth.schemas import UserRole
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.configs.app_configs import IDP_PROFILE_ENRICHMENT_ENABLED
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 
 router = APIRouter(prefix="/admin/oauth-test")
 
@@ -52,6 +55,16 @@ async def get_oauth_login_claims(
     logged in through the IdP since capture was enabled.
     """
     target_email = email or user.email
+    # IdP claims can carry sensitive directory attributes/groups: everyone may
+    # inspect their own snapshot, but only full admins may look up other users.
+    if (
+        target_email.lower() != (user.email or "").lower()
+        and user.role != UserRole.ADMIN
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Only admins can inspect other users' OAuth claims",
+        )
     snapshot = await get_captured_oauth_claims(target_email)
     if snapshot is None:
         return OAuthClaimsSnapshot(found=False, email=target_email)

--- a/backend/onyx/server/manage/oauth_test.py
+++ b/backend/onyx/server/manage/oauth_test.py
@@ -15,9 +15,9 @@ from pydantic import BaseModel
 
 from onyx.auth.oauth_claims_capture import get_captured_oauth_claims
 from onyx.auth.oauth_claims_capture import get_idp_profile_fields
-from onyx.auth.schemas import UserRole
-from onyx.auth.users import current_curator_or_admin_user
+from onyx.auth.permissions import require_permission
 from onyx.configs.app_configs import IDP_PROFILE_ENRICHMENT_ENABLED
+from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -46,24 +46,20 @@ class OAuthClaimsSnapshot(BaseModel):
 @router.get("/claims")
 async def get_oauth_login_claims(
     email: str | None = None,
-    user: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
 ) -> OAuthClaimsSnapshot:
     """Last captured IdP claims for the given user (defaults to the caller).
 
-    Claims are captured on every OAuth/OIDC login (when
-    IDP_PROFILE_ENRICHMENT_ENABLED); if nothing is found the user has not
-    logged in through the IdP since capture was enabled.
+    Admin-only: the raw id_token/userinfo claims can carry sensitive directory
+    attributes and group memberships. Claims are captured on every OAuth/OIDC
+    login when IDP_PROFILE_ENRICHMENT_ENABLED is set. If nothing is found, the
+    user has not logged in through the IdP since capture was enabled.
     """
     target_email = email or user.email
-    # IdP claims can carry sensitive directory attributes/groups: everyone may
-    # inspect their own snapshot, but only full admins may look up other users.
-    if (
-        target_email.lower() != (user.email or "").lower()
-        and user.role != UserRole.ADMIN
-    ):
+    if not target_email:
         raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "Only admins can inspect other users' OAuth claims",
+            OnyxErrorCode.VALIDATION_ERROR,
+            "An email is required to inspect OAuth claims",
         )
     snapshot = await get_captured_oauth_claims(target_email)
     if snapshot is None:

--- a/backend/tests/unit/onyx/auth/test_oauth_claims_capture.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_claims_capture.py
@@ -1,0 +1,364 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import jwt
+import pytest
+
+import onyx.auth.oauth_claims_capture as claims_capture
+from onyx.auth.oauth_claims_capture import capture_oauth_login_claims
+from onyx.auth.oauth_claims_capture import get_captured_oauth_claims
+from onyx.auth.oauth_claims_capture import get_idp_profile_fields
+from onyx.auth.oauth_claims_capture import get_idp_profile_placeholder_values
+
+
+@pytest.fixture(autouse=True)
+def _enable_enrichment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(claims_capture, "IDP_PROFILE_ENRICHMENT_ENABLED", True)
+
+
+class _FakeOAuthClient:
+    name = "openid"
+
+    def __init__(self, userinfo_endpoint: str | None = None):
+        self.openid_configuration: dict[str, Any] = {}
+        if userinfo_endpoint:
+            self.openid_configuration["userinfo_endpoint"] = userinfo_endpoint
+
+
+def _make_token(claims: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "access_token": "at-123",
+        "token_type": "Bearer",
+        "scope": "openid profile email",
+        "expires_at": 1_900_000_000,
+        "id_token": jwt.encode(claims, "test-secret", algorithm="HS256"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_capture_stores_id_token_claims_and_token_meta() -> None:
+    claims = {
+        "sub": "abc",
+        "email": "user@example.com",
+        "name": "User Example",
+        "groups": ["g1", "g2"],
+    }
+    redis = AsyncMock()
+
+    with patch(
+        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        return_value=redis,
+    ):
+        await capture_oauth_login_claims(
+            _FakeOAuthClient(), "user@example.com", _make_token(claims)
+        )
+
+    redis.set.assert_awaited_once()
+    key, payload = redis.set.await_args.args
+    assert "user@example.com" in key
+    snapshot = json.loads(payload)
+    assert snapshot["id_token_claims"] == claims
+    assert snapshot["oauth_name"] == "openid"
+    # No userinfo endpoint configured -> empty userinfo, but capture still works
+    assert snapshot["userinfo"] == {}
+    meta = snapshot["token_meta"]
+    assert meta["has_id_token"] is True
+    assert meta["has_refresh_token"] is False
+    assert meta["scope"] == "openid profile email"
+    assert "access_token" in meta["keys"]
+    # Raw token values must never be persisted
+    assert "at-123" not in payload
+
+
+@pytest.mark.asyncio
+async def test_capture_fetches_userinfo_when_endpoint_available() -> None:
+    userinfo = {"sub": "abc", "department": "R&D", "preferred_username": "user"}
+    redis = AsyncMock()
+
+    with (
+        patch(
+            "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+            return_value=redis,
+        ),
+        patch(
+            "onyx.auth.oauth_claims_capture._fetch_userinfo",
+            new=AsyncMock(return_value=userinfo),
+        ) as fetch_mock,
+    ):
+        await capture_oauth_login_claims(
+            _FakeOAuthClient("https://idp.example.com/userinfo"),
+            "user@example.com",
+            _make_token({"sub": "abc"}),
+        )
+
+    fetch_mock.assert_awaited_once_with("https://idp.example.com/userinfo", "at-123")
+    snapshot = json.loads(redis.set.await_args.args[1])
+    assert snapshot["userinfo"] == userinfo
+    # Non-Microsoft IdP -> no Graph profile fetch
+    assert snapshot["directory_profile"] is None
+
+
+@pytest.mark.asyncio
+async def test_capture_fetches_directory_profile_for_entra() -> None:
+    """When the userinfo endpoint is Microsoft Graph (Entra ID), the capture
+    also pulls the directory profile with country/usageLocation."""
+    directory_profile = {"country": "Netherlands", "usageLocation": "NL", "city": "Ams"}
+    redis = AsyncMock()
+
+    with (
+        patch(
+            "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+            return_value=redis,
+        ),
+        patch(
+            "onyx.auth.oauth_claims_capture._fetch_userinfo",
+            new=AsyncMock(return_value={"sub": "abc"}),
+        ),
+        patch(
+            "onyx.auth.oauth_claims_capture._fetch_ms_graph_profile",
+            new=AsyncMock(return_value=directory_profile),
+        ) as graph_mock,
+    ):
+        await capture_oauth_login_claims(
+            _FakeOAuthClient("https://graph.microsoft.com/oidc/userinfo"),
+            "user@example.com",
+            _make_token({"sub": "abc"}),
+        )
+
+    graph_mock.assert_awaited_once_with("at-123")
+    snapshot = json.loads(redis.set.await_args.args[1])
+    assert snapshot["directory_profile"] == directory_profile
+    assert snapshot["directory_source"] == "ms_graph"
+
+
+@pytest.mark.asyncio
+async def test_capture_never_raises_when_redis_is_down() -> None:
+    redis = AsyncMock()
+    redis.set.side_effect = ConnectionError("redis down")
+
+    with patch(
+        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        return_value=redis,
+    ):
+        # Must not raise — login flow depends on it
+        await capture_oauth_login_claims(
+            _FakeOAuthClient(), "user@example.com", _make_token({"sub": "abc"})
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_captured_oauth_claims_roundtrip() -> None:
+    stored = {"captured_at": "2026-07-02T00:00:00+00:00", "id_token_claims": {}}
+    redis = AsyncMock()
+    redis.get.return_value = json.dumps(stored)
+
+    with patch(
+        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        return_value=redis,
+    ):
+        assert await get_captured_oauth_claims("user@example.com") == stored
+
+    redis.get.return_value = None
+    with patch(
+        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        return_value=redis,
+    ):
+        assert await get_captured_oauth_claims("user@example.com") is None
+
+
+def test_get_idp_profile_fields_maps_directory_profile() -> None:
+    snapshot = {
+        "directory_profile": {
+            "country": "Germany",
+            "usageLocation": "DE",
+            "city": "Berlin",
+            "state": None,
+            "department": "Technology",
+            "jobTitle": "SRE",
+            "companyName": "ExampleCorp",
+        }
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        fields = get_idp_profile_fields("user@example.com")
+
+    assert fields == {
+        "Country": "Germany",
+        "Usage location (ISO code)": "DE",
+        "City": "Berlin",
+        "Department": "Technology",
+        "Job title": "SRE",
+        "Company": "ExampleCorp",
+    }
+
+
+def test_get_idp_profile_fields_empty_on_missing_or_error() -> None:
+    redis = MagicMock()
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        redis.get.return_value = None
+        assert get_idp_profile_fields("user@example.com") == {}
+
+        redis.get.return_value = json.dumps(
+            {"directory_profile": {"error": "Graph /me returned HTTP 403."}}
+        )
+        assert get_idp_profile_fields("user@example.com") == {}
+
+        redis.get.side_effect = ConnectionError("redis down")
+        assert get_idp_profile_fields("user@example.com") == {}
+
+
+def test_get_idp_profile_placeholder_values_maps_directory_profile() -> None:
+    snapshot = {
+        "directory_profile": {
+            "country": "Germany",
+            "usageLocation": "DE",
+            "city": "Berlin",
+            "state": None,
+            "department": "Technology",
+            "jobTitle": "SRE",
+            "companyName": "ExampleCorp",
+        }
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        values = get_idp_profile_placeholder_values("user@example.com")
+
+    # Snake_case placeholder keys; empty/absent fields dropped.
+    assert values == {
+        "country": "Germany",
+        "usage_location": "DE",
+        "city": "Berlin",
+        "department": "Technology",
+        "job_title": "SRE",
+        "company_name": "ExampleCorp",
+    }
+
+
+def test_get_idp_profile_placeholder_values_empty_on_missing_or_error() -> None:
+    redis = MagicMock()
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        redis.get.return_value = None
+        assert get_idp_profile_placeholder_values("user@example.com") == {}
+
+        redis.get.return_value = json.dumps(
+            {"directory_profile": {"error": "Graph /me returned HTTP 403."}}
+        )
+        assert get_idp_profile_placeholder_values("user@example.com") == {}
+
+        redis.get.side_effect = ConnectionError("redis down")
+        assert get_idp_profile_placeholder_values("user@example.com") == {}
+
+
+@pytest.mark.asyncio
+async def test_capture_noop_when_enrichment_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(claims_capture, "IDP_PROFILE_ENRICHMENT_ENABLED", False)
+    redis = AsyncMock()
+    with patch(
+        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        return_value=redis,
+    ):
+        await capture_oauth_login_claims(
+            _FakeOAuthClient(), "user@example.com", _make_token({"sub": "abc"})
+        )
+    redis.set.assert_not_awaited()
+
+
+def test_getters_empty_when_enrichment_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(claims_capture, "IDP_PROFILE_ENRICHMENT_ENABLED", False)
+    redis = MagicMock()
+    redis.get.return_value = json.dumps({"directory_profile": {"country": "Germany"}})
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        assert get_idp_profile_fields("user@example.com") == {}
+        assert get_idp_profile_placeholder_values("user@example.com") == {}
+
+
+def test_profile_resolves_from_userinfo_for_generic_oidc() -> None:
+    """Okta/Keycloak-style: no directory API, but userinfo carries the
+    equivalent claims — the claim map must pick them up."""
+    snapshot = {
+        "directory_profile": None,
+        "userinfo": {
+            "department": "Support",
+            "title": "Engineer",  # Okta's job-title claim
+            "locale": "en-US",  # standard OIDC
+            "zoneinfo": "Europe/Amsterdam",  # standard OIDC
+            "organization": "ExampleCorp",
+        },
+        "id_token_claims": {"sub": "abc"},
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        values = get_idp_profile_placeholder_values("user@example.com")
+
+    assert values == {
+        "department": "Support",
+        "job_title": "Engineer",
+        "preferred_language": "en-US",
+        "timezone": "Europe/Amsterdam",
+        "company_name": "ExampleCorp",
+    }
+
+
+def test_profile_falls_back_to_id_token_claims() -> None:
+    snapshot = {
+        "directory_profile": None,
+        "userinfo": {},
+        "id_token_claims": {"ctry": "NL", "department": "Legal"},
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        fields = get_idp_profile_fields("user@example.com")
+
+    assert fields == {"Country": "NL", "Department": "Legal"}
+
+
+def test_directory_profile_takes_precedence_over_userinfo() -> None:
+    snapshot = {
+        "directory_profile": {"department": "Directory Dept"},
+        "userinfo": {"department": "Userinfo Dept"},
+        "id_token_claims": {"department": "Token Dept"},
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        values = get_idp_profile_placeholder_values("user@example.com")
+
+    assert values["department"] == "Directory Dept"
+
+
+def test_claim_map_override_takes_precedence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """IDP_PROFILE_CLAIM_MAP lets a deployment map custom claim names."""
+    monkeypatch.setattr(
+        claims_capture, "IDP_PROFILE_CLAIM_MAP", {"department": ["custom_dept"]}
+    )
+    snapshot = {
+        "directory_profile": None,
+        "userinfo": {"custom_dept": "Platform", "department": "Ignored?"},
+        "id_token_claims": {},
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        values = get_idp_profile_placeholder_values("user@example.com")
+
+    # Configured alias wins; built-in aliases remain as fallback.
+    assert values["department"] == "Platform"

--- a/backend/tests/unit/onyx/auth/test_oauth_claims_capture.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_claims_capture.py
@@ -362,3 +362,20 @@ def test_claim_map_override_takes_precedence(
 
     # Configured alias wins; built-in aliases remain as fallback.
     assert values["department"] == "Platform"
+
+
+def test_source_precedence_holds_across_aliases() -> None:
+    """A higher-priority source must win even via a lower-priority alias:
+    directory `division` beats userinfo `department`."""
+    snapshot = {
+        "directory_profile": {"division": "Directory Division"},
+        "userinfo": {"department": "Userinfo Dept"},
+        "id_token_claims": {},
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        values = get_idp_profile_placeholder_values("user@example.com")
+
+    assert values["department"] == "Directory Division"

--- a/backend/tests/unit/onyx/prompts/test_prompt_utils.py
+++ b/backend/tests/unit/onyx/prompts/test_prompt_utils.py
@@ -1,5 +1,6 @@
 from onyx.prompts.constants import REMINDER_TAG_DESCRIPTION
 from onyx.prompts.prompt_utils import replace_reminder_tag
+from onyx.prompts.prompt_utils import substitute_user_placeholders
 
 
 def test_replace_reminder_tag_pattern() -> None:
@@ -13,3 +14,92 @@ def test_replace_reminder_tag_no_pattern() -> None:
     prompt = "Some text without any pattern"
     result = replace_reminder_tag(prompt)
     assert result == prompt
+
+
+# --- {{user.<key>}} placeholder substitution ---
+
+_VALUES = {
+    "department": "Engineering",
+    "city": "Berlin",
+    "email": "a@example.com",
+}
+
+
+def test_substitute_known_key_is_replaced_with_value() -> None:
+    assert (
+        substitute_user_placeholders("Dept: {{user.department}}", _VALUES)
+        == "Dept: Engineering"
+    )
+
+
+def test_substitute_tolerates_inner_whitespace() -> None:
+    assert (
+        substitute_user_placeholders("City: {{ user.city }}", _VALUES) == "City: Berlin"
+    )
+
+
+def test_substitute_known_key_without_value_becomes_empty() -> None:
+    # `state` is a recognized key but the user has no captured value for it.
+    assert substitute_user_placeholders("State=[{{user.state}}]", _VALUES) == "State=[]"
+
+
+def test_substitute_unknown_key_is_left_literal() -> None:
+    # A typo / unrecognized key must survive so the author notices it.
+    text = "Typo: {{user.deparment}}"
+    assert substitute_user_placeholders(text, _VALUES) == text
+
+
+def test_substitute_leaves_literal_braces_untouched() -> None:
+    # User prompts routinely contain literal braces (JSON/code/LaTeX); they must
+    # never be treated as placeholders and must never raise.
+    text = 'Return JSON like {"a": 1, "nested": {"b": 2}} and \\frac{x}{y}.'
+    assert substitute_user_placeholders(text, _VALUES) == text
+
+
+def test_substitute_multiple_placeholders_in_one_string() -> None:
+    result = substitute_user_placeholders(
+        "{{user.department}} in {{user.city}} <{{user.email}}>", _VALUES
+    )
+    assert result == "Engineering in Berlin <a@example.com>"
+
+
+def test_substitute_non_entra_user_empties_all_known_keys() -> None:
+    # Empty value map (user never logged in via Entra): known keys resolve to ""
+    # (no raw leak), unknown keys stay literal.
+    text = "D={{user.department}} X={{user.bogus}}"
+    assert substitute_user_placeholders(text, {}) == "D= X={{user.bogus}}"
+
+
+def test_substitute_ignores_non_user_namespace() -> None:
+    # Only the `user.` namespace is handled; other double-brace tags are left
+    # alone for their own handlers (e.g. {{CURRENT_DATETIME}}).
+    text = "Now: {{CURRENT_DATETIME}} and {{user.city}}"
+    assert (
+        substitute_user_placeholders(text, _VALUES)
+        == "Now: {{CURRENT_DATETIME}} and Berlin"
+    )
+
+
+def test_frontend_placeholder_catalog_matches_backend_allowlist() -> None:
+    """The UI catalog (userPlaceholders.ts) must offer exactly the keys the
+    backend recognizes — a drifted catalog either hides usable placeholders or
+    offers ones that silently resolve to ''."""
+    import re
+    from pathlib import Path
+
+    from onyx.prompts.prompt_utils import USER_PLACEHOLDER_KEYS
+
+    ts_path = (
+        Path(__file__).parents[5]
+        / "web"
+        / "src"
+        / "lib"
+        / "agents"
+        / "userPlaceholders.ts"
+    )
+    if not ts_path.exists():  # backend-only checkouts
+        import pytest
+
+        pytest.skip("web/ not present in this checkout")
+    frontend_keys = set(re.findall(r'key: "([a-z_]+)"', ts_path.read_text()))
+    assert frontend_keys == set(USER_PLACEHOLDER_KEYS)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -260,6 +260,13 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # OPENID_CONFIG_URL=
 # OIDC_PKCE_ENABLED=
 # TRACK_EXTERNAL_IDP_EXPIRY=
+# Opt-in: capture IdP directory claims at OAuth/OIDC login to enrich chat
+# prompts and resolve {{user.<key>}} agent placeholders. Sends directory data
+# to the configured LLM, so off by default. Single-tenant deployments only.
+# IDP_PROFILE_ENRICHMENT_ENABLED=
+# Optional JSON overriding directory claim aliases per field, e.g.
+# '{"department": ["dept", "division"], "country": ["c"]}'.
+# IDP_PROFILE_CLAIM_MAP=
 # Comma-separated list of origins allowed to make cross-origin (CORS) requests,
 # e.g. "https://onyx.example.com". When unset, all origins are allowed but
 # credentialed (cookie-authenticated) cross-origin requests are disabled.

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.12
+version: 0.6.13
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1481,6 +1481,13 @@ configMap:
   AUTH_TYPE: "basic"
   # Enable PKCE for OIDC login flow. Leave empty/false for backward compatibility.
   OIDC_PKCE_ENABLED: ""
+  # Opt-in: capture IdP directory claims at OAuth/OIDC login and use them to
+  # enrich chat prompts and resolve {{user.<key>}} agent placeholders. Sends
+  # directory data to the configured LLM, so off by default. Single-tenant only.
+  IDP_PROFILE_ENRICHMENT_ENABLED: ""
+  # Optional JSON overriding the directory claim aliases per profile field, e.g.
+  # '{"department": ["dept", "division"], "country": ["c"]}'.
+  IDP_PROFILE_CLAIM_MAP: ""
   # 1 Day Default
   SESSION_EXPIRE_TIME_SECONDS: "86400"
   # Can be something like onyx.app, as an extra double-check

--- a/web/src/app/admin/oauth-test/page.tsx
+++ b/web/src/app/admin/oauth-test/page.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { PageLoader } from "@/refresh-components/PageLoader";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { SettingsLayouts } from "@opal/layouts";
+import { ErrorCallout } from "@/components/ErrorCallout";
+import useSWR from "swr";
+import {
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+  Table,
+} from "@/components/ui/table";
+import { Button, Text } from "@opal/components";
+import { ADMIN_ROUTES } from "@/lib/admin-routes";
+
+const route = ADMIN_ROUTES.OAUTH_TEST;
+
+const CLAIMS_ENDPOINT = "/api/admin/oauth-test/claims";
+// Runs the normal OIDC login flow and lands back on this page — the backend
+// re-captures the claims on every login.
+const RERUN_URL =
+  "/api/auth/oidc/authorize?next=/admin/oauth-test&redirect=true";
+
+// --- Types ---
+
+interface OAuthClaimsSnapshot {
+  found: boolean;
+  email: string;
+  captured_at: string | null;
+  oauth_name: string | null;
+  id_token_claims: Record<string, unknown> | null;
+  userinfo: Record<string, unknown> | null;
+  directory_profile: Record<string, unknown> | null;
+  directory_source: string | null;
+  resolved_profile: Record<string, string> | null;
+  enrichment_enabled: boolean;
+  token_meta: Record<string, unknown> | null;
+}
+
+// --- Components ---
+
+function formatClaimValue(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function ClaimsTable({
+  title,
+  subtitle,
+  claims,
+}: {
+  title: string;
+  subtitle: string;
+  claims: Record<string, unknown>;
+}) {
+  const entries = Object.entries(claims);
+  return (
+    <div className="flex flex-col gap-2">
+      <Text font="heading-h3">{title}</Text>
+      <Text font="main-ui-body" color="text-03">
+        {subtitle}
+      </Text>
+      {entries.length === 0 ? (
+        <Text font="main-ui-body" color="text-03">
+          No claims received.
+        </Text>
+      ) : (
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-64">Claim</TableHead>
+              <TableHead>Value</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {entries.map(([key, value]) => (
+              <TableRow key={key}>
+                <TableCell className="font-mono text-xs align-top">
+                  {key}
+                </TableCell>
+                <TableCell className="font-mono text-xs whitespace-pre-wrap break-all">
+                  {formatClaimValue(value)}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  );
+}
+
+function Main() {
+  const {
+    data: snapshot,
+    error,
+    isLoading,
+  } = useSWR<OAuthClaimsSnapshot>(CLAIMS_ENDPOINT, errorHandlingFetcher);
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
+  if (error || !snapshot) {
+    return (
+      <ErrorCallout
+        errorTitle="Failed to load OAuth claims"
+        errorMsg={error?.info?.detail || String(error)}
+      />
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6 pb-8">
+      <div className="flex flex-col gap-2">
+        <Text font="main-ui-body" color="text-03">
+          Shows the raw fields your identity provider sent about you during your
+          last OAuth/OIDC login: the id_token claims and the userinfo endpoint
+          response. Use it to verify which attributes the IdP is configured to
+          release. Claims are captured at every login.
+        </Text>
+        <div>
+          <Button onClick={() => (window.location.href = RERUN_URL)}>
+            Re-run OAuth login
+          </Button>
+        </div>
+      </div>
+
+      {!snapshot.found ? (
+        <ErrorCallout
+          errorTitle="No captured claims yet"
+          errorMsg={`No OAuth login snapshot found for ${snapshot.email}. Log in through the identity provider (button above) and reload this page.`}
+        />
+      ) : (
+        <>
+          <div className="flex flex-col gap-1">
+            <Text font="main-ui-body" color="text-03">
+              {`User: ${snapshot.email}`}
+            </Text>
+            <Text font="main-ui-body" color="text-03">
+              {`Provider: ${snapshot.oauth_name ?? "-"}`}
+            </Text>
+            <Text font="main-ui-body" color="text-03">
+              {`Captured at: ${snapshot.captured_at ?? "-"}`}
+            </Text>
+            <Text font="main-ui-body" color="text-03">
+              {`Token response fields: ${formatClaimValue(
+                snapshot.token_meta?.keys ?? []
+              )}`}
+            </Text>
+          </div>
+
+          <ClaimsTable
+            title="id_token claims"
+            subtitle="Decoded from the id_token JWT returned by the token endpoint."
+            claims={snapshot.id_token_claims ?? {}}
+          />
+          <ClaimsTable
+            title="userinfo claims"
+            subtitle="Response of the OIDC userinfo endpoint for your access token."
+            claims={snapshot.userinfo ?? {}}
+          />
+          {snapshot.directory_profile && (
+            <ClaimsTable
+              title={`Directory profile (${snapshot.directory_source ?? "provider API"})`}
+              subtitle="Directory fields fetched from the provider API — e.g. Microsoft Graph /me for Entra ID, which carries country/usageLocation that the id_token omits unless the ctry optional claim is configured."
+              claims={snapshot.directory_profile}
+            />
+          )}
+          {snapshot.resolved_profile &&
+            Object.keys(snapshot.resolved_profile).length > 0 && (
+              <ClaimsTable
+                title="Resolved profile (used for prompts)"
+                subtitle="The claim-mapped directory profile that actually feeds the Organization Profile prompt block and {{user.*}} placeholders."
+                claims={snapshot.resolved_profile}
+              />
+            )}
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function Page() {
+  return (
+    <SettingsLayouts.Root>
+      <SettingsLayouts.Header icon={route.icon} title={route.title} divider />
+      <SettingsLayouts.Body>
+        <Main />
+      </SettingsLayouts.Body>
+    </SettingsLayouts.Root>
+  );
+}

--- a/web/src/app/admin/oauth-test/page.tsx
+++ b/web/src/app/admin/oauth-test/page.tsx
@@ -5,6 +5,7 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SettingsLayouts } from "@opal/layouts";
 import { ErrorCallout } from "@/components/ErrorCallout";
 import useSWR from "swr";
+import { SWR_KEYS } from "@/lib/swr-keys";
 import {
   TableBody,
   TableCell,
@@ -18,7 +19,6 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 
 const route = ADMIN_ROUTES.OAUTH_TEST;
 
-const CLAIMS_ENDPOINT = "/api/admin/oauth-test/claims";
 // Runs the normal OIDC login flow and lands back on this page — the backend
 // re-captures the claims on every login.
 const RERUN_URL =
@@ -98,7 +98,7 @@ function Main() {
     data: snapshot,
     error,
     isLoading,
-  } = useSWR<OAuthClaimsSnapshot>(CLAIMS_ENDPOINT, errorHandlingFetcher);
+  } = useSWR<OAuthClaimsSnapshot>(SWR_KEYS.adminOAuthTestClaims, errorHandlingFetcher);
 
   if (isLoading) {
     return <PageLoader />;

--- a/web/src/app/admin/oauth-test/page.tsx
+++ b/web/src/app/admin/oauth-test/page.tsx
@@ -98,7 +98,10 @@ function Main() {
     data: snapshot,
     error,
     isLoading,
-  } = useSWR<OAuthClaimsSnapshot>(SWR_KEYS.adminOAuthTestClaims, errorHandlingFetcher);
+  } = useSWR<OAuthClaimsSnapshot>(
+    SWR_KEYS.adminOAuthTestClaims,
+    errorHandlingFetcher
+  );
 
   if (isLoading) {
     return <PageLoader />;

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -254,6 +254,12 @@ export const ADMIN_ROUTES = {
     title: "SCIM",
     sidebarLabel: "SCIM",
   },
+  OAUTH_TEST: {
+    path: "/admin/oauth-test",
+    icon: SvgUserKey,
+    title: "OAuth Test",
+    sidebarLabel: "OAuth Test",
+  },
   DEBUG: {
     path: "/admin/debug",
     icon: SvgDownload,

--- a/web/src/lib/agents/userPlaceholders.ts
+++ b/web/src/lib/agents/userPlaceholders.ts
@@ -1,0 +1,43 @@
+// Catalog of `{{user.<key>}}` placeholders an agent author can insert into the
+// Instructions / Reminders prompts. At chat time the backend substitutes each
+// with the current user's IdP directory attribute (or basic identity).
+// MUST stay in sync with the backend allow-list (enforced by
+// backend/tests/unit/onyx/prompts/test_prompt_utils.py):
+//   - onyx/prompts/prompt_utils.py `USER_PLACEHOLDER_KEYS`
+//   - onyx/auth/oauth_claims_capture.py `_PROFILE_FIELDS`
+
+export interface UserPlaceholder {
+  key: string;
+  label: string;
+}
+
+// Directory profile fields sourced from the IdP login snapshot.
+export const USER_DIRECTORY_PLACEHOLDERS: UserPlaceholder[] = [
+  { key: "department", label: "Department" },
+  { key: "job_title", label: "Job title" },
+  { key: "city", label: "City" },
+  { key: "state", label: "State" },
+  { key: "country", label: "Country" },
+  { key: "office_location", label: "Office location" },
+  { key: "usage_location", label: "Usage location" },
+  { key: "company_name", label: "Company" },
+  { key: "preferred_language", label: "Preferred language" },
+  { key: "timezone", label: "Timezone" },
+];
+
+// Basic identity fields sourced from the user record.
+export const USER_IDENTITY_PLACEHOLDERS: UserPlaceholder[] = [
+  { key: "email", label: "Email" },
+  { key: "name", label: "Name" },
+  { key: "role", label: "Role" },
+];
+
+export const USER_PLACEHOLDERS: UserPlaceholder[] = [
+  ...USER_DIRECTORY_PLACEHOLDERS,
+  ...USER_IDENTITY_PLACEHOLDERS,
+];
+
+// The token inserted into the prompt for a given placeholder key.
+export function userPlaceholderToken(key: string): string {
+  return `{{user.${key}}}`;
+}

--- a/web/src/lib/swr-keys.ts
+++ b/web/src/lib/swr-keys.ts
@@ -130,6 +130,7 @@ export const SWR_KEYS = {
   tools: "/api/tool",
   openApiTools: "/api/tool/openapi",
   oauthTokenStatus: "/api/user-oauth-token/status",
+  adminOAuthTestClaims: "/api/admin/oauth-test/claims",
 
   // ── Voice ─────────────────────────────────────────────────────────────────
   voiceProviders: "/api/admin/voice/providers",

--- a/web/src/sections/agents/InsertUserVariableMenu.tsx
+++ b/web/src/sections/agents/InsertUserVariableMenu.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState } from "react";
+import { useFormikContext } from "formik";
+import { Popover, PopoverMenu } from "@opal/components";
+import LineItem from "@/refresh-components/buttons/LineItem";
+import IconButton from "@/refresh-components/buttons/IconButton";
+import { SvgBracketCurly } from "@opal/icons";
+import {
+  USER_DIRECTORY_PLACEHOLDERS,
+  USER_IDENTITY_PLACEHOLDERS,
+  UserPlaceholder,
+  userPlaceholderToken,
+} from "@/lib/agents/userPlaceholders";
+
+interface InsertUserVariableMenuProps {
+  // Formik field name of the target textarea. Doubles as the textarea DOM id
+  // (InputTextAreaField sets `id={name}`), which lets us insert at the caret.
+  fieldName: string;
+}
+
+// A compact "insert variable" affordance for agent prompt textareas. Lists the
+// available `{{user.<key>}}` placeholders and splices the chosen token at the
+// current caret position of the associated textarea.
+export default function InsertUserVariableMenu({
+  fieldName,
+}: InsertUserVariableMenuProps) {
+  const [open, setOpen] = useState(false);
+  const { setFieldValue, values } = useFormikContext<Record<string, unknown>>();
+
+  function insertToken(key: string) {
+    const token = userPlaceholderToken(key);
+    const textarea = document.getElementById(
+      fieldName
+    ) as HTMLTextAreaElement | null;
+
+    if (textarea) {
+      const start = textarea.selectionStart ?? textarea.value.length;
+      const end = textarea.selectionEnd ?? textarea.value.length;
+      const next =
+        textarea.value.slice(0, start) + token + textarea.value.slice(end);
+      setFieldValue(fieldName, next);
+      // Restore focus and place the caret right after the inserted token, once
+      // the controlled value has been applied.
+      requestAnimationFrame(() => {
+        textarea.focus();
+        const caret = start + token.length;
+        textarea.setSelectionRange(caret, caret);
+      });
+    } else {
+      const current = String(values[fieldName] ?? "");
+      setFieldValue(fieldName, current + token);
+    }
+
+    setOpen(false);
+  }
+
+  function renderItem(placeholder: UserPlaceholder) {
+    return (
+      <LineItem
+        key={placeholder.key}
+        icon={SvgBracketCurly}
+        description={userPlaceholderToken(placeholder.key)}
+        onClick={() => insertToken(placeholder.key)}
+      >
+        {placeholder.label}
+      </LineItem>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <Popover.Trigger asChild>
+        <div>
+          <IconButton
+            internal
+            small
+            icon={SvgBracketCurly}
+            tooltip="Insert user variable"
+          />
+        </div>
+      </Popover.Trigger>
+      <Popover.Content>
+        <PopoverMenu>
+          {[
+            ...USER_DIRECTORY_PLACEHOLDERS.map(renderItem),
+            ...USER_IDENTITY_PLACEHOLDERS.map(renderItem),
+          ]}
+        </PopoverMenu>
+      </Popover.Content>
+    </Popover>
+  );
+}

--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -12,6 +12,7 @@ import { Formik, Form, FieldArray } from "formik";
 import * as Yup from "yup";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
+import InsertUserVariableMenu from "@/sections/agents/InsertUserVariableMenu";
 import InputTypeInElementField from "@/refresh-components/form/InputTypeInElementField";
 import InputDatePickerField from "@/refresh-components/form/InputDatePickerField";
 import {
@@ -1402,6 +1403,9 @@ export default function AgentEditorPage({
                           <InputTextAreaField
                             name="instructions"
                             placeholder="Think step by step and show reasoning for complex problems. Use specific examples. Emphasize action items, and leave blanks for the human to fill in when you have unknown. Use a polite enthusiastic tone."
+                            rightSection={
+                              <InsertUserVariableMenu fieldName="instructions" />
+                            }
                           />
                         </InputVertical>
 
@@ -1764,6 +1768,9 @@ export default function AgentEditorPage({
                                 <InputTextAreaField
                                   name="reminders"
                                   placeholder="Remember, I want you to always format your response as a numbered list."
+                                  rightSection={
+                                    <InsertUserVariableMenu fieldName="reminders" />
+                                  }
                                 />
                               </InputVertical>
                               <Text text03 secondaryBody>


### PR DESCRIPTION
Modified mirror of #12905 (external contribution), created via `ods run-ci` to run CI.

Changes on top of the original, all to let it merge safely for the customer's single-tenant OIDC use case:

- Gate `IDP_PROFILE_ENRICHMENT_ENABLED` off under `MULTI_TENANT`. Capture runs before tenant resolution in the unauthenticated OAuth callback, so it is single-tenant only until per-tenant capture lands.
- Bound the login-time claim capture with an `asyncio` timeout so a slow IdP or an unreachable Redis can never stall login.
- Restrict `/admin/oauth-test/claims` to admins and return a 400 instead of crashing on a missing email (Greptile findings).
- Document the two operator-facing env vars in `env.template` and Helm values, and bump the chart.

Rebased onto current main. Follow-ups tracked separately: SAML capture, cloud multi-tenant support.

Merge this mirror and close #12905 once CI is green.


## Additional Options
- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check