### PR TITLE
feat(open_url): Sharepoint urls read indexed document

### DIFF
--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -4,8 +4,12 @@ from collections.abc import Iterator
 from types import TracebackType
 from typing import Any
 from typing import Generic
+from typing import TYPE_CHECKING
 from typing import TypeAlias
 from typing import TypeVar
+
+if TYPE_CHECKING:
+    from sqlalchemy.orm import Session
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -111,9 +115,28 @@ class BaseConnector(abc.ABC, Generic[CT]):
         """Normalize a URL to match the canonical Document.id format used during ingestion.
 
         Connectors that use URLs as document IDs should override this method.
-        Returns NormalizationResult with use_default=True if not implemented.
+        Must be a pure function of the URL — no I/O; index-dependent resolution
+        belongs in resolve_url_candidates. Returns NormalizationResult with
+        use_default=True if not implemented.
         """
         return NormalizationResult(normalized_url=None, use_default=True)
+
+    @classmethod
+    def resolve_url_candidates(
+        cls,
+        url: str,  # noqa: ARG003
+        db_session: "Session",  # noqa: ARG003
+    ) -> list[str]:
+        """Resolve a URL to candidate Document.ids using deployment state.
+
+        Override for connectors whose Document.ids can't be computed from the
+        URL alone (e.g. SharePoint's Graph ids, which embed a per-drive hash
+        that appears in no URL) and require lookups through the caller's
+        session. Candidates may be speculative — the caller keeps only ids
+        that exist in the index. Keep implementations cheap: this runs once
+        per pasted URL in the chat flow.
+        """
+        return []
 
     def build_dummy_checkpoint(self) -> CT:
         return ConnectorCheckpoint(has_more=True)  # ty: ignore[invalid-return-type]

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -53,6 +53,7 @@ from onyx.connectors.interfaces import CheckpointedConnectorWithPermSync
 from onyx.connectors.interfaces import CheckpointOutput
 from onyx.connectors.interfaces import GenerateSlimDocumentOutput
 from onyx.connectors.interfaces import IndexingHeartbeatInterface
+from onyx.connectors.interfaces import NormalizationResult
 from onyx.connectors.interfaces import Resolver
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.interfaces import SlimConnector
@@ -72,6 +73,11 @@ from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
 from onyx.connectors.sharepoint.connector_utils import get_sharepoint_external_access
+from onyx.connectors.sharepoint.url_utils import extract_sharepoint_document_guid
+from onyx.connectors.sharepoint.url_utils import sharepoint_page_url_variants
+from onyx.db.document import fetch_document_id_by_link_substring
+from onyx.db.document import fetch_document_ids_by_links
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import HierarchyNodeType
 from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
