### PR TITLE
fix(chat): use text-04 for message body text

### DIFF
--- a/web/src/app/app/message/HumanMessage.tsx
+++ b/web/src/app/app/message/HumanMessage.tsx
@@ -245,6 +245,7 @@ const HumanMessage = React.memo(function HumanMessage({
                   as="p"
                   className="inline-block align-middle"
                   mainContentBody
+                  text04
                 >
                   {content}
                 </Text>

--- a/web/src/app/app/message/MemoizedTextComponents.tsx
+++ b/web/src/app/app/message/MemoizedTextComponents.tsx
@@ -236,7 +236,7 @@ export const MemoizedParagraph = memo(function MemoizedParagraph({
   children,
 }: MemoizedParagraphProps) {
   return (
-    <Text as="p" mainContentBody className={className}>
+    <Text as="p" mainContentBody text04 className={className}>
       {children}
     </Text>
   );

--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -26,7 +26,7 @@
    These auto-switch for dark mode via colors.css — no dark: modifier needed.
    Note: text-05 = highest contrast, text-01 = lowest. */
 .prose-onyx {
-  --tw-prose-body: var(--text-05);
+  --tw-prose-body: var(--text-04);
   --tw-prose-headings: var(--text-05);
   --tw-prose-lead: var(--text-04);
   --tw-prose-links: var(--action-link-05);

--- a/web/src/app/app/message/custom-code-styles.css
+++ b/web/src/app/app/message/custom-code-styles.css
@@ -27,7 +27,7 @@
    Note: text-05 = highest contrast, text-01 = lowest. */
 .prose-onyx {
   --tw-prose-body: var(--text-04);
-  --tw-prose-headings: var(--text-05);
+  --tw-prose-headings: var(--text-04);
   --tw-prose-lead: var(--text-04);
   --tw-prose-links: var(--action-link-05);
   --tw-prose-bold: var(--text-05);


### PR DESCRIPTION
## Description

Main chat message text was rendering at `text-05` when it should be `text-04`:

- **Assistant messages**: `.prose-onyx` mapped `--tw-prose-body` and `--tw-prose-headings` to `var(--text-05)` (introduced in #10093). Both now `var(--text-04)`.
- **Assistant paragraphs**: the chat renderer overrides `p` with `MemoizedParagraph`, whose `<Text>` fell back to the `text-05` default, overriding the prose variable. Now passes `text04` explicitly.
- **User messages**: `HumanMessage` had the same `<Text>` default fallback. Now passes `text04` explicitly.

Bold and inline code intentionally stay at `text-05` as emphasis levels above body text.

## How Has This Been Tested?

Rendered a markdown kitchen-sink chat (all heading levels, emphasis, lists, quotes, code, tables, math) on a local frontend against the st-dev backend. Verified computed styles: paragraphs and headings resolve to `#000000bf` (text-04), bold to `#000000e5` (text-05) in light mode; dark mode auto-switches via colors.css.

### Dark - before / after
<img width="376" alt="before - text-05 dark" src="https://github.com/user-attachments/assets/816b440f-5e25-495e-a339-4d0f50152b85" /> <img width="376" alt="after - text-04 dark" src="https://github.com/user-attachments/assets/faf4b813-f4d8-445e-801a-0e8c6201ce29" />

### Light - before / after
<img width="376" alt="before - text-05 light" src="https://github.com/user-attachments/assets/8853c5dd-a250-4814-a12e-3fadbde1df08" /> <img width="376" alt="after - text-04 light" src="https://github.com/user-attachments/assets/73738d5d-8c9b-4c61-8d9f-100b59bb8138" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)