### PR TITLE
feat(auth): per-tenant claims capture, enable IdP enrichment on multi-tenant

### DIFF
--- a/backend/onyx/auth/login_claims_capture.py
+++ b/backend/onyx/auth/login_claims_capture.py
@@ -31,6 +31,7 @@ from typing import Any
 
 import httpx
 import jwt
+from fastapi_users import exceptions as fastapi_users_exceptions
 
 from onyx.configs.app_configs import (
     IDP_PROFILE_CLAIM_MAP,
@@ -38,6 +39,8 @@ from onyx.configs.app_configs import (
 )
 from onyx.redis.redis_pool import get_async_redis_connection
 from onyx.utils.logger import setup_logger
+from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
+from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -70,10 +73,41 @@ def _oauth_claims_key(tenant_id: str, email: str) -> str:
     return f"{_OAUTH_CLAIMS_KEY_PREFIX}:{tenant_id}:{email.lower()}"
 
 
+async def _resolve_capture_tenant_id(email: str) -> str | None:
+    """Tenant to key the snapshot under. The login callbacks that run capture are
+    unauthenticated, so the tenant contextvar still holds the default schema
+    there. On multi-tenant the user's tenant must come from the email mapping.
+    Returns None when the mapping cannot resolve the email (brand-new user, or a
+    lookup failure surfaced as UserNotExists), in which case capture is skipped
+    and the next login picks it up. The mapping is a sync DB call, so it runs in
+    a thread to stay preemptible under the capture timeout.
+    """
+    if not MULTI_TENANT:
+        return get_current_tenant_id()
+    try:
+        tenant_id = await asyncio.to_thread(
+            fetch_ee_implementation_or_noop(
+                "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
+            ),
+            email,
+        )
+    except fastapi_users_exceptions.UserNotExists:
+        return None
+    return tenant_id if isinstance(tenant_id, str) else None
+
+
 async def _store_claims_snapshot(email: str, snapshot: dict[str, Any]) -> None:
+    tenant_id = await _resolve_capture_tenant_id(email)
+    if tenant_id is None:
+        logger.debug(
+            "Skipping claims capture for %s: tenant not yet resolved "
+            "(new user or lookup failed)",
+            email,
+        )
+        return
     redis = await get_async_redis_connection()
     await redis.set(
-        _oauth_claims_key(get_current_tenant_id(), email),
+        _oauth_claims_key(tenant_id, email),
         json.dumps(snapshot, default=str),
         ex=_OAUTH_CLAIMS_TTL_SECONDS,
     )

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -266,13 +266,8 @@ OIDC_PKCE_ENABLED = os.environ.get("OIDC_PKCE_ENABLED", "").lower() == "true"
 # an "Organization Profile" block in the system prompt plus `{{user.<key>}}`
 # placeholders in agent prompts. Off by default: it sends directory data to
 # the configured LLM, which deployments must consciously opt into.
-# Forced off under multi-tenancy: claims are captured in the unauthenticated
-# OAuth callback, where the tenant is not yet resolved, so the snapshot would be
-# written under the default tenant id and never read back. Single-tenant only
-# until per-tenant capture lands.
 IDP_PROFILE_ENRICHMENT_ENABLED = (
     os.environ.get("IDP_PROFILE_ENRICHMENT_ENABLED", "").lower() == "true"
-    and not MULTI_TENANT
 )
 
 # Optional per-deployment claim-alias overrides for the directory profile,

--- a/backend/tests/unit/onyx/auth/test_login_claims_capture.py
+++ b/backend/tests/unit/onyx/auth/test_login_claims_capture.py
@@ -433,3 +433,57 @@ async def test_capture_saml_noop_when_enrichment_disabled(
             "user@example.com", {"department": ["Legal"]}, "okta-saml"
         )
     redis.set.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_multi_tenant_capture_keys_by_mapped_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On multi-tenant the capture callbacks run unauthenticated, so the key
+    tenant must come from the email mapping, not the request contextvar."""
+    monkeypatch.setattr(claims_capture, "MULTI_TENANT", True)
+    redis = AsyncMock()
+
+    with (
+        patch(
+            "onyx.auth.login_claims_capture.get_async_redis_connection",
+            return_value=redis,
+        ),
+        patch(
+            "onyx.auth.login_claims_capture.fetch_ee_implementation_or_noop",
+            return_value=lambda _email: "tenant_abc123",
+        ),
+    ):
+        await capture_oauth_login_claims(
+            _FakeOAuthClient(), "user@example.com", _make_token({"sub": "abc"})
+        )
+
+    key = redis.set.await_args.args[0]
+    assert "tenant_abc123" in key
+
+
+@pytest.mark.asyncio
+async def test_multi_tenant_capture_skips_unmapped_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(claims_capture, "MULTI_TENANT", True)
+    redis = AsyncMock()
+
+    def _raise_user_not_exists(_email: str) -> str:
+        raise claims_capture.fastapi_users_exceptions.UserNotExists()
+
+    with (
+        patch(
+            "onyx.auth.login_claims_capture.get_async_redis_connection",
+            return_value=redis,
+        ),
+        patch(
+            "onyx.auth.login_claims_capture.fetch_ee_implementation_or_noop",
+            return_value=_raise_user_not_exists,
+        ),
+    ):
+        await capture_oauth_login_claims(
+            _FakeOAuthClient(), "new-user@example.com", _make_token({"sub": "abc"})
+        )
+
+    redis.set.assert_not_awaited()

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -262,7 +262,7 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # TRACK_EXTERNAL_IDP_EXPIRY=
 # Opt-in: capture IdP directory claims at OAuth/OIDC login to enrich chat
 # prompts and resolve {{user.<key>}} agent placeholders. Sends directory data
-# to the configured LLM, so off by default. Single-tenant deployments only.
+# to the configured LLM, so off by default.
 # IDP_PROFILE_ENRICHMENT_ENABLED=
 # Optional JSON overriding directory claim aliases per field, e.g.
 # '{"department": ["dept", "division"], "country": ["c"]}'.

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.6.15
+version: 0.6.16
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1482,7 +1482,7 @@ configMap:
   OIDC_PKCE_ENABLED: ""
   # Opt-in: capture IdP directory claims at OAuth/OIDC login and use them to
   # enrich chat prompts and resolve {{user.<key>}} agent placeholders. Sends
-  # directory data to the configured LLM, so off by default. Single-tenant only.
+  # directory data to the configured LLM, so off by default.
   IDP_PROFILE_ENRICHMENT_ENABLED: ""
   # Optional JSON overriding the directory claim aliases per profile field, e.g.
   # '{"department": ["dept", "division"], "country": ["c"]}'.


### PR DESCRIPTION
## Description

Stacked on #13019 (merge that first). Removes the multi-tenant restriction from IdP profile enrichment.

- The login callbacks that run claims capture are unauthenticated, so the tenant contextvar holds the default schema there. Capture now resolves the tenant from the email mapping (the same lookup `complete_login_flow` uses) and keys the snapshot with it.
- Drops the `MULTI_TENANT` force-off gate. Single-tenant behavior unchanged.
- First login of a brand-new user (no mapping yet) skips capture rather than writing under the default schema; the next login captures.

Design note for review: write-side keys by the email mapping, read-side keys by the authenticated request's contextvar. These agree under Onyx's one-active-tenant-per-email model.

## How Has This Been Tested?

<!--- filled in by reviewer -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check