### PR TITLE
feat(llm): curate context windows in recommended-models.json

### DIFF
--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -141,8 +141,17 @@ def llm_max_input_tokens(
     model_map: dict,
     model_name: str,
     model_provider: str,
+    fallback_max_input_tokens: int | None = None,
 ) -> int:
-    """Best effort attempt to get the max input tokens for the LLM."""
+    """Best effort attempt to get the max input tokens for the LLM.
+
+    LiteLLM is the source of truth when it knows the model. Only when it doesn't
+    do we use `fallback_max_input_tokens` (e.g. a value curated in
+    recommended-models.json for a model LiteLLM hasn't caught up to yet), and
+    only then GEN_AI_MODEL_FALLBACK_MAX_TOKENS.
+    """
+    fallback = fallback_max_input_tokens or GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+
     if GEN_AI_MAX_TOKENS:
         # This is an override, so always return this
         logger.info("Using override GEN_AI_MAX_TOKENS: %s", GEN_AI_MAX_TOKENS)
@@ -157,9 +166,9 @@ def llm_max_input_tokens(
         logger.warning(
             "Model '%s' not found in LiteLLM. Falling back to %s tokens.",
             model_name,
-            GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+            fallback,
         )
-        return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+        return fallback
 
     max_input_tokens = model_obj.get("max_input_tokens")
     if max_input_tokens is not None:
@@ -172,9 +181,9 @@ def llm_max_input_tokens(
     logger.warning(
         "No max tokens found for '%s'. Falling back to %s tokens.",
         model_name,
-        GEN_AI_MODEL_FALLBACK_MAX_TOKENS,
+        fallback,
     )
-    return GEN_AI_MODEL_FALLBACK_MAX_TOKENS
+    return fallback
 
 
 def get_llm_max_output_tokens(
@@ -218,6 +227,7 @@ def get_max_input_tokens(
     model_name: str,
     model_provider: str,
     output_tokens: int = GEN_AI_NUM_RESERVED_OUTPUT_TOKENS,
+    fallback_max_input_tokens: int | None = None,
 ) -> int:
     # NOTE: we previously used `litellm.get_max_tokens()`, but despite the name, this actually
     # returns the max OUTPUT tokens. Under the hood, this uses the `litellm.model_cost` dict,
@@ -232,6 +242,7 @@ def get_max_input_tokens(
             model_name=model_name,
             model_provider=model_provider,
             model_map=litellm_model_map,
+            fallback_max_input_tokens=fallback_max_input_tokens,
         )
         - output_tokens
     )

--- a/backend/onyx/llm/well_known_providers/auto_update_models.py
+++ b/backend/onyx/llm/well_known_providers/auto_update_models.py
@@ -39,7 +39,8 @@ class LLMRecommendations(BaseModel):
     def get_visible_models(self, provider_name: str) -> list[SimpleKnownModel]:
         """Default model first, then additional models, deduped by name. The
         default is often repeated in additional_visible_models (where it carries
-        a display name), so keep the entry that has one."""
+        a display name and context window), so merge the per-name entries rather
+        than dropping either one's metadata."""
         provider_config = self.providers.get(provider_name)
         if provider_config is None:
             return []
@@ -49,8 +50,14 @@ class LLMRecommendations(BaseModel):
             *provider_config.additional_visible_models,
         ]:
             existing = by_name.get(model.name)
-            if existing is None or (model.display_name and not existing.display_name):
+            if existing is None:
                 by_name[model.name] = model
