### PR TITLE
refactor(auth): gate cloud-only behavior on MULTI_TENANT

### DIFF
--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -42,14 +42,12 @@ from ee.onyx.utils.encryption import test_encryption
 from onyx.auth.users import auth_backend
 from onyx.auth.users import create_onyx_oauth_router
 from onyx.auth.users import fastapi_users
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
 from onyx.configs.app_configs import GOOGLE_OAUTH_SCOPE_OVERRIDE
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
 from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
 from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.configs.app_configs import WEB_DOMAIN
-from onyx.configs.constants import AuthType
 from onyx.main import get_application as get_application_base
 from onyx.main import include_auth_router_with_prefix
 from onyx.main import include_router_with_global_prefix_prepended
@@ -101,7 +99,7 @@ def get_application() -> FastAPI:
         # MT deployments use control plane gating via is_tenant_gated() instead
         add_license_enforcement_middleware(application, logger)
 
-    if AUTH_TYPE == AuthType.CLOUD:
+    if MULTI_TENANT:
         # For Google OAuth, refresh tokens are requested by:
         # 1. Adding the right scopes
         # 2. Properly configuring OAuth in Google Cloud Console to allow offline access

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -342,8 +342,9 @@ def verify_email_domain(
     domain = domain.lower()
     local_part = local_part.lower()
 
-    if AUTH_TYPE == AuthType.CLOUD:
-        # Normalize googlemail.com to gmail.com (they deliver to the same inbox)
+    if MULTI_TENANT:
+        # Reject googlemail.com so gmail.com is the single canonical form
+        # (they deliver to the same inbox).
         if domain == "googlemail.com":
             raise OnyxError(
                 OnyxErrorCode.INVALID_INPUT,
@@ -1624,7 +1625,7 @@ def get_jwt_strategy() -> SingleTenantJWTStrategy:
 
 
 if AUTH_BACKEND == AuthBackend.JWT:
-    if MULTI_TENANT or AUTH_TYPE == AuthType.CLOUD:
+    if MULTI_TENANT:
         raise ValueError(
             "JWT auth backend is only supported for single-tenant, self-hosted deployments. Use 'redis' or 'postgres' instead."
         )

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -45,12 +45,10 @@ from onyx.background.indexing.checkpointing_utils import (
 )
 from onyx.background.indexing.index_attempt_utils import cleanup_index_attempts
 from onyx.background.indexing.index_attempt_utils import get_old_index_attempt_ids
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import MANAGED_VESPA
 from onyx.configs.app_configs import PERSISTENT_INDEXING
 from onyx.configs.app_configs import VESPA_CLOUD_CERT_PATH
 from onyx.configs.app_configs import VESPA_CLOUD_KEY_PATH
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import CELERY_GENERIC_BEAT_LOCK_TIMEOUT
 from onyx.configs.constants import CELERY_INDEXING_LOCK_TIMEOUT
 from onyx.configs.constants import DocumentSource
@@ -1027,7 +1025,7 @@ def check_for_indexing(self: Task, *, tenant_id: str) -> int | None:
                     # to prevent continued indexing retry attempts burning through embedding credits.
                     # NOTE: only for Cloud, since most self-hosted users use self-hosted embedding
                     # models. Also, they are more prone to repeated failures -> eventual success.
-                    if AUTH_TYPE == AuthType.CLOUD:
+                    if MULTI_TENANT:
                         update_connector_credential_pair_from_id(
                             db_session=db_session,
                             cc_pair_id=cc_pair.id,

--- a/backend/onyx/onyxbot/discord/utils.py
+++ b/backend/onyx/onyxbot/discord/utils.py
@@ -1,10 +1,9 @@
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import DISCORD_BOT_TOKEN
-from onyx.configs.constants import AuthType
 from onyx.db.discord_bot import get_discord_bot_config
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
+from shared_configs.configs import MULTI_TENANT
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 logger = setup_logger()
@@ -26,7 +25,7 @@ def get_bot_token() -> str | None:
         return DISCORD_BOT_TOKEN
 
     # Cloud should always have env var; if not, return None
-    if AUTH_TYPE == AuthType.CLOUD:
+    if MULTI_TENANT:
         logger.warning("Cloud deployment missing DISCORD_BOT_TOKEN env var")
         return None
 

--- a/backend/onyx/server/features/build/rate_limit.py
+++ b/backend/onyx/server/features/build/rate_limit.py
@@ -8,8 +8,6 @@ from typing import Literal
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from onyx.configs.app_configs import AUTH_TYPE
-from onyx.configs.constants import AuthType
 from onyx.db.models import User
 from onyx.feature_flags.factory import get_default_feature_flag_provider
 from onyx.server.features.build.configs import CRAFT_PAID_USER_RATE_LIMIT
@@ -85,7 +83,7 @@ def get_user_rate_limit_status(
     """
     # Rate limits apply only on Onyx Cloud (multi-tenant); all other deployments
     # are unlimited.
-    if not MULTI_TENANT or AUTH_TYPE != AuthType.CLOUD:
+    if not MULTI_TENANT:
         return RateLimitResponse(
             is_limited=False,
             limit_type="weekly",

--- a/backend/onyx/server/manage/discord_bot/api.py
+++ b/backend/onyx/server/manage/discord_bot/api.py
@@ -7,9 +7,7 @@ from fastapi import status
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import DISCORD_BOT_TOKEN
-from onyx.configs.constants import AuthType
 from onyx.db.discord_bot import create_discord_bot_config
 from onyx.db.discord_bot import create_guild_config
 from onyx.db.discord_bot import delete_discord_bot_config
@@ -33,6 +31,7 @@ from onyx.server.manage.discord_bot.models import DiscordGuildConfigCreateRespon
 from onyx.server.manage.discord_bot.models import DiscordGuildConfigResponse
 from onyx.server.manage.discord_bot.models import DiscordGuildConfigUpdateRequest
 from onyx.server.manage.discord_bot.utils import generate_discord_registration_key
+from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
 router = APIRouter(prefix="/manage/admin/discord-bot")
@@ -45,7 +44,7 @@ def _check_bot_config_api_access() -> None:
     - On Cloud (managed by Onyx)
     - When DISCORD_BOT_TOKEN env var is set (managed via env)
     """
-    if AUTH_TYPE == AuthType.CLOUD:
+    if MULTI_TENANT:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Discord bot configuration is managed by Onyx on Cloud.",
@@ -230,7 +229,7 @@ def delete_guild_request(
         raise HTTPException(status_code=404, detail="Guild config not found")
 
     # On Cloud, delete service API key when all guilds are removed
-    if AUTH_TYPE == AuthType.CLOUD:
+    if MULTI_TENANT:
         remaining_guilds = get_guild_configs(db_session)
         if not remaining_guilds:
             delete_discord_service_api_key(db_session)

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -73,7 +73,7 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
     # The reason is this is used during the login flow, but we don't know which tenant the user is supposed to be
     # associated with until they auth.
     has_users = True
-    if AUTH_TYPE != AuthType.CLOUD:
+    if not MULTI_TENANT:
         user_count = await get_user_count()
         has_users = user_count > 0
 

--- a/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
+++ b/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 
 import pytest
 
-from onyx.configs.constants import AuthType
 from onyx.db.discord_bot import get_guild_config_by_registration_key
 from onyx.db.discord_bot import register_guild
 from onyx.db.engine.sql_engine import get_session_with_tenant
@@ -29,7 +28,7 @@ class TestBotConfigIsolationCloudMode:
 
     def test_cannot_create_bot_config_in_cloud_mode(self) -> None:
         """Bot config creation is blocked in cloud mode."""
-        with patch("onyx.configs.app_configs.AUTH_TYPE", AuthType.CLOUD):
+        with patch("onyx.server.manage.discord_bot.api.MULTI_TENANT", True):
             from fastapi import HTTPException
 
             from onyx.server.manage.discord_bot.api import _check_bot_config_api_access
@@ -46,7 +45,7 @@ class TestBotConfigIsolationCloudMode:
 
         with (
             patch("onyx.onyxbot.discord.utils.DISCORD_BOT_TOKEN", "env_token"),
-            patch("onyx.onyxbot.discord.utils.AUTH_TYPE", AuthType.CLOUD),
+            patch("onyx.onyxbot.discord.utils.MULTI_TENANT", True),
         ):
             result = get_bot_token()
 

--- a/backend/tests/integration/tests/indexing/test_repeated_error_state.py
+++ b/backend/tests/integration/tests/indexing/test_repeated_error_state.py
@@ -121,9 +121,9 @@ def test_repeated_error_state_detection_and_recovery(
             )
             assert cc_pair_obj is not None
             if cc_pair_obj.in_repeated_error_state:
-                # Pausing only happens for cloud deployments and the IT don't run with
-                # that auth type :(
-                # if AUTH_TYPE == AuthType.CLOUD:
+                # Pausing only happens on Cloud (multi-tenant) and the IT suite
+                # doesn't run multi-tenant.
+                # if MULTI_TENANT:
                 #     assert cc_pair_obj.status == ConnectorCredentialPairStatus.PAUSED, (
                 #         f"Expected status to be PAUSED when in repeated error state, "
                 #         f"but got {cc_pair_obj.status}"

--- a/backend/tests/unit/onyx/auth/test_verify_email_domain.py
+++ b/backend/tests/unit/onyx/auth/test_verify_email_domain.py
@@ -2,7 +2,6 @@ import pytest
 
 import onyx.auth.users as users
 from onyx.auth.users import verify_email_domain
-from onyx.configs.constants import AuthType
 from onyx.error_handling.exceptions import OnyxError
 
 
@@ -28,7 +27,7 @@ def test_verify_email_domain_invalid_email_format() -> None:
 def test_verify_email_domain_rejects_plus_addressing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
+    monkeypatch.setattr(users, "MULTI_TENANT", True, raising=False)
 
     with pytest.raises(OnyxError) as exc:
         verify_email_domain("user+tag@gmail.com", valid_email_domains=[])
@@ -39,7 +38,7 @@ def test_verify_email_domain_rejects_plus_addressing(
 def test_verify_email_domain_allows_plus_for_onyx_app(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
+    monkeypatch.setattr(users, "MULTI_TENANT", True, raising=False)
 
     # Should not raise for onyx.app domain
     verify_email_domain("user+tag@onyx.app", valid_email_domains=[])
@@ -48,7 +47,7 @@ def test_verify_email_domain_allows_plus_for_onyx_app(
 def test_verify_email_domain_rejects_dotted_gmail_on_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
+    monkeypatch.setattr(users, "MULTI_TENANT", True, raising=False)
 
     with pytest.raises(OnyxError) as exc:
         verify_email_domain(
@@ -63,7 +62,7 @@ def test_verify_email_domain_rejects_dotted_gmail_on_registration(
 def test_verify_email_domain_dotted_gmail_allowed_when_not_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
+    monkeypatch.setattr(users, "MULTI_TENANT", True, raising=False)
 
     # Existing user signing in — should not be blocked
     verify_email_domain(
@@ -74,7 +73,7 @@ def test_verify_email_domain_dotted_gmail_allowed_when_not_registration(
 def test_verify_email_domain_allows_dotted_non_gmail_on_registration(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
+    monkeypatch.setattr(users, "MULTI_TENANT", True, raising=False)
 
     verify_email_domain(
         "first.last@example.com",
@@ -86,7 +85,7 @@ def test_verify_email_domain_allows_dotted_non_gmail_on_registration(
 def test_verify_email_domain_dotted_gmail_allowed_when_not_cloud(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
+    monkeypatch.setattr(users, "MULTI_TENANT", False, raising=False)
 
     verify_email_domain(
         "first.last@gmail.com",
@@ -98,7 +97,7 @@ def test_verify_email_domain_dotted_gmail_allowed_when_not_cloud(
 def test_verify_email_domain_rejects_googlemail(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.CLOUD, raising=False)
+    monkeypatch.setattr(users, "MULTI_TENANT", True, raising=False)
 
     with pytest.raises(OnyxError) as exc:
         verify_email_domain("user@googlemail.com", valid_email_domains=[])

--- a/backend/tests/unit/onyx/onyxbot/discord/test_discord_utils.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_discord_utils.py
@@ -30,7 +30,7 @@ class TestGetBotToken:
 
         with (
             patch("onyx.onyxbot.discord.utils.DISCORD_BOT_TOKEN", None),
-            patch("onyx.onyxbot.discord.utils.AUTH_TYPE", "basic"),  # Not CLOUD
+            patch("onyx.onyxbot.discord.utils.MULTI_TENANT", False),  # Not cloud
             patch("onyx.onyxbot.discord.utils.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.utils.get_discord_bot_config",
@@ -46,7 +46,7 @@ class TestGetBotToken:
         """When no env var and no DB config, returns None."""
         with (
             patch("onyx.onyxbot.discord.utils.DISCORD_BOT_TOKEN", None),
-            patch("onyx.onyxbot.discord.utils.AUTH_TYPE", "basic"),  # Not CLOUD
+            patch("onyx.onyxbot.discord.utils.MULTI_TENANT", False),  # Not cloud
             patch("onyx.onyxbot.discord.utils.get_session_with_tenant") as mock_session,
             patch(
                 "onyx.onyxbot.discord.utils.get_discord_bot_config",


### PR DESCRIPTION
## Description

PR 1 of the `AUTH_TYPE` removal stack (context: multi-SSO makes auth a runtime concern, so the env var's jobs move to better homes).

- The nine pure "is this Onyx Cloud" checks gate on `MULTI_TENANT` instead of `AUTH_TYPE == CLOUD`: cloud Google login setup, gmail normalization, JWT-backend validation, discord bot token/config/service-key handling, repeated-error connector pausing, `/auth/type` user-count skip, and chat rate limits.
- Two dual checks collapse (`MULTI_TENANT or CLOUD`, `not MULTI_TENANT or not CLOUD`) — every cloud deployment sets both (the EE tier resolver's multi-tenant branch requires the control plane).
- Password-model sites mixing BASIC and CLOUD are deliberately untouched; they're handled later in the stack.
- Also fixes a silently no-op test patch (`test_discord_bot_multitenant.py` patched the source module, not the consuming binding).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check