### PR TITLE
feat(auth): remove legacy single-provider SSO modes

### DIFF
--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -9,6 +9,7 @@ Create Date: 2026-07-06 21:34:08.516250
 from __future__ import annotations
 
 import json
+import os
 
 from alembic import op
 import sqlalchemy as sa
@@ -58,14 +59,15 @@ def _sso_provider_table(metadata: sa.MetaData) -> sa.Table:
 
 def _seed_from_env(table: sa.Table) -> None:
     """One-time import of legacy single-provider config. The DB is the source
-    of truth afterwards; env vars are never read at request time.
+    of truth afterwards. Env vars are never read at request time.
 
-    Reads the already-resolved app_config constants (not raw os.environ) so
-    the legacy GOOGLE_OAUTH_* fallbacks and the VALID_EMAIL_DOMAINS parsing
-    stay in one place. Skipped in multi-tenant (cloud auth does not use
-    per-instance provider rows) and when the table already has any row.
+    Reads the already-resolved app_config constants for credentials and
+    domains so the legacy GOOGLE_OAUTH_* fallbacks and the VALID_EMAIL_DOMAINS
+    parsing stay in one place, but AUTH_TYPE comes from raw os.environ because
+    app_configs coerces legacy SSO values to BASIC. Skipped in multi-tenant
+    (cloud auth does not use per-instance provider rows) and when the table
+    already has any row.
     """
-    from onyx.configs.app_configs import AUTH_TYPE
     from onyx.configs.app_configs import OAUTH_CLIENT_ID
     from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
     from onyx.configs.app_configs import OPENID_CONFIG_URL
@@ -76,13 +78,15 @@ def _seed_from_env(table: sa.Table) -> None:
     if MULTI_TENANT:
         return
 
+    raw_auth_type = (os.environ.get("AUTH_TYPE") or "").lower()
+
     # provider_type is the enum member NAME (Enum(native_enum=False) storage);
     # the login `name` matches the oauth_name existing linked accounts carry so
     # linkage survives the routing cutover.
-    if AUTH_TYPE == AuthType.GOOGLE_OAUTH:
+    if raw_auth_type == AuthType.GOOGLE_OAUTH.value:
         provider_type, name = "GOOGLE_OAUTH", "google"
         display_name, config_url = "Continue with Google", None
-    elif AUTH_TYPE == AuthType.OIDC:
+    elif raw_auth_type == AuthType.OIDC.value:
         if not OPENID_CONFIG_URL:
             return
         provider_type, name = "OIDC", "openid"

--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -23,11 +23,19 @@ logger = setup_logger()
 
 
 def verify_auth_setting() -> None:
-    # All the Auth flows are valid for EE version, but warn about deprecated 'disabled'
+    # Unlike the MIT version, 'cloud' is valid here. Warn on removed legacy values.
     raw_auth_type = (os.environ.get("AUTH_TYPE") or "").lower()
     if raw_auth_type == "disabled":
         logger.warning(
             "AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration."
+        )
+    if raw_auth_type in ("google_oauth", "oidc", "saml"):
+        logger.warning(
+            "AUTH_TYPE='%s' single-provider mode was removed and Onyx is running "
+            "as 'basic'. SSO login is now served by SSO provider rows (Admin "
+            "Panel > Organization > SSO Providers). Update AUTH_TYPE to 'basic' "
+            "and remove the legacy SSO env vars.",
+            raw_auth_type,
         )
     logger.notice("Using Auth Type: %s", AUTH_TYPE.value)
 

--- a/backend/ee/onyx/main.py
+++ b/backend/ee/onyx/main.py
@@ -41,7 +41,6 @@ from ee.onyx.server.user_group.api import router as user_group_router
 from ee.onyx.utils.encryption import test_encryption
 from onyx.auth.users import auth_backend
 from onyx.auth.users import create_onyx_oauth_router
-from onyx.auth.users import fastapi_users
 from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
 from onyx.configs.app_configs import GOOGLE_OAUTH_SCOPE_OVERRIDE
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
@@ -124,13 +123,6 @@ def get_application() -> FastAPI:
                 redirect_url=f"{WEB_DOMAIN}/auth/oauth/callback",
             ),
             prefix="/auth/oauth",
-        )
-
-        # Need basic auth router for `logout` endpoint
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_logout_router(auth_backend),
-            prefix="/auth",
         )
 
     # RBAC / group access control

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1673,7 +1673,7 @@ mobile_auth_backend = AuthenticationBackend(
 )
 
 
