### PR TITLE
refactor: unify datetime to utc

### DIFF
--- a/backend/onyx/connectors/bitbucket/utils.py
+++ b/backend/onyx/connectors/bitbucket/utils.py
@@ -4,7 +4,6 @@ import time
 from collections.abc import Callable
 from collections.abc import Iterator
 from datetime import datetime
-from datetime import timezone
 from typing import Any
 
 import httpx
@@ -16,6 +15,7 @@ from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.models import Document
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_after import parse_retry_after_seconds
 from onyx.utils.retry_wrapper import retry_builder
@@ -73,7 +73,7 @@ def parse_bitbucket_datetime(value: str | None) -> datetime | None:
     """Parse a Bitbucket ISO-8601 timestamp into a tz-aware UTC datetime."""
     if not isinstance(value, str):
         return None
-    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+    return datetime_to_utc(datetime.fromisoformat(value.replace("Z", "+00:00")))
 
 
 # Minimal fields for repository list calls
@@ -214,16 +214,12 @@ def map_pr_to_document(pr: dict[str, Any], workspace: str, repo_slug: str) -> Do
     created_on = pr.get("created_on")
     updated_on = pr.get("updated_on")
     updated_dt = (
-        datetime.fromisoformat(updated_on.replace("Z", "+00:00")).astimezone(
-            timezone.utc
-        )
+        datetime_to_utc(datetime.fromisoformat(updated_on.replace("Z", "+00:00")))
         if isinstance(updated_on, str)
         else None
     )
     created_dt = (
-        datetime.fromisoformat(created_on.replace("Z", "+00:00")).astimezone(
-            timezone.utc
-        )
+        datetime_to_utc(datetime.fromisoformat(created_on.replace("Z", "+00:00")))
         if isinstance(created_on, str)
         else None
     )

--- a/backend/onyx/connectors/braintrust/connector.py
+++ b/backend/onyx/connectors/braintrust/connector.py
@@ -30,6 +30,7 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import EntityFailure
 from onyx.connectors.models import TabularSection
 from onyx.connectors.models import TextSection
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_wrapper import retry_builder
 
@@ -90,8 +91,7 @@ def _parse_time(time_str: str | None) -> datetime | None:
     if not time_str:
         return None
     try:
-        dt = datetime.fromisoformat(time_str.replace("Z", "+00:00"))
-        return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+        return datetime_to_utc(datetime.fromisoformat(time_str.replace("Z", "+00:00")))
     except ValueError:
         return None
 

--- a/backend/onyx/connectors/coda/connector.py
+++ b/backend/onyx/connectors/coda/connector.py
@@ -1,7 +1,6 @@
 import os
 from collections.abc import Generator
 from datetime import datetime
-from datetime import timezone
 from typing import Any
 from typing import cast
 from typing import Dict
@@ -25,6 +24,7 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.utils.batching import batch_generator
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_wrapper import retry_builder
 
@@ -478,8 +478,8 @@ class CodaConnector(LoadConnector, PollConnector):
 
     def _convert_page_to_document(self, page: CodaPage, content: str = "") -> Document:
         """Convert a page into a Document."""
-        page_updated = datetime.fromisoformat(page.updated_at).astimezone(timezone.utc)
-        page_created = datetime.fromisoformat(page.created_at).astimezone(timezone.utc)
+        page_updated = datetime_to_utc(datetime.fromisoformat(page.updated_at))
+        page_created = datetime_to_utc(datetime.fromisoformat(page.created_at))
 
         text_parts = [page.name, page.browser_link]
         if content:
@@ -506,12 +506,8 @@ class CodaConnector(LoadConnector, PollConnector):
         self, table: CodaTable, rows: List[CodaRow]
     ) -> Document:
         """Convert a table and its rows into a single Document with multiple sections (one per row)."""