+                continue
+            by_name[model.name] = SimpleKnownModel(
+                name=model.name,
+                display_name=existing.display_name or model.display_name,
+                max_input_tokens=existing.max_input_tokens or model.max_input_tokens,
+            )
         return list(by_name.values())
 
     def get_default_model(self, provider_name: str) -> SimpleKnownModel | None:

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -257,6 +257,12 @@ def model_configurations_for_provider(
     display_name_by_name = {
         m.name: m.display_name for m in recommended_visible_models if m.display_name
     }
+    # Curated context windows, used only when LiteLLM doesn't know the model yet.
+    max_input_tokens_by_name = {
+        m.name: m.max_input_tokens
+        for m in recommended_visible_models
+        if m.max_input_tokens
+    }
     default_model = llm_recommendations.get_default_model(provider_name)
     default_model_name = default_model.name if default_model else None
 
@@ -281,7 +287,11 @@ def model_configurations_for_provider(
             name=model_name,
             is_visible=model_name in recommended_visible_models_names,
             is_recommended_default=model_name == default_model_name,
-            max_input_tokens=get_max_input_tokens(model_name, provider_name),
+            max_input_tokens=get_max_input_tokens(
+                model_name,
+                provider_name,
+                fallback_max_input_tokens=max_input_tokens_by_name.get(model_name),
+            ),
             supports_image_input=model_supports_image_input(model_name, provider_name),
             display_name=display_name_by_name.get(model_name),
         )

--- a/backend/onyx/llm/well_known_providers/models.py
+++ b/backend/onyx/llm/well_known_providers/models.py
@@ -22,6 +22,12 @@ class CustomConfigKeyType(str, Enum):
 class SimpleKnownModel(BaseModel):
     name: str
     display_name: str | None = None
+    # Full context window (input + output), in the same sense as LiteLLM's
+    # `max_input_tokens`. Used only as a fallback for models the LiteLLM cost map
+    # doesn't know yet — LiteLLM stays the source of truth when it has the model.
+    # Prevents brand-new recommended models from silently falling back to
+    # GEN_AI_MODEL_FALLBACK_MAX_TOKENS while LiteLLM catches up.
+    max_input_tokens: int | None = None
 
 
 class WellKnownLLMProviderDescriptor(BaseModel):

--- a/backend/scripts/update_recommended_models.py
+++ b/backend/scripts/update_recommended_models.py
@@ -4,9 +4,11 @@ Applies the curation rules in update_recommended_models_rules.json (trusted
 vendors + model-family regexes) to the official OpenRouter catalog
 (https://openrouter.ai/api/v1/models) and rewrites
 backend/onyx/llm/well_known_providers/recommended-models.json with the newest
-matching models per provider section. The rules file is the human-editable
-knob: which families are recommendable, how many models to keep, id/display
-name overrides, pinned defaults.
+matching models per provider section, each carrying the catalog's context
+window (max_input_tokens) so brand-new models don't fall back to the 32K default
+while LiteLLM's cost map catches up. The rules file is the human-editable knob:
+which families are recommendable, how many models to keep, id/display name
+overrides, pinned defaults.
 
 The generated file is live production config — deployments poll it from GitHub
 raw main (AUTO_LLM_CONFIG_URL) — so this script never pushes anything itself.
@@ -55,6 +57,9 @@ ID_TRANSFORMS = ("strip_prefix", "strip_prefix_dots_to_dashes", "keep_full_id")
 class RecommendedModel:
     name: str
     display_name: str | None = None
+    # Full context window (input + output). Consumed at runtime only as a
+    # fallback for models LiteLLM's cost map doesn't know yet.
+    max_input_tokens: int | None = None
 
 
 @dataclass
@@ -88,6 +93,7 @@ class CatalogModel:
     pricing: dict[str, Any]
     architecture: dict[str, Any]
     expiration_date: str | None
+    context_length: int | None = None
 
     @classmethod
     def from_json(cls, entry: dict[str, Any]) -> "CatalogModel":
@@ -98,7 +104,21 @@ class CatalogModel:
             pricing=entry.get("pricing") or {},
             architecture=entry.get("architecture") or {},
             expiration_date=entry.get("expiration_date"),
+            context_length=cls._parse_context_length(entry),
         )
+
+    @staticmethod
+    def _parse_context_length(entry: dict[str, Any]) -> int | None:
+        """The model's native context window. Prefer the top-level value and
+        fall back to top_provider; both are ints in the OpenRouter catalog."""
+        candidates: list[Any] = [entry.get("context_length")]
+        top_provider = entry.get("top_provider")
+        if isinstance(top_provider, dict):
+            candidates.append(top_provider.get("context_length"))
+        for value in candidates:
+            if isinstance(value, int) and value > 0:
+                return value
+        return None
 
     @property
     def output_modalities(self) -> list[str]:
@@ -217,7 +237,9 @@ def load_previous(path: Path) -> RecommendedModelsFile:
                 default_model=section["default_model"],
                 additional_visible_models=[
                     RecommendedModel(
-                        name=model["name"], display_name=model.get("display_name")
+                        name=model["name"],
+                        display_name=model.get("display_name"),
+                        max_input_tokens=model.get("max_input_tokens"),
                     )
                     for model in section.get("additional_visible_models", [])
                 ],
@@ -329,8 +351,14 @@ def _visible_models(section: ProviderSection | None) -> list[RecommendedModel]:
         *section.additional_visible_models,
     ]:
         existing = by_name.get(model.name)
