### PR TITLE
feat(metrics): MCP server/client metrics + DB-snapshot connector state gauges [mirror of #12904 for edits]

### DIFF
--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -3,9 +3,11 @@ from enum import Enum
 from typing import TypeVarTuple
 
 from fastapi import HTTPException
+from pydantic import BaseModel
 from sqlalchemy import delete
 from sqlalchemy import desc
 from sqlalchemy import exists
+from sqlalchemy import func
 from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy import update
@@ -14,6 +16,7 @@ from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
+from onyx.configs.constants import DEFAULT_CC_PAIR_ID
 from onyx.configs.constants import DocumentSource
 from onyx.db.connector import fetch_connector_by_id
 from onyx.db.credentials import fetch_credential_by_id
@@ -21,6 +24,7 @@ from onyx.db.credentials import fetch_credential_by_id_for_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingMode
 from onyx.db.enums import ProcessingMode
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
@@ -39,11 +43,95 @@ from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 logger = setup_logger()
 
 R = TypeVarTuple("R")
+_CONNECTOR_STATE_QUERY_TIMEOUT = "7s"
 
 
 class ConnectorType(str, Enum):
     STANDARD = "standard"
     USER_FILE = "user_file"
+
+
+class ConnectorStateSnapshot(BaseModel):
+    cc_pair_id: int
+    cc_pair_name: str
+    status: ConnectorCredentialPairStatus
+    last_successful_index_time: datetime | None
+    last_pruned: datetime | None
+    last_time_perm_sync: datetime | None
+    last_time_external_group_sync: datetime | None
+    total_docs_indexed: int
+    access_type: AccessType
+    indexing_trigger: IndexingMode | None
+    auto_sync_enabled: bool
+    in_repeated_error_state: bool
+    source: DocumentSource
+    credential_id: int
+
+
+def get_connector_state_snapshots(
+    db_session: Session,
+) -> list[ConnectorStateSnapshot]:
+    db_session.execute(
+        select(
+            func.set_config("statement_timeout", _CONNECTOR_STATE_QUERY_TIMEOUT, True)
+        )
+    )
+    rows = db_session.execute(
+        select(
+            ConnectorCredentialPair.id,
+            ConnectorCredentialPair.name,
+            ConnectorCredentialPair.status,
+            ConnectorCredentialPair.last_successful_index_time,
+            ConnectorCredentialPair.last_pruned,
+            ConnectorCredentialPair.last_time_perm_sync,
+            ConnectorCredentialPair.last_time_external_group_sync,
+            ConnectorCredentialPair.total_docs_indexed,
+            ConnectorCredentialPair.access_type,
+            ConnectorCredentialPair.indexing_trigger,
+            ConnectorCredentialPair.auto_sync_options,
+            ConnectorCredentialPair.in_repeated_error_state,
+            Connector.source,
+            Credential.id,
+        )
+        .join(ConnectorCredentialPair.connector)
+        .join(ConnectorCredentialPair.credential)
+        .where(ConnectorCredentialPair.id != DEFAULT_CC_PAIR_ID)
+    ).all()
+
+    return [
+        ConnectorStateSnapshot(
+            cc_pair_id=cc_pair_id,
+            cc_pair_name=cc_pair_name,
+            status=status,
+            last_successful_index_time=last_successful_index_time,
+            last_pruned=last_pruned,
+            last_time_perm_sync=last_time_perm_sync,
+            last_time_external_group_sync=last_time_external_group_sync,
+            total_docs_indexed=total_docs_indexed or 0,
+            access_type=access_type,
+            indexing_trigger=indexing_trigger,
+            auto_sync_enabled=bool(auto_sync_options),
+            in_repeated_error_state=in_repeated_error_state,
+            source=source,
+            credential_id=credential_id,
+        )
+        for (
+            cc_pair_id,
+            cc_pair_name,
+            status,
+            last_successful_index_time,
+            last_pruned,
+            last_time_perm_sync,
+            last_time_external_group_sync,
+            total_docs_indexed,
+            access_type,
+            indexing_trigger,
+            auto_sync_options,
+            in_repeated_error_state,
+            source,
+            credential_id,
+        ) in rows
+    ]
 
 
 def _add_user_filters(

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -137,6 +137,7 @@ from onyx.server.manage.voice.api import admin_router as voice_admin_router
 from onyx.server.manage.voice.user_api import router as voice_router
 from onyx.server.manage.voice.websocket_api import router as voice_websocket_router
 from onyx.server.manage.web_search.api import admin_router as web_search_admin_router
+from onyx.server.metrics.connector_state_metrics import register_connector_state_metrics
 from onyx.server.metrics.postgres_connection_pool import (
     setup_postgres_connection_pool_metrics,
 )
@@ -355,6 +356,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:  # noqa: ARG001
     # Register pool metrics now that engines are created.
     # HTTP instrumentation is set up earlier in get_application() since it
     # adds middleware (which Starlette forbids after the app has started).
+    register_connector_state_metrics()
     setup_postgres_connection_pool_metrics(
         engines={
             "sync": SqlEngine.get_engine(),

--- a/backend/onyx/mcp_server/api.py
+++ b/backend/onyx/mcp_server/api.py
@@ -9,7 +9,6 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.responses import Response
 from fastmcp import FastMCP
-from prometheus_fastapi_instrumentator import Instrumentator
 from starlette.datastructures import MutableHeaders
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.types import Receive
@@ -17,8 +16,11 @@ from starlette.types import Scope
 from starlette.types import Send
 
 from onyx.configs.app_configs import MCP_SERVER_CORS_ORIGINS
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
 from onyx.mcp_server.auth import OnyxTokenVerifier
 from onyx.mcp_server.utils import shutdown_http_client
+from onyx.server.metrics.prometheus_setup import create_prometheus_instrumentator
+from onyx.server.metrics.prometheus_setup import expose_prometheus_metrics
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable
 from shared_configs.configs import cors_allow_credentials
@@ -86,6 +88,7 @@ def create_mcp_fastapi_app() -> FastAPI:
         version="1.0.0",
         lifespan=combined_lifespan,
     )
+    register_onyx_exception_handlers(app)
 
     # Public health check endpoint (bypasses MCP auth)
     @app.middleware("http")
@@ -108,7 +111,7 @@ def create_mcp_fastapi_app() -> FastAPI:
             allow_headers=["*"],
         )
 
-    Instrumentator().instrument(app).expose(app)
+    expose_prometheus_metrics(app, create_prometheus_instrumentator())
 
     app.mount("/", _ensure_streamable_accept_header)
 

--- a/backend/onyx/mcp_server/api.py
+++ b/backend/onyx/mcp_server/api.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.responses import Response
 from fastmcp import FastMCP
+from prometheus_fastapi_instrumentator import Instrumentator
 from starlette.datastructures import MutableHeaders
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.types import Receive
@@ -106,6 +107,8 @@ def create_mcp_fastapi_app() -> FastAPI:
             allow_methods=["*"],
             allow_headers=["*"],
         )
+
+    Instrumentator().instrument(app).expose(app)
 
     app.mount("/", _ensure_streamable_accept_header)
 

--- a/backend/onyx/mcp_server/auth.py
+++ b/backend/onyx/mcp_server/auth.py
@@ -4,12 +4,19 @@ from typing import Optional
 
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.auth import TokenVerifier
+from prometheus_client import Counter
 
 from onyx.mcp_server.utils import get_http_client
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
+
+MCP_SERVER_AUTH_TOTAL = Counter(
+    "onyx_mcp_server_auth_total",
+    "MCP server authentication attempts",
+    ["result"],  # success, rejected, error
+)
 
 
 class OnyxTokenVerifier(TokenVerifier):
@@ -23,6 +30,7 @@ class OnyxTokenVerifier(TokenVerifier):
                 headers={"Authorization": f"Bearer {token}"},
             )
         except Exception as exc:
