### PR TITLE
feat(opal): searchable InputSelect via a Search compound slot

### DIFF
--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -139,6 +139,7 @@ export {
   type InputSelectRootProps,
   type InputSelectTriggerProps,
   type InputSelectItemProps,
+  type InputSelectSearchProps,
 } from "@opal/components/inputs/input-select/components";
 
 /* InputTags */

--- a/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/InputSelect.stories.tsx
@@ -103,3 +103,51 @@ export const Disabled: Story = {
     </div>
   ),
 };
+
+const AGENTS = [
+  "General Assistant",
+  "Search Copilot",
+  "Sales Researcher",
+  "Support Triage",
+  "Code Reviewer",
+  "Data Analyst",
+  "Meeting Notetaker",
+  "Onboarding Guide",
+];
+
+function SearchableHarness() {
+  const [value, setValue] = useState("");
+  const [query, setQuery] = useState("");
+  const filtered = AGENTS.filter((name) =>
+    name.toLowerCase().includes(query.toLowerCase())
+  );
+  return (
+    <div className="w-72">
+      <InputSelect
+        value={value}
+        onValueChange={setValue}
+        onOpenChange={(open) => {
+          if (open) setQuery("");
+        }}
+      >
+        <InputSelect.Trigger placeholder="Select an agent" />
+        <InputSelect.Content>
+          <InputSelect.Search
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search agents..."
+          />
+          {filtered.map((name) => (
+            <InputSelect.Item key={name} value={name}>
+              {name}
+            </InputSelect.Item>
+          ))}
+        </InputSelect.Content>
+      </InputSelect>
+    </div>
+  );
+}
+
+export const Searchable: Story = {
+  render: () => <SearchableHarness />,
+};

--- a/web/lib/opal/src/components/inputs/input-select/README.md
+++ b/web/lib/opal/src/components/inputs/input-select/README.md
@@ -4,6 +4,23 @@
 
 Styled dropdown on Radix Select, the Figma `Input/Select`. Compound component: the root owns value state (controlled or uncontrolled), `Trigger` renders the `.opal-input` chrome with the selected item's icon and label (truncating with a tooltip when clipped), `Content` is the popper matching the trigger width, `Item`s render as `ContentAction` rows with Radix driving highlight and selection.
 
