### PR TITLE
feat(mcp): emit craft-enabled MCP servers into opencode config

### DIFF
--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -58,13 +58,20 @@ def get_mcp_servers_by_owner(owner_email: str, db_session: Session) -> list[MCPS
     )
 
 
-def get_craft_enabled_mcp_servers(db_session: Session) -> list[MCPServer]:
-    """Get all MCP servers an admin has made available to the Craft agent"""
-    return list(
-        db_session.scalars(
-            select(MCPServer).where(MCPServer.available_in_craft.is_(True))
-        ).all()
-    )
+def get_craft_enabled_mcp_servers(
+    db_session: Session, user: User | None
+) -> list[MCPServer]:
+    """MCP servers an admin has made available to the Craft agent.
+
+    With ``user``, only servers that user may use (public, shared with them,
+    or owned). ``None`` skips the access filter — reserved for callers that
+    match by host before a user is known (the proxy's claim path); user-facing
+    surfaces must pass the user.
+    """
+    stmt = select(MCPServer).where(MCPServer.available_in_craft.is_(True))
+    if user is not None:
+        stmt = _add_mcp_server_access_filter(stmt, user)
+    return list(db_session.scalars(stmt).all())
 
 
 def get_mcp_servers_for_persona(

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -279,6 +279,15 @@ def get_all_mcp_tools_for_server(server_id: int, db_session: Session) -> list[To
     )
 
 
+def get_mcp_tools_for_servers(server_ids: list[int], db_session: Session) -> list[Tool]:
+    """All MCP tools across ``server_ids`` in a single query"""
+    if not server_ids:
+        return []
+    return list(
+        db_session.scalars(select(Tool).where(Tool.mcp_server_id.in_(server_ids))).all()
+    )
+
+
 def add_user_to_mcp_server(server_id: int, user_id: UUID, db_session: Session) -> None:
     """Grant a user access to an MCP server"""
     server = get_mcp_server_by_id(server_id, db_session)

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -61,13 +61,9 @@ def get_mcp_servers_by_owner(owner_email: str, db_session: Session) -> list[MCPS
 def get_craft_enabled_mcp_servers(
     db_session: Session, user: User | None
 ) -> list[MCPServer]:
-    """MCP servers an admin has made available to the Craft agent.
-
-    With ``user``, only servers that user may use (public, shared with them,
-    or owned). ``None`` skips the access filter — reserved for callers that
-    match by host before a user is known (the proxy's claim path); user-facing
-    surfaces must pass the user.
-    """
+    """MCP servers an admin has made available to the Craft agent, filtered to
+    those ``user`` may use (public / shared / owned). ``None`` skips the access
+    filter — only for host matching before a user is known (proxy claim path)."""
     stmt = select(MCPServer).where(MCPServer.available_in_craft.is_(True))
     if user is not None:
         stmt = _add_mcp_server_access_filter(stmt, user)

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -167,8 +167,7 @@ class MCPServerResolver(CredentialResolver):
                     f"sandbox user {short_log_id(user_id)} not found"
                 )
             if not user_can_access_mcp_server(user, server.id, db):
-                # Craft-enabled but not shared with this user: never inject
-                # the admin's credentials for them.
+                # Not shared with this user — never inject admin creds for them.
                 raise CredentialUnavailableError(
                     f"user {short_log_id(user_id)} lacks access to MCP server "
                     f"{server.id}"
@@ -248,8 +247,7 @@ class MCPServerResolver(CredentialResolver):
 
     def _load_targets(self, tenant_id: str) -> tuple[_CraftMCPTarget, ...]:
         with get_session_with_tenant(tenant_id=tenant_id) as db:
-            # No user yet at claim time — host matching only; per-user access
-            # is enforced in resolve().
+            # No user at claim time; access is enforced in resolve().
             servers = get_craft_enabled_mcp_servers(db, None)
             parsed = [_parse_target(s.id, s.server_url) for s in servers]
         return tuple(t for t in parsed if t is not None)

--- a/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
+++ b/backend/onyx/sandbox_proxy/resolvers/mcp_server.py
@@ -27,6 +27,7 @@ from onyx.db.mcp import (
     get_craft_enabled_mcp_servers,
     get_mcp_server_by_id,
     resolve_mcp_credentials,
+    user_can_access_mcp_server,
 )
 from onyx.db.models import MCPServer
 from onyx.db.users import fetch_user_by_id
@@ -165,6 +166,13 @@ class MCPServerResolver(CredentialResolver):
                 raise CredentialUnavailableError(
                     f"sandbox user {short_log_id(user_id)} not found"
                 )
+            if not user_can_access_mcp_server(user, server.id, db):
+                # Craft-enabled but not shared with this user: never inject
+                # the admin's credentials for them.
+                raise CredentialUnavailableError(
+                    f"user {short_log_id(user_id)} lacks access to MCP server "
+                    f"{server.id}"
+                )
             try:
                 creds = resolve_mcp_credentials(server, user, db)
             except MCPCredentialsError as e:
@@ -240,7 +248,9 @@ class MCPServerResolver(CredentialResolver):
 
     def _load_targets(self, tenant_id: str) -> tuple[_CraftMCPTarget, ...]:
         with get_session_with_tenant(tenant_id=tenant_id) as db:
-            servers = get_craft_enabled_mcp_servers(db)
+            # No user yet at claim time — host matching only; per-user access
+            # is enforced in resolve().
+            servers = get_craft_enabled_mcp_servers(db, None)
             parsed = [_parse_target(s.id, s.server_url) for s in servers]
         return tuple(t for t in parsed if t is not None)
 

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -131,8 +131,8 @@ class SandboxManager(_ServeMixin, ABC):
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
 
         ``mcp_servers``: craft-enabled MCP servers to pre-register as remote
-        MCP endpoints in opencode's startup config (URL only; the proxy injects
-        credentials). Like ``all_llm_configs``, pre-loaded once at provision.
+        MCP endpoints in opencode's startup config (URL only; the proxy
+        injects credentials).
 
         Creates the sandbox container/directory with:
         - sessions/ directory for per-session workspaces

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -31,6 +31,7 @@ from onyx.server.features.build.sandbox.event_schema import (
     ToolCallStart,
 )
 from onyx.server.features.build.sandbox.models import (
+    CraftMCPServerConfig,
     FatalWriteError,
     FileSet,
     FilesystemEntry,
@@ -120,6 +121,7 @@ class SandboxManager(_ServeMixin, ABC):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        mcp_servers: list[CraftMCPServerConfig] | None = None,
     ) -> SandboxInfo:
         """Provision a new sandbox for a user.
 
@@ -127,6 +129,10 @@ class SandboxManager(_ServeMixin, ABC):
         configured. K8s pre-loads each into opencode-serve's startup config
         so per-prompt model overrides can cross providers without restarting
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
+
+        ``mcp_servers``: craft-enabled MCP servers to pre-register as remote
+        MCP endpoints in opencode's startup config (URL only; the proxy injects
+        credentials). Like ``all_llm_configs``, pre-loaded once at provision.
 
         Creates the sandbox container/directory with:
         - sessions/ directory for per-session workspaces

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -16,7 +16,7 @@ Architecture Note (User-Shared Sandbox Model):
 
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from uuid import UUID
 
@@ -121,7 +121,7 @@ class SandboxManager(_ServeMixin, ABC):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        mcp_servers: list[CraftMCPServerConfig] | None = None,
+        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         """Provision a new sandbox for a user.
 

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -120,6 +120,7 @@ from onyx.server.features.build.sandbox.labels import (
     LABEL_TENANT_ID,
 )
 from onyx.server.features.build.sandbox.models import (
+    CraftMCPServerConfig,
     FileSet,
     FilesystemEntry,
     LLMProviderConfig,
@@ -826,6 +827,7 @@ class DockerSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        mcp_servers: list[CraftMCPServerConfig] | None = None,
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")
@@ -875,6 +877,7 @@ class DockerSandboxManager(SandboxManager):
                     default_model=llm_config.model_name,
                     disabled_tools=OPENCODE_DISABLED_TOOLS,
                     plugins=plugins,
+                    mcp_servers=mcp_servers,
                 )
             )
             self._ensure_sandbox_image()

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -68,7 +68,7 @@ import shlex
 import tarfile
 import threading
 import time
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from pathlib import Path
 from typing import TypedDict
 from uuid import UUID