+            MCP_SERVER_AUTH_TOTAL.labels(result="error").inc()
             logger.error(
                 "MCP server failed to reach API /me for authentication: %s",
                 exc,
@@ -31,12 +39,14 @@ class OnyxTokenVerifier(TokenVerifier):
             return None
 
         if response.status_code != 200:
+            MCP_SERVER_AUTH_TOTAL.labels(result="rejected").inc()
             logger.warning(
                 "API server rejected MCP auth token with status %s",
                 response.status_code,
             )
             return None
 
+        MCP_SERVER_AUTH_TOTAL.labels(result="success").inc()
         return AccessToken(
             token=token,
             client_id="mcp",

--- a/backend/onyx/mcp_server/auth.py
+++ b/backend/onyx/mcp_server/auth.py
@@ -4,19 +4,14 @@ from typing import Optional
 
 from fastmcp.server.auth.auth import AccessToken
 from fastmcp.server.auth.auth import TokenVerifier
-from prometheus_client import Counter
 
 from onyx.mcp_server.utils import get_http_client
+from onyx.server.metrics.mcp_server import MCPAuthResult
+from onyx.server.metrics.mcp_server import record_mcp_auth_result
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
-
-MCP_SERVER_AUTH_TOTAL = Counter(
-    "onyx_mcp_server_auth_total",
-    "MCP server authentication attempts",
-    ["result"],  # success, rejected, error
-)
 
 
 class OnyxTokenVerifier(TokenVerifier):
@@ -30,7 +25,7 @@ class OnyxTokenVerifier(TokenVerifier):
                 headers={"Authorization": f"Bearer {token}"},
             )
         except Exception as exc:
-            MCP_SERVER_AUTH_TOTAL.labels(result="error").inc()
+            record_mcp_auth_result(MCPAuthResult.ERROR)
             logger.error(
                 "MCP server failed to reach API /me for authentication: %s",
                 exc,
@@ -39,14 +34,14 @@ class OnyxTokenVerifier(TokenVerifier):
             return None
 
         if response.status_code != 200:
-            MCP_SERVER_AUTH_TOTAL.labels(result="rejected").inc()
+            record_mcp_auth_result(MCPAuthResult.REJECTED)
             logger.warning(
                 "API server rejected MCP auth token with status %s",
                 response.status_code,
             )
             return None
 
-        MCP_SERVER_AUTH_TOTAL.labels(result="success").inc()
+        record_mcp_auth_result(MCPAuthResult.SUCCESS)
         return AccessToken(
             token=token,
             client_id="mcp",

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -1,10 +1,13 @@
 """Search tools for MCP server - document and web search."""
 
+import time
 from datetime import datetime
 from typing import Any
 
 import httpx
 from fastmcp.server.auth.auth import AccessToken
+from prometheus_client import Counter
+from prometheus_client import Histogram
 from pydantic import BaseModel
 from pydantic import TypeAdapter
 from pydantic import ValidationError
@@ -25,6 +28,31 @@ from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
+
+# Operational metrics
+MCP_SERVER_TOOL_LATENCY = Histogram(
+    "onyx_mcp_server_tool_latency_seconds",
+    "MCP server tool execution latency",
+    ["tool"],
+    buckets=(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+MCP_SERVER_TOOL_TOTAL = Counter(
+    "onyx_mcp_server_tool_calls_total",
+    "MCP server tool calls",
+    ["tool", "status"],  # status: success, error
+)
+# Product metrics
+MCP_SERVER_SEARCH_RESULTS = Histogram(
+    "onyx_mcp_server_search_results_count",
+    "Number of results returned by MCP server search tools",
+    ["tool"],
+    buckets=(0, 1, 2, 5, 10, 20, 50),
+)
+MCP_SERVER_SEARCH_SOURCES = Counter(
+    "onyx_mcp_server_search_by_source_total",
+    "MCP server document searches broken down by requested source type",
+    ["source_type"],
+)
 
 
 async def _post_model(
@@ -127,6 +155,7 @@ async def search_indexed_documents(
     }
     ```
     """
+    _start = time.monotonic()
     logger.info(
         "Onyx MCP Server: document search: query='%s', sources=%s, document_sets=%s",
         query,
@@ -134,8 +163,14 @@ async def search_indexed_documents(
         document_set_names,
     )
 
-    # Normalize empty list inputs to None so the API treats them as "no filter"
-    # rather than "match zero".
+    # Track requested source types for product metrics
+    if source_types:
+        for src in source_types:
+            MCP_SERVER_SEARCH_SOURCES.labels(source_type=src.lower()).inc()
+
+    # Normalize empty list inputs to None so downstream filter construction is
+    # consistent — BaseFilters treats [] as "match zero" which differs from
+    # "no filter" (None).
     source_types = source_types or None
     document_set_names = document_set_names or None
 
@@ -202,11 +237,27 @@ async def search_indexed_documents(
         payload = SearchResponse.model_validate_json(response.content)
         results = [_to_mcp_dict(result) for result in payload.results]
 
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(
+            tool="search_indexed_documents", status="success"
+        ).inc()
+        MCP_SERVER_SEARCH_RESULTS.labels(tool="search_indexed_documents").observe(
+            len(results)
+        )
+
         logger.info(
             "Onyx MCP Server: Internal search returned %s results", len(results)
         )
         return {"results": results}
     except Exception as err:
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(
+            tool="search_indexed_documents", status="error"
+        ).inc()
         logger.error("Onyx MCP Server: Document search error: %s", err, exc_info=True)
         return _error_payload(f"Document search failed: {str(err)}")
 
@@ -231,6 +282,7 @@ async def search_web(
     }
     ```
     """
+    _start = time.monotonic()
     logger.info("Onyx MCP Server: Web search: query='%s', limit=%s", query, limit)
 
     access_token = require_access_token()
@@ -248,11 +300,24 @@ async def search_web(
                 "query": query,
             }
         payload = WebSearchToolResponse.model_validate_json(response.content)
+
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="success").inc()
+        MCP_SERVER_SEARCH_RESULTS.labels(tool="search_web").observe(
+            len(payload.results)
+        )
+
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
             "query": query,
         }
     except Exception as e:
+        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="error").inc()
         logger.error("Onyx MCP Server: Web search error: %s", e, exc_info=True)
         return {
             "error": f"Web search failed: {str(e)}",
@@ -281,6 +346,7 @@ async def open_urls(
     }
     ```
     """
+    _start = time.monotonic()
     logger.info("Onyx MCP Server: Open URL: fetching %s URLs", len(urls))
 
     access_token = require_access_token()
@@ -294,9 +360,19 @@ async def open_urls(
         if not response.is_success:
             return _error_payload(_extract_error_detail(response))
         payload = OpenUrlsToolResponse.model_validate_json(response.content)
+
+        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="success").inc()
+
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
         }
     except Exception as err:
+        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
+            time.monotonic() - _start
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="error").inc()
         logger.error("Onyx MCP Server: URL fetch error: %s", err, exc_info=True)
         return _error_payload(f"URL fetch failed: {str(err)}")

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -6,8 +6,6 @@ from typing import Any
 
 import httpx
 from fastmcp.server.auth.auth import AccessToken
-from prometheus_client import Counter
-from prometheus_client import Histogram
 from pydantic import BaseModel
 from pydantic import TypeAdapter
 from pydantic import ValidationError
@@ -24,42 +22,16 @@ from onyx.server.features.web_search.models import OpenUrlsToolRequest
 from onyx.server.features.web_search.models import OpenUrlsToolResponse
 from onyx.server.features.web_search.models import WebSearchToolRequest
 from onyx.server.features.web_search.models import WebSearchToolResponse
+from onyx.server.metrics.mcp_common import MCPToolCallStatus
+from onyx.server.metrics.mcp_server import MCPServerToolName
+from onyx.server.metrics.mcp_server import record_mcp_search_results
+from onyx.server.metrics.mcp_server import record_mcp_search_source
+from onyx.server.metrics.mcp_server import record_mcp_server_tool_outcome
+from onyx.server.metrics.mcp_server import UNKNOWN_SOURCE_LABEL
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import build_api_server_url_for_http_requests
 
 logger = setup_logger()
-
-# Operational metrics
-MCP_SERVER_TOOL_LATENCY = Histogram(
-    "onyx_mcp_server_tool_latency_seconds",
-    "MCP server tool execution latency",
-    ["tool"],
-    buckets=(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
-)
-MCP_SERVER_TOOL_TOTAL = Counter(
-    "onyx_mcp_server_tool_calls_total",
-    "MCP server tool calls",
-    ["tool", "status"],  # status: success, error
-)
-# Product metrics
-MCP_SERVER_SEARCH_RESULTS = Histogram(
-    "onyx_mcp_server_search_results_count",
-    "Number of results returned by MCP server search tools",
-    ["tool"],
-    buckets=(0, 1, 2, 5, 10, 20, 50),
-)
-MCP_SERVER_SEARCH_SOURCES = Counter(
-    "onyx_mcp_server_search_by_source_total",
-    "MCP server document searches broken down by requested source type",
-    ["source_type"],
-)
-
-
-def _record_tool_outcome(tool: str, start: float, status: str) -> None:
-    """Record latency + outcome for a tool call. Every return path of a tool
-    must go through this exactly once so failures aren't understated."""
-    MCP_SERVER_TOOL_LATENCY.labels(tool=tool).observe(time.monotonic() - start)
-    MCP_SERVER_TOOL_TOTAL.labels(tool=tool, status=status).inc()
 
 
 async def _post_model(
@@ -117,6 +89,17 @@ def _error_payload(error: str) -> dict[str, Any]:
 _TIME_CUTOFF_ADAPTER: TypeAdapter[datetime | None] = TypeAdapter(datetime | None)
 
 
+def _record_requested_sources(source_types: list[str] | None) -> None:
+    canonical_sources: set[str] = set()
+    for source in source_types or []:
+        try:
+            canonical_sources.add(DocumentSource(source.lower()).value)
+        except ValueError:
+            canonical_sources.add(UNKNOWN_SOURCE_LABEL)
+    for source in canonical_sources:
+        record_mcp_search_source(source)
+
+
 @mcp_server.tool()
 async def search_indexed_documents(
     query: str,
@@ -163,6 +146,7 @@ async def search_indexed_documents(
     ```
     """
     _start = time.monotonic()
+    tool = MCPServerToolName.SEARCH_INDEXED_DOCUMENTS
     logger.info(
         "Onyx MCP Server: document search: query='%s', sources=%s, document_sets=%s",
         query,
@@ -170,16 +154,7 @@ async def search_indexed_documents(
         document_set_names,
     )
 
-    # Track requested source types for product metrics. Only canonical
-    # DocumentSource values become label values — arbitrary client strings
-    # would otherwise mint unbounded Prometheus series.
-    if source_types:
-        for src in source_types:
-            try:
-                canonical = DocumentSource(src.lower()).value
-            except ValueError:
-                canonical = "unknown"
-            MCP_SERVER_SEARCH_SOURCES.labels(source_type=canonical).inc()
+    _record_requested_sources(source_types)
 
     # Normalize empty list inputs to None so downstream filter construction is
     # consistent — BaseFilters treats [] as "match zero" which differs from
@@ -189,83 +164,78 @@ async def search_indexed_documents(
 
     # Get authenticated user from FastMCP's access token
     access_token = require_access_token()
+    outcome = MCPToolCallStatus.ERROR
+    result_count: int | None = None
 
     try:
-        sources = await get_indexed_sources(access_token)
-    except Exception as err:
-        logger.error(
-            "Onyx MCP Server: Error checking indexed sources: %s",
-            err,
-            exc_info=True,
+        try:
+            sources = await get_indexed_sources(access_token)
+        except Exception as err:
+            logger.error(
+                "Onyx MCP Server: Error checking indexed sources: %s",
+                err,
+                exc_info=True,
+            )
+            return _error_payload(f"Failed to check indexed sources: {str(err)}")
+
+        if not sources:
+            logger.info("Onyx MCP Server: No indexed sources available for tenant")
+            outcome = MCPToolCallStatus.SUCCESS
+            result_count = 0
+            return _error_payload(
+                "No document sources are indexed yet. Add connectors or upload data "
+                "through Onyx before calling search_indexed_documents."
+            )
+
+        source_type_enums: list[DocumentSource] | None = None
+        if source_types is not None:
+            source_type_enums = []
+            for source_str in source_types:
+                try:
+                    source_type_enums.append(DocumentSource(source_str.lower()))
+                except ValueError:
+                    logger.warning(
+                        "Onyx MCP Server: Invalid source type '%s' - skipping",
+                        source_str,
+                    )
+
+        try:
+            parsed_cutoff = _TIME_CUTOFF_ADAPTER.validate_python(time_cutoff)
+        except ValidationError as err:
+            logger.warning(
+                "Onyx MCP Server: invalid time_cutoff '%s' (%s); continuing without time filter",
+                time_cutoff,
+                err,
+            )
+            parsed_cutoff = None
+
+        request = SearchRequest(
+            query=query,
+            sources=source_type_enums,
+            document_sets=document_set_names,
+            time_cutoff=parsed_cutoff,
+            skip_query_expansion=skip_query_expansion,
         )
-        _record_tool_outcome("search_indexed_documents", _start, "error")
-        return _error_payload(f"Failed to check indexed sources: {str(err)}")
-
-    if not sources:
-        logger.info("Onyx MCP Server: No indexed sources available for tenant")
-        _record_tool_outcome("search_indexed_documents", _start, "error")
-        return _error_payload(
-            "No document sources are indexed yet. Add connectors or upload data "
-            "through Onyx before calling search_indexed_documents."
-        )
-
-    # Convert source_types strings to DocumentSource enums; skip unknown values.
-    source_type_enums: list[DocumentSource] | None = None
-    if source_types is not None:
-        source_type_enums = []
-        for source_str in source_types:
-            try:
-                source_type_enums.append(DocumentSource(source_str.lower()))
-            except ValueError:
-                logger.warning(
-                    "Onyx MCP Server: Invalid source type '%s' - skipping",
-                    source_str,
-                )
-
-    # Parse time_cutoff via Pydantic (accepts ISO 8601 with offset, "Z",
-    # naive, and date-only). Bad LLM-generated cutoffs fall back to no filter
-    # so they can't break the whole call.
-    try:
-        parsed_cutoff = _TIME_CUTOFF_ADAPTER.validate_python(time_cutoff)
-    except ValidationError as err:
-        logger.warning(
-            "Onyx MCP Server: invalid time_cutoff '%s' (%s); continuing without time filter",
-            time_cutoff,
-            err,
-        )
-        parsed_cutoff = None
-
-    request = SearchRequest(
-        query=query,
-        sources=source_type_enums,
-        document_sets=document_set_names,
-        time_cutoff=parsed_cutoff,
-        skip_query_expansion=skip_query_expansion,
-    )
-
-    endpoint = f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/search"
-    try:
+        endpoint = f"{build_api_server_url_for_http_requests(respect_env_override_if_set=True)}/search"
         response = await _post_model(endpoint, request, access_token)
         if not response.is_success:
-            _record_tool_outcome("search_indexed_documents", _start, "error")
             return _error_payload(_extract_error_detail(response))
 
         payload = SearchResponse.model_validate_json(response.content)
         results = [_to_mcp_dict(result) for result in payload.results]
-
-        _record_tool_outcome("search_indexed_documents", _start, "success")
-        MCP_SERVER_SEARCH_RESULTS.labels(tool="search_indexed_documents").observe(
-            len(results)
-        )
-
+        outcome = MCPToolCallStatus.SUCCESS
+        result_count = len(results)
         logger.info(
             "Onyx MCP Server: Internal search returned %s results", len(results)
         )
         return {"results": results}
     except Exception as err:
-        _record_tool_outcome("search_indexed_documents", _start, "error")
         logger.error("Onyx MCP Server: Document search error: %s", err, exc_info=True)
         return _error_payload(f"Document search failed: {str(err)}")
+    finally:
+        record_mcp_server_tool_outcome(tool, _start, outcome)
+        if result_count is not None:
+            record_mcp_search_results(tool, result_count)
 
 
 @mcp_server.tool()
@@ -289,9 +259,12 @@ async def search_web(
     ```
     """
     _start = time.monotonic()
+    tool = MCPServerToolName.SEARCH_WEB
     logger.info("Onyx MCP Server: Web search: query='%s', limit=%s", query, limit)
 
     access_token = require_access_token()
+    outcome = MCPToolCallStatus.ERROR
+    result_count: int | None = None
 
     try:
         response = await _post_model(
@@ -300,31 +273,29 @@ async def search_web(
             access_token,
         )
         if not response.is_success:
-            _record_tool_outcome("search_web", _start, "error")
             return {
                 "error": _extract_error_detail(response),
                 "results": [],
                 "query": query,
             }
         payload = WebSearchToolResponse.model_validate_json(response.content)
-
-        _record_tool_outcome("search_web", _start, "success")
-        MCP_SERVER_SEARCH_RESULTS.labels(tool="search_web").observe(
-            len(payload.results)
-        )
-
+        outcome = MCPToolCallStatus.SUCCESS
+        result_count = len(payload.results)
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
             "query": query,
         }
     except Exception as e:
-        _record_tool_outcome("search_web", _start, "error")
         logger.error("Onyx MCP Server: Web search error: %s", e, exc_info=True)
         return {
             "error": f"Web search failed: {str(e)}",
             "results": [],
             "query": query,
         }
+    finally:
+        record_mcp_server_tool_outcome(tool, _start, outcome)
+        if result_count is not None:
+            record_mcp_search_results(tool, result_count)
 
 
 @mcp_server.tool()
@@ -348,9 +319,11 @@ async def open_urls(
     ```
     """
     _start = time.monotonic()
+    tool = MCPServerToolName.OPEN_URLS
     logger.info("Onyx MCP Server: Open URL: fetching %s URLs", len(urls))
 
     access_token = require_access_token()
+    outcome = MCPToolCallStatus.ERROR
 
     try:
         response = await _post_model(
@@ -359,16 +332,14 @@ async def open_urls(
             access_token,
         )
         if not response.is_success:
-            _record_tool_outcome("open_urls", _start, "error")
             return _error_payload(_extract_error_detail(response))
         payload = OpenUrlsToolResponse.model_validate_json(response.content)
-
-        _record_tool_outcome("open_urls", _start, "success")
-
+        outcome = MCPToolCallStatus.SUCCESS
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
         }
     except Exception as err:
-        _record_tool_outcome("open_urls", _start, "error")
         logger.error("Onyx MCP Server: URL fetch error: %s", err, exc_info=True)
         return _error_payload(f"URL fetch failed: {str(err)}")
+    finally:
+        record_mcp_server_tool_outcome(tool, _start, outcome)

--- a/backend/onyx/mcp_server/tools/search.py
+++ b/backend/onyx/mcp_server/tools/search.py
@@ -55,6 +55,13 @@ MCP_SERVER_SEARCH_SOURCES = Counter(
 )
 
 
+def _record_tool_outcome(tool: str, start: float, status: str) -> None:
+    """Record latency + outcome for a tool call. Every return path of a tool
+    must go through this exactly once so failures aren't understated."""
+    MCP_SERVER_TOOL_LATENCY.labels(tool=tool).observe(time.monotonic() - start)
+    MCP_SERVER_TOOL_TOTAL.labels(tool=tool, status=status).inc()
+
+
 async def _post_model(
     url: str,
     body: BaseModel,
@@ -163,10 +170,16 @@ async def search_indexed_documents(
         document_set_names,
     )
 
-    # Track requested source types for product metrics
+    # Track requested source types for product metrics. Only canonical
+    # DocumentSource values become label values — arbitrary client strings
+    # would otherwise mint unbounded Prometheus series.
     if source_types:
         for src in source_types:
-            MCP_SERVER_SEARCH_SOURCES.labels(source_type=src.lower()).inc()
+            try:
+                canonical = DocumentSource(src.lower()).value
+            except ValueError:
+                canonical = "unknown"
+            MCP_SERVER_SEARCH_SOURCES.labels(source_type=canonical).inc()
 
     # Normalize empty list inputs to None so downstream filter construction is
     # consistent — BaseFilters treats [] as "match zero" which differs from
@@ -185,10 +198,12 @@ async def search_indexed_documents(
             err,
             exc_info=True,
         )
+        _record_tool_outcome("search_indexed_documents", _start, "error")
         return _error_payload(f"Failed to check indexed sources: {str(err)}")
 
     if not sources:
         logger.info("Onyx MCP Server: No indexed sources available for tenant")
+        _record_tool_outcome("search_indexed_documents", _start, "error")
         return _error_payload(
             "No document sources are indexed yet. Add connectors or upload data "
             "through Onyx before calling search_indexed_documents."
@@ -232,17 +247,13 @@ async def search_indexed_documents(
     try:
         response = await _post_model(endpoint, request, access_token)
         if not response.is_success:
+            _record_tool_outcome("search_indexed_documents", _start, "error")
             return _error_payload(_extract_error_detail(response))
 
         payload = SearchResponse.model_validate_json(response.content)
         results = [_to_mcp_dict(result) for result in payload.results]
 
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(
-            tool="search_indexed_documents", status="success"
-        ).inc()
+        _record_tool_outcome("search_indexed_documents", _start, "success")
         MCP_SERVER_SEARCH_RESULTS.labels(tool="search_indexed_documents").observe(
             len(results)
         )
@@ -252,12 +263,7 @@ async def search_indexed_documents(
         )
         return {"results": results}
     except Exception as err:
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_indexed_documents").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(
-            tool="search_indexed_documents", status="error"
-        ).inc()
+        _record_tool_outcome("search_indexed_documents", _start, "error")
         logger.error("Onyx MCP Server: Document search error: %s", err, exc_info=True)
         return _error_payload(f"Document search failed: {str(err)}")
 
@@ -294,6 +300,7 @@ async def search_web(
             access_token,
         )
         if not response.is_success:
+            _record_tool_outcome("search_web", _start, "error")
             return {
                 "error": _extract_error_detail(response),
                 "results": [],
@@ -301,10 +308,7 @@ async def search_web(
             }
         payload = WebSearchToolResponse.model_validate_json(response.content)
 
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="success").inc()
+        _record_tool_outcome("search_web", _start, "success")
         MCP_SERVER_SEARCH_RESULTS.labels(tool="search_web").observe(
             len(payload.results)
         )
@@ -314,10 +318,7 @@ async def search_web(
             "query": query,
         }
     except Exception as e:
-        MCP_SERVER_TOOL_LATENCY.labels(tool="search_web").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="search_web", status="error").inc()
+        _record_tool_outcome("search_web", _start, "error")
         logger.error("Onyx MCP Server: Web search error: %s", e, exc_info=True)
         return {
             "error": f"Web search failed: {str(e)}",
@@ -358,21 +359,16 @@ async def open_urls(
             access_token,
         )
         if not response.is_success:
+            _record_tool_outcome("open_urls", _start, "error")
             return _error_payload(_extract_error_detail(response))
         payload = OpenUrlsToolResponse.model_validate_json(response.content)
 
-        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="success").inc()
+        _record_tool_outcome("open_urls", _start, "success")
 
         return {
             "results": [result.model_dump(mode="json") for result in payload.results],
         }
     except Exception as err:
-        MCP_SERVER_TOOL_LATENCY.labels(tool="open_urls").observe(
-            time.monotonic() - _start
-        )
-        MCP_SERVER_TOOL_TOTAL.labels(tool="open_urls", status="error").inc()
+        _record_tool_outcome("open_urls", _start, "error")
         logger.error("Onyx MCP Server: URL fetch error: %s", err, exc_info=True)
         return _error_payload(f"URL fetch failed: {str(err)}")

--- a/backend/onyx/server/metrics/connector_state_metrics.py
+++ b/backend/onyx/server/metrics/connector_state_metrics.py
@@ -24,6 +24,9 @@ from prometheus_client.core import REGISTRY
 from prometheus_client.registry import Collector
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingMode
 from onyx.db.models import Connector
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
@@ -32,11 +35,12 @@ from shared_configs.configs import MULTI_TENANT
 
 logger = logging.getLogger(__name__)
 
-# One-hot label values; anything else is reported as UNKNOWN so a new enum
-# value can't silently create an unbounded label set.
-_VALID_CC_PAIR_STATUSES = ("ACTIVE", "PAUSED", "DELETING")
-_VALID_ACCESS_TYPES = ("PUBLIC", "PRIVATE", "SYNC")
-_VALID_INDEXING_MODES = ("SCHEDULED", "ON_DEMAND")
+# One-hot label values, derived from the source enums so every persisted
+# state gets its own series; anything outside them (bad data) collapses to
+# UNKNOWN instead of minting unbounded label values.
+_VALID_CC_PAIR_STATUSES = tuple(s.value for s in ConnectorCredentialPairStatus)
+_VALID_ACCESS_TYPES = tuple(a.value for a in AccessType)
+_VALID_INDEXING_MODES = tuple(m.value for m in IndexingMode)
 
 
 def _to_unix_ts(dt: datetime | None) -> int:

--- a/backend/onyx/server/metrics/connector_state_metrics.py
+++ b/backend/onyx/server/metrics/connector_state_metrics.py
@@ -1,0 +1,304 @@
+"""DB-snapshot connector state metrics.
+
+Complements connector_health_metrics.py: those are event-driven counters
+emitted from the celery workers, so they reset on worker restart and say
+nothing about connectors that haven't run since. This collector reads the
+current state straight from Postgres on each scrape, giving absolute truth
+for staleness alerting (e.g. "connector hasn't indexed successfully in N
+hours") regardless of process restarts.
+
+Registered on the API server (see main.py); one cheap query per scrape.
+Skipped in multi-tenant deployments — a scrape-time collector has no tenant
+context to enumerate.
+"""
+
+import logging
+from collections.abc import Iterator
+from datetime import datetime
+from datetime import timezone
+
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.core import InfoMetricFamily
+from prometheus_client.core import Metric
+from prometheus_client.core import REGISTRY
+from prometheus_client.registry import Collector
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import User
+from shared_configs.configs import MULTI_TENANT
+
+logger = logging.getLogger(__name__)
+
+# One-hot label values; anything else is reported as UNKNOWN so a new enum
+# value can't silently create an unbounded label set.
+_VALID_CC_PAIR_STATUSES = ("ACTIVE", "PAUSED", "DELETING")
+_VALID_ACCESS_TYPES = ("PUBLIC", "PRIVATE", "SYNC")
+_VALID_INDEXING_MODES = ("SCHEDULED", "ON_DEMAND")
+
+
+def _to_unix_ts(dt: datetime | None) -> int:
+    """Convert datetime to Unix timestamp, return 0 if None."""
+    if not dt:
+        return 0
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp())
+
+
+def _enum_str(value: object, valid: tuple[str, ...]) -> str:
+    raw = getattr(value, "value", None) or getattr(value, "name", None) or str(value)
+    return raw if raw in valid else "UNKNOWN"
+
+
+class ConnectorStateMetricsCollector(Collector):
+    """Prometheus collector exposing per-cc-pair state gauges from the DB."""
+
+    def collect(self) -> Iterator[Metric]:
+        g_last_pruned = GaugeMetricFamily(
+            "onyx_connector_last_pruned_timestamp_seconds",
+            "Unix timestamp of the last successful prune operation (0 if never).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_last_perm_sync = GaugeMetricFamily(
+            "onyx_connector_last_perm_sync_timestamp_seconds",
+            "Unix timestamp of the last permission sync (0 if never).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_last_external_group_sync = GaugeMetricFamily(
+            "onyx_connector_last_external_group_sync_timestamp_seconds",
+            "Unix timestamp of the last external group sync (0 if never).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_cc_pair_status = GaugeMetricFamily(
+            "onyx_connector_status",
+            "Current connector credential pair status as one-hot encoding.",
+            labels=["cc_pair_id", "cc_pair_name", "source_type", "status"],
+        )
+        g_access_type = GaugeMetricFamily(
+            "onyx_connector_access_type",
+            "Access type of the connector as one-hot encoding.",
+            labels=["cc_pair_id", "cc_pair_name", "source_type", "access_type"],
+        )
+        g_indexing_trigger = GaugeMetricFamily(
+            "onyx_connector_indexing_trigger",
+            "Indexing trigger mode as one-hot encoding.",
+            labels=["cc_pair_id", "cc_pair_name", "source_type", "trigger_mode"],
+        )
+        g_auto_sync_enabled = GaugeMetricFamily(
+            "onyx_connector_auto_sync_enabled",
+            "Whether auto-sync is configured (1 = enabled, 0 = disabled).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_time_since_last_success = GaugeMetricFamily(
+            "onyx_connector_seconds_since_last_success",
+            "Seconds since the last successful indexing (0 if never indexed).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_time_since_last_prune = GaugeMetricFamily(
+            "onyx_connector_seconds_since_last_prune",
+            "Seconds since the last prune operation (0 if never pruned).",
+            labels=["cc_pair_id", "cc_pair_name", "source_type"],
+        )
+        g_total_connectors = GaugeMetricFamily(
+            "onyx_connectors_total",
+            "Total number of connector credential pairs by source type and status.",
+            labels=["source_type", "status"],
+        )
+        g_total_docs_by_source = GaugeMetricFamily(
+            "onyx_connector_docs_by_source_total",
+            "Total documents currently indexed across all connectors by source type.",
+            labels=["source_type"],
+        )
+        g_connector_info = InfoMetricFamily(
+            "onyx_connector",
+            "Metadata information about connector credential pairs.",
+            labels=["cc_pair_id"],
+        )
+
+        try:
+            with get_session_with_current_tenant() as db:
+                rows = (
+                    db.query(
+                        ConnectorCredentialPair.id,
+                        ConnectorCredentialPair.name,
+                        ConnectorCredentialPair.status,
+                        ConnectorCredentialPair.last_successful_index_time,
+                        ConnectorCredentialPair.last_pruned,
+                        ConnectorCredentialPair.last_time_perm_sync,
+                        ConnectorCredentialPair.last_time_external_group_sync,
+                        ConnectorCredentialPair.total_docs_indexed,
+                        ConnectorCredentialPair.access_type,
+                        ConnectorCredentialPair.indexing_trigger,
+                        ConnectorCredentialPair.auto_sync_options,
+                        Connector.source,
+                        Credential.id,
+                        Credential.name,
+                        User.email,  # ty: ignore[invalid-argument-type]
+                    )
+                    .join(ConnectorCredentialPair.connector)
+                    .join(ConnectorCredentialPair.credential)
+                    .outerjoin(ConnectorCredentialPair.creator)
+                    .filter(ConnectorCredentialPair.name != "DefaultCCPair")
+                    .all()
+                )
+
+            connector_counts: dict[tuple[str, str], int] = {}
+            docs_by_source: dict[str, int] = {}
+            current_time = datetime.now(timezone.utc)
+
+            for (
+                cc_pair_id,
+                cc_pair_name,
+                status,
+                last_successful_index_time,
+                last_pruned,
+                last_time_perm_sync,
+                last_time_external_group_sync,
+                total_docs_indexed,
+                access_type,
+                indexing_trigger,
+                auto_sync_options,
+                source,
+                credential_id,
+                credential_name,
+                creator_email,
+            ) in rows:
+                cc_pair_id_str = str(cc_pair_id)
+                cc_pair_name_str = cc_pair_name or ""
+                source_str = (
+                    getattr(source, "value", None)
+                    or getattr(source, "name", None)
+                    or str(source)
+                )
+                status_str = _enum_str(status, _VALID_CC_PAIR_STATUSES)
+                access_type_str = _enum_str(access_type, _VALID_ACCESS_TYPES)
+                indexing_trigger_str = (
+                    _enum_str(indexing_trigger, _VALID_INDEXING_MODES)
+                    if indexing_trigger
+                    else "NONE"
+                )
+
+                common_labels = [cc_pair_id_str, cc_pair_name_str, source_str]
+
+                g_last_pruned.add_metric(common_labels, float(_to_unix_ts(last_pruned)))
+                g_last_perm_sync.add_metric(
+                    common_labels, float(_to_unix_ts(last_time_perm_sync))
+                )
+                g_last_external_group_sync.add_metric(
+                    common_labels,
+                    float(_to_unix_ts(last_time_external_group_sync)),
+                )
+
+                for st in _VALID_CC_PAIR_STATUSES:
+                    g_cc_pair_status.add_metric(
+                        [*common_labels, st], 1.0 if st == status_str else 0.0
+                    )
+                for at in _VALID_ACCESS_TYPES:
+                    g_access_type.add_metric(
+                        [*common_labels, at], 1.0 if at == access_type_str else 0.0
+                    )
+                for mode in [*_VALID_INDEXING_MODES, "NONE"]:
+                    g_indexing_trigger.add_metric(
+                        [*common_labels, mode],
+                        1.0 if mode == indexing_trigger_str else 0.0,
+                    )
+
+                g_auto_sync_enabled.add_metric(
+                    common_labels, 1.0 if auto_sync_options else 0.0
+                )
+
+                if last_successful_index_time:
+                    seconds_since_success = (
+                        current_time
+                        - last_successful_index_time.replace(tzinfo=timezone.utc)
+                    ).total_seconds()
+                    g_time_since_last_success.add_metric(
+                        common_labels, max(0.0, seconds_since_success)
+                    )
+                else:
+                    g_time_since_last_success.add_metric(common_labels, 0.0)
+
+                if last_pruned:
+                    seconds_since_prune = (
+                        current_time - last_pruned.replace(tzinfo=timezone.utc)
+                    ).total_seconds()
+                    g_time_since_last_prune.add_metric(
+                        common_labels, max(0.0, seconds_since_prune)
+                    )
+                else:
+                    g_time_since_last_prune.add_metric(common_labels, 0.0)
+
+                g_connector_info.add_metric(
+                    [cc_pair_id_str],
+                    {
+                        "cc_pair_name": cc_pair_name_str,
+                        "source_type": source_str,
+                        "credential_id": str(credential_id),
+                        "credential_name": credential_name or "",
+                        "creator_email": creator_email or "unknown",
+                        "status": status_str,
+                        "access_type": access_type_str,
+                    },
+                )
+
+                connector_counts[(source_str, status_str)] = (
+                    connector_counts.get((source_str, status_str), 0) + 1
+                )
+                docs_by_source[source_str] = docs_by_source.get(source_str, 0) + (
+                    total_docs_indexed or 0
+                )
+
+            for (source_type, status_val), count in connector_counts.items():
+                g_total_connectors.add_metric([source_type, status_val], float(count))
+            for source_type, total_docs in docs_by_source.items():
+                g_total_docs_by_source.add_metric([source_type], float(total_docs))
+
+        except RuntimeError as e:
+            if "Engine not initialized" in str(e):
+                logger.warning(
+                    "Database engine not initialized yet, "
+                    "skipping connector state metrics collection"
+                )
+            else:
+                logger.error(
+                    "Error collecting connector state metrics: %s", e, exc_info=True
+                )
+        except Exception as e:
+            logger.error(
+                "Unexpected error collecting connector state metrics: %s",
+                e,
+                exc_info=True,
+            )
+
+        # Always yield metric families, even if empty.
+        yield g_last_pruned
+        yield g_last_perm_sync
+        yield g_last_external_group_sync
+        yield g_cc_pair_status
+        yield g_access_type
+        yield g_indexing_trigger
+        yield g_auto_sync_enabled
+        yield g_time_since_last_success
+        yield g_time_since_last_prune
+        yield g_total_connectors
+        yield g_total_docs_by_source
+        yield g_connector_info
+
+
+def register_connector_state_metrics() -> None:
+    """Register the connector state collector with the default registry."""
+    if MULTI_TENANT:
+        # A scrape-time collector has no tenant context; per-tenant state
+        # metrics need a different mechanism in cloud deployments.
+        logger.info(
+            "Multi-tenant deployment — skipping connector state metrics collector"
+        )
+        return
+    try:
+        REGISTRY.register(ConnectorStateMetricsCollector())
+        logger.info("Connector state metrics collector registered")
+    except ValueError:
+        logger.debug("Connector state metrics collector already registered")

--- a/backend/onyx/server/metrics/connector_state_metrics.py
+++ b/backend/onyx/server/metrics/connector_state_metrics.py
@@ -1,21 +1,10 @@
-"""DB-snapshot connector state metrics.
+"""Restart-proof connector state metrics for single-tenant deployments."""
 
-Complements connector_health_metrics.py: those are event-driven counters
-emitted from the celery workers, so they reset on worker restart and say
-nothing about connectors that haven't run since. This collector reads the
-current state straight from Postgres on each scrape, giving absolute truth
-for staleness alerting (e.g. "connector hasn't indexed successfully in N
-hours") regardless of process restarts.
-
-Registered on the API server (see main.py); one cheap query per scrape.
-Skipped in multi-tenant deployments — a scrape-time collector has no tenant
-context to enumerate.
-"""
-
-import logging
+import concurrent.futures
+import threading
 from collections.abc import Iterator
 from datetime import datetime
-from datetime import timezone
+from typing import NamedTuple
 
 from prometheus_client.core import GaugeMetricFamily
 from prometheus_client.core import InfoMetricFamily
@@ -23,286 +12,298 @@ from prometheus_client.core import Metric
 from prometheus_client.core import REGISTRY
 from prometheus_client.registry import Collector
 
+from onyx.db.connector_credential_pair import get_connector_state_snapshots
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import IndexingMode
-from onyx.db.models import Connector
-from onyx.db.models import ConnectorCredentialPair
-from onyx.db.models import Credential
-from onyx.db.models import User
+from onyx.utils.datetime import datetime_to_utc
+from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 
-logger = logging.getLogger(__name__)
+logger = setup_logger()
 
-# One-hot label values, derived from the source enums so every persisted
-# state gets its own series; anything outside them (bad data) collapses to
-# UNKNOWN instead of minting unbounded label values.
-_VALID_CC_PAIR_STATUSES = tuple(s.value for s in ConnectorCredentialPairStatus)
-_VALID_ACCESS_TYPES = tuple(a.value for a in AccessType)
-_VALID_INDEXING_MODES = tuple(m.value for m in IndexingMode)
+_UNKNOWN_LABEL = "UNKNOWN"
+_NO_TRIGGER_LABEL = "NONE"
+_CC_PAIR_STATUS_LABELS = tuple(
+    status.value for status in ConnectorCredentialPairStatus
+) + (_UNKNOWN_LABEL,)
+_ACCESS_TYPE_LABELS = tuple(access_type.value for access_type in AccessType) + (
+    _UNKNOWN_LABEL,
+)
+_INDEXING_MODE_LABELS = tuple(mode.value for mode in IndexingMode) + (
+    _NO_TRIGGER_LABEL,
+    _UNKNOWN_LABEL,
+)
+_CONNECTOR_LABELS = ["source", "cc_pair_id"]
+_COLLECTION_TIMEOUT_SECONDS = 8.0
 
 
 def _to_unix_ts(dt: datetime | None) -> int:
-    """Convert datetime to Unix timestamp, return 0 if None."""
     if not dt:
         return 0
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return int(dt.timestamp())
+    return int(datetime_to_utc(dt).timestamp())
 
 
-def _enum_str(value: object, valid: tuple[str, ...]) -> str:
+def _enum_label(value: object, valid: tuple[str, ...]) -> str:
     raw = getattr(value, "value", None) or getattr(value, "name", None) or str(value)
-    return raw if raw in valid else "UNKNOWN"
+    return raw if raw in valid else _UNKNOWN_LABEL
+
+
+class _ConnectorMetricFamilies(NamedTuple):
+    last_success: GaugeMetricFamily
+    last_pruned: GaugeMetricFamily
+    last_perm_sync: GaugeMetricFamily
+    last_external_group_sync: GaugeMetricFamily
+    repeated_error: GaugeMetricFamily
+    cc_pair_status: GaugeMetricFamily
+    access_type: GaugeMetricFamily
+    indexing_trigger: GaugeMetricFamily
+    auto_sync_enabled: GaugeMetricFamily
+    connector_count: GaugeMetricFamily
+    document_count: GaugeMetricFamily
+    connector_info: InfoMetricFamily
+
+
+def _create_metric_families() -> _ConnectorMetricFamilies:
+    return _ConnectorMetricFamilies(
+        last_success=GaugeMetricFamily(
+            "onyx_connector_last_successful_index_timestamp_seconds",
+            "Unix timestamp of the last successful indexing (0 if never).",
+            labels=_CONNECTOR_LABELS,
+        ),
+        last_pruned=GaugeMetricFamily(
+            "onyx_connector_last_pruned_timestamp_seconds",
+            "Unix timestamp of the last successful prune operation (0 if never).",
+            labels=_CONNECTOR_LABELS,
+        ),
+        last_perm_sync=GaugeMetricFamily(
+            "onyx_connector_last_perm_sync_timestamp_seconds",
+            "Unix timestamp of the last permission sync (0 if never).",
+            labels=_CONNECTOR_LABELS,
+        ),
+        last_external_group_sync=GaugeMetricFamily(
+            "onyx_connector_last_external_group_sync_timestamp_seconds",
+            "Unix timestamp of the last external group sync (0 if never).",
+            labels=_CONNECTOR_LABELS,
+        ),
+        repeated_error=GaugeMetricFamily(
+            "onyx_connector_repeated_error_state",
+            "Whether the connector is in a repeated error state.",
+            labels=_CONNECTOR_LABELS,
+        ),
+        cc_pair_status=GaugeMetricFamily(
+            "onyx_connector_status",
+            "Current connector credential pair status as one-hot encoding.",
+            labels=[*_CONNECTOR_LABELS, "status"],
+        ),
+        access_type=GaugeMetricFamily(
+            "onyx_connector_access_type",
+            "Access type of the connector as one-hot encoding.",
+            labels=[*_CONNECTOR_LABELS, "access_type"],
+        ),
+        indexing_trigger=GaugeMetricFamily(
+            "onyx_connector_indexing_trigger",
+            "Indexing trigger mode as one-hot encoding.",
+            labels=[*_CONNECTOR_LABELS, "trigger_mode"],
+        ),
+        auto_sync_enabled=GaugeMetricFamily(
+            "onyx_connector_auto_sync_enabled",
+            "Whether auto-sync is configured (1 = enabled, 0 = disabled).",
+            labels=_CONNECTOR_LABELS,
+        ),
+        connector_count=GaugeMetricFamily(
+            "onyx_connector_count",
+            "Current connector credential pair count by source and status.",
+            labels=["source", "status"],
+        ),
+        document_count=GaugeMetricFamily(
+            "onyx_connector_document_count",
+            "Current indexed document count across connectors by source.",
+            labels=["source"],
+        ),
+        connector_info=InfoMetricFamily(
+            "onyx_connector",
+            "Connector credential pair metadata.",
+            labels=["cc_pair_id"],
+        ),
+    )
+
+
+def _collection_success_metric() -> GaugeMetricFamily:
+    return GaugeMetricFamily(
+        "onyx_connector_state_collection_success",
+        "Whether the latest connector state collection succeeded.",
+    )
 
 
 class ConnectorStateMetricsCollector(Collector):
-    """Prometheus collector exposing per-cc-pair state gauges from the DB."""
+    """Build connector state gauges from the current Postgres snapshot."""
+
+    def __init__(self, timeout: float = _COLLECTION_TIMEOUT_SECONDS) -> None:
+        self._timeout = timeout
+        self._executor = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1,
+            thread_name_prefix=type(self).__name__,
+        )
+        self._inflight: concurrent.futures.Future[list[Metric]] | None = None
+        self._lock = threading.Lock()
 
     def collect(self) -> Iterator[Metric]:
-        g_last_pruned = GaugeMetricFamily(
-            "onyx_connector_last_pruned_timestamp_seconds",
-            "Unix timestamp of the last successful prune operation (0 if never).",
-            labels=["cc_pair_id", "cc_pair_name", "source_type"],
-        )
-        g_last_perm_sync = GaugeMetricFamily(
-            "onyx_connector_last_perm_sync_timestamp_seconds",
-            "Unix timestamp of the last permission sync (0 if never).",
-            labels=["cc_pair_id", "cc_pair_name", "source_type"],
-        )
-        g_last_external_group_sync = GaugeMetricFamily(
-            "onyx_connector_last_external_group_sync_timestamp_seconds",
-            "Unix timestamp of the last external group sync (0 if never).",
-            labels=["cc_pair_id", "cc_pair_name", "source_type"],
-        )
-        g_cc_pair_status = GaugeMetricFamily(
-            "onyx_connector_status",
-            "Current connector credential pair status as one-hot encoding.",
-            labels=["cc_pair_id", "cc_pair_name", "source_type", "status"],
-        )
-        g_access_type = GaugeMetricFamily(
-            "onyx_connector_access_type",
-            "Access type of the connector as one-hot encoding.",
-            labels=["cc_pair_id", "cc_pair_name", "source_type", "access_type"],
-        )
-        g_indexing_trigger = GaugeMetricFamily(
-            "onyx_connector_indexing_trigger",
-            "Indexing trigger mode as one-hot encoding.",
-            labels=["cc_pair_id", "cc_pair_name", "source_type", "trigger_mode"],
-        )
-        g_auto_sync_enabled = GaugeMetricFamily(
-            "onyx_connector_auto_sync_enabled",
-            "Whether auto-sync is configured (1 = enabled, 0 = disabled).",
-            labels=["cc_pair_id", "cc_pair_name", "source_type"],
-        )
-        g_time_since_last_success = GaugeMetricFamily(
-            "onyx_connector_seconds_since_last_success",
-            "Seconds since the last successful indexing (0 if never indexed).",
-            labels=["cc_pair_id", "cc_pair_name", "source_type"],
-        )
-        g_time_since_last_prune = GaugeMetricFamily(
-            "onyx_connector_seconds_since_last_prune",
-            "Seconds since the last prune operation (0 if never pruned).",
-            labels=["cc_pair_id", "cc_pair_name", "source_type"],
-        )
-        g_total_connectors = GaugeMetricFamily(
-            "onyx_connectors_total",
-            "Total number of connector credential pairs by source type and status.",
-            labels=["source_type", "status"],
-        )
-        g_total_docs_by_source = GaugeMetricFamily(
-            "onyx_connector_docs_by_source_total",
-            "Total documents currently indexed across all connectors by source type.",
-            labels=["source_type"],
-        )
-        g_connector_info = InfoMetricFamily(
-            "onyx_connector",
-            "Metadata information about connector credential pairs.",
-            labels=["cc_pair_id"],
-        )
-
-        try:
-            with get_session_with_current_tenant() as db:
-                rows = (
-                    db.query(
-                        ConnectorCredentialPair.id,
-                        ConnectorCredentialPair.name,
-                        ConnectorCredentialPair.status,
-                        ConnectorCredentialPair.last_successful_index_time,
-                        ConnectorCredentialPair.last_pruned,
-                        ConnectorCredentialPair.last_time_perm_sync,
-                        ConnectorCredentialPair.last_time_external_group_sync,
-                        ConnectorCredentialPair.total_docs_indexed,
-                        ConnectorCredentialPair.access_type,
-                        ConnectorCredentialPair.indexing_trigger,
-                        ConnectorCredentialPair.auto_sync_options,
-                        Connector.source,
-                        Credential.id,
-                        Credential.name,
-                        User.email,  # ty: ignore[invalid-argument-type]
-                    )
-                    .join(ConnectorCredentialPair.connector)
-                    .join(ConnectorCredentialPair.credential)
-                    .outerjoin(ConnectorCredentialPair.creator)
-                    .filter(ConnectorCredentialPair.name != "DefaultCCPair")
-                    .all()
-                )
-
-            connector_counts: dict[tuple[str, str], int] = {}
-            docs_by_source: dict[str, int] = {}
-            current_time = datetime.now(timezone.utc)
-
-            for (
-                cc_pair_id,
-                cc_pair_name,
-                status,
-                last_successful_index_time,
-                last_pruned,
-                last_time_perm_sync,
-                last_time_external_group_sync,
-                total_docs_indexed,
-                access_type,
-                indexing_trigger,
-                auto_sync_options,
-                source,
-                credential_id,
-                credential_name,
-                creator_email,
-            ) in rows:
-                cc_pair_id_str = str(cc_pair_id)
-                cc_pair_name_str = cc_pair_name or ""
-                source_str = (
-                    getattr(source, "value", None)
-                    or getattr(source, "name", None)
-                    or str(source)
-                )
-                status_str = _enum_str(status, _VALID_CC_PAIR_STATUSES)
-                access_type_str = _enum_str(access_type, _VALID_ACCESS_TYPES)
-                indexing_trigger_str = (
-                    _enum_str(indexing_trigger, _VALID_INDEXING_MODES)
-                    if indexing_trigger
-                    else "NONE"
-                )
-
-                common_labels = [cc_pair_id_str, cc_pair_name_str, source_str]
-
-                g_last_pruned.add_metric(common_labels, float(_to_unix_ts(last_pruned)))
-                g_last_perm_sync.add_metric(
-                    common_labels, float(_to_unix_ts(last_time_perm_sync))
-                )
-                g_last_external_group_sync.add_metric(
-                    common_labels,
-                    float(_to_unix_ts(last_time_external_group_sync)),
-                )
-
-                for st in _VALID_CC_PAIR_STATUSES:
-                    g_cc_pair_status.add_metric(
-                        [*common_labels, st], 1.0 if st == status_str else 0.0
-                    )
-                for at in _VALID_ACCESS_TYPES:
-                    g_access_type.add_metric(
-                        [*common_labels, at], 1.0 if at == access_type_str else 0.0
-                    )
-                for mode in [*_VALID_INDEXING_MODES, "NONE"]:
-                    g_indexing_trigger.add_metric(
-                        [*common_labels, mode],
-                        1.0 if mode == indexing_trigger_str else 0.0,
-                    )
-
-                g_auto_sync_enabled.add_metric(
-                    common_labels, 1.0 if auto_sync_options else 0.0
-                )
-
-                if last_successful_index_time:
-                    seconds_since_success = (
-                        current_time
-                        - last_successful_index_time.replace(tzinfo=timezone.utc)
-                    ).total_seconds()
-                    g_time_since_last_success.add_metric(
-                        common_labels, max(0.0, seconds_since_success)
-                    )
-                else:
-                    g_time_since_last_success.add_metric(common_labels, 0.0)
-
-                if last_pruned:
-                    seconds_since_prune = (
-                        current_time - last_pruned.replace(tzinfo=timezone.utc)
-                    ).total_seconds()
-                    g_time_since_last_prune.add_metric(
-                        common_labels, max(0.0, seconds_since_prune)
-                    )
-                else:
-                    g_time_since_last_prune.add_metric(common_labels, 0.0)
-
-                g_connector_info.add_metric(
-                    [cc_pair_id_str],
-                    {
-                        "cc_pair_name": cc_pair_name_str,
-                        "source_type": source_str,
-                        "credential_id": str(credential_id),
-                        "credential_name": credential_name or "",
-                        "creator_email": creator_email or "unknown",
-                        "status": status_str,
-                        "access_type": access_type_str,
-                    },
-                )
-
-                connector_counts[(source_str, status_str)] = (
-                    connector_counts.get((source_str, status_str), 0) + 1
-                )
-                docs_by_source[source_str] = docs_by_source.get(source_str, 0) + (
-                    total_docs_indexed or 0
-                )
-
-            for (source_type, status_val), count in connector_counts.items():
-                g_total_connectors.add_metric([source_type, status_val], float(count))
-            for source_type, total_docs in docs_by_source.items():
-                g_total_docs_by_source.add_metric([source_type], float(total_docs))
-
-        except RuntimeError as e:
-            if "Engine not initialized" in str(e):
-                logger.warning(
-                    "Database engine not initialized yet, "
-                    "skipping connector state metrics collection"
-                )
+        collection_success = _collection_success_metric()
+        with self._lock:
+            if self._inflight is not None and self._inflight.done():
+                self._inflight = None
+            if self._inflight is None:
+                self._inflight = self._executor.submit(self._collect_fresh)
+                future: concurrent.futures.Future[list[Metric]] | None = self._inflight
             else:
-                logger.error(
-                    "Error collecting connector state metrics: %s", e, exc_info=True
+                future = None
+
+        if future is None:
+            metrics: list[Metric] = []
+            collection_success.add_metric([], 0.0)
+        else:
+            try:
+                metrics = future.result(timeout=self._timeout)
+                collection_success.add_metric([], 1.0)
+            except concurrent.futures.TimeoutError:
+                logger.warning(
+                    "Connector state collection timed out after %ss",
+                    self._timeout,
                 )
-        except Exception as e:
-            logger.error(
-                "Unexpected error collecting connector state metrics: %s",
-                e,
-                exc_info=True,
+                metrics = []
+                collection_success.add_metric([], 0.0)
+            except Exception:
+                logger.exception("Connector state collection failed")
+                metrics = []
+                collection_success.add_metric([], 0.0)
+            finally:
+                if future.done():
+                    with self._lock:
+                        if self._inflight is future:
+                            self._inflight = None
+
+        yield collection_success
+        yield from metrics
+
+    def describe(self) -> Iterator[Metric]:
+        yield _collection_success_metric()
+        yield from _create_metric_families()
+
+    def _collect_fresh(self) -> list[Metric]:
+        families = _create_metric_families()
+        g_last_success = families.last_success
+        g_last_pruned = families.last_pruned
+        g_last_perm_sync = families.last_perm_sync
+        g_last_external_group_sync = families.last_external_group_sync
+        g_repeated_error = families.repeated_error
+        g_cc_pair_status = families.cc_pair_status
+        g_access_type = families.access_type
+        g_indexing_trigger = families.indexing_trigger
+        g_auto_sync_enabled = families.auto_sync_enabled
+        g_connector_count = families.connector_count
+        g_document_count = families.document_count
+        g_connector_info = families.connector_info
+        with get_session_with_current_tenant() as db:
+            snapshots = get_connector_state_snapshots(db)
+
+        connector_counts: dict[tuple[str, str], int] = {}
+        docs_by_source: dict[str, int] = {}
+
+        for snapshot in snapshots:
+            cc_pair_id_str = str(snapshot.cc_pair_id)
+            source_str = snapshot.source.value
+            status_str = _enum_label(snapshot.status, _CC_PAIR_STATUS_LABELS)
+            access_type_str = _enum_label(snapshot.access_type, _ACCESS_TYPE_LABELS)
+            indexing_trigger_str = (
+                _enum_label(snapshot.indexing_trigger, _INDEXING_MODE_LABELS)
+                if snapshot.indexing_trigger
+                else _NO_TRIGGER_LABEL
             )
 
-        # Always yield metric families, even if empty.
-        yield g_last_pruned
-        yield g_last_perm_sync
-        yield g_last_external_group_sync
-        yield g_cc_pair_status
-        yield g_access_type
-        yield g_indexing_trigger
-        yield g_auto_sync_enabled
-        yield g_time_since_last_success
-        yield g_time_since_last_prune
-        yield g_total_connectors
-        yield g_total_docs_by_source
-        yield g_connector_info
+            common_labels = [source_str, cc_pair_id_str]
+
+            g_last_success.add_metric(
+                common_labels,
+                float(_to_unix_ts(snapshot.last_successful_index_time)),
+            )
+            g_last_pruned.add_metric(
+                common_labels, float(_to_unix_ts(snapshot.last_pruned))
+            )
+            g_last_perm_sync.add_metric(
+                common_labels,
+                float(_to_unix_ts(snapshot.last_time_perm_sync)),
+            )
+            g_last_external_group_sync.add_metric(
+                common_labels,
+                float(_to_unix_ts(snapshot.last_time_external_group_sync)),
+            )
+            g_repeated_error.add_metric(
+                common_labels,
+                1.0 if snapshot.in_repeated_error_state else 0.0,
+            )
+
+            for status_label in _CC_PAIR_STATUS_LABELS:
+                g_cc_pair_status.add_metric(
+                    [*common_labels, status_label],
+                    1.0 if status_label == status_str else 0.0,
+                )
+            for access_type_label in _ACCESS_TYPE_LABELS:
+                g_access_type.add_metric(
+                    [*common_labels, access_type_label],
+                    1.0 if access_type_label == access_type_str else 0.0,
+                )
+            for mode_label in _INDEXING_MODE_LABELS:
+                g_indexing_trigger.add_metric(
+                    [*common_labels, mode_label],
+                    1.0 if mode_label == indexing_trigger_str else 0.0,
+                )
+
+            g_auto_sync_enabled.add_metric(
+                common_labels, 1.0 if snapshot.auto_sync_enabled else 0.0
+            )
+
+            g_connector_info.add_metric(
+                [cc_pair_id_str],
+                {
+                    "connector_name": snapshot.cc_pair_name,
+                    "source": source_str,
+                    "credential_id": str(snapshot.credential_id),
+                    "status": status_str,
+                    "access_type": access_type_str,
+                },
+            )
+
+            connector_counts[(source_str, status_str)] = (
+                connector_counts.get((source_str, status_str), 0) + 1
+            )
+            docs_by_source[source_str] = (
+                docs_by_source.get(source_str, 0) + snapshot.total_docs_indexed
+            )
+
+        for (source, status), count in connector_counts.items():
+            g_connector_count.add_metric([source, status], float(count))
+        for source, total_docs in docs_by_source.items():
+            g_document_count.add_metric([source], float(total_docs))
+
+        return list(families)
+
+
+_CONNECTOR_STATE_COLLECTOR = ConnectorStateMetricsCollector()
+_CONNECTOR_STATE_COLLECTOR_REGISTERED = False
 
 
 def register_connector_state_metrics() -> None:
-    """Register the connector state collector with the default registry."""
+    global _CONNECTOR_STATE_COLLECTOR_REGISTERED
     if MULTI_TENANT:
-        # A scrape-time collector has no tenant context; per-tenant state
-        # metrics need a different mechanism in cloud deployments.
         logger.info(
             "Multi-tenant deployment — skipping connector state metrics collector"
         )
         return
-    try:
-        REGISTRY.register(ConnectorStateMetricsCollector())
-        logger.info("Connector state metrics collector registered")
-    except ValueError:
+    if _CONNECTOR_STATE_COLLECTOR_REGISTERED:
         logger.debug("Connector state metrics collector already registered")
+        return
+    REGISTRY.register(_CONNECTOR_STATE_COLLECTOR)
+    _CONNECTOR_STATE_COLLECTOR_REGISTERED = True
+    logger.info("Connector state metrics collector registered")

--- a/backend/onyx/server/metrics/mcp_client.py
+++ b/backend/onyx/server/metrics/mcp_client.py
@@ -1,0 +1,41 @@
+import time
+
+from prometheus_client import Counter
+from prometheus_client import Histogram
+
+from onyx.server.metrics.mcp_common import MCPToolCallStatus
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+MCP_CLIENT_TOOL_TOTAL = Counter(
+    "onyx_mcp_client_tool_calls_total",
+    "External MCP tool calls made by Onyx",
+    ["server_name", "tool_name", "status"],
+)
+MCP_CLIENT_TOOL_LATENCY = Histogram(
+    "onyx_mcp_client_tool_latency_seconds",
+    "External MCP tool call latency",
+    ["server_name", "tool_name"],
+    buckets=(0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
+)
+
+
+def record_mcp_client_tool_outcome(
+    server_name: str,
+    tool_name: str,
+    start_time: float,
+    status: MCPToolCallStatus,
+) -> None:
+    try:
+        MCP_CLIENT_TOOL_LATENCY.labels(
+            server_name=server_name,
+            tool_name=tool_name,
+        ).observe(time.monotonic() - start_time)
+        MCP_CLIENT_TOOL_TOTAL.labels(
+            server_name=server_name,
+            tool_name=tool_name,
+            status=status.value,
+        ).inc()
+    except Exception:
+        logger.debug("Failed to record MCP client tool metrics", exc_info=True)

--- a/backend/onyx/server/metrics/mcp_common.py
+++ b/backend/onyx/server/metrics/mcp_common.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class MCPToolCallStatus(str, Enum):
+    SUCCESS = "success"
+    AUTH_ERROR = "auth_error"
+    ERROR = "error"

--- a/backend/onyx/server/metrics/mcp_server.py
+++ b/backend/onyx/server/metrics/mcp_server.py
@@ -1,0 +1,95 @@
+import time
+from enum import Enum
+
+from prometheus_client import Counter
+from prometheus_client import Histogram
+
+from onyx.server.metrics.mcp_common import MCPToolCallStatus
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+class MCPAuthResult(str, Enum):
+    SUCCESS = "success"
+    REJECTED = "rejected"
+    ERROR = "error"
+
+
+class MCPServerToolName(str, Enum):
+    SEARCH_INDEXED_DOCUMENTS = "search_indexed_documents"
+    SEARCH_WEB = "search_web"
+    OPEN_URLS = "open_urls"
+
+
+# TODO: Add resource metrics when MCP resource usage expands beyond discovery.
+UNKNOWN_SOURCE_LABEL = "unknown"
+
+MCP_SERVER_AUTH_TOTAL = Counter(
+    "onyx_mcp_server_auth_total",
+    "MCP server token verification outcomes",
+    ["result"],
+)
+MCP_SERVER_TOOL_LATENCY = Histogram(
+    "onyx_mcp_server_tool_latency_seconds",
+    "MCP server tool execution latency",
+    ["tool"],
+    buckets=(0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
+)
+MCP_SERVER_TOOL_TOTAL = Counter(
+    "onyx_mcp_server_tool_calls_total",
+    "MCP server tool calls",
+    ["tool", "status"],
+)
+MCP_SERVER_SEARCH_RESULTS = Histogram(
+    "onyx_mcp_server_search_results",
+    "Results returned by MCP server search tools",
+    ["tool"],
+    buckets=(0, 1, 2, 5, 10, 20, 50),
+)
+MCP_SERVER_SEARCH_SOURCES = Counter(
+    "onyx_mcp_server_search_by_source_total",
+    "MCP server document searches by requested source type",
+    ["source_type"],
+)
+
+
+def record_mcp_auth_result(result: MCPAuthResult) -> None:
+    try:
+        MCP_SERVER_AUTH_TOTAL.labels(result=result.value).inc()
+    except Exception:
+        logger.debug("Failed to record MCP auth metric", exc_info=True)
+
+
+def record_mcp_server_tool_outcome(
+    tool: MCPServerToolName,
+    start_time: float,
+    status: MCPToolCallStatus,
+) -> None:
+    try:
+        MCP_SERVER_TOOL_LATENCY.labels(tool=tool.value).observe(
+            time.monotonic() - start_time
+        )
+        MCP_SERVER_TOOL_TOTAL.labels(
+            tool=tool.value,
+            status=status.value,
+        ).inc()
+    except Exception:
+        logger.debug("Failed to record MCP server tool metrics", exc_info=True)
+
+
+def record_mcp_search_results(
+    tool: MCPServerToolName,
+    result_count: int,
+) -> None:
+    try:
+        MCP_SERVER_SEARCH_RESULTS.labels(tool=tool.value).observe(result_count)
+    except Exception:
+        logger.debug("Failed to record MCP search result metric", exc_info=True)
+
+
+def record_mcp_search_source(source: str) -> None:
+    try:
+        MCP_SERVER_SEARCH_SOURCES.labels(source_type=source).inc()
+    except Exception:
+        logger.debug("Failed to record MCP search source metric", exc_info=True)

--- a/backend/onyx/server/metrics/prometheus_setup.py
+++ b/backend/onyx/server/metrics/prometheus_setup.py
@@ -43,6 +43,31 @@ _LATENCY_BUCKETS = (
 )
 
 
+def create_prometheus_instrumentator() -> Instrumentator:
+    instrumentator = Instrumentator(
+        should_group_status_codes=False,
+        should_ignore_untemplated=False,
+        should_group_untemplated=True,
+        should_instrument_requests_inprogress=True,
+        inprogress_labels=True,
+        excluded_handlers=_EXCLUDED_HANDLERS,
+    )
+    default_callback = default_metrics(latency_lowr_buckets=_LATENCY_BUCKETS)
+    if default_callback:
+        instrumentator.add(default_callback)
+    return instrumentator
+
+
+def expose_prometheus_metrics(
+    app: Starlette,
+    instrumentator: Instrumentator,
+) -> None:
+    instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(
+        app,
+        dependencies=[Depends(verify_metrics_token)],
+    )
+
+
 def setup_prometheus_metrics(app: Starlette) -> None:
     """Initialize HTTP request metrics for the Onyx API server.
 
@@ -54,28 +79,7 @@ def setup_prometheus_metrics(app: Starlette) -> None:
     """
     app.add_exception_handler(SATimeoutError, pool_timeout_handler)
 
-    instrumentator = Instrumentator(
-        should_group_status_codes=False,
-        should_ignore_untemplated=False,
-        should_group_untemplated=True,
-        should_instrument_requests_inprogress=True,
-        inprogress_labels=True,
-        excluded_handlers=_EXCLUDED_HANDLERS,
-    )
-
-    # Explicitly create the default metrics (http_requests_total,
-    # http_request_duration_seconds, etc.) and add them first.  The library
-    # skips creating defaults when ANY custom instrumentations are registered
-    # via .add(), so we must include them ourselves.
-    default_callback = default_metrics(latency_lowr_buckets=_LATENCY_BUCKETS)
-    if default_callback:
-        instrumentator.add(default_callback)
-
+    instrumentator = create_prometheus_instrumentator()
     instrumentator.add(slow_request_callback)
     instrumentator.add(per_tenant_request_callback)
-
-    # `dependencies` is forwarded to the FastAPI route created by `.expose()`.
-    # `verify_metrics_token` is a no-op unless METRICS_AUTH_TOKEN is configured.
-    instrumentator.instrument(app, latency_lowr_buckets=_LATENCY_BUCKETS).expose(
-        app, dependencies=[Depends(verify_metrics_token)]
-    )
+    expose_prometheus_metrics(app, instrumentator)

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -3,8 +3,6 @@ import time
 from typing import Any
 
 from mcp.client.auth import OAuthClientProvider
-from prometheus_client import Counter
-from prometheus_client import Histogram
 
 from onyx.chat.emitter import Emitter
 from onyx.db.enums import MCPAuthenticationType
@@ -17,6 +15,8 @@ from onyx.server.features.mcp.models import DENYLISTED_MCP_HEADERS
 from onyx.server.features.mcp.oauth import make_oauth_provider
 from onyx.server.features.mcp.oauth import refresh_mcp_oauth_token_if_expired
 from onyx.server.features.mcp.oauth import UNUSED_RETURN_PATH
+from onyx.server.metrics.mcp_client import record_mcp_client_tool_outcome
+from onyx.server.metrics.mcp_common import MCPToolCallStatus
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import CustomToolDelta
 from onyx.server.query_and_chat.streaming_models import CustomToolStart
@@ -29,17 +29,16 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# MCP client metrics (Onyx calling external MCP servers)
-MCP_CLIENT_TOOL_TOTAL = Counter(
-    "onyx_mcp_client_tool_calls_total",
-    "External MCP tool calls made by Onyx",
-    ["server_name", "tool_name", "status"],  # status: success, auth_error, error
-)
-MCP_CLIENT_TOOL_LATENCY = Histogram(
-    "onyx_mcp_client_tool_latency_seconds",
-    "External MCP tool call latency",
-    ["server_name", "tool_name"],
-    buckets=(0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
+_AUTH_ERROR_INDICATORS = (
+    "401",
+    "unauthorized",
+    "authentication",
+    "forbidden",
+    "access denied",
+    "invalid token",
+    "invalid api key",
+    "invalid credentials",
+    "please reconnect to the server",
 )
 
 # TODO: for now we're fitting MCP tool responses into the CustomToolCallSummary class
@@ -145,6 +144,7 @@ class MCPTool(Tool[None]):
         """Execute the MCP tool by calling the MCP server"""
         _start = time.monotonic()
         _server = self.mcp_server.name
+        outcome = MCPToolCallStatus.ERROR
         try:
             # Build headers with proper precedence:
             # 1. Start with additional headers from API request (filled in first, excluding denylisted)
@@ -225,6 +225,7 @@ class MCPTool(Tool[None]):
                     )
                 )
 
+                outcome = MCPToolCallStatus.AUTH_ERROR
                 return ToolResponse(
                     rich_response=CustomToolCallSummary(
                         tool_name=self._name,
@@ -279,12 +280,6 @@ class MCPTool(Tool[None]):
                 auth=auth,
             )
 
-            MCP_CLIENT_TOOL_LATENCY.labels(
-                server_name=_server, tool_name=self._name
-            ).observe(time.monotonic() - _start)
-            MCP_CLIENT_TOOL_TOTAL.labels(
-                server_name=_server, tool_name=self._name, status="success"
-            ).inc()
             logger.info("MCP tool '%s' executed successfully", self._name)
 
             # Format the tool result for response
@@ -303,7 +298,7 @@ class MCPTool(Tool[None]):
                 )
             )
 
-            return ToolResponse(
+            response = ToolResponse(
                 rich_response=CustomToolCallSummary(
                     tool_name=self._name,
                     response_type="json",
@@ -311,38 +306,19 @@ class MCPTool(Tool[None]):
                 ),
                 llm_facing_response=llm_facing_response,
             )
+            outcome = MCPToolCallStatus.SUCCESS
+            return response
 
         except Exception as e:
-            MCP_CLIENT_TOOL_LATENCY.labels(
-                server_name=_server, tool_name=self._name
-            ).observe(time.monotonic() - _start)
             error_str = str(e).lower()
             logger.error("Failed to execute MCP tool '%s': %s", self._name, e)
 
-            # Check for authentication-related errors
-            auth_error_indicators = [
-                "401",
-                "unauthorized",
-                "authentication",
-                "auth",
-                "forbidden",
-                "access denied",
-                "invalid token",
-                "invalid api key",
-                "invalid credentials",
-                "please reconnect to the server",
-            ]
-
             is_auth_error = any(
-                indicator in error_str for indicator in auth_error_indicators
+                indicator in error_str for indicator in _AUTH_ERROR_INDICATORS
             )
 
             if is_auth_error:
-                MCP_CLIENT_TOOL_TOTAL.labels(
-                    server_name=_server,
-                    tool_name=self._name,
-                    status="auth_error",
-                ).inc()
+                outcome = MCPToolCallStatus.AUTH_ERROR
                 auth_error_msg = (
                     f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
                     f"Please use the MCP dropdown in the chat bar to update your credentials "
@@ -350,11 +326,6 @@ class MCPTool(Tool[None]):
                 )
                 error_result = {"error": auth_error_msg}
             else:
-                MCP_CLIENT_TOOL_TOTAL.labels(
-                    server_name=_server,
-                    tool_name=self._name,
-                    status="error",
-                ).inc()
                 error_result = {"error": f"Tool execution failed: {str(e)}"}
 
             llm_facing_response = json.dumps(error_result)
@@ -378,4 +349,11 @@ class MCPTool(Tool[None]):
                     tool_result=error_result,
                 ),
                 llm_facing_response=llm_facing_response,
+            )
+        finally:
+            record_mcp_client_tool_outcome(
+                server_name=_server,
+                tool_name=self._name,
+                start_time=_start,
+                status=outcome,
             )

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -1,7 +1,10 @@
 import json
+import time
 from typing import Any
 
 from mcp.client.auth import OAuthClientProvider
+from prometheus_client import Counter
+from prometheus_client import Histogram
 
 from onyx.chat.emitter import Emitter
 from onyx.db.enums import MCPAuthenticationType
@@ -25,6 +28,19 @@ from onyx.tools.tool_name import sanitize_tool_name
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# MCP client metrics (Onyx calling external MCP servers)
+MCP_CLIENT_TOOL_TOTAL = Counter(
+    "onyx_mcp_client_tool_calls_total",
+    "External MCP tool calls made by Onyx",
+    ["server_name", "tool_name", "status"],  # status: success, auth_error, error
+)
+MCP_CLIENT_TOOL_LATENCY = Histogram(
+    "onyx_mcp_client_tool_latency_seconds",
+    "External MCP tool call latency",
+    ["server_name", "tool_name"],
+    buckets=(0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0),
+)
 
 # TODO: for now we're fitting MCP tool responses into the CustomToolCallSummary class
 # In the future we may want custom handling for MCP tool responses
@@ -127,6 +143,8 @@ class MCPTool(Tool[None]):
         **llm_kwargs: Any,
     ) -> ToolResponse:
         """Execute the MCP tool by calling the MCP server"""
+        _start = time.monotonic()
+        _server = self.mcp_server.name
         try:
             # Build headers with proper precedence:
             # 1. Start with additional headers from API request (filled in first, excluding denylisted)
@@ -261,6 +279,12 @@ class MCPTool(Tool[None]):
                 auth=auth,
             )
 
+            MCP_CLIENT_TOOL_LATENCY.labels(
+                server_name=_server, tool_name=self._name
+            ).observe(time.monotonic() - _start)
+            MCP_CLIENT_TOOL_TOTAL.labels(
+                server_name=_server, tool_name=self._name, status="success"
+            ).inc()
             logger.info("MCP tool '%s' executed successfully", self._name)
 
             # Format the tool result for response
@@ -289,6 +313,9 @@ class MCPTool(Tool[None]):
             )
 
         except Exception as e:
+            MCP_CLIENT_TOOL_LATENCY.labels(
+                server_name=_server, tool_name=self._name
+            ).observe(time.monotonic() - _start)
             error_str = str(e).lower()
             logger.error("Failed to execute MCP tool '%s': %s", self._name, e)
 
@@ -311,6 +338,11 @@ class MCPTool(Tool[None]):
             )
 
             if is_auth_error:
+                MCP_CLIENT_TOOL_TOTAL.labels(
+                    server_name=_server,
+                    tool_name=self._name,
+                    status="auth_error",
+                ).inc()
                 auth_error_msg = (
                     f"Authentication failed for the {self._name} tool from {self.mcp_server.name}. "
                     f"Please use the MCP dropdown in the chat bar to update your credentials "
@@ -318,6 +350,11 @@ class MCPTool(Tool[None]):
                 )
                 error_result = {"error": auth_error_msg}
             else:
+                MCP_CLIENT_TOOL_TOTAL.labels(
+                    server_name=_server,
+                    tool_name=self._name,
+                    status="error",
+                ).inc()
                 error_result = {"error": f"Tool execution failed: {str(e)}"}
 
             llm_facing_response = json.dumps(error_result)

--- a/backend/tests/external_dependency_unit/db/test_connector_state_snapshot_query.py
+++ b/backend/tests/external_dependency_unit/db/test_connector_state_snapshot_query.py
@@ -3,6 +3,7 @@ from datetime import timezone
 
 from sqlalchemy.orm import Session
 
+from onyx.configs.constants import DEFAULT_CC_PAIR_ID
 from onyx.configs.constants import DocumentSource
 from onyx.db.connector_credential_pair import ConnectorStateSnapshot
 from onyx.db.connector_credential_pair import get_connector_state_snapshots
@@ -17,7 +18,10 @@ def test_connector_state_snapshot_query(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
-    pair = make_cc_pair(db_session)
+    pairs = [make_cc_pair(db_session)]
+    if pairs[0].id == DEFAULT_CC_PAIR_ID:
+        pairs.append(make_cc_pair(db_session))
+    pair = pairs[-1]
     timestamp = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
     pair.last_successful_index_time = timestamp
     pair.last_pruned = timestamp
@@ -54,4 +58,5 @@ def test_connector_state_snapshot_query(
         )
     finally:
         db_session.rollback()
-        cleanup_cc_pair(db_session, pair)
+        for created_pair in reversed(pairs):
+            cleanup_cc_pair(db_session, created_pair)

--- a/backend/tests/external_dependency_unit/db/test_connector_state_snapshot_query.py
+++ b/backend/tests/external_dependency_unit/db/test_connector_state_snapshot_query.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from datetime import timezone
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.db.connector_credential_pair import ConnectorStateSnapshot
+from onyx.db.connector_credential_pair import get_connector_state_snapshots
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingMode
+from tests.external_dependency_unit.indexing_helpers import cleanup_cc_pair
+from tests.external_dependency_unit.indexing_helpers import make_cc_pair
+
+
+def test_connector_state_snapshot_query(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    pair = make_cc_pair(db_session)
+    timestamp = datetime(2026, 7, 16, 12, tzinfo=timezone.utc)
+    pair.last_successful_index_time = timestamp
+    pair.last_pruned = timestamp
+    pair.last_time_perm_sync = timestamp
+    pair.last_time_external_group_sync = timestamp
+    pair.total_docs_indexed = 17
+    pair.access_type = AccessType.SYNC
+    pair.indexing_trigger = IndexingMode.UPDATE
+    pair.auto_sync_options = {"enabled": True}
+    pair.in_repeated_error_state = True
+    db_session.commit()
+
+    try:
+        snapshot = next(
+            item
+            for item in get_connector_state_snapshots(db_session)
+            if item.cc_pair_id == pair.id
+        )
+        assert snapshot == ConnectorStateSnapshot(
+            cc_pair_id=pair.id,
+            cc_pair_name=pair.name,
+            status=ConnectorCredentialPairStatus.ACTIVE,
+            last_successful_index_time=timestamp,
+            last_pruned=timestamp,
+            last_time_perm_sync=timestamp,
+            last_time_external_group_sync=timestamp,
+            total_docs_indexed=17,
+            access_type=AccessType.SYNC,
+            indexing_trigger=IndexingMode.UPDATE,
+            auto_sync_enabled=True,
+            in_repeated_error_state=True,
+            source=DocumentSource.MOCK_CONNECTOR,
+            credential_id=pair.credential_id,
+        )
+    finally:
+        db_session.rollback()
+        cleanup_cc_pair(db_session, pair)

--- a/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
+++ b/backend/tests/unit/onyx/server/test_prometheus_instrumentation.py
@@ -66,7 +66,13 @@ def test_slow_request_callback_skips_at_exact_threshold() -> None:
 
 
 def test_setup_attaches_instrumentator_to_app() -> None:
-    with patch("onyx.server.metrics.prometheus_setup.Instrumentator") as mock_cls:
+    with (
+        patch("onyx.server.metrics.prometheus_setup.Instrumentator") as mock_cls,
+        patch(
+            "onyx.server.metrics.prometheus_setup.default_metrics",
+            return_value=MagicMock(),
+        ),
+    ):
         mock_instance = MagicMock()
         mock_instance.instrument.return_value = mock_instance
         mock_cls.return_value = mock_instance

--- a/backend/tests/unit/server/metrics/test_connector_state_metrics.py
+++ b/backend/tests/unit/server/metrics/test_connector_state_metrics.py
@@ -1,14 +1,57 @@
 """Unit tests for the DB-snapshot connector state metrics collector."""
 
+from contextlib import nullcontext
 from datetime import datetime
+from datetime import timedelta
 from datetime import timezone
+from threading import Event
+from threading import Thread
+from unittest.mock import MagicMock
 
 import pytest
+from prometheus_client import CollectorRegistry
 
 import onyx.server.metrics.connector_state_metrics as csm
-from onyx.server.metrics.connector_state_metrics import _enum_str
+from onyx.configs.constants import DocumentSource
+from onyx.db.connector_credential_pair import ConnectorStateSnapshot
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import IndexingMode
+from onyx.server.metrics.connector_state_metrics import _enum_label
 from onyx.server.metrics.connector_state_metrics import _to_unix_ts
 from onyx.server.metrics.connector_state_metrics import ConnectorStateMetricsCollector
+
+
+def _snapshot() -> ConnectorStateSnapshot:
+    return ConnectorStateSnapshot(
+        cc_pair_id=42,
+        cc_pair_name="Engineering Drive",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        last_successful_index_time=datetime(
+            2026,
+            7,
+            11,
+            14,
+            tzinfo=timezone(timedelta(hours=2)),
+        ),
+        last_pruned=None,
+        last_time_perm_sync=datetime(2026, 7, 11, 12, tzinfo=timezone.utc),
+        last_time_external_group_sync=None,
+        total_docs_indexed=17,
+        access_type=AccessType.SYNC,
+        indexing_trigger=IndexingMode.UPDATE,
+        auto_sync_enabled=True,
+        in_repeated_error_state=True,
+        source=DocumentSource.GOOGLE_DRIVE,
+        credential_id=7,
+    )
+
+
+def _sample_value(
+    family: csm.Metric,
+    labels: dict[str, str],
+) -> float:
+    return next(sample.value for sample in family.samples if sample.labels == labels)
 
 
 def test_to_unix_ts() -> None:
@@ -19,24 +62,160 @@ def test_to_unix_ts() -> None:
     assert _to_unix_ts(naive) == int(aware.timestamp())  # naive treated as UTC
 
 
-def test_enum_str_guards_label_cardinality() -> None:
+def test_enum_label_guards_label_cardinality() -> None:
     class _FakeEnum:
         value = "ACTIVE"
 
-    assert _enum_str(_FakeEnum(), ("ACTIVE", "PAUSED")) == "ACTIVE"
+    assert _enum_label(_FakeEnum(), ("ACTIVE", "PAUSED")) == "ACTIVE"
     # Unexpected values collapse to UNKNOWN instead of minting new label values.
-    assert _enum_str("SOMETHING_NEW", ("ACTIVE", "PAUSED")) == "UNKNOWN"
+    assert _enum_label("SOMETHING_NEW", ("ACTIVE", "PAUSED")) == "UNKNOWN"
 
 
-def test_collect_yields_all_families_when_db_unavailable() -> None:
-    """A scrape must never crash the /metrics endpoint: with no DB engine the
-    collector logs and still yields every (empty) metric family."""
-    families = list(ConnectorStateMetricsCollector().collect())
-    names = {f.name for f in families}
-    assert len(families) == 12
-    assert "onyx_connector_seconds_since_last_success" in names
-    assert "onyx_connectors_total" in names
-    assert all(not f.samples for f in families)
+def test_collect_reports_failure_when_db_unavailable() -> None:
+    collector = ConnectorStateMetricsCollector()
+    try:
+        families = list(collector.collect())
+    finally:
+        collector._executor.shutdown(wait=True)
+
+    assert [family.name for family in families] == [
+        "onyx_connector_state_collection_success"
+    ]
+    assert families[0].samples[0].value == 0.0
+
+
+def test_collect_maps_snapshot_to_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        csm,
+        "get_session_with_current_tenant",
+        lambda: nullcontext(MagicMock()),
+    )
+    monkeypatch.setattr(
+        csm,
+        "get_connector_state_snapshots",
+        lambda _db: [_snapshot()],
+    )
+
+    collector = ConnectorStateMetricsCollector()
+    try:
+        families = {family.name: family for family in collector.collect()}
+    finally:
+        collector._executor.shutdown(wait=True)
+    connector_labels = {"source": "google_drive", "cc_pair_id": "42"}
+
+    assert _sample_value(families["onyx_connector_state_collection_success"], {}) == 1.0
+    assert (
+        _sample_value(
+            families["onyx_connector_last_successful_index_timestamp_seconds"],
+            connector_labels,
+        )
+        == datetime(2026, 7, 11, 12, tzinfo=timezone.utc).timestamp()
+    )
+    assert (
+        _sample_value(
+            families["onyx_connector_last_pruned_timestamp_seconds"],
+            connector_labels,
+        )
+        == 0.0
+    )
+    assert (
+        _sample_value(
+            families["onyx_connector_repeated_error_state"],
+            connector_labels,
+        )
+        == 1.0
+    )
+    assert (
+        _sample_value(
+            families["onyx_connector_status"],
+            {**connector_labels, "status": "ACTIVE"},
+        )
+        == 1.0
+    )
+    assert (
+        _sample_value(
+            families["onyx_connector_status"],
+            {**connector_labels, "status": "UNKNOWN"},
+        )
+        == 0.0
+    )
+    assert (
+        _sample_value(
+            families["onyx_connector_count"],
+            {"source": "google_drive", "status": "ACTIVE"},
+        )
+        == 1.0
+    )
+    assert (
+        _sample_value(
+            families["onyx_connector_document_count"],
+            {"source": "google_drive"},
+        )
+        == 17.0
+    )
+
+    info_labels = families["onyx_connector"].samples[0].labels
+    assert info_labels == {
+        "cc_pair_id": "42",
+        "connector_name": "Engineering Drive",
+        "source": "google_drive",
+        "credential_id": "7",
+        "status": "ACTIVE",
+        "access_type": "sync",
+    }
+
+
+def test_collect_does_not_start_overlapping_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    started = Event()
+    release = Event()
+    calls = 0
+    collector = ConnectorStateMetricsCollector(timeout=2.0)
+
+    def _slow_collect() -> list[csm.Metric]:
+        nonlocal calls
+        calls += 1
+        started.set()
+        release.wait()
+        return []
+
+    first_result: list[csm.Metric] = []
+    monkeypatch.setattr(collector, "_collect_fresh", _slow_collect)
+    first_scrape = Thread(target=lambda: first_result.extend(collector.collect()))
+    first_scrape.start()
+    try:
+        assert started.wait(timeout=1.0)
+        second = list(collector.collect())
+        assert first_scrape.is_alive()
+    finally:
+        release.set()
+        first_scrape.join()
+        collector._executor.shutdown(wait=True)
+
+    assert calls == 1
+    assert first_result[0].samples[0].value == 1.0
+    assert second[0].samples[0].value == 0.0
+
+
+def test_describe_does_not_query_database(monkeypatch: pytest.MonkeyPatch) -> None:
+    collector = ConnectorStateMetricsCollector()
+    collect_fresh = MagicMock(
+        side_effect=AssertionError("describe queried the database")
+    )
+    monkeypatch.setattr(
+        collector,
+        "_collect_fresh",
+        collect_fresh,
+    )
+    try:
+        families = list(collector.describe())
+    finally:
+        collector._executor.shutdown(wait=True)
+
+    assert len(families) == 13
+    assert families[0].name == "onyx_connector_state_collection_success"
+    collect_fresh.assert_not_called()
 
 
 def test_register_skipped_in_multi_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -52,9 +231,27 @@ def test_register_skipped_in_multi_tenant(monkeypatch: pytest.MonkeyPatch) -> No
 def test_register_in_single_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
     registered: list[object] = []
     monkeypatch.setattr(csm, "MULTI_TENANT", False)
+    monkeypatch.setattr(csm, "_CONNECTOR_STATE_COLLECTOR_REGISTERED", False)
     monkeypatch.setattr(csm.REGISTRY, "register", registered.append)
 
+    csm.register_connector_state_metrics()
     csm.register_connector_state_metrics()
 
     assert len(registered) == 1
     assert isinstance(registered[0], ConnectorStateMetricsCollector)
+
+
+def test_registration_does_not_collect(monkeypatch: pytest.MonkeyPatch) -> None:
+    collect_fresh = MagicMock(side_effect=AssertionError("registration queried the DB"))
+    monkeypatch.setattr(csm, "MULTI_TENANT", False)
+    monkeypatch.setattr(csm, "_CONNECTOR_STATE_COLLECTOR_REGISTERED", False)
+    monkeypatch.setattr(csm, "REGISTRY", CollectorRegistry(auto_describe=True))
+    monkeypatch.setattr(
+        csm._CONNECTOR_STATE_COLLECTOR,
+        "_collect_fresh",
+        collect_fresh,
+    )
+
+    csm.register_connector_state_metrics()
+
+    collect_fresh.assert_not_called()

--- a/backend/tests/unit/server/metrics/test_connector_state_metrics.py
+++ b/backend/tests/unit/server/metrics/test_connector_state_metrics.py
@@ -1,0 +1,60 @@
+"""Unit tests for the DB-snapshot connector state metrics collector."""
+
+from datetime import datetime
+from datetime import timezone
+
+import pytest
+
+import onyx.server.metrics.connector_state_metrics as csm
+from onyx.server.metrics.connector_state_metrics import _enum_str
+from onyx.server.metrics.connector_state_metrics import _to_unix_ts
+from onyx.server.metrics.connector_state_metrics import ConnectorStateMetricsCollector
+
+
+def test_to_unix_ts() -> None:
+    assert _to_unix_ts(None) == 0
+    aware = datetime(2026, 7, 11, 12, 0, 0, tzinfo=timezone.utc)
+    assert _to_unix_ts(aware) == int(aware.timestamp())
+    naive = datetime(2026, 7, 11, 12, 0, 0)
+    assert _to_unix_ts(naive) == int(aware.timestamp())  # naive treated as UTC
+
+
+def test_enum_str_guards_label_cardinality() -> None:
+    class _FakeEnum:
+        value = "ACTIVE"
+
+    assert _enum_str(_FakeEnum(), ("ACTIVE", "PAUSED")) == "ACTIVE"
+    # Unexpected values collapse to UNKNOWN instead of minting new label values.
+    assert _enum_str("SOMETHING_NEW", ("ACTIVE", "PAUSED")) == "UNKNOWN"
+
+
+def test_collect_yields_all_families_when_db_unavailable() -> None:
+    """A scrape must never crash the /metrics endpoint: with no DB engine the
+    collector logs and still yields every (empty) metric family."""
+    families = list(ConnectorStateMetricsCollector().collect())
+    names = {f.name for f in families}
+    assert len(families) == 12
+    assert "onyx_connector_seconds_since_last_success" in names
+    assert "onyx_connectors_total" in names
+    assert all(not f.samples for f in families)
+
+
+def test_register_skipped_in_multi_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    registered: list[object] = []
+    monkeypatch.setattr(csm, "MULTI_TENANT", True)
+    monkeypatch.setattr(csm.REGISTRY, "register", registered.append)
+
+    csm.register_connector_state_metrics()
+
+    assert registered == []
+
+
+def test_register_in_single_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    registered: list[object] = []
+    monkeypatch.setattr(csm, "MULTI_TENANT", False)
+    monkeypatch.setattr(csm.REGISTRY, "register", registered.append)
+
+    csm.register_connector_state_metrics()
+
+    assert len(registered) == 1
+    assert isinstance(registered[0], ConnectorStateMetricsCollector)

--- a/backend/tests/unit/server/metrics/test_mcp_metrics.py
+++ b/backend/tests/unit/server/metrics/test_mcp_metrics.py
@@ -1,0 +1,201 @@
+import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import httpx
+import pytest
+from fastapi.testclient import TestClient
+
+from onyx.db.enums import MCPAuthenticationType
+from onyx.mcp_server.api import create_mcp_fastapi_app
+from onyx.mcp_server.auth import OnyxTokenVerifier
+from onyx.mcp_server.tools import search
+from onyx.server.metrics import mcp_client
+from onyx.server.metrics import metrics_auth
+from onyx.server.metrics.mcp_common import MCPToolCallStatus
+from onyx.server.metrics.mcp_server import MCPAuthResult
+from onyx.server.metrics.mcp_server import MCPServerToolName
+from onyx.server.query_and_chat.placement import Placement
+from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
+
+
+def _mcp_tool(
+    auth_type: MCPAuthenticationType = MCPAuthenticationType.NONE,
+) -> MCPTool:
+    server = MagicMock()
+    server.name = "Customer MCP"
+    server.server_url = "https://mcp.example"
+    server.auth_type = auth_type
+    server.transport = None
+    return MCPTool(
+        tool_id=1,
+        emitter=MagicMock(),
+        mcp_server=server,
+        tool_name="lookup",
+        tool_description="Lookup",
+        tool_definition={"type": "object", "properties": {}},
+    )
+
+
+def test_client_records_success_once() -> None:
+    tool = _mcp_tool()
+    with (
+        patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            return_value={"ok": True},
+        ),
+        patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool."
+            "record_mcp_client_tool_outcome"
+        ) as record,
+    ):
+        tool.run(Placement(turn_index=0))
+
+    record.assert_called_once()
+    assert record.call_args.kwargs["status"] == MCPToolCallStatus.SUCCESS
+
+
+def test_client_records_missing_credentials_as_auth_error() -> None:
+    tool = _mcp_tool(MCPAuthenticationType.API_TOKEN)
+    with patch(
+        "onyx.tools.tool_implementations.mcp.mcp_tool.record_mcp_client_tool_outcome"
+    ) as record:
+        tool.run(Placement(turn_index=0))
+
+    record.assert_called_once()
+    assert record.call_args.kwargs["status"] == MCPToolCallStatus.AUTH_ERROR
+
+
+def test_client_records_post_call_failure_once() -> None:
+    tool = _mcp_tool()
+    with (
+        patch.object(
+            tool.emitter,
+            "emit",
+            side_effect=[RuntimeError("emit failed"), None],
+        ),
+        patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool.call_mcp_tool",
+            return_value={"ok": True},
+        ),
+        patch(
+            "onyx.tools.tool_implementations.mcp.mcp_tool."
+            "record_mcp_client_tool_outcome"
+        ) as record,
+    ):
+        response = tool.run(Placement(turn_index=0))
+
+    assert "emit failed" in response.llm_facing_response
+    record.assert_called_once()
+    assert record.call_args.kwargs["status"] == MCPToolCallStatus.ERROR
+
+
+def test_client_metric_failure_does_not_raise() -> None:
+    with patch.object(
+        mcp_client.MCP_CLIENT_TOOL_LATENCY,
+        "labels",
+        side_effect=RuntimeError("metric failed"),
+    ):
+        mcp_client.record_mcp_client_tool_outcome(
+            server_name="Customer MCP",
+            tool_name="lookup",
+            start_time=0.0,
+            status=MCPToolCallStatus.SUCCESS,
+        )
+
+
+def test_server_empty_state_is_success() -> None:
+    with (
+        patch.object(search, "require_access_token", return_value=MagicMock()),
+        patch.object(search, "get_indexed_sources", new=AsyncMock(return_value=[])),
+        patch.object(search, "record_mcp_server_tool_outcome") as outcome,
+        patch.object(search, "record_mcp_search_results") as results,
+    ):
+        response = asyncio.run(search.search_indexed_documents("query"))
+
+    assert response["results"] == []
+    outcome.assert_called_once()
+    assert outcome.call_args.args[2] == MCPToolCallStatus.SUCCESS
+    results.assert_called_once_with(MCPServerToolName.SEARCH_INDEXED_DOCUMENTS, 0)
+
+
+def test_server_upstream_failure_is_recorded_once() -> None:
+    failed_response = httpx.Response(
+        503,
+        json={"detail": "unavailable"},
+        request=httpx.Request("POST", "https://api.example/search"),
+    )
+    with (
+        patch.object(search, "require_access_token", return_value=MagicMock()),
+        patch.object(
+            search,
+            "_post_model",
+            new=AsyncMock(return_value=failed_response),
+        ),
+        patch.object(search, "record_mcp_server_tool_outcome") as outcome,
+    ):
+        response = asyncio.run(search.search_web("query"))
+
+    assert response["error"] == "unavailable"
+    outcome.assert_called_once()
+    assert outcome.call_args.args[2] == MCPToolCallStatus.ERROR
+
+
+def test_server_deduplicates_requested_sources() -> None:
+    with patch.object(search, "record_mcp_search_source") as record:
+        search._record_requested_sources(["github", "GITHUB", "invalid", "other"])
+
+    assert {call.args[0] for call in record.call_args_list} == {
+        "github",
+        "unknown",
+    }
+
+
+def test_auth_verifier_records_success() -> None:
+    client = MagicMock()
+    client.get = AsyncMock(return_value=MagicMock(status_code=200))
+    with (
+        patch("onyx.mcp_server.auth.get_http_client", return_value=client),
+        patch("onyx.mcp_server.auth.record_mcp_auth_result") as record,
+    ):
+        token = asyncio.run(OnyxTokenVerifier().verify_token("token"))
+
+    assert token is not None
+    record.assert_called_once_with(MCPAuthResult.SUCCESS)
+
+
+def test_auth_verifier_records_rejection_and_backend_error() -> None:
+    client = MagicMock()
+    client.get = AsyncMock(return_value=MagicMock(status_code=401))
+    with (
+        patch("onyx.mcp_server.auth.get_http_client", return_value=client),
+        patch("onyx.mcp_server.auth.record_mcp_auth_result") as record,
+    ):
+        assert asyncio.run(OnyxTokenVerifier().verify_token("token")) is None
+    record.assert_called_once_with(MCPAuthResult.REJECTED)
+
+    client.get = AsyncMock(side_effect=RuntimeError("offline"))
+    with (
+        patch("onyx.mcp_server.auth.get_http_client", return_value=client),
+        patch("onyx.mcp_server.auth.record_mcp_auth_result") as record,
+    ):
+        assert asyncio.run(OnyxTokenVerifier().verify_token("token")) is None
+    record.assert_called_once_with(MCPAuthResult.ERROR)
+
+
+def test_mcp_metrics_endpoint_uses_shared_bearer_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(metrics_auth, "DISABLE_METRICS_AUTH", False)
+    monkeypatch.setattr(metrics_auth, "METRICS_AUTH_TOKEN", "metrics-token")
+    client = TestClient(create_mcp_fastapi_app(), raise_server_exceptions=False)
+
+    assert client.get("/metrics").status_code == 401
+    response = client.get(
+        "/metrics",
+        headers={"Authorization": "Bearer metrics-token"},
+    )
+
+    assert response.status_code == 200
+    assert "onyx_mcp_server_auth_total" in response.text

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.13
+version: 0.6.14
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,10 +16,10 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: changed
-      description: Increase the default sandbox proxy memory request from 256Mi to 512Mi and its
-        memory limit from 1Gi to 2Gi, providing more headroom for transient proxy workloads and
-        reducing the risk of out-of-memory termination.
+    - kind: added
+      description: Add authenticated Prometheus scraping for the MCP server.
+    - kind: fixed
+      description: Scope metrics credentials and ServiceMonitor selectors to the intended workloads.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -87,7 +87,8 @@ Create env vars from secrets (global secrets only — skips entries with allPods
 */}}
 {{- define "onyx.envSecrets" -}}
     {{- range $secretSuffix, $secretContent := .Values.auth }}
-    {{- if and (ne (toString $secretContent.enabled) "false") ($secretContent.secretKeys) (ne (toString (index $secretContent "allPods" | default "true")) "false") }}
+    {{- $allPods := or (not (hasKey $secretContent "allPods")) (ne (toString $secretContent.allPods) "false") }}
+    {{- if and (ne $secretSuffix "metricsAuth") (ne (toString $secretContent.enabled) "false") ($secretContent.secretKeys) $allPods }}
     {{- range $name, $key := $secretContent.secretKeys }}
 - name: {{ $name | upper | replace "-" "_" | quote }}
   valueFrom:
@@ -104,7 +105,8 @@ Create env vars from secrets restricted to specific pods (entries with allPods: 
 */}}
 {{- define "onyx.envSecretsRestricted" -}}
     {{- range $secretSuffix, $secretContent := .Values.auth }}
-    {{- if and (ne (toString $secretContent.enabled) "false") ($secretContent.secretKeys) (eq (toString (index $secretContent "allPods" | default "true")) "false") }}
+    {{- $restricted := and (hasKey $secretContent "allPods") (eq (toString $secretContent.allPods) "false") }}
+    {{- if and (ne $secretSuffix "metricsAuth") (ne (toString $secretContent.enabled) "false") ($secretContent.secretKeys) $restricted }}
     {{- range $name, $key := $secretContent.secretKeys }}
 - name: {{ $name | upper | replace "-" "_" | quote }}
   valueFrom:
@@ -113,6 +115,20 @@ Create env vars from secrets restricted to specific pods (entries with allPods: 
       key: {{ default $name $key }}
     {{- end }}
     {{- end }}
+    {{- end }}
+{{- end }}
+
+{{/*
+Inject metrics auth only into pods that expose the protected endpoint.
+*/}}
+{{- define "onyx.metricsAuthEnv" -}}
+    {{- $metricsAuth := .Values.auth.metricsAuth | default dict }}
+    {{- if dig "enabled" false $metricsAuth }}
+- name: METRICS_AUTH_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "onyx.secretName" $metricsAuth }}
+      key: {{ default "METRICS_AUTH_TOKEN" (dig "secretKeys" "METRICS_AUTH_TOKEN" "" $metricsAuth) }}
     {{- end }}
 {{- end }}
 

