### PR TITLE
fix(chat): use text-04 for message body text

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -245,6 +245,7 @@ const HumanMessage = React.memo(function HumanMessage({
                   as="p"
                   className="inline-block align-middle"
                   mainContentBody
+                  text04
                 >
                   {content}
                 </Text>

--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -26,7 +26,7 @@
    These auto-switch for dark mode via colors.css — no dark: modifier needed.
    Note: text-05 = highest contrast, text-01 = lowest. */
 .prose-onyx {
-  --tw-prose-body: var(--text-05);
+  --tw-prose-body: var(--text-04);
   --tw-prose-headings: var(--text-05);
   --tw-prose-lead: var(--text-04);
   --tw-prose-links: var(--action-link-05);


### PR DESCRIPTION
## Description

Main chat message text was rendering at `text-05` when it should be `text-04`:

- **Assistant messages**: `.prose-onyx` mapped `--tw-prose-body` to `var(--text-05)` (introduced in #10093). Now `var(--text-04)`.
- **User messages**: `HumanMessage` rendered content with `<Text mainContentBody>` and no color prop, falling back to the `Text` component's `text-05` default. Now passes `text04` explicitly.

Headings, bold, and inline code intentionally stay at `text-05` as emphasis levels above body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)