### PR TITLE
fix(helm): increase sandbox proxy memory allocation

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.12
+version: 0.6.13
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,12 +16,10 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: Mark a docfetching attempt INTERRUPTED (resumable, not failed) when the worker
-        is stopped by a graceful shutdown such as a rolling deploy or KEDA scale-down, so it
-        resumes from checkpoint instead of counting toward the repeated-error auto-pause. Adds a
-        terminationGracePeriodSeconds to the docfetching deployment, so a rollout is required for
-        existing deployments to pick it up.
+    - kind: changed
+      description: Increase the default sandbox proxy memory request from 256Mi to 512Mi and its
+        memory limit from 1Gi to 2Gi, providing more headroom for transient proxy workloads and
+        reducing the risk of out-of-memory termination.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1647,10 +1647,10 @@ sandboxProxy:
   resources:
     requests:
       cpu: 100m
-      memory: 256Mi
+      memory: 512Mi
     limits:
       cpu: 1000m
-      memory: 1Gi
+      memory: 2Gi
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Description

Increase the default Kubernetes memory allocation for the sandbox proxy:

- Request: 256 Mi to 512 Mi
- Limit: 1 Gi to 2 Gi

The higher request gives the scheduler a more realistic baseline for the proxy, while the higher limit provides headroom for transient memory spikes (i.e. running `uv sync` in the sandbox for the onyx repo)

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check