### PR TITLE
feat(tracing): upgrade Langfuse integration to Python SDK v4

### DIFF
--- a/backend/onyx/tracing/langfuse_tracing_processor.py
+++ b/backend/onyx/tracing/langfuse_tracing_processor.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import threading
 from datetime import datetime
 from typing import Any
+from typing import ContextManager
 from typing import Optional
 from typing import Union
 
 from langfuse import Langfuse
+from langfuse import propagate_attributes
 from langfuse._client.span import LangfuseObservationWrapper
 
 from onyx.tracing.framework.processor_interface import TracingProcessor
@@ -56,6 +59,14 @@ class LangfuseTracingProcessor(TracingProcessor):
         self._first_input: dict[str, Any] = {}
         self._last_output: dict[str, Any] = {}
         self._trace_metadata: dict[str, dict[str, Any]] = {}
+        # kwargs for propagate_attributes(), captured at trace start. SDK v4 is
+        # observations-first: trace-level fields (name, user, session, metadata)
+        # must be stamped on every observation via propagate_attributes(). The
+        # propagation context lives in thread-local OTel contextvars, and Onyx
+        # creates child observations from parallel threads, so these are
+        # re-applied on every child-creation path instead of relying on the
+        # ambient context from trace start.
+        self._trace_attributes: dict[str, dict[str, Any]] = {}
         # Langfuse IDs for thread-safe parent linking via trace_context
         self._langfuse_trace_ids: dict[
             str, str
@@ -115,28 +126,31 @@ class LangfuseTracingProcessor(TracingProcessor):
             trace_meta = trace.export() or {}
             metadata = trace_meta.get("metadata") or {}
 
-            # Create a root span which implicitly creates a Langfuse trace
-            # The span name becomes the trace name in Langfuse UI
-            # In Langfuse SDK v3, use start_observation instead of start_span
-            langfuse_span = client.start_observation(
-                name=trace.name,
-            )
-
             # Promote first-class Langfuse fields out of metadata so they
             # populate the dedicated UI facets (Sessions, Users) rather than
             # only the metadata JSON blob.
             session_id = metadata.get("chat_session_id")
             user_id = metadata.get("user_id")
-            langfuse_span.update_trace(
-                name=trace.name,
-                session_id=session_id if session_id else None,
-                user_id=str(user_id) if user_id else None,
-                metadata=metadata if metadata else None,
-            )
+            trace_attributes: dict[str, Any] = {
+                "trace_name": trace.name,
+                "user_id": str(user_id) if user_id else None,
+                "session_id": str(session_id) if session_id else None,
+                "metadata": metadata if metadata else None,
+            }
+
+            # Create a root span which implicitly creates a Langfuse trace.
+            # propagate_attributes replaces SDK v3's update_trace: it stamps the
+            # trace name, user, session, and metadata onto observations created
+            # within its scope.
+            with propagate_attributes(**trace_attributes):
+                langfuse_span = client.start_observation(
+                    name=trace.name,
+                )
 
             with self._lock:
                 if metadata:
                     self._trace_metadata[trace.trace_id] = metadata
+                self._trace_attributes[trace.trace_id] = trace_attributes
                 self._trace_spans[trace.trace_id] = langfuse_span
                 # Store Langfuse IDs for thread-safe parent linking
                 self._langfuse_trace_ids[trace.trace_id] = langfuse_span.trace_id
@@ -151,6 +165,7 @@ class LangfuseTracingProcessor(TracingProcessor):
             with self._lock:
                 langfuse_span = self._trace_spans.pop(trace.trace_id, None)
                 self._trace_metadata.pop(trace.trace_id, None)
+                self._trace_attributes.pop(trace.trace_id, None)
                 self._langfuse_trace_ids.pop(trace.trace_id, None)  # Clean up trace ID
                 self._langfuse_span_ids.pop(
                     trace.trace_id, None
@@ -184,6 +199,7 @@ class LangfuseTracingProcessor(TracingProcessor):
             # Get Langfuse IDs and metadata under lock for thread-safe access
             with self._lock:
                 trace_metadata = self._trace_metadata.get(span.trace_id)
+                trace_attributes = self._trace_attributes.get(span.trace_id)
                 langfuse_trace_id = self._langfuse_trace_ids.get(span.trace_id)
                 # Get parent's Langfuse span ID
                 if span.parent_id is not None:
@@ -192,6 +208,15 @@ class LangfuseTracingProcessor(TracingProcessor):
                     # Parent is the root trace span (use trace_id as key)
                     parent_langfuse_id = self._langfuse_span_ids.get(span.trace_id)
 
+            # Re-apply the trace-level attributes captured at trace start. Spans
+            # are created from parallel threads, so the propagation context
+            # entered in on_trace_start is not visible here.
+            propagation: ContextManager[Any] = (
+                propagate_attributes(**trace_attributes)
+                if trace_attributes
+                else contextlib.nullcontext()
+            )
+
             # If no trace ID found, we can't create a properly linked span
             if langfuse_trace_id is None:
                 logger.warning(
@@ -199,11 +224,11 @@ class LangfuseTracingProcessor(TracingProcessor):
                     span.span_id,
                 )
                 # Fall back to creating an orphan span
-                # In Langfuse SDK v3, use start_observation instead of start_span
                 client = self._get_client()
-                langfuse_span = client.start_observation(
-                    name=data.type if hasattr(data, "type") else "unknown",
-                )
+                with propagation:
+                    langfuse_span = client.start_observation(
+                        name=data.type if hasattr(data, "type") else "unknown",
+                    )
                 with self._lock:
                     self._spans[span.span_id] = langfuse_span
                     self._langfuse_span_ids[span.span_id] = langfuse_span.id
@@ -219,42 +244,42 @@ class LangfuseTracingProcessor(TracingProcessor):
                 trace_context["parent_span_id"] = parent_langfuse_id
 
             # Create spans using trace_context (thread-safe ID-based approach)
-            # In Langfuse SDK v3, use start_observation with as_type parameter
-            if isinstance(data, GenerationSpanData):
-                langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
-                    trace_context=trace_context,
-                    name=self._get_generation_name(data),
-                    as_type="generation",
-                    metadata=trace_metadata,
-                    model=data.model,
-                    model_parameters=self._get_model_parameters(data),
-                )
-            elif isinstance(data, FunctionSpanData):
-                langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
-                    trace_context=trace_context,
-                    name=data.name,
-                    as_type="tool",
-                    metadata=trace_metadata,
-                )
-            elif isinstance(data, AgentSpanData):
-                langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
-                    trace_context=trace_context,
-                    name=data.name,
-                    as_type="agent",
-                    metadata={
-                        **(trace_metadata or {}),
-                        "tools": data.tools,
-                        "handoffs": data.handoffs,
-                        "output_type": data.output_type,
-                    },
-                )
-            else:
-                langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
-                    trace_context=trace_context,
-                    name=data.type if hasattr(data, "type") else "unknown",
-                    as_type="span",
-                    metadata=trace_metadata,
-                )
+            with propagation:
+                if isinstance(data, GenerationSpanData):
+                    langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=self._get_generation_name(data),
+                        as_type="generation",
+                        metadata=trace_metadata,
+                        model=data.model,
+                        model_parameters=self._get_model_parameters(data),
+                    )
+                elif isinstance(data, FunctionSpanData):
+                    langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=data.name,
+                        as_type="tool",
+                        metadata=trace_metadata,
+                    )
+                elif isinstance(data, AgentSpanData):
+                    langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=data.name,
+                        as_type="agent",
+                        metadata={
+                            **(trace_metadata or {}),
+                            "tools": data.tools,
+                            "handoffs": data.handoffs,
+                            "output_type": data.output_type,
+                        },
+                    )
+                else:
+                    langfuse_span = client.start_observation(  # ty: ignore[no-matching-overload]
+                        trace_context=trace_context,
+                        name=data.type if hasattr(data, "type") else "unknown",
+                        as_type="span",
+                        metadata=trace_metadata,
+                    )
 
             with self._lock:
                 self._spans[span.span_id] = langfuse_span

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -1340,9 +1340,9 @@ langchain-protocol==0.0.15 \
 langdetect==1.0.9 \
     --hash=sha256:cbc1fef89f8d062739774bd51eda3da3274006b3661d199c2655f6b3f6d605a0
     # via unstructured
