### PR TITLE
feat(craft): add slack_session_link table + accessors

### DIFF
--- a/backend/alembic/versions/716d0d180a2a_add_slack_session_link_table.py
+++ b/backend/alembic/versions/716d0d180a2a_add_slack_session_link_table.py
@@ -1,0 +1,59 @@
+"""add slack_session_link table
+
+Revision ID: 716d0d180a2a
+Revises: bd38e2a494ff
+Create Date: 2026-07-15 11:35:03.737280
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = "716d0d180a2a"
+down_revision = "bd38e2a494ff"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "slack_session_link",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("slack_team_id", sa.String(), nullable=False),
+        sa.Column("channel_id", sa.String(), nullable=False),
+        sa.Column("thread_ts", sa.String(), nullable=False),
+        sa.Column(
+            "build_session_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["build_session_id"], ["build_session.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "slack_team_id",
+            "channel_id",
+            "thread_ts",
+            name="uq_slack_session_link_thread",
+        ),
+        sa.UniqueConstraint(
+            "build_session_id", name="uq_slack_session_link_build_session_id"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("slack_session_link")

--- a/backend/alembic/versions/716d0d180a2a_add_slack_thread_build_session_table.py
+++ b/backend/alembic/versions/716d0d180a2a_add_slack_thread_build_session_table.py
@@ -1,4 +1,4 @@
-"""add slack_session_link table
+"""add slack_thread__build_session table
 
 Revision ID: 716d0d180a2a
 Revises: bd38e2a494ff
@@ -19,7 +19,7 @@ depends_on = None
 
 def upgrade() -> None:
     op.create_table(
-        "slack_session_link",
+        "slack_thread__build_session",
         sa.Column(
             "id",
             postgresql.UUID(as_uuid=True),
@@ -47,13 +47,13 @@ def upgrade() -> None:
             "slack_team_id",
             "channel_id",
             "thread_ts",
-            name="uq_slack_session_link_thread",
+            name="uq_slack_thread__build_session_thread",
         ),
         sa.UniqueConstraint(
-            "build_session_id", name="uq_slack_session_link_build_session_id"
+            "build_session_id", name="uq_slack_thread__build_session_session"
         ),
     )
 
 
 def downgrade() -> None:
-    op.drop_table("slack_session_link")
+    op.drop_table("slack_thread__build_session")

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -317,13 +317,16 @@ class SessionOrigin(str, PyEnum):
     """How a BuildSession was created.
 
     INTERACTIVE: session started by a user in the Craft UI.
