### PR TITLE
feat(mcp): add available_in_craft flag + craft-enabled listing API

### DIFF
--- a/backend/alembic/versions/565c5b57a573_add_available_in_craft_to_mcp_server.py
+++ b/backend/alembic/versions/565c5b57a573_add_available_in_craft_to_mcp_server.py
@@ -1,7 +1,7 @@
 """add available_in_craft to mcp_server
 
 Revision ID: 565c5b57a573
-Revises: eec4fc85ef28
+Revises: e2875ce6454b
 Create Date: 2026-07-15 14:56:39.502921
 
 """
@@ -11,7 +11,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "565c5b57a573"
-down_revision = "eec4fc85ef28"
+down_revision = "e2875ce6454b"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/565c5b57a573_add_available_in_craft_to_mcp_server.py
+++ b/backend/alembic/versions/565c5b57a573_add_available_in_craft_to_mcp_server.py
@@ -1,0 +1,32 @@
+"""add available_in_craft to mcp_server
+
+Revision ID: 565c5b57a573
+Revises: eec4fc85ef28
+Create Date: 2026-07-15 14:56:39.502921
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "565c5b57a573"
+down_revision = "eec4fc85ef28"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "mcp_server",
+        sa.Column(
+            "available_in_craft",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_server", "available_in_craft")

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -62,9 +62,7 @@ def get_craft_enabled_mcp_servers(db_session: Session) -> list[MCPServer]:
     """Get all MCP servers an admin has made available to the Craft agent"""
     return list(
         db_session.scalars(
-            select(MCPServer)
-            .where(MCPServer.available_in_craft.is_(True))
-            .order_by(MCPServer.created_at)
+            select(MCPServer).where(MCPServer.available_in_craft.is_(True))
         ).all()
     )
 

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -58,6 +58,17 @@ def get_mcp_servers_by_owner(owner_email: str, db_session: Session) -> list[MCPS
     )
 
 
+def get_craft_enabled_mcp_servers(db_session: Session) -> list[MCPServer]:
+    """Get all MCP servers an admin has made available to the Craft agent"""
+    return list(
+        db_session.scalars(
+            select(MCPServer)
+            .where(MCPServer.available_in_craft.is_(True))
+            .order_by(MCPServer.created_at)
+        ).all()
+    )
+
+
 def get_mcp_servers_for_persona(
     persona_id: int,
     db_session: Session,
@@ -205,6 +216,7 @@ def update_mcp_server__no_commit(
     status: MCPServerStatus | None = None,
     last_refreshed_at: datetime.datetime | None = None,
     is_public: bool | None = None,
+    available_in_craft: bool | None = None,
 ) -> MCPServer:
     """Update an existing MCP server"""
     server = get_mcp_server_by_id(server_id, db_session)
@@ -239,6 +251,8 @@ def update_mcp_server__no_commit(
         server.status = status
     if last_refreshed_at is not None:
         server.last_refreshed_at = last_refreshed_at
+    if available_in_craft is not None:
+        server.available_in_craft = available_in_craft
 
     db_session.flush()  # Don't commit yet, let caller decide when to commit
     return server

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5298,6 +5298,10 @@ class MCPServer(Base):
         nullable=False,
         server_default="CREATED",
     )
+    # Whether the Craft agent may use this server (admin-controlled)
+    available_in_craft: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
     # Admin connection config - used for the config page
     # and (when applicable) admin-managed auth
     # and (when applicable) per-user auth

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1313,7 +1313,7 @@ def get_mcp_servers_for_user(
     return MCPServersResponse(mcp_servers=mcp_servers)
 
 
-@router.get("/servers/craft")
+@router.get("/servers/craft", response_model=MCPServersResponse)
 def get_craft_mcp_servers_for_user(
     db: Session = Depends(get_session),
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -47,6 +47,7 @@ from onyx.db.mcp import (
     delete_mcp_server,
     extract_connection_data,
     get_all_mcp_servers,
+    get_craft_enabled_mcp_servers,
     get_mcp_server_by_id,
     get_mcp_servers_accessible_to_user,
     get_mcp_servers_for_persona,
@@ -1257,6 +1258,7 @@ def _db_mcp_server_to_api_mcp_server(
         is_public=db_server.is_public,
         groups=[group.id for group in db_server.user_groups],
         users=[user.id for user in db_server.users],
+        available_in_craft=db_server.available_in_craft,
         last_refreshed_at=db_server.last_refreshed_at,
         tool_count=tool_count,
         auth_template=auth_template,
@@ -1304,6 +1306,24 @@ def get_mcp_servers_for_user(
     Chat uses ``/servers/persona/{id}`` for servers already on a persona.
     """
     db_mcp_servers = get_mcp_servers_accessible_to_user(user, db)