-        table_updated = datetime.fromisoformat(table.updated_at).astimezone(
-            timezone.utc
-        )
-        table_created = datetime.fromisoformat(table.created_at).astimezone(
-            timezone.utc
-        )
+        table_updated = datetime_to_utc(datetime.fromisoformat(table.updated_at))
+        table_created = datetime_to_utc(datetime.fromisoformat(table.created_at))
 
         sections: List[TextSection] = []
         for row in rows:
@@ -623,11 +619,9 @@ class CodaConnector(LoadConnector, PollConnector):
                 try:
                     pages = self._list_pages_in_doc(doc.id)
                     for page in pages:
-                        page_timestamp = (
+                        page_timestamp = datetime_to_utc(
                             datetime.fromisoformat(page.updated_at)
-                            .astimezone(timezone.utc)
-                            .timestamp()
-                        )
+                        ).timestamp()
                         if start < page_timestamp <= end:
                             content = ""
                             if self.index_page_content:
@@ -646,11 +640,9 @@ class CodaConnector(LoadConnector, PollConnector):
                 try:
                     tables = self._list_tables(doc.id)
                     for table in tables:
-                        table_timestamp = (
+                        table_timestamp = datetime_to_utc(
                             datetime.fromisoformat(table.updated_at)
-                            .astimezone(timezone.utc)
-                            .timestamp()
-                        )
+                        ).timestamp()
 
                         try:
                             rows = self._list_rows_and_values(doc.id, table.id)
@@ -658,11 +650,9 @@ class CodaConnector(LoadConnector, PollConnector):
                             table_or_rows_updated = start < table_timestamp <= end
                             if not table_or_rows_updated:
                                 for row in rows:
-                                    row_timestamp = (
+                                    row_timestamp = datetime_to_utc(
                                         datetime.fromisoformat(row.updated_at)
-                                        .astimezone(timezone.utc)
-                                        .timestamp()
-                                    )
+                                    ).timestamp()
                                     if start < row_timestamp <= end:
                                         table_or_rows_updated = True
                                         break

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -29,6 +29,7 @@ from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.file_processing.file_types import OnyxMimeTypes
 from onyx.file_processing.image_utils import store_image_and_create_section
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_after import parse_retry_after_seconds
 
