### PR TITLE
refactor(llm): drop hardcoded infer_vision_support, use LiteLLM cost map

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -2065,7 +2065,6 @@ def get_openai_compatible_server_available_models(
                     name=model_id,
                     display_name=model_name,
                     max_input_tokens=model.get("context_length"),
-                    # Vision support from the LiteLLM cost map, not a hardcoded list
                     supports_image_input=litellm_thinks_model_supports_image_input(
                         model_id, LlmProviderNames.OPENAI_COMPATIBLE
                     ),

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1209,8 +1209,6 @@ def get_bedrock_available_models(
                                 if profile_name
                                 else generate_bedrock_display_name(profile_id)
                             ),
-                            # Vision support from the LiteLLM cost map, not a
-                            # hardcoded list
                             "supports_image_input": (
                                 litellm_thinks_model_supports_image_input(
                                     profile_id, LlmProviderNames.BEDROCK

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -105,7 +105,6 @@ from onyx.server.manage.llm.provider_cache import get_cached_provider_listing
 from onyx.server.manage.llm.provider_cache import invalidate_provider_listing_cache
 from onyx.server.manage.llm.utils import generate_bedrock_display_name
 from onyx.server.manage.llm.utils import generate_ollama_display_name
-from onyx.server.manage.llm.utils import infer_vision_support
 from onyx.server.manage.llm.utils import is_embedding_model
 from onyx.server.manage.llm.utils import is_reasoning_model
 from onyx.server.manage.llm.utils import is_valid_bedrock_model
@@ -1210,8 +1209,13 @@ def get_bedrock_available_models(
                                 if profile_name
                                 else generate_bedrock_display_name(profile_id)
                             ),
-                            # Infer vision support from known vision models
-                            "supports_image_input": infer_vision_support(profile_id),
+                            # Vision support from the LiteLLM cost map, not a
+                            # hardcoded list
+                            "supports_image_input": (
+                                litellm_thinks_model_supports_image_input(
+                                    profile_id, LlmProviderNames.BEDROCK
+                                )
+                            ),
                         }
         except Exception as e:
             logger.warning("Couldn't fetch inference profiles for Bedrock: %s", e)
@@ -2061,7 +2065,10 @@ def get_openai_compatible_server_available_models(
                     name=model_id,
                     display_name=model_name,
                     max_input_tokens=model.get("context_length"),
-                    supports_image_input=infer_vision_support(model_id),
+                    # Vision support from the LiteLLM cost map, not a hardcoded list
+                    supports_image_input=litellm_thinks_model_supports_image_input(
+                        model_id, LlmProviderNames.OPENAI_COMPATIBLE
+                    ),
                     supports_reasoning=is_reasoning_model(model_id, model_name),
                 )
             )

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -4,7 +4,7 @@ LLM Provider Utilities
 Utilities for dynamic LLM providers (Bedrock, Ollama, OpenRouter):
 - Display name generation from model identifiers
 - Model validation and filtering
-- Vision/reasoning capability inference
+- Reasoning capability inference
 """
 
 import re
@@ -40,36 +40,6 @@ class ModelMetadata(TypedDict):
 # Non-LLM model patterns to filter out (image gen, embeddings, etc.)
 NON_LLM_PATTERNS = frozenset({"embed", "stable-", "titan-image", "titan-embed"})
 
-# Known Bedrock vision-capable models (for fallback when base model not in region)
-BEDROCK_VISION_MODELS = frozenset(
-    {
-        "anthropic.claude-3",
-        "anthropic.claude-4",
-        "amazon.nova-pro",
-        "amazon.nova-lite",
-        "amazon.nova-premier",
-    }
-)
-
-# Known Bifrost/OpenAI-compatible vision-capable model families where the
-# source API does not expose this metadata directly.
-BIFROST_VISION_MODEL_FAMILIES = frozenset(
-    {
-        "anthropic/claude-3",
-        "anthropic/claude-4",
-        "amazon/nova-pro",
-        "amazon/nova-lite",
-        "amazon/nova-premier",
-        "openai/gpt-4o",
-        "openai/gpt-4.1",
-        "google/gemini",
-        "meta-llama/llama-3.2",
-        "mistral/pixtral",
-        "qwen/qwen2.5-vl",
-        "qwen/qwen-vl",
-    }
-)
-
 
 def is_valid_bedrock_model(
     model_id: str,
@@ -91,23 +61,6 @@ def is_valid_bedrock_model(
     if not supports_streaming:
         return False
     return True
-
-
-def infer_vision_support(model_id: str) -> bool:
-    """Infer vision support from model ID when base model metadata unavailable.
-
-    Used for providers like Bedrock and Bifrost where vision support may
-    need to be inferred from vendor/model naming conventions.
-    """
-    model_id_lower = model_id.lower()
-    if any(vision_model in model_id_lower for vision_model in BEDROCK_VISION_MODELS):
-        return True
-
-    normalized_model_id = model_id_lower.replace(".", "/")
-    return any(
-        vision_model in normalized_model_id
-        for vision_model in BIFROST_VISION_MODEL_FAMILIES
-    )
 
 
 def generate_bedrock_display_name(model_id: str) -> str:

--- a/backend/tests/unit/onyx/server/manage/llm/test_llm_provider_utils.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_llm_provider_utils.py
@@ -2,7 +2,6 @@
 
 from onyx.server.manage.llm.utils import generate_bedrock_display_name
 from onyx.server.manage.llm.utils import generate_ollama_display_name
-from onyx.server.manage.llm.utils import infer_vision_support
 from onyx.server.manage.llm.utils import is_embedding_model
 from onyx.server.manage.llm.utils import is_reasoning_model
 from onyx.server.manage.llm.utils import is_valid_bedrock_model
@@ -192,34 +191,6 @@ class TestIsValidBedrockModel:
     def test_empty_model_id(self) -> None:
         """Test that empty model ID is invalid."""
         assert is_valid_bedrock_model("", True) is False
-
-
-class TestInferVisionSupport:
-    """Tests for vision support inference."""
-
-    def test_claude_3_has_vision(self) -> None:
-        """Test Claude 3 models have vision."""
-        assert infer_vision_support("anthropic.claude-3-5-sonnet") is True
-
-    def test_claude_4_has_vision(self) -> None:
-        """Test Claude 4 models have vision."""
-        assert infer_vision_support("anthropic.claude-4-opus") is True
-
-    def test_nova_pro_has_vision(self) -> None:
-        """Test Nova Pro has vision."""
-        assert infer_vision_support("amazon.nova-pro-v1") is True
-
-    def test_bifrost_claude_has_vision(self) -> None:
-        """Test Bifrost Claude models are recognized as vision-capable."""
-        assert infer_vision_support("anthropic/claude-3-5-sonnet") is True
-
-    def test_bifrost_gpt4o_has_vision(self) -> None:
-        """Test Bifrost GPT-4o models are recognized as vision-capable."""
-        assert infer_vision_support("openai/gpt-4o") is True
-
-    def test_mistral_no_vision(self) -> None:
-        """Test Mistral doesn't have vision (not in known list)."""
-        assert infer_vision_support("mistral.mistral-large") is False
 
 
 class TestIsReasoningModel:


### PR DESCRIPTION
## Summary

`supports_image_input` was determined inconsistently across dynamic LLM providers. Most read it from the source API (Bedrock `inputModalities`, OpenRouter `input_modalities`, LM Studio `capabilities.vision`, Ollama `capabilities`). **Bifrost already switched to `litellm_thinks_model_supports_image_input`** — "*Vision support from the LiteLLM cost map, not a hardcoded list*" — leaving `infer_vision_support` (and its two hardcoded substring lists, including the Bifrost-named `BIFROST_VISION_MODEL_FAMILIES`) used by only two call sites:

- Bedrock inference-profile **fallback** (`get_bedrock_available_models`) — hit only when the base model isn't in-region
- OpenAI-compatible `/v1/models` (`get_openai_compatible_server_available_models`)

This routes both through `litellm_thinks_model_supports_image_input` and deletes `infer_vision_support`, `BEDROCK_VISION_MODELS`, and `BIFROST_VISION_MODEL_FAMILIES`, so vision support is sourced consistently.

## Changes

- `onyx/server/manage/llm/api.py` — both call sites now use `litellm_thinks_model_supports_image_input(<model_id>, <provider>)`; dropped the unused import.
- `onyx/server/manage/llm/utils.py` — deleted `infer_vision_support` and its two backing frozensets; updated the module docstring.
- `tests/unit/.../test_llm_provider_utils.py` — removed `TestInferVisionSupport`.

## Behavioral notes (LiteLLM vs. the old hardcoded lists)

Verified head-to-head against real Bedrock inference-profile IDs:

- **Same** for every common vision family — Claude 3/4, Nova Pro/Lite — and correct `False` for text-only (Nova Micro, Llama 3.2 1B, Mistral Large).
- **Better**: the old list contained no Bedrock Llama entries, so `meta.llama3-2-11b-instruct` (vision-capable) was wrongly reported as no-vision; LiteLLM gets it right.
- **Known regression (narrow)**: `mistral.pixtral-large-2502` is vision-capable and the old list caught it, but LiteLLM ships the Bedrock key with `supports_vision` **unset** (`None`), so it now reports `False`. This only surfaces in the *fallback* branch (AWS returns the Pixtral inference profile but not the base foundation model); the primary path still reads AWS's own `inputModalities` and is authoritative. It's recoverable via the DB-stored `supports_image_input` flag in the admin UI, and is a LiteLLM data gap likely to be fixed upstream.
- OpenAI-compatible: unknown model IDs LiteLLM doesn't recognize now resolve to `False` (with a debug-warning log) instead of matching the old substrings; self-hosted vision models absent from LiteLLM can be flagged via the admin UI.

## Testing

- `pytest backend/tests/unit/onyx/server/manage/llm/test_llm_provider_utils.py` — 44 passed
- `pytest backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py` — 49 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)