-langfuse==3.10.0 \
-    --hash=sha256:7a9254103da50cabcf46a7e7ae9d2cf1f8267f09b6036abdb4a9c6f2f3d15104 \
-    --hash=sha256:c7c10607c6fe560990d0973566afd3c5513f7ff97cc31691af72711ad5441d8c
+langfuse==4.14.0 \
+    --hash=sha256:31b875c8d09eee39c558584b9424bbd5ed014965c5944c4528a37947ae4b7787 \
+    --hash=sha256:632b74abfa14d9ad3dccbe3322bf7e11b0dce9be0de451b0d134db9bff246d44
 langsmith==0.8.18 \
     --hash=sha256:32dde9c0e67e053e0fb738921fc8ced768af7b8fa83d7a0e3fd63597cf8776dd \
     --hash=sha256:3940183349993faef48e6c7d08e4822ee9cefd906b362d0e3c2d650314d2f282
@@ -1792,7 +1792,6 @@ openai==2.38.0 \
     --hash=sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c
     # via
     #   exa-py
-    #   langfuse
     #   litellm
     #   onyx
 openapi-pydantic==0.5.1 \
@@ -2640,7 +2639,6 @@ requests==2.33.0 \
     #   huggingface-hub
     #   jira
     #   kubernetes
-    #   langfuse
     #   langsmith
     #   markitdown
     #   matrix-client

