### PR TITLE
feat(mobile): web-parity auto-scroll control for streaming chat

### DIFF
--- a/mobile/src/chat/__tests__/autoScroll.test.ts
+++ b/mobile/src/chat/__tests__/autoScroll.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  AT_BOTTOM_THRESHOLD_PX,
+  contentSignature,
+  distanceFromBottom,
+  isWithinBottomBand,
+  ScrollMetrics,
+} from "@/chat/autoScroll";
+import { Message } from "@/chat/interfaces";
+
+// A long chat scrolled to various positions. contentHeight 1000, viewport 600 → max offset 400.
+function metrics(offsetY: number): ScrollMetrics {
+  return { offsetY, contentHeight: 1000, viewportHeight: 600 };
+}
+
+function node(over: Partial<Message>): Message {
+  return {
+    nodeId: 1,
+    parentNodeId: null,
+    type: "assistant",
+    message: "",
+    files: [],
+    packets: [],
+    ...over,
+  };
+}
+
+describe("distanceFromBottom", () => {
+  it("is zero at the very bottom", () => {
+    expect(distanceFromBottom(metrics(400))).toBe(0);
+  });
+
+  it("grows as the user scrolls up", () => {
+    expect(distanceFromBottom(metrics(300))).toBe(100);
+    expect(distanceFromBottom(metrics(0))).toBe(400);
+  });
+
+  it("is negative when content is shorter than the viewport", () => {
+    expect(
+      distanceFromBottom({
+        offsetY: 0,
+        contentHeight: 200,
+        viewportHeight: 600,
+      }),
+    ).toBe(-400);
+  });
+});
+
+describe("isWithinBottomBand", () => {
+  it("treats a short (unscrollable) chat as at the bottom", () => {
+    expect(
+      isWithinBottomBand({
+        offsetY: 0,
+        contentHeight: 200,
+        viewportHeight: 600,
+      }),
+    ).toBe(true);
+  });
+
+  it("is inclusive of the threshold boundary", () => {
+    expect(isWithinBottomBand(metrics(400 - AT_BOTTOM_THRESHOLD_PX))).toBe(
+      true,
+    );
+    expect(isWithinBottomBand(metrics(400 - AT_BOTTOM_THRESHOLD_PX - 1))).toBe(
+      false,
+    );
+  });
+});
+
+describe("contentSignature", () => {
+  it("is stable when nothing changed", () => {
+    const messages = [node({ nodeId: 1, message: "hi" })];
+    expect(contentSignature(messages)).toBe(contentSignature([...messages]));
+  });
+
+  it("changes when a streaming flush appends packets to the last node", () => {
+    const before = contentSignature([node({ nodeId: 1, packets: [] })]);
+    const after = contentSignature([
+      node({ nodeId: 1, packets: [{} as never] }),
+    ]);
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when a new turn is appended", () => {
+    const before = contentSignature([node({ nodeId: 1, message: "q" })]);
+    const after = contentSignature([
+      node({ nodeId: 1, message: "q" }),
+      node({ nodeId: 2, message: "" }),
+    ]);
+    expect(after).not.toBe(before);
+  });
+
+  it("handles an empty chat", () => {
+    expect(contentSignature([])).toBe(`0::0:0`);
+  });
+});

--- a/mobile/src/chat/autoScroll.ts
+++ b/mobile/src/chat/autoScroll.ts
@@ -1,0 +1,38 @@
+// Pure scroll-position helpers for the chat message list, kept side-effect-free so they can be
+// unit-tested without RN/FlashList. See useChatAutoScroll for the follow model these feed.
+import { Message } from "@/chat/interfaces";
+
+// Newest turn this far (px) below the viewport counts as "scrolled up": reveal the jump button and
+// stop following. Web uses 32px; 48px matches this list's existing button threshold.
+export const AT_BOTTOM_THRESHOLD_PX = 48;
+
+export interface ScrollMetrics {
+  offsetY: number;
+  contentHeight: number;
+  viewportHeight: number;
+}
+
+// Distance from the bottom of the content to the bottom of the viewport. Negative when the content
+// is shorter than the viewport (short chat) — treated as "at bottom".
+export function distanceFromBottom(metrics: ScrollMetrics): number {
+  return metrics.contentHeight - (metrics.offsetY + metrics.viewportHeight);
+}
+
+export function isWithinBottomBand(
+  metrics: ScrollMetrics,
+  threshold: number = AT_BOTTOM_THRESHOLD_PX,
+): boolean {
+  return distanceFromBottom(metrics) <= threshold;
+}
+
+// A value that changes exactly when the list's rendered content grows: a new turn (count/last node)
+// or a streaming flush (the last assistant node's packets append). Drives the auto-follow — comparing
+// it, rather than reacting to every render, means the follow fires only on real content growth.
+//
+// Known gap: it is height-blind. Growth from late async layout (e.g. an image finishing load after
+// the final packet) doesn't change it, so that growth isn't followed. FlashList v2 exposes no
+// content-size callback to key off instead.
+export function contentSignature(messages: Message[]): string {
+  const last = messages.length ? messages[messages.length - 1] : undefined;
+  return `${messages.length}:${last?.nodeId ?? ""}:${last?.packets.length ?? 0}:${last?.message.length ?? 0}`;
+}

