### PR TITLE
fix(reindex): version reindex index names per model

### DIFF
--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -82,6 +82,25 @@ def create_search_settings(
     return embedding_model
 
 
+def get_next_index_name(db_session: Session, base_index_name: str) -> str:
+    """Next reindex index name: "<base>_<NNNNNN>", a zero-padded six-digit sequence that is
+    the latest existing same-model sequence + 1 (000001 if none). Mirrors the OpenSearch
+    rollover convention (my-index-000001) so indices sort in order. Each reindex increments,
+    so a name is never reused -- the reindex port writes create-only, and reusing a name
+    lets it silently skip chunks already present in a stale index. Legacy names with no
+    numeric suffix (the bare base, or the old "<base>__danswer_alt_index") are ignored, so a
+    model starts at 000001.
+    """
+    prefix = f"{base_index_name}_"
+    latest = 0
+    for name in db_session.scalars(select(SearchSettings.index_name)):
+        if name.startswith(prefix):
+            suffix = name[len(prefix) :]
+            if suffix.isdigit():
+                latest = max(latest, int(suffix))
+    return f"{base_index_name}_{latest + 1:06d}"
+
+
 def get_embedding_provider_from_provider_type(
     db_session: Session, provider_type: EmbeddingProvider
 ) -> CloudEmbeddingProvider | None:

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -93,11 +93,16 @@ def get_next_index_name(db_session: Session, base_index_name: str) -> str:
     """
     prefix = f"{base_index_name}_"
     latest = 0
-    for name in db_session.scalars(select(SearchSettings.index_name)):
-        if name.startswith(prefix):
-            suffix = name[len(prefix) :]
-            if suffix.isdigit():
-                latest = max(latest, int(suffix))
+    # autoescape keeps the underscores in the model name literal rather than LIKE
+    # single-char wildcards, so the predicate matches exactly this base's names.
+    for name in db_session.scalars(
+        select(SearchSettings.index_name).where(
+            SearchSettings.index_name.startswith(prefix, autoescape=True)
+        )
+    ):
+        suffix = name[len(prefix) :]
+        if suffix.isdigit():
+            latest = max(latest, int(suffix))
     return f"{base_index_name}_{latest + 1:06d}"
 
 

--- a/backend/onyx/db/search_settings.py
+++ b/backend/onyx/db/search_settings.py
@@ -1,3 +1,5 @@
+from collections.abc import Callable
+
 from sqlalchemy import and_
 from sqlalchemy import delete
 from sqlalchemy import inspect as sa_inspect
@@ -82,7 +84,11 @@ def create_search_settings(
     return embedding_model
 
 
-def get_next_index_name(db_session: Session, base_index_name: str) -> str:
+def get_next_index_name(
+    db_session: Session,
+    base_index_name: str,
+    index_exists: Callable[[str], bool] | None = None,
+) -> str:
     """Next reindex index name: "<base>_<NNNNNN>", a zero-padded six-digit sequence that is
     the latest existing same-model sequence + 1 (000001 if none). Mirrors the OpenSearch
     rollover convention (my-index-000001) so indices sort in order. Each reindex increments,
@@ -90,6 +96,11 @@ def get_next_index_name(db_session: Session, base_index_name: str) -> str:
     lets it silently skip chunks already present in a stale index. Legacy names with no
     numeric suffix (the bare base, or the old "<base>__danswer_alt_index") are ignored, so a
     model starts at 000001.
+
+    The DB max alone isn't enough: deleting a PAST row frees its version while its
+    OpenSearch index lingers (deletion doesn't drop the index), so `index_exists` -- when
+    provided -- is consulted to skip any candidate whose index still physically exists,
+    guaranteeing the target starts empty regardless of DB/index divergence.
     """
     prefix = f"{base_index_name}_"
     latest = 0
@@ -103,7 +114,13 @@ def get_next_index_name(db_session: Session, base_index_name: str) -> str:
         suffix = name[len(prefix) :]
         if suffix.isdigit():
             latest = max(latest, int(suffix))
-    return f"{base_index_name}_{latest + 1:06d}"
+
+    version = latest + 1
+    candidate = f"{base_index_name}_{version:06d}"
+    while index_exists is not None and index_exists(candidate):
+        version += 1
+        candidate = f"{base_index_name}_{version:06d}"
+    return candidate
 
 
 def get_embedding_provider_from_provider_type(

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -48,6 +48,7 @@ from onyx.db.search_settings import update_current_search_settings
 from onyx.db.search_settings import update_search_settings_status
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.factory import get_default_document_index
+from onyx.document_index.opensearch.client import OpenSearchIndexClient
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_processing.unstructured import delete_unstructured_api_key
@@ -129,7 +130,15 @@ def set_new_search_settings(
         # _id as a benign 409, so it would silently promote a STALE index.
         base = f"danswer_chunk_{clean_model_name(search_settings_new.model_name)}"
         search_values = search_settings_new.model_dump()
-        search_values["index_name"] = get_next_index_name(db_session, base)
+        # Skip any version whose OpenSearch index still exists (e.g. an orphan left by a
+        # deleted PAST row) so the port never writes into a lingering, possibly stale index.
+        search_values["index_name"] = get_next_index_name(
+            db_session,
+            base,
+            index_exists=lambda name: OpenSearchIndexClient(
+                index_name=name
+            ).index_exists(),
+        )
         new_search_settings_request = SavedSearchSettings(**search_values)
     else:
         new_search_settings_request = SavedSearchSettings(

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -41,6 +41,7 @@ from onyx.db.search_settings import create_search_settings
 from onyx.db.search_settings import delete_search_settings
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.search_settings import get_embedding_provider_from_provider_type
+from onyx.db.search_settings import get_next_index_name
 from onyx.db.search_settings import get_secondary_search_settings
 from onyx.db.search_settings import update_current_search_settings
 from onyx.db.search_settings import update_search_settings_status
@@ -57,7 +58,6 @@ from onyx.server.manage.models import FullModelVersionResponse
 from onyx.server.models import IdReturn
 from onyx.server.utils_vector_db import require_vector_db
 from onyx.utils.logger import setup_logger
-from shared_configs.configs import ALT_INDEX_SUFFIX
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -121,15 +121,14 @@ def set_new_search_settings(
         )
 
     if search_settings_new.index_name is None:
-        # We define index name here.
-        index_name = f"danswer_chunk_{clean_model_name(search_settings_new.model_name)}"
-        if (
-            search_settings_new.model_name == search_settings.model_name
-            and not search_settings.index_name.endswith(ALT_INDEX_SUFFIX)
-        ):
-            index_name += ALT_INDEX_SUFFIX
+        # Version the index per model so each reindex targets a fresh, never-reused name
+        # (latest same-model version + 1). The old scheme toggled between "<base>" and
+        # "<base>__danswer_alt_index", so a repeated same-model reindex cycled back onto a
+        # still-existing prior index; the port writes create-only and skips any existing
+        # _id as a benign 409, so it would silently promote a STALE index.
+        base = f"danswer_chunk_{clean_model_name(search_settings_new.model_name)}"
         search_values = search_settings_new.model_dump()
-        search_values["index_name"] = index_name
+        search_values["index_name"] = get_next_index_name(db_session, base)
         new_search_settings_request = SavedSearchSettings(**search_values)
     else:
         new_search_settings_request = SavedSearchSettings(

--- a/backend/onyx/server/manage/search_settings.py
+++ b/backend/onyx/server/manage/search_settings.py
@@ -5,6 +5,7 @@ from fastapi import Depends
 from fastapi import HTTPException
 from fastapi import status
 from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
@@ -223,8 +224,17 @@ def set_new_search_settings(
                 poll_range_end=poll_range_end,
             )
 
-    # Atomic: FUTURE row and its seeds become visible together.
-    db_session.commit()
+    # Atomic: FUTURE row and its seeds become visible together. A concurrent second
+    # reindex races here; the partial unique index on status=FUTURE lets only one commit,
+    # so surface the loser as a clean 409 rather than an unhandled IntegrityError (500).
+    try:
+        db_session.commit()
+    except IntegrityError:
+        db_session.rollback()
+        raise OnyxError(
+            OnyxErrorCode.CONFLICT,
+            "A reindex is already in progress; wait for it to finish or cancel it.",
+        )
     return IdReturn(id=new_search_settings.id)
 
 

--- a/backend/tests/integration/tests/search_settings/test_search_settings.py
+++ b/backend/tests/integration/tests/search_settings/test_search_settings.py
@@ -384,3 +384,48 @@ def test_set_new_search_settings_replaces_previous_secondary(
     assert secondary["contextual_rag_model_configuration_id"] == mc_id
 
     _cancel_new_embedding(admin_user)
+
+
+def test_reindex_uses_unique_index_name_per_call(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+) -> None:
+    """Every reindex must target a fresh, never-reused index name.
+
+    Regression: the old scheme toggled between "<base>" and "<base>__danswer_alt_index",
+    so two same-model reindexes from the same PRESENT both produced "<base>__danswer_alt_index".
+    Reusing a name lets the port's create-only write silently skip chunks already in a
+    stale index, promoting a stale index with no error. Each reindex now gets a per-model
+    versioned name (latest same-model version + 1), so it is never reused.
+    """
+    current = _get_current_search_settings(admin_user)
+    current_index = current["index_name"]
+
+    _set_new_search_settings(
+        user=admin_user, current_settings=current
+    ).raise_for_status()
+    first_secondary = _get_secondary_search_settings(admin_user)
+    assert first_secondary is not None
+    first_index = first_secondary["index_name"]
+    _cancel_new_embedding(admin_user)
+
+    _set_new_search_settings(
+        user=admin_user, current_settings=current
+    ).raise_for_status()
+    second_secondary = _get_secondary_search_settings(admin_user)
+    assert second_secondary is not None
+    second_index = second_secondary["index_name"]
+    _cancel_new_embedding(admin_user)
+
+    # Both are versioned (numeric suffix) and distinct from the live index, and the second
+    # reindex increments the first's version by one (latest same-model version + 1).
+    assert first_index != current_index
+    assert second_index != current_index
+    assert first_index.startswith("danswer_chunk_")
+    assert second_index.startswith("danswer_chunk_")
+    first_suffix = first_index.rsplit("_", 1)[-1]
+    second_suffix = second_index.rsplit("_", 1)[-1]
+    # Zero-padded 6-digit sequence (OpenSearch rollover convention), incrementing by one.
+    assert len(first_suffix) == 6 and first_suffix.isdigit()
+    assert len(second_suffix) == 6 and second_suffix.isdigit()
+    assert int(second_suffix) == int(first_suffix) + 1

--- a/backend/tests/unit/onyx/db/test_search_settings.py
+++ b/backend/tests/unit/onyx/db/test_search_settings.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+from onyx.db.search_settings import get_next_index_name
+
+
+def _db_returning(index_names: list[str]) -> MagicMock:
+    """A db_session whose scalars() yields the given index_names (the query is mocked
+    away, so pass the names the same-model prefix filter would return)."""
+    db = MagicMock()
+    db.scalars.return_value = index_names
+    return db
+
+
+def test_get_next_index_name_increments_from_db_max() -> None:
+    db = _db_returning(
+        [
+            "danswer_chunk_m_000001",
+            "danswer_chunk_m_000002",
+            "danswer_chunk_m__danswer_alt_index",  # legacy, non-numeric -> ignored
+        ]
+    )
+    assert get_next_index_name(db, "danswer_chunk_m") == "danswer_chunk_m_000003"
+
+
+def test_get_next_index_name_starts_at_one_when_no_versioned_names() -> None:
+    db = _db_returning(["danswer_chunk_m__danswer_alt_index"])
+    assert get_next_index_name(db, "danswer_chunk_m") == "danswer_chunk_m_000001"
+
+
+def test_get_next_index_name_skips_versions_whose_index_still_exists() -> None:
+    """DB max is 000003, but 000004's OpenSearch index lingers (its PAST row was deleted).
+    The allocator must skip it rather than reuse a stale index the create-only port would
+    409-skip and silently promote."""
+    db = _db_returning(["danswer_chunk_m_000003"])
+    lingering = {"danswer_chunk_m_000004"}
+    name = get_next_index_name(
+        db, "danswer_chunk_m", index_exists=lambda n: n in lingering
+    )
+    assert name == "danswer_chunk_m_000005"


### PR DESCRIPTION
## Description

- Fix a silent stale-index bug: the reindex index name toggled between `<base>` and `<base>__danswer_alt_index`, so a repeated same-model reindex cycled back onto a still-existing prior-generation index. The port writes create-only and treats an existing `_id` as a benign 409, so it silently skipped every already-present chunk and promoted a **stale** index with no error (e.g. toggling contextual RAG on/off twice keeps the old embeddings).
- Name each reindex `<base>_<NNNNNN>` — a zero-padded 6-digit per-model sequence (latest existing same-model version + 1), matching the OpenSearch rollover convention (`my-index-000001`), so the target index is always fresh and empty and create-only writes every re-embedded chunk.
- Legacy names (bare base, old `__danswer_alt_index`) are ignored by the version parser, so existing deployments transition cleanly to `_000001` with no migration and no collision. GC of demoted indices is a separate follow-up.

### Index name examples (model `nomic-ai/nomic-embed-text-v1`)

| when | index name |
| --- | --- |
| initial (created at setup) | `danswer_chunk_nomic_ai_nomic_embed_text_v1` |
| 1st reindex | `danswer_chunk_nomic_ai_nomic_embed_text_v1_000001` |
| 2nd reindex | `danswer_chunk_nomic_ai_nomic_embed_text_v1_000002` |
| 3rd reindex | `danswer_chunk_nomic_ai_nomic_embed_text_v1_000003` |

An existing deployment on the bare base **or** the `__danswer_alt_index` name goes to `_000001` on its first reindex (both legacy forms count as version 0), then `_000002`, `_000003`, ...

## How Has This Been Tested?

- Added `test_reindex_uses_unique_index_name_per_call`: asserts two same-model reindexes produce distinct 6-digit zero-padded suffixes that increment by one. Passes locally; the rest of the `search_settings` integration suite is unaffected.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale reindexes by using per-model, versioned index names and skipping any version whose OpenSearch index still exists, so each reindex writes to a fresh, empty index. Also returns a clear 409 when two reindex requests race.

- **Bug Fixes**
  - Version the target index per model as "<base>_<NNNNNN>" and skip versions whose index still exists; legacy bare names and `__danswer_alt_index` count as version 0, so the first reindex becomes "_000001" with no migration or collisions.
  - Return HTTP 409 (conflict) instead of 500 when a concurrent reindex is attempted.

- **Refactors**
  - Optimized `get_next_index_name` by filtering in SQL with escaped `startswith`, avoiding full-table scans.

<sup>Written for commit a406b371f275a077ee84c110cb0238edc06175e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



