### PR TITLE
feat(auth): key the invite-list bypass on per-user SSO provenance

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -284,9 +284,16 @@ def workspace_invite_only_enabled() -> bool:
     return settings.invite_only_enabled
 
 
-def verify_email_is_invited(email: str) -> None:
+def verify_email_is_invited(email: str, *, sso_managed: bool = False) -> None:
+    # An SSO provider manages membership for users it provisions, and its
+    # allowed_email_domains is the admin's per-provider control, so the
+    # workspace invite list does not apply.
+    if sso_managed:
+        return
+
+    # Legacy single-provider modes imply every signup is IdP-provisioned.
+    # Dies with those modes.
     if AUTH_TYPE in {AuthType.SAML, AuthType.OIDC}:
-        # SSO providers manage membership; allow JIT provisioning regardless of invites
         return
 
     if not workspace_invite_only_enabled():
@@ -323,10 +330,12 @@ def verify_email_is_invited(email: str) -> None:
     )
 
 
-def verify_email_in_whitelist(email: str, tenant_id: str) -> None:
+def verify_email_in_whitelist(
+    email: str, tenant_id: str, *, sso_managed: bool = False
+) -> None:
     with get_session_with_tenant(tenant_id=tenant_id) as db_session:
         if not get_user_by_email(email, db_session):
-            verify_email_is_invited(email)
+            verify_email_is_invited(email, sso_managed=sso_managed)
 
 
 def verify_email_domain(
@@ -548,6 +557,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         user_create: schemas.UC | UserCreate,
         safe: bool = False,
         request: Optional[Request] = None,
+        *,
+        sso_managed: bool = False,
     ) -> User:
         # Check for disposable emails FIRST so obvious throwaway domains are
         # rejected before hitting Google's siteverify API. Cheap local check.
@@ -630,10 +641,13 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     user_count = await get_user_count()
                     if user_count > 0:
                         # Tenant already has users - require invite for new users
-                        verify_email_is_invited(user_create.email)
+                        verify_email_is_invited(
+                            user_create.email, sso_managed=sso_managed
+                        )
                 else:
-                    # Single-tenant: Check invite list (skips if SAML/OIDC or no list configured)
-                    verify_email_is_invited(user_create.email)
+                    # Single-tenant: the gate self-skips for SSO-managed users
+                    # and when invite-only is off
+                    verify_email_is_invited(user_create.email, sso_managed=sso_managed)
                 if MULTI_TENANT:
                     tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
                         db_session, User, OAuthAccount
@@ -865,6 +879,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
         allowed_email_domains_override: Sequence[str] | None = None,
+        sso_managed: bool = False,
     ) -> User:
         referral_source = (
             getattr(request.state, "referral_source", None) if request else None
@@ -888,7 +903,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         async with get_async_session_context_manager(tenant_id) as db_session:
             token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-            verify_email_in_whitelist(account_email, tenant_id)
+            verify_email_in_whitelist(account_email, tenant_id, sso_managed=sso_managed)
             oauth_security_settings = get_security_settings()
             effective_valid_email_domains = (
                 allowed_email_domains_override
@@ -2348,6 +2363,7 @@ async def complete_login_flow(
     associate_by_email: bool,
     is_verified_by_default: bool,
     allowed_email_domains_override: Sequence[str] | None = None,
+    sso_managed: bool = False,
 ) -> RedirectResponse:
     """Shared post-token OAuth/OIDC login: read the verified identity, create or
     authenticate the user, and return a web or mobile redirect."""
@@ -2397,6 +2413,7 @@ async def complete_login_flow(
             associate_by_email=associate_by_email,
             is_verified_by_default=is_verified_by_default,
             allowed_email_domains_override=allowed_email_domains_override,  # ty: ignore[unknown-argument]
+            sso_managed=sso_managed,  # ty: ignore[unknown-argument]
         )
     except UserAlreadyExists:
         raise OnyxError(

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -299,6 +299,8 @@ async def oidc_login_callback_for_provider(
         associate_by_email=_ALLOW_AUTO_LINK,
         is_verified_by_default=True,
         allowed_email_domains_override=provider.allowed_email_domains,
+        # Provider rows delegate membership to the IdP.
+        sso_managed=True,
     )
 
     if OIDC_PKCE_ENABLED:

--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -113,7 +113,8 @@ async def upsert_saml_user(email: str) -> User:
                         password=secure_random_password,  # Pass raw password, not hash
                         role=role,
                         is_verified=True,  # SAML users are pre-verified by their IdP
-                    )
+                    ),
+                    sso_managed=True,
                 )
 
                 return user

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -243,7 +243,9 @@ class TestMultiTenantInviteLogic:
             pass
 
         # Verify invite check WAS called (user_count > 0)
-        mock_verify_invited.assert_called_once_with(mock_user_create.email)
+        mock_verify_invited.assert_called_once_with(
+            mock_user_create.email, sso_managed=False
+        )
 
 
 class TestSingleTenantInviteLogic:
@@ -293,7 +295,9 @@ class TestSingleTenantInviteLogic:
             pass
 
         # Verify invite check was called
-        mock_verify_invited.assert_called_once_with(mock_user_create.email)
+        mock_verify_invited.assert_called_once_with(
+            mock_user_create.email, sso_managed=False
+        )
 
 
 class TestSAMLOIDCBehavior:

--- a/backend/tests/unit/onyx/auth/test_verify_email_invite.py
+++ b/backend/tests/unit/onyx/auth/test_verify_email_invite.py
@@ -53,3 +53,37 @@ def test_verify_email_is_invited_skipped_when_invite_only_disabled(
     )
 
     verify_email_is_invited("newuser@example.com")
+
+
+def test_sso_managed_bypasses_whitelist_under_basic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A provider-row login on a BASIC deployment is IdP-managed, so the
+    workspace invite list must not block its JIT-provisioned users."""
+    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
+    monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
+    monkeypatch.setattr(
+        users,
+        "get_invited_users",
+        lambda: ["allowed@example.com"],
+        raising=False,
+    )
+
+    verify_email_is_invited("newuser@example.com", sso_managed=True)
+
+
+def test_sso_managed_default_false_keeps_enforcement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Callers that do not declare SSO provenance keep the invite check."""
+    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
+    monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
+    monkeypatch.setattr(
+        users,
+        "get_invited_users",
+        lambda: ["allowed@example.com"],
+        raising=False,
+    )
+
+    with pytest.raises(OnyxError):
+        verify_email_is_invited("newuser@example.com", sso_managed=False)


### PR DESCRIPTION
## Description

PR 2 of the `AUTH_TYPE` removal stack (stacked on #13017).

- `verify_email_is_invited` gains a keyword-only `sso_managed` flag, threaded from the provider callbacks (`oidc_multi` rows, SAML upsert) through `create` / `oauth_callback` / `complete_login_flow`.
- **Fixes a live multi-SSO gap**: a BASIC deployment with provider rows applied the workspace invite list to SSO JIT users, because the old bypass only fired under legacy `AUTH_TYPE=saml/oidc`. Provider rows delegate membership to the IdP, with per-provider `allowed_email_domains` as the admin control.
- Built-in cloud and env Google login keep invite enforcement (legacy parity: Google never had the bypass), and JWT provisioning keeps its explicit check.
- The legacy `AUTH_TYPE in {SAML, OIDC}` bypass leg stays until those modes are removed later in the stack.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check