--- a/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py
@@ -1,71 +1,207 @@
-"""Unit tests for LangfuseTracingProcessor metadata handling."""
+"""Unit tests for LangfuseTracingProcessor trace-attribute propagation.
 
+These run the real Langfuse SDK (v4) with the OTLP exporter patched to capture
+spans in-memory, so assertions cover what would actually be exported to
+Langfuse — including the propagated trace-level attributes (user, session,
+trace name, metadata) that SDK v4 requires on every observation.
+"""
+
+import threading
+from collections.abc import Iterator
 from collections.abc import Mapping
 from typing import Any
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
+import pytest
+from langfuse import Langfuse
+from langfuse import LangfuseOtelSpanAttributes
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExportResult
+
+from onyx.tracing.framework.span_data import FunctionSpanData
 from onyx.tracing.langfuse_tracing_processor import LangfuseTracingProcessor
 
+_USER_ID_ATTR = LangfuseOtelSpanAttributes.TRACE_USER_ID
+_SESSION_ID_ATTR = LangfuseOtelSpanAttributes.TRACE_SESSION_ID
+_TRACE_NAME_ATTR = LangfuseOtelSpanAttributes.TRACE_NAME
+_TRACE_METADATA_PREFIX = f"{LangfuseOtelSpanAttributes.TRACE_METADATA}."
 
-def _make_trace(metadata: Mapping[str, Any]) -> MagicMock:
+_captured_spans: list[ReadableSpan] = []
+
+
+@pytest.fixture(scope="module")
+def langfuse_client() -> Iterator[Langfuse]:
+    """A real Langfuse client whose OTLP export is captured in-memory."""
+
+    def _capture(
+        _self: Any, spans: list[ReadableSpan], **_kwargs: Any
+    ) -> SpanExportResult:
+        _captured_spans.extend(spans)
+        return SpanExportResult.SUCCESS
+
+    with patch(
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter.OTLPSpanExporter.export",
+        _capture,
+    ):
+        client = Langfuse(
+            public_key="pk-lf-unit-test",
+            secret_key="sk-lf-unit-test",
+            host="http://localhost:9",
+            tracing_enabled=True,
+        )
+        yield client
+        client.shutdown()
+
+
+@pytest.fixture
+def exported_spans() -> list[ReadableSpan]:
+    _captured_spans.clear()
+    return _captured_spans
+
+
+def _make_trace(trace_id: str, name: str, metadata: Mapping[str, Any]) -> MagicMock:
     trace = MagicMock()
-    trace.trace_id = "trace-123"
-    trace.name = "run_llm_loop"
-    trace.export.return_value = {"metadata": metadata}
+    trace.trace_id = trace_id
+    trace.name = name
+    trace.export.return_value = {"metadata": dict(metadata)}
     return trace
 
 