--- a/deployment/helm/charts/onyx/templates/api-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/api-deployment.yaml
@@ -107,6 +107,7 @@ spec:
             {{- end }}
             {{- include "onyx.envSecrets" . | nindent 12}}
             {{- include "onyx.envSecretsRestricted" . | nindent 12}}
+            {{- include "onyx.metricsAuthEnv" . | nindent 12}}
             {{- with include "onyx.customCACerts.env" . }}
             {{- . | nindent 12 }}
             {{- end }}

--- a/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-deployment.yaml
@@ -103,6 +103,7 @@ spec:
             - name: API_SERVER_URL_OVERRIDE_FOR_HTTP_REQUESTS
               value: "http://{{ include "onyx.fullname" . }}-api-service:{{ .Values.api.service.servicePort }}"
             {{- include "onyx.envSecrets" . | nindent 12 }}
+            {{- include "onyx.metricsAuthEnv" . | nindent 12 }}
             {{- with include "onyx.customCACerts.env" . }}
             {{- . | nindent 12 }}
             {{- end }}

--- a/deployment/helm/charts/onyx/templates/mcp-server-servicemonitor.yaml
+++ b/deployment/helm/charts/onyx/templates/mcp-server-servicemonitor.yaml
@@ -1,8 +1,8 @@
-{{- if .Values.monitoring.serviceMonitors.enabled }}
+{{- if and .Values.monitoring.serviceMonitors.enabled .Values.mcpServer.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ include "onyx.fullname" . }}-api
+  name: {{ include "onyx.fullname" . }}-mcp-server
   labels:
     {{- include "onyx.labels" . | nindent 4 }}
     {{- with .Values.monitoring.serviceMonitors.labels }}