-    SCHEDULED:   session started by the scheduled-tasks executor (or any
-                 future non-interactive caller). Sessions with this origin
-                 are excluded from the Craft sidebar list.
+    SCHEDULED:   session started by the scheduled-tasks executor. Sessions
+                 with this origin are excluded from the Craft sidebar list.
+    SLACK:       session started by a Slack thread mention. Surfaces in
+                 Slack (and a future admin list), not the user sidebar.
+                 Excluded from the Craft sidebar list.
     """
 
     INTERACTIVE = "INTERACTIVE"
     SCHEDULED = "SCHEDULED"
+    SLACK = "SLACK"
 
 
 class SharingScope(str, PyEnum):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5793,10 +5793,10 @@ class BuildSession(Base):
     )
 
 
-class SlackSessionLink(Base):
+class SlackThread__BuildSession(Base):
     """Maps a Slack thread to the BuildSession handling it (one thread per session)."""
 
-    __tablename__ = "slack_session_link"
+    __tablename__ = "slack_thread__build_session"
 
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True), primary_key=True, default=uuid4
@@ -5820,10 +5820,10 @@ class SlackSessionLink(Base):
             "slack_team_id",
             "channel_id",
             "thread_ts",
-            name="uq_slack_session_link_thread",
+            name="uq_slack_thread__build_session_thread",
         ),
         UniqueConstraint(
-            "build_session_id", name="uq_slack_session_link_build_session_id"
+            "build_session_id", name="uq_slack_thread__build_session_session"
         ),
     )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5793,6 +5793,39 @@ class BuildSession(Base):
     )
 
 
+class SlackSessionLink(Base):
+    """Maps a Slack thread to the BuildSession handling it (one thread per session)."""
+
+    __tablename__ = "slack_session_link"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), primary_key=True, default=uuid4
+    )
+    slack_team_id: Mapped[str] = mapped_column(String, nullable=False)
+    channel_id: Mapped[str] = mapped_column(String, nullable=False)
+    thread_ts: Mapped[str] = mapped_column(String, nullable=False)
+    build_session_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("build_session.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+    )
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+
+    session: Mapped["BuildSession"] = relationship("BuildSession")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "slack_team_id",
+            "channel_id",
+            "thread_ts",
+            name="uq_slack_session_link_thread",
+        ),
+    )
+
+
 class Sandbox(Base):
     """Stores sandbox container metadata for users (one sandbox per user)."""
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5751,8 +5751,8 @@ class BuildSession(Base):
         default=SharingScope.PRIVATE,
         server_default="private",
     )
-    # Distinguishes user-initiated sessions from sessions created by the
-    # scheduled-tasks executor (or any future non-interactive caller). The
+    # Distinguishes user-initiated sessions from sessions created by
+    # non-interactive callers (scheduled-tasks executor, Slack bot). The
     # Craft sidebar filters on origin == INTERACTIVE.
     origin: Mapped[SessionOrigin] = mapped_column(
         Enum(SessionOrigin, native_enum=False, name="sessionorigin"),

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5808,7 +5808,6 @@ class SlackSessionLink(Base):
         PGUUID(as_uuid=True),
         ForeignKey("build_session.id", ondelete="CASCADE"),
         nullable=False,
-        unique=True,
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
@@ -5822,6 +5821,9 @@ class SlackSessionLink(Base):
             "channel_id",
             "thread_ts",
             name="uq_slack_session_link_thread",
+        ),
+        UniqueConstraint(
+            "build_session_id", name="uq_slack_session_link_build_session_id"
         ),
     )
 

--- a/backend/onyx/db/slack_session_link.py
+++ b/backend/onyx/db/slack_session_link.py
@@ -4,7 +4,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from onyx.db.models import SlackSessionLink
+from onyx.db.models import SlackThread__BuildSession
 
 
 def get_session_id_for_slack_thread(
@@ -14,10 +14,10 @@ def get_session_id_for_slack_thread(
     thread_ts: str,
 ) -> UUID | None:
     link = db_session.scalar(
-        select(SlackSessionLink).where(
-            SlackSessionLink.slack_team_id == slack_team_id,
-            SlackSessionLink.channel_id == channel_id,
-            SlackSessionLink.thread_ts == thread_ts,
+        select(SlackThread__BuildSession).where(
+            SlackThread__BuildSession.slack_team_id == slack_team_id,
+            SlackThread__BuildSession.channel_id == channel_id,
+            SlackThread__BuildSession.thread_ts == thread_ts,
         )
     )
     return link.build_session_id if link else None
@@ -29,10 +29,10 @@ def insert_slack_session_link(
     channel_id: str,
     thread_ts: str,
     build_session_id: UUID,
-) -> SlackSessionLink:
+) -> SlackThread__BuildSession:
     """Raises IntegrityError on a race between concurrent inserts for the same
     thread; callers should catch it and re-fetch the winning link."""
-    link = SlackSessionLink(
+    link = SlackThread__BuildSession(
         slack_team_id=slack_team_id,
         channel_id=channel_id,
         thread_ts=thread_ts,
@@ -50,9 +50,9 @@ def insert_slack_session_link(
 def get_link_for_session(
     db_session: Session,
     build_session_id: UUID,
-) -> SlackSessionLink | None:
+) -> SlackThread__BuildSession | None:
     return db_session.scalar(
-        select(SlackSessionLink).where(
-            SlackSessionLink.build_session_id == build_session_id
+        select(SlackThread__BuildSession).where(
+            SlackThread__BuildSession.build_session_id == build_session_id
         )
     )

--- a/backend/onyx/db/slack_session_link.py
+++ b/backend/onyx/db/slack_session_link.py
@@ -1,0 +1,58 @@
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from onyx.db.models import SlackSessionLink
+
+
+def get_session_id_for_slack_thread(
+    db_session: Session,
+    slack_team_id: str,
+    channel_id: str,
+    thread_ts: str,
+) -> UUID | None:
+    link = db_session.scalar(
+        select(SlackSessionLink).where(
+            SlackSessionLink.slack_team_id == slack_team_id,
+            SlackSessionLink.channel_id == channel_id,
+            SlackSessionLink.thread_ts == thread_ts,
+        )
+    )
+    return link.build_session_id if link else None
+
+
+def insert_slack_session_link(
+    db_session: Session,
+    slack_team_id: str,
+    channel_id: str,
+    thread_ts: str,
+    build_session_id: UUID,
+) -> SlackSessionLink:
+    """Raises IntegrityError on a race between concurrent inserts for the same
+    thread; callers should catch it and re-fetch the winning link."""
+    link = SlackSessionLink(
+        slack_team_id=slack_team_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        build_session_id=build_session_id,
+    )
+    db_session.add(link)
+    try:
+        db_session.commit()
+    except IntegrityError:
+        db_session.rollback()
+        raise
+    return link
+
+
+def get_link_for_session(
+    db_session: Session,
+    build_session_id: UUID,
+) -> SlackSessionLink | None:
+    return db_session.scalar(
+        select(SlackSessionLink).where(
+            SlackSessionLink.build_session_id == build_session_id
+        )
+    )

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -153,6 +153,8 @@ def get_empty_session_for_user(
     """Get an empty (pre-provisioned) session for the user if one exists.
 
     Returns a session with no messages, or None if all sessions have messages.
