### PR TITLE
feat(pptx-lint): density profiles — dense mode relaxes margin warning to 0.25"

### DIFF
--- a/backend/onyx/skills/builtin/pptx/SKILL.md
+++ b/backend/onyx/skills/builtin/pptx/SKILL.md
@@ -183,6 +183,7 @@ python .opencode/skills/pptx/scripts/lint.py outputs/output.pptx
 - **Fix every ERROR** before moving on. Review each WARN and fix it unless the layout is genuinely intentional (e.g., a deliberate design overlap).
 - Re-run after each fix batch — it's instant, so lint until clean before spending time on rendering.
 - The linter checks contrast only for explicit solid colors; text over images/gradients is skipped and noted — verify those visually.
+- **Content-dense decks** (analytical / consulting-style slides with intentionally tight margins) generate many advisory MARGIN warnings under the default profile. For those, lint with `--profile dense` (relaxes the margin warning from 0.5" to 0.25"); error-level checks are unchanged. Tight margins on a dense analytical slide are a deliberate style, not a defect — don't strip density to silence standard-profile MARGIN warnings.
 
 ### Content QA
 

--- a/backend/onyx/skills/builtin/pptx/scripts/lint.py
+++ b/backend/onyx/skills/builtin/pptx/scripts/lint.py
@@ -25,7 +25,7 @@ Output protocol (stdout):
 Exit code: 1 if any ERROR finding, 0 otherwise (2 on usage error).
 
 Usage:
