### PR TITLE
docs(auth): Update docstring for `_maybe_refresh_oauth_tokens`

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -1933,22 +1933,21 @@ async def _maybe_refresh_oauth_tokens(
 ) -> None:
     """Best-effort refresh of any near-expiry OAuth access tokens.
 
-    PT_OAUTH MCP tools and any custom HTTP tool with bearer pass-through
-    forward `user.oauth_accounts[0].access_token` directly to the upstream
-    service. The web client's /auth/refresh ticker is gated off for
-    OIDC/SAML (see `web/src/hooks/useTokenRefresh.ts`), so without this hook
-    the stored access_token would rot at the IdP's lifetime (~1 h on
-    Microsoft Entra default) and downstream calls would 401 until the user
-    signs out and back in.
+    PT_OAUTH MCP tools and any custom HTTP tool with bearer pass-through forward
+    `user.oauth_accounts[0].access_token` directly to the upstream service. The
+    web client's /auth/refresh ticker (``useTokenRefresh`` in
+    `web/src/lib/auth/hooks.ts`) only fires for visible tabs, so without this
+    hook the stored access_token could rot at the IdP's lifetime (~1 h on
+    Microsoft Entra default) and downstream calls would 401 until the user signs
+    out and back in.
 
     Refreshing here on every authenticated request is cheap — the underlying
-    `check_and_refresh_oauth_tokens` short-circuits when no account is
-    within the 5-minute renewal buffer. Failures log and return, so a
-    misconfigured IdP can never break authentication of an otherwise-valid
-    request.
+    `check_and_refresh_oauth_tokens` short-circuits when no account is within
+    the 5-minute renewal buffer. Failures log and return, so a misconfigured IdP
+    can never break authentication of an otherwise-valid request.
     """
-    # Local import mirrors the pattern at `get_refresh_router` to keep the
-    # auth module's load order resilient.
+    # Local import mirrors the pattern at `get_refresh_router` to keep the auth
+    # module's load order resilient.
     from onyx.auth.oauth_refresher import check_and_refresh_oauth_tokens
 
     try:


### PR DESCRIPTION
## Description

After #13029 this docstring was out of date, it is in fact gated on for OIDC/SAML.

## How Has This Been Tested?

By reading the text thoroughly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `_maybe_refresh_oauth_tokens` docstring to reflect current behavior and correct file paths. Removes the outdated OIDC/SAML gating note, notes the refresh ticker runs only on visible tabs (`web/src/lib/auth/hooks.ts`), and clarifies the 5-minute buffer and failure handling.

<sup>Written for commit 2c454396ea2bb26bd342ce77590387725e75a9be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

