### PR TITLE
fix(craft): stop killing slow tool turns + gracefully recover from step timeouts

### DIFF
--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -30,13 +30,6 @@ Ephemeral VM with Python 3.11 and Node v22. A Python virtual environment is alre
 Install anything else with `pip install <pkg>`, or `bun install <pkg>` from
 `outputs/web`. Your LLM is {{LLM_PROVIDER_NAME}} / {{LLM_MODEL_NAME}}.
 
-Long commands have limits. The bash tool stops a command after ~3 minutes by default, and a
-hard ~200s turn-level backstop kills the whole turn if any single command runs that long
-without producing output. Most slow commands (image generation, installs) finish well under
-this. For work that would exceed it, split it into steps or run it in the background — do not
-raise a command's `timeout` past the backstop, which just kills the turn instead of failing
-the one command.
-
 ### Workspace layout
 
 Your working directory is the session root. Everything you produce goes under `outputs/`.

--- a/backend/onyx/server/features/build/AGENTS.template.md
+++ b/backend/onyx/server/features/build/AGENTS.template.md
@@ -30,6 +30,13 @@ Ephemeral VM with Python 3.11 and Node v22. A Python virtual environment is alre
 Install anything else with `pip install <pkg>`, or `bun install <pkg>` from
 `outputs/web`. Your LLM is {{LLM_PROVIDER_NAME}} / {{LLM_MODEL_NAME}}.
 