+    Only considers INTERACTIVE sessions — non-interactive origins (e.g. Slack)
+    skip port allocation and must not be handed to the Craft UI.
     """
     has_messages = exists().where(BuildMessage.session_id == BuildSession.id)
 
@@ -160,6 +162,7 @@ def get_empty_session_for_user(
         db_session.query(BuildSession)
         .filter(
             BuildSession.user_id == user_id,
+            BuildSession.origin == SessionOrigin.INTERACTIVE,
             ~has_messages,
         )
         .first()

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -125,8 +125,8 @@ def get_user_build_sessions(
     """Get a user's interactive build sessions that have at least one message.
 
     Sessions created by non-interactive callers (e.g. the scheduled-tasks
-    executor) are intentionally excluded from this listing so they don't
-    leak into the Craft sidebar. The covering composite index
+    executor or the Slack bot) are intentionally excluded from this listing
+    so they don't leak into the Craft sidebar. The covering composite index
     ``ix_build_session_user_origin_created`` is built for this exact query
     shape: ``(user_id, origin, created_at DESC)``.
     """

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -309,8 +309,8 @@ class SessionManager:
             llm_provider_type: Provider type from user's cookie (e.g., "anthropic", "openai")
             llm_model_name: Model name from user's cookie (e.g., "claude-opus-4-5")
             origin: Provenance of the session. INTERACTIVE (default) sessions
-                appear in the Craft sidebar; SCHEDULED sessions (created by
-                the scheduled-tasks executor) are excluded.
+                appear in the Craft sidebar; SCHEDULED (scheduled-tasks
+                executor) and SLACK (Slack bot) sessions are excluded.
 
         Returns:
             The created BuildSession model
@@ -331,11 +331,11 @@ class SessionManager:
 
         # Allocate port for this session (per-session port allocation).
         # Both LOCAL and KUBERNETES backends use the same port allocation
-        # strategy. Skipped for SCHEDULED sessions: scheduled-task fires
-        # are headless, never attach a preview, and pile up so fast they'd
-        # exhaust the [3010, 3100) range on a busy tenant.
+        # strategy. Skipped for non-interactive origins (SCHEDULED, SLACK):
+        # those sessions are headless, never attach a preview, and pile up
+        # fast enough to exhaust the [3010, 3100) range on a busy tenant.
         nextjs_port: int | None
-        if origin == SessionOrigin.SCHEDULED or headless:
+        if origin != SessionOrigin.INTERACTIVE or headless:
             nextjs_port = None
         else:
             nextjs_port = allocate_nextjs_port(self._db_session)

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -1081,7 +1081,7 @@ class TestSidebarOriginFilter:
         db_session: Session,
         test_user: User,
     ) -> None:
-        """``get_user_build_sessions`` filters out ``origin=SCHEDULED`` rows.
+        """``get_user_build_sessions`` filters out non-INTERACTIVE rows.
 
         Relocated from ``backend/tests/integration/tests/craft/
         test_scheduled_tasks_api.py`` — the original test inserted
@@ -1095,12 +1095,12 @@ class TestSidebarOriginFilter:
         The covering composite index
         ``ix_build_session_user_origin_created`` is built for this exact
         ``(user_id, origin, created_at DESC)`` shape — a regression here
-        would silently leak scheduled-task fire sessions into the Craft
-        sidebar.
+        would silently leak scheduled-task fire or Slack sessions into the
+        Craft sidebar.
         """