-class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
+class FastAPIUserWithRefreshRouter(FastAPIUsers[models.UP, models.ID]):
     def get_refresh_router(
         self,
         backend: AuthenticationBackend,
@@ -1758,7 +1758,7 @@ class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
         return router
 
 
-fastapi_users = FastAPIUserWithLogoutRouter[User, uuid.UUID](
+fastapi_users = FastAPIUserWithRefreshRouter[User, uuid.UUID](
     get_user_manager, [auth_backend, mobile_auth_backend]
 )
 

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -108,7 +108,6 @@ from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import ANONYMOUS_USER_COOKIE_NAME
 from onyx.configs.constants import ANONYMOUS_USER_EMAIL
 from onyx.configs.constants import ANONYMOUS_USER_UUID
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
 from onyx.configs.constants import DANSWER_API_KEY_PREFIX
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
@@ -188,6 +187,14 @@ def verify_auth_setting() -> None:
         logger.warning(
             "AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration."
         )
+    if raw_auth_type in ("google_oauth", "oidc", "saml"):
+        logger.warning(
+            "AUTH_TYPE='%s' single-provider mode was removed and Onyx is running "
+            "as 'basic'. SSO login is now served by SSO provider rows (Admin "
+            "Panel > Organization > SSO Providers). Update AUTH_TYPE to 'basic' "
+            "and remove the legacy SSO env vars.",
+            raw_auth_type,
+        )
 
     logger.notice("Using Auth Type: %s", AUTH_TYPE.value)
 
@@ -259,12 +266,9 @@ def generate_password() -> str:
 
 
 def user_needs_to_be_verified() -> bool:
-    if AUTH_TYPE == AuthType.BASIC or AUTH_TYPE == AuthType.CLOUD:
-        return REQUIRE_EMAIL_VERIFICATION
-
-    # For other auth types, if the user is authenticated it's assumed that
-    # the user is already verified via the external IDP
-    return False
+    # SSO-provisioned users are created is_verified, so this only ever bites
+    # password signups.
+    return REQUIRE_EMAIL_VERIFICATION
 
 
 def anonymous_user_enabled(*, tenant_id: str | None = None) -> bool:
@@ -289,11 +293,6 @@ def verify_email_is_invited(email: str, *, sso_managed: bool = False) -> None:
     # allowed_email_domains is the admin's per-provider control, so the
     # workspace invite list does not apply.
     if sso_managed:
-        return
-
-    # Legacy single-provider modes imply every signup is IdP-provisioned.
-    # Dies with those modes.
-    if AUTH_TYPE in {AuthType.SAML, AuthType.OIDC}:
         return
 
     if not workspace_invite_only_enabled():
@@ -1675,48 +1674,6 @@ mobile_auth_backend = AuthenticationBackend(
 
 
 class FastAPIUserWithLogoutRouter(FastAPIUsers[models.UP, models.ID]):
-    def get_logout_router(
-        self,
-        backend: AuthenticationBackend,
-        requires_verification: bool = REQUIRE_EMAIL_VERIFICATION,
-    ) -> APIRouter:
-        """
-        Provide a router for logout only for OAuth/OIDC Flows.
-        This way the login router does not need to be included
-        """
-        router = APIRouter()
-
-        get_current_user_token = self.authenticator.current_user_token(
-            active=True, verified=requires_verification
-        )
-
-        logout_responses: OpenAPIResponseType = {
-            **{
-                status.HTTP_401_UNAUTHORIZED: {
-                    "description": "Missing token or inactive user."
-                }
-            },
-            **backend.transport.get_openapi_logout_responses_success(),
-        }
-
-        @router.post(
-            "/logout", name=f"auth:{backend.name}.logout", responses=logout_responses
-        )
-        async def logout(
-            user_token: Tuple[models.UP, str] = Depends(get_current_user_token),
-            strategy: Strategy[models.UP, models.ID] = Depends(backend.get_strategy),
-        ) -> Response:
-            user, token = user_token
-            result = await backend.logout(strategy, user, token)
-            emit_audit_event(
-                AuditAction.LOGOUT,
-                AuditOutcome.SUCCESS,
-                actor=AuditActor(user_id=str(user.id), email=user.email),
-            )
-            return result
-
-        return router
-
     def get_refresh_router(
         self,
         backend: AuthenticationBackend,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -138,6 +138,13 @@ if _auth_type_str in [auth_type.value for auth_type in AuthType]:
 else:
     AUTH_TYPE = AuthType.BASIC
 
+# Legacy single-provider SSO values run as BASIC. Login for those deployments
+# is served by sso_provider rows instead. verify_auth_setting warns at startup,
+# and the row seeds (alembic 1fc2904131a3 and the SAML conf-dir import) read
+# raw os.environ because this coercion hides the legacy value.
+if AUTH_TYPE in (AuthType.GOOGLE_OAUTH, AuthType.OIDC, AuthType.SAML):
+    AUTH_TYPE = AuthType.BASIC
+
 PASSWORD_MIN_LENGTH = int(os.getenv("PASSWORD_MIN_LENGTH", 8))
 PASSWORD_MAX_LENGTH = int(os.getenv("PASSWORD_MAX_LENGTH", 64))
 PASSWORD_REQUIRE_UPPERCASE = (

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 from pathlib import Path
 from typing import Any
@@ -10,7 +11,6 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import SAML_CONF_DIR
 from onyx.configs.app_configs import VALID_EMAIL_DOMAINS
 from onyx.configs.constants import AuthType
@@ -182,8 +182,10 @@ def seed_saml_provider_from_conf_dir(db_session: Session) -> None:
         logger.debug("Skipping legacy SAML seed because multi-tenant mode is enabled")
         return
 
-    if AUTH_TYPE != AuthType.SAML:
-        logger.debug("Skipping legacy SAML seed because auth type is %s", AUTH_TYPE)
+    # Raw env read: app_configs coerces legacy SSO values to BASIC, which
+    # would hide the AUTH_TYPE=saml deployments this seed exists to migrate.
+    if (os.environ.get("AUTH_TYPE") or "").lower() != AuthType.SAML.value:
+        logger.debug("Skipping legacy SAML seed because auth type is not saml")
         return
 
     for provider in fetch_sso_providers(db_session):

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -19,8 +19,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from httpx_oauth.clients.google import GoogleOAuth2
-from httpx_oauth.clients.openid import BASE_SCOPES
-from httpx_oauth.clients.openid import OpenID
 from sentry_sdk.integrations.fastapi import FastApiIntegration
 from sentry_sdk.integrations.starlette import StarletteIntegration
 from starlette.types import Lifespan
@@ -39,7 +37,6 @@ from onyx.configs.app_configs import API_SERVER_THREADPOOL_SIZE
 from onyx.configs.app_configs import APP_API_PREFIX
 from onyx.configs.app_configs import APP_HOST
 from onyx.configs.app_configs import APP_PORT
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import CACHE_BACKEND
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.app_configs import ENABLE_PUBLIC_DOCS
@@ -49,9 +46,6 @@ from onyx.configs.app_configs import LOG_ENDPOINT_LATENCY
 from onyx.configs.app_configs import OAUTH_CLIENT_ID
 from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
 from onyx.configs.app_configs import OAUTH_ENABLED
-from onyx.configs.app_configs import OIDC_PKCE_ENABLED
-from onyx.configs.app_configs import OIDC_SCOPE_OVERRIDE
-from onyx.configs.app_configs import OPENID_CONFIG_URL
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_OVERFLOW
 from onyx.configs.app_configs import POSTGRES_API_SERVER_POOL_SIZE
 from onyx.configs.app_configs import POSTGRES_API_SERVER_READ_ONLY_POOL_OVERFLOW
@@ -59,7 +53,6 @@ from onyx.configs.app_configs import POSTGRES_API_SERVER_READ_ONLY_POOL_SIZE
 from onyx.configs.app_configs import SYSTEM_RECURSION_LIMIT
 from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.configs.app_configs import WEB_DOMAIN
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import POSTGRES_WEB_APP_NAME
 from onyx.db.engine.async_sql_engine import get_sqlalchemy_async_engine
 from onyx.db.engine.async_sql_engine import reset_sqlalchemy_async_engine
@@ -594,50 +587,46 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, pat_router)
     include_router_with_global_prefix_prepended(application, captcha_router)
 
-    if AUTH_TYPE == AuthType.BASIC or AUTH_TYPE == AuthType.CLOUD:
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_auth_router(auth_backend),
-            prefix="/auth",
-        )
+    # AUTH_TYPE is always BASIC or CLOUD (legacy single-provider modes coerce
+    # to BASIC in app_configs), so password auth always mounts.
+    include_auth_router_with_prefix(
+        application,
+        fastapi_users.get_auth_router(auth_backend),
+        prefix="/auth",
+    )
 
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_register_router(UserRead, UserCreate),
-            prefix="/auth",
-        )
+    include_auth_router_with_prefix(
+        application,
+        fastapi_users.get_register_router(UserRead, UserCreate),
+        prefix="/auth",
+    )
 
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_reset_password_router(),
-            prefix="/auth",
-        )
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_verify_router(UserRead),
-            prefix="/auth",
-        )
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_users_router(UserRead, UserUpdate),
-            prefix="/users",
-        )
+    include_auth_router_with_prefix(
+        application,
+        fastapi_users.get_reset_password_router(),
+        prefix="/auth",
+    )
+    include_auth_router_with_prefix(
+        application,
+        fastapi_users.get_verify_router(UserRead),
+        prefix="/auth",
+    )
+    include_auth_router_with_prefix(
+        application,
+        fastapi_users.get_users_router(UserRead, UserUpdate),
+        prefix="/users",
+    )
 
