### PR TITLE
fix(mcp): single-flight the OAuth refresh primitive per config row

### DIFF
--- a/backend/onyx/cache/interface.py
+++ b/backend/onyx/cache/interface.py
@@ -28,6 +28,12 @@ class CacheLockLostError(Exception):
     it — mutual exclusion is already gone, unlike CACHE_TRANSIENT_ERRORS."""
 
 
+class CacheLockAcquisitionError(Exception):
+    """A shared cache lock could not be acquired within the allotted wait — a
+    concurrent holder still owns it. Distinct from CacheLockLostError, which is
+    about losing a lock already held."""
+
+
 class CacheLock(abc.ABC):
     """Abstract distributed lock returned by CacheBackend.lock()."""
 

--- a/backend/onyx/cache/locks.py
+++ b/backend/onyx/cache/locks.py
@@ -1,0 +1,61 @@
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from logging import Logger
+from logging import LoggerAdapter
+
+from onyx.cache.factory import get_shared_cache_backend
+from onyx.cache.interface import CacheLockAcquisitionError
+
+
+@contextmanager
+def cache_shared_lock(
+    lock_name: str,
+    max_time_lock_held_s: float,
+    wait_for_lock_s: float,
+    logger: Logger | LoggerAdapter,
+) -> Generator[None, None, None]:
+    """Acquire a system-wide (cross-tenant) distributed lock via the configured
+    cache backend.
+
+    Unlike ``redis_shared_lock``, this works on every deployment: full ones back
+    the lock with Redis, Lite (``CACHE_BACKEND=postgres``) with a PostgreSQL
+    advisory lock — same single-flight guarantee without assuming Redis.
+
+    ``max_time_lock_held_s`` is a lease enforced only on Redis, where the lock
+    auto-releases after it even if the holder wedges. A Postgres advisory lock
+    has no TTL — it is held until the guarded block exits or the holding
+    connection drops, so there a wedged holder keeps the lock until it unwinds.
+    Callers must therefore bound their own work under the lock; on Postgres that
+    is the only limit. (A *crashed* holder frees the lock on both backends: Redis
+    lease expiry / Postgres connection close.)
+
+    Raises ``CacheLockAcquisitionError`` if not acquired within ``wait_for_lock_s``.
+    """
+    lock = get_shared_cache_backend().lock(lock_name, timeout=max_time_lock_held_s)
+    acquired = False
+    start_time = time.monotonic()
+    try:
+        acquired = lock.acquire(blocking=True, blocking_timeout=wait_for_lock_s)
+        if not acquired:
+            raise CacheLockAcquisitionError(
+                f"Timed out waiting to acquire cache lock {lock_name} after "
+                f"{time.monotonic() - start_time:.3f} seconds."
+            )
+        yield
+    finally:
+        if acquired:
+            held_s = time.monotonic() - start_time
+            if lock.owned():
+                lock.release()
+                logger.debug("Cache lock %s released after %.3fs.", lock_name, held_s)
+            else:
+                # Lease expired before we finished, so a second caller may
+                # already hold it. The fix is a larger max_time_lock_held_s.
+                logger.warning(
+                    "Cache lock %s lost before release: held %.3fs, exceeding the "
+                    "%.3fs lease. Mutual exclusion may have been violated.",
+                    lock_name,
+                    held_s,
+                    max_time_lock_held_s,
+                )

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -12,6 +12,7 @@ import time
 from typing import Any
 from urllib.parse import urlparse
 
+import httpx
 from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth import TokenStorage
 from mcp.client.auth.oauth2 import OAuthContext
@@ -23,6 +24,8 @@ from pydantic import AnyUrl
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.cache.interface import CacheLockAcquisitionError
+from onyx.cache.locks import cache_shared_lock
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPOAuthProviderMode
@@ -34,16 +37,32 @@ from onyx.db.models import MCPServer as DbMCPServer
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
+from onyx.server.features.mcp.models import MCPConnectionData
 from onyx.server.features.mcp.models import MCPOAuthKeys
 from onyx.server.features.mcp.ssrf import mcp_ssrf_httpx_client_factory
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
 # Refresh slightly before the real expiry to absorb network latency and clock
 # skew between us and the provider, avoiding edge-of-expiry 401s.
 TOKEN_EXPIRY_BUFFER_SECONDS = 30.0
+
+# The refresh POST is a small JSON exchange, so bound it well under the SDK's
+# SSE-sized default timeout.
+_REFRESH_POST_TIMEOUT_S = 30.0
+# How long a contention loser waits for the lock. It must outlast the winner's
+# whole refresh (POST + a couple of quick DB writes) so the loser wakes to the
+# freshly persisted token instead of timing out mid-refresh and falling back to
+# a stale/None header (which 401s). No cost in the common case: acquire returns
+# the instant the winner releases — this is only the cap for a slow winner.
+_REFRESH_LOCK_WAIT_S = _REFRESH_POST_TIMEOUT_S + 5.0
+# Lease bounds how long the holder may keep the lock; exceeds the worst-case
+# refresh so it can't expire mid-refresh and let a second caller reuse the
+# rotating refresh token. Redis-enforced only (see cache_shared_lock).
+_REFRESH_LOCK_LEASE_S = 60.0
 
 
 STATE_TTL_SECONDS = 60 * 5  # 5 minutes
@@ -149,7 +168,9 @@ async def _refresh_mcp_oauth_token_if_expired(
         return f"{current_tokens.token_type} {current_tokens.access_token}"
 
     refresh_request = await provider._refresh_token()
-    async with mcp_ssrf_httpx_client_factory() as client:
+    async with mcp_ssrf_httpx_client_factory(
+        timeout=httpx.Timeout(_REFRESH_POST_TIMEOUT_S)
+    ) as client:
         response = await client.send(refresh_request)
 
     if not await provider._handle_refresh_response(response):
@@ -173,11 +194,53 @@ def refresh_mcp_oauth_token_if_expired(
     connection_config_id: int,
     user_id: str,
 ) -> str | None:
-    """Sync wrapper for `_refresh_mcp_oauth_token_if_expired` (see there for
-    behavior), for the sync `MCPTool.run` call site."""
-    return run_async_sync_no_cancel(
-        _refresh_mcp_oauth_token_if_expired(mcp_server, connection_config_id, user_id)
-    )
+    """Sync entry point for `_refresh_mcp_oauth_token_if_expired`, single-flighted
+    per connection-config row (via `cache_shared_lock`) so two racing refreshes
+    can't redeem — and burn — the same rotating refresh token.
+
+    On contention the loser waits out the in-flight refresh (the wait outlasts a
+    refresh POST) and returns the winner's freshly persisted header. Only if the
+    lock still can't be acquired *and* the stored token is expired does it return
+    None; the caller then falls back to its existing header.
+    """
+    lock_name = f"mcp_token_refresh:{get_current_tenant_id()}:{connection_config_id}"
+    try:
+        with cache_shared_lock(
+            lock_name,
+            max_time_lock_held_s=_REFRESH_LOCK_LEASE_S,
+            wait_for_lock_s=_REFRESH_LOCK_WAIT_S,
+            logger=logger,
+        ):
+            return run_async_sync_no_cancel(
+                _refresh_mcp_oauth_token_if_expired(
+                    mcp_server, connection_config_id, user_id
+                )
+            )
+    except CacheLockAcquisitionError:
+        # Couldn't acquire within the wait; return whatever the winner persisted
+        # (None if it hasn't finished and the stored token is still expired).
+        logger.info(
+            "mcp_token_refresh.lock_contended config_id=%s", connection_config_id
+        )
+        return _persisted_auth_header(connection_config_id)
+
+
+def mcp_token_expired(config_data: MCPConnectionData) -> bool:
+    """True iff the stored access token is past its persisted expiry."""
+    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+    return expires_at is not None and float(expires_at) <= time.time()
+
+
+def _persisted_auth_header(connection_config_id: int) -> str | None:
+    """The stored ``Authorization`` header when the persisted token is still
+    fresh, else None — used as the fallback when a concurrent refresh wins."""
+    with get_session_with_current_tenant() as db:
+        config_data = extract_connection_data(
+            get_connection_config_by_id(connection_config_id, db)
+        )
+    if mcp_token_expired(config_data):
+        return None
+    return (config_data.get("headers") or {}).get("Authorization")
 
 
 def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -8,6 +8,8 @@ the DB layer and the outbound network call.
 """
 
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 from typing import cast
@@ -17,6 +19,7 @@ import httpx
 import pytest
 
 import onyx.server.features.mcp.oauth as mcp_oauth
