### PR TITLE
feat(pptx-skill): reliability fixes — deck-first build order, context discipline, pack-early

### DIFF
--- a/backend/onyx/skills/builtin/pptx/SKILL.md
+++ b/backend/onyx/skills/builtin/pptx/SKILL.md
@@ -44,6 +44,7 @@ built. To reuse figures from a source PDF, extract the embedded images
 directly — no rendering, no cropping, no visual inspection:
 
 ```bash
+mkdir -p outputs/figs/
 pdfimages -png -p source.pdf outputs/figs/fig   # fig-<page>-<n>.png per image
 python -c "from PIL import Image; import glob; [print(p, Image.open(p).size) for p in sorted(glob.glob('outputs/figs/*.png'))]"
 ```

--- a/backend/onyx/skills/builtin/pptx/SKILL.md
+++ b/backend/onyx/skills/builtin/pptx/SKILL.md
@@ -19,6 +19,41 @@ license: Proprietary. LICENSE.txt has complete terms
 
 ---
 
+## Build Order (required)
+
+**A complete, text-viable deck must exist in `outputs/` before any asset
+enhancement.** The worst outcome is a turn that ends with no deck at all.
+
+1. **Draft**: full deck — all slides, titles, text content, layout structure —
+   written and saved to `outputs/<name>.pptx`. On the template-editing path
+   this means an EARLY first clean+pack (see [editing.md](editing.md)): edits
+   stranded in `outputs/unpacked/` deliver nothing.
+2. **Enhance in passes** (charts, icons), re-saving the deck after each pass.
+3. **Lint + QA** last (see QA below).
+
+If time or context is running short at any point, stop enhancing and ship the
+current saved deck. Never spend the start of a turn generating or inspecting
+assets for a deck that doesn't exist yet.
+
+## Reading Source Materials (context discipline)
+
+Read attached/source documents as **text** (`python -m markitdown file.pdf`).
+**Never `view_image` source pages or figure crops** — image reads exhaust the
+model context in a handful of pages and the turn dies before the deck is
+built. To reuse figures from a source PDF, extract the embedded images
+directly — no rendering, no cropping, no visual inspection:
+
+```bash
+pdfimages -png -p source.pdf outputs/figs/fig   # fig-<page>-<n>.png per image
+python -c "from PIL import Image; import glob; [print(p, Image.open(p).size) for p in sorted(glob.glob('outputs/figs/*.png'))]"
+```
+
+Pick figures by page number and pixel size (real figures are large; icons and
+logos are small), place them directly, and verify them in the rendered-slide
+QA pass at the end — never by viewing each extraction.
+
+---
+
 ## Choosing a Template (do this first)
 
 Starting from a well-designed template produces far better decks than building from scratch. There are **two distinct sources** of templates — check both:

--- a/backend/onyx/skills/builtin/pptx/editing.md
+++ b/backend/onyx/skills/builtin/pptx/editing.md
@@ -38,12 +38,17 @@ When using an existing presentation as a template:
    - Reorder slides in `<p:sldIdLst>`
    - **Complete all structural changes before step 5**
 
-5. **Edit content**: Update text in each `slide{N}.xml`.
+5. **First pack (do this EARLY)**: as soon as the structure is set and first-pass content is in, clean + pack so a viewable deck exists:
+   ```bash
+   python .opencode/skills/pptx/scripts/clean.py outputs/unpacked/
+   python .opencode/skills/pptx/scripts/office/pack.py outputs/unpacked/ outputs/output.pptx --original template.pptx
+   ```
+   A turn that ends with edits stranded in `outputs/unpacked/` delivers **nothing** — the packed `.pptx` is the deliverable (SKILL.md → Build Order). Never do fine-grained restyling before the first pack exists.
+
+6. **Refine content**: update text in each `slide{N}.xml`.
    **Use subagents here if available** — slides are separate XML files, so subagents can edit in parallel.
 
-6. **Clean**: `python .opencode/skills/pptx/scripts/clean.py outputs/unpacked/`
-
-7. **Pack**: `python .opencode/skills/pptx/scripts/office/pack.py outputs/unpacked/ outputs/output.pptx --original template.pptx`
+7. **Re-clean + re-pack after each batch of edits** (same commands as step 5) — the packed deck in `outputs/` should always reflect your latest good state.
 
 ---
 


### PR DESCRIPTION
> **Draft.** Composes with the other pptx-skill PRs (linter #13060, components #13079, charts/icons #13101, density profiles #13103) — SKILL.md may need light reconciliation as those merge.

## Description

Skill-doc fixes for three confirmed `no_pptx` failure modes observed (and diagnosed from live transcripts) during the slide-quality eval. These are behavioral guardrails, not new capabilities.

1. **Build Order (SKILL.md)** — a complete, text-viable deck must be saved to `outputs/` before any asset enhancement; if time/context runs short, ship the current saved state. Fixes turns that ended with **no deck** because the agent front-loaded asset generation/inspection.
2. **Reading Source Materials / context discipline (SKILL.md)** — read source docs as text (`markitdown`), **never `view_image` source pages or figure crops**, and extract figures with `pdfimages` (no render→crop→inspect loop). Fixes context-exhaustion deaths on source-heavy tasks: academic-PDF tasks went from **0 completions to fully cleared** once this landed. The strongest fix of the set.
3. **Pack early (editing.md)** — on the template-editing path, clean+pack as soon as structure + first-pass content exist; edits stranded in `outputs/unpacked/` deliver nothing. Fixes the editing-path variant of the no-deck failure.

**Intentionally excluded** (both were part of the v2 work but shouldn't ship): *density moderation* — the eval showed 'exactly one dominant visual' slightly hurt content scores and cut visual richness 89%→76%; and the *no-deck-no-images gate* — moot, since generated imagery was scrapped.

## How Has This Been Tested?

Doc-only change (no code). Validated behaviorally in the eval: with these fixes deployed, the improved variant cleared the entire academia/economics PresentBench block that the pre-fix variant failed 0-for-N on, and produced decks on the editing-path task that previously stranded edits unpacked. No unit tests apply.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve pptx-skill reliability by enforcing deck-first build order, strict text-only source reading, and early packing on the editing path. Prevents no-deck turns and reduces context exhaustion on source-heavy tasks.

- **Bug Fixes**
  - Deck-first build order: save a complete text-viable deck to `outputs/*.pptx` before assets; re-save after passes; ship current deck if time/context is short.
  - Source discipline: read sources as text with `markitdown`; never `view_image` source pages/crops; extract figures with `pdfimages` (create `outputs/figs/` first) and verify in final QA.
  - Pack early (editing path): clean + pack once structure and first-pass content exist; then re-clean/re-pack after batches to avoid stranded edits in `outputs/unpacked/`.

<sup>Written for commit 25a2a4f095980c7c39d59ff5d818dbb219433fd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

