### PR TITLE
fix: github empty repos should not cause exception

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -109,6 +109,9 @@ GITHUB_MAX_FILE_SIZE_BYTES = 1_000_000
 # Number of files emitted per checkpoint batch in the FILES stage.
 FILE_BATCH_SIZE = 100
 
+_GITHUB_EMPTY_REPOSITORY_TREE_STATUS = 409
+_GITHUB_EMPTY_REPOSITORY_TREE_MESSAGE = "Git Repository is empty."
+
 
 def _is_indexable_path(path: str, size: int | None) -> bool:
     """Pure predicate: should this repo file be indexed?
@@ -765,6 +768,21 @@ class GithubConnector(
         except RateLimitExceededException:
             sleep_after_rate_limit_exception(self.github_client)
             return self._list_indexable_files(repo, attempt_num + 1)
+        except GithubException as e:
+            error_message = (
+                e.data.get("message") if isinstance(e.data, dict) else e.message
+            )
+            if not (
+                e.status == _GITHUB_EMPTY_REPOSITORY_TREE_STATUS
+                and error_message == _GITHUB_EMPTY_REPOSITORY_TREE_MESSAGE
+            ):
+                raise
+
+            logger.info(
+                "Skipping files for empty repo: %s",
+                repo.full_name,
+            )
+            return [], False
 
     def _fetch_file_content(
         self, repo: Repository.Repository, path: str, attempt_num: int = 0

--- a/backend/tests/integration/connector_job_tests/github/test_github_empty_repository.py
+++ b/backend/tests/integration/connector_job_tests/github/test_github_empty_repository.py
@@ -1,0 +1,64 @@
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
+from onyx.db.enums import IndexingStatus
+from tests.integration.common_utils.document_acl import get_all_connector_documents
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.index_attempt import IndexAttemptManager
+from tests.integration.common_utils.managers.llm_provider import LLMProviderManager
+from tests.integration.common_utils.test_models import DATestUser
+
+EMPTY_GITHUB_REPOSITORY_OWNER = "onyx-dot-app"
+EMPTY_GITHUB_REPOSITORY_NAME = "github-connector-empty-repo-test"
+
+
+def test_github_empty_repository_file_sync_completes(
+    github_access_token: str,
+    new_admin_user: DATestUser,
+) -> None:
+    """An empty GitHub repository must complete file indexing without errors.
+
+    The dedicated repository must remain uninitialized: no README, license,
+    .gitignore, or other initial commit.
+    """
+    LLMProviderManager.create(user_performing_action=new_admin_user)
+    cc_pair = CCPairManager.create_from_scratch(
+        name="github-empty-repository",
+        source=DocumentSource.GITHUB,
+        input_type=InputType.POLL,
+        connector_specific_config={
+            "repo_owner": EMPTY_GITHUB_REPOSITORY_OWNER,
+            "repositories": EMPTY_GITHUB_REPOSITORY_NAME,
+            "include_prs": False,
+            "include_issues": False,
+            "include_files": True,
+        },
+        credential_json={"github_access_token": github_access_token},
+        access_type=AccessType.PUBLIC,
+        user_performing_action=new_admin_user,
+    )
+
+    index_attempt = IndexAttemptManager.wait_for_index_attempt_start(
+        cc_pair_id=cc_pair.id,
+        user_performing_action=new_admin_user,
+    )
+    IndexAttemptManager.wait_for_index_attempt_completion(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=new_admin_user,
+        timeout=900,
+    )
+    completed_attempt = IndexAttemptManager.get_index_attempt_by_id(
+        index_attempt_id=index_attempt.id,
+        cc_pair_id=cc_pair.id,
+        user_performing_action=new_admin_user,
+    )
+
+    assert completed_attempt.status == IndexingStatus.SUCCESS
+    assert completed_attempt.error_count == 0
+    assert completed_attempt.new_docs_indexed == 0
+    assert completed_attempt.total_docs_indexed == 0
+
+    with get_session_with_current_tenant() as db_session:
+        assert get_all_connector_documents(cc_pair, db_session) == []

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 from github import Github
+from github.GithubException import GithubException
 from github.GithubException import UnknownObjectException
 from github.RateLimit import RateLimit
 from github.Requester import Requester
@@ -312,6 +313,25 @@ def test_truncated_tree_yields_failure(
     assert len(failures) == 1
     assert failures[0].failed_entity is not None
     assert "truncated" in failures[0].failure_message.lower()
+
+
+def test_empty_repository_tree_skips_file_stage(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    """GitHub returns 409 when listing the tree of an empty repository."""
+    connector = _build_connector(mock_github_client)
+    mock_repo = create_mock_repo({})
+    mock_repo.get_git_tree.side_effect = GithubException(
+        409, {"message": "Git Repository is empty."}, {}
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    assert _all_items(outputs) == []
+    assert outputs[-1].next_checkpoint.has_more is False
 
 
 def test_prs_disabled_404_does_not_crash_files(


### PR DESCRIPTION
## Summary
- Treat GitHub’s 409 "Git Repository is empty." response as a non-fatal case during file listing
- Skip the file stage cleanly for empty repositories instead of raising an error
- Add a unit test covering the empty-repo tree response path

How Has This Been Tested?
Additional Options
 [Optional] Please cherry-pick this PR to the latest release version.
 [x] Override Linear Check

