### PR TITLE
fix(background): batch orphan-tag cleanup to bounded server-side deletes

### DIFF
--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -513,7 +513,8 @@ def monitor_connector_deletion_taskset(
                 db_session=db_session,
             )
 
-            # delete orphan tags
+            # best-effort bounded orphan tag cleanup; a full drain would balloon
+            # this transaction, remaining orphans are swept by the pruning monitor
             delete_orphan_tags__no_commit(db_session)
 
             # Store IDs before potentially expiring cc_pair

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -61,7 +61,7 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import HierarchyNode as DBHierarchyNode
 from onyx.db.sync_record import insert_sync_record
 from onyx.db.sync_record import update_sync_record_status
-from onyx.db.tag import delete_orphan_tags__no_commit
+from onyx.db.tag import delete_orphan_tags_batched
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_prune import RedisConnectorPrune
 from onyx.redis.redis_connector_prune import RedisConnectorPrunePayload
@@ -842,11 +842,16 @@ def monitor_ccpair_pruning_taskset(
         num_docs_synced=initial,
     )
 
-    delete_orphan_tags__no_commit(db_session)
-
     redis_connector.prune.taskset_clear()
     redis_connector.prune.generator_clear()
     redis_connector.prune.set_fence(None)
+
+    # Orphan tags can only appear when the prune actually removed documents.
+    # All prior DB writes in this session are already committed
+    # (mark_ccpair_as_pruned / update_sync_record_status commit internally),
+    # so the per-batch commits of the drain are safe here.
+    if initial > 0:
+        delete_orphan_tags_batched(db_session)
 
 
 def validate_pruning_fences(

--- a/backend/onyx/db/tag.py
+++ b/backend/onyx/db/tag.py
@@ -295,9 +295,12 @@ def delete_orphan_tags_batched(
     batch_count = 0
     while True:
         num_deleted = _delete_orphan_tags_batch(db_session, batch_size)
-        db_session.commit()
         if num_deleted == 0:
+            # nothing to persist, but the probe opened a transaction — end it
+            # rather than leaving the session idle-in-transaction
+            db_session.rollback()
             break
+        db_session.commit()
         total_deleted += num_deleted
         batch_count += 1
 

--- a/backend/onyx/db/tag.py
+++ b/backend/onyx/db/tag.py
@@ -5,6 +5,7 @@ from sqlalchemy import delete
 from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import aliased
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource
@@ -14,6 +15,11 @@ from onyx.db.models import Tag
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# Orphan-tag deletes must stay bounded: a single unbounded DELETE over millions
+# of orphans generates one massive transaction (locks + WAL burst) that can
+# saturate the primary DB.
+ORPHAN_TAG_DELETION_BATCH_SIZE = 5000
 
 
 def check_tag_validity(tag_key: str, tag_value: str) -> bool:
@@ -239,15 +245,62 @@ def delete_document_tags_for_documents__no_commit(
     db_session.execute(stmt)
 
 
-def delete_orphan_tags__no_commit(db_session: Session) -> None:
-    orphan_tags_query = select(Tag.id).where(
-        ~db_session.query(Document__Tag.tag_id)
-        .filter(Document__Tag.tag_id == Tag.id)
-        .exists()
+def _delete_orphan_tags_batch(db_session: Session, batch_size: int) -> int:
+    """Deletes at most batch_size orphan tags in a single server-side statement.
+
+    The candidate ids are selected via a LIMITed subquery so no ids are ever
+    materialized into Python. Returns the number of tags deleted.
+    """
+    # Alias Tag so the subquery doesn't auto-correlate against the DELETE target.
+    candidate_tag = aliased(Tag)
+    orphan_tag_ids = (
+        select(candidate_tag.id)
+        .where(
+            ~select(Document__Tag.tag_id)
+            .where(Document__Tag.tag_id == candidate_tag.id)
+            .exists()
+        )
+        .limit(batch_size)
+        .scalar_subquery()
     )
+    delete_stmt = (
+        delete(Tag)
+        .where(Tag.id.in_(orphan_tag_ids))
+        .execution_options(synchronize_session=False)
+    )
+    result = db_session.execute(delete_stmt)
+    return result.rowcount  # ty: ignore[unresolved-attribute]
 
-    orphan_tags = db_session.execute(orphan_tags_query).scalars().all()
 
-    if orphan_tags:
-        delete_orphan_tags_stmt = delete(Tag).where(Tag.id.in_(orphan_tags))
-        db_session.execute(delete_orphan_tags_stmt)
+def delete_orphan_tags__no_commit(
+    db_session: Session,
+    batch_size: int = ORPHAN_TAG_DELETION_BATCH_SIZE,
+) -> int:
+    """Best-effort cleanup of at most one batch of orphan tags inside the
+    caller's transaction. Intentionally bounded so callers holding long
+    transactions (e.g. connector deletion) don't balloon them; use
+    delete_orphan_tags_batched for a full drain."""
+    return _delete_orphan_tags_batch(db_session, batch_size)
+
+
+def delete_orphan_tags_batched(
+    db_session: Session,
+    batch_size: int = ORPHAN_TAG_DELETION_BATCH_SIZE,
+) -> int:
+    """Deletes all orphan tags in bounded batches, committing after each batch.
+
+    Only call with no uncommitted work pending on db_session, since each batch
+    commits. Returns the total number of tags deleted."""
+    total_deleted = 0
+    batch_count = 0
+    while True:
+        num_deleted = _delete_orphan_tags_batch(db_session, batch_size)
+        db_session.commit()
+        if num_deleted == 0:
+            break
+        total_deleted += num_deleted
+        batch_count += 1
+
+    if total_deleted:
+        logger.info("Deleted %d orphan tags in %d batches", total_deleted, batch_count)
+    return total_deleted

--- a/backend/scripts/force_delete_connector_by_id.py
+++ b/backend/scripts/force_delete_connector_by_id.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from onyx.db.document import delete_documents_complete__no_commit
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.search_settings import get_active_search_settings
-from onyx.db.tag import delete_orphan_tags__no_commit
+from onyx.db.tag import delete_orphan_tags_batched
 
 # Modify sys.path
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -83,7 +83,6 @@ def _unsafe_deletion(
             db_session=db_session,
             document_ids=[document.id for document in documents],
         )
-        delete_orphan_tags__no_commit(db_session=db_session)
 
         num_docs_deleted += len(documents)
 
@@ -134,6 +133,9 @@ def _unsafe_deletion(
         logger.debug("Found no credentials left for connector, deleting connector")
         db_session.delete(connector)
     db_session.commit()
+
+    # runs after the commit above since it commits per batch
+    delete_orphan_tags_batched(db_session)
 
     logger.notice(
         "Successfully deleted connector_credential_pair with connector_id: '%s' and credential_id: '%s'. Deleted %s docs.",

--- a/backend/scripts/orphan_doc_cleanup_script.py
+++ b/backend/scripts/orphan_doc_cleanup_script.py
@@ -16,7 +16,7 @@ from onyx.db.document import delete_documents_complete__no_commit  # noqa: E402
 from onyx.db.document import get_document  # noqa: E402
 from onyx.db.engine.sql_engine import get_session_with_current_tenant  # noqa: E402
 from onyx.db.search_settings import get_current_search_settings  # noqa: E402
-from onyx.db.tag import delete_orphan_tags__no_commit  # noqa: E402
+from onyx.db.tag import delete_orphan_tags_batched  # noqa: E402
 from onyx.document_index.interfaces_new import DocumentSectionRequest  # noqa: E402
 from onyx.document_index.interfaces_new import TenantState  # noqa: E402
 from onyx.document_index.vespa.vespa_document_index import (  # noqa: E402
@@ -132,8 +132,8 @@ def main() -> None:
                 delete_documents_complete__no_commit(
                     db_session, successfully_vespa_deleted_doc_ids
                 )
-                delete_orphan_tags__no_commit(db_session)
                 db_session.commit()
+                delete_orphan_tags_batched(db_session)
             except Exception as e:
                 print(f"Error deleting documents from Postgres: {e}")
                 break

--- a/backend/tests/external_dependency_unit/db/test_orphan_tag_cleanup.py
+++ b/backend/tests/external_dependency_unit/db/test_orphan_tag_cleanup.py
@@ -1,0 +1,142 @@
+"""
+Tests for batched orphan-tag cleanup.
+
+Orphan tags (tags with no Document__Tag link) must be deleted in bounded
+server-side batches rather than one unbounded IN-list DELETE.
+"""
+
+from unittest.mock import patch
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import Document
+from onyx.db.models import Document__Tag
+from onyx.db.models import Tag
+from onyx.db.tag import _delete_orphan_tags_batch
+from onyx.db.tag import delete_orphan_tags__no_commit
+from onyx.db.tag import delete_orphan_tags_batched
+
+
+def _seed_orphan_tags(db_session: Session, count: int) -> list[int]:
+    """Create tags with no Document__Tag links. Returns their ids."""
+    run_id = uuid4().hex[:8]
+    tags = [
+        Tag(
+            tag_key=f"orphan_key_{run_id}_{i}",
+            tag_value=f"orphan_value_{run_id}_{i}",
+            source=DocumentSource.FILE,
+            is_list=False,
+        )
+        for i in range(count)
+    ]
+    db_session.add_all(tags)
+    db_session.commit()
+    return [tag.id for tag in tags]
+
+
+def _seed_linked_tags(db_session: Session, count: int) -> list[int]:
+    """Create tags each linked to a document. Returns the tag ids."""
+    run_id = uuid4().hex[:8]
+    document = Document(
+        id=f"orphan_tag_test_doc_{run_id}",
+        semantic_id=f"semantic_orphan_tag_test_doc_{run_id}",
+        boost=0,
+        hidden=False,
+        from_ingestion_api=False,
+    )
+    db_session.add(document)
+
+    tags = [
+        Tag(
+            tag_key=f"linked_key_{run_id}_{i}",
+            tag_value=f"linked_value_{run_id}_{i}",
+            source=DocumentSource.FILE,
+            is_list=False,
+        )
+        for i in range(count)
+    ]
+    db_session.add_all(tags)
+    db_session.flush()
+
+    db_session.add_all(
+        Document__Tag(document_id=document.id, tag_id=tag.id) for tag in tags
+    )
+    db_session.commit()
+    return [tag.id for tag in tags]
+
+
+def _fetch_existing_tag_ids(tag_ids: list[int]) -> set[int]:
+    with get_session_with_current_tenant() as session:
+        return set(
+            session.execute(select(Tag.id).where(Tag.id.in_(tag_ids))).scalars().all()
+        )
+
+
+class TestOrphanTagCleanup:
+    def test_batched_drain_deletes_all_orphans_across_batches(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        # Drain any orphans left over from other tests so counts are exact.
+        delete_orphan_tags_batched(db_session)
+
+        orphan_ids = _seed_orphan_tags(db_session, 25)
+        linked_ids = _seed_linked_tags(db_session, 3)
+
+        with patch(
+            "onyx.db.tag._delete_orphan_tags_batch",
+            wraps=_delete_orphan_tags_batch,
+        ) as batch_spy:
+            total_deleted = delete_orphan_tags_batched(db_session, batch_size=10)
+
+        assert total_deleted == 25
+        # 10 + 10 + 5 + terminating 0-row batch
+        assert batch_spy.call_count == 4
+
+        assert _fetch_existing_tag_ids(orphan_ids) == set()
+        assert _fetch_existing_tag_ids(linked_ids) == set(linked_ids)
+
+    def test_batched_drain_no_orphans_is_noop(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        delete_orphan_tags_batched(db_session)
+
+        linked_ids = _seed_linked_tags(db_session, 2)
+
+        with patch(
+            "onyx.db.tag._delete_orphan_tags_batch",
+            wraps=_delete_orphan_tags_batch,
+        ) as batch_spy:
+            total_deleted = delete_orphan_tags_batched(db_session, batch_size=10)
+
+        assert total_deleted == 0
+        assert batch_spy.call_count == 1
+
+        assert _fetch_existing_tag_ids(linked_ids) == set(linked_ids)
+
+    def test_no_commit_variant_is_bounded_and_does_not_commit(
+        self,
+        db_session: Session,
+        tenant_context: None,  # noqa: ARG002
+    ) -> None:
+        delete_orphan_tags_batched(db_session)
+
+        orphan_ids = _seed_orphan_tags(db_session, 25)
+
+        num_deleted = delete_orphan_tags__no_commit(db_session, batch_size=10)
+        assert num_deleted == 10
+
+        # Uncommitted: rolling back must restore every seeded orphan.
+        db_session.rollback()
+        assert _fetch_existing_tag_ids(orphan_ids) == set(orphan_ids)
+
+        # Cleanup so later tests start from a clean slate.
+        delete_orphan_tags_batched(db_session)
+        assert _fetch_existing_tag_ids(orphan_ids) == set()


### PR DESCRIPTION
## Description

Orphan-tag cleanup (`delete_orphan_tags__no_commit`) SELECTed every orphan tag id into Python and issued a single `DELETE FROM tag WHERE id IN (<literals>)`. With millions of orphaned tags (large connector deletions / prunes) this produces one massive statement and transaction — huge parse cost, long lock hold, and a WAL burst that can saturate the database — and the pruning monitor re-ran the full sweep after every prune completion.

Changes:
- `_delete_orphan_tags_batch`: server-side `DELETE ... WHERE id IN (SELECT ... NOT EXISTS ... LIMIT n)` — no ids ever materialize into Python; batch size 5000.
- `delete_orphan_tags__no_commit` now performs at most one bounded batch (keeps caller transaction semantics; connector deletion no longer balloons its transaction).
- New `delete_orphan_tags_batched` drains fully with a commit per batch and logs total deleted + batch count; used by the pruning monitor (only when the prune actually removed documents) and the two cleanup scripts, in both cases after prior work is committed.

Tradeoff: a tenant that only deletes connectors (never prunes) may retain orphans beyond the inline batch until a later prune or the cleanup script sweeps them — harmless residue vs. an unbounded delete inside the deletion transaction.

## How Has This Been Tested?

New External Dependency Unit tests (`backend/tests/external_dependency_unit/db/test_orphan_tag_cleanup.py`, 3 passed):
- 25 orphans + linked tags at `batch_size=10` → all orphans deleted across exactly 4 batch statements, linked tags untouched.
- Zero-orphan case is a single cheap probe returning 0.
- `__no_commit` deletes exactly one batch and a rollback restores everything (proves no commit).

Pre-commit hooks pass on all touched files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch orphan-tag cleanup now runs as bounded server-side deletes to avoid huge transactions and DB saturation. Inline paths delete one batch; the new drain commits per batch and rolls back on empty probes; used by pruning and cleanup scripts.

- **Bug Fixes**
  - Replaced one huge delete with server-side `DELETE ... WHERE id IN (SELECT ... LIMIT n)`.
  - Batch size is 5000 to cap lock time and WAL spikes.
  - Pruning monitor runs the drain only when documents were removed.
  - Empty-orphan probe now ends with a rollback instead of a commit to avoid idle transactions.

- **New Features**
  - Added `_delete_orphan_tags_batch` and `delete_orphan_tags_batched` (drains all, commit per batch, logs totals).
  - `delete_orphan_tags__no_commit` deletes at most one batch to keep caller transactions small.
  - Updated call sites: pruning uses the batched drain; connector deletion uses the bounded no-commit variant; `force_delete_connector_by_id.py` and `orphan_doc_cleanup_script.py` run the batched drain after committing prior work.
  - Added tests for batching behavior, zero-orphan no-op, and no-commit semantics.

<sup>Written for commit f9bfd2d9434e7658e37663b9d5f600e2b541f722. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

