### PR TITLE
ci: skip Linear check for Dependabot PRs

### DIFF
--- a/.github/workflows/pr-linear-check.yml
+++ b/.github/workflows/pr-linear-check.yml
@@ -20,6 +20,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           IGNORED_AUTHORS: |
+            dependabot[bot]
             jmelahman
         run: |
           normalized_author="$(printf '%s' "${PR_AUTHOR}" | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
## Description

Adds `dependabot[bot]` to the Linear check's existing author ignore list so Dependabot-generated PRs do not need a Linear reference or manual override.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `.github/workflows/pr-linear-check.yml` to skip the Linear check for Dependabot by adding `dependabot[bot]` to the ignored authors. This prevents bot PRs from failing the Linear gate and removes the need for manual overrides.

<sup>Written for commit 837ad6fb0ac1ce40547a14696179cf3ed1555a0b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