@@ -827,7 +827,7 @@ class DockerSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        mcp_servers: list[CraftMCPServerConfig] | None = None,
+        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -108,6 +108,7 @@ from onyx.server.features.build.sandbox.labels import (
     LABEL_TENANT_ID,
 )
 from onyx.server.features.build.sandbox.models import (
+    CraftMCPServerConfig,
     FatalWriteError,
     FileSet,
     FilesystemEntry,
@@ -1007,6 +1008,7 @@ class KubernetesSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        mcp_servers: list[CraftMCPServerConfig] | None = None,
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1120,6 +1122,7 @@ class KubernetesSandboxManager(SandboxManager):
                             _OPENCODE_CONNECT_APP_PLUGIN_PATH,
                             _OPENCODE_SESSION_TAG_PLUGIN_PATH,
                         ],
+                        mcp_servers=mcp_servers,
                     )
                 )
                 self._provision_opencode_secret(str(sandbox_id), opencode_config_json)

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -49,7 +49,7 @@ import tarfile
 import tempfile
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from typing import cast
@@ -1008,7 +1008,7 @@ class KubernetesSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        mcp_servers: list[CraftMCPServerConfig] | None = None,
+        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -24,17 +24,11 @@ class LLMProviderConfig(BaseModel):
 
 
 class CraftMCPServerConfig(BaseModel):
-    """A craft-enabled MCP server, resolved for opencode `mcp` emission.
-
-    Static (URL only) — credentials are never in opencode.json; the sandbox
-    proxy injects them per request. ``key`` is the opencode server id (the tool
-    namespace the agent sees). ``disabled_tools`` are chat-side tool-curation
-    disables (from ``Tool.enabled``) carried over to Craft.
-    """
+    """A craft-enabled MCP server resolved for opencode `mcp` emission (URL only;
+    the proxy injects credentials). ``key`` is the opencode server id."""
 
     key: str
     url: str
-    enabled_tools: tuple[str, ...] = ()
     disabled_tools: tuple[str, ...] = ()
 
 

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -23,6 +23,21 @@ class LLMProviderConfig(BaseModel):
     api_base: str | None
 
 
+class CraftMCPServerConfig(BaseModel):
+    """A craft-enabled MCP server, resolved for opencode `mcp` emission.
+
+    Static (URL only) — credentials are never in opencode.json; the sandbox
+    proxy injects them per request. ``key`` is the opencode server id (the tool
+    namespace the agent sees). ``disabled_tools`` are chat-side tool-curation
+    disables (from ``Tool.enabled``) carried over to Craft.
+    """
+
+    key: str
+    url: str
+    enabled_tools: tuple[str, ...] = ()
+    disabled_tools: tuple[str, ...] = ()
+
+
 class SandboxInfo(BaseModel):
     """Information about a sandbox instance.
 

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -27,10 +27,9 @@ def resolve_craft_mcp_servers(
     """Craft-enabled MCP servers ``user`` may use, as opencode config input.
     Two queries: the servers, then a bulk fetch of their tools.
 
-    Access (public / shared / owned) is filtered here; authentication is not —
-    auth state changes mid-session (connect, token expiry) while this config is
-    baked at provision, so the proxy enforces credentials per request and
-    surfaces a "connect this server" detail for unauthenticated ones."""
+    Access is filtered here; authentication is not — auth state changes
+    mid-session while this config is baked at provision, so the proxy enforces
+    credentials per request."""
     servers = get_craft_enabled_mcp_servers(db_session, user)
     disabled_by_server: dict[int, list[str]] = defaultdict(list)
     for tool in get_mcp_tools_for_servers([s.id for s in servers], db_session):

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from sqlalchemy.orm import Session
 
 from onyx.db.mcp import get_craft_enabled_mcp_servers, get_mcp_tools_for_servers
-from onyx.db.models import MCPServer
+from onyx.db.models import MCPServer, User
 from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
 
 _NON_IDENTIFIER = re.compile(r"[^a-z0-9]+")
