### PR TITLE
feat(craft): sandbox-proxy MCP credential resolver

### DIFF
--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -595,8 +595,13 @@ class GateAddon:
         # ALWAYS / DENY / off-catalog terminate here; ASK falls through to the
         # approval pipeline in `request()`.
         if matched_actions is None:
-            injection = self._dispatch_injection_or_block(
-                flow, sandbox=sandbox, matched_actions=None
+            # Off-thread like the ALWAYS path: host-claiming resolvers may hit
+            # the DB or refresh an expiring OAuth token before injecting.
+            injection = await asyncio.to_thread(
+                self._dispatch_injection_or_block,
+                flow,
+                sandbox=sandbox,
+                matched_actions=None,
             )
             if injection is InjectionOutcome.BLOCKED:
                 logger.warning(
@@ -1060,16 +1065,18 @@ class GateAddon:
         matched_actions: AllMatchedActions | None,
     ) -> InjectionOutcome:
         """Runs the credential dispatcher; Fails closed with a 403 on BLOCKED."""
-        outcome = self._credential_dispatcher.apply(
+        result = self._credential_dispatcher.apply(
             flow,
             InjectionContext(
                 sandbox=sandbox,
                 matched_actions=matched_actions,
             ),
         )
-        if outcome is InjectionOutcome.BLOCKED:
-            flow.response = http_403(SandboxProxyError.CREDENTIAL_ERROR)
-        return outcome
+        if result.outcome is InjectionOutcome.BLOCKED:
+            flow.response = http_403(
+                SandboxProxyError.CREDENTIAL_ERROR, detail=result.block_detail
+            )
+        return result.outcome
 
     def _terminalize_after_unhandled_error(
         self, approval_id: UUID, tenant_id: str

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -15,6 +15,8 @@ from enum import Enum
 from typing import Protocol
 
 from mitmproxy import http
+from pydantic import BaseModel
+from pydantic import ConfigDict
 
 from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.identity import ResolvedSandbox
@@ -24,7 +26,15 @@ logger = setup_logger()
 
 
 class CredentialUnavailableError(Exception):
-    """A resolver claimed a request but couldn't produce its credential."""
+    """A resolver claimed a request but couldn't produce its credential.
+
+    `sandbox_detail`, when set, is agent-facing 403-body prose — never secrets
+    or internal ids; the exception message itself is internal (logs only).
+    """
+
+    def __init__(self, message: str, *, sandbox_detail: str | None = None) -> None:
+        super().__init__(message)
+        self.sandbox_detail = sandbox_detail
 
 
 @dataclass(frozen=True)
@@ -47,8 +57,10 @@ class CredentialResolver(Protocol):
         """Cheap predicate: does this resolver own this request?
 
         Implementations should key off `request.host` (and `ctx.matched_actions` /
-        `ctx.sandbox.tenant_id` for per-context routing); they MUST NOT open
-        a DB session — that's `resolve()`'s job.
+        `ctx.sandbox.tenant_id` for per-context routing). Avoid opening a DB
+        session here — that's `resolve()`'s job; a resolver that must consult the
+        DB to decide ownership should serve `claims()` from a short-TTL cache
+        refreshed at most once per interval (see `MCPServerResolver`).
         """
         ...
 
@@ -64,17 +76,27 @@ class InjectionOutcome(Enum):
     BLOCKED = "blocked"
 
 
+class InjectionResult(BaseModel):
+    """Outcome of one dispatch. `block_detail` is agent-facing prose for the
+    403 body, present only on BLOCKED when the resolver supplied one."""
+
+    model_config = ConfigDict(frozen=True)
+
+    outcome: InjectionOutcome
+    block_detail: str | None = None
+
+
 class CredentialInjectionDispatcher:
     """First-claim-wins dispatch across a fixed list of resolvers."""
 
     def __init__(self, resolvers: list[CredentialResolver]) -> None:
         self._resolvers = list(resolvers)
 
-    def apply(self, flow: http.HTTPFlow, ctx: InjectionContext) -> InjectionOutcome:
+    def apply(self, flow: http.HTTPFlow, ctx: InjectionContext) -> InjectionResult:
         host = flow.request.host
         resolver = self._pick(flow.request, ctx)
         if resolver is None:
-            return InjectionOutcome.PASS_THROUGH
+            return InjectionResult(outcome=InjectionOutcome.PASS_THROUGH)
 
         resolver_name = type(resolver).__name__
         try:
@@ -86,14 +108,16 @@ class CredentialInjectionDispatcher:
                 host,
                 str(e),
             )
-            return InjectionOutcome.BLOCKED
+            return InjectionResult(
+                outcome=InjectionOutcome.BLOCKED, block_detail=e.sandbox_detail
+            )
         except Exception:
             logger.exception(
                 "credential_resolver_error resolver=%s host=%s",
                 resolver_name,
                 host,
             )
-            return InjectionOutcome.BLOCKED
+            return InjectionResult(outcome=InjectionOutcome.BLOCKED)
 
         if not headers:
             logger.debug(
@@ -104,7 +128,7 @@ class CredentialInjectionDispatcher:
                 0,
                 "-",
             )
-            return InjectionOutcome.CLAIMED
+            return InjectionResult(outcome=InjectionOutcome.CLAIMED)
 
         for name, value in headers.items():
             flow.request.headers[name] = value
@@ -116,7 +140,7 @@ class CredentialInjectionDispatcher:
             len(headers),
             ",".join(sorted(headers)),
         )
-        return InjectionOutcome.INJECTED
+        return InjectionResult(outcome=InjectionOutcome.INJECTED)
 
     def _pick(
         self, request: http.Request, ctx: InjectionContext

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -15,8 +15,7 @@ from enum import Enum
 from typing import Protocol
 
 from mitmproxy import http
-from pydantic import BaseModel
-from pydantic import ConfigDict
+from pydantic import BaseModel, ConfigDict
 
 from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.identity import ResolvedSandbox

--- a/backend/onyx/sandbox_proxy/errors.py
+++ b/backend/onyx/sandbox_proxy/errors.py
@@ -103,14 +103,18 @@ _SANDBOX_ERROR_MESSAGES: dict[SandboxProxyError, str] = {
 }
 
 
-def http_403(code: SandboxProxyError) -> http.Response:
+def http_403(code: SandboxProxyError, detail: str | None = None) -> http.Response:
     """Build a sandbox-visible 403.
 
     The JSON body is `{"error": <code>, "message": <prose>}`: the stable `error`
     code for tooling to match on, and human-readable `message` prose the agent
-    can act on.
+    can act on. `detail`, when given, adds request-specific prose (e.g. which
+    integration is missing credentials) — never secrets or internal ids.
     """
-    body = json.dumps({"error": code.value, "message": code.message}).encode()
+    payload: dict[str, str] = {"error": code.value, "message": code.message}
+    if detail:
+        payload["detail"] = detail
+    body = json.dumps(payload).encode()
     return http.Response.make(
         403,
         content=body,

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -1,0 +1,265 @@
+"""Craft MCP-server credential resolver.
+
+Claims sandbox egress to a craft-enabled `MCPServer`'s `server_url` and injects
+the sandbox owner's credentials from the same `mcp_connection_config` rows chat
+writes, so authenticating on either surface authenticates both. Attribution is
+an exact scheme + host + port + path-prefix match; a request to a claimed host
+outside every configured prefix fails closed. `claims()` serves from a
+short-TTL per-tenant cache — the one deliberate DB touch on the claims path.
+"""
+
+from __future__ import annotations
+
+import posixpath
+import threading
+from urllib.parse import unquote
+from urllib.parse import urlparse
+from uuid import UUID
+
+from cachetools import TTLCache
+from mitmproxy import http
+from pydantic import BaseModel
+
+from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.mcp import extract_connection_data
+from onyx.db.mcp import get_craft_enabled_mcp_servers
+from onyx.db.mcp import get_mcp_server_by_id
+from onyx.db.mcp import MCPCredentialsError
+from onyx.db.mcp import resolve_mcp_credentials
+from onyx.db.models import MCPServer
+from onyx.db.users import fetch_user_by_id
+from onyx.sandbox_proxy.credential_injection import CredentialResolver
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.logging_utils import short_log_id
+from onyx.server.features.mcp.oauth import mcp_token_expired
+from onyx.server.features.mcp.oauth import refresh_mcp_oauth_token_if_expired
+from onyx.utils.credential_audit import emit_credential_access
+from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+logger = setup_logger()
+
+_TARGET_CACHE_TTL_S = 30.0
+_SCHEME_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+class _CraftMCPTarget(BaseModel):
+    """One craft-enabled server's parsed `server_url`, ready for matching."""
+
+    model_config = {"frozen": True}
+
+    server_id: int
+    scheme: str
+    host: str
+    port: int
+    path_prefix: str  # no trailing slash; "" claims the whole host
+
+
+def _parse_target(server_id: int, server_url: str) -> _CraftMCPTarget | None:
+    parsed = urlparse(server_url)
+    scheme = (parsed.scheme or "").lower()
+    port = parsed.port or _SCHEME_DEFAULT_PORTS.get(scheme)
+    if not scheme or not parsed.hostname or port is None:
+        logger.warning(
+            "craft MCP server %s has an unusable server_url; "
+            "it will not be reachable from Craft",
+            server_id,
+        )
+        return None
+    return _CraftMCPTarget(
+        server_id=server_id,
+        scheme=scheme,
+        host=parsed.hostname.lower(),
+        port=port,
+        path_prefix=parsed.path.rstrip("/"),
+    )
+
+
+def _normalized_request_path(raw_path: str) -> str:
+    """Percent-decode and collapse `.`/`..` so prefix matching can't be escaped
+    by traversal (`/mcp/../admin`) the upstream would resolve to another path."""
+    path = unquote(raw_path.split("?", 1)[0].split("#", 1)[0])
+    return posixpath.normpath(path)
+
+
+def _path_matches(request_path: str, path_prefix: str) -> bool:
+    if not path_prefix:
+        return True
+    return request_path == path_prefix or request_path.startswith(path_prefix + "/")
+
+
+class MCPServerResolver(CredentialResolver):
+    """Injects stored MCP credentials on craft-enabled servers' URLs."""
+
+    def __init__(self, cache_ttl_s: float = _TARGET_CACHE_TTL_S) -> None:
+        self._cache_lock = threading.Lock()
+        self._targets_by_tenant: TTLCache[str, tuple[_CraftMCPTarget, ...]] = TTLCache(
+            maxsize=10_000, ttl=cache_ttl_s
+        )
+
+    def claims(self, request: http.Request, ctx: InjectionContext) -> bool:
+        # A matched request belongs to an external app on a shared host (MCP
+        # servers aren't in that catalog) — defer to ExternalAppResolver.
+        if ctx.matched_actions is not None:
+            return False
+        return bool(self._host_targets(request, ctx.sandbox.tenant_id))
+
+    def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
+        tenant_id = ctx.sandbox.tenant_id
+        user_id = ctx.sandbox.user_id
+        path = _normalized_request_path(request.path)
+        candidates = [
+            t
+            for t in self._host_targets(request, tenant_id)
+            if _path_matches(path, t.path_prefix)
+        ]
+        if not candidates:
+            raise CredentialUnavailableError(
+                f"request path {path!r} on MCP host {request.host} matches no "
+                "configured server_url prefix",
+                sandbox_detail=(
+                    "This host belongs to an MCP server configured in Onyx, but "
+                    "the request path is outside the server's MCP endpoint, so "
+                    "it was blocked. Only the configured MCP endpoint is "
+                    "reachable on this host."
+                ),
+            )
+        # Longest prefix wins when servers share a host.
+        target = max(candidates, key=lambda t: len(t.path_prefix))
+
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
+            server = get_mcp_server_by_id(target.server_id, db)
+            admin_managed = server.auth_performer == MCPAuthenticationPerformer.ADMIN
+            if not server.available_in_craft:
+                # Flag flipped since the cache entry was built.
+                raise CredentialUnavailableError(
+                    f"MCP server {server.id} is no longer craft-enabled",
+                    sandbox_detail=_connect_detail(server.name, admin_managed),
+                )
+            user = fetch_user_by_id(db, user_id)
+            if user is None:
+                raise CredentialUnavailableError(
+                    f"sandbox user {short_log_id(user_id)} not found"
+                )
+            try:
+                creds = resolve_mcp_credentials(server, user, db)
+            except MCPCredentialsError as e:
+                raise CredentialUnavailableError(
+                    str(e), sandbox_detail=_connect_detail(server.name, admin_managed)
+                ) from e
+            headers = creds.build_headers()
+            expired_oauth_config_id: int | None = None
+            if (
+                server.auth_type == MCPAuthenticationType.OAUTH
+                and creds.connection_config is not None
+                and mcp_token_expired(extract_connection_data(creds.connection_config))
+            ):
+                expired_oauth_config_id = creds.connection_config.id
+
+        # Refresh after the session closes — the primitive opens its own.
+        if expired_oauth_config_id is not None:
+            headers = _refresh_oauth_headers(
+                tenant_id, server, str(user_id), expired_oauth_config_id
+            )
+            if not headers:
+                raise CredentialUnavailableError(
+                    f"OAuth token for MCP server {server.id} is expired and "
+                    "could not be refreshed",
+                    sandbox_detail=_reconnect_detail(server.name, admin_managed),
+                )
+
+        requires_auth = server.auth_type not in (None, MCPAuthenticationType.NONE)
+        if requires_auth and not headers:
+            raise CredentialUnavailableError(
+                f"no stored credentials for user {short_log_id(user_id)} on "
+                f"server {server.id}",
+                sandbox_detail=_connect_detail(server.name, admin_managed),
+            )
+        if headers:
+            self._audit(server, user_id)
+        return headers
+
+    def _audit(self, server: MCPServer, user_id: UUID) -> None:
+        emit_credential_access(
+            credential_type="mcp_server",
+            provider=server.name,
+            row_id=server.id,
+            user_id=str(user_id),
+            auth_type=server.auth_type.value if server.auth_type else None,
+        )
+
+    def _host_targets(
+        self, request: http.Request, tenant_id: str
+    ) -> list[_CraftMCPTarget]:
+        # Scheme must match so an HTTPS server's bearer is never injected onto a
+        # plaintext request to the same host:port.
+        scheme = request.scheme.lower()
+        host = request.host.lower()
+        port = request.port
+        return [
+            t
+            for t in self._targets(tenant_id)
+            if t.scheme == scheme and t.host == host and t.port == port
+        ]
+
+    def _targets(self, tenant_id: str) -> tuple[_CraftMCPTarget, ...]:
+        with self._cache_lock:
+            cached = self._targets_by_tenant.get(tenant_id)
+        if cached is not None:
+            return cached
+        # Loaded outside the lock so a slow query can't stall other tenants'
+        # claims; a concurrent duplicate load is harmless.
+        targets = self._load_targets(tenant_id)
+        with self._cache_lock:
+            self._targets_by_tenant[tenant_id] = targets
+        return targets
+
+    def _load_targets(self, tenant_id: str) -> tuple[_CraftMCPTarget, ...]:
+        with get_session_with_tenant(tenant_id=tenant_id) as db:
+            servers = get_craft_enabled_mcp_servers(db)
+            parsed = [_parse_target(s.id, s.server_url) for s in servers]
+        return tuple(t for t in parsed if t is not None)
+
+
+def _refresh_oauth_headers(
+    tenant_id: str, server: MCPServer, user_id: str, connection_config_id: int
+) -> dict[str, str] | None:
+    """Fresh auth headers after refreshing the expired OAuth token, or None if
+    it couldn't be refreshed. Sets the tenant contextvar the shared refresh
+    primitive reads."""
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
+    try:
+        auth_header = refresh_mcp_oauth_token_if_expired(
+            server, connection_config_id, user_id
+        )
+    except Exception:
+        logger.exception("mcp_token_refresh.failed config_id=%s", connection_config_id)
+        return None
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+    return {"Authorization": auth_header} if auth_header else None
+
+
+def _fix_instruction(admin_managed: bool, *, reconnect: bool) -> str:
+    verb = "reconnect" if reconnect else "connect"
+    if admin_managed:
+        return f"Ask a workspace admin to {verb} it on the MCP actions page in Onyx."
+    return f"Ask the user to {verb} it from the Apps page in Craft, then retry."
+
+
+def _connect_detail(server_name: str, admin_managed: bool) -> str:
+    return (
+        f'The MCP server "{server_name}" is not connected. '
+        f"{_fix_instruction(admin_managed, reconnect=False)}"
+    )
+
+
+def _reconnect_detail(server_name: str, admin_managed: bool) -> str:
+    return (
+        f'The saved credentials for the MCP server "{server_name}" are expired and '
+        "could not be refreshed right now — another request may be refreshing them. "
+        f"Retry shortly. If it keeps failing: {_fix_instruction(admin_managed, reconnect=True)}"
+    )

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -127,8 +127,25 @@ class MCPServerResolver(CredentialResolver):
                     "reachable on this host."
                 ),
             )
-        # Longest prefix wins when servers share a host.
-        target = max(candidates, key=lambda t: len(t.path_prefix))
+        # Longest prefix wins when servers share a host. A tie at the longest
+        # prefix means two configs claim the same endpoint with no way to tell
+        # which owns the request — fail closed rather than inject an arbitrary
+        # config's credentials.
+        longest = max(len(t.path_prefix) for t in candidates)
+        winners = [t for t in candidates if len(t.path_prefix) == longest]
+        if len(winners) > 1:
+            raise CredentialUnavailableError(
+                f"request path {path!r} on MCP host {request.host} matches "
+                f"{len(winners)} MCP servers ({sorted(w.server_id for w in winners)}) "
+                "at the same endpoint; credential attribution is ambiguous",
+                sandbox_detail=(
+                    "Multiple MCP servers in Onyx are configured with the same "
+                    "URL, so Craft cannot tell which one's credentials to use. "
+                    "Ask a workspace admin to remove the duplicate MCP server "
+                    "configuration."
+                ),
+            )
+        target = winners[0]
 
         with get_session_with_tenant(tenant_id=tenant_id) as db:
             server = get_mcp_server_by_id(target.server_id, db)

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -12,8 +12,7 @@ from __future__ import annotations
 
 import posixpath
 import threading
-from urllib.parse import unquote
-from urllib.parse import urlparse
+from urllib.parse import unquote, urlparse
 from uuid import UUID
 
 from cachetools import TTLCache
@@ -21,21 +20,26 @@ from mitmproxy import http
 from pydantic import BaseModel
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
-from onyx.db.enums import MCPAuthenticationPerformer
-from onyx.db.enums import MCPAuthenticationType
-from onyx.db.mcp import extract_connection_data
-from onyx.db.mcp import get_craft_enabled_mcp_servers
-from onyx.db.mcp import get_mcp_server_by_id
-from onyx.db.mcp import MCPCredentialsError
-from onyx.db.mcp import resolve_mcp_credentials
+from onyx.db.enums import MCPAuthenticationPerformer, MCPAuthenticationType
+from onyx.db.mcp import (
+    MCPCredentialsError,
+    extract_connection_data,
+    get_craft_enabled_mcp_servers,
+    get_mcp_server_by_id,
+    resolve_mcp_credentials,
+)
 from onyx.db.models import MCPServer
 from onyx.db.users import fetch_user_by_id
-from onyx.sandbox_proxy.credential_injection import CredentialResolver
-from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
-from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.credential_injection import (
+    CredentialResolver,
+    CredentialUnavailableError,
+    InjectionContext,
+)
 from onyx.sandbox_proxy.logging_utils import short_log_id
-from onyx.server.features.mcp.oauth import mcp_token_expired
-from onyx.server.features.mcp.oauth import refresh_mcp_oauth_token_if_expired
+from onyx.server.features.mcp.oauth import (
+    mcp_token_expired,
+    refresh_mcp_oauth_token_if_expired,
+)
 from onyx.utils.credential_audit import emit_credential_access
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR

--- a/backend/onyx/sandbox_proxy/server.py
+++ b/backend/onyx/sandbox_proxy/server.py
@@ -26,6 +26,7 @@ from onyx.sandbox_proxy.identity import IdentityResolver, SandboxIPLookup
 from onyx.sandbox_proxy.request_evaluator import ExternalAppRequestEvaluator
 from onyx.sandbox_proxy.resolvers.external_app import ExternalAppResolver
 from onyx.sandbox_proxy.resolvers.llm_provider_key import LLMProviderKeyResolver
+from onyx.sandbox_proxy.resolvers.mcp_server import MCPServerResolver
 from onyx.sandbox_proxy.resolvers.onyx_pat import OnyxPatResolver
 from onyx.server.features.build.configs import (
     SANDBOX_NAMESPACE,
@@ -163,7 +164,12 @@ def build_resolvers() -> list[CredentialResolver]:
     canonical hosts). Order is a safety net against accidental overlap, not a
     designed-in priority.
     """
-    return [OnyxPatResolver(), LLMProviderKeyResolver(), ExternalAppResolver()]
+    return [
+        OnyxPatResolver(),
+        LLMProviderKeyResolver(),
+        MCPServerResolver(),
+        ExternalAppResolver(),
+    ]
 
 
 def _install_signal_handlers(

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
@@ -10,8 +10,7 @@ credentials fail closed with agent-facing prose naming the server.
 from __future__ import annotations
 
 import time
-from collections.abc import Callable
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from typing import Any
 from unittest.mock import MagicMock
 from urllib.parse import parse_qsl
@@ -22,24 +21,27 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.cache.interface import CacheLockAcquisitionError
-from onyx.db.enums import MCPAuthenticationPerformer
-from onyx.db.enums import MCPAuthenticationType
-from onyx.db.enums import MCPOAuthProviderMode
-from onyx.db.enums import MCPTransport
-from onyx.db.mcp import create_connection_config
-from onyx.db.mcp import create_mcp_server__no_commit
-from onyx.db.mcp import extract_connection_data
-from onyx.db.mcp import get_connection_config_by_id
-from onyx.db.mcp import update_mcp_server__no_commit
-from onyx.db.models import MCPServer
-from onyx.db.models import OAuthAccount
-from onyx.db.models import User
-from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
-from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPOAuthProviderMode,
+    MCPTransport,
+)
+from onyx.db.mcp import (
+    create_connection_config,
+    create_mcp_server__no_commit,
+    extract_connection_data,
+    get_connection_config_by_id,
+    update_mcp_server__no_commit,
+)
+from onyx.db.models import MCPServer, OAuthAccount, User
+from onyx.sandbox_proxy.credential_injection import (
+    CredentialUnavailableError,
+    InjectionContext,
+)
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.resolvers.mcp_server import MCPServerResolver
-from onyx.server.features.mcp.models import MCPConnectionData
-from onyx.server.features.mcp.models import MCPOAuthKeys
+from onyx.server.features.mcp.models import MCPConnectionData, MCPOAuthKeys
 from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
 from tests.external_dependency_unit.conftest import create_test_user
 

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
@@ -311,6 +311,40 @@ def test_longest_prefix_wins_when_servers_share_a_host(
     }
 
 
+def test_duplicate_endpoint_attribution_fails_closed(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    """Two craft servers with the same URL claim the same endpoint with no way
+    to tell which owns the request — resolve must fail closed rather than inject
+    an arbitrary config's credentials."""
+    user = create_test_user(db_session, "mcp_resolver_dup")
+    host = _unique_host()
+    first = craft_server(
+        host=host,
+        path="/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    _attach_admin_config(
+        db_session, first, MCPConnectionData(headers={"Authorization": "Bearer first"})
+    )
+    second = craft_server(
+        host=host,
+        path="/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    _attach_admin_config(
+        db_session,
+        second,
+        MCPConnectionData(headers={"Authorization": "Bearer second"}),
+    )
+
+    with pytest.raises(CredentialUnavailableError) as exc_info:
+        MCPServerResolver().resolve(_request(host, path="/mcp/call"), _ctx(user))
+    assert "ambiguous" in str(exc_info.value)
+
+
 def test_flag_flipped_since_cache_is_blocked(
     db_session: Session, craft_server: CraftServerFactory
 ) -> None:

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py
@@ -1,0 +1,604 @@
+"""External-dependency-unit tests for `MCPServerResolver` against a real DB.
+
+Pins the claim->resolve contract per MCP auth mode: craft-enabled servers are
+claimed by exact URL-prefix attribution, credentials come from the same
+`mcp_connection_config` rows chat writes, an expired OAuth token is refreshed
+through the token endpoint and persisted back to the shared row, and missing
+credentials fail closed with agent-facing prose naming the server.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock
+from urllib.parse import parse_qsl
+from uuid import uuid4
+
+import httpx
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.cache.interface import CacheLockAcquisitionError
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPOAuthProviderMode
+from onyx.db.enums import MCPTransport
+from onyx.db.mcp import create_connection_config
+from onyx.db.mcp import create_mcp_server__no_commit
+from onyx.db.mcp import extract_connection_data
+from onyx.db.mcp import get_connection_config_by_id
+from onyx.db.mcp import update_mcp_server__no_commit
+from onyx.db.models import MCPServer
+from onyx.db.models import OAuthAccount
+from onyx.db.models import User
+from onyx.sandbox_proxy.credential_injection import CredentialUnavailableError
+from onyx.sandbox_proxy.credential_injection import InjectionContext
+from onyx.sandbox_proxy.identity import ResolvedSandbox
+from onyx.sandbox_proxy.resolvers.mcp_server import MCPServerResolver
+from onyx.server.features.mcp.models import MCPConnectionData
+from onyx.server.features.mcp.models import MCPOAuthKeys
+from shared_configs.contextvars import POSTGRES_DEFAULT_SCHEMA
+from tests.external_dependency_unit.conftest import create_test_user
+
+CraftServerFactory = Callable[..., MCPServer]
+
+
+@pytest.fixture
+def craft_server(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[CraftServerFactory, None, None]:
+    """Factory for craft-enabled MCP servers, auto-deleted with their connection
+    configs at teardown (via `mcp_server_id` cascade)."""
+    created: list[MCPServer] = []
+
+    def _make(
+        *,
+        auth_type: MCPAuthenticationType,
+        auth_performer: MCPAuthenticationPerformer,
+        host: str | None = None,
+        path: str = "/mcp",
+        available_in_craft: bool = True,
+        oauth_provider_mode: MCPOAuthProviderMode = MCPOAuthProviderMode.AUTO_DISCOVERY,
+        oauth_authorization_endpoint: str | None = None,
+        oauth_token_endpoint: str | None = None,
+    ) -> MCPServer:
+        server = create_mcp_server__no_commit(
+            owner_email="admin@example.com",
+            name=f"test-mcp-{uuid4().hex[:8]}",
+            description=None,
+            server_url=f"https://{host or _unique_host()}{path}",
+            auth_type=auth_type,
+            transport=MCPTransport.STREAMABLE_HTTP,
+            auth_performer=auth_performer,
+            db_session=db_session,
+            oauth_provider_mode=oauth_provider_mode,
+            oauth_authorization_endpoint=oauth_authorization_endpoint,
+            oauth_token_endpoint=oauth_token_endpoint,
+        )
+        update_mcp_server__no_commit(
+            server_id=server.id,
+            db_session=db_session,
+            available_in_craft=available_in_craft,
+        )
+        db_session.commit()
+        created.append(server)
+        return server
+
+    yield _make
+    db_session.rollback()
+    for server in created:
+        db_session.delete(server)
+    db_session.commit()
+
+
+def _unique_host() -> str:
+    return f"api-{uuid4().hex[:8]}.example.com"
+
+
+def _server_host(server: MCPServer) -> str:
+    return server.server_url.split("://", 1)[1].split("/", 1)[0]
+
+
+def _attach_admin_config(
+    db_session: Session, server: MCPServer, config_data: MCPConnectionData
+) -> int:
+    config = create_connection_config(config_data, db_session, mcp_server_id=server.id)
+    update_mcp_server__no_commit(
+        server_id=server.id,
+        db_session=db_session,
+        admin_connection_config_id=config.id,
+    )
+    db_session.commit()
+    return config.id
+
+
+def _attach_user_config(
+    db_session: Session,
+    server: MCPServer,
+    user_email: str,
+    config_data: MCPConnectionData,
+) -> int:
+    config = create_connection_config(
+        config_data, db_session, mcp_server_id=server.id, user_email=user_email
+    )
+    db_session.commit()
+    return config.id
+
+
+def _ctx(user: User) -> InjectionContext:
+    return InjectionContext(
+        sandbox=ResolvedSandbox(
+            sandbox_id=uuid4(),
+            user_id=user.id,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA,
+            sandbox_name="sandbox-test",
+            sandbox_ip="127.0.0.1",
+        ),
+        matched_actions=None,
+    )
+
+
+def _request(
+    host: str, path: str = "/mcp", port: int = 443, scheme: str = "https"
+) -> MagicMock:
+    return MagicMock(host=host, port=port, path=path, scheme=scheme)
+
+
+def test_admin_api_token_injects_stored_headers(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_api_token")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    host = _server_host(server)
+    _attach_admin_config(
+        db_session,
+        server,
+        MCPConnectionData(headers={"Authorization": "Bearer admin-token"}),
+    )
+
+    resolver = MCPServerResolver()
+    ctx = _ctx(user)
+    assert resolver.claims(_request(host), ctx) is True
+    assert resolver.claims(_request("unrelated.example.com"), ctx) is False
+    assert resolver.resolve(_request(host), ctx) == {
+        "Authorization": "Bearer admin-token"
+    }
+
+
+def test_per_user_missing_config_is_blocked_naming_server(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_missing")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+    )
+
+    with pytest.raises(CredentialUnavailableError) as exc_info:
+        MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user))
+    assert server.name in (exc_info.value.sandbox_detail or "")
+
+
+def test_non_craft_enabled_server_is_not_claimed(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_disabled")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        available_in_craft=False,
+    )
+
+    assert (
+        MCPServerResolver().claims(_request(_server_host(server)), _ctx(user)) is False
+    )
+
+
+def test_request_outside_server_url_prefix_is_blocked(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_prefix")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    host = _server_host(server)
+    _attach_admin_config(
+        db_session,
+        server,
+        MCPConnectionData(headers={"Authorization": "Bearer admin-token"}),
+    )
+
+    resolver = MCPServerResolver()
+    ctx = _ctx(user)
+    # The whole host is claimed...
+    assert resolver.claims(_request(host, path="/other"), ctx) is True
+    # ...but only the configured MCP endpoint resolves; siblings fail closed.
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_request(host, path="/other"), ctx)
+    assert resolver.resolve(_request(host, path="/mcp"), ctx) != {}
+    assert resolver.resolve(_request(host, path="/mcp/session"), ctx) != {}
+
+
+@pytest.mark.parametrize(
+    "attack_path",
+    ["/mcp/../admin", "/mcp/%2e%2e/admin", "/mcp/subtool/../../secret"],
+)
+def test_path_traversal_is_blocked(
+    db_session: Session, craft_server: CraftServerFactory, attack_path: str
+) -> None:
+    """A path that normalizes outside the configured prefix must not get creds,
+    even though its raw form is prefixed by the server_url path."""
+    user = create_test_user(db_session, "mcp_resolver_traversal")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    _attach_admin_config(
+        db_session,
+        server,
+        MCPConnectionData(headers={"Authorization": "Bearer admin-token"}),
+    )
+
+    with pytest.raises(CredentialUnavailableError):
+        MCPServerResolver().resolve(
+            _request(_server_host(server), path=attack_path), _ctx(user)
+        )
+
+
+def test_plaintext_request_to_https_server_is_not_claimed(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    """An https server's bearer must never be injected onto a plaintext http
+    request to the same host:port."""
+    user = create_test_user(db_session, "mcp_resolver_scheme")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    host = _server_host(server)
+    _attach_admin_config(
+        db_session, server, MCPConnectionData(headers={"Authorization": "Bearer x"})
+    )
+
+    resolver = MCPServerResolver()
+    ctx = _ctx(user)
+    assert resolver.claims(_request(host, scheme="https"), ctx) is True
+    assert resolver.claims(_request(host, port=443, scheme="http"), ctx) is False
+
+
+def test_longest_prefix_wins_when_servers_share_a_host(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    """Two craft servers on one host: a request under the more specific prefix
+    gets that server's credentials, not the broader one's."""
+    user = create_test_user(db_session, "mcp_resolver_prefix_tie")
+    host = _unique_host()
+    broad = craft_server(
+        host=host,
+        path="/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    _attach_admin_config(
+        db_session, broad, MCPConnectionData(headers={"Authorization": "Bearer broad"})
+    )
+    specific = craft_server(
+        host=host,
+        path="/mcp/v2",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    _attach_admin_config(
+        db_session,
+        specific,
+        MCPConnectionData(headers={"Authorization": "Bearer specific"}),
+    )
+
+    resolver = MCPServerResolver()
+    assert resolver.resolve(_request(host, path="/mcp/v2/call"), _ctx(user)) == {
+        "Authorization": "Bearer specific"
+    }
+    assert resolver.resolve(_request(host, path="/mcp/call"), _ctx(user)) == {
+        "Authorization": "Bearer broad"
+    }
+
+
+def test_flag_flipped_since_cache_is_blocked(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    """A server cached as craft-enabled but disabled since is blocked on the
+    resolve() re-read, not served from the stale claims() cache."""
+    user = create_test_user(db_session, "mcp_resolver_flipped")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    host = _server_host(server)
+    _attach_admin_config(
+        db_session, server, MCPConnectionData(headers={"Authorization": "Bearer x"})
+    )
+
+    resolver = MCPServerResolver()
+    # Warm the target cache while the server is still enabled.
+    assert resolver.claims(_request(host), _ctx(user)) is True
+    update_mcp_server__no_commit(
+        server_id=server.id, db_session=db_session, available_in_craft=False
+    )
+    db_session.commit()
+    with pytest.raises(CredentialUnavailableError):
+        resolver.resolve(_request(host), _ctx(user))
+
+
+def test_matched_request_is_not_claimed(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    """A request the external-app matcher already attributed belongs to that
+    resolver, even on a shared host — MCP defers."""
+    user = create_test_user(db_session, "mcp_resolver_matched")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+    host = _server_host(server)
+
+    resolver = MCPServerResolver()
+    ctx = _ctx(user)
+    assert resolver.claims(_request(host), ctx) is True
+    matched_ctx = InjectionContext(sandbox=ctx.sandbox, matched_actions=MagicMock())
+    assert resolver.claims(_request(host), matched_ctx) is False
+
+
+def test_admin_managed_server_detail_points_to_admin(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    """An admin-performer server with no config tells the agent to reach an
+    admin, not to connect it from the user's Apps page."""
+    user = create_test_user(db_session, "mcp_resolver_admin_copy")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+
+    with pytest.raises(CredentialUnavailableError) as exc_info:
+        MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user))
+    detail = exc_info.value.sandbox_detail or ""
+    assert "admin" in detail.lower()
+    assert "Apps page in Craft" not in detail
+
+
+def test_none_auth_claims_without_injecting(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_none")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.NONE,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+    )
+
+    assert MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user)) == {}
+
+
+def test_pt_oauth_injects_user_login_token(
+    db_session: Session, craft_server: CraftServerFactory
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_pt")
+    db_session.add(
+        OAuthAccount(
+            user_id=user.id,
+            oauth_name="google",
+            account_id=f"acct-{uuid4().hex[:8]}",
+            account_email=user.email,
+            access_token="login-oauth-token",
+            refresh_token="",
+        )
+    )
+    db_session.commit()
+    db_session.refresh(user)
+
+    server = craft_server(
+        auth_type=MCPAuthenticationType.PT_OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+    )
+
+    headers = MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user))
+    assert headers == {"Authorization": "Bearer login-oauth-token"}
+
+
+def test_valid_oauth_token_injected_without_refresh(
+    db_session: Session,
+    craft_server: CraftServerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_oauth_ok")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+    )
+    _attach_user_config(
+        db_session,
+        server,
+        user.email,
+        MCPConnectionData(
+            headers={"Authorization": "Bearer current-token"},
+            tokens={
+                "access_token": "current-token",
+                "token_type": "Bearer",
+                "refresh_token": "rt-1",
+            },
+            token_expires_at=time.time() + 3600,
+        ),
+    )
+
+    def _fail_refresh(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("refresh must not run for an unexpired token")
+
+    monkeypatch.setattr(
+        "onyx.sandbox_proxy.resolvers.mcp_server.refresh_mcp_oauth_token_if_expired",
+        _fail_refresh,
+    )
+
+    headers = MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user))
+    assert headers == {"Authorization": "Bearer current-token"}
+
+
+def _mock_token_endpoint(
+    monkeypatch: pytest.MonkeyPatch, respond: Callable[[httpx.Request], httpx.Response]
+) -> None:
+    """Swap the SSRF-guarded httpx factory the shared refresh primitive uses for
+    one whose transport answers the token-refresh POST locally, 404ing the rest."""
+
+    def _handle(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/token":
+            return respond(request)
+        return httpx.Response(404)
+
+    def _factory(
+        headers: dict[str, str] | None = None,
+        timeout: httpx.Timeout | None = None,  # noqa: ARG001
+        auth: httpx.Auth | None = None,
+    ) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            transport=httpx.MockTransport(_handle), headers=headers, auth=auth
+        )
+
+    monkeypatch.setattr(
+        "onyx.server.features.mcp.oauth.mcp_ssrf_httpx_client_factory", _factory
+    )
+
+
+_CLIENT_INFO = {
+    "client_id": "cid",
+    "client_secret": "csecret",
+    "redirect_uris": ["https://app.example.com/mcp/oauth/callback"],
+}
+
+
+def _expired_oauth_config(refresh_token: str) -> MCPConnectionData:
+    return MCPConnectionData(
+        headers={"Authorization": "Bearer stale-token"},
+        tokens={
+            "access_token": "stale-token",
+            "token_type": "Bearer",
+            "refresh_token": refresh_token,
+        },
+        client_info=_CLIENT_INFO,
+        token_expires_at=time.time() - 60,
+    )
+
+
+def test_expired_oauth_token_refreshed_and_persisted(
+    db_session: Session,
+    craft_server: CraftServerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_oauth_refresh")
+    auth_host = f"auth-{uuid4().hex[:8]}.example.com"
+    token_endpoint = f"https://{auth_host}/token"
+    # KNOWN_PROVIDER so make_oauth_provider hydrates the SDK with the real token
+    # endpoint — the same path chat's per-tool-call refresh exercises.
+    server = craft_server(
+        auth_type=MCPAuthenticationType.OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        oauth_provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER,
+        oauth_authorization_endpoint=f"https://{auth_host}/authorize",
+        oauth_token_endpoint=token_endpoint,
+    )
+    config_id = _attach_user_config(
+        db_session, server, user.email, _expired_oauth_config("rt-1")
+    )
+
+    posted: dict[str, Any] = {}
+
+    def _respond(request: httpx.Request) -> httpx.Response:
+        posted["url"] = str(request.url)
+        posted["data"] = dict(parse_qsl(request.content.decode()))
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "fresh-token",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "rt-2",
+            },
+        )
+
+    _mock_token_endpoint(monkeypatch, _respond)
+
+    headers = MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user))
+    assert headers == {"Authorization": "Bearer fresh-token"}
+    assert posted["url"] == token_endpoint
+    assert posted["data"]["grant_type"] == "refresh_token"
+    assert posted["data"]["refresh_token"] == "rt-1"
+
+    # The refresh persisted to the shared row chat reads.
+    db_session.expire_all()
+    config_data = extract_connection_data(
+        get_connection_config_by_id(config_id, db_session), apply_mask=False
+    )
+    assert config_data["headers"] == {"Authorization": "Bearer fresh-token"}
+    assert config_data[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "rt-2"
+    assert config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+
+
+def test_expired_oauth_token_unrefreshable_is_blocked(
+    db_session: Session,
+    craft_server: CraftServerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = create_test_user(db_session, "mcp_resolver_oauth_dead")
+    auth_host = f"auth-{uuid4().hex[:8]}.example.com"
+    server = craft_server(
+        auth_type=MCPAuthenticationType.OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        oauth_provider_mode=MCPOAuthProviderMode.KNOWN_PROVIDER,
+        oauth_authorization_endpoint=f"https://{auth_host}/authorize",
+        oauth_token_endpoint=f"https://{auth_host}/token",
+    )
+    _attach_user_config(
+        db_session, server, user.email, _expired_oauth_config("rt-dead")
+    )
+
+    _mock_token_endpoint(
+        monkeypatch,
+        lambda _request: httpx.Response(400, json={"error": "invalid_grant"}),
+    )
+
+    with pytest.raises(CredentialUnavailableError) as exc_info:
+        MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user))
+    assert server.name in (exc_info.value.sandbox_detail or "")
+
+
+def test_refresh_lock_contention_yields_retry_detail(
+    db_session: Session,
+    craft_server: CraftServerFactory,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the shared single-flight lock is held by another refresher and the
+    token hasn't been refreshed yet, the agent is told to retry, not just to
+    reconnect a server that may be fine."""
+    user = create_test_user(db_session, "mcp_resolver_contended")
+    server = craft_server(
+        auth_type=MCPAuthenticationType.OAUTH,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        oauth_token_endpoint=f"https://auth-{uuid4().hex[:8]}.example.com/token",
+    )
+    _attach_user_config(db_session, server, user.email, _expired_oauth_config("rt-1"))
+
+    def _contended(*_args: Any, **_kwargs: Any) -> Any:
+        raise CacheLockAcquisitionError("held by another refresher")
+
+    monkeypatch.setattr("onyx.server.features.mcp.oauth.cache_shared_lock", _contended)
+
+    with pytest.raises(CredentialUnavailableError) as exc_info:
+        MCPServerResolver().resolve(_request(_server_host(server)), _ctx(user))
+    detail = exc_info.value.sandbox_detail or ""
+    assert "retry" in detail.lower()
+    assert server.name in detail

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -36,9 +36,9 @@ def test_no_resolver_claims_returns_pass_through() -> None:
     flow = make_flow()
     flow.request.headers["X-Existing"] = "preserve"
 
-    outcome = CredentialInjectionDispatcher([a, b]).apply(flow, _ctx())
+    result = CredentialInjectionDispatcher([a, b]).apply(flow, _ctx())
 
-    assert outcome is InjectionOutcome.PASS_THROUGH
+    assert result.outcome is InjectionOutcome.PASS_THROUGH
     assert flow.request.headers["X-Existing"] == "preserve"
     assert a.claims_calls and b.claims_calls
     assert a.resolve_calls == [] and b.resolve_calls == []
@@ -79,9 +79,9 @@ def test_resolver_claiming_but_returning_no_headers_is_claimed() -> None:
     """A resolver can claim a request without writing any headers."""
     resolver = RecordingCredentialResolver(claims_result=True, headers={})
 
-    outcome = CredentialInjectionDispatcher([resolver]).apply(make_flow(), _ctx())
+    result = CredentialInjectionDispatcher([resolver]).apply(make_flow(), _ctx())
 
-    assert outcome is InjectionOutcome.CLAIMED
+    assert result.outcome is InjectionOutcome.CLAIMED
 
 
 def test_credential_unavailable_returns_blocked() -> None:
@@ -90,10 +90,27 @@ def test_credential_unavailable_returns_blocked() -> None:
     )
     flow = make_flow()
 
-    outcome = CredentialInjectionDispatcher([resolver]).apply(flow, _ctx())
+    result = CredentialInjectionDispatcher([resolver]).apply(flow, _ctx())
 
-    assert outcome is InjectionOutcome.BLOCKED
+    assert result.outcome is InjectionOutcome.BLOCKED
+    assert result.block_detail is None
     assert "Authorization" not in flow.request.headers
+
+
+def test_credential_unavailable_sandbox_detail_reaches_result() -> None:
+    """Agent-facing prose on the error surfaces as the result's block_detail."""
+    resolver = RecordingCredentialResolver(
+        claims_result=True,
+        exc=CredentialUnavailableError(
+            "internal: no config row 42",
+            sandbox_detail="Connect the GitHub MCP server, then retry.",
+        ),
+    )
+
+    result = CredentialInjectionDispatcher([resolver]).apply(make_flow(), _ctx())
+
+    assert result.outcome is InjectionOutcome.BLOCKED
+    assert result.block_detail == "Connect the GitHub MCP server, then retry."
 
 
 def test_unexpected_exception_returns_blocked() -> None:
@@ -102,9 +119,9 @@ def test_unexpected_exception_returns_blocked() -> None:
         claims_result=True, exc=RuntimeError("db down mid-resolve")
     )
 