+from onyx.cache.interface import CacheLockAcquisitionError
 from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.server.features.mcp.models import MCPOAuthKeys
@@ -68,6 +71,13 @@ class _FakeAsyncHttpClient:
         return self._response
 
 
+@contextmanager
+def _noop_shared_lock(*_args: Any, **_kwargs: Any) -> Iterator[None]:
+    """Stand-in for the real shared cache lock so these stay pure unit tests (no
+    live Redis/Postgres). Single-flight coordination is covered elsewhere."""
+    yield
+
+
 def _install_mocks(
     monkeypatch: pytest.MonkeyPatch,
     config_data: dict[str, Any],
@@ -80,6 +90,8 @@ def _install_mocks(
     """
     captured: dict[str, Any] = {}
 
+    # Keep this a true unit test: no live cache backend for the single-flight lock.
+    monkeypatch.setattr(mcp_oauth, "cache_shared_lock", _noop_shared_lock)
     monkeypatch.setattr(
         mcp_oauth, "get_session_with_current_tenant", lambda: _FakeDbSession()
     )
@@ -102,7 +114,11 @@ def _install_mocks(
     monkeypatch.setattr(mcp_oauth, "update_connection_config", _fake_update)
 
     fake_client = _FakeAsyncHttpClient(response or httpx.Response(400), captured)
-    monkeypatch.setattr(mcp_oauth, "mcp_ssrf_httpx_client_factory", lambda: fake_client)
+    monkeypatch.setattr(
+        mcp_oauth,
+        "mcp_ssrf_httpx_client_factory",
+        lambda **_kwargs: fake_client,
+    )
     return captured
 
 
@@ -352,3 +368,51 @@ def test_refresh_failure_is_non_fatal_to_caller(
 
     with pytest.raises(RuntimeError):
         refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+
+@pytest.mark.parametrize(
+    ("expiry_offset_s", "expected_header"),
+    [
+        # Winner already persisted a fresh token: hand its header back.
+        (3600, "Bearer PERSISTED"),
+        # Winner still refreshing, so the stored token is expired and there is no
+        # fresh header yet: return None. The caller (MCPTool.run) then falls back
+        # to its existing header (which will 401 until the refresh lands).
+        (-60, None),
+    ],
+)
+def test_lock_contention_returns_persisted_header_or_none(
+    monkeypatch: pytest.MonkeyPatch,
+    expiry_offset_s: float,
+    expected_header: str | None,
+) -> None:
+    """On lock contention we skip our own refresh and hand back whatever is
+    persisted: the winner's fresh header if it has written one, else None when
+    the stored token is still expired. Never a network call."""
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer PERSISTED"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "PERSISTED",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_2",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() + expiry_offset_s,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "redirect_uris": [_REDIRECT_URI],
+        },
+    }
+    captured = _install_mocks(monkeypatch, config_data, response=_token_response())
+
+    @contextmanager
+    def _contended_lock(*_args: Any, **_kwargs: Any) -> Iterator[None]:
+        raise CacheLockAcquisitionError("held by a concurrent refresher")
+        yield  # pragma: no cover — unreachable, satisfies the generator contract
+
+    monkeypatch.setattr(mcp_oauth, "cache_shared_lock", _contended_lock)
+
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    assert header == expected_header
+    assert "sent_request" not in captured


### PR DESCRIPTION
## Description

`refresh_mcp_oauth_token_if_expired` (the shared MCP OAuth refresh primitive, added in #13085) has no concurrency control. Two in-process refreshes racing the same `mcp_connection_config` row can each redeem the same rotating refresh token; a provider that rotates refresh tokens on use may then reject the loser **and revoke the whole grant** as reuse detection. This is reachable on main today — two concurrent chat SSE tool calls to the same server with an expiring token, or two api-server processes — with no Craft involvement.

- Serialize the primitive with a Redis single-flight lock keyed by `(tenant, connection_config_id)`. On lock contention, hand back whatever the winning refresher has already persisted rather than refreshing again.
- Bound the token-refresh POST to an explicit 30s timeout instead of the MCP SDK client's SSE-sized default (30s connect but **300s read**), and size the lease (60s) to strictly outlast a whole refresh so the lock can't expire mid-POST and re-open the race.
- `mcp_token_expired` moves here as the shared freshness predicate (also used by the contention fallback).

Every in-process caller of this primitive is now coordinated: chat's SSE tool calls today, and the Craft sandbox proxy (#13126) once it lands.

**Known residual:** chat's STREAMABLE_HTTP path refreshes in-band through the MCP SDK's own `httpx.Auth` flow, which does not call this function and so isn't covered by this lock. Coordinating that path is the unify-oauth-refresh follow-up.

## How Has This Been Tested?

Existing MCP OAuth refresh coverage (`tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py`, `test_mcp_known_provider_oauth_helpers.py` — 32 tests) passes with the refactor. The single-flight lock's proxy-facing behavior (contention → persisted-header fallback) is exercised end-to-end in the Craft resolver's suite in #13126.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-flight MCP OAuth token refresh per connection-config row using a backend-agnostic `cache_shared_lock` to stop racing refreshes from burning rotating tokens. On contention, the loser waits out the refresh and returns the winner’s persisted Authorization header; the refresh POST is capped at 30s with a 60s lease.

- **Bug Fixes**
  - Serialize refresh with `cache_shared_lock` keyed by tenant and `connection_config_id`; wait up to 35s to outlast the 30s POST, then return the persisted header via `mcp_token_expired` (or None if still expired).
  - Set an explicit 30s `httpx` timeout for the refresh POST; lock lease is 60s to avoid mid-refresh expiry. Note: the STREAMABLE_HTTP path via the SDK’s `httpx.Auth` is not yet coordinated.

- **New Features**
  - Add `cache_shared_lock` context manager and `CacheLockAcquisitionError`, backed by the configured cache backend (Redis or Postgres advisory locks) for cross-deployment single-flight.

<sup>Written for commit 55b6f2257b5f7eccd5876e9ec4501e401e728156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13143?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



