### PR TITLE
fix(enterprise-settings): stop custom-analytics-script 500 on tenant-less MT requests

### DIFF
--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -238,6 +238,16 @@ def upload_custom_analytics_script(
 
 @basic_router.get("/custom-analytics-script")
 def fetch_custom_analytics_script() -> str | None:
+    if MULTI_TENANT:
+        tenant_id = get_current_tenant_id()
+        if not tenant_id or tenant_id == POSTGRES_DEFAULT_SCHEMA:
+            # Pre-auth / anonymous page loads reach this route with no tenant
+            # context resolved (the contextvar defaults to the public schema,
+            # which has no per-tenant key_value_store). Such a visitor has no
+            # custom analytics script by definition — return None rather than
+            # letting the KV lookup 500 against public.key_value_store.
+            return None
+
     return load_analytics_script()
 
 

--- a/backend/tests/external_dependency_unit/ee/onyx/server/enterprise_settings/test_custom_analytics_script.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/enterprise_settings/test_custom_analytics_script.py
@@ -1,0 +1,95 @@
+"""
+Tests for the `GET /enterprise-settings/custom-analytics-script` handler.
+
+Regression coverage for the multi-tenant case where a pre-auth / anonymous
+page load reaches the endpoint with no tenant context resolved (the contextvar
+defaults to the public schema, which has no per-tenant `key_value_store`). The
+handler must return `None` in that case rather than 500ing with
+`UndefinedTable: relation "public.key_value_store" does not exist`.
+
+These are external dependency unit tests because they need a real database but
+also need to control the `MULTI_TENANT` setting via patching.
+"""
+
+from collections.abc import Generator
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from ee.onyx.server.enterprise_settings.api import fetch_custom_analytics_script
+from onyx.configs.constants import KV_CUSTOM_ANALYTICS_SCRIPT_KEY
+from onyx.key_value_store.factory import get_kv_store
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+@pytest.fixture(scope="function")
+def clean_analytics_script(
+    db_session: Session,  # noqa: ARG001
+) -> Generator[None, None, None]:
+    """Ensure no analytics script is set before/after the test, in the public
+    schema, so single-tenant assertions start from a known state. Depends on
+    `db_session` to guarantee the SQL engine is initialized before KV access."""
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        kv_store = get_kv_store()
+        kv_store.delete(KV_CUSTOM_ANALYTICS_SCRIPT_KEY)
+    except Exception:
+        pass
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+    yield
+
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        get_kv_store().delete(KV_CUSTOM_ANALYTICS_SCRIPT_KEY)
+    except Exception:
+        pass
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+def test_returns_none_when_tenant_unresolved__multi_tenant() -> None:
+    """Pre-auth request on MT: tenant context resolves to the public schema
+    (no per-tenant key_value_store). Must return None, not raise."""
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        with (
+            patch("ee.onyx.server.enterprise_settings.api.MULTI_TENANT", True),
+            patch(
+                "ee.onyx.server.enterprise_settings.api.POSTGRES_DEFAULT_SCHEMA",
+                POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE,
+            ),
+        ):
+            assert fetch_custom_analytics_script() is None
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+def test_returns_none_when_no_script_set__single_tenant(
+    clean_analytics_script: None,  # noqa: ARG001
+) -> None:
+    """Single-tenant with no script configured returns None (not an error)."""
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        with patch("ee.onyx.server.enterprise_settings.api.MULTI_TENANT", False):
+            assert fetch_custom_analytics_script() is None
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+
+def test_returns_script_when_set__single_tenant(
+    clean_analytics_script: None,  # noqa: ARG001
+) -> None:
+    """Single-tenant with a script configured returns the stored script."""
+    script = f"console.log('analytics-{uuid4().hex[:8]}');"
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
+    try:
+        get_kv_store().store(KV_CUSTOM_ANALYTICS_SCRIPT_KEY, script)
+        with patch("ee.onyx.server.enterprise_settings.api.MULTI_TENANT", False):
+            assert fetch_custom_analytics_script() == script
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)