-        # Both sessions need a BuildMessage row because
+        # Every session needs a BuildMessage row because
         # ``get_user_build_sessions`` requires ``EXISTS messages`` —
-        # without one, BOTH origin types would be filtered and we'd have
+        # without one, ALL origin types would be filtered and we'd have
         # nothing to compare against.
         interactive = BuildSession(
             id=uuid4(),
@@ -1116,7 +1116,14 @@ class TestSidebarOriginFilter:
             status=BuildSessionStatus.ACTIVE,
             origin=SessionOrigin.SCHEDULED,
         )
-        db_session.add_all([interactive, scheduled])
+        slack = BuildSession(
+            id=uuid4(),
+            user_id=test_user.id,
+            name="slack-thread",
+            status=BuildSessionStatus.ACTIVE,
+            origin=SessionOrigin.SLACK,
+        )
+        db_session.add_all([interactive, scheduled, slack])
         db_session.flush()
         db_session.add_all(
             [
@@ -1138,6 +1145,15 @@ class TestSidebarOriginFilter:
                         "content": {"text": "fire"},
                     },
                 ),
+                BuildMessage(
+                    session_id=slack.id,
+                    turn_index=0,
+                    type=MessageType.USER,
+                    message_metadata={
+                        "type": "user_message",
+                        "content": {"text": "@bot hi"},
+                    },
+                ),
             ]
         )
         db_session.commit()
@@ -1145,7 +1161,8 @@ class TestSidebarOriginFilter:
         listed = get_user_build_sessions(test_user.id, db_session)
         listed_ids = {s.id for s in listed}
 
-        # Observable outcome: the SCHEDULED row is invisible to the
+        # Observable outcome: SCHEDULED and SLACK rows are invisible to the
         # sidebar query while the INTERACTIVE row is visible.
         assert interactive.id in listed_ids
         assert scheduled.id not in listed_ids
+        assert slack.id not in listed_ids

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -1116,14 +1116,14 @@ class TestSidebarOriginFilter:
             status=BuildSessionStatus.ACTIVE,
             origin=SessionOrigin.SCHEDULED,
         )