-    # Mobile bearer gateway (login/refresh/logout + the SSO code exchange). Must cover
-    # google_oauth too — its /auth/mobile/sso/exchange lives here — so it can't be nested
-    # in the basic/cloud block above (that 404'd the exchange on a google_oauth instance).
-    if AUTH_TYPE in (AuthType.BASIC, AuthType.CLOUD, AuthType.GOOGLE_OAUTH):
-        include_auth_router_with_prefix(
-            application,
-            mobile_auth_router,
-            prefix="/auth/mobile",
-        )
+    # Mobile bearer gateway (login/refresh/logout + the SSO code exchange).
+    include_auth_router_with_prefix(
+        application,
+        mobile_auth_router,
+        prefix="/auth/mobile",
+    )
 
-    # Register Google OAuth when AUTH_TYPE is GOOGLE_OAUTH, or when
-    # AUTH_TYPE is BASIC and OAuth credentials are configured
-    if AUTH_TYPE == AuthType.GOOGLE_OAUTH or (
-        AUTH_TYPE == AuthType.BASIC and OAUTH_ENABLED
-    ):
+    # Env-credential Google login rides alongside provider rows when OAuth
+    # credentials are configured.
+    if OAUTH_ENABLED:
         google_login_scopes = list(
             GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES
         )