@@ -21,10 +21,17 @@ def _server_key(server: MCPServer) -> str:
     return f"{slug}-{server.id}"
 
 
-def resolve_craft_mcp_servers(db_session: Session) -> list[CraftMCPServerConfig]:
-    """Craft-enabled MCP servers as opencode config input. Two queries: the
-    servers, then a bulk fetch of their tools."""
-    servers = get_craft_enabled_mcp_servers(db_session)
+def resolve_craft_mcp_servers(
+    db_session: Session, user: User
+) -> list[CraftMCPServerConfig]:
+    """Craft-enabled MCP servers ``user`` may use, as opencode config input.
+    Two queries: the servers, then a bulk fetch of their tools.
+
+    Access (public / shared / owned) is filtered here; authentication is not —
+    auth state changes mid-session (connect, token expiry) while this config is
+    baked at provision, so the proxy enforces credentials per request and
+    surfaces a "connect this server" detail for unauthenticated ones."""
+    servers = get_craft_enabled_mcp_servers(db_session, user)
     disabled_by_server: dict[int, list[str]] = defaultdict(list)
     for tool in get_mcp_tools_for_servers([s.id for s in servers], db_session):
         if tool.mcp_server_id is not None and not tool.enabled:

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -1,0 +1,44 @@
+"""Resolve craft-enabled MCP servers into static opencode `mcp` config.
+
+Credentials are deliberately absent — the sandbox proxy injects them per
+request, so the emitted config is identical whether or not a user has connected
+a server. Chat-side per-tool curation (`Tool.enabled`) carries over as opencode
+enable/disable entries.
+"""
+
+from __future__ import annotations
+
+import re
+
+from sqlalchemy.orm import Session
+
+from onyx.db.mcp import get_all_mcp_tools_for_server
+from onyx.db.mcp import get_craft_enabled_mcp_servers
+from onyx.db.models import MCPServer
+from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
+
+_NON_IDENTIFIER = re.compile(r"[^a-z0-9]+")
+
+
+def _server_key(server: MCPServer) -> str:
+    """A stable, identifier-safe opencode server id. The row id suffix keeps it
+    unique across servers that slugify to the same name."""
+    slug = _NON_IDENTIFIER.sub("-", server.name.lower()).strip("-") or "mcp"
+    return f"{slug}-{server.id}"
+
+
+def resolve_craft_mcp_servers(db_session: Session) -> list[CraftMCPServerConfig]:
+    """Every craft-enabled MCP server as opencode config input, with its tools
+    split into enabled/disabled by the admin's chat-side curation."""
+    configs: list[CraftMCPServerConfig] = []
+    for server in get_craft_enabled_mcp_servers(db_session):
+        tools = get_all_mcp_tools_for_server(server.id, db_session)
+        configs.append(
+            CraftMCPServerConfig(
+                key=_server_key(server),
+                url=server.server_url,
+                enabled_tools=tuple(t.name for t in tools if t.enabled),
+                disabled_tools=tuple(t.name for t in tools if not t.enabled),
+            )
+        )
+    return configs

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -1,19 +1,13 @@
-"""Resolve craft-enabled MCP servers into static opencode `mcp` config.
-
-Credentials are deliberately absent — the sandbox proxy injects them per
-request, so the emitted config is identical whether or not a user has connected
-a server. Chat-side per-tool curation (`Tool.enabled`) carries over as opencode
-enable/disable entries.
-"""
+"""Resolve craft-enabled MCP servers into opencode `mcp` config input."""
 
 from __future__ import annotations
 
 import re
+from collections import defaultdict
 
 from sqlalchemy.orm import Session
 
-from onyx.db.mcp import get_all_mcp_tools_for_server
-from onyx.db.mcp import get_craft_enabled_mcp_servers
+from onyx.db.mcp import get_craft_enabled_mcp_servers, get_mcp_tools_for_servers
 from onyx.db.models import MCPServer
 from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
 
@@ -21,24 +15,25 @@ _NON_IDENTIFIER = re.compile(r"[^a-z0-9]+")
 
 
 def _server_key(server: MCPServer) -> str:
-    """A stable, identifier-safe opencode server id. The row id suffix keeps it
-    unique across servers that slugify to the same name."""
+    """Identifier-safe opencode server id; the id suffix keeps it unique across
+    servers that slugify to the same name."""
     slug = _NON_IDENTIFIER.sub("-", server.name.lower()).strip("-") or "mcp"
     return f"{slug}-{server.id}"
 
 
 def resolve_craft_mcp_servers(db_session: Session) -> list[CraftMCPServerConfig]:
