### PR TITLE
fix: sharepoint group permissions (#13109) to release v4.2

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -37,6 +37,7 @@ ANONYMOUS_USER_PRINCIPAL_TYPE = 3  # Anonymous/unauthenticated users (public acc
 AZURE_AD_GROUP_PRINCIPAL_TYPE = 4  # Azure Active Directory security groups
 SHAREPOINT_GROUP_PRINCIPAL_TYPE = 8  # SharePoint site groups (local to the site)
 MICROSOFT_DOMAIN = ".onmicrosoft"
+SHAREPOINT_GROUP_SCOPE_SEPARATOR = "::"
 # Limited Access role type, limited access is a travel through permission not a actual permission
 LIMITED_ACCESS_ROLE_TYPES = [1, 9]
 LIMITED_ACCESS_ROLE_NAMES = ["Limited Access", "Web-Only Limited Access"]
@@ -203,49 +204,6 @@ def _get_group_guid_from_identifier(
         return None
 
 
-def _get_security_group_owners(graph_client: GraphClient, group_id: str) -> list[str]:
-    try:
-        # Get group owners using Graph API
-        group = graph_client.groups[group_id]
-        owners = sleep_and_retry(
-            group.owners.get_all(page_loaded=lambda _: None),
-            "get_security_group_owners",
-        )
-
-        owner_emails: list[str] = []
-        logger.info("Owners: %s", owners)
-
-        for owner in owners:
-            owner_data = owner.to_json()
-
-            # Extract email from the JSON data
-            mail: str | None = owner_data.get("mail")
-            user_principal_name: str | None = owner_data.get("userPrincipalName")
-
-            # Check if owner is a user and has an email
-            if mail:
-                if MICROSOFT_DOMAIN in mail:
-                    mail = mail.replace(MICROSOFT_DOMAIN, "")
-                owner_emails.append(mail)
-            elif user_principal_name:
-                if MICROSOFT_DOMAIN in user_principal_name:
-                    user_principal_name = user_principal_name.replace(
-                        MICROSOFT_DOMAIN, ""
-                    )
-                owner_emails.append(user_principal_name)
-
-        logger.info(
-            "Retrieved %s owners from security group %s", len(owner_emails), group_id
-        )
-        return owner_emails
-
-    except Exception as e:
-        logger.error(
-            "Failed to get security group owners for group %s: %s", group_id, e
-        )
-        return []
-
-
 def _get_sharepoint_list_item_id(drive_item: DriveItem) -> str | None:
     try:
         # First try to get the list item directly from the drive item
@@ -324,6 +282,14 @@ def _get_group_name_with_suffix(
     return f"{group_name}_{ad_group_suffix}"
 
 
+def _get_site_scoped_group_name(
+    client_context: ClientContext,
+    group_name: str,
+) -> str:
+    site_url = client_context.base_url.rstrip("/")
+    return f"{site_url}{SHAREPOINT_GROUP_SCOPE_SEPARATOR}{group_name}"
+
+
 def _get_sharepoint_groups(
     client_context: ClientContext, group_name: str, graph_client: GraphClient
 ) -> tuple[set[SharepointGroup], set[str]]:
@@ -360,6 +326,8 @@ def _get_sharepoint_groups(
                     name = _get_group_name_with_suffix(
                         user.login_name, name, graph_client
                     )
+                else:
+                    name = _get_site_scoped_group_name(client_context, name)
                 groups.add(
                     SharepointGroup(
                         login_name=user.login_name,
@@ -466,9 +434,6 @@ def _get_azuread_groups(
     sleep_and_retry(
         group.members.get_all(page_loaded=process_members), "get_azuread_groups"
     )
-
-    owner_emails = _get_security_group_owners(graph_client, group_id)
-    user_emails.update(owner_emails)
 
     return groups, user_emails
 
@@ -597,6 +562,8 @@ def get_external_access_from_sharepoint(
                         name = _get_group_name_with_suffix(
                             member.login_name, name, graph_client
                         )
+                    else:
+                        name = _get_site_scoped_group_name(client_context, name)
                     groups.add(
                         SharepointGroup(
                             login_name=member.login_name,
@@ -785,6 +752,8 @@ def get_sharepoint_external_groups(
                         name = _get_group_name_with_suffix(
                             member.login_name, name, graph_client
                         )
+                    else:
+                        name = _get_site_scoped_group_name(client_context, name)
 
                     groups.add(
                         SharepointGroup(

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -8,6 +8,7 @@ import pytest
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _enumerate_ad_groups_paginated,
 )
+from ee.onyx.external_permissions.sharepoint.permission_utils import _get_azuread_groups
 from ee.onyx.external_permissions.sharepoint.permission_utils import _is_public_item
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _iter_graph_collection,
@@ -23,6 +24,9 @@ from ee.onyx.external_permissions.sharepoint.permission_utils import (
     get_sharepoint_external_groups,
 )
 from ee.onyx.external_permissions.sharepoint.permission_utils import GroupsResult
+from ee.onyx.external_permissions.sharepoint.permission_utils import (
+    SHAREPOINT_GROUP_PRINCIPAL_TYPE,
+)
 
 MODULE = "ee.onyx.external_permissions.sharepoint.permission_utils"
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
@@ -172,6 +176,43 @@ def test_enumerate_ad_groups_circuit_breaker(mock_get: MagicMock) -> None:
     assert len(results) <= AD_GROUP_ENUMERATION_THRESHOLD
 
 
+@patch(f"{MODULE}.sleep_and_retry", side_effect=lambda query, _label: query)
+def test_azuread_group_owners_are_not_treated_as_members(
+    _mock_sleep: MagicMock,
+) -> None:
+    member = MagicMock()
+    member.to_json.return_value = {
+        "userPrincipalName": "member@contoso.com",
+        "mail": "member@contoso.com",
+    }
+    owner = MagicMock()
+    owner.to_json.return_value = {
+        "userPrincipalName": "owner@contoso.com",
+        "mail": "owner@contoso.com",
+    }
+    members = MagicMock()
+    members.current_page = [member]
+
+    group = MagicMock()
+
+    def get_all(*, page_loaded: Any) -> MagicMock:
+        page_loaded(members)
+        return members
+
+    group.members.get_all.side_effect = get_all
+    group.owners.get_all.return_value = [owner]
+    graph_client = MagicMock()
+    graph_client.groups.__getitem__.return_value = group
+
+    _, user_emails = _get_azuread_groups(
+        graph_client,
+        "11111111-1111-1111-1111-111111111111",
+    )
+
+    assert user_emails == {"member@contoso.com"}
+    group.owners.get_all.assert_not_called()
+
+
 # ---------------------------------------------------------------------------
 # get_sharepoint_external_groups
 # ---------------------------------------------------------------------------
@@ -212,6 +253,72 @@ def test_default_skips_ad_enumeration(
     assert len(results) == 1
     assert results[0].id == "SiteGroup_abc"
     assert results[0].user_emails == ["alice@contoso.com"]
+
+
+@patch(f"{MODULE}._get_groups_and_members_recursively")
+@patch(f"{MODULE}.sleep_and_retry", side_effect=lambda query, _label: query)
+def test_sharepoint_group_ids_are_scoped_to_their_site(
+    _mock_sleep: MagicMock,
+    mock_recursive: MagicMock,
+) -> None:
+    def resolve_groups(
+        client_context: MagicMock,
+        _graph_client: MagicMock,
+        groups: set[Any],
+        is_group_sync: bool = False,
+    ) -> GroupsResult:
+        assert is_group_sync
+        group_name = next(iter(groups)).name
+        email = (
+            "alice@contoso.com"
+            if client_context.base_url.endswith("/first")
+            else "bob@contoso.com"
+        )
+        return GroupsResult(
+            groups_to_emails={group_name: {email}},
+            found_public_group=False,
+        )
+
+    mock_recursive.side_effect = resolve_groups
+
+    def make_site_context(site_url: str) -> MagicMock:
+        member = MagicMock()
+        member.principal_type = SHAREPOINT_GROUP_PRINCIPAL_TYPE
+        member.title = "Project Members"
+        member.login_name = "Project Members"
+        assignment = MagicMock()
+        assignment.role_definition_bindings = None
+        assignment.member = member
+        assignments = MagicMock()
+        assignments.current_page = [assignment]
+
+        def get_all(*, page_size: int, page_loaded: Any) -> MagicMock:
+            assert page_size > 0
+            page_loaded(assignments)
+            return assignments
+
+        client_context = MagicMock()
+        client_context.base_url = site_url
+        client_context.web.role_assignments.expand.return_value.get_all.side_effect = (
+            get_all
+        )
+        return client_context
+
+    first_site = make_site_context("https://contoso.sharepoint.com/sites/first")
+    second_site = make_site_context("https://contoso.sharepoint.com/sites/second")
+
+    first_groups = get_sharepoint_external_groups(
+        client_context=first_site,
+        graph_client=MagicMock(),
+        graph_api_base=GRAPH_API_BASE,
+    )
+    second_groups = get_sharepoint_external_groups(
+        client_context=second_site,
+        graph_client=MagicMock(),
+        graph_api_base=GRAPH_API_BASE,
+    )
+
+    assert first_groups[0].id != second_groups[0].id
 
 
 @patch(f"{MODULE}._enumerate_ad_groups_paginated")


### PR DESCRIPTION
Cherry-pick of commit a4a5d7b5b5a80fb2ea5033cf87e367b3b501a6f3 to release/v4.2 branch.

Original PR: #13109

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint permission sync by uniquely scoping site groups and limiting Azure AD group membership to actual members. This prevents cross-site group ID collisions and stops owners from being treated as members.

- **Bug Fixes**
  - Scope SharePoint site groups as "<site-url>::<group-name>" to keep group IDs unique per site.
  - Stop including Azure AD group owners; only direct members are resolved.

<sup>Written for commit c3410f1df33abfbf7810eb055e5bc61b5b3242cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