@@ -677,55 +666,9 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
             prefix="/auth/mobile/oauth",
         )
 
-        # Need logout router for GOOGLE_OAUTH only (BASIC already has it from above)
-        if AUTH_TYPE == AuthType.GOOGLE_OAUTH:
-            include_auth_router_with_prefix(
-                application,
-                fastapi_users.get_logout_router(auth_backend),
-                prefix="/auth",
-            )
-
-    if AUTH_TYPE == AuthType.OIDC:
-        # Ensure we request offline_access for refresh tokens
-        try:
-            oidc_scopes = list(OIDC_SCOPE_OVERRIDE or BASE_SCOPES)
-            if "offline_access" not in oidc_scopes:
-                oidc_scopes.append("offline_access")
-        except Exception as e:
-            logger.warning("Error configuring OIDC scopes: %s", e)
-            # Fall back to default scopes if there's an error
-            oidc_scopes = BASE_SCOPES
-
-        include_auth_router_with_prefix(
-            application,
-            create_onyx_oauth_router(
-                OpenID(
-                    OAUTH_CLIENT_ID,
-                    OAUTH_CLIENT_SECRET,
-                    OPENID_CONFIG_URL,
-                    # Use the configured scopes
-                    base_scopes=oidc_scopes,
-                ),
-                auth_backend,
-                USER_AUTH_SECRET,
-                associate_by_email=True,
-                is_verified_by_default=True,
-                redirect_url=f"{WEB_DOMAIN}/auth/oidc/callback",
-                enable_pkce=OIDC_PKCE_ENABLED,
-            ),
-            prefix="/auth/oidc",
-        )
-
-        # need basic auth router for `logout` endpoint
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_auth_router(auth_backend),
-            prefix="/auth",
-        )
-
     # The only SAML router. Always mounted: it resolves provider rows per request
-    # (parametric authorize, one issuer-resolved callback) and 404s when none
-    # exist, so it ships dark. A single-SAML deployment's row is seeded from
+    # (fixed and parametric authorize, one issuer-resolved callback) and rejects
+    # requests when no rows exist, so it ships dark. A single-SAML deployment's row is seeded from
     # SAML_CONF_DIR at startup, so its login keeps working with no reconfig.
     include_auth_router_with_prefix(
         application,
@@ -733,25 +676,17 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     )
 
     # DB-backed multi-provider OIDC/Google router. Always mounted: resolves
-    # provider rows per request and 404s when none exist, so it ships dark next
-    # to the single-provider /auth/oidc and /auth/oauth routes.
+    # provider rows per request and 404s when none exist, so it ships dark.
     include_auth_router_with_prefix(
         application,
         oidc_multi_router,
     )
 
