### PR TITLE
fix(llm): resolve reasoning support from LiteLLM cost map for dynamic providers (#13051) to release v4.3

### DIFF
--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -54,6 +54,7 @@ from onyx.llm.utils import get_bedrock_token_limit
 from onyx.llm.utils import get_llm_contextual_cost
 from onyx.llm.utils import is_sensitive_custom_config_key
 from onyx.llm.utils import litellm_thinks_model_supports_image_input
+from onyx.llm.utils import model_is_reasoning_model
 from onyx.llm.utils import test_llm
 from onyx.llm.well_known_providers.auto_update_service import (
     fetch_llm_recommendations_from_github,
@@ -1826,7 +1827,12 @@ def get_bifrost_available_models(
                     supports_image_input=litellm_thinks_model_supports_image_input(
                         model_id, LlmProviderNames.BIFROST
                     ),
-                    supports_reasoning=is_reasoning_model(model_id, model_name),
+                    # Reasoning support from the LiteLLM cost map, with the
+                    # substring heuristic covering models LiteLLM doesn't know
+                    supports_reasoning=model_is_reasoning_model(
+                        model_id, LlmProviderNames.BIFROST
+                    )
+                    or is_reasoning_model(model_id, model_name),
                 )
             )
         except Exception as e:
@@ -1962,7 +1968,11 @@ def get_nebius_tokenfactory_available_models(
                 supports_reasoning = "reasoning" in feature_list
             else:
                 feature_list = []
-                supports_reasoning = is_reasoning_model(model_id, display_name)
+                # No feature data from the source; fall back to the LiteLLM
+                # cost map, then the substring heuristic
+                supports_reasoning = model_is_reasoning_model(
+                    model_id, LlmProviderNames.NEBIUS_TOKENFACTORY
+                ) or is_reasoning_model(model_id, display_name)
 
             # Display-only metadata for the model picker.
             regions = model.get("regions") or []
@@ -2066,7 +2076,12 @@ def get_openai_compatible_server_available_models(
                     supports_image_input=litellm_thinks_model_supports_image_input(
                         model_id, LlmProviderNames.OPENAI_COMPATIBLE
                     ),
-                    supports_reasoning=is_reasoning_model(model_id, model_name),
+                    # Reasoning support from the LiteLLM cost map, with the
+                    # substring heuristic covering models LiteLLM doesn't know
+                    supports_reasoning=model_is_reasoning_model(
+                        model_id, LlmProviderNames.OPENAI_COMPATIBLE
+                    )
+                    or is_reasoning_model(model_id, model_name),
                 )
             )
         except Exception as e:

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -266,12 +266,15 @@ class ModelConfigurationView(BaseModel):
                         model_configuration_model.name, provider_name
                     )
                 ),
