### PR TITLE
feat(desktop): add Windows ARM64 desktop builds

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -310,12 +310,18 @@ jobs:
         include:
           - platform: "macos-latest" # Build a universal image for macOS.
             args: "--target universal-apple-darwin"
+            rust-targets: "aarch64-apple-darwin,x86_64-apple-darwin"
           - platform: "ubuntu-24.04"
             args: "--bundles deb,rpm"
           - platform: "ubuntu-24.04-arm" # Only available in public repos.
             args: "--bundles deb,rpm"
           - platform: "windows-latest"
             args: ""
+          # Cross-compiled Windows ARM64 build. Only the NSIS bundle supports
+          # ARM64 (WiX/MSI does not), hence --bundles nsis.
+          - platform: "windows-latest"
+            args: "--target aarch64-pc-windows-msvc --bundles nsis"
+            rust-targets: "aarch64-pc-windows-msvc"
 
     runs-on: ${{ matrix.platform }}
     timeout-minutes: 90
@@ -371,8 +377,9 @@ jobs:
       - name: install Rust stable
         uses: dtolnay/rust-toolchain@6d9817901c499d6b02debbb57edb38d33daa680b # zizmor: ignore[impostor-commit]
         with:
-          # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
-          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+          # Extra targets for jobs that cross-compile (macOS universal, Windows ARM64).
+          # Jobs building only for the host architecture leave this empty.
+          targets: ${{ matrix.rust-targets || '' }}
 
       - name: install frontend dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Description

Adds Windows ARM64 support to the desktop release matrix in `deployment.yml`.

- New `build-desktop` matrix entry on `windows-latest` that cross-compiles with `--target aarch64-pc-windows-msvc --bundles nsis`. NSIS-only because Tauri's WiX/MSI bundler does not support ARM64 ([Tauri docs](https://v2.tauri.app/distribute/windows-installer/)); the existing x64 job still produces both MSI and NSIS.
- Replaced the macOS-only inline `targets:` conditional on the Rust toolchain step with a `rust-targets` matrix key, shared by the macOS universal and Windows ARM64 cross-compiling jobs.

Notes:

- Cross-compiling from x64 (rather than the native `windows-11-arm` runner) is the officially documented Tauri route; `windows-latest` ships the MSVC ARM64 build tools, and this keeps the toolchain identical to the proven x64 job (native Windows ARM64 Bun only shipped in v1.3.10 and `setup-bun` support is still settling).
- `assetNamePattern: "[name]_[arch][ext]"` yields `arm64`-suffixed release assets, so there is no collision with the x64 job's uploads.
- Known Tauri quirk: the NSIS installer executable itself runs as x86 under emulation on ARM devices, but it installs a native ARM64 app.

## How Has This Been Tested?

- `pre-commit run --files .github/workflows/deployment.yml` — check-yaml, actionlint, and zizmor all pass.
- Verified `windows-latest` runner images include `Microsoft.VisualStudio.Component.VC.Tools.ARM64` (required for cross-linking).

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Windows ARM64 desktop builds to the release workflow. Generates native ARM64 NSIS installers by cross-compiling on `windows-latest`.

- **New Features**
  - Added `build-desktop` matrix entry with `--target aarch64-pc-windows-msvc --bundles nsis` (Tauri WiX/MSI lacks ARM64 support).
  - ARM64 release assets are suffixed via `assetNamePattern: "[name]_[arch][ext]"` to avoid collisions.

- **Refactors**
  - Replaced the macOS-only Rust `targets` conditional with a shared `rust-targets` matrix key for all cross-compiling jobs.

<sup>Written for commit 9f0d978acdbcdf65499ef1f5e6932ddadf90feba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

