### PR TITLE
feat(desktop): add --version flag

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1204,9 +1204,7 @@ struct VersionResponse {
 
 /// Whether the process was launched with `--version` / `-v`.
 fn wants_version() -> bool {
-    std::env::args()
-        .skip(1)
-        .any(|arg| arg == "--version" || arg == "-v")
+    std::env::args().any(|arg| arg == "--version" || arg == "-v")
 }
 
 /// Fetch the backend version from the configured server's public `/api/version`
@@ -1219,7 +1217,13 @@ fn fetch_server_version(server_url: &str) -> Result<Option<String>, String> {
             .timeout(std::time::Duration::from_secs(5))
             .build()
             .map_err(|e| e.to_string())?;
-        let resp = client.get(&url).send().await.map_err(|e| e.to_string())?;
+        let resp = client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| e.to_string())?
+            .error_for_status()
+            .map_err(|e| e.to_string())?;
         let text = resp.text().await.map_err(|e| e.to_string())?;
         let body: VersionResponse =
             serde_json::from_str(&text).map_err(|e| e.to_string())?;
@@ -1242,7 +1246,7 @@ fn print_version_info() {
     match fetch_server_version(&server_url) {
         Ok(Some(version)) => println!("Server version: {}", version),
         Ok(None) => println!("Server version: unknown (empty response from {})", server_url),
-        Err(_) => println!("Server version: unknown (could not reach {})", server_url),
+        Err(_) => println!("Server version: unknown (could not fetch from {})", server_url),
     }
 }
 

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -1194,10 +1194,68 @@ fn setup_tray_icon(app: &AppHandle) -> tauri::Result<()> {
 }
 
 // ============================================================================
+// Version
+// ============================================================================
+
+#[derive(Deserialize)]
+struct VersionResponse {
+    backend_version: String,
+}
+
+/// Whether the process was launched with `--version` / `-v`.
+fn wants_version() -> bool {
+    std::env::args()
+        .skip(1)
+        .any(|arg| arg == "--version" || arg == "-v")
+}
+
+/// Fetch the backend version from the configured server's public `/api/version`
+/// endpoint. `Ok(None)` means the server answered but reported no version.
+fn fetch_server_version(server_url: &str) -> Result<Option<String>, String> {
+    let url = format!("{}/api/version", server_url.trim_end_matches('/'));
+
+    tauri::async_runtime::block_on(async move {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .map_err(|e| e.to_string())?;
+        let resp = client.get(&url).send().await.map_err(|e| e.to_string())?;
+        let text = resp.text().await.map_err(|e| e.to_string())?;
+        let body: VersionResponse =
+            serde_json::from_str(&text).map_err(|e| e.to_string())?;
+        if body.backend_version.trim().is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(body.backend_version))
+        }
+    })
+}
+
+/// Print client and (if reachable) server version, mirroring the CLI's
+/// `--version` output.
+fn print_version_info() {
+    println!("Client version: {}", env!("CARGO_PKG_VERSION"));
+
+    let (config, _) = load_config();
+    let server_url = config.server_url;
+
+    match fetch_server_version(&server_url) {
+        Ok(Some(version)) => println!("Server version: {}", version),
+        Ok(None) => println!("Server version: unknown (empty response from {})", server_url),
+        Err(_) => println!("Server version: unknown (could not reach {})", server_url),
+    }
+}
+
+// ============================================================================
 // Main
 // ============================================================================
 
 fn main() {
+    if wants_version() {
+        print_version_info();
+        return;
+    }
+
     let (config, config_initialized) = load_config();
     let debug_mode = is_debug_mode();
 


### PR DESCRIPTION
## Description

Adds a `--version` flag to the desktop (Tauri) app, mirroring the CLI's `--version` output. Launching the binary with `--version` (or `-v`) now prints:

- **Client version** — from `CARGO_PKG_VERSION` (CI injects the real version into `Cargo.toml` at build time).
- **Server version** — fetched from the configured server's public `GET /api/version` endpoint (the same endpoint the CLI uses), with graceful fallbacks when the server is unreachable or reports no version.

```
Client version: 1.2.3
Server version: 3.1.0
```

The check runs at the top of `main()` and exits before the Tauri app is built. It reuses the existing async `reqwest` client via `tauri::async_runtime::block_on` and the existing config loader, so no `Cargo.toml`/lockfile changes were needed (the body is parsed with the already-present `serde_json` to avoid enabling reqwest's `json` feature).

Similar in spirit to `cli/internal/version/version.go` + the CLI's `printVersion`.

## How Has This Been Tested?

This repo's dev container has no Rust toolchain (`cargo`/`rustc` unavailable), so it hasn't been compiled locally yet — relying on the desktop-build CI (`pr-desktop-build.yml`) for the compile check. The change follows existing patterns in `main.rs` (`Deserialize` already imported; `reqwest`, `serde_json`, and `tauri::async_runtime` already used).

> **Note:** On Windows release builds (`windows_subsystem = "windows"`), `println!` output isn't visible unless launched from an attached console — same limitation as the existing `--debug` mode. macOS/Linux work normally.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--version` (`-v`) flag to the desktop app that prints the client and connected server versions, then exits. It runs before the Tauri app starts and mirrors the CLI’s output.

- **New Features**
  - Prints “Client version: X” and “Server version: Y” (or “unknown” if unreachable/empty), using the configured server’s `/api/version`.

- **Bug Fixes**
  - Validate HTTP status before parsing; non-2xx now reports “could not fetch from <server>” instead of a JSON parse error.
  - Simplified `--version` arg scan to match existing flag handling.

<sup>Written for commit f50108c124620a15e43ea7b408d55cd8bd6c128c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