-    outcome = CredentialInjectionDispatcher([resolver]).apply(make_flow(), _ctx())
+    result = CredentialInjectionDispatcher([resolver]).apply(make_flow(), _ctx())
 
-    assert outcome is InjectionOutcome.BLOCKED
+    assert result.outcome is InjectionOutcome.BLOCKED
 
 
 def test_claims_exception_falls_through_to_next_resolver() -> None:
@@ -114,9 +131,9 @@ def test_claims_exception_falls_through_to_next_resolver() -> None:
     good = RecordingCredentialResolver(claims_result=True, headers={"X-Hdr": "val"})
     flow = make_flow()
 
-    outcome = CredentialInjectionDispatcher([bad, good]).apply(flow, _ctx())
+    result = CredentialInjectionDispatcher([bad, good]).apply(flow, _ctx())
 
-    assert outcome is InjectionOutcome.INJECTED
+    assert result.outcome is InjectionOutcome.INJECTED
     assert flow.request.headers["X-Hdr"] == "val"
 
 
@@ -127,9 +144,9 @@ def test_all_claims_raise_returns_pass_through() -> None:
     b = MagicMock(spec=CredentialResolver)
     b.claims.side_effect = RuntimeError("b")
 
-    outcome = CredentialInjectionDispatcher([a, b]).apply(make_flow(), _ctx())
+    result = CredentialInjectionDispatcher([a, b]).apply(make_flow(), _ctx())
 
