### PR TITLE
feat(auth): Classify Redis session token rejection; Redis entries now outlive logical TTL for visibility

### DIFF
--- a/backend/onyx/auth/session_tokens.py
+++ b/backend/onyx/auth/session_tokens.py
@@ -91,8 +91,8 @@ def build_session_token_value(
     *,
     user_id: str,
     tenant_id: str | None,
-    issued_at: datetime,
-    expires_at: datetime | None,
+    issued_at: AwareDatetime,
+    expires_at: AwareDatetime | None,
 ) -> str:
     return SessionTokenValue(
         sub=user_id,
@@ -123,8 +123,8 @@ def build_session_tombstone_value(
 
 
 def compute_session_expires_at(
-    issued_at: datetime, lifetime_seconds: int | None
-) -> datetime | None:
+    issued_at: AwareDatetime, lifetime_seconds: int | None
+) -> AwareDatetime | None:
     if lifetime_seconds is None:
         return None
     return issued_at + timedelta(seconds=lifetime_seconds)
@@ -181,13 +181,15 @@ def classify_session_token_value(
 
 def record_session_rejection(rejection: SessionRejection) -> None:
     """
-    A rejection backed by a stored value outranks a bare NOT_FOUND miss from a
-    second presented credential.
+    The first rejection backed by a stored value wins; a bare NOT_FOUND miss
+    only fills a void.
     """
     existing = _SESSION_REJECTION.get()
-    if existing is not None and rejection.reason == SessionRejectionReason.NOT_FOUND:
-        return
-    _SESSION_REJECTION.set(rejection)
+    if existing is None or (
+        existing.reason == SessionRejectionReason.NOT_FOUND
+        and rejection.reason != SessionRejectionReason.NOT_FOUND
+    ):
+        _SESSION_REJECTION.set(rejection)
 
 
 def get_session_rejection() -> SessionRejection | None:

--- a/backend/onyx/auth/session_tokens.py
+++ b/backend/onyx/auth/session_tokens.py
@@ -1,0 +1,222 @@
+"""Redis session-token value format and rejection classification.
+
+Token values embed their logical expiry; the physical TTL adds a grace window
+and logout writes a tombstone instead of deleting, so a rejected token can be
+classified: EXPIRED (embedded expiry passed), TERMINATED (tombstone), NOT_FOUND
+(no entry: cookie outlived the grace window, or Redis dropped the key), LEGACY
+(pre-format value; one-time sign-out on upgrade).
+
+``read_token`` must return None rather than raise (API keys/PATs/JWTs share the
+bearer transport and legitimately miss in Redis), so the classification is
+stashed in a request-scoped ContextVar and turned into a reasoned ``OnyxError``
+only where authentication has conclusively failed for the request.
+"""
+
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from enum import Enum
+
+from pydantic import AwareDatetime
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+from onyx.auth.constants import API_KEY_PREFIX
+from onyx.auth.constants import DEPRECATED_API_KEY_PREFIX
+from onyx.auth.constants import PAT_PREFIX
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+# How long an entry outlives its logical expiry (and how long a tombstone
+# lingers); past this, rejections classify as NOT_FOUND.
+SESSION_TOKEN_GRACE_PERIOD_SECONDS = 60 * 60
+
+
+class SessionTokenValue(BaseModel):
+    """
+    JSON stored under ``fastapi_users_token:<token>``. All fields optional so
+    legacy values and tombstones parse too; ``AwareDatetime`` rejects naive
+    timestamps at parse time.
+    """
+
+    sub: str | None = None
+    tenant_id: str | None = None
+    issued_at: AwareDatetime | None = None
+    expires_at: AwareDatetime | None = None
+    logged_out_at: AwareDatetime | None = None
+
+
+class SessionRejectionReason(Enum):
+    EXPIRED = "expired"
+    TERMINATED = "terminated"
+    NOT_FOUND = "not_found"
+    LEGACY = "legacy"
+
+
+_REASON_TO_ERROR_CODE = {
+    SessionRejectionReason.EXPIRED: OnyxErrorCode.SESSION_EXPIRED,
+    SessionRejectionReason.TERMINATED: OnyxErrorCode.SESSION_TERMINATED,
+    SessionRejectionReason.NOT_FOUND: OnyxErrorCode.SESSION_UNRECOGNIZED,
+    SessionRejectionReason.LEGACY: OnyxErrorCode.SESSION_TERMINATED,
+}
+
+_REASON_TO_DETAIL = {
+    SessionRejectionReason.EXPIRED: "Session expired. Please log in again.",
+    SessionRejectionReason.TERMINATED: "Session was signed out. Please log in again.",
+    SessionRejectionReason.NOT_FOUND: "Session not recognized. Please log in again.",
+    SessionRejectionReason.LEGACY: "Session is no longer valid. Please log in again.",
+}
+
+
+@dataclass(frozen=True)
+class SessionRejection:
+    reason: SessionRejectionReason
+    # None when nothing was stored or the value was unparseable.
+    token_value: SessionTokenValue | None
+
+
+_SESSION_REJECTION: ContextVar[SessionRejection | None] = ContextVar(
+    "session_rejection", default=None
+)
+
+
+def build_session_token_value(
+    *,
+    user_id: str,
+    tenant_id: str | None,
+    issued_at: datetime,
+    expires_at: datetime | None,
+) -> str:
+    return SessionTokenValue(
+        sub=user_id,
+        tenant_id=tenant_id,
+        issued_at=issued_at,
+        expires_at=expires_at,
+    ).model_dump_json(exclude_none=True)
+
+
+def build_session_tombstone_value(
+    previous_raw_value: str | bytes | None, fallback_user_id: str
+) -> str:
+    """
+    Builds the logout tombstone, preserving the original fields when the
+    previous value parses.
+    """
+    previous: SessionTokenValue | None = None
+    if previous_raw_value is not None:
+        try:
+            previous = SessionTokenValue.model_validate_json(previous_raw_value)
+        except ValidationError:
+            previous = None
+    if previous is None:
+        previous = SessionTokenValue(sub=fallback_user_id)
+    return previous.model_copy(
+        update={"logged_out_at": datetime.now(timezone.utc)}
+    ).model_dump_json(exclude_none=True)
+
+
+def compute_session_expires_at(
+    issued_at: datetime, lifetime_seconds: int | None
+) -> datetime | None:
+    if lifetime_seconds is None:
+        return None
+    return issued_at + timedelta(seconds=lifetime_seconds)
+
+
+def physical_session_ttl_seconds(lifetime_seconds: int | None) -> int | None:
+    if lifetime_seconds is None:
+        return None
+    return lifetime_seconds + SESSION_TOKEN_GRACE_PERIOD_SECONDS
+
+
+def may_be_session_token(token: str) -> bool:
+    """
+    Session tokens are bare ``token_urlsafe()`` strings: no prefix, no dots.
+    Excludes API keys / PATs / JWTs so their expected misses never classify.
+    """
+    if token.startswith((API_KEY_PREFIX, DEPRECATED_API_KEY_PREFIX, PAT_PREFIX)):
+        return False
+    return "." not in token
+
+
+def classify_session_token_value(
+    raw_value: str | bytes | None,
+) -> SessionTokenValue | SessionRejection:
+    """Returns the parsed value if the session is live, else the rejection."""
+    if raw_value is None:
+        return SessionRejection(
+            reason=SessionRejectionReason.NOT_FOUND, token_value=None
+        )
+
+    try:
+        value = SessionTokenValue.model_validate_json(raw_value)
+    except ValidationError:
+        return SessionRejection(reason=SessionRejectionReason.LEGACY, token_value=None)
+
+    if value.logged_out_at is not None:
+        return SessionRejection(
+            reason=SessionRejectionReason.TERMINATED, token_value=value
+        )
+    if value.sub is None or value.issued_at is None:
+        return SessionRejection(reason=SessionRejectionReason.LEGACY, token_value=value)
+    if value.expires_at is not None and value.expires_at <= datetime.now(timezone.utc):
+        return SessionRejection(
+            reason=SessionRejectionReason.EXPIRED, token_value=value
+        )
+    return value
+
+
+def record_session_rejection(rejection: SessionRejection) -> None:
+    """
+    A rejection backed by a stored value outranks a bare NOT_FOUND miss from a
+    second presented credential.
+    """
+    existing = _SESSION_REJECTION.get()
+    if existing is not None and rejection.reason == SessionRejectionReason.NOT_FOUND:
+        return
+    _SESSION_REJECTION.set(rejection)
+
+
+def get_session_rejection() -> SessionRejection | None:
+    return _SESSION_REJECTION.get()
+
+
+def build_session_rejection_error() -> OnyxError | None:
+    """
+    Turns the request's recorded rejection (if any) into a reasoned
+    ``OnyxError``, logging the diagnostic WARNING.
+    """
+    rejection = _SESSION_REJECTION.get()
+    if rejection is None:
+        return None
+
+    value = rejection.token_value
+    token_age: timedelta | None = None
+    if value is not None and value.issued_at is not None:
+        token_age = datetime.now(timezone.utc) - value.issued_at
+
+    logger.warning(
+        "Rejected session token: reason=%s user_id=%s token_age=%s issued_at=%s "
+        "expires_at=%s logged_out_at=%s",
+        rejection.reason.value,
+        value.sub if value else None,
+        token_age,
+        value.issued_at if value else None,
+        value.expires_at if value else None,
+        value.logged_out_at if value else None,
+    )
+    if rejection.reason == SessionRejectionReason.NOT_FOUND:
+        logger.warning(
+            "Presented session token has no Redis entry: the cookie outlived "
+            "the grace window, or Redis dropped the key (restart/eviction/flush)."
+        )
+
+    return OnyxError(
+        _REASON_TO_ERROR_CODE[rejection.reason],
+        _REASON_TO_DETAIL[rejection.reason],
+    )

--- a/backend/onyx/auth/session_tokens.py
+++ b/backend/onyx/auth/session_tokens.py
@@ -3,8 +3,10 @@
 Token values embed their logical expiry; the physical TTL adds a grace window
 and logout writes a tombstone instead of deleting, so a rejected token can be
 classified: EXPIRED (embedded expiry passed), TERMINATED (tombstone), NOT_FOUND
-(no entry: cookie outlived the grace window, or Redis dropped the key), LEGACY
-(pre-format value; one-time sign-out on upgrade).
+(no entry: cookie outlived the grace window, or Redis dropped the key),
+MALFORMED (unparseable or sub-less value). Pre-upgrade values (sub present, no
+issued_at) stay valid on bare key existence; their physical TTL is their
+pre-upgrade logical expiry, so deploying this format signs nobody out.
 
 ``read_token`` must return None rather than raise (API keys/PATs/JWTs share the
 bearer transport and legitimately miss in Redis), so the classification is
@@ -55,21 +57,21 @@ class SessionRejectionReason(Enum):
     EXPIRED = "expired"
     TERMINATED = "terminated"
     NOT_FOUND = "not_found"
-    LEGACY = "legacy"
+    MALFORMED = "malformed"
 
 
 _REASON_TO_ERROR_CODE = {
     SessionRejectionReason.EXPIRED: OnyxErrorCode.SESSION_EXPIRED,
     SessionRejectionReason.TERMINATED: OnyxErrorCode.SESSION_TERMINATED,
     SessionRejectionReason.NOT_FOUND: OnyxErrorCode.SESSION_UNRECOGNIZED,
-    SessionRejectionReason.LEGACY: OnyxErrorCode.SESSION_TERMINATED,
+    SessionRejectionReason.MALFORMED: OnyxErrorCode.SESSION_UNRECOGNIZED,
 }
 
 _REASON_TO_DETAIL = {
     SessionRejectionReason.EXPIRED: "Session expired. Please log in again.",
     SessionRejectionReason.TERMINATED: "Session was signed out. Please log in again.",
     SessionRejectionReason.NOT_FOUND: "Session not recognized. Please log in again.",
-    SessionRejectionReason.LEGACY: "Session is no longer valid. Please log in again.",
+    SessionRejectionReason.MALFORMED: "Session not recognized. Please log in again.",
 }
 
 
@@ -156,14 +158,20 @@ def classify_session_token_value(
     try:
         value = SessionTokenValue.model_validate_json(raw_value)
     except ValidationError:
-        return SessionRejection(reason=SessionRejectionReason.LEGACY, token_value=None)
+        return SessionRejection(
+            reason=SessionRejectionReason.MALFORMED, token_value=None
+        )
 
     if value.logged_out_at is not None:
         return SessionRejection(
             reason=SessionRejectionReason.TERMINATED, token_value=value
         )
-    if value.sub is None or value.issued_at is None:
-        return SessionRejection(reason=SessionRejectionReason.LEGACY, token_value=value)
+    if value.sub is None:
+        return SessionRejection(
+            reason=SessionRejectionReason.MALFORMED, token_value=value
+        )
+    # Pre-upgrade values (no issued_at / expires_at) fall through as valid:
+    # their physical TTL is their pre-upgrade logical expiry.
     if value.expires_at is not None and value.expires_at <= datetime.now(timezone.utc):
         return SessionRejection(
             reason=SessionRejectionReason.EXPIRED, token_value=value

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1,6 +1,5 @@
 import base64
 import hashlib
-import json
 import os
 import random
 import secrets
@@ -91,6 +90,16 @@ from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.schemas import AuthBackend
 from onyx.auth.schemas import UserCreate
 from onyx.auth.schemas import UserRole
+from onyx.auth.session_tokens import build_session_rejection_error
+from onyx.auth.session_tokens import build_session_token_value
+from onyx.auth.session_tokens import build_session_tombstone_value
+from onyx.auth.session_tokens import classify_session_token_value
+from onyx.auth.session_tokens import compute_session_expires_at
+from onyx.auth.session_tokens import may_be_session_token
+from onyx.auth.session_tokens import physical_session_ttl_seconds
+from onyx.auth.session_tokens import record_session_rejection
+from onyx.auth.session_tokens import SESSION_TOKEN_GRACE_PERIOD_SECONDS
+from onyx.auth.session_tokens import SessionRejection
 from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
 from onyx.configs.app_configs import AUTH_BACKEND
 from onyx.configs.app_configs import AUTH_COOKIE_EXPIRE_TIME_SECONDS
@@ -1436,6 +1445,9 @@ class TenantAwareRedisStrategy(RedisStrategy[User, uuid.UUID]):
     """
     A custom strategy that fetches the actual async Redis connection inside each method.
     We do NOT pass a synchronous or "coroutine" redis object to the constructor.
+
+    Token values embed their logical expiry and outlive it by a grace window;
+    see ``onyx/auth/session_tokens.py``.
     """
 
     def __init__(
@@ -1455,41 +1467,63 @@ class TenantAwareRedisStrategy(RedisStrategy[User, uuid.UUID]):
             async_return_default_schema,
         )(email=user.email)
 
-        token_data = {
-            "sub": str(user.id),
-            "tenant_id": tenant_id,
-        }
+        now = datetime.now(timezone.utc)
         token = secrets.token_urlsafe()
         await redis.set(
             f"{self.key_prefix}{token}",
-            json.dumps(token_data),
-            ex=self.lifetime_seconds,
+            build_session_token_value(
+                user_id=str(user.id),
+                tenant_id=tenant_id,
+                issued_at=now,
+                expires_at=compute_session_expires_at(now, self.lifetime_seconds),
+            ),
+            ex=physical_session_ttl_seconds(self.lifetime_seconds),
         )
         return token
 
     async def read_token(
         self, token: Optional[str], user_manager: BaseUserManager[User, uuid.UUID]
     ) -> Optional[User]:
+        if token is None:
+            return None
+
         redis = await get_async_redis_connection()
-        token_data_str = await redis.get(f"{self.key_prefix}{token}")
-        if not token_data_str:
+        raw_value = await redis.get(f"{self.key_prefix}{token}")
+        if raw_value is None and not may_be_session_token(token):
+            # Expected miss for API keys / PATs / JWTs on the bearer transport.
+            return None
+
+        result = classify_session_token_value(raw_value)
+        if isinstance(result, SessionRejection):
+            record_session_rejection(result)
+            return None
+        if result.sub is None:
             return None
 
         try:
-            token_data = json.loads(token_data_str)
-            user_id = token_data["sub"]
-            parsed_id = user_manager.parse_id(user_id)
+            parsed_id = user_manager.parse_id(result.sub)
             return await user_manager.get(parsed_id)
-        except (exceptions.UserNotExists, exceptions.InvalidID, KeyError):
+        except (exceptions.UserNotExists, exceptions.InvalidID):
             return None
 
-    async def destroy_token(self, token: str, user: User) -> None:  # noqa: ARG002
-        """Properly delete the token from async redis."""
+    async def destroy_token(self, token: str, user: User) -> None:
+        """
+        Overwrites the token with a tombstone so other tabs' rejections classify
+        as a sign-out rather than an anomalous drop.
+        """
         redis = await get_async_redis_connection()
-        await redis.delete(f"{self.key_prefix}{token}")
+        token_key = f"{self.key_prefix}{token}"
+        previous_raw_value = await redis.get(token_key)
+        await redis.set(
+            token_key,
+            build_session_tombstone_value(
+                previous_raw_value, fallback_user_id=str(user.id)
+            ),
+            ex=SESSION_TOKEN_GRACE_PERIOD_SECONDS,
+        )
 
     async def refresh_token(self, token: Optional[str], user: User) -> str:
-        """Refresh a token by extending its expiration time in Redis."""
+        """Refreshes a token by extending its expiration time in Redis."""
         if token is None:
             # If no token provided, create a new one
             return await self.write_token(user)
@@ -1497,18 +1531,23 @@ class TenantAwareRedisStrategy(RedisStrategy[User, uuid.UUID]):
         redis = await get_async_redis_connection()
         token_key = f"{self.key_prefix}{token}"
 
-        # Check if token exists
-        token_data_str = await redis.get(token_key)
-        if not token_data_str:
-            # Token not found, create new one
+        raw_value = await redis.get(token_key)
+        result = classify_session_token_value(raw_value)
+        if isinstance(result, SessionRejection) or result.sub is None:
+            # Only a live session is extendable; mint a fresh one otherwise.
             return await self.write_token(user)
 
-        # Token exists, extend its lifetime
-        token_data = json.loads(token_data_str)
+        # Extend the logical expiry; keep the original issue time.
+        now = datetime.now(timezone.utc)
         await redis.set(
             token_key,
-            json.dumps(token_data),
-            ex=self.lifetime_seconds,
+            build_session_token_value(
+                user_id=result.sub,
+                tenant_id=result.tenant_id,
+                issued_at=result.issued_at or now,
+                expires_at=compute_session_expires_at(now, self.lifetime_seconds),
+            ),
+            ex=physical_session_ttl_seconds(self.lifetime_seconds),
         )
 
         return token
@@ -2064,6 +2103,10 @@ async def double_check_user(
 
     if allow_anonymous_access:
         return get_anonymous_user()
+
+    session_rejection_error = build_session_rejection_error()
+    if session_rejection_error is not None:
+        raise session_rejection_error
 
     raise BasicAuthenticationError(
         detail="Access denied. User is not authenticated.",

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -15,22 +15,27 @@ class OnyxErrorCode(Enum):
     """
     Each member is a tuple of (error_code_string, http_status_code).
 
-    The error_code_string is a stable, machine-readable identifier that
-    API consumers can match on. The http_status_code is the default HTTP
-    status to return.
+    The error_code_string is a stable, machine-readable identifier that API
+    consumers can match on. The http_status_code is the default HTTP status to
+    return.
     """
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Authentication (401)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     UNAUTHENTICATED = ("UNAUTHENTICATED", 401)
     INVALID_TOKEN = ("INVALID_TOKEN", 401)
     TOKEN_EXPIRED = ("TOKEN_EXPIRED", 401)
     CSRF_FAILURE = ("CSRF_FAILURE", 403)
+    # Session rejection reasons (see onyx/auth/session_tokens.py); 403 so the
+    # web client's "403 from /me = session ended" contract holds.
+    SESSION_EXPIRED = ("SESSION_EXPIRED", 403)
+    SESSION_TERMINATED = ("SESSION_TERMINATED", 403)
+    SESSION_UNRECOGNIZED = ("SESSION_UNRECOGNIZED", 403)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Authorization (403)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     UNAUTHORIZED = ("UNAUTHORIZED", 403)
     INSUFFICIENT_PERMISSIONS = ("INSUFFICIENT_PERMISSIONS", 403)
     ADMIN_ONLY = ("ADMIN_ONLY", 403)
@@ -38,17 +43,17 @@ class OnyxErrorCode(Enum):
     SINGLE_TENANT_ONLY = ("SINGLE_TENANT_ONLY", 403)
     ENV_VAR_GATED = ("ENV_VAR_GATED", 403)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Validation / Bad Request (400)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     VALIDATION_ERROR = ("VALIDATION_ERROR", 400)
     INVALID_INPUT = ("INVALID_INPUT", 400)
     MISSING_REQUIRED_FIELD = ("MISSING_REQUIRED_FIELD", 400)
     QUERY_REJECTED = ("QUERY_REJECTED", 400)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Not Found (404)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     NOT_FOUND = ("NOT_FOUND", 404)
     CONNECTOR_NOT_FOUND = ("CONNECTOR_NOT_FOUND", 404)
     CREDENTIAL_NOT_FOUND = ("CREDENTIAL_NOT_FOUND", 404)
@@ -57,36 +62,36 @@ class OnyxErrorCode(Enum):
     SESSION_NOT_FOUND = ("SESSION_NOT_FOUND", 404)
     USER_NOT_FOUND = ("USER_NOT_FOUND", 404)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Conflict (409)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     CONFLICT = ("CONFLICT", 409)
     DUPLICATE_RESOURCE = ("DUPLICATE_RESOURCE", 409)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Rate Limiting / Quotas (429 / 402)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     RATE_LIMITED = ("RATE_LIMITED", 429)
     SEAT_LIMIT_EXCEEDED = ("SEAT_LIMIT_EXCEEDED", 402)
     TRIAL_INVITE_LIMIT_EXCEEDED = ("TRIAL_INVITE_LIMIT_EXCEEDED", 403)
     FEATURE_NOT_AVAILABLE = ("FEATURE_NOT_AVAILABLE", 402)
     SUBSCRIPTION_INACTIVE = ("SUBSCRIPTION_INACTIVE", 402)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Payload (413)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     PAYLOAD_TOO_LARGE = ("PAYLOAD_TOO_LARGE", 413)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Connector / Credential Errors (400-range)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     CONNECTOR_VALIDATION_FAILED = ("CONNECTOR_VALIDATION_FAILED", 400)
     CREDENTIAL_INVALID = ("CREDENTIAL_INVALID", 400)
     CREDENTIAL_EXPIRED = ("CREDENTIAL_EXPIRED", 401)
 
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     # Server Errors (5xx)
-    # ------------------------------------------------------------------
+    # --------------------------------------------------------------------------
     INTERNAL_ERROR = ("INTERNAL_ERROR", 500)
     NOT_IMPLEMENTED = ("NOT_IMPLEMENTED", 501)
     SERVICE_UNAVAILABLE = ("SERVICE_UNAVAILABLE", 503)

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -919,6 +919,13 @@ def get_current_auth_token_expiry_redis(
             )
             return None
 
+        if result.issued_at is None:
+            # Pre-upgrade value: its physical TTL is its logical expiry.
+            ttl = cast(int, redis.ttl(REDIS_AUTH_KEY_PREFIX + token))
+            if ttl <= 0:
+                return None
+            return datetime.now(timezone.utc) + timedelta(seconds=ttl)
+
         return result.expires_at
 
     except Exception as e:

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -898,7 +898,9 @@ def get_current_auth_token_expiry_redis(
     """
     Reads the logical expiry embedded in the Redis token value; the physical TTL
     outlives it by the grace window, so TTL back-calculation would overstate the
-    remaining session time.
+    remaining session time. Pre-upgrade values are the exception: written
+    without the grace window, their TTL is the exact logical expiry, so it is
+    used directly.
     """
     # Anonymous users don't have auth tokens.
     if user.is_anonymous:

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -30,6 +30,9 @@ from onyx.auth.invited_users import write_invited_users
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
+from onyx.auth.session_tokens import build_session_rejection_error
+from onyx.auth.session_tokens import classify_session_token_value
+from onyx.auth.session_tokens import SessionRejection
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.auth.users import enforce_seat_limit_locked
@@ -889,43 +892,34 @@ async def get_user_role(
     return UserRoleResponse(role=user.role)
 
 
-def get_current_auth_token_creation_redis(
+def get_current_auth_token_expiry_redis(
     user: User, request: Request
 ) -> datetime | None:
-    """Calculate the token creation time from Redis TTL information.
-
-    This function retrieves the authentication token from cookies,
-    checks its TTL in Redis, and calculates when the token was created.
-    Despite the function name, it returns the token creation time, not the expiration time.
     """
-    # Anonymous users don't have auth tokens
+    Reads the logical expiry embedded in the Redis token value; the physical TTL
+    outlives it by the grace window, so TTL back-calculation would overstate the
+    remaining session time.
+    """
+    # Anonymous users don't have auth tokens.
     if user.is_anonymous:
         return None
     try:
-        # Get the token from the request
         token = request.cookies.get(FASTAPI_USERS_AUTH_COOKIE_NAME)
         if not token:
             logger.debug("No auth token cookie found")
             return None
 
-        # Get the Redis client
         redis = get_raw_redis_client()
-        redis_key = REDIS_AUTH_KEY_PREFIX + token
-
-        # Get the TTL of the token
-        ttl = cast(int, redis.ttl(redis_key))
-        if ttl <= 0:
-            logger.error("Token has expired or doesn't exist in Redis")
+        raw_value = redis.get(REDIS_AUTH_KEY_PREFIX + token)
+        result = classify_session_token_value(cast(str | bytes | None, raw_value))
+        if isinstance(result, SessionRejection):
+            logger.error(
+                "Token of authenticated request is not live in Redis: %s",
+                result.reason.value,
+            )
             return None
 
-        # Calculate the creation time based on TTL and session expiry
-        # Current time minus (total session length minus remaining TTL)
-        current_time = datetime.now(timezone.utc)
-        token_creation_time = current_time - timedelta(
-            seconds=(SESSION_EXPIRE_TIME_SECONDS - ttl)
-        )
-
-        return token_creation_time
+        return result.expires_at
 
     except Exception as e:
         logger.error("Error retrieving token expiration from Redis: %s", e)
@@ -972,14 +966,19 @@ def get_current_token_creation_jwt(user: User, request: Request) -> datetime | N
         return None
 
 
-def _get_token_created_at(
+def _get_token_expires_at(
     user: User, request: Request, db_session: Session
 ) -> datetime | None:
     if AUTH_BACKEND == AuthBackend.REDIS:
-        return get_current_auth_token_creation_redis(user, request)
+        return get_current_auth_token_expiry_redis(user, request)
+
     if AUTH_BACKEND == AuthBackend.JWT:
-        return get_current_token_creation_jwt(user, request)
-    return get_current_token_creation_postgres(user, db_session)
+        token_created_at = get_current_token_creation_jwt(user, request)
+    else:
+        token_created_at = get_current_token_creation_postgres(user, db_session)
+    if token_created_at is None:
+        return None
+    return token_created_at + timedelta(seconds=SESSION_EXPIRE_TIME_SECONDS)
 
 
 @router.get("/me/permissions", tags=PUBLIC_API_TAGS)
@@ -1004,6 +1003,9 @@ def verify_user_logged_in(
         if anonymous_user_enabled(tenant_id=tenant_id):
             store = get_kv_store()
             return fetch_anonymous_user_info(store)
+        session_rejection_error = build_session_rejection_error()
+        if session_rejection_error is not None:
+            raise session_rejection_error
         raise BasicAuthenticationError(detail="Unauthorized")
 
     if user.oidc_expiry and user.oidc_expiry < datetime.now(timezone.utc):
@@ -1011,13 +1013,7 @@ def verify_user_logged_in(
             detail="Access denied. User's OIDC token has expired.",
         )
 
-    token_created_at = _get_token_created_at(user, request, db_session)
-
-    token_expires_at: datetime | None = None
-    if token_created_at is not None:
-        token_expires_at = token_created_at + timedelta(
-            seconds=SESSION_EXPIRE_TIME_SECONDS
-        )
+    token_expires_at = _get_token_expires_at(user, request, db_session)
     track_oidc = get_security_settings().track_external_idp_expiry
     # When OIDC tracking is enabled, cap expiry at the IdP token's lifetime.
     # Guard against stale oidc_expiry from a previous OIDC session (same comment

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -910,7 +910,8 @@ def get_current_auth_token_expiry_redis(
             return None
 
         redis = get_raw_redis_client()
-        raw_value = redis.get(REDIS_AUTH_KEY_PREFIX + token)
+        redis_key = REDIS_AUTH_KEY_PREFIX + token
+        raw_value = redis.get(redis_key)
         result = classify_session_token_value(cast(str | bytes | None, raw_value))
         if isinstance(result, SessionRejection):
             logger.error(
@@ -921,7 +922,7 @@ def get_current_auth_token_expiry_redis(
 
         if result.issued_at is None:
             # Pre-upgrade value: its physical TTL is its logical expiry.
-            ttl = cast(int, redis.ttl(REDIS_AUTH_KEY_PREFIX + token))
+            ttl = cast(int, redis.ttl(redis_key))
             if ttl <= 0:
                 return None
             return datetime.now(timezone.utc) + timedelta(seconds=ttl)

--- a/backend/tests/external_dependency_unit/auth/conftest.py
+++ b/backend/tests/external_dependency_unit/auth/conftest.py
@@ -1,0 +1,17 @@
+from collections.abc import Generator
+
+import pytest
+
+import onyx.db.engine.async_sql_engine as async_sql_engine
+
+
+@pytest.fixture(autouse=True)
+def null_pool_async_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> Generator[None, None, None]:
+    # Pooled asyncpg connections bind to the creating loop; NullPool keeps the
+    # engine usable across pytest-asyncio's per-test loops.
+    monkeypatch.setattr(async_sql_engine, "POSTGRES_USE_NULL_POOL", True)
+    async_sql_engine._ASYNC_ENGINE = None
+    yield
+    async_sql_engine._ASYNC_ENGINE = None

--- a/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
+++ b/backend/tests/external_dependency_unit/auth/test_oidc_multi_live_idp.py
@@ -27,7 +27,6 @@ from httpx import ASGITransport
 from httpx import AsyncClient
 from sqlalchemy.orm import Session
 
-import onyx.db.engine.async_sql_engine as async_sql_engine
 from onyx.auth.users import cookie_transport
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
@@ -79,20 +78,6 @@ def require_mock_oidc() -> None:
     # never makes a network call.
     if not _mock_reachable():
         pytest.skip("requires navikt/mock-oauth2-server (MOCK_OIDC_URL)")
-
-
-@pytest.fixture(autouse=True)
-def null_pool_async_engine(
-    monkeypatch: pytest.MonkeyPatch,
-) -> Generator[None, None, None]:
-    # A pooled asyncpg connection is bound to the loop that created it, so the
-    # process async engine cannot be reused across the per-test event loops that
-    # pytest-asyncio creates. NullPool gives each request a fresh connection in
-    # the current loop, and rebuilding drops any engine bound to a dead loop.
-    monkeypatch.setattr(async_sql_engine, "POSTGRES_USE_NULL_POOL", True)
-    async_sql_engine._ASYNC_ENGINE = None
-    yield
-    async_sql_engine._ASYNC_ENGINE = None
 
 
 def _config_url(issuer: str) -> str:

--- a/backend/tests/external_dependency_unit/auth/test_session_rejection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_session_rejection_contract.py
@@ -1,0 +1,81 @@
+"""
+The strategy's classification must survive the fastapi-users plumbing (which
+collapses invalid tokens to None) and land as an error_code in the /me 403 body.
+The classification matrix lives in test_session_token_strategy.py.
+"""
+
+import json
+import secrets
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport
+from httpx import AsyncClient
+from sqlalchemy.orm import Session
+
+from onyx.auth.users import TenantAwareRedisStrategy
+from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
+from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.redis.redis_pool import get_raw_redis_client
+from onyx.server.manage.users import router as user_router
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(user_router)
+    register_onyx_exception_handlers(fastapi_app)
+    return fastapi_app
+
+
+def _client(app: FastAPI, token: str) -> AsyncClient:
+    client = AsyncClient(transport=ASGITransport(app=app), base_url="http://testserver")
+    client.cookies.set(FASTAPI_USERS_AUTH_COOKIE_NAME, token)
+    return client
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_expired_session_yields_403_with_expired_code(
+    app: FastAPI, db_session: Session
+) -> None:
+    user = create_test_user(db_session, "session_contract_expired")
+    strategy = TenantAwareRedisStrategy()
+    token = await strategy.write_token(user)
+    redis = get_raw_redis_client()
+    redis_key = REDIS_AUTH_KEY_PREFIX + token
+    try:
+        # Push the logical expiry into the past; the physical key stays put.
+        raw_value = cast(bytes | None, redis.get(redis_key))
+        assert raw_value is not None
+        data = json.loads(raw_value)
+        data["expires_at"] = (
+            datetime.now(timezone.utc) - timedelta(minutes=5)
+        ).isoformat()
+        redis.set(redis_key, json.dumps(data), keepttl=True)
+
+        async with _client(app, token) as client:
+            response = await client.get("/me")
+
+        assert response.status_code == 403
+        assert response.json()["error_code"] == "SESSION_EXPIRED"
+    finally:
+        redis.delete(redis_key)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context", "db_session")
+async def test_absent_session_yields_403_with_unrecognized_code(
+    app: FastAPI,
+) -> None:
+    async with _client(app, secrets.token_urlsafe()) as client:
+        response = await client.get("/me")
+
+    assert response.status_code == 403
+    assert response.json()["error_code"] == "SESSION_UNRECOGNIZED"

--- a/backend/tests/external_dependency_unit/auth/test_session_rejection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_session_rejection_contract.py
@@ -45,6 +45,7 @@ def _client(app: FastAPI, token: str) -> AsyncClient:
 async def test_expired_session_yields_403_with_expired_code(
     app: FastAPI, db_session: Session
 ) -> None:
+    # Precondition.
     user = create_test_user(db_session, "session_contract_expired")
     strategy = TenantAwareRedisStrategy()
     token = await strategy.write_token(user)
@@ -60,9 +61,11 @@ async def test_expired_session_yields_403_with_expired_code(
         ).isoformat()
         redis.set(redis_key, json.dumps(data), keepttl=True)
 
+        # Under test.
         async with _client(app, token) as client:
             response = await client.get("/me")
 
+        # Postcondition.
         assert response.status_code == 403
         assert response.json()["error_code"] == "SESSION_EXPIRED"
     finally:

--- a/backend/tests/external_dependency_unit/auth/test_session_token_strategy.py
+++ b/backend/tests/external_dependency_unit/auth/test_session_token_strategy.py
@@ -1,0 +1,249 @@
+"""
+Redis session-token tests: embedded expiry, grace TTL, tombstones, and rejection
+classification. Real Redis + Postgres, strategy called directly. The
+request-level 403 contract lives in test_session_rejection_contract.py.
+"""
+
+import contextvars
+import json
+import secrets
+from datetime import datetime
+from datetime import timedelta
+from datetime import timezone
+from typing import cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.auth.session_tokens import get_session_rejection
+from onyx.auth.session_tokens import record_session_rejection
+from onyx.auth.session_tokens import SESSION_TOKEN_GRACE_PERIOD_SECONDS
+from onyx.auth.session_tokens import SessionRejection
+from onyx.auth.session_tokens import SessionRejectionReason
+from onyx.auth.session_tokens import SessionTokenValue
+from onyx.auth.users import TenantAwareRedisStrategy
+from onyx.auth.users import UserManager
+from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
+from onyx.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
+from onyx.db.auth import SQLAlchemyUserAdminDB
+from onyx.db.engine.async_sql_engine import get_async_session_context_manager
+from onyx.db.models import OAuthAccount
+from onyx.db.models import User
+from onyx.redis.redis_pool import get_raw_redis_client
+from tests.external_dependency_unit.conftest import create_test_user
+
+# Covers the delay between the strategy's SET and the test's TTL read.
+_TTL_SLACK_SECONDS = 60
+
+
+async def _read_token(strategy: TenantAwareRedisStrategy, token: str) -> User | None:
+    async with get_async_session_context_manager() as async_session:
+        user_db = SQLAlchemyUserAdminDB(async_session, User, OAuthAccount)
+        return await strategy.read_token(token, UserManager(user_db))
+
+
+def _redis_key(token: str) -> str:
+    return REDIS_AUTH_KEY_PREFIX + token
+
+
+def _get_raw_value(token: str) -> bytes | None:
+    return cast(bytes | None, get_raw_redis_client().get(_redis_key(token)))
+
+
+def _delete_key(token: str) -> None:
+    get_raw_redis_client().delete(_redis_key(token))
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_write_read_round_trip(db_session: Session) -> None:
+    user = create_test_user(db_session, "session_round_trip")
+    strategy = TenantAwareRedisStrategy()
+    token = await strategy.write_token(user)
+    try:
+        raw_value = _get_raw_value(token)
+        assert raw_value is not None
+        value = SessionTokenValue.model_validate_json(raw_value)
+        assert value.sub == str(user.id)
+        assert value.issued_at is not None
+        assert value.expires_at is not None
+        assert value.logged_out_at is None
+
+        expected_expiry = value.issued_at + timedelta(
+            seconds=SESSION_EXPIRE_TIME_SECONDS
+        )
+        assert value.expires_at == expected_expiry
+
+        # The physical TTL outlives the logical expiry by the grace window.
+        ttl = get_raw_redis_client().ttl(_redis_key(token))
+        assert isinstance(ttl, int)
+        nominal_ttl = SESSION_EXPIRE_TIME_SECONDS + SESSION_TOKEN_GRACE_PERIOD_SECONDS
+        assert nominal_ttl - _TTL_SLACK_SECONDS <= ttl <= nominal_ttl
+
+        read_user = await _read_token(strategy, token)
+        assert read_user is not None
+        assert read_user.id == user.id
+        assert get_session_rejection() is None
+    finally:
+        _delete_key(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_logical_expiry_enforced_while_key_present(db_session: Session) -> None:
+    user = create_test_user(db_session, "session_expired")
+    strategy = TenantAwareRedisStrategy()
+    token = await strategy.write_token(user)
+    try:
+        # push the logical expiry into the past; the physical key stays put
+        raw_value = _get_raw_value(token)
+        assert raw_value is not None
+        data = json.loads(raw_value)
+        data["expires_at"] = (
+            datetime.now(timezone.utc) - timedelta(minutes=5)
+        ).isoformat()
+        redis = get_raw_redis_client()
+        redis.set(_redis_key(token), json.dumps(data), keepttl=True)
+
+        read_user = await _read_token(strategy, token)
+        assert read_user is None
+
+        rejection = get_session_rejection()
+        assert rejection is not None
+        assert rejection.reason == SessionRejectionReason.EXPIRED
+        assert rejection.token_value is not None
+        assert rejection.token_value.sub == str(user.id)
+
+        assert redis.exists(_redis_key(token)) == 1
+    finally:
+        _delete_key(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_destroy_token_writes_tombstone(db_session: Session) -> None:
+    user = create_test_user(db_session, "session_tombstone")
+    strategy = TenantAwareRedisStrategy()
+    token = await strategy.write_token(user)
+    try:
+        await strategy.destroy_token(token, user)
+
+        raw_value = _get_raw_value(token)
+        assert raw_value is not None
+        value = SessionTokenValue.model_validate_json(raw_value)
+        assert value.logged_out_at is not None
+        # original fields carry over into the tombstone
+        assert value.sub == str(user.id)
+        assert value.issued_at is not None
+
+        ttl = get_raw_redis_client().ttl(_redis_key(token))
+        assert isinstance(ttl, int)
+        assert (
+            SESSION_TOKEN_GRACE_PERIOD_SECONDS - _TTL_SLACK_SECONDS
+            <= ttl
+            <= SESSION_TOKEN_GRACE_PERIOD_SECONDS
+        )
+
+        read_user = await _read_token(strategy, token)
+        assert read_user is None
+
+        rejection = get_session_rejection()
+        assert rejection is not None
+        assert rejection.reason == SessionRejectionReason.TERMINATED
+    finally:
+        _delete_key(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_absent_token_classified_not_found() -> None:
+    strategy = TenantAwareRedisStrategy()
+    read_user = await _read_token(strategy, secrets.token_urlsafe())
+    assert read_user is None
+
+    rejection = get_session_rejection()
+    assert rejection is not None
+    assert rejection.reason == SessionRejectionReason.NOT_FOUND
+    assert rejection.token_value is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_legacy_value_rejected(db_session: Session) -> None:
+    # pre-upgrade values have no embedded expiry and are signed out once
+    user = create_test_user(db_session, "session_legacy")
+    strategy = TenantAwareRedisStrategy()
+    token = secrets.token_urlsafe()
+    get_raw_redis_client().set(
+        _redis_key(token),
+        json.dumps({"sub": str(user.id), "tenant_id": "public"}),
+        ex=SESSION_EXPIRE_TIME_SECONDS,
+    )
+    try:
+        read_user = await _read_token(strategy, token)
+        assert read_user is None
+
+        rejection = get_session_rejection()
+        assert rejection is not None
+        assert rejection.reason == SessionRejectionReason.LEGACY
+    finally:
+        _delete_key(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_api_key_shaped_token_miss_not_classified() -> None:
+    # bearer-transport credentials that miss in Redis must not classify
+    strategy = TenantAwareRedisStrategy()
+    for credential in (
+        f"on_{secrets.token_urlsafe()}",
+        f"onyx_pat_{secrets.token_urlsafe()}",
+        "header.payload.signature",
+    ):
+        read_user = await _read_token(strategy, credential)
+        assert read_user is None
+    assert get_session_rejection() is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_refresh_extends_expiry_and_preserves_issue_time(
+    db_session: Session,
+) -> None:
+    user = create_test_user(db_session, "session_refresh")
+    strategy = TenantAwareRedisStrategy()
+    token = await strategy.write_token(user)
+    try:
+        raw_value = _get_raw_value(token)
+        assert raw_value is not None
+        original = SessionTokenValue.model_validate_json(raw_value)
+        assert original.issued_at is not None
+        assert original.expires_at is not None
+
+        refreshed_token = await strategy.refresh_token(token, user)
+        assert refreshed_token == token
+
+        raw_value = _get_raw_value(token)
+        assert raw_value is not None
+        refreshed = SessionTokenValue.model_validate_json(raw_value)
+        assert refreshed.issued_at == original.issued_at
+        assert refreshed.expires_at is not None
+        assert refreshed.expires_at > original.expires_at
+    finally:
+        _delete_key(token)
+
+
+def test_not_found_never_overwrites_stored_value_rejection() -> None:
+    def scenario() -> None:
+        stored_value_rejection = SessionRejection(
+            reason=SessionRejectionReason.EXPIRED,
+            token_value=SessionTokenValue(sub="some-user"),
+        )
+        record_session_rejection(stored_value_rejection)
+        record_session_rejection(
+            SessionRejection(reason=SessionRejectionReason.NOT_FOUND, token_value=None)
+        )
+        assert get_session_rejection() == stored_value_rejection
+
+    # copy_context so this sync test doesn't leak the var into later tests
+    contextvars.copy_context().run(scenario)

--- a/backend/tests/external_dependency_unit/auth/test_session_token_strategy.py
+++ b/backend/tests/external_dependency_unit/auth/test_session_token_strategy.py
@@ -13,6 +13,7 @@ from datetime import timezone
 from typing import cast
 
 import pytest
+from fastapi import Request
 from sqlalchemy.orm import Session
 
 from onyx.auth.session_tokens import get_session_rejection
@@ -25,11 +26,13 @@ from onyx.auth.users import TenantAwareRedisStrategy
 from onyx.auth.users import UserManager
 from onyx.configs.app_configs import REDIS_AUTH_KEY_PREFIX
 from onyx.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
+from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.db.auth import SQLAlchemyUserAdminDB
 from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 from onyx.db.models import OAuthAccount
 from onyx.db.models import User
 from onyx.redis.redis_pool import get_raw_redis_client
+from onyx.server.manage.users import get_current_auth_token_expiry_redis
 from tests.external_dependency_unit.conftest import create_test_user
 
 # Covers the delay between the strategy's SET and the test's TTL read.
@@ -57,11 +60,16 @@ def _delete_key(token: str) -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("tenant_context")
 async def test_write_read_round_trip(db_session: Session) -> None:
+    # Precondition.
     user = create_test_user(db_session, "session_round_trip")
     strategy = TenantAwareRedisStrategy()
+
+    # Under test.
     token = await strategy.write_token(user)
     try:
         raw_value = _get_raw_value(token)
+
+        # Postcondition.
         assert raw_value is not None
         value = SessionTokenValue.model_validate_json(raw_value)
         assert value.sub == str(user.id)
@@ -91,11 +99,12 @@ async def test_write_read_round_trip(db_session: Session) -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("tenant_context")
 async def test_logical_expiry_enforced_while_key_present(db_session: Session) -> None:
+    # Precondition.
     user = create_test_user(db_session, "session_expired")
     strategy = TenantAwareRedisStrategy()
     token = await strategy.write_token(user)
     try:
-        # push the logical expiry into the past; the physical key stays put
+        # Push the logical expiry into the past; the physical key stays put.
         raw_value = _get_raw_value(token)
         assert raw_value is not None
         data = json.loads(raw_value)
@@ -105,7 +114,10 @@ async def test_logical_expiry_enforced_while_key_present(db_session: Session) ->
         redis = get_raw_redis_client()
         redis.set(_redis_key(token), json.dumps(data), keepttl=True)
 
+        # Under test.
         read_user = await _read_token(strategy, token)
+
+        # Postcondition.
         assert read_user is None
 
         rejection = get_session_rejection()
@@ -122,17 +134,20 @@ async def test_logical_expiry_enforced_while_key_present(db_session: Session) ->
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("tenant_context")
 async def test_destroy_token_writes_tombstone(db_session: Session) -> None:
+    # Precondition.
     user = create_test_user(db_session, "session_tombstone")
     strategy = TenantAwareRedisStrategy()
     token = await strategy.write_token(user)
     try:
+        # Under test.
         await strategy.destroy_token(token, user)
 
+        # Postcondition.
         raw_value = _get_raw_value(token)
         assert raw_value is not None
         value = SessionTokenValue.model_validate_json(raw_value)
         assert value.logged_out_at is not None
-        # original fields carry over into the tombstone
+        # Original fields carry over into the tombstone.
         assert value.sub == str(user.id)
         assert value.issued_at is not None
 
@@ -169,8 +184,9 @@ async def test_absent_token_classified_not_found() -> None:
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("tenant_context")
-async def test_legacy_value_rejected(db_session: Session) -> None:
-    # pre-upgrade values have no embedded expiry and are signed out once
+async def test_legacy_value_accepted(db_session: Session) -> None:
+    # Precondition.
+    # Pre-upgrade values stay valid on key existence; deploy signs nobody out.
     user = create_test_user(db_session, "session_legacy")
     strategy = TenantAwareRedisStrategy()
     token = secrets.token_urlsafe()
@@ -180,12 +196,70 @@ async def test_legacy_value_rejected(db_session: Session) -> None:
         ex=SESSION_EXPIRE_TIME_SECONDS,
     )
     try:
+        # Under test.
         read_user = await _read_token(strategy, token)
+
+        # Postcondition.
+        assert read_user is not None
+        assert read_user.id == user.id
+        assert get_session_rejection() is None
+
+        # The read path never rewrites: the stored value keeps its legacy shape.
+        raw_value = _get_raw_value(token)
+        assert raw_value is not None
+        assert SessionTokenValue.model_validate_json(raw_value).issued_at is None
+    finally:
+        _delete_key(token)
+
+
+def test_legacy_expiry_reported_from_ttl(db_session: Session) -> None:
+    # Precondition.
+    # /me's expiry for a legacy value comes from the physical TTL.
+    user = create_test_user(db_session, "session_legacy_expiry")
+    token = secrets.token_urlsafe()
+    remaining_seconds = 1234
+    get_raw_redis_client().set(
+        _redis_key(token),
+        json.dumps({"sub": str(user.id), "tenant_id": "public"}),
+        ex=remaining_seconds,
+    )
+    request = Request(
+        scope={
+            "type": "http",
+            "headers": [
+                (b"cookie", f"{FASTAPI_USERS_AUTH_COOKIE_NAME}={token}".encode())
+            ],
+        }
+    )
+    try:
+        # Under test.
+        expires_at = get_current_auth_token_expiry_redis(user, request)
+
+        # Postcondition.
+        assert expires_at is not None
+        expected = datetime.now(timezone.utc) + timedelta(seconds=remaining_seconds)
+        assert abs((expires_at - expected).total_seconds()) < _TTL_SLACK_SECONDS
+    finally:
+        _delete_key(token)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("tenant_context")
+async def test_unparseable_value_rejected() -> None:
+    # Precondition.
+    strategy = TenantAwareRedisStrategy()
+    token = secrets.token_urlsafe()
+    get_raw_redis_client().set(_redis_key(token), "not-json", ex=60)
+    try:
+        # Under test.
+        read_user = await _read_token(strategy, token)
+
+        # Postcondition.
         assert read_user is None
 
         rejection = get_session_rejection()
         assert rejection is not None
-        assert rejection.reason == SessionRejectionReason.LEGACY
+        assert rejection.reason == SessionRejectionReason.MALFORMED
     finally:
         _delete_key(token)
 
@@ -193,6 +267,7 @@ async def test_legacy_value_rejected(db_session: Session) -> None:
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("tenant_context")
 async def test_api_key_shaped_token_miss_not_classified() -> None:
+    # Precondition.
     # bearer-transport credentials that miss in Redis must not classify
     strategy = TenantAwareRedisStrategy()
     for credential in (
@@ -200,7 +275,10 @@ async def test_api_key_shaped_token_miss_not_classified() -> None:
         f"onyx_pat_{secrets.token_urlsafe()}",
         "header.payload.signature",
     ):
+        # Under test.
         read_user = await _read_token(strategy, credential)
+
+        # Postcondition.
         assert read_user is None
     assert get_session_rejection() is None
 
@@ -210,6 +288,7 @@ async def test_api_key_shaped_token_miss_not_classified() -> None:
 async def test_refresh_extends_expiry_and_preserves_issue_time(
     db_session: Session,
 ) -> None:
+    # Precondition.
     user = create_test_user(db_session, "session_refresh")
     strategy = TenantAwareRedisStrategy()
     token = await strategy.write_token(user)
@@ -220,7 +299,10 @@ async def test_refresh_extends_expiry_and_preserves_issue_time(
         assert original.issued_at is not None
         assert original.expires_at is not None
 
+        # Under test.
         refreshed_token = await strategy.refresh_token(token, user)
+
+        # Postcondition.
         assert refreshed_token == token
 
         raw_value = _get_raw_value(token)

--- a/backend/tests/external_dependency_unit/auth/test_session_token_strategy.py
+++ b/backend/tests/external_dependency_unit/auth/test_session_token_strategy.py
@@ -315,17 +315,30 @@ async def test_refresh_extends_expiry_and_preserves_issue_time(
         _delete_key(token)
 
 
-def test_not_found_never_overwrites_stored_value_rejection() -> None:
+def test_first_stored_value_rejection_wins() -> None:
     def scenario() -> None:
-        stored_value_rejection = SessionRejection(
+        not_found = SessionRejection(
+            reason=SessionRejectionReason.NOT_FOUND, token_value=None
+        )
+        expired = SessionRejection(
             reason=SessionRejectionReason.EXPIRED,
             token_value=SessionTokenValue(sub="some-user"),
         )
-        record_session_rejection(stored_value_rejection)
-        record_session_rejection(
-            SessionRejection(reason=SessionRejectionReason.NOT_FOUND, token_value=None)
+        terminated = SessionRejection(
+            reason=SessionRejectionReason.TERMINATED,
+            token_value=SessionTokenValue(sub="some-user"),
         )
-        assert get_session_rejection() == stored_value_rejection
+
+        # A stored-value-backed rejection replaces a bare miss.
+        record_session_rejection(not_found)
+        record_session_rejection(expired)
+        assert get_session_rejection() == expired
+
+        # But nothing replaces it: not a later strong rejection, not a miss.
+        record_session_rejection(terminated)
+        assert get_session_rejection() == expired
+        record_session_rejection(not_found)
+        assert get_session_rejection() == expired
 
     # copy_context so this sync test doesn't leak the var into later tests
     contextvars.copy_context().run(scenario)

--- a/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
+++ b/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
@@ -143,7 +143,7 @@ def test_me_service_account_skips_tenant_mapping_lookup() -> None:
             "onyx.server.manage.users.get_security_settings",
             return_value=_settings(user_directory_admin_only=False),
         ),
-        patch("onyx.server.manage.users._get_token_created_at", return_value=None),
+        patch("onyx.server.manage.users._get_token_expires_at", return_value=None),
         patch("onyx.server.manage.users.UserInfo") as mock_user_info,
     ):
         verify_user_logged_in(request=MagicMock(), user=user, db_session=MagicMock())


### PR DESCRIPTION
## Description

**Problem:** When a session ends, neither we nor the user knows why. Redis TTL expiry is silent, so a genuine expiry is indistinguishable from Redis dropping entries (restart without persistence, eviction, flush); auth rejections log at debug level only; and the client gets the same generic 403 for every cause.

**This PR:** Session-token values now embed `issued_at`/`expires_at`. The physical Redis TTL is the logical lifetime plus a grace window (1hr), and logout overwrites the value with a tombstone instead of deleting it, so a rejected token stays classifiable: expired (embedded expiry passed), terminated (tombstone), or unrecognized (no entry: cookie outlived the grace window, or Redis dropped the key). Because `read_token` must return `None` for any invalid token (API keys/PATs/JWTs share the bearer transport and legitimately miss in Redis), the classification rides a request-scoped `ContextVar` and is raised as a reasoned `OnyxError` only where authentication conclusively fails (`double_check_user`, `/me`): the 403 body carries `SESSION_EXPIRED` / `SESSION_TERMINATED` / `SESSION_UNRECOGNIZED`, and the rejection logs at WARNING with reason, token age, and user.

Pre-upgrade values (no embedded expiry) remain valid on bare key existence, so deploying this signs nobody out.

A follow-up PR will update the logged-out modal copy based on these codes.

## How Has This Been Tested?

- [x] External-dependency-unit classification matrix against real Redis/Postgres: write/read round trip, logical expiry enforced while the key exists, tombstone on logout, absent key, legacy value accepted without rewrite, malformed value rejected, refresh extends expiry, rejection priority.
- [x] Request-level `/me` contract: expired session -> 403 `SESSION_EXPIRED`, absent session -> 403 `SESSION_UNRECOGNIZED`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Redis-backed session token with embedded expiry and a 1-hour grace TTL, so session endings are explainable; logout writes a tombstone instead of deleting. `/me` and auth checks return precise 403 codes for expired, terminated, or unrecognized sessions; API keys, PATs, and JWTs are not misclassified.

- **New Features**
  - Token value stores sub, tenant_id, issued_at, expires_at; physical TTL = logical TTL + 1h; logout overwrites with a tombstone so other tabs see a sign-out.
  - Rejections classify as EXPIRED, TERMINATED, NOT_FOUND, MALFORMED; they map to 403 codes: SESSION_EXPIRED, SESSION_TERMINATED, SESSION_UNRECOGNIZED; warnings include user and token age; a stored-value-backed rejection replaces a bare miss.
  - Legacy values (no issued_at/expires_at) remain valid on key existence; `/me` reads embedded `expires_at`, or falls back to Redis TTL for legacy keys.

- **Refactors**
  - Read path parses the value and records rejections via a request-scoped ContextVar; `double_check_user` and `/me` raise a reasoned `OnyxError`. Refresh extends logical expiry while preserving `issued_at`; logout tombstones use the grace TTL; API keys/PATs/JWTs skip classification.
  - Added tests for token format, grace TTL, tombstones, classification (including replacement rules), and the `/me` 403 contract; standardized async engine `NullPool` fixture.

<sup>Written for commit e71552c55b2cf1ac98909dc114fd5967de029b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