-        slack = BuildSession(
+        slack_session = BuildSession(
             id=uuid4(),
             user_id=test_user.id,
             name="slack-thread",
             status=BuildSessionStatus.ACTIVE,
             origin=SessionOrigin.SLACK,
         )
-        db_session.add_all([interactive, scheduled, slack])
+        db_session.add_all([interactive, scheduled, slack_session])
         db_session.flush()
         db_session.add_all(
             [
@@ -1146,7 +1146,7 @@ class TestSidebarOriginFilter:
                     },
                 ),
                 BuildMessage(
-                    session_id=slack.id,
+                    session_id=slack_session.id,
                     turn_index=0,
                     type=MessageType.USER,
                     message_metadata={
@@ -1165,4 +1165,4 @@ class TestSidebarOriginFilter:
         # sidebar query while the INTERACTIVE row is visible.
         assert interactive.id in listed_ids
         assert scheduled.id not in listed_ids
-        assert slack.id not in listed_ids
+        assert slack_session.id not in listed_ids

--- a/backend/tests/external_dependency_unit/craft/test_slack_session_link.py
+++ b/backend/tests/external_dependency_unit/craft/test_slack_session_link.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from onyx.db.models import BuildSession
+from onyx.db.slack_session_link import get_link_for_session
+from onyx.db.slack_session_link import get_session_id_for_slack_thread
+from onyx.db.slack_session_link import insert_slack_session_link
+
+
+def _make_build_session(db_session: Session) -> BuildSession:
+    session = BuildSession(id=uuid4())
+    db_session.add(session)
+    db_session.commit()
+    return session
+
+
+def _random_thread_ts() -> str:
+    return f"{uuid4().int % 10_000_000_000}.{uuid4().int % 1_000_000:06d}"
+
+
+def test_insert_and_lookup_by_thread_and_session(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    build_session = _make_build_session(db_session)
+    team_id, channel_id, thread_ts = f"T-{uuid4()}", f"C-{uuid4()}", _random_thread_ts()
+
+    link = insert_slack_session_link(
+        db_session,
+        slack_team_id=team_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        build_session_id=build_session.id,
+    )
+    assert link.build_session_id == build_session.id
+
+    found_id = get_session_id_for_slack_thread(
+        db_session,
+        slack_team_id=team_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+    )
+    assert found_id == build_session.id
+
+    reverse_link = get_link_for_session(db_session, build_session.id)
+    assert reverse_link is not None
+    assert reverse_link.slack_team_id == team_id
+    assert reverse_link.channel_id == channel_id
+    assert reverse_link.thread_ts == thread_ts
+
+
+def test_lookup_miss_returns_none(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    assert (
+        get_session_id_for_slack_thread(
+            db_session,
+            slack_team_id=f"T-{uuid4()}",
+            channel_id=f"C-{uuid4()}",
+            thread_ts=_random_thread_ts(),
+        )
+        is None
+    )
+    assert get_link_for_session(db_session, uuid4()) is None
+
+
+def test_duplicate_thread_raises_integrity_error(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    session_a = _make_build_session(db_session)
+    session_b = _make_build_session(db_session)
+    team_id, channel_id, thread_ts = f"T-{uuid4()}", f"C-{uuid4()}", _random_thread_ts()
+
+    insert_slack_session_link(
+        db_session,
+        slack_team_id=team_id,
+        channel_id=channel_id,
+        thread_ts=thread_ts,
+        build_session_id=session_a.id,
+    )
+
+    with pytest.raises(IntegrityError):
+        insert_slack_session_link(
+            db_session,
+            slack_team_id=team_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+            build_session_id=session_b.id,
+        )
+
+    assert (
+        get_session_id_for_slack_thread(
+            db_session,
+            slack_team_id=team_id,
+            channel_id=channel_id,
+            thread_ts=thread_ts,
+        )
+        == session_a.id
+    )
+
+
+def test_same_thread_ts_different_channel_succeeds(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """The unique constraint is composite over all three columns, not just
+    thread_ts, so the same thread_ts under a different team/channel is fine."""
+    session_a = _make_build_session(db_session)
+    session_b = _make_build_session(db_session)
+    shared_thread_ts = _random_thread_ts()
+    team_a, channel_a = f"T-{uuid4()}", f"C-{uuid4()}"
+    team_b, channel_b = f"T-{uuid4()}", f"C-{uuid4()}"
+
+    insert_slack_session_link(
+        db_session,
+        slack_team_id=team_a,
+        channel_id=channel_a,
+        thread_ts=shared_thread_ts,
+        build_session_id=session_a.id,
+    )
+    insert_slack_session_link(
+        db_session,
+        slack_team_id=team_b,
+        channel_id=channel_b,
+        thread_ts=shared_thread_ts,
+        build_session_id=session_b.id,
+    )
+
+    assert (
+        get_session_id_for_slack_thread(
+            db_session,
+            slack_team_id=team_a,
+            channel_id=channel_a,
+            thread_ts=shared_thread_ts,
+        )
+        == session_a.id
+    )
+    assert (
+        get_session_id_for_slack_thread(
+            db_session,
+            slack_team_id=team_b,
+            channel_id=channel_b,
+            thread_ts=shared_thread_ts,
+        )
+        == session_b.id
+    )
+
+
+def test_duplicate_build_session_raises_integrity_error(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    build_session = _make_build_session(db_session)
+    team_a, channel_a, thread_ts_a = (
+        f"T-{uuid4()}",
+        f"C-{uuid4()}",
+        _random_thread_ts(),
+    )
+    team_b, channel_b, thread_ts_b = (
+        f"T-{uuid4()}",
+        f"C-{uuid4()}",
+        _random_thread_ts(),
+    )
+
+    insert_slack_session_link(
+        db_session,
+        slack_team_id=team_a,
+        channel_id=channel_a,
+        thread_ts=thread_ts_a,
+        build_session_id=build_session.id,
+    )
+
+    with pytest.raises(IntegrityError):
+        insert_slack_session_link(
+            db_session,
+            slack_team_id=team_b,
+            channel_id=channel_b,
+            thread_ts=thread_ts_b,
+            build_session_id=build_session.id,
+        )
+
+    assert (
+        get_session_id_for_slack_thread(
+            db_session,
+            slack_team_id=team_a,
+            channel_id=channel_a,
+            thread_ts=thread_ts_a,
+        )
+        == build_session.id
+    )

--- a/web/src/app/craft/types/streamingTypes.ts
+++ b/web/src/app/craft/types/streamingTypes.ts
@@ -4,7 +4,7 @@
 
 export type SharingScope = "private" | "public_org";
 
-export type SessionOrigin = "INTERACTIVE" | "SCHEDULED";
+export type SessionOrigin = "INTERACTIVE" | "SCHEDULED" | "SLACK";
 
 // =============================================================================
 // Session Error Constants


### PR DESCRIPTION
## Description

Second foundation task for the Craft Slackbot (stacked on #13050, which adds `SessionOrigin.SLACK`). Adds the `slack_session_link` table mapping `(slack_team_id, channel_id, thread_ts) -> build_session_id`, so an inbound Slack thread message can find its existing Craft `BuildSession` (thread continuation) or trigger creation of a new one. One Slack thread maps to exactly one `BuildSession` and vice versa (enforced by two unique constraints).

Scope is intentionally tight: table + migration + accessors + tests only. No Slack event handling, bot user, or API endpoints yet (later tasks).

Changes:
- `backend/onyx/db/models.py`: new `SlackSessionLink` model (composite unique constraint on the thread tuple, unique `build_session_id`, CASCADE FK to `build_session.id`).
- `backend/alembic/versions/716d0d180a2a_add_slack_session_link_table.py`: hand-written migration creating/dropping the table.
- `backend/onyx/db/slack_session_link.py`: accessors `get_session_id_for_slack_thread`, `insert_slack_session_link` (commits, lets `IntegrityError` propagate on a thread/session race after rolling back so the caller's session stays usable), `get_link_for_session`.
- `backend/tests/external_dependency_unit/craft/test_slack_session_link.py`: new external-dependency-unit tests.

## How Has This Been Tested?

- `alembic upgrade head` / `alembic downgrade -1` / `alembic upgrade head` all succeed cleanly against local Postgres.
- New external-dependency-unit test suite (real Postgres, no Onyx services) — 5 tests, all passing:
  - insert + lookup by thread and by session
  - lookup miss returns `None` for both accessors
  - duplicate thread raises `IntegrityError` and leaves the session usable afterward
  - same `thread_ts` under a different team/channel succeeds (proves the unique constraint is composite over all three columns, not just `thread_ts`)
  - duplicate `build_session_id` raises `IntegrityError` and leaves the session usable afterward
- Ran via `python -m dotenv -f .vscode/.env run -- pytest backend/tests/external_dependency_unit/craft/test_slack_session_link.py -xv`.
- Reviewed by a 2-lens agent team (correctness/data-access, test-coverage); correctness lens found nothing; test-coverage lens flagged two coverage gaps, both fixed (composite-uniqueness positive test, post-rollback session-usability assertions). Tests were also hardened to use randomized identifiers per run so they don't collide with leftover committed rows on rerun.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

**Stack:**
1. [craft-slack-session-origin #13050](https://github.com/onyx-dot-app/onyx/pull/13050)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `slack_thread__build_session` mapping to link a Slack thread (team, channel, thread_ts) to one BuildSession and prevent duplicates. Also adds `SessionOrigin.SLACK` so Slack sessions are headless and stay out of the Craft sidebar.

- **New Features**
  - New `slack_thread__build_session` table with composite unique on `(slack_team_id, channel_id, thread_ts)` and unique `build_session_id`; named constraints `uq_slack_thread__build_session_thread` and `uq_slack_thread__build_session_session`; CASCADE FK to `build_session.id`.
  - Accessors: `get_session_id_for_slack_thread`, `insert_slack_session_link` (raises `IntegrityError` and rolls back on conflicts), `get_link_for_session`.
  - Session lifecycle: added `SessionOrigin.SLACK`; excluded from sidebar queries, skip port allocation, and only reuse empty sessions for `INTERACTIVE`.
  - Alembic migration included.
  - Tests and types: external-dependency unit tests for insert/lookup/uniqueness and rollback usability; updated sidebar test to cover Slack; web `SessionOrigin` type now includes `"SLACK"`.

<sup>Written for commit 9999fb32ef6f93f6a2907192f573fd3f7fa68505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

