### PR TITLE
refactor(llm): move DYNAMIC_LLM_PROVIDERS to llm/constants

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -164,6 +164,19 @@ AGGREGATOR_PROVIDERS: set[str] = {
     LlmProviderNames.NEBIUS_TOKENFACTORY,
 }
 
+# Dynamic providers fetch models directly from source APIs (not LiteLLM).
+# A subset of AGGREGATOR_PROVIDERS.
+DYNAMIC_LLM_PROVIDERS: frozenset[str] = frozenset(
+    {
+        LlmProviderNames.OPENROUTER,
+        LlmProviderNames.BEDROCK,
+        LlmProviderNames.OLLAMA_CHAT,
+        LlmProviderNames.LM_STUDIO,
+        LlmProviderNames.BIFROST,
+        LlmProviderNames.OPENAI_COMPATIBLE,
+    }
+)
+
 # Model family name mappings for display name generation
 # Used by Bedrock display name generator
 BEDROCK_MODEL_NAME_MAPPINGS: dict[str, str] = {

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -11,10 +11,10 @@ from pydantic import Field
 from pydantic import field_validator
 
 from onyx.db.enums import LLMModelFlowType
+from onyx.llm.constants import DYNAMIC_LLM_PROVIDERS
 from onyx.llm.model_capabilities import get_max_input_tokens
 from onyx.llm.model_capabilities import litellm_thinks_model_supports_image_input
 from onyx.llm.model_capabilities import model_is_reasoning_model
-from onyx.server.manage.llm.utils import DYNAMIC_LLM_PROVIDERS
 from onyx.server.manage.llm.utils import extract_vendor_from_model_name
 from onyx.server.manage.llm.utils import filter_model_configurations
 from onyx.server.manage.llm.utils import is_reasoning_model

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -17,18 +17,6 @@ from onyx.llm.constants import OLLAMA_MODEL_NAME_MAPPINGS
 from onyx.llm.constants import OLLAMA_MODEL_TO_VENDOR
 from onyx.llm.constants import PROVIDER_DISPLAY_NAMES
 
-# Dynamic providers fetch models directly from source APIs (not LiteLLM)
-DYNAMIC_LLM_PROVIDERS = frozenset(
-    {
-        LlmProviderNames.OPENROUTER,
-        LlmProviderNames.BEDROCK,
-        LlmProviderNames.OLLAMA_CHAT,
-        LlmProviderNames.LM_STUDIO,
-        LlmProviderNames.BIFROST,
-        LlmProviderNames.OPENAI_COMPATIBLE,
-    }
-)
-
 
 class ModelMetadata(TypedDict):
     """Metadata about a model from the provider API."""


### PR DESCRIPTION
## Summary

Moves `DYNAMIC_LLM_PROVIDERS` from `backend/onyx/server/manage/llm/utils.py` into `backend/onyx/llm/constants.py`, next to the related `AGGREGATOR_PROVIDERS` (of which it is a subset).

### Why

- `DYNAMIC_LLM_PROVIDERS` is a **provider taxonomy** — the same kind of thing as `WELL_KNOWN_PROVIDER_NAMES` and `AGGREGATOR_PROVIDERS`, both of which already live in `onyx/llm/constants.py`. Keeping it in `server/manage/llm/utils.py` was an inconsistency.
- It depends only on `LlmProviderNames`, which is defined in `constants.py` — so it's more at home there. No circular-import risk (`constants.py` imports only `enum`).
- Placing it adjacent to `AGGREGATOR_PROVIDERS` documents that dynamic providers are the subset of aggregators that fetch models from source APIs rather than LiteLLM.

Pattern/behavior constants tied to functions in `utils.py` (`NON_LLM_PATTERNS`, `REASONING_MODEL_PATTERNS`) intentionally stay put — only the taxonomy moved.

## Changes

- `onyx/llm/constants.py`: add `DYNAMIC_LLM_PROVIDERS` after `AGGREGATOR_PROVIDERS`.
- `onyx/server/manage/llm/utils.py`: remove the definition.
- `onyx/server/manage/llm/models.py`: import from `onyx.llm.constants`.

## Testing

- `pytest tests/unit/onyx/server/manage/llm/test_model_configuration.py` — 16 passed.
- `pre-commit` (ty, ruff, ruff format) on changed files — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move `DYNAMIC_LLM_PROVIDERS` into `onyx/llm/constants.py` next to `AGGREGATOR_PROVIDERS` to keep provider taxonomies together. No behavior change; only the import path changed.

- **Refactors**
  - Added `DYNAMIC_LLM_PROVIDERS` to `backend/onyx/llm/constants.py`.
  - Removed its definition from `backend/onyx/server/manage/llm/utils.py`.
  - Updated import in `backend/onyx/server/manage/llm/models.py`.

<sup>Written for commit cc49004494ab46e37827ee3e7d221f6944416018. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

