### PR TITLE
ci(deployment): drop -cloud image repos, standardize to single repos

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -729,7 +729,7 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     env:
-      REGISTRY_IMAGE: onyxdotapp/onyx-web-server-cloud
+      REGISTRY_IMAGE: onyxdotapp/onyx-web-server
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -822,7 +822,7 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     env:
-      REGISTRY_IMAGE: onyxdotapp/onyx-web-server-cloud
+      REGISTRY_IMAGE: onyxdotapp/onyx-web-server
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -915,7 +915,7 @@ jobs:
     timeout-minutes: 90
     environment: release
     env:
-      REGISTRY_IMAGE: onyxdotapp/onyx-web-server-cloud
+      REGISTRY_IMAGE: onyxdotapp/onyx-web-server
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -979,7 +979,7 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     env:
-      REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-backend-cloud' || 'onyxdotapp/onyx-backend' }}
+      REGISTRY_IMAGE: onyxdotapp/onyx-backend
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -1051,7 +1051,7 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     env:
-      REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-backend-cloud' || 'onyxdotapp/onyx-backend' }}
+      REGISTRY_IMAGE: onyxdotapp/onyx-backend
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -1123,7 +1123,7 @@ jobs:
     timeout-minutes: 90
     environment: release
     env:
-      REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-backend-cloud' || 'onyxdotapp/onyx-backend' }}
+      REGISTRY_IMAGE: onyxdotapp/onyx-backend
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -1194,7 +1194,7 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     env:
-      REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-model-server-cloud' || 'onyxdotapp/onyx-model-server' }}
+      REGISTRY_IMAGE: onyxdotapp/onyx-model-server
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -1280,7 +1280,7 @@ jobs:
     outputs:
       digest: ${{ steps.build.outputs.digest }}
     env:
-      REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-model-server-cloud' || 'onyxdotapp/onyx-model-server' }}
+      REGISTRY_IMAGE: onyxdotapp/onyx-model-server
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -1365,7 +1365,7 @@ jobs:
     timeout-minutes: 90
     environment: release
     env:
-      REGISTRY_IMAGE: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-model-server-cloud' || 'onyxdotapp/onyx-model-server' }}
+      REGISTRY_IMAGE: onyxdotapp/onyx-model-server
     steps:
       - uses: runs-on/action@4e5f72399b6b17f2e79c511c1b38a315a64d22dc
 
@@ -1832,11 +1832,11 @@ jobs:
           - component: web
             registry-image: onyxdotapp/onyx-web-server
           - component: web-cloud
-            registry-image: onyxdotapp/onyx-web-server-cloud
+            registry-image: onyxdotapp/onyx-web-server
           - component: backend
-            registry-image: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-backend-cloud' || 'onyxdotapp/onyx-backend' }}
+            registry-image: onyxdotapp/onyx-backend
           - component: model-server
-            registry-image: ${{ contains(github.ref_name, 'cloud') && 'onyxdotapp/onyx-model-server-cloud' || 'onyxdotapp/onyx-model-server' }}
+            registry-image: onyxdotapp/onyx-model-server
           - component: sandbox
             registry-image: onyxdotapp/sandbox
     steps:


### PR DESCRIPTION
## What

Drops the separate `-cloud` Docker Hub repositories in `.github/workflows/deployment.yml` and standardizes every image to its single (community) repo:

| Component | Before (on a `-cloud` tag) | After |
|---|---|---|
| web | `onyxdotapp/onyx-web-server-cloud` | `onyxdotapp/onyx-web-server` |
| backend | `onyxdotapp/onyx-backend-cloud` (via `contains(ref,'cloud')`) | `onyxdotapp/onyx-backend` |
| model-server | `onyxdotapp/onyx-model-server-cloud` (via conditional) | `onyxdotapp/onyx-model-server` |

The dedicated `build-web-cloud-*` / `merge-web-cloud` / `image-audit` (web-cloud) jobs are **kept** — the cloud web build bakes in different (cloud) config, so it still builds separately; it just publishes to the shared repo now.

## Why it's safe

**No baked-in secrets in the web image.** Everything embedded into the cloud web image is either a build flag or a `NEXT_PUBLIC_*` value (PostHog project key, Sentry DSN, Stripe *publishable* key, reCAPTCHA *site* key) — all public-by-design since Next.js inlines them into the client JS bundle. The only real secret, `SENTRY_AUTH_TOKEN`, is a BuildKit secret mount and never lands in an image layer. Publishing cloud-configured images into the public repo exposes nothing new.

**No looser tags on `-cloud` releases.** Cloud tags (`vX.Y.Z-cloud.N`) fail the `is-stable` regex (`^v[0-9]+\.[0-9]+\.[0-9]+$`), so `latest`, `edge`, `beta`, and the semver patterns (`{{version}}` / `{{major}}.{{minor}}` / `{{major}}`) all stay gated off. A `-cloud` release lands under **only** its raw tag (e.g. `onyxdotapp/onyx-web-server:v4.4.0-cloud.0`), so there's no collision with community images in the shared repos.

## ⚠️ Downstream follow-up (outside this repo)

The `dispatch-cloud-deployment` job fires a `new-cloud-image` dispatch to the private `CLOUD_DEPLOYMENT_REPO`. If that repo pulls images by the old `-cloud` names, it must be updated to pull from `onyx-web-server` / `onyx-backend` / `onyx-model-server` at the `vX.Y.Z-cloud.N` tag, in lockstep with this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drop the `*-cloud` Docker Hub repos and publish all components to their single repos, with cloud builds tagged `vX.Y.Z-cloud.N`. CI is simpler and safer: tag gating prevents collisions and all jobs now push to the standard repos.

- **Refactors**
  - Standardize publishing of web, backend, and model-server to `onyxdotapp/onyx-web-server`, `onyxdotapp/onyx-backend`, and `onyxdotapp/onyx-model-server` (remove `*-cloud` repos and `contains(ref, 'cloud')` conditionals).
  - Update the release digest matrix so `web-cloud` also points to `onyxdotapp/onyx-web-server`.
  - `-cloud` tags are not “stable,” so no `latest`/`edge`/`beta` or semver aliases are created.

- **Migration**
  - Update `CLOUD_DEPLOYMENT_REPO` to pull from `onyxdotapp/onyx-web-server`, `onyxdotapp/onyx-backend`, and `onyxdotapp/onyx-model-server` using `vX.Y.Z-cloud.N` tags (stop using `*-cloud` repos).

<sup>Written for commit ff033aaeeb43236870b61605b3de23739dac952c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

