### PR TITLE
chore: confluence test drift

### DIFF
--- a/backend/tests/daily/connectors/confluence/test_confluence_permissions_basic.py
+++ b/backend/tests/daily/connectors/confluence/test_confluence_permissions_basic.py
@@ -151,7 +151,6 @@ def test_confluence_connector_restriction_handling(
     non_restricted_user_groups = {
         "confluence-admins-danswerai",
         "org-admins",
-        "atlassian-addons-admin",
         "confluence-users-danswerai",
     }
 


### PR DESCRIPTION
## Description

CI was failing because confluence stopped returning  atlassian-addons-admin from one of their APIs, this doesn't change connector behavior in practice so I cut it from the test

## How Has This Been Tested?

CI

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Confluence permissions test to remove `atlassian-addons-admin`, which the Confluence API no longer returns. This fixes CI failures without changing connector behavior.

<sup>Written for commit 54c95b3fb34cfb48879bd5872e81ab5cf38d381c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13077?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