@@ -1273,6 +1279,47 @@ class SharepointConnector(
                 raise ConnectorValidationError(
                     f"Invalid site URL '{site_url}': {e}"
                 ) from e
+
+    @classmethod
+    @override
+    def normalize_url(cls, url: str) -> NormalizationResult:
+        """Resolve a pasted SharePoint URL to the indexed Document.id.
+
+        Unlike connectors whose ids are computable from the URL (Google Drive,
+        Notion, Slack), Document.ids here are Graph ids that appear in no URL
+        form: drive items use "01" + base32 of a drive-scoped hash plus the
+        file's unique-ID GUID; site pages use a bare page GUID. The stored
+        Document.link does identify the document — for files it contains the
+        unique-ID GUID (`sourcedoc=%7B<GUID>%7D`) that Doc.aspx URLs and
+        `/:w:/s/...` sharing links carry, and for site pages it is the plain
+        page URL — so look the id up by link. Hence the DB read, which the
+        open_url flow (the only caller) always runs with an engine and tenant
+        context available.
+        """
+        split = urlsplit(url)
+
+        if "sharepoint" not in split.netloc.lower():
+            return NormalizationResult(normalized_url=None, use_default=False)
+
+        guid = extract_sharepoint_document_guid(split.query, split.path)
+        with get_session_with_current_tenant() as db_session:
+            if guid:
+                doc_id = fetch_document_id_by_link_substring(db_session, guid)
+            else:
+                link_to_doc_id = fetch_document_ids_by_links(
+                    db_session, sharepoint_page_url_variants(url)
+                )
+                doc_id = next(iter(link_to_doc_id.values()), None)
+
+        if doc_id:
+            return NormalizationResult(
+                normalized_url=None,
+                use_default=False,
+                candidate_document_ids=[doc_id],
+            )
+        # Miss: a GUID-bearing URL has nothing else to try; for other shapes keep
+        # default normalization so the generic link fallback still applies.
+        return NormalizationResult(normalized_url=None, use_default=guid is None)
 
     def probe_role_assignments_permission(self) -> None:
         """Verify the Azure AD app can read SharePoint RoleAssignments.

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1285,16 +1285,13 @@ class SharepointConnector(
     def normalize_url(cls, url: str) -> NormalizationResult:
         """Resolve a pasted SharePoint URL to the indexed Document.id.
 
-        Unlike connectors whose ids are computable from the URL (Google Drive,
-        Notion, Slack), Document.ids here are Graph ids that appear in no URL
-        form: drive items use "01" + base32 of a drive-scoped hash plus the
-        file's unique-ID GUID; site pages use a bare page GUID. The stored
-        Document.link does identify the document — for files it contains the
-        unique-ID GUID (`sourcedoc=%7B<GUID>%7D`) that Doc.aspx URLs and
-        `/:w:/s/...` sharing links carry, and for site pages it is the plain
-        page URL — so look the id up by link. Hence the DB read, which the
-        open_url flow (the only caller) always runs with an engine and tenant
-        context available.
+        Unlike connectors whose ids are computable from the URL, Document.ids
+        here are Graph ids that appear in no URL form — but the stored
+        Document.link identifies the document: file links carry the unique-ID
+        GUID (`sourcedoc=%7B<GUID>%7D`) that pasted URLs also carry, and
+        site-page links are the plain page URL. A site page's GUID *is* its
+        Document.id, so an extracted GUID is also offered as a speculative
+        candidate that open_url keeps only if it exists in the index.
         """
         split = urlsplit(url)
 
@@ -1302,24 +1299,30 @@ class SharepointConnector(
             return NormalizationResult(normalized_url=None, use_default=False)
 
         guid = extract_sharepoint_document_guid(split.query, split.path)
+        candidate_ids: list[str] = []
         with get_session_with_current_tenant() as db_session:
             if guid:
                 doc_id = fetch_document_id_by_link_substring(db_session, guid)
+                if doc_id:
+                    candidate_ids.append(doc_id)
+                candidate_ids.append(guid.lower())
             else:
                 link_to_doc_id = fetch_document_ids_by_links(
                     db_session, sharepoint_page_url_variants(url)
                 )
                 doc_id = next(iter(link_to_doc_id.values()), None)
+                if doc_id:
+                    candidate_ids.append(doc_id)
 
-        if doc_id:
+        if candidate_ids:
             return NormalizationResult(
                 normalized_url=None,
                 use_default=False,
-                candidate_document_ids=[doc_id],
+                candidate_document_ids=candidate_ids,
             )
-        # Miss: a GUID-bearing URL has nothing else to try; for other shapes keep
-        # default normalization so the generic link fallback still applies.
-        return NormalizationResult(normalized_url=None, use_default=guid is None)
+        # Plain-page miss: keep default normalization so the generic link
+        # fallback still applies.
+        return NormalizationResult(normalized_url=None, use_default=True)
 
     def probe_role_assignments_permission(self) -> None:
         """Verify the Azure AD app can read SharePoint RoleAssignments.

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -37,6 +37,7 @@ from office365.sharepoint.client_context import ClientContext
 from pydantic import BaseModel
 from pydantic import Field
 from requests.exceptions import HTTPError
+from sqlalchemy.orm import Session
 from typing_extensions import override
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
@@ -73,11 +74,13 @@ from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
 from onyx.connectors.sharepoint.connector_utils import get_sharepoint_external_access
+from onyx.connectors.sharepoint.url_utils import DRIVE_ITEM_ID_PREFIX
+from onyx.connectors.sharepoint.url_utils import DRIVE_ITEM_ID_PREFIX_LENGTH
 from onyx.connectors.sharepoint.url_utils import extract_sharepoint_document_guid
+from onyx.connectors.sharepoint.url_utils import sharepoint_drive_item_id_candidates
 from onyx.connectors.sharepoint.url_utils import sharepoint_page_url_variants
-from onyx.db.document import fetch_document_id_by_link_substring
+from onyx.db.document import fetch_document_id_prefixes
 from onyx.db.document import fetch_document_ids_by_links
-from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import HierarchyNodeType
 from onyx.file_processing.extract_file_text import extract_text_and_images
 from onyx.file_processing.extract_file_text import get_file_ext
@@ -1283,15 +1286,12 @@ class SharepointConnector(
     @classmethod
     @override
     def normalize_url(cls, url: str) -> NormalizationResult:
-        """Resolve a pasted SharePoint URL to the indexed Document.id.
+        """Pure part of URL → Document.id resolution.
 
-        Unlike connectors whose ids are computable from the URL, Document.ids
-        here are Graph ids that appear in no URL form — but the stored
-        Document.link identifies the document: file links carry the unique-ID
-        GUID (`sourcedoc=%7B<GUID>%7D`) that pasted URLs also carry, and
-        site-page links are the plain page URL. A site page's GUID *is* its
-        Document.id, so an extracted GUID is also offered as a speculative
-        candidate that open_url keeps only if it exists in the index.
+        A site page's unique-ID GUID (carried by Doc.aspx URLs, sharing-link
+        tokens, and share= params) *is* its Document.id, so it's offered as a
+        speculative candidate that open_url keeps only if indexed. File ids and
+        plain page URLs need index state — see resolve_url_candidates.
         """
         split = urlsplit(url)
 
@@ -1299,30 +1299,48 @@ class SharepointConnector(
             return NormalizationResult(normalized_url=None, use_default=False)
 
         guid = extract_sharepoint_document_guid(split.query, split.path)
-        candidate_ids: list[str] = []
-        with get_session_with_current_tenant() as db_session:
-            if guid:
-                doc_id = fetch_document_id_by_link_substring(db_session, guid)
-                if doc_id:
-                    candidate_ids.append(doc_id)
-                candidate_ids.append(guid.lower())
-            else:
-                link_to_doc_id = fetch_document_ids_by_links(
-                    db_session, sharepoint_page_url_variants(url)
-                )
-                doc_id = next(iter(link_to_doc_id.values()), None)
-                if doc_id:
-                    candidate_ids.append(doc_id)
-
-        if candidate_ids:
+        if guid:
             return NormalizationResult(
                 normalized_url=None,
                 use_default=False,
-                candidate_document_ids=candidate_ids,
+                candidate_document_ids=[guid.lower()],
             )
-        # Plain-page miss: keep default normalization so the generic link
+        # Plain page URL: keep default normalization so the generic link
         # fallback still applies.
         return NormalizationResult(normalized_url=None, use_default=True)
+
+    @classmethod
+    @override
+    def resolve_url_candidates(cls, url: str, db_session: Session) -> list[str]:
+        """Index-aware part of URL → Document.id resolution.
+
+        A file's drive-item Document.id embeds its unique-ID GUID next to a
+        4-byte drive hash that appears in no URL form, so candidate ids are
+        reconstructed from the drive-hash prefixes present in the index. Plain
+        page URLs (no GUID) match the stored page link directly, modulo
+        encoding. Candidates are validated against the index by the caller.
+        """
+        split = urlsplit(url)
+
+        if "sharepoint" not in split.netloc.lower():
+            return []
+
+        guid = extract_sharepoint_document_guid(split.query, split.path)
+        if guid:
+            drive_prefixes = fetch_document_id_prefixes(
+                db_session,
+                prefix=DRIVE_ITEM_ID_PREFIX,
+                prefix_length=DRIVE_ITEM_ID_PREFIX_LENGTH,
+            )
+            return sharepoint_drive_item_id_candidates(guid, drive_prefixes)
+
+        link_variants = sharepoint_page_url_variants(url)
+        link_to_doc_id = fetch_document_ids_by_links(db_session, link_variants)
+        # Earlier variants are closer to the pasted form; prefer their matches.
+        for variant in link_variants:
+            if variant in link_to_doc_id:
+                return [link_to_doc_id[variant]]
+        return []
 
     def probe_role_assignments_permission(self) -> None:
         """Verify the Azure AD app can read SharePoint RoleAssignments.

--- a/backend/onyx/connectors/sharepoint/url_utils.py
+++ b/backend/onyx/connectors/sharepoint/url_utils.py
@@ -18,6 +18,15 @@ from uuid import UUID
 _SOURCEDOC_PARAM = "sourcedoc"
 _SHARE_PARAM = "share"
 
+_BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+# Graph drive-item ids are "01" + base32(4-byte drive hash + item unique-ID GUID
+# little-endian). Undocumented but stable; verified against live Graph data.
+# An id prefix of this length pins 30 of the 32 drive-hash bits (the remaining
+# 2 bits straddle the next base32 char and are enumerated at lookup time).
+DRIVE_ITEM_ID_PREFIX = "01"
+DRIVE_ITEM_ID_PREFIX_LENGTH = 8
+
 # Sharing links look like /:w:/s/<site-name>/<base64url-token>. The token decodes
 # to a "!\x00" header followed by the item's unique-ID GUID in little-endian
 # (the same GUID Doc.aspx URLs carry in `sourcedoc=`), then opaque trailing bytes.
@@ -74,6 +83,42 @@ def _guid_from_sharing_token(path: str) -> str | None:
     if not match:
         return None
     return _guid_from_token(match.group(1))
+
+
+def sharepoint_drive_item_id_candidates(
+    guid: str, drive_id_prefixes: list[str]
+) -> list[str]:
+    """Construct the candidate drive-item Document.ids for a file's unique-ID GUID.
+
+    Each 8-char prefix ("01" + 6 base32 chars) fixes 30 drive-hash bits; the 2
+    unresolved bits give 4 candidate ids per prefix. Prefixes that aren't valid
+    drive-item id prefixes (other connectors' ids can also start with "01") are
+    skipped.
+    """
+    try:
+        guid_bytes = UUID(guid).bytes_le
+    except ValueError:
+        return []
+
+    candidates: list[str] = []
+    for prefix in drive_id_prefixes:
+        if len(prefix) != DRIVE_ITEM_ID_PREFIX_LENGTH or not prefix.startswith(
+            DRIVE_ITEM_ID_PREFIX
+        ):
+            continue
+        hash_bits = 0
+        try:
+            for char in prefix[len(DRIVE_ITEM_ID_PREFIX) :]:
+                hash_bits = (hash_bits << 5) | _BASE32_ALPHABET.index(char)
+        except ValueError:
+            continue
+        for low_bits in range(4):
+            drive_hash = ((hash_bits << 2) | low_bits).to_bytes(4, "big")
+            candidates.append(
+                DRIVE_ITEM_ID_PREFIX
+                + base64.b32encode(drive_hash + guid_bytes).decode()
+            )
+    return candidates
 
 
 def sharepoint_page_url_variants(url: str) -> list[str]:

--- a/backend/onyx/connectors/sharepoint/url_utils.py
+++ b/backend/onyx/connectors/sharepoint/url_utils.py
@@ -1,0 +1,96 @@
+"""URL helpers for SharePoint that must stay import-light.
+
+This module must not pull in the heavy connector dependencies (office365,
+msal, etc.), so it can be imported wherever URL parsing is needed.
+"""
+
+import base64
+import binascii
+import re
+from urllib.parse import parse_qs
+from urllib.parse import urlsplit
+from urllib.parse import urlunsplit
+from uuid import UUID
+
+_SOURCEDOC_PARAM = "sourcedoc"
+
+# Sharing links look like /:w:/s/<site-name>/<base64url-token>. The token decodes
+# to a "!\x00" header followed by the item's unique-ID GUID in little-endian
+# (the same GUID Doc.aspx URLs carry in `sourcedoc=`), then opaque trailing bytes.
+_SHARING_LINK_PATH_PATTERN = re.compile(
+    r"^/:[a-z]:/s/[^/]+/([A-Za-z0-9_-]{20,})/?$", re.IGNORECASE
+)
+_SHARING_TOKEN_HEADER = b"!\x00"
+_SHARING_TOKEN_MIN_BYTES = len(_SHARING_TOKEN_HEADER) + 16
+
+
+def _parse_guid(value: str) -> str | None:
+    """Canonicalize a GUID in any common form (braced, dashed, bare hex) to
+    uppercase dashed, or None if invalid."""
+    try:
+        return str(UUID(value.strip())).upper()
+    except ValueError:
+        return None
+
+
+def _guid_from_sourcedoc_query(query: str) -> str | None:
+    if not query or _SOURCEDOC_PARAM not in query.lower():
+        return None
+
+    for key, values in parse_qs(query).items():
+        if key.lower() != _SOURCEDOC_PARAM:
+            continue
+        for value in values:
+            guid = _parse_guid(value)
+            if guid:
+                return guid
+    return None
+
+
+def _guid_from_sharing_token(path: str) -> str | None:
+    match = _SHARING_LINK_PATH_PATTERN.match(path)
+    if not match:
+        return None
+
+    token = match.group(1)
+    try:
+        raw = base64.urlsafe_b64decode(token + "=" * (-len(token) % 4))
+    except (binascii.Error, ValueError):
+        return None
+
+    if len(raw) < _SHARING_TOKEN_MIN_BYTES or not raw.startswith(_SHARING_TOKEN_HEADER):
+        # Other token families (e.g. E...-prefixed) have an unverified layout; punt
+        # so resolution falls back to the crawl path rather than joining on a
+        # misparsed GUID.
+        return None
+
+    guid_bytes = raw[len(_SHARING_TOKEN_HEADER) : len(_SHARING_TOKEN_HEADER) + 16]
+    return str(UUID(bytes_le=guid_bytes)).upper()
+
+
+def sharepoint_page_url_variants(url: str) -> list[str]:
+    """Candidate stored-link forms for a GUID-less SharePoint URL.
+
+    Site pages (and other non-file content) are stored with the plain page URL
+    as Document.link, so exact-link matching works once volatile parts (query
+    like `?web=1`, fragment, trailing slash) are stripped. Returns the pasted
+    URL plus its stripped form.
+    """
+    split = urlsplit(url)
+    if not split.netloc:
+        return []
+    stripped = urlunsplit(
+        (split.scheme or "https", split.netloc.lower(), split.path.rstrip("/"), "", "")
+    )
+    return list(dict.fromkeys([url, stripped]))
+
+
+def extract_sharepoint_document_guid(query: str, path: str) -> str | None:
+    """Extract a SharePoint file's unique-ID GUID from a pasted URL's parts.
+
+    Handles Doc.aspx-style URLs (`sourcedoc=%7B<GUID>%7D`, raw-brace, or
+    brace-less) and `/:w:/s/<site>/<token>` sharing links whose token embeds the
+    same GUID. Returns the uppercase, brace-less GUID, or None when the URL
+    doesn't carry one (e.g. SitePages URLs).
+    """
+    return _guid_from_sourcedoc_query(query) or _guid_from_sharing_token(path)

--- a/backend/onyx/connectors/sharepoint/url_utils.py
+++ b/backend/onyx/connectors/sharepoint/url_utils.py
@@ -7,12 +7,16 @@ msal, etc.), so it can be imported wherever URL parsing is needed.
 import base64
 import binascii
 import re