-def _make_client_with_observation() -> tuple[MagicMock, MagicMock]:
-    observation = MagicMock()
-    observation.trace_id = "lf-trace-1"
-    observation.id = "lf-span-1"
-    client = MagicMock()
-    client.start_observation.return_value = observation
-    return client, observation
+def _make_span(trace_id: str, span_id: str, name: str) -> MagicMock:
+    span = MagicMock()
+    span.trace_id = trace_id
+    span.span_id = span_id
+    span.parent_id = None
+    span.error = None
+    span.span_data = FunctionSpanData(name=name, input=None, output=None)
+    return span
 
 
-def test_on_trace_start_promotes_user_id_and_session_id() -> None:
-    """user_id and chat_session_id in metadata must be passed as first-class
-    fields on update_trace so Langfuse populates the Users and Sessions views.
+def _attrs(span: ReadableSpan) -> dict[str, Any]:
+    return dict(span.attributes or {})
+
+
+def _span_by_name(spans: list[ReadableSpan], name: str) -> ReadableSpan:
+    matches = [s for s in spans if s.name == name]
+    assert len(matches) == 1, f"expected exactly one span named {name!r}"
+    return matches[0]
+
+
+def test_root_observation_carries_promoted_trace_attributes(
+    langfuse_client: Langfuse, exported_spans: list[ReadableSpan]
+) -> None:
+    """user_id / chat_session_id in trace metadata must be promoted to the
+    first-class user/session attributes (plus trace name and metadata) on the
+    root observation so Langfuse populates the Users and Sessions views.
     """
-    client, observation = _make_client_with_observation()
-    processor = LangfuseTracingProcessor(client=client)
+    processor = LangfuseTracingProcessor(client=langfuse_client)
 
     metadata = {
         "tenant_id": "tenant-abc",
         "chat_session_id": "session-xyz",
         "user_id": "user-42",
     }
-    processor.on_trace_start(_make_trace(metadata))
+    trace = _make_trace("trace-root-attrs", "run_llm_loop", metadata)
+    processor.on_trace_start(trace)
+    processor.on_trace_end(trace)
+    processor.force_flush()
 
-    observation.update_trace.assert_called_once()
-    kwargs = observation.update_trace.call_args.kwargs
-    assert kwargs["user_id"] == "user-42"
-    assert kwargs["session_id"] == "session-xyz"
-    assert kwargs["name"] == "run_llm_loop"
-    assert kwargs["metadata"] == metadata
+    root = _span_by_name(exported_spans, "run_llm_loop")
+    attrs = _attrs(root)
+    assert attrs[_USER_ID_ATTR] == "user-42"
+    assert attrs[_SESSION_ID_ATTR] == "session-xyz"
+    assert attrs[_TRACE_NAME_ATTR] == "run_llm_loop"
+    for key, value in metadata.items():
+        assert attrs[f"{_TRACE_METADATA_PREFIX}{key}"] == value
 
 
-def test_on_trace_start_user_id_missing_passes_none() -> None:
-    """Anonymous / unattributed traces still update successfully with user_id=None."""
-    client, observation = _make_client_with_observation()
-    processor = LangfuseTracingProcessor(client=client)
+def test_missing_user_id_still_traces(
+    langfuse_client: Langfuse, exported_spans: list[ReadableSpan]
+) -> None:
+    """Anonymous / unattributed traces still export, just without a user."""
+    processor = LangfuseTracingProcessor(client=langfuse_client)
 
     metadata = {"tenant_id": "tenant-abc", "chat_session_id": "session-xyz"}
-    processor.on_trace_start(_make_trace(metadata))
+    trace = _make_trace("trace-no-user", "anon_loop", metadata)
+    processor.on_trace_start(trace)
+    processor.on_trace_end(trace)
+    processor.force_flush()
 
-    kwargs = observation.update_trace.call_args.kwargs
-    assert kwargs["user_id"] is None
-    assert kwargs["session_id"] == "session-xyz"
+    attrs = _attrs(_span_by_name(exported_spans, "anon_loop"))
+    assert _USER_ID_ATTR not in attrs
+    assert attrs[_SESSION_ID_ATTR] == "session-xyz"
 
 
-def test_on_trace_start_coerces_non_string_user_id() -> None:
-    """User ids that arrive as ints (e.g. from User.id) are coerced to strings."""
-    client, observation = _make_client_with_observation()
-    processor = LangfuseTracingProcessor(client=client)
+def test_non_string_user_id_coerced(
+    langfuse_client: Langfuse, exported_spans: list[ReadableSpan]
+) -> None:
+    """User ids that arrive as ints (e.g. from User.id) are coerced to strings;
+    v4 drops non-string propagated values outright, so coercion is required."""
+    processor = LangfuseTracingProcessor(client=langfuse_client)
 
-    metadata = {"chat_session_id": "session-xyz", "user_id": 7}
-    processor.on_trace_start(_make_trace(metadata))
+    trace = _make_trace(
+        "trace-int-user", "int_user_loop", {"chat_session_id": "s", "user_id": 7}
+    )
+    processor.on_trace_start(trace)
+    processor.on_trace_end(trace)
+    processor.force_flush()
 
-    kwargs = observation.update_trace.call_args.kwargs
-    assert kwargs["user_id"] == "7"
+    attrs = _attrs(_span_by_name(exported_spans, "int_user_loop"))
+    assert attrs[_USER_ID_ATTR] == "7"
+
+
+def test_threaded_children_carry_user_and_session(
+    langfuse_client: Langfuse, exported_spans: list[ReadableSpan]
+) -> None:
+    """Regression test for the SDK v4 migration: propagate_attributes() lives in
+    thread-local OTel context, but Onyx creates child observations from parallel
+    threads. Every child must still carry the trace's user/session/name
+    attributes and parent-link to the root observation.
+    """
+    processor = LangfuseTracingProcessor(client=langfuse_client)
+
+    metadata = {
+        "tenant_id": "tenant-abc",
+        "chat_session_id": "session-threaded",
+        "user_id": "user-99",
+    }
+    trace = _make_trace("trace-threaded", "threaded_loop", metadata)
+    processor.on_trace_start(trace)
+
+    num_children = 8
+    barrier = threading.Barrier(num_children)
+
+    def run_child(i: int) -> None:
+        span = _make_span("trace-threaded", f"span-{i}", f"tool-{i}")
+        barrier.wait()  # maximize overlap between threads
+        processor.on_span_start(span)
+        processor.on_span_end(span)
+
+    threads = [
+        threading.Thread(target=run_child, args=(i,)) for i in range(num_children)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    processor.on_trace_end(trace)
+    processor.force_flush()
+
+    root = _span_by_name(exported_spans, "threaded_loop")
+    root_trace_id = root.context.trace_id
+    root_span_id = root.context.span_id
+
+    for i in range(num_children):
+        child = _span_by_name(exported_spans, f"tool-{i}")
+        attrs = _attrs(child)
+        assert attrs[_USER_ID_ATTR] == "user-99"
+        assert attrs[_SESSION_ID_ATTR] == "session-threaded"
+        assert attrs[_TRACE_NAME_ATTR] == "threaded_loop"
+        assert attrs[f"{_TRACE_METADATA_PREFIX}tenant_id"] == "tenant-abc"
+        # Children created from worker threads must still land in the same
+        # Langfuse trace, parented to the root observation.
+        assert child.context.trace_id == root_trace_id
+        assert child.parent is not None
+        assert child.parent.span_id == root_span_id

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ backend = [
     "sendgrid==6.12.5",
     "exa_py==1.15.4",
     "braintrust==0.3.9",
-    "langfuse==3.10.0",
+    "langfuse==4.14.0",
     "nest_asyncio==1.6.0",
     "openinference-instrumentation==0.1.42",
     "opentelemetry-proto>=1.42.1",

--- a/uv.lock
+++ b/uv.lock
@@ -3120,23 +3120,21 @@ sdist = { url = "https://files.pythonhosted.org/packages/0e/72/a3add0e4eec4eb9e2
 
 [[package]]
 name = "langfuse"
-version = "3.10.0"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
     { name = "httpx" },
-    { name = "openai" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp-proto-http" },
     { name = "opentelemetry-sdk" },
     { name = "packaging" },
     { name = "pydantic" },
-    { name = "requests" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/97/bacdac633511a1c9895d9e3b1720c3d008a0f5d7d5c0e058d8cf79040773/langfuse-3.10.0.tar.gz", hash = "sha256:7a9254103da50cabcf46a7e7ae9d2cf1f8267f09b6036abdb4a9c6f2f3d15104", size = 220516, upload-time = "2025-11-14T12:15:56.839Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/752661e4376dcaa73bf839703296530d91807e90e219e1fc0d24c5460bc2/langfuse-4.14.0.tar.gz", hash = "sha256:31b875c8d09eee39c558584b9424bbd5ed014965c5944c4528a37947ae4b7787", size = 363802, upload-time = "2026-07-10T11:33:39.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/05/343e8fa3e5d48035422e1385105aeb986130d3de3264ec732c890dab2d16/langfuse-3.10.0-py3-none-any.whl", hash = "sha256:c7c10607c6fe560990d0973566afd3c5513f7ff97cc31691af72711ad5441d8c", size = 390745, upload-time = "2025-11-14T12:15:54.912Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c7/ca0f591e1184415ffcd920a4107f3d2638ab5af7ff7e498d99a9b8b2bb13/langfuse-4.14.0-py3-none-any.whl", hash = "sha256:632b74abfa14d9ad3dccbe3322bf7e11b0dce9be0de451b0d134db9bff246d44", size = 638356, upload-time = "2026-07-10T11:33:37.419Z" },
 ]
 
 [[package]]
@@ -4047,7 +4045,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4058,7 +4056,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4085,9 +4083,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4098,7 +4096,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4427,7 +4425,7 @@ backend = [
     { name = "jira", specifier = "==3.10.5" },
     { name = "kubernetes", specifier = "==31.0.0" },
     { name = "langchain-core", specifier = "==1.3.3" },
-    { name = "langfuse", specifier = "==3.10.0" },
+    { name = "langfuse", specifier = "==4.14.0" },
     { name = "libpass", specifier = "==1.9.3" },
     { name = "lxml", specifier = "==6.1.0" },
     { name = "markitdown", extras = ["pdf", "docx", "pptx", "xlsx", "xls"], specifier = "==0.1.2" },
@@ -4898,7 +4896,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6503,8 +6501,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Description

Upgrades the Langfuse tracing integration from Python SDK v3 (`3.10.0`) to v4 (`4.14.0`), as requested by the Langfuse team for compatibility with Langfuse Cloud's observations-first Fast Preview UI.

Closes #13026

### Changes

- **Dependency**: `langfuse==3.10.0` → `langfuse==4.14.0` in `pyproject.toml`; `uv.lock` and hash-locked `backend/requirements/default.txt` regenerated.
- **`update_trace()` → `propagate_attributes()`**: v4 removed the observation-level `update_trace()`. Trace name, user, session, and metadata are now propagated via the `propagate_attributes()` context manager, entered around root-observation creation.
- **Cross-thread propagation**: `propagate_attributes()` stores state in thread-local OTel context, but Onyx creates child observations from parallel threads (research agents) with explicit `trace_context`. The processor captures the propagation kwargs at trace start and re-enters `propagate_attributes()` around every child-observation creation path, so user/session/name/metadata land on each observation regardless of the creating thread.
- **`session_id` coercion**: v4 silently drops non-string propagated values, so `session_id` is now coerced to `str` like `user_id` already was.
- **Preserved behavior**: root span input/output at trace end, generation usage/cost details, masking, and ID-based parent linking via `trace_context` are unchanged (all still supported by v4's `start_observation`/`update`).

### Tests

Rewrote `backend/tests/unit/onyx/tracing/test_langfuse_tracing_processor.py` to run the real v4 SDK with the OTLP exporter patched to capture spans in-memory, asserting on the attributes actually exported:

- root observation carries promoted `user.id` / `session.id` / trace name / trace metadata,
- anonymous traces export without a user,
- non-string user ids are coerced,
- **regression test**: 8 children created from parallel threads each carry user/session/name/metadata and parent-link to the root observation.

`pytest backend/tests/unit/onyx/tracing` (17 passed) and `pytest backend/tests/external_dependency_unit/tracing` (27 passed); full unit suite green except pre-existing sandbox-environment failures in `test_process_isolation.py` unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades the Langfuse tracing integration to `langfuse` v4.14.0 to support the observations-first Langfuse Cloud UI. Replaces `update_trace()` with `propagate_attributes()` and ensures trace attributes propagate to all observations, including those created from parallel threads.

- **Refactors**
  - Replace root `update_trace()` with `propagate_attributes()` to set trace name, `user_id`, `session_id`, and metadata.
  - Capture and re-apply propagation args on every child-observation path (thread-safe; works with explicit `trace_context`).
  - Coerce `session_id` to `str`; preserve root I/O, generation usage/cost, masking, and ID-based parent linking.
  - Update unit tests to run against v4 with in-memory OTLP capture, including a threaded propagation regression test.

- **Dependencies**
  - Bump `langfuse` 3.10.0 → 4.14.0; regenerate `uv.lock` and `backend/requirements/default.txt`.
  - Lock file reflects updated transitive dependencies from v4.

<sup>Written for commit bc62314a002e87c5615cbc03c8b23956fb665e28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

