### PR TITLE
fix(web): flush chat scrollbar with the viewport edge

### DIFF
--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -54,7 +54,11 @@ export interface ChatScrollContainerProps {
   /** Hide the scrollbar (scroll still works, just invisible) */
   hideScrollbar?: boolean;
 
-  /** Drop the content-wrapper horizontal padding so content sits flush with the chat edge. */
+  /**
+   * Full-width mode: the scroll container spans edge-to-edge (auto scrollbar
+   * gutter) and content uses the input-bar-matching px-2 sm:px-4 rather than the
+   * centered reading layout. The scrollbar stays flush with the edge either way.
+   */
   flushContent?: boolean;
 }
 
@@ -378,7 +382,10 @@ const ChatScrollContainer = React.memo(
               ref={contentWrapperRef}
               className={cn(
                 "w-full flex-1 flex flex-col items-center",
-                !flushContent && "px-4"
+                // Content stays padded in both modes; the scroll container itself
+                // reaches the edge so the scrollbar isn't inset. Full-width mirrors
+                // the input bar's px-2 sm:px-4 so messages line up with it.
+                flushContent ? "px-2 sm:px-4" : "px-4"
               )}
               data-scroll-ready={isScrollReady}
               style={{

--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -54,9 +54,9 @@ export interface ChatScrollContainerProps {
   /** Hide the scrollbar (scroll still works, just invisible) */
   hideScrollbar?: boolean;
 
-  /** Full-width mode: edge-to-edge scroll container with input-bar-matching
-   *  content padding, instead of the centered reading layout. */
-  flushContent?: boolean;
+  /** Full-width mode: edge-to-edge scroll container instead of the centered
+   *  reading layout (drops the reserved scrollbar gutter). */
+  fullWidth?: boolean;
 }
 
 // Build a CSS mask that fades content opacity at top/bottom edges
@@ -78,7 +78,7 @@ const ChatScrollContainer = React.memo(
         onScrollButtonVisibilityChange,
         sessionId,
         hideScrollbar = false,
-        flushContent = false,
+        fullWidth = false,
       }: ChatScrollContainerProps,
       ref: ForwardedRef<ChatScrollContainerHandle>
     ) => {
@@ -369,7 +369,7 @@ const ChatScrollContainer = React.memo(
             style={{
               // Full-width drops the reserved gutters so content sits flush with
               // the chat edge; centered mode keeps both-edges to avoid shift.
-              scrollbarGutter: flushContent ? "auto" : "stable both-edges",
+              scrollbarGutter: fullWidth ? "auto" : "stable both-edges",
               // Apply mask to fade content opacity at edges
               maskImage: contentMask,
               WebkitMaskImage: contentMask,
@@ -378,9 +378,8 @@ const ChatScrollContainer = React.memo(
             <div
               ref={contentWrapperRef}
               className={cn(
-                "w-full flex-1 flex flex-col items-center",
-                // Full-width matches the input bar's px-2 sm:px-4; centered uses px-4.
-                flushContent ? "px-2 sm:px-4" : "px-4"
+                // px-2 sm:px-4 matches the input bar's horizontal padding.
+                "w-full flex-1 flex flex-col items-center px-2 sm:px-4"
               )}
               data-scroll-ready={isScrollReady}
               style={{

--- a/web/src/sections/chat/ChatScrollContainer.tsx
+++ b/web/src/sections/chat/ChatScrollContainer.tsx
@@ -54,11 +54,8 @@ export interface ChatScrollContainerProps {
   /** Hide the scrollbar (scroll still works, just invisible) */
   hideScrollbar?: boolean;
 
-  /**
-   * Full-width mode: the scroll container spans edge-to-edge (auto scrollbar
-   * gutter) and content uses the input-bar-matching px-2 sm:px-4 rather than the
-   * centered reading layout. The scrollbar stays flush with the edge either way.
-   */
+  /** Full-width mode: edge-to-edge scroll container with input-bar-matching
+   *  content padding, instead of the centered reading layout. */
   flushContent?: boolean;
 }
 
@@ -382,9 +379,7 @@ const ChatScrollContainer = React.memo(
               ref={contentWrapperRef}
               className={cn(
                 "w-full flex-1 flex flex-col items-center",
-                // Content stays padded in both modes; the scroll container itself
-                // reaches the edge so the scrollbar isn't inset. Full-width mirrors
-                // the input bar's px-2 sm:px-4 so messages line up with it.
+                // Full-width matches the input bar's px-2 sm:px-4; centered uses px-4.
                 flushContent ? "px-2 sm:px-4" : "px-4"
               )}
               data-scroll-ready={isScrollReady}

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -811,7 +811,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       autoScroll={autoScrollEnabled}
                       isStreaming={isStreaming}
                       onScrollButtonVisibilityChange={setShowScrollButton}
-                      flushContent={fullWidthActive}
+                      fullWidth={fullWidthActive}
                     >
                       <ChatUI
                         liveAgent={liveAgent!}

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -791,10 +791,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
-                {/* No horizontal padding here: the chat scroll container fills the
-                    full width so its scrollbar sits flush with the edge (it applies
-                    its own content padding internally). Non-chat siblings below add
-                    their own px-2 sm:px-4. */}
+                {/* No horizontal padding: the scroll container reaches the edge so
+                    its scrollbar sits flush; non-chat siblings add their own px. */}
                 <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center">
                   {/* ChatUI */}
                   <Fade

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -791,7 +791,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 style={gridStyle}
               >
                 {/* ── Top row: ChatUI / WelcomeMessage / ProjectUI ── */}
-                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center px-2 sm:px-4">
+                {/* No horizontal padding here: the chat scroll container fills the
+                    full width so its scrollbar sits flush with the edge (it applies
+                    its own content padding internally). Non-chat siblings below add
+                    their own px-2 sm:px-4. */}
+                <div className="row-start-1 min-h-0 overflow-hidden flex flex-col items-center">
                   {/* ChatUI */}
                   <Fade
                     show={
@@ -833,7 +837,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                   {/* Session fetch error (404 / 403) */}
                   <Fade
                     show={appFocus.isChat() && sessionFetchError !== null}
-                    className="h-full w-full flex flex-col items-center justify-center"
+                    className="h-full w-full flex flex-col items-center justify-center px-2 sm:px-4"
                   >
                     {sessionFetchError && (
                       <Section
@@ -871,7 +875,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
                   {/* ProjectUI */}
                   {appFocus.isProject() && (
-                    <div className="w-full max-h-[50vh] overflow-y-auto overscroll-y-none">
+                    <div className="w-full max-h-[50vh] overflow-y-auto overscroll-y-none px-2 sm:px-4">
                       <ProjectContextPanel
                         projectTokenCount={projectContextTokenCount}
                         availableContextTokens={availableContextTokens}
@@ -886,7 +890,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       (appFocus.isNewSession() || appFocus.isAgent()) &&
                       (state.phase === "idle" || state.phase === "classifying")
                     }
-                    className="w-full flex-1 flex flex-col items-center justify-end"
+                    className="w-full flex-1 flex flex-col items-center justify-end px-2 sm:px-4"
                   >
                     <Section
                       flexDirection="row"


### PR DESCRIPTION
## Problem

The `px-2 sm:px-4` on `AppPage`'s `row-start-1` wrapper inset the chat `ChatScrollContainer` (the scrolling element) from the column edge, so its **scrollbar rendered padded rather than flush** with the edge. It also double-padded the chat, since `ChatScrollContainer` already applies its own horizontal content padding internally.

## Fix

- **`AppPage.tsx`** — Drop the horizontal padding from the `row-start-1` wrapper so the scroll container reaches the column edge and the scrollbar sits flush. Move that padding onto the non-chat siblings that were relying on it (session-error, project, welcome), which don't own a scrollbar.
- **`ChatScrollContainer.tsx`** — Full-width mode (`flushContent`) previously zeroed its content padding, relying on the parent padding that was just removed. Pad it with `px-2 sm:px-4` instead so full-width chat content still lines up with the input bar, while the scroll container itself stays edge-flush.

## Both modes stay correct

- **Centered mode:** scroll container reaches the edge → scrollbar flush; content keeps its `px-4` + `stable both-edges` gutter, so messages stay centered at the 720px reading width, aligned with the input bar. `NRFPage` (the only other consumer) uses this mode and is unchanged.
- **Full-width mode:** scrollbar flush; content padding `px-2 sm:px-4` now matches the input bar, preserving the prior inset that used to come from the parent.

Side benefit: the chat content is no longer double-padded, so on desktop the messages line up with the input bar more precisely than before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**before**
<img width="2349" height="2085" alt="20260716_11h18m42s_grim" src="https://github.com/user-attachments/assets/f64c8c54-0726-4b01-9288-a01c7f63f073" />

**after**
<img width="2349" height="2085" alt="20260716_11h18m50s_grim" src="https://github.com/user-attachments/assets/dc4fed54-3cf0-4885-a89c-03eed4ffb2e4" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the chat scrollbar sit flush with the viewport edge and remove double padding so messages line up with the input bar.

- **Bug Fixes**
  - Removed horizontal padding from `AppPage`’s top-row wrapper so the chat scroll container spans full width and the scrollbar is flush.
  - Added `px-2 sm:px-4` to non-chat siblings (session error, project panel, welcome).

- **Refactors**
  - Renamed `flushContent` to `fullWidth` in `ChatScrollContainer`/`AppPage`; it now only controls the `scrollbar-gutter`.
  - Unified chat content padding to `px-2 sm:px-4` in all modes (matches the input bar).

<sup>Written for commit 2b0d632776c2b8aef5f9212f916e7ce91a8f5f60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

