### PR TITLE
fix(chat): ensure agent persists correctly after page refresh

### DIFF
--- a/web/src/lib/agents/hooks.ts
+++ b/web/src/lib/agents/hooks.ts
@@ -266,19 +266,29 @@ export function useAgentController(
     return pinnedAgents[0] || availableAgents[0];
   }, [selectedAgent, pinnedAgents, availableAgents, disableDefaultAssistant]);
 
+  const availableAgentsRef = useRef<MinimalAgent[]>(availableAgents);
+  const defaultAgentIdRef = useRef<number | undefined>(defaultAgentId);
+  availableAgentsRef.current = availableAgents;
+  defaultAgentIdRef.current = defaultAgentId;
   const setSelectedAgentFromId = useCallback(
     (agentId: number | null | undefined) => {
+      const latestAvailableAgents = availableAgentsRef.current;
+      const latestDefaultAgentId = defaultAgentIdRef.current;
+
       let newAssistant =
         agentId !== null
-          ? availableAgents.find((a) => a.id === agentId)
+          ? latestAvailableAgents.find((a) => a.id === agentId)
           : undefined;
-      if (!newAssistant && defaultAgentId !== undefined) {
-        newAssistant = availableAgents.find((a) => a.id === defaultAgentId);
+
+      if (!newAssistant && latestDefaultAgentId !== undefined) {
+        newAssistant = latestAvailableAgents.find(
+          (a) => a.id === latestDefaultAgentId
+        );
       }
       setSelectedAssistant(newAssistant);
       onAgentSelect?.();
     },
-    [availableAgents, defaultAgentId, onAgentSelect]
+    [onAgentSelect]
   );
 
   return { selectedAgent, setSelectedAgentFromId, liveAgent };


### PR DESCRIPTION
## Description

Fixes https://github.com/onyx-dot-app/onyx/issues/8087.

- [x] Override Linear Check

**Description of the bug**
On page refresh in an existing chat session, `selectedAgent` could become undefined, causing the UI to display the wrong agent.

**Root cause**
`useChatSessionController` calls `setSelectedAgentFromId` asynchronously with the correct agent ID, but `setSelectedAgentFromId` could resolve against a stale captured snapshot of `availableAgents` instead of the latest list.

**Fix**
`setSelectedAgentFromId` now always resolves using the latest available agent list at call time, preventing refresh-time resets to undefined and keeping the selected agent consistent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the selected agent after a page refresh by resolving selection against the latest agent list, preventing resets to undefined. Fixes #8087.

- **Bug Fixes**
  - `setSelectedAgentFromId` reads `availableAgents` and `defaultAgentId` from `useRef` to avoid stale snapshots.
  - The callback now depends only on `onAgentSelect`, avoiding stale closures.

<sup>Written for commit 95507d8046b1fdf6d45f14e2a622de20b1910ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