--- a/web/src/lib/analytics/hooks.ts
+++ b/web/src/lib/analytics/hooks.ts
@@ -13,6 +13,7 @@ import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { useSettings } from "@/lib/settings/hooks";
+import { useUser } from "@/providers/UserProvider";
 import { EE_ENABLED } from "@/lib/constants";
 
 // ─── Feature Flag Registry ─────────────────────────────────────────────────
@@ -82,13 +83,18 @@ export function usePHFeatureFlag(flag: PHFeatureFlag): boolean {
 /**
  * Fetches the admin-configured custom analytics script string.
  *
- * Self-gated on EE availability. Returns `null` when EE is disabled or no
- * script is configured.
+ * Self-gated on EE availability and on an authenticated session. Returns
+ * `null` when EE is disabled, no user is logged in, or no script is
+ * configured. Gating on a session avoids firing the request on pre-auth page
+ * loads (e.g. the login page), which on multi-tenant deployments arrive with
+ * no tenant context resolved and would otherwise 500.
  */
 export function useCustomAnalyticsScript(): string | null {
   const { isLoading, error, ee_features_enabled } = useSettings();
+  const { user } = useUser();
   const shouldFetch =
-    EE_ENABLED || (!isLoading && !error && ee_features_enabled !== false);
+    !!user &&
+    (EE_ENABLED || (!isLoading && !error && ee_features_enabled !== false));
 
   const { data } = useSWR<string>(
     shouldFetch ? SWR_KEYS.customAnalyticsScript : null,


### PR DESCRIPTION
## Description

`GET /enterprise-settings/custom-analytics-script` returns HTTP 500 on the multi-tenant deployment whenever a **pre-auth / anonymous page load** hits it. Such requests reach the KV layer with no tenant context resolved — the contextvar defaults to the `public` schema, which has no per-tenant `key_value_store` — so the lookup raises:

```
psycopg2.errors.UndefinedTable: relation "public.key_value_store" does not exist
```

This single endpoint accounts for essentially the entire steady-state 5xx floor of the MT api-server fleet (~244 req/hr), polluting error-rate dashboards/alerting and burning a DB roundtrip + traceback per page load.

**Backend** (`ee/onyx/server/enterprise_settings/api.py`): guard `fetch_custom_analytics_script()` for the tenant-less case — mirroring the existing guard in `ee_fetch_settings` — and return `None`. An anonymous visitor has no custom analytics script by definition. Uses an explicit tenant-context check rather than catching `ProgrammingError`/`UndefinedTable`, so genuine schema regressions still surface.

**Frontend** (`web/src/lib/analytics/hooks.ts`): tighten the `useCustomAnalyticsScript` `shouldFetch` gate to also require an authenticated session, so the request never fires on pre-auth page loads (e.g. the login page) in the first place. Both call sites render inside `UserProvider`, so `useUser()` is safe.

## How Has This Been Tested?

- New External Dependency Unit test `test_custom_analytics_script.py` (3 cases, all passing):
  - MT + tenant resolves to public schema → returns `None`, no exception (regression test for the traceback above).
  - Single-tenant, no script set → `None`.
  - Single-tenant, script set → returns the stored script.
- `npx tsc --noEmit` clean on the frontend change.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops 500s from GET /enterprise-settings/custom-analytics-script on multi-tenant, pre-auth requests by handling tenant-less contexts and gating the frontend fetch behind an authenticated session. This removes steady-state 5xx noise and avoids unnecessary DB hits.

- **Bug Fixes**
  - Backend: In `fetch_custom_analytics_script`, return `None` when MT and tenant is unresolved/default schema; avoid `public.key_value_store` lookup with an explicit tenant check.
  - Frontend: `useCustomAnalyticsScript` only fetches when a user is logged in; prevents pre-auth page requests from firing.
  - Tests: Added coverage for MT tenant-less, single-tenant with no script, and single-tenant with a script.

<sup>Written for commit b1e92580c57f3da43b816d5d2404990841db48b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

