### PR TITLE
refactor(mcp): Extract resolving mcp credentials

### DIFF
--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -2,6 +2,8 @@ import datetime
 from typing import cast
 from uuid import UUID
 
+from pydantic import BaseModel
+from pydantic import ConfigDict
 from sqlalchemy import and_
 from sqlalchemy import delete
 from sqlalchemy import select
@@ -282,6 +284,70 @@ def get_user_connection_config(
             )
         )
     )
+
+
+class MCPCredentialsError(Exception):
+    """Credentials for an MCP server cannot be resolved for this user."""
+
+
+class ResolvedMCPCredentials(BaseModel):
+    """Credential source for one (server, user) pair.
+
+    Exactly one of the fields is populated (both are None for auth type NONE):
+    `connection_config` for API_TOKEN / OAUTH servers, `user_oauth_token` for
+    PT_OAUTH servers.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, frozen=True)
+
+    connection_config: MCPConnectionConfig | None
+    user_oauth_token: str | None
+
+
+def resolve_mcp_credentials(
+    mcp_server: MCPServer,
+    user: User,
+    db_session: Session,
+) -> ResolvedMCPCredentials:
+    """Resolve which stored credentials authenticate `user` against `mcp_server`.
+
+    The single source of truth for the performer/auth-type branching, shared by
+    chat's MCPTool construction and Craft's sandbox-proxy credential injection:
+    - PT_OAUTH: the user's login OAuth token; no stored config row.
+    - API_TOKEN / OAUTH: the user's own `mcp_connection_config` row for
+      PER_USER servers, the admin config row otherwise.
+    - NONE: no credentials.
+
+    Raises MCPCredentialsError for PT_OAUTH with the anonymous user, who has no
+    login OAuth token.
+    """
+    if mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
+        if user.is_anonymous:
+            raise MCPCredentialsError(
+                f"Anonymous user cannot use PT_OAUTH MCP server {mcp_server.id}"
+            )
+        return ResolvedMCPCredentials(
+            connection_config=None,
+            user_oauth_token=(
+                user.oauth_accounts[0].access_token if user.oauth_accounts else None
+            ),
+        )
+
+    if mcp_server.auth_type in (
+        MCPAuthenticationType.API_TOKEN,
+        MCPAuthenticationType.OAUTH,
+    ):
+        if mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER:
+            connection_config = get_user_connection_config(
+                mcp_server.id, user.email, db_session
+            )
+        else:
+            connection_config = mcp_server.admin_connection_config
+        return ResolvedMCPCredentials(
+            connection_config=connection_config, user_oauth_token=None
+        )
+
+    return ResolvedMCPCredentials(connection_config=None, user_oauth_token=None)
 
 
 def get_user_connection_configs_for_server(

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -12,11 +12,10 @@ from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.context.search.models import BaseFilters
 from onyx.context.search.models import PersonaSearchInfo
 from onyx.db.engine.sql_engine import get_session_with_current_tenant_if_none
-from onyx.db.enums import MCPAuthenticationPerformer
-from onyx.db.enums import MCPAuthenticationType
 from onyx.db.mcp import get_all_mcp_tools_for_server
 from onyx.db.mcp import get_mcp_server_by_id
-from onyx.db.mcp import get_user_connection_config
+from onyx.db.mcp import MCPCredentialsError
+from onyx.db.mcp import resolve_mcp_credentials
 from onyx.db.models import Persona
 from onyx.db.models import User
 from onyx.db.oauth_config import get_oauth_config
@@ -419,32 +418,11 @@ def _construct_tools_impl(
 
             mcp_server = get_mcp_server_by_id(db_tool_model.mcp_server_id, db_session)
 
-            # Get user-specific connection config if needed
-            connection_config = None
-            user_email = user.email
-            mcp_user_oauth_token = None
-
-            if mcp_server.auth_type == MCPAuthenticationType.PT_OAUTH:
-                # Pass-through OAuth: use the user's login OAuth token
-                if user.is_anonymous:
-                    logger.warning(
-                        "Anonymous user cannot use PT_OAUTH MCP server %s",
-                        mcp_server.id,
-                    )
-                    continue
-                mcp_user_oauth_token = user_oauth_token
-            elif (
-                mcp_server.auth_type == MCPAuthenticationType.API_TOKEN
-                or mcp_server.auth_type == MCPAuthenticationType.OAUTH
-            ):
-                # If server has a per-user template, only use that user's config
-                if mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER:
-                    connection_config = get_user_connection_config(
-                        mcp_server.id, user_email, db_session
-                    )
-                else:
-                    # No per-user template: use admin config
-                    connection_config = mcp_server.admin_connection_config
+            try:
+                mcp_credentials = resolve_mcp_credentials(mcp_server, user, db_session)
+            except MCPCredentialsError as e:
+                logger.warning(str(e))
+                continue
 
             # Get all saved tools for this MCP server
             saved_tools = get_all_mcp_tools_for_server(mcp_server.id, db_session)
@@ -468,10 +446,10 @@ def _construct_tools_impl(
                     tool_name=saved_tool.name,
                     tool_description=saved_tool.description,
                     tool_definition=saved_tool.mcp_input_schema or {},
-                    connection_config=connection_config,
-                    user_email=user_email,
+                    connection_config=mcp_credentials.connection_config,
+                    user_email=user.email,
                     user_id=str(user.id),
-                    user_oauth_token=mcp_user_oauth_token,
+                    user_oauth_token=mcp_credentials.user_oauth_token,
                     additional_headers=additional_mcp_headers,
                 )
                 mcp_tool_cache[db_tool_model.mcp_server_id][saved_tool.id] = mcp_tool


### PR DESCRIPTION
## Description
Extracts the resolving of mcp credentials into it's own function

## How Has This Been Tested?
Manual + Tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized MCP credential resolution into `resolve_mcp_credentials` and updated MCP tool construction to use it. Removes duplicated auth branching and ensures consistent handling of `PT_OAUTH`, per-user/admin, and `NONE` auth.

- **Refactors**
  - Added `ResolvedMCPCredentials` (frozen Pydantic) and `MCPCredentialsError`.
  - Implemented `resolve_mcp_credentials` in `backend/onyx/db/mcp.py` for `PT_OAUTH`, `API_TOKEN`/`OAUTH` (per-user vs admin), and `NONE`.
  - Replaced inline auth logic in `backend/onyx/tools/tool_constructor.py` with the resolver; for anonymous `PT_OAUTH`, raise, log, and skip tools.
  - MCP tool creation now reads `connection_config` and `user_oauth_token` from the resolver.

<sup>Written for commit ce3da7a6ed1a3280b7f8fda29fb63132e03ce744. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