+For filterable lists, render `Search` as the first child of `Content`. It is a sticky query row: the consumer owns the query state and renders only the matching `Item`s. The row keeps printable keys in its input (Radix typeahead never fires), focuses itself when the menu opens, hands focus to the option list on ArrowDown (Radix then drives highlight and Enter), and lets Escape close the menu. Clear the query in `onOpenChange` so each open starts unfiltered.
+
+```tsx
+<InputSelect.Content>
+  <InputSelect.Search
+    value={query}
+    onChange={(e) => setQuery(e.target.value)}
+    placeholder="Search agents..."
+  />
+  {filtered.map((a) => (
+    <InputSelect.Item key={a.id} value={String(a.id)}>
+      {a.name}
+    </InputSelect.Item>
+  ))}
+</InputSelect.Content>
+```
+
 ```tsx
 <InputSelect value={value} onValueChange={setValue} error={touched && !value}>
   <InputSelect.Trigger placeholder="Choose a model" />

--- a/web/lib/opal/src/components/inputs/input-select/components.tsx
+++ b/web/lib/opal/src/components/inputs/input-select/components.tsx
@@ -12,7 +12,7 @@ import type {
   RichStr,
   WithoutStyles,
 } from "@opal/types";
-import { Divider, Text, Tooltip } from "@opal/components";
+import { Divider, InputTypeIn, Text, Tooltip } from "@opal/components";
 import { toPlainString } from "@opal/components/text/InlineMarkdown";
 import { ContentAction } from "@opal/layouts";
 import { SvgChevronDownSmall } from "@opal/icons";
@@ -450,13 +450,87 @@ function InputSelectSeparator({
 }
 
 // ---------------------------------------------------------------------------
+// Search
+// ---------------------------------------------------------------------------
+
+interface InputSelectSearchProps {
+  /** Controlled query. The consumer filters its own Items from it. */
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  placeholder?: string;
+}
+
+/**
+ * Sticky search row at the top of Content for filterable selects. The
+ * consumer owns the query and renders only the Items that match. The row
+ * owns focus and keyboard isolation: printable keys stay in the input so
+ * Radix's item typeahead never fires, and ArrowDown hands focus to the
+ * option list where Radix drives highlight and Enter natively.
+ */
+function InputSelectSearch({
+  value,
+  onChange,
+  placeholder = "Search...",
+}: InputSelectSearchProps) {
+  const rowRef = React.useRef<HTMLDivElement>(null);
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Focus a frame after mount, past Radix's own open autofocus in the
+  // normal path, so typing searches immediately instead of jumping the
+  // highlight via typeahead.
+  React.useEffect(() => {
+    const id = requestAnimationFrame(() => inputRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, []);
+
+  function focusFirstOption() {
+    const listbox = rowRef.current?.closest('[role="listbox"]');
+    listbox
+      ?.querySelector<HTMLElement>('[role="option"]:not([data-disabled])')
+      ?.focus();
+  }
+
+  return (
+    <div
+      ref={rowRef}
+      className="opal-input-select-search"
+      // Mousedown must not reach Content, whose preventDefault would kill
+      // caret placement and text selection in the input.
+      onMouseDown={(e) => e.stopPropagation()}
+      onKeyDown={(e) => {
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          e.stopPropagation();
+          focusFirstOption();
+          return;
+        }
+        // Keep keys out of Radix's item typeahead. Escape still closes the
+        // menu: Radix listens at document capture, ahead of this handler.
+        e.stopPropagation();
+      }}
+    >
+      <InputTypeIn
+        ref={inputRef}
+        variant="internal"
+        searchIcon
+        clearButton
+        value={value}
+        onChange={onChange}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Exports
 // ---------------------------------------------------------------------------
 
 /**
  * InputSelect (Figma Input/Select): styled dropdown on Radix Select.
  * Compound: Trigger opens the popper Content, Items are Radix options
- * rendered as ContentAction rows, Group/Label/Separator organize them.
+ * rendered as ContentAction rows, Group/Label/Separator organize them, and
+ * Search makes the list filterable.
  */
 const InputSelect = Object.assign(InputSelectRoot, {
   Trigger: InputSelectTrigger,
@@ -465,6 +539,7 @@ const InputSelect = Object.assign(InputSelectRoot, {
   Group: InputSelectGroup,
   Label: InputSelectLabel,
   Separator: InputSelectSeparator,
+  Search: InputSelectSearch,
 });
 
 export {
@@ -472,4 +547,5 @@ export {
   type InputSelectRootProps,
   type InputSelectTriggerProps,
   type InputSelectItemProps,
+  type InputSelectSearchProps,
 };

--- a/web/lib/opal/src/components/inputs/input-select/styles.css
+++ b/web/lib/opal/src/components/inputs/input-select/styles.css
@@ -49,6 +49,12 @@
   width: var(--radix-select-trigger-width);
 }
 
+/* Full-bleed over the content's p-1 (negative margins) so scrolling items
+   pass behind a solid, bordered row pinned to the scrollport top. */
+.opal-input-select-search {
+  @apply sticky -top-1 z-1 -mx-1 -mt-1 mb-1 border-b bg-background-neutral-00 p-1;
+}
+
 /* The rows sit outside any .interactive ancestor (portaled), so the item
    provides the base foreground vars ContentAction's interactive color reads,
    plus the shared Interactive timing so highlight animates like every other


### PR DESCRIPTION
## Description

Adds `InputSelect.Search`, a sticky query row rendered as the first child of `Content`, so filterable dropdowns can migrate to Opal.

- The consumer owns the query and renders only the matching `Item`s.
- The row wraps `InputTypeIn` (internal variant, search icon, clear button).
- Printable keys stay in the input so Radix's item typeahead never fires; the row autofocuses on open so type-to-search works immediately.
- ArrowDown hands focus to the option list, where Radix drives highlight and Enter natively. Escape closes via Radix's document-capture listener.
- Mousedown is isolated from `Content`, whose `preventDefault` would otherwise kill caret placement and text selection in the input.

Unblocks migrating the last shadcn `ui/select` consumer (PersonaMessagesChart, whose dropdown embeds a search filter) — that migration lands on #12994.

Stacked on #12881.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check