### PR TITLE
chore(docs): fix `cn` reference to legacy `/lib/utils`

### DIFF
--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -32,12 +32,12 @@ import { Content, ContentAction, IllustrationContent } from "@opal/layouts";
 A two-axis layout component that automatically routes to the correct internal layout
 (`ContentXl`, `ContentLg`, `ContentMd`, `ContentSm`) based on `sizePreset` and `variant`:
 
-| sizePreset | variant | Routes to | Layout |
-|---|---|---|---|
-| `headline` / `section` | `heading` | `ContentXl` | Icon on top (flex-col) |
-| `headline` / `section` | `section` | `ContentLg` | Icon inline (flex-row) |
-| `main-content` / `main-ui` / `secondary` | `section` / `heading` | `ContentMd` | Compact inline |
-| `main-content` / `main-ui` / `secondary` | `body` | `ContentSm` | Body text layout |
+| sizePreset                               | variant               | Routes to   | Layout                 |
+| ---------------------------------------- | --------------------- | ----------- | ---------------------- |
+| `headline` / `section`                   | `heading`             | `ContentXl` | Icon on top (flex-col) |
+| `headline` / `section`                   | `section`             | `ContentLg` | Icon inline (flex-row) |
+| `main-content` / `main-ui` / `secondary` | `section` / `heading` | `ContentMd` | Compact inline         |
+| `main-content` / `main-ui` / `secondary` | `body`                | `ContentSm` | Body text layout       |
 
 ```typescript
 <Content
@@ -54,6 +54,7 @@ A two-axis layout component that automatically routes to the correct internal la
 **Use this when a Content block needs right-side actions** (buttons, badges, icons, etc.).
 
 Wraps `Content` and adds a `rightChildren` slot. Accepts all `Content` props plus:
+
 - `rightChildren`: `ReactNode` — actions rendered on the right
 - `padding`: `SizeVariant` — controls outer padding
 
@@ -86,6 +87,7 @@ import SvgNoResult from "@opal/illustrations/no-result";
 ```
 
 Props:
+
 - `illustration`: `IconFunctionComponent` — optional, from `@opal/illustrations`
 - `title`: `string` — required
 - `description`: `string` — optional
@@ -119,6 +121,7 @@ function MySettingsPage() {
 ```
 
 Sub-components:
+
 - **`SettingsLayouts.Root`** — Wrapper with centered, scrollable container. Width options:
   `"sm"` (672px), `"sm-md"` (752px), `"md"` (872px, default), `"lg"` (992px), `"full"` (100%).
 - **`SettingsLayouts.Header`** — Sticky header with icon, title, description, optional
@@ -141,6 +144,7 @@ import FileCard from "@/sections/cards/FileCard";
 ```
 
 Guidelines:
+
 - One card per entity type — keep card-specific logic within the card component.
 - Cards should be reusable across different pages and contexts.
 - Use shared components from `@opal/components`, `@opal/layouts`, and `@/refresh-components`
@@ -166,6 +170,7 @@ import { Button } from "@opal/components/buttons/button/components";
 ```
 
 Key props:
+
 - `variant`: `"default"` | `"action"` | `"danger"` | `"none"`
 - `prominence`: `"primary"` | `"secondary"` | `"tertiary"` | `"internal"`
 - `size`: `"lg"` | `"md"` | `"sm"` | `"xs"` | `"2xs"` | `"fit"`
@@ -349,6 +354,7 @@ import Text from "@/refresh-components/texts/Text";
 ```
 
 Key props:
+
 - `font`: `TextFont` — font preset (e.g., `"main-ui-body"`, `"heading-h2"`, `"secondary-action"`)
 - `color`: `TextColor` — text color (e.g., `"text-03"`, `"text-inverted-05"`)
 - `as`: `"p" | "span" | "li" | "h1" | "h2" | "h3"` — HTML tag (default: `"span"`)
@@ -578,7 +584,7 @@ divs that exist solely for spacing.
 **Reason:** `cn`s are easier to read. They also allow for more complex types (i.e., string-arrays) to get formatted properly (it flattens each element in that string array down). As a result, it can allow things such as conditionals (i.e., `myCondition && "some-tailwind-class"`, which evaluates to `false` when `myCondition` is `false`) to get filtered out.
 
 ```typescript
-import { cn } from '@/lib/utils'
+import { cn } from "@opal/utils";
 
 // ✅ Good
 <div className={cn(
@@ -601,6 +607,7 @@ import { cn } from '@/lib/utils'
 Only fall back to `web/src/hooks/` for genuinely general-purpose hooks with no feature home.**
 
 Priority order:
+
 1. **Feature hook** (`web/src/lib/<feature>/hooks.ts`) — if the hook is specific to a domain
    (users, billing, connectors, etc.), it lives alongside the rest of that feature's code.
 2. **Opal** (`web/lib/opal/src/`) — if the hook is a reusable UI primitive with no


### PR DESCRIPTION
## Description

I noticed Claude reference this library mid-task and had to correct. I'm guessing it was from this reference. 

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated AGENTS.md to import `cn` from `@opal/utils` instead of legacy `@/lib/utils`, and cleaned up table alignment and bullet spacing for readability.

<sup>Written for commit 7b7581241e96b6b81892cd65e25f2cc54d115914. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

