### PR TITLE
fix(ci): stamp the opal release version without touching the install tree

### DIFF
--- a/.github/workflows/release-opal.yml
+++ b/.github/workflows/release-opal.yml
@@ -44,10 +44,13 @@ jobs:
       # The repo keeps web/lib/opal/package.json at 0.0.0; the opal/v* tag is the
       # source of truth. Stamp the version from the tag here — after the frozen
       # install (which expects the committed 0.0.0) and before build/publish.
+      # `npm pkg set` edits package.json only; `npm version` reifies the tree via
+      # arborist, which crashes (null Link.matches) on the bun-installed
+      # node_modules with the file:../shared link.
       - name: Set version from tag
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#opal/v}"
-          npm version "${TAG_VERSION}" --no-git-tag-version --allow-same-version
+          npm pkg set version="${TAG_VERSION}"
 
       # Opal's CSS build inlines @onyx-ai/shared's generated design tokens, and its
       # dts build (tsup `dts: { resolve: true }`) inlines shared's contracts types


### PR DESCRIPTION
## Description

The `opal/v0.1.16` release run died at "Set version from tag":
`npm error Cannot read properties of null (reading 'matches')`.

`npm version` reifies node_modules via arborist, which crashes at `Link.matches` on the bun-installed workspace tree with the `file:../shared` link (reproduced locally on npm 11.12.1, same stack). The regression window matches #12886 adding the `react-day-picker` peer dep, which changed the graph shape arborist tries to place. It also half-applies: package.json gets stamped, then the step exits 1.

Fix: `npm pkg set version="${TAG_VERSION}"`, which edits package.json only. The dropped flags are meaningless to it (no git tagging, no same-version error). Verified locally: exit 0, version stamped, no tree access. `npm publish` is unaffected (it does not reify; six prior releases prove it).

Re-pushing the `opal/v0.1.16` tag after merge will publish.

## How Has This Been Tested?

## Additional Options

- [ ] This PR should be considered for cherry-picking to the current release branch
- [x] Override Linear Check