### PR TITLE
fix(craft): preserve stale skill refresh ordering

### DIFF
--- a/web/src/app/craft/hooks/useBuildSessionController.test.tsx
+++ b/web/src/app/craft/hooks/useBuildSessionController.test.tsx
@@ -101,4 +101,32 @@ describe("useBuildSessionController", () => {
       useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
     ).toBe(false);
   });
+
+  it("applies stale state after an unrelated session update", async () => {
+    let resolveRefresh:
+      | ((value: { skills_stale: boolean }) => void)
+      | undefined;
+    jest.mocked(api.fetchSession).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefresh = resolve;
+      }) as never
+    );
+
+    renderHook(() =>
+      useBuildSessionController({ existingSessionId: SESSION_ID })
+    );
+    await waitFor(() => expect(api.fetchSession).toHaveBeenCalled());
+
+    await act(async () => {
+      useBuildSessionStore.getState().updateSessionData(SESSION_ID, {
+        status: "running",
+      });
+      resolveRefresh?.({ skills_stale: true });
+      await Promise.resolve();
+    });
+
+    expect(
+      useBuildSessionStore.getState().sessions.get(SESSION_ID)?.skillsStale
+    ).toBe(true);
+  });
 });

--- a/web/src/app/craft/hooks/useBuildSessionController.ts
+++ b/web/src/app/craft/hooks/useBuildSessionController.ts
@@ -102,6 +102,7 @@ export function useBuildSessionController({
         .getState()
         .sessions.get(sessionId);
       if (!cachedSession?.isLoaded) return;
+      const skillsStaleRevision = cachedSession.skillsStaleRevision;
 
       try {
         const session = await fetchSession(sessionId, {
@@ -110,7 +111,7 @@ export function useBuildSessionController({
         const currentSession = useBuildSessionStore
           .getState()
           .sessions.get(sessionId);
-        if (currentSession !== cachedSession) return;
+        if (currentSession?.skillsStaleRevision !== skillsStaleRevision) return;
         updateSessionData(sessionId, {
           skillsStale: session.skills_stale,
         });

--- a/web/src/app/craft/hooks/useBuildSessionStore.ts
+++ b/web/src/app/craft/hooks/useBuildSessionStore.ts
@@ -632,6 +632,8 @@ export interface BuildSessionData {
   agentProvider: string | null;
   agentModel: string | null;
   skillsStale: boolean;
+  /** Incremented only with skillsStale so async refreshes can reject stale responses. */
+  skillsStaleRevision: number;
   origin: SessionOrigin;
   abortController: AbortController;
   lastAccessed: Date;
@@ -878,6 +880,7 @@ const createInitialSessionData = (
   agentProvider: null,
   agentModel: null,
   skillsStale: false,
+  skillsStaleRevision: 0,
   origin: "INTERACTIVE",
   abortController: new AbortController(),
   lastAccessed: new Date(),
@@ -1023,6 +1026,10 @@ export const useBuildSessionStore = create<BuildSessionStore>()((set, get) => ({
       const updatedSession: BuildSessionData = {
         ...session,
         ...updates,
+        skillsStaleRevision:
+          updates.skillsStale === undefined
+            ? session.skillsStaleRevision
+            : session.skillsStaleRevision + 1,
         lastAccessed: new Date(),
       };
       const newSessions = new Map(state.sessions);


### PR DESCRIPTION
## Description

Prevent delayed session-state refreshes from either overwriting a completed skills reload or being discarded by unrelated session updates.

A client-only stale-state revision now advances only when skillsStale changes. In-flight refreshes are accepted across unrelated session updates and rejected after a newer reload or stale-state update, including false → true → false transitions.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check