-    """Every craft-enabled MCP server as opencode config input, with its tools
-    split into enabled/disabled by the admin's chat-side curation."""
-    configs: list[CraftMCPServerConfig] = []
-    for server in get_craft_enabled_mcp_servers(db_session):
-        tools = get_all_mcp_tools_for_server(server.id, db_session)
-        configs.append(
-            CraftMCPServerConfig(
-                key=_server_key(server),
-                url=server.server_url,
-                enabled_tools=tuple(t.name for t in tools if t.enabled),
-                disabled_tools=tuple(t.name for t in tools if not t.enabled),
-            )
+    """Craft-enabled MCP servers as opencode config input. Two queries: the
+    servers, then a bulk fetch of their tools."""
+    servers = get_craft_enabled_mcp_servers(db_session)
+    disabled_by_server: dict[int, list[str]] = defaultdict(list)
+    for tool in get_mcp_tools_for_servers([s.id for s in servers], db_session):
+        if tool.mcp_server_id is not None and not tool.enabled:
+            disabled_by_server[tool.mcp_server_id].append(tool.name)
+    return [
+        CraftMCPServerConfig(
+            key=_server_key(server),
+            url=server.server_url,
+            disabled_tools=tuple(disabled_by_server.get(server.id, ())),
         )
-    return configs
+        for server in servers
+    ]

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -9,8 +9,10 @@ restart.
 
 from typing import Any
 
-from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
-from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.models import (
+    CraftMCPServerConfig,
+    LLMProviderConfig,
+)
 
 # 4.6+ supports adaptive thinking; older needs enabled+budgetTokens.
 _ADAPTIVE_THINKING_MODELS = frozenset(
@@ -119,17 +121,14 @@ def _build_permissions(
 
 
 def _mcp_tool_id(server_key: str, tool_name: str) -> str:
-    """opencode namespaces an MCP tool as ``<serverKey>_<toolName>``. Isolated
-    here since it's the one opencode-version-coupled string in MCP emission."""
+    """opencode's tool id for an MCP tool: ``<serverKey>_<toolName>``."""
     return f"{server_key}_{tool_name}"
 
 
 def _build_mcp_block(
     mcp_servers: list[CraftMCPServerConfig],
 ) -> dict[str, dict[str, Any]]:
-    """opencode `mcp` entries for craft-enabled servers: remote transport, real
-    URL, **no auth headers** (the sandbox proxy injects them per request, so the
-    static config never changes when a user connects a server)."""
+    """opencode remote `mcp` entries. No auth headers — the proxy injects them."""
     return {
         server.key: {"type": "remote", "url": server.url, "enabled": True}
         for server in mcp_servers
@@ -139,12 +138,11 @@ def _build_mcp_block(
 def _apply_mcp_permissions(
     permissions: dict[str, Any], mcp_servers: list[CraftMCPServerConfig]
 ) -> None:
-    """MCP tools are proxy-gated, so opencode must not also prompt: enabled tools
-    are ``allow``. Admin-disabled tools are ``deny`` so chat-side curation carries
-    over (they never reach the proxy)."""
+    """Allow all of a server's MCP tools (the proxy is the sole gate; the
+    wildcard also covers tools discovered at runtime), hard-denying the
+    admin-disabled ones."""
     for server in mcp_servers:
-        for tool_name in server.enabled_tools:
-            permissions[_mcp_tool_id(server.key, tool_name)] = "allow"
+        permissions[f"{server.key}_*"] = "allow"
         for tool_name in server.disabled_tools:
             permissions[_mcp_tool_id(server.key, tool_name)] = "deny"
 
@@ -178,10 +176,8 @@ def build_multi_provider_opencode_config(
     ``plugins`` is an optional list of opencode plugin specs (npm names or
     absolute file paths) loaded once per session Instance.
 
-    ``mcp_servers`` are craft-enabled MCP servers to expose to the agent as
-    remote MCP endpoints. Pre-registered statically (URL only) regardless of
-    per-user connection state — the proxy injects credentials, so connecting a
-    server needs no config change (mirrors the LLM-provider pre-load).
+    ``mcp_servers`` are craft-enabled servers exposed as remote MCP endpoints
+    (URL only; the proxy injects credentials).
 
     Raises:
         ValueError: If ``providers`` is empty or ``default_provider`` is

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -120,9 +120,8 @@ def _build_permissions(
     if disabled_tools:
         for tool in disabled_tools:
             permissions[tool] = "deny"
-    # MCP tool ids are ``<serverKey>_<toolName>``. Allow each server's tools
-    # wholesale (the proxy is the sole gate; the wildcard also covers tools
-    # discovered at runtime), hard-denying the admin-disabled ones.
+    # MCP tool ids are ``<serverKey>_<toolName>``. The wildcard allow defers
+    # gating to the proxy and covers tools discovered at runtime.
     for server in mcp_servers:
         permissions[f"{server.key}_*"] = "allow"
         for tool_name in server.disabled_tools:

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -7,6 +7,7 @@ key otherwise — letting per-prompt model overrides cross providers without a
 restart.
 """
 
+from collections.abc import Sequence
 from typing import Any
 
 from onyx.server.features.build.sandbox.models import (
@@ -105,7 +106,9 @@ _TMP_EXTERNAL_DIRECTORY_RULES: dict[str, str] = {
 
 
 def _build_permissions(
-    disabled_tools: list[str] | None, dev_mode: bool
+    disabled_tools: list[str] | None,
+    dev_mode: bool,
+    mcp_servers: Sequence[CraftMCPServerConfig],
 ) -> dict[str, Any]:
     permissions: dict[str, Any] = {
         k: (v.copy() if isinstance(v, dict) else v)
@@ -117,34 +120,24 @@ def _build_permissions(
     if disabled_tools:
         for tool in disabled_tools:
             permissions[tool] = "deny"
+    # MCP tool ids are ``<serverKey>_<toolName>``. Allow each server's tools
+    # wholesale (the proxy is the sole gate; the wildcard also covers tools
+    # discovered at runtime), hard-denying the admin-disabled ones.
+    for server in mcp_servers:
+        permissions[f"{server.key}_*"] = "allow"
+        for tool_name in server.disabled_tools:
+            permissions[f"{server.key}_{tool_name}"] = "deny"
     return permissions
 
 
-def _mcp_tool_id(server_key: str, tool_name: str) -> str:
-    """opencode's tool id for an MCP tool: ``<serverKey>_<toolName>``."""
-    return f"{server_key}_{tool_name}"
-
-
 def _build_mcp_block(
-    mcp_servers: list[CraftMCPServerConfig],
+    mcp_servers: Sequence[CraftMCPServerConfig],
 ) -> dict[str, dict[str, Any]]:
     """opencode remote `mcp` entries. No auth headers — the proxy injects them."""
     return {
         server.key: {"type": "remote", "url": server.url, "enabled": True}
         for server in mcp_servers
     }
-
-
-def _apply_mcp_permissions(
-    permissions: dict[str, Any], mcp_servers: list[CraftMCPServerConfig]
-) -> None:
-    """Allow all of a server's MCP tools (the proxy is the sole gate; the
-    wildcard also covers tools discovered at runtime), hard-denying the
-    admin-disabled ones."""
-    for server in mcp_servers:
-        permissions[f"{server.key}_*"] = "allow"
-        for tool_name in server.disabled_tools:
-            permissions[_mcp_tool_id(server.key, tool_name)] = "deny"
 
 
 def _build_provider_block(
@@ -168,7 +161,7 @@ def build_multi_provider_opencode_config(
     disabled_tools: list[str] | None = None,
     dev_mode: bool = False,
     plugins: list[str] | None = None,
-    mcp_servers: list[CraftMCPServerConfig] | None = None,
+    mcp_servers: Sequence[CraftMCPServerConfig] = (),
 ) -> dict[str, Any]:
     """opencode.json with every provider pre-registered so per-prompt
     ``body["model"]`` overrides can target any of them.
@@ -203,9 +196,7 @@ def build_multi_provider_opencode_config(
             f" {sorted(provider_names)}"
         )
 
-    permissions = _build_permissions(disabled_tools, dev_mode)
-    if mcp_servers:
-        _apply_mcp_permissions(permissions, mcp_servers)
+    permissions = _build_permissions(disabled_tools, dev_mode, mcp_servers)
     config: dict[str, Any] = {
         "$schema": "https://opencode.ai/config.json",
         "model": f"{default_provider}/{default_model}",

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -9,6 +9,7 @@ restart.
 
 from typing import Any
 
+from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 
 # 4.6+ supports adaptive thinking; older needs enabled+budgetTokens.
@@ -117,6 +118,37 @@ def _build_permissions(
     return permissions
 
 
+def _mcp_tool_id(server_key: str, tool_name: str) -> str:
+    """opencode namespaces an MCP tool as ``<serverKey>_<toolName>``. Isolated
+    here since it's the one opencode-version-coupled string in MCP emission."""
+    return f"{server_key}_{tool_name}"
+
+
+def _build_mcp_block(
+    mcp_servers: list[CraftMCPServerConfig],
+) -> dict[str, dict[str, Any]]:
+    """opencode `mcp` entries for craft-enabled servers: remote transport, real
+    URL, **no auth headers** (the sandbox proxy injects them per request, so the
+    static config never changes when a user connects a server)."""
+    return {
+        server.key: {"type": "remote", "url": server.url, "enabled": True}
+        for server in mcp_servers
+    }
+
+
+def _apply_mcp_permissions(
+    permissions: dict[str, Any], mcp_servers: list[CraftMCPServerConfig]
+) -> None:
+    """MCP tools are proxy-gated, so opencode must not also prompt: enabled tools
+    are ``allow``. Admin-disabled tools are ``deny`` so chat-side curation carries
+    over (they never reach the proxy)."""
+    for server in mcp_servers:
+        for tool_name in server.enabled_tools:
+            permissions[_mcp_tool_id(server.key, tool_name)] = "allow"
+        for tool_name in server.disabled_tools:
+            permissions[_mcp_tool_id(server.key, tool_name)] = "deny"
+
+
 def _build_provider_block(
     provider_config: LLMProviderConfig,
 ) -> dict[str, Any]:
@@ -138,12 +170,18 @@ def build_multi_provider_opencode_config(
     disabled_tools: list[str] | None = None,
     dev_mode: bool = False,
     plugins: list[str] | None = None,
+    mcp_servers: list[CraftMCPServerConfig] | None = None,
 ) -> dict[str, Any]:
     """opencode.json with every provider pre-registered so per-prompt
     ``body["model"]`` overrides can target any of them.
 
     ``plugins`` is an optional list of opencode plugin specs (npm names or
     absolute file paths) loaded once per session Instance.
+
+    ``mcp_servers`` are craft-enabled MCP servers to expose to the agent as
+    remote MCP endpoints. Pre-registered statically (URL only) regardless of
+    per-user connection state — the proxy injects credentials, so connecting a
+    server needs no config change (mirrors the LLM-provider pre-load).
 
     Raises:
         ValueError: If ``providers`` is empty or ``default_provider`` is
@@ -169,13 +207,18 @@ def build_multi_provider_opencode_config(
             f" {sorted(provider_names)}"
         )
 
+    permissions = _build_permissions(disabled_tools, dev_mode)
+    if mcp_servers:
+        _apply_mcp_permissions(permissions, mcp_servers)
     config: dict[str, Any] = {
         "$schema": "https://opencode.ai/config.json",
         "model": f"{default_provider}/{default_model}",
         "provider": {p.provider: _build_provider_block(p) for p in providers},
         "enabled_providers": sorted(provider_names),
-        "permission": _build_permissions(disabled_tools, dev_mode),
+        "permission": permissions,
     }
     if plugins:
         config["plugin"] = list(plugins)
+    if mcp_servers:
+        config["mcp"] = _build_mcp_block(mcp_servers)
     return config

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -249,7 +249,7 @@ def provision_sandbox(
         llm_config=all_llm_configs[0],
         onyx_pat=onyx_pat,
         all_llm_configs=all_llm_configs,
-        mcp_servers=resolve_craft_mcp_servers(db_session),
+        mcp_servers=resolve_craft_mcp_servers(db_session, user),
     )
     if sandbox_info.status == SandboxStatus.RUNNING:
         hydrate_managed_content(sandbox_manager, sandbox.id, user, db_session)

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -42,6 +42,7 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
+from onyx.server.features.build.sandbox.util.mcp_config import resolve_craft_mcp_servers
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.skills.push import (
     build_user_skills_payload,
@@ -248,6 +249,7 @@ def provision_sandbox(
         llm_config=all_llm_configs[0],
         onyx_pat=onyx_pat,
         all_llm_configs=all_llm_configs,
+        mcp_servers=resolve_craft_mcp_servers(db_session),
     )
     if sandbox_info.status == SandboxStatus.RUNNING:
         hydrate_managed_content(sandbox_manager, sandbox.id, user, db_session)

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1323,7 +1323,7 @@ def get_craft_mcp_servers_for_user(
     rows as chat, so a server connected in either surface shows as
     authenticated here.
     """
-    db_mcp_servers = get_craft_enabled_mcp_servers(db)
+    db_mcp_servers = get_craft_enabled_mcp_servers(db, user)
     mcp_servers = [
         _db_mcp_server_to_api_mcp_server(db_server, db, request_user=user)
         for db_server in db_mcp_servers

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -50,12 +50,13 @@ Usage
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Sequence
 from typing import Any, cast
 from uuid import UUID
 
 from onyx.server.features.build.sandbox.base import SandboxEvent, SandboxManager
 from onyx.server.features.build.sandbox.models import (
+    CraftMCPServerConfig,
     FileSet,
     FilesystemEntry,
     LLMProviderConfig,
@@ -283,6 +284,7 @@ class StubSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
+        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         self.provision_count += 1
         self.last_provision_payload = {
@@ -292,6 +294,7 @@ class StubSandboxManager(SandboxManager):
             "llm_config": llm_config,
             "onyx_pat": onyx_pat,
             "all_llm_configs": all_llm_configs,
+            "mcp_servers": mcp_servers,
         }
         if self.provision_returns is None:
             raise _not_configured("provision")

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -13,13 +13,13 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import MCPAuthenticationPerformer
-from onyx.db.enums import MCPAuthenticationType
-from onyx.db.enums import MCPTransport
-from onyx.db.mcp import create_mcp_server__no_commit
-from onyx.db.mcp import update_mcp_server__no_commit
-from onyx.db.models import MCPServer
-from onyx.db.models import Tool
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.db.mcp import create_mcp_server__no_commit, update_mcp_server__no_commit
+from onyx.db.models import MCPServer, Tool
 from onyx.server.features.build.sandbox.util.mcp_config import resolve_craft_mcp_servers
 
 
@@ -74,5 +74,5 @@ def test_only_craft_enabled_servers_resolved_with_tool_curation(
     assert off.server_url not in by_url
     config = by_url[craft.server_url]
     assert config.key == f"linear-mcp-{craft.id}"
-    assert set(config.enabled_tools) == {"list_issues", "create_issue"}
+    # Only disabled tools are tracked; enabled ones ride the wildcard allow.
     assert config.disabled_tools == ("delete_issue",)

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -19,7 +19,7 @@ from onyx.db.enums import (
     MCPTransport,
 )
 from onyx.db.mcp import create_mcp_server__no_commit, update_mcp_server__no_commit
-from onyx.db.models import MCPServer, Tool, User
+from onyx.db.models import MCPServer, Tool
 from onyx.server.features.build.sandbox.util.mcp_config import resolve_craft_mcp_servers
 from tests.external_dependency_unit.conftest import create_test_user
 
@@ -64,19 +64,14 @@ def craft_server(
     db_session.commit()
 
 
-def _basic_user(db_session: Session) -> User:
-    return create_test_user(db_session, "mcp_config")
-
-
 def test_only_craft_enabled_servers_resolved_with_tool_curation(
     db_session: Session,
     craft_server: tuple[MCPServer, MCPServer],
 ) -> None:
     craft, off = craft_server
-    user = _basic_user(db_session)
+    user = create_test_user(db_session, "mcp_config")
     by_url = {c.url: c for c in resolve_craft_mcp_servers(db_session, user)}
 
-    # The non-craft server is excluded; the craft-enabled one is present.
     assert off.server_url not in by_url
     config = by_url[craft.server_url]
     assert config.key == f"linear-mcp-{craft.id}"
@@ -94,7 +89,7 @@ def test_private_unshared_server_excluded_for_user(
     craft.is_public = False
     db_session.commit()
 
-    user = _basic_user(db_session)
+    user = create_test_user(db_session, "mcp_config")
     assert craft.server_url not in {
         c.url for c in resolve_craft_mcp_servers(db_session, user)
     }

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -1,0 +1,78 @@
+"""External-dependency-unit tests for `resolve_craft_mcp_servers`.
+
+Verifies the DB → opencode-config-input step: only craft-enabled servers are
+emitted, tools split into enabled/disabled by the admin's chat-side curation,
+and the opencode server key is stable + identifier-safe.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import MCPAuthenticationPerformer
+from onyx.db.enums import MCPAuthenticationType
+from onyx.db.enums import MCPTransport
+from onyx.db.mcp import create_mcp_server__no_commit
+from onyx.db.mcp import update_mcp_server__no_commit
+from onyx.db.models import MCPServer
+from onyx.db.models import Tool
+from onyx.server.features.build.sandbox.util.mcp_config import resolve_craft_mcp_servers
+
+
+@pytest.fixture
+def craft_server(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[tuple[MCPServer, MCPServer], None, None]:
+    created: list[MCPServer] = []
+
+    def _server(name: str, *, available_in_craft: bool) -> MCPServer:
+        server = create_mcp_server__no_commit(
+            owner_email="admin@example.com",
+            name=name,
+            description=None,
+            server_url=f"https://api-{uuid4().hex[:8]}.example.com/mcp",
+            auth_type=MCPAuthenticationType.API_TOKEN,
+            transport=MCPTransport.STREAMABLE_HTTP,
+            auth_performer=MCPAuthenticationPerformer.ADMIN,
+            db_session=db_session,
+        )
+        update_mcp_server__no_commit(
+            server_id=server.id,
+            db_session=db_session,
+            available_in_craft=available_in_craft,
+        )
+        created.append(server)
+        return server
+
+    craft = _server("Linear MCP", available_in_craft=True)
+    db_session.add(Tool(name="list_issues", mcp_server_id=craft.id, enabled=True))
+    db_session.add(Tool(name="create_issue", mcp_server_id=craft.id, enabled=True))
+    db_session.add(Tool(name="delete_issue", mcp_server_id=craft.id, enabled=False))
+    off = _server("Off Server", available_in_craft=False)
+    db_session.commit()
+
+    yield craft, off  # type: ignore[misc]
+    db_session.rollback()
+    for server in created:
+        db_session.delete(server)
+    db_session.commit()
+
+
+def test_only_craft_enabled_servers_resolved_with_tool_curation(
+    db_session: Session,
+    craft_server: tuple[MCPServer, MCPServer],
+) -> None:
+    craft, off = craft_server
+    by_url = {c.url: c for c in resolve_craft_mcp_servers(db_session)}
+
+    # The non-craft server is excluded; the craft-enabled one is present.
+    assert off.server_url not in by_url
+    config = by_url[craft.server_url]
+    assert config.key == f"linear-mcp-{craft.id}"
+    assert set(config.enabled_tools) == {"list_issues", "create_issue"}
+    assert config.disabled_tools == ("delete_issue",)

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -1,8 +1,8 @@
 """External-dependency-unit tests for `resolve_craft_mcp_servers`.
 
-Verifies the DB → opencode-config-input step: only craft-enabled servers are
-emitted, tools split into enabled/disabled by the admin's chat-side curation,
-and the opencode server key is stable + identifier-safe.
+Verifies the DB → opencode-config-input step: only craft-enabled servers the
+user may access are emitted, tools split into enabled/disabled by the admin's
+chat-side curation, and the opencode server key is stable + identifier-safe.
 """
 
 from __future__ import annotations
@@ -19,8 +19,9 @@ from onyx.db.enums import (
     MCPTransport,
 )
 from onyx.db.mcp import create_mcp_server__no_commit, update_mcp_server__no_commit
-from onyx.db.models import MCPServer, Tool
+from onyx.db.models import MCPServer, Tool, User
 from onyx.server.features.build.sandbox.util.mcp_config import resolve_craft_mcp_servers
+from tests.external_dependency_unit.conftest import create_test_user
 
 
 @pytest.fixture
@@ -63,12 +64,17 @@ def craft_server(
     db_session.commit()
 
 
+def _basic_user(db_session: Session) -> User:
+    return create_test_user(db_session, "mcp_config")
+
+
 def test_only_craft_enabled_servers_resolved_with_tool_curation(
     db_session: Session,
     craft_server: tuple[MCPServer, MCPServer],
 ) -> None:
     craft, off = craft_server
-    by_url = {c.url: c for c in resolve_craft_mcp_servers(db_session)}
+    user = _basic_user(db_session)
+    by_url = {c.url: c for c in resolve_craft_mcp_servers(db_session, user)}
 
     # The non-craft server is excluded; the craft-enabled one is present.
     assert off.server_url not in by_url
@@ -76,3 +82,26 @@ def test_only_craft_enabled_servers_resolved_with_tool_curation(
     assert config.key == f"linear-mcp-{craft.id}"
     # Only disabled tools are tracked; enabled ones ride the wildcard allow.
     assert config.disabled_tools == ("delete_issue",)
+
+
+def test_private_unshared_server_excluded_for_user(
+    db_session: Session,
+    craft_server: tuple[MCPServer, MCPServer],
+) -> None:
+    """A craft-enabled but private, unshared server is not emitted into another
+    user's sandbox config (the owner still sees it)."""
+    craft, _ = craft_server
+    craft.is_public = False
+    db_session.commit()
+
+    user = _basic_user(db_session)
+    assert craft.server_url not in {
+        c.url for c in resolve_craft_mcp_servers(db_session, user)
+    }
+
+    owner = create_test_user(db_session, "mcp_owner")
+    craft.owner = owner.email
+    db_session.commit()
+    assert craft.server_url in {
+        c.url for c in resolve_craft_mcp_servers(db_session, owner)
+    }

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -269,7 +269,6 @@ def test_mcp_servers_emit_remote_entries_without_headers() -> None:
         default_model="claude-opus-4-7",
         mcp_servers=[_mcp("linear-7", url="https://mcp.linear.app/mcp")],
     )
-    # No auth headers — the proxy injects credentials.
     assert config["mcp"] == {
         "linear-7": {
             "type": "remote",

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import pytest
 
-from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
-from onyx.server.features.build.sandbox.models import LLMProviderConfig
+from onyx.server.features.build.sandbox.models import (
+    CraftMCPServerConfig,
+    LLMProviderConfig,
+)
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
 )
@@ -246,15 +248,9 @@ def test_plugins_are_emitted_when_provided() -> None:
 def _mcp(
     key: str,
     url: str = "https://mcp.example.com/mcp",
-    enabled_tools: tuple[str, ...] = (),
     disabled_tools: tuple[str, ...] = (),
 ) -> CraftMCPServerConfig:
-    return CraftMCPServerConfig(
-        key=key,
-        url=url,
-        enabled_tools=enabled_tools,
-        disabled_tools=disabled_tools,
-    )
+    return CraftMCPServerConfig(key=key, url=url, disabled_tools=disabled_tools)
 
 
 def test_no_mcp_servers_omits_mcp_key() -> None:
@@ -273,8 +269,7 @@ def test_mcp_servers_emit_remote_entries_without_headers() -> None:
         default_model="claude-opus-4-7",
         mcp_servers=[_mcp("linear-7", url="https://mcp.linear.app/mcp")],
     )
-    # Remote transport, real URL, and crucially NO auth headers — the proxy
-    # injects credentials so the static config never changes on connect.
+    # No auth headers — the proxy injects credentials.
     assert config["mcp"] == {
         "linear-7": {
             "type": "remote",
@@ -284,22 +279,25 @@ def test_mcp_servers_emit_remote_entries_without_headers() -> None:
     }
 
 
-def test_mcp_tool_curation_maps_to_allow_and_deny_permissions() -> None:
+def test_mcp_tool_curation_maps_to_wildcard_allow_and_deny_permissions() -> None:
     config = build_multi_provider_opencode_config(
         providers=[_cfg("anthropic", "claude-opus-4-7")],
         default_provider="anthropic",
         default_model="claude-opus-4-7",
-        mcp_servers=[
-            _mcp(
-                "linear-7",
-                enabled_tools=("list_issues", "create_issue"),
-                disabled_tools=("delete_issue",),
-            )
-        ],
+        mcp_servers=[_mcp("linear-7", disabled_tools=("delete_issue",))],
     )
     permission = config["permission"]
-    # Enabled MCP tools are auto-allowed (the proxy is the sole gate); the
-    # admin-disabled tool is denied so chat-side curation carries over.
-    assert permission["linear-7_list_issues"] == "allow"
-    assert permission["linear-7_create_issue"] == "allow"
+    assert permission["linear-7_*"] == "allow"
     assert permission["linear-7_delete_issue"] == "deny"
+
+
+def test_uncurated_mcp_server_still_gets_wildcard_allow() -> None:
+    # Zero Tool rows: the wildcard must still allow so runtime-discovered tools
+    # don't fall through to opencode's default "ask".
+    config = build_multi_provider_opencode_config(
+        providers=[_cfg("anthropic", "claude-opus-4-7")],
+        default_provider="anthropic",
+        default_model="claude-opus-4-7",
+        mcp_servers=[_mcp("linear-7")],
+    )
+    assert config["permission"]["linear-7_*"] == "allow"

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import pytest
 
+from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
@@ -240,3 +241,65 @@ def test_plugins_are_emitted_when_provided() -> None:
         plugins=["/workspace/opencode-plugins/session-proxy-tag.ts"],
     )
     assert config["plugin"] == ["/workspace/opencode-plugins/session-proxy-tag.ts"]
+
+
+def _mcp(
+    key: str,
+    url: str = "https://mcp.example.com/mcp",
+    enabled_tools: tuple[str, ...] = (),
+    disabled_tools: tuple[str, ...] = (),
+) -> CraftMCPServerConfig:
+    return CraftMCPServerConfig(
+        key=key,
+        url=url,
+        enabled_tools=enabled_tools,
+        disabled_tools=disabled_tools,
+    )
+
+
+def test_no_mcp_servers_omits_mcp_key() -> None:
+    config = build_multi_provider_opencode_config(
+        providers=[_cfg("anthropic", "claude-opus-4-7")],
+        default_provider="anthropic",
+        default_model="claude-opus-4-7",
+    )
+    assert "mcp" not in config
+
+
+def test_mcp_servers_emit_remote_entries_without_headers() -> None:
+    config = build_multi_provider_opencode_config(
+        providers=[_cfg("anthropic", "claude-opus-4-7")],
+        default_provider="anthropic",
+        default_model="claude-opus-4-7",
+        mcp_servers=[_mcp("linear-7", url="https://mcp.linear.app/mcp")],
+    )
+    # Remote transport, real URL, and crucially NO auth headers — the proxy
+    # injects credentials so the static config never changes on connect.
+    assert config["mcp"] == {
+        "linear-7": {
+            "type": "remote",
+            "url": "https://mcp.linear.app/mcp",
+            "enabled": True,
+        }
+    }
+
+
+def test_mcp_tool_curation_maps_to_allow_and_deny_permissions() -> None:
+    config = build_multi_provider_opencode_config(
+        providers=[_cfg("anthropic", "claude-opus-4-7")],
+        default_provider="anthropic",
+        default_model="claude-opus-4-7",
+        mcp_servers=[
+            _mcp(
+                "linear-7",
+                enabled_tools=("list_issues", "create_issue"),
+                disabled_tools=("delete_issue",),
+            )
+        ],
+    )
+    permission = config["permission"]
+    # Enabled MCP tools are auto-allowed (the proxy is the sole gate); the
+    # admin-disabled tool is denied so chat-side curation carries over.
+    assert permission["linear-7_list_issues"] == "allow"
+    assert permission["linear-7_create_issue"] == "allow"
+    assert permission["linear-7_delete_issue"] == "deny"


### PR DESCRIPTION
## What

Makes MCP servers usable by the Craft agent by emitting an opencode `mcp` block for every craft-enabled server and threading it through the sandbox provision path. This is the "config emission" phase of Craft MCP Support (stacked on the proxy resolver PR).

## How

- `build_multi_provider_opencode_config` gains a keyword-only `mcp_servers` param and emits `config["mcp"]` = `{key: {type: "remote", url, enabled}}` — **no auth headers** (the sandbox proxy injects credentials per request, so the static config never changes when a user connects a server).
- `resolve_craft_mcp_servers` (new `sandbox/util/mcp_config.py`) builds that input from `get_craft_enabled_mcp_servers` + each server's `Tool.enabled` curation, and maps enabled tools → `allow` / disabled → `deny` in the permission block (proxy is the sole gate, so opencode must not double-prompt).
- Threaded through `provision()` in both the k8s and docker managers alongside `all_llm_configs`, resolved in `provision_sandbox`. Pre-registered regardless of per-user connection state (mirrors the LLM-provider pre-load); regenerate-on-wake is free via re-provisioning.
- Backwards compatible: `mcp_servers` defaults to `None`, so existing provision callers are unaffected, and no `mcp` key is emitted when there are none.

## Validation

Verified live against opencode **1.15.7** with a real Braintrust MCP server (always-allow, i.e. approval gating not yet wired):

- New pod config contains `braintrust-mcp-1` (`type:remote`, url, no headers) and `<serverKey>_<tool>: allow` permission entries.
- opencode: `mcp key=braintrust-mcp-1 transport=StreamableHTTP connected`, `toolCount=7 create() successfully created client`.
- Sandbox proxy: every `api.braintrust.dev` request `credential_outcome=headers_injected` — opencode's remote-MCP client honors the proxy env (a previously-unverified risk).
- opencode evaluated `braintrust-mcp-1_<tool>` permissions to `allow` and the agent called the tools without an in-sandbox prompt.

## Notes / follow-ups

- **Approval gating is a separate PR.** Until it lands, MCP is effectively always-allow in the sandbox (off-catalog credential injection). Config emission must not ship to users ahead of the gating PR.
- Per-tool **disable** behavior is implemented (permission `deny`) but not yet exercised live (the test server had all tools enabled).
- AGENTS.md per-server connection-state hint is not included here (small follow-up).

## Tests

- Unit: `mcp` block emission, no-`mcp`-key-when-empty, and enabled→allow / disabled→deny permission mapping in `test_opencode_config.py`.
- External-dependency-unit: `resolve_craft_mcp_servers` against a seeded craft-enabled server + tools (`test_mcp_config_resolution.py`).

- [x] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Craft MCP support by emitting an `opencode` `mcp` block and wiring it through sandbox provisioning so the agent can call remote MCP tools without extra prompts. Servers are scoped to each user’s access; the proxy enforces access and injects credentials per request, and static config never includes auth.

- **New Features**
  - `build_multi_provider_opencode_config` accepts `mcp_servers` (Sequence, default `()`) and emits `mcp` entries with `type: "remote"`, real `url`, `enabled: true`; permissions add `<serverKey>_*: allow` plus per-tool `deny` from admin curation (now built in `_build_permissions`).
  - Added `CraftMCPServerConfig`; `resolve_craft_mcp_servers` builds stable keys (`slug-id`), bulk-fetches tool curation via `get_mcp_tools_for_servers`, and threads into Docker/Kubernetes `provision` and `provision_sandbox` with an always-present `mcp_servers` flow.

- **Bug Fixes**
  - Filter craft-enabled servers to public/shared/owned for the user in config emission and the `/servers/craft` listing, and require access in the proxy before credential injection; host-claim matching stays unfiltered (no user yet) and auth remains per-request via the proxy.

<sup>Written for commit 8dfcfbc0ca771a015108c32f8a4db702800d25f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