-    if (
-        AUTH_TYPE == AuthType.CLOUD
-        or AUTH_TYPE == AuthType.BASIC
-        or AUTH_TYPE == AuthType.GOOGLE_OAUTH
-        or AUTH_TYPE == AuthType.OIDC
-    ):
-        # Add refresh token endpoint for OAuth as well
-        include_auth_router_with_prefix(
-            application,
-            fastapi_users.get_refresh_router(auth_backend),
-            prefix="/auth",
-        )
+    include_auth_router_with_prefix(
+        application,
+        fastapi_users.get_refresh_router(auth_backend),
+        prefix="/auth",
+    )
 
     application.add_exception_handler(
         RequestValidationError, validation_exception_handler

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -39,7 +39,9 @@ from onyx.auth.users import OAuth2AuthorizeResponse
 from onyx.auth.users import STATE_TOKEN_LIFETIME_SECONDS
 from onyx.auth.users import UserManager
 from onyx.configs.app_configs import GOOGLE_LOGIN_BASE_SCOPES
+from onyx.configs.app_configs import GOOGLE_OAUTH_SCOPE_OVERRIDE
 from onyx.configs.app_configs import OIDC_PKCE_ENABLED
+from onyx.configs.app_configs import OIDC_SCOPE_OVERRIDE
 from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -94,18 +96,23 @@ def _resolve_oidc_provider(
 
 def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
     if provider.provider_type is SSOProviderType.OIDC:
+        # Env override lets deployments request extra API scopes (e.g. MS Graph
+        # User.Read for claims capture). offline_access secures refresh tokens.
+        scopes = list(OIDC_SCOPE_OVERRIDE or BASE_SCOPES)
+        if "offline_access" not in scopes:
+            scopes.append("offline_access")
         return VerifiedEmailOpenID(
             config["client_id"],
             config["client_secret"],
             config["openid_config_url"],
             name=provider.name,
-            base_scopes=list(BASE_SCOPES) + ["offline_access"],
+            base_scopes=scopes,
         )
     if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
         return GoogleOAuth2(
             config["client_id"],
             config["client_secret"],
-            scopes=list(GOOGLE_LOGIN_BASE_SCOPES),
+            scopes=list(GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES),
             name=provider.name,
         )
 

--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -1,29 +1,16 @@
 import contextlib
 import secrets
 import string
-import uuid
 from typing import Any
 from urllib.parse import urlparse
 
-from fastapi import APIRouter
-from fastapi import Depends
-from fastapi import HTTPException
 from fastapi import Request
-from fastapi import Response
-from fastapi import status
 from fastapi_users import exceptions
-from fastapi_users.authentication import Strategy
-from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from pydantic import BaseModel
 
 from onyx.auth.schemas import UserCreate
 from onyx.auth.schemas import UserRole
-from onyx.auth.users import auth_backend
-from onyx.auth.users import fastapi_users
 from onyx.auth.users import get_user_manager
-from onyx.auth.users import UserManager
-from onyx.configs.app_configs import REQUIRE_EMAIL_VERIFICATION
-from onyx.configs.app_configs import SAML_CONF_DIR
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.auth import get_user_count
 from onyx.db.auth import get_user_db
@@ -32,7 +19,6 @@ from onyx.db.models import User
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-router = APIRouter(prefix="/auth/saml")
 
 # Azure AD / Entra ID often returns the email attribute under different keys.
 # Keep a list of common variations so we can fall back gracefully if the IdP
@@ -188,111 +174,3 @@ def _sanitize_relay_state(candidate: str | None) -> str | None:
         return None
 
     return relay_state
-
-
-@router.get("/authorize")
-async def saml_login(request: Request) -> SAMLAuthorizeResponse:
-    req = await prepare_from_fastapi_request(request)
-    auth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_CONF_DIR)
-    return_to = _sanitize_relay_state(request.query_params.get("next"))
-    callback_url = auth.login(return_to=return_to)
-    return SAMLAuthorizeResponse(authorization_url=callback_url)
-
-
-@router.get("/callback")
-async def saml_login_callback_get(
-    request: Request,
-    strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
-    user_manager: UserManager = Depends(get_user_manager),
-) -> Response:
-    """Handle SAML callback via HTTP-Redirect binding (GET request)"""
-    return await _process_saml_callback(request, strategy, user_manager)
-
-
-@router.post("/callback")
-async def saml_login_callback(
-    request: Request,
-    strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
-    user_manager: UserManager = Depends(get_user_manager),
-) -> Response:
-    """Handle SAML callback via HTTP-POST binding (POST request)"""
-    return await _process_saml_callback(request, strategy, user_manager)
-
-
-async def _process_saml_callback(
-    request: Request,
-    strategy: Strategy[User, uuid.UUID],
-    user_manager: UserManager,
-) -> Response:
-    req = await prepare_from_fastapi_request(request)
-    auth = OneLogin_Saml2_Auth(req, custom_base_path=SAML_CONF_DIR)
-    auth.process_response()
-    errors = auth.get_errors()
-    if len(errors) != 0:
-        logger.error(
-            "Error when processing SAML Response: %s %s"
-            % (", ".join(errors), auth.get_last_error_reason())
-        )
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Access denied. Failed to parse SAML Response.",
-        )
-
-    if not auth.is_authenticated():
-        detail = "Access denied. User was not authenticated"
-        logger.error(detail)
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail=detail,
-        )
-
-    user_email: str | None = None
-
-    # The OneLogin toolkit normalizes attribute keys, but still performs a
-    # case-sensitive lookup. Try the common keys first and then fall back to a
-    # case-insensitive scan of all returned attributes.
-    for attribute_key in EMAIL_ATTRIBUTE_KEYS:
-        attribute_values = auth.get_attribute(attribute_key)
-        if attribute_values:
-            user_email = attribute_values[0]
-            break
-
-    if not user_email:
-        # Fallback: perform a case-insensitive lookup across all attributes in
-        # case the IdP sent the email claim with a different capitalization.
-        attributes = auth.get_attributes()
-        for key, values in attributes.items():
-            if key.lower() in EMAIL_ATTRIBUTE_KEYS_LOWER:
-                if values:
-                    user_email = values[0]
-                    break
-        if not user_email:
-            detail = "SAML is not set up correctly, email attribute must be provided."
-            logger.error(detail)
-            logger.debug(
-                "Received SAML attributes without email: %s",
-                list(attributes.keys()),
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=detail,
-            )
-
-    user = await upsert_saml_user(email=user_email)
-
-    response = await auth_backend.login(strategy, user)
-    await user_manager.on_after_login(user, request, response)
-    return response
-
-
-@router.post("/logout")
-async def saml_logout(
-    user_token: tuple[User, str] = Depends(
-        fastapi_users.authenticator.current_user_token(
-            active=True, verified=REQUIRE_EMAIL_VERIFICATION
-        )
-    ),
-    strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
-) -> Response:
-    user, token = user_token
-    return await auth_backend.logout(strategy, user, token)

