### PR TITLE
fix(mcp): proactively refresh OAuth tokens for SSE transport [mirror of #12903 for edits]

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -27,6 +27,7 @@ from mcp.types import InitializeResult
 from mcp.types import Tool as MCPLibTool
 from pydantic import AnyUrl
 from pydantic import BaseModel
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import build_oauth_authorization_url
@@ -428,6 +429,16 @@ def refresh_mcp_oauth_token_if_expired(
     the existing stored header. All failures raise; the caller is expected to
     treat a refresh failure as non-fatal.
     """
+    # Serialize concurrent refreshes for the same connection: providers that
+    # rotate refresh tokens invalidate the old one, so two racing exchanges
+    # would leave the loser with a dead token. The row lock is held until
+    # update_connection_config commits; a blocked second caller then re-reads
+    # a fresh (non-expired) expiry below and returns without refreshing.
+    db_session.execute(
+        select(MCPConnectionConfig)
+        .where(MCPConnectionConfig.id == connection_config_id)
+        .with_for_update()
+    ).scalar_one()
     config = get_connection_config_by_id(connection_config_id, db_session)
     config_data = extract_connection_data(config)
 
@@ -484,7 +495,12 @@ def refresh_mcp_oauth_token_if_expired(
         config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
 
     header_value = f"{new_tokens.token_type} {new_tokens.access_token}"
-    config_data["headers"] = {"Authorization": header_value}
+    # Merge, don't replace: the connection may carry static headers alongside
+    # the OAuth Authorization header.
+    config_data["headers"] = {
+        **config_data.get("headers", {}),
+        "Authorization": header_value,
+    }
     update_connection_config(config.id, db_session, config_data)
 
     logger.info(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -388,6 +388,113 @@ def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
     return time.time() + tokens.expires_in - TOKEN_EXPIRY_BUFFER_SECONDS
 
 
+def _resolve_mcp_oauth_token_endpoint(
+    mcp_server: DbMCPServer, config_data: MCPConnectionData
+) -> str | None:
+    """Token endpoint to hit for a refresh: the server row's configured endpoint
+    for a KNOWN_PROVIDER, else the discovered endpoint persisted in METADATA."""
+    if (
+        mcp_server.oauth_provider_mode == MCPOAuthProviderMode.KNOWN_PROVIDER
+        and mcp_server.oauth_token_endpoint
+    ):
+        return mcp_server.oauth_token_endpoint
+    metadata_raw = config_data.get(MCPOAuthKeys.METADATA.value)
+    if metadata_raw:
+        token_endpoint = metadata_raw.get("token_endpoint")
+        if token_endpoint:
+            return str(token_endpoint)
+    return None
+
+
+def refresh_mcp_oauth_token_if_expired(
+    mcp_server: DbMCPServer,
+    connection_config_id: int,
+    db_session: Session,
+) -> str | None:
+    """Proactively refresh a per-user MCP OAuth token when it is at/near expiry.
+
+    The MCP SDK's ``OAuthClientProvider`` (an ``httpx.Auth``) normally drives
+    refresh, but it is disabled for SSE transport because ``requires_response_body``
+    is incompatible with an open SSE stream (see ``mcp_client.py``). That leaves
+    the stored ``Authorization: Bearer <access_token>`` header frozen, so once
+    the token expires every SSE tool call fails with an auth error until the user
+    manually reconnects (DST-1273).
+
+    This performs a transport-independent ``grant_type=refresh_token`` exchange,
+    persists the rotated tokens/expiry/header (mirroring ``OnyxTokenStorage.set_tokens``),
+    and returns the fresh ``Authorization`` header value to use for the current
+    call. Returns ``None`` when no refresh was needed or possible (still-valid
+    token, no refresh token, no client/endpoint) — the caller then falls back to
+    the existing stored header. All failures raise; the caller is expected to
+    treat a refresh failure as non-fatal.
+    """
+    config = get_connection_config_by_id(connection_config_id, db_session)
+    config_data = extract_connection_data(config)
+
+    tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
+    refresh_token = tokens_raw.get("refresh_token") if tokens_raw else None
+    if not refresh_token:
+        return None
+
+    # Only refresh when we KNOW the token has expired. A missing expiry means we
+    # can't tell (e.g. a connection made before expiry was persisted) — refreshing
+    # on every call there would hammer the token endpoint and needlessly rotate
+    # the refresh token, so leave those to the one-time manual reconnect.
+    # `token_expires_at` already bakes in TOKEN_EXPIRY_BUFFER_SECONDS.
+    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+    if expires_at is None or time.time() < float(expires_at):
+        return None
+
+    token_endpoint = _resolve_mcp_oauth_token_endpoint(mcp_server, config_data)
+    if not token_endpoint:
+        return None
+
+    client_info_raw = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
+    client_id = client_info_raw.get("client_id") if client_info_raw else None
+    if not client_id:
+        return None
+
+    request_data: dict[str, str] = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    }
+    client_secret = client_info_raw.get("client_secret") if client_info_raw else None
+    if client_secret:
+        request_data["client_secret"] = client_secret
+
+    validate_oauth_endpoint_url(token_endpoint)
+    response = requests.post(
+        token_endpoint,
+        data=request_data,
+        headers={"Accept": "application/json"},
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    new_tokens = OAuthToken.model_validate(response.json())
+
+    config_data[MCPOAuthKeys.TOKENS.value] = _token_dict_with_preserved_refresh(
+        new_tokens, tokens_raw
+    )
+    new_expiry = _absolute_token_expiry(new_tokens)
+    if new_expiry is not None:
+        config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = new_expiry
+    else:
+        config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
+
+    header_value = f"{new_tokens.token_type} {new_tokens.access_token}"
+    config_data["headers"] = {"Authorization": header_value}
+    update_connection_config(config.id, db_session, config_data)
+
+    logger.info(
+        "Refreshed SSE MCP OAuth token for server '%s' (config %s)",
+        mcp_server.name,
+        connection_config_id,
+    )
+    return header_value
+
+
 def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:
     """Expose a KNOWN_PROVIDER server's configured endpoints as SDK OAuth
     metadata so refresh targets the real token endpoint, not the SDK's

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -27,7 +27,6 @@ from mcp.types import InitializeResult
 from mcp.types import Tool as MCPLibTool
 from pydantic import AnyUrl
 from pydantic import BaseModel
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import build_oauth_authorization_url
@@ -93,10 +92,12 @@ from onyx.server.features.tool.models import ToolSnapshot
 from onyx.tools.tool_implementations.mcp.mcp_client import discover_mcp_tools
 from onyx.tools.tool_implementations.mcp.mcp_client import initialize_mcp_client
 from onyx.tools.tool_implementations.mcp.mcp_client import log_exception_group
+from onyx.tools.tool_implementations.mcp.mcp_ssrf import mcp_ssrf_httpx_client_factory
 from onyx.tools.tool_implementations.mcp.mcp_ssrf import validate_mcp_outbound_url
 from onyx.utils.encryption import mask_string
 from onyx.utils.encryption import reject_masked_credentials
 from onyx.utils.logger import setup_logger
+from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
 from onyx.utils.url import BLOCKED_HOSTNAMES
 from onyx.utils.url import SSRFException
 from shared_configs.contextvars import get_current_tenant_id
@@ -389,126 +390,97 @@ def _absolute_token_expiry(tokens: OAuthToken) -> float | None:
     return time.time() + tokens.expires_in - TOKEN_EXPIRY_BUFFER_SECONDS
 
 
-def _resolve_mcp_oauth_token_endpoint(
-    mcp_server: DbMCPServer, config_data: MCPConnectionData
-) -> str | None:
-    """Token endpoint to hit for a refresh: the server row's configured endpoint
-    for a KNOWN_PROVIDER, else the discovered endpoint persisted in METADATA."""
-    if (
-        mcp_server.oauth_provider_mode == MCPOAuthProviderMode.KNOWN_PROVIDER
-        and mcp_server.oauth_token_endpoint
-    ):
-        return mcp_server.oauth_token_endpoint
-    metadata_raw = config_data.get(MCPOAuthKeys.METADATA.value)
-    if metadata_raw:
-        token_endpoint = metadata_raw.get("token_endpoint")
-        if token_endpoint:
-            return str(token_endpoint)
-    return None
-
-
-def refresh_mcp_oauth_token_if_expired(
+async def _refresh_mcp_oauth_token_if_expired(
     mcp_server: DbMCPServer,
     connection_config_id: int,
-    db_session: Session,
+    user_id: str,
 ) -> str | None:
     """Proactively refresh a per-user MCP OAuth token when it is at/near expiry.
 
     The MCP SDK's ``OAuthClientProvider`` (an ``httpx.Auth``) normally drives
-    refresh, but it is disabled for SSE transport because ``requires_response_body``
-    is incompatible with an open SSE stream (see ``mcp_client.py``). That leaves
-    the stored ``Authorization: Bearer <access_token>`` header frozen, so once
-    the token expires every SSE tool call fails with an auth error until the user
-    manually reconnects (DST-1273).
+    refresh transparently, but it's disabled for SSE transport because
+    ``requires_response_body`` is incompatible with an open SSE stream (see
+    ``mcp_client.py``). That leaves the stored ``Authorization: Bearer
+    <access_token>`` header frozen, so once the token expires every SSE tool
+    call fails with an auth error until the user manually reconnects
+    (DST-1273).
 
-    This performs a transport-independent ``grant_type=refresh_token`` exchange,
-    persists the rotated tokens/expiry/header (mirroring ``OnyxTokenStorage.set_tokens``),
-    and returns the fresh ``Authorization`` header value to use for the current
-    call. Returns ``None`` when no refresh was needed or possible (still-valid
-    token, no refresh token, no client/endpoint) — the caller then falls back to
-    the existing stored header. All failures raise; the caller is expected to
-    treat a refresh failure as non-fatal.
+    Rather than reimplementing the refresh grant, this drives the same
+    ``OAuthClientProvider`` used by every other MCP OAuth path (see
+    ``make_oauth_provider``, used for the initial connect handshake and for
+    non-SSE tool calls) through its refresh step directly, outside the
+    ``httpx.Auth`` flow that SSE can't use. That gets us, for free, the same
+    client-authentication handling (``client_secret_basic`` vs.
+    ``client_secret_post``, negotiated via DCR — see the comment in
+    ``_build_oauth_admin_config_data_for_update``) and the same
+    ``OnyxTokenStorage``-backed persistence (rotated tokens/expiry/header,
+    refresh-token preservation) as the rest of the codebase, instead of a
+    second, independently-maintained implementation.
+
+    ``provider._initialize``/``_refresh_token``/``_handle_refresh_response``
+    are private SDK methods — there's no public "just refresh if needed" API
+    — so this may need adjusting on MCP SDK upgrades.
+
+    Returns the ``Authorization`` header value to use for the current call,
+    or ``None`` when we have no opinion (no refresh token / no client info)
+    and the caller should fall back to whatever header it already built. All
+    failures raise; the caller is expected to treat a refresh failure as
+    non-fatal.
     """
-    # Serialize concurrent refreshes for the same connection: providers that
-    # rotate refresh tokens invalidate the old one, so two racing exchanges
-    # would leave the loser with a dead token. The row lock is held until
-    # update_connection_config commits; a blocked second caller then re-reads
-    # a fresh (non-expired) expiry below and returns without refreshing.
-    db_session.execute(
-        select(MCPConnectionConfig)
-        .where(MCPConnectionConfig.id == connection_config_id)
-        .with_for_update()
-    ).scalar_one()
-    config = get_connection_config_by_id(connection_config_id, db_session)
-    config_data = extract_connection_data(config)
-
-    tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
-    refresh_token = tokens_raw.get("refresh_token") if tokens_raw else None
-    if not refresh_token:
-        return None
-
-    # Only refresh when we KNOW the token has expired. A missing expiry means we
-    # can't tell (e.g. a connection made before expiry was persisted) — refreshing
-    # on every call there would hammer the token endpoint and needlessly rotate
-    # the refresh token, so leave those to the one-time manual reconnect.
-    # `token_expires_at` already bakes in TOKEN_EXPIRY_BUFFER_SECONDS.
-    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
-    if expires_at is None or time.time() < float(expires_at):
-        return None
-
-    token_endpoint = _resolve_mcp_oauth_token_endpoint(mcp_server, config_data)
-    if not token_endpoint:
-        return None
-
-    client_info_raw = config_data.get(MCPOAuthKeys.CLIENT_INFO.value)
-    client_id = client_info_raw.get("client_id") if client_info_raw else None
-    if not client_id:
-        return None
-
-    request_data: dict[str, str] = {
-        "grant_type": "refresh_token",
-        "refresh_token": refresh_token,
-        "client_id": client_id,
-    }
-    client_secret = client_info_raw.get("client_secret") if client_info_raw else None
-    if client_secret:
-        request_data["client_secret"] = client_secret
-
-    validate_oauth_endpoint_url(token_endpoint)
-    response = requests.post(
-        token_endpoint,
-        data=request_data,
-        headers={"Accept": "application/json"},
-        timeout=30,
+    # user_id is only consulted by redirect_handler/callback_handler, which
+    # UNUSED_RETURN_PATH ensures we never invoke here (see make_oauth_provider).
+    provider = make_oauth_provider(
+        mcp_server,
+        user_id,
+        UNUSED_RETURN_PATH,
+        connection_config_id,
+        None,
     )
-    response.raise_for_status()
+    context = provider.context
+    await provider._initialize()
 
-    new_tokens = OAuthToken.model_validate(response.json())
+    if not context.can_refresh_token():
+        return None
 
-    config_data[MCPOAuthKeys.TOKENS.value] = _token_dict_with_preserved_refresh(
-        new_tokens, tokens_raw
-    )
-    new_expiry = _absolute_token_expiry(new_tokens)
-    if new_expiry is not None:
-        config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] = new_expiry
-    else:
-        config_data.pop(MCPOAuthKeys.TOKEN_EXPIRES_AT.value, None)
+    if context.is_token_valid():
+        # Not expired — either it never was (no persisted expiry: treated as
+        # valid, same as the SDK's own is_token_valid()), or a racing call
+        # already refreshed it. Either way, hand back whatever's currently
+        # persisted so the caller doesn't use a pre-refresh header snapshot.
+        current_tokens = context.current_tokens
+        assert current_tokens is not None  # implied by can_refresh_token()
+        return f"{current_tokens.token_type} {current_tokens.access_token}"
 
-    header_value = f"{new_tokens.token_type} {new_tokens.access_token}"
-    # Merge, don't replace: the connection may carry static headers alongside
-    # the OAuth Authorization header.
-    config_data["headers"] = {
-        **config_data.get("headers", {}),
-        "Authorization": header_value,
-    }
-    update_connection_config(config.id, db_session, config_data)
+    refresh_request = await provider._refresh_token()
+    async with mcp_ssrf_httpx_client_factory() as client:
+        response = await client.send(refresh_request)
+
+    if not await provider._handle_refresh_response(response):
+        raise RuntimeError(
+            f"MCP OAuth refresh failed for server '{mcp_server.name}' "
+            f"(config {connection_config_id}): {response.status_code}"
+        )
 
     logger.info(
         "Refreshed SSE MCP OAuth token for server '%s' (config %s)",
         mcp_server.name,
         connection_config_id,
     )
-    return header_value
+    new_tokens = context.current_tokens
+    assert new_tokens is not None  # set by _handle_refresh_response on success
+    return f"{new_tokens.token_type} {new_tokens.access_token}"
+
+
+def refresh_mcp_oauth_token_if_expired(
+    mcp_server: DbMCPServer,
+    connection_config_id: int,
+    user_id: str,
+) -> str | None:
+    """Sync wrapper for ``_refresh_mcp_oauth_token_if_expired`` (see there for
+    behavior), for the sync ``MCPTool.run`` call site."""
+    return run_async_sync_no_cancel(
+        _refresh_mcp_oauth_token_if_expired(mcp_server, connection_config_id, user_id)
+    )
 
 
 def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -395,40 +395,24 @@ async def _refresh_mcp_oauth_token_if_expired(
     connection_config_id: int,
     user_id: str,
 ) -> str | None:
-    """Proactively refresh a per-user MCP OAuth token when it is at/near expiry.
+    """Refresh an SSE-transport MCP server's OAuth token via the same
+    `OAuthClientProvider`/`OnyxTokenStorage` every other MCP OAuth path uses
+    (see `make_oauth_provider`) — the SDK's own httpx.Auth refresh can't run
+    over an open SSE stream, so this drives the provider's refresh step
+    directly instead of the full httpx.Auth flow. That gets client-auth-method
+    handling (`client_secret_basic` vs. `client_secret_post`) and token
+    persistence for free, instead of a second implementation to keep in sync.
 
-    The MCP SDK's ``OAuthClientProvider`` (an ``httpx.Auth``) normally drives
-    refresh transparently, but it's disabled for SSE transport because
-    ``requires_response_body`` is incompatible with an open SSE stream (see
-    ``mcp_client.py``). That leaves the stored ``Authorization: Bearer
-    <access_token>`` header frozen, so once the token expires every SSE tool
-    call fails with an auth error until the user manually reconnects
-    (DST-1273).
+    Uses private SDK methods (`_initialize`/`_refresh_token`/
+    `_handle_refresh_response`) since there's no public "refresh if needed"
+    API — may need adjusting on MCP SDK upgrades.
 
-    Rather than reimplementing the refresh grant, this drives the same
-    ``OAuthClientProvider`` used by every other MCP OAuth path (see
-    ``make_oauth_provider``, used for the initial connect handshake and for
-    non-SSE tool calls) through its refresh step directly, outside the
-    ``httpx.Auth`` flow that SSE can't use. That gets us, for free, the same
-    client-authentication handling (``client_secret_basic`` vs.
-    ``client_secret_post``, negotiated via DCR — see the comment in
-    ``_build_oauth_admin_config_data_for_update``) and the same
-    ``OnyxTokenStorage``-backed persistence (rotated tokens/expiry/header,
-    refresh-token preservation) as the rest of the codebase, instead of a
-    second, independently-maintained implementation.
-
-    ``provider._initialize``/``_refresh_token``/``_handle_refresh_response``
-    are private SDK methods — there's no public "just refresh if needed" API
-    — so this may need adjusting on MCP SDK upgrades.
-
-    Returns the ``Authorization`` header value to use for the current call,
-    or ``None`` when we have no opinion (no refresh token / no client info)
-    and the caller should fall back to whatever header it already built. All
-    failures raise; the caller is expected to treat a refresh failure as
-    non-fatal.
+    Returns the `Authorization` header to use now, or `None` with no opinion
+    (no refresh token / client info) — caller falls back to its own header.
+    Raises on failure; caller treats that as non-fatal.
     """
-    # user_id is only consulted by redirect_handler/callback_handler, which
-    # UNUSED_RETURN_PATH ensures we never invoke here (see make_oauth_provider).
+    # user_id only matters to redirect/callback handlers, never invoked here
+    # since UNUSED_RETURN_PATH short-circuits them.
     provider = make_oauth_provider(
         mcp_server,
         user_id,
@@ -443,10 +427,8 @@ async def _refresh_mcp_oauth_token_if_expired(
         return None
 
     if context.is_token_valid():
-        # Not expired — either it never was (no persisted expiry: treated as
-        # valid, same as the SDK's own is_token_valid()), or a racing call
-        # already refreshed it. Either way, hand back whatever's currently
-        # persisted so the caller doesn't use a pre-refresh header snapshot.
+        # Valid (no persisted expiry also reads as valid), or a racing call
+        # already refreshed it — hand back the current header either way.
         current_tokens = context.current_tokens
         assert current_tokens is not None  # implied by can_refresh_token()
         return f"{current_tokens.token_type} {current_tokens.access_token}"
@@ -476,8 +458,8 @@ def refresh_mcp_oauth_token_if_expired(
     connection_config_id: int,
     user_id: str,
 ) -> str | None:
-    """Sync wrapper for ``_refresh_mcp_oauth_token_if_expired`` (see there for
-    behavior), for the sync ``MCPTool.run`` call site."""
+    """Sync wrapper for `_refresh_mcp_oauth_token_if_expired` (see there for
+    behavior), for the sync `MCPTool.run` call site."""
     return run_async_sync_no_cancel(
         _refresh_mcp_oauth_token_if_expired(mcp_server, connection_config_id, user_id)
     )

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -227,11 +227,8 @@ class MCPTool(Tool[None]):
                 and self._user_id
             ):
                 if self.mcp_server.transport == MCPTransport.SSE:
-                    # The SDK OAuthClientProvider (httpx.Auth) that drives refresh
-                    # is incompatible with an open SSE stream, so refresh it
-                    # ourselves before the call: rotate the token when expired and
-                    # swap in the fresh Authorization header. Any failure is
-                    # non-fatal — fall back to the stored token.
+                    # httpx.Auth refresh can't run over an open SSE stream;
+                    # refresh proactively here instead. Non-fatal on failure.
                     try:
                         from onyx.server.features.mcp.api import (
                             refresh_mcp_oauth_token_if_expired,

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -227,10 +227,32 @@ class MCPTool(Tool[None]):
                 and self._user_id
             ):
                 if self.mcp_server.transport == MCPTransport.SSE:
-                    logger.warning(
-                        "MCP tool '%s': OAuth token refresh is not supported for SSE transport — auth provider will be ignored. Re-authentication may be required after token expiry.",
-                        self._name,
-                    )
+                    # The SDK OAuthClientProvider (httpx.Auth) that drives refresh
+                    # is incompatible with an open SSE stream, so refresh it
+                    # ourselves before the call: rotate the token when expired and
+                    # swap in the fresh Authorization header. Any failure is
+                    # non-fatal — fall back to the stored token.
+                    try:
+                        from onyx.db.engine.sql_engine import (
+                            get_session_with_current_tenant,
+                        )
+                        from onyx.server.features.mcp.api import (
+                            refresh_mcp_oauth_token_if_expired,
+                        )
+
+                        with get_session_with_current_tenant() as refresh_session:
+                            refreshed_header = refresh_mcp_oauth_token_if_expired(
+                                self.mcp_server,
+                                self.connection_config.id,
+                                refresh_session,
+                            )
+                        if refreshed_header:
+                            headers["Authorization"] = refreshed_header
+                    except Exception:
+                        logger.exception(
+                            "MCP tool '%s': proactive SSE OAuth token refresh failed; using existing token",
+                            self._name,
+                        )
                 else:
                     from onyx.server.features.mcp.api import make_oauth_provider
                     from onyx.server.features.mcp.api import UNUSED_RETURN_PATH

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -233,19 +233,15 @@ class MCPTool(Tool[None]):
                     # swap in the fresh Authorization header. Any failure is
                     # non-fatal — fall back to the stored token.
                     try:
-                        from onyx.db.engine.sql_engine import (
-                            get_session_with_current_tenant,
-                        )
                         from onyx.server.features.mcp.api import (
                             refresh_mcp_oauth_token_if_expired,
                         )
 
-                        with get_session_with_current_tenant() as refresh_session:
-                            refreshed_header = refresh_mcp_oauth_token_if_expired(
-                                self.mcp_server,
-                                self.connection_config.id,
-                                refresh_session,
-                            )
+                        refreshed_header = refresh_mcp_oauth_token_if_expired(
+                            self.mcp_server,
+                            self.connection_config.id,
+                            self._user_id,
+                        )
                         if refreshed_header:
                             headers["Authorization"] = refreshed_header
                     except Exception:

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -1,0 +1,170 @@
+"""Unit tests for transport-independent MCP OAuth refresh (DST-1273).
+
+The SDK OAuthClientProvider that drives refresh is disabled for SSE transport,
+so an SSE GitLab MCP server's access token never rotated and gitlab_search
+started failing with "no credentials" once the token expired.
+refresh_mcp_oauth_token_if_expired performs the refresh directly. These tests
+mock the DB layer and the token endpoint, so no services are required.
+"""
+
+import time
+from types import SimpleNamespace
+from typing import Any
+from typing import cast
+
+import pytest
+
+import onyx.server.features.mcp.api as mcp_api
+from onyx.db.enums import MCPOAuthProviderMode
+from onyx.db.models import MCPServer as DbMCPServer
+from onyx.server.features.mcp.api import refresh_mcp_oauth_token_if_expired
+from onyx.server.features.mcp.models import MCPOAuthKeys
+
+_TOKEN_ENDPOINT = "https://gitlab.example.com/oauth/token"
+
+
+def _server_stub() -> DbMCPServer:
+    return cast(
+        DbMCPServer,
+        SimpleNamespace(
+            name="gitlab",
+            oauth_provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER,
+            oauth_token_endpoint=_TOKEN_ENDPOINT,
+        ),
+    )
+
+
+def _install_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    config_data: dict[str, Any],
+    *,
+    refresh_response: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Patch the DB accessors + token endpoint the refresh helper touches.
+
+    Returns a ``captured`` dict recording the outbound POST and the persisted
+    config so tests can assert on them.
+    """
+    captured: dict[str, Any] = {"post_called": False}
+
+    monkeypatch.setattr(
+        mcp_api,
+        "get_connection_config_by_id",
+        lambda config_id, _db_session: SimpleNamespace(id=config_id),
+    )
+    # extract_connection_data returns the same dict the helper mutates in place.
+    monkeypatch.setattr(
+        mcp_api,
+        "extract_connection_data",
+        lambda _config, _apply_mask=False: config_data,
+    )
+    monkeypatch.setattr(mcp_api, "validate_oauth_endpoint_url", lambda _url: None)
+
+    def _fake_update(config_id: int, _db_session: Any, data: Any = None) -> Any:
+        captured["updated_config_data"] = data
+        return SimpleNamespace(id=config_id)
+
+    monkeypatch.setattr(mcp_api, "update_connection_config", _fake_update)
+
+    class _Resp:
+        def json(self) -> dict[str, Any]:
+            return refresh_response or {}
+
+        def raise_for_status(self) -> None:
+            return None
+
+    def _fake_post(url: str, data: Any = None, **_kwargs: Any) -> Any:
+        captured["post_called"] = True
+        captured["url"] = url
+        captured["data"] = data
+        return _Resp()
+
+    monkeypatch.setattr(mcp_api.requests, "post", _fake_post)
+    return captured
+
+
+def test_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,  # expired
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "client_secret": "csecret",
+        },
+    }
+    captured = _install_mocks(
+        monkeypatch,
+        config_data,
+        refresh_response={
+            "access_token": "NEW",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_2",
+            "scope": "api",
+        },
+    )
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, object())
+    )
+
+    assert header == "Bearer NEW"
+    # Outbound refresh POST is a correct grant_type=refresh_token exchange.
+    assert captured["url"] == _TOKEN_ENDPOINT
+    assert captured["data"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "REFRESH_1",
+        "client_id": "cid",
+        "client_secret": "csecret",
+    }
+    # Rotated token + header are persisted for the next call.
+    persisted = captured["updated_config_data"]
+    assert persisted[MCPOAuthKeys.TOKENS.value]["access_token"] == "NEW"
+    assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
+    assert persisted["headers"]["Authorization"] == "Bearer NEW"
+    assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+
+
+def test_no_refresh_when_token_still_valid(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() + 3600,  # still valid
+        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+    }
+    captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, object())
+    )
+
+    assert header is None
+    assert captured["post_called"] is False
+
+
+def test_no_refresh_without_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {"access_token": "OLD", "token_type": "Bearer"},
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+    }
+    captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, object())
+    )
+
+    assert header is None
+    assert captured["post_called"] is False

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -1,14 +1,10 @@
-"""Unit tests for transport-independent MCP OAuth refresh.
+"""Regression coverage for SSE-transport MCP OAuth refresh: SSE can't use the
+SDK's httpx.Auth refresh (open stream), so refresh_mcp_oauth_token_if_expired
+drives OAuthClientProvider's refresh step directly instead.
 
