### PR TITLE
feat(mobile): agentic timeline grouping engine + packet contracts

### DIFF
--- a/docs/mobile-chat/9b-timeline/00-index.md
+++ b/docs/mobile-chat/9b-timeline/00-index.md
@@ -1,0 +1,31 @@
+# Mobile Chat 9b — Agentic Reasoning Timeline
+
+> Status: **active** — feature-flow complete (all 5 gated artifacts + plan-challenge). Ready to execute PR-by-PR.
+
+Sub-phase 9b of the deferred rich-chat work in `../05-pr-roadmap.md` (the parent mobile-chat roadmap). A
+**faithful 1:1 port of web's agent timeline shell** (`web/src/app/app/message/messageComponents/**`) to the React
+Native app, wiring **only the reasoning renderer**. Approach **C — Faithful Shell First** (owner: "match web, no
+refactor later, want everything"). Every tool renderer (search/fetch/python/custom-tool/deep-research/memory) and
+9c–9e is an immediate follow-up PR on the **zero-refactor seam** this phase builds. Builds on the 9a foundation
+(`../9a-citations/`, shipped #13025). No backend/DB changes.
+
+## Artifacts
+
+1. [01-research.md](01-research.md) — requirement, locked scope, codebase + backend + web + industry findings, the
+   three approaches, and the chosen one (C).
+2. [02-high-level-design.md](02-high-level-design.md) — end-to-end flow, component interaction diagram, key decisions.
+3. [03-detailed-design.md](03-detailed-design.md) — exact contracts, new files, file tree, per-file responsibilities,
+   integration points, the two ref-restructures, the documented divergences.
+4. [04-implementation-plan.md](04-implementation-plan.md) — CLAUDE.md-format plan + appended plan-challenge results
+   (all six pass; web-verified).
+5. [05-pr-roadmap.md](05-pr-roadmap.md) — the 7-PR delivery sequence (9b.1 engine → … → 9b.7 composition/device gate).
+
+Supporting reference (gitignored): `.context/pr9b-deepread/*.md` — verbatim web timeline contracts extracted for
+the faithful port.
+
+## One-line summary
+
+Port web's agent reasoning timeline shell to mobile 1:1 (grouping engine + `section_end` synthesis + pacing +
+7-state machine + render-prop renderer contract + StepContainer/collapse), wiring only the reasoning renderer;
+delivered as 7 layered PRs so the tool renderers drop in later with zero refactor. One accepted, platform-forced
+divergence: the two ref-during-render hooks are restructured (behavior-preserving) to satisfy `react-hooks/refs`.

--- a/docs/mobile-chat/9b-timeline/01-research.md
+++ b/docs/mobile-chat/9b-timeline/01-research.md
@@ -1,0 +1,250 @@
+> Status: draft · Task: 9b-timeline · Parent: `../05-pr-roadmap.md` (PR 9b) · Prior phase: `../9a-citations/` (shipped #13025)
+
+# Mobile Chat 9b — Agentic Reasoning Timeline · Research
+
+## Requirement
+
+Port web's chat **agentic reasoning timeline** (`AgentTimeline` — reasoning/search/tool sub-steps with step
+containers, headers, icons, connector lines, collapse/expand) to the Onyx React Native + Expo mobile app
+(`mobile/`), at **web parity** (match web's look AND structure), extending the 9a foundation and registering
+into the PR-3 renderer dispatch. Backend is unchanged. This is the rich-chat phase that additionally builds the
+**`AgentTimeline` composition layer** that every later phase (search/fetch/tool renderers, 9c–9e) plugs into.
+
+## Clarifications
+
+- **Scope of 9b (locked, owner 2026-07-16): FOUNDATION-ONLY FIRST.** The thinnest walking skeleton of the
+  timeline — (1) the turn/tab **grouping engine**, (2) the **`AgentTimeline` composition layer** (real steps +
+  collapse/expand), (3) the **reasoning** step renderer only (`reasoning_start/delta/done`). **Every tool
+  renderer is a separate follow-up phase**: internal/web search, fetch/open_url, python/code, coding-agent+bash,
+  custom-tool, deep-research + nested (`sub_turn_index`) agents, memory. Image generation is a separate phase
+  (9e). Multi-model (`model_index`) is out (mobile is single-model) but the grouping must **tolerate** non-zero
+  `model_index`. Parallel-tool tabs (`tab_index` parallelism) are a follow-up, but the grouping key + data model
+  should not **preclude** them.
+- **Web parity is required** (per `../05-pr-roadmap.md` PR 9a–9e callout): match web's look AND structure; port
+  the step-container/header/icon/connector/collapse shape, don't invent a new mobile timeline. Document any
+  platform-driven divergence.
+- **Chat layer is native** (`mobile/src/chat/`, NOT `@onyx-ai/shared`) per the PR-2 decision. Web is untouched.
+  Backend is unchanged (reasoning packets already exist).
+
+## Current status & reuse (from codebase scan — exact paths, validated by direct read)
+
+**The 9b seams already exist and are explicitly reserved:**
+
+- `mobile/src/chat/messageProcessor.ts` — flat, cursor-incremental (`nextPacketIndex`) packet→state reducer.
+  `ProcessedMessageState = {nodeId, nextPacketIndex, citationMap, citations, seenCitationDocIds, documentMap,
+  isComplete, stopReason}`. **Header comment: _"9b extends it with turn/tab grouping + timeline steps, so the
+  shape here stays deliberately flat (grouping-free)."_**
+- `mobile/src/components/chat/AgentTimeline.tsx` — **existing stub**: 36px rail (`w-36`), 24px `AgentAvatar`,
+  reanimated shimmer `ThinkingLabel`, and a `TimelineStep` list primitive (`TimelineStepData = {key, label,
+  status:"running"|"done"|"error", icon?}`; connector lines `h-8 w-[1px] bg-border-01` with `opacity-0` on
+  first/last; fallback node dot `h-8 w-8 rounded-full bg-text-04`; step `Icon size=12`). **`steps` prop always
+  `[]` — nothing populates it.** Rendered in `MessageRow.AssistantMessage` **above** the answer:
+  `<AgentTimeline agent isLoading={!hasContent && !processed.isComplete} />`.
+- `mobile/src/components/chat/renderers/registry.ts` — `MessageRenderer = {matches(packets), Component}`;
+  `MessageRendererProps = {packets, processed}`; first-match-wins `RENDERERS`; `findRenderer`. **Simpler than
+  web's render-prop `MessageRenderer<T,S>`.** Only `MessageTextRenderer` registered.
+- `mobile/src/hooks/usePacketDisplay.ts` — `processed = useMemo(() => processPackets(createInitialState(nodeId),
+  packets), [nodeId, packets])` — **full recompute per flush** (array identity changes each flush).
+  **Deliberately NOT a render-mutated ref** — mobile's `react-hooks/refs` lint forbids `ref.current` access
+  during render, so **web's ref-held `usePacketProcessor` pattern is illegal here.**
+- `mobile/src/components/chat/MessageRow.tsx` — `AssistantMessage`: `usePacketDisplay(node)` →
+  `<Renderer packets processed/>` inside `<View className="px-12">`; `AgentTimeline` above; `CitedSources` (9a)
+  below. `hasContent = Renderer != null && packets.length > 0`.
+- `mobile/src/chat/streamingModels.ts` — `PacketType` currently: `MESSAGE_START/DELTA/END`, `STOP`,
+  `SECTION_END`, `ERROR`, `CITATION_INFO`, `SEARCH_TOOL_DOCUMENTS_DELTA`, `OPEN_URL_DOCUMENTS`. **`Placement`
+  already carries all 4 fields** (`turn_index`, `tab_index`, `sub_turn_index`, `model_index`). Must **add**
+  `REASONING_START/DELTA/DONE` (+ `TOP_LEVEL_BRANCHING` for grouping tolerance).
+- `mobile/src/chat/contracts/documents.ts` — full `SearchDoc`/`StreamingCitation`/`CitationMap` (9a). Reused by
+  the **deferred** search/fetch renderers, not by reasoning.
+- 9a source-UI (`SourceRow`/`SourceIcon`/`openSource`/`CitedSources`) — reusable by the **deferred** search/fetch
+  renderers.
+
+**Backend (reasoning packets — already emitted, no backend change):** `ReasoningStart type="reasoning_start"`
+(no fields), `ReasoningDelta type="reasoning_delta" {reasoning: str}`, `ReasoningDone type="reasoning_done"`,
+from `backend/onyx/chat/llm_step.py`, carrying `Placement.turn_index/tab_index`. **There is NO `message_end` on
+the wire** — the whole turn completes only via `OverallStop (type="stop")`. **`SECTION_END` is usually
+client-synthesized** (web injects it into prior groups on a new `turn_index` and into all open groups on STOP —
+this is how a step is marked "complete"). `TopLevelBranching {num_parallel_branches}` is pre-parallel metadata.
+
+**Web source-of-truth (parity target), all under `web/src/app/app/message/messageComponents/`:**
+
+- Grouping: `timeline/hooks/packetProcessor.ts` (group by `${turn_index}-${tab_index ?? 0}`, synthesize
+  `SECTION_END`, categorize tool/display groups) → `timeline/transformers.ts` (`GroupedPacket[]` →
+  `TransformedStep[]` → `TurnGroup[]`; `isParallel = >1 step share a turn_index`).
+- Composition: `AgentMessage.tsx` runs `usePacketProcessor` + `usePacedTurnGroups` (200ms staggered reveal) →
+  `<AgentTimeline>` above + final-answer `RendererComponent` below.
+- Shell: `AgentTimeline.tsx` + `useTimelineUIState` (7 states: `EMPTY / DISPLAY_CONTENT_ONLY /
+  STREAMING_SEQUENTIAL / STREAMING_PARALLEL / STOPPED / COMPLETED_COLLAPSED / COMPLETED_EXPANDED`) +
+  `useTimelineExpansion` (default collapsed; auto-collapse on stop/answer-start unless `userHasToggled`) +
+  `useTimelineHeader` (shimmer header text) + `useTimelineMetrics`.
+- Per-step: `TimelineRendererComponent` (per-step `isExpanded`, `renderType = override ?? (isExpanded?FULL:COMPACT)`)
+  + `StepContainer` (`TimelineIconColumn` rail + `TimelineSurface` tint + `TimelineStepContent` header+collapse+body);
+  Done/Stopped terminal step appended.
+- Renderer contract (`interfaces.ts`): **render-prop** `MessageRenderer<T,S>` — computes `RendererResult[]`
+  (`{icon, status, content, expandedText?, supportsCollapsible?, alwaysCollapsible?, timelineLayout?,
+  noPaddingRight?, surfaceBackground?}`) and calls `children(results)`; the parent `StepContainer` owns the wrapper.
+- Reasoning renderer: `timeline/renderers/reasoning/ReasoningRenderer.tsx` — `SvgCircle` icon, status
+  `"Thinking"` (or extracted markdown heading), `ExpandableTextDisplay` of streamed reasoning markdown, 500ms
+  min-thinking gate.
+
+**Mobile primitives + gotchas (from render-infra scan):** available — `View`, `Text` (font+color enum), `Icon`,
+`Separator`, `Button`, `Card`, `Content/ContentAction`, `Spinner` (RN `Animated`, jest-safe), `StreamingMarkdown`
+(enriched-markdown; colors must resolve to concrete hex via `varsLight/varsDark` + `textPresets` from
+`@onyx-ai/shared/native` — NativeWind classes don't apply inside the markdown lib), `reanimated 4.3.1` (shimmer
+today; `ChatSurface` uses `LinearTransition/FadeIn/FadeOut`). **No `Collapsible`/`Accordion` primitive exists** —
+expand/collapse is net-new (ASK owner: port web UX vs compose reanimated). **No chevron-up** (rotate
+`chevron-down`); **no brain/reasoning icon** and **no plain circle** glyph (web reasoning uses `SvgCircle`) —
+adding an icon is a small owner-port decision. NativeWind spacing is **pixel-valued** (class number == px). No
+hover on RN (drop web `isHover` branches). **reanimated jest gotcha**: keep pure logic (grouping / step
+derivation / state machine) in reanimated-free modules; import leaf components directly. Streaming re-render
+perf: memoize rows, coalesce updates; auto-collapse height animation can jank mid-stream (prefer fixed-height
+summary + tap-to-expand). Accessibility: trigger = `accessibilityRole="button"` + `accessibilityState={{expanded}}`;
+collapsed children removed from AX/focus tree.
+
+## Industry best practices
+
+- **Progressive disclosure is the mainstream** — collapse-by-default; during streaming show a compact
+  "Thinking… (Ns)" label with an animated glyph + elapsed timer; auto-collapse to a one-line summary on
+  completion; **do not dump full chain-of-thought by default** (DeepSeek-style firehose is called out as
+  overwhelming). — <https://www.digestibleux.com/p/how-ai-models-show-their-reasoning>
+- **Agent-UX "Activity Timeline"** — collapsible verbosity, a pinned "current step", tiered transparency; a
+  scrolling chat thread is a poor workflow tracker, so a structured timeline (not inline text) is the right
+  container. — <https://hatchworks.com/blog/ai-agents/agent-ux-patterns/>
+- **Touch disclosure accessibility** — trigger must expose expanded/collapsed state; a collapsed panel's children
+  must be removed from the AX/focus tree, not just visually hidden. — <https://www.w3.org/WAI/ARIA/apg/patterns/accordion/>,
+  <https://webaim.org/techniques/disclosures/>
+- **RN streaming re-render pitfalls** — memoize rows (`React.memo`) + `useCallback` `renderItem`; don't hand every
+  row fresh object/function identities each tick; coalesce/throttle stream `setState` (don't setState per token).
+  — <https://reactnative.dev/docs/optimizing-flatlist-configuration>
+- **Hover→touch trap** — every desktop hover-reveal must become an always-visible or explicit-tap affordance with
+  a real hit target (RN has no hover at all). — <https://uxpickle.com/alternatives-to-hover-interaction-on-touchscreens/>
+- **RN timeline/step-indicator libs are thin/unmaintained** — expect to **build** the rail/dot/collapsible node
+  from primitives; existing libs are linear form-wizard steppers, not streaming/nested timelines. —
+  <https://www.npmjs.com/package/react-native-step-indicator>
+
+## Approaches
+
+### Approach A — Simplicity-First: "Lean Steps" (grouping-in-processor + reasoning leaf into the existing rail)
+
+Extend exactly two existing seams and add one leaf. The grouping lives **inside** the already-pure
+`messageProcessor` (emits a new `steps: TimelineStep[]` on `ProcessedMessageState`), so the whole
+`usePacketDisplay` full-recompute-per-flush path stays untouched and jest-safe. Feed the **existing**
+`AgentTimeline` stub real reasoning steps and add one `ReasoningStep` leaf (streamed `StreamingMarkdown` body +
+tap-to-toggle collapse, leaf-local elapsed timer). The flat `{packets, processed}` renderer contract is preserved
+verbatim — **reasoning is timeline-resident, not a registry renderer**, so `findRenderer`/`RENDERERS` and the 9a
+citations path are undisturbed. No web machinery ported (no render-prop contract, no 7-state machine, no pacing).
+
+- **Files:** MODIFY `streamingModels.ts` (+4 enum, +4 interfaces), `messageProcessor.ts` (grouping →
+  `steps`/`stepByKey`), `AgentTimeline.tsx` (render `TimelineStep[]`, `switch(kind)`), `MessageRow.tsx` (pass
+  steps; refine `isLoading`); NEW `ReasoningStep.tsx`, reasoning grouping unit tests.
+- **Est:** ~360–420 LOC, **1 PR**.
+- **Trade-off:** smallest surface, zero risk to 9a, fully unit-testable pure grouping; but no pacing / no 7-state
+  header / no per-step render-prop contract, and the 2nd renderer slots in via a new `kind` + a `case` (not
+  `findRenderer`), i.e. a bounded refactor of `AgentTimeline` when a real tool needs tint surfaces / per-step
+  collapse.
+- **Follow-up fit:** each deferred phase adds a `kind` + reducer cases + a leaf + one `case`; 9a's SourceRow drops
+  into search/fetch leaves; the heavier machinery (pacing, render-prop `RendererResult`) is introduced as a
+  bounded evolution of this seam **when a real tool justifies it**, not before.
+
+### Approach B — Flexibility-First: "The Extensible Step Seam"
+
+A pure turn/tab **grouping module** (`chat/timeline/grouping.ts`) runs **alongside** the existing flat
+`processPackets` (both hosted via `useMemo`, honoring the refs-lint ban), producing `TurnGroup[]` of
+`TransformedStep[]`. Each step is resolved by a **priority-ordered step registry** (mirroring web `findRenderer`)
+to a step renderer that returns a mobile analog of web's **`RendererResult` data contract (NOT JSX)** — a plain
+object return, simpler than web's render-prop but equally extensible. A single **`StepContainer`** (rail + tinted
+surface + header + collapse body) owns all chrome; renderers never draw their own wrapper. Reasoning is renderer
+#1 (and last-in-chain fallback). `messageProcessor` stays flat (grouping is a sibling, honoring its header
+comment). Adds a lean `useTimelineExpansion` + lean `useTimelineUIState`, and a net-new `Collapsible` primitive +
+reasoning icon (both owner-ASK).
+
+- **Files:** NEW `chat/timeline/{grouping,stepContract,stepRegistry}.ts`,
+  `chat/timeline/renderers/reasoning/ReasoningRenderer.tsx`, `components/chat/timeline/StepContainer.tsx`,
+  `components/chat/timeline/{useTimelineExpansion,useTimelineUIState}.ts`, `components/ui/collapsible.tsx`
+  (ASK), `icons/reasoning-circle.tsx` (ASK); MODIFY `streamingModels.ts`, `usePacketDisplay.ts` (+turnGroups),
+  `AgentTimeline.tsx`, `MessageRow.tsx`.
+- **Est:** ~1,810 LOC (prod+test), **2 PRs** — 9b-1 pure engine (grouping + contract + registry + reasoning
+  derivation + tests, no UI), 9b-2 UI + wiring (Collapsible, StepContainer, expansion/uiState, view layer,
+  AgentTimeline rewrite).
+- **Trade-off:** every deferred phase is a single new file (predicate + renderer returning `RendererResult`) with
+  zero edits to grouping/container/collapse/MessageRow — retrofit cost amortized to ~0; but ~2× the LOC of A and
+  it introduces contract fields (`alwaysCollapsible`, `timelineLayout`) that reasoning barely exercises (some
+  speculative until phase 2), plus 2 owner-gated artifacts add decision latency.
+- **Follow-up fit:** near-perfect — this **is** the seam. search/fetch reuse 9a's SourceRow verbatim; parallel
+  tabs already distinguished in the key; `model_index` tolerated; nesting is the only phase that may extend
+  `groupStepsByTurn`.
+
+### Approach C — Full-Parity: "Faithful Shell First"
+
+Port web's **entire timeline shell 1:1 now** — grouping + `transformers` + `usePacedTurnGroups` (200ms stagger) +
+the full `useTimelineUIState` (7 states) + `useTimelineExpansion` + `useTimelineHeader` + `useStreamingDuration`
+(live "Ns"/"Thought for {duration}") + `useTimelineMetrics` + the render-prop renderer contract + `StepContainer`
++ `TimelineRendererComponent` + Streaming/Stopped/Completed headers + Done/Stopped terminal step — wiring **only**
+the reasoning renderer body. Keeps mobile's recompute-per-flush model (web's ref-held `usePacketProcessor` is
+illegal here) by making grouping a pure function; `usePacedTurnGroups` must be **restructured off web's
+render-time ref reads** to satisfy the refs lint. The shell is behaviorally indistinguishable from web with
+reasoning-only content, so deferred phases only add renderer bodies.
+
+- **Files:** ~22 new + 6 modified (grouping, transformers, interfaces, pacing hook, 4 state/header/metrics hooks,
+  duration hook, 3 rail/surface/content primitives, StepContainer + TimelineRendererComponent, 3 header
+  components, ReasoningRenderer, Collapsible/ExpandableTextDisplay (ASK), circle icon, AgentTimeline rewrite;
+  MODIFY `streamingModels`, `usePacketDisplay`, `MessageRow`, `registry`).
+- **Est:** ~3,700–4,300 LOC, **honestly 5–6 PRs** (wire → pacing → state → primitives → renderer → headers+composition).
+- **Trade-off:** shell is web-faithful day one (header/timer/auto-collapse/stagger/Done-Stopped/tint surfaces) and
+  every deferred renderer is a pure additive with zero shell rework and zero drift; but by far the most LOC/review
+  surface for a reasoning-only phase, large tracts of the 7-state machine ship as **dead paths** until parallelism
+  exists, pacing + auto-collapse height animation add real streaming-perf/jank risk, and `usePacedTurnGroups`
+  (restructured off render-time refs) is the highest-bug-density file with behavioral-divergence risk.
+- **Follow-up fit:** best-in-class — parallel-tab data model + `sub_turn_index`/`model_index` tolerance built-in
+  and dormant; but that maximal extensibility is the entire justification for paying the shell cost up front.
+
+## Cross-comparison
+
+- **LOC / PRs:** A ≈ 400 (1 PR) · B ≈ 1,800 (2 PRs) · C ≈ 4,000 (5–6 PRs). All three add the same
+  `streamingModels` packet types and the same grouping **key** (`${turn_index}-${tab_index ?? 0}`, `model_index`
+  ignored) — they diverge only on how much shell/contract is built now.
+- **Refs-lint constraint** binds all three: none may port web's render-mutated `usePacketProcessor` ref; grouping
+  is a pure `useMemo`. C carries the most risk here (pacing hook restructure).
+- **Extensibility vs YAGNI:** A defers the render-prop/pacing/state-machine until a 2nd renderer proves the shape
+  (risk: bounded `AgentTimeline` refactor later); B front-loads the **data contract + registry** (the genuinely
+  expensive-to-retrofit part) but not pacing/full-state; C front-loads **everything** (risk: dead code + jank +
+  porting a moving target).
+- **Parity now:** only C makes the *shell* web-faithful immediately (shimmer header text, live timer, staggered
+  reveal, auto-collapse-on-answer, Done/Stopped). A and B render reasoning correctly but with a simpler shell;
+  the roadmap's parity requirement is about *look AND structure* — reasoning-only, A/B can still match the
+  step/rail/collapse shape while deferring the header state machine.
+- **Owner-ASK artifacts:** A needs none (no new primitive/icon). B and C both need the `Collapsible` primitive +
+  a reasoning icon decision before UI lands.
+
+## Chosen approach
+
+**Approach C — "Faithful Shell First" (Full parity).** Selected at GATE 1 (owner, 2026-07-16).
+
+**Owner directive (verbatim intent):** _"I want something that matches web. I am going to build the renderers
+immediately — current PR goes in [first], then the renderers. I don't want any refactor later. I'm fine with any
+number of lines — I want everything, whatever way we need it. Just don't drift away from web."_
+
+**What this means for 9b:**
+
+- Port web's **entire timeline shell 1:1**: the render-prop `MessageRenderer<T,S>` contract + `RendererResult` /
+  `RenderType` (HIGHLIGHT/FULL/COMPACT/INLINE), the pure grouping (`packetProcessor` → `transformers`),
+  `usePacedTurnGroups` (200ms staggered reveal), the full `useTimelineUIState` (7 states) + `useTimelineExpansion`
+  + `useTimelineHeader` + `useStreamingDuration` + `useTimelineMetrics`, `StepContainer` +
+  `TimelineRendererComponent` + the rail/surface/content primitives, the Streaming/Stopped/Completed headers, and
+  the Done/Stopped terminal step. Adopt **web's render-prop renderer contract exactly** (not Approach B's
+  simplified data-object) so each future web renderer ports **near-mechanically**.
+- Wire **only the reasoning renderer** body in 9b. The dormant parallel-tab state (`isParallel`,
+  `STREAMING_PARALLEL`, `showParallelTabs`) and `sub_turn_index`/`model_index` tolerance ship with the shell (as
+  in web) so parallelism / nesting / multi-model are later **UI-only** follow-ups with no seam change.
+- **Scope of the 9b feature-flow (confirmed):** this spec covers the **full shell + reasoning renderer** only.
+  Each tool renderer (internal/web search, fetch/open_url, python/code, coding-agent+bash, custom-tool,
+  deep-research + nested agents, memory) is its **own immediate follow-up PR** on the zero-refactor seam, spec'd
+  per-phase (grill-first) as the owner builds it — not designed here. The design must nonetheless fully specify
+  the render-prop contract + the per-tool renderer **inventory/dispatch** so those follow-ups are mechanical.
+
+**The one accepted divergence from web (platform-forced, behavior-preserving):** web's `usePacketProcessor` and
+`usePacedTurnGroups` read `stateRef.current` **during render** (reset detection / bypass), which mobile's
+`react-hooks/refs` lint **forbids**. These are restructured to a `useMemo`-recompute + effect-only-ref-write model
+that preserves the same grouping output and the same 200ms reveal timing. This is an implementation-level
+necessity, **not** a look/structure drift — the rendered timeline is web-faithful. Documented in `03-detailed-design.md`.
+