--- a/backend/tests/external_dependency_unit/auth/test_mobile_oauth_registration.py
+++ b/backend/tests/external_dependency_unit/auth/test_mobile_oauth_registration.py
@@ -1,27 +1,22 @@
-"""Regression guard: the mobile Google OAuth surface must register under google_oauth.
+"""Regression guard: the mobile Google OAuth surface must register whenever env
+Google OAuth credentials are configured.
 
-Two bugs reached a running google_oauth deployment because the rest of the suite
-only ever boots the app under basic auth:
-  1. /auth/mobile/oauth/{authorize,callback} were missing from PUBLIC_ENDPOINT_SPECS,
-     so check_router_auth raised at startup and crash-looped the api_server.
-  2. The mobile gateway (which owns /auth/mobile/sso/exchange) was mounted only for
-     AUTH_TYPE basic/cloud, so the SSO exchange 404'd on a google_oauth instance.
-
-get_application() reads AUTH_TYPE as a module global at call time, so monkeypatching
-it boots the google_oauth surface in-process. Building it also runs check_router_auth,
-so bug #1 raises here while the assertions cover bug #2.
+get_application() reads OAUTH_ENABLED and the client credentials as module
+globals at call time, so monkeypatching boots the OAuth-enabled surface
+in-process. Building the app also runs check_router_auth, which raises if the
+mobile routes are missing from PUBLIC_ENDPOINT_SPECS. The assertions cover the
+gateway's SSO exchange and the dedicated mobile OAuth router.
 """
 
 import pytest
 
 import onyx.main as onyx_main
-from onyx.configs.constants import AuthType
 
 
-def test_mobile_routes_registered_under_google_oauth(
+def test_mobile_routes_registered_with_env_google_oauth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(onyx_main, "AUTH_TYPE", AuthType.GOOGLE_OAUTH)
+    monkeypatch.setattr(onyx_main, "OAUTH_ENABLED", True)
     monkeypatch.setattr(onyx_main, "OAUTH_CLIENT_ID", "test-client-id")
     monkeypatch.setattr(onyx_main, "OAUTH_CLIENT_SECRET", "test-client-secret")
 

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -4,9 +4,8 @@ Unit tests for the user registration workflow in UserManager.create().
 Tests cover:
 1. Disposable email validation (before tenant provisioning)
 2. Multi-tenant vs single-tenant invite logic
-3. SAML/OIDC SSO bypass behavior
-4. Empty whitelist vs populated whitelist scenarios
-5. Case-insensitive email matching for existing user checks
+3. Empty whitelist vs populated whitelist scenarios
+4. Case-insensitive email matching for existing user checks
 """
 
 from types import TracebackType
@@ -19,7 +18,6 @@ from fastapi_users import exceptions
 
 from onyx.auth.schemas import UserCreate
 from onyx.auth.users import UserManager
