### PR TITLE
feat(auth): remove AUTH_TYPE and the AuthType enum, serve multi_tenant

### DIFF
--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -64,15 +64,13 @@ def _seed_from_env(table: sa.Table) -> None:
     Reads the already-resolved app_config constants for credentials and
     domains so the legacy GOOGLE_OAUTH_* fallbacks and the VALID_EMAIL_DOMAINS
     parsing stay in one place, but AUTH_TYPE comes from raw os.environ because
-    app_configs coerces legacy SSO values to BASIC. Skipped in multi-tenant
-    (cloud auth does not use per-instance provider rows) and when the table
-    already has any row.
+    app_configs does not read it. Skipped in multi-tenant (cloud auth does not
+    use per-instance provider rows) and when the table already has any row.
     """
     from onyx.configs.app_configs import OAUTH_CLIENT_ID
     from onyx.configs.app_configs import OAUTH_CLIENT_SECRET
     from onyx.configs.app_configs import OPENID_CONFIG_URL
     from onyx.configs.app_configs import VALID_EMAIL_DOMAINS
-    from onyx.configs.constants import AuthType
     from shared_configs.configs import MULTI_TENANT
 
     if MULTI_TENANT:
@@ -83,10 +81,10 @@ def _seed_from_env(table: sa.Table) -> None:
     # provider_type is the enum member NAME (Enum(native_enum=False) storage);
     # the login `name` matches the oauth_name existing linked accounts carry so
     # linkage survives the routing cutover.
-    if raw_auth_type == AuthType.GOOGLE_OAUTH.value:
+    if raw_auth_type == "google_oauth":
         provider_type, name = "GOOGLE_OAUTH", "google"
         display_name, config_url = "Continue with Google", None
-    elif raw_auth_type == AuthType.OIDC.value:
+    elif raw_auth_type == "oidc":
         if not OPENID_CONFIG_URL:
             return
         provider_type, name = "OIDC", "openid"

--- a/backend/alembic/versions/90e3b9af7da4_tag_fix.py
+++ b/backend/alembic/versions/90e3b9af7da4_tag_fix.py
@@ -18,8 +18,7 @@ import sqlalchemy as sa
 
 from onyx.document_index.vespa_constants import DOCUMENT_ID_ENDPOINT
 from onyx.db.search_settings import SearchSettings
-from onyx.configs.app_configs import AUTH_TYPE
-from onyx.configs.constants import AuthType
+from shared_configs.configs import MULTI_TENANT
 from onyx.document_index.vespa.shared_utils.utils import get_vespa_http_client
 
 logger = logging.getLogger("alembic.runtime.migration")
@@ -34,7 +33,7 @@ depends_on = None
 SKIP_TAG_FIX = os.environ.get("SKIP_TAG_FIX", "true").lower() == "true"
 
 # override for cloud
-if AUTH_TYPE == AuthType.CLOUD:
+if MULTI_TENANT:
     SKIP_TAG_FIX = True
 
 

--- a/backend/ee/onyx/auth/users.py
+++ b/backend/ee/onyx/auth/users.py
@@ -1,4 +1,3 @@
-import os
 import secrets
 from datetime import datetime
 from datetime import timezone
@@ -13,31 +12,12 @@ from ee.onyx.configs.app_configs import SUPER_CLOUD_API_KEY
 from ee.onyx.configs.app_configs import SUPER_USERS
 from ee.onyx.server.seeding import get_seed_config
 from onyx.auth.permissions import require_permission
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import USER_AUTH_SECRET
 from onyx.db.enums import Permission
 from onyx.db.models import User
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-
-def verify_auth_setting() -> None:
-    # Unlike the MIT version, 'cloud' is valid here. Warn on removed legacy values.
-    raw_auth_type = (os.environ.get("AUTH_TYPE") or "").lower()
-    if raw_auth_type == "disabled":
-        logger.warning(
-            "AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration."
-        )
-    if raw_auth_type in ("google_oauth", "oidc", "saml"):
-        logger.warning(
-            "AUTH_TYPE='%s' single-provider mode was removed and Onyx is running "
-            "as 'basic'. SSO login is now served by SSO provider rows (Admin "
-            "Panel > Organization > SSO Providers). Update AUTH_TYPE to 'basic' "
-            "and remove the legacy SSO env vars.",
-            raw_auth_type,
-        )
-    logger.notice("Using Auth Type: %s", AUTH_TYPE.value)
 
 
 def get_default_admin_user_emails_() -> list[str]:

--- a/backend/onyx/auth/email_utils.py
+++ b/backend/onyx/auth/email_utils.py
@@ -29,7 +29,6 @@ from onyx.configs.app_configs import SMTP_SERVER
 from onyx.configs.app_configs import SMTP_STARTTLS
 from onyx.configs.app_configs import SMTP_USER
 from onyx.configs.app_configs import WEB_DOMAIN
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME
 from onyx.configs.constants import ONYX_DISCORD_URL
 from onyx.db.models import User
@@ -364,25 +363,19 @@ def send_subscription_cancellation_email(user_email: str) -> None:
 
 
 def build_user_email_invite(
-    from_email: str, to_email: str, application_name: str, auth_type: AuthType
+    from_email: str, to_email: str, application_name: str
 ) -> tuple[str, str]:
     heading = "You've Been Invited!"
 
-    # the exact action taken by the user, and thus the message, depends on the auth type
     message = f"<p>You have been invited by {from_email} to join an organization on {application_name}.</p>"
-    if auth_type == AuthType.CLOUD:
+    # Cloud offers Google login alongside password signup.
+    if MULTI_TENANT:
         message += (
             "<p>To join the organization, please click the button below to set a password "
             "or login with Google and complete your registration.</p>"
         )
-    elif auth_type == AuthType.BASIC:
-        message += "<p>To join the organization, please click the button below to set a password and complete your registration.</p>"
-    elif auth_type == AuthType.GOOGLE_OAUTH:
-        message += "<p>To join the organization, please click the button below to login with Google and complete your registration.</p>"
-    elif auth_type == AuthType.OIDC or auth_type == AuthType.SAML:
-        message += "<p>To join the organization, please click the button below to complete your registration.</p>"
     else:
-        raise ValueError(f"Invalid auth type: {auth_type}")
+        message += "<p>To join the organization, please click the button below to set a password and complete your registration.</p>"
 
     cta_text = "Join Organization"
     cta_link = f"{WEB_DOMAIN}/auth/signup?email={to_email}"
@@ -395,22 +388,19 @@ def build_user_email_invite(
         cta_link,
     )
 
-    # text content is the fallback for clients that don't support HTML
-    # not as critical, so not having special cases for each auth type
+    # Plain-text fallback for clients that don't render HTML.
     text_content = (
         f"You have been invited by {from_email} to join an organization on {application_name}.\n"
         "To join the organization, please visit the following link:\n"
         f"{WEB_DOMAIN}/auth/signup?email={to_email}\n"
     )
-    if auth_type == AuthType.CLOUD:
+    if MULTI_TENANT:
         text_content += "You'll be asked to set a password or login with Google to complete your registration."
 
     return text_content, html_content
 
 
-def send_user_email_invite(
-    user_email: str, current_user: User, auth_type: AuthType
-) -> None:
+def send_user_email_invite(user_email: str, current_user: User) -> None:
     try:
         load_runtime_settings_fn = fetch_versioned_implementation(
             "onyx.server.enterprise_settings.store", "load_runtime_settings"
@@ -425,7 +415,7 @@ def send_user_email_invite(
     subject = f"Invitation to Join {application_name} Organization"
 
     text_content, html_content = build_user_email_invite(
-        current_user.email, user_email, application_name, auth_type
+        current_user.email, user_email, application_name
     )
 
     send_email(

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -95,7 +95,6 @@ from onyx.auth.schemas import UserRole
 from onyx.auth.signup_rate_limit import enforce_signup_rate_limit
 from onyx.configs.app_configs import AUTH_BACKEND
 from onyx.configs.app_configs import AUTH_COOKIE_EXPIRE_TIME_SECONDS
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import DEV_MODE
 from onyx.configs.app_configs import EMAIL_CONFIGURED
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
@@ -173,30 +172,25 @@ def is_user_admin(user: User) -> bool:
 
 
 def verify_auth_setting() -> None:
-    """Log warnings for AUTH_TYPE issues.
-
-    This only runs on app startup not during migrations/scripts.
-    """
+    """Warn operators about inert AUTH_TYPE env values so they get cleaned up.
+    Call at app startup only, not from migrations/scripts."""
     raw_auth_type = (os.environ.get("AUTH_TYPE") or "").lower()
 
-    if raw_auth_type == "cloud":
-        raise ValueError(
-            "'cloud' is not a valid auth type for self-hosted deployments."
-        )
     if raw_auth_type == "disabled":
         logger.warning(
-            "AUTH_TYPE='disabled' is no longer supported. Using 'basic' instead. Please update your configuration."
+            "AUTH_TYPE='disabled' is no longer supported. Authentication is "
+            "always enabled. Remove the env var."
         )
     if raw_auth_type in ("google_oauth", "oidc", "saml"):
         logger.warning(
             "AUTH_TYPE='%s' single-provider mode was removed and Onyx is running "
             "as 'basic'. SSO login is now served by SSO provider rows (Admin "
-            "Panel > Organization > SSO Providers). Update AUTH_TYPE to 'basic' "
-            "and remove the legacy SSO env vars.",
+            "Panel > Organization > SSO Providers). Remove AUTH_TYPE and the "
+            "legacy SSO env vars.",
             raw_auth_type,
         )
 
-    logger.notice("Using Auth Type: %s", AUTH_TYPE.value)
+    logger.notice("Using Auth Type: %s", "cloud" if MULTI_TENANT else "basic")
 
 
 def verify_user_auth_secret() -> None:

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -7,7 +7,6 @@ from typing import cast
 
 from onyx.auth.schemas import AuthBackend
 from onyx.cache.interface import CacheBackendType
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import QueryHistoryType
 from onyx.document_index.opensearch.constants import OpenSearchAuthMethod
 from onyx.file_processing.enums import HtmlBasedConnectorTransformLinksStrategy
@@ -130,21 +129,6 @@ POSTHOG_HOST = os.environ.get("POSTHOG_HOST") or "https://us.i.posthog.com"
 #####
 # Auth Configs
 #####
-# Silently default to basic - warnings/errors logged in verify_auth_setting()
-# which only runs on app startup, not during migrations/scripts
-_auth_type_str = (os.environ.get("AUTH_TYPE") or "").lower()
-if _auth_type_str in [auth_type.value for auth_type in AuthType]:
-    AUTH_TYPE = AuthType(_auth_type_str)
-else:
-    AUTH_TYPE = AuthType.BASIC
-
-# Legacy single-provider SSO values run as BASIC. Login for those deployments
-# is served by sso_provider rows instead. verify_auth_setting warns at startup,
-# and the row seeds (alembic 1fc2904131a3 and the SAML conf-dir import) read
-# raw os.environ because this coercion hides the legacy value.
-if AUTH_TYPE in (AuthType.GOOGLE_OAUTH, AuthType.OIDC, AuthType.SAML):
-    AUTH_TYPE = AuthType.BASIC
-
 PASSWORD_MIN_LENGTH = int(os.getenv("PASSWORD_MIN_LENGTH", 8))
 PASSWORD_MAX_LENGTH = int(os.getenv("PASSWORD_MAX_LENGTH", 64))
 PASSWORD_REQUIRE_UPPERCASE = (
@@ -233,9 +217,8 @@ OAUTH_CLIENT_SECRET = (
 # Whether Google OAuth is enabled (requires both client ID and secret)
 OAUTH_ENABLED = bool(OAUTH_CLIENT_ID and OAUTH_CLIENT_SECRET)
 
-# Default scopes requested when signing in with Google (AUTH_TYPE=google_oauth
-# or AUTH_TYPE=cloud, and the BASIC + OAuth fallback path). These are the
-# minimum required to identify the user via OpenID Connect.
+# Default Google sign-in scopes, the minimum required to identify the user
+# via OpenID Connect.
 GOOGLE_LOGIN_BASE_SCOPES = ["openid", "email", "profile"]
 
 # Applicable for Google OAuth login, allows you to override the scopes that
@@ -1961,7 +1944,7 @@ INSTANCE_TYPE = (
     "managed"
     if os.environ.get("IS_MANAGED_INSTANCE", "").lower() == "true"
     else "cloud"
-    if AUTH_TYPE == AuthType.CLOUD
+    if MULTI_TENANT
     else "self_hosted"
 )
 

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -323,13 +323,6 @@ class DocumentIndexType(str, Enum):
     SPLIT = "split"  # Typesense + Qdrant
 
 
-class AuthType(str, Enum):
-    BASIC = "basic"
-
-    # password plus Google login
-    CLOUD = "cloud"
-
-
 class QueryHistoryType(str, Enum):
     DISABLED = "disabled"
     ANONYMIZED = "anonymized"

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -325,11 +325,8 @@ class DocumentIndexType(str, Enum):
 
 class AuthType(str, Enum):
     BASIC = "basic"
-    GOOGLE_OAUTH = "google_oauth"
-    OIDC = "oidc"
-    SAML = "saml"
 
-    # google auth and basic
+    # password plus Google login
     CLOUD = "cloud"
 
 

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import SAML_CONF_DIR
 from onyx.configs.app_configs import VALID_EMAIL_DOMAINS
-from onyx.configs.constants import AuthType
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
 from onyx.utils.logger import setup_logger
@@ -182,9 +181,9 @@ def seed_saml_provider_from_conf_dir(db_session: Session) -> None:
         logger.debug("Skipping legacy SAML seed because multi-tenant mode is enabled")
         return
 
-    # Raw env read: app_configs coerces legacy SSO values to BASIC, which
-    # would hide the AUTH_TYPE=saml deployments this seed exists to migrate.
-    if (os.environ.get("AUTH_TYPE") or "").lower() != AuthType.SAML.value:
+    # This env read exists only to migrate legacy AUTH_TYPE=saml deployments
+    # to a provider row.
+    if (os.environ.get("AUTH_TYPE") or "").lower() != "saml":
         logger.debug("Skipping legacy SAML seed because auth type is not saml")
         return
 

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -31,6 +31,7 @@ from onyx.auth.users import auth_backend
 from onyx.auth.users import create_onyx_oauth_router
 from onyx.auth.users import fastapi_users
 from onyx.auth.users import mobile_auth_backend
+from onyx.auth.users import verify_auth_setting
 from onyx.auth.users import verify_user_auth_secret
 from onyx.cache.interface import CacheBackendType
 from onyx.configs.app_configs import API_SERVER_THREADPOOL_SIZE
@@ -367,12 +368,8 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
         "onyx.server.metrics.license_metrics", "register_license_metrics"
     )()
 
-    verify_auth = fetch_versioned_implementation(
-        "onyx.auth.users", "verify_auth_setting"
-    )
-
-    # Will throw exception if an issue is found
-    verify_auth()
+    # Warns on stale AUTH_TYPE env values.
+    verify_auth_setting()
 
     # Will throw exception if USER_AUTH_SECRET is missing on a real deployment
     verify_user_auth_secret()
@@ -587,8 +584,7 @@ def get_application(lifespan_override: Lifespan | None = None) -> FastAPI:
     include_router_with_global_prefix_prepended(application, pat_router)
     include_router_with_global_prefix_prepended(application, captcha_router)
 
-    # AUTH_TYPE is always BASIC or CLOUD (legacy single-provider modes coerce
-    # to BASIC in app_configs), so password auth always mounts.
+    # Password login is served in every deployment mode.
     include_auth_router_with_prefix(
         application,
         fastapi_users.get_auth_router(auth_backend),

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -1,7 +1,9 @@
 import concurrent.futures
 import re
+import threading
 
 import requests
+from cachetools import TTLCache
 from fastapi import APIRouter
 from fastapi import HTTPException
 from fastapi import Response
@@ -11,7 +13,6 @@ from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
 from onyx.configs.app_configs import OAUTH_ENABLED
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import DEV_VERSION_PATTERN
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.configs.constants import STABLE_VERSION_PATTERN
@@ -20,7 +21,7 @@ from onyx.db.engine.sql_engine import get_session_with_shared_schema
 from onyx.db.enums import SSOProviderType
 from onyx.db.sso_provider import fetch_sso_providers
 from onyx.server.manage.models import AllVersions
-from onyx.server.manage.models import AuthTypeResponse
+from onyx.server.manage.models import AuthConfigResponse
 from onyx.server.manage.models import ContainerVersions
 from onyx.server.manage.models import SSOProviderOption
 from onyx.server.manage.models import VersionResponse
@@ -39,24 +40,53 @@ _SSO_AUTHORIZE_ROUTER = {
 }
 
 
+# TTL matches the endpoint's HTTP max-age (60s). The two windows stack.
+# Admin mutations invalidate this pod directly. Other pods ride the TTL.
+_SSO_OPTIONS_TTL_SECONDS = 60
+_SSO_OPTIONS_CACHE: TTLCache[str, list[SSOProviderOption]] = TTLCache(
+    maxsize=1, ttl=_SSO_OPTIONS_TTL_SECONDS
+)
+_SSO_OPTIONS_KEY = "options"
+_SSO_OPTIONS_LOCK = threading.Lock()
+
+# Login-page traffic must not COUNT users on every request. Users are never
+# un-created in practice, so once a user exists the flag is latched for the
+# life of the process.
+_HAS_USERS_LATCHED = False
+
+
+def invalidate_sso_provider_options_cache() -> None:
+    """Call after any sso_provider mutation so admin edits show immediately."""
+    with _SSO_OPTIONS_LOCK:
+        _SSO_OPTIONS_CACHE.pop(_SSO_OPTIONS_KEY, None)
+
+
 def _fetch_sso_provider_options() -> list[SSOProviderOption]:
     # Single-tenant only. /auth/type runs before any tenant context, so a
     # multi-tenant lookup has no tenant to key on.
     if MULTI_TENANT:
         return []
-    with get_session_with_shared_schema() as db_session:
-        return [
-            SSOProviderOption(
-                name=provider.name,
-                display_name=provider.display_name,
-                provider_type=provider.provider_type,
-                authorize_url=(
-                    f"/api/auth/{_SSO_AUTHORIZE_ROUTER[provider.provider_type]}"
-                    f"/{provider.name}/authorize"
-                ),
-            )
-            for provider in fetch_sso_providers(db_session, enabled_only=True)
-        ]
+    # The lock spans the DB read so a mutation's invalidate cannot land between
+    # read and cache write, which would pin a pre-mutation snapshot for a TTL.
+    with _SSO_OPTIONS_LOCK:
+        cached = _SSO_OPTIONS_CACHE.get(_SSO_OPTIONS_KEY)
+        if cached is not None:
+            return cached
+        with get_session_with_shared_schema() as db_session:
+            options = [
+                SSOProviderOption(
+                    name=provider.name,
+                    display_name=provider.display_name,
+                    provider_type=provider.provider_type,
+                    authorize_url=(
+                        f"/api/auth/{_SSO_AUTHORIZE_ROUTER[provider.provider_type]}"
+                        f"/{provider.name}/authorize"
+                    ),
+                )
+                for provider in fetch_sso_providers(db_session, enabled_only=True)
+            ]
+        _SSO_OPTIONS_CACHE[_SSO_OPTIONS_KEY] = options
+        return options
 
 
 @router.get("/health", tags=PUBLIC_API_TAGS)
@@ -65,20 +95,22 @@ async def healthcheck() -> StatusResponse:
 
 
 @router.get("/auth/type", tags=PUBLIC_API_TAGS)
-async def get_auth_type(response: Response) -> AuthTypeResponse:
+async def get_auth_type(response: Response) -> AuthConfigResponse:
     # NOTE: This endpoint is critical for the multi-tenant flow and is hit before there is a tenant context
     # The reason is this is used during the login flow, but we don't know which tenant the user is supposed to be
     # associated with until they auth.
+    global _HAS_USERS_LATCHED
     has_users = True
-    if not MULTI_TENANT:
-        user_count = await get_user_count()
-        has_users = user_count > 0
+    if not MULTI_TENANT and not _HAS_USERS_LATCHED:
+        has_users = await get_user_count() > 0
+        _HAS_USERS_LATCHED = has_users
 
     # Cache only after bootstrap; the first user flow depends on a live
     # has_users flag so avoid serving a stale redirect. no-store in that
     # case prevents an intermediate CDN with a default TTL from pinning
     # has_users=false past the first signup. sso_providers rides this cache
-    # too, so a disabled provider's button can linger up to 60s. Clicking it
+    # too, so a disabled provider's button can linger for the server TTL plus
+    # this max-age (~2 min worst case on pods the mutation did not touch). Clicking it
     # still fails closed (authorize resolves enabled_only), so this is a UX
     # blip, not an access path. Reduce the window if that is too slow.
     response.headers["Cache-Control"] = (
@@ -86,8 +118,8 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
     )
 
     security = get_security_settings()
-    return AuthTypeResponse(
-        auth_type=AuthType.CLOUD if MULTI_TENANT else AuthType.BASIC,
+    return AuthConfigResponse(
+        multi_tenant=MULTI_TENANT,
         requires_verification=user_needs_to_be_verified(),
         anonymous_user_enabled=anonymous_user_enabled(),
         password_min_length=security.password_min_length,

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -10,7 +10,6 @@ from fastapi.concurrency import run_in_threadpool
 from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import user_needs_to_be_verified
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import OAUTH_ENABLED
 from onyx.configs.constants import AuthType
 from onyx.configs.constants import DEV_VERSION_PATTERN
@@ -41,11 +40,9 @@ _SSO_AUTHORIZE_ROUTER = {
 
 
 def _fetch_sso_provider_options() -> list[SSOProviderOption]:
-    # Single-tenant BASIC only. /auth/type runs before any tenant context, so a
-    # multi-tenant lookup has no tenant to key on, and only a BASIC deployment
-    # renders the provider buttons (legacy oidc/saml auto-redirect to the one IdP
-    # and never consume this list), so the query is pure overhead elsewhere.
-    if MULTI_TENANT or AUTH_TYPE != AuthType.BASIC:
+    # Single-tenant only. /auth/type runs before any tenant context, so a
+    # multi-tenant lookup has no tenant to key on.
+    if MULTI_TENANT:
         return []
     with get_session_with_shared_schema() as db_session:
         return [
@@ -90,7 +87,7 @@ async def get_auth_type(response: Response) -> AuthTypeResponse:
 
     security = get_security_settings()
     return AuthTypeResponse(
-        auth_type=AUTH_TYPE,
+        auth_type=AuthType.CLOUD if MULTI_TENANT else AuthType.BASIC,
         requires_verification=user_needs_to_be_verified(),
         anonymous_user_enabled=anonymous_user_enabled(),
         password_min_length=security.password_min_length,

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -11,7 +11,6 @@ from pydantic import field_validator
 from pydantic import model_validator
 
 from onyx.auth.schemas import UserRole
-from onyx.configs.constants import AuthType
 from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import DefaultAppMode
 from onyx.db.enums import SSOProviderType
@@ -60,8 +59,9 @@ class SSOProviderOption(BaseModel):
     authorize_url: str
 
 
-class AuthTypeResponse(BaseModel):
-    auth_type: AuthType
+class AuthConfigResponse(BaseModel):
+    # Cloud (multi-tenant) signup provisions a tenant and offers Google login.
+    multi_tenant: bool
     # specifies whether the current auth setup requires
     # users to have verified emails
     requires_verification: bool
@@ -76,7 +76,8 @@ class AuthTypeResponse(BaseModel):
     has_users: bool = True
     oauth_enabled: bool = False
     # Enabled DB-backed SSO providers, one login button each. Empty on cloud and
-    # on instances with no provider rows, so the page falls back to auth_type.
+    # on instances with no provider rows, so the page falls back to the built-in
+    # password (and Google when oauth_enabled) login.
     sso_providers: list[SSOProviderOption] = []
 
 

--- a/backend/onyx/server/manage/sso/api.py
+++ b/backend/onyx/server/manage/sso/api.py
@@ -17,6 +17,7 @@ from onyx.db.sso_provider import set_sso_provider_enabled
 from onyx.db.sso_provider import update_sso_provider
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.get_state import invalidate_sso_provider_options_cache
 from onyx.server.manage.sso.models import SSOProviderCreateRequest
 from onyx.server.manage.sso.models import SSOProviderEnabledRequest
 from onyx.server.manage.sso.models import SSOProviderResponse
@@ -93,6 +94,7 @@ def create_sso_provider_endpoint(
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
 
+    invalidate_sso_provider_options_cache()
     return SSOProviderResponse.from_model(provider, WEB_DOMAIN)
 
 
@@ -129,6 +131,7 @@ def update_sso_provider_endpoint(
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e
 
+    invalidate_sso_provider_options_cache()
     return SSOProviderResponse.from_model(updated_provider, WEB_DOMAIN)
 
 
@@ -149,4 +152,5 @@ def set_sso_provider_enabled_endpoint(
         provider_id=provider_id,
         enabled=request.enabled,
     )
+    invalidate_sso_provider_options_cache()
     return SSOProviderResponse.from_model(provider, WEB_DOMAIN)

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -36,7 +36,6 @@ from onyx.auth.users import enforce_seat_limit_locked
 from onyx.auth.users import optional_user
 from onyx.auth.users import scope_exempt
 from onyx.configs.app_configs import AUTH_BACKEND
-from onyx.configs.app_configs import AUTH_TYPE
 from onyx.configs.app_configs import AuthBackend
 from onyx.configs.app_configs import DEV_MODE
 from onyx.configs.app_configs import EMAIL_CONFIGURED
@@ -615,7 +614,7 @@ def bulk_invite_users(
     else:
         try:
             for email in emails_needing_seats:
-                send_user_email_invite(email, current_user, AUTH_TYPE)
+                send_user_email_invite(email, current_user)
             email_invite_status = EmailInviteStatus.SENT
         except Exception as e:
             logger.error("Error sending email invite to invited users: %s", e)

--- a/backend/tests/unit/onyx/auth/test_email.py
+++ b/backend/tests/unit/onyx/auth/test_email.py
@@ -2,7 +2,6 @@ import pytest
 
 from onyx.auth.email_utils import build_user_email_invite
 from onyx.auth.email_utils import send_email
-from onyx.configs.constants import AuthType
 from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
@@ -23,7 +22,7 @@ def test_send_user_email_invite() -> None:
     FROM_EMAIL = "noreply@onyx.app"
     TO_EMAIL = "support@onyx.app"
     text_content, html_content = build_user_email_invite(
-        FROM_EMAIL, TO_EMAIL, ONYX_DEFAULT_APPLICATION_NAME, AuthType.CLOUD
+        FROM_EMAIL, TO_EMAIL, ONYX_DEFAULT_APPLICATION_NAME
     )
 
     send_email(

--- a/backend/tests/unit/onyx/auth/test_verify_auth_setting.py
+++ b/backend/tests/unit/onyx/auth/test_verify_auth_setting.py
@@ -5,17 +5,42 @@ import pytest
 import onyx.auth.users as users
 from onyx.auth.users import verify_auth_setting
 from onyx.auth.users import verify_user_auth_secret
-from onyx.configs.constants import AuthType
 
 
-def test_verify_auth_setting_raises_for_cloud(
+@pytest.mark.parametrize("stale_value", ["", "basic", "cloud"])
+def test_verify_auth_setting_silent_for_inert_values(
+    monkeypatch: pytest.MonkeyPatch,
+    stale_value: str,
+) -> None:
+    """Inert values (unset, basic, cloud) log only the mode notice, no warning."""
+    if stale_value:
+        monkeypatch.setenv("AUTH_TYPE", stale_value)
+    else:
+        monkeypatch.delenv("AUTH_TYPE", raising=False)
+
+    mock_logger = MagicMock()
+    monkeypatch.setattr(users, "logger", mock_logger)
+    monkeypatch.setattr(users, "MULTI_TENANT", False)
+
+    verify_auth_setting()
+
+    mock_logger.warning.assert_not_called()
+    mock_logger.notice.assert_called_once_with("Using Auth Type: %s", "basic")
+
+
+def test_verify_auth_setting_reports_cloud_when_multi_tenant(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Cloud auth type is not valid for self-hosted deployments."""
-    monkeypatch.setenv("AUTH_TYPE", "cloud")
+    monkeypatch.delenv("AUTH_TYPE", raising=False)
 
