### PR TITLE
chore: web server type gen

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,7 @@
     "start": "next start",
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
-    "types:check": "node node_modules/typescript-7/bin/tsc --noEmit --project tsconfig.types.json",
+    "types:check": "next typegen && node node_modules/typescript-7/bin/tsc --noEmit --project tsconfig.types.json",
     "format": "oxfmt src",
     "format:check": "oxfmt --check src",
     "playwright": "playwright test",


### PR DESCRIPTION
## Description

generate types before type checking so a stale .next cache doesn't blow up pre-commit

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `next typegen` before TypeScript type checking to ensure server types are generated and prevent stale `.next` cache errors during pre-commit.

<sup>Written for commit 15ee12bb6a7b174bbe5c3dfe4c743d8ffe79b6e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

