### PR TITLE
fix(auth): admin modal shows the SAML ACS the flow actually validates

### DIFF
--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -90,8 +90,11 @@ def sso_login_callback_uri(
     operator must allowlist at the IdP. Rows migrated from single-provider env
     config keep the legacy URI their IdP client already allowlists."""
     if provider.provider_type is SSOProviderType.SAML:
-        # Single issuer-resolved ACS for every SAML row.
-        return f"{web_domain}/api/auth/saml/callback"
+        # Single issuer-resolved ACS for every SAML row. No /api prefix: the
+        # AuthnRequest advertises this exact URL, nginx routes /auth/saml to
+        # the backend directly, and strict Destination validation compares
+        # against the stripped path.
+        return f"{web_domain}/auth/saml/callback"
     if config.get("legacy_callback"):
         if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
             return f"{web_domain}/auth/oauth/callback"

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -284,8 +284,9 @@ def test_create_saml_provider(
     provider_names.append(name)
     body = response.json()
     assert body["provider_type"] == SSOProviderType.SAML.value
-    # Single issuer-resolved ACS for every SAML row.
-    assert body["redirect_uri"] == f"{WEB_DOMAIN}/api/auth/saml/callback"
+    # Single issuer-resolved ACS for every SAML row, no /api prefix (the
+    # AuthnRequest advertises this exact URL).
+    assert body["redirect_uri"] == f"{WEB_DOMAIN}/auth/saml/callback"
     assert is_masked_credential(body["config"]["sp_private_key"]) is True
 
     raw = _stored_config(db_session, body["id"])

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -277,7 +277,7 @@ def test_login_callback_uri_saml_is_fixed_acs() -> None:
 
     provider = _provider(name="corp-saml", provider_type=SSOProviderType.SAML)
     uri = sso_login_callback_uri(provider, {}, "https://onyx.example.com")
-    assert uri == "https://onyx.example.com/api/auth/saml/callback"
+    assert uri == "https://onyx.example.com/auth/saml/callback"
 
 
 def test_fixed_callback_rejects_missing_state() -> None:


### PR DESCRIPTION
## Description

The SSO provider modal (and docs) told operators to register `{WEB_DOMAIN}/api/auth/saml/callback` as the ACS. The SAML flow disagrees on all three enforcement points:

- the AuthnRequest advertises `{WEB_DOMAIN}/auth/saml/callback` (`saml_multi.py` `assertionConsumerService`),
- nginx routes `^/auth/saml` directly to the backend,
- python3-saml strict mode validates the response `Destination` against the current URL built from the stripped path.

Registering the displayed `/api` form makes the advertised ACS differ from the registration and fails the Destination check. `sso_login_callback_uri` now returns the non-`/api` form for SAML rows; the two tests that pinned the `/api` form are updated. OIDC/Google branches untouched (plain OAuth redirects, the `/api`-routed form is correct there).

Display-only: the flow's own URLs are unchanged.

## How Has This Been Tested?

## Additional Options

- [x] I have considered whether this PR needs to be cherry-picked to the latest release branch.
- [x] Override Linear Check