+from collections.abc import Callable
 from urllib.parse import parse_qs
+from urllib.parse import quote
+from urllib.parse import unquote
 from urllib.parse import urlsplit
 from urllib.parse import urlunsplit
 from uuid import UUID
 
 _SOURCEDOC_PARAM = "sourcedoc"
+_SHARE_PARAM = "share"
 
 # Sharing links look like /:w:/s/<site-name>/<base64url-token>. The token decodes
 # to a "!\x00" header followed by the item's unique-ID GUID in little-endian
@@ -33,26 +37,23 @@ def _parse_guid(value: str) -> str | None:
         return None
 
 
-def _guid_from_sourcedoc_query(query: str) -> str | None:
-    if not query or _SOURCEDOC_PARAM not in query.lower():
+def _guid_from_query_param(
+    query: str, param: str, extract: Callable[[str], str | None]
+) -> str | None:
+    if not query or param not in query.lower():
         return None
 
     for key, values in parse_qs(query).items():
-        if key.lower() != _SOURCEDOC_PARAM:
+        if key.lower() != param:
             continue
         for value in values:
-            guid = _parse_guid(value)
+            guid = extract(value)
             if guid:
                 return guid
     return None
 
 
-def _guid_from_sharing_token(path: str) -> str | None:
-    match = _SHARING_LINK_PATH_PATTERN.match(path)
-    if not match:
-        return None
-
-    token = match.group(1)
+def _guid_from_token(token: str) -> str | None:
     try:
         raw = base64.urlsafe_b64decode(token + "=" * (-len(token) % 4))
     except (binascii.Error, ValueError):
@@ -68,29 +69,53 @@ def _guid_from_sharing_token(path: str) -> str | None:
     return str(UUID(bytes_le=guid_bytes)).upper()
 
 
+def _guid_from_sharing_token(path: str) -> str | None:
+    match = _SHARING_LINK_PATH_PATTERN.match(path)
+    if not match:
+        return None
+    return _guid_from_token(match.group(1))
+
+
 def sharepoint_page_url_variants(url: str) -> list[str]:
     """Candidate stored-link forms for a GUID-less SharePoint URL.
 
     Site pages (and other non-file content) are stored with the plain page URL
     as Document.link, so exact-link matching works once volatile parts (query
-    like `?web=1`, fragment, trailing slash) are stripped. Returns the pasted
-    URL plus its stripped form.
+    like `?web=1`, fragment, trailing slash) are stripped. Stored links come
+    from Graph webUrl, whose percent-encoding can differ from a browser's
+    clipboard form (Graph encodes spaces as %20 but keeps sub-delims like
+    `!'()` raw), so encoding-normalized forms of the path are included too.
     """
     split = urlsplit(url)
     if not split.netloc:
         return []
-    stripped = urlunsplit(
-        (split.scheme or "https", split.netloc.lower(), split.path.rstrip("/"), "", "")
-    )
-    return list(dict.fromkeys([url, stripped]))
+
+    def _with_path(path: str) -> str:
+        return urlunsplit((split.scheme or "https", split.netloc.lower(), path, "", ""))
+
+    path = split.path.rstrip("/")
+    decoded_path = unquote(path)
+    variants = [
+        url,
+        _with_path(path),
+        _with_path(decoded_path),
+        _with_path(quote(decoded_path, safe="/!$&'()*+,;=:@")),
+    ]
+    return list(dict.fromkeys(variants))
 
 
 def extract_sharepoint_document_guid(query: str, path: str) -> str | None:
     """Extract a SharePoint file's unique-ID GUID from a pasted URL's parts.
 
     Handles Doc.aspx-style URLs (`sourcedoc=%7B<GUID>%7D`, raw-brace, or
-    brace-less) and `/:w:/s/<site>/<token>` sharing links whose token embeds the
-    same GUID. Returns the uppercase, brace-less GUID, or None when the URL
-    doesn't carry one (e.g. SitePages URLs).
+    brace-less), `/:w:/s/<site>/<token>` sharing links whose token embeds the
+    same GUID, and share-redirect URLs carrying that token in a `share=` query
+    param. Returns the uppercase, brace-less GUID, or None when the URL
+    doesn't carry one (e.g. plain SitePages URLs).
     """
