### PR TITLE
feat(auth): capture SAML directory attributes for profile enrichment

### DIFF
--- a/backend/onyx/auth/login_claims_capture.py
+++ b/backend/onyx/auth/login_claims_capture.py
@@ -1,20 +1,23 @@
-"""Capture the OIDC/OAuth claims received at login and derive a directory
-profile from them.
+"""Capture the identity attributes an IdP sends at login and derive a
+directory profile from them, independent of login protocol.
 
-The IdP sends user information in the id_token and on the userinfo endpoint,
-but the login flow only consumes ``sub`` and ``email`` — everything else is
-discarded. When ``IDP_PROFILE_ENRICHMENT_ENABLED`` is set, this module
-snapshots the full claim set into Redis at login time and derives a
-"directory profile" (country, department, job title, ...) from it, which is
-then used to (a) enrich the chat system prompt and (b) resolve
-author-controlled ``{{user.<key>}}`` placeholders in agent prompts.
+Both protocols feed this module: OAuth/OIDC logins contribute id_token and
+userinfo claims (plus the Microsoft Graph profile for Entra ID), and SAML
+logins contribute assertion attributes. The login flow itself only consumes
+``sub`` and ``email``, and everything else is discarded. When
+``IDP_PROFILE_ENRICHMENT_ENABLED`` is set, this module snapshots the full
+attribute set into Redis at login time and derives a "directory profile"
+(country, department, job title, ...) from it, which is then used to (a)
+enrich the chat system prompt and (b) resolve author-controlled
+``{{user.<key>}}`` placeholders in agent prompts.
 
 Profile fields are resolved through a provider-agnostic claim map: each field
-has an ordered list of claim aliases checked against three sources in
+has an ordered list of claim aliases checked against the captured sources in
 precedence order — the provider directory API (Microsoft Graph for Entra ID),
-the OIDC userinfo response, then the raw id_token claims. Okta/Keycloak/Google
-deployments therefore work out of the box for whatever claims they release,
-and the map can be extended per-deployment via ``IDP_PROFILE_CLAIM_MAP``.
+the OIDC userinfo response, the raw id_token claims, then SAML assertion
+attributes. Okta/Keycloak/Google deployments therefore work out of the box for
+whatever claims they release, and the map can be extended per-deployment via
+``IDP_PROFILE_CLAIM_MAP``.
 
 Capture is strictly best-effort: any failure is logged and swallowed so the
 login flow can never break because of it. No tokens are persisted — only
@@ -40,7 +43,7 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 _OAUTH_CLAIMS_KEY_PREFIX = "oauth_login_claims"
-# Long enough that an admin can log in and inspect at leisure; short enough
+# Long enough that an admin can log in and inspect at leisure, short enough
 # that stale directory data doesn't linger forever.
 _OAUTH_CLAIMS_TTL_SECONDS = 60 * 60 * 24 * 30
 
@@ -50,7 +53,7 @@ _OAUTH_CLAIMS_TTL_SECONDS = 60 * 60 * 24 * 30
 # dropping one is harmless.
 _OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS = 10
 
-# Entra ID hosts its OIDC userinfo endpoint on Microsoft Graph; when we see
+# Entra ID hosts its OIDC userinfo endpoint on Microsoft Graph. When we see
 # that host we can also query the Graph profile, which carries directory
 # fields the id_token/userinfo never include (country, usageLocation, ...).
 _MS_GRAPH_HOST = "graph.microsoft.com"
@@ -67,10 +70,19 @@ def _oauth_claims_key(tenant_id: str, email: str) -> str:
     return f"{_OAUTH_CLAIMS_KEY_PREFIX}:{tenant_id}:{email.lower()}"
 
 
+async def _store_claims_snapshot(email: str, snapshot: dict[str, Any]) -> None:
+    redis = await get_async_redis_connection()
+    await redis.set(
+        _oauth_claims_key(get_current_tenant_id(), email),
+        json.dumps(snapshot, default=str),
+        ex=_OAUTH_CLAIMS_TTL_SECONDS,
+    )
+
+
 def _decode_id_token_claims(raw_id_token: str) -> dict[str, Any]:
     # Display-only decode: the token was just received directly from the
     # IdP's token endpoint over TLS, so skipping signature verification is
