### PR TITLE
feat(skills): import skills from GitHub

### DIFF
--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -15,6 +15,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.db.engine.sql_engine import get_session
+from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import AccountType
 from onyx.db.enums import ExternalAppType
 from onyx.db.enums import Permission
@@ -80,14 +81,28 @@ from shared_configs.contextvars import get_current_tenant_id
 user_router = APIRouter(prefix="/skills")
 
 
-def _github_authorization_header(user: User, db_session: Session) -> str | None:
-    github_app = get_built_in_external_app(db_session, ExternalAppType.GITHUB)
-    if github_app is None:
-        return None
-    ensure_fresh_credentials(get_current_tenant_id(), github_app.id, user.id)
-    return resolve_injection_headers(db_session, github_app.id, user.id).get(
-        "Authorization"
-    )
+def _github_authorization_header(user: User) -> str | None:
+    tenant_id = get_current_tenant_id()
+    with get_session_with_tenant(tenant_id=tenant_id) as db_session:
+        github_app = get_built_in_external_app(db_session, ExternalAppType.GITHUB)
+        if (
+            github_app is None
+            or fetch_skill(
+                github_app.skill_id,
+                policy=SkillAccessPolicy.USE,
+                user=user,
+                db_session=db_session,
+            )
+            is None
+        ):
+            return None
+        github_app_id = github_app.id
+
+    ensure_fresh_credentials(tenant_id, github_app_id, user.id)
+    with get_session_with_tenant(tenant_id=tenant_id) as db_session:
+        return resolve_injection_headers(db_session, github_app_id, user.id).get(
+            "Authorization"
+        )
 
 
 def _ensure_can_edit_org_visibility(skill: Skill, user: User) -> None:
@@ -311,14 +326,20 @@ def create_custom_skill_from_editor(
 def preview_github_skills(
     request: GitHubSkillsPreviewRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
-    db_session: Session = Depends(get_session),
 ) -> GitHubSkillsPreviewResponse:
     repository, skills = fetch_github_skill_bundles(
         request.repository,
-        _github_authorization_header(user, db_session),
+        _github_authorization_header(user),
     )
+    if repository.ref is None:
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
+            "GitHub did not return a repository revision.",
+        )
     return GitHubSkillsPreviewResponse(
         repository=f"{repository.owner}/{repository.repo}",
+        revision=repository.ref,
+        subpath=repository.subpath,
         skills=[
             GitHubSkillPreview(
                 path=skill.path,
@@ -339,7 +360,9 @@ def import_github_skills(
 ) -> list[SkillResponse]:
     _, available_skills = fetch_github_skill_bundles(
         request.repository,
-        _github_authorization_header(user, db_session),
+        _github_authorization_header(user),
+        revision=request.revision,
+        subpath=request.subpath,
     )
     skills_by_path = {skill.path: skill for skill in available_skills}
     selected_paths = list(dict.fromkeys(request.paths))

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -1,5 +1,6 @@
 import io
 import zipfile
+from contextlib import ExitStack
 from typing import Annotated
 from uuid import UUID
 
@@ -15,8 +16,10 @@ from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccountType
+from onyx.db.enums import ExternalAppType
 from onyx.db.enums import Permission
 from onyx.db.enums import SkillSharePermission
+from onyx.db.external_app import get_built_in_external_app
 from onyx.db.models import Skill
 from onyx.db.models import User
 from onyx.db.skill import affected_user_ids_for_skill
@@ -32,7 +35,13 @@ from onyx.db.skill import update_skill_fields
 from onyx.db.users import fetch_user_by_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.external_apps.credentials import resolve_injection_headers
+from onyx.external_apps.token_refresh import ensure_fresh_credentials
 from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.models import GitHubSkillPreview
+from onyx.server.features.skill.models import GitHubSkillsImportRequest
+from onyx.server.features.skill.models import GitHubSkillsPreviewRequest
+from onyx.server.features.skill.models import GitHubSkillsPreviewResponse
 from onyx.server.features.skill.models import SkillBundleInspectResponse
 from onyx.server.features.skill.models import SkillCreateRequest
 from onyx.server.features.skill.models import SkillEditableDetailResponse
@@ -60,13 +69,25 @@ from onyx.skills.bundle import slug_from_skill_name
 from onyx.skills.bundle import update_custom_bundle_files
 from onyx.skills.bundle import validate_and_normalize_custom_bundle
 from onyx.skills.content import read_custom_skill_bundle_bytes
+from onyx.skills.github_import import fetch_github_skill_bundles
 from onyx.skills.ingest import delete_bundle_blob
 from onyx.skills.ingest import ingested_skill_bundle
 from onyx.skills.ingest import save_skill_bundle_bytes
 from onyx.skills.push import push_skill_to_affected_sandboxes
 from onyx.skills.push import push_skills_for_users
+from shared_configs.contextvars import get_current_tenant_id
 
 user_router = APIRouter(prefix="/skills")
+
+
+def _github_authorization_header(user: User, db_session: Session) -> str | None:
+    github_app = get_built_in_external_app(db_session, ExternalAppType.GITHUB)
+    if github_app is None:
+        return None
+    ensure_fresh_credentials(get_current_tenant_id(), github_app.id, user.id)
+    return resolve_injection_headers(db_session, github_app.id, user.id).get(
+        "Authorization"
+    )
 
 
 def _ensure_can_edit_org_visibility(skill: Skill, user: User) -> None:
@@ -284,6 +305,119 @@ def create_custom_skill_from_editor(
 
     push_skill_to_affected_sandboxes(skill, db_session)
     return _editable_skill_response(skill, user, db_session)
+
+
+@user_router.post("/github/preview")
+def preview_github_skills(
+    request: GitHubSkillsPreviewRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> GitHubSkillsPreviewResponse:
+    repository, skills = fetch_github_skill_bundles(
+        request.repository,
+        _github_authorization_header(user, db_session),
+    )
+    return GitHubSkillsPreviewResponse(
+        repository=f"{repository.owner}/{repository.repo}",
+        skills=[
+            GitHubSkillPreview(
+                path=skill.path,
+                name=skill.name,
+                description=skill.description,
+                unavailable_reason=skill.unavailable_reason,
+            )
+            for skill in skills
+        ],
+    )
+
+
+@user_router.post("/github/import")
+def import_github_skills(
+    request: GitHubSkillsImportRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[SkillResponse]:
+    _, available_skills = fetch_github_skill_bundles(
+        request.repository,
+        _github_authorization_header(user, db_session),
+    )
+    skills_by_path = {skill.path: skill for skill in available_skills}
+    selected_paths = list(dict.fromkeys(request.paths))
+    missing_paths = [path for path in selected_paths if path not in skills_by_path]
+    if missing_paths:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"These skills are no longer available in the repository: {', '.join(missing_paths)}. Search the repository again.",
+        )
+    selected_skills = [skills_by_path[path] for path in selected_paths]
+    unavailable_reason = next(
+        (
+            skill.unavailable_reason
+            for skill in selected_skills
+            if skill.unavailable_reason is not None
+        ),
+        None,
+    )
+    if unavailable_reason is not None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            unavailable_reason,
+        )
+    slugs = [skill.slug for skill in selected_skills]
+    if len(slugs) != len(set(slugs)):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Two or more selected skills have the same name. Rename one in SKILL.md, then try again.",
+        )
+
+    file_store = get_default_file_store()
+    created_skills: list[Skill] = []
+    with ExitStack() as ingested_bundles:
+        for selected_skill in selected_skills:
+            if selected_skill.bundle_bytes is None:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"Skill at '{selected_skill.path}' cannot be imported.",
+                )
+            ingested = ingested_bundles.enter_context(
+                ingested_skill_bundle(
+                    selected_skill.bundle_bytes,
+                    f"{selected_skill.slug}.zip",
+                    file_store,
+                    slug=selected_skill.slug,
+                )
+            )
+            try:
+                skill = create_skill__no_commit(
+                    slug=ingested.slug,
+                    name=ingested.name,
+                    description=ingested.description,
+                    bundle_file_id=ingested.bundle_file_id,
+                    bundle_sha256=ingested.bundle_sha256,
+                    is_public=False,
+                    author_user_id=user.id,
+                    db_session=db_session,
+                )
+            except OnyxError as exc:
+                if exc.error_code == OnyxErrorCode.DUPLICATE_RESOURCE:
+                    raise OnyxError(
+                        OnyxErrorCode.DUPLICATE_RESOURCE,
+                        f'A skill named "{selected_skill.name}" already exists in this workspace. Rename it in SKILL.md, then try again.',
+                    ) from exc
+                raise
+            created_skills.append(skill)
+        db_session.commit()
+
+    push_skills_for_users({user.id}, db_session)
+    return [
+        skill_response_for_user(
+            skill,
+            user,
+            db_session,
+            include_share_details=True,
+        )
+        for skill in created_skills
+    ]
 
 
 @user_router.get("/custom/{skill_id}/edit")

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -185,6 +185,28 @@ class SkillBundleInspectResponse(BaseModel):
     files: list[SkillBundleFile]
 
 
+class GitHubSkillPreview(BaseModel):
+    path: str
+    name: str
+    description: str
+    unavailable_reason: str | None
+
+
+class GitHubSkillsPreviewRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    repository: str
+
+
+class GitHubSkillsPreviewResponse(BaseModel):
+    repository: str
+    skills: list[GitHubSkillPreview]
+
+
+class GitHubSkillsImportRequest(GitHubSkillsPreviewRequest):
+    paths: list[str] = Field(min_length=1)
+
+
 class SkillCreateRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -200,10 +200,14 @@ class GitHubSkillsPreviewRequest(BaseModel):
 
 class GitHubSkillsPreviewResponse(BaseModel):
     repository: str
+    revision: str
+    subpath: str | None
     skills: list[GitHubSkillPreview]
 
 
 class GitHubSkillsImportRequest(GitHubSkillsPreviewRequest):
+    revision: str = Field(pattern=r"^[0-9a-fA-F]{40}$")
+    subpath: str | None = None
     paths: list[str] = Field(min_length=1)
 
 

--- a/backend/onyx/skills/github_import.py
+++ b/backend/onyx/skills/github_import.py
@@ -344,7 +344,7 @@ def fetch_github_skill_bundles(
         archive = tarfile.open(
             fileobj=io.BytesIO(b"".join(archive_chunks)), mode="r:gz"
         )
-    except tarfile.TarError as exc:
+    except (tarfile.TarError, EOFError, OSError) as exc:
         raise OnyxError(
             OnyxErrorCode.BAD_GATEWAY,
             "GitHub returned an unreadable repository download. Try again.",
@@ -352,55 +352,61 @@ def fetch_github_skill_bundles(
 
     files: dict[str, bytes] = {}
     total_size = 0
-    with archive:
-        for member_index, member in enumerate(archive, start=1):
-            if member_index > _ARCHIVE_MAX_MEMBERS:
-                raise OnyxError(
-                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
-                    f"Repository archive contains more than {_ARCHIVE_MAX_MEMBERS:,} entries. Use a smaller repository and try again.",
-                )
-            member_path = member.name.rstrip("/") if member.isdir() else member.name
-            path_parts = member_path.split("/")
-            if (
-                not member_path
-                or member_path.startswith("/")
-                or "\\" in member_path
-                or any(part in {"", ".", ".."} for part in path_parts)
-            ):
-                raise OnyxError(
-                    OnyxErrorCode.INVALID_INPUT,
-                    f"Repository contains unsupported path '{member.name}'. Remove or rename it and try again.",
-                )
-            if member.isdir():
-                continue
-            if not member.isfile():
-                raise OnyxError(
-                    OnyxErrorCode.INVALID_INPUT,
-                    f"Repository contains a symbolic link at '{member.name}'. Replace it with a regular file and try again.",
-                )
-            if member.size > DEFAULT_PER_FILE_MAX_BYTES:
-                raise OnyxError(
-                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
-                    f"Repository file '{member.name}' exceeds the {DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB limit. Reduce or remove the file and try again.",
-                )
-            total_size += member.size
-            if total_size > DEFAULT_TOTAL_MAX_BYTES:
-                raise OnyxError(
-                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
-                    f"Repository exceeds the {DEFAULT_TOTAL_MAX_BYTES // (1024 * 1024)} MiB uncompressed limit. Remove large files or move the skills to a smaller repository.",
-                )
-            extracted = archive.extractfile(member)
-            if extracted is None:
-                raise OnyxError(
-                    OnyxErrorCode.BAD_GATEWAY,
-                    f"Could not read repository file '{member.name}'. Try again.",
-                )
-            if member.name in files:
-                raise OnyxError(
-                    OnyxErrorCode.INVALID_INPUT,
-                    f"Repository contains duplicate path '{member.name}'. Remove the duplicate and try again.",
-                )
-            files[member.name] = extracted.read(DEFAULT_PER_FILE_MAX_BYTES + 1)
+    try:
+        with archive:
+            for member_index, member in enumerate(archive, start=1):
+                if member_index > _ARCHIVE_MAX_MEMBERS:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"Repository archive contains more than {_ARCHIVE_MAX_MEMBERS:,} entries. Use a smaller repository and try again.",
+                    )
+                member_path = member.name.rstrip("/") if member.isdir() else member.name
+                path_parts = member_path.split("/")
+                if (
+                    not member_path
+                    or member_path.startswith("/")
+                    or "\\" in member_path
+                    or any(part in {"", ".", ".."} for part in path_parts)
+                ):
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"Repository contains unsupported path '{member.name}'. Remove or rename it and try again.",
+                    )
+                if member.isdir():
+                    continue
+                if not member.isfile():
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"Repository contains a symbolic link at '{member.name}'. Replace it with a regular file and try again.",
+                    )
+                if member.size > DEFAULT_PER_FILE_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"Repository file '{member.name}' exceeds the {DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB limit. Reduce or remove the file and try again.",
+                    )
+                total_size += member.size
+                if total_size > DEFAULT_TOTAL_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"Repository exceeds the {DEFAULT_TOTAL_MAX_BYTES // (1024 * 1024)} MiB uncompressed limit. Remove large files or move the skills to a smaller repository.",
+                    )
+                extracted = archive.extractfile(member)
+                if extracted is None:
+                    raise OnyxError(
+                        OnyxErrorCode.BAD_GATEWAY,
+                        f"Could not read repository file '{member.name}'. Try again.",
+                    )
+                if member.name in files:
+                    raise OnyxError(
+                        OnyxErrorCode.INVALID_INPUT,
+                        f"Repository contains duplicate path '{member.name}'. Remove the duplicate and try again.",
+                    )
+                files[member.name] = extracted.read(DEFAULT_PER_FILE_MAX_BYTES + 1)
+    except (tarfile.TarError, EOFError, OSError) as exc:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "GitHub returned an unreadable repository download. Try again.",
+        ) from exc
 
     root_directories = {path.split("/", maxsplit=1)[0] for path in files}
     if len(root_directories) != 1:

--- a/backend/onyx/skills/github_import.py
+++ b/backend/onyx/skills/github_import.py
@@ -37,6 +37,9 @@ _FETCH_TIMEOUT_SECONDS: Final[int] = 30
 def fetch_github_skill_bundles(
     source: str,
     authorization_header: str | None = None,
+    *,
+    revision: str | None = None,
+    subpath: str | None = None,
 ) -> tuple[GitHubRepository, list[GitHubSkillBundle]]:
     """Fetch a repository and return every directory containing SKILL.md."""
     value = source.strip().rstrip("/")