-    assert outcome is InjectionOutcome.PASS_THROUGH
+    assert result.outcome is InjectionOutcome.PASS_THROUGH
 
 
 def test_resolver_receives_request_and_full_context() -> None:


### PR DESCRIPTION
## Description

PR 3 of the Craft MCP Support plan: MCP servers an admin flags `available_in_craft` become reachable from the Craft sandbox with **zero credential duplication** — the proxy injects the sandbox owner's credentials from the same `mcp_connection_config` rows chat writes, so connecting a server on either surface authenticates both. The sandbox dials the real server URL with no auth headers; secrets only ever exist at the proxy.

**`sandbox_proxy/resolvers/mcp_server.py`** (registered in `build_resolvers()`):
- Exact URL-prefix attribution against craft-enabled servers' `server_url` — no glob/provider patterns. A request to a claimed host outside every configured prefix is **denied, never forwarded**: an MCP host must not double as a generic egress route.
- Credential resolution via the shared `resolve_mcp_credentials` / `build_headers()` (all four auth modes: NONE / API_TOKEN / OAUTH / PT_OAUTH).
- `claims()` runs on the off-catalog hot path, so craft-enabled targets are held in a 30s-TTL per-tenant cache — the one deliberate, documented exception to the "no DB in claims" rule. Admin flag flips converge within the TTL.

