### PR TITLE
fix(sandbox): avoid LLM provider memory tax in proxy

### DIFF
--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -527,8 +527,8 @@ def fetch_first_accessible_llm_provider_by_type(
 ) -> LLMProviderModel | None:
     """Fetch the lowest-ID provider usable without a persona context.
 
-    Load only the fields and relationships used by the existing access policy;
-    model configurations and provider display metadata stay unloaded.
+    Load only the fields and relationships used by the existing access policy,
+    then load the API key for the selected provider.
     """
     providers = db_session.scalars(
         select(LLMProviderModel)
@@ -536,7 +536,6 @@ def fetch_first_accessible_llm_provider_by_type(
         .options(
             load_only(
                 LLMProviderModel.id,
-                LLMProviderModel.api_key,
                 LLMProviderModel.is_public,
             ),
             selectinload(LLMProviderModel.groups).load_only(UserGroup.id),
@@ -546,7 +545,7 @@ def fetch_first_accessible_llm_provider_by_type(
     )
     user_group_ids = fetch_user_group_ids(db_session, user)
     is_admin = user.role == UserRole.ADMIN
-    return next(
+    provider = next(
         (
             provider
             for provider in providers
@@ -559,6 +558,9 @@ def fetch_first_accessible_llm_provider_by_type(
         ),
         None,
     )
+    if provider is not None:
+        db_session.refresh(provider, attribute_names=["api_key"])
+    return provider
 
 
 def fetch_existing_llm_provider(

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -3,9 +3,11 @@ from sqlalchemy import or_
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.orm import load_only
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
+from onyx.auth.schemas import UserRole
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.models import CloudEmbeddingProvider as CloudEmbeddingProviderModel
 from onyx.db.models import DocumentSet
@@ -20,6 +22,7 @@ from onyx.db.models import SearchSettings
 from onyx.db.models import Tool as ToolModel
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup
 from onyx.llm.utils import model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations
 from onyx.server.manage.embedding.models import CloudEmbeddingProvider
@@ -515,6 +518,47 @@ def fetch_existing_llm_providers(
     if only_public:
         return [provider for provider in providers if provider.is_public]
     return providers
+
+
+def fetch_first_accessible_llm_provider_by_type(
+    provider_type: str,
+    user: User,
+    db_session: Session,
+) -> LLMProviderModel | None:
+    """Fetch the lowest-ID provider usable without a persona context.
+
+    Load only the fields and relationships used by the existing access policy;
+    model configurations and provider display metadata stay unloaded.
+    """
+    providers = db_session.scalars(
+        select(LLMProviderModel)
+        .where(LLMProviderModel.provider == provider_type)
+        .options(
+            load_only(
+                LLMProviderModel.id,
+                LLMProviderModel.api_key,
+                LLMProviderModel.is_public,
+            ),
+            selectinload(LLMProviderModel.groups).load_only(UserGroup.id),
+            selectinload(LLMProviderModel.personas).load_only(Persona.id),
+        )
+        .order_by(LLMProviderModel.id.asc())
+    )
+    user_group_ids = fetch_user_group_ids(db_session, user)
+    is_admin = user.role == UserRole.ADMIN
+    return next(
+        (
+            provider
+            for provider in providers
+            if can_user_access_llm_provider(
+                provider,
+                user_group_ids,
+                persona=None,
+                is_admin=is_admin,
+            )
+        ),
+        None,
+    )
 
 
 def fetch_existing_llm_provider(

--- a/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
+++ b/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
@@ -14,14 +14,13 @@ from mitmproxy import http
 from onyx.auth.constants import API_KEY_HEADER_NAME
 from onyx.auth.constants import BEARER_PREFIX
 from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.llm import fetch_first_accessible_llm_provider_by_type
 from onyx.db.users import fetch_user_by_id
 from onyx.sandbox_proxy.credential_injection import CredentialResolver
 from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
 from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.logging_utils import short_log_id
-from onyx.server.features.build.db.build_session import (
-    fetch_all_supported_build_llm_providers,
-)
+from onyx.utils.credential_audit import emit_credential_access
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -54,11 +53,10 @@ class LLMProviderKeyResolver(CredentialResolver):
                 raise CredentialUnavailableError(
                     f"sandbox user {short_log_id(user_id)} not found"
                 )
-            providers = fetch_all_supported_build_llm_providers(db, user)
+            provider = fetch_first_accessible_llm_provider_by_type(
+                provider_type, user, db
+            )
 
-        # First accessible provider of the type, matching how provisioning picks
-        # the key (get_all_build_mode_llm_configs dedups by type, first wins).
-        provider = next((p for p in providers if p.provider == provider_type), None)
         if provider is None:
             raise CredentialUnavailableError(
                 f"no accessible {provider_type} provider for user {short_log_id(user_id)}"
@@ -67,10 +65,17 @@ class LLMProviderKeyResolver(CredentialResolver):
             raise CredentialUnavailableError(
                 f"{provider_type} provider for user {short_log_id(user_id)} has no api_key"
             )
+        emit_credential_access(
+            credential_type="llm_provider",
+            provider=provider_type,
+            row_id=provider.id,
+            user_id=None,
+        )
+        api_key = provider.api_key.get_value(apply_mask=False)
 
         logger.debug(
             "llm_provider_key_resolver.resolved provider=%s host=%s",
             provider_type,
             request.host,
         )
-        return {header: f"{prefix}{provider.api_key}"}
+        return {header: f"{prefix}{api_key}"}

--- a/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
+++ b/backend/onyx/sandbox_proxy/resolvers/llm_provider_key.py
@@ -69,7 +69,7 @@ class LLMProviderKeyResolver(CredentialResolver):
             credential_type="llm_provider",
             provider=provider_type,
             row_id=provider.id,
-            user_id=None,
+            user_id=str(user_id),
         )
         api_key = provider.api_key.get_value(apply_mask=False)
 

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -584,10 +584,13 @@ def fetch_all_supported_build_llm_providers(
 ) -> list[LLMProviderView]:
     """Every provider of a Craft-supported type (anthropic, openai, openrouter)
     that the ``user`` can access. Respects is_public / group restrictions so a
-    user never gets a sandbox keyed with a provider they can't use."""
+    user never gets a sandbox keyed with a provider they can't use. Providers
+    are ordered by ID so provisioning and proxy credential selection agree on
+    the first provider of each type."""
     provider_models = db_session.scalars(
         select(LLMProviderModel)
         .where(LLMProviderModel.provider.in_(BUILD_MODE_ALLOWED_PROVIDER_TYPES))
+        .order_by(LLMProviderModel.id.asc())
         .options(
             selectinload(LLMProviderModel.model_configurations),
             selectinload(LLMProviderModel.groups),

--- a/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_build_llm_provider_access.py
@@ -9,10 +9,15 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+from sqlalchemy import delete
 from sqlalchemy.orm import Session
 
+from onyx.db.llm import fetch_first_accessible_llm_provider_by_type
 from onyx.db.llm import remove_llm_provider
 from onyx.db.llm import upsert_llm_provider
+from onyx.db.models import LLMProvider
+from onyx.db.models import LLMProvider__Persona
+from onyx.db.models import LLMProvider__UserGroup
 from onyx.db.models import User
 from onyx.db.models import UserRole
 from onyx.server.features.build.db.build_session import (
@@ -23,6 +28,7 @@ from onyx.server.manage.llm.models import ModelConfigurationUpsertRequest
 from tests.external_dependency_unit.craft.db_helpers import add_user_to_group
 from tests.external_dependency_unit.craft.db_helpers import make_group
 from tests.external_dependency_unit.craft.db_helpers import make_user
+from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
 
 
 def _make_group_restricted_anthropic_provider(
@@ -75,3 +81,164 @@ def test_group_restricted_provider_scoped_by_membership(
     finally:
         remove_llm_provider(db_session, provider_id)
         db_session.commit()
+
+
+def _make_llm_provider(
+    db_session: Session,
+    *,
+    provider_type: str,
+    api_key: str,
+    is_public: bool,
+) -> LLMProvider:
+    provider = LLMProvider(
+        name=f"sandbox-credential-{uuid4().hex[:8]}",
+        provider=provider_type,
+        api_key=api_key,
+        is_public=is_public,
+    )
+    db_session.add(provider)
+    db_session.flush()
+    return provider
+
+
+def _delete_llm_providers(db_session: Session, provider_ids: list[int]) -> None:
+    db_session.execute(
+        delete(LLMProvider__UserGroup).where(
+            LLMProvider__UserGroup.llm_provider_id.in_(provider_ids)
+        )
+    )
+    db_session.execute(
+        delete(LLMProvider__Persona).where(
+            LLMProvider__Persona.llm_provider_id.in_(provider_ids)
+        )
+    )
+    db_session.execute(delete(LLMProvider).where(LLMProvider.id.in_(provider_ids)))
+    db_session.commit()
+
+
+def test_focused_provider_fetch_is_ordered_and_access_scoped(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    member = make_user(db_session)
+    non_member = make_user(db_session)
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    group = make_group(db_session)
+    add_user_to_group(db_session, member, group)
+
+    public_provider_type = f"sandbox-public-{uuid4().hex}"
+    first_public_provider = _make_llm_provider(
+        db_session,
+        provider_type=public_provider_type,
+        api_key="sk-first",
+        is_public=True,
+    )
+    second_public_provider = _make_llm_provider(
+        db_session,
+        provider_type=public_provider_type,
+        api_key="sk-second",
+        is_public=True,
+    )
+
+    group_provider_type = f"sandbox-group-{uuid4().hex}"
+    group_provider = _make_llm_provider(
+        db_session,
+        provider_type=group_provider_type,
+        api_key="sk-group",
+        is_public=False,
+    )
+    db_session.add(
+        LLMProvider__UserGroup(
+            llm_provider_id=group_provider.id,
+            user_group_id=group.id,
+        )
+    )
+
+    locked_provider_type = f"sandbox-locked-{uuid4().hex}"
+    locked_provider = _make_llm_provider(
+        db_session,
+        provider_type=locked_provider_type,
+        api_key="sk-locked",
+        is_public=False,
+    )
+
+    persona = create_test_persona(db_session, owner=admin)
+    persona_provider_type = f"sandbox-persona-{uuid4().hex}"
+    persona_provider = _make_llm_provider(
+        db_session,
+        provider_type=persona_provider_type,
+        api_key="sk-persona",
+        is_public=True,
+    )
+    db_session.add(
+        LLMProvider__Persona(
+            llm_provider_id=persona_provider.id,
+            persona_id=persona.id,
+        )
+    )
+    db_session.commit()
+
+    provider_ids = [
+        first_public_provider.id,
+        second_public_provider.id,
+        group_provider.id,
+        locked_provider.id,
+        persona_provider.id,
+    ]
+    try:
+        selected = fetch_first_accessible_llm_provider_by_type(
+            public_provider_type, non_member, db_session
+        )
+        assert selected is not None
+        assert selected.id == first_public_provider.id
+        assert selected.api_key is not None
+        assert selected.api_key.get_value(apply_mask=False) == "sk-first"
+
+        assert (
+            fetch_first_accessible_llm_provider_by_type(
+                group_provider_type, member, db_session
+            )
+            is not None
+        )
+        assert (
+            fetch_first_accessible_llm_provider_by_type(
+                group_provider_type, non_member, db_session
+            )
+            is None
+        )
+        assert (
+            fetch_first_accessible_llm_provider_by_type(
+                group_provider_type, admin, db_session
+            )
+            is not None
+        )
+
+        assert (
+            fetch_first_accessible_llm_provider_by_type(
+                locked_provider_type, non_member, db_session
+            )
+            is None
+        )
+        assert (
+            fetch_first_accessible_llm_provider_by_type(
+                locked_provider_type, admin, db_session
+            )
+            is not None
+        )
+
+        # Craft has no persona context, so persona restrictions apply even to
+        # public providers and administrators.
+        assert (
+            fetch_first_accessible_llm_provider_by_type(
+                persona_provider_type, member, db_session
+            )
+            is None
+        )
+        assert (
+            fetch_first_accessible_llm_provider_by_type(
+                persona_provider_type, admin, db_session
+            )
+            is None
+        )
+    finally:
+        _delete_llm_providers(db_session, provider_ids)

--- a/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -21,14 +21,15 @@ from onyx.sandbox_proxy.credential_injection import InjectionContext
 from onyx.sandbox_proxy.resolvers import llm_provider_key
 from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
 from onyx.server.features.build.configs import BUILD_MODE_ALLOWED_PROVIDER_TYPES
+from onyx.utils.sensitive import make_mock_sensitive_value
 from tests.unit.sandbox_proxy.conftest import make_flow
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox
 
 
 class _FakeProvider:
-    def __init__(self, provider: str, api_key: str | None) -> None:
-        self.provider = provider
-        self.api_key = api_key
+    def __init__(self, api_key: str | None) -> None:
+        self.id = 1
+        self.api_key = make_mock_sensitive_value(api_key)
 
 
 def _noop_db_factory() -> Any:
@@ -44,6 +45,7 @@ def _patch_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """The resolver opens its own tenant session via `get_session_with_tenant`;
     yield a dummy so the patched DB-access functions receive it."""
     monkeypatch.setattr(llm_provider_key, "get_session_with_tenant", _noop_db_factory())
+    monkeypatch.setattr(llm_provider_key, "emit_credential_access", MagicMock())
 
 
 def _ctx() -> InjectionContext:
@@ -58,13 +60,13 @@ def resolver() -> LLMProviderKeyResolver:
 
 
 def _patch_providers(
-    monkeypatch: pytest.MonkeyPatch, providers: list[_FakeProvider]
+    monkeypatch: pytest.MonkeyPatch, providers: dict[str, _FakeProvider]
 ) -> None:
     monkeypatch.setattr(llm_provider_key, "fetch_user_by_id", lambda *_: object())
     monkeypatch.setattr(
         llm_provider_key,
-        "fetch_all_supported_build_llm_providers",
-        lambda *_: providers,
+        "fetch_first_accessible_llm_provider_by_type",
+        lambda provider_type, _user, _db: providers.get(provider_type),
     )
 
 
@@ -81,7 +83,10 @@ def test_openai_and_openrouter_render_bearer(
 ) -> None:
     _patch_providers(
         monkeypatch,
-        [_FakeProvider("openai", "sk-oai"), _FakeProvider("openrouter", "sk-or")],
+        {
+            "openai": _FakeProvider("sk-oai"),
+            "openrouter": _FakeProvider("sk-or"),
+        },
     )
     assert resolver.resolve(make_flow(host="api.openai.com").request, _ctx()) == {
         "Authorization": "Bearer sk-oai"
@@ -94,27 +99,76 @@ def test_openai_and_openrouter_render_bearer(
 def test_anthropic_renders_x_api_key_only(
     resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_providers(monkeypatch, [_FakeProvider("anthropic", "sk-ant")])
+    _patch_providers(monkeypatch, {"anthropic": _FakeProvider("sk-ant")})
     # x-api-key only — anthropic-version and other SDK headers must survive.
     assert resolver.resolve(make_flow(host="api.anthropic.com").request, _ctx()) == {
         "x-api-key": "sk-ant"
     }
 
 
-def test_selects_first_provider_of_claimed_type(
+def test_queries_only_claimed_provider_type(
     resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_providers(
-        monkeypatch,
-        [
-            _FakeProvider("openai", "sk-first"),
-            _FakeProvider("openai", "sk-second"),
-            _FakeProvider("anthropic", "sk-ant"),
-        ],
+    requested_provider_types: list[str] = []
+    monkeypatch.setattr(llm_provider_key, "fetch_user_by_id", lambda *_: object())
+
+    def fetch_provider(provider_type: str, _user: object, _db: object) -> _FakeProvider:
+        requested_provider_types.append(provider_type)
+        return _FakeProvider("sk-openai")
+
+    monkeypatch.setattr(
+        llm_provider_key,
+        "fetch_first_accessible_llm_provider_by_type",
+        fetch_provider,
     )
     assert resolver.resolve(make_flow(host="api.openai.com").request, _ctx()) == {
-        "Authorization": "Bearer sk-first"
+        "Authorization": "Bearer sk-openai"
     }
+    assert requested_provider_types == ["openai"]
+
+
+def test_unwraps_api_key_with_masking_disabled(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    api_key = make_mock_sensitive_value("sk-openai")
+    provider = MagicMock(api_key=api_key)
+    monkeypatch.setattr(llm_provider_key, "fetch_user_by_id", lambda *_: object())
+    monkeypatch.setattr(
+        llm_provider_key,
+        "fetch_first_accessible_llm_provider_by_type",
+        lambda *_: provider,
+    )
+    assert resolver.resolve(make_flow(host="api.openai.com").request, _ctx()) == {
+        "Authorization": "Bearer sk-openai"
+    }
+    api_key.get_value.assert_called_once_with(apply_mask=False)
+
+
+def test_audits_credential_decryption(
+    resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    provider = MagicMock(
+        id=42,
+        api_key=make_mock_sensitive_value("sk-openai"),
+    )
+    monkeypatch.setattr(llm_provider_key, "fetch_user_by_id", lambda *_: object())
+    monkeypatch.setattr(
+        llm_provider_key,
+        "fetch_first_accessible_llm_provider_by_type",
+        lambda *_: provider,
+    )
+    audit = MagicMock()
+    monkeypatch.setattr(llm_provider_key, "emit_credential_access", audit)
+
+    ctx = _ctx()
+    resolver.resolve(make_flow(host="api.openai.com").request, ctx)
+
+    audit.assert_called_once_with(
+        credential_type="llm_provider",
+        provider="openai",
+        row_id=42,
+        user_id=None,
+    )
 
 
 def test_resolve_raises_when_user_missing(
@@ -128,7 +182,7 @@ def test_resolve_raises_when_user_missing(
 def test_resolve_raises_when_no_provider_of_type(
     resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_providers(monkeypatch, [_FakeProvider("anthropic", "sk-ant")])
+    _patch_providers(monkeypatch, {})
     with pytest.raises(CredentialUnavailableError):
         resolver.resolve(make_flow(host="api.openai.com").request, _ctx())
 
@@ -136,7 +190,7 @@ def test_resolve_raises_when_no_provider_of_type(
 def test_resolve_raises_when_provider_has_no_key(
     resolver: LLMProviderKeyResolver, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    _patch_providers(monkeypatch, [_FakeProvider("openai", None)])
+    _patch_providers(monkeypatch, {"openai": _FakeProvider(None)})
     with pytest.raises(CredentialUnavailableError):
         resolver.resolve(make_flow(host="api.openai.com").request, _ctx())
 

--- a/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
+++ b/backend/tests/unit/sandbox_proxy/test_llm_provider_key_resolver.py
@@ -167,7 +167,7 @@ def test_audits_credential_decryption(
         credential_type="llm_provider",
         provider="openai",
         row_id=42,
-        user_id=None,
+        user_id=str(ctx.sandbox.user_id),
     )
 
 


### PR DESCRIPTION
## Description

Avoid loading every supported build-mode LLM provider when the sandbox proxy only needs one credential. The proxy now fetches the first accessible provider of the requested type with only the credential and access-control fields required by the existing authorization policy.

This removes the large retained LiteLLM/provider initialization cost from the proxy request path while preserving group, persona, administrator, provider-ordering, and credential-audit behavior. Build-session provisioning continues to fetch complete provider and model configuration data because that path needs it.

## How Has This Been Tested?

- Ran the focused resolver unit tests: 11 passed.
- Built the backend image and loaded it into the local kind cluster.
- Sent 32 proxied Anthropic requests from two live sandbox pods; all 32 injected credentials and reached the upstream service.
- Observed approximately 232 MiB RSS at startup and approximately 262 MiB after the repeated-request run, with no LiteLLM provider-loading warnings or pod restarts.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid loading all build-mode LLM providers in the sandbox proxy. The proxy now fetches only the first accessible provider for the requested type and injects its key, reducing memory and startup cost while keeping access controls and auditing.

- **Refactors**
  - Added fetch_first_accessible_llm_provider_by_type that loads only id, is_public, groups, and personas, then loads api_key for the selected provider; preserves public, group, persona, and admin access rules.
  - Proxy resolver now queries only the requested provider type, unwraps the sensitive api_key with masking disabled, and emits emit_credential_access.
  - Ordered providers by ID in fetch_all_supported_build_llm_providers so proxy and provisioning select the same first provider of each type; provisioning still loads full configs.
  - Extended tests for ordering, access scoping (group, persona, admin), minimal provider queries, masked key unwrapping, header rendering, auditing, and error cases.

<sup>Written for commit cd535a8685efaf9d63592fed5d7226f3eefc465c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