-from onyx.configs.constants import AuthType
 from onyx.error_handling.exceptions import OnyxError
 
 # Note: Only async test methods are marked with @pytest.mark.asyncio individually
@@ -300,57 +298,11 @@ class TestSingleTenantInviteLogic:
         )
 
 
-class TestSAMLOIDCBehavior:
-    """Test SSO (SAML/OIDC) bypass of invite whitelist."""
-
-    @pytest.mark.parametrize("auth_type", [AuthType.SAML, AuthType.OIDC])
-    @patch("onyx.auth.users.get_invited_users")
-    @patch("onyx.auth.users.workspace_invite_only_enabled", return_value=True)
-    @patch("onyx.auth.users.AUTH_TYPE")
-    def test_sso_bypasses_whitelist(
-        self,
-        mock_auth_type: MagicMock,
-        _mock_invite_only: MagicMock,
-        mock_get_invited: MagicMock,
-        auth_type: AuthType,
-    ) -> None:
-        """SAML/OIDC should bypass invite whitelist."""
-        from onyx.auth.users import verify_email_is_invited
-
-        # Setup
-        mock_auth_type.return_value = auth_type
-        mock_get_invited.return_value = ["allowed@example.com"]
-
-        # Execute - should not raise even with populated whitelist
-        with patch("onyx.auth.users.AUTH_TYPE", auth_type):
-            verify_email_is_invited("newuser@example.com")  # Should not raise
-
-    @patch("onyx.auth.users.get_invited_users")
-    @patch("onyx.auth.users.workspace_invite_only_enabled", return_value=True)
-    @patch("onyx.auth.users.AUTH_TYPE", AuthType.BASIC)
-    def test_basic_auth_enforces_whitelist(
-        self,
-        mock_get_invited: MagicMock,
-        _mock_invite_only: MagicMock,
-    ) -> None:
-        """Basic auth should enforce invite whitelist."""
-        from onyx.auth.users import verify_email_is_invited
-
-        # Setup
-        mock_get_invited.return_value = ["allowed@example.com"]
-
-        # Execute & Assert
-        with pytest.raises(OnyxError) as exc:
-            verify_email_is_invited("newuser@example.com")
-        assert exc.value.status_code == 403
-
-
 class TestWhitelistBehavior:
     """Test invite whitelist scenarios."""
 
     @patch("onyx.auth.users.workspace_invite_only_enabled", return_value=False)
     @patch("onyx.auth.users.get_invited_users")
