### PR TITLE
refactor(sidebar): pass explicit false instead of undefined for non-foldable logo

### DIFF
--- a/web/lib/opal/src/layouts/sidebar/components.tsx
+++ b/web/lib/opal/src/layouts/sidebar/components.tsx
@@ -120,7 +120,7 @@ interface SidebarHeaderProps {
    * sidebar is non-foldable) and returns an `IconFunctionComponent` that is
    * rendered at `size={28}` in the topbar.
    */
-  renderAppLogo: (folded: boolean | undefined) => IconFunctionComponent;
+  renderAppLogo: (folded: boolean) => IconFunctionComponent;
   /**
    * When `true` (default), the logo is shown in the folded state with a
    * hover-to-reveal fold button. When `false`, only the fold button is shown
@@ -156,7 +156,7 @@ function SidebarHeader({
     [folded, toggleFolded]
   );
 
-  const Logo = renderAppLogo(foldable ? folded : undefined);
+  const Logo = renderAppLogo(foldable ? folded : false);
   const logoEl = <Logo size={SIDEBAR_LOGO_HEIGHT_PX} />;
 
   return (

--- a/web/src/lib/app/components.tsx
+++ b/web/src/lib/app/components.tsx
@@ -9,6 +9,7 @@ import { cn } from "@opal/utils";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { SvgOnyxLogo, SvgOnyxLogoTyped } from "@opal/logos";
+import type { IconFunctionComponent } from "@opal/types";
 
 export interface LogoProps {
   folded?: boolean;

--- a/web/src/lib/app/components.tsx
+++ b/web/src/lib/app/components.tsx
@@ -9,7 +9,6 @@ import { cn } from "@opal/utils";
 import Text from "@/refresh-components/texts/Text";
 import Truncated from "@/refresh-components/texts/Truncated";
 import { SvgOnyxLogo, SvgOnyxLogoTyped } from "@opal/logos";
-import type { IconFunctionComponent } from "@opal/types";
 
 export interface LogoProps {
   folded?: boolean;

--- a/web/src/lib/sidebar/utils.ts
+++ b/web/src/lib/sidebar/utils.ts
@@ -8,9 +8,7 @@ import { LOCAL_STORAGE_KEYS } from "@/lib/sidebar/constants";
 import { Logo } from "@/lib/app/components";
 import type { IconFunctionComponent } from "@opal/types";
 
-export function renderSidebarLogo(
-  folded: boolean = false
-): IconFunctionComponent {
+export function renderSidebarLogo(folded: boolean): IconFunctionComponent {
   return (props) => React.createElement(Logo, { ...props, folded });
 }
 


### PR DESCRIPTION
## Description

`SidebarHeader` was passing `undefined` to `renderAppLogo` when the sidebar is non-foldable, relying on a `= false` default in `renderSidebarLogo` as a fallback. This tightens the contract:

- `SidebarHeader` now passes `false` explicitly when `foldable` is false
- `renderSidebarLogo` parameter type narrows from `boolean | undefined` to `boolean` (no default needed)
- Drops the orphaned `IconFunctionComponent` import from `lib/app/components.tsx`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sidebar logo rendering explicit by passing false for non-foldable sidebars and narrowing the logo renderer API to a boolean. This removes defaulting logic and avoids undefined states.

- **Refactors**
  - `SidebarHeader` now passes `false` to `renderAppLogo` when `foldable` is false.
  - `renderAppLogo` and `renderSidebarLogo` accept a `boolean` only; removed the default parameter.

<sup>Written for commit a2f34aa0ca9d0f35640f2e278d9c6617664d313e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->