### PR TITLE
feat(craft): add SessionOrigin.SLACK for headless Slack sessions

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -317,13 +317,16 @@ class SessionOrigin(str, PyEnum):
     """How a BuildSession was created.
 
     INTERACTIVE: session started by a user in the Craft UI.
-    SCHEDULED:   session started by the scheduled-tasks executor (or any
-                 future non-interactive caller). Sessions with this origin
-                 are excluded from the Craft sidebar list.
+    SCHEDULED:   session started by the scheduled-tasks executor. Sessions
+                 with this origin are excluded from the Craft sidebar list.
+    SLACK:       session started by a Slack thread mention. Surfaces in
+                 Slack (and a future admin list), not the user sidebar.
+                 Excluded from the Craft sidebar list.
     """
 
     INTERACTIVE = "INTERACTIVE"
     SCHEDULED = "SCHEDULED"
+    SLACK = "SLACK"
 
 
 class SharingScope(str, PyEnum):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5751,8 +5751,8 @@ class BuildSession(Base):
         default=SharingScope.PRIVATE,
         server_default="private",
     )
-    # Distinguishes user-initiated sessions from sessions created by the
-    # scheduled-tasks executor (or any future non-interactive caller). The
+    # Distinguishes user-initiated sessions from sessions created by
+    # non-interactive callers (scheduled-tasks executor, Slack bot). The
     # Craft sidebar filters on origin == INTERACTIVE.
     origin: Mapped[SessionOrigin] = mapped_column(
         Enum(SessionOrigin, native_enum=False, name="sessionorigin"),

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -153,6 +153,8 @@ def get_empty_session_for_user(
     """Get an empty (pre-provisioned) session for the user if one exists.
 
     Returns a session with no messages, or None if all sessions have messages.
+    Only considers INTERACTIVE sessions — non-interactive origins (e.g. Slack)
+    skip port allocation and must not be handed to the Craft UI.
     """
     has_messages = exists().where(BuildMessage.session_id == BuildSession.id)
 
@@ -160,6 +162,7 @@ def get_empty_session_for_user(
         db_session.query(BuildSession)
         .filter(
             BuildSession.user_id == user_id,
+            BuildSession.origin == SessionOrigin.INTERACTIVE,
             ~has_messages,
         )
         .first()

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -125,8 +125,8 @@ def get_user_build_sessions(
     """Get a user's interactive build sessions that have at least one message.
 
     Sessions created by non-interactive callers (e.g. the scheduled-tasks
-    executor) are intentionally excluded from this listing so they don't
-    leak into the Craft sidebar. The covering composite index
+    executor or the Slack bot) are intentionally excluded from this listing
+    so they don't leak into the Craft sidebar. The covering composite index
     ``ix_build_session_user_origin_created`` is built for this exact query
     shape: ``(user_id, origin, created_at DESC)``.
     """

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -309,8 +309,8 @@ class SessionManager:
             llm_provider_type: Provider type from user's cookie (e.g., "anthropic", "openai")
             llm_model_name: Model name from user's cookie (e.g., "claude-opus-4-5")
             origin: Provenance of the session. INTERACTIVE (default) sessions
-                appear in the Craft sidebar; SCHEDULED sessions (created by
-                the scheduled-tasks executor) are excluded.
+                appear in the Craft sidebar; SCHEDULED (scheduled-tasks
+                executor) and SLACK (Slack bot) sessions are excluded.
 
         Returns:
             The created BuildSession model
@@ -331,11 +331,11 @@ class SessionManager:
 
         # Allocate port for this session (per-session port allocation).
         # Both LOCAL and KUBERNETES backends use the same port allocation
-        # strategy. Skipped for SCHEDULED sessions: scheduled-task fires
-        # are headless, never attach a preview, and pile up so fast they'd
-        # exhaust the [3010, 3100) range on a busy tenant.
+        # strategy. Skipped for non-interactive origins (SCHEDULED, SLACK):
+        # those sessions are headless, never attach a preview, and pile up
+        # fast enough to exhaust the [3010, 3100) range on a busy tenant.
         nextjs_port: int | None
-        if origin == SessionOrigin.SCHEDULED or headless:
+        if origin != SessionOrigin.INTERACTIVE or headless:
             nextjs_port = None
         else:
             nextjs_port = allocate_nextjs_port(self._db_session)

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -1081,7 +1081,7 @@ class TestSidebarOriginFilter:
         db_session: Session,
         test_user: User,
     ) -> None:
-        """``get_user_build_sessions`` filters out ``origin=SCHEDULED`` rows.
+        """``get_user_build_sessions`` filters out non-INTERACTIVE rows.
 
         Relocated from ``backend/tests/integration/tests/craft/
         test_scheduled_tasks_api.py`` — the original test inserted
@@ -1095,12 +1095,12 @@ class TestSidebarOriginFilter:
         The covering composite index
         ``ix_build_session_user_origin_created`` is built for this exact
         ``(user_id, origin, created_at DESC)`` shape — a regression here
-        would silently leak scheduled-task fire sessions into the Craft
-        sidebar.
+        would silently leak scheduled-task fire or Slack sessions into the
+        Craft sidebar.
         """
-        # Both sessions need a BuildMessage row because
+        # Every session needs a BuildMessage row because
         # ``get_user_build_sessions`` requires ``EXISTS messages`` —
-        # without one, BOTH origin types would be filtered and we'd have
+        # without one, ALL origin types would be filtered and we'd have
         # nothing to compare against.
         interactive = BuildSession(
             id=uuid4(),
@@ -1116,7 +1116,14 @@ class TestSidebarOriginFilter:
             status=BuildSessionStatus.ACTIVE,
             origin=SessionOrigin.SCHEDULED,
         )
-        db_session.add_all([interactive, scheduled])
+        slack = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="slack-thread",
+            status=BuildSessionStatus.ACTIVE,
+            origin=SessionOrigin.SLACK,
+        )
+        db_session.add_all([interactive, scheduled, slack])
         db_session.flush()
         db_session.add_all(
             [
@@ -1138,6 +1145,15 @@ class TestSidebarOriginFilter:
                         "content": {"text": "fire"},
                     },
                 ),
+                BuildMessage(
+                    session_id=slack.id,
+                    turn_index=0,
+                    type=MessageType.USER,
+                    message_metadata={
+                        "type": "user_message",
+                        "content": {"text": "@bot hi"},
+                    },
+                ),
             ]
         )
         db_session.commit()
@@ -1145,7 +1161,8 @@ class TestSidebarOriginFilter:
         listed = get_user_build_sessions(test_user.id, db_session)
         listed_ids = {s.id for s in listed}
 
-        # Observable outcome: the SCHEDULED row is invisible to the
+        # Observable outcome: SCHEDULED and SLACK rows are invisible to the
         # sidebar query while the INTERACTIVE row is visible.
         assert interactive.id in listed_ids
         assert scheduled.id not in listed_ids
+        assert slack.id not in listed_ids

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -1116,14 +1116,14 @@ class TestSidebarOriginFilter:
             status=BuildSessionStatus.ACTIVE,
             origin=SessionOrigin.SCHEDULED,
         )
-        slack = BuildSession(
+        slack_session = BuildSession(
             id=uuid4(),
             user_id=test_user.id,
             name="slack-thread",
             status=BuildSessionStatus.ACTIVE,
             origin=SessionOrigin.SLACK,
         )
-        db_session.add_all([interactive, scheduled, slack])
+        db_session.add_all([interactive, scheduled, slack_session])
         db_session.flush()
         db_session.add_all(
             [
@@ -1146,7 +1146,7 @@ class TestSidebarOriginFilter:
                     },
                 ),
                 BuildMessage(
-                    session_id=slack.id,
+                    session_id=slack_session.id,
                     turn_index=0,
                     type=MessageType.USER,
                     message_metadata={
@@ -1165,4 +1165,4 @@ class TestSidebarOriginFilter:
         # sidebar query while the INTERACTIVE row is visible.
         assert interactive.id in listed_ids
         assert scheduled.id not in listed_ids
-        assert slack.id not in listed_ids
+        assert slack_session.id not in listed_ids

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -4,7 +4,7 @@
 
 export type SharingScope = "private" | "public_org";
 
-export type SessionOrigin = "INTERACTIVE" | "SCHEDULED";
+export type SessionOrigin = "INTERACTIVE" | "SCHEDULED" | "SLACK";
 
 // =============================================================================
 // Session Error Constants


### PR DESCRIPTION
## Description

First foundation piece of the Craft Slackbot project (spec: `docs/craft/specs/craft-slackbot.md`). Adds `SessionOrigin.SLACK` and threads it through session creation, the headless port-allocation branch, and the interactive-sidebar filter, so future Slack-originated sessions behave like `SCHEDULED` ones: headless, no preview port, excluded from the Craft sidebar.

- `backend/onyx/db/enums.py` — add `SLACK = "SLACK"` to `SessionOrigin`; update docstring.
- `backend/onyx/db/models.py` — update comment on `BuildSession.origin` (non-native varchar enum, verified no migration needed: column is `character varying(11)` sized for `INTERACTIVE`, no CHECK constraint, and `SLACK` fits under that width).
- `backend/onyx/server/features/build/session/manager.py` — `create_session__no_commit`'s headless/port-skip condition changed from `origin == SessionOrigin.SCHEDULED` to `origin != SessionOrigin.INTERACTIVE`, so it also covers `SLACK` (behavior-identical for existing origins, now correct for the new one).
- `backend/onyx/server/features/build/db/build_session.py` — docstring update on `get_user_build_sessions` (exclusion of `SLACK` is automatic since it already filters on `origin == INTERACTIVE`; no code change needed there).
- `web/src/app/craft/types/streamingTypes.ts` — extend the `SessionOrigin` union type with `"SLACK"`.
- `backend/tests/external_dependency_unit/craft/test_session_lifecycle.py` — extended the existing sidebar-origin-filter test with a `SLACK`-origin session, asserting it persists with that origin and is excluded from `get_user_build_sessions` alongside the existing `SCHEDULED` case.

Swept the rest of backend + frontend for `SessionOrigin` usage/exhaustive matching (grep) — no other call site needed changes.

## How Has This Been Tested?

- Extended `TestSidebarOriginFilter::test_scheduled_origin_session_excluded_from_sidebar_listing` to also cover `SLACK`; full file run: `pytest backend/tests/external_dependency_unit/craft/test_session_lifecycle.py` — 21 passed (1 pre-existing unrelated failure deselected: `test_delete_session_removes_s3_snapshots`, fails locally due to missing S3 credentials, unrelated to this change).
- Verified DB storage directly (`\d build_session` on the local Postgres): `origin` is `character varying(11)` with no CHECK constraint, confirming no migration is required for the new enum value.
- `pre-commit run` on all changed files: ruff, ty, TypeScript type check, oxlint/oxfmt all passed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `SessionOrigin.SLACK` for Slack-triggered build sessions. Slack sessions are headless, skip preview port allocation, and are hidden from the Craft sidebar like `SCHEDULED`; the UI only reuses empty sessions that are `INTERACTIVE`.

- **New Features**
  - Added `SLACK` to `SessionOrigin` in backend and `web`.
  - Skip preview port when origin is not `INTERACTIVE`.
  - Only reuse empty sessions with origin `INTERACTIVE`.
  - Sidebar list stays `INTERACTIVE`-only; tests cover `SLACK`; no DB migration.

<sup>Written for commit 899530b9d56269ddad6c093ab8af4312c2d46469. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