-The SDK OAuthClientProvider that drives refresh is disabled for SSE transport,
-so an SSE server's access token never rotates and tool calls start failing
-once the token expires. refresh_mcp_oauth_token_if_expired drives that same
-provider's refresh step directly, outside the httpx.Auth flow SSE can't use.
-
-These tests exercise the REAL OAuthClientProvider/OnyxTokenStorage/OAuthContext
-SDK code (client-auth-method branching, token endpoint resolution, persistence)
-end-to-end — only the DB layer and the outbound network call are mocked, so no
-services are required.
+Exercises the real OAuthClientProvider/OAuthContext/OnyxTokenStorage code —
+client-auth-method branching, endpoint resolution, persistence — mocking only
+the DB layer and the outbound network call.
 """
 
 import time
@@ -31,11 +27,9 @@ _REDIRECT_URI = "https://onyx.example.com/mcp/oauth/callback"
 
 
 def _server_stub() -> DbMCPServer:
-    # AUTO_DISCOVERY: token endpoint resolution comes from persisted METADATA
-    # (via OnyxTokenStorage.get_tokens' re-seed), same as real DCR-registered
-    # servers -- KNOWN_PROVIDER servers never negotiate client_secret_basic
-    # (see _build_oauth_admin_config_data), so this mode is what actually
-    # exercises that branch.
+    # AUTO_DISCOVERY: token endpoint comes from persisted METADATA, matching
+    # real DCR-registered servers (KNOWN_PROVIDER never negotiates
+    # client_secret_basic — see _build_oauth_admin_config_data).
     return cast(
         DbMCPServer,
         SimpleNamespace(
@@ -80,12 +74,9 @@ def _install_mocks(
     *,
     response: httpx.Response | None,
 ) -> dict[str, Any]:
-    """Patch the DB layer OnyxTokenStorage touches and the outbound network
-    call, leaving the real OAuthClientProvider/OAuthContext/OnyxTokenStorage
-    SDK code paths untouched.
-
-    Returns a ``captured`` dict recording the outbound refresh request and the
-    persisted config so tests can assert on them.
+    """Patch the DB layer OnyxTokenStorage uses and the outbound network call;
+    the real OAuthClientProvider/OAuthContext/OnyxTokenStorage code runs
+    untouched. Returns a dict capturing the outbound request + persisted config.
     """
     captured: dict[str, Any] = {}
 
