### PR TITLE
Add Eden AI as an LLM provider

### DIFF
--- a/backend/onyx/llm/constants.py
+++ b/backend/onyx/llm/constants.py
@@ -20,6 +20,7 @@ class LlmProviderNames(str, Enum):
     BEDROCK_CONVERSE = "bedrock_converse"
     VERTEX_AI = "vertex_ai"
     OPENROUTER = "openrouter"
+    EDENAI = "edenai"
     AZURE = "azure"
     OLLAMA_CHAT = "ollama_chat"
     LM_STUDIO = "lm_studio"
@@ -43,6 +44,7 @@ WELL_KNOWN_PROVIDER_NAMES = [
     LlmProviderNames.VERTEX_AI,
     LlmProviderNames.BEDROCK,
     LlmProviderNames.OPENROUTER,
+    LlmProviderNames.EDENAI,
     LlmProviderNames.AZURE,
     LlmProviderNames.OLLAMA_CHAT,
     LlmProviderNames.LM_STUDIO,
@@ -62,6 +64,7 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     LlmProviderNames.BEDROCK_CONVERSE: "Bedrock",
     LlmProviderNames.VERTEX_AI: "Vertex AI",
     LlmProviderNames.OPENROUTER: "OpenRouter",
+    LlmProviderNames.EDENAI: "Eden AI",
     LlmProviderNames.AZURE: "Azure",
     "ollama": "Ollama",
     LlmProviderNames.OLLAMA_CHAT: "Ollama",
@@ -154,6 +157,7 @@ AGGREGATOR_PROVIDERS: set[str] = {
     LlmProviderNames.BEDROCK,
     LlmProviderNames.BEDROCK_CONVERSE,
     LlmProviderNames.OPENROUTER,
+    LlmProviderNames.EDENAI,
     LlmProviderNames.OLLAMA_CHAT,
     LlmProviderNames.LM_STUDIO,
     LlmProviderNames.VERTEX_AI,
@@ -169,6 +173,7 @@ AGGREGATOR_PROVIDERS: set[str] = {
 DYNAMIC_LLM_PROVIDERS: frozenset[str] = frozenset(
     {
         LlmProviderNames.OPENROUTER,
+        LlmProviderNames.EDENAI,
         LlmProviderNames.BEDROCK,
         LlmProviderNames.OLLAMA_CHAT,
         LlmProviderNames.LM_STUDIO,

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -40,7 +40,10 @@ from onyx.llm.models import (
 )
 from onyx.llm.request_context import get_llm_mock_response
 from onyx.llm.utils import build_litellm_passthrough_kwargs
-from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
+from onyx.llm.well_known_providers.constants import (
+    EDENAI_API_BASE,
+    VERTEX_LOCATION_KWARG,
+)
 from onyx.utils.encryption import mask_env_value_for_logging, mask_string
 from onyx.utils.logger import setup_logger
 
@@ -415,6 +418,17 @@ class LitellmLLM(LLM):
                 self._api_base = base if base.endswith("/v1") else f"{base}/v1"
                 model_kwargs["api_base"] = self._api_base
 
+        # Eden AI: an OpenAI-compatible aggregator. We route through LiteLLM's
+        # openai provider with Eden AI's base URL. Unlike the proxies above,
+        # Eden AI's base already ends in /v3, so we must NOT append /v1.
+        if model_provider == LlmProviderNames.EDENAI:
+            self._custom_llm_provider = "openai"
+            if not self._api_key:
+                model_kwargs.setdefault("api_key", "not-needed")
+            base = (self._api_base or EDENAI_API_BASE).rstrip("/")
+            self._api_base = base
+            model_kwargs["api_base"] = base
+
         # This is needed for Ollama to do proper function calling
         if model_provider == LlmProviderNames.OLLAMA_CHAT and api_base is not None:
             model_kwargs["api_base"] = api_base
@@ -543,7 +557,14 @@ class LitellmLLM(LLM):
             if is_openai_model  # Uses litellm's completions -> responses bridge
             else self.config.model_provider
         )
-        if is_openai_compatible_proxy:
+        if self._model_provider == LlmProviderNames.EDENAI:
+            # Eden AI is reached through LiteLLM's openai-compatible path
+            # (custom_llm_provider="openai"). LiteLLM strips exactly one leading
+            # "<provider>/" segment from the model string, so we prepend "openai/"
+            # to preserve Eden AI's full "<vendor>/<model>" id. Example:
+            # "openai/anthropic/claude-sonnet-4-5" -> "anthropic/claude-sonnet-4-5".
+            model = f"openai/{self.config.deployment_name or self.config.model_name}"
+        elif is_openai_compatible_proxy:
             # OpenAI-compatible proxies (Bifrost, generic OpenAI-compatible
             # servers) expect model names sent directly to their endpoint.
             # We use custom_llm_provider="openai" so LiteLLM doesn't try

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -551,6 +551,11 @@ class LitellmLLM(LLM):
             LlmProviderNames.BIFROST,
             LlmProviderNames.OPENAI_COMPATIBLE,
             LlmProviderNames.NEBIUS_TOKENFACTORY,
+            # Eden AI is reached through LiteLLM's openai-compatible path too, so
+            # it needs the same tool_choice forwarding even when the underlying
+            # model is Claude or Mistral. Its extra "openai/" model prefix is
+            # handled by the dedicated branch below.
+            LlmProviderNames.EDENAI,
         )
         model_provider = (
             f"{self.config.model_provider}/responses"

--- a/backend/onyx/llm/prompt_cache/providers/factory.py
+++ b/backend/onyx/llm/prompt_cache/providers/factory.py
@@ -39,7 +39,10 @@ def get_provider_adapter(llm_config: LLMConfig) -> PromptCacheProvider:
         return AnthropicPromptCacheProvider()
     elif llm_config.model_provider == LlmProviderNames.VERTEX_AI:
         return VertexAIPromptCacheProvider()
-    elif llm_config.model_provider == LlmProviderNames.OPENROUTER:
+    elif llm_config.model_provider in (
+        LlmProviderNames.OPENROUTER,
+        LlmProviderNames.EDENAI,
+    ):
         model_name = llm_config.model_name or ""
         if model_name.startswith(OPENROUTER_ANTHROPIC_PREFIX):
             logger.debug(

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -26,6 +26,10 @@ PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING: dict[str, str] = {
 # OpenRouter
 OPENROUTER_PROVIDER_NAME = "openrouter"
 
+# Eden AI
+EDENAI_PROVIDER_NAME = "edenai"
+EDENAI_API_BASE = "https://api.edenai.run/v3"
+
 ANTHROPIC_PROVIDER_NAME = "anthropic"
 
 AZURE_PROVIDER_NAME = "azure"

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -19,6 +19,7 @@ from onyx.llm.well_known_providers.constants import (
     AZURE_PROVIDER_NAME,
     BEDROCK_PROVIDER_NAME,
     BIFROST_PROVIDER_NAME,
+    EDENAI_PROVIDER_NAME,
     LITELLM_PROXY_PROVIDER_NAME,
     LM_STUDIO_PROVIDER_NAME,
     NEBIUS_TOKENFACTORY_PROVIDER_NAME,
@@ -55,6 +56,7 @@ def _get_provider_to_models_map() -> dict[str, list[str]]:
         OLLAMA_PROVIDER_NAME: [],  # Dynamic - fetched from Ollama API
         LM_STUDIO_PROVIDER_NAME: [],  # Dynamic - fetched from LM Studio API
         OPENROUTER_PROVIDER_NAME: [],  # Dynamic - fetched from OpenRouter API
+        EDENAI_PROVIDER_NAME: [],  # Dynamic - fetched from Eden AI /v3/models
         LITELLM_PROXY_PROVIDER_NAME: [],  # Dynamic - fetched from LiteLLM proxy API
         BIFROST_PROVIDER_NAME: [],  # Dynamic - fetched from Bifrost API
         OPENAI_COMPATIBLE_PROVIDER_NAME: [],  # Dynamic - fetched from OpenAI-compatible API
@@ -351,6 +353,7 @@ def get_provider_display_name(provider_name: str) -> str:
         BEDROCK_PROVIDER_NAME: "Amazon Bedrock",
         VERTEXAI_PROVIDER_NAME: "Google Vertex AI",
         OPENROUTER_PROVIDER_NAME: "OpenRouter",
+        EDENAI_PROVIDER_NAME: "Eden AI",
         LITELLM_PROXY_PROVIDER_NAME: "LiteLLM Proxy",
         OPENAI_COMPATIBLE_PROVIDER_NAME: "OpenAI-Compatible",
         NEBIUS_TOKENFACTORY_PROVIDER_NAME: "Nebius TokenFactory",

--- a/backend/onyx/llm/well_known_providers/recommended-models.json
+++ b/backend/onyx/llm/well_known_providers/recommended-models.json
@@ -73,6 +73,39 @@
           "display_name": "Kimi K3"
         }
       ]
+    },
+    "edenai": {
+      "default_model": "anthropic/claude-sonnet-4-5",
+      "additional_visible_models": [
+        {
+          "name": "anthropic/claude-sonnet-4-5",
+          "display_name": "Claude Sonnet 4.5"
+        },
+        {
+          "name": "anthropic/claude-haiku-4-5",
+          "display_name": "Claude Haiku 4.5"
+        },
+        {
+          "name": "openai/gpt-4o",
+          "display_name": "GPT-4o"
+        },
+        {
+          "name": "openai/gpt-4o-mini",
+          "display_name": "GPT-4o mini"
+        },
+        {
+          "name": "google/gemini-2.5-flash",
+          "display_name": "Gemini 2.5 Flash"
+        },
+        {
+          "name": "mistral/mistral-large-latest",
+          "display_name": "Mistral Large"
+        },
+        {
+          "name": "mistral/mistral-small-latest",
+          "display_name": "Mistral Small"
+        }
+      ]
     }
   }
 }

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -1532,21 +1532,18 @@ def get_openrouter_available_models(
 
 
 def _get_edenai_models_response(api_base: str, api_key: str | None) -> dict:
-    """Perform GET to the Eden AI /models endpoint and return parsed JSON."""
+    """Perform GET to the Eden AI /models endpoint and return parsed JSON.
+
+    Delegates to the shared OpenAI-compatible helper so invalid credentials and
+    bad base URLs surface as actionable validation errors (rather than a generic
+    502) with consistent request-context logging.
+    """
     cleaned_api_base = api_base.strip().rstrip("/")
-    url = f"{cleaned_api_base}/models"
-    headers: dict[str, str] = {}
-    if api_key:
-        headers["Authorization"] = f"Bearer {api_key}"
-    try:
-        response = httpx.get(url, headers=headers, timeout=10.0)
-        response.raise_for_status()
-        return response.json()
-    except Exception as e:
-        raise OnyxError(
-            OnyxErrorCode.BAD_GATEWAY,
-            f"Failed to fetch Eden AI models: {e}",
-        )
+    return _get_openai_compatible_models_response(
+        url=f"{cleaned_api_base}/models",
+        source_name="Eden AI",
+        api_key=api_key,
+    )
 
 
 @admin_router.post("/edenai/available-models")

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -80,6 +80,9 @@ from onyx.server.manage.llm.models import (
     BifrostModelsRequest,
     CustomProviderOption,
     DefaultModel,
+    EdenAiFinalModelResponse,
+    EdenAiModelDetails,
+    EdenAiModelsRequest,
     LitellmFinalModelResponse,
     LitellmModelDetails,
     LitellmModelsRequest,
@@ -1523,6 +1526,108 @@ def get_openrouter_available_models(
                 for r in sorted_results
             ],
             source_label="OpenRouter",
+        )
+
+    return sorted_results
+
+
+def _get_edenai_models_response(api_base: str, api_key: str | None) -> dict:
+    """Perform GET to the Eden AI /models endpoint and return parsed JSON."""
+    cleaned_api_base = api_base.strip().rstrip("/")
+    url = f"{cleaned_api_base}/models"
+    headers: dict[str, str] = {}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    try:
+        response = httpx.get(url, headers=headers, timeout=10.0)
+        response.raise_for_status()
+        return response.json()
+    except Exception as e:
+        raise OnyxError(
+            OnyxErrorCode.BAD_GATEWAY,
+            f"Failed to fetch Eden AI models: {e}",
+        )
+
+
+@admin_router.post("/edenai/available-models")
+def get_edenai_available_models(
+    request: EdenAiModelsRequest,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> list[EdenAiFinalModelResponse]:
+    """Fetch available models from the Eden AI `/v3/models` endpoint.
+
+    Parses id, model_name (display), context_length, and capabilities
+    (input/output modalities). Keeps text-generation (chat) models only.
+    """
+
+    api_key = _resolve_api_key(
+        request.api_key, request.provider_id, request.api_base, db_session
+    )
+
+    response_json = _get_edenai_models_response(
+        api_base=request.api_base, api_key=api_key
+    )
+
+    data = response_json.get("data", [])
+    if not isinstance(data, list) or len(data) == 0:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No models found from your Eden AI endpoint",
+        )
+
+    results: list[EdenAiFinalModelResponse] = []
+    for item in data:
+        try:
+            model_details = EdenAiModelDetails.model_validate(item)
+
+            # Keep chat models only (skip audio / image / embedding models)
+            if not model_details.is_text_output:
+                continue
+
+            # Eden AI already returns the bare model name; fall back to the id.
+            display_name = model_details.model_name or model_details.id
+
+            # Treat context_length of 0 as unknown (None)
+            context_length = model_details.context_length or None
+
+            results.append(
+                EdenAiFinalModelResponse(
+                    name=model_details.id,
+                    display_name=display_name,
+                    max_input_tokens=context_length,
+                    supports_image_input=model_details.supports_image_input,
+                )
+            )
+        except Exception as e:
+            logger.warning(
+                "Failed to parse Eden AI model entry",
+                extra={"error": str(e), "item": str(item)[:1000]},
+            )
+
+    if not results:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "No compatible models found from Eden AI",
+        )
+
+    sorted_results = sorted(results, key=lambda m: m.name.lower())
+
+    # Sync new models to DB if provider_id is specified
+    if request.provider_id is not None:
+        _sync_fetched_models(
+            db_session=db_session,
+            provider_id=request.provider_id,
+            models=[
+                SyncModelEntry(
+                    name=r.name,
+                    display_name=r.display_name,
+                    max_input_tokens=r.max_input_tokens,
+                    supports_image_input=r.supports_image_input,
+                )
+                for r in sorted_results
+            ],
+            source_label="Eden AI",
         )
 
     return sorted_results

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -459,6 +459,50 @@ class OpenRouterFinalModelResponse(BaseModel):
     supports_image_input: bool
 
 
+# Eden AI dynamic models fetch
+class EdenAiModelsRequest(BaseModel):
+    api_base: str
+    api_key: str
+    # Existing provider id; resolves the stored key and syncs fetched models on edit
+    provider_id: int | None = None
+
+
+class EdenAiModelDetails(BaseModel):
+    """Response model for the Eden AI /v3/models endpoint."""
+
+    # Ignore any extra fields returned by the API
+    model_config = {"extra": "ignore"}
+
+    id: str
+    # Eden AI returns the bare model name (without the vendor prefix)
+    model_name: str | None = None
+    # context_length may be missing or 0 for some models
+    context_length: int | None = None
+    # Contains 'input_modalities' / 'output_modalities' lists and supports_* flags
+    capabilities: dict[str, Any] = {}
+
+    @property
+    def supports_image_input(self) -> bool:
+        modalities = self.capabilities.get("input_modalities", [])
+        return isinstance(modalities, list) and "image" in modalities
+
+    @property
+    def is_text_output(self) -> bool:
+        # Keep chat models only; skip audio / image / embedding models.
+        # If Eden AI omits the field, keep the model (fail open).
+        modalities = self.capabilities.get("output_modalities")
+        if not isinstance(modalities, list) or not modalities:
+            return True
+        return "text" in modalities
+
+
+class EdenAiFinalModelResponse(BaseModel):
+    name: str  # Model ID (e.g., "anthropic/claude-sonnet-4-5")
+    display_name: str  # Human-readable name
+    max_input_tokens: int | None  # From Eden AI context_length (may be missing)
+    supports_image_input: bool
+
+
 # LM Studio dynamic models fetch
 class LMStudioModelsRequest(BaseModel):
     api_base: str

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -316,7 +316,11 @@ def extract_vendor_from_model_name(model_name: str, provider: str) -> str | None
         - Ollama: "llama3:70b" → "Meta"
         - Ollama: "qwen2.5:7b" → "Alibaba"
     """
-    if provider in (LlmProviderNames.OPENROUTER, LlmProviderNames.BIFROST):
+    if provider in (
+        LlmProviderNames.OPENROUTER,
+        LlmProviderNames.BIFROST,
+        LlmProviderNames.EDENAI,
+    ):
         # Format: "vendor/model-name" e.g., "anthropic/claude-3-5-sonnet"
         if "/" in model_name:
             vendor_key = model_name.split("/")[0].lower()

--- a/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
+++ b/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
@@ -258,6 +258,8 @@ def _get_internal_search_tool_id(admin_user: DATestUser) -> int:
 def _default_api_base_for_provider(provider: str) -> str | None:
     if provider == "openrouter":
         return "https://openrouter.ai/api/v1"
+    if provider == "edenai":
+        return "https://api.edenai.run/v3"
     if provider == "ollama_chat":
         # host.docker.internal works when tests are running inside the integration test container.
         return "http://host.docker.internal:11434"

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -475,6 +475,34 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         assert "temperature" not in kwargs
 
 
+def test_edenai_routing_wraps_model_and_keeps_v3_base() -> None:
+    # Eden AI is an OpenAI-compatible aggregator. Onyx must:
+    #  - route via custom_llm_provider="openai"
+    #  - keep Eden AI's base URL ending in /v3 (NOT append /v1 like other proxies)
+    #  - send the model as "openai/<eden_id>" so LiteLLM's one-segment strip
+    #    preserves Eden AI's full "<vendor>/<model>" id. Regression lock.
+    model_name = "anthropic/claude-sonnet-4-5"
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.EDENAI,
+        model_name=model_name,
+        api_base="https://api.edenai.run/v3",
+        max_input_tokens=200000,
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["custom_llm_provider"] == "openai"
+        assert kwargs["model"] == f"openai/{model_name}"
+        assert kwargs["base_url"] == "https://api.edenai.run/v3"
+
+
 @pytest.mark.parametrize(
     "model_name",
     [

--- a/backend/tests/unit/onyx/llm/test_true_openai_model.py
+++ b/backend/tests/unit/onyx/llm/test_true_openai_model.py
@@ -55,6 +55,12 @@ class TestIsTrueOpenAIModel:
         """Test that Ollama provider returns False."""
         assert is_true_openai_model(LlmProviderNames.OLLAMA_CHAT, "llama3.1") is False
 
+    def test_non_openai_provider_edenai(self) -> None:
+        """Test that Eden AI provider returns False (routed via openai-compatible)."""
+        assert (
+            is_true_openai_model(LlmProviderNames.EDENAI, "openai/gpt-4o-mini") is False
+        )
+
     def test_openai_compatible_not_in_registry(self) -> None:
         """Test that OpenAI-compatible model not in registry returns False."""
         # Custom model served via vLLM or LiteLLM proxy

--- a/web/lib/opal/src/logos/edenai.tsx
+++ b/web/lib/opal/src/logos/edenai.tsx
@@ -1,0 +1,27 @@
+import type { IconProps } from "@opal/types";
+
+// Placeholder mark for Eden AI (the letters "EA"). Swap for the official
+// Eden AI brand SVG when available.
+const SvgEdenai = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 48 48"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <title>Eden AI</title>
+    <g fill="var(--text-05)">
+      <rect x="8" y="6" width="6" height="36" />
+      <rect x="8" y="6" width="18" height="6" />
+      <rect x="8" y="21" width="15" height="6" />
+      <rect x="8" y="36" width="18" height="6" />
+      <polygon points="34,6 40,6 33,42 27,42" />
+      <polygon points="34,6 40,6 47,42 41,42" />
+      <rect x="31" y="27" width="12" height="6" />
+    </g>
+  </svg>
+);
+
+export default SvgEdenai;

--- a/web/lib/opal/src/logos/index.ts
+++ b/web/lib/opal/src/logos/index.ts
@@ -23,6 +23,7 @@ export { default as SvgDiscourse } from "@opal/logos/discourse";
 export { default as SvgDocument360 } from "@opal/logos/document-360";
 export { default as SvgDropbox } from "@opal/logos/dropbox";
 export { default as SvgDrupal } from "@opal/logos/drupal";
+export { default as SvgEdenai } from "@opal/logos/edenai";
 export { default as SvgEgnyte } from "@opal/logos/egnyte";
 export { default as SvgElevenLabs } from "@opal/logos/eleven-labs";
 export { default as SvgExa } from "@opal/logos/exa";

--- a/web/src/lib/languageModels/index.ts
+++ b/web/src/lib/languageModels/index.ts
@@ -7,6 +7,7 @@ import {
   SvgOllama,
   SvgAws,
   SvgOpenrouter,
+  SvgEdenai,
   SvgAzure,
   SvgGemini,
   SvgLitellm,
@@ -31,6 +32,7 @@ import AzureModal from "@/sections/modals/languageModels/AzureModal";
 import BedrockModal from "@/sections/modals/languageModels/BedrockModal";
 import VertexAIModal from "@/sections/modals/languageModels/VertexAIModal";
 import OpenRouterModal from "@/sections/modals/languageModels/OpenRouterModal";
+import EdenAiModal from "@/sections/modals/languageModels/EdenAiModal";
 import CustomModal from "@/sections/modals/languageModels/CustomModal";
 import LMStudioModal from "@/sections/modals/languageModels/LMStudioModal";
 import LiteLLMProxyModal from "@/sections/modals/languageModels/LiteLLMProxyModal";
@@ -102,6 +104,12 @@ const PROVIDERS: Record<string, ProviderEntry> = {
     companyName: "OpenRouter",
     Modal: OpenRouterModal,
   },
+  [LLMProviderName.EDENAI]: {
+    icon: SvgEdenai,
+    productName: "Eden AI",
+    companyName: "Eden AI",
+    Modal: EdenAiModal,
+  },
   [LLMProviderName.LM_STUDIO]: {
     icon: SvgLmStudio,
     productName: "LM Studio",
@@ -148,6 +156,7 @@ const CUSTOM_CONFIG_OVERRIDES = new Set<string>([
   LLMProviderName.ANTHROPIC,
   LLMProviderName.AZURE,
   LLMProviderName.OPENROUTER,
+  LLMProviderName.EDENAI,
 ]);
 
 export function getProvider(
@@ -178,6 +187,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   LLMProviderName.BEDROCK,
   "bedrock_converse",
   LLMProviderName.OPENROUTER,
+  LLMProviderName.EDENAI,
   LLMProviderName.OLLAMA_CHAT,
   LLMProviderName.LM_STUDIO,
   LLMProviderName.LITELLM_PROXY,
@@ -195,6 +205,7 @@ const MODEL_ICON_MAP: Record<string, IconFunctionComponent> = {
   [LLMProviderName.OLLAMA_CHAT]: SvgOllama,
   [LLMProviderName.LM_STUDIO]: SvgLmStudio,
   [LLMProviderName.OPENROUTER]: SvgOpenrouter,
+  [LLMProviderName.EDENAI]: SvgEdenai,
   [LLMProviderName.VERTEX_AI]: SvgGemini,
   [LLMProviderName.BEDROCK]: SvgAws,
   [LLMProviderName.LITELLM_PROXY]: SvgLitellm,

--- a/web/src/lib/languageModels/svc.ts
+++ b/web/src/lib/languageModels/svc.ts
@@ -16,6 +16,7 @@ import {
   type ModelConfiguration,
   type OllamaModelResponse,
   type OpenRouterModelResponse,
+  type EdenAiModelResponse,
   type BedrockModelResponse,
   type LMStudioModelResponse,
   type LiteLLMProxyModelResponse,
@@ -24,6 +25,7 @@ import {
   type OllamaFetchParams,
   type LMStudioFetchParams,
   type OpenRouterFetchParams,
+  type EdenAiFetchParams,
   type LiteLLMProxyFetchParams,
   type BifrostFetchParams,
   type OpenAICompatibleFetchParams,
@@ -102,6 +104,7 @@ export const AGGREGATOR_PROVIDERS = new Set([
   "bedrock",
   "bedrock_converse",
   "openrouter",
+  "edenai",
   "ollama_chat",
   "lm_studio",
   "litellm_proxy",
@@ -273,6 +276,68 @@ export const fetchOpenRouterModels = async (
     }
 
     const data: OpenRouterModelResponse[] = await response.json();
+    const models: ModelConfiguration[] = data.map((modelData) => ({
+      name: modelData.name,
+      display_name: modelData.display_name,
+      is_visible: true,
+      max_input_tokens: modelData.max_input_tokens,
+      supports_image_input: modelData.supports_image_input,
+      supports_reasoning: false,
+      effectiveDisplayName: modelData.display_name || modelData.name,
+    }));
+
+    return { models };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : "Unknown error";
+    return { models: [], error: errorMessage };
+  }
+};
+
+/**
+ * Fetches Eden AI models directly without any form state dependencies.
+ * Uses snake_case params to match API structure.
+ */
+export const fetchEdenAiModels = async (
+  params: EdenAiFetchParams
+): Promise<{ models: ModelConfiguration[]; error?: string }> => {
+  const apiBase = params.api_base;
+  const apiKey = params.api_key;
+  if (!apiBase) {
+    return { models: [], error: "API Base is required" };
+  }
+  if (!apiKey) {
+    return { models: [], error: "API Key is required" };
+  }
+
+  try {
+    const response = await fetch("/api/admin/llm/edenai/available-models", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        api_base: apiBase,
+        api_key: apiKey,
+        provider_id: params.provider_id,
+      }),
+    });
+
+    if (!response.ok) {
+      let errorMessage = "Failed to fetch models";
+      try {
+        const errorData = await response.json();
+        errorMessage = errorData.detail || errorData.message || errorMessage;
+      } catch (jsonError) {
+        console.warn(
+          "Failed to parse Eden AI model fetch error response",
+          jsonError
+        );
+      }
+      return { models: [], error: errorMessage };
+    }
+
+    const data: EdenAiModelResponse[] = await response.json();
     const models: ModelConfiguration[] = data.map((modelData) => ({
       name: modelData.name,
       display_name: modelData.display_name,
@@ -572,6 +637,12 @@ export const fetchModels = async (
       });
     case LLMProviderName.OPENROUTER:
       return fetchOpenRouterModels({
+        api_base: formValues.api_base,
+        api_key: formValues.api_key,
+        provider_id: formValues.id,
+      });
+    case LLMProviderName.EDENAI:
+      return fetchEdenAiModels({
         api_base: formValues.api_base,
         api_key: formValues.api_key,
         provider_id: formValues.id,

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -38,6 +38,7 @@ export enum LLMProviderName {
   LM_STUDIO = "lm_studio",
   AZURE = "azure",
   OPENROUTER = "openrouter",
+  EDENAI = "edenai",
   VERTEX_AI = "vertex_ai",
   BEDROCK = "bedrock",
   LITELLM = "litellm",
@@ -107,6 +108,13 @@ export interface OpenRouterModelResponse {
   supports_image_input: boolean;
 }
 
+export interface EdenAiModelResponse {
+  name: string;
+  display_name: string;
+  max_input_tokens: number | null;
+  supports_image_input: boolean;
+}
+
 export interface BedrockModelResponse {
   name: string;
   display_name: string;
@@ -164,6 +172,12 @@ export interface OllamaFetchParams {
 }
 
 export interface OpenRouterFetchParams {
+  api_base?: string;
+  api_key?: string;
+  provider_id?: number;
+}
+
+export interface EdenAiFetchParams {
   api_base?: string;
   api_key?: string;
   provider_id?: number;
@@ -250,6 +264,7 @@ export type FetchModelsParams =
   | BedrockFetchParams
   | OllamaFetchParams
   | OpenRouterFetchParams
+  | EdenAiFetchParams
   | LiteLLMProxyFetchParams
   | BifrostFetchParams
   | OpenAICompatibleFetchParams

--- a/web/src/sections/modals/languageModels/EdenAiModal.tsx
+++ b/web/src/sections/modals/languageModels/EdenAiModal.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useSWRConfig } from "swr";
+import { useFormikContext } from "formik";
+import { InputDivider, toast } from "@opal/layouts";
+import {
+  LLMProviderFormProps,
+  LLMProviderName,
+  LLMProviderView,
+} from "@/lib/languageModels/types";
+import { fetchEdenAiModels } from "@/lib/languageModels/svc";
+import {
+  useInitialValues,
+  buildValidationSchema,
+  BaseLLMFormValues,
+  mergeFetchedModelConfigurations,
+} from "@/sections/modals/languageModels/utils";
+import { submitProvider } from "@/sections/modals/languageModels/svc";
+import { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
+import {
+  APIKeyField,
+  APIBaseField,
+  ModelSelectionField,
+  DisplayNameField,
+  ModelAccessField,
+  ModalWrapper,
+} from "@/sections/modals/languageModels/shared";
+import { refreshLlmProviderCaches } from "@/lib/languageModels/cache";
+
+const DEFAULT_API_BASE = "https://api.edenai.run/v3";
+
+interface EdenAiModalValues extends BaseLLMFormValues {
+  api_key: string;
+  api_base: string;
+}
+
+interface EdenAiModalInternalsProps {
+  existingLlmProvider: LLMProviderView | undefined;
+  isOnboarding: boolean;
+}
+
+function EdenAiModalInternals({
+  existingLlmProvider,
+  isOnboarding,
+}: EdenAiModalInternalsProps) {
+  const formikProps = useFormikContext<EdenAiModalValues>();
+
+  const isFetchDisabled =
+    !formikProps.values.api_base || !formikProps.values.api_key;
+
+  const handleFetchModels = async () => {
+    const { models: fetched, error } = await fetchEdenAiModels({
+      api_base: formikProps.values.api_base,
+      api_key: formikProps.values.api_key,
+      provider_id: existingLlmProvider?.id ?? undefined,
+    });
+    if (error) {
+      throw new Error(error);
+    }
+    formikProps.setFieldValue(
+      "model_configurations",
+      mergeFetchedModelConfigurations(
+        fetched,
+        formikProps.values.model_configurations
+      )
+    );
+  };
+
+  return (
+    <>
+      <APIBaseField
+        subDescription="Paste your Eden AI-compatible endpoint URL or use Eden AI API directly."
+        placeholder="Your Eden AI base URL"
+      />
+
+      <APIKeyField providerName="Eden AI" />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <DisplayNameField />
+        </>
+      )}
+
+      <InputDivider />
+      <ModelSelectionField
+        shouldShowAutoUpdateToggle={true}
+        onRefetch={isFetchDisabled ? undefined : handleFetchModels}
+      />
+
+      {!isOnboarding && (
+        <>
+          <InputDivider />
+          <ModelAccessField />
+        </>
+      )}
+    </>
+  );
+}
+
+export default function EdenAiModal({
+  variant = "llm-configuration",
+  existingLlmProvider,
+  shouldMarkAsDefault,
+  onOpenChange,
+  onSuccess,
+  analyticsSource,
+}: LLMProviderFormProps) {
+  const isOnboarding = variant === "onboarding";
+  const { mutate } = useSWRConfig();
+
+  const onClose = () => onOpenChange?.(false);
+
+  const initialValues: EdenAiModalValues = {
+    ...useInitialValues(
+      isOnboarding,
+      LLMProviderName.EDENAI,
+      existingLlmProvider
+    ),
+    api_base: existingLlmProvider?.api_base ?? DEFAULT_API_BASE,
+  } as EdenAiModalValues;
+
+  const validationSchema = buildValidationSchema(isOnboarding, {
+    apiKey: true,
+    apiBase: true,
+  });
+
+  return (
+    <ModalWrapper
+      providerName={LLMProviderName.EDENAI}
+      llmProvider={existingLlmProvider}
+      onClose={onClose}
+      initialValues={initialValues}
+      validationSchema={validationSchema}
+      onSubmit={async (values, { setSubmitting, setStatus }) => {
+        await submitProvider({
+          analyticsSource:
+            analyticsSource ??
+            (isOnboarding
+              ? LLMProviderConfiguredSource.CHAT_ONBOARDING
+              : LLMProviderConfiguredSource.ADMIN_PAGE),
+          providerName: LLMProviderName.EDENAI,
+          values,
+          initialValues,
+          existingLlmProvider,
+          shouldMarkAsDefault,
+          setStatus,
+          setSubmitting,
+          onClose,
+          onSuccess: async () => {
+            if (onSuccess) {
+              await onSuccess();
+            } else {
+              await refreshLlmProviderCaches(mutate);
+              toast.success(
+                existingLlmProvider
+                  ? "Provider updated successfully!"
+                  : "Provider enabled successfully!"
+              );
+            }
+          },
+        });
+      }}
+    >
+      <EdenAiModalInternals
+        existingLlmProvider={existingLlmProvider}
+        isOnboarding={isOnboarding}
+      />
+    </ModalWrapper>
+  );
+}

--- a/web/src/views/admin/LanguageModelsPage.tsx
+++ b/web/src/views/admin/LanguageModelsPage.tsx
@@ -72,6 +72,7 @@ const PROVIDER_GROUPS: ProviderGroup[] = [
     title: "Gateways & Routers",
     providerNames: [
       LLMProviderName.OPENROUTER,
+      LLMProviderName.EDENAI,
       LLMProviderName.LITELLM_PROXY,
       LLMProviderName.NEBIUS_TOKENFACTORY,
       LLMProviderName.BIFROST,


### PR DESCRIPTION
Hi team, thanks for building Onyx.

This adds Eden AI as a first-class LLM provider, wired the same way as OpenRouter.

Related issue: #13128

Eden AI is an EU-based, OpenAI-compatible gateway. One API key gives access to models from many providers (OpenAI, Anthropic, Google, Mistral, Cohere and more), with EU data residency options.

What this does:
- Adds "edenai" as a named provider (enum, registries, display name, prompt caching).
- Routes calls through LiteLLM's openai-compatible path with a fixed base URL (https://api.edenai.run/v3). Two small but important details: we do not append /v1 because the base already ends in /v3, and we send the model as "openai/vendor/model" so LiteLLM keeps the full id after it strips one segment.
- Adds a /edenai/available-models endpoint so admins can fetch the live model list, plus a small curated default list.
- Adds the provider to the admin UI (picker, modal, logo) under Gateways and Routers.

How it was tested:
- Live calls against the real Eden AI API through the exact routing Onyx uses, on three vendors (openai/gpt-4o-mini, mistral/mistral-small-latest, anthropic/claude-sonnet-4-5). All returned the expected content.
- The /v3/models parser was checked against the real catalog.
- Added a unit test that locks the routing, a case in the is_true_openai test, and an edenai branch in the nightly provider chat test.

Notes:
- The provider logo is a simple placeholder for now, happy to swap it for the official SVG.
- A docs page will follow in a PR to the documentation repo.
- We are on the Eden AI team and will keep this provider maintained.

Happy to adjust anything you would like before merge. Thanks for taking a look.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Eden AI as a first-class LLM provider with Admin configuration, live model sync, and OpenAI-compatible routing via `LiteLLM` to Eden’s `/v3` base. Also forwards `tool_choice`, preserves `vendor/model` ids with an `openai/` prefix, and uses the shared models-fetch helper for clearer errors.

- **New Features**
  - Adds `edenai` provider (enums, registries, dynamic sets, display name, vendor extraction).
  - Routes via `LiteLLM`’s OpenAI path with base https://api.edenai.run/v3 (do not append `/v1`); prefixes models with `openai/` to keep `vendor/model`; forwards `tool_choice`.
  - Adds `POST /api/admin/llm/edenai/available-models` to fetch/sync `/v3/models` (text-output only; captures context length and image input support) using the shared OpenAI-compatible fetch helper.
  - Admin UI: Eden AI card, modal, and logo; “Fetch models” with auto-update; prompt cache support; curated recommended models.
  - Tests: routing regression (base and model prefix), non-OpenAI checks, and nightly provider workflow.

- **Migration**
  - In Admin → Language Models, add Eden AI with base `https://api.edenai.run/v3`.
  - Add your Eden API key, click “Fetch models,” choose defaults, and save. Optional: set Eden AI as default.

<sup>Written for commit 7aab6bb6a1c917608233dbc6fbb04f39ca571f23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

