### PR TITLE
fix(prompts): apply placeholders consistently across all agent prompts (mirror of #13028) (#13072) to release v4.3

### DIFF
--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -24,6 +24,7 @@ from onyx.chat.models import ToolCallSimple
 from onyx.chat.prompt_utils import build_reminder_message
 from onyx.chat.prompt_utils import build_system_prompt
 from onyx.chat.prompt_utils import get_default_base_system_prompt
+from onyx.chat.prompt_utils import process_prompt_template
 from onyx.configs.app_configs import INTEGRATION_TESTS_MODE
 from onyx.configs.chat_configs import MAX_LLM_CYCLES
 from onyx.configs.constants import DocumentSource
@@ -757,15 +758,27 @@ def run_llm_loop(
             # Handling the system prompt and custom agent prompt
             # The section below calculates the available tokens for history a bit more accurately
             # now that project files are loaded in.
+            persona_datetime_aware = persona.datetime_aware if persona else True
+            cite_documents = should_cite_documents or always_cite_documents
             if persona and persona.replace_base_system_prompt:
                 # Handles the case where user has checked off the "Replace base system prompt" checkbox
-                system_prompt = (
-                    ChatMessageSimple(
-                        message=persona.system_prompt,
-                        token_count=token_counter(persona.system_prompt),
-                        message_type=MessageType.SYSTEM,
+                processed_system_prompt = (
+                    process_prompt_template(
+                        persona.system_prompt,
+                        datetime_aware=persona_datetime_aware,
+                        append_datetime_if_aware=True,
+                        should_cite_documents=cite_documents,
                     )
                     if persona.system_prompt
+                    else None
+                )
+                system_prompt = (
+                    ChatMessageSimple(
+                        message=processed_system_prompt,
+                        token_count=token_counter(processed_system_prompt),
+                        message_type=MessageType.SYSTEM,
+                    )
+                    if processed_system_prompt
                     else None
                 )
                 custom_agent_prompt_msg = None
@@ -783,47 +796,74 @@ def run_llm_loop(
                     )
                     system_prompt_str = build_system_prompt(
                         base_system_prompt=default_base_system_prompt,
-                        datetime_aware=persona.datetime_aware if persona else True,
+                        datetime_aware=persona_datetime_aware,
                         user_memory_context=prompt_memory_context,
                         tools=tools,
-                        should_cite_documents=should_cite_documents
-                        or always_cite_documents,
+                        should_cite_documents=cite_documents,
                     )
                     system_prompt = ChatMessageSimple(
                         message=system_prompt_str,
                         token_count=token_counter(system_prompt_str),
                         message_type=MessageType.SYSTEM,
                     )
-                    custom_agent_prompt_msg = (
-                        ChatMessageSimple(
-                            message=custom_agent_prompt,
-                            token_count=token_counter(custom_agent_prompt),
-                            message_type=MessageType.USER,
+                    processed_custom_agent_prompt = (
+                        process_prompt_template(
+                            custom_agent_prompt,
+                            datetime_aware=persona_datetime_aware,
+                            append_datetime_if_aware=False,
+                            should_cite_documents=cite_documents,
                         )
                         if custom_agent_prompt
+                        else None
+                    )
+                    custom_agent_prompt_msg = (
+                        ChatMessageSimple(
+                            message=processed_custom_agent_prompt,
+                            token_count=token_counter(processed_custom_agent_prompt),
+                            message_type=MessageType.USER,
+                        )
+                        if processed_custom_agent_prompt
                         else None
                     )
                 else:
                     # If there is a custom agent prompt, it replaces the system prompt when the default system prompt is empty
-                    system_prompt = (
-                        ChatMessageSimple(
-                            message=custom_agent_prompt,
-                            token_count=token_counter(custom_agent_prompt),
-                            message_type=MessageType.SYSTEM,
+                    processed_custom_agent_prompt = (
+                        process_prompt_template(
+                            custom_agent_prompt,
+                            datetime_aware=persona_datetime_aware,
+                            append_datetime_if_aware=True,
+                            should_cite_documents=cite_documents,
                         )
                         if custom_agent_prompt
                         else None
                     )
+                    system_prompt = (
+                        ChatMessageSimple(
+                            message=processed_custom_agent_prompt,
+                            token_count=token_counter(processed_custom_agent_prompt),
+                            message_type=MessageType.SYSTEM,
+                        )
+                        if processed_custom_agent_prompt
+                        else None
+                    )
                     custom_agent_prompt_msg = None
 
+            processed_task_prompt = (
+                process_prompt_template(
+                    persona.task_prompt,
+                    datetime_aware=persona_datetime_aware,
+                    append_datetime_if_aware=False,
+                    should_cite_documents=cite_documents,
+                )
+                if persona and persona.task_prompt
+                else None
+            )
             reminder_message_text = select_reminder_text(
                 ran_image_gen=ran_image_gen,
                 just_ran_web_search=just_ran_web_search,
                 has_open_url_tool=has_open_url_tool,
                 out_of_cycles=out_of_cycles,
-                persona_task_prompt=(
-                    persona.task_prompt if persona and persona.task_prompt else None
-                ),
+                persona_task_prompt=processed_task_prompt,
                 include_citation_reminder=should_cite_documents
                 or always_cite_documents,
                 include_file_reminder=code_interpreter_file_generated,

--- a/backend/onyx/chat/prompt_utils.py
+++ b/backend/onyx/chat/prompt_utils.py
@@ -13,10 +13,8 @@ from onyx.prompts.chat_prompts import DEFAULT_SYSTEM_PROMPT
 from onyx.prompts.chat_prompts import FILE_REMINDER
 from onyx.prompts.chat_prompts import LAST_CYCLE_CITATION_REMINDER
 from onyx.prompts.chat_prompts import REQUIRE_CITATION_GUIDANCE
+from onyx.prompts.prompt_utils import apply_prompt_placeholders
 from onyx.prompts.prompt_utils import get_company_context
-from onyx.prompts.prompt_utils import handle_onyx_date_awareness
-from onyx.prompts.prompt_utils import replace_citation_guidance_tag
-from onyx.prompts.prompt_utils import replace_reminder_tag
 from onyx.prompts.tool_prompts import GENERATE_IMAGE_GUIDANCE
 from onyx.prompts.tool_prompts import INTERNAL_SEARCH_GUIDANCE
 from onyx.prompts.tool_prompts import MEMORY_GUIDANCE
@@ -138,6 +136,24 @@ def build_reminder_message(
     return reminder if reminder else None
 
 
+def process_prompt_template(
+    prompt_str: str,
+    *,
+    datetime_aware: bool,
+    append_datetime_if_aware: bool,
+    should_cite_documents: bool,
+) -> str:
+    """Apply standard prompt placeholders to any agent or task prompt."""
+    processed_prompt, _ = apply_prompt_placeholders(
+        prompt_str,
+        datetime_aware=datetime_aware,
+        append_datetime_if_aware=append_datetime_if_aware,
+        should_cite_documents=should_cite_documents,
+        append_citation_if_missing=False,
+    )
+    return processed_prompt
+
+
 def _build_user_information_section(
     user_memory_context: UserMemoryContext | None,
     company_context: str | None,
@@ -202,17 +218,14 @@ def build_system_prompt(
     """Should only be called with the default behavior system prompt.
     If the user has replaced the default behavior prompt with their custom agent prompt, do not call this function.
     """
-    system_prompt = handle_onyx_date_awareness(base_system_prompt, datetime_aware)
-
-    # Replace citation guidance placeholder if present
-    system_prompt, should_append_citation_guidance = replace_citation_guidance_tag(
-        system_prompt,
+    system_prompt, should_append_citation_guidance = apply_prompt_placeholders(
+        base_system_prompt,
+        datetime_aware=datetime_aware,
+        append_datetime_if_aware=True,
         should_cite_documents=should_cite_documents,
         include_all_guidance=include_all_guidance,
+        append_citation_if_missing=True,
     )
-
-    # Replace reminder tag placeholder if present
-    system_prompt = replace_reminder_tag(system_prompt)
 
     company_context = get_company_context()
     user_info_section = _build_user_information_section(

--- a/backend/onyx/prompts/prompt_template.py
+++ b/backend/onyx/prompts/prompt_template.py
@@ -46,10 +46,10 @@ class PromptTemplate:
         return self._pattern.sub(repl, self._template)
 
     def _postprocess(self, text: str) -> str:
-        """Apply global replacements such as [[CURRENT_DATETIME]]."""
+        """Apply global replacements such as {{CURRENT_DATETIME}}."""
         if not text:
             return text
-        # Ensure [[CURRENT_DATETIME]] matches shared prompt formatting
+        # Ensure datetime placeholders match shared prompt formatting
         return replace_current_datetime_tag(
             text,
             full_sentence=True,

--- a/backend/onyx/prompts/prompt_utils.py
+++ b/backend/onyx/prompts/prompt_utils.py
@@ -64,6 +64,7 @@ def replace_citation_guidance_tag(
     *,
     should_cite_documents: bool = False,
     include_all_guidance: bool = False,
+    append_citation_if_missing: bool = True,
 ) -> tuple[str, bool]:
     """
     Replace {{CITATION_GUIDANCE}} placeholder with citation guidance if needed.
@@ -79,8 +80,10 @@ def replace_citation_guidance_tag(
     if not placeholder_was_present:
         # Placeholder not present - caller should append if citations are needed
         should_append = (
-            should_cite_documents or include_all_guidance
-        ) and REQUIRE_CITATION_GUIDANCE not in prompt_str
+            append_citation_if_missing
+            and (should_cite_documents or include_all_guidance)
+            and REQUIRE_CITATION_GUIDANCE not in prompt_str
+        )
         return prompt_str, should_append
 
     citation_guidance = (
@@ -107,35 +110,47 @@ def replace_reminder_tag(prompt_str: str) -> str:
     return prompt_str
 
 
-def handle_onyx_date_awareness(
+def apply_prompt_placeholders(
     prompt_str: str,
-    # We always replace the pattern {{CURRENT_DATETIME}} if it shows up
-    # but if it doesn't show up and the prompt is datetime aware, add it to the prompt at the end.
+    *,
     datetime_aware: bool = False,
-) -> str:
-    """
-    If there is a {{CURRENT_DATETIME}} tag, replace it with the current date and time no matter what.
-    If the prompt is datetime aware, and there are no datetime tags, add it to the prompt.
-    Do nothing otherwise.
-    This can later be expanded to support other tags.
-    """
+    append_datetime_if_aware: bool = False,
+    should_cite_documents: bool = False,
+    include_all_guidance: bool = False,
+    append_citation_if_missing: bool = False,
+) -> tuple[str, bool]:
+    """Apply standard Onyx prompt placeholders to any prompt string.
 
-    prompt_with_datetime = replace_current_datetime_tag(
+    Supported placeholders:
+    - {{CURRENT_DATETIME}}
+    - {{CITATION_GUIDANCE}}
+    - {{REMINDER_TAG_DESCRIPTION}}
+
+    Returns:
+        tuple[str, bool]: (processed prompt, whether citation guidance should be appended)
+    """
+    prompt_str = replace_reminder_tag(prompt_str)
+
+    original_prompt = prompt_str
+    prompt_str = replace_current_datetime_tag(
         prompt_str,
         full_sentence=False,
         include_day_of_week=True,
     )
-    if prompt_with_datetime != prompt_str:
-        return prompt_with_datetime
-
-    if datetime_aware:
-        return prompt_str + ADDITIONAL_INFO.format(
+    # If no datetime tag was present (string unchanged), optionally append the date.
+    if prompt_str == original_prompt and append_datetime_if_aware and datetime_aware:
+        prompt_str = prompt_str + ADDITIONAL_INFO.format(
             datetime_info=_BASIC_TIME_STR.format(
                 datetime_info=get_current_llm_day_time()
             )
         )
 
-    return prompt_str
+    return replace_citation_guidance_tag(
+        prompt_str,
+        should_cite_documents=should_cite_documents,
+        include_all_guidance=include_all_guidance,
+        append_citation_if_missing=append_citation_if_missing,
+    )
 
 
 def get_company_context() -> str | None:

--- a/backend/tests/unit/onyx/prompts/test_prompt_utils.py
+++ b/backend/tests/unit/onyx/prompts/test_prompt_utils.py
@@ -1,4 +1,12 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from onyx.prompts.chat_prompts import CITATION_GUIDANCE_REPLACEMENT_PAT
+from onyx.prompts.chat_prompts import DATETIME_REPLACEMENT_PAT
+from onyx.prompts.chat_prompts import REQUIRE_CITATION_GUIDANCE
 from onyx.prompts.constants import REMINDER_TAG_DESCRIPTION
+from onyx.prompts.prompt_utils import apply_prompt_placeholders
+from onyx.prompts.prompt_utils import replace_current_datetime_tag
 from onyx.prompts.prompt_utils import replace_reminder_tag
 
 
@@ -13,3 +21,50 @@ def test_replace_reminder_tag_no_pattern() -> None:
     prompt = "Some text without any pattern"
     result = replace_reminder_tag(prompt)
     assert result == prompt
+
+
+@patch(
+    "onyx.prompts.prompt_utils.get_current_llm_day_time",
+    return_value="Wednesday July 15, 2026",
+)
+def test_replace_current_datetime_tag(mock_get_time: MagicMock) -> None:
+    prompt = f"The current date is {DATETIME_REPLACEMENT_PAT}."
+    result = replace_current_datetime_tag(prompt)
+    assert result == "The current date is Wednesday July 15, 2026."
+    mock_get_time.assert_called_once()
+
+
+@patch(
+    "onyx.prompts.prompt_utils.get_current_llm_day_time",
+    return_value="Wednesday July 15, 2026",
+)
+def test_apply_prompt_placeholders_appends_datetime_when_aware(
+    mock_get_time: MagicMock,
+) -> None:
+    prompt = "Custom agent instructions."
+    result, should_append_citation = apply_prompt_placeholders(
+        prompt,
+        datetime_aware=True,
+        append_datetime_if_aware=True,
+    )
+    assert "Wednesday July 15, 2026" in result
+    assert should_append_citation is False
+    mock_get_time.assert_called()
+
+
+@patch(
+    "onyx.prompts.prompt_utils.get_current_llm_day_time",
+    return_value="Wednesday July 15, 2026",
+)
+def test_apply_prompt_placeholders_replaces_citation_guidance(
+    _mock_get_time: MagicMock,
+) -> None:
+    prompt = f"Answer with citations. {CITATION_GUIDANCE_REPLACEMENT_PAT}"
+    result, should_append_citation = apply_prompt_placeholders(
+        prompt,
+        should_cite_documents=True,
+        append_citation_if_missing=False,
+    )
+    assert REQUIRE_CITATION_GUIDANCE in result
+    assert CITATION_GUIDANCE_REPLACEMENT_PAT not in result
+    assert should_append_citation is False


### PR DESCRIPTION
Cherry-pick of commit ac4a86487a158744f97137c2c44d3f02bb54fe30 to release/v4.3 branch.

Original PR: #13028, #13072

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Apply prompt placeholders (datetime, citation guidance, reminder) consistently across system, custom agent, and task prompts to prevent missing or duplicated guidance in v4.3.

- **Bug Fixes**
  - Centralized placeholder handling with `apply_prompt_placeholders` and `process_prompt_template`.
  - Uniformly process `persona.system_prompt`, custom agent prompt, and `persona.task_prompt` in `llm_loop`, respecting `datetime_aware` and citation flags.
  - Updated `build_system_prompt` to use shared logic for datetime and citation guidance; reminder tag handled consistently.
  - Aligned datetime placeholder format in `prompt_template`; added unit tests for datetime replacement, append-when-aware, and citation guidance.

<sup>Written for commit 0518837a679c6c5e32ff5afbe680e0ba994c9b76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13142?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

