### PR TITLE
fix(auth): keep legacy SSO redirect URIs working after row migration

### DIFF
--- a/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
+++ b/backend/alembic/versions/1fc2904131a3_add_sso_provider_table_and_seed_from_env.py
@@ -100,9 +100,12 @@ def _seed_from_env(table: sa.Table) -> None:
         return
 
     # Store the config the way the ORM does: JSON-encode, then encrypt.
-    config: dict[str, str] = {
+    # legacy_callback keeps the redirect URI the deployment's IdP client
+    # already allowlists, so upgrading never requires an IdP console change.
+    config: dict[str, str | bool] = {
         "client_id": OAUTH_CLIENT_ID,
         "client_secret": OAUTH_CLIENT_SECRET,
+        "legacy_callback": True,
     }
     if config_url is not None:
         config["openid_config_url"] = config_url

--- a/backend/alembic/versions/8f3b2c91d4e7_backfill_legacy_callback_on_seeded_sso_.py
+++ b/backend/alembic/versions/8f3b2c91d4e7_backfill_legacy_callback_on_seeded_sso_.py
@@ -1,0 +1,76 @@
+"""backfill legacy_callback on seeded sso rows
+
+Revision ID: 8f3b2c91d4e7
+Revises: d396075958bd
+Create Date: 2026-07-16 15:30:00.000000
+
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import sqlalchemy as sa
+from alembic import op
+
+from onyx.utils.encryption import decrypt_bytes_to_string
+from onyx.utils.encryption import encrypt_string_to_bytes
+
+# revision identifiers, used by Alembic.
+revision = "8f3b2c91d4e7"
+down_revision = "d396075958bd"
+branch_labels = None
+depends_on = None
+
+# The names 1fc2904131a3's seed assigned. Rows created through the admin API
+# are matched only when their client_id equals the env credential the seed
+# copied, so an operator-authored row with its own IdP client is never touched.
+_SEEDED_NAMES = ("google", "openid")
+
+
+def upgrade() -> None:
+    """Stamp legacy_callback=true onto rows the 1fc2904131a3 seed created
+    before the flag existed, so their flows keep sending the redirect URI the
+    deployment's IdP client already allowlists.
+
+    Matches on the seeded name plus the still-present env client_id. A
+    deployment that already removed its env credentials has either registered
+    the parametric URI or reconfigured, and flipping it here could break it.
+    """
+    from shared_configs.configs import MULTI_TENANT
+
+    if MULTI_TENANT:
+        return
+
+    env_client_id = os.environ.get("OAUTH_CLIENT_ID") or os.environ.get(
+        "GOOGLE_OAUTH_CLIENT_ID"
+    )
+    if not env_client_id:
+        return
+
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text("SELECT id, config FROM sso_provider WHERE name IN :names").bindparams(
+            sa.bindparam("names", expanding=True)
+        ),
+        {"names": list(_SEEDED_NAMES)},
+    ).fetchall()
+
+    for row_id, config_bytes in rows:
+        config = json.loads(decrypt_bytes_to_string(bytes(config_bytes)))
+        if config.get("client_id") != env_client_id:
+            continue
+        if config.get("legacy_callback"):
+            continue
+        config["legacy_callback"] = True
+        bind.execute(
+            sa.text("UPDATE sso_provider SET config = :config WHERE id = :id"),
+            {"config": encrypt_string_to_bytes(json.dumps(config)), "id": row_id},
+        )
+
+
+def downgrade() -> None:
+    # The flag is additive and validated as optional. Leaving it in place on
+    # downgrade is harmless.
+    pass

--- a/backend/alembic/versions/8f3b2c91d4e7_backfill_legacy_callback_on_seeded_sso_.py
+++ b/backend/alembic/versions/8f3b2c91d4e7_backfill_legacy_callback_on_seeded_sso_.py
@@ -9,7 +9,6 @@ Create Date: 2026-07-16 15:30:00.000000
 from __future__ import annotations
 
 import json
-import os
 
 import sqlalchemy as sa
 from alembic import op
@@ -38,14 +37,15 @@ def upgrade() -> None:
     deployment that already removed its env credentials has either registered
     the parametric URI or reconfigured, and flipping it here could break it.
     """
+    from onyx.configs.app_configs import OAUTH_CLIENT_ID
     from shared_configs.configs import MULTI_TENANT
 
     if MULTI_TENANT:
         return
 
-    env_client_id = os.environ.get("OAUTH_CLIENT_ID") or os.environ.get(
-        "GOOGLE_OAUTH_CLIENT_ID"
-    )
+    # Resolve the credential exactly as the 1fc2904131a3 seed did, so the
+    # match sees the same value the seed stored.
+    env_client_id = OAUTH_CLIENT_ID
     if not env_client_id:
         return
 

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -34,12 +34,16 @@ class _ProviderConfig(BaseModel):
 class GoogleProviderConfig(_ProviderConfig):
     client_id: str
     client_secret: str
+    # Rows migrated from single-provider env config keep the redirect URI the
+    # customer's IdP client already allowlists.
+    legacy_callback: bool = False
 
 
 class OIDCProviderConfig(_ProviderConfig):
     client_id: str
     client_secret: str
     openid_config_url: str
+    legacy_callback: bool = False
 
 
 class SAMLProviderConfig(_ProviderConfig):
@@ -77,6 +81,23 @@ def validate_sso_config(
         return _CONFIG_MODEL_BY_TYPE[provider_type].model_validate(config).model_dump()
     except ValidationError as e:
         raise ValueError(f"invalid {provider_type.value} provider config: {e}") from e
+
+
+def sso_login_callback_uri(
+    provider: SSOProvider, config: dict[str, Any], web_domain: str
+) -> str:
+    """The redirect URI this row's login flow sends, which is also the URL an
+    operator must allowlist at the IdP. Rows migrated from single-provider env
+    config keep the legacy URI their IdP client already allowlists."""
+    if provider.provider_type is SSOProviderType.SAML:
+        # Single issuer-resolved ACS for every SAML row.
+        return f"{web_domain}/api/auth/saml/callback"
+    if config.get("legacy_callback"):
+        if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
+            return f"{web_domain}/auth/oauth/callback"
+        return f"{web_domain}/auth/oidc/callback"
+    # The IdP redirects the browser, so route through /api to reach FastAPI.
+    return f"{web_domain}/api/auth/oidc/{provider.name}/callback"
 
 
 def validate_sso_provider_name(name: str) -> None:

--- a/backend/onyx/server/manage/sso/models.py
+++ b/backend/onyx/server/manage/sso/models.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel
 
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
+from onyx.db.sso_provider import sso_login_callback_uri
 
 
 class SSOProviderCreateRequest(BaseModel):
@@ -39,14 +40,9 @@ class SSOProviderResponse(BaseModel):
     @classmethod
     def from_model(cls, provider: SSOProvider, web_domain: str) -> SSOProviderResponse:
         config = provider.config.get_value(apply_mask=True) if provider.config else {}
-
-        if provider.provider_type in (
-            SSOProviderType.GOOGLE_OAUTH,
-            SSOProviderType.OIDC,
-        ):
-            redirect_uri = f"{web_domain}/api/auth/oidc/{provider.name}/callback"
-        else:
-            redirect_uri = f"{web_domain}/api/auth/saml/{provider.name}/callback"
+        # Masking leaves booleans untouched, so legacy_callback is readable and
+        # the displayed URI always matches what the flow sends.
+        redirect_uri = sso_login_callback_uri(provider, config, web_domain)
 
         return cls(
             id=provider.id,

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -49,6 +49,7 @@ from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
 from onyx.db.models import User
 from onyx.db.sso_provider import fetch_sso_provider_by_name
+from onyx.db.sso_provider import sso_login_callback_uri
 from onyx.db.sso_provider import validate_sso_config
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -173,10 +174,11 @@ def _delete_pkce_cookie(response: Response, state: str) -> None:
     )
 
 
-def _callback_uri(provider_name: str) -> str:
-    # The IdP redirects the browser here, so route it through /api to reach
-    # FastAPI. The bare /auth/oidc path is served by the web app, not the API.
-    return f"{WEB_DOMAIN}/api/auth/oidc/{provider_name}/callback"
+def _callback_uri(provider: SSOProvider, config: dict[str, Any]) -> str:
+    # Legacy-callback rows land on the web wrappers at the legacy paths, which
+    # forward to this router. The fixed /callback below resolves the row from
+    # the signed state.
+    return sso_login_callback_uri(provider, config, WEB_DOMAIN)
 
 
 @router.get("/{provider_name}/authorize")
@@ -187,7 +189,7 @@ async def oidc_login_for_provider(
 ) -> Response:
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
-    redirect_uri = _callback_uri(provider_name)
+    redirect_uri = _callback_uri(provider, config)
     next_url = sanitize_next_url(request.query_params.get("next"))
     csrf_token = generate_csrf_token()
     state = generate_state_token(
@@ -240,6 +242,47 @@ async def oidc_login_for_provider(
     return response
 
 
+@router.get("/callback")
+async def oidc_login_callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+    db_session: Session = Depends(get_session),
+    strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
+    user_manager: UserManager = Depends(get_user_manager),
+) -> Response:
+    """Fixed callback for rows whose IdP client allowlists a legacy redirect
+    URI. The row is resolved from the signed state, the same per-request
+    routing the SAML callback does with issuers."""
+    if state is None:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Missing state parameter in OAuth callback",
+        )
+    state_data = decode_and_validate_oauth_state(
+        request=request,
+        state_value=state,
+        state_secret=USER_AUTH_SECRET,
+    )
+    provider_name = state_data.get("provider_name")
+    if not provider_name:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "OAuth state does not identify a provider",
+        )
+    return await oidc_login_callback_for_provider(
+        provider_name=provider_name,
+        request=request,
+        code=code,
+        state=state,
+        error=error,
+        db_session=db_session,
+        strategy=strategy,
+        user_manager=user_manager,
+    )
+
+
 @router.get("/{provider_name}/callback")
 async def oidc_login_callback_for_provider(
     provider_name: str,
@@ -253,7 +296,7 @@ async def oidc_login_callback_for_provider(
 ) -> Response:
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
-    redirect_uri = _callback_uri(provider_name)
+    redirect_uri = _callback_uri(provider, config)
 
     if error is not None:
         raise OnyxError(

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -284,7 +284,8 @@ def test_create_saml_provider(
     provider_names.append(name)
     body = response.json()
     assert body["provider_type"] == SSOProviderType.SAML.value
-    assert body["redirect_uri"] == f"{WEB_DOMAIN}/api/auth/saml/{name}/callback"
+    # Single issuer-resolved ACS for every SAML row.
+    assert body["redirect_uri"] == f"{WEB_DOMAIN}/api/auth/saml/callback"
     assert is_masked_credential(body["config"]["sp_private_key"]) is True
 
     raw = _stored_config(db_session, body["id"])

--- a/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
+++ b/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
@@ -174,7 +174,10 @@ def test_partial_update_preserves_config(
     updated = update_sso_provider(db_session, created.id, display_name="Renamed")
     assert updated.display_name == "Renamed"
     assert updated.config is not None
-    assert updated.config.get_value(apply_mask=False) == _GOOGLE_CONFIG
+    assert updated.config.get_value(apply_mask=False) == {
+        **_GOOGLE_CONFIG,
+        "legacy_callback": False,
+    }
 
 
 def test_disable_keeps_row_and_filters(db_session: Session, provider_name: str) -> None:

--- a/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
+++ b/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
@@ -63,7 +63,10 @@ def test_create_and_fetch_roundtrip(db_session: Session, provider_name: str) -> 
     assert fetched.allowed_email_domains == ["companya.com"]
     # config decrypts to the original and masks the secret by default
     assert fetched.config is not None
-    assert fetched.config.get_value(apply_mask=False) == _GOOGLE_CONFIG
+    assert fetched.config.get_value(apply_mask=False) == {
+        **_GOOGLE_CONFIG,
+        "legacy_callback": False,
+    }
     assert fetched.config.get_value(apply_mask=True)["client_secret"] != "super-secret"
 
 

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -49,7 +49,7 @@ def test_resolve_oidc_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     resolved, config = oidc_multi._resolve_oidc_provider(_DB, "okta")
     assert resolved is provider
-    assert config == dict(_OIDC_CONFIG)
+    assert config == {**_OIDC_CONFIG, "legacy_callback": False}
 
 
 def test_resolve_google_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -62,7 +62,7 @@ def test_resolve_google_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
         oidc_multi, "fetch_sso_provider_by_name", lambda **_kw: provider
     )
     _resolved, config = oidc_multi._resolve_oidc_provider(_DB, "google")
-    assert config == dict(_GOOGLE_CONFIG)
+    assert config == {**_GOOGLE_CONFIG, "legacy_callback": False}
 
 
 def test_resolve_fail_closed_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -206,4 +206,116 @@ def test_decode_state_rejects_bad_jwt() -> None:
             state_value="not-a-jwt",
             state_secret=_TEST_SECRET,
             expected_provider_name="okta",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Legacy callback routing: migrated rows keep the redirect URI their IdP
+# client already allowlists, so upgrading never requires an IdP console edit.
+# ---------------------------------------------------------------------------
+
+
+def test_callback_uri_parametric_by_default() -> None:
+    provider = _provider()
+    assert oidc_multi._callback_uri(provider, dict(_OIDC_CONFIG)).endswith(
+        "/api/auth/oidc/okta/callback"
+    )
+
+
+def test_callback_uri_legacy_oidc() -> None:
+    provider = _provider()
+    config: dict[str, object] = {**_OIDC_CONFIG, "legacy_callback": True}
+    uri = oidc_multi._callback_uri(provider, config)
+    assert uri.endswith("/auth/oidc/callback")
+    assert "/api/" not in uri
+
+
+def test_callback_uri_legacy_google() -> None:
+    provider = _provider(name="google", provider_type=SSOProviderType.GOOGLE_OAUTH)
+    config: dict[str, object] = {**_GOOGLE_CONFIG, "legacy_callback": True}
+    uri = oidc_multi._callback_uri(provider, config)
+    assert uri.endswith("/auth/oauth/callback")
+    assert "/api/" not in uri
+
+
+def test_validate_config_accepts_legacy_callback_for_oauth_types() -> None:
+    from onyx.db.sso_provider import validate_sso_config
+
+    oidc = validate_sso_config(
+        SSOProviderType.OIDC, {**_OIDC_CONFIG, "legacy_callback": True}
+    )
+    assert oidc["legacy_callback"] is True
+    google = validate_sso_config(
+        SSOProviderType.GOOGLE_OAUTH, {**_GOOGLE_CONFIG, "legacy_callback": True}
+    )
+    assert google["legacy_callback"] is True
+    # Omitting the flag stays valid and defaults off.
+    assert (
+        validate_sso_config(SSOProviderType.OIDC, dict(_OIDC_CONFIG))["legacy_callback"]
+        is False
+    )
+
+
+def test_validate_config_rejects_legacy_callback_for_saml() -> None:
+    from onyx.db.sso_provider import validate_sso_config
+
+    with pytest.raises(ValueError):
+        validate_sso_config(
+            SSOProviderType.SAML,
+            {
+                "idp_entity_id": "e",
+                "idp_sso_url": "https://idp/sso",
+                "idp_x509_cert": "cert",
+                "sp_entity_id": "sp",
+                "legacy_callback": True,
+            },
+        )
+
+
+def test_login_callback_uri_saml_is_fixed_acs() -> None:
+    from onyx.db.sso_provider import sso_login_callback_uri
+
+    provider = _provider(name="corp-saml", provider_type=SSOProviderType.SAML)
+    uri = sso_login_callback_uri(provider, {}, "https://onyx.example.com")
+    assert uri == "https://onyx.example.com/api/auth/saml/callback"
+
+
+def test_fixed_callback_rejects_missing_state() -> None:
+    import asyncio
+
+    request = cast(Any, SimpleNamespace(cookies={}))
+    with pytest.raises(OnyxError):
+        asyncio.run(
+            oidc_multi.oidc_login_callback(
+                request=request,
+                code="code",
+                state=None,
+                error=None,
+                db_session=_DB,
+                strategy=cast(Any, None),
+                user_manager=cast(Any, None),
+            )
+        )
+
+
+def test_fixed_callback_rejects_state_without_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import asyncio
+
+    monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
+    csrf = generate_csrf_token()
+    state = generate_state_token({"next_url": "/", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET)
+    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
+    with pytest.raises(OnyxError):
+        asyncio.run(
+            oidc_multi.oidc_login_callback(
+                request=request,
+                code="code",
+                state=state,
+                error=None,
+                db_session=_DB,
+                strategy=cast(Any, None),
+                user_manager=cast(Any, None),
+            )
         )

--- a/web/src/app/auth/oauth/callback/route.ts
+++ b/web/src/app/auth/oauth/callback/route.ts
@@ -3,10 +3,29 @@ import { getDomain } from "@/lib/redirectSS";
 import { buildUrl } from "@/lib/utilsSS";
 import { NextRequest, NextResponse } from "next/server";
 
+// A provider-row Google flow round-trips its row name inside the signed
+// state, while the env-credential flow does not. Routing only, the backend
+// still verifies the signature.
+function isProviderRowState(state: string | null): boolean {
+  if (!state) return false;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(state.split(".")[1] ?? "", "base64url").toString("utf8")
+    );
+    return typeof payload.provider_name === "string";
+  } catch {
+    return false;
+  }
+}
+
 export const GET = async (request: NextRequest) => {
-  // Wrapper around the FastAPI endpoint /auth/oauth/callback,
-  // which adds back a redirect to the main app.
-  const url = new URL(buildUrl("/auth/oauth/callback"));
+  // Wrapper around the FastAPI callback, which adds back a redirect to the
+  // main app. Migrated provider rows allowlist this URL at the IdP, so their
+  // flows land here too and are dispatched to the row callback.
+  const rowFlow = isProviderRowState(request.nextUrl.searchParams.get("state"));
+  const url = new URL(
+    buildUrl(rowFlow ? "/auth/oidc/callback" : "/auth/oauth/callback")
+  );
   url.search = request.nextUrl.search;
   const cookieHeader = request.headers.get("cookie") || "";
 


### PR DESCRIPTION
## Description

Fixes the `redirect_uri_mismatch` hit on st-dev after #13027: a migrated deployment's login sent a redirect URI its IdP client never allowlisted. **Customers must never edit their OAuth clients on upgrade.**

- Rows seeded from legacy env config carry `legacy_callback: true` and their flows send the redirect URI the IdP already allowlists (`/auth/oauth/callback` for Google, `/auth/oidc/callback` for OIDC), at authorize and token exchange.
- New fixed `GET /api/auth/oidc/callback` resolves the row from the signed state's `provider_name` claim, the same per-request routing the SAML callback does with issuers. The existing OIDC web wrapper already forwards there.
- The `/auth/oauth/callback` web wrapper dispatches row-state requests to that fixed route; env-credential and cloud flows fall through unchanged (their state carries no `provider_name`).
- The admin modal now displays the URI the flow actually sends, via one shared helper (`sso_login_callback_uri`). This also fixes the modal showing a nonexistent parametric SAML ACS; the real ACS is the fixed `/api/auth/saml/callback`.
- SAML needs nothing: its ACS path never changed.

Known pre-existing gap, unchanged here: row-based Google callbacks (parametric or fixed) sit outside `CaptchaCookieMiddleware`'s guarded paths; guarding them requires captcha support in the row login flow (FE+BE).

## How Has This Been Tested?

## Additional Options

- [ ] I have considered whether this PR needs to be cherry-picked to the latest release branch.
- [x] Override Linear Check