--- a/mobile/src/chat/autoScroll.ts
+++ b/mobile/src/chat/autoScroll.ts
@@ -29,9 +29,9 @@ export function isWithinBottomBand(
 // or a streaming flush (the last assistant node's packets append). Drives the auto-follow — comparing
 // it, rather than reacting to every render, means the follow fires only on real content growth.
 //
-// Known gap: it is height-blind. Growth from late async layout (e.g. an image finishing load after
-// the final packet) doesn't change it, so that growth isn't followed. FlashList v2 exposes no
-// content-size callback to key off instead.
+// It is height-blind: growth from late async layout (e.g. an image finishing load after the final
+// packet) doesn't change it, so the follow won't chase that growth — but the jump button still
+// surfaces it, via onContentSizeChange in useChatAutoScroll.
 export function contentSignature(messages: Message[]): string {
   const last = messages.length ? messages[messages.length - 1] : undefined;
   return `${messages.length}:${last?.nodeId ?? ""}:${last?.packets.length ?? 0}:${last?.message.length ?? 0}`;

--- a/mobile/src/components/chat/MessageList.tsx
+++ b/mobile/src/components/chat/MessageList.tsx
@@ -37,8 +37,10 @@ export function MessageList({ messages, agent }: MessageListProps) {
   const autoScrollEnabled = useSettings((state) => state.autoScrollEnabled);
   const {
     onLoad,
+    onLayout,
     onScroll,
     onScrollBeginDrag,
+    onContentSizeChange,
     scrollToBottom,
     showScrollButton,
     maintainVisibleContentPosition,
@@ -53,7 +55,7 @@ export function MessageList({ messages, agent }: MessageListProps) {
   );
 
   return (
-    <View className="flex-1">
+    <View className="flex-1" onLayout={onLayout}>
       <FlashList
         ref={listRef}
         data={messages}
@@ -62,6 +64,7 @@ export function MessageList({ messages, agent }: MessageListProps) {
         onLoad={onLoad}
         onScroll={onScroll}
         onScrollBeginDrag={onScrollBeginDrag}
+        onContentSizeChange={onContentSizeChange}
         scrollEventThrottle={16}
         maintainVisibleContentPosition={maintainVisibleContentPosition}
         contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 8 }}

--- a/mobile/src/components/chat/MessageList.tsx
+++ b/mobile/src/components/chat/MessageList.tsx
@@ -1,19 +1,17 @@
-// Top-anchored FlashList mirroring web: short chats read top→down; MVCP autoscroll pins to the
-// latest turn while streaming only when the user is near the bottom; a floating chevron returns
-// after scrolling up.
-import { useCallback, useRef, useState } from "react";
-import {
-  NativeScrollEvent,
-  NativeSyntheticEvent,
-  Pressable,
-  View,
-} from "react-native";
+// Top-anchored FlashList mirroring web (short chats read top→down). Streaming auto-follow, the
+// scroll-up-to-pause behavior, and the floating jump chevron all live in useChatAutoScroll; it honors
+// the app-wide autoScroll setting.
+import { useCallback, useRef } from "react";
+import { Pressable, View } from "react-native";
 import { FlashList, FlashListRef } from "@shopify/flash-list";
 
 import { Message } from "@/chat/interfaces";
 import { MinimalAgent } from "@/chat/agents";
+import { contentSignature } from "@/chat/autoScroll";
 import { MessageRow } from "@/components/chat/MessageRow";
 import { Icon } from "@/components/ui/icon";
+import { useChatAutoScroll } from "@/hooks/useChatAutoScroll";
+import { useSettings } from "@/state/settingsStore";
 import SvgChevronDown from "@/icons/chevron-down";
 
 interface MessageListProps {
@@ -21,9 +19,6 @@ interface MessageListProps {
   // for the assistant-message avatar
   agent: MinimalAgent | null;
 }
-
-// Newest turn this far below viewport → "scrolled up", reveal the button (web uses 32px).
-const AT_BOTTOM_THRESHOLD_PX = 48;
 
 const FAB_SHADOW = {
   shadowColor: "#000000",
@@ -39,36 +34,23 @@ function keyExtractor(item: Message): string {
 
 export function MessageList({ messages, agent }: MessageListProps) {
   const listRef = useRef<FlashListRef<Message>>(null);
-  const didInitialScroll = useRef(false);
-  const [showScrollButton, setShowScrollButton] = useState(false);
+  const autoScrollEnabled = useSettings((state) => state.autoScrollEnabled);
+  const {
+    onLoad,
+    onScroll,
+    onScrollBeginDrag,
+    scrollToBottom,
+    showScrollButton,
+    maintainVisibleContentPosition,
+  } = useChatAutoScroll(listRef, {
+    enabled: autoScrollEnabled,
+    contentSignature: contentSignature(messages),
+  });
 
   const renderItem = useCallback(
     ({ item }: { item: Message }) => <MessageRow node={item} agent={agent} />,
     [agent],
   );
-
-  // Land on newest turn when opening a chat (web's session-load scroll-to-bottom); no-op for short
-  // chats. Reset per session by keying this list on sessionId (see ChatSurface).
-  const handleLoad = useCallback(() => {
-    if (didInitialScroll.current) return;
-    didInitialScroll.current = true;
-    listRef.current?.scrollToEnd({ animated: false });
-  }, []);
-
-  const handleScroll = useCallback(
-    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const { contentOffset, contentSize, layoutMeasurement } =
-        event.nativeEvent;
-      const distanceFromBottom =
-        contentSize.height - (contentOffset.y + layoutMeasurement.height);
-      setShowScrollButton(distanceFromBottom > AT_BOTTOM_THRESHOLD_PX);
-    },
-    [],
-  );
-
-  const scrollToBottom = useCallback(() => {
-    listRef.current?.scrollToEnd({ animated: true });
-  }, []);
 
   return (
     <View className="flex-1">
@@ -77,10 +59,11 @@ export function MessageList({ messages, agent }: MessageListProps) {
         data={messages}
         renderItem={renderItem}
         keyExtractor={keyExtractor}
-        onLoad={handleLoad}
-        onScroll={handleScroll}
+        onLoad={onLoad}
+        onScroll={onScroll}
+        onScrollBeginDrag={onScrollBeginDrag}
         scrollEventThrottle={16}
-        maintainVisibleContentPosition={{ autoscrollToBottomThreshold: 0.2 }}
+        maintainVisibleContentPosition={maintainVisibleContentPosition}
         contentContainerStyle={{ paddingHorizontal: 16, paddingVertical: 8 }}
       />
       {showScrollButton ? (

--- a/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
@@ -232,6 +232,37 @@ describe("useChatAutoScroll", () => {
     expect(scrollToEnd).not.toHaveBeenCalled();
   });
 
+  // Re-enabling auto-scroll while at the bottom should catch up to the latest (and hide the button),
+  // not blindly hide a button that reflects real content grown below while auto-scroll was off.
+  it("catches up to the bottom when auto-scroll is re-enabled while pinned", () => {
+    const { result, rerender, scrollToEnd } = setup({
+      enabled: false,
+      contentSignature: "0",
+    });
+    act(() => result.current.onLoad());
+    act(() => result.current.onLayout(layoutEvent(600)));
+    act(() => result.current.onScroll(scrollEvent(400))); // at bottom → pinned
+    act(() => result.current.onContentSizeChange(0, 2000)); // grew below → button shows
+    expect(result.current.showScrollButton).toBe(true);
+
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: true, contentSignature: "0" })); // re-enable, no content change
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: true });
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it("does not catch up on re-enable when the user is scrolled up", () => {
+    const { result, rerender, scrollToEnd } = setup({
+      enabled: false,
+      contentSignature: "0",
+    });
+    act(() => result.current.onScroll(scrollEvent(200))); // scrolled up → not pinned
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: true, contentSignature: "0" }));
+    expect(scrollToEnd).not.toHaveBeenCalled();
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
   it("exposes anchoring-only MVCP (no autoscroll threshold that would fight the manual follow)", () => {
     const { result } = setup();
     expect(result.current.maintainVisibleContentPosition).toEqual({});

--- a/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
@@ -1,7 +1,11 @@
 import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { act, renderHook } from "@testing-library/react-native";
 import type { RefObject } from "react";
-import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+import type {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from "react-native";
 
 import {
   useChatAutoScroll,
@@ -50,6 +54,12 @@ function scrollEvent(
       layoutMeasurement: { height: viewportHeight },
     },
   } as unknown as NativeSyntheticEvent<NativeScrollEvent>;
+}
+
+function layoutEvent(height: number): LayoutChangeEvent {
+  return {
+    nativeEvent: { layout: { height } },
+  } as unknown as LayoutChangeEvent;
 }
 
 function setup(
@@ -149,24 +159,37 @@ describe("useChatAutoScroll", () => {
     expect(scrollToEnd).toHaveBeenCalledTimes(1);
   });
 
-  it("reveals the jump button when content grows below an un-followed viewport", () => {
-    const { result, rerender } = setup({
-      enabled: false,
-      contentSignature: "0",
-    });
-    act(() => result.current.onScroll(scrollEvent(400))); // marks overflow, at bottom
+  // The reported gap: with auto-scroll off, content growing past the viewport must reveal the button
+  // even though the user never scrolled (content growth fires no onScroll). onContentSizeChange does.
+  it("reveals the jump button when content grows to overflow while not following", () => {
+    const { result } = setup({ enabled: false, contentSignature: "0" });
+    act(() => result.current.onLoad()); // marks the initial scroll done
+    act(() => result.current.onLayout(layoutEvent(600))); // viewport known
+    act(() => result.current.onContentSizeChange(0, 500)); // still fits → hidden
     expect(result.current.showScrollButton).toBe(false);
-    act(() => rerender({ enabled: false, contentSignature: "1" }));
+    act(() => result.current.onContentSizeChange(0, 1000)); // overflows at offset 0 → shown
     expect(result.current.showScrollButton).toBe(true);
   });
 
-  it("does not flash the button on a content change in a short (non-overflowing) chat", () => {
-    const { result, rerender } = setup({
-      enabled: false,
-      contentSignature: "0",
-    });
-    act(() => result.current.onScroll(scrollEvent(0, 300, 600))); // fits → never overflowed
-    act(() => rerender({ enabled: false, contentSignature: "1" }));
+  it("does not flash the button on content growth that still fits the viewport", () => {
+    const { result } = setup({ enabled: false, contentSignature: "0" });
+    act(() => result.current.onLoad());
+    act(() => result.current.onLayout(layoutEvent(600)));
+    act(() => result.current.onContentSizeChange(0, 400)); // fits
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it("leaves the button to the follow loop while pinned+enabled (content-size change is a no-op)", () => {
+    const { result } = setup({ enabled: true, contentSignature: "0" });
+    act(() => result.current.onLoad());
+    act(() => result.current.onLayout(layoutEvent(600)));
+    act(() => result.current.onContentSizeChange(0, 1000)); // following → button untouched
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it("ignores content-size changes before the initial scroll or before layout", () => {
+    const { result } = setup({ enabled: false, contentSignature: "0" });
+    act(() => result.current.onContentSizeChange(0, 1000)); // no onLoad / onLayout yet
     expect(result.current.showScrollButton).toBe(false);
   });
 

--- a/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
@@ -193,6 +193,20 @@ describe("useChatAutoScroll", () => {
     expect(result.current.showScrollButton).toBe(false);
   });
 
+  // A viewport resize (keyboard, rotation, split-screen) changes the bottom distance but fires no
+  // scroll/content-size event, so onLayout must recompute the button, not just capture the height.
+  it("refreshes the jump button on a viewport resize while not following", () => {
+    const { result } = setup({ enabled: false, contentSignature: "0" });
+    act(() => result.current.onLoad());
+    act(() => result.current.onLayout(layoutEvent(600)));
+    act(() => result.current.onContentSizeChange(0, 640)); // 40px over → within band → hidden
+    expect(result.current.showScrollButton).toBe(false);
+    act(() => result.current.onLayout(layoutEvent(400))); // shrinks (keyboard) → 240px below → shown
+    expect(result.current.showScrollButton).toBe(true);
+    act(() => result.current.onLayout(layoutEvent(600))); // restored → back within band → hidden
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
   it("scrollToBottom re-pins, jumps animated, and keeps the button hidden through the settle", () => {
     const { result, rerender, scrollToEnd } = setup();
     act(() => result.current.onScroll(scrollEvent(200))); // unpin, button shows

--- a/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
+++ b/mobile/src/hooks/__tests__/useChatAutoScroll.test.tsx
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { act, renderHook } from "@testing-library/react-native";
+import type { RefObject } from "react";
+import type { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+
+import {
+  useChatAutoScroll,
+  type UseChatAutoScrollParams,
+} from "@/hooks/useChatAutoScroll";
+
+// Deferred requestAnimationFrame: callbacks queue by id and run only on flushRaf(). This preserves
+// the real schedule→fire gap so a test can interleave an onScroll (unpin) between a content-change
+// rerender and the follow scroll — the window the fire-time-staleness race lives in. cancel truly
+// drops a pending callback, so the coalescing path is exercised too.
+let rafCbs: Map<number, FrameRequestCallback>;
+let nextRafId: number;
+
+function flushRaf() {
+  const entries = [...rafCbs.entries()];
+  rafCbs.clear();
+  entries.forEach(([, cb]) => cb(0));
+}
+
+beforeEach(() => {
+  rafCbs = new Map();
+  nextRafId = 1;
+  jest
+    .spyOn(global, "requestAnimationFrame")
+    .mockImplementation((cb: FrameRequestCallback) => {
+      const id = nextRafId++;
+      rafCbs.set(id, cb);
+      return id as unknown as number;
+    });
+  jest
+    .spyOn(global, "cancelAnimationFrame")
+    .mockImplementation((id: number | null | undefined) => {
+      if (id != null) rafCbs.delete(id);
+    });
+});
+
+function scrollEvent(
+  offsetY: number,
+  contentHeight = 1000,
+  viewportHeight = 600,
+): NativeSyntheticEvent<NativeScrollEvent> {
+  return {
+    nativeEvent: {
+      contentOffset: { y: offsetY },
+      contentSize: { height: contentHeight },
+      layoutMeasurement: { height: viewportHeight },
+    },
+  } as unknown as NativeSyntheticEvent<NativeScrollEvent>;
+}
+
+function setup(
+  initial: UseChatAutoScrollParams = { enabled: true, contentSignature: "0" },
+) {
+  const scrollToEnd = jest.fn();
+  const listRef = { current: { scrollToEnd } } as RefObject<{
+    scrollToEnd: (params?: { animated?: boolean }) => void;
+  } | null>;
+  const view = renderHook(
+    (props: UseChatAutoScrollParams) => useChatAutoScroll(listRef, props),
+    { initialProps: initial },
+  );
+  return { ...view, scrollToEnd };
+}
+
+describe("useChatAutoScroll", () => {
+  it("scrolls to the bottom once on load", () => {
+    const { result, scrollToEnd } = setup();
+    act(() => {
+      result.current.onLoad();
+      result.current.onLoad();
+    });
+    expect(scrollToEnd).toHaveBeenCalledTimes(1);
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+
+  it("follows content growth while parked at the bottom", () => {
+    const { rerender, scrollToEnd } = setup();
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: true, contentSignature: "1" }));
+    act(() => flushRaf());
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+
+  // The core fix: a scroll-up that lands in the frame gap between a flush scheduling the follow and
+  // that follow firing must NOT be yanked back. (Regression guard for the reintroduced race.)
+  it("does not follow if the user scrolls up between the flush and the deferred scroll", () => {
+    const { result, rerender, scrollToEnd } = setup();
+    act(() => result.current.onScroll(scrollEvent(400))); // parked at bottom
+    scrollToEnd.mockClear();
+
+    act(() => rerender({ enabled: true, contentSignature: "1" })); // schedules the follow rAF
+    act(() => result.current.onScroll(scrollEvent(200))); // user drags up in the gap → unpin
+    act(() => flushRaf()); // rAF fires — must re-check the pin and bail
+
+    expect(scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it("stops following after the user scrolls up, and resumes at the bottom", () => {
+    const { result, rerender, scrollToEnd } = setup();
+    act(() => result.current.onScroll(scrollEvent(200))); // unpin
+    expect(result.current.showScrollButton).toBe(true);
+
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: true, contentSignature: "1" }));
+    act(() => flushRaf());
+    expect(scrollToEnd).not.toHaveBeenCalled();
+
+    act(() => result.current.onScroll(scrollEvent(360))); // back within the 48px band → re-pin
+    expect(result.current.showScrollButton).toBe(false);
+    act(() => rerender({ enabled: true, contentSignature: "2" }));
+    act(() => flushRaf());
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+
+  // Absolute-distance pin, not per-event direction: the band-crossing step here is only 4px, which a
+  // direction check (unpin on a >4px up-move) would miss — so it stays pinned there — while the
+  // absolute pin unpins. This is the case that actually distinguishes the two.
+  it("unpins when a small step crosses the band (a direction epsilon would miss it)", () => {
+    const { result } = setup();
+    act(() => result.current.onScroll(scrollEvent(400))); // at bottom, pinned
+    act(() => result.current.onScroll(scrollEvent(354))); // 46px up → still within the band
+    expect(result.current.showScrollButton).toBe(false);
+    act(() => result.current.onScroll(scrollEvent(350))); // +4px → 50px, just past the band
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
+  it("never follows when auto-scroll is disabled", () => {
+    const { rerender, scrollToEnd } = setup({
+      enabled: false,
+      contentSignature: "0",
+    });
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: false, contentSignature: "1" }));
+    act(() => flushRaf());
+    expect(scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it("coalesces rapid flushes into a single scroll", () => {
+    const { rerender, scrollToEnd } = setup();
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: true, contentSignature: "1" }));
+    act(() => rerender({ enabled: true, contentSignature: "2" }));
+    act(() => rerender({ enabled: true, contentSignature: "3" }));
+    act(() => flushRaf());
+    expect(scrollToEnd).toHaveBeenCalledTimes(1);
+  });
+
+  it("reveals the jump button when content grows below an un-followed viewport", () => {
+    const { result, rerender } = setup({
+      enabled: false,
+      contentSignature: "0",
+    });
+    act(() => result.current.onScroll(scrollEvent(400))); // marks overflow, at bottom
+    expect(result.current.showScrollButton).toBe(false);
+    act(() => rerender({ enabled: false, contentSignature: "1" }));
+    expect(result.current.showScrollButton).toBe(true);
+  });
+
+  it("does not flash the button on a content change in a short (non-overflowing) chat", () => {
+    const { result, rerender } = setup({
+      enabled: false,
+      contentSignature: "0",
+    });
+    act(() => result.current.onScroll(scrollEvent(0, 300, 600))); // fits → never overflowed
+    act(() => rerender({ enabled: false, contentSignature: "1" }));
+    expect(result.current.showScrollButton).toBe(false);
+  });
+
+  it("scrollToBottom re-pins, jumps animated, and keeps the button hidden through the settle", () => {
+    const { result, rerender, scrollToEnd } = setup();
+    act(() => result.current.onScroll(scrollEvent(200))); // unpin, button shows
+    expect(result.current.showScrollButton).toBe(true);
+
+    scrollToEnd.mockClear();
+    act(() => result.current.scrollToBottom());
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: true });
+    expect(result.current.showScrollButton).toBe(false);
+
+    // mid-animation scroll frames (still far from bottom) must NOT re-show the button
+    act(() => result.current.onScroll(scrollEvent(200)));
+    expect(result.current.showScrollButton).toBe(false);
+    // arriving at the bottom clears the guard, and following resumes on the next flush
+    act(() => result.current.onScroll(scrollEvent(400)));
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: true, contentSignature: "1" }));
+    act(() => flushRaf());
+    expect(scrollToEnd).toHaveBeenCalledWith({ animated: false });
+  });
+
+  // Regression guard: a drag started during the jump's settle must unpin, not be swallowed and then
+  // re-followed by the next streaming flush.
+  it("releases the jump guard when the user grabs the list mid-settle", () => {
+    const { result, rerender, scrollToEnd } = setup();
+    act(() => result.current.onScroll(scrollEvent(200))); // scrolled up
+    act(() => result.current.scrollToBottom()); // jump: guard on, pinned, button hidden
+    expect(result.current.showScrollButton).toBe(false);
+
+    act(() => result.current.onScrollBeginDrag()); // user grabs the list
+    act(() => result.current.onScroll(scrollEvent(200))); // drag up now honored → unpin
+    expect(result.current.showScrollButton).toBe(true);
+
+    scrollToEnd.mockClear();
+    act(() => rerender({ enabled: true, contentSignature: "1" })); // a flush must NOT re-follow
+    act(() => flushRaf());
+    expect(scrollToEnd).not.toHaveBeenCalled();
+  });
+
+  it("exposes anchoring-only MVCP (no autoscroll threshold that would fight the manual follow)", () => {
+    const { result } = setup();
+    expect(result.current.maintainVisibleContentPosition).toEqual({});
+    expect(
+      "autoscrollToBottomThreshold" in
+        result.current.maintainVisibleContentPosition,
+    ).toBe(false);
+  });
+});

--- a/mobile/src/hooks/useChatAutoScroll.ts
+++ b/mobile/src/hooks/useChatAutoScroll.ts
@@ -27,8 +27,10 @@ interface ScrollableRef {
   scrollToEnd: (params?: { animated?: boolean }) => void;
 }
 
-// Anchoring-only MVCP: enabled (its `disabled` defaults to false) but with no autoscroll threshold,
-// so FlashList never auto-follows — we do. Stable identity avoids re-initializing MVCP per render.
+// Anchoring-only MVCP: no autoscroll threshold, so FlashList never auto-follows — we do — while its
+// default-on anchoring holds the read position. FlashList's MVCP is its own recycler-level feature
+// (not RN ScrollView's): it supplies `minIndexForVisible: 0` to the underlying ScrollView itself, so
+// an empty config still anchors. Stable identity avoids re-initializing MVCP per render.
 export const ANCHOR_ONLY_MVCP = {} as const;
 
 // Fallback window for ignoring the animated jump's own scroll events, in case it never reports
@@ -71,6 +73,7 @@ export function useChatAutoScroll(
   const isAutoScrollingRef = useRef(false);
   const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevSignatureRef = useRef(contentSignature);
+  const prevEnabledRef = useRef(enabled);
   const rafRef = useRef<number | null>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);
 
@@ -175,6 +178,16 @@ export function useChatAutoScroll(
       }
     };
   }, [contentSignature, enabled, listRef]);
+
+  // Re-enabling auto-scroll while parked at the bottom resumes following immediately: catch up to the
+  // latest turn (which also clears the jump button) instead of waiting for the next flush — otherwise,
+  // if the stream already ended, the list would sit below content that grew while auto-scroll was off.
+  // If the user is scrolled up, leave them be; following resumes when they return to the bottom.
+  useEffect(() => {
+    const reEnabled = !prevEnabledRef.current && enabled;
+    prevEnabledRef.current = enabled;
+    if (reEnabled && pinnedRef.current) scrollToBottom();
+  }, [enabled, scrollToBottom]);
 
   useEffect(
     () => () => {

--- a/mobile/src/hooks/useChatAutoScroll.ts
+++ b/mobile/src/hooks/useChatAutoScroll.ts
@@ -14,7 +14,11 @@
 // always lands at the bottom, so any scroll event reporting a position beyond the band is the user
 // pulling away, and content growth fires no scroll event so it can't move the pin.
 import { RefObject, useCallback, useEffect, useRef, useState } from "react";
-import { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+import {
+  LayoutChangeEvent,
+  NativeScrollEvent,
+  NativeSyntheticEvent,
+} from "react-native";
 
 import { isWithinBottomBand } from "@/chat/autoScroll";
 
@@ -40,8 +44,10 @@ export interface UseChatAutoScrollParams {
 
 export interface ChatAutoScroll {
   onLoad: () => void;
+  onLayout: (event: LayoutChangeEvent) => void;
   onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   onScrollBeginDrag: () => void;
+  onContentSizeChange: (width: number, height: number) => void;
   scrollToBottom: () => void;
   showScrollButton: boolean;
   maintainVisibleContentPosition: typeof ANCHOR_ONLY_MVCP;
@@ -55,7 +61,10 @@ export function useChatAutoScroll(
   // pinnedRef = "follow the bottom". A ref (not state): nothing rendered depends on it, so flipping
   // it must not re-render; it's read fresh in onScroll and at the follow rAF's fire time.
   const pinnedRef = useRef(true);
-  const hasOverflowedRef = useRef(false);
+  // Last known viewport and scroll offset, so onContentSizeChange can compute the button from the
+  // real content height without waiting for a scroll event (content growth fires none).
+  const viewportRef = useRef(0);
+  const lastOffsetRef = useRef(0);
   // True while our own animated jump is running, so its scroll events don't flicker the button or
   // unpin the list before it reaches the bottom. Cleared when it reaches the bottom, when the user
   // grabs the list (onScrollBeginDrag), or by a fallback timer.
@@ -91,13 +100,36 @@ export function useChatAutoScroll(
         return;
       }
 
-      if (metrics.contentHeight > metrics.viewportHeight) {
-        hasOverflowedRef.current = true;
-      }
+      viewportRef.current = metrics.viewportHeight;
+      lastOffsetRef.current = metrics.offsetY;
       pinnedRef.current = atBottom;
       setShowScrollButton(!atBottom);
     },
     [],
+  );
+
+  // The list's viewport height, captured before content measures so onContentSizeChange has it.
+  const onLayout = useCallback((event: LayoutChangeEvent) => {
+    viewportRef.current = event.nativeEvent.layout.height;
+  }, []);
+
+  // FlashList v2 forwards this to its underlying ScrollView (FlashListProps extends ScrollViewProps),
+  // so it fires post-measurement whenever content height changes — including growth below the
+  // viewport, which fires no scroll event. Used to keep the jump button correct while NOT following
+  // (following manages its own scroll + button via the effect and onScroll). Fixes: with auto-scroll
+  // off, a chat growing from fitting to overflowing now reveals the button without a manual scroll.
+  const onContentSizeChange = useCallback(
+    (_width: number, height: number) => {
+      if (!didInitialScroll.current || viewportRef.current <= 0) return;
+      if (enabled && pinnedRef.current) return;
+      const atBottom = isWithinBottomBand({
+        offsetY: lastOffsetRef.current,
+        contentHeight: height,
+        viewportHeight: viewportRef.current,
+      });
+      setShowScrollButton(!atBottom);
+    },
+    [enabled],
   );
 
   // The user grabbed the list: a programmatic jump never fires this, so it cleanly ends the jump
@@ -119,33 +151,29 @@ export function useChatAutoScroll(
     }, AUTO_SCROLL_SETTLE_MS);
   }, [listRef]);
 
-  // Follow on content growth. The rAF defers one frame so FlashList has measured the appended content
-  // before we scroll to its end (FlashList v2 has no onContentSizeChange), and coalesces rapid flushes
-  // via the cleanup cancel. The pin is re-checked when the frame FIRES: an onScroll unpin in the gap
-  // can't re-run this effect (pinnedRef is a ref), so the schedule-time check is already stale.
+  // Follow on content growth. The rAF defers one frame so the appended content is laid out before we
+  // scroll to its end, and coalesces rapid flushes via the cleanup cancel. The pin is re-checked when
+  // the frame FIRES: an onScroll unpin in the gap can't re-run this effect (pinnedRef is a ref), so
+  // the schedule-time check is already stale. (The button while not following is handled separately
+  // by onContentSizeChange.)
   useEffect(() => {
     const contentChanged = prevSignatureRef.current !== contentSignature;
     prevSignatureRef.current = contentSignature;
     if (!contentChanged) return;
+    if (!(enabled && pinnedRef.current)) return;
 
-    if (enabled && pinnedRef.current) {
-      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
-      rafRef.current = requestAnimationFrame(() => {
+    if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      if (!pinnedRef.current) return; // user scrolled up between schedule and fire → don't yank
+      listRef.current?.scrollToEnd({ animated: false });
+    });
+    return () => {
+      if (rafRef.current != null) {
+        cancelAnimationFrame(rafRef.current);
         rafRef.current = null;
-        if (!pinnedRef.current) return; // user scrolled up between schedule and fire → don't yank
-        listRef.current?.scrollToEnd({ animated: false });
-      });
-      return () => {
-        if (rafRef.current != null) {
-          cancelAnimationFrame(rafRef.current);
-          rafRef.current = null;
-        }
-      };
-    }
-
-    // Not following: content grew below the viewport, which fires no scroll event, so onScroll can't
-    // reveal the jump button. Do it here — guarded on known overflow so a short chat never flashes it.
-    if (hasOverflowedRef.current) setShowScrollButton(true);
+      }
+    };
   }, [contentSignature, enabled, listRef]);
 
   useEffect(
@@ -158,8 +186,10 @@ export function useChatAutoScroll(
 
   return {
     onLoad,
+    onLayout,
     onScroll,
     onScrollBeginDrag,
+    onContentSizeChange,
     scrollToBottom,
     showScrollButton,
     maintainVisibleContentPosition: ANCHOR_ONLY_MVCP,

--- a/mobile/src/hooks/useChatAutoScroll.ts
+++ b/mobile/src/hooks/useChatAutoScroll.ts
@@ -63,9 +63,10 @@ export function useChatAutoScroll(
   // pinnedRef = "follow the bottom". A ref (not state): nothing rendered depends on it, so flipping
   // it must not re-render; it's read fresh in onScroll and at the follow rAF's fire time.
   const pinnedRef = useRef(true);
-  // Last known viewport and scroll offset, so onContentSizeChange can compute the button from the
-  // real content height without waiting for a scroll event (content growth fires none).
+  // Last measured viewport, content height, and scroll offset. Kept so the jump button can be
+  // recomputed from real geometry on a content-size OR viewport change (neither fires a scroll event).
   const viewportRef = useRef(0);
+  const contentHeightRef = useRef(0);
   const lastOffsetRef = useRef(0);
   // True while our own animated jump is running, so its scroll events don't flicker the button or
   // unpin the list before it reaches the bottom. Cleared when it reaches the bottom, when the user
@@ -111,28 +112,46 @@ export function useChatAutoScroll(
     [],
   );
 
-  // The list's viewport height, captured before content measures so onContentSizeChange has it.
-  const onLayout = useCallback((event: LayoutChangeEvent) => {
-    viewportRef.current = event.nativeEvent.layout.height;
-  }, []);
+  // Recompute the jump button from the latest geometry, for changes that fire no scroll event. Only
+  // while NOT following — when following, the effect scrolls to the bottom and onScroll owns the
+  // button. Skipped until the initial scroll and until both dimensions are known.
+  const refreshIdleButton = useCallback(() => {
+    if (
+      !didInitialScroll.current ||
+      viewportRef.current <= 0 ||
+      contentHeightRef.current <= 0
+    ) {
+      return;
+    }
+    if (enabled && pinnedRef.current) return;
+    const atBottom = isWithinBottomBand({
+      offsetY: lastOffsetRef.current,
+      contentHeight: contentHeightRef.current,
+      viewportHeight: viewportRef.current,
+    });
+    setShowScrollButton(!atBottom);
+  }, [enabled]);
+
+  // A viewport resize (rotation, split-screen, keyboard) changes the bottom distance without a scroll
+  // or content-size event, so refresh the button too — not just capture the height.
+  const onLayout = useCallback(
+    (event: LayoutChangeEvent) => {
+      viewportRef.current = event.nativeEvent.layout.height;
+      refreshIdleButton();
+    },
+    [refreshIdleButton],
+  );
 
   // FlashList v2 forwards this to its underlying ScrollView (FlashListProps extends ScrollViewProps),
   // so it fires post-measurement whenever content height changes — including growth below the
-  // viewport, which fires no scroll event. Used to keep the jump button correct while NOT following
-  // (following manages its own scroll + button via the effect and onScroll). Fixes: with auto-scroll
-  // off, a chat growing from fitting to overflowing now reveals the button without a manual scroll.
+  // viewport, which fires no scroll event. Fixes: with auto-scroll off, a chat growing from fitting to
+  // overflowing reveals the button without a manual scroll.
   const onContentSizeChange = useCallback(
     (_width: number, height: number) => {
-      if (!didInitialScroll.current || viewportRef.current <= 0) return;
-      if (enabled && pinnedRef.current) return;
-      const atBottom = isWithinBottomBand({
-        offsetY: lastOffsetRef.current,
-        contentHeight: height,
-        viewportHeight: viewportRef.current,
-      });
-      setShowScrollButton(!atBottom);
+      contentHeightRef.current = height;
+      refreshIdleButton();
     },
-    [enabled],
+    [refreshIdleButton],
   );
 
   // The user grabbed the list: a programmatic jump never fires this, so it cleanly ends the jump

--- a/mobile/src/hooks/useChatAutoScroll.ts
+++ b/mobile/src/hooks/useChatAutoScroll.ts
@@ -1,0 +1,167 @@
+// Web-parity auto-scroll for the chat message list (see web ChatScrollContainer).
+//
+// While the assistant streams, the list follows the latest turn only while the user is parked at the
+// bottom; scrolling up stops the follow (so earlier content can be read) and returning to the bottom
+// resumes it. The `enabled` flag turns following off entirely.
+//
+// The follow is driven MANUALLY (scrollToEnd per content change while pinned), NOT via FlashList's
+// maintainVisibleContentPosition.autoscrollToBottomThreshold: its built-in follow arms an internal
+// flag from a wider band a frame before a prop change lands, and dropping the threshold can't cancel
+// it, so a slow scroll-up gets snapped back. MVCP stays on for anchoring only (no threshold set), so
+// the read position holds if content above the viewport reflows.
+//
+// The pin is ABSOLUTE distance to the bottom (isWithinBottomBand), not scroll direction: the follow
+// always lands at the bottom, so any scroll event reporting a position beyond the band is the user
+// pulling away, and content growth fires no scroll event so it can't move the pin.
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { NativeScrollEvent, NativeSyntheticEvent } from "react-native";
+
+import { isWithinBottomBand } from "@/chat/autoScroll";
+
+// The subset of the FlashList ref this hook drives — decoupled from the list item type.
+interface ScrollableRef {
+  scrollToEnd: (params?: { animated?: boolean }) => void;
+}
+
+// Anchoring-only MVCP: enabled (its `disabled` defaults to false) but with no autoscroll threshold,
+// so FlashList never auto-follows — we do. Stable identity avoids re-initializing MVCP per render.
+export const ANCHOR_ONLY_MVCP = {} as const;
+
+// Fallback window for ignoring the animated jump's own scroll events, in case it never reports
+// reaching the bottom (e.g. a no-op jump when already there). Web uses 600ms.
+const AUTO_SCROLL_SETTLE_MS = 600;
+
+export interface UseChatAutoScrollParams {
+  // Master toggle (app setting). When off, the list never auto-follows; the jump button still works.
+  enabled: boolean;
+  // Changes whenever the rendered content grows (new turn or a streaming flush). Drives the follow.
+  contentSignature: string;
+}
+
+export interface ChatAutoScroll {
+  onLoad: () => void;
+  onScroll: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
+  onScrollBeginDrag: () => void;
+  scrollToBottom: () => void;
+  showScrollButton: boolean;
+  maintainVisibleContentPosition: typeof ANCHOR_ONLY_MVCP;
+}
+
+export function useChatAutoScroll(
+  listRef: RefObject<ScrollableRef | null>,
+  { enabled, contentSignature }: UseChatAutoScrollParams,
+): ChatAutoScroll {
+  const didInitialScroll = useRef(false);
+  // pinnedRef = "follow the bottom". A ref (not state): nothing rendered depends on it, so flipping
+  // it must not re-render; it's read fresh in onScroll and at the follow rAF's fire time.
+  const pinnedRef = useRef(true);
+  const hasOverflowedRef = useRef(false);
+  // True while our own animated jump is running, so its scroll events don't flicker the button or
+  // unpin the list before it reaches the bottom. Cleared when it reaches the bottom, when the user
+  // grabs the list (onScrollBeginDrag), or by a fallback timer.
+  const isAutoScrollingRef = useRef(false);
+  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevSignatureRef = useRef(contentSignature);
+  const rafRef = useRef<number | null>(null);
+  const [showScrollButton, setShowScrollButton] = useState(false);
+
+  // Land on the newest turn when a chat opens (web's session-load scroll-to-bottom); no-op for short
+  // chats. Reset per session by keying the list on sessionId (see MessageList / ChatSurface).
+  const onLoad = useCallback(() => {
+    if (didInitialScroll.current) return;
+    didInitialScroll.current = true;
+    listRef.current?.scrollToEnd({ animated: false });
+  }, [listRef]);
+
+  const onScroll = useCallback(
+    (event: NativeSyntheticEvent<NativeScrollEvent>) => {
+      const { contentOffset, contentSize, layoutMeasurement } =
+        event.nativeEvent;
+      const metrics = {
+        offsetY: contentOffset.y,
+        contentHeight: contentSize.height,
+        viewportHeight: layoutMeasurement.height,
+      };
+      const atBottom = isWithinBottomBand(metrics);
+
+      // Ignore the animated jump's own scroll stream until it lands, so it doesn't unpin/flicker.
+      // A user drag is exempt (see onScrollBeginDrag) so a mid-jump grab isn't swallowed.
+      if (isAutoScrollingRef.current) {
+        if (atBottom) isAutoScrollingRef.current = false;
+        return;
+      }
+
+      if (metrics.contentHeight > metrics.viewportHeight) {
+        hasOverflowedRef.current = true;
+      }
+      pinnedRef.current = atBottom;
+      setShowScrollButton(!atBottom);
+    },
+    [],
+  );
+
+  // The user grabbed the list: a programmatic jump never fires this, so it cleanly ends the jump
+  // guard. Without it a drag started during the settle is swallowed and the next flush re-follows.
+  const onScrollBeginDrag = useCallback(() => {
+    isAutoScrollingRef.current = false;
+  }, []);
+
+  // Explicit jump: re-pin so streaming resumes following from the bottom.
+  const scrollToBottom = useCallback(() => {
+    pinnedRef.current = true;
+    setShowScrollButton(false);
+    isAutoScrollingRef.current = true;
+    listRef.current?.scrollToEnd({ animated: true });
+    if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+    settleTimerRef.current = setTimeout(() => {
+      isAutoScrollingRef.current = false;
+      settleTimerRef.current = null;
+    }, AUTO_SCROLL_SETTLE_MS);
+  }, [listRef]);
+
+  // Follow on content growth. The rAF defers one frame so FlashList has measured the appended content
+  // before we scroll to its end (FlashList v2 has no onContentSizeChange), and coalesces rapid flushes
+  // via the cleanup cancel. The pin is re-checked when the frame FIRES: an onScroll unpin in the gap
+  // can't re-run this effect (pinnedRef is a ref), so the schedule-time check is already stale.
+  useEffect(() => {
+    const contentChanged = prevSignatureRef.current !== contentSignature;
+    prevSignatureRef.current = contentSignature;
+    if (!contentChanged) return;
+
+    if (enabled && pinnedRef.current) {
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = requestAnimationFrame(() => {
+        rafRef.current = null;
+        if (!pinnedRef.current) return; // user scrolled up between schedule and fire → don't yank
+        listRef.current?.scrollToEnd({ animated: false });
+      });
+      return () => {
+        if (rafRef.current != null) {
+          cancelAnimationFrame(rafRef.current);
+          rafRef.current = null;
+        }
+      };
+    }
+
+    // Not following: content grew below the viewport, which fires no scroll event, so onScroll can't
+    // reveal the jump button. Do it here — guarded on known overflow so a short chat never flashes it.
+    if (hasOverflowedRef.current) setShowScrollButton(true);
+  }, [contentSignature, enabled, listRef]);
+
+  useEffect(
+    () => () => {
+      if (settleTimerRef.current) clearTimeout(settleTimerRef.current);
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+    },
+    [],
+  );
+
+  return {
+    onLoad,
+    onScroll,
+    onScrollBeginDrag,
+    scrollToBottom,
+    showScrollButton,
+    maintainVisibleContentPosition: ANCHOR_ONLY_MVCP,
+  };
+}

--- a/mobile/src/state/settingsStore.ts
+++ b/mobile/src/state/settingsStore.ts
@@ -1,0 +1,28 @@
+// User-facing app preferences, kept out of chat/session state so a future Settings screen can bind
+// switches straight to this store. Persisted directly to MMKV (like session.ts) so choices survive
+// relaunch.
+import { create } from "zustand";
+
+import { appStorage } from "@/state/storage";
+
+const AUTO_SCROLL_ENABLED_KEY = "onyx.settings.auto_scroll_enabled";
+
+function readAutoScrollEnabled(): boolean {
+  // Default ON (unset key): following the latest turn while streaming is the expected chat default.
+  return appStorage.getBoolean(AUTO_SCROLL_ENABLED_KEY) ?? true;
+}
+
+interface SettingsState {
+  // When off, the chat list never auto-follows the streaming turn (the jump-to-bottom button still
+  // works). Wire this to a Settings toggle later; flip it now via useSettings.getState().
+  autoScrollEnabled: boolean;
+  setAutoScrollEnabled: (enabled: boolean) => void;
+}
+
+export const useSettings = create<SettingsState>((set) => ({
+  autoScrollEnabled: readAutoScrollEnabled(),
+  setAutoScrollEnabled: (autoScrollEnabled) => {
+    appStorage.set(AUTO_SCROLL_ENABLED_KEY, autoScrollEnabled);
+    set({ autoScrollEnabled });
+  },
+}));


### PR DESCRIPTION
## Description

While a message streams in mobile chat, the list now follows the latest turn only while you're parked at the bottom — scrolling up stops the follow so you can read earlier content, and returning to the bottom resumes it (previously it stayed locked scrolling down until streaming finished). Adds a persisted `autoScrollEnabled` setting (default on) as the on/off seam for a future Settings screen.

## How Has This Been Tested?

Added 22 unit/hook tests covering the pin logic and the full follow → stop-on-scroll-up → resume-at-bottom loop (including a deferred-rAF regression guard); `bun run typecheck`, `bun run lint`, and the mobile jest suite pass. Not yet exercised on a physical device.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds web-parity auto-follow for streaming chat with pause-on-scroll-up and resume-at-bottom; replaces `FlashList` autoscroll and persists an `autoScrollEnabled` setting. Also fixes jump-to-bottom visibility on overflow with auto-scroll off, refreshes it on viewport resize, and catches up to bottom when re-enabling auto-scroll while pinned.

- **New Features**
  - Introduced `useChatAutoScroll` to drive manual follow, the jump-to-bottom button, and anchoring-only MVCP.
  - Added pure helpers for bottom-band detection and a content signature to detect real content growth.
  - Persisted `autoScrollEnabled` in the settings store for a future Settings toggle.

- **Bug Fixes**
  - Reveals the jump button when content grows past the viewport with auto-scroll disabled via `onContentSizeChange` + last offset/viewport.
  - Stops yank-back when the user scrolls up mid-stream by re-checking the pin at rAF fire time.
  - Coalesces rapid streaming flushes into a single scroll to reduce jitter.
  - Prevents button flicker during animated jumps and cleanly releases the guard on user drag.
  - Refreshes the jump button on viewport resize (keyboard, rotation, split-screen) while not following.
  - Catches up to bottom immediately when auto-scroll is re-enabled while pinned; leaves scrolled-up users unchanged.

<sup>Written for commit 6e261ad3d46f0c214d47c1ba1b55e3cb834511f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


