### PR TITLE
fix(web): scope PostHog identity cookie to exact host

### DIFF
--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -15,11 +15,6 @@ export function initPostHog(key: string, host?: string | null): void {
     ui_host: host || "https://us.posthog.com",
     person_profiles: "identified_only",
     capture_pageview: false,
-    // Scope the identity cookie to the exact host. Cloud tenants share
-    // *.onyx.app, so a top-level-domain cookie would link one browser's
-    // identity across tenants (and across st-dev/cloud). This also skips
-    // posthog's dmn_chk_* domain-probe cookie, which browsers log as
-    // "rejected for invalid domain".
     cross_subdomain_cookie: false,
     session_recording: {
       // Sensitive inputs should use data-ph-no-capture attribute

--- a/web/src/app/providers.tsx
+++ b/web/src/app/providers.tsx
@@ -15,6 +15,12 @@ export function initPostHog(key: string, host?: string | null): void {
     ui_host: host || "https://us.posthog.com",
     person_profiles: "identified_only",
     capture_pageview: false,
+    // Scope the identity cookie to the exact host. Cloud tenants share
+    // *.onyx.app, so a top-level-domain cookie would link one browser's
+    // identity across tenants (and across st-dev/cloud). This also skips
+    // posthog's dmn_chk_* domain-probe cookie, which browsers log as
+    // "rejected for invalid domain".
+    cross_subdomain_cookie: false,
     session_recording: {
       // Sensitive inputs should use data-ph-no-capture attribute
       maskAllInputs: false,


### PR DESCRIPTION
## Problem

Firefox consoles on Onyx deployments log:

> Cookie "dmn_chk_019f6295-..." has been rejected for invalid domain.

The `dmn_chk_<uuid>` cookie is posthog-js's cookie-domain discovery probe: with the default `cross_subdomain_cookie: true`, it walks the hostname from the broadest suffix down (`.app` → `.onyx.app`), setting a throwaway cookie at each level to find the widest domain the browser accepts. The first attempt always targets a public suffix and is always rejected — Firefox is just the browser that logs it loudly.

The warning is cosmetic, but the behavior behind it isn't ideal: the probe lands on `.onyx.app` (verified it is not on the Public Suffix List), so PostHog's identity cookie is shared across **all** `*.onyx.app` subdomains. One browser visiting `cloud.onyx.app` and a customer tenant at `foo.onyx.app` — or `st-dev` and `cloud` — shares a single PostHog device identity across them.

## Fix

Set `cross_subdomain_cookie: false` so the identity cookie is scoped to the exact host. Each tenant/environment gets an independent PostHog identity, and the `dmn_chk_*` probe (and its console warning) goes away.

## Why nothing is lost

The only benefit of a TLD-scoped cookie would be identity stitching with the marketing site. Verified against the live sites that this doesn't exist today:

- `cloud.onyx.app` bundles PostHog project key `phc_Qs1pC...R806`
- `www.onyx.app` (onyx-website repo) uses a different project, `phc_dtjLOW...bULO`, and sets its own `.onyx.app`-scoped cookie in its middleware

PostHog cookie names embed the project token, so the two instances never read each other's cookies regardless of domain scope. Existing `.onyx.app`-scoped app cookies in the wild remain readable by name after this change, so identities carry over rather than resetting, and they age out naturally.

## Testing

- `bun run types:check` — no new errors vs. baseline (none in `providers.tsx`)
- `bun run format:check` / `oxlint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the PostHog identity cookie to the exact host by setting `cross_subdomain_cookie: false` in `posthog-js` initialization. This isolates identities per `*.onyx.app` subdomain and removes Firefox “rejected for invalid domain” logs from the `dmn_chk_*` probe.

<sup>Written for commit 39c04b72f520916c4defda809c31edb129b5a2e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