+Long commands have limits. The bash tool stops a command after ~3 minutes by default, and a
+hard ~200s turn-level backstop kills the whole turn if any single command runs that long
+without producing output. Most slow commands (image generation, installs) finish well under
+this. For work that would exceed it, split it into steps or run it in the background — do not
+raise a command's `timeout` past the backstop, which just kills the turn instead of failing
+the one command.
+
 ### Workspace layout
 
 Your working directory is the session root. Everything you produce goes under `outputs/`.

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -163,9 +163,13 @@ SANDBOX_DOCKER_CPU_LIMIT = float(os.environ.get("SANDBOX_DOCKER_CPU_LIMIT", "1.0
 
 SSE_KEEPALIVE_INTERVAL = float(os.environ.get("SSE_KEEPALIVE_INTERVAL", "15.0"))
 
-# Maximum time opencode-serve may go without emitting a turn event.
+# Maximum time opencode-serve may go without emitting a turn event. Coarse
+# liveness backstop only: it must stay above opencode's own per-tool timeouts
+# (bash defaults to 300s here, webfetch 120s) so it never pre-empts a healthy
+# long-running tool — it exists to catch stalls opencode does not bound itself
+# (LLM-stream hangs, non-bash/MCP tool hangs). The turn budget is the hard ceiling.
 OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS = float(
-    os.environ.get("OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS", "60.0")
+    os.environ.get("OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS", "300.0")
 )
 
 # Hard ceiling for background prompt-slot renewal, so a leaked holder cannot

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -165,11 +165,11 @@ SSE_KEEPALIVE_INTERVAL = float(os.environ.get("SSE_KEEPALIVE_INTERVAL", "15.0"))
 
 # Maximum time opencode-serve may go without emitting a turn event. Coarse
 # liveness backstop only: it must stay above opencode's own per-tool timeouts
-# (bash defaults to 300s here, webfetch 120s) so it never pre-empts a healthy
+# (bash defaults to 180s here, webfetch 120s) so it never pre-empts a healthy
 # long-running tool — it exists to catch stalls opencode does not bound itself
 # (LLM-stream hangs, non-bash/MCP tool hangs). The turn budget is the hard ceiling.
 OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS = float(
-    os.environ.get("OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS", "300.0")
+    os.environ.get("OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS", "200.0")
 )
 
 # Hard ceiling for background prompt-slot renewal, so a leaked holder cannot

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -10,6 +10,9 @@ from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.cache.interface import CacheBackend
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.server.features.build.configs import (
+    OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS,
+)
 from onyx.server.features.build.db.build_session import update_session_activity
 from onyx.server.features.build.interactive_turns.state import claim_turn_for_runner
 from onyx.server.features.build.interactive_turns.state import finish_turn
@@ -19,6 +22,7 @@ from onyx.server.features.build.interactive_turns.state import touch_turn
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_CANCELLED
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_SUCCEEDED
+from onyx.server.features.build.sandbox.event_schema import ActivityTimeoutError
 from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.serve_transport import (
@@ -39,6 +43,14 @@ from shared_configs.contextvars import get_current_tenant_id
 logger = setup_logger()
 
 DEFAULT_INTERACTIVE_TURN_BUDGET_SECONDS = 30 * 60
+
+MAX_TIMEOUT_CONTINUATIONS = 2
+_TOOL_TIMEOUT_CONTINUATION_PROMPT = (
+    f"Your last step was cancelled — it exceeded the "
+    f"{int(OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS)}s activity limit with no "
+    "output. Don't just retry it; split the work into shorter steps or run it in "
+    "the background, then continue."
+)
 
 
 def _can_clear_interrupt_fence(
@@ -152,8 +164,7 @@ def _drive_interactive_turn(
         state = BuildStreamingState(turn_index=turn_index)
         deadline = time.monotonic() + budget_seconds
         deadline_exceeded = False
-        final_event_seen = False
-        cancelled_event_seen = False
+        timeout_continuations = 0
 
         def interrupt_requested() -> bool:
             nonlocal deadline_exceeded
@@ -212,61 +223,95 @@ def _drive_interactive_turn(
                 )
                 return
 
-            ownership_lost = False
+            current_prompt = prompt
+            while True:
+                ownership_lost = False
+                final_event_seen = False
+                cancelled_event_seen = False
+                timed_out_for_continuation = False
 
-            event_stream = session_manager.yield_sandbox_events(
-                sandbox.id,
-                session_id,
-                prompt,
-                should_interrupt=interrupt_requested,
-                should_abort_on_teardown=lambda: not ownership_lost,
-            )
+                event_stream = session_manager.yield_sandbox_events(
+                    sandbox.id,
+                    session_id,
+                    current_prompt,
+                    should_interrupt=interrupt_requested,
+                    should_abort_on_teardown=lambda: not ownership_lost,
+                )
 
-            for sandbox_event in event_stream:
-                if time.monotonic() > deadline:
-                    deadline_exceeded = True
-                if deadline_exceeded:
+                for sandbox_event in event_stream:
+                    if time.monotonic() > deadline:
+                        deadline_exceeded = True
+                    if deadline_exceeded:
+                        continue
+
+                    if not touch_turn(
+                        cache=cache, turn_id=turn_id, runner_id=runner_id
+                    ):
+                        logger.info(
+                            "Interactive turn %s runner ownership lost", turn_id
+                        )
+                        ownership_lost = True
+                        return
+                    slot.extend()
+                    if slot.lost:
+                        ownership_lost = True
+                        session_manager.finalize_persist(session_id, state)
+                        db_session.commit()
+                        finish_turn(
+                            cache=cache,
+                            turn_id=turn_id,
+                            status=TURN_STATUS_FAILED,
+                            error_detail="Prompt slot lease lost mid-turn.",
+                            runner_id=runner_id,
+                        )
+                        return
+                    if isinstance(sandbox_event, SSEKeepalive):
+                        continue
+
+                    # The transport already aborted the timed-out step; re-prompt.
+                    if (
+                        isinstance(sandbox_event, ActivityTimeoutError)
+                        and not deadline_exceeded
+                        and timeout_continuations < MAX_TIMEOUT_CONTINUATIONS
+                    ):
+                        timed_out_for_continuation = True
+                        continue
+
+                    session_manager.persist_sandbox_event(
+                        session_id, state, sandbox_event
+                    )
+                    db_session.commit()
+
+                    if isinstance(sandbox_event, SandboxError):
+                        session_manager.finalize_persist(session_id, state)
+                        db_session.commit()
+                        finish_turn(
+                            cache=cache,
+                            turn_id=turn_id,
+                            status=TURN_STATUS_FAILED,
+                            error_detail=sandbox_event.message,
+                            runner_id=runner_id,
+                        )
+                        return
+
+                    if isinstance(sandbox_event, PromptResponse):
+                        final_event_seen = True
+                        cancelled_event_seen = (
+                            getattr(sandbox_event, "stop_reason", None) == "cancelled"
+                        )
+
+                if timed_out_for_continuation:
+                    timeout_continuations += 1
+                    logger.info(
+                        "Interactive turn %s step timed out; re-prompting (%s/%s)",
+                        turn_id,
+                        timeout_continuations,
+                        MAX_TIMEOUT_CONTINUATIONS,
+                    )
+                    current_prompt = _TOOL_TIMEOUT_CONTINUATION_PROMPT
                     continue
 
-                if not touch_turn(cache=cache, turn_id=turn_id, runner_id=runner_id):
-                    logger.info("Interactive turn %s runner ownership lost", turn_id)
-                    ownership_lost = True
-                    return
-                slot.extend()
-                if slot.lost:
-                    ownership_lost = True
-                    session_manager.finalize_persist(session_id, state)
-                    db_session.commit()
-                    finish_turn(
-                        cache=cache,
-                        turn_id=turn_id,
-                        status=TURN_STATUS_FAILED,
-                        error_detail="Prompt slot lease lost mid-turn.",
-                        runner_id=runner_id,
-                    )
-                    return
-                if isinstance(sandbox_event, SSEKeepalive):
-                    continue
-                session_manager.persist_sandbox_event(session_id, state, sandbox_event)
-                db_session.commit()
-
-                if isinstance(sandbox_event, SandboxError):
-                    session_manager.finalize_persist(session_id, state)
-                    db_session.commit()
-                    finish_turn(
-                        cache=cache,
-                        turn_id=turn_id,
-                        status=TURN_STATUS_FAILED,
-                        error_detail=sandbox_event.message,
-                        runner_id=runner_id,
-                    )
-                    return
-
-                if isinstance(sandbox_event, PromptResponse):
-                    final_event_seen = True
-                    cancelled_event_seen = (
-                        getattr(sandbox_event, "stop_reason", None) == "cancelled"
-                    )
+                break
 
             session_manager.finalize_persist(session_id, state)
             db_session.commit()

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -249,6 +249,7 @@ def _drive_interactive_turn(
                 ownership_lost = False
                 final_event_seen = False
                 cancelled_event_seen = False
+                timed_out = False
 
                 event_stream = session_manager.yield_sandbox_events(
                     sandbox.id,
@@ -288,10 +289,12 @@ def _drive_interactive_turn(
                     if isinstance(sandbox_event, SSEKeepalive):
                         continue
 
-                    # The transport already aborted the timed-out step; the caller
-                    # re-prompts so the agent can adapt.
+                    # The transport already aborted the timed-out step and ends the
+                    # stream after this event; drain it (don't return early, which
+                    # would GeneratorExit and re-abort) and let the caller re-prompt.
                     if isinstance(sandbox_event, ActivityTimeoutError) and can_continue:
-                        return _PromptResult(_PromptOutcome.TIMED_OUT)
+                        timed_out = True
+                        continue
 
                     session_manager.persist_sandbox_event(
                         session_id, state, sandbox_event
@@ -316,6 +319,8 @@ def _drive_interactive_turn(
                             getattr(sandbox_event, "stop_reason", None) == "cancelled"
                         )
 
+                if timed_out:
+                    return _PromptResult(_PromptOutcome.TIMED_OUT)
                 return _PromptResult(
                     _PromptOutcome.COMPLETED,
                     final_event_seen=final_event_seen,

--- a/backend/onyx/server/features/build/interactive_turns/executor.py
+++ b/backend/onyx/server/features/build/interactive_turns/executor.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import threading
 import time
+from dataclasses import dataclass
+from enum import auto
+from enum import Enum
 from uuid import UUID
 
 from onyx.cache.factory import get_cache_backend
@@ -46,11 +49,24 @@ DEFAULT_INTERACTIVE_TURN_BUDGET_SECONDS = 30 * 60
 
 MAX_TIMEOUT_CONTINUATIONS = 2
 _TOOL_TIMEOUT_CONTINUATION_PROMPT = (
-    f"Your last step was cancelled — it exceeded the "
+    "Your last step was cancelled — it exceeded the "
     f"{int(OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS)}s activity limit with no "
     "output. Don't just retry it; split the work into shorter steps or run it in "
     "the background, then continue."
 )
+
+
+class _PromptOutcome(Enum):
+    TERMINATED = auto()  # the turn was already finished; the caller returns
+    TIMED_OUT = auto()  # step went silent; the caller re-prompts
+    COMPLETED = auto()  # the opencode stream ended; run the terminal handling
+
+
+@dataclass
+class _PromptResult:
+    outcome: _PromptOutcome
+    final_event_seen: bool = False
+    cancelled: bool = False
 
 
 def _can_clear_interrupt_fence(
@@ -164,7 +180,6 @@ def _drive_interactive_turn(
         state = BuildStreamingState(turn_index=turn_index)
         deadline = time.monotonic() + budget_seconds
         deadline_exceeded = False
-        timeout_continuations = 0
 
         def interrupt_requested() -> bool:
             nonlocal deadline_exceeded
@@ -223,12 +238,17 @@ def _drive_interactive_turn(
                 )
                 return
 
-            current_prompt = prompt
-            while True:
+            def drive_one_prompt(
+                current_prompt: str, *, can_continue: bool
+            ) -> _PromptResult:
+                """Stream one opencode prompt to completion, timeout, or a
+                turn-ending failure. On the recoverable inactivity timeout it
+                returns TIMED_OUT (only while ``can_continue``); failures finish
+                the turn here and return TERMINATED so the caller just returns."""
+                nonlocal deadline_exceeded
                 ownership_lost = False
                 final_event_seen = False
                 cancelled_event_seen = False
-                timed_out_for_continuation = False
 
                 event_stream = session_manager.yield_sandbox_events(
                     sandbox.id,
@@ -251,7 +271,7 @@ def _drive_interactive_turn(
                             "Interactive turn %s runner ownership lost", turn_id
                         )
                         ownership_lost = True
-                        return
+                        return _PromptResult(_PromptOutcome.TERMINATED)
                     slot.extend()
                     if slot.lost:
                         ownership_lost = True
@@ -264,18 +284,14 @@ def _drive_interactive_turn(
                             error_detail="Prompt slot lease lost mid-turn.",
                             runner_id=runner_id,
                         )
-                        return
+                        return _PromptResult(_PromptOutcome.TERMINATED)
                     if isinstance(sandbox_event, SSEKeepalive):
                         continue
 
-                    # The transport already aborted the timed-out step; re-prompt.
-                    if (
-                        isinstance(sandbox_event, ActivityTimeoutError)
-                        and not deadline_exceeded
-                        and timeout_continuations < MAX_TIMEOUT_CONTINUATIONS
-                    ):
-                        timed_out_for_continuation = True
-                        continue
+                    # The transport already aborted the timed-out step; the caller
+                    # re-prompts so the agent can adapt.
+                    if isinstance(sandbox_event, ActivityTimeoutError) and can_continue:
+                        return _PromptResult(_PromptOutcome.TIMED_OUT)
 
                     session_manager.persist_sandbox_event(
                         session_id, state, sandbox_event
@@ -292,7 +308,7 @@ def _drive_interactive_turn(
                             error_detail=sandbox_event.message,
                             runner_id=runner_id,
                         )
-                        return
+                        return _PromptResult(_PromptOutcome.TERMINATED)
 
                     if isinstance(sandbox_event, PromptResponse):
                         final_event_seen = True
@@ -300,18 +316,35 @@ def _drive_interactive_turn(
                             getattr(sandbox_event, "stop_reason", None) == "cancelled"
                         )
 
-                if timed_out_for_continuation:
-                    timeout_continuations += 1
-                    logger.info(
-                        "Interactive turn %s step timed out; re-prompting (%s/%s)",
-                        turn_id,
-                        timeout_continuations,
-                        MAX_TIMEOUT_CONTINUATIONS,
-                    )
-                    current_prompt = _TOOL_TIMEOUT_CONTINUATION_PROMPT
-                    continue
+                return _PromptResult(
+                    _PromptOutcome.COMPLETED,
+                    final_event_seen=final_event_seen,
+                    cancelled=cancelled_event_seen,
+                )
 
-                break
+            result = _PromptResult(_PromptOutcome.COMPLETED)
+            current_prompt = prompt
+            for attempt in range(MAX_TIMEOUT_CONTINUATIONS + 1):
+                result = drive_one_prompt(
+                    current_prompt,
+                    can_continue=attempt < MAX_TIMEOUT_CONTINUATIONS,
+                )
+                if result.outcome is not _PromptOutcome.TIMED_OUT:
+                    break
+                # Flush the aborted step's partial output as its own message so it
+                # can't merge with the continuation, then steer the agent.
+                session_manager.finalize_persist(session_id, state)
+                db_session.commit()
+                logger.info(
+                    "Interactive turn %s step timed out; re-prompting (%s/%s)",
+                    turn_id,
+                    attempt + 1,
+                    MAX_TIMEOUT_CONTINUATIONS,
+                )
+                current_prompt = _TOOL_TIMEOUT_CONTINUATION_PROMPT
+
+            if result.outcome is _PromptOutcome.TERMINATED:
+                return
 
             session_manager.finalize_persist(session_id, state)
             db_session.commit()
@@ -326,7 +359,7 @@ def _drive_interactive_turn(
                 )
                 return
 
-            if not final_event_seen:
+            if not result.final_event_seen:
                 finish_turn(
                     cache=cache,
                     turn_id=turn_id,
@@ -336,7 +369,7 @@ def _drive_interactive_turn(
                 )
                 return
 
-            if cancelled_event_seen:
+            if result.cancelled:
                 finish_turn(
                     cache=cache,
                     turn_id=turn_id,

--- a/backend/onyx/server/features/build/sandbox/event_schema.py
+++ b/backend/onyx/server/features/build/sandbox/event_schema.py
@@ -23,7 +23,16 @@ TURN_ERROR_CODE_SESSION = -1  # opencode reported an error during the turn
 TURN_ERROR_CODE_TIMEOUT = -2
 TURN_ERROR_CODE_TRANSPORT = -3
 
+
+class ActivityTimeoutError(Error):
+    """A step produced no output within the inactivity window — recoverable by
+    re-prompting, unlike a hard absolute/budget timeout."""
+
+    code: int = TURN_ERROR_CODE_TIMEOUT
+
+
 __all__ = [
+    "ActivityTimeoutError",
     "AgentMessageChunk",
     "AgentPlanUpdate",
     "AgentThoughtChunk",

--- a/backend/onyx/server/features/build/sandbox/event_schema.py
+++ b/backend/onyx/server/features/build/sandbox/event_schema.py
@@ -26,7 +26,8 @@ TURN_ERROR_CODE_TRANSPORT = -3
 
 class ActivityTimeoutError(Error):
     """A step produced no output within the inactivity window — recoverable by
-    re-prompting, unlike a hard absolute/budget timeout."""
+    re-prompting, unlike a hard absolute/budget timeout. The distinction is
+    carried by the type, not ``code`` (which it shares with the hard timeout)."""
 
     code: int = TURN_ERROR_CODE_TIMEOUT
 

--- a/backend/onyx/server/features/build/sandbox/image/entrypoint.sh
+++ b/backend/onyx/server/features/build/sandbox/image/entrypoint.sh
@@ -12,6 +12,11 @@ OPENCODE_PORT=4096
 export XDG_DATA_HOME="${OPENCODE_DATA_HOME:-/workspace/.opencode-data}"
 mkdir -p "$XDG_DATA_HOME"
 
+# opencode's bash tool defaults to 120s, which is too tight for legitimately slow
+# tools (e.g. image generation). Raise it so opencode bounds long tools itself
+# rather than the coarser api-server inactivity backstop killing the whole turn.
+export OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS="${OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS:-300000}"
+
 child_pid=
 trap 'if [ -n "$child_pid" ]; then kill -TERM "$child_pid" 2>/dev/null || true; fi; exit 0' SIGTERM SIGINT
 

--- a/backend/onyx/server/features/build/sandbox/image/entrypoint.sh
+++ b/backend/onyx/server/features/build/sandbox/image/entrypoint.sh
@@ -15,7 +15,7 @@ mkdir -p "$XDG_DATA_HOME"
 # opencode's bash tool defaults to 120s, which is too tight for legitimately slow
 # tools (e.g. image generation). Raise it so opencode bounds long tools itself
 # rather than the coarser api-server inactivity backstop killing the whole turn.
-export OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS="${OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS:-300000}"
+export OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS="${OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS:-180000}"
 
 child_pid=
 trap 'if [ -n "$child_pid" ]; then kill -TERM "$child_pid" 2>/dev/null || true; fi; exit 0' SIGTERM SIGINT

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -39,6 +39,7 @@ from onyx.server.features.build.configs import SSE_KEEPALIVE_INTERVAL
 from onyx.server.features.build.packets import CompactionPacket
 from onyx.server.features.build.packets import ContextUsagePacket
 from onyx.server.features.build.packets import SubagentStartedPacket
+from onyx.server.features.build.sandbox.event_schema import ActivityTimeoutError
 from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
 from onyx.server.features.build.sandbox.event_schema import AgentThoughtChunk
 from onyx.server.features.build.sandbox.event_schema import Error
@@ -1550,17 +1551,15 @@ class OpencodeServeClient:
             remaining = min(inactivity_remaining, absolute_remaining)
             if remaining <= 0:
                 self.abort(opencode_session_id, directory=directory)
-                message = (
-                    "Turn exceeded maximum duration"
-                    if absolute_remaining <= 0
-                    else "Timeout waiting for activity"
-                )
-                yield Error.model_validate(
-                    {
-                        "code": TURN_ERROR_CODE_TIMEOUT,
-                        "message": message,
-                    }
-                )
+                if absolute_remaining <= 0:
+                    yield Error.model_validate(
+                        {
+                            "code": TURN_ERROR_CODE_TIMEOUT,
+                            "message": "Turn exceeded maximum duration",
+                        }
+                    )
+                else:
+                    yield ActivityTimeoutError(message="Timeout waiting for activity")
                 return
 
             try:

--- a/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
@@ -20,6 +20,7 @@ from onyx.server.features.build.interactive_turns.state import TURN_STATUS_CANCE
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_FAILED
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_RUNNING
 from onyx.server.features.build.interactive_turns.state import TURN_STATUS_SUCCEEDED
+from onyx.server.features.build.sandbox.event_schema import ActivityTimeoutError
 from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
 from onyx.server.features.build.sandbox.serve_transport import (
@@ -672,6 +673,142 @@ def test_start_interactive_turn_runner_preserves_tenant_context(
     assert observed_turn_id == turn.turn_id
     assert observed_tenant == "tenant-a"
     assert observed_runner_id is not None
+
+
+def _run_turn_with_batches(
+    monkeypatch: pytest.MonkeyPatch,
+    batches: list[list[object]],
+) -> SimpleNamespace:
+    cache = FakeCache()
+    db_session = _FakeDbSession()
+    session_id = uuid4()
+    user_id = uuid4()
+    sandbox_id = uuid4()
+    prompt_slot = _FakePromptSlot()
+    persisted: list[object] = []
+    finalized: list[UUID] = []
+    prompts_seen: list[str] = []
+
+    turn = create_interactive_turn(
+        cache=cache,
+        session_id=session_id,
+        user_id=user_id,
+        client_request_id="req-1",
+        prompt="hello",
+        turn_index=0,
+    )
+
+    class FakeSessionManager:
+        def __init__(self, db_session_arg: _FakeDbSession) -> None:
+            assert db_session_arg is db_session
+
+        def ensure_sandbox_running(self, user_id_arg: UUID) -> SimpleNamespace:
+            assert user_id_arg == user_id
+            return SimpleNamespace(id=sandbox_id)
+
+        def prompt_slot(
+            self,
+            sandbox_id_arg: UUID,
+            session_id_arg: UUID,
+            acquire_timeout: float = PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
+        ) -> _FakePromptSlot:
+            assert sandbox_id_arg == sandbox_id
+            assert session_id_arg == session_id
+            prompt_slot.acquire_timeouts.append(acquire_timeout)
+            return prompt_slot
+
+        def yield_sandbox_events(
+            self,
+            sandbox_id_arg: UUID,
+            session_id_arg: UUID,
+            prompt: str,
+            *,
+            should_interrupt: object,
+            should_abort_on_teardown: Callable[[], bool],
+        ) -> Iterator[object]:
+            assert sandbox_id_arg == sandbox_id
+            assert session_id_arg == session_id
+            assert should_interrupt is not None
+            assert should_abort_on_teardown() is True
+            idx = len(prompts_seen)
+            prompts_seen.append(prompt)
+            yield from (batches[idx] if idx < len(batches) else [])
+
+        def persist_sandbox_event(
+            self, session_id_arg: UUID, state: object, sandbox_event: object
+        ) -> None:
+            assert session_id_arg == session_id
+            assert state is not None
+            persisted.append(sandbox_event)
+
+        def finalize_persist(self, session_id_arg: UUID, state: object) -> None:
+            assert state is not None
+            finalized.append(session_id_arg)
+
+    monkeypatch.setattr(executor, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(
+        executor,
+        "get_session_with_current_tenant",
+        lambda: _fake_db_scope(db_session),
+    )
+    monkeypatch.setattr(executor, "SessionManager", FakeSessionManager)
+    monkeypatch.setattr(executor, "update_session_activity", lambda *_: None)
+    monkeypatch.setattr(executor, "is_interrupt_requested", lambda *_: False)
+    monkeypatch.setattr(executor, "clear_interrupt", lambda *_: None)
+
+    claimed = claim_turn_for_runner(cache=cache, turn_id=turn.turn_id)
+    assert claimed is not None
+    executor.run_claimed_interactive_build_turn(claimed, budget_seconds=30)
+
+    return SimpleNamespace(
+        cache=cache,
+        turn=turn,
+        session_id=session_id,
+        user_id=user_id,
+        persisted=persisted,
+        finalized=finalized,
+        prompts_seen=prompts_seen,
+        prompt_slot=prompt_slot,
+    )
+
+
+def test_runner_continues_after_tool_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timeout = ActivityTimeoutError(message="Timeout waiting for activity")
+    done = PromptResponse.model_validate({"stopReason": "end_turn"})
+
+    result = _run_turn_with_batches(monkeypatch, [[timeout], [done]])
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_SUCCEEDED
+    assert result.persisted == [done]
+    assert result.prompts_seen == [
+        "hello",
+        executor._TOOL_TIMEOUT_CONTINUATION_PROMPT,
+    ]
+    assert result.finalized == [result.session_id]
+    assert result.prompt_slot.exited
+
+
+def test_runner_fails_after_max_timeout_continuations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    timeout = ActivityTimeoutError(message="Timeout waiting for activity")
+    batches: list[list[object]] = [
+        [timeout] for _ in range(executor.MAX_TIMEOUT_CONTINUATIONS + 1)
+    ]
+
+    result = _run_turn_with_batches(monkeypatch, batches)
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_FAILED
+    assert finished.error_detail == "Timeout waiting for activity"
+    assert len(result.prompts_seen) == executor.MAX_TIMEOUT_CONTINUATIONS + 1
+    assert result.persisted == [timeout]
+    assert result.prompt_slot.exited
 
 
 def test_start_interactive_turn_runner_skips_fresh_running_turn(

--- a/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
+++ b/backend/tests/unit/onyx/server/features/build/interactive_turns/test_executor.py
@@ -23,6 +23,7 @@ from onyx.server.features.build.interactive_turns.state import TURN_STATUS_SUCCE
 from onyx.server.features.build.sandbox.event_schema import ActivityTimeoutError
 from onyx.server.features.build.sandbox.event_schema import Error as SandboxError
 from onyx.server.features.build.sandbox.event_schema import PromptResponse
+from onyx.server.features.build.sandbox.event_schema import TURN_ERROR_CODE_TIMEOUT
 from onyx.server.features.build.sandbox.serve_transport import (
     PROMPT_SLOT_FAST_FAIL_ACQUIRE_SECONDS,
 )
@@ -788,7 +789,9 @@ def test_runner_continues_after_tool_timeout(
         "hello",
         executor._TOOL_TIMEOUT_CONTINUATION_PROMPT,
     ]
-    assert result.finalized == [result.session_id]
+    # The aborted step is flushed before the re-prompt, then the turn is
+    # finalized once more at the end.
+    assert result.finalized == [result.session_id, result.session_id]
     assert result.prompt_slot.exited
 
 
@@ -809,6 +812,49 @@ def test_runner_fails_after_max_timeout_continuations(
     assert len(result.prompts_seen) == executor.MAX_TIMEOUT_CONTINUATIONS + 1
     assert result.persisted == [timeout]
     assert result.prompt_slot.exited
+
+
+def test_runner_does_not_continue_on_absolute_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A hard absolute/budget timeout is a plain Error with the same code -2 as the
+    # recoverable inactivity timeout; only the TYPE differs. It must fail the turn
+    # immediately, never re-prompt.
+    absolute = SandboxError(
+        code=TURN_ERROR_CODE_TIMEOUT, message="Turn exceeded maximum duration"
+    )
+
+    result = _run_turn_with_batches(monkeypatch, [[absolute]])
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_FAILED
+    assert finished.error_detail == "Turn exceeded maximum duration"
+    assert result.prompts_seen == ["hello"]
+    assert result.persisted == [absolute]
+    assert result.prompt_slot.exited
+
+
+def test_runner_preserves_output_before_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    before = object()
+    after = object()
+    timeout = ActivityTimeoutError(message="Timeout waiting for activity")
+    done = PromptResponse.model_validate({"stopReason": "end_turn"})
+
+    result = _run_turn_with_batches(monkeypatch, [[before, timeout], [after, done]])
+
+    finished = get_turn(result.cache, result.turn.turn_id)
+    assert finished is not None
+    assert finished.status == TURN_STATUS_SUCCEEDED
+    # Output emitted before the timeout is persisted; the timeout event itself is
+    # not, and the continuation's output follows it.
+    assert result.persisted == [before, after, done]
+    assert result.prompts_seen == [
+        "hello",
+        executor._TOOL_TIMEOUT_CONTINUATION_PROMPT,
+    ]
 
 
 def test_start_interactive_turn_runner_skips_fresh_running_turn(

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_send_message_with_bus.py
@@ -28,6 +28,7 @@ from typing import Any
 import httpx
 import pytest
 
+from onyx.server.features.build.sandbox.event_schema import ActivityTimeoutError
 from onyx.server.features.build.sandbox.event_schema import AgentMessageChunk
 from onyx.server.features.build.sandbox.event_schema import AgentThoughtChunk
 from onyx.server.features.build.sandbox.event_schema import Error
@@ -621,9 +622,8 @@ def test_send_message_inactivity_timeout_aborts(bus: PodEventBus) -> None:
     events = list(
         client.send_message(_SESSION, "hi", directory=_DIRECTORY, timeout=0.3)
     )
-    assert any(
-        isinstance(e, Error) and e.code == TURN_ERROR_CODE_TIMEOUT for e in events
-    )
+    # Inactivity timeout is the recoverable subtype so the executor can re-prompt.
+    assert any(isinstance(e, ActivityTimeoutError) for e in events)
     assert any("/abort" in p for p in aborts)
 
 
@@ -727,6 +727,9 @@ def test_send_message_absolute_timeout_is_not_renewed(bus: PodEventBus) -> None:
     assert len(errors) == 1
     assert errors[0].code == TURN_ERROR_CODE_TIMEOUT
     assert errors[0].message == "Turn exceeded maximum duration"
+    # The hard budget timeout is NOT the recoverable subtype — it must not be
+    # re-prompted by the executor.
+    assert not isinstance(errors[0], ActivityTimeoutError)
 
 
 def test_send_message_aborts_on_generator_exit(bus: PodEventBus) -> None:


### PR DESCRIPTION
## Description

Craft interactive turns were hanging/dying on slow or silent steps. Two root causes, observed live on st-dev and craft-dev:

1. **Timeouts tighter than the work they guard.** The api-server inactivity backstop was **60s**, *below* opencode's own bash-tool timeout (**120s**), so it pre-empted opencode's graceful per-tool handling and aborted the whole turn during legitimately slow tools (e.g. `onyx-cli image generate`).
2. **A step timeout killed the entire turn.** When a step went silent past the backstop, the turn was marked FAILED with a bare `GeneratorExit` — no recovery, and no clear signal to the agent.

This PR fixes both:

### Timeout tuning (keeps a clear invariant)
- `OPENCODE_PROMPT_INACTIVITY_TIMEOUT_SECONDS`: **60 → 200s**. It's a coarse liveness backstop now — it must stay **above** opencode's own per-tool timeouts so it never pre-empts a healthy long tool; it only catches stalls opencode doesn't bound itself (LLM-stream hangs, non-bash/MCP tool hangs). The turn budget remains the hard ceiling.
- `entrypoint.sh` bakes `OPENCODE_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=180000` into the sandbox image (opencode bash default **120 → 180s**), so opencode bounds long tools itself (graceful error + retry hint) below the 200s backstop. *(Takes effect for sandboxes built from the new image.)*

### Graceful step-timeout recovery
- New `ActivityTimeoutError(Error)` distinguishes the **recoverable inactivity timeout** from a **hard absolute/budget timeout**. `serve_client` yields it for inactivity, a plain `Error` for the absolute ceiling. The distinction is carried by the type, not the shared `code`.
- On an `ActivityTimeoutError`, the interactive turn executor **re-prompts the same opencode session** with a short feedback message ("your last step was cancelled — split the work / run it in the background, then continue") so the agent adapts, instead of failing the turn. Bounded by `MAX_TIMEOUT_CONTINUATIONS = 2`, then it hard-fails; the 30-min turn budget is the ultimate ceiling. The aborted step's partial output is flushed as its own message before re-prompting so it can't merge with the continuation.
- The turn driver was refactored: the per-prompt event loop is now a `drive_one_prompt(...) -> _PromptOutcome` helper driven by a small bounded retry loop (replacing a nested `while True` + flags).

Why not do this inside opencode / inject a tool result instead of re-prompting? opencode is the upstream binary; its only external control is a **turn-level** `/abort` (no per-tool cancel or tool-result injection API). So graceful per-tool recovery from onyx's side is necessarily abort + re-prompt.

## How Has This Been Tested?

- **Unit tests (58 passing)** across `interactive_turns` + sandbox suites, including new coverage:
  - re-prompt continuation on inactivity timeout, and hard-fail after `MAX_TIMEOUT_CONTINUATIONS`
  - a plain `Error(code=-2)` (hard absolute timeout) is **not** re-prompted (guards the type-vs-code discrimination)
  - pre-timeout output is preserved across a continuation (guards the partial-flush)
  - `serve_client` producer split: inactivity → `ActivityTimeoutError`, absolute → plain `Error`
- `ruff`, `ty`, and pre-commit hooks pass.
- Reviewed with a multi-lens review team (correctness / readability / regressions / tests); all confirmed findings fixed.
- **End-to-end validated on a local kind cluster** (backend run from this branch via telepresence intercept, inactivity lowered to 25s to observe the path):
  - A `sleep 45` foreground step timed out at ~25s and the executor re-prompted the same opencode session (`step timed out; re-prompting (1/2)`) instead of failing; the agent adapted (ran it in the background and polled) and the turn completed successfully (`got_prompt_response=True`).
  - After the drain fix, the graceful re-prompt logs **no** `turn failed … GeneratorExit` warning and issues no redundant abort.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