-    # safe here — we never make authorization decisions from this data.
+    # safe here. We never make authorization decisions from this data.
     return jwt.decode(
         raw_id_token,
         options={"verify_signature": False, "verify_aud": False, "verify_exp": False},
@@ -175,7 +187,7 @@ async def _capture_oauth_login_claims(
             except Exception as e:
                 logger.warning("OAuth claims capture: userinfo fetch failed: %s", e)
 
-        # Entra ID: also pull the Graph directory profile — country and
+        # Entra ID: also pull the Graph directory profile. Country and
         # usageLocation live there, not in the id_token/userinfo (unless the
         # `ctry` optional claim is configured on the app registration). Other
         # providers release directory data directly in userinfo/id_token.
@@ -197,7 +209,7 @@ async def _capture_oauth_login_claims(
             "directory_profile": directory_profile,
             "directory_source": directory_source,
             "token_meta": {
-                # Which fields the token response contained — values omitted.
+                # Which fields the token response contained, values omitted.
                 "keys": sorted(token.keys()),
                 "scope": token.get("scope"),
                 "token_type": token.get("token_type"),
@@ -207,12 +219,7 @@ async def _capture_oauth_login_claims(
             },
         }
 
-        redis = await get_async_redis_connection()
-        await redis.set(
-            _oauth_claims_key(get_current_tenant_id(), email),
-            json.dumps(snapshot, default=str),
-            ex=_OAUTH_CLAIMS_TTL_SECONDS,
-        )
+        await _store_claims_snapshot(email, snapshot)
     except Exception:
         logger.warning(
             "OAuth claims capture failed for %s (login unaffected)",
@@ -221,9 +228,66 @@ async def _capture_oauth_login_claims(
         )
 
 
+async def capture_saml_login_claims(
+    email: str,
+    saml_attributes: dict[str, list[str]],
+    provider_name: str,
+) -> None:
+    """Snapshot the directory attributes a SAML IdP asserted at login.
+
+    SAML carries the same directory data (department, title, ...) as OIDC, just
+    as assertion attributes instead of token claims. Resolution reuses the same
+    claim map, so deployments map their attribute names via IDP_PROFILE_CLAIM_MAP.
+    No-op unless IDP_PROFILE_ENRICHMENT_ENABLED. Never raises, and never holds the
+    login open past _OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS.
+    """
+    if not IDP_PROFILE_ENRICHMENT_ENABLED:
+        return
+    try:
+        await asyncio.wait_for(
+            _capture_saml_login_claims(email, saml_attributes, provider_name),
+            timeout=_OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        logger.warning("SAML claims capture timed out for %s (login unaffected)", email)
+
+
+async def _capture_saml_login_claims(
+    email: str,
+    saml_attributes: dict[str, list[str]],
+    provider_name: str,
+) -> None:
+    try:
+        # OneLogin returns each attribute as a list. Keep the first string value
+        # so the claim-map resolver can treat it like any other source.
+        flattened = {
+            name: values[0]
+            for name, values in saml_attributes.items()
+            if isinstance(values, list) and values and isinstance(values[0], str)
+        }
+        snapshot = {
+            "captured_at": datetime.now(timezone.utc).isoformat(),
+            "oauth_name": provider_name,
+            "email": email,
+            "id_token_claims": {},
+            "userinfo": {},
+            "directory_profile": None,
+            "directory_source": None,
+            "saml_attributes": flattened,
+            "token_meta": {"source": "saml"},
+        }
+        await _store_claims_snapshot(email, snapshot)
+    except Exception:
+        logger.warning(
+            "SAML claims capture failed for %s (login unaffected)",
+            email,
+            exc_info=True,
+        )
+
+
 # Profile field definitions: (placeholder_key, human-readable label, ordered
 # claim aliases). Aliases are checked against each captured source in
-# precedence order (directory API -> userinfo -> id_token claims); the first
+# precedence order (directory API -> userinfo -> id_token claims). The first
 # non-empty string wins. Aliases cover Microsoft Graph names plus the common
 # OIDC/Okta/Keycloak claim names for the same concept, and can be extended
 # per-deployment via IDP_PROFILE_CLAIM_MAP. This is the single source of truth
@@ -284,6 +348,12 @@ def _load_profile_sources(email: str) -> list[dict[str, Any]]:
     id_token_claims = snapshot.get("id_token_claims")
     if isinstance(id_token_claims, dict):
         sources.append(id_token_claims)
+    # Lowest priority by convention. A snapshot is written whole per login, so
+    # today a SAML snapshot never carries the OIDC sources above and ordering
+    # only matters if a future path mixes them.
+    saml_attributes = snapshot.get("saml_attributes")
+    if isinstance(saml_attributes, dict):
+        sources.append(saml_attributes)
     return sources
 
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -70,12 +70,12 @@ from onyx.auth.email_utils import (
 )
 from onyx.auth.invited_users import get_invited_users, remove_user_from_invited_users
 from onyx.auth.jwt import verify_jwt_token
+from onyx.auth.login_claims_capture import capture_oauth_login_claims
 from onyx.auth.mobile_sso.sso_completion import (
     apply_mobile_state,
     complete_mobile_sso,
     is_mobile_sso,
 )
-from onyx.auth.oauth_claims_capture import capture_oauth_login_claims
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.auth.schemas import AuthBackend, UserCreate, UserRole
 from onyx.auth.session_tokens import (

--- a/backend/onyx/db/memory.py
+++ b/backend/onyx/db/memory.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
-from onyx.auth.oauth_claims_capture import (
+from onyx.auth.login_claims_capture import (
     get_idp_profile_fields,
     get_idp_profile_placeholder_values,
 )

--- a/backend/onyx/prompts/prompt_utils.py
+++ b/backend/onyx/prompts/prompt_utils.py
@@ -4,7 +4,7 @@ from typing import cast
 
 from langchain_core.messages import BaseMessage
 
-from onyx.auth.oauth_claims_capture import IDP_PLACEHOLDER_KEYS
+from onyx.auth.login_claims_capture import IDP_PLACEHOLDER_KEYS
 from onyx.configs.constants import DocumentSource
 from onyx.prompts.chat_prompts import (
     ADDITIONAL_INFO,

--- a/backend/onyx/server/manage/oauth_test.py
+++ b/backend/onyx/server/manage/oauth_test.py
@@ -1,7 +1,7 @@
 """Admin "OAuth Test" API.
 
 Exposes the claims snapshot captured at OAuth/OIDC login time (see
-onyx/auth/oauth_claims_capture.py) so admins can inspect which user fields
+onyx/auth/login_claims_capture.py) so admins can inspect which user fields
 the IdP actually releases about a user, and debug the directory-profile
 enrichment. To refresh the snapshot the admin simply goes through the login
 flow again.
@@ -12,7 +12,7 @@ from typing import Any
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from onyx.auth.oauth_claims_capture import (
+from onyx.auth.login_claims_capture import (
     get_captured_oauth_claims,
     get_idp_profile_fields,
 )

--- a/backend/onyx/server/saml_multi.py
+++ b/backend/onyx/server/saml_multi.py
@@ -9,6 +9,7 @@ from onelogin.saml2.xml_utils import OneLogin_Saml2_XML
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
+from onyx.auth.login_claims_capture import capture_saml_login_claims
 from onyx.auth.users import UserManager, auth_backend, fastapi_users, get_user_manager
 from onyx.configs.app_configs import REQUIRE_EMAIL_VERIFICATION, WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -323,6 +324,10 @@ async def _process_saml_callback(
     _enforce_allowed_email_domain(provider, user_email)
 
     user = await upsert_saml_user(email=user_email)
+    # Best-effort directory-profile capture from the SAML assertion attributes.
+    await capture_saml_login_claims(
+        user_email, auth.get_attributes(), provider.name or "saml"
+    )
     response = await auth_backend.login(strategy, user)
     await user_manager.on_after_login(user, request, response)
     return response

--- a/backend/tests/unit/onyx/auth/test_login_claims_capture.py
+++ b/backend/tests/unit/onyx/auth/test_login_claims_capture.py
@@ -5,9 +5,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import jwt
 import pytest
 
-import onyx.auth.oauth_claims_capture as claims_capture
-from onyx.auth.oauth_claims_capture import (
+import onyx.auth.login_claims_capture as claims_capture
+from onyx.auth.login_claims_capture import (
     capture_oauth_login_claims,
+    capture_saml_login_claims,
     get_captured_oauth_claims,
     get_idp_profile_fields,
     get_idp_profile_placeholder_values,
@@ -49,7 +50,7 @@ async def test_capture_stores_id_token_claims_and_token_meta() -> None:
     redis = AsyncMock()
 
     with patch(
-        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        "onyx.auth.login_claims_capture.get_async_redis_connection",
         return_value=redis,
     ):
         await capture_oauth_login_claims(
@@ -80,11 +81,11 @@ async def test_capture_fetches_userinfo_when_endpoint_available() -> None:
 
     with (
         patch(
-            "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+            "onyx.auth.login_claims_capture.get_async_redis_connection",
             return_value=redis,
         ),
         patch(
-            "onyx.auth.oauth_claims_capture._fetch_userinfo",
+            "onyx.auth.login_claims_capture._fetch_userinfo",
             new=AsyncMock(return_value=userinfo),
         ) as fetch_mock,
     ):
@@ -110,15 +111,15 @@ async def test_capture_fetches_directory_profile_for_entra() -> None:
 
     with (
         patch(
-            "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+            "onyx.auth.login_claims_capture.get_async_redis_connection",
             return_value=redis,
         ),
         patch(
-            "onyx.auth.oauth_claims_capture._fetch_userinfo",
+            "onyx.auth.login_claims_capture._fetch_userinfo",
             new=AsyncMock(return_value={"sub": "abc"}),
         ),
         patch(
-            "onyx.auth.oauth_claims_capture._fetch_ms_graph_profile",
+            "onyx.auth.login_claims_capture._fetch_ms_graph_profile",
             new=AsyncMock(return_value=directory_profile),
         ) as graph_mock,
     ):
@@ -140,10 +141,10 @@ async def test_capture_never_raises_when_redis_is_down() -> None:
     redis.set.side_effect = ConnectionError("redis down")
 
     with patch(
-        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        "onyx.auth.login_claims_capture.get_async_redis_connection",
         return_value=redis,
     ):
-        # Must not raise — login flow depends on it
+        # Must not raise, login flow depends on it
         await capture_oauth_login_claims(
             _FakeOAuthClient(), "user@example.com", _make_token({"sub": "abc"})
         )
@@ -156,14 +157,14 @@ async def test_get_captured_oauth_claims_roundtrip() -> None:
     redis.get.return_value = json.dumps(stored)
 
     with patch(
-        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        "onyx.auth.login_claims_capture.get_async_redis_connection",
         return_value=redis,
     ):
         assert await get_captured_oauth_claims("user@example.com") == stored
 
     redis.get.return_value = None
     with patch(
-        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        "onyx.auth.login_claims_capture.get_async_redis_connection",
         return_value=redis,
     ):
         assert await get_captured_oauth_claims("user@example.com") is None
@@ -230,7 +231,7 @@ def test_get_idp_profile_placeholder_values_maps_directory_profile() -> None:
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
 
-    # Snake_case placeholder keys; empty/absent fields dropped.
+    # Snake_case placeholder keys. Empty/absent fields dropped.
     assert values == {
         "country": "Germany",
         "usage_location": "DE",
@@ -263,7 +264,7 @@ async def test_capture_noop_when_enrichment_disabled(
     monkeypatch.setattr(claims_capture, "IDP_PROFILE_ENRICHMENT_ENABLED", False)
     redis = AsyncMock()
     with patch(
-        "onyx.auth.oauth_claims_capture.get_async_redis_connection",
+        "onyx.auth.login_claims_capture.get_async_redis_connection",
         return_value=redis,
     ):
         await capture_oauth_login_claims(
@@ -360,7 +361,7 @@ def test_claim_map_override_takes_precedence(
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
 
-    # Configured alias wins; built-in aliases remain as fallback.
+    # Configured alias wins. Built-in aliases remain as fallback.
     assert values["department"] == "Platform"
 
 
@@ -379,3 +380,56 @@ def test_source_precedence_holds_across_aliases() -> None:
         values = get_idp_profile_placeholder_values("user@example.com")
 
     assert values["department"] == "Directory Division"
+
+
+@pytest.mark.asyncio
+async def test_capture_saml_stores_flattened_attributes() -> None:
+    """SAML attributes arrive as {name: [values]}. Capture keeps the first value
+    so the shared claim-map resolver can treat them like any other source."""
+    redis = AsyncMock()
+    with patch(
+        "onyx.auth.login_claims_capture.get_async_redis_connection",
+        return_value=redis,
+    ):
+        await capture_saml_login_claims(
+            "user@example.com",
+            {"department": ["Legal"], "jobTitle": ["Counsel"], "empty": []},
+            "okta-saml",
+        )
+
+    redis.set.assert_awaited_once()
+    snapshot = json.loads(redis.set.await_args.args[1])
+    assert snapshot["saml_attributes"] == {"department": "Legal", "jobTitle": "Counsel"}
+    assert snapshot["oauth_name"] == "okta-saml"
+
+
+def test_profile_resolves_from_saml_attributes() -> None:
+    snapshot = {
+        "saml_attributes": {"department": "Legal", "jobTitle": "Counsel", "ctry": "US"},
+        "directory_profile": None,
+        "userinfo": {},
+        "id_token_claims": {},
+    }
+    redis = MagicMock()
+    redis.get.return_value = json.dumps(snapshot)
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        values = get_idp_profile_placeholder_values("user@example.com")
+
+    assert values == {"department": "Legal", "job_title": "Counsel", "country": "US"}
+
+
+@pytest.mark.asyncio
+async def test_capture_saml_noop_when_enrichment_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(claims_capture, "IDP_PROFILE_ENRICHMENT_ENABLED", False)
+    redis = AsyncMock()
+    with patch(
+        "onyx.auth.login_claims_capture.get_async_redis_connection",
+        return_value=redis,
+    ):
+        await capture_saml_login_claims(
+            "user@example.com", {"department": ["Legal"]}, "okta-saml"
+        )
+    redis.set.assert_not_awaited()

--- a/web/src/lib/agents/userPlaceholders.ts
+++ b/web/src/lib/agents/userPlaceholders.ts
@@ -4,7 +4,7 @@
 // MUST stay in sync with the backend allow-list (enforced by
 // backend/tests/unit/onyx/prompts/test_prompt_utils.py):
 //   - onyx/prompts/prompt_utils.py `USER_PLACEHOLDER_KEYS`
-//   - onyx/auth/oauth_claims_capture.py `_PROFILE_FIELDS`
+//   - onyx/auth/login_claims_capture.py `_PROFILE_FIELDS`
 
 export interface UserPlaceholder {
   key: string;


### PR DESCRIPTION
## Description

Extends the opt-in IdP directory-profile enrichment (#12997) to SAML logins.

- SAML asserts the same directory data (department, title, ...) as OIDC, just as assertion attributes instead of token claims.
- Capture flattens `auth.get_attributes()` into the same Redis snapshot under a `saml_attributes` source. Resolution reuses the existing claim map, so deployments map attribute names via `IDP_PROFILE_CLAIM_MAP` exactly like OIDC.
- Hooked into the active multi-IdP SAML callback (`saml_multi.py`), best-effort and timeout-bounded like the OAuth path.
- Single-tenant only until per-tenant capture. The `MULTI_TENANT` gate still applies.

## How Has This Been Tested?

<!--- filled in by reviewer -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check