-    @patch("onyx.auth.users.AUTH_TYPE", AuthType.BASIC)
     def test_empty_whitelist_allows_all(
         self,
         mock_get_invited: MagicMock,
@@ -367,7 +319,6 @@ class TestWhitelistBehavior:
 
     @patch("onyx.auth.users.workspace_invite_only_enabled", return_value=False)
     @patch("onyx.auth.users.get_invited_users")
-    @patch("onyx.auth.users.AUTH_TYPE", AuthType.BASIC)
     def test_invite_only_disabled_allows_non_invited_users(
         self,
         mock_get_invited: MagicMock,
@@ -381,7 +332,6 @@ class TestWhitelistBehavior:
 
     @patch("onyx.auth.users.workspace_invite_only_enabled", return_value=True)
     @patch("onyx.auth.users.get_invited_users")
-    @patch("onyx.auth.users.AUTH_TYPE", AuthType.BASIC)
     def test_whitelist_blocks_non_invited(
         self,
         mock_get_invited: MagicMock,
@@ -401,7 +351,6 @@ class TestWhitelistBehavior:
 
     @patch("onyx.auth.users.workspace_invite_only_enabled", return_value=True)
     @patch("onyx.auth.users.get_invited_users")
-    @patch("onyx.auth.users.AUTH_TYPE", AuthType.BASIC)
     def test_whitelist_allows_invited_case_insensitive(
         self,
         mock_get_invited: MagicMock,

--- a/backend/tests/unit/onyx/auth/test_verify_auth_setting.py
+++ b/backend/tests/unit/onyx/auth/test_verify_auth_setting.py
@@ -34,25 +34,40 @@ def test_verify_auth_setting_warns_for_disabled(
     assert "no longer supported" in mock_logger.warning.call_args[0][0]
 
 
-@pytest.mark.parametrize(
-    "auth_type",
-    [AuthType.BASIC, AuthType.GOOGLE_OAUTH, AuthType.OIDC, AuthType.SAML],
-)
-def test_verify_auth_setting_valid_auth_types(
+def test_verify_auth_setting_basic_no_warning(
     monkeypatch: pytest.MonkeyPatch,
-    auth_type: AuthType,
 ) -> None:
-    """Valid auth types work without errors or warnings."""
-    monkeypatch.setenv("AUTH_TYPE", auth_type.value)
+    """Basic auth starts without errors or warnings."""
+    monkeypatch.setenv("AUTH_TYPE", "basic")
 
     mock_logger = MagicMock()
     monkeypatch.setattr(users, "logger", mock_logger)
-    monkeypatch.setattr(users, "AUTH_TYPE", auth_type)
+    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC)
 
     verify_auth_setting()
 
     mock_logger.warning.assert_not_called()
-    mock_logger.notice.assert_called_once_with("Using Auth Type: %s", auth_type.value)
+    mock_logger.notice.assert_called_once_with("Using Auth Type: %s", "basic")
+
+
+@pytest.mark.parametrize("legacy_value", ["google_oauth", "oidc", "saml"])
+def test_verify_auth_setting_warns_for_legacy_sso_modes(
+    monkeypatch: pytest.MonkeyPatch,
+    legacy_value: str,
+) -> None:
+    """Legacy single-provider modes warn that the config migrated to a
+    provider row and the deployment runs as basic."""
+    monkeypatch.setenv("AUTH_TYPE", legacy_value)
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr(users, "logger", mock_logger)
+    # app_configs coerces these values to BASIC at import
+    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC)
+
+    verify_auth_setting()
+
+    mock_logger.warning.assert_called_once()
+    assert "SSO provider row" in mock_logger.warning.call_args[0][0]
 
 
 def test_verify_user_auth_secret_rejects_empty_secret_in_production(

--- a/backend/tests/unit/onyx/auth/test_verify_email_invite.py
+++ b/backend/tests/unit/onyx/auth/test_verify_email_invite.py
@@ -2,31 +2,12 @@ import pytest
 
 import onyx.auth.users as users
 from onyx.auth.users import verify_email_is_invited
-from onyx.configs.constants import AuthType
 from onyx.error_handling.exceptions import OnyxError
-
-
-@pytest.mark.parametrize("auth_type", [AuthType.SAML, AuthType.OIDC])
-def test_verify_email_is_invited_skips_whitelist_for_sso(
-    monkeypatch: pytest.MonkeyPatch, auth_type: AuthType
-) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", auth_type, raising=False)
-    monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
-    monkeypatch.setattr(
-        users,
-        "get_invited_users",
-        lambda: ["allowed@example.com"],
-        raising=False,
-    )
-
-    # Should not raise even though whitelist is populated
-    verify_email_is_invited("newuser@example.com")
 
 
 def test_verify_email_is_invited_enforced_for_basic_auth(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
     monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
     monkeypatch.setattr(
         users,
@@ -43,7 +24,6 @@ def test_verify_email_is_invited_enforced_for_basic_auth(
 def test_verify_email_is_invited_skipped_when_invite_only_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
     monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: False)
     monkeypatch.setattr(
         users,
@@ -60,7 +40,6 @@ def test_sso_managed_bypasses_whitelist_under_basic(
 ) -> None:
     """A provider-row login on a BASIC deployment is IdP-managed, so the
     workspace invite list must not block its JIT-provisioned users."""
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
     monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
     monkeypatch.setattr(
         users,
@@ -76,7 +55,6 @@ def test_sso_managed_default_false_keeps_enforcement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Callers that do not declare SSO provenance keep the invite check."""
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC, raising=False)
     monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
     monkeypatch.setattr(
         users,


### PR DESCRIPTION
## Description

Stacked on #13018. PR 3 of the AUTH_TYPE removal stack.

**Do not merge until the v4.4.0 sso_provider row migration has shipped in a release.** Legacy deployments must pick up the seed before the routes disappear.

- `AUTH_TYPE=google_oauth/oidc/saml` coerce to `BASIC` in app_configs. Provider rows serve their login. `verify_auth_setting` warns the operator at startup.
- Deletes the legacy OIDC mount block, the GOOGLE_OAUTH-only logout mount, and the legacy `/auth/saml` router (helpers stay, saml_multi consumes them). Password/mobile/refresh routers mount unconditionally. Env-Google rides on `OAUTH_ENABLED`.
- Deletes the blanket SAML/OIDC invite-whitelist bypass. Per-user `sso_managed` from #13018 replaces it.
- Seeds that migrate legacy config (alembic `1fc2904131a3` and the SAML conf-dir import) read raw `os.environ["AUTH_TYPE"]` since the coercion hides the legacy value.
- Removes the EE cloud logout mount that duplicated the now-unconditional auth router, and `get_logout_router` with it.

## How Has This Been Tested?

## Additional Options

- [ ] I have considered whether this PR needs to be cherry-picked to the latest release branch.
- [x] Override Linear Check