### PR TITLE
feat(cache): add cache_shared_lock backend-agnostic distributed lock

### DIFF
--- a/backend/onyx/cache/interface.py
+++ b/backend/onyx/cache/interface.py
@@ -28,6 +28,12 @@ class CacheLockLostError(Exception):
     it — mutual exclusion is already gone, unlike CACHE_TRANSIENT_ERRORS."""
 
 
+class CacheLockAcquisitionError(Exception):
+    """A shared cache lock could not be acquired within the allotted wait — a
+    concurrent holder still owns it. Distinct from CacheLockLostError, which is
+    about losing a lock already held."""
+
+
 class CacheLock(abc.ABC):
     """Abstract distributed lock returned by CacheBackend.lock()."""
 

--- a/backend/onyx/cache/locks.py
+++ b/backend/onyx/cache/locks.py
@@ -18,10 +18,6 @@ def cache_shared_lock(
     """Acquire a system-wide (cross-tenant) distributed lock via the configured
     cache backend.
 
-    Unlike ``redis_shared_lock``, this works on every deployment: full ones back
-    the lock with Redis, Lite (``CACHE_BACKEND=postgres``) with a PostgreSQL
-    advisory lock — same single-flight guarantee without assuming Redis.
-
     ``max_time_lock_held_s`` is a lease enforced only on Redis, where the lock
     auto-releases after it even if the holder wedges. A Postgres advisory lock
     has no TTL — it is held until the guarded block exits or the holding

--- a/backend/onyx/cache/locks.py
+++ b/backend/onyx/cache/locks.py
@@ -1,0 +1,61 @@
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from logging import Logger
+from logging import LoggerAdapter
+
+from onyx.cache.factory import get_shared_cache_backend
+from onyx.cache.interface import CacheLockAcquisitionError
+
+
+@contextmanager
+def cache_shared_lock(
+    lock_name: str,
+    max_time_lock_held_s: float,
+    wait_for_lock_s: float,
+    logger: Logger | LoggerAdapter,
+) -> Generator[None, None, None]:
+    """Acquire a system-wide (cross-tenant) distributed lock via the configured
+    cache backend.
+
+    Unlike ``redis_shared_lock``, this works on every deployment: full ones back
+    the lock with Redis, Lite (``CACHE_BACKEND=postgres``) with a PostgreSQL
+    advisory lock — same single-flight guarantee without assuming Redis.
+
+    ``max_time_lock_held_s`` is a lease enforced only on Redis, where the lock
+    auto-releases after it even if the holder wedges. A Postgres advisory lock
+    has no TTL — it is held until the guarded block exits or the holding
+    connection drops, so there a wedged holder keeps the lock until it unwinds.
+    Callers must therefore bound their own work under the lock; on Postgres that
+    is the only limit. (A *crashed* holder frees the lock on both backends: Redis
+    lease expiry / Postgres connection close.)
+
+    Raises ``CacheLockAcquisitionError`` if not acquired within ``wait_for_lock_s``.
+    """
+    lock = get_shared_cache_backend().lock(lock_name, timeout=max_time_lock_held_s)
+    acquired = False
+    start_time = time.monotonic()
+    try:
+        acquired = lock.acquire(blocking=True, blocking_timeout=wait_for_lock_s)
+        if not acquired:
+            raise CacheLockAcquisitionError(
+                f"Timed out waiting to acquire cache lock {lock_name} after "
+                f"{time.monotonic() - start_time:.3f} seconds."
+            )
+        yield
+    finally:
+        if acquired:
+            held_s = time.monotonic() - start_time
+            if lock.owned():
+                lock.release()
+                logger.debug("Cache lock %s released after %.3fs.", lock_name, held_s)
+            else:
+                # Lease expired before we finished, so a second caller may
+                # already hold it. The fix is a larger max_time_lock_held_s.
+                logger.warning(
+                    "Cache lock %s lost before release: held %.3fs, exceeding the "
+                    "%.3fs lease. Mutual exclusion may have been violated.",
+                    lock_name,
+                    held_s,
+                    max_time_lock_held_s,
+                )


### PR DESCRIPTION
## What

Adds `cache_shared_lock`, a system-wide (cross-tenant) distributed lock context manager acquired through the configured `CacheBackend`, plus `CacheLockAcquisitionError` for the contended case.

## Why

Unlike `redis_shared_lock`, this works on **every** deployment:
- Full deployments back the lock with **Redis**.
- Lite deployments (`CACHE_BACKEND=postgres`) back it with a **PostgreSQL advisory lock**.

Callers get the same single-flight guarantee without assuming Redis is available — the engineering rules require code to work on both full and Lite deployments.

This is the base of a small stack: the first consumer is the MCP OAuth single-flight refresh (#follow-up PR), which is why this lands on its own so the primitive can be reviewed independently.

## Notes

- No caller on this branch yet — the consumer arrives in the stacked PR.
- Semantics mirror the existing `redis_shared_lock` (blocking acquire with wait timeout, auto-release on exit), but delegate to `CacheBackend.lock()`.


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a backend-agnostic distributed lock context manager `cache_shared_lock` for cross-tenant single-flight via the configured `CacheBackend`. Introduces `CacheLockAcquisitionError` on acquisition timeouts and logs a warning if the lease expires mid-work.

- **New Features**
  - Cross-tenant `cache_shared_lock(...)` via `get_shared_cache_backend().lock(...)`, backed by Redis (Full) or PostgreSQL advisory locks (Lite).
  - Blocking acquire with `wait_for_lock_s` and lease `max_time_lock_held_s`; auto-release on exit with a debug log; raises `CacheLockAcquisitionError` on timeout; warns if the lease is exceeded (lease TTL enforced on Redis; Postgres advisory locks have no TTL).

<sup>Written for commit a952f604fd97233ab5881dea77dde2f19ecc4641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13145?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



