### PR TITLE
fix(web): don't show a bare em dash in document title while chat name is pending

### DIFF
--- a/web/src/lib/app/hooks.ts
+++ b/web/src/lib/app/hooks.ts
@@ -21,7 +21,8 @@ export function useAppDocumentTitle(): void {
   const { currentChatSession } = useChatSessions();
   useLayoutEffect(() => {
     const appendChatNameToDocumentTitle =
-      (appFocus.isChat() || appFocus.isSharedChat()) && currentChatSession;
+      (appFocus.isChat() || appFocus.isSharedChat()) &&
+      currentChatSession?.name;
     document.title = appendChatNameToDocumentTitle
       ? `${currentChatSession.name} — ${appName}`
       : appName;


### PR DESCRIPTION
## Description

Newly created chat sessions are registered as pending with an empty `name` until the auto-generated summary arrives (`web/src/hooks/useChatSessions.ts`). `useAppDocumentTitle` only checked that a `currentChatSession` existed before building the `` `${name} — ${appName}` `` title, so during that window the browser tab showed a bare em dash: `" — Onyx"`.

Now the chat name is only prepended when it's non-empty; until then the title is just the app name. The effect already depends on `currentChatSession?.name`, so the title updates automatically once the generated name arrives.

## How Has This Been Tested?

- `bunx tsc --noEmit` reports no errors in the edited file (remaining errors are pre-existing in unrelated Opal files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop showing a bare em dash in the browser tab for new chats. The title now shows only the app name until a non-empty chat name is available, then updates automatically.

<sup>Written for commit c7f1383784670468ae7343e89c240b91cdb1e3f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

