### PR TITLE
fix(indexing): don't invalidate saturated-but-alive index attempts

### DIFF
--- a/backend/onyx/background/celery/tasks/docprocessing/heartbeat.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/heartbeat.py
@@ -10,12 +10,20 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# After this many consecutive failed beats we escalate WARNING -> ERROR. A
+# stalled heartbeat is dangerous: the stall watchdog reads the counter as a
+# liveness signal, so a silently-wedged heartbeat (e.g. the write starving for a
+# DB connection against the shared worker pool) can get a live attempt
+# invalidated. Surfacing sustained failures loudly lets operators catch it.
+_HEARTBEAT_FAILURE_ESCALATION_THRESHOLD = 3
+
 
 def start_heartbeat(index_attempt_id: int) -> tuple[threading.Thread, threading.Event]:
     """Start a heartbeat thread for the given index attempt"""
     stop_event = threading.Event()
 
     def heartbeat_loop() -> None:
+        consecutive_failures = 0
         while not stop_event.wait(INDEXING_WORKER_HEARTBEAT_INTERVAL):
             try:
                 with get_session_with_current_tenant() as db_session:
@@ -25,11 +33,37 @@ def start_heartbeat(index_attempt_id: int) -> tuple[threading.Thread, threading.
                         .values(heartbeat_counter=IndexAttempt.heartbeat_counter + 1)
                     )
                     db_session.commit()
+                if consecutive_failures:
+                    logger.info(
+                        "Heartbeat for index attempt %s recovered after %s "
+                        "consecutive failures",
+                        index_attempt_id,
+                        consecutive_failures,
+                    )
+                consecutive_failures = 0
             except Exception:
-                logger.exception(
-                    "Failed to update heartbeat counter for index attempt %s",
-                    index_attempt_id,
-                )
+                consecutive_failures += 1
+                # A single miss is tolerable; sustained misses mean the counter
+                # is stalling while the worker may well be alive, which can lead
+                # the watchdog to misclassify a healthy attempt as crashed.
+                if consecutive_failures >= _HEARTBEAT_FAILURE_ESCALATION_THRESHOLD:
+                    logger.error(
+                        "Heartbeat for index attempt %s has failed %s consecutive "
+                        "times (~%ss stalled) — the stall watchdog may misread this "
+                        "attempt as crashed",
+                        index_attempt_id,
+                        consecutive_failures,
+                        consecutive_failures * INDEXING_WORKER_HEARTBEAT_INTERVAL,
+                        exc_info=True,
+                    )
+                else:
+                    logger.warning(
+                        "Failed to update heartbeat counter for index attempt %s "
+                        "(consecutive_failures=%s)",
+                        index_attempt_id,
+                        consecutive_failures,
+                        exc_info=True,
+                    )
 
     # Ensure contextvars from the outer context are available in the thread
     context = contextvars.copy_context()

--- a/backend/onyx/background/celery/tasks/docprocessing/heartbeat.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/heartbeat.py
@@ -10,6 +10,17 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+# TODO(bo): root-cause and properly fix why heartbeat_counter can stall for the
+# full watchdog timeout (~30m) while the worker is alive. The corroboration in
+# validate_active_indexing_attempts (completed-batch progress + Celery
+# worker-liveness ping) stops us destroying live attempts, but it is a
+# mitigation, not a root fix. Candidate mechanisms, none yet confirmed from logs:
+#   - this heartbeat write starving on the shared worker DB pool (pool_size =
+#     concurrency + 8) while task threads block on a saturated embedder;
+#   - row-lock contention on the index_attempt row (no lock_timeout is set);
+#   - CPU/GIL starvation of the docprocessing pod's daemon threads.
+# The escalated ERROR logging below is the diagnostic hook to tell these apart.
+
 # After this many consecutive failed beats we escalate WARNING -> ERROR. A
 # stalled heartbeat is dangerous: the stall watchdog reads the counter as a
 # liveness signal, so a silently-wedged heartbeat (e.g. the write starving for a

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -239,6 +239,13 @@ def validate_active_indexing_attempts(
             .all()
         )
 
