### PR TITLE
feat(pptx-skill): deterministic layout linter as QA step 0

### DIFF
--- a/backend/onyx/skills/builtin/pptx/SKILL.md
+++ b/backend/onyx/skills/builtin/pptx/SKILL.md
@@ -15,6 +15,7 @@ license: Proprietary. LICENSE.txt has complete terms
 | Read/analyze content | `python -m markitdown presentation.pptx` |
 | Edit or create from template | Read [editing.md](editing.md) |
 | Create from scratch | Read [pptxgenjs.md](pptxgenjs.md) |
+| Lint layout (QA step 0) | `python .opencode/skills/pptx/scripts/lint.py outputs/output.pptx` |
 
 ---
 
@@ -170,6 +171,19 @@ Use **Fira Code** for code samples or dense numeric/stat blocks.
 
 Your first render is almost never correct. Approach QA as a bug hunt, not a confirmation step. If you found zero issues on first inspection, you weren't looking hard enough.
 
+### Layout Lint (run first)
+
+Before any render or vision pass, run the deterministic layout linter — it catches the mechanical defects (off-slide shapes, sub-margin text, text overflow, overlapping text frames, low-contrast explicit colors, unknown fonts) with exact slide/shape references:
+
+```bash
+python .opencode/skills/pptx/scripts/lint.py outputs/output.pptx
+```
+
+- Exit 0 with `LINT_CLEAN` means no findings; nonzero means ERRORs exist.
+- **Fix every ERROR** before moving on. Review each WARN and fix it unless the layout is genuinely intentional (e.g., a deliberate design overlap).
+- Re-run after each fix batch — it's instant, so lint until clean before spending time on rendering.
+- The linter checks contrast only for explicit solid colors; text over images/gradients is skipped and noted — verify those visually.
+
 ### Content QA
 
 ```bash
@@ -196,17 +210,15 @@ Convert slides to images (see [Converting to Images](#converting-to-images)), th
 Visually inspect these slides. Assume there are issues — find them.
 
 Look for:
-- Overlapping elements (text through shapes, lines through words, stacked elements)
-- Text overflow or cut off at edges/box boundaries
 - Decorative lines positioned for single-line text but title wrapped to two lines
 - Source citations or footers colliding with content above
 - Elements too close (< 0.3" gaps) or cards/sections nearly touching
 - Uneven gaps (large empty area in one place, cramped in another)
-- Insufficient margin from slide edges (< 0.5")
 - Columns or similar elements not aligned consistently
-- Low-contrast text (e.g., light gray text on cream-colored background)
+- Low-contrast text over images or gradients (the linter can't check these)
 - Low-contrast icons (e.g., dark icons on dark backgrounds without a contrasting circle)
 - Text boxes too narrow causing excessive wrapping
+- Inconsistent styling across slides (fonts, colors, motifs drifting)
 - Leftover placeholder content
 
 For each slide, list issues or areas of concern, even if minor.
@@ -220,11 +232,12 @@ Report ALL issues found, including minor ones.
 
 ### Verification Loop
 
-1. Generate slides → Convert to images → Inspect
-2. **List issues found** (if none found, look again more critically)
-3. Fix issues
-4. **Re-verify affected slides** — one fix often creates another problem
-5. Repeat until a full pass reveals no new issues
+1. Generate slides → **Run `lint.py`** → fix every ERROR (and unjustified WARNs)
+2. Re-run lint after each fix batch — it's instant — until clean
+3. Convert to images → Inspect (subagent vision pass for the final aesthetic check)
+4. **List issues found** (if none found, look again more critically)
+5. Fix issues → **re-run lint** (one fix often creates another problem), then re-verify affected slides
+6. Repeat until lint is clean and a full visual pass reveals no new issues
 
 **Do not declare success until you've completed at least one fix-and-verify cycle.**
 

--- a/backend/onyx/skills/builtin/pptx/scripts/lint.py
+++ b/backend/onyx/skills/builtin/pptx/scripts/lint.py
@@ -1,0 +1,842 @@
+"""Deterministic layout linter for PowerPoint files.
+
+Statically checks a .pptx for mechanical layout defects that vision QA is
+slow and unreliable at catching:
+
+    BOUNDS    shape partially or fully off the slide canvas
+    MARGIN    text content closer than 0.5" to a slide edge
+    OVERFLOW  estimated text height/width exceeds its box (PIL font metrics)
+    OVERLAP   two text frames intersect, or text spills past its container
+    CONTRAST  explicit text color vs. resolved solid background below WCAG-ish
+              thresholds (image/theme backgrounds are skipped, not guessed)
+    FONT      run font not in the sandbox's known-available set
+
+Precision over recall: thresholds are lenient and intentional-overlap
+patterns (text over pictures, shape-in-shape containment, full-bleed
+backgrounds) are allowlisted. Rotated shapes and group internals are skipped
+for geometric checks.
+
+Output protocol (stdout):
+    Line 1: status — LINT_CLEAN, LINT_ISSUES <n_errors> <n_warnings>, or ERROR_NOT_FOUND
+    Lines 2+: one finding per line:
+        slide N | shape "Name" (id=K) | SEVERITY CHECK | detail | text: "snippet"
+
+Exit code: 1 if any ERROR finding, 0 otherwise (2 on usage error).
+
+Usage:
+    python lint.py /path/to/file.pptx
+"""
+
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from PIL import ImageFont
+from pptx import Presentation
+from pptx.enum.dml import MSO_COLOR_TYPE
+from pptx.enum.dml import MSO_FILL
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+from pptx.enum.text import MSO_AUTO_SIZE
+from pptx.util import Emu
+
+EMU_PER_INCH = 914400
+EMU_PER_PT = 12700
+
+# --- Thresholds (lenient by design) ---
+MARGIN_MIN_EMU = int(0.45 * EMU_PER_INCH)  # nominal 0.5", tolerance for rounding
+FULL_BLEED_FRACTION = 0.9  # shape covering >=90% of a slide dimension is exempt
+BOUNDS_OVERSHOOT_EMU = int(0.1 * EMU_PER_INCH)  # ignore bleed smaller than this
+BOUNDS_ERROR_FRACTION = 0.35  # >35% of shape area off-slide is an ERROR
+OVERFLOW_WARN_RATIO = 1.1  # est. content > 110% of box height
+OVERFLOW_ERROR_RATIO = 1.35
+OVERLAP_MIN_DIM_EMU = int(0.1 * EMU_PER_INCH)
+OVERLAP_MIN_AREA_FRACTION = 0.15  # of the smaller shape
+CONTAINER_SPILL_EMU = int(0.1 * EMU_PER_INCH)
+CONTRAST_ERROR_RATIO = 2.5
+CONTRAST_WARN_RATIO = 3.5  # slides are mostly large text; WCAG AA-large is 3:1
+FOOTER_MAX_HEIGHT_EMU = int(0.4 * EMU_PER_INCH)
+FOOTER_ZONE_FRACTION = 0.85  # shapes starting in the bottom 15% are footers
+LINE_SPACING_FACTOR = 1.2
+MEASURE_SCALE = 4  # render fonts at 4x pt size for sub-pixel width precision
+
+# Fonts installed (or metric-substituted) in the sandbox image, per SKILL.md.
+KNOWN_FONTS = {
+    "inter",
+    "montserrat",
+    "lato",
+    "eb garamond",
+    "fira code",
+    "calibri",
+    "cambria",
+    "arial",
+    "arial black",
+    "times new roman",
+    "liberation sans",
+    "liberation serif",
+    "liberation mono",
+    "carlito",
+    "caladea",
+    "dejavu sans",
+    "dejavu serif",
+    "dejavu sans mono",
+}
+
+_NSMAP = {
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+}
+
+
+@dataclass
+class Finding:
+    slide: int  # 1-based
+    shape_name: str
+    shape_id: int
+    severity: str  # ERROR | WARN
+    check: str
+    detail: str
+    text: str = ""
+
+    def render(self) -> str:
+        line = (
+            f'slide {self.slide} | shape "{self.shape_name}" (id={self.shape_id})'
+            f" | {self.severity} {self.check} | {self.detail}"
+        )
+        if self.text:
+            snippet = self.text.replace("\n", " ").strip()
+            if len(snippet) > 40:
+                snippet = snippet[:40] + "…"
+            line += f' | text: "{snippet}"'
+        return line
+
+
+@dataclass
+class Box:
+    left: int
+    top: int
+    width: int
+    height: int
+
+    @property
+    def right(self) -> int:
+        return self.left + self.width
+
+    @property
+    def bottom(self) -> int:
+        return self.top + self.height
+
+    @property
+    def area(self) -> int:
+        return max(self.width, 0) * max(self.height, 0)
+
+    def intersect(self, other: "Box") -> "Box":
+        left = max(self.left, other.left)
+        top = max(self.top, other.top)
+        right = min(self.right, other.right)
+        bottom = min(self.bottom, other.bottom)
+        return Box(left, top, max(right - left, 0), max(bottom - top, 0))
+
+    def contains(self, other: "Box") -> bool:
+        return (
+            self.left <= other.left
+            and self.top <= other.top
+            and self.right >= other.right
+            and self.bottom >= other.bottom
+        )
+
+    def contains_point(self, x: float, y: float) -> bool:
+        return self.left <= x <= self.right and self.top <= y <= self.bottom
+
+
+def _shape_box(shape) -> Box | None:
+    try:
+        left, top = shape.left, shape.top
+        width, height = shape.width, shape.height
+    except (AttributeError, TypeError, ValueError):
+        return None
+    if None in (left, top, width, height):
+        return None
+    return Box(int(left), int(top), int(width), int(height))
+
+
+def _is_rotated(shape) -> bool:
+    try:
+        return bool(shape.rotation) and abs(shape.rotation) % 360 > 1
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _shape_text(shape) -> str:
+    if getattr(shape, "has_text_frame", False):
+        return shape.text_frame.text
+    return ""
+
+
+def _is_full_bleed(box: Box, slide_w: int, slide_h: int) -> bool:
+    return (
+        box.width >= FULL_BLEED_FRACTION * slide_w
+        and box.height >= FULL_BLEED_FRACTION * slide_h
+    )
+
+
+def _is_picture(shape) -> bool:
+    return shape.shape_type in (MSO_SHAPE_TYPE.PICTURE, MSO_SHAPE_TYPE.LINKED_PICTURE)
+
+
+def _is_line(shape) -> bool:
+    return shape.shape_type == MSO_SHAPE_TYPE.LINE
+
+
+# --- Font measurement -------------------------------------------------------
+
+_font_file_cache: dict[tuple[str, bool], str | None] = {}
+_font_cache: dict[tuple[str, bool, int], ImageFont.ImageFont] = {}
+_HAS_FC_MATCH = shutil.which("fc-match") is not None
+
+
+def _find_font_file(family: str, bold: bool) -> str | None:
+    key = (family.lower(), bold)
+    if key in _font_file_cache:
+        return _font_file_cache[key]
+    path: str | None = None
+    if _HAS_FC_MATCH:
+        pattern = f"{family}:weight={'bold' if bold else 'regular'}"
+        try:
+            result = subprocess.run(
+                ["fc-match", "-f", "%{file}", pattern],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                path = result.stdout.strip()
+        except (OSError, subprocess.SubprocessError):
+            path = None
+    _font_file_cache[key] = path
+    return path
+
+
+def _load_font(family: str, size_pt: float, bold: bool) -> ImageFont.ImageFont:
+    px = max(int(round(size_pt * MEASURE_SCALE)), 4)
+    key = (family.lower(), bold, px)
+    cached = _font_cache.get(key)
+    if cached is not None:
+        return cached
+    font: ImageFont.ImageFont | None = None
+    path = _find_font_file(family, bold)
+    if path:
+        try:
+            font = ImageFont.truetype(path, px)
+        except OSError:
+            font = None
+    if font is None:
+        try:
+            font = ImageFont.load_default(px)  # scalable since Pillow 10.1
+        except TypeError:
+            font = ImageFont.load_default()
+    _font_cache[key] = font
+    return font
+
+
+def _text_width_pt(text: str, font: ImageFont.ImageFont, size_pt: float) -> float:
+    try:
+        return float(font.getlength(text)) / MEASURE_SCALE
+    except AttributeError:
+        # Bitmap fallback font: approximate with an average glyph width.
+        return len(text) * size_pt * 0.55
+
+
+# --- Paragraph layout estimation --------------------------------------------
+
+
+def _run_size_pt(run, para) -> float | None:
+    size = run.font.size
+    if size is None:
+        size = para.font.size
+    return float(size.pt) if size is not None else None
+
+
+def _para_font(para) -> tuple[str, float, bool] | None:
+    """Dominant (family, size_pt, bold) for a paragraph.
+
+    Returns None when no run carries an explicit size — inherited sizes
+    (theme/master/layout) are not resolved, and guessing produces false
+    overflow findings.
+    """
+    family = "Inter"
+    size_pt = 0.0
+    bold = False
+    for run in para.runs:
+        rs = _run_size_pt(run, para)
+        if rs is not None and rs > size_pt:
+            size_pt = rs
+            family = run.font.name or para.font.name or family
+            bold = bool(run.font.bold)
+    if size_pt == 0.0:
+        pf = para.font
+        if pf.size is None:
+            return None
+        size_pt = float(pf.size.pt)
+        family = pf.name or family
+        bold = bool(pf.bold)
+    return family, size_pt, bold
+
+
+def _wrap_line_count(text: str, usable_w_pt: float, font, size_pt: float) -> int:
+    if not text.strip():
+        return 1
+    lines = 1
+    current = 0.0
+    space_w = _text_width_pt(" ", font, size_pt)
+    for word in text.split():
+        w = _text_width_pt(word, font, size_pt)
+        w = min(w, usable_w_pt)  # a single over-wide word char-wraps; don't explode
+        if current > 0 and current + space_w + w > usable_w_pt:
+            lines += 1
+            current = w
+        else:
+            current = current + (space_w if current > 0 else 0.0) + w
+    return lines
+
+
+def _estimate_text_extent(shape, box: Box) -> tuple[float, float, float, float] | None:
+    """Return (est_height_emu, avail_height_emu, max_line_w_pt, usable_w_pt).
+
+    Returns None when any paragraph's font size can't be resolved from
+    explicit run/paragraph properties — the estimate would be a guess.
+    """
+    tf = shape.text_frame
+    usable_w_emu = box.width - int(tf.margin_left or 0) - int(tf.margin_right or 0)
+    avail_h_emu = box.height - int(tf.margin_top or 0) - int(tf.margin_bottom or 0)
+    usable_w_pt = max(usable_w_emu / EMU_PER_PT, 1.0)
+    wrap = tf.word_wrap is not False  # None (inherit) treated as wrapping
+
+    est_h_pt = 0.0
+    max_line_w_pt = 0.0
+    min_line_h_pt: float | None = None
+    for para in tf.paragraphs:
+        if not "".join(run.text for run in para.runs).strip():
+            continue  # blank spacer paragraph at unknown size — ignore
+        para_font = _para_font(para)
+        if para_font is None:
+            return None
+        family, size_pt, bold = para_font
+        font = _load_font(family, size_pt, bold)
+        text = "".join(run.text for run in para.runs)
+        if wrap:
+            lines = _wrap_line_count(text, usable_w_pt, font, size_pt)
+        else:
+            lines = 1
+            max_line_w_pt = max(max_line_w_pt, _text_width_pt(text, font, size_pt))
+        line_h = size_pt * LINE_SPACING_FACTOR
+        spacing = para.line_spacing
+        if isinstance(spacing, float):
+            line_h = size_pt * LINE_SPACING_FACTOR * spacing
+        elif spacing is not None:  # Length
+            line_h = float(spacing.pt)
+        est_h_pt += lines * line_h
+        min_line_h_pt = line_h if min_line_h_pt is None else min(min_line_h_pt, line_h)
+        if para.space_before is not None:
+            est_h_pt += float(para.space_before.pt)
+        if para.space_after is not None:
+            est_h_pt += float(para.space_after.pt)
+    if min_line_h_pt is not None and avail_h_emu < 0.9 * min_line_h_pt * EMU_PER_PT:
+        # Box can't even fit one line: an intentional anchor/label pattern
+        # where text deliberately renders past the box, not a layout bug.
+        return None
+    return est_h_pt * EMU_PER_PT, float(avail_h_emu), max_line_w_pt, usable_w_pt
+
+
+# --- Color / contrast helpers ------------------------------------------------
+
+
+def _rel_luminance(rgb: tuple[int, int, int]) -> float:
+    def channel(c: int) -> float:
+        v = c / 255.0
+        return v / 12.92 if v <= 0.03928 else ((v + 0.055) / 1.055) ** 2.4
+
+    r, g, b = (channel(c) for c in rgb)
+    return 0.2126 * r + 0.7152 * g + 0.0722 * b
+
+
+def _contrast_ratio(a: tuple[int, int, int], b: tuple[int, int, int]) -> float:
+    la, lb = _rel_luminance(a), _rel_luminance(b)
+    lighter, darker = max(la, lb), min(la, lb)
+    return (lighter + 0.05) / (darker + 0.05)
+
+
+def _solid_fill_rgb(shape) -> tuple[int, int, int] | None:
+    try:
+        fill = shape.fill
+        if fill.type != MSO_FILL.SOLID:
+            return None
+        color = fill.fore_color
+        if color.type != MSO_COLOR_TYPE.RGB:
+            return None
+        rgb = color.rgb
+        return (rgb[0], rgb[1], rgb[2])
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _fill_state(shape) -> str:
+    """Classify a shape's fill: "solid_rgb", "none", or "unresolvable"."""
+    try:
+        fill = shape.fill
+    except (AttributeError, TypeError, ValueError):
+        return "unresolvable"  # groups etc. — children could paint anything
+    try:
+        fill_type = fill.type
+    except (AttributeError, TypeError, ValueError):
+        return "unresolvable"
+    if fill_type in (None, MSO_FILL.BACKGROUND):
+        return "none"
+    if fill_type == MSO_FILL.SOLID:
+        try:
+            if fill.fore_color.type == MSO_COLOR_TYPE.RGB:
+                return "solid_rgb"
+        except (AttributeError, TypeError, ValueError):
+            pass
+        return "unresolvable"  # theme-colored solid — not resolved here
+    return "unresolvable"  # gradient / pattern / picture fill
+
+
+def _slide_background_rgb(slide) -> tuple[int, int, int] | None:
+    try:
+        fill = slide.background.fill
+        if fill.type != MSO_FILL.SOLID:
+            return None
+        color = fill.fore_color
+        if color.type != MSO_COLOR_TYPE.RGB:
+            return None
+        rgb = color.rgb
+        return (rgb[0], rgb[1], rgb[2])
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+def _run_rgb(run) -> tuple[int, int, int] | None:
+    try:
+        color = run.font.color
+        if color.type != MSO_COLOR_TYPE.RGB:
+            return None
+        rgb = color.rgb
+        return (rgb[0], rgb[1], rgb[2])
+    except (AttributeError, TypeError, ValueError):
+        return None
+
+
+# --- Checks -------------------------------------------------------------------
+
+
+def check_bounds(
+    slide_no: int, shapes: list, slide_w: int, slide_h: int
+) -> list[Finding]:
+    findings: list[Finding] = []
+    slide_box = Box(0, 0, slide_w, slide_h)
+    for shape, box in shapes:
+        if _is_full_bleed(box, slide_w, slide_h):
+            continue
+        if box.area == 0:
+            continue
+        clipped = box.intersect(slide_box)
+        outside_fraction = 1.0 - clipped.area / box.area
+        if outside_fraction <= 0.0:
+            continue
+        overshoot = max(
+            0 - box.left,
+            0 - box.top,
+            box.right - slide_w,
+            box.bottom - slide_h,
+        )
+        if outside_fraction < 0.02 or overshoot <= BOUNDS_OVERSHOOT_EMU:
+            continue
+        is_content = bool(_shape_text(shape).strip()) or _is_picture(shape)
+        if not is_content:
+            # Decorative shapes (freeforms, groups, accent blobs) bleeding off
+            # the edge is an intentional design technique — only flag when the
+            # shape is mostly off-slide.
+            if outside_fraction <= 0.5:
+                continue
+            severity = "WARN"
+        else:
+            severity = "ERROR" if outside_fraction > BOUNDS_ERROR_FRACTION else "WARN"
+        findings.append(
+            Finding(
+                slide_no,
+                shape.name,
+                shape.shape_id,
+                severity,
+                "BOUNDS",
+                f"{outside_fraction:.0%} of shape is off-slide "
+                f'(overshoot {overshoot / EMU_PER_INCH:.2f}")',
+                _shape_text(shape),
+            )
+        )
+    return findings
+
+
+def check_margins(
+    slide_no: int, shapes: list, slide_w: int, slide_h: int
+) -> list[Finding]:
+    findings: list[Finding] = []
+    for shape, box in shapes:
+        text = _shape_text(shape).strip()
+        if not text:
+            continue  # only text content; decorative shapes may touch edges
+        if (
+            box.height <= FOOTER_MAX_HEIGHT_EMU
+            and box.top >= FOOTER_ZONE_FRACTION * slide_h
+        ):
+            continue  # footer strips (page numbers, dates) legitimately hug edges
+        exempt_h = box.width >= FULL_BLEED_FRACTION * slide_w
+        exempt_v = box.height >= FULL_BLEED_FRACTION * slide_h
+        edges = {
+            "left": box.left,
+            "right": slide_w - box.right,
+            "top": box.top,
+            "bottom": slide_h - box.bottom,
+        }
+        bad = [
+            (name, dist)
+            for name, dist in edges.items()
+            if 0 <= dist < MARGIN_MIN_EMU
+            and not (exempt_h and name in ("left", "right"))
+            and not (exempt_v and name in ("top", "bottom"))
+        ]
+        if bad:
+            desc = ", ".join(f'{name} {dist / EMU_PER_INCH:.2f}"' for name, dist in bad)
+            findings.append(
+                Finding(
+                    slide_no,
+                    shape.name,
+                    shape.shape_id,
+                    "WARN",
+                    "MARGIN",
+                    f'text within 0.5" of slide edge ({desc})',
+                    text,
+                )
+            )
+    return findings
+
+
+def check_overflow(slide_no: int, shapes: list) -> list[Finding]:
+    findings: list[Finding] = []
+    for shape, box in shapes:
+        if not getattr(shape, "has_text_frame", False):
+            continue
+        tf = shape.text_frame
+        if not tf.text.strip():
+            continue
+        if tf.auto_size in (
+            MSO_AUTO_SIZE.TEXT_TO_FIT_SHAPE,
+            MSO_AUTO_SIZE.SHAPE_TO_FIT_TEXT,
+        ):
+            continue  # PowerPoint will shrink text / grow the box
+        extent = _estimate_text_extent(shape, box)
+        if extent is None:
+            continue  # inherited font sizes — estimate would be a guess
+        est_h, avail_h, max_line_w_pt, usable_w_pt = extent
+        if avail_h <= 0:
+            continue
+        if tf.word_wrap is False:
+            if max_line_w_pt > 1.1 * usable_w_pt:
+                findings.append(
+                    Finding(
+                        slide_no,
+                        shape.name,
+                        shape.shape_id,
+                        "WARN",
+                        "OVERFLOW",
+                        f"no-wrap text est. {max_line_w_pt:.0f}pt wide in "
+                        f"{usable_w_pt:.0f}pt box",
+                        tf.text,
+                    )
+                )
+            continue
+        ratio = est_h / avail_h
+        if ratio <= OVERFLOW_WARN_RATIO:
+            continue
+        severity = "ERROR" if ratio > OVERFLOW_ERROR_RATIO else "WARN"
+        findings.append(
+            Finding(
+                slide_no,
+                shape.name,
+                shape.shape_id,
+                severity,
+                "OVERFLOW",
+                f'est. text height {est_h / EMU_PER_INCH:.2f}" in '
+                f'{avail_h / EMU_PER_INCH:.2f}" box ({ratio:.0%})',
+                tf.text,
+            )
+        )
+    return findings
+
+
+def check_overlap(
+    slide_no: int, shapes: list, slide_w: int, slide_h: int
+) -> list[Finding]:
+    findings: list[Finding] = []
+    slide_area = slide_w * slide_h
+
+    def _box_is_authoritative(shape) -> bool:
+        # spAutoFit boxes get resized by PowerPoint at render time; the stored
+        # bbox routinely overhangs the actual text and yields false overlaps.
+        if not getattr(shape, "has_text_frame", False):
+            return True
+        return shape.text_frame.auto_size != MSO_AUTO_SIZE.SHAPE_TO_FIT_TEXT
+
+    text_shapes = [
+        (i, shape, box)
+        for i, (shape, box) in enumerate(shapes)
+        if _shape_text(shape).strip()
+        and not _is_full_bleed(box, slide_w, slide_h)
+        and _box_is_authoritative(shape)
+    ]
+
+    # Text frame on text frame (partial intersection only; containment allowed).
+    for a in range(len(text_shapes)):
+        for b in range(a + 1, len(text_shapes)):
+            _, shape_a, box_a = text_shapes[a]
+            _, shape_b, box_b = text_shapes[b]
+            if box_a.contains(box_b) or box_b.contains(box_a):
+                continue
+            inter = box_a.intersect(box_b)
+            if inter.width < OVERLAP_MIN_DIM_EMU or inter.height < OVERLAP_MIN_DIM_EMU:
+                continue
+            smaller_area = min(box_a.area, box_b.area)
+            if (
+                smaller_area == 0
+                or inter.area < OVERLAP_MIN_AREA_FRACTION * smaller_area
+            ):
+                continue
+            findings.append(
+                Finding(
+                    slide_no,
+                    shape_a.name,
+                    shape_a.shape_id,
+                    "ERROR",
+                    "OVERLAP",
+                    f'text frames intersect: overlaps shape "{shape_b.name}" '
+                    f"(id={shape_b.shape_id}) by "
+                    f'{inter.width / EMU_PER_INCH:.2f}" x '
+                    f'{inter.height / EMU_PER_INCH:.2f}"',
+                    _shape_text(shape_a),
+                )
+            )
+
+    # Text spilling past a smaller container shape it sits on (card pattern).
+    for _, text_shape, text_box in text_shapes:
+        cx = text_box.left + text_box.width / 2
+        cy = text_box.top + text_box.height / 2
+        for container, cbox in shapes:
+            if container is text_shape:
+                continue
+            if _is_picture(container) or _is_line(container):
+                continue
+            if _shape_text(container).strip():
+                continue  # text-on-text handled above
+            if cbox.area == 0 or cbox.area > 0.5 * slide_area:
+                continue  # background-sized shapes are fine to overhang
+            if not cbox.contains_point(cx, cy):
+                continue
+            if cbox.contains(text_box):
+                continue
+            spill = max(
+                cbox.left - text_box.left,
+                cbox.top - text_box.top,
+                text_box.right - cbox.right,
+                text_box.bottom - cbox.bottom,
+            )
+            if spill <= CONTAINER_SPILL_EMU:
+                continue
+            findings.append(
+                Finding(
+                    slide_no,
+                    text_shape.name,
+                    text_shape.shape_id,
+                    "WARN",
+                    "OVERLAP",
+                    f'text extends {spill / EMU_PER_INCH:.2f}" beyond container '
+                    f'shape "{container.name}" (id={container.shape_id})',
+                    _shape_text(text_shape),
+                )
+            )
+    return findings
+
+
+def check_contrast(slide_no: int, slide, shapes: list) -> tuple[list[Finding], int]:
+    """Returns (findings, skipped_run_count)."""
+    findings: list[Finding] = []
+    skipped = 0
+    slide_bg = _slide_background_rgb(slide)
+
+    for idx, (shape, box) in enumerate(shapes):
+        if not getattr(shape, "has_text_frame", False):
+            continue
+        if not shape.text_frame.text.strip():
+            continue
+        # Resolve the effective solid background behind this shape by walking
+        # down the z-order. Stop at the first shape that visibly paints under
+        # the text: solid RGB fill → usable; picture / gradient / theme /
+        # group → unresolvable (skip, never guess past it); no fill → keep
+        # walking.
+        bg: tuple[int, int, int] | None = None
+        unresolvable = False
+        cx = box.left + box.width / 2
+        cy = box.top + box.height / 2
+        for j in range(idx, -1, -1):  # include the shape's own fill first
+            other, obox = shapes[j]
+            if other is not shape and not obox.contains_point(cx, cy):
+                continue
+            if _is_picture(other):
+                unresolvable = True
+                break
+            fill_state = _fill_state(other)
+            if fill_state == "none":
+                continue
+            if fill_state == "unresolvable":
+                unresolvable = True
+                break
+            bg = _solid_fill_rgb(other)
+            break
+        if bg is None and not unresolvable:
+            bg = slide_bg
+
+        for para in shape.text_frame.paragraphs:
+            for run in para.runs:
+                if not run.text.strip():
+                    continue
+                fg = _run_rgb(run)
+                if fg is None:
+                    continue  # theme/inherited color — out of scope
+                if bg is None:
+                    skipped += 1
+                    continue
+                ratio = _contrast_ratio(fg, bg)
+                if ratio >= CONTRAST_WARN_RATIO:
+                    continue
+                severity = "ERROR" if ratio < CONTRAST_ERROR_RATIO else "WARN"
+                findings.append(
+                    Finding(
+                        slide_no,
+                        shape.name,
+                        shape.shape_id,
+                        severity,
+                        "CONTRAST",
+                        f"contrast {ratio:.1f}:1 "
+                        f"(text #{fg[0]:02X}{fg[1]:02X}{fg[2]:02X} on "
+                        f"#{bg[0]:02X}{bg[1]:02X}{bg[2]:02X})",
+                        run.text,
+                    )
+                )
+    return findings, skipped
+
+
+def _embedded_font_names(prs) -> set[str]:
+    try:
+        elements = prs.part._element.findall(
+            "p:embeddedFontLst/p:embeddedFont/p:font", _NSMAP
+        )
+        return {e.get("typeface", "").lower() for e in elements if e.get("typeface")}
+    except (AttributeError, ValueError):
+        return set()
+
+
+def check_fonts(prs) -> list[Finding]:
+    available = KNOWN_FONTS | _embedded_font_names(prs)
+    findings: list[Finding] = []
+    seen: set[str] = set()
+    for slide_no, slide in enumerate(prs.slides, start=1):
+        for shape in slide.shapes:
+            if not getattr(shape, "has_text_frame", False):
+                continue
+            for para in shape.text_frame.paragraphs:
+                names = [para.font.name] + [run.font.name for run in para.runs]
+                for name in names:
+                    if not name or name.startswith("+"):
+                        continue  # theme font references resolve fine
+                    if name.lower() in available or name.lower() in seen:
+                        continue
+                    seen.add(name.lower())
+                    findings.append(
+                        Finding(
+                            slide_no,
+                            shape.name,
+                            shape.shape_id,
+                            "WARN",
+                            "FONT",
+                            f'font "{name}" is not installed in the sandbox — '
+                            "it will silently render as a fallback font",
+                        )
+                    )
+    return findings
+
+
+# --- Driver -------------------------------------------------------------------
+
+
+def lint_presentation(prs) -> tuple[list[Finding], int]:
+    """Lint an open Presentation. Returns (findings, contrast_skipped_runs)."""
+    slide_w = int(prs.slide_width or Emu(int(10 * EMU_PER_INCH)))
+    slide_h = int(prs.slide_height or Emu(int(7.5 * EMU_PER_INCH)))
+
+    findings: list[Finding] = []
+    total_skipped = 0
+    for slide_no, slide in enumerate(prs.slides, start=1):
+        shapes: list = []
+        for shape in slide.shapes:
+            box = _shape_box(shape)
+            if box is None or _is_rotated(shape):
+                continue
+            shapes.append((shape, box))
+
+        findings.extend(check_bounds(slide_no, shapes, slide_w, slide_h))
+        findings.extend(check_margins(slide_no, shapes, slide_w, slide_h))
+        findings.extend(check_overflow(slide_no, shapes))
+        findings.extend(check_overlap(slide_no, shapes, slide_w, slide_h))
+        contrast_findings, skipped = check_contrast(slide_no, slide, shapes)
+        findings.extend(contrast_findings)
+        total_skipped += skipped
+
+    findings.extend(check_fonts(prs))
+    findings.sort(key=lambda f: (f.slide, 0 if f.severity == "ERROR" else 1, f.check))
+    return findings, total_skipped
+
+
+def lint_file(path: Path) -> tuple[list[Finding], int]:
+    return lint_presentation(Presentation(str(path)))
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print(f"Usage: {sys.argv[0]} <pptx_path>", file=sys.stderr)
+        sys.exit(2)
+
+    pptx_path = Path(sys.argv[1])
+    if not pptx_path.is_file():
+        print("ERROR_NOT_FOUND")
+        sys.exit(1)
+
+    findings, contrast_skipped = lint_file(pptx_path)
+    errors = sum(1 for f in findings if f.severity == "ERROR")
+    warnings = sum(1 for f in findings if f.severity == "WARN")
+
+    if not findings:
+        print("LINT_CLEAN")
+    else:
+        print(f"LINT_ISSUES {errors} {warnings}")
+        for finding in findings:
+            print(finding.render())
+    if contrast_skipped:
+        print(
+            f"note: contrast skipped for {contrast_skipped} run(s) over "
+            "image/unresolvable backgrounds — verify those visually"
+        )
+    sys.exit(1 if errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/onyx/skills/builtin/pptx/scripts/lint.py
+++ b/backend/onyx/skills/builtin/pptx/scripts/lint.py
@@ -39,6 +39,7 @@ from pptx.enum.dml import MSO_COLOR_TYPE
 from pptx.enum.dml import MSO_FILL
 from pptx.enum.shapes import MSO_SHAPE_TYPE
 from pptx.enum.text import MSO_AUTO_SIZE
+from pptx.shapes.base import BaseShape
 from pptx.util import Emu
 
 EMU_PER_INCH = 914400
@@ -175,9 +176,14 @@ def _shape_text(shape) -> str:
 
 
 def _is_full_bleed(box: Box, slide_w: int, slide_h: int) -> bool:
+    # A shape only counts as a full-bleed background if it actually covers the
+    # slide — full-bleed dimensions with most of the area off-slide don't qualify.
+    clipped = box.intersect(Box(0, 0, slide_w, slide_h))
     return (
         box.width >= FULL_BLEED_FRACTION * slide_w
         and box.height >= FULL_BLEED_FRACTION * slide_h
+        and box.area > 0
+        and clipped.area >= FULL_BLEED_FRACTION * box.area
     )
 
 
@@ -284,20 +290,26 @@ def _para_font(para) -> tuple[str, float, bool] | None:
     return family, size_pt, bold
 
 
-def _wrap_line_count(text: str, usable_w_pt: float, font, size_pt: float) -> int:
+def _wrap_line_count(
+    text: str, usable_w_pt: float, font: ImageFont.ImageFont, size_pt: float
+) -> int:
     if not text.strip():
         return 1
-    lines = 1
-    current = 0.0
+    lines = 0
     space_w = _text_width_pt(" ", font, size_pt)
-    for word in text.split():
-        w = _text_width_pt(word, font, size_pt)
-        w = min(w, usable_w_pt)  # a single over-wide word char-wraps; don't explode
-        if current > 0 and current + space_w + w > usable_w_pt:
-            lines += 1
-            current = w
-        else:
-            current = current + (space_w if current > 0 else 0.0) + w
+    # Hard line breaks (a:br) surface as "\v" in python-pptx paragraph text.
+    for hard_line in text.replace("\v", "\n").split("\n"):
+        lines += 1
+        current = 0.0
+        for word in hard_line.split():
+            w = _text_width_pt(word, font, size_pt)
+            # a single over-wide word char-wraps; don't explode
+            w = min(w, usable_w_pt)
+            if current > 0 and current + space_w + w > usable_w_pt:
+                lines += 1
+                current = w
+            else:
+                current = current + (space_w if current > 0 else 0.0) + w
     return lines
 
 
@@ -317,19 +329,24 @@ def _estimate_text_extent(shape, box: Box) -> tuple[float, float, float, float] 
     max_line_w_pt = 0.0
     min_line_h_pt: float | None = None
     for para in tf.paragraphs:
-        if not "".join(run.text for run in para.runs).strip():
+        # para.text includes hard line breaks (a:br) as "\v", unlike para.runs.
+        text = para.text
+        if not text.strip():
             continue  # blank spacer paragraph at unknown size — ignore
         para_font = _para_font(para)
         if para_font is None:
             return None
         family, size_pt, bold = para_font
         font = _load_font(family, size_pt, bold)
-        text = "".join(run.text for run in para.runs)
         if wrap:
             lines = _wrap_line_count(text, usable_w_pt, font, size_pt)
         else:
-            lines = 1
-            max_line_w_pt = max(max_line_w_pt, _text_width_pt(text, font, size_pt))
+            hard_lines = text.replace("\v", "\n").split("\n")
+            lines = len(hard_lines)
+            max_line_w_pt = max(
+                max_line_w_pt,
+                max(_text_width_pt(ln, font, size_pt) for ln in hard_lines),
+            )
         line_h = size_pt * LINE_SPACING_FACTOR
         spacing = para.line_spacing
         if isinstance(spacing, float):
@@ -432,7 +449,7 @@ def _run_rgb(run) -> tuple[int, int, int] | None:
 
 
 def check_bounds(
-    slide_no: int, shapes: list, slide_w: int, slide_h: int
+    slide_no: int, shapes: list[tuple[BaseShape, Box]], slide_w: int, slide_h: int
 ) -> list[Finding]:
     findings: list[Finding] = []
     slide_box = Box(0, 0, slide_w, slide_h)
@@ -479,7 +496,7 @@ def check_bounds(
 
 
 def check_margins(
-    slide_no: int, shapes: list, slide_w: int, slide_h: int
+    slide_no: int, shapes: list[tuple[BaseShape, Box]], slide_w: int, slide_h: int
 ) -> list[Finding]:
     findings: list[Finding] = []
     for shape, box in shapes:
@@ -522,7 +539,7 @@ def check_margins(
     return findings
 
 
-def check_overflow(slide_no: int, shapes: list) -> list[Finding]:
+def check_overflow(slide_no: int, shapes: list[tuple[BaseShape, Box]]) -> list[Finding]:
     findings: list[Finding] = []
     for shape, box in shapes:
         if not getattr(shape, "has_text_frame", False):
@@ -576,7 +593,7 @@ def check_overflow(slide_no: int, shapes: list) -> list[Finding]:
 
 
 def check_overlap(
-    slide_no: int, shapes: list, slide_w: int, slide_h: int
+    slide_no: int, shapes: list[tuple[BaseShape, Box]], slide_w: int, slide_h: int
 ) -> list[Finding]:
     findings: list[Finding] = []
     slide_area = slide_w * slide_h
@@ -667,7 +684,9 @@ def check_overlap(
     return findings
 
 
-def check_contrast(slide_no: int, slide, shapes: list) -> tuple[list[Finding], int]:
+def check_contrast(
+    slide_no: int, slide, shapes: list[tuple[BaseShape, Box]]
+) -> tuple[list[Finding], int]:
     """Returns (findings, skipped_run_count)."""
     findings: list[Finding] = []
     skipped = 0
@@ -786,7 +805,7 @@ def lint_presentation(prs) -> tuple[list[Finding], int]:
     findings: list[Finding] = []
     total_skipped = 0
     for slide_no, slide in enumerate(prs.slides, start=1):
-        shapes: list = []
+        shapes: list[tuple[BaseShape, Box]] = []
         for shape in slide.shapes:
             box = _shape_box(shape)
             if box is None or _is_rotated(shape):
@@ -833,7 +852,8 @@ def main() -> None:
     if contrast_skipped:
         print(
             f"note: contrast skipped for {contrast_skipped} run(s) over "
-            "image/unresolvable backgrounds — verify those visually"
+            "image/unresolvable backgrounds — verify those visually",
+            file=sys.stderr,
         )
     sys.exit(1 if errors else 0)
 

--- a/backend/tests/unit/onyx/skills/test_pptx_lint.py
+++ b/backend/tests/unit/onyx/skills/test_pptx_lint.py
@@ -1,0 +1,255 @@
+"""Unit tests for the pptx skill's layout linter (scripts/lint.py).
+
+Fixture decks are generated in-test with python-pptx — one per defect class
+plus a clean deck — and thresholds are validated in both directions: each
+defect is caught, and the clean deck produces zero findings.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+pptx = pytest.importorskip("pptx")
+pytest.importorskip("PIL")
+
+from pptx.dml.color import RGBColor  # noqa: E402
+from pptx.enum.text import MSO_AUTO_SIZE  # noqa: E402
+from pptx.util import Inches  # noqa: E402
+from pptx.util import Pt  # noqa: E402
+
+LINT_PATH = (
+    Path(__file__).parents[4]
+    / "onyx"
+    / "skills"
+    / "builtin"
+    / "pptx"
+    / "scripts"
+    / "lint.py"
+)
+
+
+def _load_lint() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("pptx_lint", LINT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["pptx_lint"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+lint = _load_lint()
+
+
+def _new_deck() -> "pptx.presentation.Presentation":
+    prs = pptx.Presentation()
+    prs.slide_width = Inches(13.333)
+    prs.slide_height = Inches(7.5)
+    return prs
+
+
+def _add_blank_slide(prs: "pptx.presentation.Presentation"):
+    return prs.slides.add_slide(prs.slide_layouts[6])
+
+
+def _add_textbox(
+    slide,
+    left: float,
+    top: float,
+    width: float,
+    height: float,
+    text: str,
+    size_pt: int = 18,
+    font_name: str = "Inter",
+):
+    box = slide.shapes.add_textbox(
+        Inches(left), Inches(top), Inches(width), Inches(height)
+    )
+    # python-pptx textboxes default to no-wrap + shape-grows-to-fit; model the
+    # common fixed-box wrapped layout instead.
+    box.text_frame.word_wrap = True
+    box.text_frame.auto_size = MSO_AUTO_SIZE.NONE
+    para = box.text_frame.paragraphs[0]
+    run = para.add_run()
+    run.text = text
+    run.font.size = Pt(size_pt)
+    run.font.name = font_name
+    return box
+
+
+def _findings_by_check(prs, check: str) -> list:
+    findings, _ = lint.lint_presentation(prs)
+    return [f for f in findings if f.check == check]
+
+
+def test_clean_deck_has_no_findings() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    _add_textbox(slide, 0.5, 0.5, 9.0, 1.0, "Quarterly Review", size_pt=40)
+    _add_textbox(
+        slide,
+        0.5,
+        2.0,
+        8.0,
+        3.0,
+        "Revenue grew 12% quarter over quarter.",
+        size_pt=16,
+    )
+    findings, _ = lint.lint_presentation(prs)
+    assert findings == []
+
+
+def test_off_slide_shape_is_error() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    # 2 of 3 inches hang off the left edge.
+    shape = _add_textbox(slide, -2.0, 2.0, 3.0, 1.0, "Off slide text")
+    findings = _findings_by_check(prs, "BOUNDS")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "ERROR"
+    assert finding.slide == 1
+    assert finding.shape_id == shape.shape_id
+
+
+def test_sub_margin_text_is_warned() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    shape = _add_textbox(slide, 0.1, 2.0, 4.0, 1.0, "Too close to the edge")
+    findings = _findings_by_check(prs, "MARGIN")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "WARN"
+    assert finding.slide == 1
+    assert finding.shape_id == shape.shape_id
+    assert "left" in finding.detail
+
+
+def test_full_bleed_shape_exempt_from_margins_and_bounds() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    # Full-slide background with slight bleed — a standard design pattern.
+    shape = slide.shapes.add_shape(
+        1, Inches(-0.05), Inches(-0.05), Inches(13.45), Inches(7.6)
+    )
+    shape.text_frame.text = "SECTION"
+    assert _findings_by_check(prs, "BOUNDS") == []
+    assert _findings_by_check(prs, "MARGIN") == []
+
+
+def test_overflowing_textbox_is_caught() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    long_text = (
+        "This is a very long paragraph of body copy that cannot possibly fit "
+        "inside a half-inch-tall text box because it will wrap onto many lines "
+        "once the eighteen point font is measured against the narrow box width "
+        "and the estimated height greatly exceeds the available space."
+    )
+    shape = _add_textbox(slide, 2.0, 2.0, 2.0, 0.5, long_text, size_pt=18)
+    findings = _findings_by_check(prs, "OVERFLOW")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "ERROR"
+    assert finding.shape_id == shape.shape_id
+
+
+def test_short_text_in_roomy_box_does_not_overflow() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    _add_textbox(slide, 2.0, 2.0, 8.0, 2.0, "Short line.", size_pt=16)
+    assert _findings_by_check(prs, "OVERFLOW") == []
+
+
+def test_overlapping_text_frames_is_error() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    a = _add_textbox(slide, 2.0, 2.0, 4.0, 2.0, "First text block")
+    _add_textbox(slide, 4.0, 3.0, 4.0, 2.0, "Second text block")
+    findings = _findings_by_check(prs, "OVERLAP")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "ERROR"
+    assert finding.shape_id == a.shape_id
+    assert "intersect" in finding.detail
+
+
+def test_contained_text_frames_are_allowed() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    _add_textbox(slide, 2.0, 2.0, 6.0, 3.0, "Outer text")
+    _add_textbox(slide, 3.0, 3.0, 2.0, 1.0, "Inner text")
+    assert _findings_by_check(prs, "OVERLAP") == []
+
+
+def test_text_spilling_past_container_card_is_warned() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    # Card (no text) with a text box centered on it but spilling out the right.
+    slide.shapes.add_shape(1, Inches(2.0), Inches(2.0), Inches(3.0), Inches(2.0))
+    text = _add_textbox(slide, 2.2, 2.5, 4.0, 1.0, "Spills past the card edge")
+    findings = _findings_by_check(prs, "OVERLAP")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "WARN"
+    assert finding.shape_id == text.shape_id
+    assert "container" in finding.detail
+
+
+def test_low_contrast_text_is_error() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    shape = slide.shapes.add_shape(
+        1, Inches(2.0), Inches(2.0), Inches(5.0), Inches(1.5)
+    )
+    shape.fill.solid()
+    shape.fill.fore_color.rgb = RGBColor(0xEE, 0xEE, 0xEE)
+    shape.line.fill.background()
+    para = shape.text_frame.paragraphs[0]
+    run = para.add_run()
+    run.text = "Barely visible"
+    run.font.size = Pt(18)
+    run.font.name = "Inter"
+    run.font.color.rgb = RGBColor(0xFF, 0xFF, 0xFF)
+    findings = _findings_by_check(prs, "CONTRAST")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "ERROR"
+    assert finding.shape_id == shape.shape_id
+
+
+def test_high_contrast_text_passes() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    shape = _add_textbox(slide, 2.0, 2.0, 5.0, 1.0, "Crisp dark text")
+    run = shape.text_frame.paragraphs[0].runs[0]
+    run.font.color.rgb = RGBColor(0x21, 0x21, 0x21)
+    fill = shape.fill
+    fill.solid()
+    fill.fore_color.rgb = RGBColor(0xF2, 0xF2, 0xF2)
+    assert _findings_by_check(prs, "CONTRAST") == []
+
+
+def test_unknown_font_is_warned_once() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    _add_textbox(slide, 2.0, 2.0, 5.0, 1.0, "Fancy", font_name="Papyrus Deluxe")
+    _add_textbox(slide, 2.0, 4.0, 5.0, 1.0, "Fancy again", font_name="Papyrus Deluxe")
+    findings = _findings_by_check(prs, "FONT")
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.severity == "WARN"
+    assert "Papyrus Deluxe" in finding.detail
+
+
+def test_errors_drive_summary_counts() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    _add_textbox(slide, -2.0, 2.0, 3.0, 1.0, "Off slide")
+    findings, _ = lint.lint_presentation(prs)
+    assert any(f.severity == "ERROR" for f in findings)
+    rendered = findings[0].render()
+    assert rendered.startswith("slide 1 | shape ")
+    assert "| ERROR " in rendered


### PR DESCRIPTION
## Description

Adds `scripts/lint.py` to the built-in pptx skill: a deterministic layout linter the Craft agent runs before rendering, catching the mechanical defects that vision QA is slow and unreliable at — shapes off-slide, sub-margin content, text overflow (PIL font-metric estimation), text-frame overlap (with an intentional-overlap allowlist), low text/background contrast, and unknown fonts. Findings are one-line, agent-consumable (`slide 3 | shape "Title 1" (id=5) | ERROR OVERFLOW | …`) with a nonzero exit on errors.

SKILL.md's QA section makes linting step 0: fix all ERRORs first, re-lint per fix batch, and reserve the subagent vision pass for aesthetic judgment (its mechanical bullets moved into the linter).

Precision-first tuning: the three built-in templates are the false-positive canary — an initial run produced 60+ false positives; each fix is a principled allowlist (z-order-aware contrast resolution, autofit and inherited-font-size exemptions, full-bleed and footer-strip margin exemptions, containment-aware overlap). Two templates lint fully clean; the third has 3 genuine borderline margin warnings.

Grouped-shape interiors, rotated geometry, and theme-color contrast resolution are documented out of scope in the module docstring.

## How Has This Been Tested?

- 13 unit tests (`backend/tests/unit/onyx/skills/test_pptx_lint.py`): fixture decks generated in-test with python-pptx, one per defect class plus a clean deck and allowlist cases; all pass on this branch.
- Template canary: linted the three built-in sandbox templates — no false-positive errors.
- Exercised end-to-end against agent-generated decks in an internal slide-quality eval; contrast and layout scores from an independent reference-free judge improved on the decks where the linter ran.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic PowerPoint layout linter to the built-in pptx skill and makes it the first QA step. It finds mechanical layout defects with agent-friendly output and a nonzero exit on errors.

- **New Features**
  - Adds `backend/onyx/skills/builtin/pptx/scripts/lint.py` to check: off-slide shapes, sub-margin text, text overflow, text-frame overlap, low-contrast explicit colors, and unknown fonts. Emits lines like: slide N | shape "…" (id=K) | SEVERITY CHECK | detail.
  - Precision-first thresholds with allowlists (full-bleed, footer strips, autofit boxes, containment). Contrast is z-order aware and skips images/gradients/theme colors; rotated/group internals are out of scope.

- **Bug Fixes**
  - Overflow estimation now counts hard line breaks (`a:br`) via `para.text`.
  - Full-bleed exemption requires shapes to actually cover the slide, not be mostly off-slide.
  - Contrast “skipped” note moved to stderr to keep stdout on-protocol.

<sup>Written for commit b7b3b246787b22fb90ac34f70e9a4377e6aa7bfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