@@ -90,9 +93,18 @@ def fetch_github_skill_bundles(
             repository = GitHubRepository(
                 owner=owner,
                 repo=repo,
-                ref=parts[3],
-                subpath="/".join(parts[4:]) or None,
+                ref="/".join(parts[3:]),
             )
+
+    if revision is not None and not re.fullmatch(r"[0-9a-fA-F]{40}", revision):
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid repository revision.")
+    if revision is not None:
+        repository = GitHubRepository(
+            owner=repository.owner,
+            repo=repository.repo,
+            ref=revision.lower(),
+            subpath=subpath,
+        )
 
     search_prefix = repository.subpath.rstrip("/") if repository.subpath else ""
     if search_prefix and (
@@ -101,20 +113,31 @@ def fetch_github_skill_bundles(
     ):
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid repository folder.")
 
-    ref = quote(repository.ref or "HEAD", safe="/")
     owner = quote(repository.owner, safe="")
     repo = quote(repository.repo, safe="")
-    if authorization_header is not None:
-        api_url = f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref}"
+
+    def get(
+        url: str,
+        *,
+        authorization: str | None = None,
+        stream: bool = False,
+        follow_redirects: bool = True,
+    ) -> requests.Response:
+        headers = (
+            {
+                "Accept": "application/vnd.github+json",
+                "Authorization": authorization,
+            }
+            if authorization is not None
+            else None
+        )
         try:
-            redirect_response = ssrf_safe_get(
-                api_url,
-                headers={
-                    "Accept": "application/vnd.github+json",
-                    "Authorization": authorization_header,
-                },
+            return ssrf_safe_get(
+                url,
+                headers=headers,
                 timeout=_FETCH_TIMEOUT_SECONDS,
-                follow_redirects=False,
+                stream=stream,
+                follow_redirects=follow_redirects,
             )
         except SSRFException as exc:
             raise OnyxError(
@@ -131,6 +154,105 @@ def fetch_github_skill_bundles(
                 OnyxErrorCode.BAD_GATEWAY,
                 "Could not reach GitHub. Check your connection and try again.",
             ) from exc
+
+    if revision is None:
+        ref_parts = repository.ref.split("/") if repository.ref else ["HEAD"]
+        candidates = [
+            ("/".join(ref_parts[:index]), "/".join(ref_parts[index:]) or None)
+            for index in range(len(ref_parts), 0, -1)
+        ]
+        resolved_revision: str | None = None
+        resolved_subpath: str | None = None
+        last_response: requests.Response | None = None
+        for candidate_ref, candidate_subpath in candidates:
+            commit_url = (
+                f"https://api.github.com/repos/{owner}/{repo}/commits/"
+                f"{quote(candidate_ref, safe='')}"
+            )
+            response = get(commit_url)
+            if response.status_code in {401, 403, 404, 429} and authorization_header:
+                response.close()
+                response = get(commit_url, authorization=authorization_header)
+            if response.status_code == 200:
+                with response:
+                    try:
+                        sha = response.json().get("sha")
+                    except (
+                        requests.JSONDecodeError,
+                        ValueError,
+                        AttributeError,
+                    ) as exc:
+                        raise OnyxError(
+                            OnyxErrorCode.BAD_GATEWAY,
+                            "GitHub returned an unreadable repository revision. Try again.",
+                        ) from exc
+                if not isinstance(sha, str) or not re.fullmatch(
+                    r"[0-9a-fA-F]{40}", sha
+                ):
+                    raise OnyxError(
+                        OnyxErrorCode.BAD_GATEWAY,
+                        "GitHub returned an invalid repository revision. Try again.",
+                    )
+                resolved_revision = sha.lower()
+                resolved_subpath = candidate_subpath
+                break
+            if last_response is not None:
+                last_response.close()
+            last_response = response
+
+        if resolved_revision is None:
+            if last_response is None:
+                raise OnyxError(OnyxErrorCode.NOT_FOUND, "Repository not found.")
+            with last_response:
+                if last_response.status_code == 401:
+                    raise OnyxError(
+                        OnyxErrorCode.UNAUTHENTICATED,
+                        "Your GitHub connection has expired. Reconnect GitHub, then try again.",
+                    )
+                if last_response.status_code in {403, 429} and (
+                    last_response.status_code == 429
+                    or last_response.headers.get("X-RateLimit-Remaining") == "0"
+                    or "Retry-After" in last_response.headers
+                ):
+                    raise OnyxError(
+                        OnyxErrorCode.RATE_LIMITED,
+                        "GitHub's API rate limit has been reached. Try again in a few minutes.",
+                    )
+                if last_response.status_code == 403 and authorization_header:
+                    raise OnyxError(
+                        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        "GitHub denied access to this repository. Make sure your connected account has access and, if required, has authorized organization SSO.",
+                    )
+                if last_response.status_code in {403, 404}:
+                    raise OnyxError(
+                        OnyxErrorCode.NOT_FOUND,
+                        "Repository or branch not found. Check the URL. If the repository is private, connect GitHub and try again.",
+                    )
+                raise OnyxError(
+                    OnyxErrorCode.BAD_GATEWAY,
+                    "Couldn't load the repository from GitHub. Try again in a few minutes.",
+                )
+        repository = GitHubRepository(
+            owner=repository.owner,
+            repo=repository.repo,
+            ref=resolved_revision,
+            subpath=resolved_subpath,
+        )
+        search_prefix = resolved_subpath or ""
+
+    if repository.ref is None:
+        raise OnyxError(OnyxErrorCode.INTERNAL_ERROR, "Repository revision is missing.")
+    ref = quote(repository.ref, safe="")
+    archive_url = f"https://codeload.github.com/{owner}/{repo}/tar.gz/{ref}"
+    response = get(archive_url, stream=True)
+    if response.status_code != 200 and authorization_header is not None:
+        response.close()
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref}"
+        redirect_response = get(
+            api_url,
+            authorization=authorization_header,
+            follow_redirects=False,
+        )
         with redirect_response:
             if redirect_response.status_code == 401:
                 raise OnyxError(
@@ -167,29 +289,7 @@ def fetch_github_skill_bundles(
                     OnyxErrorCode.BAD_GATEWAY,
                     "GitHub didn't provide a repository download. Try again.",
                 )
-    else:
-        archive_url = f"https://codeload.github.com/{owner}/{repo}/tar.gz/{ref}"
-    try:
-        response = ssrf_safe_get(
-            archive_url,
-            timeout=_FETCH_TIMEOUT_SECONDS,
-            stream=True,
-        )
-    except SSRFException as exc:
-        raise OnyxError(
-            OnyxErrorCode.BAD_GATEWAY,
-            "GitHub returned an unsupported repository download URL. Try again.",
-        ) from exc
-    except requests.Timeout as exc:
-        raise OnyxError(
-            OnyxErrorCode.GATEWAY_TIMEOUT,
-            "GitHub took too long to respond. Try again.",
-        ) from exc
-    except requests.RequestException as exc:
-        raise OnyxError(
-            OnyxErrorCode.BAD_GATEWAY,
-            "Could not reach GitHub. Check your connection and try again.",
-        ) from exc
+        response = get(archive_url, stream=True)
 
     with response:
         if response.status_code == 404:
@@ -212,6 +312,11 @@ def fetch_github_skill_bundles(
             raise OnyxError(
                 OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
                 "GitHub denied access to this repository. Make sure your connected account has access and, if required, has authorized organization SSO.",
+            )
+        if response.status_code == 403:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                "Repository not found. Check the URL. If the repository is private, connect GitHub and try again.",
             )
         if response.status_code != 200:
             raise OnyxError(
@@ -333,6 +438,28 @@ def fetch_github_skill_bundles(
             "No SKILL.md files were found in this repository. Add a SKILL.md file, then try again.",
         )
 
+    skill_directories = {
+        ""
+        if str(PurePosixPath(path).parent) == "."
+        else str(PurePosixPath(path).parent)
+        for path in skill_md_paths
+    }
+    files_by_skill: dict[str, dict[str, bytes]] = {
+        directory: {} for directory in skill_directories
+    }
+    for path, content in files.items():
+        parent = str(PurePosixPath(path).parent)
+        parent = "" if parent == "." else parent
+        while True:
+            if parent in skill_directories:
+                prefix = f"{parent}/" if parent else ""
+                files_by_skill[parent][path.removeprefix(prefix)] = content
+                break
+            if not parent:
+                break
+            next_parent = str(PurePosixPath(parent).parent)
+            parent = "" if next_parent == "." else next_parent
+
     skills: list[GitHubSkillBundle] = []
     for skill_md_path in skill_md_paths:
         skill_directory = str(PurePosixPath(skill_md_path).parent)
@@ -366,11 +493,7 @@ def fetch_github_skill_bundles(
         with zipfile.ZipFile(
             output, mode="w", compression=zipfile.ZIP_DEFLATED
         ) as bundle:
-            prefix = f"{skill_directory}/" if skill_directory else ""
-            for path, content in files.items():
-                if prefix and not path.startswith(prefix):
-                    continue
-                relative_path = path.removeprefix(prefix)
+            for relative_path, content in files_by_skill[skill_directory].items():
                 if not relative_path or relative_path.endswith(TEMPLATE_SUFFIX):
                     continue
                 if "__pycache__" in PurePosixPath(relative_path).parts:

--- a/backend/onyx/skills/github_import.py
+++ b/backend/onyx/skills/github_import.py
@@ -1,0 +1,391 @@
+"""Fetch and discover skills from GitHub repository archives."""
+
+from __future__ import annotations
+
+import io
+import re
+import tarfile
+import zipfile
+from pathlib import PurePosixPath
+from typing import Final
+from urllib.parse import quote
+from urllib.parse import unquote
+from urllib.parse import urlparse
+
+import requests
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.built_in import BUILT_IN_SKILLS
+from onyx.skills.bundle import DEFAULT_PER_FILE_MAX_BYTES
+from onyx.skills.bundle import DEFAULT_TOTAL_MAX_BYTES
+from onyx.skills.bundle import parse_skill_md_metadata
+from onyx.skills.bundle import SKILL_MD_NAME
+from onyx.skills.bundle import slug_from_skill_name
+from onyx.skills.bundle import TEMPLATE_SUFFIX
+from onyx.skills.bundle import validate_and_normalize_custom_bundle
+from onyx.skills.models import GitHubRepository
+from onyx.skills.models import GitHubSkillBundle
+from onyx.utils.url import ssrf_safe_get
+from onyx.utils.url import SSRFException
+
+_ARCHIVE_MAX_BYTES: Final[int] = 25 * 1024 * 1024
+_ARCHIVE_MAX_MEMBERS: Final[int] = 10_000
+_FETCH_TIMEOUT_SECONDS: Final[int] = 30
+
+
+def fetch_github_skill_bundles(
+    source: str,
+    authorization_header: str | None = None,
+) -> tuple[GitHubRepository, list[GitHubSkillBundle]]:
+    """Fetch a repository and return every directory containing SKILL.md."""
+    value = source.strip().rstrip("/")
+    if not value:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Enter a GitHub repository URL or owner/repository.",
+        )
+
+    if "://" not in value:
+        parts = value.removesuffix(".git").split("/")
+        if len(parts) != 2 or not all(
+            re.fullmatch(r"[A-Za-z0-9_.-]+", part) for part in parts
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "Enter a GitHub repository URL or owner/repository.",
+            )
+        repository = GitHubRepository(owner=parts[0], repo=parts[1])
+    else:
+        parsed = urlparse(value)
+        if parsed.scheme != "https" or parsed.hostname not in {
+            "github.com",
+            "www.github.com",
+        }:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "Enter an HTTPS github.com repository URL.",
+            )
+
+        parts = [unquote(part) for part in parsed.path.split("/") if part]
+        if len(parts) < 2:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT, "Invalid GitHub repository URL."
+            )
+        owner, repo = parts[0], parts[1].removesuffix(".git")
+        if not all(
+            re.fullmatch(r"[A-Za-z0-9_.-]+", component) for component in (owner, repo)
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT, "Invalid GitHub repository URL."
+            )
+        if len(parts) == 2:
+            repository = GitHubRepository(owner=owner, repo=repo)
+        else:
+            if len(parts) < 4 or parts[2] != "tree":
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    "Enter a repository URL or a URL for a folder within a repository.",
+                )
+            repository = GitHubRepository(
+                owner=owner,
+                repo=repo,
+                ref=parts[3],
+                subpath="/".join(parts[4:]) or None,
+            )
+
+    search_prefix = repository.subpath.rstrip("/") if repository.subpath else ""
+    if search_prefix and (
+        "\\" in search_prefix
+        or any(part in {"", ".", ".."} for part in search_prefix.split("/"))
+    ):
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "Invalid repository folder.")
+
+    ref = quote(repository.ref or "HEAD", safe="/")
+    owner = quote(repository.owner, safe="")
+    repo = quote(repository.repo, safe="")
+    if authorization_header is not None:
+        api_url = f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref}"
+        try:
+            redirect_response = ssrf_safe_get(
+                api_url,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": authorization_header,
+                },
+                timeout=_FETCH_TIMEOUT_SECONDS,
+                follow_redirects=False,
+            )
+        except SSRFException as exc:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "Couldn't securely connect to GitHub. Try again.",
+            ) from exc
+        except requests.Timeout as exc:
+            raise OnyxError(
+                OnyxErrorCode.GATEWAY_TIMEOUT,
+                "GitHub took too long to respond. Try again.",
+            ) from exc
+        except requests.RequestException as exc:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "Could not reach GitHub. Check your connection and try again.",
+            ) from exc
+        with redirect_response:
+            if redirect_response.status_code == 401:
+                raise OnyxError(
+                    OnyxErrorCode.UNAUTHENTICATED,
+                    "Your GitHub connection has expired. Reconnect GitHub, then try again.",
+                )
+            if redirect_response.status_code in {403, 429}:
+                if (
+                    redirect_response.status_code == 429
+                    or redirect_response.headers.get("X-RateLimit-Remaining") == "0"
+                    or "Retry-After" in redirect_response.headers
+                ):
+                    raise OnyxError(
+                        OnyxErrorCode.RATE_LIMITED,
+                        "GitHub's API rate limit has been reached. Try again in a few minutes.",
+                    )
+                raise OnyxError(
+                    OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                    "GitHub denied access to this repository. Make sure your connected account has access and, if required, has authorized organization SSO.",
+                )
+            if redirect_response.status_code == 404:
+                raise OnyxError(
+                    OnyxErrorCode.NOT_FOUND,
+                    "Repository or branch not found. Check the URL and confirm that your connected GitHub account has access.",
+                )
+            if redirect_response.status_code not in {301, 302, 307, 308}:
+                raise OnyxError(
+                    OnyxErrorCode.BAD_GATEWAY,
+                    "Couldn't download the repository from GitHub. Try again in a few minutes.",
+                )
+            archive_url = redirect_response.headers.get("Location")
+            if not archive_url:
+                raise OnyxError(
+                    OnyxErrorCode.BAD_GATEWAY,
+                    "GitHub didn't provide a repository download. Try again.",
+                )
+    else:
+        archive_url = f"https://codeload.github.com/{owner}/{repo}/tar.gz/{ref}"
+    try:
+        response = ssrf_safe_get(
+            archive_url,
+            timeout=_FETCH_TIMEOUT_SECONDS,
+            stream=True,
+        )
+    except SSRFException as exc:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "GitHub returned an unsupported repository download URL. Try again.",
+        ) from exc
+    except requests.Timeout as exc:
+        raise OnyxError(
+            OnyxErrorCode.GATEWAY_TIMEOUT,
+            "GitHub took too long to respond. Try again.",
+        ) from exc
+    except requests.RequestException as exc:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "Could not reach GitHub. Check your connection and try again.",
+        ) from exc
+
+    with response:
+        if response.status_code == 404:
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                "Repository or branch not found. Check the URL. If the repository is private, connect GitHub and try again.",
+            )
+        if response.status_code == 429 or (
+            response.status_code == 403
+            and (
+                response.headers.get("X-RateLimit-Remaining") == "0"
+                or "Retry-After" in response.headers
+            )
+        ):
+            raise OnyxError(
+                OnyxErrorCode.RATE_LIMITED,
+                "GitHub's API rate limit has been reached. Try again in a few minutes.",
+            )
+        if response.status_code == 403 and authorization_header is not None:
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                "GitHub denied access to this repository. Make sure your connected account has access and, if required, has authorized organization SSO.",
+            )
+        if response.status_code != 200:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "Couldn't download the repository from GitHub. Try again in a few minutes.",
+            )
+        archive_chunks: list[bytes] = []
+        archive_size = 0
+        try:
+            for chunk in response.iter_content(chunk_size=64 * 1024):
+                archive_size += len(chunk)
+                if archive_size > _ARCHIVE_MAX_BYTES:
+                    raise OnyxError(
+                        OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                        f"Repository download exceeds the {_ARCHIVE_MAX_BYTES // (1024 * 1024)} MiB limit. Remove large files or move the skills to a smaller repository.",
+                    )
+                archive_chunks.append(chunk)
+        except requests.RequestException as exc:
+            raise OnyxError(
+                OnyxErrorCode.BAD_GATEWAY,
+                "The GitHub repository download was interrupted. Try again.",
+            ) from exc
+
+    try:
+        archive = tarfile.open(
+            fileobj=io.BytesIO(b"".join(archive_chunks)), mode="r:gz"
+        )
+    except tarfile.TarError as exc:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "GitHub returned an unreadable repository download. Try again.",
+        ) from exc
+
+    files: dict[str, bytes] = {}
+    total_size = 0
+    with archive:
+        for member_index, member in enumerate(archive, start=1):
+            if member_index > _ARCHIVE_MAX_MEMBERS:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"Repository archive contains more than {_ARCHIVE_MAX_MEMBERS:,} entries. Use a smaller repository and try again.",
+                )
+            member_path = member.name.rstrip("/") if member.isdir() else member.name
+            path_parts = member_path.split("/")
+            if (
+                not member_path
+                or member_path.startswith("/")
+                or "\\" in member_path
+                or any(part in {"", ".", ".."} for part in path_parts)
+            ):
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"Repository contains unsupported path '{member.name}'. Remove or rename it and try again.",
+                )
+            if member.isdir():
+                continue
+            if not member.isfile():
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"Repository contains a symbolic link at '{member.name}'. Replace it with a regular file and try again.",
+                )
+            if member.size > DEFAULT_PER_FILE_MAX_BYTES:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"Repository file '{member.name}' exceeds the {DEFAULT_PER_FILE_MAX_BYTES // (1024 * 1024)} MiB limit. Reduce or remove the file and try again.",
+                )
+            total_size += member.size
+            if total_size > DEFAULT_TOTAL_MAX_BYTES:
+                raise OnyxError(
+                    OnyxErrorCode.PAYLOAD_TOO_LARGE,
+                    f"Repository exceeds the {DEFAULT_TOTAL_MAX_BYTES // (1024 * 1024)} MiB uncompressed limit. Remove large files or move the skills to a smaller repository.",
+                )
+            extracted = archive.extractfile(member)
+            if extracted is None:
+                raise OnyxError(
+                    OnyxErrorCode.BAD_GATEWAY,
+                    f"Could not read repository file '{member.name}'. Try again.",
+                )
+            if member.name in files:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"Repository contains duplicate path '{member.name}'. Remove the duplicate and try again.",
+                )
+            files[member.name] = extracted.read(DEFAULT_PER_FILE_MAX_BYTES + 1)
+
+    root_directories = {path.split("/", maxsplit=1)[0] for path in files}
+    if len(root_directories) != 1:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            "GitHub returned an unexpected repository download. Enter a standard GitHub repository URL and try again.",
+        )
+    files = {
+        path.split("/", maxsplit=1)[1]: content
+        for path, content in files.items()
+        if "/" in path
+    }
+
+    if search_prefix and not any(
+        path == search_prefix or path.startswith(f"{search_prefix}/") for path in files
+    ):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "Repository folder not found. Check the GitHub URL and try again.",
+        )
+
+    skill_md_paths = sorted(
+        path
+        for path in files
+        if PurePosixPath(path).name == SKILL_MD_NAME
+        and (
+            not search_prefix
+            or path.startswith(f"{search_prefix}/")
+            or path == search_prefix
+        )
+    )
+    if not skill_md_paths:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "No SKILL.md files were found in this repository. Add a SKILL.md file, then try again.",
+        )
+
+    skills: list[GitHubSkillBundle] = []
+    for skill_md_path in skill_md_paths:
+        skill_directory = str(PurePosixPath(skill_md_path).parent)
+        if skill_directory == ".":
+            skill_directory = ""
+        try:
+            name, description = parse_skill_md_metadata(files[skill_md_path])
+        except OnyxError as exc:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"Invalid SKILL.md at '{skill_md_path}': {exc.detail}",
+            ) from exc
+
+        slug = slug_from_skill_name(name)
+        if slug in BUILT_IN_SKILLS:
+            skills.append(
+                GitHubSkillBundle(
+                    path=skill_directory or ".",
+                    slug=slug,
+                    name=name,
+                    description=description,
+                    bundle_bytes=None,
+                    unavailable_reason=(
+                        f"Can't import: '{slug}' is a reserved skill name in Onyx."
+                    ),
+                )
+            )
+            continue
+
+        output = io.BytesIO()
+        with zipfile.ZipFile(
+            output, mode="w", compression=zipfile.ZIP_DEFLATED
+        ) as bundle:
+            prefix = f"{skill_directory}/" if skill_directory else ""
+            for path, content in files.items():
+                if prefix and not path.startswith(prefix):
+                    continue
+                relative_path = path.removeprefix(prefix)
+                if not relative_path or relative_path.endswith(TEMPLATE_SUFFIX):
+                    continue
+                if "__pycache__" in PurePosixPath(relative_path).parts:
+                    continue
+                bundle.writestr(relative_path, content)
+
+        skills.append(
+            GitHubSkillBundle(
+                path=skill_directory or ".",
+                slug=slug,
+                name=name,
+                description=description,
+                bundle_bytes=validate_and_normalize_custom_bundle(
+                    output.getvalue(), slug=slug
+                ),
+            )
+        )
+    return repository, skills

