### PR TITLE
feat(opal): add TextButton component

### DIFF
--- a/web/lib/opal/src/components/buttons/text-button/README.md
+++ b/web/lib/opal/src/components/buttons/text-button/README.md
@@ -1,0 +1,85 @@
+# TextButton
+
+**Import:** `import { TextButton, type TextButtonProps } from "@opal/components";`
+
+A clickable [`Text`](../../text/README.md): the same variant/prominence hover-and-active
+color animation as [`Button`](../button/README.md), but with **no background, border,
+padding, or rounding**. Use it wherever a `Button` would be too heavy visually — inline
+text actions, quiet toolbar actions, footer links styled as actions — and
+[`LinkButton`](../link-button/README.md) is too narrow (no variant/prominence matrix, no
+icon support, always underlined).
+
+## Architecture
+
+```
+Interactive.Stateless              <- variant, prominence, interaction, disabled, href, onClick
+  └─ TextButtonSurface             <- <Link> / <button> / <span>, no height/rounding/padding/border
+       └─ .opal-text-button.interactive-foreground
+            ├─ Icon?                 (interactive-foreground-icon)
+            ├─ <Text color="inherit">?
+            └─ RightIcon?            (interactive-foreground-icon)
+```
+
+- **Colors are not in `TextButton`.** Same as `Button`: `Interactive.Stateless` sets
+  `--interactive-foreground` and `--interactive-foreground-icon` per variant/prominence/state.
+  `TextButton` opts into text color via `.interactive-foreground`; icons opt in via
+  `iconWrapper`'s `.interactive-foreground-icon`.
+- **`Interactive.Stateless` also sets a `background-color`** per variant/prominence (that's
+  what `Interactive.Container` normally displays). `TextButton` force-clears it
+  (`background-color: transparent !important` in `styles.css`) since it never renders a
+  `Container` — only the foreground color transition survives.
+- **`TextButtonSurface`** is a trimmed-down copy of `Interactive.Container`'s `<Link>` /
+  `<button>` / `<span>` element selection, without the height/rounding/padding/border logic
+  that `Container` adds for traditional buttons.
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `variant` | `"default" \| "action" \| "danger" \| "none"` | `"default"` | Color variant |
+| `prominence` | `"primary" \| "secondary" \| "tertiary" \| "internal"` | `"tertiary"` | Color prominence. Defaults to `"tertiary"` (unlike `Button`'s `"primary"`) — `"primary"`'s white-on-color foreground assumes a colored surface `TextButton` doesn't provide. |
+| `interaction` | `"rest" \| "hover" \| "active"` | `"rest"` | JS-controlled interaction override |
+| `icon` | `IconFunctionComponent` | — | Left icon |
+| `children` | `string \| RichStr` | — | Label text. Omit for icon-only |
+| `rightIcon` | `IconFunctionComponent` | — | Right icon |
+| `size` | `"lg" \| "md" \| "sm" \| "xs" \| "2xs" \| "fit"` | `"lg"` | Controls label/icon size (`"lg"` uses `main-ui-body`, everything else `secondary-body`) |
+| `type` | `"submit" \| "button" \| "reset"` | `"button"` | HTML button type |
+| `tooltip` | `string` | — | Tooltip text |
+| `tooltipSide` | `TooltipSide` | `"top"` | Tooltip placement |
+| `disabled` | `boolean` | `false` | Disables the button |
+| `href` | `string` | — | URL; renders as a link |
+
+## Usage
+
+```tsx
+import { TextButton } from "@opal/components";
+import { SvgPlus, SvgArrowRight } from "@opal/icons";
+
+// Bare text action — no background, just a color shift on hover
+<TextButton onClick={handleClick}>Dismiss</TextButton>
+
+// With an icon
+<TextButton icon={SvgPlus} onClick={handleAdd}>Add item</TextButton>
+
+// As a link
+<TextButton href="/admin/settings" rightIcon={SvgArrowRight}>
+  Go to settings
+</TextButton>
+
+// Danger variant, disabled
+<TextButton variant="danger" disabled onClick={handleDelete}>
+  Delete account
+</TextButton>
+```
+
+## When to use `Text`, `LinkButton`, `TextButton`, or `Button`
+
+- **`Text`** — not interactive at all; plain styled text.
+- **`LinkButton`** — inline references inside prose ("Learn more", "Docs"). Always
+  underlined, no variant/prominence matrix, no icon support beyond a fixed trailing
+  external-link glyph.
+- **`TextButton`** — a real action (click handler or navigation) that should read as
+  text, not a button — full variant/prominence color matrix and icon slots, no
+  underline, no background.
+- **`Button`** — a traditional button surface with background, border, padding, and
+  rounding.

--- a/web/lib/opal/src/components/buttons/text-button/README.md
+++ b/web/lib/opal/src/components/buttons/text-button/README.md
@@ -15,11 +15,17 @@ slots).
 
 ```
 Interactive.Stateless              <- always variant="default" / prominence="tertiary"; disabled, href, onClick
-  └─ TextButtonSurface             <- <Link> / <button>, no height/rounding/padding/border
-       └─ .opal-text-button.interactive-foreground
-            └─ <Text font={font} color="inherit">
+  └─ <Link> / <button>             <- .opal-text-button.interactive-foreground, no height/rounding/padding/border
+       └─ <Text font={font} color="inherit">
 ```
 
