### PR TITLE
feat(auth): retain per-provider IdP claim snapshots

### DIFF
--- a/backend/onyx/auth/login_claims_capture.py
+++ b/backend/onyx/auth/login_claims_capture.py
@@ -27,7 +27,7 @@ claims and token metadata (key names, scope, expiry).
 import asyncio
 import json
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Awaitable, cast
 
 import httpx
 import jwt
@@ -45,16 +45,19 @@ from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
-_OAUTH_CLAIMS_KEY_PREFIX = "oauth_login_claims"
+# Redis HASH per (tenant, email): field = provider name, value = snapshot JSON.
+# Keeping one field per provider means a login through a second IdP never
+# clobbers the first provider's directory data.
+_IDP_CLAIMS_KEY_PREFIX = "idp_login_claims"
 # Long enough that an admin can log in and inspect at leisure, short enough
-# that stale directory data doesn't linger forever.
-_OAUTH_CLAIMS_TTL_SECONDS = 60 * 60 * 24 * 30
+# that data for users who stop logging in doesn't linger forever.
+_IDP_CLAIMS_TTL_SECONDS = 60 * 60 * 24 * 30
 
 # Hard ceiling on the whole best-effort capture. It runs inline in the login
 # flow, so a slow userinfo/Graph endpoint or an unreachable Redis must never
 # hold the login open indefinitely. Capture is refreshed on every login, so
 # dropping one is harmless.
-_OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS = 10
+_IDP_CLAIMS_CAPTURE_TIMEOUT_SECONDS = 10
 
 # Entra ID hosts its OIDC userinfo endpoint on Microsoft Graph. When we see
 # that host we can also query the Graph profile, which carries directory
@@ -69,8 +72,8 @@ _MS_GRAPH_SELECT_FIELDS = (
 )
 
 
-def _oauth_claims_key(tenant_id: str, email: str) -> str:
-    return f"{_OAUTH_CLAIMS_KEY_PREFIX}:{tenant_id}:{email.lower()}"
+def _idp_claims_key(tenant_id: str, email: str) -> str:
+    return f"{_IDP_CLAIMS_KEY_PREFIX}:{tenant_id}:{email.lower()}"
 
 
 async def _resolve_capture_tenant_id(email: str) -> str | None:
@@ -105,12 +108,44 @@ async def _store_claims_snapshot(email: str, snapshot: dict[str, Any]) -> None:
             email,
         )
         return
+    provider = str(snapshot.get("oauth_name") or "unknown")
+    key = _idp_claims_key(tenant_id, email)
     redis = await get_async_redis_connection()
-    await redis.set(
-        _oauth_claims_key(tenant_id, email),
-        json.dumps(snapshot, default=str),
-        ex=_OAUTH_CLAIMS_TTL_SECONDS,
-    )
+    # TTL is per key, so any login through any provider keeps the whole hash
+    # alive. Fields for abandoned providers persist until the hash expires.
+    pipe = redis.pipeline()
+    pipe.hset(key, provider, json.dumps(snapshot, default=str))
+    pipe.expire(key, _IDP_CLAIMS_TTL_SECONDS)
+    await pipe.execute()
+
+
+def _snapshot_captured_at(snapshot: dict[str, Any]) -> datetime:
+    """Parsed capture timestamp for ordering. Offset-aware parsing keeps the
+    ordering correct even if a snapshot were ever written with a non-UTC
+    offset. Unparseable or missing timestamps sort last (oldest)."""
+    try:
+        captured_at = datetime.fromisoformat(str(snapshot.get("captured_at")))
+    except ValueError:
+        return datetime.min.replace(tzinfo=timezone.utc)
+    if captured_at.tzinfo is None:
+        captured_at = captured_at.replace(tzinfo=timezone.utc)
+    return captured_at
+
+
+def _sorted_snapshots(raw_values: list[Any]) -> list[dict[str, Any]]:
+    """Parse hash values into snapshots, most recent login first. Corrupt or
+    non-dict entries are dropped so one bad provider field cannot poison the
+    rest."""
+    snapshots: list[dict[str, Any]] = []
+    for raw in raw_values:
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(parsed, dict):
+            snapshots.append(parsed)
+    snapshots.sort(key=_snapshot_captured_at, reverse=True)
+    return snapshots
 
 
 def _decode_id_token_claims(raw_id_token: str) -> dict[str, Any]:
@@ -178,14 +213,14 @@ async def capture_oauth_login_claims(
     ``openid_configuration`` — present on OpenID clients — supplies the
     userinfo endpoint). No-op unless IDP_PROFILE_ENRICHMENT_ENABLED.
     Never raises, and never holds the login open past
-    _OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS.
+    _IDP_CLAIMS_CAPTURE_TIMEOUT_SECONDS.
     """
     if not IDP_PROFILE_ENRICHMENT_ENABLED:
         return
     try:
         await asyncio.wait_for(
             _capture_oauth_login_claims(oauth_client, email, token),
-            timeout=_OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS,
+            timeout=_IDP_CLAIMS_CAPTURE_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
         logger.warning(
@@ -273,14 +308,14 @@ async def capture_saml_login_claims(
     as assertion attributes instead of token claims. Resolution reuses the same
     claim map, so deployments map their attribute names via IDP_PROFILE_CLAIM_MAP.
     No-op unless IDP_PROFILE_ENRICHMENT_ENABLED. Never raises, and never holds the
-    login open past _OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS.
+    login open past _IDP_CLAIMS_CAPTURE_TIMEOUT_SECONDS.
     """
     if not IDP_PROFILE_ENRICHMENT_ENABLED:
         return
     try:
         await asyncio.wait_for(
             _capture_saml_login_claims(email, saml_attributes, provider_name),
-            timeout=_OAUTH_CLAIMS_CAPTURE_TIMEOUT_SECONDS,
+            timeout=_IDP_CLAIMS_CAPTURE_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
         logger.warning("SAML claims capture timed out for %s (login unaffected)", email)
@@ -356,22 +391,9 @@ def _claim_aliases(placeholder_key: str, defaults: tuple[str, ...]) -> tuple[str
     return tuple(override) + tuple(a for a in defaults if a not in override)
 
 
-def _load_profile_sources(email: str) -> list[dict[str, Any]]:
-    """Read the captured login snapshot and return the claim sources to
-    resolve profile fields against, in precedence order.
-
-    Must use the RAW client — the capture writes via the raw async connection,
-    and the tenant-prefixing TenantRedisClient would look up a different key
-    (the tenant id is already part of ``_oauth_claims_key``). Best-effort: the
-    chat pipeline that consumes this must treat the profile as optional."""
-    from onyx.redis.redis_pool import get_raw_redis_client
-
-    redis = get_raw_redis_client()
-    raw = redis.get(_oauth_claims_key(get_current_tenant_id(), email))
-    if not isinstance(raw, (str, bytes)):
-        return []
-    snapshot = json.loads(raw)
-
+def _snapshot_sources(snapshot: dict[str, Any]) -> list[dict[str, Any]]:
+    """Claim sources of one snapshot in precedence order (directory API,
+    userinfo, id_token, then SAML assertion attributes)."""
     sources: list[dict[str, Any]] = []
     directory_profile = snapshot.get("directory_profile")
     if isinstance(directory_profile, dict) and "error" not in directory_profile:
@@ -388,6 +410,28 @@ def _load_profile_sources(email: str) -> list[dict[str, Any]]:
     saml_attributes = snapshot.get("saml_attributes")
     if isinstance(saml_attributes, dict):
         sources.append(saml_attributes)
+    return sources
+
+
+def _load_profile_sources(email: str) -> list[dict[str, Any]]:
+    """Read all captured provider snapshots and return the claim sources to
+    resolve profile fields against, in precedence order: every source of the
+    most recent login first, then older providers' sources as gap fillers.
+
+    Must use the RAW client — the capture writes via the raw async connection,
+    and the tenant-prefixing TenantRedisClient would look up a different key
+    (the tenant id is already part of ``_idp_claims_key``). Best-effort: the
+    chat pipeline that consumes this must treat the profile as optional."""
+    from onyx.redis.redis_pool import get_raw_redis_client
+
+    redis = get_raw_redis_client()
+    raw_map = redis.hgetall(_idp_claims_key(get_current_tenant_id(), email))
+    if not isinstance(raw_map, dict) or not raw_map:
+        return []
+
+    sources: list[dict[str, Any]] = []
+    for snapshot in _sorted_snapshots(list(raw_map.values())):
+        sources.extend(_snapshot_sources(snapshot))
     return sources
 
 
@@ -418,8 +462,8 @@ def _resolve_profile(email: str) -> dict[str, tuple[str, str]]:
 
 
 def get_idp_profile_fields(email: str) -> dict[str, str]:
-    """Directory profile of the user (country, department, ...) from the last
-    captured login snapshot, as ordered ``{label: value}`` pairs for the auto
+    """Directory profile of the user (country, department, ...) from the
+    captured IdP login snapshots, as ordered ``{label: value}`` pairs for the auto
     "Organization Profile" prompt block. Best-effort: returns ``{}`` when the
     feature is disabled, nothing is captured, or Redis is unavailable —
     callers must treat the profile as optional."""
@@ -461,13 +505,14 @@ def get_idp_profile_placeholder_values(email: str) -> dict[str, str]:
 
 
 async def get_captured_oauth_claims(email: str) -> dict[str, Any] | None:
-    """Return the last captured claims snapshot for ``email``, or None."""
+    """Return the most recent captured claims snapshot for ``email``, or None."""
     redis = await get_async_redis_connection()
-    raw = await redis.get(_oauth_claims_key(get_current_tenant_id(), email))
-    if not raw:
+    # redis-py types hash commands as a sync-or-async union. This is the async client.
+    raw_map = await cast(
+        Awaitable[dict[Any, Any]],
+        redis.hgetall(_idp_claims_key(get_current_tenant_id(), email)),
+    )
+    if not raw_map:
         return None
-    try:
-        data = json.loads(raw)
-        return data if isinstance(data, dict) else None
-    except json.JSONDecodeError:
-        return None
+    snapshots = _sorted_snapshots(list(raw_map.values()))
+    return snapshots[0] if snapshots else None

--- a/backend/tests/unit/onyx/auth/test_login_claims_capture.py
+++ b/backend/tests/unit/onyx/auth/test_login_claims_capture.py
@@ -29,6 +29,16 @@ class _FakeOAuthClient:
             self.openid_configuration["userinfo_endpoint"] = userinfo_endpoint
 
 
+def _redis_with_pipeline() -> tuple[AsyncMock, MagicMock]:
+    """Async redis mock whose pipeline() returns a sync pipeline mock, matching
+    how the capture writes (queue commands synchronously, await execute())."""
+    redis = AsyncMock()
+    pipe = MagicMock()
+    pipe.execute = AsyncMock()
+    redis.pipeline = MagicMock(return_value=pipe)
+    return redis, pipe
+
+
 def _make_token(claims: dict[str, Any]) -> dict[str, Any]:
     return {
         "access_token": "at-123",
@@ -47,7 +57,7 @@ async def test_capture_stores_id_token_claims_and_token_meta() -> None:
         "name": "User Example",
         "groups": ["g1", "g2"],
     }
-    redis = AsyncMock()
+    redis, pipe = _redis_with_pipeline()
 
     with patch(
         "onyx.auth.login_claims_capture.get_async_redis_connection",
@@ -57,8 +67,8 @@ async def test_capture_stores_id_token_claims_and_token_meta() -> None:
             _FakeOAuthClient(), "user@example.com", _make_token(claims)
         )
 
-    redis.set.assert_awaited_once()
-    key, payload = redis.set.await_args.args
+    pipe.hset.assert_called_once()
+    key, _provider, payload = pipe.hset.call_args.args
     assert "user@example.com" in key
     snapshot = json.loads(payload)
     assert snapshot["id_token_claims"] == claims
@@ -77,7 +87,7 @@ async def test_capture_stores_id_token_claims_and_token_meta() -> None:
 @pytest.mark.asyncio
 async def test_capture_fetches_userinfo_when_endpoint_available() -> None:
     userinfo = {"sub": "abc", "department": "R&D", "preferred_username": "user"}
-    redis = AsyncMock()
+    redis, pipe = _redis_with_pipeline()
 
     with (
         patch(
@@ -96,7 +106,7 @@ async def test_capture_fetches_userinfo_when_endpoint_available() -> None:
         )
 
     fetch_mock.assert_awaited_once_with("https://idp.example.com/userinfo", "at-123")
-    snapshot = json.loads(redis.set.await_args.args[1])
+    snapshot = json.loads(pipe.hset.call_args.args[2])
     assert snapshot["userinfo"] == userinfo
     # Non-Microsoft IdP -> no Graph profile fetch
     assert snapshot["directory_profile"] is None
@@ -107,7 +117,7 @@ async def test_capture_fetches_directory_profile_for_entra() -> None:
     """When the userinfo endpoint is Microsoft Graph (Entra ID), the capture
     also pulls the directory profile with country/usageLocation."""
     directory_profile = {"country": "Netherlands", "usageLocation": "NL", "city": "Ams"}
-    redis = AsyncMock()
+    redis, pipe = _redis_with_pipeline()
 
     with (
         patch(
@@ -130,15 +140,15 @@ async def test_capture_fetches_directory_profile_for_entra() -> None:
         )
 
     graph_mock.assert_awaited_once_with("at-123")
-    snapshot = json.loads(redis.set.await_args.args[1])
+    snapshot = json.loads(pipe.hset.call_args.args[2])
     assert snapshot["directory_profile"] == directory_profile
     assert snapshot["directory_source"] == "ms_graph"
 
 
 @pytest.mark.asyncio
 async def test_capture_never_raises_when_redis_is_down() -> None:
-    redis = AsyncMock()
-    redis.set.side_effect = ConnectionError("redis down")
+    redis, pipe = _redis_with_pipeline()
+    pipe.execute.side_effect = ConnectionError("redis down")
 
     with patch(
         "onyx.auth.login_claims_capture.get_async_redis_connection",
@@ -154,7 +164,7 @@ async def test_capture_never_raises_when_redis_is_down() -> None:
 async def test_get_captured_oauth_claims_roundtrip() -> None:
     stored = {"captured_at": "2026-07-02T00:00:00+00:00", "id_token_claims": {}}
     redis = AsyncMock()
-    redis.get.return_value = json.dumps(stored)
+    redis.hgetall.return_value = {"openid": json.dumps(stored)}
 
     with patch(
         "onyx.auth.login_claims_capture.get_async_redis_connection",
@@ -162,7 +172,7 @@ async def test_get_captured_oauth_claims_roundtrip() -> None:
     ):
         assert await get_captured_oauth_claims("user@example.com") == stored
 
-    redis.get.return_value = None
+    redis.hgetall.return_value = {}
     with patch(
         "onyx.auth.login_claims_capture.get_async_redis_connection",
         return_value=redis,
@@ -183,7 +193,7 @@ def test_get_idp_profile_fields_maps_directory_profile() -> None:
         }
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         fields = get_idp_profile_fields("user@example.com")
@@ -201,15 +211,17 @@ def test_get_idp_profile_fields_maps_directory_profile() -> None:
 def test_get_idp_profile_fields_empty_on_missing_or_error() -> None:
     redis = MagicMock()
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
-        redis.get.return_value = None
+        redis.hgetall.return_value = {}
         assert get_idp_profile_fields("user@example.com") == {}
 
-        redis.get.return_value = json.dumps(
-            {"directory_profile": {"error": "Graph /me returned HTTP 403."}}
-        )
+        redis.hgetall.return_value = {
+            "openid": json.dumps(
+                {"directory_profile": {"error": "Graph /me returned HTTP 403."}}
+            )
+        }
         assert get_idp_profile_fields("user@example.com") == {}
 
-        redis.get.side_effect = ConnectionError("redis down")
+        redis.hgetall.side_effect = ConnectionError("redis down")
         assert get_idp_profile_fields("user@example.com") == {}
 
 
@@ -226,7 +238,7 @@ def test_get_idp_profile_placeholder_values_maps_directory_profile() -> None:
         }
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
@@ -245,15 +257,17 @@ def test_get_idp_profile_placeholder_values_maps_directory_profile() -> None:
 def test_get_idp_profile_placeholder_values_empty_on_missing_or_error() -> None:
     redis = MagicMock()
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
-        redis.get.return_value = None
+        redis.hgetall.return_value = {}
         assert get_idp_profile_placeholder_values("user@example.com") == {}
 
-        redis.get.return_value = json.dumps(
-            {"directory_profile": {"error": "Graph /me returned HTTP 403."}}
-        )
+        redis.hgetall.return_value = {
+            "openid": json.dumps(
+                {"directory_profile": {"error": "Graph /me returned HTTP 403."}}
+            )
+        }
         assert get_idp_profile_placeholder_values("user@example.com") == {}
 
-        redis.get.side_effect = ConnectionError("redis down")
+        redis.hgetall.side_effect = ConnectionError("redis down")
         assert get_idp_profile_placeholder_values("user@example.com") == {}
 
 
@@ -270,7 +284,7 @@ async def test_capture_noop_when_enrichment_disabled(
         await capture_oauth_login_claims(
             _FakeOAuthClient(), "user@example.com", _make_token({"sub": "abc"})
         )
-    redis.set.assert_not_awaited()
+    redis.pipeline.assert_not_called()
 
 
 def test_getters_empty_when_enrichment_disabled(
@@ -278,7 +292,9 @@ def test_getters_empty_when_enrichment_disabled(
 ) -> None:
     monkeypatch.setattr(claims_capture, "IDP_PROFILE_ENRICHMENT_ENABLED", False)
     redis = MagicMock()
-    redis.get.return_value = json.dumps({"directory_profile": {"country": "Germany"}})
+    redis.hgetall.return_value = {
+        "openid": json.dumps({"directory_profile": {"country": "Germany"}})
+    }
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         assert get_idp_profile_fields("user@example.com") == {}
         assert get_idp_profile_placeholder_values("user@example.com") == {}
@@ -299,7 +315,7 @@ def test_profile_resolves_from_userinfo_for_generic_oidc() -> None:
         "id_token_claims": {"sub": "abc"},
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
@@ -320,7 +336,7 @@ def test_profile_falls_back_to_id_token_claims() -> None:
         "id_token_claims": {"ctry": "NL", "department": "Legal"},
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         fields = get_idp_profile_fields("user@example.com")
@@ -335,7 +351,7 @@ def test_directory_profile_takes_precedence_over_userinfo() -> None:
         "id_token_claims": {"department": "Token Dept"},
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
@@ -356,7 +372,7 @@ def test_claim_map_override_takes_precedence(
         "id_token_claims": {},
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
@@ -374,7 +390,7 @@ def test_source_precedence_holds_across_aliases() -> None:
         "id_token_claims": {},
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
@@ -386,7 +402,7 @@ def test_source_precedence_holds_across_aliases() -> None:
 async def test_capture_saml_stores_flattened_attributes() -> None:
     """SAML attributes arrive as {name: [values]}. Capture keeps the first value
     so the shared claim-map resolver can treat them like any other source."""
-    redis = AsyncMock()
+    redis, pipe = _redis_with_pipeline()
     with patch(
         "onyx.auth.login_claims_capture.get_async_redis_connection",
         return_value=redis,
@@ -397,8 +413,8 @@ async def test_capture_saml_stores_flattened_attributes() -> None:
             "okta-saml",
         )
 
-    redis.set.assert_awaited_once()
-    snapshot = json.loads(redis.set.await_args.args[1])
+    pipe.hset.assert_called_once()
+    snapshot = json.loads(pipe.hset.call_args.args[2])
     assert snapshot["saml_attributes"] == {"department": "Legal", "jobTitle": "Counsel"}
     assert snapshot["oauth_name"] == "okta-saml"
 
@@ -411,7 +427,7 @@ def test_profile_resolves_from_saml_attributes() -> None:
         "id_token_claims": {},
     }
     redis = MagicMock()
-    redis.get.return_value = json.dumps(snapshot)
+    redis.hgetall.return_value = {"openid": json.dumps(snapshot)}
 
     with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
         values = get_idp_profile_placeholder_values("user@example.com")
@@ -432,7 +448,7 @@ async def test_capture_saml_noop_when_enrichment_disabled(
         await capture_saml_login_claims(
             "user@example.com", {"department": ["Legal"]}, "okta-saml"
         )
-    redis.set.assert_not_awaited()
+    redis.pipeline.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -442,7 +458,7 @@ async def test_multi_tenant_capture_keys_by_mapped_tenant(
     """On multi-tenant the capture callbacks run unauthenticated, so the key
     tenant must come from the email mapping, not the request contextvar."""
     monkeypatch.setattr(claims_capture, "MULTI_TENANT", True)
-    redis = AsyncMock()
+    redis, pipe = _redis_with_pipeline()
 
     with (
         patch(
@@ -458,7 +474,7 @@ async def test_multi_tenant_capture_keys_by_mapped_tenant(
             _FakeOAuthClient(), "user@example.com", _make_token({"sub": "abc"})
         )
 
-    key = redis.set.await_args.args[0]
+    key = pipe.hset.call_args.args[0]
     assert "tenant_abc123" in key
 
 
@@ -486,4 +502,34 @@ async def test_multi_tenant_capture_skips_unmapped_email(
             _FakeOAuthClient(), "new-user@example.com", _make_token({"sub": "abc"})
         )
 
-    redis.set.assert_not_awaited()
+    redis.pipeline.assert_not_called()
+
+
+def test_multiple_providers_are_retained_and_most_recent_wins() -> None:
+    """A second IdP login must not clobber the first provider's data. The most
+    recent login's values win per field, older providers fill remaining gaps."""
+    entra = {
+        "captured_at": "2026-07-01T00:00:00+00:00",
+        "oauth_name": "entra",
+        "directory_profile": {"department": "Entra Dept", "country": "NL"},
+        "userinfo": {},
+        "id_token_claims": {},
+    }
+    okta = {
+        "captured_at": "2026-07-10T00:00:00+00:00",
+        "oauth_name": "okta",
+        "directory_profile": None,
+        "userinfo": {"department": "Okta Dept"},
+        "id_token_claims": {},
+    }
+    redis = MagicMock()
+    redis.hgetall.return_value = {
+        "entra": json.dumps(entra),
+        "okta": json.dumps(okta),
+    }
+
+    with patch("onyx.redis.redis_pool.get_raw_redis_client", return_value=redis):
+        values = get_idp_profile_placeholder_values("user@example.com")
+
+    # Okta login is newer, so its department wins. Entra still supplies country.
+    assert values == {"department": "Okta Dept", "country": "NL"}


### PR DESCRIPTION
## Description

Stacked on #13135 (merge order: #13019 -> #13135 -> this). Fixes multi-IdP clobbering.

- A login through a second IdP used to overwrite the whole claims snapshot. Snapshots now live in a Redis hash per tenant+email with one field per provider.
- Resolution merges snapshots newest-login-first: the latest login wins each profile field, older providers fill gaps. Admin endpoint still returns the most recent snapshot.
- Write is a pipeline (hset + expire), so no first-write window without a TTL.
- New key prefix (`idp_login_claims`): old string keys age out on their own TTL and profiles repopulate on next login.

## How Has This Been Tested?

<!--- filled in by reviewer -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check