-    with pytest.raises(ValueError, match="'cloud' is not a valid auth type"):
-        verify_auth_setting()
+    mock_logger = MagicMock()
+    monkeypatch.setattr(users, "logger", mock_logger)
+    monkeypatch.setattr(users, "MULTI_TENANT", True)
+
+    verify_auth_setting()
+
+    mock_logger.warning.assert_not_called()
+    mock_logger.notice.assert_called_once_with("Using Auth Type: %s", "cloud")
 
 
 def test_verify_auth_setting_warns_for_disabled(
@@ -26,28 +51,12 @@ def test_verify_auth_setting_warns_for_disabled(
 
     mock_logger = MagicMock()
     monkeypatch.setattr(users, "logger", mock_logger)
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC)
+    monkeypatch.setattr(users, "MULTI_TENANT", False)
 
     verify_auth_setting()
 
     mock_logger.warning.assert_called_once()
     assert "no longer supported" in mock_logger.warning.call_args[0][0]
-
-
-def test_verify_auth_setting_basic_no_warning(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Basic auth starts without errors or warnings."""
-    monkeypatch.setenv("AUTH_TYPE", "basic")
-
-    mock_logger = MagicMock()
-    monkeypatch.setattr(users, "logger", mock_logger)
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC)
-
-    verify_auth_setting()
-
-    mock_logger.warning.assert_not_called()
-    mock_logger.notice.assert_called_once_with("Using Auth Type: %s", "basic")
 
 
 @pytest.mark.parametrize("legacy_value", ["google_oauth", "oidc", "saml"])
@@ -61,8 +70,7 @@ def test_verify_auth_setting_warns_for_legacy_sso_modes(
 
     mock_logger = MagicMock()
     monkeypatch.setattr(users, "logger", mock_logger)
-    # app_configs coerces these values to BASIC at import
-    monkeypatch.setattr(users, "AUTH_TYPE", AuthType.BASIC)
+    monkeypatch.setattr(users, "MULTI_TENANT", False)
 
     verify_auth_setting()
 

--- a/mobile/src/api/auth/__tests__/providers.test.ts
+++ b/mobile/src/api/auth/__tests__/providers.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "@jest/globals";
 
 import { visibleProviders } from "@/api/auth/providers";
-import type { AuthType, AuthTypeMetadata } from "@/api/types";
+import type { AuthTypeMetadata } from "@/api/types";
 
-function config(auth_type: AuthType, oauth_enabled: boolean): AuthTypeMetadata {
+function config(
+  multi_tenant: boolean,
+  oauth_enabled: boolean,
+): AuthTypeMetadata {
   return {
-    auth_type,
+    multi_tenant,
     requires_verification: false,
     password_min_length: 8,
     has_users: true,
@@ -22,29 +25,20 @@ describe("visibleProviders", () => {
     expect(visibleProviders(undefined)).toEqual([]);
   });
 
-  it("shows only password for a basic instance", () => {
-    expect(ids(config("basic", false))).toEqual(["password"]);
+  it("shows only password for a self-hosted instance without oauth creds", () => {
+    expect(ids(config(false, false))).toEqual(["password"]);
   });
 
   it("shows password and Google for cloud", () => {
-    expect(ids(config("cloud", true))).toEqual(["password", "google"]);
+    expect(ids(config(true, true))).toEqual(["password", "google"]);
   });
 
-  it("shows only Google for a google_oauth-only instance", () => {
-    expect(ids(config("google_oauth", true))).toEqual(["google"]);
-  });
-
-  it("hides Google when oauth is disabled even on a Google auth_type", () => {
-    expect(ids(config("google_oauth", false))).toEqual([]);
-  });
-
-  it("shows nothing for SSO types not yet supported on mobile", () => {
-    expect(ids(config("saml", true))).toEqual([]);
-    expect(ids(config("oidc", true))).toEqual([]);
+  it("shows password and Google for a self-hosted instance with oauth creds", () => {
+    expect(ids(config(false, true))).toEqual(["password", "google"]);
   });
 
   it("marks Google as a browser provider with an authorize path", () => {
-    const google = visibleProviders(config("cloud", true)).find(
+    const google = visibleProviders(config(true, true)).find(
       (provider) => provider.id === "google",
     );
     expect(google?.kind).toBe("browser");

--- a/mobile/src/api/auth/instanceUrl.ts
+++ b/mobile/src/api/auth/instanceUrl.ts
@@ -29,11 +29,15 @@ export function normalizeServerUrl(input: string): string {
 }
 
 // Reject non-Onyx responses (captive portal, HTML error page) so we don't commit a dead URL.
+// Servers older than the multi_tenant field serve auth_type instead.
 function isAuthTypeMetadata(value: unknown): value is AuthTypeMetadata {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
   return (
-    typeof value === "object" &&
-    value !== null &&
-    typeof (value as Record<string, unknown>).auth_type === "string"
+    typeof record.multi_tenant === "boolean" ||
+    typeof record.auth_type === "string"
   );
 }
 

--- a/mobile/src/api/auth/providers.ts
+++ b/mobile/src/api/auth/providers.ts
@@ -1,4 +1,4 @@
-import type { AuthType, AuthTypeMetadata } from "@/api/types";
+import type { AuthTypeMetadata } from "@/api/types";
 
 export type ProviderId = "password" | "google" | "oidc" | "saml" | "apple";
 export type ProviderKind = "password" | "browser";
@@ -24,17 +24,6 @@ export const PROVIDER_REGISTRY: Partial<
   },
 };
 
-// `cloud` accepts password too (Google + basic).
-const PASSWORD_AUTH_TYPES: ReadonlySet<AuthType> = new Set<AuthType>([
-  "basic",
-  "cloud",
-]);
-
-const GOOGLE_AUTH_TYPES: ReadonlySet<AuthType> = new Set<AuthType>([
-  "google_oauth",
-  "cloud",
-]);
-
 // Returns [] until the backend config loads.
 export function visibleProviders(
   config: AuthTypeMetadata | undefined,
@@ -43,15 +32,13 @@ export function visibleProviders(
 
   const providers: ProviderDescriptor[] = [];
   const password = PROVIDER_REGISTRY.password;
-  if (password && PASSWORD_AUTH_TYPES.has(config.auth_type)) {
+  // Every deployment mode serves password login.
+  if (password) {
     providers.push(password);
   }
   const google = PROVIDER_REGISTRY.google;
-  if (
-    google &&
-    config.oauth_enabled &&
-    GOOGLE_AUTH_TYPES.has(config.auth_type)
-  ) {
+  // The mobile Google OAuth router mounts whenever env credentials exist.
+  if (google && config.oauth_enabled) {
     providers.push(google);
   }
   return providers;

--- a/mobile/src/api/types.ts
+++ b/mobile/src/api/types.ts
@@ -24,11 +24,9 @@ export interface CurrentUser {
   preferences: UserPreferences;
 }
 
-// `cloud` = Google OAuth + basic email/password.
-export type AuthType = "basic" | "google_oauth" | "oidc" | "saml" | "cloud";
-
 export interface AuthTypeMetadata {
-  auth_type: AuthType;
+  // Cloud (multi-tenant) signup provisions a tenant.
+  multi_tenant: boolean;
   requires_verification: boolean;
   anonymous_user_enabled?: boolean | null;
   password_min_length: number;

--- a/web/src/app/app/settings/accounts-access/page.tsx
+++ b/web/src/app/app/settings/accounts-access/page.tsx
@@ -3,21 +3,20 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useUser } from "@/providers/UserProvider";
-import { useAuthType } from "@/lib/auth/hooks";
-import { AuthType } from "@/lib/auth/types";
+import { useIsMultiTenant } from "@/lib/auth/hooks";
 import { AccountsAccessSettings } from "@/views/SettingsPage";
 
 export default function AccountsAccessPage() {
   const router = useRouter();
   const { user } = useUser();
-  const authType = useAuthType();
+  const isMultiTenant = useIsMultiTenant();
 
   const showPasswordSection = Boolean(user?.password_configured);
-  const showTokensSection = authType !== null;
+  const showTokensSection = isMultiTenant !== null;
   const hasAccess = showPasswordSection || showTokensSection;
 
-  // Only redirect after authType has loaded to avoid redirecting during loading state
-  const isAuthTypeLoaded = authType !== null;
+  // Only redirect after metadata has loaded to avoid redirecting during loading state
+  const isAuthTypeLoaded = isMultiTenant !== null;
 
   useEffect(() => {
     if (isAuthTypeLoaded && !hasAccess) {
@@ -25,7 +24,7 @@ export default function AccountsAccessPage() {
     }
   }, [isAuthTypeLoaded, hasAccess, router]);
 
-  // Don't render content until authType is loaded and access is determined
+  // Don't render content until metadata has loaded and access is determined
   if (!isAuthTypeLoaded || !hasAccess) {
     return null;
   }

--- a/web/src/app/app/settings/layout.tsx
+++ b/web/src/app/app/settings/layout.tsx
@@ -7,7 +7,7 @@ import { SidebarTab, Text } from "@opal/components";
 import { SvgSliders } from "@opal/icons";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { useUser } from "@/providers/UserProvider";
-import { useAuthType } from "@/lib/auth/hooks";
+import { useIsMultiTenant } from "@/lib/auth/hooks";
 import { Section } from "@/layouts/general-layouts";
 
 interface LayoutProps {
@@ -23,10 +23,10 @@ export default function Layout({ children }: LayoutProps) {
   const pathname = usePathname();
   const router = useRouter();
   const { user } = useUser();
-  const authType = useAuthType();
+  const isMultiTenant = useIsMultiTenant();
 
   const showPasswordSection = Boolean(user?.password_configured);
-  const showTokensSection = authType !== null;
+  const showTokensSection = isMultiTenant !== null;
   const showAccountsAccessTab = showPasswordSection || showTokensSection;
 
   const tabs: SettingsTab[] = [

--- a/web/src/app/auth/join/page.tsx
+++ b/web/src/app/auth/join/page.tsx
@@ -1,7 +1,7 @@
 import { User } from "@/lib/types";
 import { getCurrentUserSS } from "@/lib/users/svcSS";
 import { getAuthTypeMetadataSS, getAuthUrlSS } from "@/lib/auth/svcSS";
-import { AuthType, AuthTypeMetadata } from "@/lib/auth/types";
+import { AuthTypeMetadata } from "@/lib/auth/types";
 import { redirect } from "next/navigation";
 import { EmailPasswordForm, SignInButton } from "@/lib/auth/components";
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
@@ -44,16 +44,16 @@ const Page = async (props: {
     }
     return redirect("/auth/waiting-on-verification");
   }
-  const cloud = authTypeMetadata?.authType === AuthType.CLOUD;
+  const cloud = authTypeMetadata?.multiTenant === true;
 
-  // only enable this page if basic login is enabled
-  if (authTypeMetadata?.authType !== AuthType.BASIC && !cloud) {
+  // No auth metadata (backend unreachable), nothing to render here.
+  if (authTypeMetadata?.multiTenant !== false && !cloud) {
     return redirect("/app");
   }
 
   let authUrl: string | null = null;
   if (cloud && authTypeMetadata) {
-    authUrl = await getAuthUrlSS(authTypeMetadata.authType, null);
+    authUrl = await getAuthUrlSS(authTypeMetadata.multiTenant, null);
   }
   const emailDomain = defaultEmail?.split("@")[1];
 
@@ -70,7 +70,7 @@ const Page = async (props: {
 
           {cloud && authUrl && (
             <div className="w-full justify-center">
-              <SignInButton authorizeUrl={authUrl} authType={AuthType.CLOUD} />
+              <SignInButton authorizeUrl={authUrl} multiTenant={cloud} />
               <div className="flex items-center w-full my-4">
                 <div className="grow border-t border-background-300"></div>
                 <span className="px-4 text-text-500">or</span>

--- a/web/src/app/auth/join/page.tsx
+++ b/web/src/app/auth/join/page.tsx
@@ -70,7 +70,7 @@ const Page = async (props: {
 
           {cloud && authUrl && (
             <div className="w-full justify-center">
-              <SignInButton authorizeUrl={authUrl} multiTenant={cloud} />
+              <SignInButton authorizeUrl={authUrl} />
               <div className="flex items-center w-full my-4">
                 <div className="grow border-t border-background-300"></div>
                 <span className="px-4 text-text-500">or</span>

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AuthType, AuthTypeMetadata } from "@/lib/auth/types";
+import { AuthTypeMetadata } from "@/lib/auth/types";
 import LoginText from "@/app/auth/login/LoginText";
 import ProviderSignInButton from "@/app/auth/login/ProviderSignInButton";
 import { SignInButton, EmailPasswordForm } from "@/lib/auth/components";
@@ -42,28 +42,14 @@ export default function LoginPage({
           title="Your email has been verified! Please sign in to continue."
         />
       )}
-      {authUrl &&
-        authTypeMetadata &&
-        authTypeMetadata.authType !== AuthType.CLOUD &&
-        // basic auth is handled below w/ the EmailPasswordForm
-        authTypeMetadata.authType !== AuthType.BASIC && (
-          <div className="flex flex-col w-full gap-4">
-            <LoginText />
-            <SignInButton
-              authorizeUrl={authUrl}
-              authType={authTypeMetadata?.authType}
-            />
-          </div>
-        )}
-
-      {authTypeMetadata?.authType === AuthType.CLOUD && (
+      {authTypeMetadata?.multiTenant === true && (
         <div className="w-full justify-center flex flex-col gap-6">
           <LoginText />
           {authUrl && authTypeMetadata && (
             <>
               <SignInButton
                 authorizeUrl={authUrl}
-                authType={authTypeMetadata?.authType}
+                multiTenant={authTypeMetadata.multiTenant}
               />
               <div className="flex flex-row items-center w-full gap-2">
                 <div className="flex-1 border-t border-text-01" />
@@ -85,7 +71,7 @@ export default function LoginPage({
         </div>
       )}
 
-      {authTypeMetadata?.authType === AuthType.BASIC && (
+      {authTypeMetadata?.multiTenant === false && (
         <div className="flex flex-col w-full gap-6">
           <LoginText />
           {ssoProviders.length > 0 && (

--- a/web/src/app/auth/login/LoginPage.tsx
+++ b/web/src/app/auth/login/LoginPage.tsx
@@ -47,10 +47,7 @@ export default function LoginPage({
           <LoginText />
           {authUrl && authTypeMetadata && (
             <>
-              <SignInButton
-                authorizeUrl={authUrl}
-                multiTenant={authTypeMetadata.multiTenant}
-              />
+              <SignInButton authorizeUrl={authUrl} />
               <div className="flex flex-row items-center w-full gap-2">
                 <div className="flex-1 border-t border-text-01" />
                 <Text as="p" text03 mainUiMuted>

--- a/web/src/app/auth/login/page.tsx
+++ b/web/src/app/auth/login/page.tsx
@@ -1,9 +1,8 @@
 import { User } from "@/lib/types";
 import { getCurrentUserSS } from "@/lib/users/svcSS";
 import { getAuthTypeMetadataSS, getAuthUrlSS } from "@/lib/auth/svcSS";
-import { AuthType, AuthTypeMetadata } from "@/lib/auth/types";
+import { AuthTypeMetadata } from "@/lib/auth/types";
 import { redirect } from "next/navigation";
-import type { Route } from "next";
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 import LoginPage from "./LoginPage";
 
@@ -13,7 +12,6 @@ export interface PageProps {
 
 export default async function Page(props: PageProps) {
   const searchParams = await props.searchParams;
-  const autoRedirectDisabled = searchParams?.disableAutoRedirect === "true";
   const autoRedirectToSignupDisabled =
     searchParams?.autoRedirectToSignup === "false";
   const nextUrl: string | null = Array.isArray(searchParams?.next)
@@ -36,13 +34,13 @@ export default async function Page(props: PageProps) {
     console.log(`Some fetch failed for the login page - ${e}`);
   }
 
-  // if there are no users, redirect to signup page for initial setup
-  // (only for auth types that support self-service signup)
+  // if there are no users, send self-hosted deployments to signup for
+  // initial setup
   if (
     authTypeMetadata &&
     !authTypeMetadata.hasUsers &&
     !autoRedirectToSignupDisabled &&
-    authTypeMetadata.authType === AuthType.BASIC
+    authTypeMetadata.multiTenant === false
   ) {
     return redirect("/auth/signup");
   }
@@ -68,30 +66,15 @@ export default async function Page(props: PageProps) {
   let authUrl: string | null = null;
   if (authTypeMetadata) {
     try {
-      authUrl = await getAuthUrlSS(authTypeMetadata.authType, nextUrl);
+      authUrl = await getAuthUrlSS(authTypeMetadata.multiTenant, nextUrl);
     } catch (e) {
       console.log(`Some fetch failed for the login page - ${e}`);
     }
   }
 
-  if (authTypeMetadata?.autoRedirect && authUrl && !autoRedirectDisabled) {
-    return redirect(authUrl as Route);
-  }
-
-  const ssoLoginFooterContent =
-    authTypeMetadata &&
-    (authTypeMetadata.authType === AuthType.GOOGLE_OAUTH ||
-      authTypeMetadata.authType === AuthType.OIDC ||
-      authTypeMetadata.authType === AuthType.SAML) ? (
-      <>Need access? Reach out to your IT admin to get access.</>
-    ) : undefined;
-
   return (
     <div className="flex flex-col ">
-      <AuthFlowContainer
-        authState="login"
-        footerContent={ssoLoginFooterContent}
-      >
+      <AuthFlowContainer authState="login">
         <LoginPage
           authUrl={authUrl}
           authTypeMetadata={authTypeMetadata}

--- a/web/src/app/auth/logout/route.ts
+++ b/web/src/app/auth/logout/route.ts
@@ -1,12 +1,11 @@
-import { getAuthTypeMetadataSS, logoutSS } from "@/lib/auth/svcSS";
+import { logoutSS } from "@/lib/auth/svcSS";
 import { SERVER_SIDE_ONLY__AUTH_COOKIE_NAME } from "@/lib/constants";
 import { NextRequest } from "next/server";
 
 export const POST = async (request: NextRequest) => {
-  // Directs the logout request to the appropriate FastAPI endpoint.
+  // Proxies logout to the backend /auth/logout endpoint.
   // Needed since env variables don't work well on the client-side
-  const authTypeMetadata = await getAuthTypeMetadataSS();
-  const response = await logoutSS(authTypeMetadata.authType, request.headers);
+  const response = await logoutSS(request.headers);
 
   if (response && !response.ok) {
     return new Response(response.body, { status: response?.status });

--- a/web/src/app/auth/signup/page.tsx
+++ b/web/src/app/auth/signup/page.tsx
@@ -1,7 +1,7 @@
 import { User } from "@/lib/types";
 import { getCurrentUserSS } from "@/lib/users/svcSS";
 import { getAuthTypeMetadataSS, getAuthUrlSS } from "@/lib/auth/svcSS";
-import { AuthType, AuthTypeMetadata } from "@/lib/auth/types";
+import { AuthTypeMetadata } from "@/lib/auth/types";
 import { redirect } from "next/navigation";
 import { EmailPasswordForm, SignInButton } from "@/lib/auth/components";
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
@@ -43,16 +43,16 @@ const Page = async (props: {
     }
     return redirect("/auth/waiting-on-verification");
   }
-  const cloud = authTypeMetadata?.authType === AuthType.CLOUD;
+  const cloud = authTypeMetadata?.multiTenant === true;
 
-  // only enable this page if basic login is enabled
-  if (authTypeMetadata?.authType !== AuthType.BASIC && !cloud) {
+  // No auth metadata (backend unreachable), nothing to render here.
+  if (authTypeMetadata?.multiTenant !== false && !cloud) {
     return redirect("/app");
   }
 
   let authUrl: string | null = null;
   if (cloud && authTypeMetadata) {
-    authUrl = await getAuthUrlSS(authTypeMetadata.authType, null);
+    authUrl = await getAuthUrlSS(authTypeMetadata.multiTenant, null);
   }
 
   return (
@@ -77,7 +77,7 @@ const Page = async (props: {
           </div>
           {cloud && authUrl && (
             <div className="w-full justify-center mt-6">
-              <SignInButton authorizeUrl={authUrl} authType={AuthType.CLOUD} />
+              <SignInButton authorizeUrl={authUrl} multiTenant={cloud} />
               <div className="flex items-center w-full my-4">
                 <div className="grow border-t border-border-01" />
                 <Text as="p" mainUiMuted text03 className="mx-2">

--- a/web/src/app/auth/signup/page.tsx
+++ b/web/src/app/auth/signup/page.tsx
@@ -77,7 +77,7 @@ const Page = async (props: {
           </div>
           {cloud && authUrl && (
             <div className="w-full justify-center mt-6">
-              <SignInButton authorizeUrl={authUrl} multiTenant={cloud} />
+              <SignInButton authorizeUrl={authUrl} />
               <div className="flex items-center w-full my-4">
                 <div className="grow border-t border-border-01" />
                 <Text as="p" mainUiMuted text03 className="mx-2">

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -4,7 +4,6 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useSearchParams } from "next/navigation";
 import { useUser } from "@/providers/UserProvider";
 import { toast } from "@opal/layouts";
-import { AuthType } from "@/lib/auth/types";
 import AppInputBar, { AppInputBarHandle } from "@/sections/input/AppInputBar";
 import { Button } from "@opal/components";
 import Modal from "@/refresh-components/Modal";
@@ -634,7 +633,7 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
           <Modal.Content width="sm" height="sm">
             <Modal.Header icon={SvgUser} title="Welcome to Onyx" />
             <Modal.Body>
-              {authTypeMetadata?.authType === AuthType.BASIC ? (
+              {authTypeMetadata?.multiTenant === false ? (
                 <LoginPage
                   authUrl={null}
                   authTypeMetadata={authTypeMetadata ?? null}

--- a/web/src/lib/auth/components.test.tsx
+++ b/web/src/lib/auth/components.test.tsx
@@ -8,7 +8,6 @@ import React from "react";
 import { render, screen, waitFor, setupUser } from "@tests/setup/test-utils";
 import { toast } from "@opal/layouts";
 import { EmailPasswordForm } from "@/lib/auth/components";
-import { AuthType } from "@/lib/auth/types";
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: jest.fn(), refresh: jest.fn() }),
@@ -22,8 +21,7 @@ jest.mock("@/providers/UserProvider", () => ({
   useUser: () => ({
     user: null,
     authTypeMetadata: {
-      authType: AuthType.BASIC,
-      autoRedirect: false,
+      multiTenant: false,
       requiresVerification: false,
       anonymousUserEnabled: null,
       passwordMinLength: 8,

--- a/web/src/lib/auth/components.tsx
+++ b/web/src/lib/auth/components.tsx
@@ -8,7 +8,6 @@ import Modal from "@/refresh-components/Modal";
 import { Button, Text } from "@opal/components";
 import { SvgLogOut, SvgCheckCircle, SvgXCircle } from "@opal/icons";
 import { SvgGoogle } from "@opal/logos";
-import type { IconProps } from "@opal/types";
 import { useCaptcha } from "@/lib/hooks/useCaptcha";
 import { verifyCaptchaForOAuth } from "@/lib/auth/svc";
 import { basicLogin, basicSignup } from "@/lib/users/svc";
@@ -114,24 +113,11 @@ export function AuthenticationShell({ children }: AuthenticationShellProps) {
 
 interface SignInButtonProps {
   authorizeUrl: string;
-  multiTenant: boolean;
 }
 
-export function SignInButton({ authorizeUrl, multiTenant }: SignInButtonProps) {
+export function SignInButton({ authorizeUrl }: SignInButtonProps) {
   const { getCaptchaToken, isCaptchaEnabled } = useCaptcha();
   const [isVerifying, setIsVerifying] = useState(false);
-
-  let button: string | undefined;
-  let icon: React.FunctionComponent<IconProps> | undefined;
-
-  if (multiTenant) {
-    button = "Continue with Google";
-    icon = SvgGoogle;
-  }
-
-  if (!button) {
-    throw new Error(`Unhandled multiTenant value: ${multiTenant}`);
-  }
 
   async function handleClick(e: React.MouseEvent) {
     e.preventDefault();
@@ -157,20 +143,20 @@ export function SignInButton({ authorizeUrl, multiTenant }: SignInButtonProps) {
     }
   }
 
-  // Only the Google OAuth callback is gated by CaptchaCookieMiddleware on the
-  // backend, so the reCAPTCHA interception applies only to the Google sign-in.
-  const intercepted = isCaptchaEnabled && multiTenant;
+  // The Google OAuth callback is gated by CaptchaCookieMiddleware on the
+  // backend, so the click is intercepted whenever reCAPTCHA is enabled.
+  const intercepted = isCaptchaEnabled;
 
   return (
     <Button
       prominence="secondary"
       width="full"
-      icon={icon}
+      icon={SvgGoogle}
       href={intercepted ? undefined : authorizeUrl}
       onClick={intercepted ? handleClick : undefined}
       disabled={isVerifying}
     >
-      {button}
+      Continue with Google
     </Button>
   );
 }

--- a/web/src/lib/auth/components.tsx
+++ b/web/src/lib/auth/components.tsx
@@ -7,7 +7,6 @@ import { getExtensionContext } from "@/lib/extension/utils";
 import Modal from "@/refresh-components/Modal";
 import { Button, Text } from "@opal/components";
 import { SvgLogOut, SvgCheckCircle, SvgXCircle } from "@opal/icons";
-import { AuthType } from "@/lib/auth/types";
 import { SvgGoogle } from "@opal/logos";
 import type { IconProps } from "@opal/types";
 import { useCaptcha } from "@/lib/hooks/useCaptcha";
@@ -88,10 +87,10 @@ export function AuthenticationShell({ children }: AuthenticationShellProps) {
 // ---------------------------------------------------------------------------
 // SignInButton
 //
-// Renders the SSO / OAuth sign-in button on the login page.
+// Renders the Google sign-in button on the login page.
 //
 // When reCAPTCHA is enabled for this deployment (NEXT_PUBLIC_RECAPTCHA_SITE_KEY
-// set at build time), the Google/OIDC/SAML OAuth click is intercepted to
+// set at build time), the Google OAuth click is intercepted to
 // (1) fetch a reCAPTCHA v3 token for the "oauth" action, (2) POST it to
 // /api/auth/captcha/oauth-verify which sets a signed HttpOnly cookie on the
 // response, and (3) then navigate to the authorize URL. The cookie is sent
@@ -115,27 +114,23 @@ export function AuthenticationShell({ children }: AuthenticationShellProps) {
 
 interface SignInButtonProps {
   authorizeUrl: string;
-  authType: AuthType;
+  multiTenant: boolean;
 }
 
-export function SignInButton({ authorizeUrl, authType }: SignInButtonProps) {
+export function SignInButton({ authorizeUrl, multiTenant }: SignInButtonProps) {
   const { getCaptchaToken, isCaptchaEnabled } = useCaptcha();
   const [isVerifying, setIsVerifying] = useState(false);
 
   let button: string | undefined;
   let icon: React.FunctionComponent<IconProps> | undefined;
 
-  if (authType === AuthType.GOOGLE_OAUTH || authType === AuthType.CLOUD) {
+  if (multiTenant) {
     button = "Continue with Google";
     icon = SvgGoogle;
-  } else if (authType === AuthType.OIDC) {
-    button = "Continue with OIDC SSO";
-  } else if (authType === AuthType.SAML) {
-    button = "Continue with SAML SSO";
   }
 
   if (!button) {
-    throw new Error(`Unhandled authType: ${authType}`);
+    throw new Error(`Unhandled multiTenant value: ${multiTenant}`);
   }
 
   async function handleClick(e: React.MouseEvent) {
@@ -163,12 +158,8 @@ export function SignInButton({ authorizeUrl, authType }: SignInButtonProps) {
   }
 
   // Only the Google OAuth callback is gated by CaptchaCookieMiddleware on the
-  // backend. OIDC/SAML callbacks have no cookie requirement, so running the
-  // reCAPTCHA interception for them is wasted friction — and worse, a failed
-  // captcha would block the sign-in entirely.
-  const intercepted =
-    isCaptchaEnabled &&
-    (authType === AuthType.GOOGLE_OAUTH || authType === AuthType.CLOUD);
+  // backend, so the reCAPTCHA interception applies only to the Google sign-in.
+  const intercepted = isCaptchaEnabled && multiTenant;
 
   return (
     <Button

--- a/web/src/lib/auth/hooks.test.tsx
+++ b/web/src/lib/auth/hooks.test.tsx
@@ -1,23 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { setDocumentVisibility } from "@tests/setup/test-utils";
 import { useTokenRefresh } from "@/lib/auth/hooks";
-import { AuthType, AuthTypeMetadata } from "@/lib/auth/types";
 import { User } from "@/lib/types";
-
-const baseAuthMetadata = (authType: AuthType): AuthTypeMetadata => ({
-  authType,
-  autoRedirect: false,
-  requiresVerification: false,
-  anonymousUserEnabled: null,
-  passwordMinLength: 0,
-  passwordMaxLength: Infinity,
-  passwordRequireUppercase: false,
-  passwordRequireLowercase: false,
-  passwordRequireDigit: false,
-  passwordRequireSpecialChar: false,
-  hasUsers: true,
-  oauthEnabled: false,
-});
 
 const fakeUser = { id: "user-1" } as User;
 
@@ -30,53 +14,13 @@ describe("useTokenRefresh", () => {
   });
 
   test("does not call /api/auth/refresh while auth type metadata is loading", () => {
-    renderHook(() =>
-      useTokenRefresh(
-        fakeUser,
-        baseAuthMetadata(AuthType.BASIC),
-        true,
-        jest.fn()
-      )
-    );
+    renderHook(() => useTokenRefresh(fakeUser, true, jest.fn()));
 
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
-  test("does not call /api/auth/refresh for SAML deployments", () => {
-    renderHook(() =>
-      useTokenRefresh(
-        fakeUser,
-        baseAuthMetadata(AuthType.SAML),
-        false,
-        jest.fn()
-      )
-    );
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("does not call /api/auth/refresh for OIDC deployments", () => {
-    renderHook(() =>
-      useTokenRefresh(
-        fakeUser,
-        baseAuthMetadata(AuthType.OIDC),
-        false,
-        jest.fn()
-      )
-    );
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  test("calls /api/auth/refresh once when auth type is BASIC and user is present", async () => {
-    renderHook(() =>
-      useTokenRefresh(
-        fakeUser,
-        baseAuthMetadata(AuthType.BASIC),
-        false,
-        jest.fn()
-      )
-    );
+  test("calls /api/auth/refresh once when user is present", async () => {
+    renderHook(() => useTokenRefresh(fakeUser, false, jest.fn()));
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
     expect(fetchMock).toHaveBeenCalledWith("/api/auth/refresh", {
@@ -90,13 +34,7 @@ describe("useTokenRefresh", () => {
     const onRefreshFail = jest.fn().mockResolvedValue(undefined);
 
     const { rerender } = renderHook(
-      ({ user }: { user: User }) =>
-        useTokenRefresh(
-          user,
-          baseAuthMetadata(AuthType.BASIC),
-          false,
-          onRefreshFail
-        ),
+      ({ user }: { user: User }) => useTokenRefresh(user, false, onRefreshFail),
       { initialProps: { user: { ...fakeUser } } }
     );
 
@@ -115,14 +53,7 @@ describe("useTokenRefresh", () => {
     jest.useFakeTimers();
     try {
       setDocumentVisibility(false);
-      renderHook(() =>
-        useTokenRefresh(
-          fakeUser,
-          baseAuthMetadata(AuthType.BASIC),
-          false,
-          jest.fn()
-        )
-      );
+      renderHook(() => useTokenRefresh(fakeUser, false, jest.fn()));
 
       await act(async () => {
         jest.advanceTimersByTime(31 * 60 * 1000);

--- a/web/src/lib/auth/hooks.ts
+++ b/web/src/lib/auth/hooks.ts
@@ -5,7 +5,7 @@ import { usePathname } from "next/navigation";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { NO_AUTH_USER_ID } from "@/lib/extension/constants";
-import { AuthType, AuthTypeMetadata } from "@/lib/auth/types";
+import { AuthTypeMetadata } from "@/lib/auth/types";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { User } from "@/lib/types";
 import { getSecondsUntilExpiration } from "@opal/time";
@@ -102,26 +102,38 @@ export function useSessionWatcher(): boolean {
   );
 }
 
-export function useAuthType(): AuthType | null {
+export function useIsMultiTenant(): boolean | null {
   // Delegate to useAuthTypeMetadata so the shared SWR key always holds the
   // camelCase-mapped shape — a raw fetcher here would poison the cache for
   // every other consumer of the key.
   const { authTypeMetadata, isLoading, error } = useAuthTypeMetadata();
 
   if (NEXT_PUBLIC_CLOUD_ENABLED) {
-    return AuthType.CLOUD;
+    return true;
   }
 
   if (error || isLoading) {
     return null;
   }
 
-  return authTypeMetadata?.authType ?? null;
+  return authTypeMetadata?.multiTenant ?? null;
+}
+
+// Pass-through forwards the logged-in user's OAuth access token, so offer it
+// only when users authenticate with an OAuth-capable method (Google/OIDC).
+// SAML grants no OAuth token, so a SAML-only deployment must not enable it.
+export function useOAuthPassThroughEnabled(): boolean {
+  const { authTypeMetadata } = useAuthTypeMetadata();
+  return (
+    authTypeMetadata?.oauthEnabled === true ||
+    (authTypeMetadata?.ssoProviders ?? []).some(
+      (p) => p.providerType === "OIDC" || p.providerType === "GOOGLE_OAUTH"
+    )
+  );
 }
 
 export function useTokenRefresh(
   user: User | null,
-  authTypeMetadata: AuthTypeMetadata | undefined,
   authTypeMetadataLoading: boolean,
   onRefreshFail: () => Promise<void>
 ) {
@@ -129,18 +141,11 @@ export function useTokenRefresh(
   const isFirstLoadRef = useRef(true);
 
   useEffect(() => {
-    // Wait for the first load to complete; don't wait on a persistent error —
-    // if metadata is unavailable we conservatively allow refresh so that BASIC
-    // sessions aren't silently killed by a transient /auth/type failure.
+    // Wait only for the initial metadata load. On persistent error we still
+    // refresh so a transient /auth/type failure cannot silently kill sessions.
     if (authTypeMetadataLoading) return;
 
-    if (
-      !user ||
-      user.id === NO_AUTH_USER_ID ||
-      user.is_anonymous_user ||
-      authTypeMetadata?.authType === AuthType.OIDC ||
-      authTypeMetadata?.authType === AuthType.SAML
-    ) {
+    if (!user || user.id === NO_AUTH_USER_ID || user.is_anonymous_user) {
       return;
     }
 
@@ -195,5 +200,5 @@ export function useTokenRefresh(
       clearInterval(intervalId);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
-  }, [user, authTypeMetadata, authTypeMetadataLoading, onRefreshFail]);
+  }, [user, authTypeMetadataLoading, onRefreshFail]);
 }

--- a/web/src/lib/auth/svc.ts
+++ b/web/src/lib/auth/svc.ts
@@ -1,8 +1,8 @@
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
-import { AuthType, AuthTypeMetadata } from "@/lib/auth/types";
+import { AuthTypeMetadata, type SSOProviderType } from "@/lib/auth/types";
 
 interface AuthTypeAPIResponse {
-  auth_type: string;
+  multi_tenant: boolean;
   requires_verification: boolean;
   anonymous_user_enabled: boolean | null;
   password_min_length: number;
@@ -13,6 +13,12 @@ interface AuthTypeAPIResponse {
   password_require_special_char: boolean;
   has_users: boolean;
   oauth_enabled: boolean;
+  sso_providers?: {
+    name: string;
+    display_name: string;
+    provider_type: SSOProviderType;
+    authorize_url: string;
+  }[];
 }
 
 export async function fetchAuthTypeMetadata(
@@ -24,12 +30,9 @@ export async function fetchAuthTypeMetadata(
     throw new Error("Failed to fetch auth type metadata");
   }
   const data: AuthTypeAPIResponse = await res.json();
-  const authType = NEXT_PUBLIC_CLOUD_ENABLED
-    ? AuthType.CLOUD
-    : (data.auth_type as AuthType);
+  const multiTenant = NEXT_PUBLIC_CLOUD_ENABLED ? true : data.multi_tenant;
   return {
-    authType,
-    autoRedirect: authType === AuthType.OIDC || authType === AuthType.SAML,
+    multiTenant,
     requiresVerification: data.requires_verification,
     anonymousUserEnabled: data.anonymous_user_enabled,
     passwordMinLength: data.password_min_length,
@@ -40,6 +43,12 @@ export async function fetchAuthTypeMetadata(
     passwordRequireSpecialChar: data.password_require_special_char,
     hasUsers: data.has_users,
     oauthEnabled: data.oauth_enabled,
+    ssoProviders: (data.sso_providers ?? []).map((provider) => ({
+      name: provider.name,
+      displayName: provider.display_name,
+      providerType: provider.provider_type,
+      authorizeUrl: provider.authorize_url,
+    })),
   };
 }
 

--- a/web/src/lib/auth/svcSS.ts
+++ b/web/src/lib/auth/svcSS.ts
@@ -4,11 +4,7 @@ import { buildUrl, UrlBuilder } from "@/lib/utilsSS";
 import { getDomain } from "@/lib/redirectSS";
 import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 import { NextRequest, NextResponse } from "next/server";
-import {
-  AuthType,
-  AuthTypeMetadata,
-  type SSOProviderType,
-} from "@/lib/auth/types";
+import { AuthTypeMetadata, type SSOProviderType } from "@/lib/auth/types";
 import { User, UserRole } from "@/lib/types";
 import { getCurrentUserSS } from "@/lib/users/svcSS";
 
@@ -19,7 +15,7 @@ export async function getAuthTypeMetadataSS(): Promise<AuthTypeMetadata> {
   }
 
   const data: {
-    auth_type: string;
+    multi_tenant: boolean;
     requires_verification: boolean;
     anonymous_user_enabled: boolean | null;
     password_min_length: number;
@@ -38,15 +34,12 @@ export async function getAuthTypeMetadataSS(): Promise<AuthTypeMetadata> {
     }[];
   } = await res.json();
 
-  const authType: AuthType = NEXT_PUBLIC_CLOUD_ENABLED
-    ? AuthType.CLOUD
-    : (data.auth_type as AuthType);
+  const multiTenant: boolean = NEXT_PUBLIC_CLOUD_ENABLED
+    ? true
+    : data.multi_tenant;
 
   return {
-    authType,
-    // for SAML / OIDC, we auto-redirect the user to the IdP when the user visits
-    // Onyx in an un-authenticated state
-    autoRedirect: authType === AuthType.OIDC || authType === AuthType.SAML,
+    multiTenant,
     requiresVerification: data.requires_verification,
     anonymousUserEnabled: data.anonymous_user_enabled,
     passwordMinLength: data.password_min_length,
@@ -66,13 +59,6 @@ export async function getAuthTypeMetadataSS(): Promise<AuthTypeMetadata> {
   };
 }
 
-async function getOIDCAuthUrlSS(nextUrl: string | null): Promise<string> {
-  const url = UrlBuilder.fromClientUrl("/api/auth/oidc/authorize");
-  if (nextUrl) url.addParam("next", nextUrl);
-  url.addParam("redirect", true);
-  return url.toString();
-}
-
 async function getGoogleOAuthUrlSS(nextUrl: string | null): Promise<string> {
   const url = UrlBuilder.fromClientUrl("/api/auth/oauth/authorize");
   if (nextUrl) url.addParam("next", nextUrl);
@@ -80,52 +66,19 @@ async function getGoogleOAuthUrlSS(nextUrl: string | null): Promise<string> {
   return url.toString();
 }
 
-async function getSAMLAuthUrlSS(nextUrl: string | null): Promise<string> {
-  const url = UrlBuilder.fromInternalUrl("/auth/saml/authorize");
-  if (nextUrl) url.addParam("next", nextUrl);
-
-  const res = await fetch(url.toString());
-  if (!res.ok) throw new Error("Failed to fetch data");
-
-  const data: { authorization_url: string } = await res.json();
-  return data.authorization_url;
-}
-
 export async function getAuthUrlSS(
-  authType: AuthType,
+  multiTenant: boolean,
   nextUrl: string | null
 ): Promise<string> {
-  switch (authType) {
-    case AuthType.BASIC:
-      return "";
-    case AuthType.GOOGLE_OAUTH:
-    case AuthType.CLOUD:
-      return getGoogleOAuthUrlSS(nextUrl);
-    case AuthType.SAML:
-      return getSAMLAuthUrlSS(nextUrl);
-    case AuthType.OIDC:
-      return getOIDCAuthUrlSS(nextUrl);
-  }
+  return multiTenant ? getGoogleOAuthUrlSS(nextUrl) : "";
 }
 
 async function logoutStandardSS(headers: Headers): Promise<Response> {
   return fetch(buildUrl("/auth/logout"), { method: "POST", headers });
 }
 
-async function logoutSAMLSS(headers: Headers): Promise<Response> {
-  return fetch(buildUrl("/auth/saml/logout"), { method: "POST", headers });
-}
-
-export async function logoutSS(
-  authType: AuthType,
-  headers: Headers
-): Promise<Response | null> {
-  switch (authType) {
-    case AuthType.SAML:
-      return logoutSAMLSS(headers);
-    default:
-      return logoutStandardSS(headers);
-  }
+export async function logoutSS(headers: Headers): Promise<Response | null> {
+  return logoutStandardSS(headers);
 }
 
 export async function authErrorRedirect(

--- a/web/src/lib/auth/types.ts
+++ b/web/src/lib/auth/types.ts
@@ -1,11 +1,3 @@
-export enum AuthType {
-  BASIC = "basic",
-  GOOGLE_OAUTH = "google_oauth",
-  OIDC = "oidc",
-  SAML = "saml",
-  CLOUD = "cloud",
-}
-
 export type SSOProviderType = "GOOGLE_OAUTH" | "OIDC" | "SAML";
 
 export interface SSOProviderOption {
@@ -16,8 +8,7 @@ export interface SSOProviderOption {
 }
 
 export interface AuthTypeMetadata {
-  authType: AuthType;
-  autoRedirect: boolean;
+  multiTenant: boolean;
   requiresVerification: boolean;
   anonymousUserEnabled: boolean | null;
   passwordMinLength: number;
@@ -28,7 +19,7 @@ export interface AuthTypeMetadata {
   passwordRequireSpecialChar: boolean;
   hasUsers: boolean;
   oauthEnabled: boolean;
-  // DB-backed SSO providers, one login button each. Absent on the client-hook
-  // path that does not fetch them. The login page treats absent as none.
+  // Enabled DB-backed SSO providers, one login button each. Empty on cloud
+  // and when no provider rows exist.
   ssoProviders?: SSOProviderOption[];
 }

--- a/web/src/lib/auth/utils.ts
+++ b/web/src/lib/auth/utils.ts
@@ -2,30 +2,14 @@
 // Auth URL helpers
 // ---------------------------------------------------------------------------
 
-import { AuthType } from "@/lib/auth/types";
-
 export function getAuthUrl(
-  authType: AuthType,
+  multiTenant: boolean,
   nextUrl: string | null
 ): string | null {
   const params = new URLSearchParams({ redirect: "true" });
   if (nextUrl) params.set("next", nextUrl);
 
-  switch (authType) {
-    case AuthType.BASIC:
-      return null;
-    case AuthType.GOOGLE_OAUTH:
-    case AuthType.CLOUD:
-      return `/api/auth/oauth/authorize?${params}`;
-    case AuthType.OIDC:
-      return `/api/auth/oidc/authorize?${params}`;
-    case AuthType.SAML:
-      // SAML authorize returns JSON ({authorization_url}), not a redirect —
-      // the IdP URL must be resolved server-side via getAuthUrlSS.
-      return null;
-    default:
-      return null;
-  }
+  return multiTenant ? `/api/auth/oauth/authorize?${params}` : null;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/constants.ts
+++ b/web/src/lib/constants.ts
@@ -1,5 +1,3 @@
-import { AuthType } from "@/lib/auth/types";
-
 export const IS_DEV = process.env.NODE_ENV === "development";
 
 export const HOST_URL = process.env.WEB_DOMAIN || "http://localhost:3000";
@@ -12,11 +10,6 @@ export const DOCS_ADMINS_PATH = `${DOCS_BASE_URL}/admins`;
 
 export const MCP_INTERNAL_URL =
   process.env.MCP_INTERNAL_URL || "http://127.0.0.1:8090";
-
-// NOTE: this should ONLY be used on the server-side (including middleware).
-// The AUTH_TYPE environment variable is set in the backend and shared with Next.js
-export const SERVER_SIDE_ONLY__AUTH_TYPE = (process.env.AUTH_TYPE ||
-  AuthType.BASIC) as AuthType;
 
 export const NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED =
   process.env.NEXT_PUBLIC_DO_NOT_USE_TOGGLE_OFF_DANSWER_POWERED?.toLowerCase() ===

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -120,12 +120,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
   const onRefreshFail = useCallback(async () => {
     await mutateUser();
   }, [mutateUser]);
-  useTokenRefresh(
-    upToDateUser,
-    authTypeMetadata,
-    authTypeMetadataLoading,
-    onRefreshFail
-  );
+  useTokenRefresh(upToDateUser, authTypeMetadataLoading, onRefreshFail);
 
   // Sync user's theme preference from DB to next-themes on load
   const { setTheme, theme } = useTheme();

--- a/web/src/proxy.ts
+++ b/web/src/proxy.ts
@@ -2,10 +2,8 @@ import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
 import {
   SERVER_SIDE_ONLY__PAID_ENTERPRISE_FEATURES_ENABLED,
-  SERVER_SIDE_ONLY__AUTH_TYPE,
   SERVER_SIDE_ONLY__AUTH_COOKIE_NAME,
 } from "./lib/constants";
-import { AuthType } from "@/lib/auth/types";
 
 // Route prefixes that never allow anonymous access, so we fast-fail at the edge
 // when no auth cookie is present. "/app" is intentionally excluded: it allows

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -36,8 +36,7 @@ import { PerUserAuthConfig } from "@/sections/actions/PerUserAuthConfig";
 import { updateMCPServerStatus, upsertMCPServer } from "@/lib/tools/mcpService";
 import { toast } from "@opal/layouts";
 import { SvgArrowExchange } from "@opal/icons";
-import { useAuthType } from "@/lib/auth/hooks";
-import { AuthType } from "@/lib/auth/types";
+import { useOAuthPassThroughEnabled } from "@/lib/auth/hooks";
 
 interface MCPAuthenticationModalProps {
   mcpServer: MCPServer | null;
@@ -151,10 +150,7 @@ export default function MCPAuthenticationModal({
   // Open the Advanced (known-provider) section by default when configured.
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
-  // Check if OAuth is enabled for the Onyx instance
-  const authType = useAuthType();
-  const isOAuthEnabled =
-    authType === AuthType.OIDC || authType === AuthType.GOOGLE_OAUTH;
+  const isOAuthEnabled = useOAuthPassThroughEnabled();
 
   const redirectUri = useMemo(() => {
     if (typeof window === "undefined") {

--- a/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/OpenAPIAuthenticationModal.tsx
@@ -17,8 +17,7 @@ import KeyValueInput, {
 import { OAuthConfig } from "@/lib/tools/interfaces";
 import { getOAuthConfig } from "@/lib/oauth/api";
 import { SvgArrowExchange } from "@opal/icons";
-import { useAuthType } from "@/lib/auth/hooks";
-import { AuthType } from "@/lib/auth/types";
+import { useOAuthPassThroughEnabled } from "@/lib/auth/hooks";
 
 export type AuthMethod = "oauth" | "custom-header" | "pt-oauth";
 
@@ -78,9 +77,7 @@ export default function OpenAPIAuthenticationModal({
   onSkip,
   entityName = null,
 }: OpenAPIAuthenticationModalProps) {
-  const authType = useAuthType();
-  const isOAuthEnabled =
-    authType === AuthType.OIDC || authType === AuthType.GOOGLE_OAUTH;
+  const isOAuthEnabled = useOAuthPassThroughEnabled();
   const [existingOAuthConfig, setExistingOAuthConfig] =
     useState<OAuthConfig | null>(null);
   const [isLoadingOAuthConfig, setIsLoadingOAuthConfig] = useState(false);
@@ -564,8 +561,8 @@ export default function OpenAPIAuthenticationModal({
 
                         <div className="flex flex-col gap-3 rounded-12 bg-background-tint-01 p-3">
                           <Text as="p" text03 secondaryBody>
-                            OAuth passthrough is only available if you enable
-                            OIDC or OAuth authentication.
+                            OAuth pass-through requires an OAuth-capable login
+                            method (Google or OIDC).
                           </Text>
                           <div className="flex flex-col gap-2 w-full">
                             <Text

--- a/web/src/sections/sidebar/AccountPopover.tsx
+++ b/web/src/sections/sidebar/AccountPopover.tsx
@@ -77,9 +77,7 @@ function SettingsPopover({
 
         const encodedRedirect = encodeURIComponent(currentUrl);
 
-        router.push(
-          `/auth/login?disableAutoRedirect=true&next=${encodedRedirect}`
-        );
+        router.push(`/auth/login?next=${encodedRedirect}`);
       })
 
       .catch(() => {

--- a/web/src/views/SettingsPage.tsx
+++ b/web/src/views/SettingsPage.tsx
@@ -37,7 +37,7 @@ import ModelSelector from "@/sections/model-selector/ModelSelector";
 import { structureValue } from "@/lib/languageModels/utils";
 import { deleteAllChatSessions } from "@/app/app/services/lib";
 import { useLlmManager } from "@/lib/hooks";
-import { useAuthType } from "@/lib/auth/hooks";
+import { useIsMultiTenant } from "@/lib/auth/hooks";
 import useChatSessions from "@/hooks/useChatSessions";
 import useSWR from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
@@ -1304,7 +1304,7 @@ function ChatPreferencesSettings() {
 
 function AccountsAccessSettings() {
   const { user, authTypeMetadata } = useUser();
-  const authType = useAuthType();
+  const isMultiTenant = useIsMultiTenant();
   const [showPasswordModal, setShowPasswordModal] = useState(false);
 
   // TODO(auth-refresh): only passwordMinLength is enforced here; the remaining
@@ -1337,7 +1337,7 @@ function AccountsAccessSettings() {
   const canCreateTokens = useCloudSubscription();
 
   const showPasswordSection = Boolean(user?.password_configured);
-  const showTokensSection = authType !== null;
+  const showTokensSection = isMultiTenant !== null;
 
   // Fetch PATs with SWR
   const {

--- a/web/src/views/admin/UsersPage/UsersSummary.tsx
+++ b/web/src/views/admin/UsersPage/UsersSummary.tsx
@@ -9,7 +9,6 @@ import Text from "@/refresh-components/texts/Text";
 import Link from "next/link";
 import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { useAuthTypeMetadata } from "@/lib/auth/hooks";
-import { AuthType } from "@/lib/auth/types";
 import InviteOnlyCard from "./InviteOnlyCard";
 
 // ---------------------------------------------------------------------------
@@ -110,10 +109,7 @@ export default function UsersSummary({
   onFilterRequests,
 }: UsersSummaryProps) {
   const { authTypeMetadata } = useAuthTypeMetadata();
-  const showInviteOnly =
-    !showScim &&
-    (authTypeMetadata?.authType === AuthType.BASIC ||
-      authTypeMetadata?.authType === AuthType.GOOGLE_OAUTH);
+  const showInviteOnly = !showScim && authTypeMetadata?.multiTenant === false;
   const showRequests = requests !== null && requests > 0;
 
   const statsCard = (


### PR DESCRIPTION
## Description

Stacked on #13027. Final PR of the AUTH_TYPE removal stack. Merge after #13027.

**Backend**
- `app_configs.AUTH_TYPE` deleted; former consumers derive from `MULTI_TENANT` (`INSTANCE_TYPE`, invite email copy, the tag-fix migration's cloud override, which imported the deleted config and would have crashed alembic).
- `AuthType` enum deleted entirely. It carried one bit: after the legacy-mode removal, `basic` vs `cloud` is exactly `MULTI_TENANT`, so `/auth/type` serves `multi_tenant: bool`. Per-provider login type lives where it belongs, in `sso_providers[].provider_type`.
- `verify_auth_setting` is a pure deprecation warner on raw `os.environ`. The identical EE override is deleted.
- `/auth/type` stops doing per-hit DB work: `has_users` latches once a user exists, and the sso options query sits behind a 60s TTLCache invalidated by the sso admin mutations.
- Migration seeds and the SAML conf-dir seed still read the raw env value so legacy deployments migrate on upgrade. Deployment templates intentionally untouched for the same reason.

**Web**
- FE `AuthType` enum and `autoRedirect` deleted; `multiTenant: boolean` with null-safe mapping (`=== false` / `!== false`) so backend-unreachable behavior is unchanged. Dead OIDC/SAML/GOOGLE_OAUTH branches removed.
- MCP/OpenAPI OAuth pass-through option re-gated on OAuth capability (`oauthEnabled` or an OIDC/Google provider row) via a shared `useOAuthPassThroughEnabled()` hook. Also now correctly available on cloud.

**Mobile** (in dev, unshipped)
- Renders password always and Google on `oauth_enabled` (heals migrated env-Google servers). Server probe accepts old and new field shapes.

Note: external readers of `GET /auth/type` should read `multi_tenant` instead of `auth_type`.

## How Has This Been Tested?

## Additional Options

- [ ] I have considered whether this PR needs to be cherry-picked to the latest release branch.
- [x] Override Linear Check