-        if existing is None or (model.display_name and not existing.display_name):
+        if existing is None:
             by_name[model.name] = model
+            continue
+        by_name[model.name] = RecommendedModel(
+            name=model.name,
+            display_name=existing.display_name or model.display_name,
+            max_input_tokens=existing.max_input_tokens or model.max_input_tokens,
+        )
     return list(by_name.values())
 
 
@@ -381,6 +409,7 @@ def build_section(
             RecommendedModel(
                 name=native_name,
                 display_name=derive_display_name(pick, native_name, section),
+                max_input_tokens=pick.context_length,
             )
         )
 
@@ -388,15 +417,25 @@ def build_section(
         (i for i, model in enumerate(models) if model.name == default_name), None
     )
     if default_index is None:
+        # Pinned default not matched by any rule: preserve its previous metadata.
+        previous_default = {
+            model.name: model for model in _visible_models(previous)
+        }.get(default_name)
         display_name: str | None = None
         if section.emit_display_name:
-            previous_display = {
-                model.name: model.display_name for model in _visible_models(previous)
-            }
-            display_name = section.display_name_overrides.get(
-                default_name
-            ) or previous_display.get(default_name)
-        models.insert(0, RecommendedModel(name=default_name, display_name=display_name))
+            display_name = section.display_name_overrides.get(default_name) or (
+                previous_default.display_name if previous_default else None
+            )
+        models.insert(
+            0,
+            RecommendedModel(
+                name=default_name,
+                display_name=display_name,
+                max_input_tokens=(
+                    previous_default.max_input_tokens if previous_default else None
+                ),
+            ),
+        )
     else:
         models.insert(0, models.pop(default_index))
 
@@ -414,7 +453,8 @@ def _sections_equal(a: ProviderSection, b: ProviderSection) -> bool:
         return (
             section.default_model,
             tuple(
-                (model.name, model.display_name) for model in _visible_models(section)
+                (model.name, model.display_name, model.max_input_tokens)
+                for model in _visible_models(section)
             ),
         )
 
