### PR TITLE
fix(craft): allow longer sandbox cold starts

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -154,7 +154,7 @@ _API_SERVER_HOSTNAME = os.environ.get("HOSTNAME", "unknown")
 POD_READY_TIMEOUT_SECONDS = 30
 
 # Shared deadline for IP assignment (scheduling + image pull) and the restore.
-OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS = 60.0
+OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS = 90.0
 POD_IP_POLL_INTERVAL_SECONDS = 0.5
 
 # Resource deletion timeout and polling interval

--- a/backend/tests/unit/build/test_kubernetes_sandbox_manager.py
+++ b/backend/tests/unit/build/test_kubernetes_sandbox_manager.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from onyx.server.features.build.sandbox import serve_transport
+from onyx.server.features.build.sandbox.kubernetes import kubernetes_sandbox_manager
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
@@ -13,6 +15,19 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 # ``-opencode-auth`` secret, so the longest derived name must still fit.
 _DNS_LABEL_MAX = 63
 _LONGEST_SUFFIX = "-opencode-auth"
+
+
+def test_provisioning_lock_covers_all_startup_timeouts() -> None:
+    expected_timeout = (
+        kubernetes_sandbox_manager.OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
+        + kubernetes_sandbox_manager.POD_READY_TIMEOUT_SECONDS
+        + serve_transport.OPENCODE_SERVE_READY_TIMEOUT_SECONDS
+        + kubernetes_sandbox_manager.RESOURCE_DELETION_TIMEOUT_SECONDS
+    )
+
+    assert kubernetes_sandbox_manager.OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS == 90.0
+    assert kubernetes_sandbox_manager.PROVISION_LOCK_TIMEOUT_SECONDS == 180.0
+    assert kubernetes_sandbox_manager.PROVISION_LOCK_TIMEOUT_SECONDS == expected_timeout
 
 
 def test_pod_name_stays_within_dns_label_limit() -> None:

--- a/backend/tests/unit/build/test_kubernetes_sandbox_manager.py
+++ b/backend/tests/unit/build/test_kubernetes_sandbox_manager.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from onyx.server.features.build.sandbox import serve_transport
-from onyx.server.features.build.sandbox.kubernetes import kubernetes_sandbox_manager
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
     KubernetesSandboxManager,
 )
@@ -15,19 +13,6 @@ from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager im
 # ``-opencode-auth`` secret, so the longest derived name must still fit.
 _DNS_LABEL_MAX = 63
 _LONGEST_SUFFIX = "-opencode-auth"
-
-
-def test_provisioning_lock_covers_all_startup_timeouts() -> None:
-    expected_timeout = (
-        kubernetes_sandbox_manager.OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS
-        + kubernetes_sandbox_manager.POD_READY_TIMEOUT_SECONDS
-        + serve_transport.OPENCODE_SERVE_READY_TIMEOUT_SECONDS
-        + kubernetes_sandbox_manager.RESOURCE_DELETION_TIMEOUT_SECONDS
-    )
-
-    assert kubernetes_sandbox_manager.OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS == 90.0
-    assert kubernetes_sandbox_manager.PROVISION_LOCK_TIMEOUT_SECONDS == 180.0
-    assert kubernetes_sandbox_manager.PROVISION_LOCK_TIMEOUT_SECONDS == expected_timeout
 
 
 def test_pod_name_stays_within_dns_label_limit() -> None:


### PR DESCRIPTION
## Description

Increase the shared Kubernetes sandbox startup and OpenCode history restore deadline from 60 to 90 seconds. A cold pull of the 1.06 GB sandbox image can exceed the previous deadline, causing provisioning to delete an otherwise healthy pod immediately before the image finishes downloading.

The provisioning lock continues to derive its timeout from the bounded startup operations, increasing its total budget from 150 to 180 seconds. Regression coverage asserts both the new startup deadline and the complete derived lock budget.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow longer Kubernetes sandbox cold starts by raising the OpenCode history restore deadline to 90s. Expands the provisioning lock budget to 180s to keep healthy pods during large image pulls.

- **Bug Fixes**
  - Increased `OPENCODE_HISTORY_RESTORE_TIMEOUT_SECONDS` from 60s to 90s to accommodate cold pulls of the 1.06 GB image.
  - Derived `PROVISION_LOCK_TIMEOUT_SECONDS` now 180s to cover all startup phases (pod ready, serve ready, cleanup).
  - Removed redundant timeout assertions in tests.

<sup>Written for commit 15663e5a967608fad3a0059a7b0f74a854bdb6ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

