### PR TITLE
fix(web): run page auth checks in a server layout instead of client render

### DIFF
--- a/web/src/app/auth/impersonate/layout.tsx
+++ b/web/src/app/auth/impersonate/layout.tsx
@@ -1,0 +1,27 @@
+import { redirect } from "next/navigation";
+import type { Route } from "next";
+import { unstable_noStore as noStore } from "next/cache";
+import { requireAuth } from "@/lib/auth/svcSS";
+
+export interface LayoutProps {
+  children: React.ReactNode;
+}
+
+// The auth gate must run server-side (as in app/layout.tsx): a client
+// component that calls redirect() during render fires before the client-side
+// user fetch resolves, so it redirects unconditionally — and prerender bakes
+// it in as a route-level 307 on next >= 16.2.10.
+export default async function Layout({ children }: LayoutProps) {
+  noStore();
+
+  const authResult = await requireAuth();
+  if (authResult.redirect) {
+    redirect(authResult.redirect as Route);
+  }
+
+  if (!authResult.user?.is_cloud_superuser) {
+    redirect("/app" as Route);
+  }
+
+  return <>{children}</>;
+}

--- a/web/src/app/auth/impersonate/page.tsx
+++ b/web/src/app/auth/impersonate/page.tsx
@@ -2,8 +2,7 @@
 
 import AuthFlowContainer from "@/components/auth/AuthFlowContainer";
 
-import { useUser } from "@/providers/UserProvider";
-import { redirect, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import type { Route } from "next";
 import { Formik, Form, FormikHelpers } from "formik";
 import * as Yup from "yup";
@@ -19,14 +18,6 @@ const ImpersonateSchema = Yup.object().shape({
 
 export default function ImpersonatePage() {
   const router = useRouter();
-  const { user, isCloudSuperuser } = useUser();
-  if (!user) {
-    redirect("/auth/login");
-  }
-
-  if (!isCloudSuperuser) {
-    redirect("/app" as Route);
-  }
 
   const handleImpersonate = async (
     values: { email: string; apiKey: string },


### PR DESCRIPTION
## Problem

`web/src/app/auth/impersonate/page.tsx` gated itself with `redirect()` calls in a client component during render. On the first render the client-side user request hasn't resolved yet, so the redirect always fired before real state was available — the page only ever worked by accident of how older Next versions deferred client-component prerendering.

Since the next 16.2.6 → 16.2.10 bump (#12778), that redirect also executes during prerender, baking a route-level 307 into the build output: every document request for the route is redirected to `/auth/login` regardless of session, so the page can never load.

## Fix

Move the checks into a server `layout.tsx` using `requireAuth()` — the same pattern as `app/layout.tsx` (`noStore()` + cookie-aware server fetch) — and drop the render-time client redirects from the page. The route becomes dynamic (`ƒ`) and gates correctly per request.

This also removes the only remaining render-time `redirect()`-on-client-user-state call site under `app/` (the other pages doing render-time redirects are server components).

## Verification

Built and served the app against a stubbed `/me`:

| Request | Response |
|---|---|
| no session | 307 → `/auth/login` |
| session with access | 200, form present in the server-rendered HTML |
| session without access | 307 → `/app` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move auth gating for `/auth/impersonate` to a server `layout.tsx` using `requireAuth()`, fixing the prerendered 307 introduced after `next@16.2.10`. The page now checks cookies on the server and redirects per request.

- **Bug Fixes**
  - Run auth in server layout with `noStore()` and `requireAuth()` from `@/lib/auth/svcSS`.
  - Remove client render-time `redirect()` calls from the page.
  - Redirects: no session → `/auth/login`; signed-in non-superuser → `/app`; authorized → render form.

<sup>Written for commit b3a54d5697acba122d003f85840bc26c7f6bb180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

