### PR TITLE
test(auth): cover IdP enrichment integration surface

### DIFF
--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -130,4 +130,6 @@ def require_permission(
         return user
 
     dependency._is_require_permission = True  # ty: ignore[unresolved-attribute]
+    # Lets tests pin a route's permission level without closure introspection.
+    dependency._required_permission = required  # ty: ignore[unresolved-attribute]
     return dependency

--- a/backend/tests/unit/onyx/chat/test_organization_profile_prompt.py
+++ b/backend/tests/unit/onyx/chat/test_organization_profile_prompt.py
@@ -1,0 +1,38 @@
+"""Guards the Organization Profile system-prompt block: it renders the resolved
+directory fields when present and is absent when the profile is empty."""
+
+from unittest.mock import patch
+
+from onyx.chat.prompt_utils import build_system_prompt
+from onyx.db.memory import UserInfo, UserMemoryContext
+
+
+def _context(organization_profile: dict[str, str]) -> UserMemoryContext:
+    return UserMemoryContext(
+        user_info=UserInfo(
+            name="User Example",
+            email="user@example.com",
+            organization_profile=organization_profile,
+        ),
+    )
+
+
+def test_organization_profile_block_renders_fields() -> None:
+    # get_company_context reads KV/cache. Patched so the test controls all inputs.
+    with patch("onyx.chat.prompt_utils.get_company_context", return_value=None):
+        prompt = build_system_prompt(
+            "Base prompt.",
+            user_memory_context=_context({"Country": "NL", "Department": "Legal"}),
+        )
+    assert "## Organization Profile" in prompt
+    assert "- Country: NL" in prompt
+    assert "- Department: Legal" in prompt
+
+
+def test_organization_profile_block_absent_when_empty() -> None:
+    with patch("onyx.chat.prompt_utils.get_company_context", return_value=None):
+        prompt = build_system_prompt(
+            "Base prompt.",
+            user_memory_context=_context({}),
+        )
+    assert "## Organization Profile" not in prompt

--- a/backend/tests/unit/onyx/prompts/test_prompt_utils.py
+++ b/backend/tests/unit/onyx/prompts/test_prompt_utils.py
@@ -161,3 +161,12 @@ def test_apply_prompt_placeholders_replaces_citation_guidance(
     assert REQUIRE_CITATION_GUIDANCE in result
     assert CITATION_GUIDANCE_REPLACEMENT_PAT not in result
     assert should_append_citation is False
+
+
+def test_placeholder_split_across_prompt_parts_stays_literal_per_part() -> None:
+    # Prompt parts are substituted independently. A placeholder split across
+    # parts has no complete {{user.<key>}} match in either, so each stays literal.
+    system_part = "System ends with {{user.dep"
+    agent_part = "artment}} and more"
+    assert substitute_user_placeholders(system_part, _VALUES) == system_part
+    assert substitute_user_placeholders(agent_part, _VALUES) == agent_part

--- a/backend/tests/unit/onyx/server/manage/test_oauth_test_endpoint.py
+++ b/backend/tests/unit/onyx/server/manage/test_oauth_test_endpoint.py
@@ -1,0 +1,89 @@
+"""Guards the admin OAuth Test endpoint: the admin-only permission gate on the
+route, the missing-email rejection, and the snapshot-to-response mapping
+(including the not-found shape)."""
+
+import inspect
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from onyx.db.enums import Permission
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.oauth_test import get_oauth_login_claims
+
+
+def _user(email: str | None) -> MagicMock:
+    user = MagicMock()
+    user.email = email
+    return user
+
+
+def test_route_is_gated_by_admin_permission_dependency() -> None:
+    """The raw claims payload is admin-only. Both the presence of the
+    require_permission gate on the route signature and its permission level
+    are pinned, so removing or downgrading the gate must fail a test."""
+    user_param = inspect.signature(get_oauth_login_claims).parameters["user"]
+    dependency = user_param.default.dependency
+    assert getattr(dependency, "_is_require_permission", False)
+    required = getattr(dependency, "_required_permission", None)
+    assert required is Permission.FULL_ADMIN_PANEL_ACCESS
+
+
+@pytest.mark.asyncio
+async def test_missing_email_rejected() -> None:
+    with pytest.raises(OnyxError):
+        await get_oauth_login_claims(email=None, user=_user(None))
+
+
+@pytest.mark.asyncio
+async def test_not_found_returns_found_false() -> None:
+    with patch(
+        "onyx.server.manage.oauth_test.get_captured_oauth_claims",
+        new=AsyncMock(return_value=None),
+    ):
+        response = await get_oauth_login_claims(
+            email=None, user=_user("admin@example.com")
+        )
+    assert response.found is False
+    assert response.email == "admin@example.com"
+
+
+@pytest.mark.asyncio
+async def test_found_snapshot_maps_to_response() -> None:
+    snapshot: dict[str, Any] = {
+        "email": "target@example.com",
+        "captured_at": "2026-07-01T00:00:00+00:00",
+        "oauth_name": "okta",
+        "id_token_claims": {"sub": "abc"},
+        "userinfo": {"department": "Legal"},
+        "directory_profile": None,
+        "directory_source": None,
+        "token_meta": {"keys": ["access_token"]},
+    }
+    with (
+        patch(
+            "onyx.server.manage.oauth_test.get_captured_oauth_claims",
+            new=AsyncMock(return_value=snapshot),
+        ),
+        patch(
+            "onyx.server.manage.oauth_test.get_idp_profile_fields",
+            return_value={"Department": "Legal"},
+        ) as fields_mock,
+    ):
+        response = await get_oauth_login_claims(
+            email="target@example.com", user=_user("admin@example.com")
+        )
+
+    fields_mock.assert_called_once_with("target@example.com")
+
+    assert response.found is True
+    assert response.email == "target@example.com"
+    assert response.captured_at == "2026-07-01T00:00:00+00:00"
+    assert response.oauth_name == "okta"
+    assert response.directory_profile is None
+    assert response.directory_source is None
+    assert response.id_token_claims == {"sub": "abc"}
+    assert response.userinfo == {"department": "Legal"}
+    assert response.resolved_profile == {"Department": "Legal"}
+    assert response.token_meta == {"keys": ["access_token"]}


### PR DESCRIPTION
## Description

Stacked on #13137 (merge order: #13019 -> #13135 -> #13136 -> #13137 -> this). Tests plus one test-support marker line in `permissions.py`.

- Admin OAuth Test endpoint: the admin permission gate on the route (presence and level pinned via a `_required_permission` marker set by `require_permission`), missing-email rejection, and the full snapshot-to-response mapping including not-found.
- Organization Profile system-prompt block: renders resolved fields, absent when the profile is empty (hermetic, company-context patched).
- Placeholder substitution at the system/agent prompt boundary: a split placeholder stays literal per part.

Token reservation internals are covered via the substitution property they rely on; `build_chat_turn` itself needs a full chat setup and stays integration-test territory.

## How Has This Been Tested?

<!--- filled in by reviewer -->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check