**`server/features/mcp/oauth_refresh.py`** — lazy OAuth refresh at the proxy. A thin wrapper over chat's shared `refresh_mcp_oauth_token_if_expired` primitive, adding only a persisted-expiry pre-check so the hot path skips refresh when the stored token is still good. The single-flight lock that serializes refreshes per config row (so a chat call and a proxy call can't race a rotating refresh token) lives on that shared primitive and is split out as #13143.

**Framework extensions** (small): the credential dispatcher returns a typed `InjectionResult` carrying agent-facing `block_detail` prose into the 403 body — missing/unrefreshable credentials fail closed with a structured 403 naming the server, which v2's connect-on-demand card will trigger off; the gate's off-catalog dispatch runs off the event loop like the ALWAYS path, since resolution can block on a token refresh.

Unreachable in practice until the opencode config emission PR turns MCP on in the sandbox — nothing is user-visible yet.

**Stacked on** #13068 (`available_in_craft` flag) and #13143 (single-flight refresh lock). The PR base is #13068's branch; #13143's commit is cherry-picked in as a dependency, so its `oauth.py` / `test_mcp_oauth_refresh.py` changes show in this diff until #13143 lands on main and the base rebases. This PR's own changes are the `sandbox_proxy/` files, `oauth_refresh.py`, and `test_mcp_server_resolver.py`.