@@ -165,8 +156,7 @@ def test_refreshes_expired_token_with_client_secret_post(
         "client_secret": ["csecret"],
     }
     assert "Authorization" not in sent_request.headers
-    # Persisted via the real OnyxTokenStorage.set_tokens, same as every other
-    # MCP OAuth path.
+    # Persisted via the real OnyxTokenStorage.set_tokens.
     persisted = captured["updated_config_data"]
     assert persisted[MCPOAuthKeys.TOKENS.value]["access_token"] == "NEW"
     assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
@@ -177,11 +167,9 @@ def test_refreshes_expired_token_with_client_secret_post(
 def test_refresh_uses_basic_auth_for_client_secret_basic(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """DCR can negotiate `client_secret_basic` (see the "healing stale
-    records" comment in `_build_oauth_admin_config_data_for_update`). Sending
-    the secret in the body instead of a Basic auth header gets `invalid_client`
-    from IdPs that require it. This drives the real
-    OAuthContext.prepare_token_auth, not a hand-rolled copy of it."""
+    """DCR can negotiate `client_secret_basic` (`_build_oauth_admin_config_data_for_update`);
+    IdPs that require it reject a body-embedded secret. Exercises the real
+    `OAuthContext.prepare_token_auth`, not a hand-rolled copy."""
     config_data: dict[str, Any] = {
         "headers": {"Authorization": "Bearer OLD"},
         MCPOAuthKeys.TOKENS.value: {
@@ -281,10 +269,8 @@ def test_no_refresh_without_client_info(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_no_refresh_without_persisted_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Connections created before expiry was persisted have no
-    `token_expires_at` — the SDK's own `is_token_valid()` treats an unknown
-    expiry as valid, so these are deliberately left to the one-time manual
-    reconnect rather than refreshed on every call."""
+    """No persisted `token_expires_at` reads as valid per `is_token_valid()` —
+    left to manual reconnect rather than refreshed every call."""
     config_data: dict[str, Any] = {
         "headers": {"Authorization": "Bearer OLD"},
         MCPOAuthKeys.TOKENS.value: {
@@ -308,12 +294,9 @@ def test_no_refresh_without_persisted_expiry(monkeypatch: pytest.MonkeyPatch) ->
 def test_refresh_persists_via_real_onyx_token_storage(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A successful refresh persists through the real
-    `OnyxTokenStorage.set_tokens` — same call every other MCP OAuth path uses
-    — so it inherits that path's exact persistence semantics (e.g. `headers`
-    is replaced with just the new `Authorization` header, not merged; any
-    other static headers on the connection are dropped, same as a non-SSE
-    refresh would do today)."""
+    """Persists via the real `OnyxTokenStorage.set_tokens`, so `headers` is
+    replaced with just the new `Authorization` value (not merged) — other
+    static headers are dropped, same as a non-SSE refresh."""
     config_data: dict[str, Any] = {
         "headers": {"Authorization": "Bearer OLD", "X-Custom": "static-value"},
         MCPOAuthKeys.TOKENS.value: {

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -1,10 +1,10 @@
-"""Unit tests for transport-independent MCP OAuth refresh (DST-1273).
+"""Unit tests for transport-independent MCP OAuth refresh.
 
 The SDK OAuthClientProvider that drives refresh is disabled for SSE transport,
-so an SSE GitLab MCP server's access token never rotated and gitlab_search
-started failing with "no credentials" once the token expired.
-refresh_mcp_oauth_token_if_expired performs the refresh directly. These tests
-mock the DB layer and the token endpoint, so no services are required.
+so an SSE server's access token never rotates and tool calls start failing
+once the token expires. refresh_mcp_oauth_token_if_expired performs the
+refresh directly. These tests mock the DB layer and the token endpoint, so no
+services are required.
 """
 
 import time
@@ -21,6 +21,13 @@ from onyx.server.features.mcp.api import refresh_mcp_oauth_token_if_expired
 from onyx.server.features.mcp.models import MCPOAuthKeys
 
 _TOKEN_ENDPOINT = "https://gitlab.example.com/oauth/token"
+
+
+class _FakeSession:
+    """Just enough Session for the row-lock statement in the refresh path."""
+
+    def execute(self, _stmt: Any) -> Any:
+        return SimpleNamespace(scalar_one=lambda: object())
 
 
 def _server_stub() -> DbMCPServer:
@@ -111,7 +118,7 @@ def test_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
     header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, object())
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
     )
 
     assert header == "Bearer NEW"
@@ -146,7 +153,7 @@ def test_no_refresh_when_token_still_valid(monkeypatch: pytest.MonkeyPatch) -> N
     captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
 
     header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, object())
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
     )
 
     assert header is None
@@ -163,8 +170,44 @@ def test_no_refresh_without_refresh_token(monkeypatch: pytest.MonkeyPatch) -> No
     captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
 
     header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, object())
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
     )
 
     assert header is None
     assert captured["post_called"] is False
+
+
+def test_refresh_preserves_static_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A connection can carry static headers alongside Authorization; a
+    refresh must merge the new header in, not replace the whole map."""
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD", "X-Custom": "static-value"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+    }
+    _install_mocks(
+        monkeypatch,
+        config_data,
+        refresh_response={
+            "access_token": "NEW",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_2",
+        },
+    )
+
+    header = refresh_mcp_oauth_token_if_expired(
+        _server_stub(), 42, db_session=cast(Any, _FakeSession())
+    )
+
+    assert header == "Bearer NEW"
+    assert config_data["headers"] == {
+        "Authorization": "Bearer NEW",
+        "X-Custom": "static-value",
+    }

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -2,8 +2,12 @@
 
 The SDK OAuthClientProvider that drives refresh is disabled for SSE transport,
 so an SSE server's access token never rotates and tool calls start failing
-once the token expires. refresh_mcp_oauth_token_if_expired performs the
-refresh directly. These tests mock the DB layer and the token endpoint, so no
+once the token expires. refresh_mcp_oauth_token_if_expired drives that same
+provider's refresh step directly, outside the httpx.Auth flow SSE can't use.
+
+These tests exercise the REAL OAuthClientProvider/OnyxTokenStorage/OAuthContext
+SDK code (client-auth-method branching, token endpoint resolution, persistence)
+end-to-end — only the DB layer and the outbound network call are mocked, so no
 services are required.
 """
 
@@ -11,7 +15,9 @@ import time
 from types import SimpleNamespace
 from typing import Any
 from typing import cast
+from urllib.parse import parse_qs
 
+import httpx
 import pytest
 
 import onyx.server.features.mcp.api as mcp_api
@@ -21,51 +27,82 @@ from onyx.server.features.mcp.api import refresh_mcp_oauth_token_if_expired
 from onyx.server.features.mcp.models import MCPOAuthKeys
 
 _TOKEN_ENDPOINT = "https://gitlab.example.com/oauth/token"
-
-
-class _FakeSession:
-    """Just enough Session for the row-lock statement in the refresh path."""
-
-    def execute(self, _stmt: Any) -> Any:
-        return SimpleNamespace(scalar_one=lambda: object())
+_REDIRECT_URI = "https://onyx.example.com/mcp/oauth/callback"
 
 
 def _server_stub() -> DbMCPServer:
+    # AUTO_DISCOVERY: token endpoint resolution comes from persisted METADATA
+    # (via OnyxTokenStorage.get_tokens' re-seed), same as real DCR-registered
+    # servers -- KNOWN_PROVIDER servers never negotiate client_secret_basic
+    # (see _build_oauth_admin_config_data), so this mode is what actually
+    # exercises that branch.
     return cast(
         DbMCPServer,
         SimpleNamespace(
             name="gitlab",
-            oauth_provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER,
-            oauth_token_endpoint=_TOKEN_ENDPOINT,
+            server_url="https://mcp.gitlab.example.com",
+            oauth_provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY,
+            oauth_authorization_endpoint=None,
+            oauth_token_endpoint=None,
         ),
     )
+
+
+class _FakeDbSession:
+    def __enter__(self) -> "_FakeDbSession":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+
+class _FakeAsyncHttpClient:
+    """Captures the refresh httpx.Request and returns a canned response."""
+
+    def __init__(self, response: httpx.Response, captured: dict[str, Any]):
+        self._response = response
+        self._captured = captured
+
+    async def __aenter__(self) -> "_FakeAsyncHttpClient":
+        return self
+
+    async def __aexit__(self, *_exc: Any) -> None:
+        return None
+
+    async def send(self, request: httpx.Request) -> httpx.Response:
+        self._captured["sent_request"] = request
+        return self._response
 
 
 def _install_mocks(
     monkeypatch: pytest.MonkeyPatch,
     config_data: dict[str, Any],
     *,
-    refresh_response: dict[str, Any] | None,
+    response: httpx.Response | None,
 ) -> dict[str, Any]:
-    """Patch the DB accessors + token endpoint the refresh helper touches.
+    """Patch the DB layer OnyxTokenStorage touches and the outbound network
+    call, leaving the real OAuthClientProvider/OAuthContext/OnyxTokenStorage
+    SDK code paths untouched.
 
-    Returns a ``captured`` dict recording the outbound POST and the persisted
-    config so tests can assert on them.
+    Returns a ``captured`` dict recording the outbound refresh request and the
+    persisted config so tests can assert on them.
     """
-    captured: dict[str, Any] = {"post_called": False}
+    captured: dict[str, Any] = {}
 
+    monkeypatch.setattr(
+        mcp_api, "get_session_with_current_tenant", lambda: _FakeDbSession()
+    )
     monkeypatch.setattr(
         mcp_api,
         "get_connection_config_by_id",
         lambda config_id, _db_session: SimpleNamespace(id=config_id),
     )
-    # extract_connection_data returns the same dict the helper mutates in place.
+    # extract_connection_data returns the same dict the SDK storage mutates.
     monkeypatch.setattr(
         mcp_api,
         "extract_connection_data",
         lambda _config, _apply_mask=False: config_data,
     )
-    monkeypatch.setattr(mcp_api, "validate_oauth_endpoint_url", lambda _url: None)
 
     def _fake_update(config_id: int, _db_session: Any, data: Any = None) -> Any:
         captured["updated_config_data"] = data
@@ -73,24 +110,25 @@ def _install_mocks(
 
     monkeypatch.setattr(mcp_api, "update_connection_config", _fake_update)
 
-    class _Resp:
-        def json(self) -> dict[str, Any]:
-            return refresh_response or {}
-
-        def raise_for_status(self) -> None:
-            return None
-
-    def _fake_post(url: str, data: Any = None, **_kwargs: Any) -> Any:
-        captured["post_called"] = True
-        captured["url"] = url
-        captured["data"] = data
-        return _Resp()
-
-    monkeypatch.setattr(mcp_api.requests, "post", _fake_post)
+    fake_client = _FakeAsyncHttpClient(response or httpx.Response(400), captured)
+    monkeypatch.setattr(mcp_api, "mcp_ssrf_httpx_client_factory", lambda: fake_client)
     return captured
 
 
-def test_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def _token_response(**overrides: Any) -> httpx.Response:
+    payload: dict[str, Any] = {
+        "access_token": "NEW",
+        "token_type": "Bearer",
+        "expires_in": 7200,
+        "refresh_token": "REFRESH_2",
+    }
+    payload.update(overrides)
+    return httpx.Response(200, json=payload)
+
+
+def test_refreshes_expired_token_with_client_secret_post(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     config_data: dict[str, Any] = {
         "headers": {"Authorization": "Bearer OLD"},
         MCPOAuthKeys.TOKENS.value: {
@@ -103,39 +141,82 @@ def test_refreshes_expired_token(monkeypatch: pytest.MonkeyPatch) -> None:
         MCPOAuthKeys.CLIENT_INFO.value: {
             "client_id": "cid",
             "client_secret": "csecret",
+            "redirect_uris": [_REDIRECT_URI],
+            "token_endpoint_auth_method": "client_secret_post",
+        },
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://gitlab.example.com",
+            "authorization_endpoint": "https://gitlab.example.com/oauth/authorize",
+            "token_endpoint": _TOKEN_ENDPOINT,
         },
     }
-    captured = _install_mocks(
-        monkeypatch,
-        config_data,
-        refresh_response={
-            "access_token": "NEW",
-            "token_type": "Bearer",
-            "expires_in": 7200,
-            "refresh_token": "REFRESH_2",
-            "scope": "api",
-        },
-    )
+    captured = _install_mocks(monkeypatch, config_data, response=_token_response())
 
-    header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, _FakeSession())
-    )
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
 
     assert header == "Bearer NEW"
-    # Outbound refresh POST is a correct grant_type=refresh_token exchange.
-    assert captured["url"] == _TOKEN_ENDPOINT
-    assert captured["data"] == {
-        "grant_type": "refresh_token",
-        "refresh_token": "REFRESH_1",
-        "client_id": "cid",
-        "client_secret": "csecret",
+    sent_request = captured["sent_request"]
+    assert str(sent_request.url) == _TOKEN_ENDPOINT
+    body = parse_qs(sent_request.content.decode())
+    assert body == {
+        "grant_type": ["refresh_token"],
+        "refresh_token": ["REFRESH_1"],
+        "client_id": ["cid"],
+        "client_secret": ["csecret"],
     }
-    # Rotated token + header are persisted for the next call.
+    assert "Authorization" not in sent_request.headers
+    # Persisted via the real OnyxTokenStorage.set_tokens, same as every other
+    # MCP OAuth path.
     persisted = captured["updated_config_data"]
     assert persisted[MCPOAuthKeys.TOKENS.value]["access_token"] == "NEW"
     assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
     assert persisted["headers"]["Authorization"] == "Bearer NEW"
     assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+
+
+def test_refresh_uses_basic_auth_for_client_secret_basic(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DCR can negotiate `client_secret_basic` (see the "healing stale
+    records" comment in `_build_oauth_admin_config_data_for_update`). Sending
+    the secret in the body instead of a Basic auth header gets `invalid_client`
+    from IdPs that require it. This drives the real
+    OAuthContext.prepare_token_auth, not a hand-rolled copy of it."""
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "redirect_uris": [_REDIRECT_URI],
+            "token_endpoint_auth_method": "client_secret_basic",
+        },
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://gitlab.example.com",
+            "authorization_endpoint": "https://gitlab.example.com/oauth/authorize",
+            "token_endpoint": _TOKEN_ENDPOINT,
+        },
+    }
+    captured = _install_mocks(monkeypatch, config_data, response=_token_response())
+
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    assert header == "Bearer NEW"
+    sent_request = captured["sent_request"]
+    # client_secret must NOT be in the body, and Basic auth header must be set.
+    body = parse_qs(sent_request.content.decode())
+    assert body == {
+        "grant_type": ["refresh_token"],
+        "refresh_token": ["REFRESH_1"],
+        "client_id": ["cid"],
+    }
+    assert sent_request.headers["Authorization"] == "Basic Y2lkOmNzZWNyZXQ="
 
 
 def test_no_refresh_when_token_still_valid(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -148,16 +229,19 @@ def test_no_refresh_when_token_still_valid(monkeypatch: pytest.MonkeyPatch) -> N
             "refresh_token": "REFRESH_1",
         },
         MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() + 3600,  # still valid
-        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "redirect_uris": [_REDIRECT_URI],
+        },
     }
-    captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
+    captured = _install_mocks(monkeypatch, config_data, response=None)
 
-    header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, _FakeSession())
-    )
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
 
-    assert header is None
-    assert captured["post_called"] is False
+    # No network call is made, but the currently-persisted header is still
+    # handed back (it may reflect a concurrent refresh from another call).
+    assert header == "Bearer OLD"
+    assert "sent_request" not in captured
 
 
 def test_no_refresh_without_refresh_token(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -165,21 +249,71 @@ def test_no_refresh_without_refresh_token(monkeypatch: pytest.MonkeyPatch) -> No
         "headers": {"Authorization": "Bearer OLD"},
         MCPOAuthKeys.TOKENS.value: {"access_token": "OLD", "token_type": "Bearer"},
         MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
-        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "redirect_uris": [_REDIRECT_URI],
+        },
     }
-    captured = _install_mocks(monkeypatch, config_data, refresh_response=None)
+    captured = _install_mocks(monkeypatch, config_data, response=None)
 
-    header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, _FakeSession())
-    )
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
 
     assert header is None
-    assert captured["post_called"] is False
+    assert "sent_request" not in captured
 
 
-def test_refresh_preserves_static_headers(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A connection can carry static headers alongside Authorization; a
-    refresh must merge the new header in, not replace the whole map."""
+def test_no_refresh_without_client_info(monkeypatch: pytest.MonkeyPatch) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+    }
+    captured = _install_mocks(monkeypatch, config_data, response=None)
+
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    assert header is None
+    assert "sent_request" not in captured
+
+
+def test_no_refresh_without_persisted_expiry(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Connections created before expiry was persisted have no
+    `token_expires_at` — the SDK's own `is_token_valid()` treats an unknown
+    expiry as valid, so these are deliberately left to the one-time manual
+    reconnect rather than refreshed on every call."""
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "redirect_uris": [_REDIRECT_URI],
+        },
+    }
+    captured = _install_mocks(monkeypatch, config_data, response=None)
+
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    assert header == "Bearer OLD"
+    assert "sent_request" not in captured
+
+
+def test_refresh_persists_via_real_onyx_token_storage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful refresh persists through the real
+    `OnyxTokenStorage.set_tokens` — same call every other MCP OAuth path uses
+    — so it inherits that path's exact persistence semantics (e.g. `headers`
+    is replaced with just the new `Authorization` header, not merged; any
+    other static headers on the connection are dropped, same as a non-SSE
+    refresh would do today)."""
     config_data: dict[str, Any] = {
         "headers": {"Authorization": "Bearer OLD", "X-Custom": "static-value"},
         MCPOAuthKeys.TOKENS.value: {
@@ -189,25 +323,49 @@ def test_refresh_preserves_static_headers(monkeypatch: pytest.MonkeyPatch) -> No
             "refresh_token": "REFRESH_1",
         },
         MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
-        MCPOAuthKeys.CLIENT_INFO.value: {"client_id": "cid"},
-    }
-    _install_mocks(
-        monkeypatch,
-        config_data,
-        refresh_response={
-            "access_token": "NEW",
-            "token_type": "Bearer",
-            "expires_in": 7200,
-            "refresh_token": "REFRESH_2",
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "redirect_uris": [_REDIRECT_URI],
         },
-    )
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://gitlab.example.com",
+            "authorization_endpoint": "https://gitlab.example.com/oauth/authorize",
+            "token_endpoint": _TOKEN_ENDPOINT,
+        },
+    }
+    _install_mocks(monkeypatch, config_data, response=_token_response())
 
-    header = refresh_mcp_oauth_token_if_expired(
-        _server_stub(), 42, db_session=cast(Any, _FakeSession())
-    )
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
 
     assert header == "Bearer NEW"
-    assert config_data["headers"] == {
-        "Authorization": "Bearer NEW",
-        "X-Custom": "static-value",
+    assert config_data["headers"] == {"Authorization": "Bearer NEW"}
+
+
+def test_refresh_failure_is_non_fatal_to_caller(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-200 refresh response raises, and the caller (MCPTool.run) is
+    expected to treat that as non-fatal and fall back to the stored token."""
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "redirect_uris": [_REDIRECT_URI],
+        },
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://gitlab.example.com",
+            "authorization_endpoint": "https://gitlab.example.com/oauth/authorize",
+            "token_endpoint": _TOKEN_ENDPOINT,
+        },
     }
+    _install_mocks(monkeypatch, config_data, response=httpx.Response(401))
+
+    with pytest.raises(RuntimeError):
+        refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")


### PR DESCRIPTION
This PR runs GitHub Actions CI for #12903.

- [x] Override Linear Check

**This PR should be closed (not merged) after CI completes.**

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Proactively refresh expired MCP OAuth tokens for SSE transport to prevent tool-call failures. We use the SDK `OAuthClientProvider` to refresh and persist tokens/expiry, then apply the fresh `Authorization` header for each SSE call; failures fall back to the stored token.

- **New Features**
  - Added `_refresh_mcp_oauth_token_if_expired` and sync wrapper `refresh_mcp_oauth_token_if_expired` using the SDK and `run_async_sync_no_cancel`.
  - Resolves the token endpoint from known-provider settings or persisted OAuth metadata; supports `client_secret_post` and `client_secret_basic`.
  - Uses SSRF-safe `mcp_ssrf_httpx_client_factory` for the refresh exchange.
  - `mcp_tool` refreshes before SSE tool calls and applies the new header when available.
  - Unit tests cover endpoint resolution, auth methods, no-op cases (valid/no refresh token/no client info/no persisted expiry), failure behavior, and persistence semantics (headers replaced with new `Authorization`).

<sup>Written for commit a208f8ab76c2c920f72c072e11a656118dc8b263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

