### PR TITLE
feat(craft): grant Slack external app files:write:user for user-token uploads

### DIFF
--- a/backend/onyx/external_apps/providers/slack.py
+++ b/backend/onyx/external_apps/providers/slack.py
@@ -118,7 +118,7 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                     "channels:history",
                     "channels:read",
                     "chat:write",
-                    "files:write",
+                    "files:write:user",
                     "groups:history",
                     "groups:read",
                     "im:history",
@@ -165,7 +165,7 @@ class SlackProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                 "Permissions, add this Onyx instance's callback URL "
                 "(/craft/v1/apps/oauth/callback) to Redirect URLs, and add the "
                 "User Token Scopes you want the agent to use (channels:history, "
-                "channels:read, chat:write, files:write, groups:history, "
+                "channels:read, chat:write, files:write:user, groups:history, "
                 "groups:read, im:history, im:read, im:write, search:read, "
                 "users:read). No "
                 "bot user is required. Then paste the app's Client ID and "

--- a/backend/tests/unit/external_apps/test_slack_catalog.py
+++ b/backend/tests/unit/external_apps/test_slack_catalog.py
@@ -75,6 +75,7 @@ def test_default_policies(action: SlackAction, expected_policy: EndpointPolicy) 
 def test_files_write_scope_and_upstream_pattern() -> None:
     spec = SlackProvider.spec
     assert "files:write:user" in spec.oauth.scope.split(",")
+    assert "files:write" not in spec.oauth.scope.split(",")
     assert (
         "https://files\\.slack\\.com/upload/v1/.*"
         in spec.descriptor.upstream_url_patterns

--- a/backend/tests/unit/external_apps/test_slack_catalog.py
+++ b/backend/tests/unit/external_apps/test_slack_catalog.py
@@ -74,7 +74,7 @@ def test_default_policies(action: SlackAction, expected_policy: EndpointPolicy) 
 
 def test_files_write_scope_and_upstream_pattern() -> None:
     spec = SlackProvider.spec
-    assert "files:write" in spec.oauth.scope.split(",")
+    assert "files:write:user" in spec.oauth.scope.split(",")
     assert (
         "https://files\\.slack\\.com/upload/v1/.*"
         in spec.descriptor.upstream_url_patterns


### PR DESCRIPTION
## Summary

The Craft Slack external app authenticates with a **user token** (`scope_param="user_scope"`). Slack's file-upload flow (`files.getUploadURLExternal` / `files.completeUploadExternal`) was failing with `missing_scope` (`needed: files:write:user`) because the provider requested the bot-token scope name `files:write` instead of the user-token scope `files:write:user`.

## Changes
- Request `files:write:user` (was `files:write`) in the Slack provider's user OAuth scopes so file/image uploads work with the user token.
- Update the admin setup instructions to list `files:write:user` in the User Token Scopes.
- Update `test_slack_catalog.py` to assert the corrected scope.

## Testing
- `py_compile` on changed Python files.
- `pytest tests/unit/external_apps/test_slack_catalog.py` — all pass.
- Verified `SlackProvider.spec.oauth.scope` contains `files:write:user` and no longer contains `files:write`.

Fixes ENG-4289

Linear: https://linear.app/onyx-app/issue/ENG-4289/slack-app-missing-fileswriteuser-scope-blocks-fileimage-uploads

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Slack external app to request the user-token scope `files:write:user` instead of `files:write`, fixing missing_scope errors and enabling file/image uploads with user tokens. Updates admin setup instructions and the unit test to assert `files:write:user` is requested and `files:write` is not (Fixes ENG-4289).

<sup>Written for commit ddbc8b79ab7f1e1d65759074119209644898fb53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