## How Has This Been Tested?

New external-dependency-unit suite `tests/external_dependency_unit/sandbox_proxy/test_mcp_server_resolver.py` (real DB + Redis): injection per auth type, expired-token refresh through the real SDK provider machinery with persistence back to the row verified, blocked-naming-the-server on missing and on unrefreshable credentials, non-enabled servers unclaimed, out-of-prefix requests denied. Plus updated dispatcher unit tests; full `tests/unit/sandbox_proxy` suite (202) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Craft sandbox-proxy resolver for MCP servers flagged `available_in_craft`. It injects the sandbox owner’s credentials from shared `mcp_connection_config`, refreshes OAuth when needed, and returns structured 403s with agent-facing detail.

- New Features
  - Proxy/matching: `MCPServerResolver` claims only exact scheme/host/port + normalized path-prefix URLs, blocks traversal and off-prefix requests, requires same-scheme, caches targets per-tenant for 30s, defers to already-matched external apps, and is registered before the external-app resolver.
  - Credentials/OAuth: supports NONE/API_TOKEN/OAUTH/PT_OAUTH; uses a persisted-expiry pre-check and the shared single-flight refresh to rotate tokens; access is audited.
  - Framework: the credential dispatcher returns `InjectionResult` with optional `block_detail`; `http_403(..., detail=...)` includes it; off-catalog dispatch runs via `asyncio.to_thread`.

<sup>Written for commit 0b109087bdfe13f9b7570e8e5aa3a0abecff3cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