-                # Prefer the stored REASONING flow; fall back to a substring
-                # heuristic on model name/display name for legacy rows that
-                # were saved before the flow existed.
+                # Prefer the stored REASONING flow; fall back to the LiteLLM
+                # cost map, then a substring heuristic on model name/display
+                # name for models LiteLLM doesn't know.
                 supports_reasoning=(
                     LLMModelFlowType.REASONING
                     in model_configuration_model.llm_model_flow_types
+                    or model_is_reasoning_model(
+                        model_configuration_model.name, provider_name
+                    )
                     or is_reasoning_model(
                         model_configuration_model.name,
                         model_configuration_model.display_name or "",

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -241,6 +241,11 @@ def is_reasoning_model(model_id: str, display_name: str) -> bool:
 
     Used for OpenRouter and other dynamic providers where we need to infer
     reasoning capability from model identifiers.
+
+    TODO: unify with model_is_reasoning_model (onyx/llm/model_capabilities.py)
+    behind a single infer_reasoning_support() helper so the dynamic-provider
+    fetch endpoints and ModelConfigurationView.from_model don't each have to
+    compose the cost-map lookup and this heuristic manually.
     """
     combined = f"{model_id} {display_name}".lower()
     return any(pattern in combined for pattern in REASONING_MODEL_PATTERNS)

--- a/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_fetch_models_api.py
@@ -24,6 +24,7 @@ from onyx.server.manage.llm.models import LMStudioFinalModelResponse
 from onyx.server.manage.llm.models import LMStudioModelsRequest
 from onyx.server.manage.llm.models import OllamaFinalModelResponse
 from onyx.server.manage.llm.models import OllamaModelsRequest
+from onyx.server.manage.llm.models import OpenAICompatibleModelsRequest
 from onyx.server.manage.llm.models import OpenRouterFinalModelResponse
 from onyx.server.manage.llm.models import OpenRouterModelsRequest
 
@@ -1413,6 +1414,49 @@ class TestGetBifrostAvailableModels:
             assert gpt4o.supports_image_input is True
             assert deepseek.supports_image_input is False
 
+    def test_infers_reasoning_support(self) -> None:
+        """Reasoning support comes from the LiteLLM cost map first — Bifrost's
+        vendor-prefixed IDs (e.g. anthropic/claude-sonnet-4-5) don't match the
+        substring heuristic — with the heuristic as fallback."""
+        from onyx.server.manage.llm.api import get_bifrost_available_models
+
+        mock_session = MagicMock()
+        response = {
+            "data": [
+                {
+                    "id": "anthropic/claude-sonnet-4-5",
+                    "name": "Claude Sonnet 4.5",
+                    "context_length": 200000,
+                },
+                {
+                    "id": "openai/gpt-4o",
+                    "name": "GPT-4o",
+                    "context_length": 128000,
+                },
+                {
+                    "id": "deepseek/deepseek-r1",
+                    "name": "DeepSeek R1",
+                    "context_length": 64000,
+                },
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = BifrostModelsRequest(api_base="https://bifrost.example.com")
+            results = get_bifrost_available_models(request, MagicMock(), mock_session)
+
+            by_name = {r.name: r.supports_reasoning for r in results}
+            # Cost map hit; the substring heuristic alone would say False
+            assert by_name["anthropic/claude-sonnet-4-5"] is True
+            assert by_name["openai/gpt-4o"] is False
+            # Reasoning-named model stays True (heuristic covers cost-map misses)
+            assert by_name["deepseek/deepseek-r1"] is True
+
     def test_existing_v1_suffix_is_not_duplicated(self) -> None:
         """Test that an existing /v1 suffix still hits a single /v1/models endpoint."""
         from onyx.server.manage.llm.api import get_bifrost_available_models
@@ -1491,6 +1535,44 @@ class TestGetBifrostAvailableModels:
 
         assert exc_info.value.error_code == OnyxErrorCode.VALIDATION_ERROR
         assert exc_info.value.status_code == 400
+
+
+class TestGetOpenAICompatibleAvailableModels:
+    """Tests for the generic OpenAI-compatible model fetch endpoint."""
+
+    def test_infers_reasoning_support(self) -> None:
+        """Reasoning support comes from the LiteLLM cost map first, with the
+        substring heuristic as fallback for models LiteLLM doesn't know."""
+        from onyx.server.manage.llm.api import (
+            get_openai_compatible_server_available_models,
+        )
+
+        mock_session = MagicMock()
+        response = {
+            "data": [
+                {"id": "gemini-2.5-pro", "name": "Gemini 2.5 Pro"},
+                {"id": "gpt-4o", "name": "GPT-4o"},
+                {"id": "deepseek-r1", "name": "DeepSeek R1"},
+            ]
+        }
+
+        with patch("onyx.server.manage.llm.api.httpx.get") as mock_get:
+            mock_response = MagicMock()
+            mock_response.json.return_value = response
+            mock_response.raise_for_status = MagicMock()
+            mock_get.return_value = mock_response
+
+            request = OpenAICompatibleModelsRequest(api_base="https://llm.example.com")
+            results = get_openai_compatible_server_available_models(
+                request, MagicMock(), mock_session
+            )
+
+            by_name = {r.name: r.supports_reasoning for r in results}
+            # Cost map hit; the substring heuristic alone would say False
+            assert by_name["gemini-2.5-pro"] is True
+            assert by_name["gpt-4o"] is False
+            # Reasoning-named model stays True (heuristic covers cost-map misses)
+            assert by_name["deepseek-r1"] is True
 
 
 class _StopBeforeSend(Exception):

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -169,6 +169,73 @@ class TestModelConfigurationViewVisionFallback:
         assert view.supports_image_input is False
 
 
+# ModelConfigurationView.from_model — reasoning fallback (dynamic providers)
+
+
+class TestModelConfigurationViewReasoningFallback:
+    """supports_reasoning resolution in the dynamic/custom-config branch:
+    stored flow → LiteLLM cost map → name-substring heuristic."""
+
+    # In DYNAMIC_LLM_PROVIDERS
+    DYNAMIC_PROVIDER = "bifrost"
+
+    def _view(self, mc: MagicMock, litellm_reasoning: bool) -> ModelConfigurationView:
+        with patch(
+            "onyx.server.manage.llm.models.model_is_reasoning_model",
+            return_value=litellm_reasoning,
+        ):
+            return ModelConfigurationView.from_model(mc, self.DYNAMIC_PROVIDER)
+
+    def test_stored_reasoning_flow_wins(self) -> None:
+        """Stored REASONING flow → True without consulting the cost map."""
+        mc = _make_model_config(
+            name="friendly-chat-bot",
+            display_name="Friendly Chat Bot",
+            flow_types=[LLMModelFlowType.CHAT, LLMModelFlowType.REASONING],
+        )
+
+        view = self._view(mc, litellm_reasoning=False)
+
+        assert view.supports_reasoning is True
+
+    def test_falls_back_to_cost_map(self) -> None:
+        """No REASONING flow but the cost map knows the model → True (the fix);
+        vendor-prefixed IDs like this don't match the substring heuristic."""
+        mc = _make_model_config(
+            name="anthropic/claude-sonnet-4-5",
+            display_name="Claude Sonnet 4.5",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._view(mc, litellm_reasoning=True)
+
+        assert view.supports_reasoning is True
+
+    def test_falls_back_to_name_heuristic_when_cost_map_unaware(self) -> None:
+        """No REASONING flow, cost map miss, but reasoning-named model → True."""
+        mc = _make_model_config(
+            name="DeepSeek-R1-Distill-Qwen-7B",
+            display_name="DeepSeek R1 Distill Qwen 7B",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._view(mc, litellm_reasoning=False)
+
+        assert view.supports_reasoning is True
+
+    def test_false_when_no_flow_and_both_fallbacks_miss(self) -> None:
+        """No REASONING flow, cost map unaware, generic name → False."""
+        mc = _make_model_config(
+            name="openai/gpt-4o",
+            display_name="GPT-4o",
+            flow_types=[LLMModelFlowType.CHAT],
+        )
+
+        view = self._view(mc, litellm_reasoning=False)
+
+        assert view.supports_reasoning is False
+
+
 # ModelConfigurationView.from_model — static provider branch
 
 

--- a/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_nebius_tokenfactory_models.py
@@ -64,12 +64,12 @@ _SAMPLE = {
 }
 
 
-def _fetch() -> dict:
+def _fetch(sample: dict | None = None) -> dict:
     with (
         patch("onyx.server.manage.llm.api._resolve_api_key", return_value="k"),
         patch(
             "onyx.server.manage.llm.api._get_nebius_tokenfactory_models_response",
-            return_value=_SAMPLE,
+            return_value=sample if sample is not None else _SAMPLE,
         ),
     ):
         results = get_nebius_tokenfactory_available_models(
@@ -106,6 +106,42 @@ def test_vision_from_modality() -> None:
 def test_reasoning_from_features() -> None:
     by_name = _fetch()
     assert by_name["Qwen/Qwen3-32B"].supports_reasoning is True
+    assert by_name["meta-llama/Llama-3.3-70B-Instruct"].supports_reasoning is False
+
+
+def test_reasoning_fallback_when_features_missing() -> None:
+    """Without supported_features, reasoning falls back to the LiteLLM cost
+    map, then the name-substring heuristic."""
+    sample = {
+        "object": "list",
+        "data": [
+            {
+                # cost map knows this is a reasoning model; the substring
+                # heuristic doesn't
+                "id": "Qwen/Qwen3-32B",
+                "name": "Qwen3-32B",
+                "context_length": 40960,
+                "architecture": {"modality": "text->text"},
+            },
+            {
+                # cost-map miss, but reasoning-named
+                "id": "deepseek-ai/DeepSeek-R1",
+                "name": "DeepSeek-R1",
+                "context_length": 163840,
+                "architecture": {"modality": "text->text"},
+            },
+            {
+                # neither source reports reasoning
+                "id": "meta-llama/Llama-3.3-70B-Instruct",
+                "name": "Llama-3.3-70B-Instruct",
+                "context_length": 131072,
+                "architecture": {"modality": "text->text"},
+            },
+        ],
+    }
+    by_name = _fetch(sample)
+    assert by_name["Qwen/Qwen3-32B"].supports_reasoning is True
+    assert by_name["deepseek-ai/DeepSeek-R1"].supports_reasoning is True
     assert by_name["meta-llama/Llama-3.3-70B-Instruct"].supports_reasoning is False
 
 


### PR DESCRIPTION
Cherry-pick of commit 1c16fcfcad to release/v4.3 branch.

Original PR: #13051

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix reasoning model detection for dynamic providers by checking the `LiteLLM` cost map first and falling back to the name-based heuristic. This makes `supports_reasoning` accurate for Bifrost, OpenAI‑compatible servers, and Nebius TokenFactory, and in `ModelConfigurationView.from_model`.

- **Bug Fixes**
  - Use `model_is_reasoning_model` (cost map) in Bifrost, OpenAI‑compatible, and Nebius TokenFactory fetchers; fall back to substring heuristic when unknown.
  - In `ModelConfigurationView.from_model` (dynamic providers): prefer stored `REASONING` flow → cost map → name heuristic.
  - Added unit tests for these paths, including vendor‑prefixed IDs and missing feature data.

<sup>Written for commit fb5d66f9eeceab3ce3641919c477428bd0773af4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

