### PR TITLE
docs(desktop): correct config.json paths and align "Server URL" label

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -139,9 +139,9 @@ The app defaults to `https://cloud.onyx.app` but supports any Onyx instance.
 
 **Config file location:**
 
-- macOS: `~/Library/Application Support/app.onyx.desktop/config.json`
-- Linux: `~/.config/app.onyx.desktop/config.json`
-- Windows: `%APPDATA%/app.onyx.desktop/config.json`
+- macOS: `~/Library/Application Support/app.onyx.onyx-desktop/config.json`
+- Linux: `~/.config/onyx-desktop/config.json` (or `$XDG_CONFIG_HOME/onyx-desktop/config.json`)
+- Windows: `%APPDATA%\onyx\onyx-desktop\config\config.json`
 
 **To use a self-hosted instance:**
 
@@ -162,10 +162,10 @@ The app defaults to `https://cloud.onyx.app` but supports any Onyx instance.
 
 ```bash
 # macOS
-open -t ~/Library/Application\ Support/app.onyx.desktop/config.json
+open -t ~/Library/Application\ Support/app.onyx.onyx-desktop/config.json
 
 # Or use any editor
-code ~/Library/Application\ Support/app.onyx.desktop/config.json
+code ~/Library/Application\ Support/app.onyx.onyx-desktop/config.json
 ```
 
 ### Change the default URL in build

--- a/desktop/src/index.html
+++ b/desktop/src/index.html
@@ -358,10 +358,10 @@
               <div class="setting-row">
                 <div class="setting-row-content">
                   <label class="setting-label" for="onyxDomain"
-                    >Root Domain</label
+                    >Server URL</label
                   >
                   <div class="setting-description">
-                    The root URL for your Onyx instance
+                    The URL for your Onyx instance
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary

Two small, related desktop cleanups around the self-hosted "Server URL" setting.

### 1. Align UI nomenclature → "Server URL"

The desktop Settings screen labeled this field **"Root Domain"**, but the README,
the config key (`server_url`), and the [public docs](https://github.com/onyx-dot-app/documentation/pull/418)
all call it **"Server URL"**. Same field, three different names — confusing. Renamed the
label (and trimmed the description) so the app matches everything else.

| | Was | Now |
|--|-----|-----|
| Label | `Root Domain` | `Server URL` |
| Description | `The root URL for your Onyx instance` | `The URL for your Onyx instance` |

### 2. Correct `config.json` paths in the README

The README documented the wrong `config.json` locations. The config directory is derived from
`ProjectDirs::from("app", "onyx", "onyx-desktop")` in `src-tauri/src/main.rs` (the `directories`
crate), **not** from the Tauri bundle identifier `app.onyx.desktop` — so the README's
`app.onyx.desktop` paths don't exist on disk.

| OS | Was (wrong) | Now (correct) |
|----|-------------|---------------|
| macOS | `~/Library/Application Support/app.onyx.desktop/config.json` | `~/Library/Application Support/app.onyx.onyx-desktop/config.json` |
| Linux | `~/.config/app.onyx.desktop/config.json` | `~/.config/onyx-desktop/config.json` (or `$XDG_CONFIG_HOME/...`) |
| Windows | `%APPDATA%/app.onyx.desktop/config.json` | `%APPDATA%\onyx\onyx-desktop\config\config.json` |

The Windows value matches what the config dir actually resolves to in practice
(`{RoamingAppData}\{organization}\{application}\config`), confirming the derivation.
Fixes the paths in both the **Config file location** list and the **Quick edit via terminal** snippet.

## Related

- Public docs updated to match: onyx-dot-app/documentation#418

## Note (not changed here)

The Keyboard Shortcuts table and step 2 still say `⌘ ,` → "Open Config File", but the menu item is
now "Settings…" (opens the in-app Settings screen, not the raw file). Left out of this PR to keep it
focused — happy to fix in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
