### PR TITLE
ci: add workflow_dispatch to recommended-models chat test

### DIFF
--- a/.github/workflows/pr-recommended-models-chat-test.yml
+++ b/.github/workflows/pr-recommended-models-chat-test.yml
@@ -20,13 +20,15 @@ on:
       - ".github/workflows/reusable-nightly-llm-provider-chat.yml"
       - ".github/actions/run-nightly-provider-chat-test/**"
       - "backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py"
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   derive-models:
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Skip fork PRs (no OIDC secrets); workflow_dispatch is write-access only, so allow it.
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     timeout-minutes: 5
     outputs:


### PR DESCRIPTION
## What

Adds `workflow_dispatch` support to the **Recommended LLM Models Chat Tests** workflow (`pr-recommended-models-chat-test.yml`), so it can be triggered manually from the Actions tab in addition to the existing `pull_request` trigger.

## Why

Today this check only runs when a PR touches `recommended-models.json` (or the workflow/test plumbing). A manual trigger is useful to re-verify that every recommended model still works end-to-end — e.g. after a provider outage or model deprecation — without having to open a throwaway PR.

## Changes

- Add an input-less `workflow_dispatch:` trigger (mirrors the sibling `nightly-llm-provider-chat.yml`).
- Extend the `derive-models` job's `if:` guard to also allow `workflow_dispatch`. The existing guard (`head.repo.full_name == github.repository`) exists to block fork PRs from reaching OIDC secrets; it evaluates to `false` on a manual dispatch (no `pull_request` context), which would otherwise skip the whole pipeline. `workflow_dispatch` is write-access only, so allowing it is safe.

The manual run derives model lists from `recommended-models.json` on the dispatched ref and runs the same non-strict provider chat pipeline. The concurrency group already falls back to `github.run_id` when `head_ref` is empty, so each manual dispatch gets its own group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `workflow_dispatch` to the Recommended LLM Models Chat Tests workflow (`.github/workflows/pr-recommended-models-chat-test.yml`) so it can be run manually from the Actions tab to re-check recommendations without opening a PR. Updates the `derive-models` job guard to allow manual runs while still blocking fork PRs from accessing OIDC secrets.

<sup>Written for commit 4e421333936563e7056e5e97590e588ca858d67b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

