### PR TITLE
feat(llm): migrate generic custom_config API keys/bases to first-class columns

### DIFF
--- a/backend/alembic/versions/39178a00fbec_normalize_llm_provider_custom_config_.py
+++ b/backend/alembic/versions/39178a00fbec_normalize_llm_provider_custom_config_.py
@@ -1,0 +1,99 @@
+"""normalize llm provider custom config api keys
+
+Revision ID: 39178a00fbec
+Revises: bd38e2a494ff
+Create Date: 2026-07-15 17:53:59.646319
+
+Moves generic ``<PROVIDER>_API_KEY`` / ``<PROVIDER>_API_BASE`` entries out of
+``llm_provider.custom_config`` and into the first-class ``api_key`` /
+``api_base`` columns when those are unset. Historically such entries only
+worked by being injected into ``os.environ`` at call time; the columns are the
+supported path now that env injection is disabled on multi-tenant deployments.
+Keys with no column equivalent are intentionally left in place.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import table
+
+from onyx.utils.encryption import encrypt_string_to_bytes
+
+# revision identifiers, used by Alembic.
+revision = "39178a00fbec"
+down_revision = "bd38e2a494ff"
+branch_labels = None
+depends_on = None
+
+
+def _normalize(value: str) -> str:
+    return value.upper().replace("_", "").replace("-", "")
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+
+    llm_table = table(
+        "llm_provider",
+        sa.Column("id", sa.Integer()),
+        sa.Column("provider", sa.String()),
+        sa.Column("api_key", sa.LargeBinary()),
+        sa.Column("api_base", sa.String()),
+        sa.Column("custom_config", postgresql.JSONB()),
+    )
+
+    rows = connection.execute(
+        sa.select(llm_table).where(llm_table.c.custom_config.isnot(None))
+    )
+
+    for row in rows:
+        custom_config = row.custom_config
+        if not isinstance(custom_config, dict) or not custom_config:
+            continue
+
+        provider_normalized = _normalize(row.provider or "")
+        if not provider_normalized:
+            continue
+
+        new_config = dict(custom_config)
+        new_api_key: bytes | None = None
+        new_api_base: str | None = None
+
+        for key, value in custom_config.items():
+            if not isinstance(value, str) or not value:
+                continue
+            key_normalized = _normalize(key)
+            if (
+                key_normalized == f"{provider_normalized}APIKEY"
+                and row.api_key is None
+                and new_api_key is None
+            ):
+                new_api_key = encrypt_string_to_bytes(value)
+                del new_config[key]
+            elif (
+                key_normalized == f"{provider_normalized}APIBASE"
+                and not row.api_base
+                and new_api_base is None
+            ):
+                new_api_base = value
+                del new_config[key]
+
+        if new_api_key is None and new_api_base is None:
+            continue
+
+        values: dict[str, object] = {"custom_config": new_config}
+        if new_api_key is not None:
+            values["api_key"] = new_api_key
+        if new_api_base is not None:
+            values["api_base"] = new_api_base
+
+        connection.execute(
+            llm_table.update().where(llm_table.c.id == row.id).values(**values)
+        )
+
+
+def downgrade() -> None:
+    # The moved values remain fully functional in the api_key / api_base
+    # columns on older code (explicit params always won over env vars), so
+    # there is nothing to restore.
+    pass


### PR DESCRIPTION
## Summary

Second of a 3-PR stack (2/3), on top of #13087.

Data migration `39178a00fbec`: moves generic `<PROVIDER>_API_KEY` / `<PROVIDER>_API_BASE` entries out of `llm_provider.custom_config` into the first-class (encrypted) `api_key` / `api_base` columns when those are unset, using the same case/underscore/dash-insensitive key matching as the runtime kwarg mapping from #13087.

Historically these entries only worked by being injected into `os.environ` at call time; the columns are the supported path now that env injection is disabled on multi-tenant deployments. Because explicit columns always won over env vars, the migration is behavior-preserving — hence the no-op downgrade. Keys with no column equivalent are intentionally left in place (they drop with a call-time warning; write-time rejection lands in the next PR of the stack).

This must be deployed before the write-time validation PR so existing providers are normalized before edits to them start being validated.

## Test Plan

- Migration is a straightforward data backfill; validated by inspection + the runtime mapping tests in #13087 which cover the same key-matching logic.
- `alembic heads` resolves to a single head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backfills LLM provider API credentials from legacy `custom_config` into first-class columns to remove reliance on env var injection. Preserves behavior and prepares providers for upcoming validation.

- **Migration**
  - Moves `<PROVIDER>_API_KEY` and `<PROVIDER>_API_BASE` from `llm_provider.custom_config` into `api_key` (encrypted) and `api_base` when columns are empty.
  - Matches keys case/underscore/dash-insensitively, consistent with runtime mapping.
  - Leaves non-mapped or non-string keys in place; downgrade is a no-op.
  - Deploy before enabling write-time validation so existing providers are normalized.

<sup>Written for commit 8b2c8d9c8372ac962b6f5d76848c6769aa413af1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