+- **No separate surface component.** `Button` needs `Interactive.Container` because it
+  has to *discover* `href`/`disabled`/etc. from Radix `Slot`-injected props (it's a
+  generic primitive reused by many callers). `TextButton` already has `href`/`target`/
+  `disabled` in scope as its own props, so it renders `<Link>`/`<button>` directly as
+  `Interactive.Stateless`'s single child. Radix `Slot` auto-merges `className` (joins
+  both), `style` (merges objects), and event handlers (chains them) onto that element —
+  everything else falls through untouched — so no manual prop-merging is needed.
 - **Colors are not in `TextButton`.** Same as `Button`: `Interactive.Stateless` sets
   `--interactive-foreground` per state. `TextButton` opts into it via
   `.interactive-foreground`, and the label reads it via `Text`'s `color="inherit"`.
@@ -32,9 +38,6 @@ Interactive.Stateless              <- always variant="default" / prominence="ter
   on hover/active (that's normally shown by `Interactive.Container`). `TextButton`
   force-clears it in `styles.css` (`background-color: transparent !important`) since it
   never renders a `Container` — only the foreground color transition survives.
-- **`TextButtonSurface`** is a trimmed-down copy of `Interactive.Container`'s `<Link>` /
-  `<button>` element selection, without the height/rounding/padding/border logic that
-  `Container` adds for traditional buttons.
 
 ## Props
 

--- a/web/lib/opal/src/components/buttons/text-button/README.md
+++ b/web/lib/opal/src/components/buttons/text-button/README.md
@@ -2,73 +2,70 @@
 
 **Import:** `import { TextButton, type TextButtonProps } from "@opal/components";`
 
-A clickable [`Text`](../../text/README.md): the same variant/prominence hover-and-active
-color animation as [`Button`](../button/README.md), but with **no background, border,
-padding, or rounding**. Use it wherever a `Button` would be too heavy visually — inline
-text actions, quiet toolbar actions, footer links styled as actions — and
-[`LinkButton`](../link-button/README.md) is too narrow (no variant/prominence matrix, no
-icon support, always underlined).
+A clickable [`Text`](../../text/README.md): the same hover/active color animation as
+[`Button`](../button/README.md), driven by `Interactive.Stateless`, but with **no
+background, border, padding, or rounding**. Props are shaped like `Text` (`font`,
+`nowrap`, required `children`), not `Button` — there's no `icon`/`rightIcon`,
+`variant`, `prominence`, `tooltip`, or `size`. Use it wherever a `Button` would be too
+heavy visually — inline text actions, quiet toolbar actions — and
+[`LinkButton`](../link-button/README.md) is too narrow (always underlined, no icon
+slots).
 
 ## Architecture
 
 ```
-Interactive.Stateless              <- variant, prominence, interaction, disabled, href, onClick
-  └─ TextButtonSurface             <- <Link> / <button> / <span>, no height/rounding/padding/border
+Interactive.Stateless              <- always variant="default" / prominence="tertiary"; disabled, href, onClick
+  └─ TextButtonSurface             <- <Link> / <button>, no height/rounding/padding/border
        └─ .opal-text-button.interactive-foreground
-            ├─ Icon?                 (interactive-foreground-icon)
-            ├─ <Text color="inherit">?
-            └─ RightIcon?            (interactive-foreground-icon)
+            └─ <Text font={font} color="inherit">
 ```
 
 - **Colors are not in `TextButton`.** Same as `Button`: `Interactive.Stateless` sets
-  `--interactive-foreground` and `--interactive-foreground-icon` per variant/prominence/state.
-  `TextButton` opts into text color via `.interactive-foreground`; icons opt in via
-  `iconWrapper`'s `.interactive-foreground-icon`.
-- **`Interactive.Stateless` also sets a `background-color`** per variant/prominence (that's
-  what `Interactive.Container` normally displays). `TextButton` force-clears it
-  (`background-color: transparent !important` in `styles.css`) since it never renders a
-  `Container` — only the foreground color transition survives.
+  `--interactive-foreground` per state. `TextButton` opts into it via
+  `.interactive-foreground`, and the label reads it via `Text`'s `color="inherit"`.
+- **`variant`/`prominence` are always `"default"`/`"tertiary"`** internally and aren't
+  exposed — `TextButton` never has a `Container` to paint a background onto, so the
+  color-family and prominence tiers `Button` offers don't apply. `TextButton` is a
+  single, fixed subtle color animation (`text-03` → `text-04` on hover → `text-05` on
+  active), same as `Button`'s default+tertiary combination.
+- **`Interactive.Stateless` still paints a background-color** for `prominence="tertiary"`
+  on hover/active (that's normally shown by `Interactive.Container`). `TextButton`
+  force-clears it in `styles.css` (`background-color: transparent !important`) since it
+  never renders a `Container` — only the foreground color transition survives.
 - **`TextButtonSurface`** is a trimmed-down copy of `Interactive.Container`'s `<Link>` /
-  `<button>` / `<span>` element selection, without the height/rounding/padding/border logic
-  that `Container` adds for traditional buttons.
+  `<button>` element selection, without the height/rounding/padding/border logic that
+  `Container` adds for traditional buttons.
 
 ## Props
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `variant` | `"default" \| "action" \| "danger" \| "none"` | `"default"` | Color variant |
-| `prominence` | `"primary" \| "secondary" \| "tertiary" \| "internal"` | `"tertiary"` | Color prominence. Defaults to `"tertiary"` (unlike `Button`'s `"primary"`) — `"primary"`'s white-on-color foreground assumes a colored surface `TextButton` doesn't provide. |
-| `interaction` | `"rest" \| "hover" \| "active"` | `"rest"` | JS-controlled interaction override |
-| `icon` | `IconFunctionComponent` | — | Left icon |
-| `children` | `string \| RichStr` | — | Label text. Omit for icon-only |
-| `rightIcon` | `IconFunctionComponent` | — | Right icon |
-| `size` | `"lg" \| "md" \| "sm" \| "xs" \| "2xs" \| "fit"` | `"lg"` | Controls label/icon size (`"lg"` uses `main-ui-body`, everything else `secondary-body`) |
-| `type` | `"submit" \| "button" \| "reset"` | `"button"` | HTML button type |
-| `tooltip` | `string` | — | Tooltip text |
-| `tooltipSide` | `TooltipSide` | `"top"` | Tooltip placement |
-| `disabled` | `boolean` | `false` | Disables the button |
+| `font` | `TextFont` | `"main-ui-body"` | Font preset, same as `Text`'s `font` prop |
+| `nowrap` | `boolean` | `true` | Prevent text wrapping (defaults `true`, unlike `Text`, since buttons don't usually wrap) |
+| `children` | `string \| RichStr` | — | Label text (required) |
 | `href` | `string` | — | URL; renders as a link |
+| `target` | `string` | — | Anchor target (e.g. `"_blank"`). Only meaningful with `href` |
+| `disabled` | `boolean` | `false` | Applies disabled styling + suppresses clicks/navigation |
 
 ## Usage
 
 ```tsx
 import { TextButton } from "@opal/components";
-import { SvgPlus, SvgArrowRight } from "@opal/icons";
 
 // Bare text action — no background, just a color shift on hover
 <TextButton onClick={handleClick}>Dismiss</TextButton>
 
-// With an icon
-<TextButton icon={SvgPlus} onClick={handleAdd}>Add item</TextButton>
-
 // As a link
-<TextButton href="/admin/settings" rightIcon={SvgArrowRight}>
-  Go to settings
+<TextButton href="/admin/settings">Go to settings</TextButton>
+
+// Disabled
+<TextButton disabled onClick={handleDelete}>
+  Delete account
 </TextButton>
 
-// Danger variant, disabled
-<TextButton variant="danger" disabled onClick={handleDelete}>
-  Delete account
+// Custom font preset
+<TextButton font="secondary-action" onClick={handleClick}>
+  Undo
 </TextButton>
 ```
 
@@ -76,10 +73,8 @@ import { SvgPlus, SvgArrowRight } from "@opal/icons";
 
 - **`Text`** — not interactive at all; plain styled text.
 - **`LinkButton`** — inline references inside prose ("Learn more", "Docs"). Always
-  underlined, no variant/prominence matrix, no icon support beyond a fixed trailing
-  external-link glyph.
+  underlined.
 - **`TextButton`** — a real action (click handler or navigation) that should read as
-  text, not a button — full variant/prominence color matrix and icon slots, no
-  underline, no background.
-- **`Button`** — a traditional button surface with background, border, padding, and
-  rounding.
+  text, not a button — no underline, no background.
+- **`Button`** — a traditional button surface with background, border, padding,
+  rounding, icon slots, and a variant/prominence color matrix.

--- a/web/lib/opal/src/components/buttons/text-button/TextButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/text-button/TextButton.stories.tsx
@@ -1,7 +1,5 @@
-import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { TextButton } from "@opal/components";
-import { SvgPlus, SvgArrowRight, SvgSettings } from "@opal/icons";
 
 const meta: Meta<typeof TextButton> = {
   title: "opal/components/TextButton",
@@ -18,83 +16,13 @@ export const Default: Story = {
   },
 };
 
-const VARIANTS = ["default", "action", "danger"] as const;
-const PROMINENCES = ["primary", "secondary", "tertiary", "internal"] as const;
-
-export const VariantProminenceGrid: Story = {
+export const Fonts: Story = {
   render: () => (
-    <div
-      style={{
-        display: "grid",
-        gridTemplateColumns: "auto repeat(4, 1fr)",
-        gap: 12,
-        alignItems: "center",
-      }}
-    >
-      {/* Header row */}
-      <div />
-      {PROMINENCES.map((p) => (
-        <div
-          key={p}
-          style={{
-            fontWeight: 600,
-            textAlign: "center",
-            textTransform: "capitalize",
-          }}
-        >
-          {p}
-        </div>
-      ))}
-
-      {/* Variant rows */}
-      {VARIANTS.map((variant) => (
-        <React.Fragment key={variant}>
-          <div style={{ fontWeight: 600, textTransform: "capitalize" }}>
-            {variant}
-          </div>
-          {PROMINENCES.map((prominence) => (
-            <TextButton
-              key={`${variant}-${prominence}`}
-              variant={variant}
-              prominence={prominence}
-            >
-              {`${variant} ${prominence}`}
-            </TextButton>
-          ))}
-        </React.Fragment>
-      ))}
-    </div>
-  ),
-};
-
-export const WithLeftIcon: Story = {
-  args: {
-    icon: SvgPlus,
-    children: "Add item",
-  },
-};
-
-export const WithRightIcon: Story = {
-  args: {
-    rightIcon: SvgArrowRight,
-    children: "Continue",
-  },
-};
-
-export const IconOnly: Story = {
-  args: {
-    icon: SvgSettings,
-  },
-};
-
-export const Sizes: Story = {
-  render: () => (
-    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
-      {(["lg", "md", "sm", "xs", "2xs", "fit"] as const).map((size) => (
-        <TextButton key={size} size={size} icon={SvgPlus}>
-          {size}
-        </TextButton>
-      ))}
+    <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+      <TextButton font="main-ui-body">main-ui-body (default)</TextButton>
+      <TextButton font="main-ui-action">main-ui-action</TextButton>
+      <TextButton font="secondary-action">secondary-action</TextButton>
+      <TextButton font="heading-h3">heading-h3</TextButton>
     </div>
   ),
 };
@@ -110,32 +38,7 @@ export const AsLink: Story = {
   args: {
     href: "https://example.com",
     children: "Visit site",
-    rightIcon: SvgArrowRight,
   },
-};
-
-export const WithTooltip: Story = {
-  args: {
-    icon: SvgSettings,
-    tooltip: "Open settings",
-    tooltipSide: "bottom",
-  },
-};
-
-export const NoBackgroundEvenOnPrimary: Story = {
-  render: () => (
-    <div style={{ display: "flex", gap: 12 }}>
-      <TextButton variant="default" prominence="primary">
-        Primary
-      </TextButton>
-      <TextButton variant="action" prominence="primary">
-        Action primary
-      </TextButton>
-      <TextButton variant="danger" prominence="primary">
-        Danger primary
-      </TextButton>
-    </div>
-  ),
 };
 
 export const InlineInProse: Story = {

--- a/web/lib/opal/src/components/buttons/text-button/TextButton.stories.tsx
+++ b/web/lib/opal/src/components/buttons/text-button/TextButton.stories.tsx
@@ -1,0 +1,148 @@
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { TextButton } from "@opal/components";
+import { SvgPlus, SvgArrowRight, SvgSettings } from "@opal/icons";
+
+const meta: Meta<typeof TextButton> = {
+  title: "opal/components/TextButton",
+  component: TextButton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof TextButton>;
+
+export const Default: Story = {
+  args: {
+    children: "Text button",
+  },
+};
+
+const VARIANTS = ["default", "action", "danger"] as const;
+const PROMINENCES = ["primary", "secondary", "tertiary", "internal"] as const;
+
+export const VariantProminenceGrid: Story = {
+  render: () => (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: "auto repeat(4, 1fr)",
+        gap: 12,
+        alignItems: "center",
+      }}
+    >
+      {/* Header row */}
+      <div />
+      {PROMINENCES.map((p) => (
+        <div
+          key={p}
+          style={{
+            fontWeight: 600,
+            textAlign: "center",
+            textTransform: "capitalize",
+          }}
+        >
+          {p}
+        </div>
+      ))}
+
+      {/* Variant rows */}
+      {VARIANTS.map((variant) => (
+        <React.Fragment key={variant}>
+          <div style={{ fontWeight: 600, textTransform: "capitalize" }}>
+            {variant}
+          </div>
+          {PROMINENCES.map((prominence) => (
+            <TextButton
+              key={`${variant}-${prominence}`}
+              variant={variant}
+              prominence={prominence}
+            >
+              {`${variant} ${prominence}`}
+            </TextButton>
+          ))}
+        </React.Fragment>
+      ))}
+    </div>
+  ),
+};
+
+export const WithLeftIcon: Story = {
+  args: {
+    icon: SvgPlus,
+    children: "Add item",
+  },
+};
+
+export const WithRightIcon: Story = {
+  args: {
+    rightIcon: SvgArrowRight,
+    children: "Continue",
+  },
+};
+
+export const IconOnly: Story = {
+  args: {
+    icon: SvgSettings,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      {(["lg", "md", "sm", "xs", "2xs", "fit"] as const).map((size) => (
+        <TextButton key={size} size={size} icon={SvgPlus}>
+          {size}
+        </TextButton>
+      ))}
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    children: "Disabled",
+  },
+};
+
+export const AsLink: Story = {
+  args: {
+    href: "https://example.com",
+    children: "Visit site",
+    rightIcon: SvgArrowRight,
+  },
+};
+
+export const WithTooltip: Story = {
+  args: {
+    icon: SvgSettings,
+    tooltip: "Open settings",
+    tooltipSide: "bottom",
+  },
+};
+
+export const NoBackgroundEvenOnPrimary: Story = {
+  render: () => (
+    <div style={{ display: "flex", gap: 12 }}>
+      <TextButton variant="default" prominence="primary">
+        Primary
+      </TextButton>
+      <TextButton variant="action" prominence="primary">
+        Action primary
+      </TextButton>
+      <TextButton variant="danger" prominence="primary">
+        Danger primary
+      </TextButton>
+    </div>
+  ),
+};
+
+export const InlineInProse: Story = {
+  render: () => (
+    <p style={{ maxWidth: "36rem", lineHeight: 1.7 }}>
+      You can undo this action within the next 30 seconds.{" "}
+      <TextButton onClick={() => alert("undone")}>Undo</TextButton>.
+    </p>
+  ),
+};

--- a/web/lib/opal/src/components/buttons/text-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/text-button/components.tsx
@@ -1,0 +1,175 @@
+import "@opal/components/buttons/text-button/styles.css";
+import type { Route } from "next";
+import Link from "next/link";
+import { Interactive, type InteractiveStatelessProps } from "@opal/core";
+import type {
+  ButtonType,
+  ContainerSizeVariants,
+  IconFunctionComponent,
+  RichStr,
+  WithoutStyles,
+} from "@opal/types";
+import { Text, Tooltip, type TooltipSide } from "@opal/components";
+import { iconWrapper } from "@opal/components/buttons/icon-wrapper";
+import { cn } from "@opal/utils";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type TextButtonContentProps =
+  | {
+      icon?: IconFunctionComponent;
+      children: string | RichStr;
+      rightIcon?: IconFunctionComponent;
+    }
+  | {
+      icon: IconFunctionComponent;
+      children?: string | RichStr;
+      rightIcon?: IconFunctionComponent;
+    };
+
+type TextButtonProps = Omit<InteractiveStatelessProps, "prominence"> & {
+  /**
+   * Color prominence within the variant.
+   * @default "tertiary"
+   *
+   * Defaults to `"tertiary"` (not `"primary"`, unlike `Button`) because
+   * `TextButton` never paints a background — `"primary"`'s white-on-color
+   * foreground assumes a colored surface that `TextButton` doesn't provide.
+   */
+  prominence?: InteractiveStatelessProps["prominence"];
+} & TextButtonContentProps & {
+    /** Size preset — controls label text size and icon size. */
+    size?: ContainerSizeVariants;
+
+    /** Tooltip text shown on hover. */
+    tooltip?: string;
+
+    /** Which side the tooltip appears on. */
+    tooltipSide?: TooltipSide;
+
+    /** Applies disabled styling and suppresses clicks. */
+    disabled?: boolean;
+  };
+
+interface TextButtonSurfaceProps extends WithoutStyles<
+  React.HTMLAttributes<HTMLElement>
+> {
+  type?: ButtonType;
+  href?: string;
+  target?: string;
+  rel?: string;
+}
+
+// ---------------------------------------------------------------------------
+// TextButtonSurface
+// ---------------------------------------------------------------------------
+
+/**
+ * Element selection for `TextButton` — mirrors `Interactive.Container`'s
+ * `<Link> / <button> / <span>` branching, minus the height/rounding/padding/
+ * border/background that `Container` applies. `TextButton` is deliberately
+ * built without `Interactive.Container` so it never gets those "traditional
+ * button" surroundings.
+ */
+function TextButtonSurface(props: TextButtonSurfaceProps) {
+  const {
+    className: slotClassName,
+    href,
+    target,
+    rel,
+    type,
+    ...rest
+  } = props as TextButtonSurfaceProps & { className?: string };
+
+  const sharedProps = {
+    ...rest,
+    className: cn("opal-text-button interactive-foreground", slotClassName),
+  };
+
+  if (href) {
+    return (
+      <Link
+        href={href as Route}
+        target={target}
+        rel={rel}
+        {...(sharedProps as React.HTMLAttributes<HTMLAnchorElement>)}
+      />
+    );
+  }
+
+  if (type) {
+    const ariaDisabled = (rest as Record<string, unknown>)["aria-disabled"];
+    const nativeDisabled =
+      ariaDisabled === true || ariaDisabled === "true" || undefined;
+    return (
+      <button
+        type={type}
+        disabled={nativeDisabled}
+        {...(sharedProps as React.HTMLAttributes<HTMLButtonElement>)}
+      />
+    );
+  }
+
+  return <span {...sharedProps} />;
+}
+
+// ---------------------------------------------------------------------------
+// TextButton
+// ---------------------------------------------------------------------------
+
+/**
+ * A clickable `Text` — same variant/prominence hover-and-active color
+ * animation as `Button`, driven by `Interactive.Stateless`, but with no
+ * `Interactive.Container` underneath. That means no background, no border,
+ * no padding, no rounding: just the label (and optional icons) shifting
+ * color on hover/active, exactly like the rest of the Opal buttons.
+ */
+function TextButton({
+  icon: Icon,
+  children,
+  rightIcon: RightIcon,
+  size = "lg",
+  type = "button",
+  prominence = "tertiary",
+  tooltip,
+  tooltipSide = "top",
+  disabled,
+  ...interactiveProps
+}: TextButtonProps) {
+  const isLarge = size === "lg";
+
+  const labelEl = children ? (
+    <Text
+      font={isLarge ? "main-ui-body" : "secondary-body"}
+      color="inherit"
+      nowrap
+    >
+      {children}
+    </Text>
+  ) : null;
+
+  const button = (
+    <Interactive.Stateless
+      type={type}
+      prominence={prominence}
+      disabled={disabled}
+      {...interactiveProps}
+    >
+      <TextButtonSurface>
+        {iconWrapper(Icon, size, !!children)}
+        {labelEl}
+        {iconWrapper(RightIcon, size, !!children)}
+      </TextButtonSurface>
+    </Interactive.Stateless>
+  );
+
+  return (
+    <Tooltip tooltip={tooltip} side={tooltipSide}>
+      {button}
+    </Tooltip>
+  );
+}
+
+export { TextButton, type TextButtonProps };

--- a/web/lib/opal/src/components/buttons/text-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/text-button/components.tsx
@@ -5,7 +5,6 @@ import Link from "next/link";
 import { Interactive } from "@opal/core";
 import type { RichStr, WithoutStyles } from "@opal/types";
 import { Text, type TextFont } from "@opal/components";
-import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,63 +32,6 @@ interface TextButtonProps extends WithoutStyles<
   children: string | RichStr;
 }
 
-interface TextButtonSurfaceProps extends WithoutStyles<
-  HTMLAttributes<HTMLElement>
-> {
-  href?: string;
-  target?: string;
-  rel?: string;
-}
-
-// ---------------------------------------------------------------------------
-// TextButtonSurface
-// ---------------------------------------------------------------------------
-
-/**
- * Element selection for `TextButton` — a trimmed-down copy of
- * `Interactive.Container`'s `<Link> / <button>` branching, minus the
- * height/rounding/padding/border/background that `Container` applies.
- * `TextButton` is deliberately built without `Interactive.Container` so it
- * never gets those "traditional button" surroundings.
- */
-function TextButtonSurface(props: TextButtonSurfaceProps) {
-  const {
-    className: slotClassName,
-    href,
-    target,
-    rel,
-    ...rest
-  } = props as TextButtonSurfaceProps & { className?: string };
-
-  const sharedProps = {
-    ...rest,
-    className: cn("opal-text-button interactive-foreground", slotClassName),
-  };
-
-  if (href) {
-    return (
-      <Link
-        href={href as Route}
-        target={target}
-        rel={rel}
-        {...(sharedProps as HTMLAttributes<HTMLAnchorElement>)}
-      />
-    );
-  }
-
-  const ariaDisabled = (rest as Record<string, unknown>)["aria-disabled"];
-  const nativeDisabled =
-    ariaDisabled === true || ariaDisabled === "true" || undefined;
-
-  return (
-    <button
-      type="button"
-      disabled={nativeDisabled}
-      {...(sharedProps as HTMLAttributes<HTMLButtonElement>)}
-    />
-  );
-}
-
 // ---------------------------------------------------------------------------
 // TextButton
 // ---------------------------------------------------------------------------
@@ -102,27 +44,56 @@ function TextButtonSurface(props: TextButtonSurfaceProps) {
  * shaped like `Text` (`font`, `nowrap`, required `children`) rather than
  * `Button` (no `icon`/`rightIcon`, `variant`, `prominence`, `tooltip`, or
  * `size`).
+ *
+ * Renders its `<Link>`/`<button>` directly as `Interactive.Stateless`'s
+ * single child — Radix `Slot` auto-merges `className`, data-attributes, and
+ * `onClick` onto it (`className`/`style` are joined, handlers are chained,
+ * everything else falls through), so no separate surface component is
+ * needed the way `Button` needs `Interactive.Container`.
  */
 function TextButton({
   font = "main-ui-body",
   nowrap = true,
   disabled,
+  href,
+  target,
   children,
   ...rest
 }: TextButtonProps) {
+  const label = (
+    <Text font={font} color="inherit" nowrap={nowrap}>
+      {children}
+    </Text>
+  );
+
   return (
     <Interactive.Stateless
       type="button"
       variant="default"
       prominence="tertiary"
       disabled={disabled}
+      href={href}
+      target={target}
       {...rest}
     >
-      <TextButtonSurface>
-        <Text font={font} color="inherit" nowrap={nowrap}>
-          {children}
-        </Text>
-      </TextButtonSurface>
+      {href ? (
+        <Link
+          href={(disabled ? undefined : href) as Route}
+          target={target}
+          rel={target === "_blank" ? "noopener noreferrer" : undefined}
+          className="opal-text-button interactive-foreground"
+        >
+          {label}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          disabled={disabled}
+          className="opal-text-button interactive-foreground"
+        >
+          {label}
+        </button>
+      )}
     </Interactive.Stateless>
   );
 }

--- a/web/lib/opal/src/components/buttons/text-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/text-button/components.tsx
@@ -1,62 +1,41 @@
 import "@opal/components/buttons/text-button/styles.css";
+import type { HTMLAttributes } from "react";
 import type { Route } from "next";
 import Link from "next/link";
-import { Interactive, type InteractiveStatelessProps } from "@opal/core";
-import type {
-  ButtonType,
-  ContainerSizeVariants,
-  IconFunctionComponent,
-  RichStr,
-  WithoutStyles,
-} from "@opal/types";
-import { Text, Tooltip, type TooltipSide } from "@opal/components";
-import { iconWrapper } from "@opal/components/buttons/icon-wrapper";
+import { Interactive } from "@opal/core";
+import type { RichStr, WithoutStyles } from "@opal/types";
+import { Text, type TextFont } from "@opal/components";
 import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-type TextButtonContentProps =
-  | {
-      icon?: IconFunctionComponent;
-      children: string | RichStr;
-      rightIcon?: IconFunctionComponent;
-    }
-  | {
-      icon: IconFunctionComponent;
-      children?: string | RichStr;
-      rightIcon?: IconFunctionComponent;
-    };
+interface TextButtonProps extends WithoutStyles<
+  Omit<HTMLAttributes<HTMLElement>, "color" | "children">
+> {
+  /** Font preset. Default: `"main-ui-body"`. */
+  font?: TextFont;
 
-type TextButtonProps = Omit<InteractiveStatelessProps, "prominence"> & {
-  /**
-   * Color prominence within the variant.
-   * @default "tertiary"
-   *
-   * Defaults to `"tertiary"` (not `"primary"`, unlike `Button`) because
-   * `TextButton` never paints a background — `"primary"`'s white-on-color
-   * foreground assumes a colored surface that `TextButton` doesn't provide.
-   */
-  prominence?: InteractiveStatelessProps["prominence"];
-} & TextButtonContentProps & {
-    /** Size preset — controls label text size and icon size. */
-    size?: ContainerSizeVariants;
+  /** Prevent text wrapping. Default: `true` (unlike `Text`, which defaults to `false`). */
+  nowrap?: boolean;
 
-    /** Tooltip text shown on hover. */
-    tooltip?: string;
+  /** Destination URL. When provided, the component renders as a link. */
+  href?: string;
 
-    /** Which side the tooltip appears on. */
-    tooltipSide?: TooltipSide;
+  /** Anchor `target` attribute (e.g. `"_blank"`). Only meaningful with `href`. */
+  target?: string;
 
-    /** Applies disabled styling and suppresses clicks. */
-    disabled?: boolean;
-  };
+  /** Applies disabled styling and suppresses clicks/navigation. */
+  disabled?: boolean;
+
+  /** Plain string or `markdown()` for inline markdown. */
+  children: string | RichStr;
+}
 
 interface TextButtonSurfaceProps extends WithoutStyles<
-  React.HTMLAttributes<HTMLElement>
+  HTMLAttributes<HTMLElement>
 > {
-  type?: ButtonType;
   href?: string;
   target?: string;
   rel?: string;
@@ -67,11 +46,11 @@ interface TextButtonSurfaceProps extends WithoutStyles<
 // ---------------------------------------------------------------------------
 
 /**
- * Element selection for `TextButton` — mirrors `Interactive.Container`'s
- * `<Link> / <button> / <span>` branching, minus the height/rounding/padding/
- * border/background that `Container` applies. `TextButton` is deliberately
- * built without `Interactive.Container` so it never gets those "traditional
- * button" surroundings.
+ * Element selection for `TextButton` — a trimmed-down copy of
+ * `Interactive.Container`'s `<Link> / <button>` branching, minus the
+ * height/rounding/padding/border/background that `Container` applies.
+ * `TextButton` is deliberately built without `Interactive.Container` so it
+ * never gets those "traditional button" surroundings.
  */
 function TextButtonSurface(props: TextButtonSurfaceProps) {
   const {
@@ -79,7 +58,6 @@ function TextButtonSurface(props: TextButtonSurfaceProps) {
     href,
     target,
     rel,
-    type,
     ...rest
   } = props as TextButtonSurfaceProps & { className?: string };
 
@@ -94,25 +72,22 @@ function TextButtonSurface(props: TextButtonSurfaceProps) {
         href={href as Route}
         target={target}
         rel={rel}
-        {...(sharedProps as React.HTMLAttributes<HTMLAnchorElement>)}
+        {...(sharedProps as HTMLAttributes<HTMLAnchorElement>)}
       />
     );
   }
 
-  if (type) {
-    const ariaDisabled = (rest as Record<string, unknown>)["aria-disabled"];
-    const nativeDisabled =
-      ariaDisabled === true || ariaDisabled === "true" || undefined;
-    return (
-      <button
-        type={type}
-        disabled={nativeDisabled}
-        {...(sharedProps as React.HTMLAttributes<HTMLButtonElement>)}
-      />
-    );
-  }
+  const ariaDisabled = (rest as Record<string, unknown>)["aria-disabled"];
+  const nativeDisabled =
+    ariaDisabled === true || ariaDisabled === "true" || undefined;
 
-  return <span {...sharedProps} />;
+  return (
+    <button
+      type="button"
+      disabled={nativeDisabled}
+      {...(sharedProps as HTMLAttributes<HTMLButtonElement>)}
+    />
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -120,55 +95,35 @@ function TextButtonSurface(props: TextButtonSurfaceProps) {
 // ---------------------------------------------------------------------------
 
 /**
- * A clickable `Text` — same variant/prominence hover-and-active color
- * animation as `Button`, driven by `Interactive.Stateless`, but with no
- * `Interactive.Container` underneath. That means no background, no border,
- * no padding, no rounding: just the label (and optional icons) shifting
- * color on hover/active, exactly like the rest of the Opal buttons.
+ * A clickable `Text` — same hover/active color animation as `Button` (driven
+ * by `Interactive.Stateless`, always at `variant="default"` /
+ * `prominence="tertiary"`), but with no `Interactive.Container` underneath:
+ * no background, no border, no padding, no rounding. Props are intentionally
+ * shaped like `Text` (`font`, `nowrap`, required `children`) rather than
+ * `Button` (no `icon`/`rightIcon`, `variant`, `prominence`, `tooltip`, or
+ * `size`).
  */
 function TextButton({
-  icon: Icon,
-  children,
-  rightIcon: RightIcon,
-  size = "lg",
-  type = "button",
-  prominence = "tertiary",
-  tooltip,
-  tooltipSide = "top",
+  font = "main-ui-body",
+  nowrap = true,
   disabled,
-  ...interactiveProps
+  children,
+  ...rest
 }: TextButtonProps) {
-  const isLarge = size === "lg";
-
-  const labelEl = children ? (
-    <Text
-      font={isLarge ? "main-ui-body" : "secondary-body"}
-      color="inherit"
-      nowrap
-    >
-      {children}
-    </Text>
-  ) : null;
-
-  const button = (
+  return (
     <Interactive.Stateless
-      type={type}
-      prominence={prominence}
+      type="button"
+      variant="default"
+      prominence="tertiary"
       disabled={disabled}
-      {...interactiveProps}
+      {...rest}
     >
       <TextButtonSurface>
-        {iconWrapper(Icon, size, !!children)}
-        {labelEl}
-        {iconWrapper(RightIcon, size, !!children)}
+        <Text font={font} color="inherit" nowrap={nowrap}>
+          {children}
+        </Text>
       </TextButtonSurface>
     </Interactive.Stateless>
-  );
-
-  return (
-    <Tooltip tooltip={tooltip} side={tooltipSide}>
-      {button}
-    </Tooltip>
   );
 }
 

--- a/web/lib/opal/src/components/buttons/text-button/styles.css
+++ b/web/lib/opal/src/components/buttons/text-button/styles.css
@@ -1,0 +1,20 @@
+@reference "#reference.css";
+
+/* ============================================================================
+   TextButton — the `Interactive.Stateless` color system without
+   `Interactive.Container`.
+
+   `Interactive.Stateless` still applies a variant/prominence
+   `background-color` directly onto whichever element it merges onto (see
+   `stateless/styles.css`) — that's normally consumed by `Interactive.Container`.
+   Since `TextButton` skips `Container` on purpose, that background is force-
+   cleared here so only the `--interactive-foreground` text-color transition
+   survives, matching a plain `Text` node with hover/active animation.
+============================================================================ */
+
+.opal-text-button {
+  @apply inline-flex flex-row items-center gap-1;
+  background-color: transparent !important;
+  border: 0;
+  padding: 0;
+}

--- a/web/lib/opal/src/components/buttons/text-button/styles.css
+++ b/web/lib/opal/src/components/buttons/text-button/styles.css
@@ -7,13 +7,15 @@
    `Interactive.Stateless` still applies a variant/prominence
    `background-color` directly onto whichever element it merges onto (see
    `stateless/styles.css`) — that's normally consumed by `Interactive.Container`.
-   Since `TextButton` skips `Container` on purpose, that background is force-
-   cleared here so only the `--interactive-foreground` text-color transition
-   survives, matching a plain `Text` node with hover/active animation.
+   TextButton always renders at prominence="tertiary" internally, which still
+   paints a background tint on hover/active. Since TextButton skips Container
+   on purpose, that background is force-cleared here so only the
+   `--interactive-foreground` text-color transition survives, matching a
+   plain `Text` node with hover/active color animation.
 ============================================================================ */
 
 .opal-text-button {
-  @apply inline-flex flex-row items-center gap-1;
+  @apply inline-flex items-center;
   background-color: transparent !important;
   border: 0;
   padding: 0;

--- a/web/lib/opal/src/components/index.ts
+++ b/web/lib/opal/src/components/index.ts
@@ -48,6 +48,12 @@ export {
   type LinkButtonProps,
 } from "@opal/components/buttons/link-button/components";
 
+/* TextButton */
+export {
+  TextButton,
+  type TextButtonProps,
+} from "@opal/components/buttons/text-button/components";
+
 /* Text */
 export {
   Text,


### PR DESCRIPTION
## Description

Adds a new `TextButton` component to `web/lib/opal/`, alongside `README.md`, `styles.css`, and `TextButton.stories.tsx`.

`TextButton` renders like `Text` but is clickable, and reuses the same `Interactive.Stateless` hover/active color-transition system as `Button` — the same "text-based animation" every other Opal button uses. The one difference: it's built without `Interactive.Container`, so it never gets a background, border, padding, or rounding. It fills the gap between `Text` (not interactive at all) and `LinkButton` (always underlined, no icon slots).

Props are intentionally shaped after `Text`, not `Button`: `font`, `nowrap`, and a required `children: string | RichStr`, plus `href`/`target` and `disabled`. There's no `icon`/`rightIcon`, `variant`, `prominence`, `tooltip`, or `size` — `TextButton` always renders at the fixed `variant="default"` / `prominence="tertiary"` color combination (`text-03` → `text-04` on hover → `text-05` on active).

Architecture:
```
Interactive.Stateless              <- always variant="default" / prominence="tertiary"; disabled, href, onClick
  └─ <Link> / <button>             <- .opal-text-button.interactive-foreground, no height/rounding/padding/border
       └─ <Text font={font} color="inherit">
```

`TextButton` renders its `<Link>`/`<button>` directly as `Interactive.Stateless`'s single child, rather than going through a `Container`-style surface component — it already has `href`/`target`/`disabled` in scope as its own props, so unlike `Interactive.Container` (a generic primitive that has to recover those from Radix `Slot`-injected props), there's nothing to discover at runtime. Radix `Slot` auto-merges `className`/`style`/handlers onto that element.

Since `Interactive.Stateless` still applies a `background-color` for `prominence="tertiary"` on hover/active (normally consumed by `Interactive.Container`), `styles.css` force-clears it so only the `--interactive-foreground` text-color transition survives.

Exported from `@opal/components` alongside the other buttons.

## Screenshots + Videos

https://github.com/user-attachments/assets/b7ce0af0-4f73-49e6-b5bc-0f3393e8059c

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `TextButton` to `@opal/components`: a clickable `Text` with the same hover/active color animation as `Button`, but with no background, border, padding, or rounding. Props follow `Text`, and it always renders with `variant="default"` / `prominence="tertiary"` internally.

- New Features
  - Built on `Interactive.Stateless`; renders Next `Link`/`<button>` directly as the child; CSS clears background so only foreground color transitions apply.
  - Props: `font`, `nowrap` (default `true`), `children`, `href`/`target`, `disabled`.
  - Renders as `<button>` or Next `Link`; no icon slots, size, tooltip, variant, or prominence props.
  - Added README, styles, and Storybook stories (default, fonts, disabled, as-link, inline in prose).
  - Exported from `@opal/components` index.

<sup>Written for commit 2ba4f6e0525b1716bd3ee157e5d717581cc36815. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