@@ -472,11 +512,13 @@ def build_recommendations(
 def serialize(recommendations: RecommendedModelsFile) -> str:
     providers: dict[str, Any] = {}
     for section_name, section in recommendations.providers.items():
-        models: list[dict[str, str]] = []
+        models: list[dict[str, Any]] = []
         for model in section.additional_visible_models:
-            entry = {"name": model.name}
+            entry: dict[str, Any] = {"name": model.name}
             if model.display_name:
                 entry["display_name"] = model.display_name
+            if model.max_input_tokens is not None:
+                entry["max_input_tokens"] = model.max_input_tokens
             models.append(entry)
         providers[section_name] = {
             "default_model": section.default_model,

--- a/backend/tests/unit/onyx/llm/test_llm_provider_options.py
+++ b/backend/tests/unit/onyx/llm/test_llm_provider_options.py
@@ -42,6 +42,87 @@ def test_get_visible_models_dedupes_default_and_prefers_display_name() -> None:
     ]
 
 
+def test_get_visible_models_merges_context_window_across_entries() -> None:
+    # The default entry carries the context window; the additional entry carries
+    # the display name. Neither should be dropped by the dedupe.
+    recommendations = LLMRecommendations(
+        version="test",
+        updated_at=datetime.now(timezone.utc),
+        providers={
+            "anthropic": LLMProviderRecommendation(
+                default_model=SimpleKnownModel(name="claude-opus-4-8"),
+                additional_visible_models=[
+                    SimpleKnownModel(
+                        name="claude-opus-4-8",
+                        display_name="Claude Opus 4.8",
+                        max_input_tokens=200_000,
+                    ),
+                ],
+            )
+        },
+    )
+
+    visible = recommendations.get_visible_models("anthropic")
+
+    assert [(m.name, m.display_name, m.max_input_tokens) for m in visible] == [
+        ("claude-opus-4-8", "Claude Opus 4.8", 200_000),
+    ]
+
+
+def test_model_configurations_use_curated_context_window_as_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # LiteLLM is unaware of the model, so the curated context window from
+    # recommended-models.json must be threaded through as the fallback rather
+    # than the 32K default.
+    monkeypatch.setattr(
+        "onyx.llm.well_known_providers.llm_provider_options.fetch_models_for_provider",
+        lambda _provider_name: [],
+    )
+    monkeypatch.setattr(
+        "onyx.llm.well_known_providers.llm_provider_options.model_supports_image_input",
+        lambda _model_name, _provider_name: False,
+    )
+    captured_fallbacks: dict[str, int | None] = {}
+
+    def fake_get_max_input_tokens(
+        model_name: str,
+        _provider_name: str,
+        fallback_max_input_tokens: int | None = None,
+    ) -> int | None:
+        captured_fallbacks[model_name] = fallback_max_input_tokens
+        return fallback_max_input_tokens
+
+    monkeypatch.setattr(
+        "onyx.llm.well_known_providers.llm_provider_options.get_max_input_tokens",
+        fake_get_max_input_tokens,
+    )
+
+    recommendations = LLMRecommendations(
+        version="test",
+        updated_at=datetime.now(timezone.utc),
+        providers={
+            "anthropic": LLMProviderRecommendation(
+                default_model=SimpleKnownModel(name="claude-opus-4-8"),
+                additional_visible_models=[
+                    SimpleKnownModel(
+                        name="claude-opus-4-8",
+                        display_name="Claude Opus 4.8",
+                        max_input_tokens=200_000,
+                    ),
+                ],
+            )
+        },
+    )
+
+    model_configurations = model_configurations_for_provider(
+        "anthropic", recommendations
+    )
+
+    assert captured_fallbacks == {"claude-opus-4-8": 200_000}
+    assert model_configurations[0].max_input_tokens == 200_000
+
+
 def _build_recommendations(
     provider_name: str, visible_model_names: list[str]
 ) -> LLMRecommendations:
@@ -69,7 +150,7 @@ def test_model_configurations_vertex_are_sorted_by_name(
     )
     monkeypatch.setattr(
         "onyx.llm.well_known_providers.llm_provider_options.get_max_input_tokens",
-        lambda _model_name, _provider_name: None,
+        lambda _model_name, _provider_name, **_kwargs: None,
     )
     monkeypatch.setattr(
         "onyx.llm.well_known_providers.llm_provider_options.model_supports_image_input",
@@ -109,7 +190,7 @@ def test_model_configurations_carry_display_name_and_dedupe_default(
     )
     monkeypatch.setattr(
         "onyx.llm.well_known_providers.llm_provider_options.get_max_input_tokens",
-        lambda _model_name, _provider_name: None,
+        lambda _model_name, _provider_name, **_kwargs: None,
     )
     monkeypatch.setattr(
         "onyx.llm.well_known_providers.llm_provider_options.model_supports_image_input",
@@ -159,7 +240,7 @@ def test_model_configurations_non_vertex_preserve_provider_order(
     )
     monkeypatch.setattr(
         "onyx.llm.well_known_providers.llm_provider_options.get_max_input_tokens",
-        lambda _model_name, _provider_name: None,
+        lambda _model_name, _provider_name, **_kwargs: None,
     )
     monkeypatch.setattr(
         "onyx.llm.well_known_providers.llm_provider_options.model_supports_image_input",

--- a/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
+++ b/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
@@ -99,6 +99,33 @@ class TestLlmMaxInputTokens:
                 == 5000
             )
 
+    def test_uses_fallback_when_model_not_found(self) -> None:
+        # Model unknown to LiteLLM: the curated context window is used instead of
+        # the 32K default (the recommended-models.json fallback path).
+        assert (
+            llm_max_input_tokens(
+                model_map={},
+                model_name="brand-new-model",
+                model_provider="openai",
+                fallback_max_input_tokens=250_000,
+            )
+            == 250_000
+        )
+
+    def test_litellm_value_wins_over_fallback(self) -> None:
+        # Once LiteLLM knows the model, its value is authoritative and the
+        # curated fallback is ignored.
+        model_map = {"openai/gpt-4o": {"max_input_tokens": 128000}}
+        assert (
+            llm_max_input_tokens(
+                model_map=model_map,
+                model_name="gpt-4o",
+                model_provider="openai",
+                fallback_max_input_tokens=250_000,
+            )
+            == 128000
+        )
+
 
 class TestGetLlmMaxOutputTokens:
     def test_prefers_max_output_tokens(self) -> None:
@@ -182,6 +209,20 @@ class TestGetMaxInputTokens:
                     output_tokens=1024,
                 )
                 == 128000 - 1024
+            )
+
+    def test_fallback_context_window_minus_reserved_output(self) -> None:
+        # Unknown model + curated fallback: the fallback flows through the same
+        # reserved-output subtraction as a real LiteLLM value would.
+        with patch("onyx.llm.model_capabilities.get_model_map", return_value={}):
+            assert (
+                get_max_input_tokens(
+                    model_name="brand-new-model",
+                    model_provider="openai",
+                    output_tokens=1024,
+                    fallback_max_input_tokens=200_000,
+                )
+                == 200_000 - 1024
             )
 
     def test_non_positive_budget_falls_back(self) -> None:


### PR DESCRIPTION
## Issues to Address

New models routinely land in `recommended-models.json` before LiteLLM's cost map knows them (related to #13131). When that happens:

1. `get_max_input_tokens` can't find the model in LiteLLM and returns `GEN_AI_MODEL_FALLBACK_MAX_TOKENS` (32K).
2. That 32K is **persisted** into `ModelConfiguration.max_input_tokens` at provider seed/creation time (`model_configurations_for_provider` → `_build_model_configuration_upsert_requests` → `insert_new_model_configuration`).
3. At runtime, `get_max_input_tokens_from_llm_provider` prefers the stored DB value, so the stale 32K sticks even after LiteLLM catches up — silently truncating context until a re-sync.

## What this does

Adds an optional `max_input_tokens` (full context window) to each recommended model and consults it as a fallback **below** LiteLLM. Resolution order in `llm_max_input_tokens`:

```
GEN_AI_MAX_TOKENS override → LiteLLM (when it knows the model) → curated JSON value → 32K default
```

LiteLLM stays the source of truth when it has the model, so the curated value only matters during the window before LiteLLM catches up — exactly the #13131 pain. The curated value flows through the same reserved-output subtraction as a real LiteLLM value.

## Auto-population (no manual upkeep)

`update_recommended_models.py` now reads each model's `context_length` from the OpenRouter catalog (preferring the top-level value, falling back to `top_provider.context_length`) and emits it as `max_input_tokens`. Since the value is part of the change-detection key, the next scheduled `update-recommended-models` run will regenerate the file with real context windows and open its usual reviewed PR — so the committed JSON is intentionally left unchanged here rather than hand-populated with guessed numbers.

## Notes / scope

- This fixes **new** provider seeds/creations. Deployments that already persisted a 32K value still need a re-sync to benefit; a follow-up could stop persisting the pure-fallback value (store `None`) so runtime always re-derives. Kept out of scope here to keep the change focused.
- Semantics match LiteLLM's `max_input_tokens` convention (full context window; output reservation applied downstream), and OpenRouter's `context_length` is that same quantity.

## Tests

- `test_token_limit_lookups.py`: `llm_max_input_tokens` / `get_max_input_tokens` use the curated fallback when LiteLLM is unaware, and LiteLLM wins when present.
- `test_llm_provider_options.py`: `get_visible_models` merges the context window across the default/additional entries; `model_configurations_for_provider` threads the curated value through as the fallback.
- `test_update_recommended_models.py` (new): catalog `context_length` parsing (top-level + `top_provider` fallback), `build_section` capture, and serialize/round-trip preservation (absent windows don't serialize `null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Curates model context windows in `recommended-models.json` and uses them as a fallback below `LiteLLM` so brand-new models avoid the 32K default. The update script auto-populates these values from OpenRouter to keep them current.

- New Features
  - Added optional `max_input_tokens` (full context window) per model in `recommended-models.json`.
  - Resolution order: env override → `LiteLLM` → curated value → 32K default; `LiteLLM` stays authoritative when available.
  - Dedupe now merges display name and context window across default/additional entries.
  - Threaded fallback through provider seeding and runtime via `get_max_input_tokens`/`llm_max_input_tokens`; `update_recommended_models.py` reads OpenRouter `context_length`, writes `max_input_tokens` (skips `null`), and preserves pinned default metadata when the default isn’t in the catalog.

- Migration
  - Existing deployments that persisted 32K for new models may need a provider re-sync to pick up correct windows.

<sup>Written for commit da61c63c5fa600de2e5c149cd2d2296f6cec8920. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