-    python lint.py /path/to/file.pptx
+    python lint.py /path/to/file.pptx [--profile {standard,dense}]
 """
 
 import shutil

--- a/backend/onyx/skills/builtin/pptx/scripts/lint.py
+++ b/backend/onyx/skills/builtin/pptx/scripts/lint.py
@@ -4,7 +4,8 @@ Statically checks a .pptx for mechanical layout defects that vision QA is
 slow and unreliable at catching:
 
     BOUNDS    shape partially or fully off the slide canvas
-    MARGIN    text content closer than 0.5" to a slide edge
+    MARGIN    text content closer than the profile margin (0.5" standard /
+              0.25" dense) to a slide edge
     OVERFLOW  estimated text height/width exceeds its box (PIL font metrics)
     OVERLAP   two text frames intersect, or text spills past its container
     CONTRAST  explicit text color vs. resolved solid background below WCAG-ish
@@ -46,7 +47,17 @@ EMU_PER_INCH = 914400
 EMU_PER_PT = 12700
 
 # --- Thresholds (lenient by design) ---
-MARGIN_MIN_EMU = int(0.45 * EMU_PER_INCH)  # nominal 0.5", tolerance for rounding
+# Margin threshold is density-profile-dependent. "standard" enforces the
+# nominal 0.5" (0.45" with rounding tolerance); "dense" relaxes to a nominal
+# 0.25" for intentionally content-dense analytical/consulting decks, whose
+# tight margins are a deliberate style, not a defect. Only the MARGIN *warning*
+# scales with profile — every ERROR-level check (off-slide clipping, unreadable
+# contrast, unknown font, genuinely-overflowing text) is profile-independent.
+MARGIN_MIN_EMU_BY_PROFILE = {
+    "standard": int(0.45 * EMU_PER_INCH),  # nominal 0.5"
+    "dense": int(0.22 * EMU_PER_INCH),  # nominal 0.25"
+}
+DEFAULT_PROFILE = "standard"
 FULL_BLEED_FRACTION = 0.9  # shape covering >=90% of a slide dimension is exempt
 BOUNDS_OVERSHOOT_EMU = int(0.1 * EMU_PER_INCH)  # ignore bleed smaller than this
 BOUNDS_ERROR_FRACTION = 0.35  # >35% of shape area off-slide is an ERROR
@@ -496,7 +507,11 @@ def check_bounds(
 
 
 def check_margins(
-    slide_no: int, shapes: list[tuple[BaseShape, Box]], slide_w: int, slide_h: int
+    slide_no: int,
+    shapes: list[tuple[BaseShape, Box]],
+    slide_w: int,
+    slide_h: int,
+    margin_min_emu: int,
 ) -> list[Finding]:
     findings: list[Finding] = []
     for shape, box in shapes:
@@ -519,7 +534,7 @@ def check_margins(
         bad = [
             (name, dist)
             for name, dist in edges.items()
-            if 0 <= dist < MARGIN_MIN_EMU
+            if 0 <= dist < margin_min_emu
             and not (exempt_h and name in ("left", "right"))
             and not (exempt_v and name in ("top", "bottom"))
         ]
@@ -797,8 +812,9 @@ def check_fonts(prs) -> list[Finding]:
 # --- Driver -------------------------------------------------------------------
 
 
-def lint_presentation(prs) -> tuple[list[Finding], int]:
+def lint_presentation(prs, profile: str = DEFAULT_PROFILE) -> tuple[list[Finding], int]:
     """Lint an open Presentation. Returns (findings, contrast_skipped_runs)."""
+    margin_min_emu = MARGIN_MIN_EMU_BY_PROFILE[profile]
     slide_w = int(prs.slide_width or Emu(int(10 * EMU_PER_INCH)))
     slide_h = int(prs.slide_height or Emu(int(7.5 * EMU_PER_INCH)))
 
@@ -813,7 +829,9 @@ def lint_presentation(prs) -> tuple[list[Finding], int]:
             shapes.append((shape, box))
 
         findings.extend(check_bounds(slide_no, shapes, slide_w, slide_h))
-        findings.extend(check_margins(slide_no, shapes, slide_w, slide_h))
+        findings.extend(
+            check_margins(slide_no, shapes, slide_w, slide_h, margin_min_emu)
+        )
         findings.extend(check_overflow(slide_no, shapes))
         findings.extend(check_overlap(slide_no, shapes, slide_w, slide_h))
         contrast_findings, skipped = check_contrast(slide_no, slide, shapes)
@@ -825,21 +843,31 @@ def lint_presentation(prs) -> tuple[list[Finding], int]:
     return findings, total_skipped
 
 
-def lint_file(path: Path) -> tuple[list[Finding], int]:
-    return lint_presentation(Presentation(str(path)))
+def lint_file(path: Path, profile: str = DEFAULT_PROFILE) -> tuple[list[Finding], int]:
+    return lint_presentation(Presentation(str(path)), profile=profile)
 
 
 def main() -> None:
-    if len(sys.argv) != 2:
-        print(f"Usage: {sys.argv[0]} <pptx_path>", file=sys.stderr)
-        sys.exit(2)
+    import argparse
 
-    pptx_path = Path(sys.argv[1])
+    parser = argparse.ArgumentParser(description="Lint a .pptx for layout defects.")
+    parser.add_argument("pptx_path", type=Path)
+    parser.add_argument(
+        "--profile",
+        choices=sorted(MARGIN_MIN_EMU_BY_PROFILE),
+        default=DEFAULT_PROFILE,
+        help="Density profile: 'standard' (0.5\" margins) or 'dense' (0.25\", "
+        "for intentionally content-dense analytical/consulting decks). Only the "
+        "MARGIN warning threshold changes; error-level checks are unaffected.",
+    )
+    args = parser.parse_args()
+
+    pptx_path = args.pptx_path
     if not pptx_path.is_file():
         print("ERROR_NOT_FOUND")
         sys.exit(1)
 
-    findings, contrast_skipped = lint_file(pptx_path)
+    findings, contrast_skipped = lint_file(pptx_path, profile=args.profile)
     errors = sum(1 for f in findings if f.severity == "ERROR")
     warnings = sum(1 for f in findings if f.severity == "WARN")
 

--- a/backend/onyx/skills/builtin/pptx/scripts/lint.py
+++ b/backend/onyx/skills/builtin/pptx/scripts/lint.py
@@ -47,12 +47,6 @@ EMU_PER_INCH = 914400
 EMU_PER_PT = 12700
 
 # --- Thresholds (lenient by design) ---
-# Margin threshold is density-profile-dependent. "standard" enforces the
-# nominal 0.5" (0.45" with rounding tolerance); "dense" relaxes to a nominal
-# 0.25" for intentionally content-dense analytical/consulting decks, whose
-# tight margins are a deliberate style, not a defect. Only the MARGIN *warning*
-# scales with profile — every ERROR-level check (off-slide clipping, unreadable
-# contrast, unknown font, genuinely-overflowing text) is profile-independent.
 MARGIN_MIN_EMU_BY_PROFILE = {
     "standard": int(0.45 * EMU_PER_INCH),  # nominal 0.5"
     "dense": int(0.22 * EMU_PER_INCH),  # nominal 0.25"

--- a/backend/onyx/skills/builtin/pptx/scripts/lint.py
+++ b/backend/onyx/skills/builtin/pptx/scripts/lint.py
@@ -51,6 +51,7 @@ MARGIN_MIN_EMU_BY_PROFILE = {
     "standard": int(0.45 * EMU_PER_INCH),  # nominal 0.5"
     "dense": int(0.22 * EMU_PER_INCH),  # nominal 0.25"
 }
+MARGIN_NOMINAL_IN_BY_PROFILE = {"standard": 0.5, "dense": 0.25}
 DEFAULT_PROFILE = "standard"
 FULL_BLEED_FRACTION = 0.9  # shape covering >=90% of a slide dimension is exempt
 BOUNDS_OVERSHOOT_EMU = int(0.1 * EMU_PER_INCH)  # ignore bleed smaller than this
@@ -506,6 +507,7 @@ def check_margins(
     slide_w: int,
     slide_h: int,
     margin_min_emu: int,
+    margin_nominal_in: float,
 ) -> list[Finding]:
     findings: list[Finding] = []
     for shape, box in shapes:
@@ -541,7 +543,7 @@ def check_margins(
                     shape.shape_id,
                     "WARN",
                     "MARGIN",
-                    f'text within 0.5" of slide edge ({desc})',
+                    f'text within {margin_nominal_in:g}" of slide edge ({desc})',
                     text,
                 )
             )
@@ -808,7 +810,11 @@ def check_fonts(prs) -> list[Finding]:
 
 def lint_presentation(prs, profile: str = DEFAULT_PROFILE) -> tuple[list[Finding], int]:
     """Lint an open Presentation. Returns (findings, contrast_skipped_runs)."""
+    if profile not in MARGIN_MIN_EMU_BY_PROFILE:
+        valid = ", ".join(sorted(MARGIN_MIN_EMU_BY_PROFILE))
+        raise ValueError(f"unknown profile {profile!r}; valid profiles: {valid}")
     margin_min_emu = MARGIN_MIN_EMU_BY_PROFILE[profile]
+    margin_nominal_in = MARGIN_NOMINAL_IN_BY_PROFILE[profile]
     slide_w = int(prs.slide_width or Emu(int(10 * EMU_PER_INCH)))
     slide_h = int(prs.slide_height or Emu(int(7.5 * EMU_PER_INCH)))
 
@@ -824,7 +830,9 @@ def lint_presentation(prs, profile: str = DEFAULT_PROFILE) -> tuple[list[Finding
 
         findings.extend(check_bounds(slide_no, shapes, slide_w, slide_h))
         findings.extend(
-            check_margins(slide_no, shapes, slide_w, slide_h, margin_min_emu)
+            check_margins(
+                slide_no, shapes, slide_w, slide_h, margin_min_emu, margin_nominal_in
+            )
         )
         findings.extend(check_overflow(slide_no, shapes))
         findings.extend(check_overlap(slide_no, shapes, slide_w, slide_h))

--- a/backend/tests/unit/onyx/skills/test_pptx_lint.py
+++ b/backend/tests/unit/onyx/skills/test_pptx_lint.py
@@ -130,7 +130,6 @@ def test_sub_margin_text_is_warned() -> None:
 def test_dense_profile_relaxes_margin_warning() -> None:
     prs = _new_deck()
     slide = _add_blank_slide(prs)
-    # 0.3" from the left: inside the 0.5" standard margin, outside 0.25" dense.
     _add_textbox(slide, 0.3, 2.0, 4.0, 1.0, "Consulting-dense label")
     standard = [f for f in lint.lint_presentation(prs)[0] if f.check == "MARGIN"]
     dense = [

--- a/backend/tests/unit/onyx/skills/test_pptx_lint.py
+++ b/backend/tests/unit/onyx/skills/test_pptx_lint.py
@@ -141,6 +141,27 @@ def test_dense_profile_relaxes_margin_warning() -> None:
     assert dense == []
 
 
+def test_margin_finding_reports_profile_nominal_limit() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    # 0.1" from the left: inside both the standard (0.5") and dense (0.25") margins.
+    _add_textbox(slide, 0.1, 2.0, 4.0, 1.0, "Edge-hugging label")
+    standard = [f for f in lint.lint_presentation(prs)[0] if f.check == "MARGIN"]
+    dense = [
+        f
+        for f in lint.lint_presentation(prs, profile="dense")[0]
+        if f.check == "MARGIN"
+    ]
+    assert len(standard) == 1 and '0.5"' in standard[0].detail
+    assert len(dense) == 1 and '0.25"' in dense[0].detail
+
+
+def test_unknown_profile_raises_value_error() -> None:
+    prs = _new_deck()
+    with pytest.raises(ValueError, match="unknown profile"):
+        lint.lint_presentation(prs, profile="premium")
+
+
 def test_full_bleed_shape_exempt_from_margins_and_bounds() -> None:
     prs = _new_deck()
     slide = _add_blank_slide(prs)

--- a/backend/tests/unit/onyx/skills/test_pptx_lint.py
+++ b/backend/tests/unit/onyx/skills/test_pptx_lint.py
@@ -127,6 +127,21 @@ def test_sub_margin_text_is_warned() -> None:
     assert "left" in finding.detail
 
 
+def test_dense_profile_relaxes_margin_warning() -> None:
+    prs = _new_deck()
+    slide = _add_blank_slide(prs)
+    # 0.3" from the left: inside the 0.5" standard margin, outside 0.25" dense.
+    _add_textbox(slide, 0.3, 2.0, 4.0, 1.0, "Consulting-dense label")
+    standard = [f for f in lint.lint_presentation(prs)[0] if f.check == "MARGIN"]
+    dense = [
+        f
+        for f in lint.lint_presentation(prs, profile="dense")[0]
+        if f.check == "MARGIN"
+    ]
+    assert len(standard) == 1 and standard[0].severity == "WARN"
+    assert dense == []
+
+
 def test_full_bleed_shape_exempt_from_margins_and_bounds() -> None:
     prs = _new_deck()
     slide = _add_blank_slide(prs)


### PR DESCRIPTION
## Description

Follow-up to the layout linter (#13060). The MARGIN check's 0.5" threshold over-fires on intentionally content-dense analytical/consulting slides, where tight margins are a deliberate style rather than a defect.

**Evidence:** a faithful reproduction of a McKinsey small-multiples slide (5 columns, ~11 rows each, 8pt labels, ~0.25" margins, edge footnotes) linted to **0 errors but 31 warnings — all MARGIN**. Overflow, overlap, contrast, and bounds stayed clean, confirming those checks are correctly lenient at real consulting density; only the margin *warning* threshold is mis-calibrated for it.

**Change:** a `--profile {standard,dense}` flag.
- `standard` (default): unchanged — nominal 0.5" margins.
- `dense`: relaxes the MARGIN warning to a nominal 0.25".

Only the MARGIN warning scales with profile. Every **error-level** check (off-slide clipping, unreadable contrast, unknown font, genuinely-overflowing text) is profile-independent, so a dense deck still cannot ship a real defect. On the repro above, `--profile dense` drops 31 warnings → 1.

SKILL.md's QA section now tells the agent to lint analytical/dense decks with `--profile dense` and not to strip density just to silence standard-profile margin warnings.

## How Has This Been Tested?

- New unit test (`test_dense_profile_relaxes_margin_warning`): a 0.3"-margin box warns under standard, is clean under dense. Full linter suite: 14 passed.
- CLI validates the `--profile` choice (rejects unknown values).
- Verified end-to-end on the dense McKinsey reproduction: standard `LINT_ISSUES 0 31` → dense `LINT_ISSUES 0 1`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add density profiles to the PPTX layout linter to cut false-positive margin warnings on analytical slides. `--profile dense` lowers the MARGIN warning to 0.25", findings show the active profile’s limit, and error checks stay the same.

- **New Features**
  - New `--profile {standard,dense}` flag; default `standard`.
  - MARGIN warnings are profile-based: 0.5" (`standard`), 0.25" (`dense`).
  - Module usage docstring now shows the `--profile` flag.

- **Bug Fixes**
  - Unknown profiles raise a clear ValueError; CLI restricts choices via `argparse`.
  - MARGIN finding text reports the active profile’s nominal limit (0.5"/0.25").

<sup>Written for commit 155f095f264831bff6164441272d1d21fd5d6e94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

