### PR TITLE
fix(mcp): single-flight the OAuth refresh primitive per config row

### DIFF
--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -12,6 +12,7 @@ import time
 from typing import Any
 from urllib.parse import urlparse
 
+import httpx
 from mcp.client.auth import OAuthClientProvider
 from mcp.client.auth import TokenStorage
 from mcp.client.auth.oauth2 import OAuthContext
@@ -23,6 +24,8 @@ from pydantic import AnyUrl
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.cache.interface import CacheLockAcquisitionError
+from onyx.cache.locks import cache_shared_lock
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPOAuthProviderMode
@@ -34,16 +37,32 @@ from onyx.db.models import MCPServer as DbMCPServer
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
+from onyx.server.features.mcp.models import MCPConnectionData
 from onyx.server.features.mcp.models import MCPOAuthKeys
 from onyx.server.features.mcp.ssrf import mcp_ssrf_httpx_client_factory
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
 # Refresh slightly before the real expiry to absorb network latency and clock
 # skew between us and the provider, avoiding edge-of-expiry 401s.
 TOKEN_EXPIRY_BUFFER_SECONDS = 30.0
+
+# The refresh POST is a small JSON exchange, so bound it well under the SDK's
+# SSE-sized default timeout.
+_REFRESH_POST_TIMEOUT_S = 30.0
+# How long a contention loser waits for the lock. It must outlast the winner's
+# whole refresh (POST + a couple of quick DB writes) so the loser wakes to the
+# freshly persisted token instead of timing out mid-refresh and falling back to
+# a stale/None header (which 401s). No cost in the common case: acquire returns
+# the instant the winner releases — this is only the cap for a slow winner.
+_REFRESH_LOCK_WAIT_S = _REFRESH_POST_TIMEOUT_S + 5.0
+# Lease bounds how long the holder may keep the lock; exceeds the worst-case
+# refresh so it can't expire mid-refresh and let a second caller reuse the
+# rotating refresh token. Redis-enforced only (see cache_shared_lock).
+_REFRESH_LOCK_LEASE_S = 60.0
 
 
 STATE_TTL_SECONDS = 60 * 5  # 5 minutes