--- a/backend/onyx/skills/models.py
+++ b/backend/onyx/skills/models.py
@@ -1,3 +1,5 @@
+from typing import NamedTuple
+
 from pydantic import BaseModel
 from pydantic import ConfigDict
 
@@ -14,3 +16,19 @@ class CustomSkillBundleContents(BaseModel):
 
     instructions_markdown: str
     files: list[SkillBundleFile]
+
+
+class GitHubRepository(NamedTuple):
+    owner: str
+    repo: str
+    ref: str | None = None
+    subpath: str | None = None
+
+
+class GitHubSkillBundle(NamedTuple):
+    path: str
+    slug: str
+    name: str
+    description: str
+    bundle_bytes: bytes | None
+    unavailable_reason: str | None = None

--- a/backend/tests/external_dependency_unit/craft/test_skill_github_import.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_github_import.py
@@ -21,6 +21,8 @@ from onyx.skills.models import GitHubRepository
 from onyx.skills.models import GitHubSkillBundle
 from tests.external_dependency_unit.craft.db_helpers import make_skill
 
+_REVISION = "a" * 40
+
 
 def _bundle(name: str, supporting_path: str) -> bytes:
     output = io.BytesIO()
@@ -64,8 +66,8 @@ def test_import_github_skills_creates_personal_skills_with_supporting_files(
     ]
     monkeypatch.setattr(
         "onyx.server.features.skill.api.fetch_github_skill_bundles",
-        lambda _source, _authorization: (
-            GitHubRepository(owner="owner", repo="repo"),
+        lambda _source, _authorization, **_kwargs: (
+            GitHubRepository(owner="owner", repo="repo", ref=_REVISION),
             discovered,
         ),
     )
@@ -81,6 +83,7 @@ def test_import_github_skills_creates_personal_skills_with_supporting_files(
     response = import_github_skills(
         GitHubSkillsImportRequest(
             repository="owner/repo",
+            revision=_REVISION,
             paths=["skills/alpha", "skills/beta"],
         ),
         user=test_user,
@@ -108,8 +111,8 @@ def test_import_github_skills_creates_personal_skills_with_supporting_files(
             stored_files.append(
                 {file.path for file in inspect_custom_bundle(stored_bundle).files}
             )
-        assert {"SKILL.md", "references/alpha.md"} in stored_files
-        assert {"SKILL.md", "scripts/beta.py"} in stored_files
+        assert {"references/alpha.md"} in stored_files
+        assert {"scripts/beta.py"} in stored_files
     finally:
         for row in rows:
             if row.bundle_file_id is not None:
@@ -147,8 +150,8 @@ def test_import_github_skills_rolls_back_the_batch_on_a_slug_collision(
     ]
     monkeypatch.setattr(
         "onyx.server.features.skill.api.fetch_github_skill_bundles",
-        lambda _source, _authorization: (
-            GitHubRepository(owner="owner", repo="repo"),
+        lambda _source, _authorization, **_kwargs: (
+            GitHubRepository(owner="owner", repo="repo", ref=_REVISION),
             discovered,
         ),
     )
@@ -161,6 +164,7 @@ def test_import_github_skills_rolls_back_the_batch_on_a_slug_collision(
         import_github_skills(
             GitHubSkillsImportRequest(
                 repository="owner/repo",
+                revision=_REVISION,
                 paths=["skills/new", "skills/existing"],
             ),
             user=test_user,
@@ -168,7 +172,7 @@ def test_import_github_skills_rolls_back_the_batch_on_a_slug_collision(
         )
 
     assert collision_name in exc_info.value.detail
-    assert "Choose a different name in SKILL.md" in exc_info.value.detail
+    assert "Rename it in SKILL.md, then try again." in exc_info.value.detail
     db_session.rollback()
     assert (
         db_session.scalar(
@@ -187,8 +191,8 @@ def test_import_github_skills_rejects_an_unavailable_selected_path(
     unavailable_reason = "Can't import: 'pptx' is a reserved skill name in Onyx."
     monkeypatch.setattr(
         "onyx.server.features.skill.api.fetch_github_skill_bundles",
-        lambda _source, _authorization: (
-            GitHubRepository(owner="anthropics", repo="skills"),
+        lambda _source, _authorization, **_kwargs: (
+            GitHubRepository(owner="anthropics", repo="skills", ref=_REVISION),
             [
                 GitHubSkillBundle(
                     path="skills/pptx",
@@ -210,6 +214,7 @@ def test_import_github_skills_rejects_an_unavailable_selected_path(
         import_github_skills(
             GitHubSkillsImportRequest(
                 repository="anthropics/skills",
+                revision=_REVISION,
                 paths=["skills/pptx"],
             ),
             user=test_user,

--- a/backend/tests/external_dependency_unit/craft/test_skill_github_import.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_github_import.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import io
+import zipfile
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.models import Skill
+from onyx.db.models import User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.skill.api import import_github_skills
+from onyx.server.features.skill.models import GitHubSkillsImportRequest
+from onyx.skills.bundle import build_skill_md
+from onyx.skills.bundle import inspect_custom_bundle
+from onyx.skills.bundle import slug_from_skill_name
+from onyx.skills.models import GitHubRepository
+from onyx.skills.models import GitHubSkillBundle
+from tests.external_dependency_unit.craft.db_helpers import make_skill
+
+
+def _bundle(name: str, supporting_path: str) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, mode="w", compression=zipfile.ZIP_DEFLATED) as bundle:
+        bundle.writestr(
+            "SKILL.md",
+            build_skill_md(
+                name=name,
+                description=f"Description for {name}",
+                instructions_markdown=f"Use {name} carefully.",
+            ),
+        )
+        bundle.writestr(supporting_path, f"Supporting content for {name}")
+    return output.getvalue()
+
+
+def test_import_github_skills_creates_personal_skills_with_supporting_files(
+    db_session: Session,
+    test_user: User,
+    initialize_file_store: None,  # noqa: ARG001
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    suffix = uuid4().hex[:8]
+    names = [f"GitHub Alpha {suffix}", f"GitHub Beta {suffix}"]
+    discovered = [
+        GitHubSkillBundle(
+            path="skills/alpha",
+            slug=slug_from_skill_name(names[0]),
+            name=names[0],
+            description=f"Description for {names[0]}",
+            bundle_bytes=_bundle(names[0], "references/alpha.md"),
+        ),
+        GitHubSkillBundle(
+            path="skills/beta",
+            slug=slug_from_skill_name(names[1]),
+            name=names[1],
+            description=f"Description for {names[1]}",
+            bundle_bytes=_bundle(names[1], "scripts/beta.py"),
+        ),
+    ]
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api.fetch_github_skill_bundles",
+        lambda _source, _authorization: (
+            GitHubRepository(owner="owner", repo="repo"),
+            discovered,
+        ),
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api._github_authorization_header",
+        lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api.push_skills_for_users",
+        lambda *_args: None,
+    )
+
+    response = import_github_skills(
+        GitHubSkillsImportRequest(
+            repository="owner/repo",
+            paths=["skills/alpha", "skills/beta"],
+        ),
+        user=test_user,
+        db_session=db_session,
+    )
+
+    rows = db_session.scalars(
+        select(Skill).where(Skill.slug.in_([skill.slug for skill in discovered]))
+    ).all()
+    file_store = get_default_file_store()
+    try:
+        assert {skill.slug for skill in response} == {
+            skill.slug for skill in discovered
+        }
+        assert len(rows) == 2
+        assert all(row.author_user_id == test_user.id for row in rows)
+        assert all(row.public_permission is None for row in rows)
+
+        stored_files = []
+        for row in rows:
+            assert row.bundle_file_id is not None
+            stored_bundle = b"".join(
+                file_store.read_file(row.bundle_file_id, use_tempfile=False)
+            )
+            stored_files.append(
+                {file.path for file in inspect_custom_bundle(stored_bundle).files}
+            )
+        assert {"SKILL.md", "references/alpha.md"} in stored_files
+        assert {"SKILL.md", "scripts/beta.py"} in stored_files
+    finally:
+        for row in rows:
+            if row.bundle_file_id is not None:
+                file_store.delete_file(row.bundle_file_id, error_on_missing=False)
+
+
+def test_import_github_skills_rolls_back_the_batch_on_a_slug_collision(
+    db_session: Session,
+    test_user: User,
+    initialize_file_store: None,  # noqa: ARG001
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    suffix = uuid4().hex[:8]
+    new_name = f"GitHub New {suffix}"
+    collision_name = f"GitHub Existing {suffix}"
+    collision_slug = slug_from_skill_name(collision_name)
+    make_skill(db_session, slug=collision_slug)
+    db_session.commit()
+    discovered = [
+        GitHubSkillBundle(
+            path="skills/new",
+            slug=slug_from_skill_name(new_name),
+            name=new_name,
+            description="New skill",
+            bundle_bytes=_bundle(new_name, "new.txt"),
+        ),
+        GitHubSkillBundle(
+            path="skills/existing",
+            slug=collision_slug,
+            name=collision_name,
+            description="Existing skill",
+            bundle_bytes=_bundle(collision_name, "existing.txt"),
+        ),
+    ]
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api.fetch_github_skill_bundles",
+        lambda _source, _authorization: (
+            GitHubRepository(owner="owner", repo="repo"),
+            discovered,
+        ),
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api._github_authorization_header",
+        lambda *_args: None,
+    )
+
+    with pytest.raises(OnyxError, match="already exists") as exc_info:
+        import_github_skills(
+            GitHubSkillsImportRequest(
+                repository="owner/repo",
+                paths=["skills/new", "skills/existing"],
+            ),
+            user=test_user,
+            db_session=db_session,
+        )
+
+    assert collision_name in exc_info.value.detail
+    assert "Choose a different name in SKILL.md" in exc_info.value.detail
+    db_session.rollback()
+    assert (
+        db_session.scalar(
+            select(Skill).where(Skill.slug == slug_from_skill_name(new_name))
+        )
+        is None
+    )
+
+
+def test_import_github_skills_rejects_an_unavailable_selected_path(
+    db_session: Session,
+    test_user: User,
+    tenant_context: None,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    unavailable_reason = "Can't import: 'pptx' is a reserved skill name in Onyx."
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api.fetch_github_skill_bundles",
+        lambda _source, _authorization: (
+            GitHubRepository(owner="anthropics", repo="skills"),
+            [
+                GitHubSkillBundle(
+                    path="skills/pptx",
+                    slug="pptx",
+                    name="pptx",
+                    description="Create and edit presentations",
+                    bundle_bytes=None,
+                    unavailable_reason=unavailable_reason,
+                )
+            ],
+        ),
+    )
+    monkeypatch.setattr(
+        "onyx.server.features.skill.api._github_authorization_header",
+        lambda *_args: None,
+    )
+
+    with pytest.raises(OnyxError, match="reserved in Onyx") as exc_info:
+        import_github_skills(
+            GitHubSkillsImportRequest(
+                repository="anthropics/skills",
+                paths=["skills/pptx"],
+            ),
+            user=test_user,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.detail == unavailable_reason

--- a/backend/tests/external_dependency_unit/craft/test_skill_github_import.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_github_import.py
@@ -210,7 +210,7 @@ def test_import_github_skills_rejects_an_unavailable_selected_path(
         lambda *_args: None,
     )
 
-    with pytest.raises(OnyxError, match="reserved in Onyx") as exc_info:
+    with pytest.raises(OnyxError) as exc_info:
         import_github_skills(
             GitHubSkillsImportRequest(
                 repository="anthropics/skills",

--- a/backend/tests/unit/onyx/skills/test_github_import.py
+++ b/backend/tests/unit/onyx/skills/test_github_import.py
@@ -343,6 +343,23 @@ def test_reports_invalid_skill_with_its_repository_path(
         fetch_github_skill_bundles("owner/repo")
 
 
+def test_reports_truncated_archive_as_a_github_download_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _repository_archive(
+        {
+            "skill/SKILL.md": _skill_md("Truncated", "Truncated archive"),
+            "skill/data.bin": b"x" * 100_000,
+        }
+    )
+    _mock_archive(monkeypatch, archive[:-32])
+
+    with pytest.raises(OnyxError, match="unreadable repository download") as exc_info:
+        fetch_github_skill_bundles("owner/repo")
+
+    assert exc_info.value.error_code == OnyxErrorCode.BAD_GATEWAY
+
+
 def test_private_repo_token_is_not_forwarded_to_archive_host(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/tests/unit/onyx/skills/test_github_import.py
+++ b/backend/tests/unit/onyx/skills/test_github_import.py
@@ -5,12 +5,15 @@ import tarfile
 import zipfile
 from collections.abc import Iterator
 from typing import Any
+from urllib.parse import unquote
 
 import pytest
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.github_import import fetch_github_skill_bundles
+
+_REVISION = "a" * 40
 
 
 class _ArchiveResponse:
@@ -19,10 +22,12 @@ class _ArchiveResponse:
         archive: bytes,
         status_code: int = 200,
         headers: dict[str, str] | None = None,
+        json_data: dict[str, Any] | None = None,
     ) -> None:
         self.archive = archive
         self.status_code = status_code
         self.headers = headers or {}
+        self.json_data = json_data
 
     def __enter__(self) -> "_ArchiveResponse":
         return self
@@ -33,6 +38,14 @@ class _ArchiveResponse:
     def iter_content(self, chunk_size: int) -> Iterator[bytes]:
         for offset in range(0, len(self.archive), chunk_size):
             yield self.archive[offset : offset + chunk_size]
+
+    def json(self) -> dict[str, Any]:
+        if self.json_data is None:
+            raise ValueError("No JSON response")
+        return self.json_data
+
+    def close(self) -> None:
+        return None
 
 
 def _skill_md(name: str, description: str) -> bytes:
@@ -52,28 +65,34 @@ def _repository_archive(files: dict[str, bytes]) -> bytes:
 
 
 def _mock_archive(monkeypatch: pytest.MonkeyPatch, archive: bytes) -> None:
+    def get(url: str, **_kwargs: Any) -> _ArchiveResponse:
+        if "/commits/" in url:
+            ref = unquote(url.rsplit("/", maxsplit=1)[1])
+            if ref not in {"HEAD", "main"}:
+                return _ArchiveResponse(b"", status_code=404)
+            return _ArchiveResponse(b"", json_data={"sha": _REVISION})
+        return _ArchiveResponse(archive)
+
     monkeypatch.setattr(
         "onyx.skills.github_import.ssrf_safe_get",
-        lambda *_args, **_kwargs: _ArchiveResponse(archive),
+        get,
     )
 
 
 @pytest.mark.parametrize(
-    "source,owner,repo,ref,subpath",
+    "source,owner,repo,subpath",
     [
-        ("onyx-dot-app/onyx", "onyx-dot-app", "onyx", None, None),
+        ("onyx-dot-app/onyx", "onyx-dot-app", "onyx", None),
         (
             "https://github.com/onyx-dot-app/onyx.git",
             "onyx-dot-app",
             "onyx",
-            None,
             None,
         ),
         (
             "https://github.com/onyx-dot-app/onyx/tree/main/skills/example",
             "onyx-dot-app",
             "onyx",
-            "main",
             "skills/example",
         ),
     ],
@@ -83,7 +102,6 @@ def test_parse_github_repository(
     source: str,
     owner: str,
     repo: str,
-    ref: str | None,
     subpath: str | None,
 ) -> None:
     _mock_archive(
@@ -96,9 +114,70 @@ def test_parse_github_repository(
     assert (parsed.owner, parsed.repo, parsed.ref, parsed.subpath) == (
         owner,
         repo,
-        ref,
+        _REVISION,
         subpath,
     )
+
+
+def test_tree_url_resolves_the_longest_matching_slash_ref(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _repository_archive(
+        {"skills/example/SKILL.md": _skill_md("Example", "Example skill")}
+    )
+    refs_seen: list[str] = []
+
+    def get(url: str, **_kwargs: Any) -> _ArchiveResponse:
+        if "/commits/" not in url:
+            return _ArchiveResponse(archive)
+        refs_seen.append(unquote(url.rsplit("/", maxsplit=1)[1]))
+        if refs_seen[-1] == "feature/foo":
+            return _ArchiveResponse(b"", json_data={"sha": _REVISION})
+        return _ArchiveResponse(b"", status_code=404)
+
+    monkeypatch.setattr("onyx.skills.github_import.ssrf_safe_get", get)
+
+    repository, skills = fetch_github_skill_bundles(
+        "https://github.com/owner/repo/tree/feature/foo/skills/example"
+    )
+
+    assert repository.ref == _REVISION
+    assert repository.subpath == "skills/example"
+    assert refs_seen == [
+        "feature/foo/skills/example",
+        "feature/foo/skills",
+        "feature/foo",
+    ]
+    assert [skill.name for skill in skills] == ["Example"]
+
+
+def test_pinned_import_uses_previewed_revision_and_subpath(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _repository_archive(
+        {
+            "skills/alpha/SKILL.md": _skill_md("Alpha", "First"),
+            "skills/beta/SKILL.md": _skill_md("Beta", "Second"),
+        }
+    )
+    urls_seen: list[str] = []
+
+    def get(url: str, **_kwargs: Any) -> _ArchiveResponse:
+        urls_seen.append(url)
+        return _ArchiveResponse(archive)
+
+    monkeypatch.setattr("onyx.skills.github_import.ssrf_safe_get", get)
+
+    repository, skills = fetch_github_skill_bundles(
+        "owner/repo",
+        revision=_REVISION,
+        subpath="skills/beta",
+    )
+
+    assert urls_seen == [f"https://codeload.github.com/owner/repo/tar.gz/{_REVISION}"]
+    assert repository.ref == _REVISION
+    assert repository.subpath == "skills/beta"
+    assert [skill.name for skill in skills] == ["Beta"]
 
 
 def test_discovers_multiple_skills_and_builds_independent_bundles(
@@ -141,6 +220,31 @@ def test_discovers_multiple_skills_and_builds_independent_bundles(
     with zipfile.ZipFile(io.BytesIO(review.bundle_bytes)) as bundle:
         assert set(bundle.namelist()) == {"SKILL.md", "scripts/check.py"}
         assert "README.md" not in bundle.namelist()
+
+
+def test_nested_skills_are_packaged_as_independent_bundles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_archive(
+        monkeypatch,
+        _repository_archive(
+            {
+                "skill/SKILL.md": _skill_md("Parent", "Parent skill"),
+                "skill/parent.txt": b"parent",
+                "skill/child/SKILL.md": _skill_md("Child", "Child skill"),
+                "skill/child/child.txt": b"child",
+            }
+        ),
+    )
+
+    _, skills = fetch_github_skill_bundles("owner/repo")
+    by_name = {skill.name: skill for skill in skills}
+    assert by_name["Parent"].bundle_bytes is not None
+    assert by_name["Child"].bundle_bytes is not None
+    with zipfile.ZipFile(io.BytesIO(by_name["Parent"].bundle_bytes)) as bundle:
+        assert set(bundle.namelist()) == {"SKILL.md", "parent.txt"}
+    with zipfile.ZipFile(io.BytesIO(by_name["Child"].bundle_bytes)) as bundle:
+        assert set(bundle.namelist()) == {"SKILL.md", "child.txt"}
 
 
 def test_reserved_skill_name_does_not_block_other_repository_skills(
@@ -249,6 +353,12 @@ def test_private_repo_token_is_not_forwarded_to_archive_host(
 
     def get(url: str, **kwargs: Any) -> _ArchiveResponse:
         requests_seen.append((url, kwargs))
+        if "/commits/" in url:
+            if kwargs.get("headers") is None:
+                return _ArchiveResponse(b"", status_code=404)
+            return _ArchiveResponse(b"", json_data={"sha": _REVISION})
+        if url.startswith("https://codeload.github.com/owner/repo/"):
+            return _ArchiveResponse(b"", status_code=404)
         if url.startswith("https://api.github.com/"):
             return _ArchiveResponse(
                 b"",
@@ -264,9 +374,40 @@ def test_private_repo_token_is_not_forwarded_to_archive_host(
     )
 
     assert [skill.name for skill in skills] == ["Private"]
-    assert requests_seen[0][1]["headers"]["Authorization"] == "Bearer private-token"
-    assert requests_seen[0][1]["follow_redirects"] is False
-    assert "headers" not in requests_seen[1][1]
+    authenticated = [
+        request for request in requests_seen if request[1].get("headers") is not None
+    ]
+    assert all(
+        request[1]["headers"]["Authorization"] == "Bearer private-token"
+        for request in authenticated
+    )
+    signed_download = requests_seen[-1]
+    assert signed_download[0] == "https://codeload.github.com/signed/archive"
+    assert signed_download[1]["headers"] is None
+
+
+def test_connected_user_downloads_public_repository_anonymously(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _repository_archive(
+        {"skill/SKILL.md": _skill_md("Public", "Public skill")}
+    )
+    requests_seen: list[dict[str, Any]] = []
+
+    def get(url: str, **kwargs: Any) -> _ArchiveResponse:
+        requests_seen.append(kwargs)
+        if "/commits/" in url:
+            return _ArchiveResponse(b"", json_data={"sha": _REVISION})
+        return _ArchiveResponse(archive)
+
+    monkeypatch.setattr("onyx.skills.github_import.ssrf_safe_get", get)
+
+    _, skills = fetch_github_skill_bundles(
+        "owner/repo", authorization_header="Bearer stale-token"
+    )
+
+    assert [skill.name for skill in skills] == ["Public"]
+    assert all(request["headers"] is None for request in requests_seen)
 
 
 @pytest.mark.parametrize(
@@ -299,12 +440,12 @@ def test_private_repo_reports_actionable_github_failures(
     error_code: OnyxErrorCode,
     message: str,
 ) -> None:
-    monkeypatch.setattr(
-        "onyx.skills.github_import.ssrf_safe_get",
-        lambda *_args, **_kwargs: _ArchiveResponse(
-            b"", status_code=status_code, headers=headers
-        ),
-    )
+    def get(_url: str, **kwargs: Any) -> _ArchiveResponse:
+        if kwargs.get("headers") is None:
+            return _ArchiveResponse(b"", status_code=404)
+        return _ArchiveResponse(b"", status_code=status_code, headers=headers)
+
+    monkeypatch.setattr("onyx.skills.github_import.ssrf_safe_get", get)
 
     with pytest.raises(OnyxError, match=message) as exc_info:
         fetch_github_skill_bundles(
@@ -312,3 +453,17 @@ def test_private_repo_reports_actionable_github_failures(
         )
 
     assert exc_info.value.error_code == error_code
+
+
+def test_unauthenticated_forbidden_repository_suggests_connecting_github(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.skills.github_import.ssrf_safe_get",
+        lambda *_args, **_kwargs: _ArchiveResponse(b"", status_code=403),
+    )
+
+    with pytest.raises(OnyxError, match="private, connect GitHub") as exc_info:
+        fetch_github_skill_bundles("owner/private-repo")
+
+    assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND

--- a/backend/tests/unit/onyx/skills/test_github_import.py
+++ b/backend/tests/unit/onyx/skills/test_github_import.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.skills.github_import import fetch_github_skill_bundles
+
+
+class _ArchiveResponse:
+    def __init__(
+        self,
+        archive: bytes,
+        status_code: int = 200,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.archive = archive
+        self.status_code = status_code
+        self.headers = headers or {}
+
+    def __enter__(self) -> "_ArchiveResponse":
+        return self
+
+    def __exit__(self, *_args: Any) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int) -> Iterator[bytes]:
+        for offset in range(0, len(self.archive), chunk_size):
+            yield self.archive[offset : offset + chunk_size]
+
+
+def _skill_md(name: str, description: str) -> bytes:
+    return (
+        f"---\nname: {name}\ndescription: {description}\n---\n\n# Instructions\n"
+    ).encode()
+
+
+def _repository_archive(files: dict[str, bytes]) -> bytes:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        for path, content in files.items():
+            member = tarfile.TarInfo(f"repo-sha/{path}")
+            member.size = len(content)
+            archive.addfile(member, io.BytesIO(content))
+    return output.getvalue()
+
+
+def _mock_archive(monkeypatch: pytest.MonkeyPatch, archive: bytes) -> None:
+    monkeypatch.setattr(
+        "onyx.skills.github_import.ssrf_safe_get",
+        lambda *_args, **_kwargs: _ArchiveResponse(archive),
+    )
+
+
+@pytest.mark.parametrize(
+    "source,owner,repo,ref,subpath",
+    [
+        ("onyx-dot-app/onyx", "onyx-dot-app", "onyx", None, None),
+        (
+            "https://github.com/onyx-dot-app/onyx.git",
+            "onyx-dot-app",
+            "onyx",
+            None,
+            None,
+        ),
+        (
+            "https://github.com/onyx-dot-app/onyx/tree/main/skills/example",
+            "onyx-dot-app",
+            "onyx",
+            "main",
+            "skills/example",
+        ),
+    ],
+)
+def test_parse_github_repository(
+    monkeypatch: pytest.MonkeyPatch,
+    source: str,
+    owner: str,
+    repo: str,
+    ref: str | None,
+    subpath: str | None,
+) -> None:
+    _mock_archive(
+        monkeypatch,
+        _repository_archive(
+            {"skills/example/SKILL.md": _skill_md("Example", "Example skill")}
+        ),
+    )
+    parsed, _ = fetch_github_skill_bundles(source)
+    assert (parsed.owner, parsed.repo, parsed.ref, parsed.subpath) == (
+        owner,
+        repo,
+        ref,
+        subpath,
+    )
+
+
+def test_discovers_multiple_skills_and_builds_independent_bundles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_archive(
+        monkeypatch,
+        _repository_archive(
+            {
+                "README.md": b"repository readme",
+                "skills/research/SKILL.md": _skill_md(
+                    "Deep Research", "Research a topic"
+                ),
+                "skills/research/references/guide.md": b"research guide",
+                ".agents/skills/review/SKILL.md": _skill_md(
+                    "Code Review", "Review a change"
+                ),
+                ".agents/skills/review/scripts/check.py": b"print('ok')",
+            }
+        ),
+    )
+
+    repository, skills = fetch_github_skill_bundles("onyx-dot-app/skills")
+
+    assert repository.owner == "onyx-dot-app"
+    assert [(skill.path, skill.slug) for skill in skills] == [
+        (".agents/skills/review", "code-review"),
+        ("skills/research", "deep-research"),
+    ]
+    by_slug = {skill.slug: skill for skill in skills}
+    research = by_slug["deep-research"]
+    assert research.description == "Research a topic"
+    assert research.bundle_bytes is not None
+    with zipfile.ZipFile(io.BytesIO(research.bundle_bytes)) as bundle:
+        assert set(bundle.namelist()) == {"SKILL.md", "references/guide.md"}
+        assert bundle.read("references/guide.md") == b"research guide"
+
+    review = by_slug["code-review"]
+    assert review.bundle_bytes is not None
+    with zipfile.ZipFile(io.BytesIO(review.bundle_bytes)) as bundle:
+        assert set(bundle.namelist()) == {"SKILL.md", "scripts/check.py"}
+        assert "README.md" not in bundle.namelist()
+
+
+def test_reserved_skill_name_does_not_block_other_repository_skills(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_archive(
+        monkeypatch,
+        _repository_archive(
+            {
+                "skills/pptx/SKILL.md": _skill_md(
+                    "pptx", "Create and edit presentations"
+                ),
+                "skills/research/SKILL.md": _skill_md("Research", "Research a topic"),
+            }
+        ),
+    )
+
+    _, skills = fetch_github_skill_bundles("anthropics/skills")
+
+    by_slug = {skill.slug: skill for skill in skills}
+    assert by_slug["pptx"].bundle_bytes is None
+    assert (
+        by_slug["pptx"].unavailable_reason
+        == "Can't import: 'pptx' is a reserved skill name in Onyx."
+    )
+    assert by_slug["research"].bundle_bytes is not None
+    assert by_slug["research"].unavailable_reason is None
+
+
+def test_tree_url_limits_discovery_to_selected_folder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_archive(
+        monkeypatch,
+        _repository_archive(
+            {
+                "skills/alpha/SKILL.md": _skill_md("Alpha", "First"),
+                "skills/beta/SKILL.md": _skill_md("Beta", "Second"),
+            }
+        ),
+    )
+
+    _, skills = fetch_github_skill_bundles(
+        "https://github.com/owner/repo/tree/main/skills/beta"
+    )
+
+    assert [(skill.path, skill.name) for skill in skills] == [("skills/beta", "Beta")]
+
+
+def test_rejects_repository_symlinks(monkeypatch: pytest.MonkeyPatch) -> None:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        skill_md = _skill_md("Unsafe", "Contains a link")
+        skill_member = tarfile.TarInfo("repo-sha/skill/SKILL.md")
+        skill_member.size = len(skill_md)
+        archive.addfile(skill_member, io.BytesIO(skill_md))
+        link_member = tarfile.TarInfo("repo-sha/skill/escape")
+        link_member.type = tarfile.SYMTYPE
+        link_member.linkname = "../../outside"
+        archive.addfile(link_member)
+    _mock_archive(monkeypatch, output.getvalue())
+
+    with pytest.raises(OnyxError, match="contains a symbolic link"):
+        fetch_github_skill_bundles("owner/repo")
+
+
+@pytest.mark.parametrize(
+    "unsafe_path",
+    ["repo-sha/skill//SKILL.md", "repo-sha/skill\\SKILL.md"],
+)
+def test_rejects_noncanonical_repository_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    unsafe_path: str,
+) -> None:
+    output = io.BytesIO()
+    with tarfile.open(fileobj=output, mode="w:gz") as archive:
+        skill_md = _skill_md("Unsafe", "Contains an unsafe path")
+        member = tarfile.TarInfo(unsafe_path)
+        member.size = len(skill_md)
+        archive.addfile(member, io.BytesIO(skill_md))
+    _mock_archive(monkeypatch, output.getvalue())
+
+    with pytest.raises(OnyxError, match="unsupported path"):
+        fetch_github_skill_bundles("owner/repo")
+
+
+def test_reports_invalid_skill_with_its_repository_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_archive(
+        monkeypatch,
+        _repository_archive({"skills/broken/SKILL.md": b"No frontmatter"}),
+    )
+
+    with pytest.raises(OnyxError, match="skills/broken/SKILL.md"):
+        fetch_github_skill_bundles("owner/repo")
+
+
+def test_private_repo_token_is_not_forwarded_to_archive_host(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    archive = _repository_archive(
+        {"skill/SKILL.md": _skill_md("Private", "Private skill")}
+    )
+    requests_seen: list[tuple[str, dict[str, Any]]] = []
+
+    def get(url: str, **kwargs: Any) -> _ArchiveResponse:
+        requests_seen.append((url, kwargs))
+        if url.startswith("https://api.github.com/"):
+            return _ArchiveResponse(
+                b"",
+                status_code=302,
+                headers={"Location": "https://codeload.github.com/signed/archive"},
+            )
+        return _ArchiveResponse(archive)
+
+    monkeypatch.setattr("onyx.skills.github_import.ssrf_safe_get", get)
+
+    _, skills = fetch_github_skill_bundles(
+        "owner/repo", authorization_header="Bearer private-token"
+    )
+
+    assert [skill.name for skill in skills] == ["Private"]
+    assert requests_seen[0][1]["headers"]["Authorization"] == "Bearer private-token"
+    assert requests_seen[0][1]["follow_redirects"] is False
+    assert "headers" not in requests_seen[1][1]
+
+
+@pytest.mark.parametrize(
+    "status_code,headers,error_code,message",
+    [
+        (
+            401,
+            {},
+            OnyxErrorCode.UNAUTHENTICATED,
+            "connection has expired",
+        ),
+        (
+            403,
+            {"X-RateLimit-Remaining": "0"},
+            OnyxErrorCode.RATE_LIMITED,
+            "API rate limit",
+        ),
+        (
+            403,
+            {},
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "organization SSO",
+        ),
+    ],
+)
+def test_private_repo_reports_actionable_github_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    status_code: int,
+    headers: dict[str, str],
+    error_code: OnyxErrorCode,
+    message: str,
+) -> None:
+    monkeypatch.setattr(
+        "onyx.skills.github_import.ssrf_safe_get",
+        lambda *_args, **_kwargs: _ArchiveResponse(
+            b"", status_code=status_code, headers=headers
+        ),
+    )
+
+    with pytest.raises(OnyxError, match=message) as exc_info:
+        fetch_github_skill_bundles(
+            "owner/repo", authorization_header="Bearer private-token"
+        )
+
+    assert exc_info.value.error_code == error_code

--- a/web/src/lib/skills/api.test.ts
+++ b/web/src/lib/skills/api.test.ts
@@ -1,0 +1,35 @@
+import { FetchError } from "@/lib/fetcher";
+import { previewGitHubSkills } from "@/lib/skills/api";
+
+describe("skills API errors", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("preserves the backend error code and actionable detail", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error_code: "RATE_LIMITED",
+          detail:
+            "GitHub's API rate limit has been reached. Try again in a few minutes.",
+        }),
+        {
+          status: 429,
+          headers: { "Content-Type": "application/json" },
+        }
+      )
+    );
+
+    const request = previewGitHubSkills("owner/repository");
+
+    await expect(request).rejects.toMatchObject<Partial<FetchError>>({
+      message:
+        "GitHub's API rate limit has been reached. Try again in a few minutes.",
+      status: 429,
+      info: {
+        error_code: "RATE_LIMITED",
+        detail:
+          "GitHub's API rate limit has been reached. Try again in a few minutes.",
+      },
+    });
+  });
+});

--- a/web/src/lib/skills/api.test.ts
+++ b/web/src/lib/skills/api.test.ts
@@ -32,4 +32,25 @@ describe("skills API errors", () => {
       },
     });
   });
+
+  it("logs malformed error responses before using the fallback", async () => {
+    const consoleError = jest
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce(new Response("not json", { status: 502 }));
+
+    await expect(previewGitHubSkills("owner/repository")).rejects.toMatchObject<
+      Partial<FetchError>
+    >({
+      message: "Request failed (502)",
+      status: 502,
+      info: undefined,
+    });
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to parse skills API error response:",
+      expect.anything()
+    );
+  });
 });

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -20,7 +20,8 @@ async function handle<T>(res: Response): Promise<T> {
     let body: unknown;
     try {
       body = await res.json();
-    } catch {
+    } catch (error) {
+      console.error("Failed to parse skills API error response:", error);
       body = undefined;
     }
     const detail =
@@ -73,12 +74,14 @@ export async function previewGitHubSkills(
 
 export async function importGitHubSkills(
   repository: string,
+  revision: string,
+  subpath: string | null,
   paths: string[]
 ): Promise<CustomSkill[]> {
   const res = await fetch("/api/skills/github/import", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ repository, paths }),
+    body: JSON.stringify({ repository, revision, subpath, paths }),
   });
   return handle<CustomSkill[]>(res);
 }

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -8,26 +8,36 @@
 
 import type {
   CustomSkill,
+  GitHubSkillsPreview,
   SkillBundleContents,
   SkillEditableDetail,
   SkillSharePermission,
 } from "@/lib/skills/types";
-
-async function readErrorDetail(res: Response): Promise<string> {
-  try {
-    const body = await res.json();
-    if (typeof body?.detail === "string") return body.detail;
-    if (Array.isArray(body?.detail) && body.detail[0]?.msg)
-      return body.detail[0].msg;
-  } catch {
-    // fall through
-  }
-  return `Request failed (${res.status})`;
-}
+import { FetchError } from "@/lib/fetcher";
 
 async function handle<T>(res: Response): Promise<T> {
   if (!res.ok) {
-    throw new Error(await readErrorDetail(res));
+    let body: unknown;
+    try {
+      body = await res.json();
+    } catch {
+      body = undefined;
+    }
+    const detail =
+      body && typeof body === "object" && "detail" in body
+        ? body.detail
+        : undefined;
+    const message =
+      typeof detail === "string"
+        ? detail
+        : Array.isArray(detail) &&
+            detail[0] &&
+            typeof detail[0] === "object" &&
+            "msg" in detail[0] &&
+            typeof detail[0].msg === "string"
+          ? detail[0].msg
+          : `Request failed (${res.status})`;
+    throw new FetchError(message, res.status, body);
   }
   if (res.status === 204) {
     return undefined as T;
@@ -48,6 +58,29 @@ export async function createCustomSkill(bundle: File): Promise<CustomSkill> {
     body: form,
   });
   return handle<CustomSkill>(res);
+}
+
+export async function previewGitHubSkills(
+  repository: string
+): Promise<GitHubSkillsPreview> {
+  const res = await fetch("/api/skills/github/preview", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ repository }),
+  });
+  return handle<GitHubSkillsPreview>(res);
+}
+
+export async function importGitHubSkills(
+  repository: string,
+  paths: string[]
+): Promise<CustomSkill[]> {
+  const res = await fetch("/api/skills/github/import", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ repository, paths }),
+  });
+  return handle<CustomSkill[]>(res);
 }
 
 export interface CreateCustomSkillInput {

--- a/web/src/lib/skills/types.ts
+++ b/web/src/lib/skills/types.ts
@@ -89,3 +89,15 @@ export interface SkillBundleContents {
   instructions_markdown: string;
   files: SkillBundleFile[];
 }
+
+export interface GitHubSkillPreview {
+  path: string;
+  name: string;
+  description: string;
+  unavailable_reason: string | null;
+}
+
+export interface GitHubSkillsPreview {
+  repository: string;
+  skills: GitHubSkillPreview[];
+}

--- a/web/src/lib/skills/types.ts
+++ b/web/src/lib/skills/types.ts
@@ -99,5 +99,7 @@ export interface GitHubSkillPreview {
 
 export interface GitHubSkillsPreview {
   repository: string;
+  revision: string;
+  subpath: string | null;
   skills: GitHubSkillPreview[];
 }

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.stories.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.stories.tsx
@@ -17,6 +17,8 @@ const githubApp: ExternalAppUserResponse = {
 
 const preview = {
   repository: "onyx-dot-app/skills",
+  revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  subpath: null,
   skills: [
     {
       path: "skills/deep-research",
@@ -99,6 +101,8 @@ export const ReservedNameAmongSkills: Story = {
     repository: "https://github.com/anthropics/skills",
     preview: {
       repository: "anthropics/skills",
+      revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      subpath: null,
       skills: [
         {
           path: "skills/pptx",
@@ -124,6 +128,8 @@ export const NoImportableSkills: Story = {
     repository: "https://github.com/example/presentation-skill",
     preview: {
       repository: "example/presentation-skill",
+      revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      subpath: null,
       skills: [
         {
           path: ".",

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.stories.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.stories.tsx
@@ -1,0 +1,230 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { FetchError } from "@/lib/fetcher";
+import { ImportSkillsFromGitHubModalView } from "@/sections/modals/skills/ImportSkillsFromGitHubModal";
+import type { ExternalAppUserResponse } from "@/app/craft/v1/apps/registry";
+
+const githubApp: ExternalAppUserResponse = {
+  id: 7,
+  name: "GitHub",
+  description: "GitHub access",
+  slug: "github",
+  app_type: "GITHUB",
+  credential_keys: ["access_token"],
+  credential_values: {},
+  authenticated: false,
+  supports_oauth: true,
+};
+
+const preview = {
+  repository: "onyx-dot-app/skills",
+  skills: [
+    {
+      path: "skills/deep-research",
+      name: "Deep Research",
+      description: "Research a topic thoroughly and report the findings.",
+      unavailable_reason: null,
+    },
+    {
+      path: "skills/code-review",
+      name: "Code Review",
+      description: "Review a change for correctness and maintainability.",
+      unavailable_reason: null,
+    },
+  ],
+};
+
+function apiError(errorCode: string, message: string, status: number) {
+  return new FetchError(message, status, {
+    error_code: errorCode,
+    detail: message,
+  });
+}
+
+const meta: Meta<typeof ImportSkillsFromGitHubModalView> = {
+  title: "Sections/Skills/Import Skills from GitHub Modal",
+  component: ImportSkillsFromGitHubModalView,
+  parameters: { layout: "fullscreen" },
+  args: {
+    open: true,
+    onClose: () => undefined,
+    repository: "",
+    preview: null,
+    selectedPaths: [],
+    loading: false,
+    error: null,
+    isAdmin: false,
+    externalApps: [],
+    onRepositoryChange: () => undefined,
+    onSelectedPathsChange: () => undefined,
+    onSubmit: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ImportSkillsFromGitHubModalView>;
+
+export const PublicRepository: Story = {};
+
+export const AdminCanSetUpGitHub: Story = {
+  args: { isAdmin: true },
+};
+
+export const PrivateRepositoryCanConnect: Story = {
+  args: { externalApps: [githubApp] },
+};
+
+export const GitHubConnected: Story = {
+  args: {
+    externalApps: [{ ...githubApp, authenticated: true }],
+  },
+};
+
+export const SearchingRepository: Story = {
+  args: {
+    repository: "https://github.com/onyx-dot-app/skills",
+    loading: true,
+  },
+};
+
+export const SkillsFound: Story = {
+  args: {
+    repository: "https://github.com/onyx-dot-app/skills",
+    preview,
+    selectedPaths: preview.skills.map((skill) => skill.path),
+  },
+};
+
+export const ReservedNameAmongSkills: Story = {
+  args: {
+    repository: "https://github.com/anthropics/skills",
+    preview: {
+      repository: "anthropics/skills",
+      skills: [
+        {
+          path: "skills/pptx",
+          name: "pptx",
+          description: "Create and edit presentation files.",
+          unavailable_reason:
+            "Can't import: 'pptx' is a reserved skill name in Onyx.",
+        },
+        {
+          path: "skills/pdf",
+          name: "PDF",
+          description: "Create and edit PDF files.",
+          unavailable_reason: null,
+        },
+      ],
+    },
+    selectedPaths: ["skills/pdf"],
+  },
+};
+
+export const NoImportableSkills: Story = {
+  args: {
+    repository: "https://github.com/example/presentation-skill",
+    preview: {
+      repository: "example/presentation-skill",
+      skills: [
+        {
+          path: ".",
+          name: "pptx",
+          description: "Create and edit presentation files.",
+          unavailable_reason:
+            "Can't import: 'pptx' is a reserved skill name in Onyx.",
+        },
+      ],
+    },
+    selectedPaths: [],
+  },
+};
+
+export const ImportingSkills: Story = {
+  args: {
+    repository: "https://github.com/onyx-dot-app/skills",
+    preview,
+    selectedPaths: preview.skills.map((skill) => skill.path),
+    loading: true,
+  },
+};
+
+export const NoSkillFound: Story = {
+  args: {
+    repository: "https://github.com/onyx-dot-app/empty-repository",
+    error: apiError(
+      "NOT_FOUND",
+      "No SKILL.md files were found in this repository. Add a SKILL.md file, then try again.",
+      404
+    ),
+  },
+};
+
+export const InvalidSkillFile: Story = {
+  args: {
+    repository: "https://github.com/onyx-dot-app/skills",
+    error: apiError(
+      "INVALID_INPUT",
+      "Invalid SKILL.md at 'skills/research/SKILL.md': SKILL.md frontmatter must include a non-empty 'description'",
+      400
+    ),
+  },
+};
+
+export const RepositoryTooLarge: Story = {
+  args: {
+    repository: "https://github.com/onyx-dot-app/skills",
+    error: apiError(
+      "PAYLOAD_TOO_LARGE",
+      "Repository download exceeds the 25 MiB limit. Remove large files or move the skills to a smaller repository.",
+      413
+    ),
+  },
+};
+
+export const GitHubConnectionExpired: Story = {
+  args: {
+    repository: "onyx-dot-app/private-skills",
+    externalApps: [{ ...githubApp, authenticated: true }],
+    error: apiError(
+      "UNAUTHENTICATED",
+      "Your GitHub connection has expired. Reconnect GitHub, then try again.",
+      401
+    ),
+  },
+};
+
+export const GitHubAccessDenied: Story = {
+  args: {
+    repository: "onyx-dot-app/private-skills",
+    externalApps: [{ ...githubApp, authenticated: true }],
+    error: apiError(
+      "INSUFFICIENT_PERMISSIONS",
+      "GitHub denied access to this repository. Make sure your connected account has access and, if required, has authorized organization SSO.",
+      403
+    ),
+  },
+};
+
+export const GitHubRateLimited: Story = {
+  args: {
+    repository: "onyx-dot-app/skills",
+    externalApps: [{ ...githubApp, authenticated: true }],
+    error: apiError(
+      "RATE_LIMITED",
+      "GitHub's API rate limit has been reached. Try again in a few minutes.",
+      429
+    ),
+  },
+};
+
+export const ImportNameConflict: Story = {
+  args: {
+    repository: "https://github.com/onyx-dot-app/skills",
+    preview,
+    selectedPaths: preview.skills.map((skill) => skill.path),
+    error: apiError(
+      "DUPLICATE_RESOURCE",
+      'A skill named "Deep Research" already exists in this workspace. Rename it in SKILL.md, then try again.',
+      409
+    ),
+  },
+};

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.stories.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.stories.tsx
@@ -57,6 +57,7 @@ const meta: Meta<typeof ImportSkillsFromGitHubModalView> = {
     isAdmin: false,
     externalApps: [],
     onRepositoryChange: () => undefined,
+    onResetPreview: () => undefined,
     onSelectedPathsChange: () => undefined,
     onSubmit: () => undefined,
   },

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.test.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.test.tsx
@@ -11,7 +11,8 @@ jest.mock("@/lib/skills/api", () => ({
   importGitHubSkills: jest.fn(),
   previewGitHubSkills: jest.fn(),
 }));
-jest.mock("@/hooks/useToast", () => ({
+jest.mock("@opal/layouts", () => ({
+  ...jest.requireActual("@opal/layouts"),
   toast: { success: jest.fn() },
 }));
 jest.mock("@/hooks/useUserExternalApps", () => ({
@@ -55,6 +56,8 @@ describe("ImportSkillsFromGitHubModal", () => {
     const user = userEvent.setup();
     mockedPreviewGitHubSkills.mockResolvedValue({
       repository: "owner/repo",
+      revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      subpath: null,
       skills: [
         {
           path: "skills/alpha",
@@ -111,7 +114,9 @@ describe("ImportSkillsFromGitHubModal", () => {
 
     await waitFor(() => {
       expect(mockedImportGitHubSkills).toHaveBeenCalledWith(
-        "https://github.com/owner/repo",
+        "owner/repo",
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        null,
         ["skills/alpha"]
       );
     });
@@ -254,6 +259,8 @@ describe("ImportSkillsFromGitHubModal", () => {
     const user = userEvent.setup();
     mockedPreviewGitHubSkills.mockResolvedValueOnce({
       repository: "owner/repository",
+      revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      subpath: null,
       skills: [
         {
           path: "skills/research",

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.test.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.test.tsx
@@ -97,7 +97,7 @@ describe("ImportSkillsFromGitHubModal", () => {
       screen.getByRole("textbox"),
       "https://github.com/owner/repo"
     );
-    await user.click(screen.getByRole("button", { name: "Search repository" }));
+    await user.click(screen.getByRole("button", { name: "Find skills" }));
 
     expect(await screen.findByText("3 skills found")).toBeInTheDocument();
     expect(
@@ -109,6 +109,7 @@ describe("ImportSkillsFromGitHubModal", () => {
     expect(
       screen.getByText("Can't import: 'pptx' is a reserved skill name in Onyx.")
     ).toBeInTheDocument();
+    expect(screen.queryByText("skills/alpha")).not.toBeInTheDocument();
     await user.click(screen.getByRole("checkbox", { name: "Select Beta" }));
     await user.click(screen.getByRole("button", { name: "Import skill" }));
 
@@ -121,6 +122,65 @@ describe("ImportSkillsFromGitHubModal", () => {
       );
     });
     expect(onCreated).toHaveBeenCalledWith([{ name: "Alpha" }]);
+  });
+
+  it("supports bulk selection and returning to the repository step", async () => {
+    const user = userEvent.setup();
+    mockedPreviewGitHubSkills.mockResolvedValueOnce({
+      repository: "owner/repository",
+      revision: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      subpath: null,
+      skills: [
+        {
+          path: "skills/alpha",
+          name: "Alpha",
+          description: "First skill",
+          unavailable_reason: null,
+        },
+        {
+          path: "skills/beta",
+          name: "Beta",
+          description: "Second skill",
+          unavailable_reason: null,
+        },
+      ],
+    });
+    mockedImportGitHubSkills.mockClear();
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    const repositoryInput = screen.getByRole("textbox");
+    await user.type(repositoryInput, "owner/repository{enter}");
+
+    expect(await screen.findByText("2 skills found")).toBeInTheDocument();
+    expect(screen.getByText("2 selected")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    expect(mockedImportGitHubSkills).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Clear all" }));
+    expect(
+      screen.getByRole("button", { name: "Select skills" })
+    ).toBeDisabled();
+    expect(
+      screen.getByRole("checkbox", { name: "Select Alpha" })
+    ).not.toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Select all" }));
+    expect(
+      screen.getByRole("checkbox", { name: "Select Alpha" })
+    ).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Select Beta" })).toBeChecked();
+
+    await user.click(screen.getByRole("button", { name: "Change" }));
+    expect(screen.getByRole("textbox")).toHaveValue("owner/repository");
+    expect(screen.queryByText("2 skills found")).not.toBeInTheDocument();
+    expect(mockedImportGitHubSkills).not.toHaveBeenCalled();
   });
 
   it("offers the existing GitHub connection flow for private repositories", () => {
@@ -140,15 +200,14 @@ describe("ImportSkillsFromGitHubModal", () => {
     );
 
     expect(
-      screen.getByText(
-        "Public repositories don't require a GitHub connection. Connect GitHub to import private repositories."
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("link", { name: "Connect GitHub" })
+      screen.getByRole("link", {
+        name: "Connect GitHub for private repositories",
+      })
     ).toHaveAttribute("href", "/craft/v1/apps?connect=github");
     expect(
-      screen.getByRole("link", { name: "Connect GitHub" })
+      screen.getByRole("link", {
+        name: "Connect GitHub for private repositories",
+      })
     ).not.toHaveAttribute("target");
   });
 
@@ -163,11 +222,13 @@ describe("ImportSkillsFromGitHubModal", () => {
 
     expect(
       screen.getByText(
-        "Public repositories don't require a GitHub connection. Ask a workspace admin to set up the GitHub App to import private repositories."
+        "Private repositories require GitHub access configured by a workspace admin."
       )
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("link", { name: "Connect GitHub" })
+      screen.queryByRole("link", {
+        name: "Connect GitHub for private repositories",
+      })
     ).not.toBeInTheDocument();
   });
 
@@ -185,20 +246,18 @@ describe("ImportSkillsFromGitHubModal", () => {
     );
 
     expect(
-      screen.getByText(
-        "Public repositories don't require a GitHub connection. Set up the GitHub App to import private repositories."
-      )
-    ).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: "Set up GitHub" })).toHaveAttribute(
-      "href",
-      "/admin/craft/apps"
-    );
+      screen.getByRole("link", {
+        name: "Set up private repository access",
+      })
+    ).toHaveAttribute("href", "/admin/craft/apps");
     expect(
-      screen.getByRole("link", { name: "Set up GitHub" })
+      screen.getByRole("link", {
+        name: "Set up private repository access",
+      })
     ).not.toHaveAttribute("target");
   });
 
-  it("quietly confirms private repository support when GitHub is connected", () => {
+  it("does not add private repository guidance when GitHub is connected", () => {
     mockedUseUserExternalApps.mockReturnValue({
       data: [{ ...githubApp, authenticated: true }],
       error: undefined,
@@ -214,14 +273,7 @@ describe("ImportSkillsFromGitHubModal", () => {
       />
     );
 
-    expect(
-      screen.getByText(
-        "You can import public repositories and any private repositories your GitHub account can access."
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.queryByRole("link", { name: "Connect GitHub" })
-    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/private repositories/i)).not.toBeInTheDocument();
   });
 
   it("shows a preview failure next to the repository controls", async () => {
@@ -243,7 +295,7 @@ describe("ImportSkillsFromGitHubModal", () => {
     );
 
     await user.type(screen.getByRole("textbox"), "owner/repository");
-    await user.click(screen.getByRole("button", { name: "Search repository" }));
+    await user.click(screen.getByRole("button", { name: "Find skills" }));
 
     expect(
       await screen.findByText("Couldn’t load repository")
@@ -287,7 +339,7 @@ describe("ImportSkillsFromGitHubModal", () => {
     );
 
     await user.type(screen.getByRole("textbox"), "owner/repository");
-    await user.click(screen.getByRole("button", { name: "Search repository" }));
+    await user.click(screen.getByRole("button", { name: "Find skills" }));
     await user.click(
       await screen.findByRole("button", { name: "Import skill" })
     );
@@ -327,7 +379,7 @@ describe("ImportSkillsFromGitHubModal", () => {
     );
 
     await user.type(screen.getByRole("textbox"), "owner/private-repository");
-    await user.click(screen.getByRole("button", { name: "Search repository" }));
+    await user.click(screen.getByRole("button", { name: "Find skills" }));
 
     expect(
       await screen.findByRole("link", { name: "Reconnect GitHub" })

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.test.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.test.tsx
@@ -1,0 +1,329 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { importGitHubSkills, previewGitHubSkills } from "@/lib/skills/api";
+import type { CustomSkill } from "@/lib/skills/types";
+import ImportSkillsFromGitHubModal from "@/sections/modals/skills/ImportSkillsFromGitHubModal";
+import useUserExternalApps from "@/hooks/useUserExternalApps";
+import { useUser } from "@/providers/UserProvider";
+import { FetchError } from "@/lib/fetcher";
+
+jest.mock("@/lib/skills/api", () => ({
+  importGitHubSkills: jest.fn(),
+  previewGitHubSkills: jest.fn(),
+}));
+jest.mock("@/hooks/useToast", () => ({
+  toast: { success: jest.fn() },
+}));
+jest.mock("@/hooks/useUserExternalApps", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("@/providers/UserProvider", () => ({
+  useUser: jest.fn(),
+}));
+
+const mockedPreviewGitHubSkills = jest.mocked(previewGitHubSkills);
+const mockedImportGitHubSkills = jest.mocked(importGitHubSkills);
+const mockedUseUserExternalApps = jest.mocked(useUserExternalApps);
+const mockedUseUser = jest.mocked(useUser);
+const githubApp = {
+  id: 7,
+  name: "GitHub",
+  description: "GitHub access",
+  slug: "github",
+  app_type: "GITHUB" as const,
+  credential_keys: ["access_token"],
+  credential_values: {},
+  authenticated: false,
+  supports_oauth: true,
+};
+
+describe("ImportSkillsFromGitHubModal", () => {
+  beforeEach(() => {
+    mockedUseUser.mockReturnValue({
+      isAdmin: false,
+    } as ReturnType<typeof useUser>);
+    mockedUseUserExternalApps.mockReturnValue({
+      data: [],
+      error: undefined,
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+  });
+
+  it("previews repository skills and imports only the selected paths", async () => {
+    const user = userEvent.setup();
+    mockedPreviewGitHubSkills.mockResolvedValue({
+      repository: "owner/repo",
+      skills: [
+        {
+          path: "skills/alpha",
+          name: "Alpha",
+          description: "First skill",
+          unavailable_reason: null,
+        },
+        {
+          path: "skills/beta",
+          name: "Beta",
+          description: "Second skill",
+          unavailable_reason: null,
+        },
+        {
+          path: "skills/pptx",
+          name: "pptx",
+          description: "Create and edit presentations",
+          unavailable_reason:
+            "Can't import: 'pptx' is a reserved skill name in Onyx.",
+        },
+      ],
+    });
+    mockedImportGitHubSkills.mockResolvedValue([
+      { name: "Alpha" } as CustomSkill,
+    ]);
+    const onCreated = jest.fn();
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={onCreated}
+      />
+    );
+
+    await user.type(
+      screen.getByRole("textbox"),
+      "https://github.com/owner/repo"
+    );
+    await user.click(screen.getByRole("button", { name: "Search repository" }));
+
+    expect(await screen.findByText("3 skills found")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", { name: "Select Alpha" })
+    ).toBeChecked();
+    expect(
+      screen.getByRole("checkbox", { name: "Select pptx" })
+    ).toHaveAttribute("data-disabled", "true");
+    expect(
+      screen.getByText("Can't import: 'pptx' is a reserved skill name in Onyx.")
+    ).toBeInTheDocument();
+    await user.click(screen.getByRole("checkbox", { name: "Select Beta" }));
+    await user.click(screen.getByRole("button", { name: "Import skill" }));
+
+    await waitFor(() => {
+      expect(mockedImportGitHubSkills).toHaveBeenCalledWith(
+        "https://github.com/owner/repo",
+        ["skills/alpha"]
+      );
+    });
+    expect(onCreated).toHaveBeenCalledWith([{ name: "Alpha" }]);
+  });
+
+  it("offers the existing GitHub connection flow for private repositories", () => {
+    mockedUseUserExternalApps.mockReturnValue({
+      data: [githubApp],
+      error: undefined,
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "Public repositories don't require a GitHub connection. Connect GitHub to import private repositories."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Connect GitHub" })
+    ).toHaveAttribute("href", "/craft/v1/apps?connect=github");
+    expect(
+      screen.getByRole("link", { name: "Connect GitHub" })
+    ).not.toHaveAttribute("target");
+  });
+
+  it("explains the admin prerequisite when GitHub is not configured", () => {
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "Public repositories don't require a GitHub connection. Ask a workspace admin to set up the GitHub App to import private repositories."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Connect GitHub" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("links admins directly to GitHub App setup", () => {
+    mockedUseUser.mockReturnValue({
+      isAdmin: true,
+    } as ReturnType<typeof useUser>);
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "Public repositories don't require a GitHub connection. Set up the GitHub App to import private repositories."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Set up GitHub" })).toHaveAttribute(
+      "href",
+      "/admin/craft/apps"
+    );
+    expect(
+      screen.getByRole("link", { name: "Set up GitHub" })
+    ).not.toHaveAttribute("target");
+  });
+
+  it("quietly confirms private repository support when GitHub is connected", () => {
+    mockedUseUserExternalApps.mockReturnValue({
+      data: [{ ...githubApp, authenticated: true }],
+      error: undefined,
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByText(
+        "You can import public repositories and any private repositories your GitHub account can access."
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Connect GitHub" })
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a preview failure next to the repository controls", async () => {
+    const user = userEvent.setup();
+    mockedPreviewGitHubSkills.mockRejectedValueOnce(
+      new FetchError(
+        "No SKILL.md files were found in this repository. Add a SKILL.md file, then try again.",
+        404,
+        { error_code: "NOT_FOUND" }
+      )
+    );
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    await user.type(screen.getByRole("textbox"), "owner/repository");
+    await user.click(screen.getByRole("button", { name: "Search repository" }));
+
+    expect(
+      await screen.findByText("Couldn’t load repository")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "No SKILL.md files were found in this repository. Add a SKILL.md file, then try again."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the preview and retries a transient import failure", async () => {
+    const user = userEvent.setup();
+    mockedPreviewGitHubSkills.mockResolvedValueOnce({
+      repository: "owner/repository",
+      skills: [
+        {
+          path: "skills/research",
+          name: "Research",
+          description: "Research a topic",
+          unavailable_reason: null,
+        },
+      ],
+    });
+    mockedImportGitHubSkills.mockRejectedValue(
+      new FetchError(
+        "GitHub's API rate limit has been reached. Try again in a few minutes.",
+        429,
+        { error_code: "RATE_LIMITED" }
+      )
+    );
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    await user.type(screen.getByRole("textbox"), "owner/repository");
+    await user.click(screen.getByRole("button", { name: "Search repository" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Import skill" })
+    );
+
+    expect(
+      await screen.findByText("Couldn’t import skills")
+    ).toBeInTheDocument();
+    expect(screen.getByText("1 skill found")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() =>
+      expect(mockedImportGitHubSkills).toHaveBeenCalledTimes(2)
+    );
+  });
+
+  it("links an expired GitHub connection to reauthorization", async () => {
+    const user = userEvent.setup();
+    mockedUseUserExternalApps.mockReturnValue({
+      data: [{ ...githubApp, authenticated: true }],
+      error: undefined,
+      isLoading: false,
+      refresh: jest.fn(),
+    });
+    mockedPreviewGitHubSkills.mockRejectedValueOnce(
+      new FetchError(
+        "Your GitHub connection has expired. Reconnect GitHub, then try again.",
+        401,
+        { error_code: "UNAUTHENTICATED" }
+      )
+    );
+
+    render(
+      <ImportSkillsFromGitHubModal
+        open
+        onClose={jest.fn()}
+        onCreated={jest.fn()}
+      />
+    );
+
+    await user.type(screen.getByRole("textbox"), "owner/private-repository");
+    await user.click(screen.getByRole("button", { name: "Search repository" }));
+
+    expect(
+      await screen.findByRole("link", { name: "Reconnect GitHub" })
+    ).toHaveAttribute("href", "/craft/v1/apps?connect=github");
+  });
+});

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
@@ -1,0 +1,381 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  Button,
+  Card,
+  Checkbox,
+  InputTypeIn,
+  MessageCard,
+  Text,
+} from "@opal/components";
+import { Content, InputVertical } from "@opal/layouts";
+import { SvgGithub } from "@opal/logos";
+import { toast } from "@/hooks/useToast";
+import { importGitHubSkills, previewGitHubSkills } from "@/lib/skills/api";
+import type { CustomSkill, GitHubSkillsPreview } from "@/lib/skills/types";
+import Modal from "@/refresh-components/Modal";
+import useUserExternalApps from "@/hooks/useUserExternalApps";
+import { useUser } from "@/providers/UserProvider";
+import { FetchError } from "@/lib/fetcher";
+import type { ExternalAppUserResponse } from "@/app/craft/v1/apps/registry";
+
+interface ImportSkillsFromGitHubModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (skills: CustomSkill[]) => void;
+}
+
+interface ImportSkillsFromGitHubModalViewProps {
+  open: boolean;
+  onClose: () => void;
+  repository: string;
+  preview: GitHubSkillsPreview | null;
+  selectedPaths: string[];
+  loading: boolean;
+  error: Error | null;
+  isAdmin: boolean;
+  externalApps: ExternalAppUserResponse[] | undefined;
+  onRepositoryChange: (repository: string) => void;
+  onSelectedPathsChange: (paths: string[]) => void;
+  onSubmit: () => void;
+}
+
+export default function ImportSkillsFromGitHubModal({
+  open,
+  onClose,
+  onCreated,
+}: ImportSkillsFromGitHubModalProps) {
+  const [repository, setRepository] = useState("");
+  const [preview, setPreview] = useState<GitHubSkillsPreview | null>(null);
+  const [selectedPaths, setSelectedPaths] = useState<string[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const { isAdmin } = useUser();
+  const { data: externalApps } = useUserExternalApps();
+
+  useEffect(() => {
+    if (!open) {
+      setRepository("");
+      setPreview(null);
+      setSelectedPaths([]);
+      setError(null);
+    }
+  }, [open]);
+
+  function handleClose() {
+    if (!loading) onClose();
+  }
+
+  async function submit() {
+    if (!repository.trim() || (preview && selectedPaths.length === 0)) return;
+    setLoading(true);
+    setError(null);
+    try {
+      if (!preview) {
+        const result = await previewGitHubSkills(repository);
+        setPreview(result);
+        setSelectedPaths(
+          result.skills
+            .filter((skill) => skill.unavailable_reason === null)
+            .map((skill) => skill.path)
+        );
+        return;
+      }
+
+      const created = await importGitHubSkills(repository, selectedPaths);
+      toast.success(
+        created.length === 1
+          ? `Imported "${created[0]!.name}"`
+          : `Imported ${created.length} skills`
+      );
+      onCreated(created);
+      onClose();
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught
+          : new Error(
+              preview ? "Couldn't import skills" : "Couldn't load repository"
+            )
+      );
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <ImportSkillsFromGitHubModalView
+      open={open}
+      onClose={handleClose}
+      repository={repository}
+      preview={preview}
+      selectedPaths={selectedPaths}
+      loading={loading}
+      error={error}
+      isAdmin={isAdmin}
+      externalApps={externalApps}
+      onRepositoryChange={(nextRepository) => {
+        setRepository(nextRepository);
+        setPreview(null);
+        setSelectedPaths([]);
+        setError(null);
+      }}
+      onSelectedPathsChange={setSelectedPaths}
+      onSubmit={() => void submit()}
+    />
+  );
+}
+
+export function ImportSkillsFromGitHubModalView({
+  open,
+  onClose,
+  repository,
+  preview,
+  selectedPaths,
+  loading,
+  error,
+  isAdmin,
+  externalApps,
+  onRepositoryChange,
+  onSelectedPathsChange,
+  onSubmit,
+}: ImportSkillsFromGitHubModalViewProps) {
+  const githubApp = externalApps?.find((app) => app.app_type === "GITHUB");
+  const privateRepositoryGuidance = githubApp?.authenticated
+    ? {
+        message:
+          "You can import public repositories and any private repositories your GitHub account can access.",
+        action: null,
+      }
+    : githubApp
+      ? {
+          message:
+            "Public repositories don't require a GitHub connection. Connect GitHub to import private repositories.",
+          action: {
+            label: "Connect GitHub",
+            href: "/craft/v1/apps?connect=github" as const,
+          },
+        }
+      : externalApps && isAdmin
+        ? {
+            message:
+              "Public repositories don't require a GitHub connection. Set up the GitHub App to import private repositories.",
+            action: {
+              label: "Set up GitHub",
+              href: "/admin/craft/apps" as const,
+            },
+          }
+        : {
+            message: externalApps
+              ? "Public repositories don't require a GitHub connection. Ask a workspace admin to set up the GitHub App to import private repositories."
+              : "Public repositories don't require a GitHub connection. Private repositories require a GitHub connection.",
+            action: null,
+          };
+  const errorCode =
+    error instanceof FetchError &&
+    error.info &&
+    typeof error.info === "object" &&
+    typeof error.info.error_code === "string"
+      ? error.info.error_code
+      : null;
+  const retryableError = [
+    "BAD_GATEWAY",
+    "GATEWAY_TIMEOUT",
+    "RATE_LIMITED",
+    "SERVICE_UNAVAILABLE",
+  ].includes(errorCode ?? "");
+  const githubErrorAction = [
+    "INSUFFICIENT_PERMISSIONS",
+    "UNAUTHENTICATED",
+  ].includes(errorCode ?? "")
+    ? githubApp
+      ? {
+          label:
+            errorCode === "UNAUTHENTICATED"
+              ? "Reconnect GitHub"
+              : "Manage GitHub",
+          href: "/craft/v1/apps?connect=github" as const,
+        }
+      : externalApps && isAdmin
+        ? {
+            label: "Set up GitHub",
+            href: "/admin/craft/apps" as const,
+          }
+        : null
+    : null;
+
+  return (
+    <Modal open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
+      <Modal.Content width="md" height="lg">
+        <Modal.Header
+          icon={SvgGithub}
+          title="Import skills from GitHub"
+          description="Choose one or more skills from a GitHub repository."
+          onClose={onClose}
+        />
+        <Modal.Body>
+          <InputVertical
+            title="GitHub repository"
+            withLabel="github-repository"
+            description="Enter a repository URL or owner/repository."
+          >
+            <InputTypeIn
+              id="github-repository"
+              value={repository}
+              placeholder="https://github.com/owner/repository"
+              variant={loading ? "disabled" : "primary"}
+              onChange={(event) => onRepositoryChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") onSubmit();
+              }}
+            />
+          </InputVertical>
+
+          <div className="flex w-full items-center justify-between gap-3">
+            <Text as="p" font="secondary-body" color="text-03">
+              {privateRepositoryGuidance.message}
+            </Text>
+            {privateRepositoryGuidance.action && (
+              <Button
+                href={privateRepositoryGuidance.action.href}
+                variant="default"
+                prominence="secondary"
+                size="sm"
+              >
+                {privateRepositoryGuidance.action.label}
+              </Button>
+            )}
+          </div>
+
+          {error && (
+            <MessageCard
+              variant="error"
+              title={
+                preview ? "Couldn’t import skills" : "Couldn’t load repository"
+              }
+              description={error.message}
+              titleMaxLines={undefined}
+              rightChildren={
+                retryableError ? (
+                  <Button
+                    prominence="secondary"
+                    size="sm"
+                    disabled={loading}
+                    onClick={onSubmit}
+                  >
+                    Retry
+                  </Button>
+                ) : githubErrorAction ? (
+                  <Button
+                    href={githubErrorAction.href}
+                    prominence="secondary"
+                    size="sm"
+                  >
+                    {githubErrorAction.label}
+                  </Button>
+                ) : undefined
+              }
+            />
+          )}
+
+          {preview && (
+            <div className="flex w-full flex-col gap-2">
+              <Content
+                title={`${preview.skills.length} ${preview.skills.length === 1 ? "skill" : "skills"} found`}
+                description={
+                  preview.skills.every(
+                    (skill) => skill.unavailable_reason !== null
+                  )
+                    ? `None of the skills found in ${preview.repository} can be imported.`
+                    : `Select the skills to import from ${preview.repository}.`
+                }
+                sizePreset="main-content"
+                variant="section"
+              />
+              <div className="flex w-full flex-col gap-1">
+                {preview.skills.map((skill) => {
+                  const checked = selectedPaths.includes(skill.path);
+                  const unavailable = skill.unavailable_reason !== null;
+                  return (
+                    <div
+                      key={skill.path}
+                      className={unavailable ? "opacity-60" : undefined}
+                    >
+                      <Card border="solid" padding="sm">
+                        <label
+                          aria-disabled={unavailable}
+                          className={`flex w-full items-start gap-3 ${unavailable ? "cursor-not-allowed" : "cursor-pointer"}`}
+                        >
+                          <Checkbox
+                            checked={checked}
+                            disabled={loading || unavailable}
+                            aria-label={`Select ${skill.name}`}
+                            onCheckedChange={(nextChecked) =>
+                              onSelectedPathsChange(
+                                nextChecked
+                                  ? [...selectedPaths, skill.path]
+                                  : selectedPaths.filter(
+                                      (path) => path !== skill.path
+                                    )
+                              )
+                            }
+                          />
+                          <div className="min-w-0 flex-1">
+                            <Text as="p" font="main-ui-action" color="text-04">
+                              {skill.name}
+                            </Text>
+                            <Text as="p" font="secondary-body" color="text-03">
+                              {skill.description}
+                            </Text>
+                            <Text as="p" font="secondary-body" color="text-02">
+                              {skill.path === "."
+                                ? "Repository root"
+                                : skill.path}
+                            </Text>
+                            {skill.unavailable_reason && (
+                              <Text
+                                as="p"
+                                font="secondary-body"
+                                color="text-03"
+                              >
+                                {skill.unavailable_reason}
+                              </Text>
+                            )}
+                          </div>
+                        </label>
+                      </Card>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button prominence="secondary" disabled={loading} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            disabled={
+              loading ||
+              !repository.trim() ||
+              (preview !== null && selectedPaths.length === 0)
+            }
+            onClick={onSubmit}
+          >
+            {loading
+              ? preview
+                ? "Importing..."
+                : "Searching..."
+              : preview
+                ? selectedPaths.length === 0
+                  ? "Nothing to import"
+                  : `Import ${selectedPaths.length === 1 ? "skill" : `${selectedPaths.length} skills`}`
+                : "Search repository"}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
@@ -9,9 +9,8 @@ import {
   MessageCard,
   Text,
 } from "@opal/components";
-import { Content, InputVertical } from "@opal/layouts";
+import { Content, InputVertical, toast } from "@opal/layouts";
 import { SvgGithub } from "@opal/logos";
-import { toast } from "@/hooks/useToast";
 import { importGitHubSkills, previewGitHubSkills } from "@/lib/skills/api";
 import type { CustomSkill, GitHubSkillsPreview } from "@/lib/skills/types";
 import Modal from "@/refresh-components/Modal";
@@ -83,7 +82,12 @@ export default function ImportSkillsFromGitHubModal({
         return;
       }
 
-      const created = await importGitHubSkills(repository, selectedPaths);
+      const created = await importGitHubSkills(
+        preview.repository,
+        preview.revision,
+        preview.subpath,
+        selectedPaths
+      );
       toast.success(
         created.length === 1
           ? `Imported "${created[0]!.name}"`

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
@@ -96,6 +96,9 @@ export default function ImportSkillsFromGitHubModal({
       onCreated(created);
       onClose();
     } catch (caught) {
+      if (!(caught instanceof Error)) {
+        console.error("Failed to import skills from GitHub:", caught);
+      }
       setError(
         caught instanceof Error
           ? caught

--- a/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
+++ b/web/src/sections/modals/skills/ImportSkillsFromGitHubModal.tsx
@@ -9,7 +9,7 @@ import {
   MessageCard,
   Text,
 } from "@opal/components";
-import { Content, InputVertical, toast } from "@opal/layouts";
+import { Content, ContentAction, InputVertical, toast } from "@opal/layouts";
 import { SvgGithub } from "@opal/logos";
 import { importGitHubSkills, previewGitHubSkills } from "@/lib/skills/api";
 import type { CustomSkill, GitHubSkillsPreview } from "@/lib/skills/types";
@@ -36,6 +36,7 @@ interface ImportSkillsFromGitHubModalViewProps {
   isAdmin: boolean;
   externalApps: ExternalAppUserResponse[] | undefined;
   onRepositoryChange: (repository: string) => void;
+  onResetPreview: () => void;
   onSelectedPathsChange: (paths: string[]) => void;
   onSubmit: () => void;
 }
@@ -128,6 +129,11 @@ export default function ImportSkillsFromGitHubModal({
         setSelectedPaths([]);
         setError(null);
       }}
+      onResetPreview={() => {
+        setPreview(null);
+        setSelectedPaths([]);
+        setError(null);
+      }}
       onSelectedPathsChange={setSelectedPaths}
       onSubmit={() => void submit()}
     />
@@ -145,40 +151,24 @@ export function ImportSkillsFromGitHubModalView({
   isAdmin,
   externalApps,
   onRepositoryChange,
+  onResetPreview,
   onSelectedPathsChange,
   onSubmit,
 }: ImportSkillsFromGitHubModalViewProps) {
   const githubApp = externalApps?.find((app) => app.app_type === "GITHUB");
-  const privateRepositoryGuidance = githubApp?.authenticated
-    ? {
-        message:
-          "You can import public repositories and any private repositories your GitHub account can access.",
-        action: null,
-      }
+  const privateRepositoryAction = githubApp?.authenticated
+    ? null
     : githubApp
       ? {
-          message:
-            "Public repositories don't require a GitHub connection. Connect GitHub to import private repositories.",
-          action: {
-            label: "Connect GitHub",
-            href: "/craft/v1/apps?connect=github" as const,
-          },
+          label: "Connect GitHub for private repositories",
+          href: "/craft/v1/apps?connect=github" as const,
         }
       : externalApps && isAdmin
         ? {
-            message:
-              "Public repositories don't require a GitHub connection. Set up the GitHub App to import private repositories.",
-            action: {
-              label: "Set up GitHub",
-              href: "/admin/craft/apps" as const,
-            },
+            label: "Set up private repository access",
+            href: "/admin/craft/apps" as const,
           }
-        : {
-            message: externalApps
-              ? "Public repositories don't require a GitHub connection. Ask a workspace admin to set up the GitHub App to import private repositories."
-              : "Public repositories don't require a GitHub connection. Private repositories require a GitHub connection.",
-            action: null,
-          };
+        : null;
   const errorCode =
     error instanceof FetchError &&
     error.info &&
@@ -211,49 +201,98 @@ export function ImportSkillsFromGitHubModalView({
           }
         : null
     : null;
+  const importablePaths =
+    preview?.skills
+      .filter((skill) => skill.unavailable_reason === null)
+      .map((skill) => skill.path) ?? [];
+  const allImportableSelected =
+    importablePaths.length > 0 &&
+    importablePaths.every((path) => selectedPaths.includes(path));
+  const unavailableCount = preview
+    ? preview.skills.length - importablePaths.length
+    : 0;
+  const previewSource = preview?.subpath
+    ? `${preview.repository}/${preview.subpath}`
+    : preview?.repository;
+  const selectionSummary = [
+    `${selectedPaths.length} selected`,
+    unavailableCount > 0 ? `${unavailableCount} unavailable` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
 
   return (
     <Modal open={open} onOpenChange={(nextOpen) => !nextOpen && onClose()}>
       <Modal.Content width="md" height="lg">
         <Modal.Header
           icon={SvgGithub}
-          title="Import skills from GitHub"
-          description="Choose one or more skills from a GitHub repository."
+          title="Import from GitHub"
+          description={
+            preview
+              ? "Choose the skills you want to import."
+              : "Paste a repository URL to find skills you can import."
+          }
           onClose={onClose}
         />
         <Modal.Body>
-          <InputVertical
-            title="GitHub repository"
-            withLabel="github-repository"
-            description="Enter a repository URL or owner/repository."
-          >
-            <InputTypeIn
-              id="github-repository"
-              value={repository}
-              placeholder="https://github.com/owner/repository"
-              variant={loading ? "disabled" : "primary"}
-              onChange={(event) => onRepositoryChange(event.target.value)}
-              onKeyDown={(event) => {
-                if (event.key === "Enter") onSubmit();
-              }}
-            />
-          </InputVertical>
-
-          <div className="flex w-full items-center justify-between gap-3">
-            <Text as="p" font="secondary-body" color="text-03">
-              {privateRepositoryGuidance.message}
-            </Text>
-            {privateRepositoryGuidance.action && (
-              <Button
-                href={privateRepositoryGuidance.action.href}
-                variant="default"
-                prominence="secondary"
-                size="sm"
+          {!preview ? (
+            <>
+              <InputVertical
+                title="Repository"
+                withLabel="github-repository"
+                description="Paste a GitHub URL or enter owner/repository."
               >
-                {privateRepositoryGuidance.action.label}
-              </Button>
-            )}
-          </div>
+                <InputTypeIn
+                  id="github-repository"
+                  value={repository}
+                  placeholder="https://github.com/owner/repository"
+                  variant={loading ? "disabled" : "primary"}
+                  onChange={(event) => onRepositoryChange(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      event.preventDefault();
+                      onSubmit();
+                    }
+                  }}
+                />
+              </InputVertical>
+
+              {privateRepositoryAction ? (
+                <Button
+                  href={privateRepositoryAction.href}
+                  variant="action"
+                  prominence="tertiary"
+                  size="sm"
+                >
+                  {privateRepositoryAction.label}
+                </Button>
+              ) : externalApps && !githubApp ? (
+                <Text as="p" font="secondary-body" color="text-03">
+                  Private repositories require GitHub access configured by a
+                  workspace admin.
+                </Text>
+              ) : null}
+            </>
+          ) : (
+            <ContentAction
+              title={previewSource ?? preview.repository}
+              description="GitHub repository"
+              sizePreset="main-ui"
+              variant="section"
+              padding="fit"
+              center
+              rightChildren={
+                <Button
+                  prominence="tertiary"
+                  size="sm"
+                  disabled={loading}
+                  onClick={onResetPreview}
+                >
+                  Change
+                </Button>
+              }
+            />
+          )}
 
           {error && (
             <MessageCard
@@ -288,74 +327,75 @@ export function ImportSkillsFromGitHubModalView({
 
           {preview && (
             <div className="flex w-full flex-col gap-2">
-              <Content
+              <ContentAction
                 title={`${preview.skills.length} ${preview.skills.length === 1 ? "skill" : "skills"} found`}
                 description={
-                  preview.skills.every(
-                    (skill) => skill.unavailable_reason !== null
-                  )
-                    ? `None of the skills found in ${preview.repository} can be imported.`
-                    : `Select the skills to import from ${preview.repository}.`
+                  importablePaths.length === 0
+                    ? "None are available to import."
+                    : selectionSummary
                 }
                 sizePreset="main-content"
                 variant="section"
-              />
-              <div className="flex w-full flex-col gap-1">
-                {preview.skills.map((skill) => {
-                  const checked = selectedPaths.includes(skill.path);
-                  const unavailable = skill.unavailable_reason !== null;
-                  return (
-                    <div
-                      key={skill.path}
-                      className={unavailable ? "opacity-60" : undefined}
+                padding="fit"
+                center
+                rightChildren={
+                  importablePaths.length > 1 ? (
+                    <Button
+                      prominence="tertiary"
+                      size="sm"
+                      disabled={loading}
+                      onClick={() =>
+                        onSelectedPathsChange(
+                          allImportableSelected ? [] : importablePaths
+                        )
+                      }
                     >
-                      <Card border="solid" padding="sm">
-                        <label
-                          aria-disabled={unavailable}
-                          className={`flex w-full items-start gap-3 ${unavailable ? "cursor-not-allowed" : "cursor-pointer"}`}
-                        >
-                          <Checkbox
-                            checked={checked}
-                            disabled={loading || unavailable}
-                            aria-label={`Select ${skill.name}`}
-                            onCheckedChange={(nextChecked) =>
-                              onSelectedPathsChange(
-                                nextChecked
-                                  ? [...selectedPaths, skill.path]
-                                  : selectedPaths.filter(
-                                      (path) => path !== skill.path
-                                    )
-                              )
-                            }
-                          />
-                          <div className="min-w-0 flex-1">
-                            <Text as="p" font="main-ui-action" color="text-04">
-                              {skill.name}
-                            </Text>
-                            <Text as="p" font="secondary-body" color="text-03">
-                              {skill.description}
-                            </Text>
-                            <Text as="p" font="secondary-body" color="text-02">
-                              {skill.path === "."
-                                ? "Repository root"
-                                : skill.path}
-                            </Text>
-                            {skill.unavailable_reason && (
-                              <Text
-                                as="p"
-                                font="secondary-body"
-                                color="text-03"
-                              >
-                                {skill.unavailable_reason}
-                              </Text>
-                            )}
-                          </div>
-                        </label>
-                      </Card>
-                    </div>
-                  );
-                })}
-              </div>
+                      {allImportableSelected ? "Clear all" : "Select all"}
+                    </Button>
+                  ) : undefined
+                }
+              />
+              <Card border="solid" padding="fit" rounding="sm">
+                <div className="divide-y divide-border-01">
+                  {preview.skills.map((skill) => {
+                    const checked = selectedPaths.includes(skill.path);
+                    const unavailable = skill.unavailable_reason !== null;
+                    return (
+                      <label
+                        key={skill.path}
+                        aria-disabled={unavailable}
+                        className={`flex w-full items-start gap-3 p-3 ${unavailable ? "cursor-not-allowed" : "cursor-pointer"}`}
+                      >
+                        <Checkbox
+                          checked={checked}
+                          disabled={loading || unavailable}
+                          aria-label={`Select ${skill.name}`}
+                          onCheckedChange={(nextChecked) =>
+                            onSelectedPathsChange(
+                              nextChecked
+                                ? [...selectedPaths, skill.path]
+                                : selectedPaths.filter(
+                                    (path) => path !== skill.path
+                                  )
+                            )
+                          }
+                        />
+                        <Content
+                          title={skill.name}
+                          description={
+                            skill.unavailable_reason ?? skill.description
+                          }
+                          titleMaxLines={1}
+                          descriptionMaxLines={2}
+                          sizePreset="main-ui"
+                          variant="section"
+                          color={unavailable ? "muted" : "default"}
+                        />
+                      </label>
+                    );
+                  })}
+                </div>
+              </Card>
             </div>
           )}
         </Modal.Body>
@@ -373,13 +413,15 @@ export function ImportSkillsFromGitHubModalView({
           >
             {loading
               ? preview
-                ? "Importing..."
-                : "Searching..."
+                ? "Importing…"
+                : "Finding skills…"
               : preview
                 ? selectedPaths.length === 0
-                  ? "Nothing to import"
+                  ? importablePaths.length === 0
+                    ? "No skills available"
+                    : "Select skills"
                   : `Import ${selectedPaths.length === 1 ? "skill" : `${selectedPaths.length} skills`}`
-                : "Search repository"}
+                : "Find skills"}
           </Button>
         </Modal.Footer>
       </Modal.Content>

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -129,43 +129,45 @@ export default function SkillsPage() {
             <Popover.Trigger asChild>
               <Button icon={SvgPlus}>Create skill</Button>
             </Popover.Trigger>
-            <Popover.Content align="end" sideOffset={4} width="xl">
-              <Popover.Menu>
-                <LineItem
-                  icon={SvgEdit}
-                  description="Write instructions and add supporting files in Onyx."
-                  wrapDescription
-                  onClick={() => {
-                    setCreateMenuOpen(false);
-                    router.push("/craft/v1/skills/new" as Route);
-                  }}
-                >
-                  Create in Onyx
-                </LineItem>
-                <LineItem
-                  icon={SvgUploadCloud}
-                  description="Upload a SKILL.md file, ZIP file, or skill folder."
-                  wrapDescription
-                  onClick={() => {
-                    setCreateMenuOpen(false);
-                    setCreateOpen(true);
-                  }}
-                >
-                  Upload a skill
-                </LineItem>
-                <LineItem
-                  icon={SvgGithub}
-                  description="Import one or more skills from a GitHub repository."
-                  wrapDescription
-                  onClick={() => {
-                    setCreateMenuOpen(false);
-                    setGitHubImportOpen(true);
-                  }}
-                >
-                  Import from GitHub
-                </LineItem>
-              </Popover.Menu>
-            </Popover.Content>
+            {createMenuOpen && (
+              <Popover.Content align="end" sideOffset={4} width="xl">
+                <Popover.Menu>
+                  <LineItem
+                    icon={SvgEdit}
+                    description="Write instructions and add supporting files in Onyx."
+                    wrapDescription
+                    onClick={() => {
+                      setCreateMenuOpen(false);
+                      router.push("/craft/v1/skills/new" as Route);
+                    }}
+                  >
+                    Create in Onyx
+                  </LineItem>
+                  <LineItem
+                    icon={SvgUploadCloud}
+                    description="Upload a SKILL.md file, ZIP file, or skill folder."
+                    wrapDescription
+                    onClick={() => {
+                      setCreateMenuOpen(false);
+                      setCreateOpen(true);
+                    }}
+                  >
+                    Upload a skill
+                  </LineItem>
+                  <LineItem
+                    icon={SvgGithub}
+                    description="Import one or more skills from a GitHub repository."
+                    wrapDescription
+                    onClick={() => {
+                      setCreateMenuOpen(false);
+                      setGitHubImportOpen(true);
+                    }}
+                  >
+                    Import from GitHub
+                  </LineItem>
+                </Popover.Menu>
+              </Popover.Content>
+            )}
           </Popover>
         }
       >

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -28,9 +28,11 @@ import SkillCard, {
   type SkillCardItem,
 } from "@/sections/cards/SkillCard";
 import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
+import ImportSkillsFromGitHubModal from "@/sections/modals/skills/ImportSkillsFromGitHubModal";
 import SkillPreviewModal from "@/sections/modals/SkillPreviewModal";
 import type { BuiltinSkill, CustomSkill } from "@/lib/skills/types";
 import LineItem from "@/refresh-components/buttons/LineItem";
+import { SvgGithub } from "@opal/logos";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -41,6 +43,7 @@ export default function SkillsPage() {
   const { data, error, isLoading, refresh } = useUserSkills();
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
+  const [githubImportOpen, setGitHubImportOpen] = useState(false);
   const [createMenuOpen, setCreateMenuOpen] = useState(false);
   const [previewTarget, setPreviewTarget] = useState<SkillCardItem | null>(
     null
@@ -130,18 +133,18 @@ export default function SkillsPage() {
               <Popover.Menu>
                 <LineItem
                   icon={SvgEdit}
-                  description="Write the instructions and add supporting files in Onyx."
+                  description="Write instructions and add supporting files in Onyx."
                   wrapDescription
                   onClick={() => {
                     setCreateMenuOpen(false);
                     router.push("/craft/v1/skills/new" as Route);
                   }}
                 >
-                  Start from scratch
+                  Create in Onyx
                 </LineItem>
                 <LineItem
                   icon={SvgUploadCloud}
-                  description="Import a SKILL.md file, ZIP file, or skill folder."
+                  description="Upload a SKILL.md file, ZIP file, or skill folder."
                   wrapDescription
                   onClick={() => {
                     setCreateMenuOpen(false);
@@ -149,6 +152,17 @@ export default function SkillsPage() {
                   }}
                 >
                   Upload a skill
+                </LineItem>
+                <LineItem
+                  icon={SvgGithub}
+                  description="Import one or more skills from a GitHub repository."
+                  wrapDescription
+                  onClick={() => {
+                    setCreateMenuOpen(false);
+                    setGitHubImportOpen(true);
+                  }}
+                >
+                  Import from GitHub
                 </LineItem>
               </Popover.Menu>
             </Popover.Content>
@@ -234,6 +248,12 @@ export default function SkillsPage() {
           refresh();
           router.push(`/craft/v1/skills/edit/${created.id}` as Route);
         }}
+      />
+
+      <ImportSkillsFromGitHubModal
+        open={githubImportOpen}
+        onClose={() => setGitHubImportOpen(false)}
+        onCreated={() => refresh()}
       />
 
       <SkillPreviewModal


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/388f32a0-89f9-4297-aeda-c108d6e9bb58


Adds GitHub as a skill import source. Users can preview and select skills from public repositories, connect GitHub for private repositories, and import supported skill bundles into their personal skills.

Includes repository and archive guardrails, actionable import errors, reserved-name handling that does not block other skills, and Storybook coverage for the relevant UI states.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub as a skill import source with a simple find-preview-import flow for public repos, and for private repos after connecting GitHub. Safe, pinned archive downloads with strict limits, and a new modal to preview, bulk-select, and import multiple skills with clear, actionable errors.

- **New Features**
  - Backend: `POST /api/skills/github/preview` and `POST /api/skills/github/import`; resolves repo/branch/folder to a pinned 40‑char revision and optional subpath; private repos use GitHub API redirect and download from `codeload.github.com` without forwarding tokens; strict limits (25 MiB download, 10k entries, per‑file/total caps), no symlinks, safe paths; built‑in reserved skill names surfaced via `unavailable_reason`; all‑or‑nothing import with duplicate‑name checks and clear messages.
  - Web: “Import from GitHub” modal (Skills → Create) with repository → preview → import steps, multi‑select with Select all/Clear all, Change repository without leaving the modal, Retry for transient errors, and connect/reconnect/setup GitHub guidance; `previewGitHubSkills` and `importGitHubSkills`; errors throw `FetchError` preserving `error_code` and `detail` with fallback logging; small copy updates in the Create menu.

- **Bug Fixes**
  - Gracefully handle malformed or truncated GitHub archives with clear errors, stabilize CI import tests, and harden private repo downloads by never forwarding tokens to archive hosts.

<sup>Written for commit fdf3a452b52646adc805b4387be39ac5b9446e02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