+    mcp_servers = [
+        _db_mcp_server_to_api_mcp_server(db_server, db, request_user=user)
+        for db_server in db_mcp_servers
+    ]
+    return MCPServersResponse(mcp_servers=mcp_servers)
+
+
+@router.get("/servers/craft")
+def get_craft_mcp_servers_for_user(
+    db: Session = Depends(get_session),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+) -> MCPServersResponse:
+    """List MCP servers an admin has made available to the Craft agent, with
+    the current user's connection/auth state. Craft reads the same credential
+    rows as chat, so a server connected in either surface shows as
+    authenticated here.
+    """
+    db_mcp_servers = get_craft_enabled_mcp_servers(db)
     mcp_servers = [
         _db_mcp_server_to_api_mcp_server(db_server, db, request_user=user)
         for db_server in db_mcp_servers
@@ -2340,6 +2360,7 @@ def create_mcp_server_simple(
         is_public=mcp_server.is_public,
         groups=[group.id for group in mcp_server.user_groups],
         users=[user.id for user in mcp_server.users],
+        available_in_craft=mcp_server.available_in_craft,
         tool_count=0,  # New server, no tools yet
         auth_template=None,
         user_credentials=None,
@@ -2371,6 +2392,7 @@ def update_mcp_server_simple(
         name=request.name,
         description=request.description,
         server_url=request.server_url,
+        available_in_craft=request.available_in_craft,
     )
 
     if any(

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -336,6 +336,9 @@ class MCPServerSimpleUpdateRequest(BaseModel):
         default=None,
         description="User IDs allowed to use this server when not public",
     )
+    available_in_craft: Optional[bool] = Field(
+        None, description="Whether the Craft agent may use this server"
+    )
 
 
 class MCPToolResponse(BaseModel):
@@ -499,6 +502,7 @@ class MCPServer(BaseModel):
     is_public: bool = True
     groups: list[int] = Field(default_factory=list)
     users: list[UUID] = Field(default_factory=list)
+    available_in_craft: bool = False
     last_refreshed_at: Optional[datetime.datetime] = None
     tool_count: int = Field(
         default=0, description="Number of tools associated with this server"

--- a/backend/tests/integration/tests/mcp/test_craft_mcp_servers.py
+++ b/backend/tests/integration/tests/mcp/test_craft_mcp_servers.py
@@ -15,9 +15,11 @@ from pathlib import Path
 
 import pytest
 
-from onyx.db.enums import MCPAuthenticationPerformer
-from onyx.db.enums import MCPAuthenticationType
-from onyx.db.enums import MCPTransport
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.test_models import DATestUser

--- a/backend/tests/integration/tests/mcp/test_craft_mcp_servers.py
+++ b/backend/tests/integration/tests/mcp/test_craft_mcp_servers.py
@@ -1,0 +1,187 @@
+"""Integration tests for the craft-enabled MCP server listing.
+
+Verifies the `available_in_craft` admin toggle and that the user-facing craft
+listing reflects chat-side credential state (one credential store for both
+surfaces).
+"""
+
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.test_models import DATestUser
+
+MCP_SERVER_HOST = os.getenv("TEST_WEB_HOSTNAME", "127.0.0.1")
+# Distinct from the no-auth test's port (8010) so the suites can't collide.
+MCP_SERVER_PORT = int(os.getenv("MOCK_MCP_PER_USER_SERVER_PORT", "8011"))
+MCP_SERVER_URL = f"http://{MCP_SERVER_HOST}:{MCP_SERVER_PORT}/mcp"
+
+# Keys baked into the mock server's pretend database.
+ALICE_API_KEY = "mcp_live-kid_alice_001-S3cr3tAlice"
+BOB_API_KEY = "mcp_live-kid_bob_001-S3cr3tBob"
+
+MCP_SERVER_SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "mock_services"
+    / "mcp_test_server"
+    / "run_mcp_server_per_user_key.py"
+)
+
+
+def _wait_for_port(
+    host: str,
+    port: int,
+    process: subprocess.Popen[bytes],
+    timeout_seconds: float = 10.0,
+) -> None:
+    start = time.monotonic()
+    while time.monotonic() - start < timeout_seconds:
+        if process.poll() is not None:
+            raise RuntimeError("MCP server process exited unexpectedly during startup")
+
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.settimeout(0.5)
+            try:
+                sock.connect((host, port))
+                return
+            except OSError:
+                time.sleep(0.1)
+
+    raise TimeoutError("Timed out waiting for MCP server to accept connections")
+
+
+@pytest.fixture(scope="module")
+def mcp_per_user_key_server() -> Generator[None, None, None]:
+    if not MCP_SERVER_SCRIPT.exists():
+        raise FileNotFoundError(
+            f"Expected MCP server script at {MCP_SERVER_SCRIPT}, but it was not found"
+        )
+
+    process = subprocess.Popen(
+        [sys.executable, str(MCP_SERVER_SCRIPT), str(MCP_SERVER_PORT)],
+        cwd=MCP_SERVER_SCRIPT.parent,
+    )
+
+    try:
+        _wait_for_port(MCP_SERVER_HOST, MCP_SERVER_PORT, process)
+        yield
+    finally:
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+
+
+def _get_craft_servers(user: DATestUser) -> list[dict]:
+    response = client.get(
+        f"{API_SERVER_URL}/mcp/servers/craft",
+        headers=user.headers,
+        cookies=user.cookies,
+    )
+    response.raise_for_status()
+    return response.json()["mcp_servers"]
+
+
+def test_craft_mcp_server_listing(
+    mcp_per_user_key_server: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+) -> None:
+    # Admin creates a per-user API-token server (not craft-enabled yet)
+    create_response = client.post(
+        f"{API_SERVER_URL}/admin/mcp/servers/create",
+        json={
+            "name": "integration-mcp-craft",
+            "description": "Integration test MCP server for craft listing",
+            "server_url": MCP_SERVER_URL,
+            "transport": MCPTransport.STREAMABLE_HTTP.value,
+            "auth_type": MCPAuthenticationType.API_TOKEN.value,
+            "auth_performer": MCPAuthenticationPerformer.PER_USER.value,
+            "auth_template": {
+                "headers": {"Authorization": "Bearer {api_key}"},
+                "required_fields": ["api_key"],
+            },
+            "admin_credentials": {"api_key": ALICE_API_KEY},
+            "admin_credentials_changed": {"api_key": True},
+        },
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    create_response.raise_for_status()
+    server_id = create_response.json()["server_id"]
+
+    # Not craft-enabled: absent from the craft listing, flag false in the
+    # regular user listing
+    assert _get_craft_servers(basic_user) == []
+    user_listing_response = client.get(
+        f"{API_SERVER_URL}/mcp/servers",
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+    )
+    user_listing_response.raise_for_status()
+    listed = [
+        server
+        for server in user_listing_response.json()["mcp_servers"]
+        if server["id"] == server_id
+    ]
+    assert len(listed) == 1
+    assert listed[0]["available_in_craft"] is False
+
+    # Admin toggles the flag on
+    toggle_response = client.patch(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}",
+        json={"available_in_craft": True},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    toggle_response.raise_for_status()
+    assert toggle_response.json()["available_in_craft"] is True
+
+    # Craft listing now includes the server; basic user has no credentials yet
+    craft_servers = _get_craft_servers(basic_user)
+    assert [server["id"] for server in craft_servers] == [server_id]
+    entry = craft_servers[0]
+    assert entry["available_in_craft"] is True
+    assert entry["user_authenticated"] is False
+    assert entry["is_authenticated"] is False
+
+    # User connects through the chat-side credential endpoint...
+    credentials_response = client.post(
+        f"{API_SERVER_URL}/mcp/user-credentials",
+        json={
+            "server_id": server_id,
+            "credentials": {"api_key": BOB_API_KEY},
+            "transport": "streamable-http",
+        },
+        headers=basic_user.headers,
+        cookies=basic_user.cookies,
+    )
+    credentials_response.raise_for_status()
+
+    # ...and the craft listing reflects the chat-side auth state
+    entry = _get_craft_servers(basic_user)[0]
+    assert entry["user_authenticated"] is True
+    assert entry["is_authenticated"] is True
+
+    # Toggling the flag off removes the server from the craft listing
+    toggle_off_response = client.patch(
+        f"{API_SERVER_URL}/admin/mcp/server/{server_id}",
+        json={"available_in_craft": False},
+        headers=admin_user.headers,
+        cookies=admin_user.cookies,
+    )
+    toggle_off_response.raise_for_status()
+    assert toggle_off_response.json()["available_in_craft"] is False
+    assert _get_craft_servers(basic_user) == []


### PR DESCRIPTION
## Description
First PR of the Craft MCP support plan. Adds an admin-controlled available_in_craft flag on mcp_server (exposed through the admin MCP CRUD) and a user-facing GET /mcp/servers/craft listing that returns craft-enabled servers with the current user's connection/auth state, reusing the chat-side credential rows. No consumer yet - invisible until the sandbox config emission and frontend PRs land.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an admin toggle to mark MCP servers as available to Craft and a new `/mcp/servers/craft` listing that returns craft-enabled servers with the current user’s auth state. Supports the Craft MCP rollout; no user-facing consumer yet.

- **New Features**
  - Admin-controlled `available_in_craft` on `mcp_server`, patchable via admin CRUD and included in `/mcp/servers` and create/update responses.
  - New GET `/mcp/servers/craft` returns craft-enabled servers plus `is_authenticated` and `user_authenticated`, sharing chat credentials.
  - Integration tests cover listing, auth reflection, and flag toggling.

- **Migration**
  - Alembic adds `available_in_craft` boolean on `mcp_server`. No breaking changes.

<sup>Written for commit 30ce5b38d05d61abaea015d8b90a2fd80b53df20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