@@ -15,19 +15,14 @@ spec:
   selector:
     matchLabels:
       {{- include "onyx.selectorLabels" . | nindent 6 }}
-      app: {{ .Values.api.deploymentLabels.app }}
+      app: {{ .Values.mcpServer.deploymentLabels.app }}
   endpoints:
-    - port: api-server-port
+    - port: mcp-server-port
       path: /metrics
       interval: 30s
       scrapeTimeout: 10s
-      {{- /* `dig` keeps this nil-safe for `helm upgrade --reuse-values` where an
-             older stored values map may lack auth.metricsAuth entirely. */}}
       {{- $metricsAuth := .Values.auth.metricsAuth | default dict }}
       {{- if dig "enabled" false $metricsAuth }}
-      {{- /* When the /metrics bearer token is enabled, Prometheus must present
-             it. References the chart-managed (or existing) metrics-auth secret;
-             the Prometheus Operator needs RBAC to read it in this namespace. */}}
       authorization:
         credentials:
           name: {{ include "onyx.secretName" $metricsAuth }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1420,15 +1420,14 @@ auth:
     values:
       user_auth_secret: ""
   metricsAuth:
-    # -- Bearer token guarding the API server's /metrics endpoint. /metrics
+    # -- Bearer token guarding the API and MCP servers' /metrics endpoints. /metrics
     # returns 401 by default until you either enable this (provide a token) or
     # explicitly opt out via configMap.DISABLE_METRICS_AUTH="true". When enabled,
     # scrapers must send the token as `Authorization: Bearer <token>` (Prometheus
-    # scrape config: `authorization`), and the api ServiceMonitor below is wired
+    # scrape config: `authorization`), and the ServiceMonitors are wired
     # to send it automatically.
     enabled: false
-    # -- Only inject the token into pods that serve the protected /metrics (the
-    # API server), not every backend pod. Routes through onyx.envSecretsRestricted.
+    # -- Only inject the token into pods that serve protected /metrics.
     allPods: false
     # -- Overwrite the default secret name, ignored if existingSecret is defined
     secretName: 'onyx-metrics-auth'

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -58,9 +58,10 @@ from onyx.server.metrics.my_metric import my_metric_callback
 instrumentator.add(my_metric_callback)
 ```
 
-### 4. Wire it into setup_prometheus_metrics (if infrastructure-scoped)
+### 4. Register infrastructure metrics after resource initialization
 
-For metrics that attach to engines, pools, or background systems, add a setup function and call it from `setup_prometheus_metrics()` in `metrics/prometheus_setup.py`:
+For metrics that attach to engines, pools, or background systems, add a setup
+function and call it from the owning process lifespan after the resource exists:
 
 ```python
 # metrics/my_metric.py
@@ -70,15 +71,13 @@ def setup_my_metrics(resource: SomeResource) -> None:
 ```
 
 ```python
-# metrics/prometheus_setup.py — inside setup_prometheus_metrics()
+# onyx/main.py — lifespan, after resource initialization
 from onyx.server.metrics.my_metric import setup_my_metrics
 
-def setup_prometheus_metrics(app, engines=None) -> None:
-    setup_my_metrics(resource)  # Add your call here
-    ...
+setup_my_metrics(resource)
 ```
 
-All metrics initialization is funneled through the single `setup_prometheus_metrics()` call in `onyx/main.py:lifespan()`. Do not add separate setup calls to `main.py`.
+Keep `setup_prometheus_metrics()` limited to shared HTTP instrumentation.
 
 ### 5. Write tests
 
@@ -129,12 +128,69 @@ These metrics are exposed at `GET /metrics` on the API server.
 | -------------------------------- | ------- | -------------------------------------------- |
 | `SLOW_REQUEST_THRESHOLD_SECONDS` | `1.0`   | Duration threshold for slow request counting |
 
+The API and MCP `/metrics` endpoints require `Authorization: Bearer
+<METRICS_AUTH_TOKEN>`. They fail closed when no token is configured; set
+`DISABLE_METRICS_AUTH=true` only when unauthenticated access is intentional.
+The Helm API and MCP ServiceMonitors automatically reference
+`auth.metricsAuth` when it is enabled.
+
 ### Instrumentator Settings
 
 - `should_group_status_codes=False` — Reports exact HTTP status codes (e.g. 401, 403, 500)
 - `should_instrument_requests_inprogress=True` — Enables the in-progress request gauge
 - `inprogress_labels=True` — Breaks down in-progress gauge by `method` and `handler`
 - `excluded_handlers=["/health", "/metrics", "/openapi.json"]` — Excludes noisy endpoints from metrics
+
+## Connector State Metrics
+
+The API server collects these metrics from Postgres on each scrape. They are
+available only in single-tenant deployments; multi-tenant collection is skipped
+to avoid cross-tenant data exposure.
+
+| Metric                                                    | Type  | Labels                                         | Description                                                   |
+| --------------------------------------------------------- | ----- | ---------------------------------------------- | ------------------------------------------------------------- |
+| `onyx_connector_state_collection_success`                 | Gauge | _(none)_                                       | Whether the latest bounded snapshot read succeeded            |
+| `onyx_connector_last_successful_index_timestamp_seconds`  | Gauge | `source`, `cc_pair_id`                         | Last successful index timestamp; zero means never              |
+| `onyx_connector_last_pruned_timestamp_seconds`            | Gauge | `source`, `cc_pair_id`                         | Last successful prune timestamp; zero means never              |
+| `onyx_connector_last_perm_sync_timestamp_seconds`         | Gauge | `source`, `cc_pair_id`                         | Last permission sync timestamp; zero means never               |
+| `onyx_connector_last_external_group_sync_timestamp_seconds` | Gauge | `source`, `cc_pair_id`                       | Last external-group sync timestamp; zero means never           |
+| `onyx_connector_repeated_error_state`                     | Gauge | `source`, `cc_pair_id`                         | Whether the connector is in a repeated error state             |
+| `onyx_connector_status`                                   | Gauge | `source`, `cc_pair_id`, `status`               | One-hot current connector status                               |
+| `onyx_connector_access_type`                              | Gauge | `source`, `cc_pair_id`, `access_type`          | One-hot connector access type                                  |
+| `onyx_connector_indexing_trigger`                         | Gauge | `source`, `cc_pair_id`, `trigger_mode`         | One-hot indexing trigger; includes `NONE` and `UNKNOWN`         |
+| `onyx_connector_auto_sync_enabled`                        | Gauge | `source`, `cc_pair_id`                         | Whether auto-sync is configured                                |
+| `onyx_connector_count`                                    | Gauge | `source`, `status`                             | Current connector count                                        |
+| `onyx_connector_document_count`                           | Gauge | `source`                                       | Current indexed document count                                 |
+| `onyx_connector_info`                                     | Info  | `cc_pair_id`, connector metadata               | Display name, source, credential ID, status, and access type   |
+
+The collector stops waiting after eight seconds and permits one in-flight read.
+It does not return stale connector samples after a timeout or error; use
+`onyx_connector_state_collection_success` to alert on missing snapshots.
+Display names appear only in the info metric, limiting rename churn to one
+series per connector.
+
+## MCP Metrics
+
+The MCP server exposes its HTTP and custom metrics on its authenticated
+`/metrics` endpoint. MCP client metrics are exposed by the API server because
+that process calls external MCP servers.
+
+| Metric                                  | Process    | Type      | Labels                               | Description                                      |
+| --------------------------------------- | ---------- | --------- | ------------------------------------ | ------------------------------------------------ |
+| `onyx_mcp_server_auth_total`            | MCP server | Counter   | `result`                             | API token verification outcomes                  |
+| `onyx_mcp_server_tool_calls_total`      | MCP server | Counter   | `tool`, `status`                     | Search-tool execution outcomes                    |
+| `onyx_mcp_server_tool_latency_seconds`  | MCP server | Histogram | `tool`                               | Search-tool execution latency                     |
+| `onyx_mcp_server_search_results`        | MCP server | Histogram | `tool`                               | Results returned by search tools                  |
+| `onyx_mcp_server_search_by_source_total`| MCP server | Counter   | `source_type`                        | Searches requesting each deduplicated source      |
+| `onyx_mcp_client_tool_calls_total`      | API server | Counter   | `server_name`, `tool_name`, `status` | Calls from Onyx to external MCP tools             |
+| `onyx_mcp_client_tool_latency_seconds`  | API server | Histogram | `server_name`, `tool_name`           | External MCP tool latency                         |
+
+Server tool statuses describe execution reliability. An empty tenant is a
+successful search with zero results. `onyx_mcp_server_auth_total` records token
+verifier outcomes; use HTTP request metrics as the source of truth for all 401s,
+including requests rejected before verification. Client `server_name` is the
+configured display name. `tool_name` is the execution name and may be sanitized
+or disambiguated when tools collide.
 
 ## Database Pool Metrics
 
@@ -427,6 +483,30 @@ histogram_quantile(0.99, sum by (handler, le) (rate(onyx_db_connection_hold_seco
 ```promql
 # Checkouts per second by engine
 sum by (engine) (rate(onyx_db_pool_checkout_total[5m]))
+```
+
+### Connector snapshot health and staleness
+
+```promql
+# Snapshot read failed or timed out
+onyx_connector_state_collection_success == 0
+
+# No successful indexing in 24 hours; zero ("never") also alerts
+time() - onyx_connector_last_successful_index_timestamp_seconds > 86400
+
+# Connectors currently stuck in repeated errors
+onyx_connector_repeated_error_state == 1
+```
+
+### MCP tool failures
+
+```promql
+# MCP server tool execution failure rate
+sum by (tool) (rate(onyx_mcp_server_tool_calls_total{status="error"}[5m]))
+  / sum by (tool) (rate(onyx_mcp_server_tool_calls_total[5m]))
+
+# External MCP client failures, including authentication errors
+sum by (server_name, tool_name) (rate(onyx_mcp_client_tool_calls_total{status!="success"}[5m]))
 ```
 
 ### OpenSearch P99 search latency by type


### PR DESCRIPTION
This PR runs GitHub Actions CI for #12904.

- [x] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Prometheus metrics for the MCP server and client, plus a scrape-time connector state collector, and exposes authenticated `/metrics` on the MCP FastAPI app. This improves visibility into auth, tool latency/outcomes, search usage, and connector freshness in single-tenant installs.

- **New Features**
  - Expose MCP server `/metrics` with `prometheus_fastapi_instrumentator` and shared bearer auth; add Helm `ServiceMonitor` for the MCP server and scope selectors; inject the metrics token only into API/MCP pods.
  - MCP server: counters for auth results; histograms for tool latency; counts for tool calls and requested source types (deduped/canonicalized); histograms for search result sizes.
  - MCP client: per-server/per-tool latency histograms and outcome counters (success/auth_error/error).
  - Connector state collector: DB-snapshot gauges for last prune/perm-sync/group-sync timestamps; one-hot status/access/trigger; auto-sync; totals by source/status (connectors) and by source (documents); an info metric; and a collection-success gauge. Single bounded query with Postgres statement_timeout and an 8s scrape timeout, allowing at most one in-flight read per scrape; registered in the API lifespan; skipped in multi-tenant.

- **Bug Fixes**
  - Record MCP server tool metrics on all return paths (including early returns and upstream HTTP errors); bound requested source labels to canonical values or "unknown".
  - Derive one-hot label sets from enums for connector metrics to include all current states and guard label cardinality.

<sup>Written for commit e086012c1df83c359e94db9ad6126ebf1764cb9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13086?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



