### PR TITLE
fix(confluence): retry transient connection errors instead of failing the index attempt

### DIFF
--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -569,7 +569,7 @@ class OnyxConfluence:
                     # connection mid-response on long crawls. Transient, so retry
                     # instead of failing the whole index attempt.
                     if attempt == MAX_RETRIES - 1:
-                        raise e
+                        raise
 
                     delay = min(5 * 2**attempt, 60)
                     # log the exception type only: the message can embed the
@@ -581,11 +581,11 @@ class OnyxConfluence:
                         type(e).__name__,
                     )
                     time.sleep(delay)
-                except AttributeError as e:
+                except AttributeError:
                     # Some error within the Confluence library, unclear why it fails.
                     # Users reported it to be intermittent, so just retry
                     if attempt == MAX_RETRIES - 1:
-                        raise e
+                        raise
 
                     logger.exception(
                         "Confluence Client raised an AttributeError. Retrying..."

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -571,7 +571,11 @@ class OnyxConfluence:
                     if attempt == MAX_RETRIES - 1:
                         raise
 
-                    delay = min(5 * 2**attempt, 60)
+                    # cap to the remaining call budget so the deadline check
+                    # at the top of the loop can fire on time
+                    delay = min(
+                        5 * 2**attempt, 60, max(0.0, timeout_at - time.monotonic())
+                    )
                     # log the exception type only: the message can embed the
                     # request URL, which may carry auth material
                     logger.warning(

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -572,11 +572,13 @@ class OnyxConfluence:
                         raise e
 
                     delay = min(5 * 2**attempt, 60)
+                    # log the exception type only: the message can embed the
+                    # request URL, which may carry auth material
                     logger.warning(
                         "Transient network error in confluence call. "
                         "Retrying in %s seconds... (%s)",
                         delay,
-                        e,
+                        type(e).__name__,
                     )
                     time.sleep(delay)
                 except AttributeError as e:

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -561,6 +561,24 @@ class OnyxConfluence:
                     while time.monotonic() < delay_until:
                         # in the future, check a signal here to exit
                         time.sleep(1)
+                except (
+                    requests.exceptions.ConnectionError,
+                    requests.exceptions.ChunkedEncodingError,
+                ) as e:
+                    # Confluence (Cloud especially) occasionally resets the TCP
+                    # connection mid-response on long crawls. Transient, so retry
+                    # instead of failing the whole index attempt.
+                    if attempt == MAX_RETRIES - 1:
+                        raise e
+
+                    delay = min(5 * 2**attempt, 60)
+                    logger.warning(
+                        "Transient network error in confluence call. "
+                        "Retrying in %s seconds... (%s)",
+                        delay,
+                        e,
+                    )
+                    time.sleep(delay)
                 except AttributeError as e:
                     # Some error within the Confluence library, unclear why it fails.
                     # Users reported it to be intermittent, so just retry

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -1334,10 +1334,12 @@ def test_supports_rest_space_permissions_false_when_probe_fails(
         server_info_mock
     )
 
-    assert confluence_server_client.supports_rest_space_permissions() is False
+    with mock.patch("time.sleep"):
+        assert confluence_server_client.supports_rest_space_permissions() is False
     assert confluence_server_client.get_server_version() is None
+    calls_after_first_probe = server_info_mock.call_count
     confluence_server_client.supports_rest_space_permissions()
-    assert server_info_mock.call_count == 1
+    assert server_info_mock.call_count == calls_after_first_probe
 
 
 def test_get_all_space_permissions_server_rest_404_raises_unavailable(
@@ -1493,3 +1495,57 @@ def test_get_user_email_from_userkey_caches_negative_result(
     assert first is None
     assert second is None
     assert user_details_mock.call_count == 1
+
+
+def test_wrapped_call_retries_transient_network_errors(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """Mid-crawl TCP resets surface as ChunkedEncodingError (reset while
+    reading the body) or ConnectionError (reset on send). Both are
+    transient and must be retried rather than failing the whole crawl.
+    """
+    success_response = _create_mock_response(
+        200, {"results": []}, url="rest/api/content/search"
+    )
+    confluence_server_client._confluence.get.side_effect = [  # ty: ignore[unresolved-attribute]
+        requests.exceptions.ChunkedEncodingError(
+            "Connection broken: ConnectionResetError(104, 'Connection reset by peer')"
+        ),
+        requests.exceptions.ConnectionError(
+            "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
+        ),
+        success_response,
+    ]
+
+    with mock.patch("time.sleep"):
+        result = confluence_server_client.get(
+            "rest/api/content/search", advanced_mode=True
+        )
+
+    assert result is success_response
+    assert (
+        confluence_server_client._confluence.get.call_count  # ty: ignore[unresolved-attribute]
+        == 3
+    )
+
+
+def test_wrapped_call_raises_after_persistent_network_errors(
+    confluence_server_client: OnyxConfluence,
+) -> None:
+    """A permanently unreachable Confluence should still fail after the
+    retry budget (5 attempts) is exhausted, not loop forever.
+    """
+    confluence_server_client._confluence.get.side_effect = (  # ty: ignore[unresolved-attribute]
+        requests.exceptions.ChunkedEncodingError(
+            "Connection broken: ConnectionResetError(104, 'Connection reset by peer')"
+        )
+    )
+
+    with mock.patch("time.sleep"):
+        with pytest.raises(requests.exceptions.ChunkedEncodingError):
+            confluence_server_client.get("rest/api/content/search", advanced_mode=True)
+
+    assert (
+        confluence_server_client._confluence.get.call_count  # ty: ignore[unresolved-attribute]
+        == 5
+    )


### PR DESCRIPTION
## Description

Long Confluence crawls (Cloud especially) occasionally hit a TCP connection reset, which `requests` surfaces as `ChunkedEncodingError` (`Connection broken: ConnectionResetError(104, 'Connection reset by peer')` while reading the response body) or `ConnectionError` (`Connection aborted.`). The retry wrapper in `OnyxConfluence` (`_make_rate_limited_confluence_method`) only retries `HTTPError` and `AttributeError`, so a single reset propagates up through `_paginate_url` and fails the entire index attempt.

On large instances where a full crawl runs for hours, the probability of at least one reset per attempt approaches 1 — the connector ends up in a repeated-error loop where every attempt re-crawls for hours and then dies on one transient reset, and no new documents get indexed.

This adds the two connection-level exception types to the retry loop with capped exponential backoff (5s doubling to a 60s cap), under the same 5-attempt / 600s budget as the existing handlers.

## How Has This Been Tested?

- New unit tests at the `wrapped_call` layer (`backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py`): one transient error of each type is retried and the call succeeds; a persistent error still raises after the 5-attempt budget.
- Updated `test_supports_rest_space_permissions_false_when_probe_fails` to keep asserting the negative-probe cache contract without pinning the pre-retry call count (and patched `time.sleep` there).
- Socket-level check: pointed the real `atlassian` client through `OnyxConfluence` at a local TCP server that hard-RSTs (`SO_LINGER=0`) the first two connections and then serves a 200 — both resets were retried and the third attempt succeeded.
- `pytest backend/tests/unit/onyx/connectors/confluence/` — 61 passed; `ruff check`, `ruff format --check`, and `ty check` clean on the touched files.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient Confluence TCP resets during long crawls instead of failing the index. Also caps retry sleep to the remaining budget, sanitizes logs, and preserves original tracebacks.

- **Bug Fixes**
  - Handle `requests.exceptions.ConnectionError` and `requests.exceptions.ChunkedEncodingError` in the `OnyxConfluence` retry wrapper with exponential backoff (5s doubling to 60s) and cap each sleep to the remaining 600s budget; bare re-raise after 5 attempts.
  - Log only the exception type in retry warnings to avoid leaking URLs or auth data.
  - Tests cover transient success and persistent failure; patched `time.sleep` and stabilized the REST-permissions probe test.

<sup>Written for commit d375bf94a69ed2b316d47a0f0e454e22ac2b6020. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