@@ -305,16 +306,7 @@ def build_confluence_document_id(
 
 
 def datetime_from_string(datetime_string: str) -> datetime:
-    datetime_object = datetime.fromisoformat(datetime_string)
-
-    if datetime_object.tzinfo is None:
-        # If no timezone info, assume it is UTC
-        datetime_object = datetime_object.replace(tzinfo=timezone.utc)
-    else:
-        # If not in UTC, translate it
-        datetime_object = datetime_object.astimezone(timezone.utc)
-
-    return datetime_object
+    return datetime_to_utc(datetime.fromisoformat(datetime_string))
 
 
 def confluence_refresh_tokens(

--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -17,19 +17,13 @@ from onyx.configs.constants import DocumentSource
 from onyx.configs.constants import IGNORE_FOR_QA
 from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.models import OnyxMetadata
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.text_processing import is_valid_email
 
 T = TypeVar("T")
 U = TypeVar("U")
 logger = setup_logger()
-
-
-def datetime_to_utc(dt: datetime) -> datetime:
-    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-
-    return dt.astimezone(timezone.utc)
 
 
 def time_str_to_utc(datetime_str: str) -> datetime:

--- a/backend/onyx/connectors/dropbox/connector.py
+++ b/backend/onyx/connectors/dropbox/connector.py
@@ -1,4 +1,3 @@
-from datetime import timezone
 from io import BytesIO
 from typing import Any
 
@@ -22,6 +21,7 @@ from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import TextSection
 from onyx.file_processing.extract_file_text import extract_file_text
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -83,14 +83,7 @@ class DropboxConnector(LoadConnector, PollConnector):
             batch: list[Document | HierarchyNode] = []
             for entry in result.entries:
                 if isinstance(entry, FileMetadata):
-                    modified_time = entry.client_modified
-                    if modified_time.tzinfo is None:
-                        # If no timezone info, assume it is UTC
-                        modified_time = modified_time.replace(tzinfo=timezone.utc)
-                    else:
-                        # If not in UTC, translate it
-                        modified_time = modified_time.astimezone(timezone.utc)
-
+                    modified_time = datetime_to_utc(entry.client_modified)
                     time_as_seconds = int(modified_time.timestamp())
                     if start and time_as_seconds < start:
                         continue

--- a/backend/onyx/connectors/gitlab/connector.py
+++ b/backend/onyx/connectors/gitlab/connector.py
@@ -25,6 +25,7 @@ from onyx.connectors.models import ConnectorMissingCredentialError
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import TextSection
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 T = TypeVar("T")
@@ -73,11 +74,7 @@ def _gitlab_datetime_to_utc(value: Any) -> datetime | None:
     if value is None:
         return None
     if isinstance(value, datetime):
-        return (
-            value.replace(tzinfo=timezone.utc)
-            if value.tzinfo is None
-            else value.astimezone(timezone.utc)
-        )
+        return datetime_to_utc(value)
     return time_str_to_utc(value)
 
 

--- a/backend/onyx/connectors/highspot/connector.py
+++ b/backend/onyx/connectors/highspot/connector.py
@@ -1,6 +1,5 @@
 import os
 from datetime import datetime
-from datetime import timezone
 from io import BytesIO
 from typing import Any
 from typing import Dict
@@ -28,6 +27,7 @@ from onyx.connectors.models import TextSection
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_processing.file_types import OnyxFileExtensions
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -42,9 +42,7 @@ def _parse_highspot_timestamp(value: Any) -> datetime | None:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
     except (ValueError, TypeError):
         return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+    return datetime_to_utc(parsed)
 
 
 class HighspotSpot(BaseModel):

--- a/backend/onyx/connectors/lumapps/connector.py
+++ b/backend/onyx/connectors/lumapps/connector.py
@@ -28,6 +28,7 @@ from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import SlimDocument
 from onyx.connectors.models import TextSection
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -82,9 +83,7 @@ def _parse_dt(value: Any) -> datetime | None:
             return _epoch_to_dt(float(value))
         except ValueError:
             return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+    return datetime_to_utc(parsed)
 
 
 class LumAppsConnector(CheckpointedConnector[LumAppsCheckpoint], SlimConnector):

--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -1,7 +1,6 @@
 import re
 from collections.abc import Generator
 from datetime import datetime
-from datetime import timezone
 from typing import Any
 from typing import cast
 from typing import Optional
@@ -32,6 +31,7 @@ from onyx.connectors.models import ImageSection
 from onyx.connectors.models import TextSection
 from onyx.db.enums import HierarchyNodeType
 from onyx.utils.batching import batch_generator
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_wrapper import retry_builder
 
@@ -958,12 +958,12 @@ class NotionConnector(LoadConnector, PollConnector):
                         sections=cast(list[TextSection | ImageSection], sections),
                         source=DocumentSource.NOTION,
                         semantic_identifier=page_title,
-                        doc_updated_at=datetime.fromisoformat(
-                            page.last_edited_time
-                        ).astimezone(timezone.utc),
-                        doc_created_at=datetime.fromisoformat(
-                            page.created_time
-                        ).astimezone(timezone.utc),
+                        doc_updated_at=datetime_to_utc(
+                            datetime.fromisoformat(page.last_edited_time)
+                        ),
+                        doc_created_at=datetime_to_utc(
+                            datetime.fromisoformat(page.created_time)
+                        ),
                         metadata={},
                         parent_hierarchy_raw_node_id=parent_raw_id,
                     )

--- a/backend/onyx/connectors/xenforo/connector.py
+++ b/backend/onyx/connectors/xenforo/connector.py
@@ -23,13 +23,13 @@ from bs4 import BeautifulSoup
 from bs4 import Tag
 
 from onyx.configs.constants import DocumentSource
-from onyx.connectors.cross_connector_utils.miscellaneous_utils import datetime_to_utc
 from onyx.connectors.interfaces import GenerateDocumentsOutput
 from onyx.connectors.interfaces import LoadConnector
 from onyx.connectors.models import BasicExpertInfo
 from onyx.connectors.models import Document
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.models import TextSection
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -47,7 +47,6 @@ from onyx.document_index.opensearch.schema import get_opensearch_doc_chunk_id
 from onyx.document_index.opensearch.schema import GLOBAL_BOOST_FIELD_NAME
 from onyx.document_index.opensearch.schema import HIDDEN_FIELD_NAME
 from onyx.document_index.opensearch.schema import PERSONAS_FIELD_NAME
-from onyx.document_index.opensearch.schema import set_or_convert_timezone_to_utc
 from onyx.document_index.opensearch.schema import USER_PROJECTS_FIELD_NAME
 from onyx.document_index.opensearch.search import DocumentQuery
 from onyx.document_index.opensearch.search import (
@@ -62,6 +61,7 @@ from onyx.document_index.opensearch.search import (
 from onyx.indexing.models import DocMetadataAwareIndexChunk
 from onyx.indexing.models import Document
 from onyx.redis.lock_context import redis_shared_lock
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from onyx.utils.text_processing import remove_invalid_unicode_chars
 from shared_configs.configs import MULTI_TENANT
@@ -605,9 +605,7 @@ class OpenSearchDocumentIndex(DocumentIndex):
             if update_request.created_at is not None:
                 # Stored as epoch seconds
                 properties_to_update[CREATED_AT_FIELD_NAME] = int(
-                    set_or_convert_timezone_to_utc(
-                        update_request.created_at
-                    ).timestamp()
+                    datetime_to_utc(update_request.created_at).timestamp()
                 )
 
             if not properties_to_update:

--- a/backend/onyx/document_index/opensearch/schema.py
+++ b/backend/onyx/document_index/opensearch/schema.py
@@ -29,6 +29,7 @@ from onyx.document_index.opensearch.string_filtering import (
 from onyx.document_index.opensearch.string_filtering import (
     MAX_DOCUMENT_ID_ENCODED_LENGTH,
 )
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.tenant import get_tenant_id_short_string
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
@@ -128,17 +129,6 @@ def get_opensearch_doc_chunk_id(
     # Do one more validation to ensure we haven't exceeded the max length.
     opensearch_doc_chunk_id = filter_and_validate_document_id(opensearch_doc_chunk_id)
     return opensearch_doc_chunk_id
-
-
-def set_or_convert_timezone_to_utc(value: datetime) -> datetime:
-    if value.tzinfo is None:
-        # astimezone will raise if value does not have a timezone set.
-        value = value.replace(tzinfo=timezone.utc)
-    else:
-        # Does appropriate time conversion if value was set in a different
-        # timezone.
-        value = value.astimezone(timezone.utc)
-    return value
 
 
 class DocumentChunkWithoutVectors(BaseModel):
@@ -256,7 +246,7 @@ class DocumentChunkWithoutVectors(BaseModel):
         """
         if value is None:
             return None
-        value = set_or_convert_timezone_to_utc(value)
+        value = datetime_to_utc(value)
         return int(value.timestamp())
 
     @field_validator("last_updated", "created_at", mode="before")
@@ -273,8 +263,7 @@ class DocumentChunkWithoutVectors(BaseModel):
         if value is None:
             return None
         if isinstance(value, datetime):
-            value = set_or_convert_timezone_to_utc(value)
-            return value
+            return datetime_to_utc(value)
         if not isinstance(value, int):
             raise ValueError(
                 f"Bug: Expected an int for the datetime property '{info.field_name}' from OpenSearch, got {type(value)} instead."

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -45,12 +45,12 @@ from onyx.document_index.opensearch.schema import MAX_CHUNK_SIZE_FIELD_NAME
 from onyx.document_index.opensearch.schema import METADATA_LIST_FIELD_NAME
 from onyx.document_index.opensearch.schema import PERSONAS_FIELD_NAME
 from onyx.document_index.opensearch.schema import PUBLIC_FIELD_NAME
-from onyx.document_index.opensearch.schema import set_or_convert_timezone_to_utc
 from onyx.document_index.opensearch.schema import SOURCE_TYPE_FIELD_NAME
 from onyx.document_index.opensearch.schema import TENANT_ID_FIELD_NAME
 from onyx.document_index.opensearch.schema import TITLE_FIELD_NAME
 from onyx.document_index.opensearch.schema import TITLE_VECTOR_FIELD_NAME
 from onyx.document_index.opensearch.schema import USER_PROJECTS_FIELD_NAME
+from onyx.utils.datetime import datetime_to_utc
 
 # See https://docs.opensearch.org/latest/query-dsl/term/terms/.
 MAX_NUM_TERMS_ALLOWED_IN_TERMS_QUERY = 65_536
@@ -1099,13 +1099,9 @@ class DocumentQuery:
             # document data.
             range_bounds: dict[str, int] = {}
             if gte is not None:
-                range_bounds["gte"] = int(
-                    set_or_convert_timezone_to_utc(gte).timestamp()
-                )
+                range_bounds["gte"] = int(datetime_to_utc(gte).timestamp())
             if lte is not None:
-                range_bounds["lte"] = int(
-                    set_or_convert_timezone_to_utc(lte).timestamp()
-                )
+                range_bounds["lte"] = int(datetime_to_utc(lte).timestamp())
 
             # Logical OR operator on its elements.
             date_range_clause: dict[str, Any] = {

--- a/backend/onyx/external_apps/token_utils.py
+++ b/backend/onyx/external_apps/token_utils.py
@@ -4,8 +4,9 @@ from providers/orchestrator) so callers can use it without an import cycle.
 
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
 from typing import Any
+
+from onyx.utils.datetime import datetime_to_utc
 
 # Refresh slightly early so no in-flight request reaches upstream with a just-
 # expired token.
@@ -56,9 +57,7 @@ def needs_refresh(
     if "expires_at" not in credentials:
         return False
     try:
-        expires_at = datetime.fromisoformat(credentials["expires_at"])
+        expires_at = datetime_to_utc(datetime.fromisoformat(credentials["expires_at"]))
     except (TypeError, ValueError):
         return True
-    if expires_at.tzinfo is None:
-        expires_at = expires_at.replace(tzinfo=timezone.utc)
     return (expires_at - now).total_seconds() <= skew_s

--- a/backend/onyx/onyxbot/slack/blocks.py
+++ b/backend/onyx/onyxbot/slack/blocks.py
@@ -42,6 +42,7 @@ from onyx.onyxbot.slack.utils import build_continue_in_web_ui_id
 from onyx.onyxbot.slack.utils import build_feedback_id
 from onyx.onyxbot.slack.utils import build_publish_ephemeral_message_id
 from onyx.onyxbot.slack.utils import remove_slack_text_interactions
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.text_processing import decode_escapes
 
 _MAX_BLURB_LEN = 45
@@ -52,12 +53,7 @@ def _format_doc_updated_at(updated_at: datetime | None) -> str | None:
     if updated_at is None:
         return None
 
-    if updated_at.tzinfo is None or updated_at.tzinfo.utcoffset(updated_at) is None:
-        aware_updated_at = updated_at.replace(tzinfo=pytz.utc)
-    else:
-        aware_updated_at = updated_at.astimezone(pytz.utc)
-
-    return timeago.format(aware_updated_at, datetime.now(pytz.utc))
+    return timeago.format(datetime_to_utc(updated_at), datetime.now(pytz.utc))
 
 
 def get_feedback_reminder_blocks(thread_link: str, include_followup: bool) -> Block:

--- a/backend/onyx/server/features/build/interactive_turns/state.py
+++ b/backend/onyx/server/features/build/interactive_turns/state.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 from onyx.cache.interface import CacheBackend
 from onyx.cache.interface import CacheLock
+from onyx.utils.datetime import datetime_to_utc
 
 
 class InteractiveTurnStatus(StrEnum):
@@ -275,10 +276,7 @@ def _runner_is_stale(
 ) -> bool:
     if turn.last_heartbeat_at is None:
         return True
-    heartbeat = turn.last_heartbeat_at
-    if heartbeat.tzinfo is None:
-        heartbeat = heartbeat.replace(tzinfo=timezone.utc)
-    age = datetime.now(tz=timezone.utc) - heartbeat
+    age = datetime.now(tz=timezone.utc) - datetime_to_utc(turn.last_heartbeat_at)
     return age.total_seconds() >= stale_after_seconds
 
 

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -57,6 +57,7 @@ from onyx.server.features.build.scheduled_tasks.schedule import EditorMode
 from onyx.server.features.build.scheduled_tasks.schedule import EditorPayload
 from onyx.server.features.build.scheduled_tasks.schedule import human_readable
 from onyx.server.features.build.scheduled_tasks.schedule import next_n_fires
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -365,9 +366,7 @@ def _parse_cursor(cursor: str | None) -> datetime | None:
             OnyxErrorCode.INVALID_INPUT,
             f"Invalid cursor (expected ISO-8601 datetime): {cursor!r}",
         ) from e
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    return datetime_to_utc(parsed)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/server/features/build/scheduled_tasks/schedule.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/schedule.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import re
 from datetime import datetime
-from datetime import timezone
 from typing import Literal
 
 from cron_descriptor import ExpressionDescriptor
@@ -34,6 +33,7 @@ from pydantic import model_validator
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.datetime import datetime_to_utc
 
 EditorMode = Literal["interval", "daily_weekly", "advanced"]
 IntervalUnit = Literal["minutes", "hours", "days"]
@@ -210,10 +210,7 @@ def compute_next_run_at(cron: str, after: datetime) -> datetime:
     """
     _validate_cron(cron)
 
-    if after.tzinfo is None:
-        after = after.replace(tzinfo=timezone.utc)
-    else:
-        after = after.astimezone(timezone.utc)
+    after = datetime_to_utc(after)
 
     try:
         itr = croniter(cron, after)
@@ -224,9 +221,7 @@ def compute_next_run_at(cron: str, after: datetime) -> datetime:
             f"Cron expression has no future fire: {cron!r}",
         ) from e
 
-    if next_fire.tzinfo is None:
-        return next_fire.replace(tzinfo=timezone.utc)
-    return next_fire.astimezone(timezone.utc)
+    return datetime_to_utc(next_fire)
 
 
 def next_n_fires(
@@ -243,10 +238,7 @@ def next_n_fires(
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "n must be positive")
     _validate_cron(cron)
 
-    if after.tzinfo is None:
-        after = after.replace(tzinfo=timezone.utc)
-    else:
-        after = after.astimezone(timezone.utc)
+    after = datetime_to_utc(after)
 
     itr = croniter(cron, after)
     fires: list[datetime] = []
@@ -258,9 +250,7 @@ def next_n_fires(
                 OnyxErrorCode.INVALID_INPUT,
                 f"Cron expression has no future fire: {cron!r}",
             ) from e
-        if nxt.tzinfo is None:
-            nxt = nxt.replace(tzinfo=timezone.utc)
-        fires.append(nxt.astimezone(timezone.utc))
+        fires.append(datetime_to_utc(nxt))
     return fires
 
 

--- a/backend/onyx/server/features/release_notes/utils.py
+++ b/backend/onyx/server/features/release_notes/utils.py
@@ -19,6 +19,7 @@ from onyx.server.features.release_notes.constants import REDIS_CACHE_TTL
 from onyx.server.features.release_notes.constants import REDIS_KEY_ETAG
 from onyx.server.features.release_notes.constants import REDIS_KEY_FETCHED_AT
 from onyx.server.features.release_notes.models import ReleaseNoteEntry
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -131,11 +132,7 @@ def get_last_fetch_time() -> datetime | None:
         if not raw:
             return None
 
-        last_fetch = datetime.fromisoformat(raw.decode("utf-8"))
-        if last_fetch.tzinfo is None:
-            last_fetch = last_fetch.replace(tzinfo=timezone.utc)
-        else:
-            last_fetch = last_fetch.astimezone(timezone.utc)
+        last_fetch = datetime_to_utc(datetime.fromisoformat(raw.decode("utf-8")))
 
         return last_fetch
     except Exception as e:

--- a/backend/onyx/utils/datetime.py
+++ b/backend/onyx/utils/datetime.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+from datetime import timezone
+
+
+def datetime_to_utc(dt: datetime) -> datetime:
+    """Normalize to timezone-aware UTC. Naive values are treated as UTC."""
+    if dt.tzinfo is None or dt.tzinfo.utcoffset(dt) is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)

--- a/backend/onyx/utils/retry_after.py
+++ b/backend/onyx/utils/retry_after.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from datetime import timezone
 from email.utils import parsedate_to_datetime
 
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -47,8 +48,7 @@ def parse_retry_after_seconds(value: str | None) -> float | None:
 
     # parsedate_to_datetime returns a naive datetime when the date carries no
     # timezone; RFC dates are GMT, so treat that as UTC.
-    if retry_at.tzinfo is None:
-        retry_at = retry_at.replace(tzinfo=timezone.utc)
+    retry_at = datetime_to_utc(retry_at)
 
     delta_seconds = (retry_at - datetime.now(timezone.utc)).total_seconds()
     return max(delta_seconds, 0.0)

--- a/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
+++ b/backend/tests/daily/connectors/gitlab/test_gitlab_basic.py
@@ -39,7 +39,7 @@ def test_gitlab_connector_basic(gitlab_connector: GitlabConnector) -> None:
     doc_batches = gitlab_connector.load_from_state()
     docs = list(itertools.chain(*doc_batches))
     # Assert right number of docs - Adjust if necessary based on test repo state
-    assert len(docs) == 79
+    assert len(docs) == 82
 
     # Find one of each type to validate
     validated_mr = False


### PR DESCRIPTION
## Description

unify all the places we coerce to utc. branch name is an oops

## How Has This Been Tested?

n/a

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized UTC normalization with `onyx.utils.datetime.datetime_to_utc` and switched all call sites to use it so naive datetimes are treated as UTC. Also adjusted a GitLab test expectation.

- **Refactors**
  - Added `backend/onyx/utils/datetime.py` with `datetime_to_utc(dt)`; naive -> UTC, tz-aware -> converted to UTC.
  - Replaced hand-rolled conversions in connectors (`Bitbucket`, `Braintrust`, `Coda`, `Confluence`, `Dropbox`, `GitLab`, `Highspot`, `LumApps`, `Notion`, `XenForo`) and server/index code (OpenSearch index/search/schema, Slack blocks, interactive turns, scheduled tasks, release notes, token utils, retry-after parsing). Removed the duplicate helper from `cross_connector_utils/miscellaneous_utils.py`.

- **Bug Fixes**
  - Updated GitLab daily test to expect 82 docs.

<sup>Written for commit 85ac36cf508b3a972d3d9997ff43aad192c5eb88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

