### PR TITLE
fix(impersonate): show loader while user data is loading to prevent premature redirect

### DIFF
--- a/web/src/app/auth/impersonate/page.tsx
+++ b/web/src/app/auth/impersonate/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
-
+import PageLoader from "@/refresh-components/PageLoader";
 import { useUser } from "@/providers/UserProvider";
 import { redirect, useRouter } from "next/navigation";
 import type { Route } from "next";
@@ -19,7 +19,12 @@ const ImpersonateSchema = Yup.object().shape({
 
 export default function ImpersonatePage() {
   const router = useRouter();
-  const { user, isCloudSuperuser } = useUser();
+  const { user, isLoading, isCloudSuperuser } = useUser();
+
+  if (isLoading) {
+    return <PageLoader />;
+  }
+
   if (!user) {
     redirect("/auth/login");
   }

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -28,6 +28,7 @@ import { useTheme } from "next-themes";
 
 interface UserContextType {
   user: User | null;
+  isLoading: boolean;
   isAdmin: boolean;
   isCurator: boolean;
   refreshUser: () => Promise<void>;
@@ -61,7 +62,7 @@ interface UserContextType {
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
-  const { user: fetchedUser, mutateUser } = useCurrentUser();
+  const { user: fetchedUser, mutateUser, isLoading } = useCurrentUser();
   const { authTypeMetadata, isLoading: authTypeMetadataLoading } =
     useAuthTypeMetadata();
   const updatedSettingsData = useSettings();
@@ -544,6 +545,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
     <UserContext.Provider
       value={{
         user: upToDateUser,
+        isLoading,
         refreshUser,
         authTypeMetadata,
         updateUserAutoScroll,

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -62,7 +62,11 @@ interface UserContextType {
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
 export function UserProvider({ children }: { children: React.ReactNode }) {
-  const { user: fetchedUser, mutateUser, isLoading } = useCurrentUser();
+  const {
+    user: fetchedUser,
+    mutateUser,
+    isLoading: isUserLoading,
+  } = useCurrentUser();
   const { authTypeMetadata, isLoading: authTypeMetadataLoading } =
     useAuthTypeMetadata();
   const updatedSettingsData = useSettings();
@@ -95,10 +99,18 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   );
 
   const [upToDateUser, setUpToDateUser] = useState<User | null>(null);
+  const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
     setUpToDateUser(mergeUserPreferences(fetchedUser ?? null));
+    setIsInitialized(true);
   }, [fetchedUser, mergeUserPreferences]);
+
+  // isLoading stays true until after the first setUpToDateUser fires; SWR's
+  // isLoading alone isn't enough because upToDateUser is updated in an effect
+  // that runs one render after SWR resolves, causing a window where isLoading
+  // is false but user is still null.
+  const isLoading = isUserLoading || !isInitialized;
 
   useEffect(() => {
     if (!posthog) return;


### PR DESCRIPTION
## Description

`ImpersonatePage` called `redirect()` on the first render before `/api/me` had resolved. Since `UserProvider` initialises `upToDateUser` as `null`, the `if (!user)` guard always fired immediately, bouncing every authenticated visitor to `/auth/login`.

Fix: expose `isLoading` from `UserProvider` (sourced from `useCurrentUser`'s SWR loading flag) and return a `<PageLoader />` while the initial fetch is in flight, so the redirect checks only run once user data is available.

## How Has This Been Tested?

Manually verified that a logged-in cloud superuser can now reach the impersonate page without being redirected, and that unauthenticated users are still redirected to `/auth/login` after the loader clears.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a loader on the impersonate page while user data is loading to prevent redirecting authenticated users to the login screen. Unauthenticated users still redirect after the loader clears.

- **Bug Fixes**
  - Expose and propagate `isLoading` via `UserProvider`/`useUser`, keeping it true until `upToDateUser` initializes to avoid a brief `user=null` window.
  - In `ImpersonatePage`, show `PageLoader` while loading and run redirect checks only after user data is available.

<sup>Written for commit 49fea5a52af2d2637bff2dafec77e71c9e72429b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

