### PR TITLE
feat(image-gen): support Vertex AI Workload Identity auth

### DIFF
--- a/backend/onyx/image_gen/providers/vertex_img_gen.py
+++ b/backend/onyx/image_gen/providers/vertex_img_gen.py
@@ -99,7 +99,7 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
 
         # In Workload Identity mode, omit vertex_credentials so LiteLLM falls back
         # to google.auth.default() (the GKE metadata server / ambient credentials).
-        if self._vertex_credentials is not None:
+        if not self._use_workload_identity and self._vertex_credentials is not None:
             kwargs["vertex_credentials"] = self._vertex_credentials
 
         with traced_llm_call(

--- a/backend/onyx/image_gen/providers/vertex_img_gen.py
+++ b/backend/onyx/image_gen/providers/vertex_img_gen.py
@@ -12,17 +12,27 @@ from onyx.image_gen.exceptions import ImageProviderCredentialsError
 from onyx.image_gen.interfaces import ImageGenerationProvider
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.image_gen.interfaces import ReferenceImage
+from onyx.llm.well_known_providers.constants import VERTEX_AUTH_METHOD_KWARG
+from onyx.llm.well_known_providers.constants import VERTEX_AUTH_METHOD_SERVICE_ACCOUNT
+from onyx.llm.well_known_providers.constants import VERTEX_AUTH_METHOD_WORKLOAD_IDENTITY
+from onyx.llm.well_known_providers.constants import VERTEX_CREDENTIALS_FILE_KWARG
+from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
+from onyx.llm.well_known_providers.constants import VERTEX_PROJECT_KWARG
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.llm_utils import traced_llm_call
 
 if TYPE_CHECKING:
     from onyx.image_gen.interfaces import ImageGenerationResponse
 
+VERTEX_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
 
 class VertexCredentials(BaseModel):
-    vertex_credentials: str
+    # None when authenticating via Workload Identity (ambient GKE credentials).
+    vertex_credentials: str | None
     vertex_location: str
     project_id: str
+    use_workload_identity: bool = False
 
 
 class VertexImageGenerationProvider(ImageGenerationProvider):
@@ -33,6 +43,7 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
         self._vertex_credentials = vertex_credentials.vertex_credentials
         self._vertex_location = vertex_credentials.vertex_location
         self._vertex_project = vertex_credentials.project_id
+        self._use_workload_identity = vertex_credentials.use_workload_identity
 
     @classmethod
     def validate_credentials(
@@ -86,6 +97,11 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
 
         from litellm import image_generation
 
+        # In Workload Identity mode, omit vertex_credentials so LiteLLM falls back
+        # to google.auth.default() (the GKE metadata server / ambient credentials).
+        if self._vertex_credentials is not None:
+            kwargs["vertex_credentials"] = self._vertex_credentials
+
         with traced_llm_call(
             flow=LLMFlow.IMAGE_GENERATION,
             model=model,
@@ -99,7 +115,6 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
                 n=n,
                 quality=quality,
                 vertex_location=self._vertex_location,
-                vertex_credentials=self._vertex_credentials,
                 vertex_project=self._vertex_project,
                 **kwargs,
             )
@@ -114,15 +129,25 @@ class VertexImageGenerationProvider(ImageGenerationProvider):
     ) -> ImageGenerationResponse:
         from google import genai
         from google.genai import types as genai_types
-        from google.oauth2 import service_account
         from litellm.types.utils import ImageObject
         from litellm.types.utils import ImageResponse
 
-        service_account_info = json.loads(self._vertex_credentials)
-        credentials = service_account.Credentials.from_service_account_info(
-            service_account_info,
-            scopes=["https://www.googleapis.com/auth/cloud-platform"],
-        )
+        credentials: Any
+        if self._use_workload_identity:
+            import google.auth
+
+            # Ambient GKE credentials (pod's bound GCP service account).
+            credentials, _ = google.auth.default(scopes=VERTEX_SCOPES)
+        else:
+            from google.oauth2 import service_account
+
+            if self._vertex_credentials is None:
+                raise ImageProviderCredentialsError("Vertex credentials are required")
+            service_account_info = json.loads(self._vertex_credentials)
+            credentials = service_account.Credentials.from_service_account_info(
+                service_account_info,
+                scopes=VERTEX_SCOPES,
+            )
 
         client = genai.Client(
             vertexai=True,
@@ -212,14 +237,34 @@ def _parse_to_vertex_credentials(
     if not custom_config:
         raise ImageProviderCredentialsError("Custom config is required")
 
-    vertex_credentials = custom_config.get("vertex_credentials")
-    vertex_location = custom_config.get("vertex_location")
-
-    if not vertex_credentials:
-        raise ImageProviderCredentialsError("Vertex credentials are required")
-
+    vertex_location = custom_config.get(VERTEX_LOCATION_KWARG)
     if not vertex_location:
         raise ImageProviderCredentialsError("Vertex location is required")
+
+    # Missing auth method is treated as service_account_json for backwards
+    # compatibility with configs created before this field existed.
+    auth_method = custom_config.get(
+        VERTEX_AUTH_METHOD_KWARG, VERTEX_AUTH_METHOD_SERVICE_ACCOUNT
+    )
+
+    if auth_method == VERTEX_AUTH_METHOD_WORKLOAD_IDENTITY:
+        # No service account JSON: authenticate via ambient GKE credentials. The
+        # project can't be inferred from a key file, so it must be explicit.
+        vertex_project = (custom_config.get(VERTEX_PROJECT_KWARG) or "").strip()
+        if not vertex_project:
+            raise ImageProviderCredentialsError(
+                "Project ID is required when using Workload Identity"
+            )
+        return VertexCredentials(
+            vertex_credentials=None,
+            vertex_location=vertex_location,
+            project_id=vertex_project,
+            use_workload_identity=True,
+        )
+
+    vertex_credentials = custom_config.get(VERTEX_CREDENTIALS_FILE_KWARG)
+    if not vertex_credentials:
+        raise ImageProviderCredentialsError("Vertex credentials are required")
 
     try:
         vertex_json = json.loads(vertex_credentials)
@@ -236,4 +281,5 @@ def _parse_to_vertex_credentials(
         vertex_credentials=vertex_credentials,
         vertex_location=vertex_location,
         project_id=vertex_project,
+        use_workload_identity=False,
     )

--- a/backend/onyx/server/manage/image_generation/api.py
+++ b/backend/onyx/server/manage/image_generation/api.py
@@ -26,6 +26,7 @@ from onyx.server.manage.image_generation.models import ImageGenerationConfigUpda
 from onyx.server.manage.image_generation.models import ImageGenerationConfigView
 from onyx.server.manage.image_generation.models import ImageGenerationCredentials
 from onyx.server.manage.image_generation.models import TestImageGenerationRequest
+from onyx.server.manage.llm.api import _validate_and_normalize_vertex_auth
 from onyx.server.manage.llm.api import _validate_llm_provider_change
 from onyx.server.manage.llm.models import LLMProviderUpsertRequest
 from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
@@ -86,6 +87,10 @@ def _build_llm_provider_request(
             api_key_changed=False,  # Using stored key from source provider
         )
 
+        custom_config = _validate_and_normalize_vertex_auth(
+            source_provider.provider, custom_config
+        )
+
         return LLMProviderUpsertRequest(
             name=f"Image Gen - {image_provider_id}",
             provider=source_provider.provider,
@@ -113,6 +118,8 @@ def _build_llm_provider_request(
             status_code=400,
             detail="No provider or source llm provided",
         )
+
+    custom_config = _validate_and_normalize_vertex_auth(provider, custom_config)
 
     credentials = ImageGenerationProviderCredentials(
         api_key=api_key,
@@ -240,6 +247,10 @@ def test_image_generation(
             detail="No provider or source llm provided",
         )
 
+    custom_config = _validate_and_normalize_vertex_auth(
+        provider, test_request.custom_config
+    )
+
     try:
         # Build image provider from credentials
         # If incorrect credentials are provided, this will raise an exception
@@ -252,7 +263,7 @@ def test_image_generation(
                 deployment_name=(
                     test_request.deployment_name or test_request.model_name
                 ),
-                custom_config=test_request.custom_config,
+                custom_config=custom_config,
             ),
         )
     except ValueError:

--- a/backend/tests/unit/onyx/image_gen/test_provider_building.py
+++ b/backend/tests/unit/onyx/image_gen/test_provider_building.py
@@ -157,6 +157,85 @@ def test_vertex_malformed_json_does_not_escape_validate_credentials() -> None:
         get_image_generation_provider("vertex_ai", credentials)
 
 
+def test_build_vertex_provider_with_workload_identity() -> None:
+    credentials = _get_default_image_gen_creds()
+    credentials.custom_config = {
+        "vertex_auth_method": "workload_identity",
+        "vertex_location": "us-central1",
+        "vertex_project": "demo_project_wi",
+    }
+
+    image_gen_provider = get_image_generation_provider(VERTEX_PROVIDER, credentials)
+
+    assert isinstance(image_gen_provider, VertexImageGenerationProvider)
+    assert image_gen_provider._vertex_credentials is None
+    assert image_gen_provider._use_workload_identity is True
+    assert image_gen_provider._vertex_location == "us-central1"
+    assert image_gen_provider._vertex_project == "demo_project_wi"
+
+
+def test_build_vertex_workload_identity_requires_project() -> None:
+    credentials = _get_default_image_gen_creds()
+    credentials.custom_config = {
+        "vertex_auth_method": "workload_identity",
+        "vertex_location": "global",
+    }
+
+    assert VertexImageGenerationProvider.validate_credentials(credentials) is False
+    with pytest.raises(ImageProviderCredentialsError):
+        get_image_generation_provider(VERTEX_PROVIDER, credentials)
+
+
+def test_vertex_workload_identity_omits_credentials_in_litellm_call() -> None:
+    credentials = _get_default_image_gen_creds()
+    credentials.custom_config = {
+        "vertex_auth_method": "workload_identity",
+        "vertex_location": "us-central1",
+        "vertex_project": "demo_project_wi",
+    }
+    provider = get_image_generation_provider(VERTEX_PROVIDER, credentials)
+    expected_response = object()
+
+    with patch("litellm.image_generation", return_value=expected_response) as mock_gen:
+        response = provider.generate_image(
+            prompt="draw a mountain",
+            model="vertex_ai/imagen-3.0",
+            size="1024x1024",
+            n=1,
+        )
+
+    assert response is expected_response
+    mock_gen.assert_called_once()
+    call_kwargs = mock_gen.call_args.kwargs
+    # Ambient credentials: LiteLLM must fall back to google.auth.default().
+    assert "vertex_credentials" not in call_kwargs
+    assert call_kwargs["vertex_project"] == "demo_project_wi"
+    assert call_kwargs["vertex_location"] == "us-central1"
+
+
+def test_vertex_service_account_passes_credentials_in_litellm_call() -> None:
+    credentials = _get_default_image_gen_creds()
+    vertex_json = json.dumps({"project_id": "demo_project_1", "private_key_id": "x"})
+    credentials.custom_config = {
+        "vertex_credentials": vertex_json,
+        "vertex_location": "global",
+    }
+    provider = get_image_generation_provider(VERTEX_PROVIDER, credentials)
+    expected_response = object()
+
+    with patch("litellm.image_generation", return_value=expected_response) as mock_gen:
+        provider.generate_image(
+            prompt="draw a mountain",
+            model="vertex_ai/imagen-3.0",
+            size="1024x1024",
+            n=1,
+        )
+
+    call_kwargs = mock_gen.call_args.kwargs
+    assert call_kwargs["vertex_credentials"] == vertex_json
+    assert call_kwargs["vertex_project"] == "demo_project_1"
+
+
 def test_openai_provider_uses_image_generation_without_reference_images() -> None:
     provider = OpenAIImageGenerationProvider(
         api_key="test-key",

--- a/web/src/views/admin/ImageGenerationPage/forms/VertexImageGenForm.tsx
+++ b/web/src/views/admin/ImageGenerationPage/forms/VertexImageGenForm.tsx
@@ -5,6 +5,7 @@ import { FormikField } from "@/refresh-components/form/FormikField";
 import { FormField } from "@/refresh-components/form/FormField";
 import { InputTypeIn } from "@opal/components";
 import InputFile from "@/refresh-components/inputs/InputFile";
+import InputSelect from "@/refresh-components/inputs/InputSelect";
 import InlineExternalLink from "@/refresh-components/InlineExternalLink";
 import { ImageGenFormWrapper } from "@/views/admin/ImageGenerationPage/forms/ImageGenFormWrapper";
 import {
@@ -14,29 +15,50 @@ import {
 } from "@/views/admin/ImageGenerationPage/forms/types";
 import { ImageProvider } from "@/views/admin/ImageGenerationPage/constants";
 import { ImageGenerationCredentials } from "@/views/admin/ImageGenerationPage/svc";
+import { useSettings } from "@/lib/settings/hooks";
 
 const VERTEXAI_PROVIDER_NAME = "vertex_ai";
 const VERTEXAI_DEFAULT_LOCATION = "global";
 
+// Kept in sync with backend onyx.llm.well_known_providers.constants
+const AUTH_METHOD_SERVICE_ACCOUNT = "service_account_json";
+const AUTH_METHOD_WORKLOAD_IDENTITY = "workload_identity";
+
 // Vertex form values
 interface VertexImageGenFormValues {
   custom_config: {
+    vertex_auth_method: string;
     vertex_credentials: string;
     vertex_location: string;
+    vertex_project: string;
   };
 }
 
 const initialValues: VertexImageGenFormValues = {
   custom_config: {
+    vertex_auth_method: AUTH_METHOD_SERVICE_ACCOUNT,
     vertex_credentials: "",
     vertex_location: VERTEXAI_DEFAULT_LOCATION,
+    vertex_project: "",
   },
 };
 
 const validationSchema = Yup.object().shape({
   custom_config: Yup.object().shape({
-    vertex_credentials: Yup.string().required("Credentials file is required"),
+    vertex_auth_method: Yup.string().required(
+      "Authentication method is required"
+    ),
     vertex_location: Yup.string().required("Location is required"),
+    vertex_credentials: Yup.string().when("vertex_auth_method", {
+      is: AUTH_METHOD_SERVICE_ACCOUNT,
+      then: (schema) => schema.required("Credentials file is required"),
+      otherwise: (schema) => schema.notRequired(),
+    }),
+    vertex_project: Yup.string().when("vertex_auth_method", {
+      is: AUTH_METHOD_WORKLOAD_IDENTITY,
+      then: (schema) => schema.required("Project ID is required"),
+      otherwise: (schema) => schema.notRequired(),
+    }),
   }),
 });
 
@@ -46,9 +68,13 @@ function getInitialValuesFromCredentials(
 ): Partial<VertexImageGenFormValues> {
   return {
     custom_config: {
+      vertex_auth_method:
+        credentials.custom_config?.vertex_auth_method ||
+        AUTH_METHOD_SERVICE_ACCOUNT,
       vertex_credentials: credentials.custom_config?.vertex_credentials || "",
       vertex_location:
         credentials.custom_config?.vertex_location || VERTEXAI_DEFAULT_LOCATION,
+      vertex_project: credentials.custom_config?.vertex_project || "",
     },
   };
 }
@@ -57,73 +83,184 @@ function transformValues(
   values: VertexImageGenFormValues,
   imageProvider: ImageProvider
 ): ImageGenSubmitPayload {
+  const authMethod = values.custom_config.vertex_auth_method;
+  const isWorkloadIdentity = authMethod === AUTH_METHOD_WORKLOAD_IDENTITY;
+
+  const customConfig: Record<string, string> = {
+    vertex_auth_method: authMethod,
+    vertex_location: values.custom_config.vertex_location,
+  };
+  if (isWorkloadIdentity) {
+    customConfig.vertex_project = values.custom_config.vertex_project;
+  } else {
+    customConfig.vertex_credentials = values.custom_config.vertex_credentials;
+  }
+
   return {
     modelName: imageProvider.model_name,
     imageProviderId: imageProvider.image_provider_id,
     provider: VERTEXAI_PROVIDER_NAME,
-    customConfig: {
-      vertex_credentials: values.custom_config.vertex_credentials,
-      vertex_location: values.custom_config.vertex_location,
-    },
+    customConfig,
   };
 }
 
 function VertexFormFields(
   props: ImageGenFormChildProps<VertexImageGenFormValues>
 ) {
-  const { apiStatus, showApiMessage, errorMessage, disabled, imageProvider } =
-    props;
+  const {
+    apiStatus,
+    showApiMessage,
+    errorMessage,
+    disabled,
+    imageProvider,
+    formikProps,
+  } = props;
+
+  const settings = useSettings();
+  // Workload Identity relies on ambient GKE credentials, which don't exist in
+  // multi-tenant/cloud deployments — only offer it for self-hosted installs.
+  const showAuthMethodSelector = !!settings.hooks_enabled;
+
+  const authMethod = formikProps.values.custom_config.vertex_auth_method;
+  const isWorkloadIdentity = authMethod === AUTH_METHOD_WORKLOAD_IDENTITY;
 
   return (
     <>
-      {/* Credentials File field */}
-      <FormikField<string>
-        name="custom_config.vertex_credentials"
-        render={(field, helper, meta, state) => (
-          <FormField
-            name="custom_config.vertex_credentials"
-            state={apiStatus === "error" ? "error" : state}
-            className="w-full"
-          >
-            <FormField.Label>Credentials File</FormField.Label>
-            <FormField.Control>
-              <InputFile
-                setValue={(value) => helper.setValue(value)}
-                error={apiStatus === "error"}
-                onBlur={field.onBlur}
-                disabled={disabled}
-                accept="application/json"
-                placeholder="Upload or paste your credentials"
-              />
-            </FormField.Control>
-            {showApiMessage ? (
-              <FormField.APIMessage
-                state={apiStatus}
-                messages={{
-                  loading: `Testing credentials with ${imageProvider.title}...`,
-                  success: "Credentials valid. Configuration saved.",
-                  error: errorMessage || "Invalid credentials",
-                }}
-              />
-            ) : (
+      {showAuthMethodSelector && (
+        <FormikField<string>
+          name="custom_config.vertex_auth_method"
+          render={(field, helper, _meta, state) => (
+            <FormField
+              name="custom_config.vertex_auth_method"
+              state={state}
+              className="w-full"
+            >
+              <FormField.Label>Authentication Method</FormField.Label>
+              <FormField.Control>
+                <InputSelect
+                  value={field.value}
+                  onValueChange={(value) => helper.setValue(value)}
+                  disabled={disabled}
+                >
+                  <InputSelect.Trigger />
+                  <InputSelect.Content>
+                    <InputSelect.Item
+                      value={AUTH_METHOD_SERVICE_ACCOUNT}
+                      description="Upload a GCP service account key JSON file"
+                    >
+                      Service Account JSON
+                    </InputSelect.Item>
+                    <InputSelect.Item
+                      value={AUTH_METHOD_WORKLOAD_IDENTITY}
+                      description="Use the pod's ambient GCP credentials (GKE Workload Identity)"
+                    >
+                      Workload Identity (GKE)
+                    </InputSelect.Item>
+                  </InputSelect.Content>
+                </InputSelect>
+              </FormField.Control>
               <FormField.Message
                 messages={{
-                  idle: (
-                    <>
-                      {"Upload or paste your "}
-                      <InlineExternalLink href="https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project">
-                        service account credentials
-                      </InlineExternalLink>
-                      {" from Google Cloud."}
-                    </>
-                  ),
-                  error: meta.error,
+                  idle: "Choose how Onyx should authenticate with Google Vertex AI.",
                 }}
               />
-            )}
-          </FormField>
-        )}
-      />
+            </FormField>
+          )}
+        />
+      )}
+
+      {/* Service Account JSON: credentials file */}
+      {!isWorkloadIdentity && (
+        <FormikField<string>
+          name="custom_config.vertex_credentials"
+          render={(field, helper, meta, state) => (
+            <FormField
+              name="custom_config.vertex_credentials"
+              state={apiStatus === "error" ? "error" : state}
+              className="w-full"
+            >
+              <FormField.Label>Credentials File</FormField.Label>
+              <FormField.Control>
+                <InputFile
+                  setValue={(value) => helper.setValue(value)}
+                  error={apiStatus === "error"}
+                  onBlur={field.onBlur}
+                  disabled={disabled}
+                  accept="application/json"
+                  placeholder="Upload or paste your credentials"
+                />
+              </FormField.Control>
+              {showApiMessage ? (
+                <FormField.APIMessage
+                  state={apiStatus}
+                  messages={{
+                    loading: `Testing credentials with ${imageProvider.title}...`,
+                    success: "Credentials valid. Configuration saved.",
+                    error: errorMessage || "Invalid credentials",
+                  }}
+                />
+              ) : (
+                <FormField.Message
+                  messages={{
+                    idle: (
+                      <>
+                        {"Upload or paste your "}
+                        <InlineExternalLink href="https://console.cloud.google.com/projectselector2/iam-admin/serviceaccounts?supportedpurview=project">
+                          service account credentials
+                        </InlineExternalLink>
+                        {" from Google Cloud."}
+                      </>
+                    ),
+                    error: meta.error,
+                  }}
+                />
+              )}
+            </FormField>
+          )}
+        />
+      )}
+
+      {/* Workload Identity: explicit GCP project ID */}
+      {isWorkloadIdentity && (
+        <FormikField<string>
+          name="custom_config.vertex_project"
+          render={(field, helper, meta, state) => (
+            <FormField
+              name="custom_config.vertex_project"
+              state={apiStatus === "error" ? "error" : state}
+              className="w-full"
+            >
+              <FormField.Label>GCP Project ID</FormField.Label>
+              <FormField.Control>
+                <InputTypeIn
+                  value={field.value}
+                  onChange={(e) => helper.setValue(e.target.value)}
+                  onBlur={field.onBlur}
+                  placeholder="my-vertex-project"
+                  variant={disabled ? "disabled" : undefined}
+                />
+              </FormField.Control>
+              {showApiMessage ? (
+                <FormField.APIMessage
+                  state={apiStatus}
+                  messages={{
+                    loading: `Testing credentials with ${imageProvider.title}...`,
+                    success: "Credentials valid. Configuration saved.",
+                    error: errorMessage || "Invalid credentials",
+                  }}
+                />
+              ) : (
+                <FormField.Message
+                  messages={{
+                    idle: "The GCP project where Vertex AI is enabled. Onyx authenticates with the pod's bound service account (GKE Workload Identity).",
+                    error: meta.error,
+                  }}
+                />
+              )}
+            </FormField>
+          )}
+        />
+      )}
 
       {/* Location field */}
       <FormikField<string>


### PR DESCRIPTION
## Description

Adds a **Workload Identity (GKE)** authentication option for Google Cloud Vertex AI in the **Image Generation** model configuration, bringing it to parity with the Language Models (LLM provider) Vertex config, which already supports it.

Previously the image-gen Vertex path only accepted a service-account JSON key: the form hard-required a credentials file, and the backend provider derived the GCP project from that key JSON with no ambient-credentials path. Self-hosted-on-GKE customers who authenticate via Workload Identity had no way to configure Vertex image generation.

Changes:
- **Frontend** (`VertexImageGenForm.tsx`): adds an "Authentication Method" selector (Service Account JSON / Workload Identity). In WI mode the credentials-file field is replaced by a required **GCP Project ID** field (the project can't be inferred without a key file). The selector is hidden in multi-tenant deployments, where WI doesn't apply.
- **Backend API** (`image_generation/api.py`): validates/normalizes Vertex auth on create/update/test via the shared `_validate_and_normalize_vertex_auth` helper already used by the LLM provider path (enforces the explicit project requirement, bans WI in multi-tenant, strips stale credential blobs).
- **Provider** (`vertex_img_gen.py`): in WI mode, omits `vertex_credentials` so LiteLLM falls back to `google.auth.default()`, and uses Application Default Credentials for the reference-image (`google-genai`) editing path.

Backwards compatible: existing configs without a `vertex_auth_method` are treated as `service_account_json`, so nothing changes for current users.

## How Has This Been Tested?

- New + existing unit tests in `tests/unit/onyx/image_gen/test_provider_building.py` (56 image-gen unit tests pass), covering: WI provider builds with project + no credentials, WI requires an explicit project, the LiteLLM call omits `vertex_credentials` in WI mode, and the service-account path still passes credentials through.
- `ty` / `ruff` / `mypy` and the web TypeScript type check + `oxlint` all pass (pre-commit).
- **Not yet exercised end-to-end against a live GKE cluster:** the Workload Identity path relies on ambient GKE credentials (`google.auth.default()`), which can only be validated on a cluster whose pod ServiceAccount is bound to a GCP Service Account with Vertex AI access. The service-account JSON path is unchanged.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Workload Identity (GKE) auth for Vertex AI image generation to match the Vertex LLM config. Self-hosted GKE users can now use ambient credentials without uploading service-account keys.

- **New Features**
  - Frontend: Authentication Method selector (Service Account JSON / Workload Identity). In WI mode, show a GCP Project ID field. Selector hidden in multi-tenant.
  - Backend/Provider: Shared Vertex auth validation on create/update/test; WI requires an explicit project. In WI, omit `vertex_credentials` so `litellm` uses `google.auth.default()`, and use ADC for the `google.genai` reference-image path. Passing of credentials is gated by an explicit `use_workload_identity` flag for consistency across generate paths.
  - Backwards compatible: configs without `vertex_auth_method` default to `service_account_json`.

- **Migration**
  - On GKE, select Workload Identity and enter the GCP Project ID. No key file needed. Ensure the pod’s Kubernetes ServiceAccount is bound to a GCP Service Account with Vertex AI access.

<sup>Written for commit a3ba7590f3ed50d5f1c1343a01c3e2d36f9d9393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