+        # Worker liveness does not change within a single watchdog pass, and the
+        # inspect ping blocks for up to DOCPROCESSING_LIVENESS_PING_TIMEOUT when
+        # workers are down. Compute it at most once per pass (lazily, only if an
+        # attempt actually needs it) so N stale attempts don't cost N pings while
+        # holding this DB session open.
+        workers_alive_this_pass: bool | None = None
+
         for attempt in active_attempts:
             lock_beat.reacquire()
 
@@ -356,8 +363,10 @@ def validate_active_indexing_attempts(
                     # dependency (e.g. a pegged embedder) blocks live workers the
                     # same way, and killing here discards potentially days of
                     # indexing progress. Corroborate with worker liveness before
-                    # the crash verdict.
-                    if _docprocessing_workers_alive():
+                    # the crash verdict (cached once per pass).
+                    if workers_alive_this_pass is None:
+                        workers_alive_this_pass = _docprocessing_workers_alive()
+                    if workers_alive_this_pass:
                         task_logger.error(
                             f"Attempt {fresh_attempt.id} heartbeat stale for "
                             f"{heartbeat_timeout_seconds}s (in_flight={in_flight} "

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -149,6 +149,10 @@ logger = setup_logger()
 # Heartbeat timeout: if no heartbeat received for 30 minutes, consider it dead.
 # This should be much longer than INDEXING_WORKER_HEARTBEAT_INTERVAL (30s).
 HEARTBEAT_TIMEOUT_SECONDS = 30 * 60  # 30 minutes
+# Timeout for the Celery inspect ping used to corroborate a stale heartbeat
+# before invalidating. Generous enough that a CPU-saturated worker's control
+# thread can still answer, but bounded so the watchdog never hangs on it.
+DOCPROCESSING_LIVENESS_PING_TIMEOUT = 4.0
 # How long a NOT_STARTED attempt must sit before we scan the broker.
 # After this window we check Redis directly — if the task is still there we
 # leave it alone, so this threshold does not cause false positives for
@@ -173,6 +177,37 @@ def _get_fence_validation_block_expiration() -> int:
         beat_multiplier = CLOUD_BEAT_MULTIPLIER_DEFAULT
 
     return int(base_expiration * beat_multiplier)
+
+
+def _docprocessing_workers_alive() -> bool:
+    """Best-effort check for whether any docprocessing worker is registered.
+
+    Uses Celery's inspect ping, which is answered by the worker's control
+    thread and therefore still responds even when every task thread is blocked
+    on a saturated dependency (e.g. a pegged embedder). The celery inspect API
+    can return empty or hang under load, so we read it asymmetrically: a
+    positive result (>=1 docprocessing worker) is trusted as proof of life,
+    while an empty result or an error is reported as "not confirmed alive" so
+    the caller falls back to its existing crash verdict. We therefore only ever
+    SPARE an attempt on a positive read, never destroy one on a flaky empty read.
+    """
+    try:
+        replies = current_app.control.inspect(
+            timeout=DOCPROCESSING_LIVENESS_PING_TIMEOUT
+        ).ping()
+    except Exception:
+        task_logger.warning(
+            "docprocessing worker liveness ping failed; "
+            "treating as not confirmed alive",
+            exc_info=True,
+        )
+        return False
+
+    if not replies:
+        return False
+
+    # Worker hostnames are of the form "docprocessing@<node>" (see supervisord).
+    return any("docprocessing" in worker_name for worker_name in replies)
 
 
 def validate_active_indexing_attempts(
@@ -219,6 +254,9 @@ def validate_active_indexing_attempts(
             if fresh_attempt.last_heartbeat_time is None:
                 # First time seeing this attempt - initialize heartbeat tracking
                 fresh_attempt.last_heartbeat_value = fresh_attempt.heartbeat_counter
+                fresh_attempt.last_batches_completed_count = (
+                    fresh_attempt.completed_batches
+                )
                 fresh_attempt.last_heartbeat_time = datetime.now(timezone.utc)
                 db_session.commit()
 
@@ -239,14 +277,26 @@ def validate_active_indexing_attempts(
                 f"last_check_time={last_check_time}"
             )
 
-            if current_counter > last_known_counter:
-                # Heartbeat has advanced - worker is alive
+            completed_now = fresh_attempt.completed_batches
+            completed_progressed = (
+                completed_now > fresh_attempt.last_batches_completed_count
+            )
+
+            if current_counter > last_known_counter or completed_progressed:
+                # Heartbeat advanced or batches completed since the last pass —
+                # the worker is alive regardless of which signal moved.
+                # Completed-batch progress is a crash-proof liveness signal:
+                # even if the heartbeat thread is starved (e.g. contending for
+                # the shared DB pool), a batch landing proves the worker pool is
+                # doing real work.
                 fresh_attempt.last_heartbeat_value = current_counter
+                fresh_attempt.last_batches_completed_count = completed_now
                 fresh_attempt.last_heartbeat_time = datetime.now(timezone.utc)
                 db_session.commit()
 
                 task_logger.debug(
-                    f"Heartbeat advanced for attempt {fresh_attempt.id}: new_counter={current_counter}"
+                    f"Liveness advanced for attempt {fresh_attempt.id}: "
+                    f"counter={current_counter} completed_batches={completed_now}"
                 )
                 continue
 
@@ -264,9 +314,10 @@ def validate_active_indexing_attempts(
             # Heartbeat is stale. If docfetching has finished (total_batches is
             # set), use the Redis counters to decide whether to invalidate:
             #
-            #   in_flight > 0               → workers crashed holding batches → invalidate
-            #   in_flight = 0, pending > 0  → batches in queue, no crash → wait
-            #   in_flight = 0, pending = 0  → no work anywhere, stuck → invalidate
+            #   in_flight > 0, workers alive → saturated/wedged → wait + alarm
+            #   in_flight > 0, workers dead  → crashed holding batches → invalidate
+            #   in_flight = 0, pending > 0   → batches in queue, no crash → wait
+            #   in_flight = 0, pending = 0   → no work anywhere, stuck → invalidate
             #
             # If total_batches is not set yet, docfetching is still running;
             # fall through to immediate invalidation (base timeout elapsed).
@@ -300,13 +351,41 @@ def validate_active_indexing_attempts(
                     continue
 
                 if in_flight > 0:
+                    # Outstanding in-flight work with a stale heartbeat used to
+                    # mean "workers crashed holding batches". But a saturated
+                    # dependency (e.g. a pegged embedder) blocks live workers the
+                    # same way, and killing here discards potentially days of
+                    # indexing progress. Corroborate with worker liveness before
+                    # the crash verdict.
+                    if _docprocessing_workers_alive():
+                        task_logger.error(
+                            f"Attempt {fresh_attempt.id} heartbeat stale for "
+                            f"{heartbeat_timeout_seconds}s (in_flight={in_flight} "
+                            f"pending={pending} "
+                            f"completed={fresh_attempt.completed_batches}/"
+                            f"{fresh_attempt.total_batches}) but docprocessing "
+                            f"workers are ALIVE — treating as saturated/wedged, not "
+                            f"crashed. NOT invalidating; investigate a saturated "
+                            f"model server or other blocked dependency."
+                        )
+                        # Reset the window so we re-evaluate a full timeout later
+                        # (throttles this loud log and keeps the attempt alive).
+                        fresh_attempt.last_heartbeat_value = current_counter
+                        fresh_attempt.last_batches_completed_count = completed_now
+                        fresh_attempt.last_heartbeat_time = datetime.now(timezone.utc)
+                        db_session.commit()
+                        continue
+
                     failure_reason = (
                         f"Heartbeat stale for {heartbeat_timeout_seconds}s with "
-                        f"{in_flight} in-flight batches — workers crashed holding batches"
+                        f"{in_flight} in-flight batches and no live docprocessing "
+                        f"workers — workers crashed holding batches"
                     )
                 else:
                     # in_flight == 0, pending == 0: no work anywhere, no forward
                     # progress possible — all batches either failed or were lost.
+                    # Worker liveness is irrelevant; there is nothing left to
+                    # process, so invalidate regardless.
                     failure_reason = (
                         f"Heartbeat stale for {heartbeat_timeout_seconds}s with "
                         f"no pending or in-flight batches — all batches failed or lost"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -2428,6 +2428,10 @@ class IndexAttempt(Base):
     last_progress_time: Mapped[datetime.datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # completed_batches observed at the previous stall-watchdog pass. The
+    # watchdog treats forward progress on completions as a crash-proof liveness
+    # signal (a batch landing means the worker pool is doing real work) even
+    # when the heartbeat counter has stalled.
     last_batches_completed_count: Mapped[int] = mapped_column(Integer, default=0)
 
     # Heartbeat tracking for worker liveness detection

--- a/backend/tests/external_dependency_unit/celery/test_indexing_stall_watchdog.py
+++ b/backend/tests/external_dependency_unit/celery/test_indexing_stall_watchdog.py
@@ -211,6 +211,36 @@ def test_stale_no_progress_no_workers_is_invalidated(db_session: Session) -> Non
     assert "workers crashed holding batches" in attempt.error_msg
 
 
+@pytest.mark.usefixtures("tenant_context")
+def test_liveness_ping_is_computed_once_per_pass(db_session: Session) -> None:
+    """Worker liveness is cached per pass — the (up to 4s) inspect ping must not
+    fire once per stale in-flight attempt."""
+    attempts = [
+        _make_attempt(
+            db_session,
+            total_batches=10,
+            completed_batches=6,
+            heartbeat_counter=5,
+            last_heartbeat_value=5,
+            last_batches_completed_count=6,
+            heartbeat_age_seconds=HEARTBEAT_TIMEOUT_SECONDS + 120,
+        )
+        for _ in range(3)
+    ]
+    for attempt in attempts:
+        _set_in_flight(attempt.id, 2)
+
+    ping = MagicMock(return_value=False)
+    with patch(f"{_WATCHDOG_PATH}._docprocessing_workers_alive", ping):
+        validate_active_indexing_attempts(MagicMock())
+
+    # Multiple stale in-flight attempts, but the ping is evaluated at most once.
+    assert ping.call_count == 1
+    for attempt in attempts:
+        db_session.refresh(attempt)
+        assert attempt.status == IndexingStatus.FAILED
+
+
 def test_heartbeat_failure_is_surfaced_loudly() -> None:
     """Killing the heartbeat's DB session factory must escalate to ERROR, not
     stay silently swallowed forever."""

--- a/backend/tests/external_dependency_unit/celery/test_indexing_stall_watchdog.py
+++ b/backend/tests/external_dependency_unit/celery/test_indexing_stall_watchdog.py
@@ -1,0 +1,243 @@
+"""External dependency unit tests for the docprocessing stall watchdog.
+
+These cover the "saturated-but-alive vs dead" distinction added to
+``validate_active_indexing_attempts``: a stale heartbeat alone must not destroy
+a multi-day index attempt when the workers are still alive (e.g. blocked on a
+saturated embedder). Real crashes (no live workers) must still be invalidated.
+
+Postgres + Redis must be available. Celery worker liveness is mocked so the
+tests do not depend on a running docprocessing worker.
+"""
+
+import threading
+from collections.abc import Generator
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.docprocessing import heartbeat as heartbeat_module
+from onyx.background.celery.tasks.docprocessing.tasks import HEARTBEAT_TIMEOUT_SECONDS
+from onyx.background.celery.tasks.docprocessing.tasks import (
+    validate_active_indexing_attempts,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import EmbeddingPrecision
+from onyx.db.enums import IndexingStatus
+from onyx.db.enums import IndexModelStatus
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import IndexAttempt
+from onyx.db.models import SearchSettings
+from onyx.redis.redis_docprocessing import RedisDocprocessing
+from onyx.redis.redis_pool import get_redis_client
+
+_WATCHDOG_PATH = "onyx.background.celery.tasks.docprocessing.tasks"
+
+
+def _make_attempt(
+    db_session: Session,
+    *,
+    total_batches: int | None,
+    completed_batches: int,
+    heartbeat_counter: int,
+    last_heartbeat_value: int,
+    last_batches_completed_count: int,
+    heartbeat_age_seconds: float,
+) -> IndexAttempt:
+    connector = Connector(
+        name=f"wd_conn_{uuid4().hex[:8]}",
+        source=DocumentSource.FILE,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={},
+        refresh_freq=3600,
+    )
+    db_session.add(connector)
+    db_session.commit()
+
+    credential = Credential(
+        name=f"wd_cred_{uuid4().hex[:8]}",
+        source=DocumentSource.FILE,
+        credential_json={},
+        admin_public=True,
+    )
+    db_session.add(credential)
+    db_session.commit()
+
+    cc_pair = ConnectorCredentialPair(
+        name=f"wd_ccpair_{uuid4().hex[:8]}",
+        connector_id=connector.id,
+        credential_id=credential.id,
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+    )
+    db_session.add(cc_pair)
+    db_session.commit()
+
+    search_settings = SearchSettings(
+        model_name="test-model",
+        model_dim=768,
+        normalize=True,
+        query_prefix="",
+        passage_prefix="",
+        status=IndexModelStatus.PRESENT,
+        index_name=f"wd_index_{uuid4().hex[:8]}",
+        embedding_precision=EmbeddingPrecision.FLOAT,
+    )
+    db_session.add(search_settings)
+    db_session.commit()
+
+    attempt = IndexAttempt(
+        connector_credential_pair_id=cc_pair.id,
+        search_settings_id=search_settings.id,
+        from_beginning=True,
+        status=IndexingStatus.IN_PROGRESS,
+        celery_task_id=f"wd_task_{uuid4().hex[:8]}",
+        total_batches=total_batches,
+        completed_batches=completed_batches,
+        heartbeat_counter=heartbeat_counter,
+        last_heartbeat_value=last_heartbeat_value,
+        last_batches_completed_count=last_batches_completed_count,
+        last_heartbeat_time=datetime.now(timezone.utc)
+        - timedelta(seconds=heartbeat_age_seconds),
+    )
+    db_session.add(attempt)
+    db_session.commit()
+    db_session.refresh(attempt)
+    return attempt
+
+
+def _set_in_flight(index_attempt_id: int, count: int) -> None:
+    rd = RedisDocprocessing(index_attempt_id, get_redis_client())
+    rd.cleanup()
+    for _ in range(count):
+        rd.incr_pending()
+        rd.decr_pending_incr_in_flight()
+
+
+@pytest.fixture(autouse=True)
+def _no_not_started_scan() -> Generator[None, None, None]:
+    """The watchdog also scans NOT_STARTED attempts via the Celery broker.
+
+    Stub it out so these tests never touch pre-existing rows in the shared DB
+    or reach for a live broker.
+    """
+    with patch(
+        f"{_WATCHDOG_PATH}.get_stale_not_started_index_attempts",
+        return_value=[],
+    ):
+        yield
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_progress_advancing_is_not_invalidated(db_session: Session) -> None:
+    """Stale heartbeat + in_flight > 0 but completed_batches advancing → alive."""
+    attempt = _make_attempt(
+        db_session,
+        total_batches=10,
+        completed_batches=6,  # advanced past last_batches_completed_count
+        heartbeat_counter=5,
+        last_heartbeat_value=5,  # counter did NOT advance
+        last_batches_completed_count=5,
+        heartbeat_age_seconds=HEARTBEAT_TIMEOUT_SECONDS + 120,
+    )
+    _set_in_flight(attempt.id, 2)
+
+    # Workers-alive should not even be consulted; assert it if it is.
+    with patch(f"{_WATCHDOG_PATH}._docprocessing_workers_alive", return_value=True):
+        validate_active_indexing_attempts(MagicMock())
+
+    db_session.refresh(attempt)
+    assert attempt.status == IndexingStatus.IN_PROGRESS
+    # Progress observation is recorded so the next pass compares against it.
+    assert attempt.last_batches_completed_count == 6
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_stale_no_progress_workers_alive_is_spared(db_session: Session) -> None:
+    """Stale heartbeat + no progress + workers alive → saturated, not crashed."""
+    attempt = _make_attempt(
+        db_session,
+        total_batches=10,
+        completed_batches=6,
+        heartbeat_counter=5,
+        last_heartbeat_value=5,
+        last_batches_completed_count=6,  # no progress since last pass
+        heartbeat_age_seconds=HEARTBEAT_TIMEOUT_SECONDS + 120,
+    )
+    _set_in_flight(attempt.id, 2)
+
+    with patch(f"{_WATCHDOG_PATH}._docprocessing_workers_alive", return_value=True):
+        validate_active_indexing_attempts(MagicMock())
+
+    db_session.refresh(attempt)
+    assert attempt.status == IndexingStatus.IN_PROGRESS
+    # The grace path resets the window so the loud log is throttled.
+    assert attempt.last_heartbeat_time is not None
+    assert attempt.last_heartbeat_time > datetime.now(timezone.utc) - timedelta(
+        seconds=HEARTBEAT_TIMEOUT_SECONDS
+    )
+
+
+@pytest.mark.usefixtures("tenant_context")
+def test_stale_no_progress_no_workers_is_invalidated(db_session: Session) -> None:
+    """Stale heartbeat + no progress + no live workers → real crash, invalidate."""
+    attempt = _make_attempt(
+        db_session,
+        total_batches=10,
+        completed_batches=6,
+        heartbeat_counter=5,
+        last_heartbeat_value=5,
+        last_batches_completed_count=6,
+        heartbeat_age_seconds=HEARTBEAT_TIMEOUT_SECONDS + 120,
+    )
+    _set_in_flight(attempt.id, 2)
+
+    with patch(f"{_WATCHDOG_PATH}._docprocessing_workers_alive", return_value=False):
+        validate_active_indexing_attempts(MagicMock())
+
+    db_session.refresh(attempt)
+    assert attempt.status == IndexingStatus.FAILED
+    assert attempt.error_msg is not None
+    assert "workers crashed holding batches" in attempt.error_msg
+
+
+def test_heartbeat_failure_is_surfaced_loudly() -> None:
+    """Killing the heartbeat's DB session factory must escalate to ERROR, not
+    stay silently swallowed forever."""
+    error_logged = threading.Event()
+
+    fake_logger = MagicMock()
+    fake_logger.error.side_effect = lambda *_a, **_k: error_logged.set()
+
+    with patch.object(heartbeat_module, "INDEXING_WORKER_HEARTBEAT_INTERVAL", 0.02):
+        with patch.object(
+            heartbeat_module,
+            "get_session_with_current_tenant",
+            side_effect=RuntimeError("session factory is dead"),
+        ):
+            with patch.object(heartbeat_module, "logger", fake_logger):
+                thread, stop_event = heartbeat_module.start_heartbeat(
+                    index_attempt_id=1
+                )
+                try:
+                    # Threshold is 3 consecutive failures at ~0.02s each.
+                    assert error_logged.wait(timeout=5.0), (
+                        "heartbeat never escalated a sustained failure to ERROR"
+                    )
+                finally:
+                    heartbeat_module.stop_heartbeat(thread, stop_event)
+
+    # Sanity: it also warned on the earlier (sub-threshold) failures.
+    assert fake_logger.warning.called
+    # And it did not simply give up silently.
+    assert fake_logger.error.called


### PR DESCRIPTION
## Description

The docprocessing stall watchdog (`validate_active_indexing_attempts`) treated any **stale heartbeat with `in_flight > 0`** as *"workers crashed holding batches"* and invalidated the index attempt. But a saturated dependency — e.g. a CPU embedder pegged at 100% with thousands of batches queued — blocks every worker thread the same way while the workers themselves are perfectly alive. In that state the watchdog would discard **multi-day indexing progress** on a connector that was merely waiting on embeddings, then restart it from scratch.

This makes invalidation require corroboration, not just a stale counter:

- **Completed-batch progress is now a crash-proof liveness signal** alongside the heartbeat counter. Forward progress on completions since the last watchdog pass resets the stall window even if the heartbeat thread itself is starved. Tracked in the previously-unused `last_batches_completed_count` column — **no migration needed**.
- **Worker-liveness cross-check before the crash verdict.** When the heartbeat is stale with `in_flight > 0` and no completion progress, we ping the docprocessing workers via Celery inspect (answered by the worker's control thread, so a CPU-pegged worker still replies). Read **asymmetrically**: a positive reply → *"saturated/wedged, workers alive"*, logged loudly at ERROR and **spared**; an empty/error reply → fall through to the existing crash verdict. We only ever *spare* on a positive read, never *destroy* on a flaky empty one. The `in_flight == 0, pending == 0` (no work anywhere) case still invalidates unconditionally.
- **Hardened the heartbeat thread**: it now escalates WARNING → ERROR after sustained consecutive failures (leading hypothesis for the original stall is the heartbeat write contending for the shared worker DB pool, `pool_size = concurrency + 8`), so a starved counter surfaces in dashboards instead of being silently swallowed.

**Real crashes (no live workers) still invalidate exactly as before** — this does not soften genuine crash detection.

Related but distinct from #12964 (bounded the unbounded model-server waits); that reduced how long a single batch can block but didn't teach the watchdog to tell "all workers blocked on a saturated dependency" from "workers crashed".

## How Has This Been Tested?

Added external-dependency-unit tests (`backend/tests/external_dependency_unit/celery/test_indexing_stall_watchdog.py`):

- Stale heartbeat + `in_flight > 0` + `completed_batches` advancing → **not** invalidated.
- Stale heartbeat + no progress + workers alive → spared (grace path, window reset).
- Stale heartbeat + no progress + no live workers → invalidated exactly as today (regression guard for real crashes).
- Heartbeat resilience: killing its DB session factory mid-run escalates to ERROR rather than being swallowed forever.

All four pass locally against the branch checkout; `ty`, `ruff`, and full `pre-commit` pass on the `main` base.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop invalidating long-running indexing attempts when workers are alive but blocked on a saturated dependency. The stall watchdog now corroborates stale heartbeats, preserves progress, and caches worker-liveness checks to avoid N× timeouts; real crashes still invalidate as before.

- **Bug Fixes**
  - Treat completed-batch progress as a liveness signal alongside the heartbeat; store in `last_batches_completed_count` (no migration).
  - For stale heartbeat with `in_flight > 0`, ping docprocessing workers via Celery inspect: positive reply → spare and reset window; empty/error → fall back to existing crash verdict; `in_flight == 0 && pending == 0` still invalidates.
  - Heartbeat thread now escalates from WARNING to ERROR after sustained failures so counter stalls are surfaced; added a TODO with candidate causes to guide root-cause investigation.

- **Performance**
  - Compute the worker‑liveness ping once per watchdog pass (cached lazily) so multiple stale attempts don’t add N× `DOCPROCESSING_LIVENESS_PING_TIMEOUT` while holding the DB session.

<sup>Written for commit 3f68d0adc42b93e3c4f40793a32b59cc1c3f4332. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