@@ -149,7 +168,9 @@ async def _refresh_mcp_oauth_token_if_expired(
         return f"{current_tokens.token_type} {current_tokens.access_token}"
 
     refresh_request = await provider._refresh_token()
-    async with mcp_ssrf_httpx_client_factory() as client:
+    async with mcp_ssrf_httpx_client_factory(
+        timeout=httpx.Timeout(_REFRESH_POST_TIMEOUT_S)
+    ) as client:
         response = await client.send(refresh_request)
 
     if not await provider._handle_refresh_response(response):
@@ -173,11 +194,53 @@ def refresh_mcp_oauth_token_if_expired(
     connection_config_id: int,
     user_id: str,
 ) -> str | None:
-    """Sync wrapper for `_refresh_mcp_oauth_token_if_expired` (see there for
-    behavior), for the sync `MCPTool.run` call site."""
-    return run_async_sync_no_cancel(
-        _refresh_mcp_oauth_token_if_expired(mcp_server, connection_config_id, user_id)
-    )
+    """Sync entry point for `_refresh_mcp_oauth_token_if_expired`, single-flighted
+    per connection-config row (via `cache_shared_lock`) so two racing refreshes
+    can't redeem — and burn — the same rotating refresh token.
+
+    On contention the loser waits out the in-flight refresh (the wait outlasts a
+    refresh POST) and returns the winner's freshly persisted header. Only if the
+    lock still can't be acquired *and* the stored token is expired does it return
+    None; the caller then falls back to its existing header.
+    """
+    lock_name = f"mcp_token_refresh:{get_current_tenant_id()}:{connection_config_id}"
+    try:
+        with cache_shared_lock(
+            lock_name,
+            max_time_lock_held_s=_REFRESH_LOCK_LEASE_S,
+            wait_for_lock_s=_REFRESH_LOCK_WAIT_S,
+            logger=logger,
+        ):
+            return run_async_sync_no_cancel(
+                _refresh_mcp_oauth_token_if_expired(
+                    mcp_server, connection_config_id, user_id
+                )
+            )
+    except CacheLockAcquisitionError:
+        # Couldn't acquire within the wait; return whatever the winner persisted
+        # (None if it hasn't finished and the stored token is still expired).
+        logger.info(
+            "mcp_token_refresh.lock_contended config_id=%s", connection_config_id
+        )
+        return _persisted_auth_header(connection_config_id)
+
+
+def mcp_token_expired(config_data: MCPConnectionData) -> bool:
+    """True iff the stored access token is past its persisted expiry."""
+    expires_at = config_data.get(MCPOAuthKeys.TOKEN_EXPIRES_AT.value)
+    return expires_at is not None and float(expires_at) <= time.time()
+
+
+def _persisted_auth_header(connection_config_id: int) -> str | None:
+    """The stored ``Authorization`` header when the persisted token is still
+    fresh, else None — used as the fallback when a concurrent refresh wins."""
+    with get_session_with_current_tenant() as db:
+        config_data = extract_connection_data(
+            get_connection_config_by_id(connection_config_id, db)
+        )
+    if mcp_token_expired(config_data):
+        return None
+    return (config_data.get("headers") or {}).get("Authorization")
 
 
 def _known_provider_oauth_metadata(mcp_server: DbMCPServer) -> OAuthMetadata | None:

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -8,6 +8,8 @@ the DB layer and the outbound network call.
 """
 
 import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any
 from typing import cast
@@ -17,6 +19,7 @@ import httpx
 import pytest
 
 import onyx.server.features.mcp.oauth as mcp_oauth
+from onyx.cache.interface import CacheLockAcquisitionError
 from onyx.db.enums import MCPOAuthProviderMode
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.server.features.mcp.models import MCPOAuthKeys
@@ -68,6 +71,13 @@ class _FakeAsyncHttpClient:
         return self._response
 
 
+@contextmanager
+def _noop_shared_lock(*_args: Any, **_kwargs: Any) -> Iterator[None]:
+    """Stand-in for the real shared cache lock so these stay pure unit tests (no
+    live Redis/Postgres). Single-flight coordination is covered elsewhere."""
+    yield
+
+
 def _install_mocks(
     monkeypatch: pytest.MonkeyPatch,
     config_data: dict[str, Any],
@@ -80,6 +90,8 @@ def _install_mocks(
     """
     captured: dict[str, Any] = {}
 
+    # Keep this a true unit test: no live cache backend for the single-flight lock.
+    monkeypatch.setattr(mcp_oauth, "cache_shared_lock", _noop_shared_lock)
     monkeypatch.setattr(
         mcp_oauth, "get_session_with_current_tenant", lambda: _FakeDbSession()
     )
@@ -102,7 +114,11 @@ def _install_mocks(
     monkeypatch.setattr(mcp_oauth, "update_connection_config", _fake_update)
 
     fake_client = _FakeAsyncHttpClient(response or httpx.Response(400), captured)
-    monkeypatch.setattr(mcp_oauth, "mcp_ssrf_httpx_client_factory", lambda: fake_client)
+    monkeypatch.setattr(
+        mcp_oauth,
+        "mcp_ssrf_httpx_client_factory",
+        lambda **_kwargs: fake_client,
+    )
     return captured
 
 
@@ -352,3 +368,51 @@ def test_refresh_failure_is_non_fatal_to_caller(
 
     with pytest.raises(RuntimeError):
         refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+
+@pytest.mark.parametrize(
+    ("expiry_offset_s", "expected_header"),
+    [
+        # Winner already persisted a fresh token: hand its header back.
+        (3600, "Bearer PERSISTED"),
+        # Winner still refreshing, so the stored token is expired and there is no
+        # fresh header yet: return None. The caller (MCPTool.run) then falls back
+        # to its existing header (which will 401 until the refresh lands).
+        (-60, None),
+    ],
+)
+def test_lock_contention_returns_persisted_header_or_none(
+    monkeypatch: pytest.MonkeyPatch,
+    expiry_offset_s: float,
+    expected_header: str | None,
+) -> None:
+    """On lock contention we skip our own refresh and hand back whatever is
+    persisted: the winner's fresh header if it has written one, else None when
+    the stored token is still expired. Never a network call."""
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer PERSISTED"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "PERSISTED",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_2",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() + expiry_offset_s,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "redirect_uris": [_REDIRECT_URI],
+        },
+    }
+    captured = _install_mocks(monkeypatch, config_data, response=_token_response())
+
+    @contextmanager
+    def _contended_lock(*_args: Any, **_kwargs: Any) -> Iterator[None]:
+        raise CacheLockAcquisitionError("held by a concurrent refresher")
+        yield  # pragma: no cover — unreachable, satisfies the generator contract
+
+    monkeypatch.setattr(mcp_oauth, "cache_shared_lock", _contended_lock)
+
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    assert header == expected_header
+    assert "sent_request" not in captured


### PR DESCRIPTION
## What

Serializes SSE-transport MCP OAuth token refreshes **per connection-config row** so two racing callers can't redeem — and burn — the same rotating refresh token. On contention, the loser returns whatever the winner has already persisted rather than refreshing again.

## Why

`refresh_mcp_oauth_token_if_expired` is hit concurrently by chat's SSE tool calls (`MCPTool.run`) and the Craft sandbox proxy. Without coordination, two callers can each POST the same refresh token; providers that rotate refresh tokens invalidate the first, breaking the other caller.

## How

Coordinates via the shared cache backend (`cache_shared_lock`) rather than a Redis-only lock, so single-flight holds on **both** full (Redis) and Lite (Postgres advisory lock) deployments without assuming Redis is available.

## Stacked on

- Base: **#13145** (`feat(cache): add cache_shared_lock ...`). This PR targets `dane/cache-shared-lock` so the diff shows only the MCP-side changes (`oauth.py` + tests). Rebase/retarget to `main` once #13145 merges.

## Tests

`backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py` — pure unit tests (cache lock stubbed, no live Redis/Postgres), covering refresh, auth-method branching, the no-refresh cases, and the lock-contention fallback.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Single-flights MCP OAuth token refresh per connection-config row (tenant-scoped) to stop two callers from redeeming the same rotating refresh token. On contention, we wait for the in-flight refresh and reuse the winner’s persisted Authorization header; if the stored token is still expired, return None.

- **Bug Fixes**
  - Coordinate refresh via `cache_shared_lock` so single-flight works in both Redis and Lite (Postgres advisory lock); key is `mcp_token_refresh:{tenant_id}:{config_id}`.
  - Use `httpx` with a 30s timeout for the refresh POST; set lock wait/lease to 35s/60s so the loser wakes after the refresh and sees the fresh header.
  - Add helpers to detect token expiry and read persisted headers; on lock acquisition failure, return the stored header only if still valid. Unit tests cover refresh, no-refresh, and contention (header or None) with no network calls.

<sup>Written for commit a59d35a5e4bfcb3fe938acc888bace6567a9bbf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