-    return _guid_from_sourcedoc_query(query) or _guid_from_sharing_token(path)
+    return (
+        _guid_from_query_param(query, _SOURCEDOC_PARAM, _parse_guid)
+        or _guid_from_sharing_token(path)
+        # share-redirect URLs carry the same token a /:x:/s/ link embeds in its path
+        or _guid_from_query_param(query, _SHARE_PARAM, _guid_from_token)
+    )

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -38,7 +38,6 @@ from onyx.db.entities import delete_from_kg_entities_extraction_staging__no_comm
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.feedback import delete_document_feedback_for_documents__no_commit
-from onyx.db.hierarchy import escape_like_pattern
 from onyx.db.index_attempt_metrics import safe_record_single_event_if_set
 from onyx.db.index_attempt_metrics_models import IndexAttemptStage
 from onyx.db.models import Connector
@@ -660,35 +659,71 @@ def fetch_document_ids_by_links(
     return {link: doc_id for link, doc_id in rows if link}
 
 
-# Reject substrings too short to be identifying, so a bad caller can't match
-# broad swaths of the table.
-_MIN_LINK_SUBSTRING_LENGTH = 8
+# Backstop against a pathological id distribution keeping the walk going forever;
+# real deployments have one prefix per SharePoint/OneDrive drive (thousands at most).
+_MAX_ID_PREFIX_WALK_STEPS = 10000
+
+# Appended to a prefix to jump past every id sharing it. 'Z' is the max base32
+# char, and the pad is longer than any real id, so the result sorts after the
+# whole prefix range under both C and glibc collations ('~' would sort *before*
+# letters under glibc and stall the walk).
+_PREFIX_JUMP_PAD = "Z" * 64
 
 
-def fetch_document_id_by_link_substring(
+def fetch_document_id_prefixes(
     db_session: Session,
-    substring: str,
-) -> str | None:
-    """Find the id of a document whose link contains the given substring
-    (case-insensitive).
+    prefix: str,
+    prefix_length: int,
+) -> list[str]:
+    """Distinct id prefixes of length `prefix_length` among documents whose id
+    starts with `prefix`.
 
-    Used for connectors whose Document.ids aren't derivable from a pasted URL
-    (e.g. SharePoint's Graph drive-item ids) but whose stored link contains an
-    identifier the URL carries (e.g. the file's sourcedoc GUID).
+    Implemented as a loose (skip) scan over the primary-key index: start at the
+    first id in scope, then repeatedly jump to the first id past the current
+    prefix's range. Each step is one indexed lookup, so cost is
+    O(#distinct prefixes * log N) instead of a table scan.
+
+    Used to enumerate SharePoint/OneDrive drive-hash prefixes ("01" + 6 base32
+    chars) so a file's Document.id can be reconstructed from its unique-ID GUID.
     """
-    if len(substring) < _MIN_LINK_SUBSTRING_LENGTH:
-        return None
-
-    stmt = (
+    first_id_in_scope = (
         select(DbDocument.id)
-        .where(
-            DbDocument.link.ilike(f"%{escape_like_pattern(substring)}%", escape="\\")
-        )
-        # Deterministic pick if multiple documents contain the identifier
+        .where(DbDocument.id >= prefix)
         .order_by(DbDocument.id)
         .limit(1)
+        .scalar_subquery()
     )
-    return db_session.execute(stmt).scalars().first()
+    walk = select(first_id_in_scope.label("id"), literal(1).label("steps")).cte(
+        "prefix_walk", recursive=True
+    )
+
+    first_id_past_current_prefix = (
+        select(DbDocument.id)
+        .where(DbDocument.id > func.left(walk.c.id, prefix_length) + _PREFIX_JUMP_PAD)
+        .order_by(DbDocument.id)
+        .limit(1)
+        .scalar_subquery()
+    )
+    still_in_scope = func.left(walk.c.id, len(prefix)) == prefix
+    walk = walk.union_all(
+        select(
+            first_id_past_current_prefix.label("id"),
+            (walk.c.steps + 1).label("steps"),
+        ).where(
+            walk.c.id.is_not(None),
+            still_in_scope,
+            walk.c.steps < _MAX_ID_PREFIX_WALK_STEPS,
+        )
+    )
+
+    # The walk's last row is the terminator (NULL or the first out-of-scope id),
+    # so the scope filter is applied once more when collecting.
+    stmt = (
+        select(func.left(walk.c.id, prefix_length))
+        .distinct()
+        .where(walk.c.id.is_not(None), func.left(walk.c.id, len(prefix)) == prefix)
+    )
+    return list(db_session.execute(stmt).scalars())
 
 
 def get_document_connector_count(

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -38,6 +38,7 @@ from onyx.db.entities import delete_from_kg_entities_extraction_staging__no_comm
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.feedback import delete_document_feedback_for_documents__no_commit
+from onyx.db.hierarchy import escape_like_pattern
 from onyx.db.index_attempt_metrics import safe_record_single_event_if_set
 from onyx.db.index_attempt_metrics_models import IndexAttemptStage
 from onyx.db.models import Connector
@@ -657,6 +658,35 @@ def fetch_document_ids_by_links(
     stmt = select(DbDocument.link, DbDocument.id).where(DbDocument.link.in_(links))
     rows = db_session.execute(stmt).all()
     return {link: doc_id for link, doc_id in rows if link}
+
+
+# Reject substrings too short to be identifying, so a bad caller can't match
+# broad swaths of the table.
+_MIN_LINK_SUBSTRING_LENGTH = 8
+
+
+def fetch_document_id_by_link_substring(
+    db_session: Session,
+    substring: str,
+) -> str | None:
+    """Find the id of a document whose link contains the given substring
+    (case-insensitive).
+
+    Used for connectors whose Document.ids aren't derivable from a pasted URL
+    (e.g. SharePoint's Graph drive-item ids) but whose stored link contains an
+    identifier the URL carries (e.g. the file's sourcedoc GUID).
+    """
+    if len(substring) < _MIN_LINK_SUBSTRING_LENGTH:
+        return None
+
+    stmt = (
+        select(DbDocument.id)
+        .where(
+            DbDocument.link.ilike(f"%{escape_like_pattern(substring)}%", escape="\\")
+        )
+        .limit(1)
+    )
+    return db_session.execute(stmt).scalars().first()
 
 
 def get_document_connector_count(

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -684,6 +684,8 @@ def fetch_document_id_by_link_substring(
         .where(
             DbDocument.link.ilike(f"%{escape_like_pattern(substring)}%", escape="\\")
         )
+        # Deterministic pick if multiple documents contain the identifier
+        .order_by(DbDocument.id)
         .limit(1)
     )
     return db_session.execute(stmt).scalars().first()

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -39,6 +39,9 @@ from onyx.tools.tool_implementations.open_url.url_normalization import (
 from onyx.tools.tool_implementations.open_url.url_normalization import (
     normalize_url_candidates,
 )
+from onyx.tools.tool_implementations.open_url.url_normalization import (
+    resolve_url_document_id_candidates,
+)
 from onyx.tools.tool_implementations.open_url.utils import (
     filter_web_contents_with_no_title_or_content,
 )
@@ -237,8 +240,13 @@ def _resolve_urls_to_document_ids(
     normalized_map: dict[str, list[str]] = {}
 
     for url in urls:
-        # A single URL may map to several candidate document IDs; match whichever is indexed.
-        candidates = normalize_url_candidates(url)
+        # A single URL may map to several candidate document IDs; match whichever
+        # is indexed. Index-aware, connector-owned candidates come first (they
+        # are the most precise), then pure URL-derived candidates.
+        candidates = resolve_url_document_id_candidates(url, db_session)
+        for candidate in normalize_url_candidates(url):
+            if candidate not in candidates:
+                candidates.append(candidate)
 
         if candidates:
             variants: list[str] = []

--- a/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
+++ b/backend/onyx/tools/tool_implementations/open_url/url_normalization.py
@@ -12,6 +12,8 @@ Usage:
 from urllib.parse import urlparse
 from urllib.parse import urlunparse
 
+from sqlalchemy.orm import Session
+
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.factory import identify_connector_class
 from onyx.utils.logger import setup_logger
@@ -102,6 +104,32 @@ def normalize_url_candidates(
 
     default = _default_url_normalizer(url)
     return [default] if default else []
+
+
+def resolve_url_document_id_candidates(
+    url: str,
+    db_session: Session,
+    source_type: DocumentSource | None = None,
+) -> list[str]:
+    """Connector-owned, index-aware resolution of a URL to candidate Document.ids.
+
+    Complements normalize_url_candidates for connectors whose ids aren't
+    computable from the URL alone. Returned candidates are unverified — the
+    caller keeps only ids that exist in the index.
+    """
+    if source_type is None:
+        source_type = _detect_source_type(url)
+    if not source_type:
+        return []
+
+    try:
+        connector_class = identify_connector_class(source_type)
+        return connector_class.resolve_url_candidates(url, db_session)
+    except Exception as exc:
+        logger.warning(
+            "Index-aware URL resolution failed for source %s: %s", source_type, exc
+        )
+        return []
 
 
 def _detect_source_type(url: str) -> DocumentSource | None:

--- a/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
+++ b/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
@@ -19,6 +19,7 @@ from onyx.kg.models import KGStage
 from onyx.tools.tool_implementations.open_url.open_url_tool import (
     _resolve_urls_to_document_ids,
 )
+from tests.utils.sharepoint import make_drive_item_id
 from tests.utils.sharepoint import make_sharing_token
 
 
@@ -91,7 +92,7 @@ def _seed_sharepoint_doc(
     Returns (doc_id, guid, stored_link).
     """
     guid = str(uuid4()).upper()
-    doc_id = f"01SFDIZ6{uuid4().hex.upper()[:24]}"
+    doc_id = make_drive_item_id(guid)
     stored_link = (
         "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
         f"?sourcedoc=%7B{guid}%7D&file=Foo.docx&action=default&mobileredirect=true"

--- a/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
+++ b/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
@@ -7,9 +7,8 @@ form must still be found when the user pastes the type-ambiguous
 `drive.google.com/file/d/<id>` form.
 """
 
-import base64
+from collections.abc import Callable
 from collections.abc import Generator
-from uuid import UUID
 from uuid import uuid4
 
 import pytest
@@ -20,6 +19,7 @@ from onyx.kg.models import KGStage
 from onyx.tools.tool_implementations.open_url.open_url_tool import (
     _resolve_urls_to_document_ids,
 )
+from tests.utils.sharepoint import make_sharing_token
 
 
 @pytest.fixture
@@ -100,69 +100,40 @@ def _seed_sharepoint_doc(
     return doc_id, guid, stored_link
 
 
-def test_sharepoint_doc_aspx_url_resolves_via_sourcedoc_guid(
+@pytest.mark.parametrize(
+    "build_pasted",
+    [
+        pytest.param(lambda _guid, stored_link: stored_link, id="stored-doc-aspx-url"),
+        pytest.param(
+            lambda guid, _stored_link: (
+                "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
+                f"?sourcedoc={{{guid.lower()}}}&file=Foo.docx&action=default&mobileredirect=true"
+            ),
+            id="raw-brace-lowercase-guid",
+        ),
+        pytest.param(
+            lambda guid, _stored_link: (
+                "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
+                f"?file=Foo.docx&wdOrigin=TEAMS&sourcedoc=%7B{guid}%7D"
+            ),
+            id="reordered-extra-params",
+        ),
+        pytest.param(
+            lambda guid, _stored_link: (
+                f"https://acme.sharepoint.com/:w:/s/eng/{make_sharing_token(guid)}?e=u4Gcoi"
+            ),
+            id="sharing-link-token",
+        ),
+    ],
+)
+def test_sharepoint_file_url_form_resolves(
     db_session: Session,
     doc_cleanup: list[str],
+    build_pasted: Callable[[str, str], str],
 ) -> None:
-    """The exact stored Doc.aspx URL resolves to the Graph drive-item Document.id."""
-    doc_id, _, stored_link = _seed_sharepoint_doc(db_session, doc_cleanup)
-
-    matches, unresolved = _resolve_urls_to_document_ids([stored_link], db_session)
-
-    assert unresolved == []
-    assert len(matches) == 1
-    assert matches[0].document_id == doc_id
-    assert matches[0].original_url == stored_link
-
-
-def test_sharepoint_url_with_decoded_braces_resolves(
-    db_session: Session,
-    doc_cleanup: list[str],
-) -> None:
-    """A re-emitted URL with raw {...} braces still resolves to the stored doc."""
-    doc_id, guid, _ = _seed_sharepoint_doc(db_session, doc_cleanup)
-
-    pasted = (
-        "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
-        f"?sourcedoc={{{guid.lower()}}}&file=Foo.docx&action=default&mobileredirect=true"
-    )
-    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
-
-    assert unresolved == []
-    assert len(matches) == 1
-    assert matches[0].document_id == doc_id
-    assert matches[0].original_url == pasted
-
-
-def test_sharepoint_url_with_reordered_extra_params_resolves(
-    db_session: Session,
-    doc_cleanup: list[str],
-) -> None:
-    """Different query-param order and extra params don't break resolution."""
-    doc_id, guid, _ = _seed_sharepoint_doc(db_session, doc_cleanup)
-
-    pasted = (
-        "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
-        f"?file=Foo.docx&wdOrigin=TEAMS&sourcedoc=%7B{guid}%7D"
-    )
-    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
-
-    assert unresolved == []
-    assert len(matches) == 1
-    assert matches[0].document_id == doc_id
-    assert matches[0].original_url == pasted
-
-
-def test_sharepoint_sharing_link_resolves_via_embedded_guid(
-    db_session: Session,
-    doc_cleanup: list[str],
-) -> None:
-    """A /:w:/s/... sharing link resolves via the GUID embedded in its token."""
-    doc_id, guid, _ = _seed_sharepoint_doc(db_session, doc_cleanup)
-
-    raw = b"!\x00" + UUID(guid).bytes_le + b"\x01" + bytes(16)
-    token = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
-    pasted = f"https://acme.sharepoint.com/:w:/s/eng/{token}?e=u4Gcoi"
+    """Every pasted file-URL form resolves to the Graph drive-item Document.id."""
+    doc_id, guid, stored_link = _seed_sharepoint_doc(db_session, doc_cleanup)
+    pasted = build_pasted(guid, stored_link)
 
     matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
 
@@ -189,6 +160,72 @@ def test_sharepoint_site_page_resolves_via_stored_link(
         assert len(matches) == 1
         assert matches[0].document_id == doc_id
         assert matches[0].original_url == pasted
+
+
+def test_sharepoint_page_sharing_link_resolves_via_guid_document_id(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """A sharing link to a site page resolves even though page links carry no
+    GUID: the page GUID is the Document.id itself, offered as a speculative
+    candidate. Rename-proof — the stored link's site name doesn't matter."""
+    page_guid = str(uuid4())
+    stored_link = "https://acme.sharepoint.com/sites/old-name/SitePages/Home.aspx"
+    _seed_doc(db_session, doc_cleanup, page_guid, link=stored_link)
+
+    token = make_sharing_token(page_guid.upper())
+    pasted = f"https://acme.sharepoint.com/:u:/s/renamed/{token}?e=O7vbMs"
+
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == page_guid
+    assert matches[0].original_url == pasted
+
+
+def test_sharepoint_share_redirect_url_resolves_for_page(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """A share-redirect page URL (`?...&share=<token>`) resolves via the token."""
+    page_guid = str(uuid4())
+    stored_link = "https://acme.sharepoint.com/sites/eng/SitePages/Home.aspx"
+    _seed_doc(db_session, doc_cleanup, page_guid, link=stored_link)
+
+    token = make_sharing_token(page_guid.upper())
+    pasted = (
+        "https://acme.sharepoint.com/:u:/r/sites/eng/SitePages/Home.aspx"
+        f"?csf=1&web=1&share={token}&e=9xtHB2"
+    )
+
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == page_guid
+    assert matches[0].original_url == pasted
+
+
+def test_sharepoint_page_url_with_encoding_mismatch_resolves(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """Exact-link matching tolerates percent-encoding differences between the
+    stored Graph webUrl and the pasted clipboard form."""
+    doc_id = str(uuid4())
+    stored_link = (
+        "https://acme.sharepoint.com/sites/eng/SitePages/What's-happening.aspx"
+    )
+    _seed_doc(db_session, doc_cleanup, doc_id, link=stored_link)
+
+    pasted = "https://acme.sharepoint.com/sites/eng/SitePages/What%27s-happening.aspx"
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == doc_id
+    assert matches[0].original_url == pasted
 
 
 def test_sharepoint_url_with_unknown_guid_is_unresolved(

--- a/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
+++ b/backend/tests/external_dependency_unit/tools/open_url/test_open_url_resolution.py
@@ -7,7 +7,9 @@ form must still be found when the user pastes the type-ambiguous
 `drive.google.com/file/d/<id>` form.
 """
 
+import base64
 from collections.abc import Generator
+from uuid import UUID
 from uuid import uuid4
 
 import pytest
@@ -36,11 +38,14 @@ def doc_cleanup(
             db_session.commit()
 
 
-def _seed_doc(db_session: Session, tracker: list[str], doc_id: str) -> None:
+def _seed_doc(
+    db_session: Session, tracker: list[str], doc_id: str, link: str | None = None
+) -> None:
     doc = DBDocument(
         id=doc_id,
         semantic_id=f"semantic-{doc_id}",
         kg_stage=KGStage.NOT_STARTED,
+        link=link,
     )
     db_session.add(doc)
     db_session.commit()
@@ -76,3 +81,126 @@ def test_unindexed_file_id_is_unresolved(
 
     assert matches == []
     assert unresolved == [pasted]
+
+
+def _seed_sharepoint_doc(
+    db_session: Session, doc_cleanup: list[str]
+) -> tuple[str, str, str]:
+    """Seed a SharePoint-shaped doc: Graph drive-item id + Doc.aspx link.
+
+    Returns (doc_id, guid, stored_link).
+    """
+    guid = str(uuid4()).upper()
+    doc_id = f"01SFDIZ6{uuid4().hex.upper()[:24]}"
+    stored_link = (
+        "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
+        f"?sourcedoc=%7B{guid}%7D&file=Foo.docx&action=default&mobileredirect=true"
+    )
+    _seed_doc(db_session, doc_cleanup, doc_id, link=stored_link)
+    return doc_id, guid, stored_link
+
+
+def test_sharepoint_doc_aspx_url_resolves_via_sourcedoc_guid(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """The exact stored Doc.aspx URL resolves to the Graph drive-item Document.id."""
+    doc_id, _, stored_link = _seed_sharepoint_doc(db_session, doc_cleanup)
+
+    matches, unresolved = _resolve_urls_to_document_ids([stored_link], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == doc_id
+    assert matches[0].original_url == stored_link
+
+
+def test_sharepoint_url_with_decoded_braces_resolves(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """A re-emitted URL with raw {...} braces still resolves to the stored doc."""
+    doc_id, guid, _ = _seed_sharepoint_doc(db_session, doc_cleanup)
+
+    pasted = (
+        "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
+        f"?sourcedoc={{{guid.lower()}}}&file=Foo.docx&action=default&mobileredirect=true"
+    )
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == doc_id
+    assert matches[0].original_url == pasted
+
+
+def test_sharepoint_url_with_reordered_extra_params_resolves(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """Different query-param order and extra params don't break resolution."""
+    doc_id, guid, _ = _seed_sharepoint_doc(db_session, doc_cleanup)
+
+    pasted = (
+        "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
+        f"?file=Foo.docx&wdOrigin=TEAMS&sourcedoc=%7B{guid}%7D"
+    )
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == doc_id
+    assert matches[0].original_url == pasted
+
+
+def test_sharepoint_sharing_link_resolves_via_embedded_guid(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """A /:w:/s/... sharing link resolves via the GUID embedded in its token."""
+    doc_id, guid, _ = _seed_sharepoint_doc(db_session, doc_cleanup)
+
+    raw = b"!\x00" + UUID(guid).bytes_le + b"\x01" + bytes(16)
+    token = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+    pasted = f"https://acme.sharepoint.com/:w:/s/eng/{token}?e=u4Gcoi"
+
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert unresolved == []
+    assert len(matches) == 1
+    assert matches[0].document_id == doc_id
+    assert matches[0].original_url == pasted
+
+
+def test_sharepoint_site_page_resolves_via_stored_link(
+    db_session: Session,
+    doc_cleanup: list[str],
+) -> None:
+    """A SitePages URL resolves to its GUID Document.id via exact-link lookup,
+    including with volatile query params attached."""
+    doc_id = str(uuid4())
+    stored_link = "https://acme.sharepoint.com/sites/eng/SitePages/Team-Updates.aspx"
+    _seed_doc(db_session, doc_cleanup, doc_id, link=stored_link)
+
+    for pasted in (stored_link, f"{stored_link}?web=1"):
+        matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+        assert unresolved == []
+        assert len(matches) == 1
+        assert matches[0].document_id == doc_id
+        assert matches[0].original_url == pasted
+
+
+def test_sharepoint_url_with_unknown_guid_is_unresolved(
+    db_session: Session,
+    doc_cleanup: list[str],  # noqa: ARG001
+) -> None:
+    """A sourcedoc GUID not in the index resolves to nothing (falls back to crawl)."""
+    pasted = (
+        "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
+        f"?sourcedoc=%7B{str(uuid4()).upper()}%7D&file=Foo.docx"
+    )
+    matches, unresolved = _resolve_urls_to_document_ids([pasted], db_session)
+
+    assert matches == []
+    assert pasted in unresolved

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_url_utils.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_url_utils.py
@@ -1,0 +1,87 @@
+"""Unit tests for SharePoint document GUID extraction."""
+
+import base64
+from urllib.parse import urlsplit
+from uuid import UUID
+
+import pytest
+
+from onyx.connectors.sharepoint.url_utils import extract_sharepoint_document_guid
+from onyx.connectors.sharepoint.url_utils import sharepoint_page_url_variants
+
+_GUID = "2AB3C4D5-6E7F-4A1B-9C0D-1E2F3A4B5C6D"
+_SITE = "https://acme.sharepoint.com/sites/eng"
+
+
+def _extract(url: str) -> str | None:
+    split = urlsplit(url)
+    return extract_sharepoint_document_guid(split.query, split.path)
+
+
+def _make_sharing_token(guid: str, header: bytes = b"!\x00") -> str:
+    """Build a sharing-link token: header + item GUID (little-endian) + opaque tail."""
+    raw = header + UUID(guid).bytes_le + b"\x01" + bytes(16)
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # percent-encoded braces (the shape SharePoint's UI produces)
+        f"{_SITE}/_layouts/15/Doc.aspx?sourcedoc=%7B{_GUID}%7D&file=Foo.docx&action=default",
+        # raw braces
+        f"{_SITE}/_layouts/15/Doc.aspx?sourcedoc={{{_GUID}}}&file=Foo.docx",
+        # no braces
+        f"{_SITE}/_layouts/15/Doc.aspx?sourcedoc={_GUID}",
+        # lowercase GUID
+        f"{_SITE}/_layouts/15/Doc.aspx?sourcedoc=%7B{_GUID.lower()}%7D",
+        # dash-less hex GUID
+        f"{_SITE}/_layouts/15/Doc.aspx?sourcedoc={_GUID.replace('-', '').lower()}",
+        # different param order / extra params
+        f"{_SITE}/_layouts/15/Doc.aspx?file=Foo.docx&mobileredirect=true&sourcedoc=%7B{_GUID}%7D",
+        # WopiFrame variant
+        f"{_SITE}/_layouts/15/WopiFrame.aspx?sourcedoc=%7B{_GUID}%7D&action=view",
+        # /:w:/r/ redirect form of the Doc.aspx URL
+        f"https://acme.sharepoint.com/:w:/r/sites/eng/_layouts/15/Doc.aspx"
+        f"?sourcedoc=%7B{_GUID}%7D&file=Foo.docx&action=default&mobileredirect=true",
+        # sharing link whose token embeds the GUID
+        f"https://acme.sharepoint.com/:w:/s/eng/{_make_sharing_token(_GUID)}?e=u4Gcoi",
+        # sharing link without the tracking param
+        f"https://acme.sharepoint.com/:x:/s/eng/{_make_sharing_token(_GUID)}",
+    ],
+)
+def test_extracts_canonical_guid(url: str) -> None:
+    assert _extract(url) == _GUID
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # SitePages URL — no sourcedoc
+        f"{_SITE}/SitePages/Team-Updates.aspx",
+        # sharing token from an unsupported family (not the "!\x00" layout)
+        f"https://acme.sharepoint.com/:w:/s/eng/{_make_sharing_token(_GUID, header=bytes(2))}",
+        # E...-family sharing token — layout unverified, deliberately punted
+        "https://acme.sharepoint.com/:w:/s/eng/EZx1y2z3AbCdEfGhIjKlMnOp",
+        # sourcedoc present but not a valid GUID
+        f"{_SITE}/_layouts/15/Doc.aspx?sourcedoc=%7Bnot-a-guid%7D",
+        # no query string at all
+        f"{_SITE}/Shared%20Documents/Foo.docx",
+        "",
+    ],
+)
+def test_returns_none_without_valid_guid(url: str) -> None:
+    assert _extract(url) is None
+
+
+def test_page_url_variants_strip_query_fragment_and_slash() -> None:
+    url = f"{_SITE}/SitePages/Team-Updates.aspx?web=1#section"
+    assert sharepoint_page_url_variants(url) == [
+        url,
+        f"{_SITE}/SitePages/Team-Updates.aspx",
+    ]
+
+
+def test_page_url_variants_dedupe_when_already_canonical() -> None:
+    url = f"{_SITE}/SitePages/Team-Updates.aspx"
+    assert sharepoint_page_url_variants(url) == [url]

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_url_utils.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_url_utils.py
@@ -5,7 +5,9 @@ from urllib.parse import urlsplit
 import pytest
 
 from onyx.connectors.sharepoint.url_utils import extract_sharepoint_document_guid
+from onyx.connectors.sharepoint.url_utils import sharepoint_drive_item_id_candidates
 from onyx.connectors.sharepoint.url_utils import sharepoint_page_url_variants
+from tests.utils.sharepoint import make_drive_item_id
 from tests.utils.sharepoint import make_sharing_token as _make_sharing_token
 
 _GUID = "2AB3C4D5-6E7F-4A1B-9C0D-1E2F3A4B5C6D"
@@ -108,3 +110,54 @@ def test_page_url_variants_requote_decoded_spaces() -> None:
     assert f"{_SITE}/Shared%20Documents/Foo%20(2022).pdf" in (
         sharepoint_page_url_variants(mixed)
     )
+
+
+@pytest.mark.parametrize(
+    "prefix,guid,expected_id",
+    [
+        # real (prefix, sourcedoc GUID, drive-item id) triples from live Graph data
+        (
+            "01RWUU3P",
+            "0320E240-B69F-4D8D-A196-89674CD60485",
+            "01RWUU3PKA4IQAHH5WRVG2DFUJM5GNMBEF",
+        ),
+        (
+            "014NAK7T",
+            "0EFE1B85-688F-4CBE-B9B7-1B8215F3A796",
+            "014NAK7T4FDP7A5D3IXZGLTNY3QIK7HJ4W",
+        ),
+        (
+            "016GMXOK",
+            "054F6393-FA7A-4996-9188-6756BBC23BE2",
+            "016GMXOKETMNHQK6X2SZEZDCDHK254EO7C",
+        ),
+    ],
+)
+def test_drive_item_id_candidates_reconstruct_real_ids(
+    prefix: str, guid: str, expected_id: str
+) -> None:
+    candidates = sharepoint_drive_item_id_candidates(guid, [prefix])
+    assert len(candidates) == 4  # 2 unresolved drive-hash bits
+    assert expected_id in candidates
+    assert all(c.startswith(prefix) for c in candidates)
+
+
+def test_drive_item_id_candidates_roundtrip_synthetic_id() -> None:
+    guid = "2AB3C4D5-6E7F-4A1B-9C0D-1E2F3A4B5C6D"
+    doc_id = make_drive_item_id(guid)
+    assert doc_id in sharepoint_drive_item_id_candidates(guid, [doc_id[:8]])
+
+
+def test_drive_item_id_candidates_skip_invalid_prefixes() -> None:
+    assert (
+        sharepoint_drive_item_id_candidates(
+            _GUID,
+            # non-base32 chars / wrong shape / wrong length — e.g. other connectors' ids
+            ["01SFDIZ0", "https://", "01AB", "02RWUU3P", ""],
+        )
+        == []
+    )
+
+
+def test_drive_item_id_candidates_invalid_guid() -> None:
+    assert sharepoint_drive_item_id_candidates("not-a-guid", ["01RWUU3P"]) == []

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_url_utils.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_url_utils.py
@@ -1,13 +1,12 @@
 """Unit tests for SharePoint document GUID extraction."""
 
-import base64
 from urllib.parse import urlsplit
-from uuid import UUID
 
 import pytest
 
 from onyx.connectors.sharepoint.url_utils import extract_sharepoint_document_guid
 from onyx.connectors.sharepoint.url_utils import sharepoint_page_url_variants
+from tests.utils.sharepoint import make_sharing_token as _make_sharing_token
 
 _GUID = "2AB3C4D5-6E7F-4A1B-9C0D-1E2F3A4B5C6D"
 _SITE = "https://acme.sharepoint.com/sites/eng"
@@ -16,12 +15,6 @@ _SITE = "https://acme.sharepoint.com/sites/eng"
 def _extract(url: str) -> str | None:
     split = urlsplit(url)
     return extract_sharepoint_document_guid(split.query, split.path)
-
-
-def _make_sharing_token(guid: str, header: bytes = b"!\x00") -> str:
-    """Build a sharing-link token: header + item GUID (little-endian) + opaque tail."""
-    raw = header + UUID(guid).bytes_le + b"\x01" + bytes(16)
-    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
 
 
 @pytest.mark.parametrize(
@@ -48,6 +41,12 @@ def _make_sharing_token(guid: str, header: bytes = b"!\x00") -> str:
         f"https://acme.sharepoint.com/:w:/s/eng/{_make_sharing_token(_GUID)}?e=u4Gcoi",
         # sharing link without the tracking param
         f"https://acme.sharepoint.com/:x:/s/eng/{_make_sharing_token(_GUID)}",
+        # share-redirect URL: same token, carried in a `share=` query param
+        f"{_SITE}/SitePages/Team-Updates.aspx"
+        f"?csf=1&web=1&share={_make_sharing_token(_GUID)}&e=9xtHB2",
+        # /:u:/r/ redirect form with the share token
+        f"https://acme.sharepoint.com/:u:/r/sites/eng/SitePages/Team-Updates.aspx"
+        f"?share={_make_sharing_token(_GUID)}",
     ],
 )
 def test_extracts_canonical_guid(url: str) -> None:
@@ -63,6 +62,10 @@ def test_extracts_canonical_guid(url: str) -> None:
         f"https://acme.sharepoint.com/:w:/s/eng/{_make_sharing_token(_GUID, header=bytes(2))}",
         # E...-family sharing token — layout unverified, deliberately punted
         "https://acme.sharepoint.com/:w:/s/eng/EZx1y2z3AbCdEfGhIjKlMnOp",
+        # E...-family token in a share= param punts the same way
+        f"{_SITE}/SitePages/Team-Updates.aspx?share=EZx1y2z3AbCdEfGhIjKlMnOp",
+        # share= value that isn't a token at all
+        f"{_SITE}/SitePages/Team-Updates.aspx?share=not-a-token",
         # sourcedoc present but not a valid GUID
         f"{_SITE}/_layouts/15/Doc.aspx?sourcedoc=%7Bnot-a-guid%7D",
         # no query string at all
@@ -85,3 +88,23 @@ def test_page_url_variants_strip_query_fragment_and_slash() -> None:
 def test_page_url_variants_dedupe_when_already_canonical() -> None:
     url = f"{_SITE}/SitePages/Team-Updates.aspx"
     assert sharepoint_page_url_variants(url) == [url]
+
+
+def test_page_url_variants_decode_clipboard_encoding() -> None:
+    """A browser may percent-encode chars Graph webUrl stores raw (e.g. `'`)."""
+    pasted = f"{_SITE}/SitePages/What%27s-happening.aspx"
+    assert f"{_SITE}/SitePages/What's-happening.aspx" in sharepoint_page_url_variants(
+        pasted
+    )
+
+
+def test_page_url_variants_requote_decoded_spaces() -> None:
+    """Graph webUrl encodes spaces as %20; a pasted URL may have them decoded."""
+    pasted = f"{_SITE}/Shared Documents/Foo (2022).pdf"
+    variants = sharepoint_page_url_variants(pasted)
+    assert f"{_SITE}/Shared%20Documents/Foo%20(2022).pdf" in variants
+    # mixed case: encoded spaces but also an encoded sub-delim Graph keeps raw
+    mixed = f"{_SITE}/Shared%20Documents/Foo%20%282022%29.pdf"
+    assert f"{_SITE}/Shared%20Documents/Foo%20(2022).pdf" in (
+        sharepoint_page_url_variants(mixed)
+    )

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
@@ -52,6 +52,15 @@ def test_google_drive_candidates_cover_all_type_forms() -> None:
     }
 
 
+def test_sharepoint_site_page_keeps_default_normalization() -> None:
+    """SitePages URLs carry no file GUID; the stored link is the plain page URL,
+    so the default normalizer applies."""
+    url = "https://acme.sharepoint.com/sites/eng/SitePages/Team-Updates.aspx?web=1"
+    assert normalize_url_candidates(url) == [
+        "https://acme.sharepoint.com/sites/eng/SitePages/Team-Updates.aspx"
+    ]
+
+
 def test_non_drive_candidates_fall_back_to_single_value() -> None:
     """Non-connector URLs return just the default-normalized value."""
     assert normalize_url_candidates("https://example.com/some/page?a=1#x") == [

--- a/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/open_url/test_url_normalization.py
@@ -61,6 +61,17 @@ def test_sharepoint_site_page_keeps_default_normalization() -> None:
     ]
 
 
+def test_sharepoint_guid_url_offers_page_guid_candidate() -> None:
+    """GUID-bearing SharePoint URLs offer the GUID as a Document.id candidate
+    (site pages use it as their id) — computed purely, with no index access."""
+    guid = "2AB3C4D5-6E7F-4A1B-9C0D-1E2F3A4B5C6D"
+    url = (
+        "https://acme.sharepoint.com/sites/eng/_layouts/15/Doc.aspx"
+        f"?sourcedoc=%7B{guid}%7D&file=Foo.docx"
+    )
+    assert normalize_url_candidates(url) == [guid.lower()]
+
+
 def test_non_drive_candidates_fall_back_to_single_value() -> None:
     """Non-connector URLs return just the default-normalized value."""
     assert normalize_url_candidates("https://example.com/some/page?a=1#x") == [

--- a/backend/tests/utils/sharepoint.py
+++ b/backend/tests/utils/sharepoint.py
@@ -7,3 +7,9 @@ def make_sharing_token(guid: str, header: bytes = b"!\x00") -> str:
     + opaque tail."""
     raw = header + UUID(guid).bytes_le + b"\x01" + bytes(16)
     return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def make_drive_item_id(guid: str, drive_hash: bytes = b"\x8d\xa9\x4d\xbd") -> str:
+    """Build a Graph drive-item Document.id: "01" + base32(drive hash + GUID
+    little-endian)."""
+    return "01" + base64.b32encode(drive_hash + UUID(guid).bytes_le).decode()

--- a/backend/tests/utils/sharepoint.py
+++ b/backend/tests/utils/sharepoint.py
@@ -1,0 +1,9 @@
+import base64
+from uuid import UUID
+
+
+def make_sharing_token(guid: str, header: bytes = b"!\x00") -> str:
+    """Build a SharePoint sharing-link token: header + item GUID (little-endian)
+    + opaque tail."""
+    raw = header + UUID(guid).bytes_le + b"\x01" + bytes(16)
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()


### PR DESCRIPTION
## Description
Currently when you pass the chat a sharepoint url, it tries to read it and fails because it is credential gated. Now, we pull the id from that sharepoint link and attempt to get the document from opensearch.

## How Has This Been Tested?
Tests + Manual

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
SharePoint URLs pasted into chat now resolve to the correct indexed document without loading gated pages. Adds pure URL parsing plus index-aware resolution for Doc.aspx, sharing links, share-redirect, SitePages, and encoding quirks.

- **New Features**
  - Split URL handling: `SharepointConnector.normalize_url` is pure; new `resolve_url_candidates` performs index-aware lookups. `open_url` now prefers connector candidates via `resolve_url_document_id_candidates`, then falls back to `normalize_url_candidates`.
  - File links: extract GUIDs from Doc.aspx `sourcedoc`, `/:<type>:/s/...` sharing-link tokens, and `?share=<token>`; reconstruct Graph drive-item `Document.id`s using indexed `01......` drive-hash prefixes via `fetch_document_id_prefixes` + `sharepoint_drive_item_id_candidates`.
  - Site pages: generate canonical link variants (strip query/fragment/trailing slash; normalize percent-encoding with `sharepoint_page_url_variants`) and match via `fetch_document_ids_by_links`. If a sharing link carries a page GUID, offer it as a candidate `Document.id`.
  - Added `onyx.connectors.sharepoint.url_utils` (GUID extraction, token decoding, path normalization); expanded tests cover all URL forms and encoding differences.

<sup>Written for commit 1479ea10adf67a4199b18c9b50f8138e14538901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