--- a/docs/mobile-chat/9b-timeline/02-high-level-design.md
+++ b/docs/mobile-chat/9b-timeline/02-high-level-design.md
@@ -1,0 +1,176 @@
+> Status: active · Task: 9b-timeline · Approach: **C — Faithful Shell First (full web parity)**
+
+# Mobile Chat 9b — Agentic Reasoning Timeline · High-Level Design
+
+## What it does
+
+When the assistant "thinks" or runs tools before answering, web shows an **agent timeline** above the answer — a
+vertical rail of steps (a reasoning "Thinking" step, search/tool steps, …), each with an icon, a status header,
+a connector line, and a body you can collapse/expand; while streaming it shows a shimmering "Thinking… (12s)"
+header that **auto-collapses** into a "Thought for 12s · 3 steps" pill once the answer starts. 9b ports that
+**entire timeline shell to mobile, 1:1**, and wires the **reasoning** step. Every other step type (search, fetch,
+python, custom-tool, deep-research, memory) is a later drop-in renderer — the shell already knows how to place it.
+
+## How it works (end-to-end walkthrough)
+
+The mobile chat stream is a flat list of `Packet`s (`{placement, obj}`) that grows as the model streams. Today
+each assistant message runs one flat pass over those packets (`messageProcessor`) to pull out citations/documents
+and mounts a single answer renderer. 9b inserts web's **grouping + pacing + state-machine** layer between the raw
+packets and the on-screen timeline, faithfully mirroring web's `AgentMessage`:
+
+1. **Group.** A pure reducer walks the packets and buckets them into **steps** by a grouping key
+   `"{turn_index}-{tab_index}"` (from each packet's `placement`). A new `turn_index` closes out ("completes")
+   every earlier step by **synthesizing a `section_end`** into it; the final `stop` packet closes whatever's left.
+   This is exactly how web decides a step is done — the backend rarely sends `section_end` itself. Steps are then
+   arranged into **turn groups** (steps that share a `turn_index` are "parallel"; single ones are "sequential").
+
+2. **Pace.** A stateful hook reveals steps with a **200 ms stagger** (first step immediately, the rest one every
+   200 ms; a `stop` flushes them all at once). It also **withholds the final answer** until the tool steps have
+   finished animating in — so the answer never pops in before the timeline. A history-reloaded (already-complete)
+   message **bypasses** pacing and shows everything instantly.
+
+3. **Derive UI state.** A pure state machine turns "what's streaming / stopped / expanded" into one of **seven
+   states** (EMPTY, DISPLAY_CONTENT_ONLY, STREAMING_SEQUENTIAL, STREAMING_PARALLEL, STOPPED, COMPLETED_COLLAPSED,
+   COMPLETED_EXPANDED) plus a set of "show this / round that" booleans. Separate small hooks compute the **header
+   text** (from the current step's first packet — "Thinking", "Searching the web", …), the **live elapsed timer**
+   (1/sec, frozen once the backend reports a duration), the **step count**, and the **expand/collapse** state
+   (default collapsed; **auto-collapses** when the answer begins, unless the user manually toggled it).
+
+4. **Render.** The **timeline shell** draws the agent avatar in a 36 px rail, the header (a shimmering
+   "Thinking…" while streaming, a "Thought for X · N steps" fold button when done), and — when expanded — the
+   full step list. Each step is drawn by a **`StepContainer`** (icon rail + connector line + tinted surface +
+   header + collapsible body). A **`TimelineRendererComponent`** owns each step's expanded/collapsed state and
+   picks the renderer via **`findRenderer`** (web's priority-ordered dispatch, reasoning last). The renderer is a
+   **render-prop component**: it computes a small `RendererResult` (`{icon, status, content, …}`) and hands it to
+   the container, which owns the visual frame. For 9b the one wired renderer is **`ReasoningRenderer`**, which
+   accumulates the streamed reasoning markdown, extracts a heading for the step title, enforces a 500 ms minimum
+   "Thinking" display, and renders the body via mobile's `StreamingMarkdown`.
+
+5. **Answer + sources.** Below the timeline, the **final answer** renders through the same renderer contract at
+   `FULL` (mobile's existing `MessageTextRenderer`, migrated to the render-prop contract), and the 9a **Sources**
+   bar renders below that — both unchanged in behavior.
+
+## Component interaction
+
+```
+ assistant node.packets[]  (flat Packet[], grows each stream flush)
+            │
+            ▼
+ ┌───────────────────────────────────────────────────────────────────────┐
+ │ MessageRow.AssistantMessage   (mobile analog of web AgentMessage)       │
+ │                                                                         │
+ │   usePacketProcessor(packets, nodeId)                                   │
+ │     └─ messageProcessor.processPackets  (PURE reducer: grouping +       │
+ │        section_end injection + citations/docs + finalAnswerComing)      │
+ │        → toolGroups, displayGroups, citations, stopPacketSeen, …        │
+ │     └─ transformers.groupStepsByTurn → toolTurnGroups: TurnGroup[]      │
+ │                                                                         │
+ │   usePacedTurnGroups(toolTurnGroups, displayGroups, stop, node, final)  │
+ │     └─ 200ms staggered reveal (timer)                                   │
+ │        → pacedTurnGroups, pacedDisplayGroups, pacedFinalAnswerComing    │
+ │                                                                         │
+ │   ┌── <AgentTimeline turnGroups=pacedTurnGroups … />  ── (ABOVE) ──┐    │
+ │   │     useTimelineUIState (7 states) · useTimelineExpansion       │    │
+ │   │     useTimelineHeader · useStreamingDuration · useMetrics      │    │
+ │   │     header switch → StreamingHeader / CompletedHeader / Stopped│    │
+ │   │     ExpandedTimelineContent → per step:                        │    │
+ │   │        TimelineStep → TimelineRendererComponent (owns expand)  │    │
+ │   │          → findRenderer(step.packets) → ReasoningRenderer      │    │
+ │   │             → children([RendererResult]) → StepContainer wraps │    │
+ │   │        + Done / Stopped terminal step                          │    │
+ │   └─────────────────────────────────────────────────────────────── ┘   │
+ │                                                                         │
+ │   pacedDisplayGroups → <RendererComponent renderType=FULL/> (BELOW)     │
+ │      → findRenderer → MessageTextRenderer → StreamingMarkdown answer    │
+ │                                                                         │
+ │   <CitedSources/>  (9a, unchanged)                                      │
+ └───────────────────────────────────────────────────────────────────────┘
+```
+
+## Key components
+
+- **`messageProcessor` (grouping engine)** — extended from the 9a flat reducer into a faithful port of web's
+  `packetProcessor`: turn/tab grouping, client-side `section_end` synthesis, tool/display categorization,
+  `finalAnswerComing`, `stopPacketSeen`, image counters — plus the existing 9a citations/documents. (modified)
+- **`transformers` / `packetUtils` / `packetHelpers` / `toolDisplay`** — pure helpers ported verbatim from web:
+  step→turn grouping, packet categorizers, per-family predicates, tool name/completion/key parsing. (new)
+- **`usePacketProcessor` / `usePacedTurnGroups`** — the two hooks that host the reducer + drive the 200 ms
+  reveal. **These are the only two files that need a lint-forced restructure** (see decisions). (new)
+- **`useTimelineUIState` / `useTimelineExpansion` / `useTimelineHeader` / `useStreamingDuration` /
+  `useTimelineMetrics` / `useTimelineStepState`** — the pure state/derive hooks, ported 1:1. (new)
+- **Renderer contract** — `RenderType`, `RendererResult`, `MessageRenderer<T,S>` render-prop type, `findRenderer`
+  priority dispatch, `TimelineRendererComponent`, `RendererComponent` — ported exactly so future tool renderers
+  are mechanical drop-ins. (new; `registry.ts` + `MessageTextRenderer` migrated to it) (modified)
+- **Timeline UI** — `AgentTimeline` (rewritten from the stub), `StepContainer`, `TimelineRendererComponent`,
+  `ExpandedTimelineContent`, `TimelineStep`, `CollapsedStreamingContent`, the rail/surface/content **primitives**,
+  and the **headers** (Streaming/Completed/Stopped; Parallel stubbed). (new + `AgentTimeline` modified)
+- **`ReasoningRenderer`** — the one wired renderer: reasoning-state accumulation + heading extraction + 500 ms
+  min-thinking + `StreamingMarkdown` body. (new)
+- **Packet contracts** — the full web `PacketType` enum + the reasoning/branching/tool-arg interfaces the engine
+  and shell dereference. (modified `streamingModels.ts`)
+
+## End-to-end scenario
+
+User asks a reasoning model a question in an existing chat:
+
+1. User sends. The stream begins; `AgentTimeline` shows the avatar + a shimmering **"Thinking…"** (state EMPTY).
+2. `reasoning_start` then `reasoning_delta` packets arrive (turn 0). The grouping engine opens step `"0-0"`; the
+   header switches to **STREAMING_SEQUENTIAL** and shimmers **"Thinking"**; the collapsed streaming preview shows
+   the latest lines of the reasoning markdown scrolling in; the elapsed timer ticks **"3s… 4s…"**.
+3. The model finishes thinking (`reasoning_done`, or a new turn / `message_start`). The reasoning step is marked
+   **done** (synthesized `section_end`); a `message_start` sets `finalAnswerComing`; the timeline **auto-collapses**
+   into **"Thought for 6s · 1 step"**.
+4. `message_delta` packets stream the answer through `MessageTextRenderer` **below** the (now collapsed) timeline;
+   the 9a **Sources** bar appears if the answer cited documents.
+5. `stop` ends the run. Tapping the "Thought for 6s" pill **expands** the timeline, showing the full reasoning
+   step (icon rail + "Thinking" header + reasoning markdown) and a terminal **"Done"** step.
+6. Reopening the chat later hydrates the saved packets, **bypasses pacing**, and renders the collapsed timeline +
+   answer instantly.
+
+## Sequence of key operations
+
+1. Stream flush appends packets to the assistant node → `usePacketProcessor` recomputes the grouped state.
+2. Reducer groups by `"{turn}-{tab}"`, synthesizes `section_end` on turn-transition / `stop`, categorizes
+   tool-vs-display groups, tracks `finalAnswerComing` / `stopPacketSeen` / citations / documents.
+3. `groupStepsByTurn` → `TurnGroup[]`; `usePacedTurnGroups` reveals steps at 200 ms and gates the answer.
+4. `AgentTimeline` derives the UI state, header text, elapsed time, expansion; renders header + (if expanded)
+   `ExpandedTimelineContent`.
+5. Each step → `TimelineRendererComponent` → `findRenderer` → `ReasoningRenderer` → `children([result])` →
+   `StepContainer` frame. Terminal Done/Stopped step appended.
+6. `pacedDisplayGroups` → final answer renderer at `FULL`; `CitedSources` below.
+
+## Key decisions & why
+
+- **Adopt web's render-prop `MessageRenderer<T,S>` contract exactly (not a simplified data object).** The owner
+  will build the tool renderers immediately as follow-up PRs and wants **zero refactor** — porting each web
+  renderer must be near-mechanical, which requires the identical `{packets, state, renderType, children(results)}`
+  shape and the identical `RendererResult` fields. Mobile's existing simpler `{matches, Component}` registry
+  (PR 3) is **migrated** to this contract now (including the final-answer `MessageTextRenderer`), because deferring
+  the migration *is* the "refactor later" we're told to avoid.
+- **Faithful `section_end` synthesis + `"{turn}-{tab}"` grouping.** A step is "complete" almost entirely via
+  **client-synthesized** `section_end` (on a new `turn_index`, or on `stop`) — the backend seldom sends it. This
+  is the load-bearing correctness rule; porting it verbatim is what keeps reasoning/tool steps closing correctly.
+  (Codebase: `web/.../timeline/hooks/packetProcessor.ts`.)
+- **The one accepted, platform-forced divergence: the two ref-during-render hooks are restructured.** Web's
+  `usePacketProcessor` mutates a state ref **during render** and `usePacedTurnGroups` reads pacing refs during
+  render — both **illegal** under mobile's `react-hooks/refs` lint. They're restructured to a `useMemo`
+  full-recompute (grouping) + effect-driven state (pacing timer), which is **behavior-preserving** (same grouped
+  output, same 200 ms cadence). This is an implementation necessity, **not** a look/structure drift — everything
+  else ports 1:1. (Documented in `03`.)
+- **Ship the full shell now; wire only reasoning.** Parallel-tab tabs (`ParallelTimelineTabs`) and nested/memory
+  paths ship **dormant** (as in web) so parallelism, deep-research nesting, and multi-model become later **UI-only**
+  follow-ups with no seam change — matching web's own "the shell already supports it" design and honoring the
+  owner's "want everything, no refactor."
+- **Progressive disclosure matches the industry default.** Collapse-by-default, a streaming "Thinking… (Ns)"
+  summary, auto-collapse-on-answer, tap (never hover) to expand — the mainstream pattern, and exactly what web
+  already does, so parity and best-practice coincide. (`digestibleux.com`, `hatchworks` agent-ux, W3C accordion.)
+
+## What existing behavior changes
+
+- **Assistant messages that involve thinking/tools now show a timeline above the answer** (today: only a static
+  "Thinking…" shimmer with no steps). Plain, tool-free answers look the same (EMPTY → straight to answer).
+- **The render path is restructured** to web's grouping/pacing/dispatch. The 9a **citations/Sources** behavior and
+  the streamed markdown answer are **preserved** (the final answer is migrated to the same contract but renders
+  identically). No backend, DB, or API change. No change to non-chat surfaces.
+- **Two new small dependencies on timing state:** a per-message `streamingStartedAt` timestamp (for the live
+  timer) is captured when a run starts; collapse/expand + a reasoning "muted markdown" variant are new UI.

--- a/docs/mobile-chat/9b-timeline/03-detailed-design.md
+++ b/docs/mobile-chat/9b-timeline/03-detailed-design.md
@@ -1,0 +1,374 @@
+> Status: active · Task: 9b-timeline · Approach: C — Faithful Shell First
+
+# Mobile Chat 9b — Agentic Reasoning Timeline · Detailed Design
+
+Faithful 1:1 port of web's agent timeline shell (`web/src/app/app/message/messageComponents/**`) to
+`mobile/`, wiring only the reasoning renderer. Line references below are to the web source (source of truth).
+Mobile spacing is **pixel-valued** (class number = px); web token **rem** strings are baked to px (rem×16),
+and web utility classes are translated (web Tailwind step N → mobile N×4 px). No backend/DB change.
+
+## Database design
+
+**N/A** — no persistence change. The timeline is derived entirely from the already-streamed/hydrated
+`Packet[]` on each assistant message node. (One in-memory addition: a per-run `streamingStartedAt` timestamp for
+the live elapsed timer — see Important Notes §7.)
+
+## Class / interface design
+
+### 1. Packet contracts — `mobile/src/chat/streamingModels.ts` (modified)
+
+Add the **full web `PacketType` enum values** (so the ported grouping engine + `packetHelpers` +
+`toolDisplay` compile with zero future enum change), plus the interfaces the **engine and shell** dereference.
+Per-tool obj interfaces beyond these are added by each tool renderer's own phase.
+
+```ts
+// New PacketType members (mirror web streamingModels.ts exactly; string values = backend wire types):
+REASONING_START = "reasoning_start", REASONING_DELTA = "reasoning_delta", REASONING_DONE = "reasoning_done",
+TOP_LEVEL_BRANCHING = "top_level_branching",
+SEARCH_TOOL_START = "search_tool_start", SEARCH_TOOL_QUERIES_DELTA = "search_tool_queries_delta",
+SEARCH_TOOL_FILTER_DELTA = "search_tool_filter_delta",
+FETCH_TOOL_START = "open_url_start", OPEN_URL_URLS = "open_url_urls",
+PYTHON_TOOL_START = "python_tool_start", PYTHON_TOOL_DELTA = "python_tool_delta",
+TOOL_CALL_ARGUMENT_DELTA = "tool_call_argument_delta",
+CUSTOM_TOOL_START = "custom_tool_start", CUSTOM_TOOL_ARGS = "custom_tool_args", CUSTOM_TOOL_DELTA = "custom_tool_delta",
+FILE_READER_START = "file_reader_start", FILE_READER_RESULT = "file_reader_result",
+MEMORY_TOOL_START = "memory_tool_start", MEMORY_TOOL_DELTA = "memory_tool_delta", MEMORY_TOOL_NO_ACCESS = "memory_tool_no_access",
+IMAGE_GENERATION_TOOL_START = "image_generation_start", IMAGE_GENERATION_TOOL_DELTA = "image_generation_final",
+DEEP_RESEARCH_PLAN_START = "deep_research_plan_start", DEEP_RESEARCH_PLAN_DELTA = "deep_research_plan_delta",
+RESEARCH_AGENT_START = "research_agent_start",
+INTERMEDIATE_REPORT_START = "intermediate_report_start", INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta",
+INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs",
+CODING_AGENT_START = "coding_agent_start", CODING_AGENT_THINKING_DELTA = "coding_agent_thinking_delta",
+CODING_AGENT_FINAL = "coding_agent_final", BASH_TOOL_START = "bash_tool_start", BASH_TOOL_DELTA = "bash_tool_delta",
+
+// New obj interfaces the ENGINE/SHELL read now (others deferred to their renderer phase):
+interface ReasoningStart  extends BaseObj { type: PacketType.REASONING_START }
+interface ReasoningDelta  extends BaseObj { type: PacketType.REASONING_DELTA; reasoning: string }
+interface ReasoningDone   extends BaseObj { type: PacketType.REASONING_DONE }
+interface TopLevelBranching extends BaseObj { type: PacketType.TOP_LEVEL_BRANCHING; num_parallel_branches: number }
+interface ToolCallArgumentDelta extends BaseObj { type: PacketType.TOOL_CALL_ARGUMENT_DELTA; tool_type: string; argument_deltas: Record<string, unknown> }
+interface SearchToolStart extends BaseObj { type: PacketType.SEARCH_TOOL_START; is_internet_search?: boolean }
+interface CustomToolStart extends BaseObj { type: PacketType.CUSTOM_TOOL_START; tool_name?: string; tool_id?: number | null }
+interface ImageGenerationToolDelta extends BaseObj { type: PacketType.IMAGE_GENERATION_TOOL_DELTA; images?: { file_id: string }[] }
+// extend existing MessageStart with: pre_answer_processing_seconds?: number | null
+export const CODE_INTERPRETER_TOOL_TYPES = { PYTHON: "python" } as const;
+// Add all new obj interfaces to the ObjTypes union.
+```
+
+### 2. Grouping engine — `mobile/src/chat/messageProcessor.ts` (modified → faithful port of web `packetProcessor.ts`)
+
+`ProcessedMessageState` gains web's grouping fields (existing 9a fields kept for `CitedSources`):
+
+```ts
+export interface ProcessedMessageState {
+  nodeId: number; nextPacketIndex: number;
+  // 9a (kept): citations, seenCitationDocIds, citationMap, documentMap, isComplete, stopReason
+  // 9b (new, mirroring web ProcessorState packetProcessor.ts:32-69):
+  groupedPacketsMap: Map<string, Packet[]>;
+  seenGroupKeys: Set<string>;
+  groupKeysWithSectionEnd: Set<string>;
+  expectedBranches: Map<number, number>;
+  toolGroupKeys: Set<string>;
+  displayGroupKeys: Set<string>;
+  isGeneratingImage: boolean; generatedImageCount: number;
+  finalAnswerComing: boolean; stopPacketSeen: boolean;
+  toolProcessingDuration: number | undefined;
+  toolGroups: GroupedPacket[];
+  potentialDisplayGroups: GroupedPacket[];
+}
+export interface GroupedPacket { turn_index: number; tab_index: number; packets: Packet[] }
+```
+
+New internal functions (ported verbatim, pure): `getGroupKey`, `injectSectionEnd`, `handleTurnTransition`,
+`handleStopPacket` (grouping half), `handleStreamingStatusPacket`, `handleToolAfterMessagePacket`,
+`buildGroupsFromKeys`, `hasContentPackets`, `CONTENT_PACKET_TYPES_SET`, `FINAL_ANSWER_PACKET_TYPES_SET`.
+`processPacket` gains the per-packet flow (packetProcessor.ts:323-382). See Important Notes §2 for the exact
+`section_end` algorithm.
+
+### 3. Pure step helpers — `mobile/src/chat/timeline/` (new)
+
+- `transformers.ts` — `TransformedStep {key, turnIndex, tabIndex, packets}`, `TurnGroup {turnIndex, steps, isParallel}`,
+  `transformPacketGroup`, `transformPacketGroups`, `groupStepsByTurn` (isParallel = `steps.length > 1`).
+- `packetUtils.ts` — `isToolPacket`, `isActualToolCallPacket`, `isDisplayPacket`, `isSearchToolPacket`,
+  `isStreamingComplete`, `isFinalAnswerComing`, `isFinalAnswerComplete`, `groupPacketsByTurnIndex`,
+  `getTextContent`, `getCitations`.
+- `packetHelpers.ts` — `COLLAPSED_STREAMING_PACKET_TYPES`, `CODING_AGENT_PACKET_TYPES`, `isReasoningPackets`,
+  `isSearchToolPackets`, `isPythonToolPackets`, `isResearchAgentPackets`, `isCodingAgentPackets`,
+  `isDeepResearchPlanPackets`, `isMemoryToolPackets`, `stepSupportsCollapsedStreaming`,
+  `stepHasCollapsedStreamingContent`.
+- `toolDisplay.ts` — `getToolKey`, `parseToolKey`, `getToolName` (pure), `hasToolError`, `isToolComplete`
+  (sub_turn_index-aware for research/coding). **Icon factory split out** to `components/chat/timeline/toolIcons.ts`
+  (returns a mobile icon component, not JSX from web react-icons).
+
+### 4. Renderer contract — `mobile/src/components/chat/renderers/timelineContract.ts` (new)
+
+Ported verbatim from web `interfaces.ts` (types only; `JSX.Element` = RN element):
+
+```ts
+export enum RenderType { HIGHLIGHT="highlight", FULL="full", COMPACT="compact", INLINE="inline" }
+export type TimelineLayout = "timeline" | "content";
+export type TimelineSurfaceBackground = "tint" | "transparent" | "error";
+export interface RendererResult {
+  icon: IconFunctionComponent | null;            // mobile icon type (from @/icons/types)
+  status: string | React.ReactElement | null;
+  content: React.ReactElement;
+  supportsCollapsible?: boolean; alwaysCollapsible?: boolean;
+  timelineLayout?: TimelineLayout; noPaddingRight?: boolean;
+  surfaceBackground?: TimelineSurfaceBackground;
+  // NOTE: web's `expandedText?` is DEAD (0 readers) — DROPPED in the port.
+}
+export type RendererOutput = RendererResult[];
+export interface FullChatState {              // mobile subset
+  agent: MinimalAgent | null;
+  citations?: CitationMap; documentMap?: Map<string, SearchDoc>;
+  openSource?: (doc: SearchDoc) => void;      // 9a
+}
+export type MessageRenderer<T extends Packet, S extends Partial<FullChatState>> = React.ComponentType<{
+  packets: T[]; state: S; messageNodeId?: number; hasTimelineThinking?: boolean;
+  onComplete: () => void; renderType: RenderType; animate: boolean;
+  stopPacketSeen: boolean; stopReason?: StopReason; isLastStep?: boolean;
+  children: (result: RendererOutput) => React.ReactElement;   // isHover DROPPED (no hover on RN)
+}>;
+export interface TimelineRendererResult extends RendererResult {
+  isExpanded: boolean; onToggle: () => void; renderType: RenderType;
+  isLastStep: boolean; timelineLayout: TimelineLayout;
+}
+```
+
+### 5. Timeline state hooks — signatures (ported 1:1 from web; see Important Notes §1 for the two restructured ones)
+
+```ts
+usePacketProcessor(packets: Packet[], nodeId: number): UsePacketProcessorResult   // RESTRUCTURED
+usePacedTurnGroups(toolTurnGroups, displayGroups, stopPacketSeen, nodeId, finalAnswerComing):
+   { pacedTurnGroups: TurnGroup[]; pacedDisplayGroups: GroupedPacket[]; pacedFinalAnswerComing: boolean } // RESTRUCTURED
+useTimelineUIState(input: TimelineUIStateInput): TimelineUIStateResult             // pure, 1:1
+useTimelineExpansion(stopPacketSeen, lastTurnGroup, hasDisplayContent): TimelineExpansionState  // 1:1
+useTimelineHeader(turnGroups, stopReason?, isGeneratingImage?): TimelineHeaderResult // 1:1 (see §6)
+useStreamingDuration(isStreaming, startTime?, backendDuration?): number             // 1:1 (RAF→interval ok)
+useTimelineMetrics(turnGroups, userStopped): TimelineMetrics                         // 1:1
+useTimelineStepState(turnGroups): MemoryStepState                                    // 1:1 (dormant/minimal)
+```
+
+`TimelineUIState` (7 states), `TimelineUIStateInput`/`Result`, `TimelineExpansionState`, `TimelineMetrics` — exact
+shapes per `01-research.md` and the deepread extract (`.context/pr9b-deepread/timeline-hooks-state.md`).
+
+## New files
+
+| File | Responsibility |
+|------|----------------|
+| `mobile/src/chat/timeline/transformers.ts` | GroupedPacket→TransformedStep→TurnGroup; parallel detection |
+| `mobile/src/chat/timeline/packetUtils.ts` | packet categorizers (tool/display/search/text/citations) |
+| `mobile/src/chat/timeline/packetHelpers.ts` | per-family predicates + collapsed-streaming sets |
+| `mobile/src/chat/timeline/toolDisplay.ts` | tool key parse, name, completion, error (pure) |
+| `mobile/src/chat/timeline/reasoningState.ts` | `extractFirstParagraph` + `constructCurrentReasoningState` (pure) |
+| `mobile/src/components/chat/renderers/timelineContract.ts` | RenderType/RendererResult/MessageRenderer/FullChatState |
+| `mobile/src/components/chat/renderers/findRenderer.ts` | priority-ordered dispatch (reasoning last) |
+| `mobile/src/components/chat/renderers/RendererComponent.tsx` | final-answer dispatch at FULL (+ mixed-content stub) |
+| `mobile/src/components/chat/renderers/ReasoningRenderer.tsx` | the one wired step renderer |
+| `mobile/src/hooks/timeline/usePacketProcessor.ts` | host reducer + derive turn groups (restructured) |
+| `mobile/src/hooks/timeline/usePacedTurnGroups.ts` | 200ms staggered reveal + answer gating (restructured) |
+| `mobile/src/hooks/timeline/useTimelineUIState.ts` | 7-state machine + show/style booleans |
+| `mobile/src/hooks/timeline/useTimelineExpansion.ts` | collapse state + auto-collapse |
+| `mobile/src/hooks/timeline/useTimelineHeader.ts` | header text map |
+| `mobile/src/hooks/timeline/useStreamingDuration.ts` | live elapsed timer (frozen by backend duration) |
+| `mobile/src/hooks/timeline/useTimelineMetrics.ts` | step count + last-step flags |
+| `mobile/src/hooks/timeline/useTimelineStepState.ts` | memory-only extraction (dormant) |
+| `mobile/src/components/chat/timeline/primitives/timelineTokens.ts` | px token constants (rail 36, icon 12, …) |
+| `mobile/src/components/chat/timeline/primitives/TimelineRoot.tsx` | outer column |
+| `mobile/src/components/chat/timeline/primitives/TimelineHeaderRow.tsx` | rail cell (avatar) + header slot |
+| `mobile/src/components/chat/timeline/primitives/TimelineRow.tsx` | icon column + content row |
+| `mobile/src/components/chat/timeline/primitives/TimelineIconColumn.tsx` | connector rail + node icon |
+| `mobile/src/components/chat/timeline/primitives/TimelineSurface.tsx` | tint/error surface + rounding |
+| `mobile/src/components/chat/timeline/primitives/TimelineStepContent.tsx` | header row + collapse control + body |
+| `mobile/src/components/chat/timeline/StepContainer.tsx` | composes the primitives into a step frame |
+| `mobile/src/components/chat/timeline/TimelineRendererComponent.tsx` | per-step expand state + renderType derive |
+| `mobile/src/components/chat/timeline/TimelineStep.tsx` | step composer (children render-prop → StepContainer) |
+| `mobile/src/components/chat/timeline/ExpandedTimelineContent.tsx` | maps TurnGroup[]→steps + Done/Stopped |
+| `mobile/src/components/chat/timeline/CollapsedStreamingContent.tsx` | streaming live preview of last step |
+| `mobile/src/components/chat/timeline/ParallelTimelineTabs.tsx` | **dormant stub** (linearizes for 9b) |
+| `mobile/src/components/chat/timeline/headers/StreamingHeader.tsx` | shimmer text + live seconds + fold |
+| `mobile/src/components/chat/timeline/headers/CompletedHeader.tsx` | "Thought for X · N steps" fold |
+| `mobile/src/components/chat/timeline/headers/StoppedHeader.tsx` | "Interrupted Thinking" + N steps |
+| `mobile/src/components/chat/timeline/headers/ParallelStreamingHeader.tsx` | **dormant stub** |
+| `mobile/src/components/chat/timeline/toolIcons.ts` | packet-type → mobile icon map (for headers/tabs) |
+| `mobile/src/components/chat/timeline/ReasoningTextWindow.tsx` | maxHeight markdown window (ExpandableTextDisplay analog) |
+| `mobile/src/icons/{circle,fold,expand,check-circle}.tsx` | new icons (ASK owner) — see §6 |
+| `mobile/src/chat/timeline/__tests__/*.test.ts` | grouping / section-end / transformers / pacing / uiState / reasoningState |
+
+**Modified:** `mobile/src/chat/streamingModels.ts` (§1), `mobile/src/chat/messageProcessor.ts` (§2),
+`mobile/src/components/chat/renderers/registry.ts` (→ re-export `findRenderer`), `MessageTextRenderer.tsx`
+(migrate to render-prop contract), `mobile/src/hooks/usePacketDisplay.ts` (fold into the new hooks / expose
+`processed` for `CitedSources`), `mobile/src/components/chat/MessageRow.tsx` (AssistantMessage → AgentMessage
+analog), `mobile/src/components/chat/AgentTimeline.tsx` (stub → full shell), `mobile/src/components/chat/StreamingMarkdown.tsx`
+(+ optional `muted` variant), and the PR-3 stream controller/store (capture `streamingStartedAt`, §7).
+
+## File structure (tree)
+
+```
+mobile/src/
+├── chat/
+│   ├── streamingModels.ts                 (modified: full PacketType enum + reasoning/branch/tool-arg objs)
+│   ├── messageProcessor.ts                (modified: + web packetProcessor grouping/section-end/finalAnswer)
+│   └── timeline/                          (new — pure, reanimated-free, unit-tested)
+│       ├── transformers.ts · packetUtils.ts · packetHelpers.ts · toolDisplay.ts · reasoningState.ts
+│       └── __tests__/
+├── hooks/
+│   ├── usePacketDisplay.ts                (modified: expose processed for CitedSources)
+│   └── timeline/                          (new)
+│       ├── usePacketProcessor.ts (restructured) · usePacedTurnGroups.ts (restructured)
+│       ├── useTimelineUIState.ts · useTimelineExpansion.ts · useTimelineHeader.ts
+│       └── useStreamingDuration.ts · useTimelineMetrics.ts · useTimelineStepState.ts
+├── components/chat/
+│   ├── MessageRow.tsx                     (modified: AssistantMessage → AgentMessage analog)
+│   ├── AgentTimeline.tsx                  (modified: stub → full shell)
+│   ├── StreamingMarkdown.tsx              (modified: + muted variant)
+│   ├── renderers/
+│   │   ├── registry.ts                    (modified: re-export findRenderer)
+│   │   ├── timelineContract.ts · findRenderer.ts · RendererComponent.tsx · ReasoningRenderer.tsx  (new)
+│   │   └── MessageTextRenderer.tsx        (modified: → render-prop contract)
+│   └── timeline/                          (new)
+│       ├── StepContainer.tsx · TimelineRendererComponent.tsx · TimelineStep.tsx
+│       ├── ExpandedTimelineContent.tsx · CollapsedStreamingContent.tsx
+│       ├── ParallelTimelineTabs.tsx (dormant) · toolIcons.ts · ReasoningTextWindow.tsx
+│       ├── primitives/ (timelineTokens, TimelineRoot/HeaderRow/Row/IconColumn/Surface/StepContent)
+│       └── headers/ (StreamingHeader, CompletedHeader, StoppedHeader, ParallelStreamingHeader[dormant])
+└── icons/  circle.tsx · fold.tsx · expand.tsx · check-circle.tsx   (new; stop-circle already exists from PR3)
+```
+
+## What each file will contain
+
+- **`messageProcessor.ts`** — the pure reducer: `processPackets(state, rawPackets)` loops from `nextPacketIndex`,
+  routes each packet through `handleTurnTransition` (synthesizes `section_end` into prior groups on a new
+  `turn_index`), grouping/categorization, citations/docs (9a), `handleStreamingStatusPacket` (finalAnswerComing +
+  `pre_answer_processing_seconds`), `handleStopPacket` (synthesizes `section_end` into all open groups), then
+  rebuilds `toolGroups`/`potentialDisplayGroups` via `buildGroupsFromKeys` (spreads packets → new array; filters
+  `hasContentPackets`; sorts by turn then tab).
+- **`usePacketProcessor.ts`** — `const state = useMemo(() => processPackets(createInitialState(nodeId), packets), [nodeId, packets])`
+  (lint-safe full recompute), then `toolTurnGroups = useMemo(groupStepsByTurn(transformPacketGroups(state.toolGroups)))`,
+  `displayGroups` gated on `finalAnswerComing || toolGroups.length===0`, `renderComplete`/`forceShowAnswer` as
+  `useState`, `isComplete = stopPacketSeen && renderComplete`. Returns `UsePacketProcessorResult`.
+- **`usePacedTurnGroups.ts`** — `useState(revealedStepKeys: Set)` + `useState(toolPacingComplete)` written by an
+  effect; timer handle in a ref (effect/cleanup only, never read in render). Effect: bypass if `stopPacketSeen &&
+  nothing revealed && groups exist`; first step immediate, rest queued 200 ms apart (`PACING_DELAY_MS=200`); `stop`
+  flushes all. Memos build `pacedTurnGroups` (filter revealed), `pacedDisplayGroups` (withheld until pacing
+  complete), `pacedFinalAnswerComing`. Web's `prevPacedRef` referential-stabilization is **dropped**.
+- **`useTimelineUIState.ts`** — pure `useMemo`: the 6-branch precedence (EMPTY → DISPLAY_CONTENT_ONLY →
+  STREAMING_PARALLEL/SEQUENTIAL → STOPPED → COMPLETED_EXPANDED → COMPLETED_COLLAPSED) + `showTintedBackground`,
+  `showRoundedBottom`, `showDoneStep`, `showStoppedStep`, `hasDoneIndicator`, `showParallelTabs`,
+  `showCollapsedCompact`, `showCollapsedParallel`, `isStreaming`, `isCompleted`, `isActivelyExecuting`.
+- **`useTimelineExpansion.ts`** — `isExpanded=useState(false)`, `userHasToggled=useRef(false)` (read only in
+  effect), auto-collapse effect on `stopPacketSeen||hasDisplayContent`, parallel-tab sync effect.
+- **`useTimelineHeader.ts`** — the exact packet-type→text map (§6). **9b caveat:** the SEARCH sub-labels
+  ("Reading" vs "Searching the web", which need `constructCurrentSearchState`) degrade to a generic label until
+  the search phase; reasoning → "Thinking", default → "Thinking…". (Documented divergence §8.)
+- **`useStreamingDuration.ts`** — `elapsedSeconds` via `requestAnimationFrame` (or `setInterval(1000)`), updates
+  only when the integer second changes; returns `backendDuration` if defined (freezes). Reset only when no
+  `startTime`.
+- **`AgentTimeline.tsx`** — runs `useTimelineExpansion` + `useTimelineUIState` + `useTimelineHeader` +
+  `useTimelineMetrics` + `useStreamingDuration`; `TimelineRoot > TimelineHeaderRow(avatar 24 in 36 rail) >
+  header`; header switch by `uiState`; body = `CollapsedStreamingContent` (streaming) or
+  `ExpandedTimelineContent` (expanded). Memoized.
+- **`StepContainer.tsx` + primitives** — `TimelineRow`(`TimelineIconColumn` rail + content); `TimelineSurface`
+  (tint/error bg, rounded bottom if last); `TimelineStepContent` (header row height 32 with `status` Text +
+  collapse control gated by `supportsCollapsible`, body `pl-1 pb-1`, right gutter 34 unless `noPaddingRight`).
+  Rail geometry: 1px line, 8px top connector (hidden if first), 20px node wrapper, 12px icon, flex-fill (hidden
+  if last). All hover branches dropped (resting colors: `bg-border-01`, `stroke-text-02`, `bg-background-tint-00`).
+- **`TimelineRendererComponent.tsx`** — `isExpanded=useState(defaultExpanded)`, `renderType = override ??
+  (isExpanded?FULL:COMPACT)`, `findRenderer(packets)` → render-prop, `enhanceResult` attaches
+  `{isExpanded,onToggle,renderType,isLastStep,timelineLayout}`; `children(results.map(enhanceResult))`.
+- **`ReasoningRenderer.tsx`** — `constructCurrentReasoningState(packets)` (hasStart/hasEnd/content=join deltas),
+  `extractFirstParagraph(content)` (markdown-heading → step title, ≤60 chars), 500 ms min-thinking gate
+  (`useState(start)` + timer ref in effect; `animate` gates the floor), then
+  `children([{ icon: SvgCircle, status: title ?? "Thinking", content: <ReasoningTextWindow .../>, noPaddingRight:true, supportsCollapsible:true }])`.
+- **`ReasoningTextWindow.tsx`** — maxHeight 192px (8×24) overflow-hidden `View` wrapping `StreamingMarkdown
+  content={displayContent} isStreaming={!hasEnd} variant="muted"`. (Web's pixel-perfect translateY auto-scroll +
+  copy/download modal are **not** ported in 9b — §8.)
+- **`findRenderer.ts`** — the full priority chain (chat → deep-research → research-agent → coding-agent →
+  web-search → internal-search → image → python → file-reader → custom-tool → fetch → memory → **reasoning
+  last**). For 9b only **chat→MessageTextRenderer** and **reasoning→ReasoningRenderer** are wired; the other 11
+  predicates are present and return their (not-yet-registered) renderer as `null`, each tagged
+  `// PR 9x: <tool>` so a follow-up is a one-line wire-up.
+- **`RendererComponent.tsx`** — final-answer path: `findRenderer({packets})` at `RenderType.FULL`; mixed
+  chat+image content handler is **stubbed** (image = 9e). Memoized on packet identity + stop flags.
+- **`MessageRow.tsx` (AssistantMessage)** — the AgentMessage analog: `usePacketProcessor` + `usePacedTurnGroups`,
+  `<AgentTimeline turnGroups=pacedTurnGroups chatState stopPacketSeen finalAnswerComing hasDisplayContent
+  toolProcessingDuration/>` above, `pacedDisplayGroups.map(<RendererComponent renderType=FULL/>)` below,
+  `<CitedSources/>` (9a) last.
+
+## Integration points
+
+- **`mobile/src/chat/messageProcessor.ts`** (9a) — extended in place; existing citation/document/`isComplete`
+  fields preserved so `CitedSources.tsx` and `usePacketDisplay` keep working.
+- **`mobile/src/components/chat/renderers/registry.ts` + `MessageTextRenderer.tsx`** (PR 3/9a) — migrated to the
+  render-prop `MessageRenderer` contract; the final answer routes through the new `RendererComponent`. Inline
+  citation links (9a) and streamed markdown render identically.
+- **`mobile/src/components/chat/AgentTimeline.tsx`** (PR 5 stub) — `steps: TimelineStepData[]` seam replaced by
+  `turnGroups: TurnGroup[]`; the existing rail geometry + reanimated shimmer are reused/expanded.
+- **`mobile/src/components/chat/MessageRow.tsx`** — `AssistantMessage` becomes the composition root; `hasContent`
+  gating updated (`isLoading` now driven by `uiState===EMPTY`).
+- **`mobile/src/components/chat/StreamingMarkdown.tsx`** (PR 3/9a) — gains a `muted`/`compact` variant so reasoning
+  bodies render `text-03` with tight margins (colors still resolved to hex via `varsLight/varsDark`).
+- **PR-3 stream controller / `chatSessionStore`** — records `streamingStartedAt` per assistant node (Important
+  Notes §7) for the live timer.
+- **`mobile/src/components/avatars/AgentAvatar`** (PR 5) — reused at `size={24}` in the rail.
+- **`@onyx-ai/shared/native`** — `varsLight/varsDark` + `textPresets` for markdown colors (unchanged pattern).
+- **Backend / DB / API** — **untouched.** Reasoning packets already stream from `backend/onyx/chat/llm_step.py`.
+
+## Important notes before implementation
+
+1. **The two ref-during-render restructures (the only accepted divergence).** `usePacketProcessor` (web mutates
+   `stateRef.current` during render) → mobile uses a **`useMemo` full recompute** per flush (9a's proven pattern;
+   O(n)/flush, fine at chat scale). `usePacedTurnGroups` (web reads pacing refs during render for
+   `shouldBypassPacing` + memos) → hoist `revealedStepKeys`/`toolPacingComplete` into **`useState`** written by the
+   effect; compute `shouldBypassPacing` from props synchronously; timer handle stays in a ref (effect-only). Both
+   are **behavior-preserving**. Verify the first-packet render + 200 ms cadence feel identical on device (a
+   reducer-in-effect can add a one-frame delay — §parity-risk in the deepread).
+2. **`section_end` synthesis is the correctness core — port it exactly.** `injectSectionEnd(state, key)`:
+   idempotent (skip if already ended); parse `{turn,tab}` from key; push a synthetic `{placement:{turn,tab},
+   obj:{type:SECTION_END}}` (NO `sub_turn_index` — so research/coding parent-completion works) into the group;
+   mark the key done. **Trigger 1:** a real `SECTION_END`/`ERROR` packet. **Trigger 2 (turn transition):** the
+   first packet of a **new `turn_index`** injects into every prior `seenGroupKey` not yet ended. **Trigger 3
+   (stop):** the first `stop` injects into all open groups. A new *`tab_index`* within a seen turn does **not**
+   trigger 2. (packetProcessor.ts:116-133, 190-208, 270-287.)
+3. **Full `PacketType` enum now, per-tool interfaces later.** Add every enum value (so the engine/helpers/Sets
+   compile with zero future enum edits) but only the obj interfaces the engine/shell dereference (§1). Each tool
+   renderer phase adds its own obj interface + wires its `findRenderer` predicate — a one-line change, no engine
+   or enum churn. This is the "zero refactor later" guarantee.
+4. **`react-hooks/refs` + reanimated jest gotcha.** Keep ALL pure logic (grouping, transformers, packetUtils,
+   packetHelpers, toolDisplay, reasoningState, the state-machine math) in **reanimated-free** modules under
+   `chat/timeline/` and import leaf components directly in tests. Refs are fine when written/read **only in
+   effects/callbacks** (timer handles, `userHasToggled`) — never during render.
+5. **Icons + primitives = owner-ASK before UI lands (PR 9b.4).** New icons: `circle` (reasoning node), `fold` /
+   `expand` (collapse control — no `chevron-up`, rotate `chevron-down` or add glyphs), `check-circle` (Done).
+   `stop-circle` already exists (PR 3). New primitive: a **tertiary icon Button** (confirm the existing mobile
+   `Button` covers it, else ASK per the web-parity principle). `x-octagon` (error surface) — confirm/port.
+6. **Header text map + tool names (`useTimelineHeader` / `getToolName`).** Port the full map; reasoning →
+   "Thinking", `stop_reason===USER_CANCELLED` → StoppedHeader. Tool sub-labels needing `constructCurrentSearchState`
+   (search "Reading" vs "Searching the web") degrade to a generic label until the search phase (§8). `getToolName`
+   ("Web Search"/"Code Interpreter"/…) is pure and ported so a *rendererless* tool step still gets a real header.
+7. **Live timer needs a per-message `streamingStartedAt`.** Web reads a `useStreamingStartTime` store. Mobile:
+   the PR-3 stream controller stamps `streamingStartedAt = Date.now()` on the assistant node/run at stream start
+   (send + resume); `AgentTimeline` passes it to `useStreamingDuration`. Without it the elapsed label never shows.
+   `toolProcessingDuration` (`message_start.pre_answer_processing_seconds`) **freezes** the timer when present.
+8. **Documented, intentional divergences from web (per the WEB-PARITY PRINCIPLE — the "as-built" note must list
+   these):** (a) the two restructured hooks (§1) — behavior-preserving; (b) shimmer = reanimated **opacity pulse**,
+   not web's `background-clip:text` gradient (no RN equivalent) — reuse the existing 9a `ThinkingLabel`; (c)
+   `ReasoningTextWindow` = fixed **maxHeight window**, not web's pixel-perfect `translateY` auto-scroll; copy/
+   download modal deferred; (d) **`ParallelTimelineTabs`/`ParallelStreamingHeader` dormant** — parallel turns
+   **linearized** into a sequential list for 9b (no `@opal` pill Tabs on mobile); (e) SEARCH header sub-labels
+   generic until the search phase; (f) entrance/`transition-colors` CSS animations optional (reanimated
+   `FadeIn`/`Layout` or dropped); (g) memory tooltip/modal dropped (memory renderer is a later phase); (h) `expandedText`
+   dead field dropped; (i) no hover anywhere (resting colors). None change the timeline's look/structure for the
+   reasoning path.
+9. **Render-prop discipline.** A renderer must call `children(results)` — never return its own `View` tree
+   directly — or `StepContainer` can't wrap it. `RenderType` policy: final-answer path = always `FULL`; timeline
+   steps = `override ?? (isExpanded?FULL:COMPACT)`. Keep BOTH entry points.
+10. **Testing (unit-first — the pure core carries the risk).** Jest over `chat/timeline/**` +
+    `hooks/timeline/**` leaf logic: grouping key + the three `section_end` triggers; `groupStepsByTurn`
+    parallel detection + turn/tab sort; `transformPacketGroups`; `usePacedTurnGroups` (first-immediate,
+    200 ms stagger with fake timers, stop-flush, history-bypass); `useTimelineUIState` all 7 states + booleans;
+    `useTimelineExpansion` auto-collapse + userHasToggled; `useStreamingDuration` tick + freeze;
+    `reasoningState` heading extraction + delta accumulation; `ReasoningRenderer` 500 ms gate (fake timers).
+    Component smoke test: a mocked reasoning packet stream renders a "Thinking" step that collapses to "Thought
+    for Xs". **HARD device gate (owner):** on a dev build, a reasoning model shows the streaming shimmer + timer,
+    auto-collapse on answer, tap-to-expand, and hydrated (history) render — the agent can't run a device build.

--- a/docs/mobile-chat/9b-timeline/04-implementation-plan.md
+++ b/docs/mobile-chat/9b-timeline/04-implementation-plan.md
@@ -1,0 +1,182 @@
+> Status: active · Task: 9b-timeline
+
+# Mobile Chat 9b — Agentic Reasoning Timeline · Implementation Plan
+
+## Issues to Address
+
+Mobile chat renders assistant answers with no visibility into the agent's **thinking/tool steps** — the
+`AgentTimeline` above each answer is a stub whose `steps` prop is always `[]`. Web shows a full **agent timeline**
+(a rail of collapsible reasoning/tool steps with a streaming "Thinking… (Ns)" header that auto-collapses to
+"Thought for Ns · N steps"). 9b ports web's **entire timeline shell 1:1** to `mobile/` and wires the **reasoning**
+step, so that: (a) thinking/tool activity is shown faithfully during and after streaming; (b) the composition
+seam is a **zero-refactor drop-in point** for the tool renderers the owner will build immediately after
+(search/fetch/python/custom-tool/deep-research/memory) and for 9c–9e. Backend, DB, and API are unchanged.
+
+## Important Notes
+
+- **The 9a foundation is the reserved seam.** `mobile/src/chat/messageProcessor.ts` is a flat, cursor-incremental
+  reducer whose header comment states 9b extends it with turn/tab grouping; `mobile/src/components/chat/AgentTimeline.tsx`
+  already has the 36px rail + 24px avatar + reanimated shimmer + a `TimelineStep` primitive; `MessageRow.AssistantMessage`
+  already mounts the timeline above the answer and `CitedSources` (9a) below. 9b builds on all three.
+- **Web is the source of truth.** Exact contracts, algorithms, and tokens are captured in `03-detailed-design.md`
+  and `.context/pr9b-deepread/*.md`, extracted verbatim from `web/src/app/app/message/messageComponents/**`
+  (`packetProcessor.ts`, `transformers.ts`, `interfaces.ts`, `renderMessageComponent.tsx`, the `timeline/hooks/*`,
+  `timeline/primitives/*`, `timeline/headers/*`, `ReasoningRenderer.tsx`). Reasoning packets already stream from
+  `backend/onyx/chat/llm_step.py`.
+- **`section_end` synthesis is the correctness core.** A step is marked complete almost entirely by
+  **client-synthesized** `section_end` — on a new `turn_index` (closes all prior groups) and on `stop` (closes all
+  open groups). The backend seldom sends it. Port `injectSectionEnd`/`handleTurnTransition`/`handleStopPacket`
+  verbatim (packetProcessor.ts:116-133, 190-208, 270-287).
+- **The one platform-forced divergence: two ref-during-render hooks.** `usePacketProcessor` (web mutates a state
+  ref during render) → mobile `useMemo` full recompute (9a's proven, lint-safe pattern). `usePacedTurnGroups` (web
+  reads pacing refs during render) → `useState` written by an effect + timer handle in a ref (effect-only). Both
+  **behavior-preserving** (same grouped output, same 200 ms cadence). This is required by mobile's
+  `react-hooks/refs` lint; it is not a look/structure drift.
+- **reanimated jest gotcha.** All pure logic (grouping, transformers, packetUtils, packetHelpers, toolDisplay,
+  reasoningState, state-machine math) lives in **reanimated-free** modules so units don't hit the "Worklets not
+  initialized" crash; import leaf components directly in tests.
+- **Streaming re-render isolation (hardening — from plan-challenge).** The live 1/sec timer + the 200 ms pacing
+  reveals re-render frequently; scope them so they can't churn the `FlatList` or the answer markdown. Concretely:
+  the message row is `React.memo`'d, `renderItem` is `useCallback`'d with stable keys, the per-second timer is
+  isolated to the header subtree (not the whole `AgentTimeline`/row), and grouped/paced outputs never hand a fresh
+  object identity to a row that didn't change. (React Native official FlatList guidance; verified 2026.)
+- **`useMemo` full-recompute cost (acknowledged).** The lint-safe `usePacketProcessor` reprocesses all packets per
+  flush (O(n)), vs web's incremental cursor. Fine at chat scale (hundreds of packets); a pathologically long
+  tool-heavy turn (thousands) doubles per-flush work. This is an internal implementation detail with no API impact,
+  so it can be re-optimized to incremental later **without touching the seam** — do not pre-optimize.
+- **Full `PacketType` enum now, per-tool interfaces later** — so the engine/helpers compile once and never need an
+  enum edit; each future tool renderer adds only its obj interface + one `findRenderer` predicate wire-up.
+- **Progressive disclosure = the industry default** (collapse-by-default, streaming "Thinking… (Ns)" summary,
+  auto-collapse-on-answer, tap-not-hover) — parity and best practice coincide (`digestibleux.com`, `hatchworks`
+  agent-ux, W3C accordion APG).
+- **Owner-ASK before UI lands:** new icons (`circle`, `fold`, `expand`, `check-circle`; `stop-circle` exists) and
+  confirming the mobile `Button` covers a tertiary icon button — per the web-parity principle, don't hand-roll a
+  divergent primitive.
+- **Documented divergences** (must appear in the "as-built" note): the two restructured hooks; shimmer = opacity
+  pulse not gradient; reasoning window = fixed maxHeight not translateY auto-scroll (copy/download modal deferred);
+  parallel-tab tabs dormant → linearized; search header sub-labels generic until the search phase; entrance CSS
+  animations optional; memory tooltip/modal dropped; `expandedText` dead field dropped; no hover anywhere.
+
+## Implementation Strategy
+
+Ordered, coherent changes. Each maps to a step Phase 5 bundles into ~500–700 LOC PRs.
+
+1. **Packet contracts.** Extend `mobile/src/chat/streamingModels.ts` with the full web `PacketType` enum values and
+   the obj interfaces the engine/shell dereference (`ReasoningStart/Delta/Done`, `TopLevelBranching`,
+   `ToolCallArgumentDelta` + `CODE_INTERPRETER_TOOL_TYPES`, `SearchToolStart.is_internet_search`,
+   `CustomToolStart.tool_name`, `ImageGenerationToolDelta.images`, `MessageStart.pre_answer_processing_seconds`);
+   extend the `ObjTypes` union.
+2. **Grouping engine.** Extend `mobile/src/chat/messageProcessor.ts` into a faithful port of web `packetProcessor.ts`:
+   add the grouping fields to `ProcessedMessageState` + `GroupedPacket`; port `getGroupKey`, `injectSectionEnd`,
+   `handleTurnTransition`, `handleStopPacket` (grouping), `handleStreamingStatusPacket`,
+   `handleToolAfterMessagePacket`, categorization, `buildGroupsFromKeys`, `hasContentPackets`, and the packet-type
+   Sets. Preserve the 9a citation/document/`isComplete` behavior.
+3. **Pure step helpers.** Add `mobile/src/chat/timeline/{transformers,packetUtils,packetHelpers,toolDisplay,reasoningState}.ts`
+   ported verbatim (step→turn grouping + parallel detection; categorizers; per-family predicates + collapsed-streaming
+   sets; tool key/name/completion; reasoning heading extraction + delta accumulation).
+4. **Processor + pacing hooks (the restructure).** Add `mobile/src/hooks/timeline/usePacketProcessor.ts` (useMemo
+   recompute + derive `toolTurnGroups`/`displayGroups`/`isComplete`) and `usePacedTurnGroups.ts` (useState +
+   effect-driven 200 ms reveal, answer gating, history bypass; drop web's `prevPacedRef`).
+5. **State/derive hooks.** Add `useTimelineUIState` (7 states + booleans), `useTimelineExpansion` (auto-collapse +
+   userHasToggled), `useTimelineHeader` (text map), `useStreamingDuration` (live timer, backend-freeze),
+   `useTimelineMetrics`, `useTimelineStepState` (memory, dormant) under `mobile/src/hooks/timeline/`.
+6. **Renderer contract + dispatch.** Add `renderers/timelineContract.ts` (RenderType/RendererResult/MessageRenderer/
+   FullChatState/TimelineRendererResult) and `renderers/findRenderer.ts` (full 13-slot priority chain; chat +
+   reasoning wired, the rest tagged `// PR 9x`). Re-export from `registry.ts`.
+7. **Renderer-path migration.** Migrate `MessageTextRenderer.tsx` to the render-prop `MessageRenderer` contract;
+   add `RendererComponent.tsx` (final-answer dispatch at `FULL`, mixed chat+image stubbed = 9e). Preserve 9a inline
+   citations + streamed markdown.
+8. **Icons + primitives (owner-ASK).** Add `circle`, `fold`, `expand`, `check-circle` icons; confirm/port a
+   tertiary icon `Button`; add a `muted`/`compact` variant to `StreamingMarkdown.tsx`.
+9. **Timeline primitives + StepContainer.** Add `components/chat/timeline/primitives/*` (`timelineTokens`,
+   `TimelineRoot/HeaderRow/Row/IconColumn/Surface/StepContent`) with baked px tokens + dropped hover; add
+   `StepContainer.tsx` and `TimelineRendererComponent.tsx` (per-step expand + `renderType` derivation).
+10. **Reasoning renderer.** Add `renderers/ReasoningRenderer.tsx` (constructReasoningState + extractFirstParagraph +
+    500 ms min-thinking gate) and `timeline/ReasoningTextWindow.tsx` (maxHeight markdown window). Register reasoning
+    in `findRenderer`.
+11. **Timeline composition + headers.** Rewrite `AgentTimeline.tsx` into the shell (runs the state hooks + header
+    switch + body), add `ExpandedTimelineContent.tsx`, `CollapsedStreamingContent.tsx`, `TimelineStep.tsx`, the
+    `headers/*` (Streaming/Completed/Stopped; Parallel* dormant stubs), `ParallelTimelineTabs.tsx` (dormant,
+    linearized), `toolIcons.ts`, the Done/Stopped terminal step.
+12. **Wire the composition root.** Update `MessageRow.AssistantMessage` into the AgentMessage analog (run
+    `usePacketProcessor` + `usePacedTurnGroups`; `AgentTimeline` above; `pacedDisplayGroups` → `RendererComponent`
+    below; `CitedSources` last); fold/adjust `usePacketDisplay` to keep exposing `processed` for `CitedSources`.
+    Capture `streamingStartedAt` per assistant node in the PR-3 stream controller/store for the live timer.
+
+## Tests
+
+**Primary type: RN Testing Library + Jest unit** (the pure core + hooks carry essentially all the risk; there is
+no backend surface — reasoning packets already exist). Cover:
+
+- **Grouping/engine (`chat/timeline` + `messageProcessor`):** group key `"{turn}-{tab}"`; the three `section_end`
+  triggers (real packet, turn-transition closes prior groups, stop closes all open); tool-vs-display
+  categorization; `finalAnswerComing` + tool-after-message reset; `hasContentPackets`; `model_index` tolerance;
+  history-reload reset (array shrink).
+- **Transformers:** `groupStepsByTurn` parallel detection + turn/tab ordering.
+- **Pacing (`usePacedTurnGroups`, fake timers):** first step immediate, subsequent 200 ms apart, `stop` flush-all,
+  history bypass reveals instantly, answer withheld until pacing completes.
+- **State hooks:** `useTimelineUIState` all 7 states + each derived boolean; `useTimelineExpansion` auto-collapse
+  on answer/stop + `userHasToggled` suppression; `useStreamingDuration` per-second tick + backend-duration freeze.
+- **Reasoning:** `reasoningState` heading extraction (markdown-heading rule, 60-char cap) + delta accumulation;
+  `ReasoningRenderer` 500 ms min-thinking gate (fake timers) + empty/pre-start branch.
+- **Component smoke test:** a mocked reasoning packet stream renders a "Thinking" step, streams markdown, marks
+  done, and collapses to "Thought for Ns · 1 step"; tap expands; a `USER_CANCELLED` stop shows the Stopped step.
+
+**HARD device gate (owner-run, not automatable):** on a dev build, drive a reasoning model and confirm the
+streaming shimmer + live timer, auto-collapse when the answer begins, tap-to-expand, the Done terminal step, and a
+hydrated (history-reloaded) render — plus that the migrated final-answer path + 9a Sources still render correctly.
+
+## Plan Challenge Results
+
+Ran the mandatory 6-point challenge (web-verified checks 3 & 4).
+
+### 1. Extendability & Scalability: PASS
+Full-shell-now means each of the 6 deferred tool renderers + 9c/9e is a single new file + one `findRenderer`
+wire-up — zero engine/enum/shell change; the grouping key already carries `tab_index`/`sub_turn_index`/`model_index`
+for parallel/nested/multi-model. Sole caveat (documented, not a rewrite): the lint-safe `usePacketProcessor` is
+O(n)/flush vs web's incremental cursor — fine at chat scale, re-optimizable later behind the same API.
+
+### 2. Fragility: CONCERN → hardened
+Two brittle points, each with a concrete mitigation now in the plan: (a) `usePacedTurnGroups` (timers +
+effect-published state) is the highest-bug-density file → fake-timer unit tests for first-immediate / 200 ms /
+stop-flush / history-bypass; (b) the 1/sec timer + 200 ms reveals could churn the `FlatList`/answer → isolate the
+timer to the header subtree, `React.memo` the row, stable keys, no per-tick identity churn (added as a hardening
+note). `section_end` synthesis depends on turn-transition ordering but is ported verbatim + unit-tested.
+
+### 3. Industry Standard: VERIFIED
+Searched render-props-vs-hooks (2025), ref-during-render/purity, and RN FlatList streaming perf. (a) Render-props /
+children-as-function remain the recognized standard **for headless renderers where the wrapper owns the tree**
+(Downshift, React Aria, TanStack Table, Framer Motion `AnimatePresence`) — exactly the `StepContainer`↔renderer
+split, so the render-prop contract is legitimate here, not legacy. (b) The ref restructure **aligns with React's
+own rule** — react.dev's `eslint-plugin-react-hooks/refs` + purity docs say reading/writing `ref.current` during
+render breaks purity/concurrent rendering; web's ref-during-render is the anti-pattern React now lints against, so
+mobile's restructure is *more* correct, not a workaround. (c) FlatList streaming perf best practices (memo rows,
+`useCallback` renderItem, stable keys, no per-tick object churn) confirmed and folded in.
+Sources: [react.dev refs lint](https://react.dev/reference/eslint-plugin-react-hooks/lints/refs),
+[react.dev purity](https://react.dev/reference/rules/components-and-hooks-must-be-pure),
+[patterns.dev render props](https://www.patterns.dev/react/render-props-pattern/),
+[RN FlatList optimization](https://reactnative.dev/docs/optimizing-flatlist-configuration).
+
+### 4. Fact Check: PASS (one honest nuance)
+Claims verified: "progressive disclosure = industry default" (Phase 1 + re-verified); "refs-during-render must be
+restructured" (React official docs, above); "render-prop makes future ports mechanical" (valid for the headless-
+renderer case). **Nuance stated plainly:** render-props are *not* the modern default for brand-new logic-sharing
+(hooks are) — mobile adopts them **purely for web-parity / mechanical future ports**, an explicit, owner-chosen
+divergence from the hooks-default norm, not an oversight.
+
+### 5. Maintainability: PASS (conditional, satisfied)
+Mirrors web's exact `timeline/` file tree (a dev who knows web finds the identical structure), pure logic isolated +
+unit-tested, clear engine/hooks/primitives/renderers boundaries. The ~35-files-for-one-wired-renderer surface only
+pays off **if the follow-up renderers get built** — which the owner has explicitly committed to doing immediately,
+so the investment is justified rather than speculative. Gotcha to guard with a comment: the render-prop inversion
+(renderer calls `children(results)`, never returns its own tree) — documented in `03` §9.
+
+### 6. Patch vs. Fix: PROPER FIX (no escalation needed)
+The render-prop migration of shipped PR-3/9a code is a **root-cause fix** — it unifies mobile onto web's contract
+now so there is *no* later refactor; the alternative (bolt reasoning onto the simpler `{matches,Component}`
+contract) is precisely the "refactor later" the owner forbade. The two hook restructures are fixes (align with
+React's purity rule), not lint-suppression. The scoped deferrals (search sub-labels, parallel tabs, reasoning
+auto-scroll) are documented scope boundaries restored by later phases, not symptom-patches. No patch-vs-fix
+decision to surface.
+
+**Verdict: all six pass (2 concerns hardened in-plan). No patch-vs-fix escalation. Cleared for Phase 5.**

--- a/docs/mobile-chat/9b-timeline/05-pr-roadmap.md
+++ b/docs/mobile-chat/9b-timeline/05-pr-roadmap.md
@@ -1,0 +1,205 @@
+> Status: active · Task: 9b-timeline · Source plan: 04-implementation-plan.md
+
+# Mobile Chat 9b — Agentic Reasoning Timeline · PR Roadmap
+
+A faithful port of web's agent timeline shell (Approach C) is honestly a **multi-PR phase** (~3.7–4.3k LOC). It's
+sliced into 7 layered, independently-mergeable PRs. **Pre-production → no feature flag:** the layers land "dark"
+(compiled + unit-tested, not yet on screen) until the composition PR (9b.7) lights the timeline up; the one
+mid-sequence behavior change is 9b.4 (the final-answer path migrates to the shared contract, behavior-identical).
+Every PR leaves `main` building, `tsc`/lint/jest green, and the app usable.
+
+## Overview
+
+| PR | Title | Est. LOC | Depends on | Key deliverable |
+|----|-------|----------|------------|-----------------|
+| 9b.1 | `feat(mobile): timeline grouping engine + packet contracts` | ~700 | — | Pure grouping reducer (turn/tab + `section_end` synthesis) + full `PacketType` enum + pure step helpers; unit-tested. Dark. |
+| 9b.2 | `feat(mobile): timeline processor + pacing hooks` | ~590 | 9b.1 | `usePacketProcessor` (lint-safe recompute) + `usePacedTurnGroups` (200ms reveal), the two restructured hooks; unit-tested. Dark. |
+| 9b.3 | `feat(mobile): timeline state hooks` | ~550 | 9b.1 | `useTimelineUIState`/`Expansion`/`Header`/`StreamingDuration`/`Metrics`/`StepState`; unit-tested. Dark. |
+| 9b.4 | `feat(mobile): render-prop renderer contract + answer migration` | ~510 | 9b.1 | `RendererResult`/`MessageRenderer` contract + `findRenderer` + `RendererComponent`; migrate final-answer `MessageTextRenderer` to it. **Live** (answer path). |
+| 9b.5 | `feat(mobile): timeline primitives + StepContainer` | ~650 | 9b.4 | Rail/surface/content primitives + `StepContainer` + `TimelineRendererComponent` + new icons/Button (ASK) + StreamingMarkdown `muted`. Dark. |
+| 9b.6 | `feat(mobile): reasoning renderer` | ~450 | 9b.4, 9b.5 | `ReasoningRenderer` + `reasoningState` + `ReasoningTextWindow`; registered in `findRenderer`; unit-tested. Dark. |
+| 9b.7 | `feat(mobile): agent timeline composition` | ~700 | 9b.2, 9b.3, 9b.5, 9b.6 | `AgentTimeline` shell + headers + Expanded/Collapsed content + `MessageRow` wiring + `streamingStartedAt`. **Lights up** the timeline. **Device gate.** |
+
+## Sequence
+
+```
+9b.1 engine+contracts+helpers ─┬─► 9b.2 processor+pacing hooks ──┐
+   (dark, unit-tested)         ├─► 9b.3 state hooks ─────────────┤
+                               └─► 9b.4 contract + answer path ──┼─► 9b.5 primitives+StepContainer ─► 9b.6 reasoning ─┐
+                                        (live: answer)           │        (dark)                        (dark)        │
+                                                                 └──────────────────────────────────────────────────►┴─► 9b.7 composition
+                                                                                                                          (LIGHTS UP + device gate)
+```
+9b.1 is the root. 9b.2 / 9b.3 / 9b.4 fan out from it (parallelizable). 9b.5→9b.6 chain on the contract. 9b.7
+depends on the hooks (9b.2/9b.3), the UI primitives (9b.5), and the reasoning renderer (9b.6) — it's the only PR
+that changes the timeline on screen.
+
+---
+
+## PR 9b.1 — Grouping engine + packet contracts + pure helpers
+- **Goal:** The pure, unit-tested data core — packets grouped into timeline steps exactly as web does.
+- **Scope (in):** full web `PacketType` enum + the engine/shell obj interfaces (§1 of `03`); extend
+  `messageProcessor` into a faithful `packetProcessor` port (grouping map, `section_end` synthesis on
+  turn-transition + stop, tool/display categorization, `finalAnswerComing`, `buildGroupsFromKeys`,
+  `hasContentPackets`); the pure step helpers.
+- **Out of scope:** all hooks, all UI, the reasoning renderer. Nothing renders differently.
+- **Files:**
+  | File | New/Modified | Slice |
+  |------|--------------|-------|
+  | `mobile/src/chat/streamingModels.ts` | modified | enum values + reasoning/branch/tool-arg interfaces + `ObjTypes` |
+  | `mobile/src/chat/messageProcessor.ts` | modified | grouping fields + `section_end` synthesis + categorization (keep 9a citations/docs) |
+  | `mobile/src/chat/timeline/transformers.ts` | new | `TransformedStep`/`TurnGroup`/`groupStepsByTurn` |
+  | `mobile/src/chat/timeline/packetUtils.ts` | new | `isToolPacket`/`isDisplayPacket`/`getTextContent`/… |
+  | `mobile/src/chat/timeline/packetHelpers.ts` | new | per-family predicates + collapsed-streaming sets |
+  | `mobile/src/chat/timeline/toolDisplay.ts` | new | `parseToolKey`/`getToolName`/`isToolComplete`/`hasToolError` |
+  | `mobile/src/chat/timeline/__tests__/*` | new | grouping key, 3 `section_end` triggers, categorization, parallel detection, `model_index` tolerance, history-reset |
+- **Est. size:** ~700 LOC (at the band; the engine + its helpers + tests are one coherent, tightly-coupled unit — splitting the helpers out would ship an engine that can't compile).
+- **Depends on:** —
+- **Feature-flag state:** N/A (pre-production; additive — dark).
+- **Tests on merge:** Jest unit — grouping + `section_end` synthesis + transformers fully covered; `messageProcessor` still passes its 9a citation/document tests.
+- **Drift checkpoint:** Confirm the backend reasoning packet shapes (`reasoning_start/delta/done`) and `Placement`
+  fields are still as `03`/deepread recorded; re-verify `web/.../packetProcessor.ts` hasn't changed since extraction.
+
+## PR 9b.2 — Processor + pacing hooks
+- **Goal:** Host the reducer and drive the 200 ms staggered reveal — the two lint-forced restructures.
+- **Scope (in):** `usePacketProcessor` (`useMemo` full recompute + derive `toolTurnGroups`/`displayGroups`/
+  `isComplete`); `usePacedTurnGroups` (`useState`+effect reveal, answer gating, history bypass; drop
+  `prevPacedRef`).
+- **Out of scope:** the state/derive hooks (9b.3), all UI.
+- **Files:**
+  | File | New/Modified | Slice |
+  |------|--------------|-------|
+  | `mobile/src/hooks/timeline/usePacketProcessor.ts` | new | recompute + group derivation + `renderComplete` gate |
+  | `mobile/src/hooks/timeline/usePacedTurnGroups.ts` | new | 200ms reveal + gating (restructured) |
+  | `mobile/src/hooks/timeline/__tests__/*` | new | fake-timer pacing (first-immediate/200ms/stop-flush/bypass) + processor derivation |
+- **Est. size:** ~590 LOC.
+- **Depends on:** 9b.1.
+- **Feature-flag state:** N/A (dark).
+- **Tests on merge:** Jest unit with fake timers — reveal cadence, stop-flush, history bypass, answer withheld until pacing completes; processor recompute correctness.
+- **Drift checkpoint:** Confirm on-device the recompute + effect-driven reveal feel identical to web (the one-frame
+  risk called out in `03` §1); if the first-packet render flashes, revisit before 9b.7 wires it.
+
+## PR 9b.3 — Timeline state hooks
+- **Goal:** The pure UI-state derivation — 7-state machine, expansion, header text, live timer, metrics.
+- **Scope (in):** `useTimelineUIState` (7 states + booleans), `useTimelineExpansion` (auto-collapse +
+  `userHasToggled`), `useTimelineHeader` (text map; search sub-labels generic for now), `useStreamingDuration`
+  (live timer + backend freeze), `useTimelineMetrics`, `useTimelineStepState` (memory, dormant).
+- **Out of scope:** all UI; the search-specific header sub-labels (search phase).
+- **Files:**
+  | File | New/Modified | Slice |
+  |------|--------------|-------|
+  | `mobile/src/hooks/timeline/useTimelineUIState.ts` | new | state machine + show/style booleans |
+  | `mobile/src/hooks/timeline/useTimelineExpansion.ts` | new | collapse + auto-collapse |
+  | `mobile/src/hooks/timeline/useTimelineHeader.ts` | new | header text map |
+  | `mobile/src/hooks/timeline/useStreamingDuration.ts` | new | live elapsed timer |
+  | `mobile/src/hooks/timeline/useTimelineMetrics.ts` | new | step count + last-step flags |
+  | `mobile/src/hooks/timeline/useTimelineStepState.ts` | new | memory extraction (dormant) |
+  | `mobile/src/hooks/timeline/__tests__/*` | new | 7 states + booleans, auto-collapse + toggle suppression, timer tick + freeze |
+- **Est. size:** ~550 LOC.
+- **Depends on:** 9b.1 (types + predicates).
+- **Feature-flag state:** N/A (dark).
+- **Tests on merge:** Jest unit — every `TimelineUIState` branch + derived boolean; expansion auto-collapse and `userHasToggled`; duration tick/freeze.
+- **Drift checkpoint:** none beyond 9b.1's.
+
+## PR 9b.4 — Render-prop renderer contract + final-answer migration
+- **Goal:** Adopt web's render-prop contract and route the final answer through it — the "no refactor later" move.
+- **Scope (in):** `timelineContract.ts` (RenderType/RendererResult/MessageRenderer/FullChatState/TimelineRendererResult);
+  `findRenderer.ts` (full 13-slot priority chain — chat wired, reasoning slot present-but-null, others tagged
+  `// PR 9x`); `RendererComponent.tsx` (final-answer at `FULL`, mixed chat+image stubbed = 9e); migrate
+  `MessageTextRenderer` to the contract; re-export from `registry.ts`; point `MessageRow`'s answer render at
+  `RendererComponent` (timeline still stub).
+- **Out of scope:** timeline UI, reasoning renderer.
+- **Files:**
+  | File | New/Modified | Slice |
+  |------|--------------|-------|
+  | `mobile/src/components/chat/renderers/timelineContract.ts` | new | the contract types |
+  | `mobile/src/components/chat/renderers/findRenderer.ts` | new | priority dispatch |
+  | `mobile/src/components/chat/renderers/RendererComponent.tsx` | new | final-answer dispatch |
+  | `mobile/src/components/chat/renderers/MessageTextRenderer.tsx` | modified | → render-prop contract |
+  | `mobile/src/components/chat/renderers/registry.ts` | modified | re-export `findRenderer` |
+  | `mobile/src/components/chat/MessageRow.tsx` | modified | answer → `RendererComponent` (timeline still stub) |
+  | `mobile/src/hooks/usePacketDisplay.ts` | modified | keep exposing `processed` for `CitedSources` |
+  | `__tests__/*` | new | findRenderer dispatch order, MessageTextRenderer render-prop, RendererComponent |
+- **Est. size:** ~510 LOC.
+- **Depends on:** 9b.1.
+- **Feature-flag state:** N/A — **live behavior change** (answer path). Must render identically.
+- **Tests on merge:** Jest — dispatch order (chat first, reasoning last); MessageTextRenderer emits `children([result])`; RendererComponent renders answer. **Manual:** confirm the streamed markdown answer + 9a inline citations + Sources bar are unchanged.
+- **Drift checkpoint:** This touches shipped PR-3/9a code — before starting, re-confirm the 9a citation-link + `CitedSources` behavior so the migration preserves it exactly.
+
+## PR 9b.5 — Timeline primitives + StepContainer
+- **Goal:** The visual step frame — rail, connector, surface, header, collapse — plus the new icons/primitives.
+- **Scope (in):** `primitives/*` (`timelineTokens` px constants, `TimelineRoot`/`HeaderRow`/`Row`/`IconColumn`/
+  `Surface`/`StepContent`, hover dropped); `StepContainer`; `TimelineRendererComponent` (per-step expand +
+  `renderType` derivation); new icons `circle`/`fold`/`expand`/`check-circle` (**owner-ASK**); confirm/port a
+  tertiary icon `Button` (**owner-ASK**); `StreamingMarkdown` `muted` variant.
+- **Out of scope:** the reasoning renderer, `AgentTimeline` composition, headers.
+- **Files:**
+  | File | New/Modified | Slice |
+  |------|--------------|-------|
+  | `mobile/src/components/chat/timeline/primitives/*` | new | tokens + 6 rail/surface/content primitives |
+  | `mobile/src/components/chat/timeline/StepContainer.tsx` | new | compose primitives into a step frame |
+  | `mobile/src/components/chat/timeline/TimelineRendererComponent.tsx` | new | per-step expand + renderType |
+  | `mobile/src/icons/{circle,fold,expand,check-circle}.tsx` | new | ASK owner |
+  | `mobile/src/components/chat/StreamingMarkdown.tsx` | modified | `muted`/`compact` variant |
+  | `__tests__/*` | new | StepContainer (collapse gating, last-step connector, error surface), renderType derivation |
+- **Est. size:** ~650 LOC.
+- **Depends on:** 9b.4 (contract).
+- **Feature-flag state:** N/A (dark — not yet mounted).
+- **Tests on merge:** RN Testing Library — StepContainer renders header/body/collapse per `renderType`; icon rail geometry; error surface.
+- **Drift checkpoint:** **Owner-ASK gate** — resolve the new-icon ports + tertiary Button before coding UI (per the web-parity principle). Re-confirm the token px values against `03` if web tokens changed.
+
+## PR 9b.6 — Reasoning renderer
+- **Goal:** The one wired step renderer — streamed reasoning with heading, 500 ms min-thinking, markdown body.
+- **Scope (in):** `reasoningState.ts` (pure `extractFirstParagraph` + `constructCurrentReasoningState`);
+  `ReasoningRenderer.tsx` (render-prop; 500 ms gate; icon `circle`; `noPaddingRight`; `supportsCollapsible`);
+  `ReasoningTextWindow.tsx` (maxHeight markdown window); register reasoning in `findRenderer`.
+- **Out of scope:** `AgentTimeline` composition (9b.7); the copy/download modal + translateY auto-scroll (deferred).
+- **Files:**
+  | File | New/Modified | Slice |
+  |------|--------------|-------|
+  | `mobile/src/chat/timeline/reasoningState.ts` | new | heading extraction + delta accumulation (pure) |
+  | `mobile/src/components/chat/renderers/ReasoningRenderer.tsx` | new | the render-prop renderer + 500ms gate |
+  | `mobile/src/components/chat/timeline/ReasoningTextWindow.tsx` | new | maxHeight markdown window |
+  | `mobile/src/components/chat/renderers/findRenderer.ts` | modified | wire the reasoning slot |
+  | `__tests__/*` | new | heading extraction rules, delta accumulation, 500ms gate (fake timers), empty/pre-start branch |
+- **Est. size:** ~450 LOC.
+- **Depends on:** 9b.4 (contract), 9b.5 (`circle` icon, `StreamingMarkdown` muted, StepContainer for the smoke test).
+- **Feature-flag state:** N/A (dark — reachable only once 9b.7 mounts the timeline).
+- **Tests on merge:** Jest — `reasoningState` heading + accumulation; `ReasoningRenderer` 500 ms gate + branches; a StepContainer-wrapped smoke render.
+- **Drift checkpoint:** Confirm `react-native-streamdown` renders the `muted` variant acceptably (color/margins) — device-adjacent; the owner's 9b.7 device gate covers it.
+
+## PR 9b.7 — Agent timeline composition (lights up)
+- **Goal:** Assemble the shell and render the timeline on screen — the walking skeleton completes.
+- **Scope (in):** rewrite `AgentTimeline` into the shell (runs the state hooks + header switch + body);
+  `ExpandedTimelineContent` + `CollapsedStreamingContent` + `TimelineStep`; headers
+  (`StreamingHeader`/`CompletedHeader`/`StoppedHeader`; `ParallelStreamingHeader` dormant stub);
+  `ParallelTimelineTabs` dormant (linearize) + `toolIcons`; Done/Stopped terminal step; wire
+  `MessageRow.AssistantMessage` into the AgentMessage analog (`usePacketProcessor` + `usePacedTurnGroups` →
+  `AgentTimeline` above + `RendererComponent` answer below + `CitedSources`); capture `streamingStartedAt` in the
+  PR-3 stream controller/store.
+- **Out of scope:** any tool renderer (follow-up phases); real parallel-tab tabs.
+- **Files:**
+  | File | New/Modified | Slice |
+  |------|--------------|-------|
+  | `mobile/src/components/chat/AgentTimeline.tsx` | modified | stub → full shell |
+  | `mobile/src/components/chat/timeline/ExpandedTimelineContent.tsx` | new | TurnGroup[]→steps + Done/Stopped |
+  | `mobile/src/components/chat/timeline/CollapsedStreamingContent.tsx` | new | streaming live preview |
+  | `mobile/src/components/chat/timeline/TimelineStep.tsx` | new | step composer (children → StepContainer) |
+  | `mobile/src/components/chat/timeline/headers/*` | new | Streaming/Completed/Stopped (+Parallel dormant) |
+  | `mobile/src/components/chat/timeline/ParallelTimelineTabs.tsx` | new | dormant stub (linearize) |
+  | `mobile/src/components/chat/timeline/toolIcons.ts` | new | packet-type → icon map |
+  | `mobile/src/components/chat/MessageRow.tsx` | modified | AssistantMessage → AgentMessage analog |
+  | stream controller / `chatSessionStore` | modified | `streamingStartedAt` per node |
+  | `__tests__/*` | new | mocked reasoning stream → "Thinking" step → collapse to "Thought for Ns"; tap expands; USER_CANCELLED → Stopped |
+- **Est. size:** ~700 LOC.
+- **Depends on:** 9b.2, 9b.3, 9b.5, 9b.6.
+- **Feature-flag state:** N/A — **the timeline goes live.**
+- **Tests on merge:** RN Testing Library — mocked reasoning packet stream renders the streaming header → step → auto-collapse → tap-expand → Done; Stopped path. **HARD device gate (owner):** dev build, reasoning model — streaming shimmer + live timer, auto-collapse on answer, tap-to-expand, Done step, hydrated render; migrated answer + 9a Sources intact; streaming re-render stays smooth (perf-isolation from `04`).
+- **Drift checkpoint:** Re-confirm the `unify-chat-input` `ChatSurface` composition (post-PR6 refactor) is where `MessageRow`/`AgentTimeline` mount, and that per-conversation draft/reset rules don't interfere with the per-node timeline state.
+
+## After 9b — the follow-up renderer phases (not designed here)
+
+Each is its own grill-first PR on the zero-refactor seam: add the tool's obj interfaces + one `findRenderer`
+predicate wire-up + one render-prop renderer returning `RendererResult` (search/fetch reuse 9a `SourceRow`).
+Order by product value (owner's call): **search → fetch → python/code → custom-tool → deep-research (+nested) →
+memory**, plus **parallel-tab tabs** (UI-only, un-dormant `ParallelTimelineTabs`) and **9c/9d/9e** independently.

--- a/mobile/src/chat/__tests__/fixtures.ts
+++ b/mobile/src/chat/__tests__/fixtures.ts
@@ -1,7 +1,11 @@
 import { type SearchDoc } from "@/chat/contracts/documents";
 import { UserFileStatus, type ProjectFile } from "@/chat/contracts/projects";
 import { ChatFileType } from "@/chat/interfaces";
-import { type ObjTypes, type Packet } from "@/chat/streamingModels";
+import {
+  type ObjTypes,
+  type Packet,
+  type Placement,
+} from "@/chat/streamingModels";
 
 // Shared ProjectFile builder so the file's shape lives in one place across tests.
 export function makeProjectFile(
@@ -21,6 +25,14 @@ export function makeProjectFile(
 
 export function makePacket(obj: ObjTypes, turnIndex = 0): Packet {
   return { placement: { turn_index: turnIndex }, obj };
+}
+
+// Packet with an explicit placement (turn/tab/sub_turn/model). turn_index defaults to 0.
+export function makePlacedPacket(
+  obj: ObjTypes,
+  placement: Partial<Placement> = {},
+): Packet {
+  return { placement: { turn_index: 0, ...placement }, obj };
 }
 
 export function makeCitationPacket(

--- a/mobile/src/chat/messageProcessor.ts
+++ b/mobile/src/chat/messageProcessor.ts
@@ -1,7 +1,10 @@
-// Pure, incremental packet -> state processor for one assistant message. A small mobile port of
-// web's `packetProcessor`: it advances a cursor (`nextPacketIndex`), processes only NEW packets each
-// call, and mutates its state in place. 9a fills it with citations + documents; 9b extends it with
-// turn/tab grouping + timeline steps, so the shape here stays deliberately flat (grouping-free).
+// Pure, incremental packet -> state processor for one assistant message. A faithful mobile port of
+// web's `packetProcessor` (web/.../timeline/hooks/packetProcessor.ts): it advances a cursor
+// (`nextPacketIndex`), processes only NEW packets each call, and mutates its state in place. It both
+// (a) keeps the 9a citation/document/completion tracking and (b) groups packets into timeline steps
+// by `${turn_index}-${tab_index}`, synthesizing SECTION_END (on a new turn, or on stop) so a step
+// reads as "complete". The owning hook holds the state instance stable and feeds the growing packet
+// array; see `hooks/timeline/usePacketProcessor`.
 
 import {
   CitationMap,
@@ -10,24 +13,65 @@ import {
 } from "@/chat/contracts/documents";
 import {
   CitationInfo,
+  CODE_INTERPRETER_TOOL_TYPES,
+  FetchToolDocuments,
+  ImageGenerationToolDelta,
   MessageStart,
-  OpenUrlDocuments,
   Packet,
   PacketType,
   SearchToolDocumentsDelta,
   Stop,
   StopReason,
+  ToolCallArgumentDelta,
+  TopLevelBranching,
 } from "@/chat/streamingModels";
+import {
+  isActualToolCallPacket,
+  isDisplayPacket,
+  isToolPacket,
+} from "@/chat/timeline/packetUtils";
+import { parseToolKey } from "@/chat/timeline/toolDisplay";
 
 export interface ProcessedMessageState {
   nodeId: number;
   nextPacketIndex: number; // cursor — process only packets past this index
+
+  // Citations (9a)
   citationMap: CitationMap;
   citations: StreamingCitation[]; // deduped, first-cite order
   seenCitationDocIds: Set<string>; // dedups `citations`
+
+  // Documents (9a)
   documentMap: Map<string, SearchDoc>;
-  isComplete: boolean; // saw MESSAGE_END or STOP
-  stopReason?: StopReason;
+
+  // Packet grouping (9b)
+  groupedPacketsMap: Map<string, Packet[]>;
+  seenGroupKeys: Set<string>;
+  groupKeysWithSectionEnd: Set<string>;
+  expectedBranches: Map<number, number>;
+  toolGroupKeys: Set<string>; // populated during processing
+  displayGroupKeys: Set<string>;
+
+  // Image generation status (9b)
+  isGeneratingImage: boolean;
+  generatedImageCount: number;
+
+  // Streaming status (9b)
+  finalAnswerComing: boolean;
+  stopPacketSeen: boolean;
+  isComplete: boolean; // saw MESSAGE_END or STOP (9a; drives CitedSources)
+  stopReason: StopReason | undefined;
+  toolProcessingDuration: number | undefined; // from MESSAGE_START.pre_answer_processing_seconds
+
+  // Result arrays (rebuilt at the end of processPackets)
+  toolGroups: GroupedPacket[];
+  potentialDisplayGroups: GroupedPacket[];
+}
+
+export interface GroupedPacket {
+  turn_index: number;
+  tab_index: number;
+  packets: Packet[];
 }
 
 export function createInitialState(nodeId: number): ProcessedMessageState {
@@ -38,56 +82,289 @@ export function createInitialState(nodeId: number): ProcessedMessageState {
     citations: [],
     seenCitationDocIds: new Set(),
     documentMap: new Map(),
+    groupedPacketsMap: new Map(),
+    seenGroupKeys: new Set(),
+    groupKeysWithSectionEnd: new Set(),
+    expectedBranches: new Map(),
+    toolGroupKeys: new Set(),
+    displayGroupKeys: new Set(),
+    isGeneratingImage: false,
+    generatedImageCount: 0,
+    finalAnswerComing: false,
+    stopPacketSeen: false,
     isComplete: false,
     stopReason: undefined,
+    toolProcessingDuration: undefined,
+    toolGroups: [],
+    potentialDisplayGroups: [],
   };
+}
+
+// Grouping helpers
+function getGroupKey(packet: Packet): string {
+  const turnIndex = packet.placement.turn_index;
+  const tabIndex = packet.placement.tab_index ?? 0;
+  return `${turnIndex}-${tabIndex}`;
+}
+
+// Push a synthetic SECTION_END into a group so its renderer reads as complete. Idempotent. The
+// synthetic packet omits sub_turn_index (=> parent-level), which is what research/coding completion
+// checks expect.
+function injectSectionEnd(
+  state: ProcessedMessageState,
+  groupKey: string,
+): void {
+  if (state.groupKeysWithSectionEnd.has(groupKey)) {
+    return;
+  }
+
+  const { turn_index, tab_index } = parseToolKey(groupKey);
+  const syntheticPacket: Packet = {
+    placement: { turn_index, tab_index },
+    obj: { type: PacketType.SECTION_END },
+  };
+
+  const existingGroup = state.groupedPacketsMap.get(groupKey);
+  if (existingGroup) {
+    existingGroup.push(syntheticPacket);
+  }
+  state.groupKeysWithSectionEnd.add(groupKey);
+}
+
+// Packet types that mean a group has meaningful content to display.
+const CONTENT_PACKET_TYPES_SET = new Set<PacketType>([
+  PacketType.MESSAGE_START,
+  PacketType.SEARCH_TOOL_START,
+  PacketType.IMAGE_GENERATION_TOOL_START,
+  PacketType.PYTHON_TOOL_START,
+  PacketType.TOOL_CALL_ARGUMENT_DELTA,
+  PacketType.CUSTOM_TOOL_START,
+  PacketType.FILE_READER_START,
+  PacketType.FETCH_TOOL_START,
+  PacketType.MEMORY_TOOL_START,
+  PacketType.MEMORY_TOOL_NO_ACCESS,
+  PacketType.REASONING_START,
+  PacketType.DEEP_RESEARCH_PLAN_START,
+  PacketType.RESEARCH_AGENT_START,
+  PacketType.CODING_AGENT_START,
+]);
+
+function hasContentPackets(packets: Packet[]): boolean {
+  return packets.some((packet) => {
+    const type = packet.obj.type as PacketType;
+    if (type === PacketType.TOOL_CALL_ARGUMENT_DELTA) {
+      return (
+        (packet.obj as ToolCallArgumentDelta).tool_type ===
+        CODE_INTERPRETER_TOOL_TYPES.PYTHON
+      );
+    }
+    return CONTENT_PACKET_TYPES_SET.has(type);
+  });
+}
+
+// Packet types that indicate final answer content is coming.
+const FINAL_ANSWER_PACKET_TYPES_SET = new Set<PacketType>([
+  PacketType.MESSAGE_START,
+  PacketType.MESSAGE_DELTA,
+  PacketType.IMAGE_GENERATION_TOOL_START,
+  PacketType.IMAGE_GENERATION_TOOL_DELTA,
+]);
+
+// Packet handlers
+function handleTopLevelBranching(
+  state: ProcessedMessageState,
+  packet: Packet,
+): void {
+  const branchingPacket = packet.obj as TopLevelBranching;
+  state.expectedBranches.set(
+    packet.placement.turn_index,
+    branchingPacket.num_parallel_branches,
+  );
+}
+
+// The first packet of a brand-new turn_index closes every prior group that hasn't ended (a new
+// tab_index within a seen turn does NOT trigger this).
+function handleTurnTransition(
+  state: ProcessedMessageState,
+  packet: Packet,
+): void {
+  const currentTurnIndex = packet.placement.turn_index;
+
+  const previousTurnIndices = new Set(
+    Array.from(state.seenGroupKeys).map((key) => parseToolKey(key).turn_index),
+  );
+
+  const isNewTurnIndex = !previousTurnIndices.has(currentTurnIndex);
+
+  if (isNewTurnIndex && state.seenGroupKeys.size > 0) {
+    state.seenGroupKeys.forEach((prevGroupKey) => {
+      if (!state.groupKeysWithSectionEnd.has(prevGroupKey)) {
+        injectSectionEnd(state, prevGroupKey);
+      }
+    });
+  }
 }
 
 function upsertDocuments(
   state: ProcessedMessageState,
-  documents: SearchDoc[],
+  documents: SearchDoc[] | null | undefined,
 ): void {
+  if (!documents) return;
   for (const doc of documents) {
-    if (doc.document_id) state.documentMap.set(doc.document_id, doc);
+    if (doc.document_id) {
+      state.documentMap.set(doc.document_id, doc);
+    }
   }
 }
 
-function processPacket(state: ProcessedMessageState, packet: Packet): void {
-  const obj = packet.obj;
-  switch (obj.type) {
-    case PacketType.CITATION_INFO: {
-      const citation = obj as CitationInfo;
-      state.citationMap[citation.citation_number] = citation.document_id;
-      if (!state.seenCitationDocIds.has(citation.document_id)) {
-        state.seenCitationDocIds.add(citation.document_id);
-        state.citations.push({
-          citation_num: citation.citation_number,
-          document_id: citation.document_id,
-        });
-      }
-      break;
-    }
-    case PacketType.SEARCH_TOOL_DOCUMENTS_DELTA:
-      upsertDocuments(state, (obj as SearchToolDocumentsDelta).documents ?? []);
-      break;
-    case PacketType.OPEN_URL_DOCUMENTS:
-      upsertDocuments(state, (obj as OpenUrlDocuments).documents ?? []);
-      break;
-    case PacketType.MESSAGE_START: {
-      const documents = (obj as MessageStart).final_documents;
-      if (documents) upsertDocuments(state, documents);
-      break;
-    }
-    case PacketType.MESSAGE_END:
-      state.isComplete = true;
-      break;
-    case PacketType.STOP:
-      state.isComplete = true;
-      state.stopReason = (obj as Stop).stop_reason;
-      break;
-    default:
-      break; // message_delta / section_end / error / heartbeat: not our concern
+function handleCitationPacket(
+  state: ProcessedMessageState,
+  packet: Packet,
+): void {
+  if (packet.obj.type !== PacketType.CITATION_INFO) {
+    return;
   }
+
+  const citationInfo = packet.obj as CitationInfo;
+  state.citationMap[citationInfo.citation_number] = citationInfo.document_id;
+
+  if (!state.seenCitationDocIds.has(citationInfo.document_id)) {
+    state.seenCitationDocIds.add(citationInfo.document_id);
+    state.citations.push({
+      citation_num: citationInfo.citation_number,
+      document_id: citationInfo.document_id,
+    });
+  }
+}
+
+function handleDocumentPacket(
+  state: ProcessedMessageState,
+  packet: Packet,
+): void {
+  if (packet.obj.type === PacketType.SEARCH_TOOL_DOCUMENTS_DELTA) {
+    upsertDocuments(state, (packet.obj as SearchToolDocumentsDelta).documents);
+  } else if (packet.obj.type === PacketType.FETCH_TOOL_DOCUMENTS) {
+    upsertDocuments(state, (packet.obj as FetchToolDocuments).documents);
+  } else if (packet.obj.type === PacketType.MESSAGE_START) {
+    // Authoritative cited-doc set for the turn (9a).
+    upsertDocuments(state, (packet.obj as MessageStart).final_documents);
+  }
+}
+
+function handleStreamingStatusPacket(
+  state: ProcessedMessageState,
+  packet: Packet,
+): void {
+  if (FINAL_ANSWER_PACKET_TYPES_SET.has(packet.obj.type as PacketType)) {
+    state.finalAnswerComing = true;
+  }
+
+  if (packet.obj.type === PacketType.MESSAGE_START) {
+    const messageStart = packet.obj as MessageStart;
+    if (messageStart.pre_answer_processing_seconds !== undefined) {
+      state.toolProcessingDuration = messageStart.pre_answer_processing_seconds;
+    }
+  }
+}
+
+function handleStopPacket(state: ProcessedMessageState, packet: Packet): void {
+  if (packet.obj.type !== PacketType.STOP || state.stopPacketSeen) {
+    return;
+  }
+
+  state.stopPacketSeen = true;
+  state.isComplete = true;
+  state.stopReason = (packet.obj as Stop).stop_reason;
+
+  // Close every still-open group (this is why the final answer group gets its SECTION_END even
+  // though the backend never sends one).
+  state.seenGroupKeys.forEach((groupKey) => {
+    if (!state.groupKeysWithSectionEnd.has(groupKey)) {
+      injectSectionEnd(state, groupKey);
+    }
+  });
+}
+
+// Claude can emit a message then start a real (non-reasoning) tool — the answer isn't actually
+// coming yet, so un-set finalAnswerComing. Reasoning packets are excluded (just thinking).
+function handleToolAfterMessagePacket(
+  state: ProcessedMessageState,
+  packet: Packet,
+): void {
+  if (
+    state.finalAnswerComing &&
+    !state.stopPacketSeen &&
+    isActualToolCallPacket(packet)
+  ) {
+    state.finalAnswerComing = false;
+  }
+}
+
+function addPacketToGroup(
+  state: ProcessedMessageState,
+  packet: Packet,
+  groupKey: string,
+): void {
+  const existingGroup = state.groupedPacketsMap.get(groupKey);
+  if (existingGroup) {
+    existingGroup.push(packet);
+  } else {
+    state.groupedPacketsMap.set(groupKey, [packet]);
+  }
+}
+
+// Main processing
+function processPacket(state: ProcessedMessageState, packet: Packet): void {
+  if (!packet) return;
+
+  // TopLevelBranching is pure metadata — record expected branches, don't add to any group.
+  if (packet.obj.type === PacketType.TOP_LEVEL_BRANCHING) {
+    handleTopLevelBranching(state, packet);
+    return;
+  }
+
+  handleTurnTransition(state, packet);
+
+  const groupKey = getGroupKey(packet);
+  state.seenGroupKeys.add(groupKey);
+
+  // A real SECTION_END or ERROR marks the group complete.
+  if (
+    packet.obj.type === PacketType.SECTION_END ||
+    packet.obj.type === PacketType.ERROR
+  ) {
+    state.groupKeysWithSectionEnd.add(groupKey);
+  }
+
+  const isFirstPacket = !state.groupedPacketsMap.get(groupKey);
+  addPacketToGroup(state, packet, groupKey);
+
+  if (isFirstPacket) {
+    if (isToolPacket(packet, false)) {
+      state.toolGroupKeys.add(groupKey);
+    }
+    if (isDisplayPacket(packet)) {
+      state.displayGroupKeys.add(groupKey);
+    }
+  }
+
+  if (packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START) {
+    state.isGeneratingImage = true;
+  }
+  if (packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_DELTA) {
+    const delta = packet.obj as ImageGenerationToolDelta;
+    state.generatedImageCount += delta.images?.length ?? 0;
+  }
+
+  if (packet.obj.type === PacketType.MESSAGE_END) {
+    state.isComplete = true;
+  }
+
+  handleCitationPacket(state, packet);
+  handleDocumentPacket(state, packet);
+  handleStreamingStatusPacket(state, packet);
+  handleStopPacket(state, packet);
+  handleToolAfterMessagePacket(state, packet);
 }
 
 export function processPackets(
@@ -99,10 +376,50 @@ export function processPackets(
   if (state.nextPacketIndex > rawPackets.length) {
     state = createInitialState(state.nodeId);
   }
+
+  const prevProcessedIndex = state.nextPacketIndex;
+
   for (let i = state.nextPacketIndex; i < rawPackets.length; i++) {
     const packet = rawPackets[i];
-    if (packet) processPacket(state, packet);
+    if (packet) {
+      processPacket(state, packet);
+    }
   }
+
   state.nextPacketIndex = rawPackets.length;
+
+  // Only rebuild result arrays when new packets arrived — preserves array identity so memoized
+  // consumers can bail out.
+  if (prevProcessedIndex !== rawPackets.length) {
+    state.toolGroups = buildGroupsFromKeys(state, state.toolGroupKeys);
+    state.potentialDisplayGroups = buildGroupsFromKeys(
+      state,
+      state.displayGroupKeys,
+    );
+  }
+
   return state;
+}
+
+// Map group keys -> GroupedPacket (spread packets to force a new array reference for change
+// detection), filter to groups with meaningful content, sort by turn then tab.
+function buildGroupsFromKeys(
+  state: ProcessedMessageState,
+  keys: Set<string>,
+): GroupedPacket[] {
+  return Array.from(keys)
+    .map((key) => {
+      const { turn_index, tab_index } = parseToolKey(key);
+      const packets = state.groupedPacketsMap.get(key);
+      return packets ? { turn_index, tab_index, packets: [...packets] } : null;
+    })
+    .filter(
+      (g): g is GroupedPacket => g !== null && hasContentPackets(g.packets),
+    )
+    .sort((a, b) => {
+      if (a.turn_index !== b.turn_index) {
+        return a.turn_index - b.turn_index;
+      }
+      return a.tab_index - b.tab_index;
+    });
 }

--- a/mobile/src/chat/messageProcessor.ts
+++ b/mobile/src/chat/messageProcessor.ts
@@ -1,10 +1,6 @@
-// Pure, incremental packet -> state processor for one assistant message. A faithful mobile port of
-// web's `packetProcessor` (web/.../timeline/hooks/packetProcessor.ts): it advances a cursor
-// (`nextPacketIndex`), processes only NEW packets each call, and mutates its state in place. It both
-// (a) keeps the 9a citation/document/completion tracking and (b) groups packets into timeline steps
-// by `${turn_index}-${tab_index}`, synthesizing SECTION_END (on a new turn, or on stop) so a step
-// reads as "complete". The owning hook holds the state instance stable and feeds the growing packet
-// array; see `hooks/timeline/usePacketProcessor`.
+// Pure incremental packet -> state reducer for one assistant message (faithful port of web's
+// packetProcessor). Advances a cursor, groups packets into timeline steps by turn/tab, synthesizes
+// SECTION_END so a step reads complete, and keeps the 9a citations/documents/completion tracking.
 
 import {
   CitationMap,
@@ -36,34 +32,28 @@ export interface ProcessedMessageState {
   nodeId: number;
   nextPacketIndex: number; // cursor — process only packets past this index
 
-  // Citations (9a)
   citationMap: CitationMap;
-  citations: StreamingCitation[]; // deduped, first-cite order
-  seenCitationDocIds: Set<string>; // dedups `citations`
+  citations: StreamingCitation[];
+  seenCitationDocIds: Set<string>;
 
-  // Documents (9a)
   documentMap: Map<string, SearchDoc>;
 
-  // Packet grouping (9b)
   groupedPacketsMap: Map<string, Packet[]>;
   seenGroupKeys: Set<string>;
   groupKeysWithSectionEnd: Set<string>;
   expectedBranches: Map<number, number>;
-  toolGroupKeys: Set<string>; // populated during processing
+  toolGroupKeys: Set<string>;
   displayGroupKeys: Set<string>;
 
-  // Image generation status (9b)
   isGeneratingImage: boolean;
   generatedImageCount: number;
 
-  // Streaming status (9b)
   finalAnswerComing: boolean;
   stopPacketSeen: boolean;
-  isComplete: boolean; // saw MESSAGE_END or STOP (9a; drives CitedSources)
+  isComplete: boolean; // saw MESSAGE_END or STOP; drives CitedSources
   stopReason: StopReason | undefined;
-  toolProcessingDuration: number | undefined; // from MESSAGE_START.pre_answer_processing_seconds
+  toolProcessingDuration: number | undefined;
 
-  // Result arrays (rebuilt at the end of processPackets)
   toolGroups: GroupedPacket[];
   potentialDisplayGroups: GroupedPacket[];
 }
@@ -100,16 +90,14 @@ export function createInitialState(nodeId: number): ProcessedMessageState {
   };
 }
 
-// Grouping helpers
 function getGroupKey(packet: Packet): string {
   const turnIndex = packet.placement.turn_index;
   const tabIndex = packet.placement.tab_index ?? 0;
   return `${turnIndex}-${tabIndex}`;
 }
 
-// Push a synthetic SECTION_END into a group so its renderer reads as complete. Idempotent. The
-// synthetic packet omits sub_turn_index (=> parent-level), which is what research/coding completion
-// checks expect.
+// Synthetic SECTION_END so the group's renderer reads complete. Idempotent; omits sub_turn_index
+// (parent-level), which research/coding completion checks require.
 function injectSectionEnd(
   state: ProcessedMessageState,
   groupKey: string,
@@ -131,7 +119,6 @@ function injectSectionEnd(
   state.groupKeysWithSectionEnd.add(groupKey);
 }
 
-// Packet types that mean a group has meaningful content to display.
 const CONTENT_PACKET_TYPES_SET = new Set<PacketType>([
   PacketType.MESSAGE_START,
   PacketType.SEARCH_TOOL_START,
@@ -162,7 +149,6 @@ function hasContentPackets(packets: Packet[]): boolean {
   });
 }
 
-// Packet types that indicate final answer content is coming.
 const FINAL_ANSWER_PACKET_TYPES_SET = new Set<PacketType>([
   PacketType.MESSAGE_START,
   PacketType.MESSAGE_DELTA,
@@ -170,7 +156,6 @@ const FINAL_ANSWER_PACKET_TYPES_SET = new Set<PacketType>([
   PacketType.IMAGE_GENERATION_TOOL_DELTA,
 ]);
 
-// Packet handlers
 function handleTopLevelBranching(
   state: ProcessedMessageState,
   packet: Packet,
@@ -182,8 +167,7 @@ function handleTopLevelBranching(
   );
 }
 
-// The first packet of a brand-new turn_index closes every prior group that hasn't ended (a new
-// tab_index within a seen turn does NOT trigger this).
+// A new turn_index closes every prior open group (a new tab_index within a seen turn does not).
 function handleTurnTransition(
   state: ProcessedMessageState,
   packet: Packet,
@@ -246,7 +230,6 @@ function handleDocumentPacket(
   } else if (packet.obj.type === PacketType.FETCH_TOOL_DOCUMENTS) {
     upsertDocuments(state, (packet.obj as FetchToolDocuments).documents);
   } else if (packet.obj.type === PacketType.MESSAGE_START) {
-    // Authoritative cited-doc set for the turn (9a).
     upsertDocuments(state, (packet.obj as MessageStart).final_documents);
   }
 }
@@ -276,8 +259,8 @@ function handleStopPacket(state: ProcessedMessageState, packet: Packet): void {
   state.isComplete = true;
   state.stopReason = (packet.obj as Stop).stop_reason;
 
-  // Close every still-open group (this is why the final answer group gets its SECTION_END even
-  // though the backend never sends one).
+  // Close every still-open group — this is why the final-answer group gets its SECTION_END (the
+  // backend never sends one).
   state.seenGroupKeys.forEach((groupKey) => {
     if (!state.groupKeysWithSectionEnd.has(groupKey)) {
       injectSectionEnd(state, groupKey);
@@ -285,8 +268,8 @@ function handleStopPacket(state: ProcessedMessageState, packet: Packet): void {
   });
 }
 
-// Claude can emit a message then start a real (non-reasoning) tool — the answer isn't actually
-// coming yet, so un-set finalAnswerComing. Reasoning packets are excluded (just thinking).
+// Claude may emit a message then start a real tool — the answer isn't actually coming yet.
+// Reasoning is excluded (just thinking, not a real tool call).
 function handleToolAfterMessagePacket(
   state: ProcessedMessageState,
   packet: Packet,
@@ -313,11 +296,9 @@ function addPacketToGroup(
   }
 }
 
-// Main processing
 function processPacket(state: ProcessedMessageState, packet: Packet): void {
   if (!packet) return;
 
-  // TopLevelBranching is pure metadata — record expected branches, don't add to any group.
   if (packet.obj.type === PacketType.TOP_LEVEL_BRANCHING) {
     handleTopLevelBranching(state, packet);
     return;
@@ -328,7 +309,6 @@ function processPacket(state: ProcessedMessageState, packet: Packet): void {
   const groupKey = getGroupKey(packet);
   state.seenGroupKeys.add(groupKey);
 
-  // A real SECTION_END or ERROR marks the group complete.
   if (
     packet.obj.type === PacketType.SECTION_END ||
     packet.obj.type === PacketType.ERROR
@@ -371,8 +351,7 @@ export function processPackets(
   state: ProcessedMessageState,
   rawPackets: Packet[],
 ): ProcessedMessageState {
-  // Array replaced by a shorter list (regenerate / history reload) -> rebuild from scratch so we
-  // never double-count a re-streamed turn.
+  // Array shrank (regenerate / history reload) -> rebuild so we never double-count a re-streamed turn.
   if (state.nextPacketIndex > rawPackets.length) {
     state = createInitialState(state.nodeId);
   }
@@ -388,8 +367,7 @@ export function processPackets(
 
   state.nextPacketIndex = rawPackets.length;
 
-  // Only rebuild result arrays when new packets arrived — preserves array identity so memoized
-  // consumers can bail out.
+  // Rebuild only when new packets arrived, to preserve array identity for memoized consumers.
   if (prevProcessedIndex !== rawPackets.length) {
     state.toolGroups = buildGroupsFromKeys(state, state.toolGroupKeys);
     state.potentialDisplayGroups = buildGroupsFromKeys(
@@ -401,8 +379,8 @@ export function processPackets(
   return state;
 }
 
-// Map group keys -> GroupedPacket (spread packets to force a new array reference for change
-// detection), filter to groups with meaningful content, sort by turn then tab.
+// Spread packets to force a new array ref (change detection); keep only content groups; sort by
+// turn then tab.
 function buildGroupsFromKeys(
   state: ProcessedMessageState,
   keys: Set<string>,

--- a/mobile/src/chat/streamingModels.ts
+++ b/mobile/src/chat/streamingModels.ts
@@ -1,4 +1,9 @@
-// Core streaming-packet contracts (NDJSON wire shapes).
+// Core streaming-packet contracts (NDJSON wire shapes). Mobile-native mirror of web's
+// `web/src/app/app/services/streamingModels.ts` — the full `PacketType` enum + every packet obj
+// interface, so the ported grouping engine + timeline helpers compile once and each future tool
+// renderer phase adds only its renderer (no enum/interface churn). Document arrays carry mobile's
+// `SearchDoc` (not web's `OnyxDocument`); the root, non-`Packet`-wrapped stream members
+// (`MessageResponseIDInfo`, `StreamingError`) are mobile-specific and kept.
 
 import type { SearchDoc } from "@/chat/contracts/documents";
 
@@ -10,16 +15,77 @@ export enum PacketType {
   MESSAGE_START = "message_start",
   MESSAGE_DELTA = "message_delta",
   MESSAGE_END = "message_end",
+
   STOP = "stop",
   SECTION_END = "section_end",
+  TOP_LEVEL_BRANCHING = "top_level_branching",
   ERROR = "error",
-  // Rich-chat (9a): citations + the documents that back them. `citation_info` is the ONLY citation
-  // packet the backend emits (web's citation_start/end are declared but never sent).
-  CITATION_INFO = "citation_info",
+
+  // Specific tool packets
+  SEARCH_TOOL_START = "search_tool_start",
+  SEARCH_TOOL_QUERIES_DELTA = "search_tool_queries_delta",
+  SEARCH_TOOL_FILTER_DELTA = "search_tool_filter_delta",
   SEARCH_TOOL_DOCUMENTS_DELTA = "search_tool_documents_delta",
-  OPEN_URL_DOCUMENTS = "open_url_documents",
+  IMAGE_GENERATION_TOOL_START = "image_generation_start",
+  IMAGE_GENERATION_TOOL_DELTA = "image_generation_final",
+  PYTHON_TOOL_START = "python_tool_start",
+  PYTHON_TOOL_DELTA = "python_tool_delta",
+  // Open-URL / fetch tool (web names these FETCH_TOOL_*; the wire values are open_url_*).
+  FETCH_TOOL_START = "open_url_start",
+  FETCH_TOOL_URLS = "open_url_urls",
+  FETCH_TOOL_DOCUMENTS = "open_url_documents",
+
+  // Streams tool args before the tool executes.
+  TOOL_CALL_ARGUMENT_DELTA = "tool_call_argument_delta",
+
+  // Custom tool packets
+  CUSTOM_TOOL_START = "custom_tool_start",
+  CUSTOM_TOOL_ARGS = "custom_tool_args",
+  CUSTOM_TOOL_DELTA = "custom_tool_delta",
+
+  // File reader tool packets
+  FILE_READER_START = "file_reader_start",
+  FILE_READER_RESULT = "file_reader_result",
+
+  // Memory tool packets
+  MEMORY_TOOL_START = "memory_tool_start",
+  MEMORY_TOOL_DELTA = "memory_tool_delta",
+  MEMORY_TOOL_NO_ACCESS = "memory_tool_no_access",
+
+  // Reasoning packets
+  REASONING_START = "reasoning_start",
+  REASONING_DELTA = "reasoning_delta",
+  REASONING_DONE = "reasoning_done",
+
+  // Citation packets. Only `citation_info` is emitted by the backend (citation_start/end are
+  // declared for parity but never sent).
+  CITATION_START = "citation_start",
+  CITATION_END = "citation_end",
+  CITATION_INFO = "citation_info",
+
+  // Deep Research packets
+  DEEP_RESEARCH_PLAN_START = "deep_research_plan_start",
+  DEEP_RESEARCH_PLAN_DELTA = "deep_research_plan_delta",
+  RESEARCH_AGENT_START = "research_agent_start",
+  INTERMEDIATE_REPORT_START = "intermediate_report_start",
+  INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta",
+  INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs",
+
+  // Coding Agent packets
+  CODING_AGENT_START = "coding_agent_start",
+  CODING_AGENT_THINKING_DELTA = "coding_agent_thinking_delta",
+  CODING_AGENT_FINAL = "coding_agent_final",
+
+  // Bash Tool packets
+  BASH_TOOL_START = "bash_tool_start",
+  BASH_TOOL_DELTA = "bash_tool_delta",
 }
 
+export const CODE_INTERPRETER_TOOL_TYPES = {
+  PYTHON: "python",
+} as const;
+
+// Basic message packets
 export interface MessageStart extends BaseObj {
   id: string;
   type: "message_start";
@@ -27,22 +93,6 @@ export interface MessageStart extends BaseObj {
   pre_answer_processing_seconds?: number;
   // Authoritative cited-doc set for the turn (present once the answer starts).
   final_documents?: SearchDoc[] | null;
-}
-
-export interface CitationInfo extends BaseObj {
-  type: "citation_info";
-  citation_number: number;
-  document_id: string;
-}
-
-export interface SearchToolDocumentsDelta extends BaseObj {
-  type: "search_tool_documents_delta";
-  documents: SearchDoc[];
-}
-
-export interface OpenUrlDocuments extends BaseObj {
-  type: "open_url_documents";
-  documents: SearchDoc[];
 }
 
 export interface MessageDelta extends BaseObj {
@@ -54,6 +104,7 @@ export interface MessageEnd extends BaseObj {
   type: "message_end";
 }
 
+// Control packets
 export enum StopReason {
   FINISHED = "finished",
   USER_CANCELLED = "user_cancelled",
@@ -68,32 +119,364 @@ export interface SectionEnd extends BaseObj {
   type: "section_end";
 }
 
+export interface TopLevelBranching extends BaseObj {
+  type: "top_level_branching";
+  num_parallel_branches: number;
+}
+
 export interface PacketError extends BaseObj {
   type: "error";
   message?: string;
 }
 
-// Filtered by the consumer, not the parser. No enum member (matches backend).
+// Filtered by the consumer, not the parser. Connection keepalive during silent stretches.
 export interface ChatHeartbeat extends BaseObj {
   type: "chat_heartbeat";
 }
 
+// Search tool
+export interface SearchToolStart extends BaseObj {
+  type: "search_tool_start";
+  is_internet_search?: boolean;
+}
+
+export interface SearchToolQueriesDelta extends BaseObj {
+  type: "search_tool_queries_delta";
+  queries: string[];
+}
+
+export interface SearchToolFilterDelta extends BaseObj {
+  type: "search_tool_filter_delta";
+  // Connector/source values this search is scoped to (empty == all).
+  sources: string[];
+}
+
+export interface SearchToolDocumentsDelta extends BaseObj {
+  type: "search_tool_documents_delta";
+  documents: SearchDoc[];
+}
+
+// Image generation
+export type ImageShape = "square" | "landscape" | "portrait";
+
+export interface GeneratedImage {
+  file_id: string;
+  url: string;
+  revised_prompt: string;
+  shape?: ImageShape;
+}
+
+export interface ImageGenerationToolStart extends BaseObj {
+  type: "image_generation_start";
+}
+
+export interface ImageGenerationToolDelta extends BaseObj {
+  type: "image_generation_final";
+  images: GeneratedImage[];
+}
+
+// Python / code interpreter
+export interface PythonToolStart extends BaseObj {
+  type: "python_tool_start";
+  code: string;
+}
+
+export interface PythonToolDelta extends BaseObj {
+  type: "python_tool_delta";
+  stdout: string;
+  stderr: string;
+  file_ids: string[];
+}
+
+export interface ToolCallArgumentDelta extends BaseObj {
+  type: "tool_call_argument_delta";
+  tool_type: string;
+  tool_id: string;
+  argument_deltas: Record<string, unknown>;
+}
+
+// Open-URL / fetch tool
+export interface FetchToolStart extends BaseObj {
+  type: "open_url_start";
+}
+
+export interface FetchToolUrls extends BaseObj {
+  type: "open_url_urls";
+  urls: string[];
+}
+
+export interface FetchToolDocuments extends BaseObj {
+  type: "open_url_documents";
+  documents: SearchDoc[];
+}
+
+// Custom tool
+export interface CustomToolErrorInfo {
+  is_auth_error: boolean;
+  status_code: number;
+  message: string;
+}
+
+export interface CustomToolStart extends BaseObj {
+  type: "custom_tool_start";
+  tool_name: string;
+  tool_id?: number | null;
+}
+
+export interface CustomToolArgs extends BaseObj {
+  type: "custom_tool_args";
+  tool_name: string;
+  tool_args: Record<string, unknown>;
+}
+
+export interface CustomToolDelta extends BaseObj {
+  type: "custom_tool_delta";
+  tool_name: string;
+  tool_id?: number | null;
+  response_type: string;
+  data?: unknown;
+  file_ids?: string[] | null;
+  error?: CustomToolErrorInfo | null;
+}
+
+// File reader
+export interface FileReaderStart extends BaseObj {
+  type: "file_reader_start";
+}
+
+export interface FileReaderResult extends BaseObj {
+  type: "file_reader_result";
+  file_name: string;
+  file_id: string;
+  start_char: number;
+  end_char: number;
+  total_chars: number;
+  preview_start: string;
+  preview_end: string;
+}
+
+// Memory tool
+export interface MemoryToolStart extends BaseObj {
+  type: "memory_tool_start";
+}
+
+export interface MemoryToolDelta extends BaseObj {
+  type: "memory_tool_delta";
+  memory_text: string;
+  operation: "add" | "update";
+  memory_id: number | null;
+  index: number | null;
+}
+
+export interface MemoryToolNoAccess extends BaseObj {
+  type: "memory_tool_no_access";
+}
+
+// Reasoning
+export interface ReasoningStart extends BaseObj {
+  type: "reasoning_start";
+}
+
+export interface ReasoningDelta extends BaseObj {
+  type: "reasoning_delta";
+  reasoning: string;
+}
+
+export interface ReasoningDone extends BaseObj {
+  type: "reasoning_done";
+}
+
+// Citations
+// The deduped, first-cite-ordered citation read-model (distinct from the wire `CitationInfo`).
+export interface StreamingCitation {
+  citation_num: number;
+  document_id: string;
+}
+
+export interface CitationStart extends BaseObj {
+  type: "citation_start";
+}
+
+export interface CitationInfo extends BaseObj {
+  type: "citation_info";
+  citation_number: number;
+  document_id: string;
+}
+
+// Deep research
+export interface DeepResearchPlanStart extends BaseObj {
+  type: "deep_research_plan_start";
+}
+
+export interface DeepResearchPlanDelta extends BaseObj {
+  type: "deep_research_plan_delta";
+  content: string;
+}
+
+export interface ResearchAgentStart extends BaseObj {
+  type: "research_agent_start";
+  research_task: string;
+}
+
+export interface IntermediateReportStart extends BaseObj {
+  type: "intermediate_report_start";
+}
+
+export interface IntermediateReportDelta extends BaseObj {
+  type: "intermediate_report_delta";
+  content: string;
+}
+
+export interface IntermediateReportCitedDocs extends BaseObj {
+  type: "intermediate_report_cited_docs";
+  cited_docs: SearchDoc[] | null;
+}
+
+// Coding agent + bash
+export interface CodingAgentStart extends BaseObj {
+  type: "coding_agent_start";
+  query: string;
+  repo: string | null;
+}
+
+export interface CodingAgentThinkingDelta extends BaseObj {
+  type: "coding_agent_thinking_delta";
+  content: string;
+}
+
+export interface CodingAgentFinal extends BaseObj {
+  type: "coding_agent_final";
+  answer: string;
+}
+
+export interface BashToolStart extends BaseObj {
+  type: "bash_tool_start";
+  cmd: string;
+}
+
+export interface BashToolDelta extends BaseObj {
+  type: "bash_tool_delta";
+  stdout: string;
+  stderr: string;
+  exit_code: number | null;
+  timed_out: boolean;
+}
+
+// Unions
 export type ChatObj = MessageStart | MessageDelta | MessageEnd;
 
+export type SearchToolObj =
+  | SearchToolStart
+  | SearchToolQueriesDelta
+  | SearchToolFilterDelta
+  | SearchToolDocumentsDelta
+  | SectionEnd
+  | PacketError;
+
+export type ImageGenerationToolObj =
+  | ImageGenerationToolStart
+  | ImageGenerationToolDelta
+  | SectionEnd
+  | PacketError;
+
+export type PythonToolObj =
+  | PythonToolStart
+  | PythonToolDelta
+  | ToolCallArgumentDelta
+  | SectionEnd
+  | PacketError;
+
+export type FetchToolObj =
+  | FetchToolStart
+  | FetchToolUrls
+  | FetchToolDocuments
+  | SectionEnd
+  | PacketError;
+
+export type CustomToolObj =
+  | CustomToolStart
+  | CustomToolArgs
+  | CustomToolDelta
+  | SectionEnd
+  | PacketError;
+
+export type FileReaderToolObj =
+  | FileReaderStart
+  | FileReaderResult
+  | SectionEnd
+  | PacketError;
+
+export type MemoryToolObj =
+  | MemoryToolStart
+  | MemoryToolDelta
+  | MemoryToolNoAccess
+  | SectionEnd
+  | PacketError;
+
+export type NewToolObj =
+  | SearchToolObj
+  | ImageGenerationToolObj
+  | PythonToolObj
+  | FetchToolObj
+  | CustomToolObj
+  | FileReaderToolObj
+  | MemoryToolObj;
+
+export type ReasoningObj =
+  | ReasoningStart
+  | ReasoningDelta
+  | ReasoningDone
+  | SectionEnd
+  | PacketError;
+
+export type CitationObj =
+  | CitationStart
+  | CitationInfo
+  | SectionEnd
+  | PacketError;
+
+export type DeepResearchPlanObj =
+  | DeepResearchPlanStart
+  | DeepResearchPlanDelta
+  | SectionEnd;
+
+export type ResearchAgentObj =
+  | ResearchAgentStart
+  | IntermediateReportStart
+  | IntermediateReportDelta
+  | IntermediateReportCitedDocs
+  | SectionEnd;
+
+export type CodingAgentObj =
+  | CodingAgentStart
+  | CodingAgentThinkingDelta
+  | CodingAgentFinal
+  | BashToolStart
+  | BashToolDelta
+  | SectionEnd
+  | PacketError;
+
+// Union type for all possible streaming objects.
 export type ObjTypes =
   | ChatObj
+  | NewToolObj
+  | ReasoningObj
   | Stop
-  | SectionEnd
-  | PacketError
   | ChatHeartbeat
-  | CitationInfo
-  | SearchToolDocumentsDelta
-  | OpenUrlDocuments;
+  | SectionEnd
+  | TopLevelBranching
+  | CitationObj
+  | DeepResearchPlanObj
+  | ResearchAgentObj
+  | CodingAgentObj
+  | PacketError;
 
 export interface Placement {
   turn_index: number;
+  // Parallel tool calls: same turn_index, different tab_index run in parallel.
   tab_index?: number;
   sub_turn_index?: number | null;
+  // Multi-model answer generation: which model produced this packet.
   model_index?: number | null;
 }
 

--- a/mobile/src/chat/streamingModels.ts
+++ b/mobile/src/chat/streamingModels.ts
@@ -1,9 +1,5 @@
-// Core streaming-packet contracts (NDJSON wire shapes). Mobile-native mirror of web's
-// `web/src/app/app/services/streamingModels.ts` — the full `PacketType` enum + every packet obj
-// interface, so the ported grouping engine + timeline helpers compile once and each future tool
-// renderer phase adds only its renderer (no enum/interface churn). Document arrays carry mobile's
-// `SearchDoc` (not web's `OnyxDocument`); the root, non-`Packet`-wrapped stream members
-// (`MessageResponseIDInfo`, `StreamingError`) are mobile-specific and kept.
+// Streaming-packet contracts (NDJSON wire shapes). Mirror of web's streamingModels, with mobile's
+// SearchDoc for document arrays and the mobile-only root types at the bottom.
 
 import type { SearchDoc } from "@/chat/contracts/documents";
 
@@ -21,7 +17,6 @@ export enum PacketType {
   TOP_LEVEL_BRANCHING = "top_level_branching",
   ERROR = "error",
 
-  // Specific tool packets
   SEARCH_TOOL_START = "search_tool_start",
   SEARCH_TOOL_QUERIES_DELTA = "search_tool_queries_delta",
   SEARCH_TOOL_FILTER_DELTA = "search_tool_filter_delta",
@@ -30,40 +25,33 @@ export enum PacketType {
   IMAGE_GENERATION_TOOL_DELTA = "image_generation_final",
   PYTHON_TOOL_START = "python_tool_start",
   PYTHON_TOOL_DELTA = "python_tool_delta",
-  // Open-URL / fetch tool (web names these FETCH_TOOL_*; the wire values are open_url_*).
+  // web names these FETCH_TOOL_*; the wire values are open_url_*
   FETCH_TOOL_START = "open_url_start",
   FETCH_TOOL_URLS = "open_url_urls",
   FETCH_TOOL_DOCUMENTS = "open_url_documents",
 
-  // Streams tool args before the tool executes.
   TOOL_CALL_ARGUMENT_DELTA = "tool_call_argument_delta",
 
-  // Custom tool packets
   CUSTOM_TOOL_START = "custom_tool_start",
   CUSTOM_TOOL_ARGS = "custom_tool_args",
   CUSTOM_TOOL_DELTA = "custom_tool_delta",
 
-  // File reader tool packets
   FILE_READER_START = "file_reader_start",
   FILE_READER_RESULT = "file_reader_result",
 
-  // Memory tool packets
   MEMORY_TOOL_START = "memory_tool_start",
   MEMORY_TOOL_DELTA = "memory_tool_delta",
   MEMORY_TOOL_NO_ACCESS = "memory_tool_no_access",
 
-  // Reasoning packets
   REASONING_START = "reasoning_start",
   REASONING_DELTA = "reasoning_delta",
   REASONING_DONE = "reasoning_done",
 
-  // Citation packets. Only `citation_info` is emitted by the backend (citation_start/end are
-  // declared for parity but never sent).
+  // Only citation_info is emitted; citation_start/end are declared for parity but never sent.
   CITATION_START = "citation_start",
   CITATION_END = "citation_end",
   CITATION_INFO = "citation_info",
 
-  // Deep Research packets
   DEEP_RESEARCH_PLAN_START = "deep_research_plan_start",
   DEEP_RESEARCH_PLAN_DELTA = "deep_research_plan_delta",
   RESEARCH_AGENT_START = "research_agent_start",
@@ -71,12 +59,10 @@ export enum PacketType {
   INTERMEDIATE_REPORT_DELTA = "intermediate_report_delta",
   INTERMEDIATE_REPORT_CITED_DOCS = "intermediate_report_cited_docs",
 
-  // Coding Agent packets
   CODING_AGENT_START = "coding_agent_start",
   CODING_AGENT_THINKING_DELTA = "coding_agent_thinking_delta",
   CODING_AGENT_FINAL = "coding_agent_final",
 
-  // Bash Tool packets
   BASH_TOOL_START = "bash_tool_start",
   BASH_TOOL_DELTA = "bash_tool_delta",
 }
@@ -85,13 +71,11 @@ export const CODE_INTERPRETER_TOOL_TYPES = {
   PYTHON: "python",
 } as const;
 
-// Basic message packets
 export interface MessageStart extends BaseObj {
   id: string;
   type: "message_start";
   content: string;
   pre_answer_processing_seconds?: number;
-  // Authoritative cited-doc set for the turn (present once the answer starts).
   final_documents?: SearchDoc[] | null;
 }
 
@@ -104,7 +88,6 @@ export interface MessageEnd extends BaseObj {
   type: "message_end";
 }
 
-// Control packets
 export enum StopReason {
   FINISHED = "finished",
   USER_CANCELLED = "user_cancelled",
@@ -129,12 +112,10 @@ export interface PacketError extends BaseObj {
   message?: string;
 }
 
-// Filtered by the consumer, not the parser. Connection keepalive during silent stretches.
 export interface ChatHeartbeat extends BaseObj {
   type: "chat_heartbeat";
 }
 
-// Search tool
 export interface SearchToolStart extends BaseObj {
   type: "search_tool_start";
   is_internet_search?: boolean;
@@ -147,7 +128,6 @@ export interface SearchToolQueriesDelta extends BaseObj {
 
 export interface SearchToolFilterDelta extends BaseObj {
   type: "search_tool_filter_delta";
-  // Connector/source values this search is scoped to (empty == all).
   sources: string[];
 }
 
@@ -156,7 +136,6 @@ export interface SearchToolDocumentsDelta extends BaseObj {
   documents: SearchDoc[];
 }
 
-// Image generation
 export type ImageShape = "square" | "landscape" | "portrait";
 
 export interface GeneratedImage {
@@ -175,7 +154,6 @@ export interface ImageGenerationToolDelta extends BaseObj {
   images: GeneratedImage[];
 }
 
-// Python / code interpreter
 export interface PythonToolStart extends BaseObj {
   type: "python_tool_start";
   code: string;
@@ -195,7 +173,6 @@ export interface ToolCallArgumentDelta extends BaseObj {
   argument_deltas: Record<string, unknown>;
 }
 
-// Open-URL / fetch tool
 export interface FetchToolStart extends BaseObj {
   type: "open_url_start";
 }
@@ -210,7 +187,6 @@ export interface FetchToolDocuments extends BaseObj {
   documents: SearchDoc[];
 }
 
-// Custom tool
 export interface CustomToolErrorInfo {
   is_auth_error: boolean;
   status_code: number;
@@ -239,7 +215,6 @@ export interface CustomToolDelta extends BaseObj {
   error?: CustomToolErrorInfo | null;
 }
 
-// File reader
 export interface FileReaderStart extends BaseObj {
   type: "file_reader_start";
 }
@@ -255,7 +230,6 @@ export interface FileReaderResult extends BaseObj {
   preview_end: string;
 }
 
-// Memory tool
 export interface MemoryToolStart extends BaseObj {
   type: "memory_tool_start";
 }
@@ -272,7 +246,6 @@ export interface MemoryToolNoAccess extends BaseObj {
   type: "memory_tool_no_access";
 }
 
-// Reasoning
 export interface ReasoningStart extends BaseObj {
   type: "reasoning_start";
 }
@@ -286,8 +259,6 @@ export interface ReasoningDone extends BaseObj {
   type: "reasoning_done";
 }
 
-// Citations
-// The deduped, first-cite-ordered citation read-model (distinct from the wire `CitationInfo`).
 export interface StreamingCitation {
   citation_num: number;
   document_id: string;
@@ -303,7 +274,6 @@ export interface CitationInfo extends BaseObj {
   document_id: string;
 }
 
-// Deep research
 export interface DeepResearchPlanStart extends BaseObj {
   type: "deep_research_plan_start";
 }
@@ -332,7 +302,6 @@ export interface IntermediateReportCitedDocs extends BaseObj {
   cited_docs: SearchDoc[] | null;
 }
 
-// Coding agent + bash
 export interface CodingAgentStart extends BaseObj {
   type: "coding_agent_start";
   query: string;
@@ -362,7 +331,6 @@ export interface BashToolDelta extends BaseObj {
   timed_out: boolean;
 }
 
-// Unions
 export type ChatObj = MessageStart | MessageDelta | MessageEnd;
 
 export type SearchToolObj =
@@ -456,7 +424,6 @@ export type CodingAgentObj =
   | SectionEnd
   | PacketError;
 
-// Union type for all possible streaming objects.
 export type ObjTypes =
   | ChatObj
   | NewToolObj
@@ -473,10 +440,8 @@ export type ObjTypes =
 
 export interface Placement {
   turn_index: number;
-  // Parallel tool calls: same turn_index, different tab_index run in parallel.
   tab_index?: number;
   sub_turn_index?: number | null;
-  // Multi-model answer generation: which model produced this packet.
   model_index?: number | null;
 }
 
@@ -485,16 +450,15 @@ export interface Packet {
   obj: ObjTypes;
 }
 
-// Root object (not wrapped in Packet.obj); wire omits `type`, so discriminate by
-// field presence (`"user_message_id" in obj`), never `obj.type`.
+// Root object (not wrapped in Packet.obj); discriminate by field presence, never obj.type.
 export interface MessageResponseIDInfo {
   type?: "message_id_info";
   user_message_id: number | null;
   reserved_assistant_message_id: number;
 }
 
-// Root-level error (backend `StreamingError`), not wrapped in Packet.obj — discriminate
-// by top-level `error`, not `obj.type`. Dropping it silently leaves the turn stuck on "…".
+// Root-level error; discriminate by top-level `error`, not obj.type. Dropping it leaves the turn
+// stuck on "…".
 export interface StreamingError {
   error: string;
   stack_trace?: string | null;

--- a/mobile/src/chat/timeline/__tests__/grouping.test.ts
+++ b/mobile/src/chat/timeline/__tests__/grouping.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+  createInitialState,
+  processPackets,
+  type GroupedPacket,
+  type ProcessedMessageState,
+} from "@/chat/messageProcessor";
+import { PacketType, type Packet } from "@/chat/streamingModels";
+
+import { makePlacedPacket } from "../../__tests__/fixtures";
+
+// Convenience builders for the packet families this PR groups.
+const reasoningStart = (turn: number, tab = 0): Packet =>
+  makePlacedPacket(
+    { type: "reasoning_start" },
+    { turn_index: turn, tab_index: tab },
+  );
+const reasoningDelta = (text: string, turn: number, tab = 0): Packet =>
+  makePlacedPacket(
+    { type: "reasoning_delta", reasoning: text },
+    { turn_index: turn, tab_index: tab },
+  );
+const searchStart = (turn: number, tab = 0, internet = false): Packet =>
+  makePlacedPacket(
+    { type: "search_tool_start", is_internet_search: internet },
+    { turn_index: turn, tab_index: tab },
+  );
+const sectionEnd = (turn: number, tab = 0): Packet =>
+  makePlacedPacket(
+    { type: "section_end" },
+    { turn_index: turn, tab_index: tab },
+  );
+const messageStart = (turn: number, preSeconds?: number): Packet =>
+  makePlacedPacket(
+    {
+      type: "message_start",
+      id: "m",
+      content: "",
+      final_documents: null,
+      ...(preSeconds !== undefined
+        ? { pre_answer_processing_seconds: preSeconds }
+        : {}),
+    },
+    { turn_index: turn },
+  );
+const stopAt = (turn: number): Packet =>
+  makePlacedPacket({ type: "stop" }, { turn_index: turn });
+const searchQueriesDelta = (turn: number, tab = 0): Packet =>
+  makePlacedPacket(
+    { type: "search_tool_queries_delta", queries: ["q"] },
+    { turn_index: turn, tab_index: tab },
+  );
+
+function run(packets: Packet[]): ProcessedMessageState {
+  return processPackets(createInitialState(1), packets);
+}
+
+const keyOf = (g: GroupedPacket) => `${g.turn_index}-${g.tab_index}`;
+const hasSectionEnd = (state: ProcessedMessageState, key: string) =>
+  (state.groupedPacketsMap.get(key) ?? []).some(
+    (p) => p.obj.type === PacketType.SECTION_END,
+  );
+
+describe("grouping engine", () => {
+  it("groups packets into tool steps by turn/tab and sorts them", () => {
+    const state = run([
+      reasoningStart(1),
+      reasoningStart(0),
+      reasoningDelta("thinking", 0),
+    ]);
+    expect(state.toolGroups.map(keyOf)).toEqual(["0-0", "1-0"]);
+  });
+
+  it("synthesizes SECTION_END into a prior group when a new turn_index starts", () => {
+    const state = run([
+      reasoningStart(0),
+      reasoningDelta("hi", 0),
+      reasoningStart(1),
+    ]);
+    // The new turn 1 closes turn 0's group.
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true);
+    expect(hasSectionEnd(state, "0-0")).toBe(true);
+    // Turn 1 is still open (no newer turn, no stop).
+    expect(state.groupKeysWithSectionEnd.has("1-0")).toBe(false);
+  });
+
+  it("does NOT close a sibling when only tab_index changes within a turn", () => {
+    const state = run([searchStart(0, 0), searchStart(0, 1)]);
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(false);
+    expect(state.groupKeysWithSectionEnd.has("0-1")).toBe(false);
+    // Both are parallel tabs of the same turn.
+    expect(state.toolGroups.map(keyOf).sort()).toEqual(["0-0", "0-1"]);
+  });
+
+  it("reaches a fully-closed, stopped end-state (via turn transitions + stop)", () => {
+    const state = run([reasoningStart(0), searchStart(1), stopAt(2)]);
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true);
+    expect(state.groupKeysWithSectionEnd.has("1-0")).toBe(true);
+    expect(state.stopPacketSeen).toBe(true);
+    expect(state.isComplete).toBe(true);
+  });
+
+  it("stop closes an open group in the SAME turn (only the stop loop can close it)", () => {
+    // message_start@turn0 then stop@turn0: there's no later turn, so the turn-transition path
+    // never fires — ONLY handleStopPacket's injection loop closes the final-answer group.
+    const state = run([messageStart(0), stopAt(0)]);
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true);
+    expect(hasSectionEnd(state, "0-0")).toBe(true);
+  });
+
+  it("treats a real SECTION_END as completion without synthesizing a duplicate", () => {
+    const state = run([
+      reasoningStart(0),
+      reasoningDelta("x", 0),
+      sectionEnd(0),
+    ]);
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true);
+    const ends = (state.groupedPacketsMap.get("0-0") ?? []).filter(
+      (p) => p.obj.type === PacketType.SECTION_END,
+    );
+    expect(ends).toHaveLength(1); // the real one, not synthesized twice
+  });
+
+  it("keeps TOP_LEVEL_BRANCHING as metadata (not in any group)", () => {
+    const state = run([
+      makePlacedPacket(
+        { type: "top_level_branching", num_parallel_branches: 2 },
+        { turn_index: 0 },
+      ),
+      searchStart(0, 0),
+      searchStart(0, 1),
+    ]);
+    expect(state.expectedBranches.get(0)).toBe(2);
+    expect(state.groupedPacketsMap.has("0-0")).toBe(true);
+    // Only the two search groups have content; the branching packet is not grouped.
+    expect(state.toolGroups.map(keyOf).sort()).toEqual(["0-0", "0-1"]);
+  });
+
+  it("categorizes tool vs display groups", () => {
+    const state = run([reasoningStart(0), messageStart(1)]);
+    expect(state.toolGroupKeys.has("0-0")).toBe(true);
+    expect(state.displayGroupKeys.has("1-0")).toBe(true);
+    expect(state.potentialDisplayGroups.map(keyOf)).toEqual(["1-0"]);
+  });
+
+  it("sets finalAnswerComing on message_start and captures processing duration", () => {
+    const state = run([reasoningStart(0), messageStart(1, 3.5)]);
+    expect(state.finalAnswerComing).toBe(true);
+    expect(state.toolProcessingDuration).toBe(3.5);
+  });
+
+  it("resets finalAnswerComing when a real tool call follows the message (Claude workaround)", () => {
+    const state = run([messageStart(0), searchStart(1)]);
+    expect(state.finalAnswerComing).toBe(false);
+  });
+
+  it("does NOT reset finalAnswerComing for reasoning after the message", () => {
+    const state = run([messageStart(0), reasoningStart(1)]);
+    expect(state.finalAnswerComing).toBe(true);
+  });
+
+  it("filters out a categorized tool group that has no content packet", () => {
+    // "0-0" is a real tool group (queries_delta is a tool packet, so it enters toolGroupKeys) but
+    // has no *_START/content packet, so hasContentPackets drops it — while the sibling with a real
+    // SEARCH_TOOL_START is kept. This exercises the content filter, not key categorization.
+    const state = run([searchQueriesDelta(0), searchStart(1)]);
+    expect(state.toolGroupKeys.has("0-0")).toBe(true); // categorized as a tool group…
+    expect(state.toolGroups.map(keyOf)).toEqual(["1-0"]); // …but filtered out for lack of content
+  });
+
+  it("tolerates a non-zero model_index (groups by turn/tab only)", () => {
+    const state = run([
+      makePlacedPacket(
+        { type: "reasoning_start" },
+        { turn_index: 0, tab_index: 0, model_index: 1 },
+      ),
+      reasoningDelta("x", 0),
+    ]);
+    expect(state.toolGroups.map(keyOf)).toEqual(["0-0"]);
+  });
+
+  it("counts generated images and flags image generation", () => {
+    const state = run([
+      makePlacedPacket({ type: "image_generation_start" }, { turn_index: 0 }),
+      makePlacedPacket(
+        {
+          type: "image_generation_final",
+          images: [
+            { file_id: "a", url: "u", revised_prompt: "p" },
+            { file_id: "b", url: "u", revised_prompt: "p" },
+          ],
+        },
+        { turn_index: 0 },
+      ),
+    ]);
+    expect(state.isGeneratingImage).toBe(true);
+    expect(state.generatedImageCount).toBe(2);
+  });
+
+  it("groups incrementally across flushes (cursor advances, prior turns survive)", () => {
+    let state = createInitialState(1);
+    state = processPackets(state, [reasoningStart(0)]);
+    expect(state.toolGroups.map(keyOf)).toEqual(["0-0"]);
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(false); // still open
+
+    // Flush 2: same prior packet + a new turn's message_start (growing array).
+    state = processPackets(state, [reasoningStart(0), messageStart(1)]);
+    expect(state.nextPacketIndex).toBe(2); // cursor advanced; turn-0 packet not re-processed
+    expect(state.toolGroups.map(keyOf)).toEqual(["0-0"]); // turn-0 group survived
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true); // closed by the turn-1 transition
+    expect(state.potentialDisplayGroups.map(keyOf)).toEqual(["1-0"]); // new display group merged in
+  });
+});

--- a/mobile/src/chat/timeline/__tests__/grouping.test.ts
+++ b/mobile/src/chat/timeline/__tests__/grouping.test.ts
@@ -10,7 +10,6 @@ import { PacketType, type Packet } from "@/chat/streamingModels";
 
 import { makePlacedPacket } from "../../__tests__/fixtures";
 
-// Convenience builders for the packet families this PR groups.
 const reasoningStart = (turn: number, tab = 0): Packet =>
   makePlacedPacket(
     { type: "reasoning_start" },
@@ -78,10 +77,8 @@ describe("grouping engine", () => {
       reasoningDelta("hi", 0),
       reasoningStart(1),
     ]);
-    // The new turn 1 closes turn 0's group.
     expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true);
     expect(hasSectionEnd(state, "0-0")).toBe(true);
-    // Turn 1 is still open (no newer turn, no stop).
     expect(state.groupKeysWithSectionEnd.has("1-0")).toBe(false);
   });
 
@@ -89,7 +86,6 @@ describe("grouping engine", () => {
     const state = run([searchStart(0, 0), searchStart(0, 1)]);
     expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(false);
     expect(state.groupKeysWithSectionEnd.has("0-1")).toBe(false);
-    // Both are parallel tabs of the same turn.
     expect(state.toolGroups.map(keyOf).sort()).toEqual(["0-0", "0-1"]);
   });
 
@@ -102,8 +98,7 @@ describe("grouping engine", () => {
   });
 
   it("stop closes an open group in the SAME turn (only the stop loop can close it)", () => {
-    // message_start@turn0 then stop@turn0: there's no later turn, so the turn-transition path
-    // never fires — ONLY handleStopPacket's injection loop closes the final-answer group.
+    // No later turn fires the turn-transition path, so only the stop loop can close this group.
     const state = run([messageStart(0), stopAt(0)]);
     expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true);
     expect(hasSectionEnd(state, "0-0")).toBe(true);
@@ -119,7 +114,7 @@ describe("grouping engine", () => {
     const ends = (state.groupedPacketsMap.get("0-0") ?? []).filter(
       (p) => p.obj.type === PacketType.SECTION_END,
     );
-    expect(ends).toHaveLength(1); // the real one, not synthesized twice
+    expect(ends).toHaveLength(1);
   });
 
   it("keeps TOP_LEVEL_BRANCHING as metadata (not in any group)", () => {
@@ -133,7 +128,6 @@ describe("grouping engine", () => {
     ]);
     expect(state.expectedBranches.get(0)).toBe(2);
     expect(state.groupedPacketsMap.has("0-0")).toBe(true);
-    // Only the two search groups have content; the branching packet is not grouped.
     expect(state.toolGroups.map(keyOf).sort()).toEqual(["0-0", "0-1"]);
   });
 
@@ -161,12 +155,11 @@ describe("grouping engine", () => {
   });
 
   it("filters out a categorized tool group that has no content packet", () => {
-    // "0-0" is a real tool group (queries_delta is a tool packet, so it enters toolGroupKeys) but
-    // has no *_START/content packet, so hasContentPackets drops it — while the sibling with a real
-    // SEARCH_TOOL_START is kept. This exercises the content filter, not key categorization.
+    // "0-0" enters toolGroupKeys (queries_delta is a tool packet) but has no *_START content, so
+    // hasContentPackets drops it — this exercises the content filter, not key categorization.
     const state = run([searchQueriesDelta(0), searchStart(1)]);
-    expect(state.toolGroupKeys.has("0-0")).toBe(true); // categorized as a tool group…
-    expect(state.toolGroups.map(keyOf)).toEqual(["1-0"]); // …but filtered out for lack of content
+    expect(state.toolGroupKeys.has("0-0")).toBe(true);
+    expect(state.toolGroups.map(keyOf)).toEqual(["1-0"]);
   });
 
   it("tolerates a non-zero model_index (groups by turn/tab only)", () => {
@@ -202,13 +195,12 @@ describe("grouping engine", () => {
     let state = createInitialState(1);
     state = processPackets(state, [reasoningStart(0)]);
     expect(state.toolGroups.map(keyOf)).toEqual(["0-0"]);
-    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(false); // still open
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(false);
 
-    // Flush 2: same prior packet + a new turn's message_start (growing array).
     state = processPackets(state, [reasoningStart(0), messageStart(1)]);
-    expect(state.nextPacketIndex).toBe(2); // cursor advanced; turn-0 packet not re-processed
-    expect(state.toolGroups.map(keyOf)).toEqual(["0-0"]); // turn-0 group survived
-    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true); // closed by the turn-1 transition
-    expect(state.potentialDisplayGroups.map(keyOf)).toEqual(["1-0"]); // new display group merged in
+    expect(state.nextPacketIndex).toBe(2);
+    expect(state.toolGroups.map(keyOf)).toEqual(["0-0"]);
+    expect(state.groupKeysWithSectionEnd.has("0-0")).toBe(true);
+    expect(state.potentialDisplayGroups.map(keyOf)).toEqual(["1-0"]);
   });
 });

--- a/mobile/src/chat/timeline/__tests__/helpers.test.ts
+++ b/mobile/src/chat/timeline/__tests__/helpers.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { type Packet } from "@/chat/streamingModels";
+import {
+  isCodingAgentPackets,
+  isPythonToolPackets,
+  isReasoningPackets,
+  isSearchToolPackets,
+} from "@/chat/timeline/packetHelpers";
+import {
+  isActualToolCallPacket,
+  isDisplayPacket,
+  isToolPacket,
+} from "@/chat/timeline/packetUtils";
+import {
+  getToolKey,
+  getToolName,
+  hasToolError,
+  isToolComplete,
+  parseToolKey,
+} from "@/chat/timeline/toolDisplay";
+
+import { makePlacedPacket } from "../../__tests__/fixtures";
+
+const reasoning: Packet = makePlacedPacket({ type: "reasoning_start" });
+const searchInternet: Packet = makePlacedPacket({
+  type: "search_tool_start",
+  is_internet_search: true,
+});
+const searchInternal: Packet = makePlacedPacket({ type: "search_tool_start" });
+const message: Packet = makePlacedPacket({
+  type: "message_start",
+  id: "m",
+  content: "",
+  final_documents: null,
+});
+const sectionEnd: Packet = makePlacedPacket({ type: "section_end" });
+const errorPacket: Packet = makePlacedPacket({ type: "error" });
+
+describe("packetUtils / packetHelpers", () => {
+  it("classifies tool vs non-tool packets", () => {
+    expect(isToolPacket(reasoning)).toBe(true);
+    expect(isToolPacket(message)).toBe(false);
+    expect(isToolPacket(sectionEnd, true)).toBe(true);
+    expect(isToolPacket(sectionEnd, false)).toBe(false);
+  });
+
+  it("excludes reasoning from actual tool calls", () => {
+    expect(isActualToolCallPacket(reasoning)).toBe(false);
+    expect(isActualToolCallPacket(searchInternal)).toBe(true);
+  });
+
+  it("identifies display packets", () => {
+    expect(isDisplayPacket(message)).toBe(true);
+    expect(isDisplayPacket(reasoning)).toBe(false);
+  });
+
+  it("has per-family predicates", () => {
+    expect(isReasoningPackets([reasoning])).toBe(true);
+    expect(isSearchToolPackets([searchInternal])).toBe(true);
+    expect(isReasoningPackets([searchInternal])).toBe(false);
+    expect(
+      isPythonToolPackets([
+        makePlacedPacket({ type: "python_tool_start", code: "x" }),
+      ]),
+    ).toBe(true);
+    expect(
+      isCodingAgentPackets([
+        makePlacedPacket({ type: "bash_tool_start", cmd: "ls" }),
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("toolDisplay", () => {
+  it("round-trips a tool key", () => {
+    expect(getToolKey(2, 3)).toBe("2-3");
+    expect(parseToolKey("2-3")).toEqual({ turn_index: 2, tab_index: 3 });
+    expect(parseToolKey("bad")).toEqual({ turn_index: NaN, tab_index: 0 });
+  });
+
+  it("names tools, discriminating internet vs internal search", () => {
+    expect(getToolName([reasoning])).toBe("Thinking");
+    expect(getToolName([searchInternet])).toBe("Web Search");
+    expect(getToolName([searchInternal])).toBe("Internal Search");
+    expect(getToolName([])).toBe("Tool");
+  });
+
+  it("detects completion and errors", () => {
+    expect(isToolComplete([reasoning, sectionEnd])).toBe(true);
+    expect(isToolComplete([reasoning])).toBe(false);
+    expect(hasToolError([reasoning, errorPacket])).toBe(true);
+    expect(hasToolError([reasoning, sectionEnd])).toBe(false);
+  });
+
+  it("only counts a research agent complete on a parent-level SECTION_END", () => {
+    const researchStart: Packet = makePlacedPacket({
+      type: "research_agent_start",
+      research_task: "t",
+    });
+    const nestedEnd: Packet = makePlacedPacket(
+      { type: "section_end" },
+      { turn_index: 0, sub_turn_index: 1 },
+    );
+    const parentEnd: Packet = makePlacedPacket({ type: "section_end" });
+    expect(isToolComplete([researchStart, nestedEnd])).toBe(false);
+    expect(isToolComplete([researchStart, parentEnd])).toBe(true);
+  });
+});

--- a/mobile/src/chat/timeline/__tests__/transformers.test.ts
+++ b/mobile/src/chat/timeline/__tests__/transformers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { type GroupedPacket } from "@/chat/messageProcessor";
+import {
+  groupStepsByTurn,
+  transformPacketGroups,
+} from "@/chat/timeline/transformers";
+
+const group = (turn_index: number, tab_index: number): GroupedPacket => ({
+  turn_index,
+  tab_index,
+  packets: [],
+});
+
+describe("transformers", () => {
+  it("transforms groups into steps with a turn-tab key", () => {
+    const steps = transformPacketGroups([group(0, 0), group(1, 2)]);
+    expect(steps.map((s) => s.key)).toEqual(["0-0", "1-2"]);
+    expect(steps[0]).toMatchObject({ turnIndex: 0, tabIndex: 0 });
+  });
+
+  it("marks a turn parallel when >1 step shares its turn_index", () => {
+    const turns = groupStepsByTurn(
+      transformPacketGroups([group(0, 0), group(0, 1), group(1, 0)]),
+    );
+    expect(turns).toHaveLength(2);
+    expect(turns[0]).toMatchObject({ turnIndex: 0, isParallel: true });
+    expect(turns[0]!.steps.map((s) => s.key)).toEqual(["0-0", "0-1"]);
+    expect(turns[1]).toMatchObject({ turnIndex: 1, isParallel: false });
+  });
+
+  it("sorts turns ascending and steps by tab_index ascending", () => {
+    const turns = groupStepsByTurn(
+      transformPacketGroups([
+        group(1, 1),
+        group(0, 2),
+        group(0, 0),
+        group(1, 0),
+      ]),
+    );
+    expect(turns.map((t) => t.turnIndex)).toEqual([0, 1]);
+    expect(turns[0]!.steps.map((s) => s.tabIndex)).toEqual([0, 2]);
+    expect(turns[1]!.steps.map((s) => s.tabIndex)).toEqual([0, 1]);
+  });
+});

--- a/mobile/src/chat/timeline/packetHelpers.ts
+++ b/mobile/src/chat/timeline/packetHelpers.ts
@@ -1,0 +1,154 @@
+// Per-family packet predicates + collapsed-streaming sets. Faithful port of web's
+// `web/.../timeline/packetHelpers.ts` (mobile imports only).
+
+import {
+  CODE_INTERPRETER_TOOL_TYPES,
+  Packet,
+  PacketType,
+  ToolCallArgumentDelta,
+} from "@/chat/streamingModels";
+
+// Packet types whose renderers support collapsed streaming mode. TOOL_CALL_ARGUMENT_DELTA is
+// intentionally excluded — it needs a tool_type check (see stepSupportsCollapsedStreaming).
+export const COLLAPSED_STREAMING_PACKET_TYPES = new Set<PacketType>([
+  PacketType.SEARCH_TOOL_START,
+  PacketType.FETCH_TOOL_START,
+  PacketType.PYTHON_TOOL_START,
+  PacketType.CUSTOM_TOOL_START,
+  PacketType.RESEARCH_AGENT_START,
+  PacketType.CODING_AGENT_START,
+  PacketType.REASONING_START,
+  PacketType.DEEP_RESEARCH_PLAN_START,
+]);
+
+// Research agent handles its own Done indicator.
+export const isResearchAgentPackets = (packets: Packet[]): boolean =>
+  packets.some((p) => p.obj.type === PacketType.RESEARCH_AGENT_START);
+
+// A coding-agent group always contains CodingAgentStart, but Bash packets are emitted into the
+// same group, so any of these types signals a coding-agent group.
+export const CODING_AGENT_PACKET_TYPES = new Set<PacketType>([
+  PacketType.CODING_AGENT_START,
+  PacketType.CODING_AGENT_THINKING_DELTA,
+  PacketType.CODING_AGENT_FINAL,
+  PacketType.BASH_TOOL_START,
+  PacketType.BASH_TOOL_DELTA,
+]);
+
+export const isCodingAgentPackets = (packets: Packet[]): boolean =>
+  packets.some((p) => CODING_AGENT_PACKET_TYPES.has(p.obj.type as PacketType));
+
+export const isSearchToolPackets = (packets: Packet[]): boolean =>
+  packets.some((p) => p.obj.type === PacketType.SEARCH_TOOL_START);
+
+export const isPythonToolPackets = (packets: Packet[]): boolean =>
+  packets.some(
+    (p) =>
+      p.obj.type === PacketType.PYTHON_TOOL_START ||
+      (p.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
+        (p.obj as ToolCallArgumentDelta).tool_type ===
+          CODE_INTERPRETER_TOOL_TYPES.PYTHON),
+  );
+
+export const isReasoningPackets = (packets: Packet[]): boolean =>
+  packets.some((p) => p.obj.type === PacketType.REASONING_START);
+
+export const stepSupportsCollapsedStreaming = (packets: Packet[]): boolean =>
+  packets.some(
+    (p) =>
+      COLLAPSED_STREAMING_PACKET_TYPES.has(p.obj.type as PacketType) ||
+      (p.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
+        (p.obj as ToolCallArgumentDelta).tool_type ===
+          CODE_INTERPRETER_TOOL_TYPES.PYTHON),
+  );
+
+// Whether packets have content worth rendering in collapsed streaming mode — avoids empty
+// containers when only START packets have arrived.
+export const stepHasCollapsedStreamingContent = (
+  packets: Packet[],
+): boolean => {
+  const packetTypes = new Set(
+    packets.map((packet) => packet.obj.type as PacketType),
+  );
+
+  // Errors render even without deltas.
+  if (packetTypes.has(PacketType.ERROR)) {
+    return true;
+  }
+
+  // Search tools need actual query/doc deltas before showing content.
+  if (
+    packetTypes.has(PacketType.SEARCH_TOOL_QUERIES_DELTA) ||
+    packetTypes.has(PacketType.SEARCH_TOOL_DOCUMENTS_DELTA)
+  ) {
+    return true;
+  }
+
+  // Fetch tool shows a loading indicator once started.
+  if (
+    packetTypes.has(PacketType.FETCH_TOOL_START) ||
+    packetTypes.has(PacketType.FETCH_TOOL_URLS) ||
+    packetTypes.has(PacketType.FETCH_TOOL_DOCUMENTS)
+  ) {
+    return true;
+  }
+
+  // Python tool renders code/output from the start packet onward.
+  if (
+    packetTypes.has(PacketType.PYTHON_TOOL_START) ||
+    packetTypes.has(PacketType.PYTHON_TOOL_DELTA) ||
+    packets.some(
+      (p) =>
+        p.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
+        (p.obj as ToolCallArgumentDelta).tool_type ===
+          CODE_INTERPRETER_TOOL_TYPES.PYTHON,
+    )
+  ) {
+    return true;
+  }
+
+  // Custom tool shows running/completed state after start.
+  if (
+    packetTypes.has(PacketType.CUSTOM_TOOL_START) ||
+    packetTypes.has(PacketType.CUSTOM_TOOL_DELTA)
+  ) {
+    return true;
+  }
+
+  // Research agent has meaningful content from start (task) or report deltas.
+  if (
+    packetTypes.has(PacketType.RESEARCH_AGENT_START) ||
+    packetTypes.has(PacketType.INTERMEDIATE_REPORT_START) ||
+    packetTypes.has(PacketType.INTERMEDIATE_REPORT_DELTA) ||
+    packetTypes.has(PacketType.INTERMEDIATE_REPORT_CITED_DOCS)
+  ) {
+    return true;
+  }
+
+  // Coding agent has meaningful content from start (task) onward.
+  if (isCodingAgentPackets(packets)) {
+    return true;
+  }
+
+  // Reasoning content only appears in deltas.
+  if (packetTypes.has(PacketType.REASONING_DELTA)) {
+    return true;
+  }
+
+  // Deep research plan content only appears in deltas.
+  if (packetTypes.has(PacketType.DEEP_RESEARCH_PLAN_DELTA)) {
+    return true;
+  }
+
+  return false;
+};
+
+export const isDeepResearchPlanPackets = (packets: Packet[]): boolean =>
+  packets.some((p) => p.obj.type === PacketType.DEEP_RESEARCH_PLAN_START);
+
+export const isMemoryToolPackets = (packets: Packet[]): boolean =>
+  packets.some(
+    (p) =>
+      p.obj.type === PacketType.MEMORY_TOOL_START ||
+      p.obj.type === PacketType.MEMORY_TOOL_NO_ACCESS,
+  );

--- a/mobile/src/chat/timeline/packetHelpers.ts
+++ b/mobile/src/chat/timeline/packetHelpers.ts
@@ -1,5 +1,4 @@
-// Per-family packet predicates + collapsed-streaming sets. Faithful port of web's
-// `web/.../timeline/packetHelpers.ts` (mobile imports only).
+// Per-family packet predicates + collapsed-streaming sets. Port of web's packetHelpers.
 
 import {
   CODE_INTERPRETER_TOOL_TYPES,
@@ -8,8 +7,8 @@ import {
   ToolCallArgumentDelta,
 } from "@/chat/streamingModels";
 
-// Packet types whose renderers support collapsed streaming mode. TOOL_CALL_ARGUMENT_DELTA is
-// intentionally excluded — it needs a tool_type check (see stepSupportsCollapsedStreaming).
+// TOOL_CALL_ARGUMENT_DELTA is intentionally excluded — it needs a tool_type check (see
+// stepSupportsCollapsedStreaming).
 export const COLLAPSED_STREAMING_PACKET_TYPES = new Set<PacketType>([
   PacketType.SEARCH_TOOL_START,
   PacketType.FETCH_TOOL_START,
@@ -21,12 +20,10 @@ export const COLLAPSED_STREAMING_PACKET_TYPES = new Set<PacketType>([
   PacketType.DEEP_RESEARCH_PLAN_START,
 ]);
 
-// Research agent handles its own Done indicator.
 export const isResearchAgentPackets = (packets: Packet[]): boolean =>
   packets.some((p) => p.obj.type === PacketType.RESEARCH_AGENT_START);
 
-// A coding-agent group always contains CodingAgentStart, but Bash packets are emitted into the
-// same group, so any of these types signals a coding-agent group.
+// Bash packets are emitted into the coding-agent group, so any of these signals it.
 export const CODING_AGENT_PACKET_TYPES = new Set<PacketType>([
   PacketType.CODING_AGENT_START,
   PacketType.CODING_AGENT_THINKING_DELTA,
@@ -62,8 +59,8 @@ export const stepSupportsCollapsedStreaming = (packets: Packet[]): boolean =>
           CODE_INTERPRETER_TOOL_TYPES.PYTHON),
   );
 
-// Whether packets have content worth rendering in collapsed streaming mode — avoids empty
-// containers when only START packets have arrived.
+// Whether a step has content worth rendering yet — avoids empty containers when only START packets
+// have arrived.
 export const stepHasCollapsedStreamingContent = (
   packets: Packet[],
 ): boolean => {
@@ -71,12 +68,10 @@ export const stepHasCollapsedStreamingContent = (
     packets.map((packet) => packet.obj.type as PacketType),
   );
 
-  // Errors render even without deltas.
   if (packetTypes.has(PacketType.ERROR)) {
     return true;
   }
 
-  // Search tools need actual query/doc deltas before showing content.
   if (
     packetTypes.has(PacketType.SEARCH_TOOL_QUERIES_DELTA) ||
     packetTypes.has(PacketType.SEARCH_TOOL_DOCUMENTS_DELTA)
@@ -84,7 +79,6 @@ export const stepHasCollapsedStreamingContent = (
     return true;
   }
 
-  // Fetch tool shows a loading indicator once started.
   if (
     packetTypes.has(PacketType.FETCH_TOOL_START) ||
     packetTypes.has(PacketType.FETCH_TOOL_URLS) ||
@@ -93,7 +87,6 @@ export const stepHasCollapsedStreamingContent = (
     return true;
   }
 
-  // Python tool renders code/output from the start packet onward.
   if (
     packetTypes.has(PacketType.PYTHON_TOOL_START) ||
     packetTypes.has(PacketType.PYTHON_TOOL_DELTA) ||
@@ -107,7 +100,6 @@ export const stepHasCollapsedStreamingContent = (
     return true;
   }
 
-  // Custom tool shows running/completed state after start.
   if (
     packetTypes.has(PacketType.CUSTOM_TOOL_START) ||
     packetTypes.has(PacketType.CUSTOM_TOOL_DELTA)
@@ -115,7 +107,6 @@ export const stepHasCollapsedStreamingContent = (
     return true;
   }
 
-  // Research agent has meaningful content from start (task) or report deltas.
   if (
     packetTypes.has(PacketType.RESEARCH_AGENT_START) ||
     packetTypes.has(PacketType.INTERMEDIATE_REPORT_START) ||
@@ -125,17 +116,14 @@ export const stepHasCollapsedStreamingContent = (
     return true;
   }
 
-  // Coding agent has meaningful content from start (task) onward.
   if (isCodingAgentPackets(packets)) {
     return true;
   }
 
-  // Reasoning content only appears in deltas.
   if (packetTypes.has(PacketType.REASONING_DELTA)) {
     return true;
   }
 
-  // Deep research plan content only appears in deltas.
   if (packetTypes.has(PacketType.DEEP_RESEARCH_PLAN_DELTA)) {
     return true;
   }

--- a/mobile/src/chat/timeline/packetUtils.ts
+++ b/mobile/src/chat/timeline/packetUtils.ts
@@ -1,0 +1,181 @@
+// Pure packet categorizers + turn/tab grouping helpers. Faithful port of web's
+// `web/src/app/app/services/packetUtils.ts` (mobile imports only).
+
+import {
+  MessageDelta,
+  MessageStart,
+  Packet,
+  PacketType,
+  StreamingCitation,
+} from "@/chat/streamingModels";
+
+export function isToolPacket(
+  packet: Packet,
+  includeSectionEnd: boolean = true,
+): boolean {
+  const toolPacketTypes: PacketType[] = [
+    PacketType.SEARCH_TOOL_START,
+    PacketType.SEARCH_TOOL_QUERIES_DELTA,
+    PacketType.SEARCH_TOOL_FILTER_DELTA,
+    PacketType.SEARCH_TOOL_DOCUMENTS_DELTA,
+    PacketType.PYTHON_TOOL_START,
+    PacketType.PYTHON_TOOL_DELTA,
+    PacketType.TOOL_CALL_ARGUMENT_DELTA,
+    PacketType.CUSTOM_TOOL_START,
+    PacketType.CUSTOM_TOOL_ARGS,
+    PacketType.CUSTOM_TOOL_DELTA,
+    PacketType.FILE_READER_START,
+    PacketType.FILE_READER_RESULT,
+    PacketType.REASONING_START,
+    PacketType.REASONING_DELTA,
+    PacketType.FETCH_TOOL_START,
+    PacketType.FETCH_TOOL_URLS,
+    PacketType.FETCH_TOOL_DOCUMENTS,
+    PacketType.MEMORY_TOOL_START,
+    PacketType.MEMORY_TOOL_DELTA,
+    PacketType.MEMORY_TOOL_NO_ACCESS,
+    PacketType.DEEP_RESEARCH_PLAN_START,
+    PacketType.DEEP_RESEARCH_PLAN_DELTA,
+    PacketType.RESEARCH_AGENT_START,
+    PacketType.INTERMEDIATE_REPORT_START,
+    PacketType.INTERMEDIATE_REPORT_DELTA,
+    PacketType.INTERMEDIATE_REPORT_CITED_DOCS,
+    PacketType.CODING_AGENT_START,
+    PacketType.CODING_AGENT_THINKING_DELTA,
+    PacketType.CODING_AGENT_FINAL,
+    PacketType.BASH_TOOL_START,
+    PacketType.BASH_TOOL_DELTA,
+  ];
+  if (includeSectionEnd) {
+    toolPacketTypes.push(PacketType.SECTION_END);
+    toolPacketTypes.push(PacketType.ERROR);
+  }
+  return toolPacketTypes.includes(packet.obj.type as PacketType);
+}
+
+// An actual tool call (not reasoning/thinking). Used to decide whether to reset
+// `finalAnswerComing` when a tool packet arrives after message packets (Claude workaround).
+export function isActualToolCallPacket(packet: Packet): boolean {
+  return (
+    isToolPacket(packet, false) &&
+    packet.obj.type !== PacketType.REASONING_START &&
+    packet.obj.type !== PacketType.REASONING_DELTA
+  );
+}
+
+export function isDisplayPacket(packet: Packet): boolean {
+  return (
+    packet.obj.type === PacketType.MESSAGE_START ||
+    packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START
+  );
+}
+
+export function isSearchToolPacket(packet: Packet): boolean {
+  return (
+    packet.obj.type === PacketType.SEARCH_TOOL_START ||
+    packet.obj.type === PacketType.SEARCH_TOOL_QUERIES_DELTA ||
+    packet.obj.type === PacketType.SEARCH_TOOL_FILTER_DELTA ||
+    packet.obj.type === PacketType.SEARCH_TOOL_DOCUMENTS_DELTA
+  );
+}
+
+export function isStreamingComplete(packets: Packet[]): boolean {
+  return packets.some((packet) => packet.obj.type === PacketType.STOP);
+}
+
+export function isFinalAnswerComing(packets: Packet[]): boolean {
+  return packets.some(
+    (packet) =>
+      packet.obj.type === PacketType.MESSAGE_START ||
+      packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START,
+  );
+}
+
+export function isFinalAnswerComplete(packets: Packet[]): boolean {
+  const messageStartPacket = packets.find(
+    (packet) =>
+      packet.obj.type === PacketType.MESSAGE_START ||
+      packet.obj.type === PacketType.IMAGE_GENERATION_TOOL_START,
+  );
+
+  if (!messageStartPacket) {
+    return false;
+  }
+
+  return packets.some(
+    (packet) =>
+      (packet.obj.type === PacketType.SECTION_END ||
+        packet.obj.type === PacketType.ERROR) &&
+      packet.placement.turn_index === messageStartPacket.placement.turn_index,
+  );
+}
+
+// Group packets by (turn_index, tab_index), ordered lowest→highest turn then tab. Supports
+// parallel tool calls (same turn_index, different tab_index).
+export function groupPacketsByTurnIndex(
+  packets: Packet[],
+): { turn_index: number; tab_index: number; packets: Packet[] }[] {
+  const groups = packets.reduce(
+    (
+      acc: Map<
+        string,
+        { turn_index: number; tab_index: number; packets: Packet[] }
+      >,
+      packet,
+    ) => {
+      const turn_index = packet.placement.turn_index;
+      const tab_index = packet.placement.tab_index ?? 0;
+      const key = `${turn_index}-${tab_index}`;
+      if (!acc.has(key)) {
+        acc.set(key, { turn_index, tab_index, packets: [] });
+      }
+      acc.get(key)!.packets.push(packet);
+      return acc;
+    },
+    new Map(),
+  );
+
+  return Array.from(groups.values()).sort((a, b) => {
+    if (a.turn_index !== b.turn_index) {
+      return a.turn_index - b.turn_index;
+    }
+    return a.tab_index - b.tab_index;
+  });
+}
+
+export function getTextContent(packets: Packet[]): string {
+  return packets
+    .map((packet) => {
+      if (
+        packet.obj.type === PacketType.MESSAGE_START ||
+        packet.obj.type === PacketType.MESSAGE_DELTA
+      ) {
+        return (packet.obj as MessageStart | MessageDelta).content || "";
+      }
+      return "";
+    })
+    .join("");
+}
+
+export function getCitations(packets: Packet[]): StreamingCitation[] {
+  const citations: StreamingCitation[] = [];
+  const seenDocIds = new Set<string>();
+
+  packets.forEach((packet) => {
+    if (packet.obj.type === PacketType.CITATION_INFO) {
+      const citationInfo = packet.obj as {
+        citation_number: number;
+        document_id: string;
+      };
+      if (!seenDocIds.has(citationInfo.document_id)) {
+        seenDocIds.add(citationInfo.document_id);
+        citations.push({
+          citation_num: citationInfo.citation_number,
+          document_id: citationInfo.document_id,
+        });
+      }
+    }
+  });
+
+  return citations;
+}

--- a/mobile/src/chat/timeline/packetUtils.ts
+++ b/mobile/src/chat/timeline/packetUtils.ts
@@ -1,5 +1,4 @@
-// Pure packet categorizers + turn/tab grouping helpers. Faithful port of web's
-// `web/src/app/app/services/packetUtils.ts` (mobile imports only).
+// Pure packet categorizers + grouping helpers. Port of web's packetUtils.
 
 import {
   MessageDelta,
@@ -53,8 +52,7 @@ export function isToolPacket(
   return toolPacketTypes.includes(packet.obj.type as PacketType);
 }
 
-// An actual tool call (not reasoning/thinking). Used to decide whether to reset
-// `finalAnswerComing` when a tool packet arrives after message packets (Claude workaround).
+// A real tool call (not reasoning) — resets finalAnswerComing when a tool follows the message.
 export function isActualToolCallPacket(packet: Packet): boolean {
   return (
     isToolPacket(packet, false) &&
@@ -110,8 +108,6 @@ export function isFinalAnswerComplete(packets: Packet[]): boolean {
   );
 }
 
-// Group packets by (turn_index, tab_index), ordered lowest→highest turn then tab. Supports
-// parallel tool calls (same turn_index, different tab_index).
 export function groupPacketsByTurnIndex(
   packets: Packet[],
 ): { turn_index: number; tab_index: number; packets: Packet[] }[] {

--- a/mobile/src/chat/timeline/toolDisplay.ts
+++ b/mobile/src/chat/timeline/toolDisplay.ts
@@ -1,0 +1,94 @@
+// Pure tool key/name/completion helpers. Port of the non-JSX functions from web's
+// `web/.../messageComponents/toolDisplayHelpers.tsx`. The icon factory (`getToolIcon`) is a mobile
+// concern and lives in `components/chat/timeline/toolIcons.ts` (added with the header UI).
+
+import { Packet, PacketType, SearchToolStart } from "@/chat/streamingModels";
+
+// A group contains an ERROR packet (tool failed).
+export function hasToolError(packets: Packet[]): boolean {
+  return packets.some((p) => p.obj.type === PacketType.ERROR);
+}
+
+// Whether a tool group is complete. Research agents complete only on a PARENT-level SECTION_END
+// (sub_turn_index null/undefined) — nested tool SECTION_ENDs (sub_turn_index set) don't count;
+// coding agents complete on CodingAgentFinal (or error); all others on any SECTION_END/ERROR.
+export function isToolComplete(packets: Packet[]): boolean {
+  const firstPacket = packets[0];
+  if (!firstPacket) return false;
+
+  if (firstPacket.obj.type === PacketType.RESEARCH_AGENT_START) {
+    return packets.some(
+      (p) =>
+        (p.obj.type === PacketType.SECTION_END ||
+          p.obj.type === PacketType.ERROR) &&
+        (p.placement.sub_turn_index === undefined ||
+          p.placement.sub_turn_index === null),
+    );
+  }
+
+  if (firstPacket.obj.type === PacketType.CODING_AGENT_START) {
+    return packets.some(
+      (p) =>
+        p.obj.type === PacketType.CODING_AGENT_FINAL ||
+        p.obj.type === PacketType.ERROR,
+    );
+  }
+
+  return packets.some(
+    (p) =>
+      p.obj.type === PacketType.SECTION_END || p.obj.type === PacketType.ERROR,
+  );
+}
+
+export function getToolKey(turn_index: number, tab_index: number): string {
+  return `${turn_index}-${tab_index}`;
+}
+
+export function parseToolKey(key: string): {
+  turn_index: number;
+  tab_index: number;
+} {
+  const parts = key.split("-");
+  return {
+    turn_index: parseInt(parts[0] ?? "0", 10),
+    tab_index: parseInt(parts[1] ?? "0", 10),
+  };
+}
+
+export function getToolName(packets: Packet[]): string {
+  const firstPacket = packets[0];
+  if (!firstPacket) return "Tool";
+
+  switch (firstPacket.obj.type) {
+    case PacketType.SEARCH_TOOL_START: {
+      // The full search-state reducer (`constructCurrentSearchState`) lands with the search
+      // renderer phase; the internet-vs-internal flag comes straight off the start packet.
+      const isInternetSearch =
+        (firstPacket.obj as SearchToolStart).is_internet_search ?? false;
+      return isInternetSearch ? "Web Search" : "Internal Search";
+    }
+    case PacketType.PYTHON_TOOL_START:
+      return "Code Interpreter";
+    case PacketType.FETCH_TOOL_START:
+      return "Open URLs";
+    case PacketType.CUSTOM_TOOL_START:
+      return (
+        (firstPacket.obj as { tool_name?: string }).tool_name || "Custom Tool"
+      );
+    case PacketType.IMAGE_GENERATION_TOOL_START:
+      return "Generate Image";
+    case PacketType.DEEP_RESEARCH_PLAN_START:
+      return "Generate plan";
+    case PacketType.RESEARCH_AGENT_START:
+      return "Research agent";
+    case PacketType.CODING_AGENT_START:
+      return "Coding agent";
+    case PacketType.REASONING_START:
+      return "Thinking";
+    case PacketType.MEMORY_TOOL_START:
+    case PacketType.MEMORY_TOOL_NO_ACCESS:
+      return "Memory";
+    default:
+      return "Tool";
+  }
+}

--- a/mobile/src/chat/timeline/toolDisplay.ts
+++ b/mobile/src/chat/timeline/toolDisplay.ts
@@ -1,17 +1,14 @@
-// Pure tool key/name/completion helpers. Port of the non-JSX functions from web's
-// `web/.../messageComponents/toolDisplayHelpers.tsx`. The icon factory (`getToolIcon`) is a mobile
-// concern and lives in `components/chat/timeline/toolIcons.ts` (added with the header UI).
+// Pure tool key/name/completion helpers. Port of web's toolDisplayHelpers (its JSX icon factory is
+// deferred to toolIcons.ts).
 
 import { Packet, PacketType, SearchToolStart } from "@/chat/streamingModels";
 
-// A group contains an ERROR packet (tool failed).
 export function hasToolError(packets: Packet[]): boolean {
   return packets.some((p) => p.obj.type === PacketType.ERROR);
 }
 
-// Whether a tool group is complete. Research agents complete only on a PARENT-level SECTION_END
-// (sub_turn_index null/undefined) — nested tool SECTION_ENDs (sub_turn_index set) don't count;
-// coding agents complete on CodingAgentFinal (or error); all others on any SECTION_END/ERROR.
+// Research agents complete only on a parent-level SECTION_END (sub_turn_index null) — nested tool
+// SECTION_ENDs don't count; coding agents on CodingAgentFinal/error; others on any SECTION_END/ERROR.
 export function isToolComplete(packets: Packet[]): boolean {
   const firstPacket = packets[0];
   if (!firstPacket) return false;
@@ -61,8 +58,8 @@ export function getToolName(packets: Packet[]): string {
 
   switch (firstPacket.obj.type) {
     case PacketType.SEARCH_TOOL_START: {
-      // The full search-state reducer (`constructCurrentSearchState`) lands with the search
-      // renderer phase; the internet-vs-internal flag comes straight off the start packet.
+      // internet-vs-internal comes off the start packet; the full search-state reducer lands with
+      // the search phase.
       const isInternetSearch =
         (firstPacket.obj as SearchToolStart).is_internet_search ?? false;
       return isInternetSearch ? "Web Search" : "Internal Search";

--- a/mobile/src/chat/timeline/transformers.ts
+++ b/mobile/src/chat/timeline/transformers.ts
@@ -1,0 +1,63 @@
+// GroupedPacket → step → turn-group transforms + parallel detection. Faithful port of web's
+// `web/.../timeline/transformers.ts` (mobile imports only).
+
+import { GroupedPacket } from "@/chat/messageProcessor";
+
+export interface TransformedStep {
+  key: string; // `${turn_index}-${tab_index}`
+  turnIndex: number;
+  tabIndex: number;
+  packets: GroupedPacket["packets"];
+}
+
+export interface TurnGroup {
+  turnIndex: number;
+  steps: TransformedStep[];
+  // True when >1 step shares a turn_index (parallel execution).
+  isParallel: boolean;
+}
+
+export function transformPacketGroup(group: GroupedPacket): TransformedStep {
+  return {
+    key: `${group.turn_index}-${group.tab_index}`,
+    turnIndex: group.turn_index,
+    tabIndex: group.tab_index,
+    packets: group.packets,
+  };
+}
+
+export function transformPacketGroups(
+  groups: GroupedPacket[],
+): TransformedStep[] {
+  return groups.map(transformPacketGroup);
+}
+
+// Group transformed steps by turn_index to detect parallel tools.
+export function groupStepsByTurn(steps: TransformedStep[]): TurnGroup[] {
+  const turnMap = new Map<number, TransformedStep[]>();
+
+  for (const step of steps) {
+    const existing = turnMap.get(step.turnIndex);
+    if (existing) {
+      existing.push(step);
+    } else {
+      turnMap.set(step.turnIndex, [step]);
+    }
+  }
+
+  const result: TurnGroup[] = [];
+  const sortedTurnIndices = Array.from(turnMap.keys()).sort((a, b) => a - b);
+
+  for (const turnIndex of sortedTurnIndices) {
+    const stepsForTurn = turnMap.get(turnIndex)!;
+    stepsForTurn.sort((a, b) => a.tabIndex - b.tabIndex);
+
+    result.push({
+      turnIndex,
+      steps: stepsForTurn,
+      isParallel: stepsForTurn.length > 1,
+    });
+  }
+
+  return result;
+}

--- a/mobile/src/chat/timeline/transformers.ts
+++ b/mobile/src/chat/timeline/transformers.ts
@@ -1,10 +1,9 @@
-// GroupedPacket → step → turn-group transforms + parallel detection. Faithful port of web's
-// `web/.../timeline/transformers.ts` (mobile imports only).
+// GroupedPacket → step → turn-group transforms + parallel detection. Port of web's transformers.
 
 import { GroupedPacket } from "@/chat/messageProcessor";
 
 export interface TransformedStep {
-  key: string; // `${turn_index}-${tab_index}`
+  key: string;
   turnIndex: number;
   tabIndex: number;
   packets: GroupedPacket["packets"];
@@ -13,7 +12,6 @@ export interface TransformedStep {
 export interface TurnGroup {
   turnIndex: number;
   steps: TransformedStep[];
-  // True when >1 step shares a turn_index (parallel execution).
   isParallel: boolean;
 }
 
@@ -32,7 +30,6 @@ export function transformPacketGroups(
   return groups.map(transformPacketGroup);
 }
 
-// Group transformed steps by turn_index to detect parallel tools.
 export function groupStepsByTurn(steps: TransformedStep[]): TurnGroup[] {
   const turnMap = new Map<number, TransformedStep[]>();
 


### PR DESCRIPTION
## Description

- Ports the data foundation for the mobile agentic reasoning timeline (PR 9b.1): the turn/tab packet **grouping engine** + client-side `section_end` synthesis, ported faithfully from web's `packetProcessor`. Computed only — not yet rendered; a later composition PR wires the timeline into the UI.
- Mirrors web's full `PacketType` enum + every packet obj interface in `streamingModels` (using mobile's `SearchDoc`), so later tool-renderer phases add no new contracts.
- Extends the shipped 9a `messageProcessor` (citations/documents/completion preserved) and adds pure helpers (`transformers`, `packetUtils`, `packetHelpers`, `toolDisplay`). No backend/DB change.
- Includes the full 9b feature-flow spec + 7-PR roadmap under `docs/mobile-chat/9b-timeline/`.

## How Has This Been Tested?

26 new unit tests (grouping, all three `section_end` triggers, transforms, predicates); `tsc` + lint clean; full mobile suite 357/357 pass.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
