### PR TITLE
feat(craft): per-tenant Craft bot service-account user

### DIFF
--- a/backend/onyx/db/craft_bot_user.py
+++ b/backend/onyx/db/craft_bot_user.py
@@ -24,6 +24,9 @@ def get_or_create_craft_bot_user(db_session: Session) -> User:
     (unlike BOT/EXT_PERM_USER) still eligible for default-group assignment
     and further group membership, so admins can widen its search ACL later.
     No login is possible: the password hash is a random, discarded secret.
+
+    Does NOT commit — new rows are flushed only, and the caller owns the
+    transaction on both the creation and found-existing paths.
     """
     existing = db_session.scalar(
         select(User).where(User.email == CRAFT_BOT_EMAIL)  # ty: ignore[invalid-argument-type]
@@ -57,5 +60,5 @@ def get_or_create_craft_bot_user(db_session: Session) -> User:
         return existing
 
     assign_user_to_default_groups__no_commit(db_session, bot_user, is_admin=False)
-    db_session.commit()
+    db_session.flush()
     return bot_user

--- a/backend/onyx/db/craft_bot_user.py
+++ b/backend/onyx/db/craft_bot_user.py
@@ -1,0 +1,61 @@
+from fastapi_users.password import PasswordHelper
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.configs.constants import DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN
+from onyx.db.enums import AccountType
+from onyx.db.models import User
+from onyx.db.users import assign_user_to_default_groups__no_commit
+
+# Ends with the same sentinel domain as API-key dummy users, so every
+# existing "exclude API key users" filter (listing endpoints, admin UI,
+# live user counts) hides the bot for free.
+CRAFT_BOT_EMAIL = f"craft-slackbot@{DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN}"
+
+
+def get_or_create_craft_bot_user(db_session: Session) -> User:
+    """Return this tenant's Craft Slackbot service-account user, creating it
+    on first call. One bot user per tenant (tenant scoping comes from the
+    caller's schema, same as every other tenant-scoped query).
+
+    BASIC role + SERVICE_ACCOUNT account type: no admin capability, but
+    (unlike BOT/EXT_PERM_USER) still eligible for default-group assignment
+    and further group membership, so admins can widen its search ACL later.
+    No login is possible: the password hash is a random, discarded secret.
+    """
+    existing = db_session.scalar(
+        select(User).where(User.email == CRAFT_BOT_EMAIL)  # ty: ignore[invalid-argument-type]
+    )
+    if existing is not None:
+        return existing
+
+    password_helper = PasswordHelper()
+    bot_user = User(
+        email=CRAFT_BOT_EMAIL,
+        hashed_password=password_helper.hash(password_helper.generate()),
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+        role=UserRole.BASIC,
+        account_type=AccountType.SERVICE_ACCOUNT,
+    )
+    # Savepoint so a lost concurrent-create race only rolls back this insert,
+    # not the caller's other pending work in the same session.
+    savepoint = db_session.begin_nested()
+    try:
+        db_session.add(bot_user)
+        savepoint.commit()
+    except IntegrityError:
+        savepoint.rollback()
+        existing = db_session.scalar(
+            select(User).where(User.email == CRAFT_BOT_EMAIL)  # ty: ignore[invalid-argument-type]
+        )
+        if existing is None:
+            raise
+        return existing
+
+    assign_user_to_default_groups__no_commit(db_session, bot_user, is_admin=False)
+    db_session.commit()
+    return bot_user

--- a/backend/tests/external_dependency_unit/craft/test_craft_bot_user.py
+++ b/backend/tests/external_dependency_unit/craft/test_craft_bot_user.py
@@ -1,0 +1,124 @@
+"""The per-tenant Craft Slackbot service-account user, against a real Postgres.
+
+get_or_create_craft_bot_user must: be idempotent (one bot user per tenant),
+survive a concurrent-create race without clobbering the caller's session,
+produce a user that can never log in, and stay invisible to the existing
+user-facing listing queries (which already filter out API-key dummy users
+by sentinel email domain).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+
+import pytest
+from fastapi_users.password import PasswordHelper
+from sqlalchemy.orm import Session
+
+from onyx.db.craft_bot_user import CRAFT_BOT_EMAIL
+from onyx.db.craft_bot_user import get_or_create_craft_bot_user
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccountType
+from onyx.db.users import delete_user_from_db
+from onyx.db.users import get_all_accepted_users
+from onyx.db.users import get_page_of_filtered_users
+from onyx.db.users import get_user_by_email
+
+
+def _delete_bot_user() -> None:
+    with get_session_with_current_tenant() as session:
+        bot_user = get_user_by_email(CRAFT_BOT_EMAIL, session)
+        if bot_user is not None:
+            delete_user_from_db(bot_user, session)
+
+
+@pytest.fixture(autouse=True)
+def _clean_bot_user(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[None, None, None]:
+    """Delete the singleton bot row before and after so every run exercises
+    the creation path (not just the found-existing branch)."""
+    _delete_bot_user()
+    yield
+    db_session.rollback()
+    _delete_bot_user()
+
+
+def test_get_or_create_is_idempotent(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    first = get_or_create_craft_bot_user(db_session)
+    second = get_or_create_craft_bot_user(db_session)
+
+    assert first.id == second.id
+    assert first.email == CRAFT_BOT_EMAIL
+
+
+def test_concurrent_create_race_returns_winner(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Simulate losing the create race: another session inserts the bot row
+    between this session's existence check and its insert."""
+    real_helper = PasswordHelper()
+    winner_ids: list[object] = []
+    race_fired = False
+
+    class _RacingPasswordHelper:
+        def generate(self) -> str:
+            return real_helper.generate()
+
+        def hash(self, password: str) -> str:
+            # One-shot: only the outer (losing) call triggers the race,
+            # otherwise the winner's own call would recurse forever.
+            nonlocal race_fired
+            if not race_fired:
+                race_fired = True
+                with get_session_with_current_tenant() as other_session:
+                    winner = get_or_create_craft_bot_user(other_session)
+                    winner_ids.append(winner.id)
+            return real_helper.hash(password)
+
+    monkeypatch.setattr("onyx.db.craft_bot_user.PasswordHelper", _RacingPasswordHelper)
+
+    loser_result = get_or_create_craft_bot_user(db_session)
+
+    assert winner_ids == [loser_result.id]
+
+    # The losing session must stay usable after the rolled-back insert.
+    assert get_user_by_email(CRAFT_BOT_EMAIL, db_session) is not None
+    db_session.commit()
+
+
+def test_bot_user_cannot_log_in(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    bot_user = get_or_create_craft_bot_user(db_session)
+
+    assert bot_user.account_type == AccountType.SERVICE_ACCOUNT
+    assert not bot_user.oauth_accounts
+
+    # The password is generated and discarded; no guess can verify.
+    assert bot_user.hashed_password
+    password_helper = PasswordHelper()
+    verified, _ = password_helper.verify_and_update(
+        "password", bot_user.hashed_password
+    )
+    assert verified is False
+
+
+def test_bot_user_excluded_from_user_listings(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    bot_user = get_or_create_craft_bot_user(db_session)
+
+    accepted_users = get_all_accepted_users(db_session)
+    assert bot_user.id not in {user.id for user in accepted_users}
+
+    paginated_users = get_page_of_filtered_users(db_session, page_size=1000, page_num=0)
+    assert bot_user.id not in {user.id for user in paginated_users}

--- a/backend/tests/external_dependency_unit/craft/test_craft_bot_user.py
+++ b/backend/tests/external_dependency_unit/craft/test_craft_bot_user.py
@@ -79,6 +79,7 @@ def test_concurrent_create_race_returns_winner(
                 race_fired = True
                 with get_session_with_current_tenant() as other_session:
                     winner = get_or_create_craft_bot_user(other_session)
+                    other_session.commit()
                     winner_ids.append(winner.id)
             return real_helper.hash(password)
 


### PR DESCRIPTION
## Description

Foundation piece for the Craft Slackbot (Task 1: bot identity). Adds `get_or_create_craft_bot_user(db_session) -> User` in `backend/onyx/db/craft_bot_user.py`, an idempotent helper that provisions the per-tenant service-account Onyx user the Slackbot will run headless Craft sessions as.

Mirrors the existing API-key dummy-user pattern (`backend/onyx/db/api_key.py`):

- Sentinel email `craft-slackbot@onyxapikey.ai` on the existing dummy domain, so every existing "exclude API-key users" filter (admin user lists, live user counts, token-limit grouping) hides the bot with zero new filter code.
- Unusable password: a random generated secret is hashed and discarded; the user has no OAuth accounts, so no login path exists.
- `BASIC` role + `SERVICE_ACCOUNT` account type: no admin capability, blocked from role changes by `validate_user_role_update`, but joins the default Basic group and can be added to user groups so admins can widen its knowledge ACL later.
- Concurrent creation races are handled with a savepoint (`begin_nested`) + unique-email constraint, matching the `batch_add_ext_perm_user_if_not_exists` idiom — a lost race never rolls back the caller's other pending session state.

Not wired into any Slackbot setup path yet — that lands with the `CraftSlackBot` admin model in a follow-up.

## How Has This Been Tested?

New external-dependency-unit tests (`backend/tests/external_dependency_unit/craft/test_craft_bot_user.py`, real Postgres):

- idempotency: two calls return the same user
- concurrent-create race: a second session wins the insert between the existence check and flush; the loser returns the winner's row and its session stays usable
- no-login: SERVICE_ACCOUNT type, no OAuth accounts, password guess fails verification
- exclusion from both admin user-listing queries (`get_all_accepted_users`, `get_page_of_filtered_users`)

All 4 pass locally; `pre-commit` (ty, ruff, ruff format, etc.) green on changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `get_or_create_craft_bot_user` to provision a per-tenant service-account user for the Craft Slackbot’s headless sessions. The helper is idempotent, flush-only (no commit), excluded from admin lists, cannot log in, and is safe under concurrent calls.

- **New Features**
  - Idempotent bot user with sentinel email `craft-slackbot@onyxapikey.ai` so existing “exclude API-key users” filters hide it.
  - `BASIC` role + `SERVICE_ACCOUNT` type; auto-joins default Basic group and can be added to user groups to widen ACL.
  - Unusable password (random, hashed, discarded) and no OAuth accounts.
  - Flush-only helper; caller controls transactions. Concurrency-safe via savepoint; losers return the winner without rolling back other session work.
  - Tests cover idempotency, race handling, no-login, and exclusion from admin listing queries.

<sup>Written for commit f7b34edbc732e453d831a98c23fd523aa370f01e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. --> 