### PR TITLE
feat(perms): group-manager assignment & membership scoping

### DIFF
--- a/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
+++ b/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
@@ -16,7 +16,6 @@ Create Date: 2026-06-29 14:15:32.889597
 from alembic import op
 import sqlalchemy as sa
 
-# revision identifiers, used by Alembic.
 revision = "c71a18ea7d07"
 down_revision = "c8e316473aaa"
 branch_labels = None

--- a/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
+++ b/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
@@ -20,7 +20,6 @@ import sqlalchemy as sa
 from alembic import op
 
 
-# revision identifiers, used by Alembic.
 revision = "c8e316473aaa"
 down_revision = "8f2c4a1d9e3b"
 branch_labels: str | None = None
@@ -37,9 +36,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Backfill any NULLs written while the column was optional before we
-    # restore the NOT NULL constraint, otherwise the downgrade would fail
-    # against rows inserted after the upgrade.
+    # Backfill NULLs written while the column was optional; otherwise
+    # restoring NOT NULL fails against rows inserted after the upgrade.
     op.execute("UPDATE \"user\" SET role = 'BASIC' WHERE role IS NULL")
     op.alter_column(
         "user",

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -473,6 +473,22 @@ def _mark_user_group__cc_pair_relationships_outdated__no_commit(
         user_group__cc_pair_relationship.is_current = False
 
 
+def _current_cc_pair_ids(db_user_group: UserGroup) -> list[int]:
+    """The cc_pairs currently attached to the group — is_current junction rows only.
+
+    A removed cc_pair keeps a stale ``is_current=False`` row until the Vespa sync
+    deletes it, and the plain ``cc_pairs`` relationship has no is_current filter, so
+    it would still surface the removed pair. Reading it as "current" lets a removed
+    (possibly public / out-of-scope) pair be re-attached without re-clearing the
+    scope gate, so always derive the current set from the live relationships.
+    """
+    return [
+        relationship.cc_pair_id
+        for relationship in db_user_group.cc_pair_relationships
+        if relationship.is_current
+    ]
+
+
 def add_users_to_user_group(
     db_session: Session,
     user: User,
@@ -504,7 +520,7 @@ def add_users_to_user_group(
 
     user_group_update = UserGroupUpdate(
         user_ids=current_user_ids + new_user_ids,
-        cc_pair_ids=[cc_pair.id for cc_pair in db_user_group.cc_pairs],
+        cc_pair_ids=_current_cc_pair_ids(db_user_group),
     )
 
     return update_user_group(
@@ -577,7 +593,7 @@ def update_user_group(
 
     _check_user_group_is_modifiable(db_user_group)
 
-    current_cc_pair_ids = set(cc_pair.id for cc_pair in db_user_group.cc_pairs)
+    current_cc_pair_ids = set(_current_cc_pair_ids(db_user_group))
     requested_cc_pair_ids = set(user_group_update.cc_pair_ids)
     _assert_group_update_within_scope(
         db_session,

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from collections.abc import Sequence
 from operator import and_
 from uuid import UUID
@@ -12,12 +13,17 @@ from sqlalchemy.orm import Session
 
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.auth.permissions import has_permission
+from onyx.auth.scoped_permissions import assert_manages_group
+from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
+from onyx.db.connector_credential_pair import get_cc_pair_groups_for_ids
 from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
 from onyx.db.enums import AccessType
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.enums import GrantSource
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import ConnectorCredentialPair
 from onyx.db.models import Credential
 from onyx.db.models import Credential__UserGroup
@@ -38,6 +44,8 @@ from onyx.db.models import UserGroup__ConnectorCredentialPair
 from onyx.db.permissions import recompute_permissions_for_group__no_commit
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from onyx.db.users import fetch_user_by_id
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -501,9 +509,54 @@ def add_users_to_user_group(
     )
 
 
+def _assert_group_update_within_scope(
+    db_session: Session,
+    user: User,
+    user_group_id: int,
+    added_cc_pair_ids: set[int],
+) -> None:
+    """GATE 2 for a scoped manager editing a group: the group must be one they
+    manage, and every newly-attached cc_pair must be a private one within their
+    managed scope — otherwise the junction rewrite could attach a public or
+    out-of-scope connector to the group, granting its members access. Admins /
+    global holders bypass both checks."""
+    assert_manages_group(user, db_session, group_id=user_group_id)
+
+    # The cc_pair re-attach vector only applies to scoped managers; a global
+    # MANAGE_USER_GROUPS holder keeps today's unrestricted attach behavior.
+    if (
+        has_permission(user, Permission.MANAGE_USER_GROUPS)
+        is not PermissionAuthority.SCOPED
+    ):
+        return
+
+    current_groups_by_cc_pair: dict[int, list[int]] = defaultdict(list)
+    for row in get_cc_pair_groups_for_ids(db_session, list(added_cc_pair_ids)):
+        if row.is_current and row.cc_pair_id is not None:
+            current_groups_by_cc_pair[row.cc_pair_id].append(row.user_group_id)
+
+    for cc_pair_id in added_cc_pair_ids:
+        cc_pair = get_connector_credential_pair_from_id(
+            db_session=db_session, cc_pair_id=cc_pair_id
+        )
+        if cc_pair is None:
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                "Group managers can only attach connectors within the groups they manage.",
+            )
+        assert_within_scope(
+            user,
+            db_session,
+            permission=Permission.MANAGE_CONNECTORS,
+            current_group_ids=current_groups_by_cc_pair[cc_pair_id],
+            requested_group_ids=[user_group_id],
+            is_non_public=cc_pair.access_type != AccessType.PUBLIC,
+        )
+
+
 def update_user_group(
     db_session: Session,
-    user: User,  # noqa: ARG001
+    user: User,
     user_group_id: int,
     user_group_update: UserGroupUpdate,
 ) -> UserGroup:
@@ -517,6 +570,15 @@ def update_user_group(
         raise ValueError(f"UserGroup with id '{user_group_id}' not found")
 
     _check_user_group_is_modifiable(db_user_group)
+
+    current_cc_pair_ids = set(cc_pair.id for cc_pair in db_user_group.cc_pairs)
+    requested_cc_pair_ids = set(user_group_update.cc_pair_ids)
+    _assert_group_update_within_scope(
+        db_session,
+        user,
+        user_group_id,
+        added_cc_pair_ids=requested_cc_pair_ids - current_cc_pair_ids,
+    )
 
     current_user_ids = set([user.id for user in db_user_group.users])
     updated_user_ids = set(user_group_update.user_ids)
@@ -548,9 +610,7 @@ def update_user_group(
             user_ids=added_user_ids,
         )
 
-    cc_pairs_updated = set([cc_pair.id for cc_pair in db_user_group.cc_pairs]) != set(
-        user_group_update.cc_pair_ids
-    )
+    cc_pairs_updated = current_cc_pair_ids != requested_cc_pair_ids
     if cc_pairs_updated:
         _mark_user_group__cc_pair_relationships_outdated__no_commit(
             db_session=db_session, user_group_id=user_group_id

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -198,6 +198,7 @@ def fetch_user_groups(
     only_up_to_date: bool = True,
     eager_load_for_snapshot: bool = False,
     include_default: bool = True,
+    restrict_to_group_ids: set[int] | None = None,
 ) -> Sequence[UserGroup]:
     """
     Fetches user groups from the database.
@@ -213,6 +214,9 @@ def fetch_user_groups(
         eager_load_for_snapshot: If True, adds eager loading for all relationships
             needed by UserGroup.from_model snapshot creation.
         include_default: If False, excludes system default groups (is_default=True).
+        restrict_to_group_ids: If provided, limits the result to these group ids — the
+            scoped-manager variant passes the groups they manage. An empty set returns
+            nothing (fail-closed); ``None`` returns all groups (admin/global).
 
     Returns:
         Sequence[UserGroup]: A sequence of `UserGroup` objects matching the query criteria.
@@ -222,6 +226,8 @@ def fetch_user_groups(
         stmt = stmt.where(UserGroup.is_up_to_date == True)  # noqa: E712
     if not include_default:
         stmt = stmt.where(UserGroup.is_default == False)  # noqa: E712
+    if restrict_to_group_ids is not None:
+        stmt = stmt.where(UserGroup.id.in_(restrict_to_group_ids))
     if eager_load_for_snapshot:
         stmt = _add_user_group_snapshot_eager_loads(stmt)
     return db_session.scalars(stmt).unique().all()

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -557,14 +557,21 @@ def _assert_group_update_within_scope(
         if row.is_current and row.cc_pair_id is not None:
             current_groups_by_cc_pair[row.cc_pair_id].append(row.user_group_id)
 
-    for cc_pair_id in added_cc_pair_ids:
-        cc_pair = get_connector_credential_pair_from_id(
-            db_session=db_session, cc_pair_id=cc_pair_id
+    cc_pairs_by_id = {
+        cc_pair.id: cc_pair
+        for cc_pair in db_session.scalars(
+            select(ConnectorCredentialPair).where(
+                ConnectorCredentialPair.id.in_(added_cc_pair_ids)
+            )
         )
+    }
+
+    for cc_pair_id in added_cc_pair_ids:
+        cc_pair = cc_pairs_by_id.get(cc_pair_id)
         if cc_pair is None:
             raise OnyxError(
-                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-                "Group managers can only attach connectors within the groups they manage.",
+                OnyxErrorCode.INVALID_INPUT,
+                f"Connector credential pair '{cc_pair_id}' not found.",
             )
         assert_within_scope(
             user,

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -575,6 +575,39 @@ def update_user_group(
     return db_user_group
 
 
+def _set_group_manager__no_commit(
+    db_session: Session, *, user_id: UUID, group_id: int, is_manager: bool
+) -> None:
+    edge = db_session.scalar(
+        select(User__UserGroup).where(
+            User__UserGroup.user_id == user_id,
+            User__UserGroup.user_group_id == group_id,
+        )
+    )
+    if edge is None:
+        raise ValueError(f"User '{user_id}' is not a member of group '{group_id}'")
+    edge.is_manager = is_manager
+    # Refresh the affected user's cached is_group_manager flag; a pure manager flip
+    # (no membership change) otherwise leaves the route-gate flag stale.
+    recompute_user_permissions__no_commit([user_id], db_session)
+
+
+def make_group_manager(db_session: Session, user_id: UUID, group_id: int) -> None:
+    """Flip is_manager=true on the (user, group) edge. The row must already exist —
+    a manager is always a member — else ValueError. Idempotent. Does NOT commit."""
+    _set_group_manager__no_commit(
+        db_session, user_id=user_id, group_id=group_id, is_manager=True
+    )
+
+
+def revoke_group_manager(db_session: Session, user_id: UUID, group_id: int) -> None:
+    """Flip is_manager=false on the (user, group) edge. The row must exist else
+    ValueError. Idempotent. Does NOT commit."""
+    _set_group_manager__no_commit(
+        db_session, user_id=user_id, group_id=group_id, is_manager=False
+    )
+
+
 def rename_user_group(
     db_session: Session,
     user_group_id: int,

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -8,13 +8,20 @@ from ee.onyx.db.token_limit import fetch_all_user_group_token_rate_limits_by_gro
 from ee.onyx.db.token_limit import fetch_user_group_token_rate_limits_for_group
 from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.db.token_limit import delete_token_rate_limit
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.token_limit import get_token_rate_limit_scope_and_group_ids
 from onyx.db.token_limit import insert_user_token_rate_limit
+from onyx.db.token_limit import update_token_rate_limit
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import any_rate_limit_exists
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
@@ -48,9 +55,14 @@ def get_all_group_token_limit_settings(
 @router.get("/user-group/{group_id}")
 def get_group_token_limit_settings(
     group_id: int,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[TokenRateLimitDisplay]:
+    # GATE 2 (read): a scoped manager may only read limits for a group they manage
+    # (global holders bypass). Single-group path param, so assert_manages_group, not a clause.
+    assert_manages_group(user, db_session, group_id=group_id)
     return [
         TokenRateLimitDisplay.from_db(token_rate_limit)
         for token_rate_limit in fetch_user_group_token_rate_limits_for_group(
@@ -89,6 +101,86 @@ def create_group_token_limit_settings(
     # clear cache in case this was the first rate limit created
     any_rate_limit_exists.cache_clear()
     return rate_limit_display
+
+
+def _authorize_group_token_rate_limit_write(
+    user: User, db_session: Session, *, group_id: int, rate_limit_id: int
+) -> None:
+    """Manager-scope gate for a group token-limit write: caller must manage group_id AND the
+    limit must belong to it — so a global/per-user id or another group's limit can't be reached
+    through this path. No current path attaches a limit to more than one group, but the schema
+    allows many-to-many; defensively, if a limit ever spans groups (a mutation hits all of them),
+    require the caller to manage every one, not just the group_id in the URL."""
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=[group_id],
+        requested_group_ids=[group_id],
+        is_non_public=True,
+    )
+    try:
+        scope, group_ids = get_token_rate_limit_scope_and_group_ids(
+            db_session, rate_limit_id
+        )
+    except ValueError:
+        scope, group_ids = None, []
+    if scope != TokenRateLimitScope.USER_GROUP or group_id not in group_ids:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, "Token rate limit not found for this group."
+        )
+    # Defensive: no current path attaches a limit to >1 group, but the schema allows it. If one
+    # ever did, the mutation would hit all of them, so require the caller to manage every one.
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=group_ids,
+        requested_group_ids=group_ids,
+        is_non_public=True,
+    )
+
+
+# Separate from the shared by-id routes so this route's require_permission caps a scoped
+# PAT to MANAGE_USER_GROUPS; a shared route would expose FULL_ADMIN global/user limits.
+@router.put("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def update_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    token_limit_settings: TokenRateLimitArgs,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> TokenRateLimitDisplay:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    rate_limit_display = TokenRateLimitDisplay.from_db(
+        update_token_rate_limit(
+            db_session=db_session,
+            token_rate_limit_id=rate_limit_id,
+            token_rate_limit_settings=token_limit_settings,
+        )
+    )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
+
+
+@router.delete("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def delete_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> None:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    delete_token_rate_limit(db_session=db_session, token_rate_limit_id=rate_limit_id)
+    any_rate_limit_exists.cache_clear()
 
 
 """

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -10,23 +10,28 @@ from ee.onyx.db.user_group import fetch_user_group
 from ee.onyx.db.user_group import fetch_user_groups
 from ee.onyx.db.user_group import fetch_user_groups_for_user
 from ee.onyx.db.user_group import insert_user_group
+from ee.onyx.db.user_group import make_group_manager
 from ee.onyx.db.user_group import prepare_user_group_for_deletion
 from ee.onyx.db.user_group import rename_user_group
+from ee.onyx.db.user_group import revoke_group_manager
 from ee.onyx.db.user_group import set_group_permissions_bulk__no_commit
 from ee.onyx.db.user_group import update_user_group
 from ee.onyx.server.user_group.models import AddUsersToUserGroupRequest
 from ee.onyx.server.user_group.models import BulkSetPermissionsRequest
 from ee.onyx.server.user_group.models import MinimalUserGroupSnapshot
+from ee.onyx.server.user_group.models import SetGroupManagerRequest
 from ee.onyx.server.user_group.models import UpdateGroupAgentsRequest
 from ee.onyx.server.user_group.models import UserGroup
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
 from onyx.auth.permissions import PERMISSION_REGISTRY
 from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
@@ -289,4 +294,34 @@ def update_group_agents(
             group_ids=[gid for gid in current_group_ids if gid != user_group_id],
         )
 
+    db_session.commit()
+
+
+@router.put("/admin/user-group/{user_group_id}/manager")
+def set_group_manager(
+    user_group_id: int,
+    request: SetGroupManagerRequest,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> None:
+    # GATE 2: an admin / global MANAGE_USER_GROUPS holder may assign in any group;
+    # a scoped manager may only (de)assign managers within a group they manage — so
+    # a manager can delegate within their own group but not beyond it.
+    if not has_global_permission(user, Permission.MANAGE_USER_GROUPS):
+        managed = get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+        if user_group_id not in managed:
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                "Group managers can only assign managers within the groups they manage.",
+            )
+    try:
+        if request.is_manager:
+            make_group_manager(db_session, request.user_id, user_group_id)
+        else:
+            revoke_group_manager(db_session, request.user_id, user_group_id)
+    except ValueError as e:
+        # Target isn't a member of the group (a manager is always a member).
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
     db_session.commit()

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -53,16 +53,17 @@ router = APIRouter(prefix="/manage", tags=PUBLIC_API_TAGS)
 def list_user_groups(
     include_default: bool = False,
     user: User = Depends(
-        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+        require_permission(Permission.READ_USER_GROUPS, allow_scope=True)
     ),
     db_session: Session = Depends(get_session),
 ) -> list[UserGroup]:
-    # GATE 2 (read): admins/global holders see every group; a scoped manager sees
-    # only the groups they manage. The group list has no built-in membership filter,
-    # so restrict it here or a manager would see the whole org.
+    # GATE 2 (read): a global READ_USER_GROUPS holder (admin, or any MANAGE_* that
+    # implies it) sees every group; a scoped manager sees only the groups they
+    # manage. The group list has no built-in membership filter, so restrict it here
+    # or a manager would see the whole org.
     restrict_to_group_ids = (
         None
-        if has_global_permission(user, Permission.MANAGE_USER_GROUPS)
+        if has_global_permission(user, Permission.READ_USER_GROUPS)
         else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
     )
     user_groups = fetch_user_groups(

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -26,11 +26,13 @@ from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
 from onyx.auth.permissions import PERMISSION_REGISTRY
 from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_manages_group
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
@@ -50,14 +52,25 @@ router = APIRouter(prefix="/manage", tags=PUBLIC_API_TAGS)
 @router.get("/admin/user-group")
 def list_user_groups(
     include_default: bool = False,
-    _: User = Depends(require_permission(Permission.READ_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[UserGroup]:
+    # GATE 2 (read): admins/global holders see every group; a scoped manager sees
+    # only the groups they manage. The group list has no built-in membership filter,
+    # so restrict it here or a manager would see the whole org.
+    restrict_to_group_ids = (
+        None
+        if has_global_permission(user, Permission.MANAGE_USER_GROUPS)
+        else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+    )
     user_groups = fetch_user_groups(
         db_session,
         only_up_to_date=False,
         eager_load_for_snapshot=True,
         include_default=include_default,
+        restrict_to_group_ids=restrict_to_group_ids,
     )
     mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -26,12 +26,11 @@ from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
 from onyx.auth.permissions import get_effective_permissions
-from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
 from onyx.auth.permissions import PERMISSION_REGISTRY
 from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
-from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
@@ -169,9 +168,13 @@ def create_user_group(
 @router.patch("/admin/user-group/rename")
 def rename_user_group_endpoint(
     rename_request: UserGroupRename,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
+    # GATE 2: rename's DB fn takes no user and re-reads nothing, so gate here.
+    assert_manages_group(user, db_session, group_id=rename_request.id)
     group = fetch_user_group(db_session, rename_request.id)
     if group and group.is_default:
         raise OnyxError(OnyxErrorCode.CONFLICT, "Cannot rename a default system group.")
@@ -200,7 +203,9 @@ def rename_user_group_endpoint(
 def patch_user_group(
     user_group_id: int,
     user_group_update: UserGroupUpdate,
-    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
     try:
@@ -221,7 +226,9 @@ def patch_user_group(
 def add_users(
     user_group_id: int,
     add_users_request: AddUsersToUserGroupRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> UserGroup:
     try:
@@ -309,13 +316,7 @@ def set_group_manager(
     # GATE 2: an admin / global MANAGE_USER_GROUPS holder may assign in any group;
     # a scoped manager may only (de)assign managers within a group they manage — so
     # a manager can delegate within their own group but not beyond it.
-    if not has_global_permission(user, Permission.MANAGE_USER_GROUPS):
-        managed = get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
-        if user_group_id not in managed:
-            raise OnyxError(
-                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-                "Group managers can only assign managers within the groups they manage.",
-            )
+    assert_manages_group(user, db_session, group_id=user_group_id)
     try:
         if request.is_manager:
             make_group_manager(db_session, request.user_id, user_group_id)

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -25,6 +25,7 @@ from ee.onyx.server.user_group.models import UserGroup
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
@@ -33,6 +34,7 @@ from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import manages_group
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
@@ -61,10 +63,16 @@ def list_user_groups(
     # implies it) sees every group; a scoped manager sees only the groups they
     # manage. The group list has no built-in membership filter, so restrict it here
     # or a manager would see the whole org.
+    # Resolve scope + global authority once so per-group stamping is pure set math (no query).
+    managed_group_ids = get_scoped_groups(
+        user, db_session, Permission.MANAGE_USER_GROUPS
+    )
+    is_user_groups_admin = has_global_permission(user, Permission.MANAGE_USER_GROUPS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
     restrict_to_group_ids = (
         None
         if has_global_permission(user, Permission.READ_USER_GROUPS)
-        else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+        else managed_group_ids
     )
     user_groups = fetch_user_groups(
         db_session,
@@ -75,7 +83,20 @@ def list_user_groups(
     )
     mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        UserGroup.from_model(user_group, mask_credential_prefix=mask_credential_prefix)
+        UserGroup.from_model(
+            user_group,
+            mask_credential_prefix=mask_credential_prefix,
+            permissions=user_group_permissions(
+                can_manage=manages_group(
+                    user,
+                    db_session,
+                    group_id=user_group.id,
+                    managed_group_ids=managed_group_ids,
+                ),
+                is_user_groups_admin=is_user_groups_admin,
+                is_full_admin=is_full_admin,
+            ),
+        )
         for user_group in user_groups
     ]
 

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -122,6 +122,11 @@ class UpdateGroupAgentsRequest(BaseModel):
     removed_agent_ids: list[int]
 
 
+class SetGroupManagerRequest(BaseModel):
+    user_id: UUID
+    is_manager: bool
+
+
 class SetPermissionRequest(BaseModel):
     permission: Permission
     enabled: bool

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.auth.permissions import Permission
 from onyx.db.models import UserGroup as UserGroupModel
@@ -17,12 +18,17 @@ class UserGroup(BaseModel):
     id: int
     name: str
     users: list[UserInfo]
+    manager_ids: list[str]
     cc_pairs: list[ConnectorCredentialPairDescriptor]
     document_sets: list[DocumentSet]
     personas: list[PersonaSnapshot]
     is_up_to_date: bool
     is_up_for_deletion: bool
     is_default: bool
+    # Per-action affordance map ({"manage": true, ...}) the client reads to show/hide
+    # controls. Empty default = every action denied (missing key is false), so it fails
+    # closed. Only the list-groups endpoint fills it in; the mutation routes leave it empty.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -30,10 +36,17 @@ class UserGroup(BaseModel):
         user_group_model: UserGroupModel,
         *,
         mask_credential_prefix: bool,
+        permissions: dict[str, bool] | None = None,
     ) -> "UserGroup":
         return cls(
+            permissions=permissions or {},
             id=user_group_model.id,
             name=user_group_model.name,
+            manager_ids=[
+                str(relationship.user_id)
+                for relationship in user_group_model.user_group_relationships
+                if relationship.is_manager and relationship.user_id is not None
+            ],
             users=[
                 UserInfo(
                     id=str(user.id),

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -1,0 +1,218 @@
+"""Read-side capability projection.
+
+Stamps a ``permissions`` map on resource DTOs from the same decision the write guards
+enforce, so the client can hide controls the user would be 403'd on.
+
+These maps are affordance hints only, never an authz input: every mutating route keeps
+its own guard as the security boundary. Fail-closed — a key absent from the map reads
+as ``False`` on the client.
+"""
+
+from typing import cast
+from typing import TypedDict
+
+# Each resource's affordance keys are a TypedDict, so a typo or a missing key in the builder
+# below is a type error rather than a silent False on the wire. The ``*_ACTIONS`` vocabulary is
+# derived from the TypedDict (one source of truth), and the builders widen to the generic
+# ``dict[str, bool]`` the DTO fields carry.
+
+
+class CCPairPermissions(TypedDict):
+    edit: bool
+    delete: bool
+    publish: bool
+
+
+CC_PAIR_ACTIONS: frozenset[str] = frozenset(CCPairPermissions.__annotations__)
+
+
+def cc_pair_permissions(
+    *, is_editable: bool, is_connectors_admin: bool
+) -> dict[str, bool]:
+    """``is_editable`` is the managed-scope editable decision the write guard enforces
+    (a scoped manager may edit a managed private connector; it also gates the
+    manage-access control, so there is no separate key). ``delete`` and ``publish``
+    (make org-wide PUBLIC) are global-only: a manager can edit a managed connector but
+    never delete it or make it public."""
+    result: CCPairPermissions = {
+        "edit": is_editable,
+        "delete": is_connectors_admin,
+        "publish": is_connectors_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class PersonaPermissions(TypedDict):
+    edit: bool
+    share: bool
+    view_stats: bool
+    delete: bool
+    publish: bool
+    feature: bool
+    list: bool
+    reorder: bool
+
+
+PERSONA_ACTIONS: frozenset[str] = frozenset(PersonaPermissions.__annotations__)
+
+
+def persona_permissions(
+    *,
+    can_edit: bool,
+    can_share: bool,
+    can_view_stats: bool,
+    can_delete: bool,
+    holds_add_agents: bool,
+    is_manage_agents_admin: bool,
+    is_full_admin: bool,
+) -> dict[str, bool]:
+    """Agent (persona) affordance map. ``edit``/``share`` gate on editable alone (their routes are
+    BASIC_ACCESS) — an editor-shared user without ADD_AGENTS may still edit and manage sharing.
+    ``edit`` is the editable-AND-managed-scope decision the update guard enforces; ``share`` is the
+    broader editable decision the share guard enforces (get_editable, no scope AND). ``publish``
+    (make org-wide public, via the share route's is_owner_or_admin gate) is owner-or-admin — no
+    ADD_AGENTS. ``delete`` ANDs ``holds_add_agents``: its route gates on ADD_AGENTS at GATE 1
+    (allow_scope), so an owner lacking it is 403'd there. ``view_stats`` is owner-or-full-admin.
+    ``feature``/``list`` need global MANAGE_AGENTS (which implies ADD_AGENTS) and ``reorder`` full
+    admin."""
+    result: PersonaPermissions = {
+        "edit": can_edit,
+        "share": can_share,
+        "view_stats": can_view_stats,
+        "delete": can_delete and holds_add_agents,
+        "publish": can_delete,
+        "feature": is_manage_agents_admin,
+        "list": is_manage_agents_admin,
+        "reorder": is_full_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class DocumentSetPermissions(TypedDict):
+    edit: bool
+    manage_access: bool
+    delete: bool
+    publish: bool
+
+
+DOCUMENT_SET_ACTIONS: frozenset[str] = frozenset(DocumentSetPermissions.__annotations__)
+
+
+def document_set_permissions(
+    *, is_editable: bool, is_document_sets_admin: bool
+) -> dict[str, bool]:
+    """Document set affordance map. ``edit`` and ``manage_access`` are the managed-scope
+    editable decision the write guard enforces (a doc set has no editor-share arm, so
+    editable membership is that decision). ``delete`` and ``publish`` (make org-wide
+    public) are global MANAGE_DOCUMENT_SETS only."""
+    result: DocumentSetPermissions = {
+        "edit": is_editable,
+        "manage_access": is_editable,
+        "delete": is_document_sets_admin,
+        "publish": is_document_sets_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class ToolPermissions(TypedDict):
+    edit: bool
+    delete: bool
+    toggle: bool
+    authenticate: bool
+
+
+TOOL_ACTIONS: frozenset[str] = frozenset(ToolPermissions.__annotations__)
+
+
+def tool_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """Custom action (OpenAPI tool) affordance map. Every action — edit, delete, toggle, and
+    authenticate (its OAuth config) — is owner-or-admin (``can_manage``): the creator fully
+    controls the action they made and an admin controls any, while a scoped manager may view
+    and create actions but not edit ones they didn't create."""
+    result: ToolPermissions = {
+        "edit": can_manage,
+        "delete": can_manage,
+        "toggle": can_manage,
+        "authenticate": can_manage,
+    }
+    return cast(dict[str, bool], result)
+
+
+class MCPServerPermissions(TypedDict):
+    edit: bool
+    delete: bool
+    authenticate: bool
+    manage_status: bool
+
+
+MCP_SERVER_ACTIONS: frozenset[str] = frozenset(MCPServerPermissions.__annotations__)
+
+
+def mcp_server_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """MCP server affordance map. Every action — edit, delete, authenticate (connect), and
+    manage_status (disconnect/refresh) — is owner-or-admin (``can_manage``): the owner fully
+    controls their server and an admin controls any, while a scoped manager may view servers
+    connected to their groups and create their own but not manage others'."""
+    result: MCPServerPermissions = {
+        "edit": can_manage,
+        "delete": can_manage,
+        "authenticate": can_manage,
+        "manage_status": can_manage,
+    }
+    return cast(dict[str, bool], result)
+
+
+class CustomSkillPermissions(TypedDict):
+    edit: bool
+    manage_access: bool
+    delete: bool
+    publish: bool
+
+
+CUSTOM_SKILL_ACTIONS: frozenset[str] = frozenset(CustomSkillPermissions.__annotations__)
+
+
+def custom_skill_permissions(
+    *, can_edit: bool, is_full_admin: bool, is_skills_admin: bool
+) -> dict[str, bool]:
+    """Custom skill affordance map. ``edit`` (replace bundle, enable/disable) and
+    ``manage_access`` (group grants) are the managed-scope editable decision the write
+    guard enforces. ``delete`` is FULL_ADMIN only (its route requires
+    FULL_ADMIN_PANEL_ACCESS, no ``allow_scope``); ``publish`` (make org-wide public)
+    needs global MANAGE_SKILLS — a scoped manager fails the guard's non-public check when
+    flipping a skill public."""
+    result: CustomSkillPermissions = {
+        "edit": can_edit,
+        "manage_access": can_edit,
+        "delete": is_full_admin,
+        "publish": is_skills_admin,
+    }
+    return cast(dict[str, bool], result)
+
+
+class UserGroupPermissions(TypedDict):
+    manage: bool
+    delete: bool
+    edit_permissions: bool
+    edit_token_limits: bool
+
+
+USER_GROUP_ACTIONS: frozenset[str] = frozenset(UserGroupPermissions.__annotations__)
+
+
+def user_group_permissions(
+    *, can_manage: bool, is_user_groups_admin: bool, is_full_admin: bool
+) -> dict[str, bool]:
+    """User group affordance map. ``manage`` (rename, membership, assign agents, set
+    manager) and ``edit_token_limits`` are the per-group ``manages_group`` decision — group
+    in the manager's managed set, or global MANAGE_USER_GROUPS. A scoped manager gets full
+    token-limit CRUD for groups they manage: every token route (read/create/update/delete)
+    now admits scope. ``delete`` needs global MANAGE_USER_GROUPS (its route has no
+    ``allow_scope``). ``edit_permissions`` is FULL_ADMIN (the permission-toggle route)."""
+    result: UserGroupPermissions = {
+        "manage": can_manage,
+        "delete": is_user_groups_admin,
+        "edit_permissions": is_full_admin,
+        "edit_token_limits": can_manage,
+    }
+    return cast(dict[str, bool], result)

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -255,6 +255,16 @@ def resolve_effective_permissions(granted: set[str]) -> set[str]:
     return effective
 
 
+# The bundle plus everything it implies. A scoped manager holds the bundle's
+# write tokens AND their implied reads (e.g. MANAGE_USER_GROUPS ⇒ READ_USER_GROUPS)
+# — scoped to their managed groups. has_permission classifies against this so a
+# manager resolves SCOPED for those reads; every READ + allow_scope endpoint must
+# still apply its own GATE 2 scope filter (they'd otherwise return all rows).
+SCOPED_MANAGER_PERMISSIONS_EXPANDED: frozenset[str] = frozenset(
+    resolve_effective_permissions({p.value for p in SCOPED_MANAGER_PERMISSIONS})
+)
+
+
 def get_effective_permissions(user: User) -> set[Permission]:
     """Read granted permissions from the column and expand implied permissions."""
     granted = set(parse_permission_values(user.effective_permissions))
@@ -282,7 +292,10 @@ def has_permission(user: User, permission: Permission) -> PermissionAuthority:
     """
     if permission in get_effective_permissions(user):
         return PermissionAuthority.GLOBAL
-    if permission in SCOPED_MANAGER_PERMISSIONS and user.is_group_manager:
+    if (
+        user.is_group_manager
+        and permission.value in SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    ):
         return PermissionAuthority.SCOPED
     return PermissionAuthority.NONE
 

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -30,8 +30,10 @@ logger = setup_logger()
 ALL_PERMISSIONS: frozenset[str] = frozenset(p.value for p in Permission)
 
 # Implication map: granted permission -> set of permissions it implies.
+# NOTE: ADD_AGENTS does NOT imply READ_AGENTS — creating your own agents must not grant
+# see-all-agents visibility. READ_AGENTS (browse every agent) comes only from the
+# MANAGE_* admin bundles below.
 IMPLIED_PERMISSIONS: dict[str, set[str]] = {
-    Permission.ADD_AGENTS.value: {Permission.READ_AGENTS.value},
     Permission.MANAGE_AGENTS.value: {
         Permission.ADD_AGENTS.value,
         Permission.READ_AGENTS.value,

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -10,6 +10,7 @@ from collections.abc import Collection
 
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS
 from onyx.db.enums import Permission
@@ -85,6 +86,21 @@ def assert_within_scope(
         OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
         "Group managers can only act on private resources "
         "within the groups they manage.",
+    )
+
+
+def assert_manages_group(user: User, db_session: Session, *, group_id: int) -> None:
+    """GATE 2 for an action scoped to a single user group (membership edits, manager
+    assignment): a GLOBAL ``MANAGE_USER_GROUPS`` holder bypasses; a scoped manager
+    passes only when ``group_id`` is one they manage. NONE, or out-of-scope, rejects.
+    Fail-closed: empty managed scope rejects."""
+    if has_global_permission(user, Permission.MANAGE_USER_GROUPS):
+        return
+    if group_id in get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS):
+        return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "Group managers can only act within the groups they manage.",
     )
 
 

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -33,23 +33,35 @@ def get_scoped_groups(
     return fetch_managed_group_ids(user, db_session)
 
 
-def agent_mediated_scope_allows(
+def within_scope(
     user: User,
     db_session: Session,
     *,
-    group_ids: set[int],
-    has_public_agent: bool,
-    has_ungrouped_private_agent: bool,
+    permission: Permission,
+    current_group_ids: Collection[int],
+    requested_group_ids: Collection[int],
+    is_non_public: bool,
+    managed_group_ids: set[int] | None = None,
 ) -> bool:
-    """Shared GATE 2 tail for resources whose scope is derived from the agents that
-    reference them (custom actions, MCP servers). A scoped manager is in scope iff
-    every referencing agent is private and in a group they manage: no agent is
-    public or ungrouped-private, there is ≥1 group, and every group is managed.
-    Callers resolve owner/admin bypasses first."""
-    if has_public_agent or has_ungrouped_private_agent or not group_ids:
-        return False
-    managed = get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
-    return group_ids.issubset(managed)
+    """Pure GATE-2 (write) decision — no raise. GLOBAL holders always pass. A SCOPED
+    manager passes only for a non-public resource whose every group (current ∪
+    requested) is one they manage, landing in >=1 group. Fail-closed: NONE,
+    out-of-scope, or empty managed scope is ``False``.
+
+    ``managed_group_ids`` lets a caller pass a preloaded managed set so per-row
+    stamping issues no DB query; ``None`` re-queries."""
+    authority = has_permission(user, permission)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        managed = (
+            managed_group_ids
+            if managed_group_ids is not None
+            else get_scoped_groups(user, db_session, permission)
+        )
+        final = set(current_group_ids) | set(requested_group_ids)
+        return bool(managed and final and final.issubset(managed) and is_non_public)
+    return False
 
 
 def assert_within_scope(
@@ -61,10 +73,7 @@ def assert_within_scope(
     requested_group_ids: Collection[int],
     is_non_public: bool,
 ) -> None:
-    """GATE 2 (write) — the authorization of record. GLOBAL holders are governed
-    by base-system rules. A SCOPED manager may only touch a non-public resource
-    whose every group (current ∪ requested) is one they manage, landing in ≥1
-    group. NONE, or out-of-scope, rejects. Fail-closed: empty scope rejects.
+    """GATE 2 (write) — the authorization of record; raises 403 when out of scope.
 
     ``is_non_public`` is the caller's non-public predicate (PUBLIC excluded; for a
     cc_pair that admits PRIVATE or SYNC). On update, AND the current and requested
@@ -72,36 +81,54 @@ def assert_within_scope(
 
     Call before any try/except in the endpoint: it raises a 403 OnyxError that a
     surrounding broad except would otherwise re-wrap as a 500. On create, pass
-    ``current_group_ids=[]`` (no existing groups); on update, pass the groups
-    re-read from the DB — never the client's — so a reassignment can't escape scope."""
-    authority = has_permission(user, permission)
-    if authority is PermissionAuthority.GLOBAL:
-        return
-    if authority is PermissionAuthority.SCOPED:
-        managed = get_scoped_groups(user, db_session, permission)
-        final = set(current_group_ids) | set(requested_group_ids)
-        if managed and final and final.issubset(managed) and is_non_public:
-            return
-    raise OnyxError(
-        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "Group managers can only act on private resources "
-        "within the groups they manage.",
+    ``current_group_ids=[]``; on update, pass the groups re-read from the DB — never
+    the client's — so a reassignment can't escape scope."""
+    if not within_scope(
+        user,
+        db_session,
+        permission=permission,
+        current_group_ids=current_group_ids,
+        requested_group_ids=requested_group_ids,
+        is_non_public=is_non_public,
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Group managers can only act on private resources "
+            "within the groups they manage.",
+        )
+
+
+def manages_group(
+    user: User,
+    db_session: Session,
+    *,
+    group_id: int,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """Pure GATE-2 decision for an action scoped to a single user group — no raise. A
+    GLOBAL ``MANAGE_USER_GROUPS`` holder always passes; a scoped manager passes only
+    for a group they manage. Fail-closed: empty managed scope is ``False``.
+    ``managed_group_ids`` lets a caller pass a preloaded set so stamping issues no DB
+    query."""
+    if has_global_permission(user, Permission.MANAGE_USER_GROUPS):
+        return True
+    managed = (
+        managed_group_ids
+        if managed_group_ids is not None
+        else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
     )
+    return group_id in managed
 
 
 def assert_manages_group(user: User, db_session: Session, *, group_id: int) -> None:
     """GATE 2 for an action scoped to a single user group (membership edits, manager
     assignment): a GLOBAL ``MANAGE_USER_GROUPS`` holder bypasses; a scoped manager
-    passes only when ``group_id`` is one they manage. NONE, or out-of-scope, rejects.
-    Fail-closed: empty managed scope rejects."""
-    if has_global_permission(user, Permission.MANAGE_USER_GROUPS):
-        return
-    if group_id in get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS):
-        return
-    raise OnyxError(
-        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "Group managers can only act within the groups they manage.",
-    )
+    passes only for a group they manage. NONE, or out-of-scope, rejects."""
+    if not manages_group(user, db_session, group_id=group_id):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "Group managers can only act within the groups they manage.",
+        )
 
 
 def assert_global(user: User, *, permission: Permission) -> None:

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -12,7 +12,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
-from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS
+from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS_EXPANDED
 from onyx.db.enums import Permission
 from onyx.db.enums import PermissionAuthority
 from onyx.db.models import User
@@ -27,8 +27,14 @@ def get_scoped_groups(
     """Imperative form for the write-side gate. Empty when ``permission`` is
     given but not scopable, so a non-bundle token never resolves a scope. When
     ``permission`` is ``None``, skips the bundle check and returns all groups the
-    user manages (scope introspection)."""
-    if permission is not None and permission not in SCOPED_MANAGER_PERMISSIONS:
+    user manages (scope introspection).
+
+    Gate on the *expanded* bundle to match has_permission: an implied read a
+    manager resolves SCOPED for must resolve a scope here, not an empty set."""
+    if (
+        permission is not None
+        and permission.value not in SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    ):
         return set()
     return fetch_managed_group_ids(user, db_session)
 

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -15,9 +15,11 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.access.hierarchy_access import get_user_external_group_ids
+from onyx.auth.permission_projection import persona_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
 from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import within_scope
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import NotificationType
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
@@ -43,9 +45,9 @@ from onyx.db.models import UserGroup
 from onyx.db.notification import create_notification
 from onyx.db.persona_sharing import get_persona_access_level
 from onyx.db.persona_sharing import get_user_group_ids_for_user
+from onyx.db.scoped_permissions import fetch_managed_group_ids
 from onyx.db.scoped_permissions import scoped_group_ids_subquery
 from onyx.db.scoped_permissions import within_managed_scope_clause
-from onyx.db.users import user_is_admin
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.features.persona.models import PersonaSharedNotificationData
@@ -380,6 +382,162 @@ def _assert_persona_update_within_managed_scope(
     )
 
 
+def persona_edit_within_scope(
+    user: User,
+    db_session: Session,
+    *,
+    group_ids: list[int],
+    is_public: bool,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """Read-mode of ``_assert_persona_update_within_managed_scope`` (requested := current).
+    Non-SCOPED holders and personal (no-group) agents pass; a scoped manager passes only
+    when within_scope holds. Pinned to that guard by the contract test."""
+    if has_permission(user, Permission.MANAGE_AGENTS) is not PermissionAuthority.SCOPED:
+        return True
+    if not group_ids:
+        return True
+    return within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_AGENTS,
+        current_group_ids=group_ids,
+        requested_group_ids=group_ids,
+        is_non_public=not is_public,
+        managed_group_ids=managed_group_ids,
+    )
+
+
+def can_edit_persona(
+    user: User,
+    persona: Persona,
+    db_session: Session,
+    *,
+    is_editable: bool,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """The get_editable filter is a superset (owner ∪ EDITOR-share ∪ managed-scope), so a
+    scoped manager EDITOR-shared on an out-of-scope grouped agent qualifies there but is
+    ANDed out by the managed-scope gate — matching the write path. ``is_editable`` is that
+    filter's result."""
+    if not is_editable:
+        return False
+    return persona_edit_within_scope(
+        user,
+        db_session,
+        group_ids=[group.id for group in persona.groups],
+        is_public=persona.is_public,
+        managed_group_ids=managed_group_ids,
+    )
+
+
+def is_persona_editable_by_user(
+    db_session: Session, persona_id: int, user: User
+) -> bool:
+    """Non-raising editability check via the same get_editable filter the edit affordance
+    should reflect (superset: owner ∪ EDITOR-share ∪ managed-scope)."""
+    stmt = select(Persona).where(Persona.id == persona_id).distinct()
+    stmt = _add_user_filters(stmt=stmt, user=user, get_editable=True)
+    return db_session.scalars(stmt).one_or_none() is not None
+
+
+def can_view_persona_stats(user: User, persona: Persona) -> bool:
+    """Owner-or-full-admin — mirrors ee ``user_can_view_assistant_stats`` (pinned by the
+    contract test). Stats are EE-only but the gate itself is trivially MIT-computable."""
+    return has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS) or (
+        persona.user_id == user.id
+    )
+
+
+def can_delete_persona(
+    user: User,
+    persona: Persona,
+    db_session: Session,
+    *,
+    user_group_ids: set[int] | None = None,
+) -> bool:
+    """Owner-or-admin — mirrors the delete/publish handlers' ownership check (via
+    ``get_persona_by_id(is_for_edit=True)``): a global MANAGE_AGENTS holder, the owner,
+    or an owner-group member. A scoped manager is NOT included: deleting or publishing a
+    managed-group agent is owner/admin only, not a manager scope.
+
+    ``user_group_ids`` lets a caller pass a preloaded set so per-row stamping issues no
+    DB query; ``None`` re-queries."""
+    if has_global_permission(user, Permission.MANAGE_AGENTS):
+        return True
+    if persona.user_id == user.id:
+        return True
+    if persona.owner_group_id is not None:
+        group_ids = (
+            user_group_ids
+            if user_group_ids is not None
+            else get_user_group_ids_for_user(db_session, user.id)
+        )
+        return persona.owner_group_id in group_ids
+    return False
+
+
+def _editable_persona_ids_among(
+    db_session: Session, user: User, persona_ids: list[int]
+) -> set[int]:
+    """Subset of ``persona_ids`` the user may edit, via the same get_editable filter the
+    write path enforces — one query for the whole page instead of a per-persona check."""
+    if not persona_ids:
+        return set()
+    stmt = select(Persona).where(Persona.id.in_(persona_ids))
+    stmt = _add_user_filters(stmt=stmt, user=user, get_editable=True)
+    return {persona.id for persona in db_session.scalars(stmt).all()}
+
+
+def stamp_minimal_persona_permissions(
+    snapshots: list[MinimalPersonaSnapshot],
+    personas: Sequence[Persona],
+    user: User,
+    db_session: Session,
+    user_group_ids: set[int],
+) -> None:
+    """Stamp each list snapshot with the same affordance map the single-agent GET does,
+    so cards gate their icons without a per-card refetch. Shared inputs (editable set,
+    managed scope, admin flags) are batched so a page costs a fixed number of queries,
+    not one per persona. ``snapshots`` and ``personas`` must be in the same order."""
+    editable_ids = _editable_persona_ids_among(
+        db_session, user, [persona.id for persona in personas]
+    )
+    # Only scoped managers consult the managed set (GLOBAL/NONE short-circuit earlier);
+    # preload it once so per-row can_edit_persona issues no query.
+    managed_group_ids = (
+        fetch_managed_group_ids(user, db_session)
+        if has_permission(user, Permission.MANAGE_AGENTS) is PermissionAuthority.SCOPED
+        else None
+    )
+    is_manage_agents_admin = has_global_permission(user, Permission.MANAGE_AGENTS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
+    # delete/publish also gate on ADD_AGENTS (GATE 1); edit/share don't. Per-user, not per-row.
+    holds_add_agents = (
+        has_permission(user, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    for snapshot, persona in zip(snapshots, personas):
+        is_editable = persona.id in editable_ids
+        snapshot.permissions = persona_permissions(
+            can_edit=can_edit_persona(
+                user,
+                persona,
+                db_session,
+                is_editable=is_editable,
+                managed_group_ids=managed_group_ids,
+            ),
+            # share tracks the share guard (get_editable), broader than edit's scope gate
+            can_share=is_editable,
+            can_view_stats=can_view_persona_stats(user, persona),
+            can_delete=can_delete_persona(
+                user, persona, db_session, user_group_ids=user_group_ids
+            ),
+            holds_add_agents=holds_add_agents,
+            is_manage_agents_admin=is_manage_agents_admin,
+            is_full_admin=is_full_admin,
+        )
+
+
 def create_update_persona(
     persona_id: int | None,
     create_persona_request: PersonaUpsertRequest,
@@ -498,19 +656,11 @@ def update_persona_shared(
         db_session=db_session, persona_id=persona_id, user=user, get_editable=True
     )
 
-    # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may
-    # edit user/group shares but must not flip is_public / public_permission
-    # (the same guard update_persona_public_status enforces).
-    is_owner_or_admin: bool = (
-        user_is_admin(user)
-        or persona.user_id == user.id
-        or (
-            persona.owner_group_id is not None
-            and persona.owner_group_id
-            in get_user_group_ids_for_user(db_session, user.id)
-        )
-    )
-    if not is_owner_or_admin:
+    # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may edit
+    # user/group shares but must not flip is_public / public_permission. Reuse the
+    # delete/publish predicate so this exactly matches the `publish` projection and the
+    # /public route (global MANAGE_AGENTS, owner, or owner-group) — not just FULL_ADMIN.
+    if not can_delete_persona(user, persona, db_session):
         is_public = None
         public_permission = None
 
@@ -639,19 +789,26 @@ def get_minimal_persona_snapshots_for_user(
             Document.parent_hierarchy_node
         ),
         selectinload(Persona.user),
+        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
+        # eager-load it so stamping the page's permissions isn't an N+1.
+        selectinload(Persona.groups),
         selectinload(Persona.owner_group),
         selectinload(Persona.user_shares),
         selectinload(Persona.group_shares),
     )
     results = db_session.scalars(stmt).all()
     user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
+    snapshots = [
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
         )
         for persona in results
     ]
+    stamp_minimal_persona_permissions(
+        snapshots, results, user, db_session, user_group_ids
+    )
+    return snapshots
 
 
 def get_persona_snapshots_for_user(
@@ -794,6 +951,9 @@ def get_minimal_persona_snapshots_paginated(
             ),
         ),
         selectinload(Persona.user),
+        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
+        # eager-load it so stamping the page's permissions isn't an N+1.
+        selectinload(Persona.groups),
         selectinload(Persona.owner_group),
         selectinload(Persona.user_shares),
         selectinload(Persona.group_shares),
@@ -801,13 +961,17 @@ def get_minimal_persona_snapshots_paginated(
 
     results = db_session.scalars(stmt).all()
     user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
+    snapshots = [
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
         )
         for persona in results
     ]
+    stamp_minimal_persona_permissions(
+        snapshots, results, user, db_session, user_group_ids
+    )
+    return snapshots
 
 
 def get_persona_snapshots_paginated(
@@ -1253,7 +1417,12 @@ def upsert_persona(
         existing_persona.default_model_configuration_id = default_model_configuration_id
         existing_persona.starter_messages = starter_messages
         existing_persona.deleted = False  # Un-delete if previously deleted
-        if is_public is not None:
+        # Publishing (org-wide public) is owner-or-admin — matches the share route and the
+        # publish projection. An editor-shared user may edit content but not flip an agent
+        # they don't own to public; the change is silently dropped, like is_listed/is_featured.
+        if is_public is not None and (
+            user is None or can_delete_persona(user, existing_persona, db_session)
+        ):
             existing_persona.is_public = is_public
         if remove_image or uploaded_image_id:
             existing_persona.uploaded_image_id = uploaded_image_id

--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -78,6 +78,27 @@ def insert_global_token_rate_limit(
     return token_limit
 
 
+def get_token_rate_limit_scope_and_group_ids(
+    db_session: Session, token_rate_limit_id: int
+) -> tuple[TokenRateLimitScope, list[int]]:
+    """Scope + every group id a rate limit is attached to (empty unless USER_GROUP). Raises
+    ValueError if the id is unknown. The API attaches a limit to one group today, but the schema
+    allows many-to-many, so an authorizing caller must check every group returned, not just one."""
+    token_limit = db_session.get(TokenRateLimit, token_rate_limit_id)
+    if token_limit is None:
+        raise ValueError(f"TokenRateLimit with id '{token_rate_limit_id}' not found")
+    if token_limit.scope != TokenRateLimitScope.USER_GROUP:
+        return token_limit.scope, []
+    group_ids = list(
+        db_session.scalars(
+            select(TokenRateLimit__UserGroup.user_group_id).where(
+                TokenRateLimit__UserGroup.rate_limit_id == token_rate_limit_id
+            )
+        ).all()
+    )
+    return token_limit.scope, group_ids
+
+
 def update_token_rate_limit(
     db_session: Session,
     token_rate_limit_id: int,

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from typing import Any
 from typing import cast
 from typing import Type
@@ -6,13 +7,16 @@ from uuid import UUID
 
 from sqlalchemy import func
 from sqlalchemy import or_
-from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_permission
 from onyx.db.constants import UNSET
 from onyx.db.constants import UnsetType
 from onyx.db.enums import MCPServerStatus
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import MCPServer
 from onyx.db.models import OAuthConfig
 from onyx.db.models import Persona
@@ -20,6 +24,7 @@ from onyx.db.models import Persona__Tool
 from onyx.db.models import Persona__UserGroup
 from onyx.db.models import Tool
 from onyx.db.models import ToolCall
+from onyx.db.models import User
 from onyx.server.features.tool.models import Header
 from onyx.tools.built_in_tools import BUILT_IN_TOOL_TYPES
 from onyx.utils.headers import HeaderItemDict
@@ -98,70 +103,54 @@ def get_tool_by_id(tool_id: int, db_session: Session) -> Tool:
     return tool
 
 
-def _agent_group_scope(
-    agent_select: Select[tuple[int, bool, int | None]], db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """Shared core of the agent-mediated action/MCP scope. Given a select of
-    ``(persona_id, is_public, owner_group_id)`` for the (non-deleted) agents
-    referencing a resource, return ``(private_agent_group_ids, has_public_agent,
-    has_ungrouped_private_agent)``. A private agent's groups are those it is shared
-    to (``Persona__UserGroup``) plus the group that owns it (``owner_group_id``); an
-    agent with neither is a personal agent outside any managed group and must be
-    tracked explicitly. A public agent is org-wide; a resource used by no agent has
-    no group context (empty set)."""
-    agent_rows = db_session.execute(agent_select).all()
-    has_public_agent = any(is_public for _, is_public, _ in agent_rows)
-    private_owner_groups = {
-        pid: owner_group_id
-        for pid, is_public, owner_group_id in agent_rows
-        if not is_public
-    }
-    if not private_owner_groups:
-        return set(), has_public_agent, False
-    share_rows = db_session.execute(
-        select(Persona__UserGroup.persona_id, Persona__UserGroup.user_group_id).where(
-            Persona__UserGroup.persona_id.in_(private_owner_groups.keys())
+def can_manage_own_tool(user: User, tool: Tool) -> bool:
+    """Owner-or-admin gate for every action on a custom action (edit, delete, toggle, OAuth
+    config), matching the routes' ``allow_scope`` guard: a global actions-admin manages any
+    action, a scoped manager only one they created. No MANAGE_ACTIONS authority — or a built-in
+    tool (no owner) — never passes."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        return tool.user_id is not None and tool.user_id == user.id
+    return False
+
+
+def can_manage_mcp_server(user: User, server: MCPServer) -> bool:
+    """Owner-or-admin gate for every action on an MCP server (edit, delete, connect, status),
+    matching the routes' ``allow_scope`` guard ∧ FULL_ADMIN-or-owner: a full admin manages any
+    server, a scoped manager only one they own (by email). No MANAGE_ACTIONS authority never
+    passes."""
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.NONE:
+        return False
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True
+    return server.owner == user.email
+
+
+def get_mcp_server_ids_connected_to_groups(
+    group_ids: Collection[int], db_session: Session
+) -> set[int]:
+    """MCP server ids exposed to any of ``group_ids`` via an agent — a persona shared to or
+    owned by the group that uses one of the server's tools. The read-visibility set for a
+    scoped manager, who may view servers connected to their groups without managing them."""
+    if not group_ids:
+        return set()
+    rows = db_session.execute(
+        select(Tool.mcp_server_id)
+        .join(Persona__Tool, Persona__Tool.tool_id == Tool.id)
+        .join(Persona, Persona.id == Persona__Tool.persona_id)
+        .outerjoin(Persona__UserGroup, Persona__UserGroup.persona_id == Persona.id)
+        .where(
+            Tool.mcp_server_id.is_not(None),
+            Persona.deleted.is_(False),
+            or_(
+                Persona__UserGroup.user_group_id.in_(group_ids),
+                Persona.owner_group_id.in_(group_ids),
+            ),
         )
     ).all()
-    group_ids: set[int] = set()
-    grouped_agent_ids: set[int] = set()
-    for persona_id, user_group_id in share_rows:
-        group_ids.add(user_group_id)
-        grouped_agent_ids.add(persona_id)
-    for persona_id, owner_group_id in private_owner_groups.items():
-        if owner_group_id is not None:
-            group_ids.add(owner_group_id)
-            grouped_agent_ids.add(persona_id)
-    has_ungrouped_private_agent = bool(
-        set(private_owner_groups.keys()) - grouped_agent_ids
-    )
-    return group_ids, has_public_agent, has_ungrouped_private_agent
-
-
-def get_action_agent_scope(
-    tool_id: int, db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """The groups a custom action is exposed to, via the agents that reference it."""
-    return _agent_group_scope(
-        select(Persona.id, Persona.is_public, Persona.owner_group_id)
-        .join(Persona__Tool, Persona__Tool.persona_id == Persona.id)
-        .where(Persona__Tool.tool_id == tool_id, Persona.deleted.is_(False)),
-        db_session,
-    )
-
-
-def get_mcp_server_agent_scope(
-    mcp_server_id: int, db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """The groups an MCP server is exposed to, via the agents that use any of its
-    tools."""
-    return _agent_group_scope(
-        select(Persona.id, Persona.is_public, Persona.owner_group_id)
-        .join(Persona__Tool, Persona__Tool.persona_id == Persona.id)
-        .join(Tool, Tool.id == Persona__Tool.tool_id)
-        .where(Tool.mcp_server_id == mcp_server_id, Persona.deleted.is_(False)),
-        db_session,
-    )
+    return {server_id for (server_id,) in rows if server_id is not None}
 
 
 def get_tool_by_name(tool_name: str, db_session: Session) -> Tool:

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -9,6 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.background.celery.tasks.pruning.tasks import try_creating_prune_generator_task
@@ -365,6 +366,7 @@ def get_cc_pair_full_info(
     return CCPairFullInfo.from_models(
         cc_pair_model=cc_pair,
         mask_credential_prefix=get_security_settings().mask_credential_prefix,
+        is_connectors_admin=has_global_permission(user, Permission.MANAGE_CONNECTORS),
         number_of_index_attempts=count_index_attempts_for_cc_pair(
             db_session=db_session,
             cc_pair_id=cc_pair_id,

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -22,7 +22,9 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.email_utils import send_email
+from onyx.auth.permission_projection import cc_pair_permissions
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.auth.users import current_chat_accessible_user
@@ -1093,7 +1095,9 @@ def get_connector_status(
 @router.post("/admin/connector/indexing-status", tags=PUBLIC_API_TAGS)
 def get_connector_indexing_status(
     request: IndexingStatusRequest,
-    user: User = Depends(require_permission(Permission.MANAGE_CONNECTORS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_CONNECTORS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[ConnectorIndexingStatusLiteResponse]:
     tenant_id = get_current_tenant_id()
@@ -1114,6 +1118,8 @@ def get_connector_indexing_status(
 
         with open(MOCK_CONNECTOR_FILE_PATH, "r") as f:
             raw_data = json.load(f)
+            for status in raw_data:
+                status.setdefault("permissions", {})  # fail-closed for mock rows
             connector_indexing_statuses = [
                 ConnectorIndexingStatusLite(**status) for status in raw_data
             ]
@@ -1205,6 +1211,14 @@ def get_connector_indexing_status(
         list[IndexAttempt], latest_successful_index_attempts
     )
 
+    # A scoped manager is always a member of the groups they manage, so their editable (managed)
+    # pairs also match the non-editable member query above; drop the overlap so each renders once
+    # (as editable, taking precedence over the read-only row).
+    editable_ids = {cc_pair.id for cc_pair in editable_cc_pairs}
+    non_editable_cc_pairs = [
+        cc_pair for cc_pair in non_editable_cc_pairs if cc_pair.id not in editable_ids
+    ]
+
     document_count_info = get_document_counts_for_all_cc_pairs(db_session)
 
     # Create lookup dictionaries for efficient access
@@ -1225,6 +1239,8 @@ def get_connector_indexing_status(
     cc_pair_to_latest_successful_index_attempt = _attempt_lookup(
         latest_successful_index_attempts
     )
+
+    is_connectors_admin = has_global_permission(user, Permission.MANAGE_CONNECTORS)
 
     def build_connector_indexing_status(
         cc_pair: ConnectorCredentialPair,
@@ -1255,6 +1271,7 @@ def get_connector_indexing_status(
             ),
             is_editable,
             doc_count,
+            is_connectors_admin=is_connectors_admin,
         )
 
     # Process editable cc_pairs
@@ -1418,6 +1435,8 @@ def _get_connector_indexing_status_lite(
     last_successful_index_time: datetime | None,
     is_editable: bool,
     document_cnt: int,
+    *,
+    is_connectors_admin: bool,
 ) -> ConnectorIndexingStatusLite | None:
     # TODO remove this to enable ingestion API
     if cc_pair.name == "DefaultCCPair":
@@ -1441,6 +1460,9 @@ def _get_connector_indexing_status_lite(
         access_type=cc_pair.access_type,
         cc_pair_status=cc_pair.status,
         is_editable=is_editable,
+        permissions=cc_pair_permissions(
+            is_editable=is_editable, is_connectors_admin=is_connectors_admin
+        ),
         in_progress=in_progress,
         in_repeated_error_state=cc_pair.in_repeated_error_state,
         last_finished_status=(

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
+from onyx.auth.permission_projection import cc_pair_permissions
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import InputType
 from onyx.db.enums import AccessType
@@ -385,6 +386,9 @@ class CCPairFullInfo(BaseModel):
     latest_deletion_attempt: DeletionAttemptSnapshot | None
     access_type: AccessType
     is_editable_for_current_user: bool
+    # per-action affordance map for the requesting user, from the same editable-scope
+    # decision the write guard enforces
+    permissions: dict[str, bool]
     deletion_failure_message: str | None
     indexing: bool
     creator: UUID | None
@@ -458,6 +462,7 @@ class CCPairFullInfo(BaseModel):
         indexing: bool,
         *,
         mask_credential_prefix: bool,
+        is_connectors_admin: bool = False,
         last_successful_index_time: datetime | None = None,
         last_permission_sync_attempt_status: PermissionSyncStatus | None = None,
         permission_syncing: bool = False,
@@ -507,6 +512,10 @@ class CCPairFullInfo(BaseModel):
             latest_deletion_attempt=latest_deletion_attempt,
             access_type=cc_pair_model.access_type,
             is_editable_for_current_user=is_editable_for_current_user,
+            permissions=cc_pair_permissions(
+                is_editable=is_editable_for_current_user,
+                is_connectors_admin=is_connectors_admin,
+            ),
             deletion_failure_message=cc_pair_model.deletion_failure_message,
             indexing=indexing,
             creator=cc_pair_model.creator_id,
@@ -593,6 +602,9 @@ class ConnectorIndexingStatusLite(BaseModel):
     last_status: IndexingStatus | None
     last_success: datetime | None
     is_editable: bool
+    # per-action affordance map for the requesting user, from the same editable-scope
+    # decision the write guard enforces
+    permissions: dict[str, bool]
     docs_indexed: int
     latest_index_attempt_docs_indexed: int | None
 

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -3,8 +3,12 @@ from fastapi import Depends
 from fastapi import Query
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import document_set_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import within_scope
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import OnyxCeleryPriority
@@ -165,7 +169,37 @@ def list_document_sets_for_user(
     document_sets = fetch_all_document_sets_for_user(
         db_session=db_session, user=user, get_editable=get_editable
     )
-    return [DocumentSetSummary.from_model(ds) for ds in document_sets]
+    # Stamp editability from the shared within_scope decision on each row's
+    # already-loaded groups, with the managed-group set resolved once — no second
+    # document-set query, and no client-side double-fetch.
+    managed_group_ids = get_scoped_groups(
+        user, db_session, Permission.MANAGE_DOCUMENT_SETS
+    )
+    is_document_sets_admin = has_global_permission(
+        user, Permission.MANAGE_DOCUMENT_SETS
+    )
+    summaries: list[DocumentSetSummary] = []
+    for ds in document_sets:
+        group_ids = [group.id for group in ds.groups]
+        is_editable = within_scope(
+            user,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not ds.is_public,
+            managed_group_ids=managed_group_ids,
+        )
+        summaries.append(
+            DocumentSetSummary.from_model(
+                ds,
+                permissions=document_set_permissions(
+                    is_editable=is_editable,
+                    is_document_sets_admin=is_document_sets_admin,
+                ),
+            )
+        )
+    return summaries
 
 
 @router.get("/document-set-public")

--- a/backend/onyx/server/features/document_set/models.py
+++ b/backend/onyx/server/features/document_set/models.py
@@ -152,14 +152,26 @@ class DocumentSetSummary(BaseModel):
     is_public: bool
     users: list[UUID]
     groups: list[int]
+    # per-action affordance map for the requesting user (mirrors the write-side gate).
+    # Defaults empty (fail-closed); the list endpoint stamps the real map.
+    permissions: dict[str, bool] = Field(default_factory=dict)
     federated_connector_summaries: list[FederatedConnectorSummary] = Field(
         default_factory=list
     )
 
     @classmethod
-    def from_model(cls, document_set: DocumentSetDBModel) -> "DocumentSetSummary":
-        """Create a summary from a DocumentSet database model"""
+    def from_model(
+        cls,
+        document_set: DocumentSetDBModel,
+        *,
+        permissions: dict[str, bool] | None = None,
+    ) -> "DocumentSetSummary":
+        """Create a summary from a DocumentSet database model. ``permissions`` defaults to
+        an empty (fail-closed) map — the document-set list endpoint stamps the real one;
+        summaries embedded in other snapshots (e.g. a persona's attached sets) carry no
+        affordances since there is no per-user edit surface there."""
         return cls(
+            permissions=permissions or {},
             id=document_set.id,
             name=document_set.name,
             description=document_set.description,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -33,10 +33,12 @@ from onyx.auth.oauth_token_manager import build_oauth_authorization_url
 from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
 from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.auth.oauth_token_manager import validate_oauth_endpoint_url
+from onyx.auth.permission_projection import mcp_server_permissions
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
-from onyx.auth.scoped_permissions import agent_mediated_scope_allows
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -66,9 +68,11 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.tools import can_manage_mcp_server
+from onyx.db.tools import can_manage_own_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
-from onyx.db.tools import get_mcp_server_agent_scope
+from onyx.db.tools import get_mcp_server_ids_connected_to_groups
 from onyx.db.tools import get_tools_by_mcp_server_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -741,7 +745,9 @@ class MCPOauthState(BaseModel):
 async def connect_admin_oauth(
     request: MCPUserOAuthConnectRequest,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPUserOAuthConnectResponse:
     """Connect OAuth flow for admin MCP server authentication"""
     return await _connect_oauth(request, db, is_admin=True, user=user)
@@ -1373,33 +1379,25 @@ def _ensure_mcp_server_owner_or_admin(server: DbMCPServer, user: User) -> None:
         )
 
 
-def _ensure_mcp_server_editable(
+def _ensure_mcp_server_viewable(
     server: DbMCPServer, user: User, db_session: Session
 ) -> None:
-    """Write gate for the standalone MCP server endpoints. Admin and owner bypass;
-    otherwise a scoped group manager may edit a server only when every agent using
-    any of its tools is private and in a group they manage. A server reachable via a
-    public agent (org-wide), or used by no agent (no group context), is owner/admin-
-    only."""
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+    """Read gate for a single MCP server: a global MANAGE_ACTIONS holder (incl. admins) views
+    any; an owner views their own; a scoped manager views a server connected to their groups
+    via an agent. Managers may view connected servers without managing them; managing is
+    owner-or-admin (``_ensure_mcp_server_owner_or_admin``)."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
         return
     if server.owner == user.email:
         return
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        group_ids, has_public_agent, has_ungrouped_private_agent = (
-            get_mcp_server_agent_scope(server.id, db_session)
-        )
-        if agent_mediated_scope_allows(
-            user,
-            db_session,
-            group_ids=group_ids,
-            has_public_agent=has_public_agent,
-            has_ungrouped_private_agent=has_ungrouped_private_agent,
-        ):
+    if authority is PermissionAuthority.SCOPED:
+        managed = get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
+        if server.id in get_mcp_server_ids_connected_to_groups(managed, db_session):
             return
     raise OnyxError(
         OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "Only the server owner or a manager of its groups can modify this MCP server.",
+        "You can only view MCP servers you own or that are connected to your groups.",
     )
 
 
@@ -1408,6 +1406,7 @@ def _db_mcp_server_to_api_mcp_server(
     db: Session,
     request_user: User | None,
     include_auth_config: bool = False,
+    permissions: dict[str, bool] | None = None,
 ) -> MCPServer:
     """Convert database MCP server to API model"""
 
@@ -1581,6 +1580,7 @@ def _db_mcp_server_to_api_mcp_server(
         auth_template=auth_template,
         user_credentials=user_credentials,
         admin_credentials=admin_credentials,
+        permissions=permissions or {},
     )
 
 
@@ -1673,7 +1673,9 @@ def _get_connection_config(
 def admin_list_mcp_tools_by_id(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPToolListResponse:
     return _list_mcp_tools_by_id(server_id, db, True, user)
 
@@ -1688,7 +1690,9 @@ def get_mcp_server_tools_snapshots(
     server_id: int,
     source: ToolSnapshotSource = ToolSnapshotSource.DB,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> list[ToolSnapshot]:
     """
     Get tools for an MCP server as ToolSnapshot objects.
@@ -1706,9 +1710,8 @@ def get_mcp_server_tools_snapshots(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(mcp_server, user)
-
     if source == ToolSnapshotSource.MCP:
+        _ensure_mcp_server_owner_or_admin(mcp_server, user)
         try:
             # Discover tools from MCP server and sync to DB
             _list_mcp_tools_by_id(server_id, db, True, user)
@@ -1735,10 +1738,20 @@ def get_mcp_server_tools_snapshots(
 
             logger.error("Failed to discover tools for MCP server: %s", e)
             raise HTTPException(status_code=500, detail="Failed to discover tools")
+    else:
+        _ensure_mcp_server_viewable(mcp_server, user, db)
 
-    # Fetch and return tools from database
+    # Fetch and return tools from database. Stamp each tool's toggle affordance
+    # (owner-or-admin, per tool) so the UI gates per tool, matching the status route:
+    # a global actions-admin toggles any tool, at parity with OpenAPI actions.
     mcp_tools = get_tools_by_mcp_server_id(server_id, db, order_by_id=True)
-    return [ToolSnapshot.from_model(tool) for tool in mcp_tools]
+    return [
+        ToolSnapshot.from_model(
+            tool,
+            permissions=tool_permissions(can_manage=can_manage_own_tool(user, tool)),
+        )
+        for tool in mcp_tools
+    ]
 
 
 @router.get("/server/{server_id}/tools")
@@ -1961,7 +1974,7 @@ def _upsert_mcp_server(
                 status_code=404,
                 detail=f"MCP server with ID {request.existing_server_id} not found",
             )
-        _ensure_mcp_server_editable(mcp_server, user, db_session)
+        _ensure_mcp_server_owner_or_admin(mcp_server, user)
         client_info: OAuthClientInformationFull | None = None
         existing_admin_config_dict: MCPConnectionData = MCPConnectionData(headers={})
         if mcp_server.admin_connection_config:
@@ -2288,7 +2301,9 @@ def _sync_tools_for_server(
 def get_mcp_server_detail(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServer:
     """Return details for one MCP server if user has access"""
     try:
@@ -2296,34 +2311,52 @@ def get_mcp_server_detail(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(server, user)
-
+    # Read gate: owner, admin, or a manager of a group the server is connected to.
+    _ensure_mcp_server_viewable(server, user, db_session)
     # TODO: user permissions per mcp server not yet implemented, for now
     # permissions are based on access to assistants
     # # Quick permission check – admin or user has access
     # if user and server not in user.accessible_mcp_servers and not user.is_superuser:
     #     raise HTTPException(status_code=403, detail="Forbidden")
-
     return _db_mcp_server_to_api_mcp_server(
         server,
         db_session,
         include_auth_config=True,
         request_user=user,
+        permissions=mcp_server_permissions(
+            can_manage=can_manage_mcp_server(user, server),
+        ),
     )
 
 
 @admin_router.get("/tools")
 def get_all_mcp_tools(
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),  # noqa: ARG001
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> list:
     """Get all tools associated with MCP servers, including both enabled and disabled tools"""
     from sqlalchemy import select
 
-    from onyx.db.models import Tool
-
     # Query MCP tools ordered by ID to maintain consistent ordering
     stmt = select(Tool).where(Tool.mcp_server_id.is_not(None)).order_by(Tool.id)
+
+    # Scope-match the /servers list: a scoped manager only sees tools on servers they own or
+    # that a group they manage is connected to; a global holder sees every server's tools.
+    if (
+        has_permission(user, Permission.MANAGE_ACTIONS)
+        is not PermissionAuthority.GLOBAL
+    ):
+        connected = get_mcp_server_ids_connected_to_groups(
+            get_scoped_groups(user, db, Permission.MANAGE_ACTIONS), db
+        )
+        visible_server_ids = {
+            server.id
+            for server in get_all_mcp_servers(db)
+            if server.owner == user.email or server.id in connected
+        }
+        stmt = stmt.where(Tool.mcp_server_id.in_(visible_server_ids))
 
     mcp_tools = db.scalars(stmt).all()
 
@@ -2336,7 +2369,9 @@ def update_mcp_server_status(
     server_id: int,
     status: MCPServerStatus,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
     """Update the status of an MCP server"""
     logger.info("Updating MCP server %s status to %s", server_id, status)
@@ -2362,7 +2397,9 @@ def update_mcp_server_status(
 @admin_router.get("/servers", response_model=MCPServersResponse)
 def get_mcp_servers_for_admin(
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServersResponse:
     """Get all MCP servers for admin display"""
 
@@ -2371,10 +2408,34 @@ def get_mcp_servers_for_admin(
     try:
         db_mcp_servers = get_all_mcp_servers(db)
 
-        # Convert to API model format
+        # A global MANAGE_ACTIONS holder (incl. admins) sees every server; a scoped manager
+        # sees only those they own or that are connected to a group they manage (one query for
+        # the connected set). Managing is owner-or-admin either way (can_manage_mcp_server).
+        if (
+            has_permission(user, Permission.MANAGE_ACTIONS)
+            is PermissionAuthority.GLOBAL
+        ):
+            visible_servers = db_mcp_servers
+        else:
+            connected = get_mcp_server_ids_connected_to_groups(
+                get_scoped_groups(user, db, Permission.MANAGE_ACTIONS), db
+            )
+            visible_servers = [
+                server
+                for server in db_mcp_servers
+                if server.owner == user.email or server.id in connected
+            ]
+
         mcp_servers = [
-            _db_mcp_server_to_api_mcp_server(db_server, db, request_user=user)
-            for db_server in db_mcp_servers
+            _db_mcp_server_to_api_mcp_server(
+                db_server,
+                db,
+                request_user=user,
+                permissions=mcp_server_permissions(
+                    can_manage=can_manage_mcp_server(user, db_server),
+                ),
+            )
+            for db_server in visible_servers
         ]
 
         return MCPServersResponse(mcp_servers=mcp_servers)
@@ -2388,7 +2449,9 @@ def get_mcp_servers_for_admin(
 def get_mcp_server_db_tools(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ServerToolsResponse:
     """Get existing database tools created for an MCP server"""
     logger.info("Getting database tools for MCP server: %s", server_id)
@@ -2518,7 +2581,7 @@ def update_mcp_server_with_tools(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_editable(mcp_server, user, db_session)
+    _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
     if mcp_server.admin_connection_config_id is None and mcp_server.auth_type not in (
         MCPAuthenticationType.NONE,
@@ -2620,7 +2683,7 @@ def update_mcp_server_simple(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_editable(mcp_server, user, db_session)
+    _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
     _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
 
@@ -2635,9 +2698,13 @@ def update_mcp_server_simple(
 
     db_session.commit()
 
-    # Return the updated server in API format
     return _db_mcp_server_to_api_mcp_server(
-        updated_server, db_session, request_user=user
+        updated_server,
+        db_session,
+        request_user=user,
+        permissions=mcp_server_permissions(
+            can_manage=can_manage_mcp_server(user, updated_server),
+        ),
     )
 
 
@@ -2645,7 +2712,9 @@ def update_mcp_server_simple(
 def delete_mcp_server_admin(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict:
     """Delete an MCP server and cascading related objects (tools, configs)."""
     try:

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -455,6 +455,8 @@ class MCPServer(BaseModel):
         None,
         description="Admin's credential key-value pairs for template substitution and storage",
     )
+    # Server-stamped affordance map; fail-closed empty (only the admin server list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
 
 class MCPServersResponse(BaseModel):

--- a/backend/onyx/server/features/oauth_config/api.py
+++ b/backend/onyx/server/features/oauth_config/api.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import OAuthTokenManager
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -20,6 +21,8 @@ from onyx.db.oauth_config import get_oauth_configs
 from onyx.db.oauth_config import get_tools_by_oauth_config
 from onyx.db.oauth_config import update_oauth_config
 from onyx.db.oauth_config import upsert_user_oauth_token
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.oauth_utils import generate_oauth_state
 from onyx.federated_connectors.oauth_utils import verify_oauth_state
 from onyx.server.features.oauth_config.models import OAuthCallbackResponse
@@ -59,13 +62,31 @@ def _oauth_config_to_snapshot(
 """Admin endpoints for OAuth configuration management"""
 
 
+def _assert_can_manage_oauth_config(
+    oauth_config: OAuthConfig, user: User, db_session: Session
+) -> None:
+    """Owner-or-admin gate: a global actions-admin manages any OAuth config; a scoped manager
+    manages one only when they own every action referencing it — editing shared credentials
+    would otherwise affect the other creators."""
+    if has_global_permission(user, Permission.MANAGE_ACTIONS):
+        return
+    tools = get_tools_by_oauth_config(oauth_config.id, db_session)
+    if tools and all(tool.user_id == user.id for tool in tools):
+        return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "You can only manage OAuth configurations for actions that you created.",
+    )
+
+
 @admin_router.post("/create")
 def create_oauth_config_endpoint(
     oauth_data: OAuthConfigCreate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)),
 ) -> OAuthConfigSnapshot:
-    """Create a new OAuth configuration (admin only)."""
+    """Create a new OAuth configuration. A scoped manager may create one and link it to an
+    action they created; get/update/delete are then owner-or-admin."""
     try:
         oauth_config = create_oauth_config(
             name=oauth_data.name,
@@ -96,14 +117,17 @@ def list_oauth_configs(
 def get_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Retrieve a single OAuth configuration (admin only)."""
+    """Retrieve a single OAuth configuration (owner or admin)."""
     oauth_config = get_oauth_config(oauth_config_id, db_session)
     if not oauth_config:
         raise HTTPException(
             status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
         )
+    _assert_can_manage_oauth_config(oauth_config, user, db_session)
     return _oauth_config_to_snapshot(oauth_config, db_session)
 
 
@@ -112,9 +136,17 @@ def update_oauth_config_endpoint(
     oauth_config_id: int,
     oauth_data: OAuthConfigUpdate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Update an OAuth configuration (admin only)."""
+    """Update an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise HTTPException(
+            status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         updated_config = update_oauth_config(
             oauth_config_id=oauth_config_id,
@@ -138,9 +170,17 @@ def update_oauth_config_endpoint(
 def delete_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
-    """Delete an OAuth configuration (admin only)."""
+    """Delete an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise HTTPException(
+            status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         delete_oauth_config(oauth_config_id, db_session)
         return {"message": "OAuth configuration deleted successfully"}

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -13,6 +13,9 @@ from pydantic import model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_chat_accessible_user
 from onyx.auth.users import current_limited_user
@@ -22,9 +25,13 @@ from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.file_record import get_filerecord_by_file_id_optional
 from onyx.db.models import User
+from onyx.db.persona import can_delete_persona
+from onyx.db.persona import can_edit_persona
+from onyx.db.persona import can_view_persona_stats
 from onyx.db.persona import create_assistant_label
 from onyx.db.persona import create_update_persona
 from onyx.db.persona import delete_persona_label
@@ -35,6 +42,7 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import get_persona_count_for_user
 from onyx.db.persona import get_persona_snapshots_for_user
 from onyx.db.persona import get_persona_snapshots_paginated
+from onyx.db.persona import is_persona_editable_by_user
 from onyx.db.persona import mark_persona_as_deleted
 from onyx.db.persona import mark_persona_as_not_deleted
 from onyx.db.persona import update_persona_featured
@@ -337,7 +345,9 @@ def create_persona(
 def update_persona(
     persona_id: int,
     persona_upsert_request: PersonaUpsertRequest,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
+    # Editable is the gate (get_editable fetch in create_update_persona), not ADD_AGENTS — an
+    # editor-shared user should be able to edit the agent they were granted access to.
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PersonaSnapshot:
     _validate_user_knowledge_enabled(persona_upsert_request, "update")
@@ -444,7 +454,9 @@ class PersonaShareRequest(BaseModel):
 def share_persona(
     persona_id: int,
     persona_share_request: PersonaShareRequest,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
+    # Editable is the gate (get_editable fetch in update_persona_shared), not ADD_AGENTS — an
+    # editor-shared user should still manage the agent's sharing.
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     user_shares = (
@@ -487,14 +499,24 @@ def share_persona(
 @basic_router.delete("/{persona_id}", tags=PUBLIC_API_TAGS)
 def delete_persona(
     persona_id: int,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS)),
+    # allow_scope admits an owner who holds ADD_AGENTS only by scope; ownership is enforced
+    # below (mark_persona_as_deleted → get_persona_by_id).
+    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    mark_persona_as_deleted(
-        persona_id=persona_id,
-        user=user,
-        db_session=db_session,
-    )
+    try:
+        mark_persona_as_deleted(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+        )
+    except ValueError as e:
+        # A non-owner failed the ownership check; its ValueError would 400 via the global
+        # handler, so surface the real authorization failure as a 403.
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You can only delete agents you created.",
+        ) from e
 
 
 @basic_router.get("")
@@ -596,6 +618,25 @@ def get_persona(
     if user is not None:
         snapshot.user_permission = get_persona_access_level(
             persona, user, user_group_ids
+        )
+        is_editable = is_persona_editable_by_user(db_session, persona.id, user)
+        snapshot.permissions = persona_permissions(
+            can_edit=can_edit_persona(
+                user, persona, db_session, is_editable=is_editable
+            ),
+            # share tracks the share guard (get_editable), broader than edit's scope gate
+            can_share=is_editable,
+            can_view_stats=can_view_persona_stats(user, persona),
+            can_delete=can_delete_persona(user, persona, db_session),
+            # delete/publish also gate on ADD_AGENTS (GATE 1); edit/share don't
+            holds_add_agents=has_permission(user, Permission.ADD_AGENTS)
+            is not PermissionAuthority.NONE,
+            is_manage_agents_admin=has_global_permission(
+                user, Permission.MANAGE_AGENTS
+            ),
+            is_full_admin=has_global_permission(
+                user, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
         )
     return snapshot
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -229,6 +229,10 @@ class MinimalPersonaSnapshot(BaseModel):
     owner_group: PersonaOwnerGroupSnapshot | None
     # Computed for the requesting user when the list endpoint provides it
     user_permission: PersonaAccessLevel | None = None
+    # Per-action affordance map for the requesting user; empty on paths that don't
+    # stamp it (fail-closed on the client). List endpoints stamp it so each card
+    # doesn't refetch the full agent just to gate its icons.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -396,6 +400,8 @@ class FullPersonaSnapshot(PersonaSnapshot):
     search_start_date: datetime | None = None
     # Per-requesting-user context, set by the single-persona endpoint
     user_permission: PersonaAccessLevel | None = None
+    # per-action affordance map for the requesting user; stamped by the endpoint
+    permissions: dict[str, bool] = Field(default_factory=dict)
     admin_count: int = 0
     ownership_vacant: bool = False
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -11,9 +11,13 @@ from fastapi import UploadFile
 from pydantic import Field
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import custom_skill_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import Permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import within_scope
 from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import Skill
@@ -70,6 +74,7 @@ def _split_rows(
     db_session: Session,
     *,
     include_grants: bool,
+    user: User | None = None,
 ) -> tuple[list[BuiltinSkillResponse], list[CustomSkillResponse]]:
     """Partition a flat row list into built-in + custom responses.
 
@@ -77,9 +82,25 @@ def _split_rows(
     in code without cleaning up the seeded row) is logged and dropped —
     we don't surface a half-broken built-in to admins. ``include_grants``
     only applies to custom skills; built-ins are not group-shareable.
+
+    When ``user`` is given (the admin listing), each custom skill is stamped with
+    its per-action affordance map, resolved once from the manager's scope.
     """
     builtins: list[BuiltinSkillResponse] = []
     customs: list[CustomSkillResponse] = []
+
+    # Resolve the manager's scope once so per-skill stamping issues no extra query.
+    managed_skill_groups: set[int] = set()
+    is_skills_full_admin = False
+    is_skills_admin = False
+    if user is not None:
+        managed_skill_groups = get_scoped_groups(
+            user, db_session, Permission.MANAGE_SKILLS
+        )
+        is_skills_full_admin = has_global_permission(
+            user, Permission.FULL_ADMIN_PANEL_ACCESS
+        )
+        is_skills_admin = has_global_permission(user, Permission.MANAGE_SKILLS)
 
     # User paths withhold group ids but still need grant existence so a
     # grants-shared skill isn't reported as personal.
@@ -103,7 +124,27 @@ def _split_rows(
             )
         elif include_grants:
             group_ids = get_group_ids_for_skill(skill.id, db_session)
-            customs.append(CustomSkillResponse.from_model(skill, group_ids=group_ids))
+            skill_perms: dict[str, bool] | None = None
+            if user is not None:
+                # Read-affordance mirroring the patch guard: within_scope on the skill's own groups.
+                skill_perms = custom_skill_permissions(
+                    can_edit=within_scope(
+                        user,
+                        db_session,
+                        permission=Permission.MANAGE_SKILLS,
+                        current_group_ids=group_ids,
+                        requested_group_ids=group_ids,
+                        is_non_public=not skill.is_public,
+                        managed_group_ids=managed_skill_groups,
+                    ),
+                    is_full_admin=is_skills_full_admin,
+                    is_skills_admin=is_skills_admin,
+                )
+            customs.append(
+                CustomSkillResponse.from_model(
+                    skill, group_ids=group_ids, permissions=skill_perms
+                )
+            )
         else:
             customs.append(
                 CustomSkillResponse.from_model(
@@ -176,7 +217,7 @@ def list_skills_admin(
     db_session: Session = Depends(get_session),
 ) -> SkillsList:
     rows = list(list_skills_for_admin(db_session=db_session, user=user))
-    builtins, customs = _split_rows(rows, db_session, include_grants=True)
+    builtins, customs = _split_rows(rows, db_session, include_grants=True, user=user)
     return SkillsList(builtins=builtins, customs=customs)
 
 

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -6,6 +6,7 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic import model_validator
 from sqlalchemy.orm import Session
 
@@ -60,6 +61,8 @@ class CustomSkillResponse(BaseModel):
     updated_at: datetime.datetime | None = None
     granted_group_ids: list[int] = []
     is_personal: bool
+    # Server-stamped affordance map; fail-closed empty (only the admin skills list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -68,6 +71,7 @@ class CustomSkillResponse(BaseModel):
         group_ids: list[int],
         *,
         has_grants: bool | None = None,
+        permissions: dict[str, bool] | None = None,
     ) -> "CustomSkillResponse":
         # Paths that withhold group ids from the response (user-facing) must
         # still pass grant existence so grants-shared skills aren't marked
@@ -77,6 +81,7 @@ class CustomSkillResponse(BaseModel):
             skill.built_in_skill_id is None and not skill.is_public and not grants_exist
         )
         return cls(
+            permissions=permissions or {},
             id=skill.id,
             slug=skill.slug,
             name=skill.name,

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -6,19 +6,16 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import get_effective_permissions
-from onyx.auth.permissions import has_permission
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import require_permission
-from onyx.auth.scoped_permissions import agent_mediated_scope_allows
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
-from onyx.db.enums import PermissionAuthority
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.tools import can_manage_own_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
-from onyx.db.tools import get_action_agent_scope
 from onyx.db.tools import get_tool_by_id
 from onyx.db.tools import get_tools
 from onyx.db.tools import get_tools_by_ids
@@ -59,57 +56,24 @@ def _validate_auth_settings(tool_data: CustomToolCreate | CustomToolUpdate) -> N
                 )
 
 
-def _assert_action_within_managed_scope(
-    tool_id: int, db_session: Session, user: User
-) -> None:
-    """A scoped group manager may edit an action only when every agent using it is
-    private and in a group they manage. An action reachable via a public agent (so
-    org-wide), or used by no agent (no group context), is owner/admin-only."""
-    group_ids, has_public_agent, has_ungrouped_private_agent = get_action_agent_scope(
-        tool_id, db_session
-    )
-    if not agent_mediated_scope_allows(
-        user,
-        db_session,
-        group_ids=group_ids,
-        has_public_agent=has_public_agent,
-        has_ungrouped_private_agent=has_ungrouped_private_agent,
-    ):
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "You can only modify actions scoped to groups you manage.",
-        )
-
-
-def _get_editable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
-    """Fetch a custom tool and ensure the caller has permission to edit it."""
+def _get_manageable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
+    """Fetch a custom tool and assert the caller may manage it (owner or admin) — the gate for
+    every action on it: edit, delete, toggle, and OAuth config."""
     try:
         tool = get_tool_by_id(tool_id, db_session)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-
     if tool.in_code_tool_id is not None:
         raise HTTPException(
             status_code=400,
             detail="Built-in tools cannot be modified through this endpoint.",
         )
-
-    # Admins bypass; owners may always edit the action they created.
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
-        return tool
-    if tool.user_id is not None and tool.user_id == user.id:
-        return tool
-
-    # A scoped group manager may edit an action scoped (via its agents) to groups
-    # they manage; everyone else is limited to actions they created.
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        _assert_action_within_managed_scope(tool_id, db_session, user)
-        return tool
-
-    raise OnyxError(
-        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "You can only modify actions that you created.",
-    )
+    if not can_manage_own_tool(user, tool):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You can only manage actions that you created.",
+        )
+    return tool
 
 
 @admin_router.post("/custom", tags=PUBLIC_API_TAGS)
@@ -146,7 +110,7 @@ def update_custom_tool(
         require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
     ),
 ) -> ToolSnapshot:
-    existing_tool = _get_editable_custom_tool(tool_id, db_session, user)
+    existing_tool = _get_manageable_custom_tool(tool_id, db_session, user)
     if tool_data.definition:
         _validate_tool_definition(tool_data.definition)
     _validate_auth_settings(tool_data)
@@ -168,9 +132,11 @@ def update_custom_tool(
 def delete_custom_tool(
     tool_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> None:
-    _ = _get_editable_custom_tool(tool_id, db_session, user)
+    _ = _get_manageable_custom_tool(tool_id, db_session, user)
     try:
         delete_tool__no_commit(tool_id, db_session)
     except ValueError as e:
@@ -195,7 +161,9 @@ class ToolStatusUpdateResponse(BaseModel):
 def update_tools_status(
     update_data: ToolStatusUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),  # noqa: ARG001
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ToolStatusUpdateResponse:
     """Enable or disable one or more tools.
 
@@ -214,6 +182,12 @@ def update_tools_status(
     for tool_id in update_data.tool_ids:
         tool = tools_by_id.get(tool_id)
         if tool:
+            # owner-or-admin, checked per tool
+            if not can_manage_own_tool(user, tool):
+                raise OnyxError(
+                    OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                    "You can only enable or disable actions that you created.",
+                )
             tool.enabled = update_data.enabled
             updated_tools.append(tool_id)
         else:
@@ -256,16 +230,24 @@ def validate_tool(
 @router.get("/openapi", tags=PUBLIC_API_TAGS)
 def list_openapi_tools(
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> list[ToolSnapshot]:
     tools = get_tools(db_session, only_openapi=True)
 
+    # Every action affordance is owner-or-admin, decided per tool with no query.
     openapi_tools: list[ToolSnapshot] = []
     for tool in tools:
         if not should_expose_tool_to_fe(tool):
             continue
 
-        openapi_tools.append(ToolSnapshot.from_model(tool))
+        openapi_tools.append(
+            ToolSnapshot.from_model(
+                tool,
+                permissions=tool_permissions(
+                    can_manage=can_manage_own_tool(user, tool)
+                ),
+            )
+        )
 
     return openapi_tools
 

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.db.models import Tool
 from onyx.server.features.tool.tool_visibility import get_tool_visibility_config
@@ -21,17 +22,23 @@ class ToolSnapshot(BaseModel):
     oauth_config_name: str | None = None
     enabled: bool = True
 
+    # Server-stamped affordance map; fail-closed empty (only the admin actions list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
+
     # Visibility settings computed from TOOL_VISIBILITY_CONFIG
     chat_selectable: bool = True
     agent_creation_selectable: bool = True
     default_enabled: bool = False
 
     @classmethod
-    def from_model(cls, tool: Tool) -> "ToolSnapshot":
+    def from_model(
+        cls, tool: Tool, *, permissions: dict[str, bool] | None = None
+    ) -> "ToolSnapshot":
         # Get visibility config for this tool
         config = get_tool_visibility_config(tool)
 
         return cls(
+            permissions=permissions or {},
             id=tool.id,
             name=tool.name,
             description=tool.description or "",

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -45,6 +45,15 @@ class BulkInviteResponse(BaseModel):
     email_invite_status: EmailInviteStatus
 
 
+class UserPermissionsResponse(BaseModel):
+    # The user's global effective permissions (implication-expanded).
+    permissions: list[str]
+    # Whether the user manages any group, plus the ids of those groups — lets the
+    # frontend reveal manager nav. Not a security boundary (backend GATE 2 enforces).
+    is_manager: bool
+    managed_group_ids: list[int]
+
+
 class VersionResponse(BaseModel):
     backend_version: str
 

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -10,6 +10,7 @@ from pydantic import Field
 from pydantic import field_validator
 from pydantic import model_validator
 
+from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS_EXPANDED
 from onyx.configs.constants import AuthType
 from onyx.context.search.models import SavedSearchSettings
 from onyx.db.enums import AccountType
@@ -128,6 +129,18 @@ class TenantInfo(BaseModel):
     new_tenant: TenantSnapshot | None = None
 
 
+def _admin_capabilities(
+    effective_permissions: list[str], is_group_manager: bool
+) -> list[str]:
+    """Admin-area reach = effective tokens plus the scoped manager bundle when the user
+    manages any group. ``effective_permissions`` itself stays global-only, so org-wide
+    gates that read it still exclude managers. Affordance hint, never an authz input."""
+    caps = set(effective_permissions)
+    if is_group_manager:
+        caps |= SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    return sorted(caps)
+
+
 class UserInfo(BaseModel):
     id: str
     email: str
@@ -146,6 +159,11 @@ class UserInfo(BaseModel):
     password_configured: bool | None = None
     tenant_info: TenantInfo | None = None
     effective_permissions: list[str] = Field(default_factory=list)
+    # True if the user manages any group — lets the client reveal manager nav.
+    # Not a security boundary (backend GATE 2 enforces scope).
+    is_group_manager: bool = False
+    # effective tokens plus the scoped bundle for a manager; drives admin-nav reveal
+    admin_capabilities: list[str] = Field(default_factory=list)
 
     @classmethod
     def from_model(
@@ -203,6 +221,10 @@ class UserInfo(BaseModel):
             is_anonymous_user=is_anonymous_user,
             tenant_info=tenant_info,
             effective_permissions=effective_permissions or [],
+            is_group_manager=user.is_group_manager,
+            admin_capabilities=_admin_capabilities(
+                effective_permissions or [], user.is_group_manager
+            ),
             personalization=UserPersonalization(
                 name=user.personal_name or "",
                 role=user.personal_role or "",

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -29,6 +29,7 @@ from onyx.auth.invited_users import remove_user_from_invited_users
 from onyx.auth.invited_users import write_invited_users
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.auth.users import anonymous_user_enabled
 from onyx.auth.users import enforce_seat_limit_locked
 from onyx.auth.users import optional_user
@@ -104,6 +105,7 @@ from onyx.server.manage.models import TenantSnapshot
 from onyx.server.manage.models import ThemePreferenceRequest
 from onyx.server.manage.models import UserByEmail
 from onyx.server.manage.models import UserInfo
+from onyx.server.manage.models import UserPermissionsResponse
 from onyx.server.manage.models import UserPreferences
 from onyx.server.manage.models import UserSpecificAssistantPreference
 from onyx.server.manage.models import UserSpecificAssistantPreferences
@@ -863,8 +865,13 @@ def _get_token_created_at(
 @router.get("/me/permissions", tags=PUBLIC_API_TAGS)
 def get_current_user_permissions(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
-) -> list[str]:
-    return sorted(p.value for p in get_effective_permissions(user))
+    db_session: Session = Depends(get_session),
+) -> UserPermissionsResponse:
+    return UserPermissionsResponse(
+        permissions=sorted(p.value for p in get_effective_permissions(user)),
+        is_manager=user.is_group_manager,
+        managed_group_ids=sorted(get_scoped_groups(user, db_session)),
+    )
 
 
 @router.get("/me", tags=PUBLIC_API_TAGS, dependencies=[Depends(scope_exempt)])

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -60,13 +60,15 @@ def update_token_limit_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:
-    return TokenRateLimitDisplay.from_db(
+    rate_limit_display = TokenRateLimitDisplay.from_db(
         update_token_rate_limit(
             db_session=db_session,
             token_rate_limit_id=token_rate_limit_id,
             token_rate_limit_settings=token_limit_settings,
         )
     )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
 
 
 @router.delete("/rate-limit/{token_rate_limit_id}")

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -1,0 +1,1055 @@
+"""The read-side permission projection must equal write-side enforcement.
+
+Each test drives the REAL guard and asserts the extracted boolean the projection
+stamps matches whether the guard raises, across an actor matrix — so the affordance
+the client renders can't silently drift from what the backend enforces.
+"""
+
+import asyncio
+import inspect
+from collections.abc import Callable
+from types import SimpleNamespace
+from uuid import uuid4
+
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from ee.onyx.db.analytics import user_can_view_assistant_stats
+from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
+from ee.onyx.server.token_rate_limits.api import _authorize_group_token_rate_limit_write
+from ee.onyx.server.token_rate_limits.api import get_group_token_limit_settings
+from ee.onyx.server.user_group.api import delete_user_group
+from ee.onyx.server.user_group.api import set_user_group_permissions
+from onyx.auth.permission_projection import CC_PAIR_ACTIONS
+from onyx.auth.permission_projection import cc_pair_permissions
+from onyx.auth.permission_projection import CUSTOM_SKILL_ACTIONS
+from onyx.auth.permission_projection import custom_skill_permissions
+from onyx.auth.permission_projection import DOCUMENT_SET_ACTIONS
+from onyx.auth.permission_projection import document_set_permissions
+from onyx.auth.permission_projection import MCP_SERVER_ACTIONS
+from onyx.auth.permission_projection import mcp_server_permissions
+from onyx.auth.permission_projection import PERSONA_ACTIONS
+from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permission_projection import TOOL_ACTIONS
+from onyx.auth.permission_projection import tool_permissions
+from onyx.auth.permission_projection import USER_GROUP_ACTIONS
+from onyx.auth.permission_projection import user_group_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
+from onyx.auth.scoped_permissions import assert_manages_group
+from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import manages_group
+from onyx.auth.scoped_permissions import within_scope
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.connector_credential_pair import (
+    get_connector_credential_pair_from_id_for_user,
+)
+from onyx.db.document_set import fetch_all_document_sets_for_user
+from onyx.db.enums import AccessType
+from onyx.db.enums import ConnectorCredentialPairStatus
+from onyx.db.enums import MCPServerStatus
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.models import Connector
+from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import Credential
+from onyx.db.models import DocumentSet
+from onyx.db.models import DocumentSet__UserGroup
+from onyx.db.models import MCPServer
+from onyx.db.models import Persona
+from onyx.db.models import Persona__Tool
+from onyx.db.models import Persona__User
+from onyx.db.models import Persona__UserGroup
+from onyx.db.models import Skill
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import TokenRateLimit__UserGroup
+from onyx.db.models import Tool
+from onyx.db.models import User
+from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup
+from onyx.db.models import UserGroup__ConnectorCredentialPair
+from onyx.db.persona import _assert_persona_update_within_managed_scope
+from onyx.db.persona import can_delete_persona
+from onyx.db.persona import can_edit_persona
+from onyx.db.persona import can_view_persona_stats
+from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona import get_persona_by_id
+from onyx.db.persona import is_persona_editable_by_user
+from onyx.db.persona import persona_edit_within_scope
+from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.token_limit import insert_global_token_rate_limit
+from onyx.db.tools import can_manage_mcp_server
+from onyx.db.tools import can_manage_own_tool
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
+from onyx.server.features.mcp.api import _ensure_mcp_server_viewable
+from onyx.server.features.persona.api import delete_persona
+from onyx.server.features.persona.models import PersonaUpsertRequest
+from onyx.server.features.tool.api import _get_manageable_custom_tool
+from onyx.server.manage.administrative import create_deletion_attempt_for_connector_id
+from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _guard_raises(
+    guard: Callable[..., object], *args: object, **kwargs: object
+) -> bool:
+    try:
+        guard(*args, **kwargs)
+        return False
+    except OnyxError:
+        return True
+
+
+def _route_admits(
+    route_func: Callable[..., object], guard_param: str, actor: User
+) -> bool:
+    """True iff the route's ``require_permission`` admits ``actor`` (unrestricted token).
+    Runs the real dependency, so the assertion tracks the route decorator — not the bool
+    that built the map, which can't catch a FULL_ADMIN vs MANAGE_USER_GROUPS drift."""
+    depends = inspect.signature(route_func).parameters[guard_param].default
+    request = SimpleNamespace(state=SimpleNamespace(token_scopes=None))
+    return not _guard_raises(lambda: asyncio.run(depends.dependency(request, actor)))
+
+
+def _make_group(db_session: Session) -> UserGroup:
+    group = UserGroup(name=f"proj-contract-{uuid4().hex[:12]}")
+    db_session.add(group)
+    db_session.flush()
+    return group
+
+
+def _manage(db_session: Session, user: User, *groups: UserGroup) -> None:
+    for group in groups:
+        db_session.add(
+            User__UserGroup(user_id=user.id, user_group_id=group.id, is_manager=True)
+        )
+    user.is_group_manager = True
+    db_session.commit()
+
+
+def _make_cc_pair(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> ConnectorCredentialPair:
+    connector = Connector(
+        name=f"proj-conn-{uuid4().hex[:12]}",
+        source=DocumentSource.FILE,
+        input_type=InputType.POLL,
+        connector_specific_config={},
+        refresh_freq=None,
+        prune_freq=None,
+        indexing_start=None,
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(source=DocumentSource.FILE, credential_json={})
+    db_session.add(credential)
+    db_session.flush()
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"proj-ccpair-{uuid4().hex[:12]}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC if is_public else AccessType.PRIVATE,
+    )
+    db_session.add(cc_pair)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            UserGroup__ConnectorCredentialPair(
+                user_group_id=group.id, cc_pair_id=cc_pair.id, is_current=True
+            )
+        )
+    db_session.commit()
+    return cc_pair
+
+
+def test_cc_pair_projection_matches_gates(db_session: Session) -> None:
+    """Each key is pinned to the real route, not the bool that built it: edit → the editable
+    query (which must agree with the within_scope write decision); delete → the deletion route's
+    GATE 1 (global MANAGE_CONNECTORS, no allow_scope); publish → the associate route's real GATE 2
+    (assert_within_scope for the PUBLIC state). So this fails if either route starts admitting a
+    scoped manager — a scoped manager edits a managed connector but can never delete/publish it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-cc-inscope")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-cc-outscope")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-cc-admin", is_admin=True)
+    db_session.commit()
+
+    cc_pair = _make_cc_pair(db_session, is_public=False, groups=[managed])
+
+    for actor in (in_scope, out_scope, admin):
+        # edit: the real editable query must agree with the within_scope write decision
+        is_editable = (
+            get_connector_credential_pair_from_id_for_user(
+                cc_pair.id, db_session, actor, get_editable=True
+            )
+            is not None
+        )
+        scope_decision = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_CONNECTORS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        assert is_editable == scope_decision, actor.email
+
+        # delete: the deletion route's GATE 1 (global only, no allow_scope)
+        delete_admits = _route_admits(
+            create_deletion_attempt_for_connector_id, "user", actor
+        )
+        # publish: the associate route's real GATE 2 for the PUBLIC state (is_non_public=False)
+        publish_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_CONNECTORS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=False,
+        )
+
+        tags = cc_pair_permissions(
+            is_editable=is_editable,
+            is_connectors_admin=has_global_permission(
+                actor, Permission.MANAGE_CONNECTORS
+            ),
+        )
+        assert tags["edit"] == scope_decision, actor.email
+        assert tags["delete"] == delete_admits, actor.email
+        assert tags["publish"] == publish_enforced, actor.email
+
+    # concrete: an in-scope manager edits but can neither delete nor publish
+    in_scope_editable = (
+        get_connector_credential_pair_from_id_for_user(
+            cc_pair.id, db_session, in_scope, get_editable=True
+        )
+        is not None
+    )
+    assert cc_pair_permissions(
+        is_editable=in_scope_editable,
+        is_connectors_admin=has_global_permission(
+            in_scope, Permission.MANAGE_CONNECTORS
+        ),
+    ) == {"edit": True, "delete": False, "publish": False}
+
+
+def test_cc_pair_projection_key_coverage() -> None:
+    stamped = set(cc_pair_permissions(is_editable=True, is_connectors_admin=True))
+    assert stamped == set(CC_PAIR_ACTIONS), (
+        "cc_pair projection keys drifted from the declared CC_PAIR_ACTIONS vocabulary"
+    )
+
+
+def _make_persona(
+    db_session: Session, *, owner: User, is_public: bool, groups: list[UserGroup]
+) -> Persona:
+    persona = Persona(
+        name=f"proj-persona-{uuid4().hex[:12]}",
+        description="contract",
+        public_permission=PersonaSharePermission.EDITOR,
+        user_id=owner.id,
+        is_public=is_public,
+    )
+    db_session.add(persona)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            Persona__UserGroup(persona_id=persona.id, user_group_id=group.id)
+        )
+    db_session.commit()
+    return persona
+
+
+def _make_doc_set(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> DocumentSet:
+    doc_set = DocumentSet(name=f"proj-ds-{uuid4().hex[:12]}", is_public=is_public)
+    db_session.add(doc_set)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            DocumentSet__UserGroup(document_set_id=doc_set.id, user_group_id=group.id)
+        )
+    db_session.commit()
+    return doc_set
+
+
+def test_persona_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks the read-editable AND managed-scope decision the write guard enforces;
+    view_stats tracks the real owner-or-admin stats gate; the rest are global-only."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "b-persona-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "b-persona-out")
+    _manage(db_session, out_scope, unmanaged)
+    out_scope.effective_permissions = []
+
+    owner = create_test_user(db_session, "b-persona-owner")
+    owner.effective_permissions = []
+
+    admin = create_test_user(db_session, "b-persona-admin", is_admin=True)
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    group_ids = [group.id for group in persona.groups]
+
+    def edit_guard_raises(actor: User) -> bool:
+        request = PersonaUpsertRequest(
+            name=persona.name,
+            description=persona.description or "",
+            system_prompt="",
+            task_prompt="",
+            datetime_aware=False,
+            document_set_ids=[],
+            tool_ids=[],
+            groups=group_ids,
+            is_public=persona.is_public,
+        )
+        return _guard_raises(
+            _assert_persona_update_within_managed_scope,
+            persona.id,
+            request,
+            actor,
+            db_session,
+        )
+
+    for actor in (in_scope, out_scope, owner, admin):
+        # read bool == the real write guard's managed-scope decision
+        assert persona_edit_within_scope(
+            actor, db_session, group_ids=group_ids, is_public=persona.is_public
+        ) == (not edit_guard_raises(actor)), actor.email
+        # view_stats == the real owner-or-admin stats gate
+        assert can_view_persona_stats(actor, persona) == user_can_view_assistant_stats(
+            db_session, actor, persona.id
+        ), actor.email
+        # delete == the real delete handler's ownership gate (get_persona_by_id is_for_edit)
+        try:
+            get_persona_by_id(persona_id=persona.id, user=actor, db_session=db_session)
+            delete_allowed = True
+        except ValueError:
+            delete_allowed = False
+        assert can_delete_persona(actor, persona, db_session) == delete_allowed, (
+            actor.email
+        )
+
+    # concrete: an in-scope manager can edit/share but not view_stats/delete/feature/reorder
+    in_scope_editable = is_persona_editable_by_user(db_session, persona.id, in_scope)
+    mgr_map = persona_permissions(
+        can_edit=can_edit_persona(
+            in_scope, persona, db_session, is_editable=in_scope_editable
+        ),
+        can_share=in_scope_editable,
+        can_view_stats=can_view_persona_stats(in_scope, persona),
+        can_delete=can_delete_persona(in_scope, persona, db_session),
+        holds_add_agents=has_permission(in_scope, Permission.ADD_AGENTS)
+        is not PermissionAuthority.NONE,
+        is_manage_agents_admin=has_global_permission(
+            in_scope, Permission.MANAGE_AGENTS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    )
+    assert mgr_map["edit"] is True and mgr_map["share"] is True
+    assert mgr_map["view_stats"] is False
+    assert not any(mgr_map[a] for a in ("delete", "publish", "feature", "reorder"))
+
+
+def test_delete_persona_route_admits_scoped_owner(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """The delete route must admit a scoped ADD_AGENTS holder (allow_scope=True); otherwise an
+    owner who holds ADD_AGENTS only by scope is 403'd before the GATE-2 ownership check, making
+    the projection's delete=true a lie for them. The gate checks above can't catch a missing
+    allow_scope. enable_ee so ADD_AGENTS is genuinely scoped — CE auto-grants it globally, which
+    would pass the gate regardless and prove nothing."""
+    manager = create_test_user(db_session, "del-route-mgr")
+    _manage(db_session, manager, _make_group(db_session))
+    manager.effective_permissions = []
+    db_session.commit()
+
+    # Premise: if the manager ever holds ADD_AGENTS globally, the route check below tests
+    # nothing — fail loudly here instead of passing vacuously.
+    assert (
+        has_permission(manager, Permission.ADD_AGENTS) is PermissionAuthority.SCOPED
+    ), "manager should hold ADD_AGENTS only by scope"
+    assert _route_admits(delete_persona, "user", manager), (
+        "delete route must admit scoped managers at GATE 1 (allow_scope=True)"
+    )
+
+
+def test_persona_share_projection_tracks_share_guard_not_edit(
+    db_session: Session,
+) -> None:
+    """share follows the share guard (fetch_persona_by_id_for_user / get_editable), which is
+    broader than edit's managed-scope AND gate: an EDITOR-shared manager outside the agent's
+    groups may share it but not update it, so ``share`` must not reuse ``can_edit``."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    # Manager of `unmanaged`, EDITOR-shared on an agent grouped in `managed` (out of scope).
+    editor = create_test_user(db_session, "share-editor")
+    _manage(db_session, editor, unmanaged)
+    editor.effective_permissions = []
+
+    owner = create_test_user(db_session, "share-owner")
+    owner.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    db_session.add(
+        Persona__User(
+            persona_id=persona.id,
+            user_id=editor.id,
+            permission=PersonaSharePermission.EDITOR,
+        )
+    )
+    db_session.commit()
+
+    is_editable = is_persona_editable_by_user(db_session, persona.id, editor)
+    can_edit = can_edit_persona(editor, persona, db_session, is_editable=is_editable)
+
+    # The real share-endpoint gate: does the editable fetch admit them?
+    try:
+        fetch_persona_by_id_for_user(
+            db_session=db_session, persona_id=persona.id, user=editor, get_editable=True
+        )
+        share_allowed = True
+    except HTTPException:
+        share_allowed = False
+
+    assert is_editable is True  # EDITOR-shared → in the editable set
+    assert can_edit is False  # ...but out of managed scope → can't update
+    assert share_allowed is True  # ...yet the share endpoint admits them
+
+    tags = persona_permissions(
+        can_edit=can_edit,
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(editor, persona),
+        can_delete=can_delete_persona(editor, persona, db_session),
+        holds_add_agents=has_permission(editor, Permission.ADD_AGENTS)
+        is not PermissionAuthority.NONE,
+        is_manage_agents_admin=has_global_permission(editor, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(editor, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert tags["share"] == share_allowed  # share tracks the share guard...
+    assert tags["edit"] is False  # ...not the stricter edit guard
+
+
+def test_persona_edit_share_editable_without_add_agents(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """edit and share gate on editable alone (their routes are BASIC_ACCESS): an EDITOR-shared
+    user without ADD_AGENTS may still edit and manage sharing, so both are True. enable_ee
+    because CE auto-grants ADD_AGENTS, which would mask that they need no create permission."""
+    owner = create_test_user(db_session, "add-share-owner")
+    owner.effective_permissions = []
+    # EDITOR-shared, but no ADD_AGENTS authority: not a manager, empty permissions.
+    editor = create_test_user(db_session, "add-share-editor")
+    editor.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[])
+    db_session.add(
+        Persona__User(
+            persona_id=persona.id,
+            user_id=editor.id,
+            permission=PersonaSharePermission.EDITOR,
+        )
+    )
+    db_session.commit()
+
+    is_editable = is_persona_editable_by_user(db_session, persona.id, editor)
+    holds_add_agents = (
+        has_permission(editor, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    assert is_editable is True  # EDITOR-shared → editable
+    assert holds_add_agents is False  # ...but no ADD_AGENTS authority under EE
+
+    tags = persona_permissions(
+        can_edit=can_edit_persona(editor, persona, db_session, is_editable=is_editable),
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(editor, persona),
+        can_delete=can_delete_persona(editor, persona, db_session),
+        holds_add_agents=holds_add_agents,
+        is_manage_agents_admin=has_global_permission(editor, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(editor, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert tags["share"] is True  # editable is enough to share (no ADD_AGENTS needed)
+    assert (
+        tags["edit"] is True
+    )  # ...and to edit — both routes gate on editable, not ADD_AGENTS
+
+
+def test_persona_publish_projection_is_owner_not_add_agents(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """publish (org-wide public, via the share route's is_owner_or_admin gate) is owner-or-admin,
+    NOT ADD_AGENTS-gated. An owner without ADD_AGENTS can publish but cannot delete (delete's
+    route requires ADD_AGENTS). enable_ee because CE auto-grants ADD_AGENTS, masking this."""
+    owner = create_test_user(db_session, "publish-owner")
+    owner.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[])
+    is_editable = is_persona_editable_by_user(db_session, persona.id, owner)
+    holds_add_agents = (
+        has_permission(owner, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    assert holds_add_agents is False  # owner holds no ADD_AGENTS authority under EE
+
+    tags = persona_permissions(
+        can_edit=can_edit_persona(owner, persona, db_session, is_editable=is_editable),
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(owner, persona),
+        can_delete=can_delete_persona(owner, persona, db_session),
+        holds_add_agents=holds_add_agents,
+        is_manage_agents_admin=has_global_permission(owner, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(owner, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert (
+        tags["publish"] is True
+    )  # owner may publish via the share route (no ADD_AGENTS)
+    assert tags["delete"] is False  # ...but delete's route requires ADD_AGENTS
+
+
+def test_document_set_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks the editable filter, which equals the within_scope decision the write
+    guard enforces; delete/publish track global MANAGE_DOCUMENT_SETS."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "b-ds-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "b-ds-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "b-ds-admin", is_admin=True)
+    db_session.commit()
+
+    doc_set = _make_doc_set(db_session, is_public=False, groups=[managed])
+
+    for actor in (in_scope, out_scope, admin):
+        editable_ids = {
+            ds.id
+            for ds in fetch_all_document_sets_for_user(
+                db_session=db_session, user=actor, get_editable=True
+            )
+        }
+        is_editable = doc_set.id in editable_ids
+        # the editable filter equals the write guard's scope decision
+        scope_decision = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        assert is_editable == scope_decision, actor.email
+
+        is_ds_admin = has_global_permission(actor, Permission.MANAGE_DOCUMENT_SETS)
+        tags = document_set_permissions(
+            is_editable=is_editable, is_document_sets_admin=is_ds_admin
+        )
+        assert tags["edit"] == scope_decision
+        assert tags["manage_access"] == scope_decision
+        assert tags["delete"] == is_ds_admin
+
+
+def test_persona_and_doc_set_key_coverage() -> None:
+    persona_keys = set(
+        persona_permissions(
+            can_edit=True,
+            can_share=True,
+            can_view_stats=True,
+            can_delete=True,
+            holds_add_agents=True,
+            is_manage_agents_admin=True,
+            is_full_admin=True,
+        )
+    )
+    assert persona_keys == set(PERSONA_ACTIONS)
+    ds_keys = set(
+        document_set_permissions(is_editable=True, is_document_sets_admin=True)
+    )
+    assert ds_keys == set(DOCUMENT_SET_ACTIONS)
+
+
+def _make_tool(
+    db_session: Session,
+    *,
+    creator: User | None = None,
+    in_code: str | None = None,
+    mcp_server_id: int | None = None,
+) -> Tool:
+    tool = Tool(
+        name=f"proj-tool-{uuid4().hex[:12]}",
+        description="contract",
+        user_id=creator.id if creator else None,
+        in_code_tool_id=in_code,
+        mcp_server_id=mcp_server_id,
+    )
+    db_session.add(tool)
+    db_session.flush()
+    return tool
+
+
+def _make_mcp_server(db_session: Session, *, owner_email: str) -> MCPServer:
+    server = MCPServer(
+        name=f"proj-mcp-{uuid4().hex[:12]}",
+        owner=owner_email,
+        server_url="https://mcp.example.com",
+        status=MCPServerStatus.CONNECTED,
+    )
+    db_session.add(server)
+    db_session.flush()
+    return server
+
+
+def _link_persona_tool(db_session: Session, persona: Persona, tool: Tool) -> None:
+    db_session.add(Persona__Tool(persona_id=persona.id, tool_id=tool.id))
+    db_session.commit()
+
+
+def _make_skill(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> Skill:
+    skill = Skill(
+        id=uuid4(),
+        slug=f"proj-skill-{uuid4().hex[:12]}",
+        name="contract skill",
+        description="contract",
+        # custom skills need a bundle source (ck_skill_definition_source)
+        bundle_file_id=f"proj-bundle-{uuid4().hex}",
+        bundle_sha256="0" * 64,
+        is_public=is_public,
+    )
+    db_session.add(skill)
+    db_session.flush()
+    for group in groups:
+        db_session.add(Skill__UserGroup(skill_id=skill.id, user_group_id=group.id))
+    db_session.commit()
+    return skill
+
+
+def test_tool_projection_matches_gates(db_session: Session) -> None:
+    """Every action affordance (edit, delete, toggle, authenticate) is owner-or-admin, pinned
+    to _get_manageable_custom_tool. The creator fully controls the action they made; a scoped
+    manager whose group the action is connected to may view/create but not manage it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-tool-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    # scoped manager who owns the action (via a group unrelated to the action's agents)
+    creator = create_test_user(db_session, "proj-tool-creator")
+    _manage(db_session, creator, _make_group(db_session))
+    creator.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-tool-admin", is_admin=True)
+    db_session.commit()
+
+    tool = _make_tool(db_session, creator=creator)
+    # a private agent in the managed group references the action -> connected to `managed`
+    persona = _make_persona(
+        db_session, owner=creator, is_public=False, groups=[managed]
+    )
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, creator, admin):
+        manage_enforced = not _guard_raises(
+            _get_manageable_custom_tool, tool.id, db_session, actor
+        )
+        can_manage = can_manage_own_tool(actor, tool)
+        assert can_manage == manage_enforced, actor.email
+        assert tool_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "toggle": manage_enforced,
+            "authenticate": manage_enforced,
+        }
+
+    # a manager of the action's connected group can't manage it (only creator/admin can)
+    assert tool_permissions(can_manage=can_manage_own_tool(in_scope, tool)) == {
+        "edit": False,
+        "delete": False,
+        "toggle": False,
+        "authenticate": False,
+    }
+    # the creator fully controls the action they made
+    assert tool_permissions(can_manage=can_manage_own_tool(creator, tool)) == {
+        "edit": True,
+        "delete": True,
+        "toggle": True,
+        "authenticate": True,
+    }
+
+
+def test_mcp_projection_matches_gates(db_session: Session) -> None:
+    """Every MCP action affordance is owner-or-admin, pinned to
+    _ensure_mcp_server_owner_or_admin. A scoped manager whose group the server is connected to
+    may view it (_ensure_mcp_server_viewable) but not manage it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-mcp-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    owner = create_test_user(db_session, "proj-mcp-owner")
+    _manage(db_session, owner, _make_group(db_session))
+    owner.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-mcp-admin", is_admin=True)
+    db_session.commit()
+
+    server = _make_mcp_server(db_session, owner_email=owner.email)
+    tool = _make_tool(db_session, mcp_server_id=server.id)
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, owner, admin):
+        manage_enforced = not _guard_raises(
+            _ensure_mcp_server_owner_or_admin, server, actor
+        )
+        can_manage = can_manage_mcp_server(actor, server)
+        assert can_manage == manage_enforced, actor.email
+        assert mcp_server_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "authenticate": manage_enforced,
+            "manage_status": manage_enforced,
+        }
+
+    # a manager of the server's connected group may VIEW but not manage it
+    assert not _guard_raises(_ensure_mcp_server_viewable, server, in_scope, db_session)
+    assert can_manage_mcp_server(in_scope, server) is False
+    # the owner fully manages their server
+    assert mcp_server_permissions(can_manage=can_manage_mcp_server(owner, server)) == {
+        "edit": True,
+        "delete": True,
+        "authenticate": True,
+        "manage_status": True,
+    }
+
+
+def test_skill_projection_matches_gates(db_session: Session) -> None:
+    """edit/manage_access track the assert_within_scope guard on the skill's groups;
+    delete is FULL_ADMIN; publish (make public) is global MANAGE_SKILLS. A scoped manager
+    edits/re-grants a managed skill but can never delete or publish it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-skill-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-skill-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-skill-admin", is_admin=True)
+    db_session.commit()
+
+    skill = _make_skill(db_session, is_public=False, groups=[managed])
+    group_ids = get_group_ids_for_skill(skill.id, db_session)
+
+    for actor in (in_scope, out_scope, admin):
+        edit_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        # publish drives the same guard with the requested public state
+        publish_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=False,
+        )
+        can_edit = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        assert can_edit == edit_enforced, actor.email
+        is_full_admin = has_global_permission(actor, Permission.FULL_ADMIN_PANEL_ACCESS)
+        is_skills_admin = has_global_permission(actor, Permission.MANAGE_SKILLS)
+        tags = custom_skill_permissions(
+            can_edit=can_edit,
+            is_full_admin=is_full_admin,
+            is_skills_admin=is_skills_admin,
+        )
+        assert tags["edit"] == edit_enforced
+        assert tags["manage_access"] == edit_enforced
+        assert tags["delete"] == is_full_admin
+        assert tags["publish"] == publish_enforced  # global MANAGE_SKILLS
+
+    # in-scope manager edits/re-grants but can't delete or publish
+    assert custom_skill_permissions(
+        can_edit=within_scope(
+            in_scope,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+        is_skills_admin=has_global_permission(in_scope, Permission.MANAGE_SKILLS),
+    ) == {"edit": True, "manage_access": True, "delete": False, "publish": False}
+
+
+def test_actions_and_skill_key_coverage() -> None:
+    assert set(tool_permissions(can_manage=True)) == set(TOOL_ACTIONS)
+    assert set(mcp_server_permissions(can_manage=True)) == set(MCP_SERVER_ACTIONS)
+    assert set(
+        custom_skill_permissions(
+            can_edit=True, is_full_admin=True, is_skills_admin=True
+        )
+    ) == set(CUSTOM_SKILL_ACTIONS)
+
+
+def test_user_group_projection_matches_gates(db_session: Session) -> None:
+    """Each flag is pinned to its real route, not the bool that built it: manage and
+    edit_token_limits → assert_manages_group (per-group scoped — the token read route now
+    admits scope), delete → delete-group (global MANAGE_USER_GROUPS), edit_permissions →
+    permission-toggle (FULL_ADMIN). groups_admin (global MANAGE_USER_GROUPS, not full admin)
+    separates the two levels; out_scope (manages a different group) pins the per-group gate."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-ug-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-ug-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-ug-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-ug-admin", is_admin=True)
+    db_session.commit()
+
+    for actor in (in_scope, out_scope, groups_admin, admin):
+        manage_enforced = not _guard_raises(
+            assert_manages_group, actor, db_session, group_id=managed.id
+        )
+        # the token-limit POST guard (scoped create) is the same managed-scope decision
+        token_create_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_USER_GROUPS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        can_manage = manages_group(actor, db_session, group_id=managed.id)
+        assert can_manage == manage_enforced, actor.email
+        assert can_manage == token_create_enforced, actor.email
+
+        tags = user_group_permissions(
+            can_manage=can_manage,
+            is_user_groups_admin=has_global_permission(
+                actor, Permission.MANAGE_USER_GROUPS
+            ),
+            is_full_admin=has_global_permission(
+                actor, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
+        )
+        assert tags["manage"] == manage_enforced, actor.email
+        assert tags["delete"] == _route_admits(delete_user_group, "_", actor), (
+            actor.email
+        )
+        assert tags["edit_permissions"] == _route_admits(
+            set_user_group_permissions, "user", actor
+        ), actor.email
+        # edit_token_limits rides the token read route: GATE 1 admits scope, GATE 2 is
+        # assert_manages_group — net per-group decision, so AND the two.
+        token_read_gate1 = _route_admits(get_group_token_limit_settings, "user", actor)
+        assert tags["edit_token_limits"] == (token_read_gate1 and manage_enforced), (
+            actor.email
+        )
+
+    assert user_group_permissions(
+        can_manage=manages_group(in_scope, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            in_scope, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": False,
+        "edit_permissions": False,
+        # scoped manager now fully manages its group's token limits
+        "edit_token_limits": True,
+    }
+
+    # groups_admin (global MANAGE_USER_GROUPS, not full admin): manages token limits and
+    # deletes the group, but can't edit permissions (FULL_ADMIN).
+    assert user_group_permissions(
+        can_manage=manages_group(groups_admin, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            groups_admin, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            groups_admin, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": True,
+        "edit_permissions": False,
+        "edit_token_limits": True,
+    }
+
+
+def test_user_group_key_coverage() -> None:
+    assert set(
+        user_group_permissions(
+            can_manage=True, is_user_groups_admin=True, is_full_admin=True
+        )
+    ) == set(USER_GROUP_ACTIONS)
+
+
+def test_group_token_rate_limit_write_scope(db_session: Session) -> None:
+    """A group token-limit write needs the caller to manage the group AND the limit to
+    belong to it — so a group admin fully manages its limits, but a global/per-user limit or
+    another group's limit can't be reached through the group path."""
+    managed = _make_group(db_session)
+    other = _make_group(db_session)
+
+    args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+    managed_limit = insert_user_group_token_rate_limit(
+        db_session=db_session, token_rate_limit_settings=args, group_id=managed.id
+    )
+    global_limit = insert_global_token_rate_limit(db_session, args)
+
+    in_scope = create_test_user(db_session, "proj-trl-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-trl-out")
+    _manage(db_session, out_scope, other)
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-trl-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-trl-admin", is_admin=True)
+
+    plain = create_test_user(db_session, "proj-trl-plain")
+    plain.effective_permissions = []
+    db_session.commit()
+
+    def denied(actor: User, group_id: int, rate_limit_id: int) -> bool:
+        return _guard_raises(
+            _authorize_group_token_rate_limit_write,
+            actor,
+            db_session,
+            group_id=group_id,
+            rate_limit_id=rate_limit_id,
+        )
+
+    assert not denied(admin, managed.id, managed_limit.id)
+    assert not denied(groups_admin, managed.id, managed_limit.id)
+    assert not denied(in_scope, managed.id, managed_limit.id)
+    assert denied(out_scope, managed.id, managed_limit.id)
+    assert denied(plain, managed.id, managed_limit.id)
+
+    # a global limit can't be reached through the group path — even for a full admin
+    assert denied(admin, managed.id, global_limit.id)
+
+    # the limit must belong to the claimed group (can't reach managed's limit via other)
+    assert denied(out_scope, other.id, managed_limit.id)
+    assert denied(in_scope, other.id, managed_limit.id)
+
+    # an unknown id folds into the same OnyxError 404, not the helper's raw ValueError
+    nonexistent_limit_id = -1
+    assert denied(in_scope, managed.id, nonexistent_limit_id)
+    assert denied(admin, managed.id, nonexistent_limit_id)
+
+
+def test_group_token_rate_limit_write_multi_group_scope(db_session: Session) -> None:
+    """Defensive: no API path attaches a limit to more than one group, but the schema allows
+    many-to-many. If a limit ever spanned groups, a mutation would hit all of them, so a manager
+    of only one attached group must be denied — the guard checks every attached group, not one
+    arbitrary association; global holders manage all groups so they pass. Builds the multi-group
+    state directly (no API can) to lock in the guard's behavior if that ever changes."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+    # limit attached to BOTH a managed and an unmanaged group
+    shared_limit = insert_user_group_token_rate_limit(
+        db_session=db_session, token_rate_limit_settings=args, group_id=managed.id
+    )
+    db_session.add(
+        TokenRateLimit__UserGroup(
+            rate_limit_id=shared_limit.id, user_group_id=unmanaged.id
+        )
+    )
+    db_session.commit()
+
+    in_scope = create_test_user(db_session, "proj-trl-multi-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-trl-multi-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-trl-multi-admin", is_admin=True)
+    db_session.commit()
+
+    def denied(actor: User) -> bool:
+        return _guard_raises(
+            _authorize_group_token_rate_limit_write,
+            actor,
+            db_session,
+            group_id=managed.id,
+            rate_limit_id=shared_limit.id,
+        )
+
+    # manager of `managed` only: mutating the shared limit would also hit `unmanaged`, so deny
+    assert denied(in_scope)
+    # global MANAGE_USER_GROUPS holders manage every group, so the shared limit is reachable
+    assert not denied(groups_admin)
+    assert not denied(admin)

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
@@ -7,15 +7,21 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import Permission
 from onyx.db.enums import PersonaAccessLevel
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.enums import PersonaSharingStatus
 from onyx.db.models import Persona__User
 from onyx.db.models import User
 from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona import get_minimal_persona_snapshots_for_user
 from onyx.db.persona import update_persona_access
+from onyx.db.persona import upsert_persona
 from onyx.db.persona_sharing import derive_persona_sharing_status
 from onyx.db.persona_sharing import get_persona_access_level
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.persona.api import delete_persona
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
 from tests.external_dependency_unit.db.agent_sharing_helpers import (
@@ -221,3 +227,110 @@ def test_sharing_status_derivation(db_session: Session) -> None:
 
     public_persona = create_test_persona(db_session, owner, is_public=True)
     assert derive_persona_sharing_status(public_persona) == PersonaSharingStatus.PUBLIC
+
+
+def _list_snapshot(db_session: Session, user: User, persona_id: int):
+    snapshots = get_minimal_persona_snapshots_for_user(
+        user=user, db_session=db_session, get_editable=False
+    )
+    return next(s for s in snapshots if s.id == persona_id)
+
+
+def test_list_stamps_affordance_map_for_owner(db_session: Session) -> None:
+    """The list endpoint stamps the per-agent permissions map, so a card gates its icons
+    from list data instead of a per-card full-agent refetch (the flicker Nik flagged)."""
+    owner = create_test_user(db_session, "list-owner")
+    persona = create_test_persona(db_session, owner)
+
+    snap = _list_snapshot(db_session, owner, persona.id)
+    assert snap.permissions.get("edit") is True
+    assert snap.permissions.get("delete") is True
+
+
+def test_list_affordance_map_fail_closed_for_viewer(db_session: Session) -> None:
+    """A viewer-shared user gets the map stamped but every mutating affordance false —
+    the client can't render an edit/delete control the write guard would 403."""
+    owner = create_test_user(db_session, "list-owner2")
+    viewer = create_test_user(db_session, "list-viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    snap = _list_snapshot(db_session, viewer, persona.id)
+    assert snap.permissions.get("edit") is False
+    assert snap.permissions.get("delete") is False
+
+
+def test_delete_persona_unowned_raises_403_not_400(db_session: Session) -> None:
+    """A non-owner admitted past GATE 1 (allow_scope) must get a 403 authorization denial, not
+    the generic 400 the global ValueError handler produces for get_persona_by_id's raise."""
+    owner = create_test_user(db_session, "del-owner")
+    stranger = create_test_user(db_session, "del-stranger")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        delete_persona(persona_id=persona.id, user=stranger, db_session=db_session)
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    assert exc_info.value.status_code == 403
+
+
+def test_add_agents_user_does_not_see_others_private_agents(
+    db_session: Session,
+) -> None:
+    """ADD_AGENTS must not imply READ_AGENTS (see-all): the browse list shows own / shared /
+    public, never another user's private agent."""
+    creator = create_test_user(db_session, "add-agents-creator")
+    creator.effective_permissions = [Permission.ADD_AGENTS.value]
+    stranger = create_test_user(db_session, "agent-stranger")
+    db_session.commit()
+
+    own = create_test_persona(db_session, creator)
+    public = create_test_persona(db_session, stranger, is_public=True)
+    shared = create_test_persona(db_session, stranger)
+    share_persona_with_user(db_session, shared, creator, PersonaSharePermission.VIEWER)
+    others_private = create_test_persona(db_session, stranger)
+
+    visible = {
+        snap.id
+        for snap in get_minimal_persona_snapshots_for_user(
+            user=creator, db_session=db_session, get_editable=False
+        )
+    }
+    assert own.id in visible
+    assert public.id in visible
+    assert shared.id in visible
+    assert others_private.id not in visible  # ADD_AGENTS no longer grants see-all
+
+
+def _edit_persona(
+    db_session: Session, persona_id: int, user: User, is_public: bool
+) -> None:
+    """Run the update-path setter as ``user`` requesting ``is_public``."""
+    upsert_persona(
+        user=user,
+        name=f"edit-{is_public}",
+        description="",
+        starter_messages=None,
+        system_prompt="",
+        task_prompt="",
+        datetime_aware=False,
+        is_public=is_public,
+        db_session=db_session,
+        persona_id=persona_id,
+    )
+
+
+def test_editor_cannot_publish_via_update(db_session: Session) -> None:
+    """An EDITOR-shared user may edit the agent but not flip it public via the update path —
+    is_public from a non-owner is dropped (owner-or-admin only, matching the share route)."""
+    owner = create_test_user(db_session, "pub-owner")
+    editor = create_test_user(db_session, "pub-editor")
+    persona = create_test_persona(db_session, owner, is_public=False)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    _edit_persona(db_session, persona.id, editor, is_public=True)
+    db_session.refresh(persona)
+    assert persona.is_public is False  # editor's publish attempt is dropped
+
+    _edit_persona(db_session, persona.id, owner, is_public=True)
+    db_session.refresh(persona)
+    assert persona.is_public is True  # owner can publish

--- a/backend/tests/integration/common_utils/managers/user.py
+++ b/backend/tests/integration/common_utils/managers/user.py
@@ -153,7 +153,7 @@ class UserManager:
             headers=user.headers,
         )
         response.raise_for_status()
-        return response.json()
+        return response.json()["permissions"]
 
     @staticmethod
     def is_admin(user_to_verify: DATestUser) -> bool:

--- a/backend/tests/integration/tests/permissions/test_group_manager_agents.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_agents.py
@@ -7,10 +7,9 @@ manage, and never widen beyond their scope:
 - **Skills**: create/grant/publish only for PRIVATE skills in managed groups;
   the admin list is scoped; DELETE is admin-only.
 - **Agents**: may group-share a PRIVATE agent only to managed groups.
-- **Actions/MCP**: actions have no group of their own, so scope is derived from
-  the agents using them — editable only when every such agent is private and in a
-  managed group; a public-agent or no-agent action is owner/admin-only; DELETE is
-  admin-only.
+- **Actions/MCP**: owner-or-admin — a manager creates and fully manages (edit/delete)
+  their own actions and servers, but cannot manage ones they didn't create, even those
+  connected to their groups via agents.
 - **Token limits**: settable only on a managed group.
 
 Managers are seeded by flipping ``User__UserGroup.is_manager`` directly (no
@@ -28,13 +27,13 @@ from typing import NamedTuple
 from uuid import uuid4
 
 import pytest
+import requests
 from sqlalchemy import update
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import Permission
-from onyx.db.models import Persona
 from onyx.db.models import User__UserGroup
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from tests.integration.common_utils.managers.persona import PersonaManager
@@ -113,7 +112,7 @@ def _create_custom_tool(user: DATestUser) -> int:
 
 
 def _create_mcp_server(user: DATestUser) -> int:
-    """Create a simple MCP server as ``user`` (must succeed); returns its id."""
+    """Create an MCP server as ``user`` (must succeed); returns its id."""
     body = {
         "name": f"mcp-{uuid4()}",
         "description": "escalation test",
@@ -145,7 +144,17 @@ _TOKEN_LIMIT_BODY: dict[str, Any] = {
 }
 
 
-# --- skills -----------------------------------------------------------------
+def _assert_manager(
+    env: _ScopedEnv,
+    method: str,
+    path: str,
+    expected: str,
+    body: dict[str, Any] | None = None,
+) -> requests.Response:
+    """Call ``path`` as the scoped manager and assert the permission gate's verdict."""
+    resp = call_endpoint(method, path, body, env.manager.headers, env.manager.cookies)
+    assert_response(resp, method, path, "manager", expected)
+    return resp
 
 
 def test_manager_creates_private_skill_in_managed_group(env: _ScopedEnv) -> None:
@@ -159,25 +168,22 @@ def test_manager_cannot_grant_skill_to_unmanaged_group(env: _ScopedEnv) -> None:
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
     path = f"/admin/skills/custom/{skill.id}/grants"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PUT",
         path,
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PUT", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint(
-        "PATCH", path, {"is_public": True}, env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PATCH", f"/admin/skills/custom/{skill.id}", "denied", {"is_public": True}
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
@@ -185,9 +191,7 @@ def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/skills/custom/{skill.id}", "denied")
 
 
 def test_manager_skill_admin_list_is_scoped(env: _ScopedEnv) -> None:
@@ -206,9 +210,6 @@ def test_manager_skill_admin_list_is_scoped(env: _ScopedEnv) -> None:
     assert str(theirs.id) not in custom_ids
 
 
-# --- agents -----------------------------------------------------------------
-
-
 def test_manager_shares_agent_to_managed_group(env: _ScopedEnv) -> None:
     PersonaManager.create(
         user_performing_action=env.manager,
@@ -223,15 +224,13 @@ def test_manager_cannot_share_agent_to_unmanaged_group(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
@@ -242,15 +241,13 @@ def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}",
+        "denied",
         _persona_upsert_body(is_public=True, groups=[env.managed_group.id]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
@@ -270,29 +267,25 @@ def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
     assert publish.status_code == 200, publish.text
     # The manager must not pull the now-public agent back to private AND keep the
     # group share in one call — the gate anchors on the original (public) state.
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"is_public": False, "group_ids": [env.managed_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_creates_personal_agent(env: _ScopedEnv) -> None:
     # A scoped manager may create a private no-group personal agent like any
     # ADD_AGENTS user; the managed-group gate applies only once a group is involved.
-    path = "/persona"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "POST",
-        path,
+        "/persona",
+        "allowed",
         _persona_upsert_body(is_public=False, groups=[]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "POST", path, "manager", "allowed")
 
 
 def test_add_agents_user_creates_personal_agent_with_empty_groups(
@@ -340,132 +333,62 @@ def test_manager_rosters_agent_shared_to_managed_group(env: _ScopedEnv) -> None:
     assert resp.status_code == 200, resp.text
 
 
-# --- custom actions (agent-mediated scope) ----------------------------------
-
-
+# Custom actions: owner-or-admin gating (not group-scoped like skills/agents).
 def test_manager_creates_own_action(env: _ScopedEnv) -> None:
     _create_custom_tool(env.manager)
 
 
-def test_manager_cannot_edit_unowned_ungrouped_action(env: _ScopedEnv) -> None:
-    # Admin owns the action and no agent uses it → no group context → owner/admin only.
-    tool_id = _create_custom_tool(env.admin)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
-
-
-def test_manager_edits_action_used_by_managed_private_agent(env: _ScopedEnv) -> None:
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "allowed")
-
-
-def test_manager_edits_action_used_by_group_owned_agent(env: _ScopedEnv) -> None:
-    # An action used only by a PRIVATE agent OWNED by the manager's group (via
-    # owner_group_id, with no share rows) is in scope through that group ownership.
-    tool_id = _create_custom_tool(env.admin)
-    agent = PersonaManager.create(
-        user_performing_action=env.admin, is_public=False, tool_ids=[tool_id]
-    )
-    # No API creates a group-owned agent in these tests, so re-own it directly
-    # (owner_group_id and user_id are mutually exclusive).
-    with get_session_with_current_tenant() as db_session:
-        db_session.execute(
-            update(Persona)
-            .where(Persona.id == agent.id)
-            .values(user_id=None, owner_group_id=env.managed_group.id)
-        )
-        db_session.commit()
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "allowed")
-
-
-def test_manager_cannot_edit_action_used_by_public_agent(env: _ScopedEnv) -> None:
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=True,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
-
-
-def test_manager_cannot_edit_action_used_by_ungrouped_private_agent(
-    env: _ScopedEnv,
-) -> None:
-    # A private agent in NO group is a personal agent outside the manager's scope;
-    # its presence must block editing even alongside a managed-group agent (the
-    # ungrouped agent adds no group to the union, so it must be tracked explicitly).
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[],
-        tool_ids=[tool_id],
-    )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
-
-
-def test_manager_cannot_delete_action(env: _ScopedEnv) -> None:
-    # Owns it — still denied: delete is admin-only (no allow_scope on the route).
+def test_manager_edits_own_action(env: _ScopedEnv) -> None:
     tool_id = _create_custom_tool(env.manager)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
+    )
 
 
-# --- MCP servers ------------------------------------------------------------
+def test_manager_deletes_own_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.manager)
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "allowed")
 
 
+def test_manager_cannot_edit_unowned_action(env: _ScopedEnv) -> None:
+    # Owner-or-admin: a manager can't edit an admin-created action, even one used by an agent
+    # in a group they manage (managers get read visibility + their own, not others').
+    tool_id = _create_custom_tool(env.admin)
+    PersonaManager.create(
+        user_performing_action=env.admin,
+        is_public=False,
+        groups=[env.managed_group.id],
+        tool_ids=[tool_id],
+    )
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
+
+
+def test_manager_cannot_delete_unowned_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.admin)
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "denied")
+
+
+# MCP servers: owner-or-admin gating (not group-scoped like skills/agents).
 def test_manager_creates_mcp_server(env: _ScopedEnv) -> None:
     _create_mcp_server(env.manager)
 
 
-def test_manager_cannot_delete_mcp_server(env: _ScopedEnv) -> None:
-    # Owns it — still denied: MCP delete is admin-only.
+def test_manager_deletes_own_mcp_server(env: _ScopedEnv) -> None:
     server_id = _create_mcp_server(env.manager)
-    path = f"/admin/mcp/server/{server_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "allowed")
+
+
+def test_manager_cannot_delete_unowned_mcp_server(env: _ScopedEnv) -> None:
+    server_id = _create_mcp_server(env.admin)
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "denied")
 
 
 def test_manager_update_via_servers_create_denied_not_masked(
     env: _ScopedEnv,
 ) -> None:
-    # Updating an out-of-scope server through /servers/create must surface the
-    # gate's 403, not a 500 masked by the handler's blanket except.
+    # Updating an unowned server through /servers/create must surface the gate's 403, not a
+    # 500 masked by the handler's blanket except.
     server_id = _create_mcp_server(env.admin)
-    path = "/admin/mcp/servers/create"
     body = {
         "name": f"mcp-{uuid4()}",
         "server_url": "https://example.com/mcp",
@@ -473,24 +396,66 @@ def test_manager_update_via_servers_create_denied_not_masked(
         "auth_performer": MCPAuthenticationPerformer.ADMIN.value,
         "existing_server_id": server_id,
     }
-    resp = call_endpoint("POST", path, body, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "POST", path, "manager", "denied")
+    _assert_manager(env, "POST", "/admin/mcp/servers/create", "denied", body)
 
 
-# --- token limits -----------------------------------------------------------
+def _group_limit_path(group_id: int, limit_id: int | None = None) -> str:
+    base = f"/admin/token-rate-limits/user-group/{group_id}"
+    return base if limit_id is None else f"{base}/rate-limit/{limit_id}"
+
+
+def _create_group_token_limit(user: DATestUser, group_id: int) -> int:
+    """Create a token limit on ``group_id`` as ``user`` (must succeed); returns its id."""
+    resp = call_endpoint(
+        "POST",
+        _group_limit_path(group_id),
+        _TOKEN_LIMIT_BODY,
+        user.headers,
+        user.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["token_id"])
 
 
 def test_manager_sets_token_limit_on_managed_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.managed_group.id}"
-    resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "POST", path, "manager", "allowed")
+    path = _group_limit_path(env.managed_group.id)
+    _assert_manager(env, "POST", path, "allowed", _TOKEN_LIMIT_BODY)
 
 
 def test_manager_cannot_set_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.other_group.id}"
-    resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
+    path = _group_limit_path(env.other_group.id)
+    _assert_manager(env, "POST", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_reads_token_limits_on_managed_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.managed_group.id), "allowed")
+
+
+def test_manager_cannot_read_token_limits_on_unmanaged_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.other_group.id), "denied")
+
+
+def test_manager_updates_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    path = _group_limit_path(env.managed_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "allowed", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_cannot_update_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    path = _group_limit_path(env.other_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_deletes_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.managed_group.id, limit_id), "allowed"
     )
-    assert_response(resp, "POST", path, "manager", "denied")
+
+
+def test_manager_cannot_delete_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.other_group.id, limit_id), "denied"
+    )

--- a/backend/tests/integration/tests/permissions/test_group_manager_membership.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_membership.py
@@ -24,6 +24,7 @@ from sqlalchemy import update
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.models import User__UserGroup
+from onyx.db.models import UserGroup__ConnectorCredentialPair
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
@@ -105,6 +106,18 @@ def _me_permissions(user: DATestUser) -> dict[str, Any]:
 
 def _patch_group_body(user_ids: list[str], cc_pair_ids: list[int]) -> dict[str, Any]:
     return {"user_ids": user_ids, "cc_pair_ids": cc_pair_ids}
+
+
+def _insert_stale_cc_pair_junction(group_id: int, cc_pair_id: int) -> None:
+    """Simulate a removed-but-not-yet-swept cc_pair: an is_current=False junction row
+    (removals mark the row stale rather than delete it, until the Vespa sync runs)."""
+    with get_session_with_current_tenant() as db_session:
+        db_session.add(
+            UserGroup__ConnectorCredentialPair(
+                user_group_id=group_id, cc_pair_id=cc_pair_id, is_current=False
+            )
+        )
+        db_session.commit()
 
 
 # --- manager assignment endpoint (GATE 2 = admin or manager-of-that-group) ---
@@ -285,6 +298,25 @@ def test_manager_cannot_attach_unmanaged_cc_pair(env: _ScopedEnv) -> None:
         "PATCH",
         path,
         _patch_group_body([env.manager.id, env.member.id], [unmanaged_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+
+
+def test_manager_cannot_reattach_removed_public_cc_pair(env: _ScopedEnv) -> None:
+    # A removed cc_pair leaves a stale is_current=False junction row until the sync
+    # sweeps it; that stale row must not make a public connector look "already
+    # attached" and slip past the re-attach gate.
+    public_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin, access_type=AccessType.PUBLIC, groups=[]
+    )
+    _insert_stale_cc_pair_junction(env.managed_group.id, public_cc_pair.id)
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [public_cc_pair.id]),
         env.manager.headers,
         env.manager.cookies,
     )

--- a/backend/tests/integration/tests/permissions/test_group_manager_membership.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_membership.py
@@ -1,0 +1,369 @@
+"""Escalation suite for group-manager assignment + membership scoping.
+
+A scoped group manager may create other managers, edit membership, rename, and
+list groups — but only within the groups they manage. They can never assign a
+manager, add users, rename, or edit a group outside their managed scope; never
+attach a public or out-of-scope connector to their group; and never create,
+delete, or set permissions on a group (all admin-only). The admin-facing group
+list and ``/me/permissions`` return only the manager's own scope. Global holders
+(admins) bypass GATE 2. Managers are seeded by flipping
+``User__UserGroup.is_manager`` directly (no manager-creation helper exists yet).
+
+Allowed actions go through the shared Manager classes (which assert real success);
+denied actions go through the shared ``_access_matrix`` helpers, which verify the
+403 is a genuine permission-gate denial rather than any incidental 403.
+"""
+
+import os
+from typing import Any
+from typing import NamedTuple
+
+import pytest
+from sqlalchemy import update
+
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.db.enums import AccessType
+from onyx.db.models import User__UserGroup
+from onyx.db.permissions import recompute_user_permissions__no_commit
+from tests.integration.common_utils.constants import API_SERVER_URL
+from tests.integration.common_utils.http_client import client
+from tests.integration.common_utils.managers.cc_pair import CCPairManager
+from tests.integration.common_utils.managers.user import UserManager
+from tests.integration.common_utils.managers.user_group import UserGroupManager
+from tests.integration.common_utils.test_models import DATestUser
+from tests.integration.common_utils.test_models import DATestUserGroup
+from tests.integration.tests.permissions._access_matrix import assert_response
+from tests.integration.tests.permissions._access_matrix import call_endpoint
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ENABLE_PAID_ENTERPRISE_EDITION_FEATURES", "").lower() != "true",
+    reason="Group manager scoping is an enterprise-only capability",
+)
+
+_GROUP_LIST_PATH = "/manage/admin/user-group"
+_RENAME_PATH = "/manage/admin/user-group/rename"
+_ME_PERMISSIONS_PATH = "/me/permissions"
+
+
+class _ScopedEnv(NamedTuple):
+    admin: DATestUser
+    manager: DATestUser
+    member: DATestUser  # plain member of managed_group (assignable target)
+    outsider: DATestUser  # member of other_group only
+    managed_group: DATestUserGroup
+    other_group: DATestUserGroup
+
+
+def _promote_to_manager(user_id: str, group_id: int) -> None:
+    """Flip is_manager on the (user, group) edge and recompute the cached flag."""
+    with get_session_with_current_tenant() as db_session:
+        db_session.execute(
+            update(User__UserGroup)
+            .where(
+                User__UserGroup.user_id == user_id,
+                User__UserGroup.user_group_id == group_id,
+            )
+            .values(is_manager=True)
+        )
+        db_session.flush()
+        recompute_user_permissions__no_commit(user_id, db_session)
+        db_session.commit()
+
+
+@pytest.fixture
+def env(reset: None, admin_user: DATestUser) -> _ScopedEnv:  # noqa: ARG001
+    manager = UserManager.create(name="scoped_manager")
+    member = UserManager.create(name="plain_member")
+    outsider = UserManager.create(name="outsider")
+    managed_group = UserGroupManager.create(
+        name="managed",
+        user_ids=[manager.id, member.id],
+        user_performing_action=admin_user,
+    )
+    other_group = UserGroupManager.create(
+        name="unmanaged", user_ids=[outsider.id], user_performing_action=admin_user
+    )
+    _promote_to_manager(manager.id, managed_group.id)
+    return _ScopedEnv(admin_user, manager, member, outsider, managed_group, other_group)
+
+
+def _manager_path(group_id: int) -> str:
+    return f"/manage/admin/user-group/{group_id}/manager"
+
+
+def _set_manager_body(user_id: str, is_manager: bool) -> dict[str, Any]:
+    return {"user_id": user_id, "is_manager": is_manager}
+
+
+def _me_permissions(user: DATestUser) -> dict[str, Any]:
+    resp = client.get(
+        url=f"{API_SERVER_URL}{_ME_PERMISSIONS_PATH}", headers=user.headers
+    )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _patch_group_body(user_ids: list[str], cc_pair_ids: list[int]) -> dict[str, Any]:
+    return {"user_ids": user_ids, "cc_pair_ids": cc_pair_ids}
+
+
+# --- manager assignment endpoint (GATE 2 = admin or manager-of-that-group) ---
+
+
+def test_admin_assigns_manager(env: _ScopedEnv) -> None:
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.member.id, True),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    perms = _me_permissions(env.member)
+    assert perms["is_manager"] is True
+    assert env.managed_group.id in perms["managed_group_ids"]
+
+
+def test_manager_delegates_within_managed_group(env: _ScopedEnv) -> None:
+    # A manager may appoint a co-manager within a group they manage.
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.member.id, True),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    assert _me_permissions(env.member)["is_manager"] is True
+
+
+def test_manager_cannot_assign_in_unmanaged_group(env: _ScopedEnv) -> None:
+    path = _manager_path(env.other_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.outsider.id, True),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")
+
+
+def test_assign_non_member_returns_400(env: _ScopedEnv) -> None:
+    # A manager is always a member — the outsider isn't in managed_group, so even
+    # an admin gets a 400 (not a gate denial).
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.outsider.id, True),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert resp.status_code == 400, resp.text
+
+
+def test_revoke_manager_clears_flag(env: _ScopedEnv) -> None:
+    manager_path = _manager_path(env.managed_group.id)
+    call_endpoint(
+        "PUT",
+        manager_path,
+        _set_manager_body(env.member.id, True),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    resp = call_endpoint(
+        "PUT",
+        manager_path,
+        _set_manager_body(env.member.id, False),
+        env.admin.headers,
+        env.admin.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    perms = _me_permissions(env.member)
+    assert perms["is_manager"] is False
+    assert env.managed_group.id not in perms["managed_group_ids"]
+
+
+def test_plain_member_cannot_assign(env: _ScopedEnv) -> None:
+    # A member without is_manager holds NONE for MANAGE_USER_GROUPS — GATE 1 rejects.
+    path = _manager_path(env.managed_group.id)
+    resp = call_endpoint(
+        "PUT",
+        path,
+        _set_manager_body(env.member.id, True),
+        env.member.headers,
+        env.member.cookies,
+    )
+    assert_response(resp, "PUT", path, "member", "denied")
+
+
+# --- membership edits (group ∈ managed) -------------------------------------
+
+
+def test_manager_adds_user_to_managed_group(env: _ScopedEnv) -> None:
+    UserGroupManager.add_users(
+        env.managed_group, [env.outsider.id], user_performing_action=env.manager
+    )
+
+
+def test_manager_cannot_add_user_to_unmanaged_group(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.other_group.id}/add-users"
+    resp = call_endpoint(
+        "POST",
+        path,
+        {"user_ids": [env.member.id]},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "POST", path, "manager", "denied")
+
+
+def test_manager_renames_managed_group(env: _ScopedEnv) -> None:
+    resp = call_endpoint(
+        "PATCH",
+        _RENAME_PATH,
+        {"id": env.managed_group.id, "name": "managed-renamed"},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+def test_manager_cannot_rename_unmanaged_group(env: _ScopedEnv) -> None:
+    resp = call_endpoint(
+        "PATCH",
+        _RENAME_PATH,
+        {"id": env.other_group.id, "name": "unmanaged-renamed"},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", _RENAME_PATH, "manager", "denied")
+
+
+def test_manager_cannot_patch_unmanaged_group(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.other_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.outsider.id], []),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+
+
+# --- cc_pair re-attach gate (§ junction-rewrite escalation) ------------------
+
+
+def test_manager_cannot_attach_public_cc_pair(env: _ScopedEnv) -> None:
+    public_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin, access_type=AccessType.PUBLIC, groups=[]
+    )
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [public_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+
+
+def test_manager_cannot_attach_unmanaged_cc_pair(env: _ScopedEnv) -> None:
+    # Admin owns a PRIVATE cc_pair in a group the manager does not manage.
+    unmanaged_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin,
+        access_type=AccessType.PRIVATE,
+        groups=[env.other_group.id],
+    )
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [unmanaged_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PATCH", path, "manager", "denied")
+
+
+def test_manager_attaches_groupless_private_cc_pair(env: _ScopedEnv) -> None:
+    # A private cc_pair in no group lands only in managed scope when attached —
+    # so the manager may pull it into their group.
+    groupless_cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin, access_type=AccessType.PRIVATE, groups=[]
+    )
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint(
+        "PATCH",
+        path,
+        _patch_group_body([env.manager.id, env.member.id], [groupless_cc_pair.id]),
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+
+
+# --- scoped group list + /me/permissions ------------------------------------
+
+
+def test_manager_group_list_only_managed(env: _ScopedEnv) -> None:
+    groups = UserGroupManager.get_all(user_performing_action=env.manager)
+    group_ids = {g.id for g in groups}
+    assert env.managed_group.id in group_ids
+    assert env.other_group.id not in group_ids
+
+
+def test_admin_group_list_includes_all(env: _ScopedEnv) -> None:
+    groups = UserGroupManager.get_all(user_performing_action=env.admin)
+    group_ids = {g.id for g in groups}
+    assert {env.managed_group.id, env.other_group.id}.issubset(group_ids)
+
+
+def test_manager_me_permissions_flags(env: _ScopedEnv) -> None:
+    perms = _me_permissions(env.manager)
+    assert perms["is_manager"] is True
+    assert env.managed_group.id in perms["managed_group_ids"]
+    assert env.other_group.id not in perms["managed_group_ids"]
+
+
+def test_member_me_permissions_not_manager(env: _ScopedEnv) -> None:
+    perms = _me_permissions(env.member)
+    assert perms["is_manager"] is False
+    assert perms["managed_group_ids"] == []
+
+
+# --- group create / delete / permissions stay admin-only --------------------
+
+
+def test_manager_cannot_create_group(env: _ScopedEnv) -> None:
+    resp = call_endpoint(
+        "POST",
+        _GROUP_LIST_PATH,
+        {"name": "new-group", "user_ids": [], "cc_pair_ids": []},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "POST", _GROUP_LIST_PATH, "manager", "denied")
+
+
+def test_manager_cannot_delete_group(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.managed_group.id}"
+    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
+    assert_response(resp, "DELETE", path, "manager", "denied")
+
+
+def test_manager_cannot_set_group_permissions(env: _ScopedEnv) -> None:
+    path = f"/manage/admin/user-group/{env.managed_group.id}/permissions"
+    resp = call_endpoint(
+        "PUT",
+        path,
+        {"permissions": []},
+        env.manager.headers,
+        env.manager.cookies,
+    )
+    assert_response(resp, "PUT", path, "manager", "denied")

--- a/backend/tests/integration/tests/permissions/test_group_manager_membership.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_membership.py
@@ -21,6 +21,7 @@ from typing import NamedTuple
 import pytest
 from sqlalchemy import update
 
+from onyx.auth.permissions import SCOPED_MANAGER_PERMISSIONS_EXPANDED
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import AccessType
 from onyx.db.models import User__UserGroup
@@ -120,9 +121,7 @@ def _insert_stale_cc_pair_junction(group_id: int, cc_pair_id: int) -> None:
         db_session.commit()
 
 
-# --- manager assignment endpoint (GATE 2 = admin or manager-of-that-group) ---
-
-
+# Manager-assignment endpoint — GATE 2 = admin or manager-of-that-group.
 def test_admin_assigns_manager(env: _ScopedEnv) -> None:
     path = _manager_path(env.managed_group.id)
     resp = call_endpoint(
@@ -213,9 +212,6 @@ def test_plain_member_cannot_assign(env: _ScopedEnv) -> None:
     assert_response(resp, "PUT", path, "member", "denied")
 
 
-# --- membership edits (group ∈ managed) -------------------------------------
-
-
 def test_manager_adds_user_to_managed_group(env: _ScopedEnv) -> None:
     UserGroupManager.add_users(
         env.managed_group, [env.outsider.id], user_performing_action=env.manager
@@ -268,9 +264,7 @@ def test_manager_cannot_patch_unmanaged_group(env: _ScopedEnv) -> None:
     assert_response(resp, "PATCH", path, "manager", "denied")
 
 
-# --- cc_pair re-attach gate (§ junction-rewrite escalation) ------------------
-
-
+# cc_pair re-attach gate — the junction-rewrite escalation vector.
 def test_manager_cannot_attach_public_cc_pair(env: _ScopedEnv) -> None:
     public_cc_pair = CCPairManager.create_from_scratch(
         user_performing_action=env.admin, access_type=AccessType.PUBLIC, groups=[]
@@ -340,9 +334,6 @@ def test_manager_attaches_groupless_private_cc_pair(env: _ScopedEnv) -> None:
     assert resp.status_code == 200, resp.text
 
 
-# --- scoped group list + /me/permissions ------------------------------------
-
-
 def test_manager_group_list_only_managed(env: _ScopedEnv) -> None:
     groups = UserGroupManager.get_all(user_performing_action=env.manager)
     group_ids = {g.id for g in groups}
@@ -362,16 +353,27 @@ def test_manager_me_permissions_flags(env: _ScopedEnv) -> None:
     assert env.managed_group.id in perms["managed_group_ids"]
     assert env.other_group.id not in perms["managed_group_ids"]
 
+    info = UserManager.get_user_info(env.manager)
+    effective = set(info.effective_permissions)
+    assert info.is_group_manager is True
+    # admin_capabilities unions the scoped bundle so the client can reveal manager nav
+    assert (
+        set(info.admin_capabilities) == effective | SCOPED_MANAGER_PERMISSIONS_EXPANDED
+    )
+    assert set(info.admin_capabilities) > effective
+
 
 def test_member_me_permissions_not_manager(env: _ScopedEnv) -> None:
     perms = _me_permissions(env.member)
     assert perms["is_manager"] is False
     assert perms["managed_group_ids"] == []
 
+    info = UserManager.get_user_info(env.member)
+    assert info.is_group_manager is False
+    assert set(info.admin_capabilities) == set(info.effective_permissions)
 
-# --- group create / delete / permissions stay admin-only --------------------
 
-
+# Group create/delete/set-permissions stay admin-only.
 def test_manager_cannot_create_group(env: _ScopedEnv) -> None:
     resp = call_endpoint(
         "POST",

--- a/backend/tests/integration/tests/permissions/test_group_manager_resources.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_resources.py
@@ -116,9 +116,6 @@ def _doc_set_body(
     return body
 
 
-# --- cc_pair create (GATE 2) ------------------------------------------------
-
-
 def test_admin_creates_public_cc_pair_bypasses_gate(env: _ScopedEnv) -> None:
     # Control: a global holder is not scope-restricted (PUBLIC, no groups).
     CCPairManager.create_from_scratch(
@@ -172,9 +169,6 @@ def test_manager_cannot_create_cc_pair_without_groups(env: _ScopedEnv) -> None:
         env.manager.cookies,
     )
     assert_response(resp, "PUT", path, "manager", "denied")
-
-
-# --- document set create / edit (GATE 2) ------------------------------------
 
 
 def test_manager_creates_private_doc_set_in_managed_group(env: _ScopedEnv) -> None:
@@ -270,9 +264,6 @@ def test_manager_edits_doc_set_within_managed_group(env: _ScopedEnv) -> None:
     DocumentSetManager.edit(doc_set, user_performing_action=env.manager)
 
 
-# --- DELETE stays admin-only ------------------------------------------------
-
-
 def test_manager_cannot_delete_doc_set(env: _ScopedEnv) -> None:
     cc_pair = CCPairManager.create_from_scratch(
         user_performing_action=env.manager,
@@ -308,10 +299,9 @@ def test_manager_cannot_delete_cc_pair(env: _ScopedEnv) -> None:
     assert_response(resp, "POST", path, "manager", "denied")
 
 
-# --- re-keyed read filter authorizes the mutate routes ----------------------
-
-
 def test_manager_pauses_own_managed_cc_pair(env: _ScopedEnv) -> None:
+    # Pause/status (mutate routes) authorize via the re-keyed read/editable filter,
+    # not a separate scope check — so managed-scope access gates mutation too.
     cc_pair = CCPairManager.create_from_scratch(
         user_performing_action=env.manager,
         access_type=AccessType.PRIVATE,
@@ -338,9 +328,6 @@ def test_manager_cannot_pause_unmanaged_cc_pair(env: _ScopedEnv) -> None:
     assert_response(resp, "PUT", path, "manager", "denied")
 
 
-# --- membership is not managership ------------------------------------------
-
-
 def test_plain_member_cannot_create_doc_set(env: _ScopedEnv) -> None:
     # A group member without is_manager has NONE authority — rejected at GATE 1.
     member = UserManager.create(name="plain_member")
@@ -355,3 +342,23 @@ def test_plain_member_cannot_create_doc_set(env: _ScopedEnv) -> None:
         member.cookies,
     )
     assert_response(resp, "POST", _DOC_SET_PATH, "member", "denied")
+
+
+def test_admin_cc_pair_detail_carries_permissions_map(env: _ScopedEnv) -> None:
+    # The connector read route is GLOBAL-only (no allow_scope), so a scoped manager
+    # can't reach it; this covers the admin wire format (the manager distinction is
+    # proven in the projection contract test).
+    cc_pair = CCPairManager.create_from_scratch(
+        user_performing_action=env.admin,
+        access_type=AccessType.PRIVATE,
+        groups=[env.managed_group.id],
+    )
+    path = f"/manage/admin/cc-pair/{cc_pair.id}"
+    resp = call_endpoint("GET", path, None, env.admin.headers, env.admin.cookies)
+    assert resp.status_code == 200
+
+    body = resp.json()
+    # admin holds global MANAGE_CONNECTORS, so every action is allowed
+    assert body["permissions"] == {"edit": True, "delete": True, "publish": True}
+    # edit is stamped from is_editable_for_current_user, so the two must agree
+    assert body["permissions"]["edit"] == body["is_editable_for_current_user"]

--- a/backend/tests/integration/tests/permissions/test_manage_user_groups.py
+++ b/backend/tests/integration/tests/permissions/test_manage_user_groups.py
@@ -71,10 +71,9 @@ def test_access_matrix(
 
 
 # PUT /manage/admin/user-group/{id}/permissions is admin-only (not
-# MANAGE_USER_GROUPS) to prevent privilege escalation — a group manager
-# could otherwise grant their own group any toggleable permission. The
-# endpoint must remain gated on FULL_ADMIN_PANEL_ACCESS, so holders of
-# MANAGE_USER_GROUPS are expected to be denied here.
+# MANAGE_USER_GROUPS) to prevent privilege escalation: a group manager
+# could otherwise grant their own group any toggleable permission. Gated
+# on FULL_ADMIN_PANEL_ACCESS, so MANAGE_USER_GROUPS holders are denied here.
 _SET_PERMISSIONS_USER_KINDS: list[tuple[str, str]] = [
     ("admin", "allowed"),
     ("holder", "denied"),

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -67,9 +67,13 @@ class TestResolveEffectivePermissions:
         """The chat write surface must not leak into the search surface."""
         assert "read:search" not in resolve_effective_permissions({"write:chat"})
 
-    def test_single_implication(self) -> None:
-        result = resolve_effective_permissions({"add:agents"})
-        assert result == {"add:agents", "read:agents"}
+    def test_manage_service_account_api_keys_implies_read_user_groups(self) -> None:
+        result = resolve_effective_permissions({"manage:service_account_api_keys"})
+        assert result == {"manage:service_account_api_keys", "read:user_groups"}
+
+    def test_add_agents_implies_nothing(self) -> None:
+        """ADD_AGENTS must NOT imply READ_AGENTS — creating agents grants no see-all."""
+        assert resolve_effective_permissions({"add:agents"}) == {"add:agents"}
 
     def test_manage_agents_implies_add_and_reads(self) -> None:
         """manage:agents implies add:agents, read:agents, and read:document_sets."""
@@ -132,7 +136,6 @@ class TestResolveEffectivePermissions:
             "read:chat",
             "write:chat",
             "add:agents",
-            "read:agents",
             "manage:connectors",
             "read:connectors",
         }
@@ -164,11 +167,12 @@ class TestGetEffectivePermissions:
         global_version.unset_ee()
 
     def test_expands_implied_permissions(self) -> None:
-        """Column stores only granted; get_effective_permissions expands implied."""
+        """Column stores only granted; get_effective_permissions expands implied. ADD_AGENTS
+        implies nothing — it must not grant READ_AGENTS (see-all-agents)."""
         user = MagicMock()
         user.effective_permissions = ["add:agents"]
         result = get_effective_permissions(user)
-        assert result == {Permission.ADD_AGENTS, Permission.READ_AGENTS}
+        assert result == {Permission.ADD_AGENTS}
 
     def test_admin_expands_to_all(self) -> None:
         user = MagicMock()
@@ -208,7 +212,7 @@ class TestCEUngatedPermissions:
         user.effective_permissions = ["basic"]
         result = get_effective_permissions(user)
         assert Permission.ADD_AGENTS in result
-        assert Permission.READ_AGENTS in result
+        assert Permission.READ_AGENTS not in result  # ADD_AGENTS doesn't grant see-all
         assert Permission.BASIC_ACCESS in result
 
     def test_empty_user_gets_ungated_permissions_in_ce(self) -> None:
@@ -216,7 +220,7 @@ class TestCEUngatedPermissions:
         user.effective_permissions = []
         result = get_effective_permissions(user)
         assert Permission.ADD_AGENTS in result
-        assert Permission.READ_AGENTS in result
+        assert Permission.READ_AGENTS not in result  # ADD_AGENTS doesn't grant see-all
 
     def test_basic_user_does_not_get_ungated_permissions_in_ee(self) -> None:
         global_version.set_ee()

--- a/docs/group-manager-scoped-permissions/00-index.md
+++ b/docs/group-manager-scoped-permissions/00-index.md
@@ -14,6 +14,7 @@ Source of truth (wiki): `Engineering Projects/Group-Based Permissions System V2/
 | 03 | [03-detailed-design.md](03-detailed-design.md) | DB design (+rationale) · auth primitives · ~4 filter rewrites (+skill, +token-limit; §11) · write-path gate insertions · PAT · API · FE · file tree · pre-impl notes · open decisions | ✅ |
 | 04 | [04-implementation-plan.md](04-implementation-plan.md) | CLAUDE.md-format plan + plan-challenge results (passed all 6) | ✅ |
 | 05 | [05-pr-roadmap.md](05-pr-roadmap.md) | 6 ordered PRs (~2.3k LOC) w/ drift checkpoints + lands-together safety invariant | ✅ |
+| 07 | [07-ui-capability-model-design.md](07-ui-capability-model-design.md) | **UI redesign** (server-driven capability model): kills client-side `visibilityPermissions()`; `/me.admin_capabilities` (coarse) + per-resource `permissions{}` map (per-item) stamped by a shared `can_<action>` helper the write-guard also calls (drift impossible by construction); `<Can>` primitive; 49/109 affordance audit + complete mapping + real contract test + 5-PR roadmap. **v2** — revised after a 34-finding adversarial pressure test | 🆕 design (v2) |
 
 **Decisions locked at GATE 2:** D1 cache `is_group_manager` boolean (route gate zero-query; managed-list stays
 live) · D2 admins-only create groups · D3 admin-or-manager-of-that-group assigns managers.

--- a/docs/group-manager-scoped-permissions/07-ui-capability-model-design.md
+++ b/docs/group-manager-scoped-permissions/07-ui-capability-model-design.md
@@ -1,0 +1,1237 @@
+# UI Capability Model — Server-Driven Affordance Gating for Scoped Group Permissions
+
+Status: design (v2, revised after adversarial pressure test) · Task: group-manager-scoped-permissions · Supersedes: 06-frontend-affordance-followups.md · Layer: UI/read-projection + a small behavior-preserving backend refactor (PR1-5 enforcement behavior unchanged)
+
+## Changelog vs v1
+
+1. **Shared decision helper (by-construction) — D1.** The projection stamps each tag by calling the *same* `can_<action>` boolean the write guard (`assert_*`) calls, so `project == enforce` holds by construction, not by discipline (§2.3, §3.1a).
+2. **Per-action predicates — D2.** Each action's tag is stamped by *its own* real gate (M / A / O / M|O / O|A), replacing the wrong "one filter per resource" that mis-stamped ≥3 actions per resource (§3.3, §5).
+3. **Hot-path / N+1 — D3.** Never stamp the chat/explore list; per-card tags ride the per-card fetch the card already makes; list callers preload the editable + managed sets once via a `ctx` so per-row stamping does no DB (§3.2, §4.4).
+4. **Drop codegen + required field — D4.** Hand-write the 7 per-resource action unions, make `permissions` a *required* (non-optional) field, and add a route-coverage test — no codegen pipeline (§4.5, §6.1).
+5. **Per-page default-deny — D5.** The SSR admin gate default-denies un-enumerated `/admin/*` paths instead of failing open (§3.5, §4.3).
+6. **Federated admin-only — D6.** Federated connectors have no scope model → gate on `isAdmin`, enumerate `/admin/federated` as FULL_ADMIN (§5.6).
+7. **Revert keeps Make-Manager — D7.** The PR6-v1 revert keeps the Make/Revoke Manager toggle — the only UI that reaches PR5's assign-manager route (§6.4).
+8. **Cached-vs-live invalidation — D8.** Every manager-status change — including external group-sync, not just the manual toggle — recomputes perms server-side and busts `['me']` (§3.4, §6.3).
+
+## Table of Contents
+
+- [1. Overview & Motivation](#1-overview--motivation)
+  - [1.1 Evidence](#11-evidence)
+  - [1.2 Three structural root causes](#12-three-structural-root-causes)
+  - [1.3 Goals](#13-goals)
+  - [1.4 Non-Goals](#14-non-goals)
+  - [1.5 Relation to PR1–6 & doc 06](#15-relation-to-pr16--doc-06)
+- [2. Architecture (High-Level Design)](#2-architecture-high-level-design)
+  - [2.1 Two-layer gate model](#21-two-layer-gate-model)
+  - [2.2 The three fields](#22-the-three-fields)
+  - [2.3 Shared-helper invariant (one `can_*`, three callers)](#23-shared-helper-invariant-one-can_-three-callers)
+  - [2.4 Before / after (one affordance)](#24-before--after-one-affordance-edit-this-agent-on-a-chat-card)
+  - [2.5 Why it stays scalable](#25-why-it-stays-scalable)
+  - [2.6 Industry grounding](#26-industry-grounding)
+- [3. Backend Design](#3-backend-design)
+  - [3.1 One shared decision helper (PDP → PEP + projection + test)](#31-one-shared-decision-helper-pdp--pep--projection--test)
+  - [3.1a D1 — One Shared Decision Helper (`can_*`), guard-by-guard](#31a-d1--one-shared-decision-helper-can_-guard-by-guard)
+  - [3.2 Read-side projection: `permissions_for` + ctx (no N+1)](#32-read-side-projection-permissions_for--ctx-no-n1)
+  - [3.3 Per-action predicate table](#33-per-action-predicate-table--each-actions-tag-comes-from-its-own-real-gate)
+  - [3.4 `/me.admin_capabilities` — server-computed Layer-1 set (+ cache coherence)](#34-meadmin_capabilities--server-computed-layer-1-set--cache-coherence)
+  - [3.5 Per-page access gate (AdminSSChrome SEAM) — default-deny](#35-per-page-access-gate-adminsschrome-seam--default-deny)
+  - [3.6 `POST /capabilities` batch endpoint — deferred](#36-post-capabilities-batch-endpoint--deferred)
+  - [3.7 Connectors is the reference implementation](#37-connectors-is-the-reference-implementation--but-does-not-generalize-to-toolmcp)
+- [4. Frontend Design](#4-frontend-design)
+  - [4.1 The `<Can>` primitive (Layer 2)](#41-the-can-primitive-layer-2)
+  - [4.2 `useUser()` new shape](#42-useuser-new-shape)
+  - [4.3 Coarse consumption (Layer 1)](#43-coarse-consumption-layer-1)
+  - [4.4 Per-item consumption — collapse the duplication](#44-per-item-consumption--collapse-the-duplication)
+  - [4.5 Hand-written per-resource action unions (no codegen in v1)](#45-hand-written-per-resource-action-unions-no-codegen-in-v1)
+  - [4.6 Deletions](#46-deletions)
+- [5. Affordance → Action Mapping (complete)](#5-affordance--action-mapping-complete)
+  - [5.1 Agents / Personas — 18](#51-agents--personas--18-dto-map-editm-deleteoa-sharem-featurea-publishoa-lista-reordera-view_statso)
+  - [5.2 Actions / MCP — 9](#52-actions--mcp--9-mcp-mcpserver-editmo-deleteo-authenticateo-manage_statuso-openapi-toolsnapshot-editmo-deletea-togglea)
+  - [5.3 Skills — 8](#53-skills--8-customskillresponse-editm-deletea-manage_accessm-publisha)
+  - [5.4 Groups — 6](#54-groups--6-usergroup-managem-per-group-deletea-edit_permissionsa-edit_token_limitsa)
+  - [5.5 Doc sets — 3](#55-doc-sets--3-documentsetsummary-editm-deletea-manage_accessm-publisha)
+  - [5.6 Connectors (cc_pair) — 3](#56-connectors-cc_pair--3-the-good-domain-is_editable_for_current_user-already-ships--the-template)
+  - [5.7 Nav / page access — 2](#57-nav--page-access--2)
+- [6. Testing, Rollout & PR Roadmap](#6-testing-rollout--pr-roadmap)
+  - [6.1 Contract test — project == enforce](#61-contract-test--project--enforce-the-anti-drift-guarantee)
+  - [6.2 Security note — flags are affordance-only](#62-security-note--flags-are-affordance-only)
+  - [6.3 Cache hygiene (React Query)](#63-cache-hygiene-react-query--incl-cached-vs-live-manager-status-d8)
+  - [6.4 Rollout](#64-rollout)
+  - [6.5 PR roadmap](#65-pr-roadmap-5-review-sized-prs-drift-checkpoint-each)
+  - [6.6 Open decisions](#66-open-decisions)
+
+---
+
+## 1. Overview & Motivation
+
+Onyx's group-manager feature lets a non-admin manage resources *within the groups they manage*. The backend enforcement for this (PR1–PR5) is built, vetted, and fail-closed — it is the real security boundary. The **UI**, however, guesses at that boundary from a second, client-side re-derivation of policy that has already drifted out of agreement with the server. The result is not a security hole; it is an **affordance-correctness** problem: buttons that shouldn't render do, buttons that should render don't, and clicks that pass the client gate 403 at the server. A ground-truth inventory of every permission-gated affordance in the web app quantifies the drift.
+
+### 1.1 Evidence
+
+An 8-agent inventory audited 109 permission-gated UI affordances against the real backend predicate. **49 (45%) are mis-gated.**
+
+| Domain | Mis-gated | Total | Rate | Notes |
+|---|---:|---:|---:|---|
+| Agents / Personas | 18 | 23 | 78% | worst cluster; 4× `canUpdateFeaturedStatus` fork (below) |
+| Actions / MCP / OpenAPI | 9 | 19 | 47% | mixes owner-only + scoped + admin in one surface |
+| Skills | 8 | 11 | 73% | no per-item signal at all |
+| User Groups | 6 | 17 | 35% | missing per-group `manage` signal |
+| Document Sets | 3 | 9 | 33% | page double-fetches + set-diffs to fake editability |
+| Connectors (cc_pair) | 3 | 18 | 17% | **the good domain** — already ships `is_editable_for_current_user` |
+| Navigation | 2 | 12 | 17% | coarse-only |
+| **Total** | **49** | **109** | **45%** | |
+
+Connectors scoring best is the tell: it is the one domain that already stamps a server-computed per-item flag (`backend/onyx/server/documents/connector.py:1231`, `cc_pair.py:323`). Everywhere the client is left to *infer* the boundary, it gets ~half the affordances wrong.
+
+### 1.2 Three structural root causes
+
+```
+                     server truth (PDP: db/scoped_permissions.py)
+                              │
+          ┌───────────────────┴─── enforced correctly (GATE 2, PR1–5)
+          │
+   client RE-DERIVES it ──► drift ──► 49/109 wrong affordances
+```
+
+1. **The client re-derives policy.** `web/src/lib/permissions.ts:33` `visibilityPermissions()` blanket-injects all 6 `SCOPED_MANAGER_PERMISSIONS` into `useUser().permissions` with **zero group scoping** — a manager appears to hold `MANAGE_AGENTS` *everywhere*. This is a second, drifting source of truth for policy the server already owns.
+
+2. **The manual 3-tier gate is un-followable.** To gate one action a dev must choose between injected `permissions`, raw `effective_permissions`, or `isAdmin` — and choose right every time. `canUpdateFeaturedStatus` exists in **four** copies; **three read the wrong tier**:
+
+   | Copy | Reads | Verdict |
+   |---|---|---|
+   | `AgentRowActions.tsx:68` | `user.effective_permissions` | ✅ correct (managers excluded) |
+   | `AgentCard.tsx:57` | injected `permissions` | ❌ manager sees Feature |
+   | `ShareAgentModal.tsx:79` | injected `permissions` | ❌ |
+   | `AgentEditorPage.tsx:492` | injected `permissions` | ❌ |
+
+   Same feature, four sites, 3-of-4 wrong — because the tier choice is manual.
+
+3. **The per-item signal doesn't exist**, so ownership stands in for editability. `checkUserOwnsAgent` (`web/src/lib/agents/utils.ts:10`) gates edit/share/delete on `agent.owner?.id === userId`. It is wrong in **both** directions: managers/editors who *can* edit but don't own → affordance hidden; rows that are readable-not-editable → affordance shown → **403 on click**.
+
+### 1.3 Goals
+
+- Make every permission-gated affordance agree with what the server enforces — **project == enforce by construction**: one shared `can_<action>` helper is called by the write guard, the read projection, and the contract test, so the projected tag and the enforced decision are literally the same boolean (§2.3) — not two implementations kept in sync by discipline.
+- Collapse the 3-tier manual choice into two mechanical primitives: `useCapabilities([...])` (Layer 1) and `<Can resource action>` (Layer 2). No dev tier-picking.
+- Delete the client-side policy re-derivation (`visibilityPermissions`); make the client a pure renderer of server-computed fields.
+- Forward-compatible: server can add an action key to a resource's `permissions` map with **no client deploy** (fail-closed: missing key ⇒ `false`).
+
+### 1.4 Non-Goals
+
+- **Not changing what backend enforcement decides.** GATE 2 / the PR1–5 PEP remain the security boundary; every guard keeps its exact `OnyxErrorCode`, message, and trigger. A small **behavior-preserving** refactor *is* in scope — it lifts each guard's boolean decision into a shared `can_<action>` helper that the guard still calls before raising (§2.3), so the guards enforce identically. The **existing PR1–5 enforcement suite is the proof**: it must stay green with zero edits.
+- **Not a security fix.** Enforcement is already fail-closed; a mis-gated button that 403s is a UX bug, not an escalation. This work is affordance-correctness + maintainability only.
+- **The `can_<action>` helper is required, not deferred.** D1 promotes it from the old "optional `can()` facade" to a v1 core — but as an **internal server function**, not an HTTP endpoint. Only the *batched* `POST /capabilities` endpoint stays deferred (§3.6).
+
+### 1.5 Relation to PR1–6 & doc 06
+
+| PR | Scope | This doc |
+|---|---|---|
+| PR1–5 (`…perms-pr5-manager-assignment-membership`) | backend PDP + PEP, built & vetted | **untouched** — the source of truth we read from |
+| PR6-v1 (on origin) | first UI pass | **reverted**; left on origin as reference |
+| **PR6-v2** (`Subash-Mohan/perms-pr6-manager-ui-v2`, off PR5) | UI/read-projection redesign | **this doc**, ~4 review-sized PRs |
+
+Doc `06-frontend-affordance-followups.md` first named the 3-tier model and the `is_editable` gap for agents. This document **supersedes and generalizes it**: the per-item flag becomes a uniform `resource.permissions: dict[str,bool]` across *all* seven domains, each entry stamped by the guard's own extracted `can_<action>` helper (§2.3), with the 3-tier choice removed rather than documented.
+
+---
+
+## 2. Architecture (High-Level Design)
+
+The client stops deriving policy. The server emits two authoritative signals — a coarse capability set on `/me` and a per-item boolean map on every resource DTO — and the client becomes a pure renderer over them. The per-item map is stamped by a shared `can_<action>` helper that the **write guard also calls** (§2.3), and the coarse set by a server-side capability union — so neither can drift from what the backend enforces. (Backend mechanics are detailed in §3; client mechanics in §4.)
+
+### 2.1 Two-layer gate model
+
+Every affordance resolves to exactly one of two questions. Never a hand-rolled token bundle.
+
+```
+                 ┌──────────────────── SERVER (authoritative) ────────────────────┐
+   GET /me ─────▶│  admin_capabilities = effective_permissions                    │
+                 │                       ∪ (SCOPED_MANAGER_PERMISSIONS if manager) │
+   GET /list ───▶│  DTO.permissions = { edit, delete, share, feature, ... }       │
+   GET /detail ─▶│  (fail-closed boolean map, one per resource row)               │
+                 └───────────────┬───────────────────────────┬────────────────────┘
+                                 │                            │
+                    LAYER 1 — COARSE               LAYER 2 — PER-ITEM
+                 "can manage X somewhere"        "can I do A to THIS x"
+                 nav link · page reach · New X    row button · menu item · modal action
+                 useCapabilities(['agent:create'])  <Can resource={x} action="edit">
+                   reads admin_capabilities           reads x.permissions["edit"]
+```
+
+- **Layer 1 (coarse)** answers *reach*: does a nav link show, does a page SSR-load, does the global "New X" button exist. Capability check — but re-sourced from server-computed `admin_capabilities`, not client-derived tokens. Managers included.
+- **Layer 2 (per-item)** answers *authority on one resource*: read `resource.permissions[action]`. No token can express "…but only for this row"; the boolean map can. Missing key ⇒ `false`.
+
+`is_admin` (`FULL_ADMIN_PANEL_ACCESS`) is retained only for affordances that are genuinely full-admin-only (e.g. reorder agents).
+
+### 2.2 The three fields
+
+The fix is refusing to overload one field. Three fields, three audiences, one of which is new-per-DTO.
+
+| field | shape | who computes | consumed by | managers in it? |
+|---|---|---|---|---|
+| `effective_permissions` | `list[str]` (raw global tokens) | unchanged | backend middleware · org-wide gates (`isAdmin`, feature/publish/delete-global) | **No** — scoped manager power is deliberately absent |
+| `admin_capabilities` | `list[str]` on `/me` (**NEW**) | server: `effective_permissions ∪ (SCOPED_MANAGER_PERMISSIONS if is_group_manager)` | **Layer 1 only** — nav/page/New-X reach; replaces `visibilityPermissions()` | **Yes** |
+| `resource.permissions` | `dict[str,bool]` per DTO (**NEW**) | server: shared `can_<action>` helper, one per action (§2.3) | **Layer 2 only** — `<Can>` on that row | Per-item (a manager is `true` on in-scope rows, `false` elsewhere) |
+
+Why `effective_permissions` and `admin_capabilities` must stay distinct: the union that lets a manager *reach* the Agents page (Layer 1) is exactly the thing that must **not** grant org-wide "feature this agent." Today `visibilityPermissions()` (`web/src/lib/permissions.ts:33`) injects the union into a single `permissions` field consumed by both, forcing devs to remember which of three tiers to read at each call site — and pick wrong (`canUpdateFeaturedStatus` is now copied to **four** sites: `AgentCard.tsx:57`, `ShareAgentModal.tsx:79`, `AgentEditorPage.tsx:492`, `AgentRowActions.tsx:68`). Splitting the field removes the choice.
+
+### 2.3 Shared-helper invariant (one `can_*`, three callers)
+
+Today each tricky guard **decides and raises in one body**; a read projection would have to **re-derive the same decision** separately — two implementations of one policy, guaranteed to drift. The fix makes drift impossible **by construction**: lift the *boolean decision* out of each guard into a shared helper `can_<action>(user, resource, db) -> bool`, then have all three consumers call it.
+
+- **Guard (write, PEP — behavior unchanged):** `assert_<action>` now calls the helper, then raises its exact same `OnyxError` on `False`. Same code, same message, same trigger.
+- **Projection (read, NEW):** stamps `dto.permissions[action] = can_<action>(user, res, db)`.
+- **Contract test:** calls the *same* helper and asserts it equals "the guard did not raise."
+
+```
+              can_<action>(user, resource, db) -> bool      ◀── ONE decision, THREE callers
+                     │
+      ┌───────────────┼─────────────────────────┐
+  assert_<action>   projection stamp          contract test
+  calls helper,     dto.permissions[a] =      assert helper == (assert_ raised?)
+  then RAISES       can_<action>(u,R,db)      across the actor × resource × action matrix
+  (UNCHANGED)             │
+      │             <Can action="edit"> renders ⇔ helper true
+  403 if false
+```
+
+Because `assert_<action>` now *calls* `can_<action>`, "what the projection stamps" and "what the PEP enforces" are the **same boolean** — not a mirror that has to be kept faithful, but literally one function. The safety net proving enforcement is unchanged is the **existing PR1–5 enforcement suite**: it drives the `assert_*` guards and must stay green after the extraction. Green suite ⇒ the decision the PEP makes is provably identical; the only new thing is that the same decision is now also *readable*.
+
+This is a small, behavior-preserving refactor across ~6 guards — `auth/scoped_permissions.py:55` (`assert_within_scope`), `:92` (`assert_manages_group`); persona `db/persona.py:340` + EE `ee/onyx/db/persona.py:73`; tool `tool/api.py:84`; mcp `mcp/api.py:1376`. Two of the underlying gates are **already booleans** (`user_can_view_assistant_stats` `ee/onyx/db/analytics.py:339`, `agent_mediated_scope_allows` `auth/scoped_permissions.py:36`) — the projection just calls them. Full per-guard extraction (Tier-0 scope booleans + Tier-1 read wrappers, and the write-shaped→read-mode adaptation) is specified in §3.1a.
+
+> **Not "one filter per resource."** Each *action* bottoms out on its own real gate with its own shape — owner-bypass, creator-bypass, single-group membership, or a global token. The helper is `can_<action>`, not `can_touch_<resource>`; the editable filter `_add_user_filters(get_editable=True)` is a superset union that mis-stamps most actions if reused alone (over-reports scoped edits → 403; under-reports owner/creator affordances → their own button vanishes). See the per-action table in §3.3.
+
+The connectors domain is the working proof that a server-computed per-item flag is enough for the client: `is_editable` / `is_editable_for_current_user` already ship on the cc_pair DTOs (`server/documents/connector.py:1231`, `cc_pair.py:324-326`) — effectively `can_edit` for a cc_pair. D1 generalizes that one flag into a `permissions` map whose every entry is stamped by the guard's own extracted helper.
+
+### 2.4 Before / after (one affordance: "edit this agent" on a chat card)
+
+Root cause #3 in miniature — ownership standing in for editability, wrong in **both** directions (a scoped manager who can edit but doesn't own → hidden; a readable-not-editable row → shown → 403 on click):
+
+```tsx
+// BEFORE — web/src/lib/agents/utils.ts:10 used as an edit GATE
+{checkUserOwnsAgent(user, agent) && <EditAgentButton agent={agent} />}
+```
+```tsx
+// AFTER — server already answered; client only renders
+<Can resource={agent} action="edit">
+  <EditAgentButton agent={agent} />
+</Can>
+// renders ⇔ agent.permissions.edit === true ; unknown/missing key ⇒ false
+```
+
+Same collapse applies to all tiers — one primitive replaces the three-way choice:
+
+| old tier / signal | old call | new |
+|---|---|---|
+| coarse token | `hasPermission(permissions, MANAGE_AGENTS)` | `useCapabilities(['agent:create'])` (Layer 1) |
+| org-wide token | `hasPermission(effective_permissions, MANAGE_AGENTS)` | `<Can resource={agent} action="feature">` (server returns `false` for managers) |
+| ownership stand-in | `checkUserOwnsAgent(user, agent)` | `<Can resource={agent} action="edit">` |
+
+`checkUserOwnsAgent` survives only as a **label** ("Your Agents"), never as a gate.
+
+### 2.5 Why it stays scalable
+
+| change | cost |
+|---|---|
+| new action on a resource (e.g. `"archive"`) | one server edit — extract/write its `can_archive` helper and add `archive` to that DTO's stamp loop. Clients not yet aware of the key render nothing (fail-closed), so **no client deploy is required** to ship the backend safely. |
+| new resource | wrap its real gate(s) as `can_<action>` and stamp the map. No new policy — the guard already owns the decision. Cost varies by resource (see caveats below); it is **not** a uniform "copy the connectors filter." |
+| policy change (scope rule) | edit the shared helper — `within_scope` / `manages_group`, or the per-resource `can_<action>` — **once**. Guard, projection, and contract test move together, or CI fails. |
+| unknown/forward-compat keys | client `<Can>` treats missing key as `false`; old clients degrade safe, never over-expose. |
+
+**Cost is not uniform — three honest caveats (see §3.2/§3.3):**
+
+- **The hottest path stays untouched.** The chat/explore agent list is `MinimalPersonaSnapshot` fetched `get_editable=False` (`persona/api.py:501-517`) — do **not** stamp `edit`/`share`/`view_stats` onto it. Those per-card tags ride the per-card `GET /persona/{id}` (`FullPersonaSnapshot`) the card already fetches via `useAgent` (`AgentCard.tsx:64`) → **zero net-new query**. Never source them from the existing `user_permission`/`PersonaAccessLevel` field — it does **not** reflect scoped-manager edit rights (silent drift).
+- **Admin lists (low traffic)** preload the editable-id set once and stamp each row from memory (the connectors template); the managed-group set rides on the `ctx` dataclass so per-row stamping does **no** DB.
+- **Tools and MCP have no `get_editable` filter at all** — editability is agent-mediated per resource (`get_action_agent_scope` / `get_mcp_server_agent_scope`, one join each). The preload-once template does **not** transfer; stamp their `edit` tag via a batch resolver (`GROUP BY tool_id`/`server_id`, managed set hoisted once) or only on the detail/edit fetch — never row-by-row on the list.
+
+The failure mode of the current design — *N* affordances × 3 tiers × hand-copied gates drifting independently (49/109 mis-gated) — is structurally removed: there is nothing left to hand-pick.
+
+### 2.6 Industry grounding
+
+The capability-on-the-DTO shape is standard: GitHub returns a `permissions` object per repo and exposes `viewerCanUpdate` / `viewerCanDelete` on GraphQL nodes — the server decides, the client renders. Batch/advisory capability probes (Google IAM `testIamPermissions`, OpenFGA `BatchCheck`, the AuthZEN advisory endpoint) inform UI only and are **never** the enforcement path — matching our split: `resource.permissions` and `admin_capabilities` gate *rendering*; GATE 2 remains the sole security boundary.
+
+---
+
+## 3. Backend Design
+
+The write-side PEP already exists and is vetted (PR1–PR5) and is the security boundary — every mutating endpoint keeps its `require_permission(...)` dependency + its GATE-2 guard, byte-for-byte. What changes is *how the read projection agrees with it.* Rather than have the read side **re-derive** the same policy (a second implementation, guaranteed to drift), this redesign **extracts the boolean decision out of each guard into a shared helper** `can_<action>(user, resource, db) -> bool`. The guard keeps deciding-and-raising (it now calls the helper, then raises — behavior unchanged); the projection stamps the DTO tag by calling the **same** helper; the contract test calls the **same** helper. `project == enforce` becomes true **by construction**, not by discipline.
+
+This promotes the previously-"deferred" `can()` idea (old §1.4 non-goal, old §6.6 open-decision) to a **required, core part of v1** — but as an *internal server function*, not an HTTP endpoint. The `POST /capabilities` HTTP facade stays deferred (§3.6).
+
+### 3.1 One shared decision helper (PDP → PEP + projection + test)
+
+There is no single SQL predicate that decides every action. Each action bottoms out on its **own** real gate — some are scope clauses (`assert_within_scope`), some are single-group membership (`assert_manages_group`), some are agent-mediated (`agent_mediated_scope_allows`), some are owner/creator-or-admin (`user_can_view_assistant_stats`, `_ensure_mcp_server_owner_or_admin`). The invariant is therefore *not* "one predicate, two call sites" — it is **one shared helper per action, called by three consumers**:
+
+```
+                 can_<action>(user, resource, db) -> bool     ◀── ONE decision, THREE callers
+                       │
+     ┌──────────────────┼───────────────────────┐
+ assert_<action>   projection stamp        contract test
+ (calls helper,    dto.permissions[a] =    assert helper == (assert_ raised?)
+  then RAISES —    can_<action>(u,R,db)    over the 5×7 matrix
+  UNCHANGED)              │
+       │            <Can action="edit"> renders ⇔ helper true
+   403 if false
+```
+
+The **safety net** that proves security is unchanged is the *existing* PR1–5 enforcement suite: it drives the `assert_*` guards and must stay green with **zero edits** after the refactor. If it stays green, the decision the PEP makes is provably identical — the only new thing is that the same decision is now *also readable* by the projection. (This replaces the old "read filter is a faithful mirror of GATE 2" framing, which was hand-wavy and — per §3.3 — wrong for most actions: the editable filter alone mis-stamps ≥3 of every resource's actions.)
+
+### 3.1a D1 — One Shared Decision Helper (`can_*`), guard-by-guard
+
+Two-tier helper layout. Tier 0 = generic scope booleans in `auth/scoped_permissions.py`; Tier 1 = per-resource read wrappers that resolve current state, then call Tier 0.
+
+| Tier | Helper | File | Extracted from | Shape |
+|---|---|---|---|---|
+| **0 (generic scope booleans)** | `within_scope(...) -> bool` | `auth/scoped_permissions.py` | `assert_within_scope` (`:55`) | write-shaped (current/requested/non-public) |
+| | `manages_group(...) -> bool` | `auth/scoped_permissions.py` | `assert_manages_group` (`:92`) | single-group |
+| | `agent_mediated_scope_allows(...)` | `auth/scoped_permissions.py:36` | — **already a bool** | reuse as-is |
+| **1 (per-resource read wrappers)** | `can_edit_persona` / `can_share_persona` | `db/persona.py`, `ee/onyx/db/persona.py` | `_assert_persona_update_within_managed_scope` (`:340`), `_assert_group_share_within_scope` (ee `:73`) | resolve current state → call Tier-0 |
+| | `can_view_persona_stats` | `ee/onyx/db/analytics.py:339` | `user_can_view_assistant_stats` — **already a bool** | reuse as-is (O-class) |
+| | `can_edit_custom_tool` | `server/features/tool/api.py` | `_get_editable_custom_tool` (`:84`) + `_assert_action_within_managed_scope` (`:62`) | admin∨creator∨scoped |
+| | `can_edit_mcp_server` | `server/features/mcp/api.py` | `_ensure_mcp_server_editable` (`:1376`) | admin∨owner(email)∨scoped |
+| | `can_manage_group` | `auth/scoped_permissions.py` | thin over `manages_group` | single-group |
+
+Two guards need **no extraction** — they are already booleans (`agent_mediated_scope_allows` `:36`, `user_can_view_assistant_stats` `:339`); the projection just calls them. That is a bonus, not the norm.
+
+#### Tier 0 — generic scope booleans (`auth/scoped_permissions.py`)
+
+`assert_within_scope` (`:55-89`) → `within_scope` + thin raiser. The current guard fuses decide + raise:
+
+```python
+def assert_within_scope(user, db_session, *, permission, current_group_ids,
+                        requested_group_ids, is_non_public) -> None:
+    authority = has_permission(user, permission)
+    if authority is PermissionAuthority.GLOBAL:
+        return
+    if authority is PermissionAuthority.SCOPED:
+        managed = get_scoped_groups(user, db_session, permission)
+        final = set(current_group_ids) | set(requested_group_ids)
+        if managed and final and final.issubset(managed) and is_non_public:
+            return
+    raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS, "Group managers can only ...")
+```
+
+Refactored — the decision is extracted; the raise is unchanged:
+
+```python
+def within_scope(user, db_session, *, permission, current_group_ids,
+                 requested_group_ids, is_non_public,
+                 managed_group_ids: set[int] | None = None) -> bool:
+    """Pure GATE-2 decision. No raise. Called by assert_within_scope (write),
+    the per-row read wrappers (projection), and the contract test.
+    `managed_group_ids` lets a list caller pass a preloaded managed set so
+    per-row stamping issues no DB query (§3.2); None re-queries (single-item/test)."""
+    authority = has_permission(user, permission)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        managed = (managed_group_ids if managed_group_ids is not None
+                   else get_scoped_groups(user, db_session, permission))
+        final = set(current_group_ids) | set(requested_group_ids)
+        return bool(managed and final and final.issubset(managed) and is_non_public)
+    return False
+
+def assert_within_scope(user, db_session, *, permission, current_group_ids,
+                        requested_group_ids, is_non_public) -> None:
+    if not within_scope(user, db_session, permission=permission,
+                        current_group_ids=current_group_ids,
+                        requested_group_ids=requested_group_ids,
+                        is_non_public=is_non_public):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        "Group managers can only act on private resources "
+                        "within the groups they manage.")
+```
+
+Same message, same trigger — the PR1–5 suite is unaffected.
+
+`assert_manages_group` (`:92-104`) → `manages_group` + thin raiser:
+
+```python
+def manages_group(user, db_session, *, group_id,
+                  managed_group_ids: set[int] | None = None) -> bool:
+    if has_global_permission(user, Permission.MANAGE_USER_GROUPS):
+        return True
+    managed = (managed_group_ids if managed_group_ids is not None
+               else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS))
+    return group_id in managed
+
+def assert_manages_group(user, db_session, *, group_id) -> None:
+    if not manages_group(user, db_session, group_id=group_id):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        "Group managers can only act within the groups they manage.")
+```
+
+#### The write-shaped → read-mode adaptation (the crux of D1)
+
+`within_scope` is **write-shaped**: it evaluates a *proposed mutation* (`current_group_ids`, `requested_group_ids`, `is_non_public`). A projection asks a different question — *"can this user edit R **as it stands right now**?"* — there is no proposed change. The per-resource read wrapper (Tier 1) is where that adaptation lives: it re-reads R's **current** state and passes **`requested := current`** and **`is_non_public := not R.is_public`**:
+
+```
+WRITE guard  →  within_scope(current=DB groups, requested=REQUEST.groups, non_public=proposed)
+READ wrapper →  within_scope(current=DB groups, requested=DB groups,      non_public=R state)
+                                                 └── same value ──┘
+```
+
+Because both bottom out on `within_scope`, `can_edit_persona(u,R,db)` and "`assert_within_scope` would not raise for R's current state" are the **same boolean by construction** — the contract test only pins the read-mode arg-supply, not the policy.
+
+#### Tier 1 — per-resource read wrappers
+
+**Persona edit / share** (`db/persona.py:340`, `ee/onyx/db/persona.py:73`). Per §3.3 (D2): the projection is **read-editable AND managed-scope** — never `_add_user_filters(get_editable=True)` alone (superset union → over-reports → 403). Extract the scope-boolean from each guard, then compose with editable-membership.
+
+`_assert_persona_update_within_managed_scope` (`:340`) short-circuits non-SCOPED holders and personal (no-group) agents, resolves current groups/privacy in-txn, then delegates the raise to `assert_within_scope`. Extract its body to a bool:
+
+```python
+# db/persona.py
+def persona_update_within_scope(user, db_session, *, persona_id,
+                                requested_group_ids, requested_is_public,
+                                managed_group_ids: set[int] | None = None) -> bool:
+    if has_permission(user, Permission.MANAGE_AGENTS) is not PermissionAuthority.SCOPED:
+        return True                              # not governed by the managed-scope gate
+    current_group_ids, current_is_public = _read_persona_scope(persona_id, db_session)
+    if not current_group_ids and not requested_group_ids:
+        return True                              # personal (no-group) agent
+    return within_scope(user, db_session, permission=Permission.MANAGE_AGENTS,
+                        current_group_ids=current_group_ids,
+                        requested_group_ids=requested_group_ids,
+                        is_non_public=not current_is_public and not requested_is_public,
+                        managed_group_ids=managed_group_ids)
+
+def _assert_persona_update_within_managed_scope(persona_id, request, user, db_session) -> None:
+    # keep the exact `requested_* := request.* if not None else current` resolution
+    # the guard already does (db/persona.py:363-368); abbreviated here.
+    if not persona_update_within_scope(user, db_session, persona_id=persona_id,
+                                       requested_group_ids=_resolved_groups(request, ...),
+                                       requested_is_public=_resolved_public(request, ...)):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS, "Group managers can only ...")
+```
+
+Read wrapper (projection + contract test call this):
+
+```python
+def can_edit_persona(user, persona: Persona, db_session, *,
+                     editable_ids: set[int], managed_group_ids: set[int] | None = None) -> bool:
+    return persona.id in editable_ids and persona_update_within_scope(   # AND, per §3.3
+        user, db_session, persona_id=persona.id,
+        requested_group_ids=[g.id for g in persona.groups],   # requested := current
+        requested_is_public=persona.is_public,
+        managed_group_ids=managed_group_ids,
+    )
+```
+
+`editable_ids` comes from the existing `_add_user_filters(get_editable=True)` (`db/persona.py:82`), preloaded once per list (§3.2). The **AND** is what keeps a non-manager member out (scope-guard `True` for non-SCOPED, but editable-membership `False`) and keeps an out-of-scope manager out (editable may be `True`, scope-guard `False`).
+
+**Share** has the same shape over `_assert_group_share_within_scope` (ee `:73`, called `:161`, body ends in `assert_within_scope` at ee `:104`): extract `persona_group_share_within_scope(...) -> bool`, then `can_share_persona = editable-membership AND persona_group_share_within_scope(read-mode: requested := current groups, original_is_public := persona.is_public)`.
+
+**Persona view_stats — reclassify M → O (already a bool).** Per §3.3, the real gate is **not** the editable filter — it is `user_can_view_assistant_stats` (`ee/onyx/db/analytics.py:339`), which returns `owner OR FULL_ADMIN`. No extraction:
+
+```python
+def can_view_persona_stats(user, persona, db_session) -> bool:
+    return user_can_view_assistant_stats(db_session, user, persona.id)   # O-class
+```
+
+**Custom tool edit — reclassify M → admin ∨ creator ∨ scoped** (`tool/api.py:84`). Stamping only the scoped term hides Edit from a plain **creator** on their own action (`tool.user_id == user.id`, `:100`). `_assert_action_within_managed_scope` (`:62`) just wraps `agent_mediated_scope_allows` — extract its bool, then extract the full disjunction:
+
+```python
+def _action_within_managed_scope(tool_id, db_session, user) -> bool:
+    group_ids, has_public, has_ungrouped = get_action_agent_scope(tool_id, db_session)   # db/tools.py:141
+    return agent_mediated_scope_allows(user, db_session, group_ids=group_ids,
+                                       has_public_agent=has_public,
+                                       has_ungrouped_private_agent=has_ungrouped)
+
+def can_edit_custom_tool(user, tool: Tool, db_session) -> bool:
+    if tool.in_code_tool_id is not None:
+        return False                                                   # built-in
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True                                                    # admin
+    if tool.user_id is not None and tool.user_id == user.id:
+        return True                                                    # creator bypass (:100)
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
+        return _action_within_managed_scope(tool.id, db_session, user) # scoped
+    return False
+```
+
+`_get_editable_custom_tool` keeps its **404** (missing) and **400** (built-in) `HTTPException` raises for precise messaging, then delegates the perms decision to `can_edit_custom_tool` (raising `INSUFFICIENT_PERMISSIONS`, "You can only modify actions that you created."). `ToolSnapshot` already ships `user_id`, so the projection has the creator datum.
+
+**MCP server edit — reclassify M → admin ∨ owner(email) ∨ scoped** (`mcp/api.py:1376`). MCP ownership is **by email** (`server.owner == user.email`, `:1386`); the DTO ships `owner: str`. Stamping only the scoped term hides Edit from the owner:
+
+```python
+def can_edit_mcp_server(user, server: DbMCPServer, db_session) -> bool:
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True                                    # admin
+    if server.owner == user.email:
+        return True                                    # owner-by-EMAIL (:1386)
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
+        group_ids, has_public, has_ungrouped = get_mcp_server_agent_scope(server.id, db_session)  # db/tools.py:153
+        return agent_mediated_scope_allows(user, db_session, group_ids=group_ids,
+                                           has_public_agent=has_public,
+                                           has_ungrouped_private_agent=has_ungrouped)
+    return False
+
+def _ensure_mcp_server_editable(server, user, db_session) -> None:
+    if not can_edit_mcp_server(user, server, db_session):
+        raise OnyxError(OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                        "Only the server owner or a manager of its groups can modify this MCP server.")
+```
+
+MCP `delete`/`authenticate`/`manage_status` stay **O** via `_ensure_mcp_server_owner_or_admin` (`:1358`) — extract a sibling `can_admin_mcp_server` the same way if those tags are stamped.
+
+**User group manage — distinct single-group shape** (`user_group`):
+
+```python
+def can_manage_group(user, group: UserGroup, db_session, *,
+                     managed_group_ids: set[int] | None = None) -> bool:
+    return manages_group(user, db_session, group_id=group.id,
+                         managed_group_ids=managed_group_ids)   # Tier-0
+```
+
+`assert_manages_group` (`:92`, called at `ee/.../user_group/api.py:191,333`, `ee/.../db/user_group.py:545`) already wraps `manages_group` after the extraction above. The `manager_ids` on the group snapshot is **not** the gate — the gate is managed-set membership OR global `MANAGE_USER_GROUPS`.
+
+#### Guard-by-guard summary
+
+| Guard (file:line) | Current shape | Extracted bool | `assert_*` after | Read wrapper (projection) |
+|---|---|---|---|---|
+| `assert_within_scope` (`auth/scoped_permissions.py:55`) | decide+raise | `within_scope` | calls bool, raises | (used by persona wrappers) |
+| `assert_manages_group` (`:92`) | decide+raise | `manages_group` | calls bool, raises | `can_manage_group` |
+| `_assert_persona_update_within_managed_scope` (`db/persona.py:340`) | resolve+delegate-raise | `persona_update_within_scope` | calls bool, raises | `can_edit_persona` = editable ∧ bool |
+| `_assert_group_share_within_scope` (`ee/…/persona.py:73`) | resolve+delegate-raise | `persona_group_share_within_scope` | calls bool, raises | `can_share_persona` = editable ∧ bool |
+| `_get_editable_custom_tool` + `_assert_action_within_managed_scope` (`tool/api.py:84,62`) | fetch+decide+raise | `can_edit_custom_tool`, `_action_within_managed_scope` | keep 404/400 raises, delegate perms | `can_edit_custom_tool` |
+| `_ensure_mcp_server_editable` (`mcp/api.py:1376`) | decide+raise | `can_edit_mcp_server` | calls bool, raises | `can_edit_mcp_server` |
+| `user_can_view_assistant_stats` (`ee/…/analytics.py:339`) | **already bool** | — | (its own callers) | `can_view_persona_stats` |
+| `agent_mediated_scope_allows` (`auth/scoped_permissions.py:36`) | **already bool** | — | — | (composed by tool/mcp wrappers) |
+
+#### Behavior-preservation invariant (for the reviewer)
+
+- Every `assert_*` keeps its **exact `OnyxErrorCode` + message**; the extraction only relocates the boolean, so the **existing PR1–5 enforcement suite is the proof security is unchanged** — it must stay green with zero edits.
+- If a contract-test cell fails, the bug is in the **read wrapper's composition** (forgot the `editable ∧` for persona; stamped only the scoped term for tool/mcp) — **never** a reason to relax a guard.
+- Fail-closed by shape: every helper's terminal branch returns `False`; unknown authority, empty managed scope, and missing resource state all deny.
+
+### 3.2 Read-side projection: `permissions_for` + ctx (no N+1)
+
+New module `backend/onyx/auth/permission_projection.py`. The projection **never re-derives policy** — it calls the §3.1 `can_<action>` helpers. To keep list paths off the N+1 path, the caller preloads a small `ctx` **once** and threads it through every per-row helper call so per-row stamping issues **no** DB query.
+
+```python
+# auth/permission_projection.py
+@dataclass
+class ScopeCtx:
+    is_admin: bool                    # has_global_permission(user, <resource perm>)
+    editable_ids: set[int]            # 1 scoped query; resources that HAVE _add_user_filters(get_editable=True)
+    managed_group_ids: set[int]       # 1 query: fetch_managed_group_ids(user, db)  ── D3: passed into helpers
+                                      #          so within_scope/manages_group do NOT re-query per row
+
+def build_persona_ctx(user, db_session) -> ScopeCtx:
+    return ScopeCtx(
+        is_admin=has_global_permission(user, Permission.MANAGE_AGENTS),
+        editable_ids=fetch_editable_persona_ids(user, db_session),   # wraps db/persona.py:82
+        managed_group_ids=fetch_managed_group_ids(user, db_session), # db/scoped_permissions.py:34
+    )
+
+def persona_permissions(user, persona, ctx: ScopeCtx) -> dict[str, bool]:
+    return {
+        "edit":       can_edit_persona(user, persona, db=None,        # pure: reads ctx, no DB
+                                       editable_ids=ctx.editable_ids,
+                                       managed_group_ids=ctx.managed_group_ids),
+        "share":      can_share_persona(user, persona, db=None,
+                                        editable_ids=ctx.editable_ids,
+                                        managed_group_ids=ctx.managed_group_ids),
+        "view_stats": ctx.is_admin or persona.user_id == user.id,    # O-class (analytics.py:339 shape)
+        "delete":     ctx.is_admin or _owner_or_owner_group(persona, ctx),  # O|A, §3.3
+        "feature":    ctx.is_admin,   # A
+        "list":       ctx.is_admin,   # A
+        "publish":    ctx.is_admin or _owner_or_owner_group(persona, ctx),  # O|A
+        "reorder":    ctx.is_admin,   # A (FULL_ADMIN)
+    }
+```
+
+> **Adding `managed_group_ids` to the ctx (D3) is the whole point:** without it, each row's `within_scope`/`manages_group` re-runs `get_scoped_groups` → `fetch_managed_group_ids` (one query per row = N+1). With it preloaded, per-row stamping is pure set math. `db=None` is legal in the read wrappers precisely because `managed_group_ids` short-circuits the only DB call `within_scope` makes.
+
+**Where each map is stamped — hot-path honesty (D3).** *Not all lists should carry the map.*
+
+| Surface | Stamp the map? | Why |
+|---|---|---|
+| **Chat/explore agent list** — `list_personas` (`persona/api.py:501-517`, `MinimalPersonaSnapshot`, `get_editable=False`) | **NO** | Hottest read path in the app. Do **not** stamp `edit`/`share`/`view_stats` here. |
+| **Agent card** — `get_persona` (`persona/api.py:568`, `FullPersonaSnapshot`) | **YES** | `AgentCard` already fetches this per card via `useAgent` (`AgentCard.tsx:64`) → **zero net-new query**; stamp the per-card tags here. |
+| **Admin agent list** — `list_personas_admin` (`persona/api.py:215`, low traffic) | **YES** | Preload `ctx` once, stamp each row from memory (connectors template, §3.7). |
+
+**Never** source per-card tags from the existing `FullPersonaSnapshot.user_permission` / `PersonaAccessLevel`: `get_persona_access_level` (`db/persona_sharing.py:40`) is documented (`:48`) as feeding "the sharing UI, not the editable fetch" — it does **not** reflect scoped-manager edit rights, so reusing it silently drifts. Stamp from the `can_*` helper, always.
+
+**Tools & MCP have no editable filter — the connectors template does NOT copy to them (D3).** There is no `_add_user_filters(get_editable=True)` for tools or MCP servers; editability is **agent-mediated per resource** (`get_action_agent_scope` / `get_mcp_server_agent_scope`, one join each). So `ctx.editable_ids` doesn't exist for them, and "preload-once, stamp from memory" does not apply. Two acceptable strategies — pick per surface:
+
+```
+TOOL / MCP list  ── choose one ──
+  (a) BATCH RESOLVER: one GROUP BY tool_id / server_id join resolving all
+      rows' agent-scope up front; hoist managed_group_ids once → stamp from memory.
+  (b) DETAIL-ONLY (v1 lean): do NOT stamp `edit` on the list; stamp it only on
+      the detail/edit fetch (single resource → one join, no N+1).
+```
+
+v1 leans **(b)** for tool/MCP lists (edit is a per-card affordance the detail fetch already loads); add the batch resolver only when a list surface must show the edit tag at scale.
+
+**List path (resources that DO have an editable filter):**
+
+```python
+ctx = build_persona_ctx(user, db_session)          # editable set + managed set resolved ONCE
+for dto in rows:
+    dto.permissions = persona_permissions(user, dto, ctx)   # pure, no DB → no N+1
+```
+
+The DTO field is **required** (D4/§3.3): `permissions: dict[str, bool]`, never optional — a stamp site that forgets to fill it is a type error, not a silently-empty map. Individual *action keys* remain fail-closed (a key absent from the dict ⇒ `false` on the client), which is what preserves forward-compat.
+
+### 3.3 Per-action predicate table — each action's tag comes from ITS OWN real gate
+
+The old "one filter per resource" was wrong: within a single resource, different actions bottom out on **different gate functions with different shapes**. This is an **action-level** table (action → real gate fn → scope class), verified against `HEAD`.
+
+**Scope legend:** `M` = scoped-manager true iff in-scope (admin also true) · `A` = global/admin token only (managers → false) · `O` = owner/creator-or-admin (managers → false unless they own it) · **`M|O`** = scoped **OR** owner/creator **OR** admin (owner-bypass) · **`O|A`** = owner-or-global (owner bypass, but **not** the scoped-manager path).
+
+| Resource | Action | Real gate (fn + file:line) | Scope | Notes |
+|---|---|---|---|---|
+| **Persona** | edit | `_assert_persona_update_within_managed_scope` → `assert_within_scope` `db/persona.py:340` (route `persona/api.py:336`, `ADD_AGENTS` allow_scope) **AND** read-editable `_add_user_filters(get_editable=True)` `db/persona.py:82` | M | Both gates; NOT `get_editable` alone (superset union → over-reports → 403) |
+| | share | `_assert_group_share_within_scope` → `assert_within_scope` **EE** `ee/onyx/db/persona.py:73` (called `:161`; route `persona/api.py:443`) **AND** read-editable | M | EE-only; `_assert_persona_update…` doesn't fire on a groups-unchanged share |
+| | **view_stats** | `user_can_view_assistant_stats` `ee/onyx/db/analytics.py:339` (route `ee/…/analytics/api.py:220`) | **O** | **M→O**: `FULL_ADMIN OR persona.user_id==user.id`. NOT the editable filter |
+| | **delete** | `get_persona_by_id(is_for_edit=True)` `db/persona.py:1426` via `mark_persona_as_deleted` (route `persona/api.py:487`, `ADD_AGENTS` **no** allow_scope) | **O\|A** | `global MANAGE_AGENTS OR owner(user_id) OR owner-group member` — excludes scoped-manager rels, so ≠ edit's `M` |
+| | feature | route `persona/api.py:177` `MANAGE_AGENTS` **no** allow_scope | A | global token |
+| | list (listed) | route `persona/api.py:143` `MANAGE_AGENTS` **no** allow_scope | A | global token |
+| | **publish** (is_public) | `update_persona_public_status` `db/persona.py:560` (route `persona/api.py:158`, `ADD_AGENTS` no allow_scope) | **O\|A** | `global MANAGE_AGENTS OR owner OR owner-group member` — a plain owner CAN org-publish their own agent; not pure A |
+| | reorder | route `persona/api.py:196` `FULL_ADMIN_PANEL_ACCESS` | A | FULL_ADMIN |
+| **DocumentSet** | edit / manage_access | `assert_within_scope` `document_set/api.py:91` (route `:76`, `MANAGE_DOCUMENT_SETS` allow_scope) + read-editable `db/document_set.py:42` | M | |
+| | delete | route `document_set/api.py:123` `MANAGE_DOCUMENT_SETS` **no** allow_scope | A | global token |
+| | publish (make-public) | create/update `is_public` → `assert_within_scope(is_non_public=…)` blocks scoped → global | A | scoped mgr can't publish org-wide |
+| **Skill** | edit | `assert_within_scope` `skill/api.py:258,:304` (routes `:233` patch, `:287` bundle, `MANAGE_SKILLS` allow_scope) | M | **No `get_editable` filter exists** — scope via managed-groups ∩ skill grants |
+| | manage_access (grants) | `assert_within_scope` `skill/api.py:355` (route `:339` `PUT …/grants`) | M | |
+| | delete | route `skill/api.py:378` `FULL_ADMIN_PANEL_ACCESS` | A | FULL_ADMIN |
+| | publish (is_public) | create/patch `is_public` → `assert_within_scope(is_non_public)` blocks scoped → global `MANAGE_SKILLS` | A | |
+| **MCP server** | **edit** | `_ensure_mcp_server_editable` `mcp/api.py:1376` | **M\|O** | `FULL_ADMIN OR server.owner==user.email OR scoped(agent-mediated)`. Owner by **EMAIL**; DTO ships `owner:str` |
+| | delete / authenticate / manage_status | `_ensure_mcp_server_owner_or_admin` `mcp/api.py:1358` | **O** | `FULL_ADMIN OR owner==email` |
+| **OpenAPI action** (Tool) | **edit** | `_get_editable_custom_tool` `tool/api.py:84` (route `:140`, `MANAGE_ACTIONS` allow_scope) | **M\|O** | `FULL_ADMIN OR tool.user_id==user.id (creator) OR scoped(_assert_action_within_managed_scope:62)` |
+| | delete | route `tool/api.py:167` `MANAGE_ACTIONS` **no** allow_scope | A | global route; creator bypass unreachable → A |
+| | toggle (status) | route `tool/api.py:194` `MANAGE_ACTIONS` **no** allow_scope | A | global token |
+| **UserGroup** | **manage** (per-group) | `assert_manages_group` `auth/scoped_permissions.py:92` (patch `:216`→`ee/…/user_group.py:545`, add-users `:239`, rename `:191`, agents `:282`, set-manager `:333`) | **M** (per-group) | `group_id ∈ managed set OR global MANAGE_USER_GROUPS` — single-group, NOT the editable filter |
+| | delete | route `user_group/api.py:262` `MANAGE_USER_GROUPS` **no** allow_scope | A | global token |
+| | edit_permissions | route `user_group/api.py:133` `PUT …/permissions` `FULL_ADMIN` | A | FULL_ADMIN |
+| | edit_token_limits | POST create `assert_within_scope` `token_rate_limits/api.py:74` (allow_scope) = M; per-row PUT/DELETE + `GET /user-groups` `FULL_ADMIN` `:32,:101` = A | M (create) / A (PUT/DELETE) | Split gate |
+| **Connector** (cc_pair) — TEMPLATE | edit / delete / manage_access | `get_connector_credential_pair_from_id_for_user(get_editable=True)` → `is_editable_for_current_user` `cc_pair.py:324-326`; list `is_editable` `connector.py:1231,1443` | M | Already ships the per-item flag |
+| | publish (make-public) | access-controls → global `MANAGE_CONNECTORS` | A | |
+
+**Why "one filter per resource" was wrong (3 lines):**
+1. Within one resource, actions bottom out on **different gate fns with different shapes** — persona alone spans `edit`=editable-filter+scoped-clause (M), `view_stats`=owner-or-admin (O), `feature/list`=global-token (A), `delete/publish`=owner-or-global (O|A). No single filter reproduces all four → a per-resource filter mis-stamps ≥3 of them.
+2. `_add_user_filters(get_editable=True)` is a **superset union** that **over-reports** for scoped actions (shows `edit` where the scoped-clause `+ is_non_public` gate would 403) *and* **under-reports** for owner/creator actions (tool/mcp/persona owners bypass the scoped path by `user_id`/`email` — stamping only the scoped term hides their own button).
+3. Three resources (skill, tool, mcp) have **no `get_editable` filter at all** — editability is `assert_within_scope` (skill) or agent-mediated joins (tool/mcp) — so "reuse the resource's editable filter" doesn't even exist for them.
+
+**Stamp sites (serializers).** Add the **required** `permissions: dict[str, bool]` and stamp via §3.2: `FullPersonaSnapshot.from_model` (per-card `GET /persona/{id}`, **not** the `MinimalPersonaSnapshot` list) · `DocumentSetSummary` · `CustomSkillResponse` · `MCPServer`/`ToolSnapshot` builders (detail/edit fetch, or batch-resolver list) · the EE `UserGroup` snapshot · connectors' `_get_connector_indexing_status_lite` (generalize its lone `is_editable` into the map; keep `is_editable` until the client cuts over).
+
+**Backend coverage test (D4) — closes the "add action, forget to register" hole.** A companion to §3.1's contract test: enumerate every mutating scoped route (`require_permission(..., allow_scope=True)` or a body-level `assert_*` guard) and assert each maps to a stamped action key that is present in the hand-written per-resource action list. A new guarded route with no stamped key fails CI, so the projection can't silently lose an affordance.
+
+```py
+# backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+CAN = {("persona","edit"): can_edit_persona, ("persona","share"): can_share_persona,
+       ("persona","view_stats"): can_view_persona_stats, ("tool","edit"): can_edit_custom_tool,
+       ("mcp_server","edit"): can_edit_mcp_server, ("user_group","manage"): can_manage_group, ...}
+
+def test_helper_matches_guard(db_session, actor, resource_kind, action):
+    u, r = make_actor(actor), make_resource(resource_kind)
+    helper_says = CAN[(resource_kind, action)](u, r, db_session)   # projection's boolean
+    raised = guard_raised(resource_kind, action, u, r, db_session) # drive the assert_* guard
+    assert helper_says == (not raised)                             # project == enforce
+
+def test_every_scoped_route_has_a_stamped_key():
+    for route in mutating_scoped_routes():                         # allow_scope / assert_* sites
+        assert route.action_key in HANDWRITTEN_ACTIONS[route.resource]   # no orphan gate
+```
+
+Because `assert_*` now *calls* the helper, `test_helper_matches_guard` is **structural**, not coincidental — a future edit to `within_scope`/`manages_group` moves both sides together or fails CI.
+
+### 3.4 `/me.admin_capabilities` — server-computed Layer-1 set (+ cache coherence)
+
+New field on `UserInfo` (`backend/onyx/server/manage/models.py:131`), derived, never persisted, never consulted by the PEP. `effective_permissions` stays **global-only, unchanged**. `admin_capabilities` is **query-free** — `is_group_manager` is a column and the bundle is a constant:
+
+```python
+# UserInfo.from_model — no DB
+caps = set(effective_permissions or [])
+if user.is_group_manager:                        # cached column
+    caps |= SCOPED_MANAGER_PERMISSIONS_EXPANDED  # auth/permissions.py:263 (implied-expanded)
+admin_capabilities = sorted(caps)
+```
+
+**Cached `is_group_manager` vs live scope — the coherence hazard (D8).** Layer-1 (`admin_capabilities`) reads the **cached** `is_group_manager` bool; Layer-2 (`resource.permissions`) and the PEP resolve **live** scope (`fetch_managed_group_ids`). If the cache drifts *stale-true* — the user was demoted but `is_group_manager` is still `true` — the nav link and page show, but **every** per-item helper resolves `false` (dead buttons). If it drifts *stale-false*, the manager can't even reach the page. Both are avoidable only by recompute-on-change:
+
+> **Requirement:** every mutation that changes a user's manager status MUST `recompute_user_permissions(user)` **and** bust the `['me']` query — **including external group-sync** (a user gains/loses a managed group via IdP/SCIM sync), not just the manual Make/Revoke-Manager toggle. §6.3 currently lists only the manual toggle; the sync path is the one that silently drifts. Document the staleness window: between a sync-driven status change and the next `['me']` refetch, Layer-1 nav can disagree with Layer-2 per-item — the PEP stays correct throughout (it never reads the cache), so the worst case is cosmetic (a shown-but-dead or hidden-but-reachable page), never an escalation.
+
+### 3.5 Per-page access gate (AdminSSChrome SEAM) — default-deny
+
+Today `AdminSSChrome.tsx` calls only `requireAdminAuth()` — coarse "has *some* admin permission" admission (`requireAuth.ts:108`). There is **no per-page check**, so a manager can SSR-load a `FULL_ADMIN_PANEL_ACCESS` page. The naïve fix (look up `ADMIN_ROUTES[path]`, redirect if `requiredPermission ∉ admin_capabilities`) **fails OPEN**: any `/admin/*` path *not in* `ADMIN_ROUTES` (`systeminfo`, `groups2`, `federated/[id]`) matches nothing and admits everyone. The gate must **default-deny**:
+
+```
+match = ADMIN_ROUTES[path]                       (admin-routes.ts:92; entry.requiredPermission single Permission, :86)
+if match is None:                                # UNMATCHED /admin/* — DEFAULT DENY
+    required = FULL_ADMIN_PANEL_ACCESS           # managers redirected off unknown admin pages
+else:
+    required = match.requiredPermission
+if required ∉ me.admin_capabilities → redirect(getFirstPermittedAdminRoute(caps))
+```
+
+Because a manager's bundle never contains `FULL_ADMIN_PANEL_ACCESS`, unknown pages and full-admin pages both redirect managers; manager-reachable pages (`MANAGE_CONNECTORS`, `MANAGE_AGENTS`, …) pass. **Enumerate the currently-missing pages in `ADMIN_ROUTES`** with their real `requiredPermission` so they gate precisely rather than via the default-deny fallback:
+
+| Route | requiredPermission |
+|---|---|
+| `/admin/systeminfo` | `FULL_ADMIN_PANEL_ACCESS` |
+| `/admin/groups2` | `MANAGE_USER_GROUPS` (or `FULL_ADMIN` if it's the settings variant) |
+| `/admin/federated`, `/admin/federated/[id]` | `FULL_ADMIN_PANEL_ACCESS` (federated has no scope model — see §5.6 / D6) |
+
+This SSR gate is **defense-in-depth / least-astonishment, not the security boundary** — the boundary remains each endpoint's `require_permission(...)` + its GATE-2 guard. A manager who somehow reaches a full-admin page still 403s on every mutating call; the gate exists so the client never renders a page whose every action would 403. `requireAdminAuth` is re-sourced from `admin_capabilities` (drop `visibilityPermissions`).
+
+### 3.6 `POST /capabilities` batch endpoint — deferred
+
+For "orphaned" global affordances (a global *New X* button whose token isn't cleanly a single `admin_capabilities` membership, or future batched per-item checks). `testIamPermissions`-shaped, advisory only — **never** an enforcement path:
+
+```
+POST /capabilities  { "permissions": ["connector:create", "agent:feature", ...] }
+  -> { "permissions": ["connector:create"] }        # allowed subset (fail-closed on omission)
+```
+
+**v1 does not need this** — `useCapabilities(['connector:create'])` reads `admin_capabilities` directly. Kept as a deferred appendix; add only when a global affordance can't be expressed as bundle membership. (Note the distinction from §3.1a's `can_*`: those are *required* internal server functions consumed by the projection; this HTTP facade is the *optional* client-facing batch probe.)
+
+### 3.7 Connectors is the reference implementation — but does NOT generalize to tool/MCP
+
+The connectors domain already does the batch pattern: preload the editable set once (`get_connector_credential_pairs_for_user(..., get_editable=True)`), split editable/non-editable, stamp `is_editable` per row (`build_connector_indexing_status(cc_pair, is_editable)`, `connector.py:1229`; detail `is_editable_for_current_user`, `cc_pair.py:326`). This PR generalizes that single boolean into the `permissions` map and copies **preload-once / stamp-each-row** to the resources that **have an editable filter**: persona (admin list), document set, skill, user group.
+
+**It does NOT copy to tools and MCP servers.** Neither has `_add_user_filters(get_editable=True)`; editability is agent-mediated per resource (`get_action_agent_scope` / `get_mcp_server_agent_scope`, `db/tools.py:141,153` — one join each). Copying "preload once" there is impossible; a naïve per-row stamp is N+1. Follow §3.2's D3 fix instead: **batch resolver** (`GROUP BY tool_id`/`server_id`, hoist `managed_group_ids` once) **or** stamp `edit` **only on the detail/edit fetch** (v1 lean). No new policy is written — only the missing per-item signal is surfaced, sourced from the §3.1a helper.
+
+---
+
+_Verified paths (HEAD):_ `backend/onyx/auth/scoped_permissions.py:36,55,92` · `backend/onyx/db/scoped_permissions.py:25,34,39` · `backend/onyx/db/persona.py:82,340,560,1426` · `backend/onyx/db/persona_sharing.py:40,48` · `backend/ee/onyx/db/persona.py:73,104,161` · `backend/onyx/server/features/persona/api.py:143,158,177,196,215,336,443,487,501,568` · `backend/onyx/server/features/tool/api.py:62,84,100,140,167,194` · `backend/onyx/server/features/mcp/api.py:1358,1376,1386` · `backend/onyx/db/tools.py:141,153` · `backend/ee/onyx/db/analytics.py:339` · `backend/onyx/server/features/document_set/api.py:76,91,123` · `backend/onyx/server/features/skill/api.py:233,258,287,304,339,355,378` · `backend/ee/onyx/server/user_group/api.py:133,191,216,239,262,282,333` · `backend/ee/onyx/db/user_group.py:545` · `backend/onyx/server/manage/models.py:131` · `backend/onyx/server/documents/connector.py:1229,1231,1443` · `backend/onyx/server/documents/cc_pair.py:324-326` · `web/src/lib/admin-routes.ts:86,92` · `web/src/lib/auth/requireAuth.ts:108` · `web/src/layouts/chromes/AdminSSChrome.tsx`.
+
+---
+
+## 4. Frontend Design
+
+The client stops computing policy. Every gate resolves to reading a server field: a coarse token in `admin_capabilities` (Layer 1) or a boolean in `resource.permissions[action]` (Layer 2). `visibilityPermissions()` — the client-side re-derivation — is deleted. The complete per-affordance inventory these primitives replace is enumerated in §5.
+
+```
+                     ┌─────────────── /me ───────────────┐
+ Layer 1 (coarse) ── │ admin_capabilities: string[]       │ ── nav / page-reach / "New X"
+                     └────────────────────────────────────┘
+                     ┌──────────── resource DTO ──────────┐
+ Layer 2 (per-item)─ │ permissions: { edit:true, ... }    │ ── <Can> around each affordance
+                     └────────────────────────────────────┘
+```
+
+Two structural rules the rest of this section enforces:
+
+- **The `permissions` field is REQUIRED, not optional** (§4.5). A DTO the server forgot to stamp is a *type error* at the serializer/consumer boundary — never a button that silently vanishes at runtime. Fail-closed (missing *key* ⇒ `false`) stays, but it guards forward-compat drift, not a forgotten stamp.
+- **Layer-2 tags are read from the fetch that already exists** (D3, §4.4). The chat/explore card reads its `permissions` off the per-card `GET /persona/{id}` (`FullPersonaSnapshot`) it *already* fetches via `useAgent` — never off the hot list DTO, never off the legacy `user_permission`/`PersonaAccessLevel` field.
+
+### 4.1 The `<Can>` primitive (Layer 2)
+
+New file `web/src/components/auth/Can.tsx`. Reads the boolean map on the resource DTO; **fail-closed** — a missing key is `false`, so the server can ship a new action key before any client deploy.
+
+```tsx
+// web/src/components/auth/Can.tsx  (NEW)
+import type { ResourceActionOf, WithPermissions } from "@/lib/permissions/resource-actions";
+
+// Bare predicate — for imperative sites (disabled=, onClick guards, useMemo).
+export function can<R extends WithPermissions>(
+  resource: R | null | undefined,
+  action: ResourceActionOf<R>,
+): boolean {
+  return resource?.permissions?.[action] ?? false; // fail-closed on null row / unknown key
+}
+
+// Declarative wrapper — the default for JSX affordances.
+export function Can<R extends WithPermissions>({
+  resource, action, children, fallback = null,
+}: {
+  resource: R;
+  action: ResourceActionOf<R>;   // per-resource union, hand-written — see §4.5
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}) {
+  return <>{can(resource, action) ? children : fallback}</>;
+}
+```
+
+Because `permissions` is a **required, exhaustive** `Record<Action, boolean>` per resource (§4.5), `resource.permissions[action]` is statically a `boolean` for a well-typed row — the `?? false` only fires for a `null` resource or a runtime key the client's union predates. Usage collapses a 3-tier hand-written decision to one line:
+
+```tsx
+<Can resource={agent} action="feature">
+  <FeatureToggle agentId={agent.id} />
+</Can>
+```
+
+### 4.2 `useUser()` new shape
+
+Drop the injection in `web/src/providers/UserProvider.tsx` (context value, lines 571/576/579). `permissions` was `visibilityPermissions(upToDateUser)` — a client-derived second source of truth. Replace with the server field `admin_capabilities`.
+
+| context field | OLD (`UserProvider.tsx`) | NEW |
+|---|---|---|
+| `isAdmin` (571) | `effective_permissions.includes(FULL_ADMIN_PANEL_ACCESS)` | **unchanged** |
+| `hasAdminAccess` (576) | `hasAnyAdminPermission(visibilityPermissions(user))` | `hasAnyAdminPermission(adminCapabilities)` |
+| `permissions` (579) | `visibilityPermissions(user)` | **removed** |
+| `adminCapabilities` | — (did not exist) | `upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS` |
+
+```tsx
+// UserProvider.tsx  value={{ ... }}
+isAdmin: (upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS)
+  .includes(Permission.FULL_ADMIN_PANEL_ACCESS),                     // unchanged
+adminCapabilities: upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS,
+hasAdminAccess: hasAnyAdminPermission(
+  upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS,             // was visibilityPermissions(user)
+),
+// permissions: REMOVED
+```
+
+Add `admin_capabilities?: string[]` to `User` in `web/src/lib/types.ts` (beside `effective_permissions?` L131, `is_group_manager?` L134). `is_group_manager` stays for labels but is **no longer read as a gate** — the server already folded it into `admin_capabilities`.
+
+> Staleness (D8): `admin_capabilities` is computed from the **cached** `is_group_manager` column, while Layer-2 `permissions` and the PEP use *live* scope. Any path that flips manager status — the manual toggle **and external group-sync** — must `recompute_user_permissions` and bust `['me']`, or nav shows while every per-item tag is `false` (dead buttons). See §6.3.
+
+### 4.3 Coarse consumption (Layer 1)
+
+All three coarse seams re-source from `admin_capabilities`; none re-derives. The token set is identical to what `visibilityPermissions()` produced, but computed **server-side** by the PDP, so it can't drift from GATE 2.
+
+| seam | file:line | change |
+|---|---|---|
+| nav sidebar | `web/src/lib/admin-sidebar-utils.ts:26` `buildItems(permissions,…)` | callers pass `adminCapabilities`; `hasPermission` body unchanged |
+| SSR admission | `web/src/lib/auth/requireAuth.ts:108` `requireAdminAuth` | `hasAnyAdminPermission(user.admin_capabilities)` — drop `visibilityPermissions(user)` |
+| **per-page guard (NEW, default-deny)** | `web/src/layouts/chromes/AdminSSChrome.tsx:12` | add a per-route check; today this is the **only** gate and it is coarse-only |
+
+**Prerequisite — the frontend token vocabulary must be a superset of what the server can emit** (D4). Nav re-sources from `admin_capabilities`, so every scoped token the server may place in that set must exist as a `Permission` enum member **and** map to an `ADMIN_ROUTES` entry — otherwise the server emits a token the client can't match and a manager's reachable page silently disappears from the nav (and the per-page gate below can't grade it).
+
+The confirmed gap: `Permission.MANAGE_SKILLS` is **absent** from the frontend enum (`web/src/lib/types.ts:65` has no member) and has **no** `ADMIN_ROUTES` entry — this is the same omission the frontend `SCOPED_MANAGER_PERMISSIONS` copy already carries (`web/src/lib/permissions.ts:4` comment admits it drops `MANAGE_SKILLS`). `MANAGE_ACTIONS` exists (`types.ts:78`) with `/admin/actions/{mcp,open-api}` routes, but has no skills sibling. **Before** the nav flips to `admin_capabilities`:
+
+1. Add `MANAGE_SKILLS = "manage:skills"` to the `Permission` enum.
+2. Enumerate the skills-manage route(s) in `ADMIN_ROUTES` with `requiredPermission: MANAGE_SKILLS`.
+3. Audit the enum + `ADMIN_ROUTES` against the backend `SCOPED_MANAGER_PERMISSIONS` bundle so no scoped token is unrepresentable client-side (the `permissions.ts` bundle itself is deleted — §4.6 — but its *members* must survive as enum + route entries).
+
+**The per-page hole (D5).** `AdminSSChrome` admits any user with *any* admin token, so a manager can SSR-load a `FULL_ADMIN`-only page. (`admin-routes.ts` docstring claims a gate "in `ClientLayout.tsx`" — that file doesn't exist; the enforcement is missing.) The naive fix `if (route && !hasPermission(...))` **fails OPEN**: paths not in `ADMIN_ROUTES` make `route` falsy and skip the check entirely. Real `/admin/*` pages that hit this today: `/admin/systeminfo`, `/admin/groups2/**`, `/admin/federated/[id]`. Gate must **default-deny**:
+
+```tsx
+// AdminSSChrome.tsx — after requireAdminAuth() passes
+const caps = authResult.user?.admin_capabilities ?? [];
+const route = matchAdminRoute(pathname);          // exact / longest-prefix, NOT bare startsWith
+// DEFAULT-DENY: an un-enumerated /admin/* path demands the highest token, so a
+// manager is redirected and any newly-added page fails closed until registered.
+const required = route?.requiredPermission ?? Permission.FULL_ADMIN_PANEL_ACCESS;
+if (!hasPermission(caps, required)) {
+  return redirect(getFirstPermittedAdminRoute(caps) as Route);
+}
+```
+
+Enumerate the missing pages in `ADMIN_ROUTES` with their **real** `requiredPermission` (so they resolve by name, not by the fail-closed catch-all):
+
+| path | requiredPermission | why |
+|---|---|---|
+| `/admin/systeminfo` | `FULL_ADMIN_PANEL_ACCESS` | system diagnostics — admin-only |
+| `/admin/federated` (+ `/[id]`) | `FULL_ADMIN_PANEL_ACCESS` | federated connectors have **no scope model**; managers get `403` on every mutation — full-admin only (D6; the "Manage Federated Connector" button is likewise re-gated on `isAdmin`, §5.6) |
+| `/admin/groups2` (+ `/[id]`, `/create`) | `MANAGE_USER_GROUPS` *(verify audience)* | groups-management surface; sibling of `/admin/groups` |
+
+> Matching hazard: the current match is `pathname.startsWith(entry.path)`, so `"/admin/groups2".startsWith("/admin/groups")` is `true` — `groups2` would *accidentally* inherit `/admin/groups`'s `MANAGE_USER_GROUPS` rather than being graded explicitly. `matchAdminRoute` must prefer an **exact / longest-prefix segment** match, and every real page must have its own entry — the default-deny catch-all is the backstop, not the primary mechanism.
+
+Because a manager's `admin_capabilities` never contains `FULL_ADMIN_PANEL_ACCESS`, full-admin pages (and every un-enumerated `/admin/*`) redirect managers automatically; manager-reachable pages (`MANAGE_CONNECTORS`, `MANAGE_AGENTS`, `MANAGE_SKILLS`, …) pass. This SSR gate is **defense-in-depth / least-astonishment, not the security boundary** — a manager who reaches a full-admin page still `403`s on every mutating call.
+
+Global **"New X"** buttons go through a hook, not an inline token check:
+
+```ts
+// web/src/lib/permissions/useCapabilities.ts  (NEW)
+const CAP_TOKEN: Record<string, Permission> = {           // v1 slug → token map
+  "connector:create": Permission.MANAGE_CONNECTORS,
+  "agent:create":     Permission.ADD_AGENTS,
+  "skill:create":     Permission.MANAGE_SKILLS,
+  // …
+};
+export function useCapabilities(required: string[]): boolean {
+  const { adminCapabilities } = useUser();               // v1: read /me
+  return required.every((c) => adminCapabilities.includes(CAP_TOKEN[c]));
+  // later: swap body for POST /capabilities batch (deferred — see §3.6 appendix), same signature
+}
+```
+
+```tsx
+const canCreate = useCapabilities(["connector:create"]);
+{canCreate && <NewConnectorButton />}
+```
+
+### 4.4 Per-item consumption — collapse the duplication
+
+**Where the tags come from (D3).** Per-card Layer-2 tags are **not** stamped onto the hottest path — the chat/explore agent list is a `MinimalPersonaSnapshot` fetched `get_editable=False` (`backend/onyx/server/features/persona/api.py:501-517`); stamping `edit`/`share`/`view_stats` there would add an N+1 scope resolve per card. Instead, `AgentCard` already fetches the per-card `FullPersonaSnapshot` via `useAgent(agent.id)` (`AgentCard.tsx:64`, a `GET /persona/{id}`) — **that** DTO carries `permissions`, so per-card gating is **zero net-new query**. Never source the tag from the existing `user_permission` / `PersonaAccessLevel` field (`ee/onyx/db/persona_sharing.py:48`): it does **not** reflect scoped-manager edit rights → silent drift. Read `fullAgent.permissions`, fall back to hidden while the per-card fetch is in flight.
+
+**Featured status (4 copies today).** The gate is a *global* manage-agents action (managers get `false`), so the server stamps `agent.permissions.feature`. All four sites become `<Can resource={agent} action="feature">`.
+
+| file:line | reads today | verdict |
+|---|---|---|
+| `AgentCard.tsx:57` | `hasPermission(permissions, MANAGE_AGENTS)` (injected) | wrong → managers see it |
+| `ShareAgentModal.tsx:79` | `hasPermission(permissions, …)` (injected) | wrong |
+| `AgentEditorPage.tsx:492` | `hasPermission(permissions, …)` (injected) | wrong |
+| `AgentRowActions.tsx:68` | `hasPermission(user.effective_permissions, …)` (raw) | correct — but the raw/injected fork is exactly what devs get wrong |
+
+→ one server field (`feature`), one primitive; the `MANAGE_AGENTS` token check disappears from all four.
+
+**Ownership-as-gate.** `checkUserOwnsAgent` (`web/src/lib/agents/utils.ts:10`) is wrong in both directions — a manager/editor who can edit but doesn't own is hidden; a readable-not-editable row is shown → 403 on click. Note the tag now carries the **owner bypass** for free: the projection stamps `edit`/`share` true for a plain owner *and* an in-scope manager (§3.3, §5.1), so no client-side owner check is reintroduced.
+
+- `AgentCard.tsx:61` `isOwnedByUser` used to gate edit/share → replace with `can(fullAgent, "edit")` / `can(fullAgent, "share")` (read off the per-card DTO, above).
+- `AgentsNavigationPage.tsx:79` — **keep** `checkUserOwnsAgent`; it only filters the "Your Agents" tab (a label, not a gate).
+
+**Doc-set double-fetch.** `page.tsx Main()` (L353–364) fetches `useDocumentSets()` **and** `useDocumentSets(true)` (`hooks.tsx:10`, two SWR keys), then set-diffs to synthesize editability (`isEditable = editableDocumentSets.some(…)`, L197; union L174–176).
+
+```
+BEFORE:  GET /document-set  +  GET /document-set?editable=true  →  client set-diff  →  isEditable
+AFTER:   GET /document-set  (rows carry permissions.edit)       →  can(ds, "edit")
+```
+
+Delete the second fetch (`SWR_KEYS.documentSetsEditable`), the union, and the `.some()` diff; `useDocumentSets(getEditable)` loses its parameter. Render `<Can resource={ds} action="edit">` / `action="delete"`.
+
+### 4.5 Hand-written per-resource action unions (no codegen in v1)
+
+The action strings must match the server's stamped keys at compile time, so a typo (`action="feaure"`) fails `tsc`, not silently fails-closed at runtime. **There is no codegen pipeline today**, and standing one up is not worth v1 — the vocabulary is 7 small unions. **Hand-write them** (they change about as often as the backend gate set — rarely) and bind each to its DTO type.
+
+```ts
+// web/src/lib/permissions/resource-actions.ts  (HAND-WRITTEN — one small union per resource)
+export type ResourceActionMap = {
+  ConnectorIndexingStatusLite: "edit" | "delete" | "manage_access" | "publish";
+  DocumentSetSummary:          "edit" | "delete" | "manage_access" | "publish";
+  PersonaSnapshot: "edit" | "share" | "view_stats" | "delete" | "feature" | "list" | "reorder" | "publish";
+  CustomSkillResponse:         "edit" | "manage_access" | "delete" | "publish";
+  MCPServer:   "edit" | "delete" | "authenticate" | "manage_status";
+  ToolSnapshot:"edit" | "delete" | "toggle";
+  UserGroup:   "manage" | "delete" | "edit_permissions" | "edit_token_limits";
+};
+
+// REQUIRED + exhaustive per resource. A DTO the server forgot to stamp — or
+// stamped with a missing action — is a *type* error here, not a vanished button.
+export interface WithPermissions<K extends keyof ResourceActionMap = keyof ResourceActionMap> {
+  __resource: K;                                   // phantom tag, set once in the DTO's parser
+  permissions: Record<ResourceActionMap[K], boolean>;
+}
+export type ResourceActionOf<R> =
+  R extends { __resource: infer K extends keyof ResourceActionMap }
+    ? ResourceActionMap[K]
+    : never;
+```
+
+Each DTO type carries a `__resource: "PersonaSnapshot"` phantom tag, so `<Can resource={agent} action="…">` only accepts that resource's actions, and its `permissions` map must be present and complete.
+
+**Required, not optional — the whole point of D4.** With `permissions?: Record<string, boolean>` (optional), a serializer that forgets a resource yields `undefined` → `<Can>` fail-closes → the button *silently disappears* with no error anywhere. Making the field **required** on both ends turns "forgot to stamp" into a hard failure:
+
+- **Backend:** the Pydantic field is `permissions: dict[str, bool]` with **no default** — a `from_model` that doesn't set it raises at construction.
+- **Frontend:** `Record<ResourceActionMap[K], boolean>` is exhaustive — a DTO parser that omits the map, or a stamp loop that drops an action, fails `tsc`.
+
+**Backend coverage test — closes the "add an action, forget to register it" hole.** Type-requiredness catches a *forgotten map*; it does not catch a *new scoped route whose action was never added to the stamp loop / union*. A cheap backend test walks the router and asserts every mutating scoped route has a home:
+
+```py
+# backend/tests/external_dependency_unit/auth/test_scoped_route_coverage.py
+def test_every_scoped_mutation_maps_to_a_stamped_action():
+    # routes carrying require_permission(..., allow_scope=True) OR assert_within_scope in the body
+    for route in scoped_mutating_routes(app):
+        resource, action = ROUTE_TO_ACTION[route.endpoint]      # explicit registry, must be total
+        assert action in STAMPED_ACTIONS[resource], \
+            f"{route.path}: '{action}' not stamped for {resource}"
+```
+
+`STAMPED_ACTIONS[resource]` is the exact key set the projection stamps (§3.3) and mirrors the hand-written frontend unions. Add a scoped route without registering its action → red CI, not a phantom `403`. This pairs with the `project == enforce` contract test (§6.1): that one proves each *stamped* key is correct; this one proves no *gate* is unstamped.
+
+The batch `POST /capabilities` probe stays deferred (§3.6 appendix) — `useCapabilities` reads `admin_capabilities` in v1; nothing here depends on it.
+
+### 4.6 Deletions
+
+| delete | file:line | replaced by |
+|---|---|---|
+| `visibilityPermissions()` + its export | `web/src/lib/permissions.ts:33` | server `admin_capabilities` (§4.2) |
+| `SCOPED_MANAGER_PERMISSIONS` (frontend copy) | `web/src/lib/permissions.ts:7` | server-owned bundle — **but first** ensure every member survives as a `Permission` enum value + `ADMIN_ROUTES` entry (`MANAGE_SKILLS` is the missing one, §4.3); the *bundle constant* goes, the *tokens* must stay |
+| `permissions` context field + all `useUser().permissions` reads | `UserProvider.tsx:579`; `AgentCard.tsx:55`, `ShareAgentModal.tsx`, `AgentEditorPage.tsx:491` | `adminCapabilities` (coarse) / `resource.permissions` (per-item) |
+| `canUpdateFeaturedStatus` (×4) | `AgentCard.tsx:57`, `ShareAgentModal.tsx:79`, `AgentEditorPage.tsx:492`, `AgentRowActions.tsx:68` | `<Can action="feature">` |
+| `checkUserOwnsAgent` **as edit/share gate** | `AgentCard.tsx:61` | `can(fullAgent,"edit"/"share")` — fn kept only for the "Your Agents" label (`AgentsNavigationPage.tsx:79`) |
+| editable doc-set double-fetch + set-diff | `page.tsx:361-364,174-176,197`; `hooks.tsx:10` param; `SWR_KEYS.documentSetsEditable` | single fetch + `can(ds,"edit")` |
+| fail-OPEN per-page gate (naive `if (route && …)`) | proposed `AdminSSChrome.tsx` guard | default-deny gate + enumerated routes (§4.3) |
+
+`hasPermission` / `hasAnyAdminPermission` / `ADMIN_ROUTES` / `buildItems` / `requireAdminAuth` survive unchanged in logic — only their **input** flips from client-derived `visibilityPermissions(user)` to server `admin_capabilities`, and `ADMIN_ROUTES` **gains** the `MANAGE_SKILLS` + `systeminfo`/`groups2`/`federated` entries (§4.3).
+
+---
+
+_Files read to verify:_ `web/src/lib/permissions.ts` (bundle L7, `visibilityPermissions` L33, comment L4 admits `MANAGE_SKILLS` drop), `web/src/lib/types.ts` (Permission enum L65 — **no `MANAGE_SKILLS` member**; `MANAGE_ACTIONS` L78), `web/src/lib/admin-routes.ts` (`requiredPermission` L86; `/admin/actions/*` = `MANAGE_ACTIONS`; **no** skills / `systeminfo` / `groups2` / `federated` entry; match is `startsWith`), `web/src/app/admin/{systeminfo,groups2,federated}` (real un-enumerated `/admin/*` pages), `web/src/lib/auth/requireAuth.ts:108`, `web/src/layouts/chromes/AdminSSChrome.tsx`, `web/src/providers/UserProvider.tsx` (ctx value 571/576/579), `web/src/lib/admin-sidebar-utils.ts` (buildItems L26), `web/src/lib/agents/utils.ts:10`, `web/src/sections/agents/AgentCard.tsx` (55/57/61; `useAgent(agent.id)` L64 — the per-card `FullPersonaSnapshot` fetch the tags ride on), `web/src/sections/modals/ShareAgentModal.tsx:79`, `web/src/refresh-pages/AgentEditorPage.tsx:492`, `web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx:68`, `web/src/refresh-pages/AgentsNavigationPage.tsx:79`, `web/src/app/admin/documents/sets/{hooks.tsx,page.tsx}`. Deviations corrected above: (1) `canUpdateFeaturedStatus` is **4** copies (`AgentRowActions.tsx:68` is a fourth, and the only correct one); (2) the per-page gate `admin-routes.ts` attributes to `ClientLayout.tsx` does not exist — per-page enforcement is genuinely absent, and the naive replacement fails OPEN on un-enumerated `/admin/*`; (3) `MANAGE_SKILLS` is absent from the frontend `Permission` enum and `ADMIN_ROUTES`, so the nav re-source silently hides scoped-skills managers until it is added.
+
+---
+
+## 5. Affordance → Action Mapping (complete)
+
+All 49 mis-gated affordances, grouped by domain. **Scope legend** for the `resource.permissions[...]` map — *each action's tag is stamped by **its own** real gate (D2), never one filter per resource*:
+
+- **M** — scoped-manager `true` iff in-scope (admin also `true`).
+- **A** — global/admin token only; managers → `false`.
+- **O** — owner/creator-or-admin; managers → `false` **unless they own it**.
+- **M|O** — union: scoped **OR** owner/creator **OR** admin (owner-bypass — the correction; stamping only the scoped term would hide the button from a plain owner/creator on their own resource).
+- **O|A** — owner-or-global (owner bypass, but **not** the scoped-manager path).
+
+Coarse rows use `hasPermission(adminCapabilities, X)` / `useCapabilities([...])`; truly FULL_ADMIN rows use `isAdmin`. Fail-closed: a missing key ⇒ `false`.
+
+`project == enforce` by construction (§3.1a): the projection stamps each `permissions[action]` by calling the **same** `can_<action>(user, resource, db)` helper the write-side guard (`assert_*`) calls, and the contract test calls it too — no re-derivation. The per-action real-gate → scope-class mapping these rows draw from is the action-level table in §3.3.
+
+### 5.1 Agents / Personas — 18 (DTO map `{edit:M, delete:O|A, share:M, feature:A, publish:O|A, list:A, reorder:A, view_stats:O}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Edit btn (admin list) | `refresh-pages/admin/AgentsPage/AgentRowActions.tsx:159` | none — row shown for every list item | `permissions.edit` (M) |
+| List/Unlist (`toggleAgentListed`) | `AgentRowActions.tsx:176` | none | `permissions.list` (A) |
+| Set/Remove Featured | `AgentRowActions.tsx:195` | `hasPermission(user.effective_permissions, …)` — *the one correct copy* | `permissions.feature` (A) |
+| Share btn (admin list) | `AgentRowActions.tsx:239` | none | `permissions.share` (M) |
+| Stats btn | `AgentRowActions.tsx:251` | none | `permissions.view_stats` (O — owner/admin, `user_can_view_assistant_stats`) |
+| Delete (`deleteAgent`) | `AgentRowActions.tsx:265` | none | `permissions.delete` (O\|A) |
+| Drag-reorder (`handleReorder`) | `refresh-pages/admin/AgentsPage/AgentsTable.tsx:123` | none | `isAdmin` (FULL_ADMIN) / `permissions.reorder` (A) |
+| Edit btn (chat/explore card) | `sections/agents/AgentCard.tsx:161` | `isOwnedByUser` = `checkUserOwnsAgent` | `permissions.edit` (M) |
+| Share btn (chat/explore card) | `AgentCard.tsx:176` | `isOwnedByUser` | `permissions.share` (M) |
+| Quick-feature star | `AgentCard.tsx:149` | `isOwnedByUser && businessTier` | `permissions.feature` (A) |
+| `canUpdateFeaturedStatus` **copy #1 (wrong)** | `AgentCard.tsx:57` | `hasPermission(permissions, …)` — injected tokens | `permissions.feature` (A) |
+| `canUpdateFeaturedStatus` **copy #2 (wrong)** | `sections/modals/ShareAgentModal.tsx:79` | `hasPermission(permissions, …)` — injected tokens | `permissions.feature` (A) |
+| Feature switch (share modal) | `ShareAgentModal.tsx:345` | rendered iff `canUpdateFeaturedStatus` (copy #2) | `permissions.feature` (A) |
+| "Publish This Agent" switch (`isPublic`) | `ShareAgentModal.tsx:340` | none — any sharer can toggle org-public | `permissions.publish` (O\|A) |
+| `canUpdateFeaturedStatus` **copy #3 (wrong)** | `refresh-pages/AgentEditorPage.tsx:492` | `hasPermission(permissions, …)` — injected tokens | `permissions.feature` (A) |
+| Feature control (editor) | `AgentEditorPage.tsx:1545` | rendered iff `canUpdateFeaturedStatus` (copy #3) | `permissions.feature` (A) |
+| Delete agent (`handleDeleteAgent`) | `AgentEditorPage.tsx:889` | none — page-reach only | `permissions.delete` (O\|A) |
+| Share/publish modal open | `AgentEditorPage.tsx:1083` | none — page-reach only | `permissions.share` (M) |
+
+**Note — where the chat-card tags come from (D3).** The chat/explore card's `edit`/`share`/`view_stats` tags are stamped on the per-card **`GET /persona/{id}`** (`FullPersonaSnapshot`) that `AgentCard` **already** fetches via `useAgent` (`AgentCard.tsx:64`) — **zero net-new query**. They are **not** stamped on the `MinimalPersonaSnapshot` chat/explore *list* (fetched `get_editable=False`, `persona/api.py:501-517` — the hottest path; leave it untagged), and are **never** sourced from `user_permission`/`PersonaAccessLevel` (`persona/models.py:398`), which does **not** reflect scoped-manager edit rights (silent drift). Admin-list rows stamp per-row from a preload-once editable-id set (connectors template).
+
+**Note — the gates (D2).** `edit`/`share` = **read-editable AND scoped-assert** — `_add_user_filters(get_editable=True)` (`db/persona.py:82`) **AND** `_assert_persona_update_within_managed_scope`→`assert_within_scope` (share adds EE `_assert_group_share_within_scope`, `ee/onyx/db/persona.py:104,161`); **never** the editable filter alone (superset union → over-reports → 403). `view_stats` = **O** (reclassified M→O): `user_can_view_assistant_stats` (`ee/onyx/db/analytics.py:339`) = owner **OR** FULL_ADMIN — **not** the editable filter. `delete`/`publish` = **O|A** (reclassified A→O|A): `global MANAGE_AGENTS OR owner OR owner-group member` — a plain owner *can* delete/org-publish their own agent, but the filter excludes scoped-manager rels, so ≠ `edit`'s M.
+
+**Note — the featured fork / labels.** `canUpdateFeaturedStatus` exists in **three injected-token copies** (`AgentCard:57`, `ShareAgentModal:79`, `AgentEditorPage:492`) vs the one correct `effective_permissions` copy (`AgentRowActions:68`) — collapse all four to `<Can resource={agent} action="feature">`. `checkUserOwnsAgent` stays only as the **"Your Agents"** label (`AgentsNavigationPage.tsx:79`), never as an edit/share gate. Coarse **"New Agent"** (`AgentsNavigationPage.tsx:105`, currently `hasPermission(permissions, ADD_AGENTS)` off injected tokens) → `useCapabilities(['agent:create'])` off `admin_capabilities`.
+
+### 5.2 Actions / MCP — 9 (MCP `MCPServer {edit:M|O, delete:O, authenticate:O, manage_status:O}`; OpenAPI `ToolSnapshot {edit:M|O, delete:A, toggle:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Edit MCP server | `sections/actions/MCPActionCard.tsx:284` | none — page-reach only | `permissions.edit` (M\|O) |
+| Delete MCP server | `MCPActionCard.tsx:213` | none | `permissions.delete` (O) |
+| Authenticate (pending) | `MCPActionCard.tsx:211` | none | `permissions.authenticate` (O) |
+| Disconnect (deauth) | `MCPActionCard.tsx:209` | none | `permissions.authenticate` (O) |
+| Refresh tools / status | `MCPActionCard.tsx:257` | none | `permissions.manage_status` (O) |
+| Edit OpenAPI action | `sections/actions/ActionCard.tsx:131` (via `OpenApiActionCard`) | none | `permissions.edit` (M\|O) |
+| Delete OpenAPI action | `sections/actions/OpenApiActionCard.tsx:130` | none | `permissions.delete` (A) |
+| Toggle tools (enable/disable) | `OpenApiActionCard.tsx:123` | none | `permissions.toggle` (A) |
+| Coarse "Add MCP Server" / "Add OpenAPI Action" | `sections/actions/MCPPageContent.tsx:495`, `OpenApiPageContent.tsx:358` | none | `useCapabilities(['action:create'])` (coarse `MANAGE_ACTIONS`) |
+
+**Note.** **`edit` is `M|O` (owner/creator bypass), not `M` (D2):** MCP edit = `_ensure_mcp_server_editable` (`mcp/api.py:1376`) = `FULL_ADMIN OR server.owner == user.email OR scoped` — MCP ownership is by **EMAIL** (`:1386`; DTO ships `owner:str`); OpenAPI edit = `_get_editable_custom_tool` (`tool/api.py:84`) = `FULL_ADMIN OR tool.user_id == user.id (creator) OR scoped` (`_assert_action_within_managed_scope:62`; `ToolSnapshot` ships `user_id`). Stamping only the scoped term would hide **Edit** from a plain owner/creator on their own resource. MCP delete/authenticate/disconnect/status stay **owner-only** (`_ensure_mcp_server_owner_or_admin`, `:1358`) — the DTO map is the only place that O-vs-M|O distinction survives to the client. OpenAPI `delete`/`toggle` are `MANAGE_ACTIONS` **no `allow_scope`** ⇒ `A`.
+
+### 5.3 Skills — 8 (`CustomSkillResponse {edit:M, delete:A, manage_access:M, publish:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Skills-manage **page access** | `layouts/craft/CraftManageLayout.tsx:22` | `hasPermission(effective_permissions, FULL_ADMIN_PANEL_ACCESS)` → redirect | coarse `hasPermission(adminCapabilities, MANAGE_SKILLS)` |
+| "Manage" entry surfacing | `refresh-pages/UserSkillsPage` (routes to manage) | same FULL_ADMIN redirect | coarse `MANAGE_SKILLS` |
+| Edit visibility (grants) | `refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx:60` | none — no per-row gate at all | `permissions.manage_access` (M) |
+| Replace bundle (edit) | `CustomSkillRowActions.tsx:71` | none | `permissions.edit` (M) |
+| Disable / Re-enable | `CustomSkillRowActions.tsx:81` | none | `permissions.edit` (M) |
+| Delete skill | `CustomSkillRowActions.tsx:92` | none | `permissions.delete` (A) |
+| Share/grant modal (group grants) | `refresh-pages/admin/SkillsPage/ShareSkillModal.tsx` + `SkillSharePicker.tsx` | none | `permissions.manage_access` (M) |
+| Coarse "Upload skill" (create) | `refresh-pages/admin/SkillsPage.tsx` (`UploadSkillModal`) | none | `useCapabilities(['skill:create'])` (coarse `MANAGE_SKILLS`) |
+
+**Note.** The whole page hides behind a **FULL_ADMIN redirect** (`CraftManageLayout`), so a manager holding scoped `MANAGE_SKILLS` (which has **no frontend token today** — see `permissions.ts:5` comment) can't reach it at all → **drop to coarse `admin_capabilities` `MANAGE_SKILLS`**, and add the token. `CustomSkillRowActions` has **zero per-item gating** — every row shows edit/replace/toggle/delete; delete is `FULL_ADMIN` (A), the rest scoped (`MANAGE_SKILLS allow_scope`); `granted_group_ids` already ships on the DTO.
+
+### 5.4 Groups — 6 (`UserGroup {manage:M (per-group), delete:A, edit_permissions:A, edit_token_limits:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Open/Manage group (row → edit) | `refresh-pages/admin/GroupsPage/GroupCard.tsx:70` | none — no **per-group** manager signal | `permissions.manage` (M, per-group) |
+| Add members | `refresh-pages/admin/GroupsPage/EditGroupPage.tsx:129` | none — page-reach only | `permissions.manage` (M) |
+| Delete group | `EditGroupPage.tsx:126` | none | `permissions.delete` (A) |
+| Toggle group permissions | `refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx:74` | data fetch gated on `isAdmin` (`:107`); section still renders | `permissions.edit_permissions` (A) |
+| Add/remove + save token limits | `refresh-pages/admin/GroupsPage/TokenLimitSection.tsx:154/144` | `disabled` from **tier only**, not role | `isAdmin` (PUT/DELETE = FULL_ADMIN); POST scoped |
+| Coarse "New Group" | `refresh-pages/admin/GroupsPage/index.tsx:69` | `actionLabel={isAdmin ? "New Group" : undefined}` — managers hidden | `useCapabilities(['group:create'])` (coarse `MANAGE_USER_GROUPS`) |
+
+**Note.** The **missing signal is per-group `manage`** — `is_group_manager` on `/me` is global; the snapshot already carries `manager_ids`, so `permissions.manage` is `assert_manages_group` (`auth/scoped_permissions.py:92`) for *this* group = `group_id ∈ managed set OR global MANAGE_USER_GROUPS` — a **single-group membership** gate (D2), **not** `within_managed_scope_clause`/the editable filter, and `manager_ids` on the snapshot is *not* itself the gate. Token-limit **PUT/DELETE are FULL_ADMIN** (`ee/.../token_rate_limits/api.py`) → `isAdmin`, not `edit_token_limits`; only POST is scoped.
+
+### 5.5 Doc sets — 3 (`DocumentSetSummary {edit:M, delete:A, manage_access:M, publish:A}`)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Edit row | `app/admin/documents/sets/page.tsx:204` (`EditRow`, `isEditable`) | client **set-diff** of two fetches (`useDocumentSets()` vs `useDocumentSets(true)`, `page.tsx:359-364`, `:197`) | `permissions.edit` (M) |
+| Delete (`DeleteButton`) | `sets/page.tsx:308` | gated by same client set-diff `isEditable` | `permissions.delete` (A) |
+| Make-public / publish badge | `sets/page.tsx:300` | none — public/private shown, not gated | `permissions.publish` (A) |
+
+**Note.** Kill the **double-fetch + client set-diff** (`hooks.tsx:10-27` + `page.tsx:359-364`) — one list call carrying `permissions.edit` replaces it. DELETE route is `MANAGE_DOCUMENT_SETS` **no `allow_scope`** ⇒ delete `A`; **make-public ⇒ `publish:A`** (managers can edit a scoped set but not publish it org-wide).
+
+### 5.6 Connectors (cc_pair) — 3 (the GOOD domain: `is_editable_for_current_user` already ships — the template)
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Federated connector "Manage" button | `app/admin/indexing/status/CCPairIndexingStatusTable.tsx:308` | ungated — 403s for managers (hard-coded `is_editable: false`; **no scope model** for federated) | **`isAdmin` / coarse `MANAGE_CONNECTORS`** (D6 — decided admin-only); `/admin/federated/[id]` enumerated **FULL_ADMIN** in `ADMIN_ROUTES` |
+| Edit gate (detail page) | `app/admin/connector/[ccPairId]/page.tsx:188-190` | client **re-derives**: `is_editable_for_current_user \|\| (MANAGE_CONNECTORS && !FULL_ADMIN && …)` | pure `permissions.edit` (M) — drop the OR-fallback |
+| Make org-public (publish) | `[ccPairId]/page.tsx` access controls | none | `permissions.publish` (A) |
+
+**Note.** Pause/Delete already gate correctly on `is_editable_for_current_user` (`page.tsx:488`, `:481`) — **this is the template** the other domains copy. **Federated connectors have no `cc_pair` row and no scope model**, so the ungated "Manage Federated Connector" button 403s for managers today. **Decided (D6): gate it on `isAdmin` / global `MANAGE_CONNECTORS` and enumerate `/admin/federated/[id]` as `FULL_ADMIN` in `ADMIN_ROUTES`** — admin-only in v1 (no `permissions.edit` until federated grows a scope source). This resolves former §6.6 open-decision #1 (no longer open). The detail-page edit gate still **re-derives policy client-side** (`MANAGE_CONNECTORS && !FULL_ADMIN`) instead of trusting `permissions.edit` alone — drop the OR-fallback.
+
+### 5.7 Nav / page access — 2
+
+| Surface | File:line | Current gate (compressed) | New gate |
+|---|---|---|---|
+| Admin page SSR access | `layouts/chromes/AdminSSChrome.tsx:13` | coarse admission only — **no per-page `requiredPermission`** ⇒ manager can SSR-load FULL_ADMIN pages | **per-page gate, DEFAULT-DENY**: matched → `hasPermission(adminCapabilities, ADMIN_ROUTES[path].requiredPermission)`; **unmatched `/admin/*` → require `FULL_ADMIN_PANEL_ACCESS`** (redirect managers) |
+| Admin sidebar items | `lib/admin-sidebar-utils.ts:36` `buildItems()` | `hasPermission(permissions, …)` off **injected** `visibilityPermissions()` | re-source `permissions` from `admin_capabilities`; delete `visibilityPermissions` |
+
+**Note.** `AdminSSChrome` is **the only page-access gate** and it's coarse-only — add the per-page check keyed on the matched `ADMIN_ROUTES[path].requiredPermission`, sourced from `admin_capabilities` (so a scoped manager reaches `/admin/agents` but a FULL_ADMIN-only route SSR-redirects). **Default-deny (D5):** a naive matched-only gate **no-ops** on `/admin/*` paths **not** in `ADMIN_ROUTES` (`systeminfo`, `groups2`, `federated/[id]`) → **fails OPEN** (managers reach them). Fix: an **unmatched `/admin/*` requires `FULL_ADMIN_PANEL_ACCESS`** (redirect managers), and the missing pages are **enumerated in `ADMIN_ROUTES`** with their real `requiredPermission` (`/admin/federated/[id]` → `FULL_ADMIN`, per D6). `buildItems()` and `requireAdminAuth` (`lib/auth/requireAuth.ts:108`) both re-source from `admin_capabilities`; **`visibilityPermissions` (`lib/permissions.ts:33`) is deleted**, closing root cause #1 (the drifting second source of truth).
+
+**Roll-up:** 18 + 9 + 8 + 6 + 3 + 3 + 2 = **49**. Every row's **New gate** is server-authoritative — a `permissions[...]` key stamped by the projection via the shared `can_<action>` helper (§3.1a), a coarse `admin_capabilities` check, or `isAdmin` for the genuinely FULL_ADMIN affordances (agent reorder, token-limit PUT/DELETE, **federated "Manage"**). The scope taxonomy is richer than M/A: **O|A** (persona `delete`/`publish` — owner bypass, no scoped path) and **M|O** (tool/MCP `edit` — owner/creator bypass by `user_id`/`email`) carry owner/creator affordances a pure-scoped stamp would wrongly hide, and **O** (`view_stats`, MCP delete/authenticate/status) resolves owner-or-admin. The client is reduced to a pure `<Can>` renderer.
+
+---
+
+_Provenance: every `file:line` in §5 was verified against the repo `HEAD` (branch `perms-pr6-manager-ui-scoped-nav`). Notable confirmations while writing this table: `canUpdateFeaturedStatus` exists in **4** copies (not 3 — `AgentRowActions.tsx:68` is a fourth, and the one correct one); the doc-set double-fetch, the `is_editable_for_current_user` connector template, the `CraftManageLayout` FULL_ADMIN skills redirect, and the `visibilityPermissions` injection point are all present; and the per-page gate that `admin-routes.ts` claims lives in `ClientLayout.tsx` does **not** exist (per-page enforcement is genuinely absent — `AdminSSChrome` is the only gate). Per-gate D2/D5/D6 verifications baked in: persona `view_stats` = `user_can_view_assistant_stats` (owner ∨ FULL_ADMIN, `ee/onyx/db/analytics.py:339`), **not** the editable filter (M→O); persona `edit`/`share` = read-editable **AND** `_assert_persona_update_within_managed_scope`/EE `_assert_group_share_within_scope` (not `get_editable` alone); MCP `edit` owner is by **EMAIL** (`mcp/api.py:1386`) and Tool `edit` has a **creator** bypass (`tool/api.py:100`) — both M→M|O; persona `delete`/`publish` are owner-or-global (A→O|A); federated connectors have no scope model → admin-only (D6); the per-page SSR gate must **default-deny** unmatched `/admin/*` (D5, else it fails open on `systeminfo`/`groups2`/`federated/[id]`)._
+
+---
+
+## 6. Testing, Rollout & PR Roadmap
+
+### 6.1 Contract test — project == enforce (the anti-drift guarantee)
+
+The guarantee is no longer "the read filter is a faithful mirror" — it is **one shared decision helper** (§3.1a). Each tricky guard's boolean is extracted into `can_<action>(user, resource, db) -> bool`; `assert_<action>` calls that helper then raises (behavior byte-for-byte unchanged), the projection stamps `resource.permissions[action]` by calling the **same** helper, and the contract test calls the **same** helper. Because `assert_*` now *calls* `can_*`, `project == enforce` is **structural**, not a coincidence a test has to keep re-checking.
+
+Two tests hold the line.
+
+**(a) Helper-parity contract test.** The centerpiece. It does **not** run a parallel `get_editable=True` read query (v1's drift risk); it drives the **real `assert_*` guard** and asserts the helper the projection stamps equals the guard's decision.
+
+```py
+# backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+# extends the scoped-perms fixtures in test_scoped_permissions.py
+
+ACTORS = ["admin", "manager_in_scope", "manager_out_of_scope", "owner", "viewer"]
+
+# (resource, action) -> the SAME can_* helper the projection stamps AND assert_* calls (§3.1a).
+# One entry per per-resource-gated action (M / O / M|O / O|A) in §3.3 + the D2 table.
+CAN = {
+  ("persona","edit"):       can_edit_persona,        # M   editable ∧ within_scope
+  ("persona","share"):      can_share_persona,       # M   editable ∧ group_share_within_scope
+  ("persona","view_stats"): can_view_persona_stats,  # O   owner ∨ FULL_ADMIN (analytics.py:339)
+  ("persona","delete"):     can_delete_persona,      # O|A owner-bypass filter (is_for_edit=True)
+  ("persona","publish"):    can_publish_persona,     # O|A owner ∨ global MANAGE_AGENTS
+  ("tool","edit"):          can_edit_custom_tool,    # M|O admin ∨ creator(user_id) ∨ scoped
+  ("mcp_server","edit"):    can_edit_mcp_server,     # M|O admin ∨ owner(email) ∨ scoped
+  ("user_group","manage"):  can_manage_group,        # M   per-group (managed set ∨ global)
+  ("document_set","edit"):  can_edit_document_set,    # M   editable-id membership
+  ("cc_pair","edit"):       can_edit_cc_pair,         # M   is_editable_for_current_user
+  # …share/manage_access variants stamped by their own can_* helper
+}
+
+@pytest.mark.parametrize("actor", ACTORS)
+@pytest.mark.parametrize(("resource_kind","action"), list(CAN))
+def test_helper_matches_guard(db_session, actor, resource_kind, action):
+    u, r = make_actor(actor), make_resource(resource_kind, actor)
+    helper_says = CAN[(resource_kind, action)](u, r, db_session=db_session)  # projection's boolean
+    raised = guard_raised(resource_kind, action, u, r, db_session)           # drives the real assert_* guard
+    assert helper_says is (not raised), f"DRIFT {resource_kind}.{action} for {actor}"
+```
+
+`guard_raised` invokes the actual `_assert_persona_update_within_managed_scope` / `_ensure_mcp_server_editable` / `assert_manages_group` / … and reports whether it raised `OnyxError`. A policy edit to `within_scope`/`manages_group` (`auth/scoped_permissions.py:55,92`) moves **both** sides at once or fails CI — this is what makes drift structurally impossible. If a cell fails, the bug is the read wrapper's *composition* (forgot the `editable ∧` for persona, or stamped only the scoped term for tool/mcp) — **never** a reason to relax a guard.
+
+**A-class (global-token) actions** — `feature`, `list`, `reorder`, and the pure-global `delete`/`toggle` — have **no per-resource guard**; the gate is the route's `require_permission(perm, allow_scope=False)`. They stamp constant-per-row from `effective_permissions`, so they are asserted against token membership directly (managers → `false`):
+
+```py
+GLOBAL = [("persona","feature",MANAGE_AGENTS), ("persona","list",MANAGE_AGENTS),
+          ("persona","reorder",FULL_ADMIN_PANEL_ACCESS), ("tool","toggle",MANAGE_ACTIONS),
+          ("tool","delete",MANAGE_ACTIONS), ("document_set","delete",MANAGE_DOCUMENT_SETS), …]
+
+@pytest.mark.parametrize("actor", ACTORS)
+@pytest.mark.parametrize(("resource_kind","action","token"), GLOBAL)
+def test_global_token_actions(db_session, actor, resource_kind, action, token):
+    u, r = make_actor(actor), make_resource(resource_kind, actor)
+    dto = to_dto(r, user=u, db=db_session)
+    assert dto.permissions[action] is (token in get_effective_permissions(u))
+```
+
+The matrix is **{admin, manager-in-scope, manager-out-of-scope, owner, viewer} × 7 resources**, so every `M`/`A`/`O`/`M|O`/`O|A` cell in §3.3 is asserted in both directions (granted *and* denied), including the D2 owner/creator bypasses (a plain owner sees `edit` on their own tool/mcp/persona; a manager does **not** see `feature`).
+
+**(b) Route-coverage test (D4).** Closes the "add a scoped route, forget to register its action" hole. Every mutating scoped route must map to an action that is (1) in the hand-written per-resource union (§4.5) and (2) stamped by the projection.
+
+```py
+# backend/tests/external_dependency_unit/auth/test_scoped_route_coverage.py
+def test_every_mutating_scoped_route_is_stamped():
+    # routes whose dep is require_permission(..., allow_scope=True) OR whose body
+    # calls assert_within_scope / assert_manages_group (introspected from the router)
+    for route in discover_scoped_mutations():
+        key = ROUTE_ACTION.get(route.endpoint)                       # (resource, action) — hand-maintained
+        assert key, f"{route.path}: no (resource,action) mapping"
+        resource, action = key
+        assert action in HAND_ACTIONS[resource], f"{action} missing from {resource} action union (§4.5)"
+        assert key in CAN or key in GLOBAL_KEYS, f"{key} not stamped by the projection"
+```
+
+Combined with the **required** (not optional) `permissions` DTO field (§4.5), a forgotten stamp is a compile error on the client and a red test on the server — never a silently-vanishing button.
+
+**E2E (Playwright).** One scenario per resource is overkill; assert the whole-surface invariant once — a scoped manager, in-scope on group G, sees *exactly* the in-scope affordances:
+
+```
+seed: manager M -> scope {G}; agent Ain∈G, Aout∉G; docset Din∈G, Dout∉G
+assert: nav shows Agents+DocSets+Groups (admin_capabilities);  NOT LLMs/Settings (FULL_ADMIN)
+assert: <Can resource=Ain action="edit"> renders;  <Can resource=Aout action="edit"> absent
+assert: Delete on Ain absent (delete=A);  Share on Ain present (share=M)
+assert: direct SSR GET /admin/configuration/llm -> redirect (per-page default-deny, §3.5/D5)
+assert: direct SSR GET /admin/systeminfo (unmapped /admin/* path) -> redirect (fails CLOSED, D5)
+```
+
+### 6.2 Security note — flags are affordance-only
+
+The `permissions{}` map and `admin_capabilities` control **rendering, not authority**. They hide buttons the user would be 403'd on. The real boundary is unchanged — and after D1 the projection is **literally the same code** the PEP's boolean runs, so there is no second decision surface to audit:
+
+| Layer | Artifact | Property |
+|---|---|---|
+| PEP (real gate) | `assert_*` (e.g. `auth/scoped_permissions.py:55`) → now calls `can_*`, then raises | A forged/replayed request with the button "un-hidden" still hits the PEP and 403s. |
+| Decision (truth) | `can_<action>` / `within_scope` / `manages_group` (§3.1a) | Single boolean; guard, projection, and contract test all call it. |
+| Projection (hint) | `resource.permissions[a]`, `admin_capabilities` | Untrusted by the server; never an input to an authz decision. |
+
+Two invariants the review must hold:
+- **Fail-closed by shape:** every helper's terminal branch returns `False` (unknown authority, empty managed scope, missing resource state all deny); on the client a missing action key ⇒ `false`. Forward-compatible — the server ships a new key before any client deploy.
+- **No new decision surface:** the extraction only *relocates* the boolean. The **existing PR1–5 enforcement suite is the proof security is unchanged** — it must stay green with zero edits. If a contract-test cell fails, it is a *projection-composition* bug, never a reason to relax the PEP.
+
+### 6.3 Cache hygiene (React Query) — incl. cached-vs-live manager status (D8)
+
+`permissions{}` rides in the resource DTO, so any mutation that changes who-can-do-what must invalidate the resource query. Additionally, Layer-1 `admin_capabilities` is computed from the **cached** `is_group_manager` column, while Layer-2 `permissions{}` and the PEP use **live** scope. If those drift apart, the failure is silent and ugly: nav shows (cached `is_group_manager=true`) but every per-item `permissions[...]` is `false` → **dead buttons** (or the inverse — hidden nav for a real manager).
+
+**Rule (D8):** *every* manager-status change must `recompute_user_permissions(user)` server-side **and** bust `['me']` client-side — not only the manual toggle, but also external group-sync and any group-membership edit that changes a manager set.
+
+| Mutation | Server | Client invalidate |
+|---|---|---|
+| share / manage_access change | — | `['<resource>', id]` **and** list key `['<resource>s']` |
+| **Make/Revoke Manager** — manual toggle (§5.4 `manage:M`, **KEPT** `3d994d5`) | `recompute_user_permissions(target)` | `['me']` (target) + `['userGroups']` + `['userGroup', gid]` |
+| **External group-sync flips manager status** (SCIM / OIDC / OAuth group sync) | `recompute_user_permissions(affected)` **in the sync task** | no client mutation fires → `['me']` refreshes on next poll (**staleness window**, below) |
+| Group-membership add/remove that changes a manager set | `recompute_user_permissions(affected)` | same as make-manager |
+| ownership transfer | — | `['<resource>', id]` + list key |
+| create / delete | — | list key only |
+
+**Reconciliation with §5.4.** The Make/Revoke Manager toggle is the per-group `manage` affordance (`permissions.manage`, M) and its UI commit `3d994d5` is **KEPT** (§6.4) — it is the only path that reaches PR5's `PUT …/manager` route, so this row is a live mutation, consistent with §5.4.
+
+**Staleness window (documented, accepted).** External group-sync runs in a background worker with no client `onSuccess`, so `['me']` is not busted synchronously — a newly-promoted/demoted manager sees stale nav/buttons until the next `/me` refetch (React Query `staleTime` / refetch-on-focus). This is **least-astonishment, not security**: the PEP still fail-closes, so a stale-*shown* button 403s and a stale-*hidden* button self-heals on refetch. Bound it with a short `staleTime` on `['me']` (or refetch-on-focus); tightening it to push-invalidation is a §6.6 tuning knob.
+
+### 6.4 Rollout
+
+- Fresh branch `Subash-Mohan/perms-pr6-manager-ui-v2` off **PR5** (`perms-pr5-manager-assignment-membership`). Leave PR6-v1 (`perms-pr6-manager-ui-scoped-nav`, **7 commits**) on origin as reference — do not force-push over it.
+- **Revert scope** = only the two commits that reveal nav / hide affordances client-side. The backend `/me` + group-snapshot additions **and the Make/Revoke Manager UI** stay — the new model builds on them.
+
+| PR6-v1 commit | Disposition | Why |
+|---|---|---|
+| `8de63e1` expose manager status on `/me` + group snapshot (`is_group_manager`, `manager_ids`) | **KEEP** | clean — backend models + FE types the v2 Layer-1/per-group signal builds on |
+| `e3532e5` log exception on failed manager assignment | **KEEP** | bundled with `3d994d5` — its log line lives *inside* that function |
+| `3d994d5` Make/Revoke Manager toggle on group edit | **KEEP** | **reverting it deletes the ONLY UI to assign a manager → PR5's `PUT …/manager` route is unreachable → nobody becomes a manager → whole feature inert.** It is an orthogonal member-table UI, independent of the nav/`visibilityPermissions` revert; gated by §5.4 `permissions.manage` (M) |
+| `dc58897` reveal scoped admin nav for managers | **REVERT** | replaced by `admin_capabilities`-sourced nav (§4.3) |
+| `0e3fb24` hide admin-only group affordances | **REVERT** | replaced by per-item `permissions{}` (§5.4) |
+| `8fa5a18` gate org-wide agent actions on global perm | **SUPERSEDE** | correct-tier idea, re-expressed as `feature/list/delete = A` in the map (§3.3) |
+| `0d4aea6` e2e for assignment & scoped nav | **REWRITE** | as the §6.1 E2E whole-surface invariant |
+
+**Roll-up:** KEEP 3 (`8de63e1`, `e3532e5`, `3d994d5` — 2 backend + the make-manager UI); REVERT 2 (`dc58897` nav reveal, `0e3fb24` hide-affordances); SUPERSEDE 1 (`8fa5a18`, folded into the map vocabulary); REWRITE 1 e2e (`0d4aea6`). *(SHAs corrected: `dc59882`→`dc58897`, `0e3f240`→`0e3fb24`.)*
+
+### 6.5 PR roadmap (5 review-sized PRs, drift checkpoint each)
+
+Re-estimated honestly: the D1 shared-helper extraction + the real contract harness + the D4 route-coverage test add scope the v1 sizing understated, so the spine splits into a backend and a frontend PR to stay review-sized. The make-manager toggle is **KEPT** (no rebuild). Per-resource `can_*` wrappers + hand-written action unions + the required `permissions` field land **with the resource that uses them**, not up front.
+
+| PR | Scope | LOC | Drift checkpoint |
+|---|---|---|---|
+| **A1 — Backend spine + shared helper + harness** | `admin_capabilities` on `/me`; **Tier-0 extraction** `within_scope`/`manages_group` from `assert_within_scope`/`assert_manages_group` (behavior-preserving); the **real contract harness** (`test_helper_matches_guard`) + **route-coverage test** (D4); **connectors** `permissions` map as proof (`can_edit_cc_pair` = existing `is_editable_for_current_user`, `cc_pair.py:326`). | ~650 | **PR1–5 enforcement suite green** (proves security byte-for-byte unchanged after extraction); helper-parity green for `cc_pair`; route-coverage green with connectors registered. |
+| **A2 — Frontend spine** | `<Can>` / `can()` + `useCapabilities()`; hand-written per-resource action unions + **required** `permissions` DTO type (D4); **per-page default-deny gate** in `AdminSSChrome` — unmatched `/admin/*` requires `FULL_ADMIN_PANEL_ACCESS` (D5) + enumerate the missing routes (`systeminfo`, `groups2`, `federated/[id]`) in `ADMIN_ROUTES`; add `MANAGE_SKILLS`/`MANAGE_ACTIONS` to the FE `Permission` enum + `ADMIN_ROUTES` (D4); **delete** `visibilityPermissions`/`SCOPED_MANAGER_PERMISSIONS`; connectors client cutover. | ~550 | grep proves **0** `visibilityPermissions`/`SCOPED_MANAGER_PERMISSIONS` sites in web; an unmapped `/admin/*` path redirects (fails closed); nav re-sourced from `admin_capabilities`. |
+| **B — Agents + Doc sets** | extract `can_edit_persona` (editable ∧ scope), `can_share_persona`, `can_view_persona_stats` (O, `analytics.py:339`), `can_delete_persona`/`can_publish_persona` (O\|A); stamp on the **per-card `GET /persona/{id}`** (D3 — never the hot chat/explore list); replace `checkUserOwnsAgent` as a gate → `<Can>` (kept only as the "Your Agents" *label*); dedupe the 3 wrong `canUpdateFeaturedStatus` copies; `DocumentSetSummary.permissions` (kills the double-fetch/set-diff). | ~700 | helper-parity green for `persona`(edit/share/view_stats/delete/publish) + `document_set`; AgentCard renders identically for owner vs in-scope editor; `view_stats` stamps `false` for an out-of-scope manager (O ≠ M). |
+| **C — Skills + Actions/MCP + Tools** | `CustomSkillResponse.permissions`; extract `can_edit_custom_tool` (**M\|O** — admin ∨ creator `user_id` ∨ scoped, `tool/api.py:84,100`) and `can_edit_mcp_server` (**M\|O** — admin ∨ owner-by-**email** ∨ scoped, `mcp/api.py:1376,1386`); tools/MCP have **no `get_editable` list filter** → stamp `edit` only on the **detail/edit fetch** or via a batch resolver, not the list (D3). | ~650 | helper-parity green for `skill`/`mcp_server`/`tool`; **owner/creator sees `edit` on their own resource** (M\|O), manager out-of-scope does not; MCP owner-by-email cell asserted. |
+| **D — Groups + Token limits + Federated + closing gate** | `UserGroup.permissions` incl. **per-group `manage:M`** via `can_manage_group` (`manages_group`, single-group); token-rate-limit map (POST=scoped M, PUT/DELETE/GET=A); **federated connectors** gated on `isAdmin`/global `MANAGE_CONNECTORS`, `/admin/federated` enumerated FULL_ADMIN (D6); land the **full** parametrized matrix + E2E as the closing gate. | ~550 | **full** matrix green (5 actors × 7 resources); per-group `manage` asserted; federated affordance no longer 403s a manager; E2E "manager sees exactly in-scope" passes; route-coverage covers *all* mutating scoped routes. |
+
+Each checkpoint = the contract harness extended to that PR's resources passes before merge; PR-D's is the complete matrix, so drift cannot survive the final merge. Admin-list stamping preloads the editable-id **set** once and stamps each row from memory (connectors template) with `managed_group_ids: set[int]` on the ctx dataclass so per-row stamping does **no** DB (D3).
+
+### 6.6 Open decisions
+
+Federated affordances (D6), the `ResourceAction` codegen (D4), and the `can()` consolidation (D1) are **no longer open** — they moved into the design (see "Resolved," below). What remains genuinely open:
+
+| # | Decision | Options / lean |
+|---|---|---|
+| 1 | **`POST /capabilities` in v1 vs fold into `/me`** | v1: `admin_capabilities` on `/me` covers all Layer-1 needs (small, static per session). A batch endpoint only pays off for large per-item capability fan-out. *Lean: ship on `/me`; add `POST /capabilities` (AuthZEN-style advisory batch) as a deferred appendix only if a screen needs per-item Layer-1 checks at scale.* |
+| 2 | **`['me']` staleness bound on external group-sync** (D8) | The sync task recomputes server-side, but no client mutation busts `['me']`, so a promoted/demoted manager sees stale nav until refetch. *Lean: short `staleTime` + refetch-on-focus on `['me']` (fail-closed already covers correctness); upgrade to push/websocket invalidation only if the window proves annoying.* |
+| 3 | **Stamp O-class MCP admin actions now vs defer** | `delete`/`authenticate`/`manage_status` are owner-or-admin (`_ensure_mcp_server_owner_or_admin`, `mcp/api.py:1358`). *Lean: extract a sibling `can_admin_mcp_server` and stamp them in PR-C alongside `edit`; trivial once the M\|O `edit` helper exists.* |
+
+**Resolved since v1 (folded into the design):**
+- **Federated connectors** (was open #1) → gate on `isAdmin`/global `MANAGE_CONNECTORS`; `/admin/federated` enumerated FULL_ADMIN (§5.6, D6). No scoped model in v1.
+- **`ResourceAction` union** → hand-written per-resource unions + **required** `permissions` field + route-coverage test (§4.5/§6.1, D4). No codegen dependency.
+- **`can()` facade** (was open #3) → **promoted to a required v1 core**: `can_<action>` is the shared decision helper that makes `project == enforce` by construction (§3.1a, D1). It is an internal server function, not an HTTP endpoint.

--- a/web/lib/opal/src/components/table/components.tsx
+++ b/web/lib/opal/src/components/table/components.tsx
@@ -47,6 +47,8 @@ type SelectionBehavior = "no-select" | "single-select" | "multi-select";
 export type DataTableProps<TData> = BaseDataTableProps<TData> & {
   /** Row selection behavior. @default "no-select" */
   selectionBehavior?: SelectionBehavior;
+  /** Per-row predicate; false pins the checkbox: disabled, stuck at its initial selection. */
+  canSelectRow?: (row: TData) => boolean;
 };
 
 // ---------------------------------------------------------------------------
@@ -152,6 +154,7 @@ export function Table<TData>(props: DataTableProps<TData>) {
     size = "lg",
     variant = "cards",
     selectionBehavior = "no-select",
+    canSelectRow,
     onSelectionChange,
     onRowClick,
     searchTerm,
@@ -226,6 +229,9 @@ export function Table<TData>(props: DataTableProps<TData>) {
     initialRowSelection,
     initialViewSelected,
     getRowId,
+    enableRowSelection: canSelectRow
+      ? (row) => canSelectRow(row.original)
+      : undefined,
     onSelectionChange,
     searchTerm,
     serverSide: serverSide
@@ -520,7 +526,7 @@ export function Table<TData>(props: DataTableProps<TData>) {
                       }
                       if (onRowClick) {
                         onRowClick(row.original);
-                      } else if (isSelectable) {
+                      } else if (isSelectable && row.getCanSelect()) {
                         if (!isMultiSelect) {
                           // single-select: clear all, then select this row
                           table.toggleAllRowsSelected(false);
@@ -550,6 +556,7 @@ export function Table<TData>(props: DataTableProps<TData>) {
                               background={qDef.background}
                               iconSize={qDef.iconSize}
                               selectable={showQualifierCheckbox}
+                              disabled={!row.getCanSelect()}
                               selected={
                                 showQualifierCheckbox && row.getIsSelected()
                               }

--- a/web/lib/opal/src/components/table/hooks/useDataTable.ts
+++ b/web/lib/opal/src/components/table/hooks/useDataTable.ts
@@ -10,6 +10,7 @@ import {
   getFilteredRowModel,
   type Table,
   type ColumnDef,
+  type Row,
   type RowData,
   type SortingState,
   type RowSelectionState,
@@ -91,8 +92,9 @@ interface UseDataTableOptions<TData extends RowData> {
   columns: ColumnDef<TData, any>[];
   /** Rows per page. Set `Infinity` to disable pagination. @default 10 */
   pageSize?: number;
-  /** Whether rows can be selected. @default true */
-  enableRowSelection?: boolean;
+  /** Whether rows can be selected — boolean, or a per-row predicate (false → row can't be
+   *  toggled, stays at its initial selection). @default true */
+  enableRowSelection?: boolean | ((row: Row<TData>) => boolean);
   /** Whether columns can be resized. @default true */
   enableColumnResizing?: boolean;
   /** Stable row identity function. TanStack tracks selection by ID instead of array index. */

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -51,7 +51,7 @@ import {
 } from "lucide-react";
 import IndexAttemptErrorsModal from "./IndexAttemptErrorsModal";
 import usePaginatedFetch from "@/hooks/usePaginatedFetch";
-import { IndexAttemptSnapshot, Permission } from "@/lib/types";
+import { IndexAttemptSnapshot } from "@/lib/types";
 import { Spinner } from "@/components/Spinner";
 import { Callout } from "@/components/ui/callout";
 import { Card } from "@/components/ui/card";
@@ -69,7 +69,7 @@ import { SvgSettings } from "@opal/icons";
 import { useUser } from "@/providers/UserProvider";
 import { resolveAllErrorsForCCPair } from "@/lib/targeted_reindex";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 // synchronize these validations with the SQLAlchemy connector class until we have a
 // centralized schema for both frontend and backend
 const RefreshFrequencySchema = Yup.object().shape({
@@ -95,7 +95,7 @@ const PAGES_PER_BATCH = 8;
 
 function Main({ ccPairId }: { ccPairId: number }) {
   const router = useRouter();
-  const { user, permissions } = useUser();
+  const { user } = useUser();
 
   const {
     data: ccPair,
@@ -184,11 +184,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   const latestIndexAttempt = indexAttempts?.[0];
   const canManageInlineFileConnectorFiles =
-    ccPair?.connector.source === "file" &&
-    (ccPair.is_editable_for_current_user ||
-      (hasPermission(permissions, Permission.MANAGE_CONNECTORS) &&
-        !hasPermission(permissions, Permission.FULL_ADMIN_PANEL_ACCESS) &&
-        ccPair.access_type === "public"));
+    ccPair?.connector.source === "file" && can(ccPair, "edit");
 
   const isResolvingErrors =
     (latestIndexAttempt?.status === "in_progress" ||
@@ -478,14 +474,14 @@ function Main({ ccPairId }: { ccPairId: number }) {
         <div className="ml-2 overflow-hidden text-ellipsis whitespace-nowrap flex-1 mr-4">
           <EditableStringFieldDisplay
             value={ccPair.name}
-            isEditable={ccPair.is_editable_for_current_user}
+            isEditable={can(ccPair, "edit")}
             onUpdate={handleUpdateName}
             scale={2.1}
           />
         </div>
 
         <div className="ml-auto flex gap-x-2">
-          {ccPair.is_editable_for_current_user && (
+          {can(ccPair, "edit") && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button prominence="secondary" icon={SvgSettings}>
@@ -550,7 +546,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
                     </span>
                   </DropdownMenuItemWithTooltip>
                 )}
-                {!isDeleting && (
+                {!isDeleting && can(ccPair, "delete") && (
                   <DropdownMenuItemWithTooltip
                     onClick={() => {
                       setShowDeleteConnectorConfirmModal(true);
@@ -691,22 +687,21 @@ function Main({ ccPairId }: { ccPairId: number }) {
         </div>
       </Card>
 
-      {credentialTemplates[ccPair.connector.source] &&
-        ccPair.is_editable_for_current_user && (
-          <>
-            <Title size="md" className="mt-10 mb-2">
-              Credential
-            </Title>
+      {credentialTemplates[ccPair.connector.source] && can(ccPair, "edit") && (
+        <>
+          <Title size="md" className="mt-10 mb-2">
+            Credential
+          </Title>
 
-            <div className="mt-2">
-              <CredentialSection
-                ccPair={ccPair}
-                sourceType={ccPair.connector.source}
-                refresh={() => refresh()}
-              />
-            </div>
-          </>
-        )}
+          <div className="mt-2">
+            <CredentialSection
+              ccPair={ccPair}
+              sourceType={ccPair.connector.source}
+              refresh={() => refresh()}
+            />
+          </div>
+        </>
+      )}
 
       {ccPair.connector.connector_specific_config &&
         Object.keys(ccPair.connector.connector_specific_config).length > 0 && (

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -51,6 +51,8 @@ export interface CCPairFullInfo {
   latest_deletion_attempt: DeletionAttemptSnapshot | null;
   access_type: AccessType;
   is_editable_for_current_user: boolean;
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: Record<string, boolean>;
   deletion_failure_message: string | null;
   indexing: boolean;
   creator: UUID | null;

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -17,6 +17,7 @@ import Title from "@/components/ui/title";
 import { DocumentSetSummary } from "@/lib/types";
 import { useState } from "react";
 import { useDocumentSets } from "./hooks";
+import { can } from "@/lib/permissions/resource-actions";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import { deleteDocumentSet } from "./lib";
 import { toast } from "@/hooks/useToast";
@@ -147,35 +148,20 @@ const EditRow = ({
 interface DocumentFeedbackTableProps {
   documentSets: DocumentSetSummary[];
   refresh: () => void;
-  refreshEditable: () => void;
-  editableDocumentSets: DocumentSetSummary[];
 }
 
 const DocumentSetTable = ({
   documentSets,
-  editableDocumentSets,
   refresh,
-  refreshEditable,
 }: DocumentFeedbackTableProps) => {
   const [page, setPage] = useState(1);
 
-  // sort by name for consistent ordering
-  documentSets.sort((a, b) => {
-    if (a.name < b.name) {
-      return -1;
-    } else if (a.name > b.name) {
-      return 1;
-    } else {
-      return 0;
-    }
+  // editable rows first, then by name — editability now rides on each row's
+  // permissions map, so no second fetch + set-diff is needed.
+  const sortedDocumentSets = [...documentSets].sort((a, b) => {
+    const editDiff = Number(can(b, "edit")) - Number(can(a, "edit"));
+    return editDiff !== 0 ? editDiff : a.name.localeCompare(b.name);
   });
-
-  const sortedDocumentSets = [
-    ...editableDocumentSets,
-    ...documentSets.filter(
-      (ds) => !editableDocumentSets.some((eds) => eds.id === ds.id)
-    ),
-  ];
 
   return (
     <div>
@@ -194,9 +180,7 @@ const DocumentSetTable = ({
           {sortedDocumentSets
             .slice((page - 1) * numToDisplay, page * numToDisplay)
             .map((documentSet) => {
-              const isEditable = editableDocumentSets.some(
-                (eds) => eds.id === documentSet.id
-              );
+              const isEditable = can(documentSet, "edit");
               return (
                 <TableRow key={documentSet.id}>
                   <TableCell className="whitespace-normal break-all">
@@ -305,7 +289,7 @@ const DocumentSetTable = ({
                     )}
                   </TableCell>
                   <TableCell>
-                    {isEditable ? (
+                    {can(documentSet, "delete") ? (
                       <DeleteButton
                         onClick={async () => {
                           const response = await deleteDocumentSet(
@@ -322,7 +306,6 @@ const DocumentSetTable = ({
                             );
                           }
                           refresh();
-                          refreshEditable();
                         }}
                       />
                     ) : (
@@ -356,14 +339,7 @@ function Main() {
     refreshDocumentSets,
   } = useDocumentSets();
 
-  const {
-    data: editableDocumentSets,
-    isLoading: isEditableDocumentSetsLoading,
-    error: editableDocumentSetsError,
-    refreshDocumentSets: refreshEditableDocumentSets,
-  } = useDocumentSets(true);
-
-  if (isDocumentSetsLoading || isEditableDocumentSetsLoading) {
+  if (isDocumentSetsLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
         <ThreeDotsLoader />
@@ -373,10 +349,6 @@ function Main() {
 
   if (documentSetsError || !documentSets) {
     return <div>Error: {documentSetsError}</div>;
-  }
-
-  if (editableDocumentSetsError || !editableDocumentSets) {
-    return <div>Error: {editableDocumentSetsError}</div>;
   }
 
   return (
@@ -405,9 +377,7 @@ function Main() {
           <Divider />
           <DocumentSetTable
             documentSets={documentSets}
-            editableDocumentSets={editableDocumentSets}
             refresh={refreshDocumentSets}
-            refreshEditable={refreshEditableDocumentSets}
           />
         </>
       )}

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -302,6 +302,7 @@ export function CCPairIndexingStatusTable({
             last_status: "success",
             source: ValidSources.File,
             access_type: "public",
+            permissions: {},
             docs_indexed: 1000,
             last_success: "2023-07-01T12:00:00Z",
             last_finished_status: "success",

--- a/web/src/app/craft/v1/apps/manage/layout.tsx
+++ b/web/src/app/craft/v1/apps/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.FULL_ADMIN_PANEL_ACCESS);

--- a/web/src/app/craft/v1/skills/manage/layout.tsx
+++ b/web/src/app/craft/v1/skills/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.MANAGE_SKILLS);

--- a/web/src/hooks/useCapabilities.ts
+++ b/web/src/hooks/useCapabilities.ts
@@ -1,0 +1,11 @@
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { Permission } from "@/lib/types";
+
+// Coarse "may this user reach X at all" check for affordances not tied to a fetched
+// resource (nav, a global "New X" button). Uses admin_capabilities, so a group manager
+// is included — unlike raw effective_permissions.
+export function useCapabilities(...required: Permission[]): boolean {
+  const { adminCapabilities } = useUser();
+  return hasPermission(adminCapabilities, ...required);
+}

--- a/web/src/hooks/useServerTools.ts
+++ b/web/src/hooks/useServerTools.ts
@@ -98,6 +98,7 @@ export default function useServerTools(
         description: tool.description,
         isAvailable: true,
         isEnabled: tool.enabled,
+        permissions: tool.permissions,
       }))
     : [];
 

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import AdminSidebar from "@/sections/sidebar/AdminSidebar";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import type { Route } from "next";
+import { useEffect } from "react";
 import { useSettingsContext } from "@/providers/SettingsProvider";
+import { useUser } from "@/providers/UserProvider";
 import { ApplicationStatus } from "@/interfaces/settings";
 import { Button, Text } from "@opal/components";
 import { markdown } from "@opal/utils";
@@ -10,18 +13,55 @@ import useScreenSize from "@/hooks/useScreenSize";
 import { SvgSidebar, SvgSimpleLoader } from "@opal/icons";
 import { RootLayout, useSidebarState } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
-import { isVectorDbRequiredRoute } from "@/lib/admin-routes";
+import { isVectorDbRequiredRoute, matchAdminRoute } from "@/lib/admin-routes";
+import {
+  getFirstPermittedAdminRoute,
+  hasAnyAdminPermission,
+  hasPermission,
+} from "@/lib/permissions";
 import LiteModeIndexingNotice from "@/sections/admin/LiteModeIndexingNotice";
 
 export interface AdminChromeProps {
   children: React.ReactNode;
+  // Server-fetched seed (AdminSSChrome) used until /api/me loads client-side.
+  initialAdminCapabilities: string[];
 }
 
-export default function AdminChrome({ children }: AdminChromeProps) {
+export default function AdminChrome({
+  children,
+  initialAdminCapabilities,
+}: AdminChromeProps) {
   const { setFolded } = useSidebarState();
   const { isMobile } = useScreenSize();
   const pathname = usePathname();
   const settings = useSettingsContext();
+  const router = useRouter();
+  const { user, adminCapabilities: liveAdminCapabilities } = useUser();
+
+  // Seed only until /api/me loads (`user` still null); then use the live set, so a now-empty
+  // set (capabilities revoked) denies instead of falling back to the stale seed.
+  const adminCapabilities = user
+    ? liveAdminCapabilities
+    : initialAdminCapabilities;
+
+  // Match-only per-page gate: if this page is a known admin route the user lacks the
+  // permission for (a group manager landing on a full-admin page), send them to their
+  // first permitted admin page. Unlisted detail sub-pages are left to the backend gate.
+  const matched = matchAdminRoute(pathname);
+  const denied =
+    matched !== undefined &&
+    !hasPermission(adminCapabilities, matched.requiredPermission);
+
+  useEffect(() => {
+    if (!denied) return;
+    // Some reach left → first permitted page; fully revoked → /app (else they'd bounce to an
+    // admin page they still can't open).
+    router.replace(
+      (hasAnyAdminPermission(adminCapabilities)
+        ? getFirstPermittedAdminRoute(adminCapabilities)
+        : "/app") as Route
+    );
+  }, [denied, router, adminCapabilities]);
 
   // Certain admin panels have their own custom sidebar.
   // For those pages, we skip rendering the default `AdminSidebar` and let those individual pages render their own.
@@ -41,6 +81,8 @@ export default function AdminChrome({ children }: AdminChromeProps) {
       content = <LiteModeIndexingNotice />;
     }
   }
+
+  if (denied) return null;
 
   return (
     <RootLayout.Root>

--- a/web/src/layouts/chromes/AdminSSChrome.tsx
+++ b/web/src/layouts/chromes/AdminSSChrome.tsx
@@ -17,8 +17,11 @@ export default async function AdminSSChrome({ children }: AdminSSChromeProps) {
     return redirect(authResult.redirect as Route);
   }
 
+  // Seed the client gate so a cold deep-link doesn't self-redirect before /api/me loads.
   return (
-    <AdminChrome>
+    <AdminChrome
+      initialAdminCapabilities={authResult.user?.admin_capabilities ?? []}
+    >
       <AnnouncementBanner />
       {children}
     </AdminChrome>

--- a/web/src/layouts/craft/CraftManageLayout.tsx
+++ b/web/src/layouts/craft/CraftManageLayout.tsx
@@ -8,22 +8,22 @@ interface CraftManageLayoutProps {
   children: React.ReactNode;
 }
 
-// Server-side admin-only gate (the /api/admin/* endpoints exclude curators,
-// unlike requireAdminAuth which allows them).
-export default async function CraftManageLayout({
-  children,
-}: CraftManageLayoutProps) {
-  const authResult = await requireAuth();
-  if (authResult.redirect) {
-    return redirect(authResult.redirect as Route);
-  }
-  if (
-    !hasPermission(
-      authResult.user?.effective_permissions ?? [],
-      Permission.FULL_ADMIN_PANEL_ACCESS
-    )
-  ) {
-    return redirect("/craft/v1" as Route);
-  }
-  return <>{children}</>;
+// Two routes share this factory but need different gates: /skills/manage passes
+// MANAGE_SKILLS (lets scoped managers in), /apps/manage passes FULL_ADMIN_PANEL_ACCESS
+// (its /admin/apps endpoints are admin-only). Both read admin_capabilities, which adds
+// the scoped-manager perms but never the full-admin token — so the apps gate still
+// rejects scoped managers.
+export function createCraftManageLayout(required: Permission) {
+  return async function CraftManageLayout({
+    children,
+  }: CraftManageLayoutProps) {
+    const authResult = await requireAuth();
+    if (authResult.redirect) {
+      return redirect(authResult.redirect as Route);
+    }
+    if (!hasPermission(authResult.user?.admin_capabilities ?? [], required)) {
+      return redirect("/craft/v1" as Route);
+    }
+    return <>{children}</>;
+  };
 }

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -487,3 +487,18 @@ export function isVectorDbRequiredRoute(pathname: string): boolean {
     pathname.startsWith(prefix)
   );
 }
+
+/**
+ * The admin route whose path is the longest prefix of `pathname`, or undefined if none
+ * matches. Detail sub-pages covered by no entry return undefined, so the per-page gate
+ * leaves them alone rather than default-denying.
+ */
+export function matchAdminRoute(pathname: string): AdminRouteEntry | undefined {
+  let match: AdminRouteEntry | undefined;
+  for (const route of Object.values(ADMIN_ROUTES) as AdminRouteEntry[]) {
+    if (pathname === route.path || pathname.startsWith(route.path + "/")) {
+      if (!match || route.path.length > match.path.length) match = route;
+    }
+  }
+  return match;
+}

--- a/web/src/lib/admin-sidebar-utils.ts
+++ b/web/src/lib/admin-sidebar-utils.ts
@@ -47,7 +47,7 @@ export function buildItems(
       requiredTier: route.requiredTier,
     };
 
-    // Special case: INDEX_SETTINGS shows reindexing error indicator
+    // INDEX_SETTINGS surfaces a reindexing-needed error indicator
     if (route.path === ADMIN_ROUTES.INDEX_SETTINGS.path) {
       item.error = settings?.settings.needs_reindexing;
     }
@@ -55,7 +55,6 @@ export function buildItems(
     items.push(item);
   }
 
-  // Upgrade Plan — only for full admins without a subscription
   if (
     userCanAccess(Permission.FULL_ADMIN_PANEL_ACCESS) &&
     !flags.hasSubscription

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -53,6 +53,8 @@ export interface MinimalAgent {
   builtin_persona: boolean;
   labels?: AgentLabel[];
   owner: MinimalUserSnapshot | null;
+  // per-action affordance map stamped by the list endpoints; empty/absent → fail-closed
+  permissions?: Record<string, boolean>;
 }
 
 export interface Agent extends MinimalAgent {
@@ -69,6 +71,8 @@ export interface Agent extends MinimalAgent {
 
 export interface FullAgent extends Agent {
   search_start_date: string | null;
+  // per-action affordance map for the requesting user; stamped by GET /persona/{id}
+  permissions: Record<string, boolean>;
 }
 
 // ── Upsert / API parameter types ──────────────────────────────────────────────

--- a/web/src/lib/auth/requireAuth.ts
+++ b/web/src/lib/auth/requireAuth.ts
@@ -100,8 +100,9 @@ export async function requireAdminAuth(): Promise<AuthCheckResult> {
 
   const { user, authTypeMetadata } = authResult;
 
-  // Check if user has any admin permission
-  if (user && !hasAnyAdminPermission(user.effective_permissions ?? [])) {
+  // Admit anyone who can reach any admin area — a group manager qualifies via the
+  // scoped bundle in admin_capabilities. Per-page and backend gates scope from here.
+  if (user && !hasAnyAdminPermission(user.admin_capabilities ?? [])) {
     return {
       user,
       authTypeMetadata,

--- a/web/src/lib/permissions.test.ts
+++ b/web/src/lib/permissions.test.ts
@@ -67,7 +67,7 @@ describe("hasAnyAdminPermission", () => {
   });
 
   it("returns false when the user only holds non-admin permissions", () => {
-    // BASIC_ACCESS is not gating any admin route — it should not unlock admin.
+    // BASIC_ACCESS gates no admin route, so it must not unlock admin.
     expect(hasAnyAdminPermission([Permission.BASIC_ACCESS])).toBe(false);
   });
 
@@ -86,9 +86,8 @@ describe("hasAnyAdminPermission", () => {
 
 describe("getFirstPermittedAdminRoute", () => {
   it("returns the first sidebar-labelled route for a full admin", () => {
-    // FULL_ADMIN_PANEL_ACCESS unlocks every route — we expect the very first
-    // entry in ADMIN_ROUTES declaration order that has a non-empty
-    // sidebarLabel. Today that is LLM_MODELS.
+    // FULL_ADMIN_PANEL_ACCESS unlocks every route, so the first ADMIN_ROUTES
+    // entry (declaration order) with a non-empty sidebarLabel wins — today LLM_MODELS.
     expect(
       getFirstPermittedAdminRoute([Permission.FULL_ADMIN_PANEL_ACCESS])
     ).toBe(ADMIN_ROUTES.LLM_MODELS.path);

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -1,0 +1,42 @@
+// Per-resource action vocabularies, hand-written to match the keys the server stamps
+// on each resource's `permissions` map. A backend coverage test guards that the server
+// never stamps a key absent here, so this stays in sync without a codegen pipeline.
+
+export interface WithPermissions {
+  permissions?: Record<string, boolean>;
+}
+
+export const RESOURCE_ACTIONS = {
+  ConnectorIndexingStatusLite: ["edit", "delete", "publish"],
+  CCPairFullInfo: ["edit", "delete", "publish"],
+  ToolSnapshot: ["edit", "delete", "toggle", "authenticate"],
+  MCPServer: ["edit", "delete", "authenticate", "manage_status"],
+  CustomSkill: ["edit", "manage_access", "delete", "publish"],
+  UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],
+  Agent: [
+    "edit",
+    "share",
+    "view_stats",
+    "delete",
+    "publish",
+    "feature",
+    "list",
+    "reorder",
+  ],
+} as const;
+
+export type ResourceName = keyof typeof RESOURCE_ACTIONS;
+export type ResourceAction<R extends ResourceName> =
+  (typeof RESOURCE_ACTIONS)[R][number];
+
+// Union of all actions — makes a typo a compile error, not a silent false.
+export type AnyResourceAction = ResourceAction<ResourceName>;
+
+// Fail-closed: a missing resource or unstamped key reads as false, so a control the
+// server hasn't authorized (or a new action an older client predates) never renders.
+export function can(
+  resource: WithPermissions | null | undefined,
+  action: AnyResourceAction
+): boolean {
+  return resource?.permissions?.[action] ?? false;
+}

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -39,6 +39,8 @@ export interface MCPServer {
   status: MCPServerStatus;
   last_refreshed_at?: string;
   tool_count: number;
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export interface MCPServersResponse {
@@ -65,6 +67,7 @@ export interface MCPTool {
   icon?: React.FunctionComponent<IconProps>;
   isAvailable: boolean;
   isEnabled: boolean;
+  permissions?: Record<string, boolean>;
 }
 
 export interface MethodSpec {
@@ -112,6 +115,9 @@ export interface ToolSnapshot {
   chat_selectable: boolean;
   agent_creation_selectable: boolean;
   default_enabled: boolean;
+
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export enum MCPAuthenticationType {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -78,6 +78,7 @@ export enum Permission {
   MANAGE_ACTIONS = "manage:actions",
   READ_QUERY_HISTORY = "read:query_history",
   MANAGE_USER_GROUPS = "manage:user_groups",
+  MANAGE_SKILLS = "manage:skills",
   CREATE_USER_API_KEYS = "create:user_api_keys",
   MANAGE_SERVICE_ACCOUNT_API_KEYS = "manage:service_account_api_keys",
   MANAGE_BOTS = "manage:bots",
@@ -130,6 +131,11 @@ export interface User {
   personalization?: UserPersonalization;
   effective_permissions?: string[];
   is_admin?: boolean;
+  // True if the user manages any group (drives manager nav visibility).
+  is_group_manager?: boolean;
+  // effective tokens plus the scoped manager bundle; source for coarse admin-reach
+  // checks (nav, page access). Server-computed so the client never re-derives policy.
+  admin_capabilities?: string[];
 }
 
 export interface TenantInfo {
@@ -298,6 +304,8 @@ export interface ConnectorIndexingStatusLite {
   last_status: ValidStatuses | null;
   last_success: string | null;
   is_editable: boolean;
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: Record<string, boolean>;
   docs_indexed: number;
   in_repeated_error_state: boolean;
   latest_index_attempt_docs_indexed: number | null;
@@ -444,6 +452,8 @@ export interface DocumentSetSummary {
   is_public: boolean;
   users: string[];
   groups: number[];
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: Record<string, boolean>;
   federated_connector_summaries: FederatedConnectorSummary[];
 }
 
@@ -532,6 +542,8 @@ export interface UserGroup {
   id: number;
   name: string;
   users: User[];
+  // ids of members who manage this group (drives the Make/Revoke Manager toggle)
+  manager_ids: string[];
   curator_ids: string[];
   cc_pairs: CCPairDescriptor<any, any>[];
   document_sets: DocumentSetSummary[];
@@ -539,6 +551,8 @@ export interface UserGroup {
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
   is_default: boolean;
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export enum ValidSources {

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -34,6 +34,9 @@ interface UserContextType {
   isAdmin: boolean;
   hasAdminAccess: boolean;
   permissions: string[];
+  // Coarse admin-reach set: effective tokens plus the scoped manager bundle. Feeds
+  // nav/page gates so a group manager is included; org-wide checks still use isAdmin.
+  adminCapabilities: string[];
   refreshUser: () => Promise<void>;
   isCloudSuperuser: boolean;
   authTypeMetadata: AuthTypeMetadata;
@@ -569,9 +572,11 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
           upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS
         ).includes(Permission.FULL_ADMIN_PANEL_ACCESS),
         hasAdminAccess: hasAnyAdminPermission(
-          upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS
+          upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS
         ),
         permissions: upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS,
+        adminCapabilities:
+          upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS,
         isCloudSuperuser: upToDateUser?.is_cloud_superuser ?? false,
       }}
     >

--- a/web/src/refresh-components/auth/Can.tsx
+++ b/web/src/refresh-components/auth/Can.tsx
@@ -1,0 +1,23 @@
+import {
+  AnyResourceAction,
+  can,
+  WithPermissions,
+} from "@/lib/permissions/resource-actions";
+
+interface CanProps {
+  resource: WithPermissions | null | undefined;
+  action: AnyResourceAction;
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+// Renders children only when the server authorized `action` on `resource`. The client
+// reads that answer; it never recomputes policy.
+export default function Can({
+  resource,
+  action,
+  children,
+  fallback = null,
+}: CanProps) {
+  return <>{can(resource, action) ? children : fallback}</>;
+}

--- a/web/src/refresh-pages/UserSkillsPage.tsx
+++ b/web/src/refresh-pages/UserSkillsPage.tsx
@@ -10,6 +10,8 @@ import TextSeparator from "@/refresh-components/TextSeparator";
 import useOnMount from "@/hooks/useOnMount";
 import useUserSkills from "@/hooks/useUserSkills";
 import { useUser } from "@/providers/UserProvider";
+import { useCapabilities } from "@/hooks/useCapabilities";
+import { Permission } from "@/lib/types";
 import SkillCard, {
   type CustomSkillCardItem,
   type SkillCardItem,
@@ -29,7 +31,9 @@ import { toast } from "@/hooks/useToast";
 
 export default function UserSkillsPage() {
   const { data, error, isLoading, refresh } = useUserSkills();
-  const { user, isAdmin } = useUser();
+  const { user } = useUser();
+  // Gate on admin_capabilities/MANAGE_SKILLS so scoped skill managers reach the manage entry, not just admins.
+  const canManageSkills = useCapabilities(Permission.MANAGE_SKILLS);
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CustomSkillCardItem | null>(
@@ -165,7 +169,7 @@ export default function UserSkillsPage() {
         description="Capability bundles your Craft agent can reach for. This page shows what's currently available to you — skills granted by admins plus your own personal skills."
         rightChildren={
           <div className="flex items-center gap-2">
-            {isAdmin && (
+            {canManageSkills && (
               <Button
                 href="/craft/v1/skills/manage"
                 prominence="secondary"

--- a/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
@@ -37,9 +37,7 @@ import {
 } from "@/lib/agents/svc";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
-import { useUser } from "@/providers/UserProvider";
-import { hasPermission } from "@/lib/permissions";
-import { Permission } from "@/lib/types";
+import { can } from "@/lib/permissions/resource-actions";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,14 +57,20 @@ export default function AgentRowActions({
   onMutate,
 }: AgentRowActionsProps) {
   const router = useRouter();
-  const { isAdmin, permissions } = useUser();
- const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
-    Permission.MANAGE_AGENTS
-  );
+  const businessTier = useTierAtLeast(Tier.BUSINESS);
   const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
   const shareModal = useCreateModal();
+
+  // Gate on the list row's stamped permissions so controls render immediately, not after the
+  // per-row fetch; fullAgent is only for the share modal's details below.
+  const canEdit = can(agent, "edit");
+  const canList = can(agent, "list");
+  const canUpdateFeaturedStatus = can(agent, "feature");
+  const canShare = can(agent, "share");
+  const canViewStats = can(agent, "view_stats");
+  const canDeleteRow = !agent.builtin_persona && can(agent, "delete");
+  const hasOverflowItems =
+    canList || canShare || (businessTier && canViewStats) || canDeleteRow;
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -148,7 +152,7 @@ export default function AgentRowActions({
             appear-on-hover animation. Making Hoverable more extensible
             (e.g. supporting table row groups) would let us use it here
             instead of raw Tailwind group-hover. */}
-        {!agent.builtin_persona && (
+        {!agent.builtin_persona && canEdit && (
           <div className="opacity-0 group-hover/row:opacity-100 transition-opacity">
             <Button
               prominence="tertiary"
@@ -164,112 +168,119 @@ export default function AgentRowActions({
             />
           </div>
         )}
-        {!agent.is_listed ? (
-          <Button
-            prominence="tertiary"
-            icon={SvgEyeOff}
-            tooltip="Re-list Agent"
-            onClick={() =>
-              handleAction(
-                () => toggleAgentListed(agent.id, agent.is_listed),
-                () => {}
-              )
-            }
-          />
-        ) : (
-          <div
-            className={cn(
-              !agent.is_featured &&
-                "opacity-0 group-hover/row:opacity-100 transition-opacity"
+        {!agent.is_listed
+          ? canList && (
+              <Button
+                prominence="tertiary"
+                icon={SvgEyeOff}
+                tooltip="Re-list Agent"
+                onClick={() =>
+                  handleAction(
+                    () => toggleAgentListed(agent.id, agent.is_listed),
+                    () => {}
+                  )
+                }
+              />
+            )
+          : canUpdateFeaturedStatus && (
+              <div
+                className={cn(
+                  !agent.is_featured &&
+                    "opacity-0 group-hover/row:opacity-100 transition-opacity"
+                )}
+              >
+                <Button
+                  prominence="tertiary"
+                  icon={SvgStar}
+                  interaction={featuredOpen ? "hover" : "rest"}
+                  tooltip={
+                    agent.is_featured ? "Remove Featured" : "Set as Featured"
+                  }
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    setFeaturedOpen(true);
+                  }}
+                />
+              </div>
             )}
-          >
-            <Button
-              prominence="tertiary"
-              icon={SvgStar}
-              interaction={featuredOpen ? "hover" : "rest"}
-              tooltip={
-                agent.is_featured ? "Remove Featured" : "Set as Featured"
-              }
-              onClick={() => {
-                setPopoverOpen(false);
-                setFeaturedOpen(true);
-              }}
-            />
-          </div>
-        )}
 
         {/* Overflow menu */}
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <div
-            className={cn(
-              !popoverOpen &&
-                "opacity-0 group-hover/row:opacity-100 transition-opacity"
-            )}
-          >
-            <Popover.Trigger asChild>
-              <Button prominence="tertiary" icon={SvgMoreHorizontal} />
-            </Popover.Trigger>
-          </div>
-          <Popover.Content align="end" width="sm">
-            <PopoverMenu>
-              {[
-                <LineItem
-                  key="visibility"
-                  icon={agent.is_listed ? SvgEyeOff : SvgEye}
-                  onClick={() => {
-                    setPopoverOpen(false);
-                    if (agent.is_listed) {
-                      setUnlistOpen(true);
-                    } else {
-                      handleAction(
-                        () => toggleAgentListed(agent.id, agent.is_listed),
-                        () => {}
-                      );
-                    }
-                  }}
-                >
-                  {agent.is_listed ? "Unlist Agent" : "List Agent"}
-                </LineItem>,
-                <LineItem
-                  key="share"
-                  icon={SvgShare}
-                  onClick={() => {
-                    setPopoverOpen(false);
-                    shareModal.toggle(true);
-                  }}
-                >
-                  Share
-                </LineItem>,
-                businessTier ? (
-                  <LineItem
-                    key="stats"
-                    icon={SvgBarChart}
-                    onClick={() => {
-                      setPopoverOpen(false);
-                      router.push(`/ee/agents/stats/${agent.id}` as Route);
-                    }}
-                  >
-                    Stats
-                  </LineItem>
-                ) : undefined,
-                !agent.builtin_persona ? null : undefined,
-                !agent.builtin_persona ? (
-                  <LineItem
-                    key="delete"
-                    icon={SvgTrash}
-                    danger
-                    onClick={() => {
-                      setPopoverOpen(false);
-                      setDeleteOpen(true);
-                    }}
-                  >
-                    Delete
-                  </LineItem>
-                ) : undefined,
-              ]}
-            </PopoverMenu>
-          </Popover.Content>
-        </Popover>
+        {hasOverflowItems && (
+          <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+            <div
+              className={cn(
+                !popoverOpen &&
+                  "opacity-0 group-hover/row:opacity-100 transition-opacity"
+              )}
+            >
+              <Popover.Trigger asChild>
+                <Button prominence="tertiary" icon={SvgMoreHorizontal} />
+              </Popover.Trigger>
+            </div>
+            <Popover.Content align="end" width="sm">
+              <PopoverMenu>
+                {[
+                  canList ? (
+                    <LineItem
+                      key="visibility"
+                      icon={agent.is_listed ? SvgEyeOff : SvgEye}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        if (agent.is_listed) {
+                          setUnlistOpen(true);
+                        } else {
+                          handleAction(
+                            () => toggleAgentListed(agent.id, agent.is_listed),
+                            () => {}
+                          );
+                        }
+                      }}
+                    >
+                      {agent.is_listed ? "Unlist Agent" : "List Agent"}
+                    </LineItem>
+                  ) : undefined,
+                  canShare ? (
+                    <LineItem
+                      key="share"
+                      icon={SvgShare}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        shareModal.toggle(true);
+                      }}
+                    >
+                      Share
+                    </LineItem>
+                  ) : undefined,
+                  businessTier && canViewStats ? (
+                    <LineItem
+                      key="stats"
+                      icon={SvgBarChart}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        router.push(`/ee/agents/stats/${agent.id}` as Route);
+                      }}
+                    >
+                      Stats
+                    </LineItem>
+                  ) : undefined,
+                  canDeleteRow ? (
+                    <LineItem
+                      key="delete"
+                      icon={SvgTrash}
+                      danger
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        setDeleteOpen(true);
+                      }}
+                    >
+                      Delete
+                    </LineItem>
+                  ) : undefined,
+                ]}
+              </PopoverMenu>
+            </Popover.Content>
+          </Popover>
+        )}
       </div>
 
       {deleteOpen && (

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -12,6 +12,7 @@ import {
   SvgMinusCircle,
   SvgPlusCircle,
   SvgSimpleLoader,
+  SvgShield,
 } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -26,6 +27,7 @@ import { toast } from "@/hooks/useToast";
 import { errorHandlingFetcher, skipRetryOnAuthError } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
 import { useSettingsContext } from "@/providers/SettingsProvider";
+import { useUser } from "@/providers/UserProvider";
 import { Tier } from "@/interfaces/settings";
 import { tierAtLeast } from "@/lib/tiers";
 import type { MemberRow, TokenRateLimitDisplay } from "./interfaces";
@@ -38,13 +40,14 @@ import {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 } from "./svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import SharedGroupResources from "@/refresh-pages/admin/GroupsPage/SharedGroupResources";
 import GroupPermissionsSection from "./GroupPermissionsSection";
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
-import { useUser } from "@/providers/UserProvider";
+import { can } from "@/lib/permissions/resource-actions";
 
 const addModeColumns = memberTableColumns;
 
@@ -60,6 +63,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const router = useRouter();
   const { mutate } = useSWRConfig();
   const settings = useSettingsContext();
+  const { user } = useUser();
+  const currentUserId = user?.id;
   const isEnterpriseTier = tierAtLeast(
     settings?.settings.tier,
     Tier.ENTERPRISE
@@ -67,7 +72,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const tokenLimitsDisabledTooltip = markdown(
     "Token rate limits are available on the [Enterprise version of Onyx](/admin/billing) only."
   );
-  const { isAdmin } = useUser();
 
   // Fetch the group data — poll every 5s while syncing so the UI updates
   // automatically when the backend finishes processing the previous edit.
@@ -87,22 +91,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [groups, groupId]
   );
 
+  const canManage = can(group, "manage");
+  const canDelete = can(group, "delete");
+  const canEditPermissions = can(group, "edit_permissions");
+  const canEditTokenLimits = can(group, "edit_token_limits");
+
   const isSyncing = group != null && !group.is_up_to_date;
 
-  // Fetch token rate limits for this group. Skip retry on tier-gated 402
-  // (BUSINESS-tier tenants don't have access) so SWR doesn't churn the form
-  // by repeatedly flipping its isLoading state.
+  // Gate on edit_token_limits so a non-manager (who'd 403 on the read) skips the fetch.
+  // Skip retry on tier-gated 402 so SWR doesn't churn isLoading.
   const { data: tokenRateLimits, isLoading: tokenLimitsLoading } = useSWR<
     TokenRateLimitDisplay[]
-  >(SWR_KEYS.userGroupTokenRateLimit(groupId), errorHandlingFetcher, {
-    onErrorRetry: skipRetryOnAuthError,
-  });
+  >(
+    canEditTokenLimits ? SWR_KEYS.userGroupTokenRateLimit(groupId) : null,
+    errorHandlingFetcher,
+    { onErrorRetry: skipRetryOnAuthError }
+  );
 
   // Fetch permissions for this group (admin only)
   const { data: groupPermissions, isLoading: permissionsLoading } = useSWR<
     string[]
   >(
-    isAdmin ? SWR_KEYS.userGroupPermissions(groupId) : null,
+    canEditPermissions ? SWR_KEYS.userGroupPermissions(groupId) : null,
     errorHandlingFetcher
   );
 
@@ -192,25 +202,107 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setSelectedUserIds((prev) => prev.filter((id) => id !== userId));
   }, []);
 
+  const managerIds = useMemo(() => new Set(group?.manager_ids ?? []), [group]);
+  // Manager must be a saved member (can't assign one that isn't persisted yet).
+  const persistedMemberIds = useMemo(
+    () => new Set(group?.users.map((u) => u.id) ?? []),
+    [group]
+  );
+  const [pendingManagerIds, setPendingManagerIds] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  // Hits its endpoint immediately (member add/remove defers to Save), then revalidates.
+  const handleToggleManager = useCallback(
+    async (userId: string, makeManager: boolean) => {
+      setPendingManagerIds((prev) => new Set(prev).add(userId));
+      try {
+        await setGroupManager(groupId, userId, makeManager);
+        await mutate(SWR_KEYS.adminUserGroups);
+        toast.success(makeManager ? "Manager assigned" : "Manager revoked");
+      } catch (err) {
+        console.error("Failed to update manager:", err);
+        toast.error(
+          err instanceof Error ? err.message : "Failed to update manager"
+        );
+      } finally {
+        setPendingManagerIds((prev) => {
+          const next = new Set(prev);
+          next.delete(userId);
+          return next;
+        });
+      }
+    },
+    [groupId, mutate]
+  );
+
   const memberColumns = useMemo(
     () => [
       ...baseColumns,
       tc.actions({
         showSorting: false,
         showColumnVisibility: false,
-        cell: (row: MemberRow) => (
-          <IconButton
-            icon={SvgMinusCircle}
-            tertiary
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRemoveMember(row.id ?? row.email);
-            }}
-          />
-        ),
+        cell: (row: MemberRow) => {
+          if (!canManage) return null;
+          const userId = row.id ?? row.email;
+          const isManager = managerIds.has(userId);
+          const isPersisted = persistedMemberIds.has(userId);
+          const isPending = pendingManagerIds.has(userId);
+          // Your own manager row: block revoke and member-remove — either drops your own
+          // access mid-edit (a manager must stay a member), leaving a stale editable page.
+          const isOwnManagerRow =
+            isManager && currentUserId != null && userId === currentUserId;
+          return (
+            <div className="flex items-center gap-1">
+              <IconButton
+                icon={isPending ? SvgSimpleLoader : SvgShield}
+                tertiary
+                transient={isManager}
+                disabled={!isPersisted || isPending || isOwnManagerRow}
+                aria-label={isManager ? "Revoke manager" : "Make manager"}
+                tooltip={
+                  !isPersisted
+                    ? "Save the group before assigning a manager"
+                    : isOwnManagerRow
+                      ? "You can't revoke your own manager access"
+                      : isManager
+                        ? "Revoke manager"
+                        : "Make manager"
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleToggleManager(userId, !isManager);
+                }}
+              />
+              <IconButton
+                icon={SvgMinusCircle}
+                tertiary
+                disabled={isOwnManagerRow}
+                aria-label="Remove member"
+                tooltip={
+                  isOwnManagerRow
+                    ? "You can't remove yourself while managing this group"
+                    : undefined
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemoveMember(userId);
+                }}
+              />
+            </div>
+          );
+        },
       }),
     ],
-    [handleRemoveMember]
+    [
+      handleRemoveMember,
+      handleToggleManager,
+      managerIds,
+      persistedMemberIds,
+      pendingManagerIds,
+      canManage,
+      currentUserId,
+    ]
   );
 
   // IDs of members not visible in the add-mode table (e.g. inactive users).
@@ -278,13 +370,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         selectedDocSetIds
       );
 
-      // Save token rate limits (create/update/delete) — Enterprise-only
-      if (isEnterpriseTier) {
+      // Group-scoped create/update/delete routes admit a group admin, so their full save
+      // (including PUT/DELETE of existing limits) is authorized.
+      if (isEnterpriseTier && canEditTokenLimits) {
         await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
       }
 
-      // Save permissions (bulk desired-state, admin only)
-      if (isAdmin) {
+      // Bulk desired-state replace; FULL_ADMIN only.
+      if (canEditPermissions) {
         await saveGroupPermissions(groupId, enabledPermissions);
       }
 
@@ -294,7 +387,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       mutate(SWR_KEYS.adminUserGroups);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
-      if (isAdmin) {
+      if (canEditPermissions) {
         mutate(SWR_KEYS.userGroupPermissions(groupId));
       }
       toast.success(`Group "${trimmed}" updated`);
@@ -352,7 +445,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       </Button>
       <Button
         onClick={handleSave}
-        disabled={!groupName.trim() || isSubmitting || isSyncing}
+        disabled={!groupName.trim() || isSubmitting || isSyncing || !canManage}
         tooltip={
           isSyncing
             ? "Document embeddings are being updated due to recent changes to this group."
@@ -436,13 +529,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                       Done
                     </Button>
                   ) : (
-                    <Button
-                      prominence="tertiary"
-                      icon={SvgPlusCircle}
-                      onClick={() => setIsAddingMembers(true)}
-                    >
-                      Add
-                    </Button>
+                    canManage && (
+                      <Button
+                        prominence="tertiary"
+                        icon={SvgPlusCircle}
+                        onClick={() => setIsAddingMembers(true)}
+                      >
+                        Add
+                      </Button>
+                    )
                   )}
                 </Section>
 
@@ -455,6 +550,16 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                     pageSize={PAGE_SIZE}
                     searchTerm={searchTerm}
                     selectionBehavior="multi-select"
+                    // Can't deselect yourself while you manage this group (would drop your
+                    // access on Save).
+                    canSelectRow={(row) => {
+                      const uid = row.id ?? row.email;
+                      return !(
+                        currentUserId != null &&
+                        uid === currentUserId &&
+                        managerIds.has(uid)
+                      );
+                    }}
                     initialRowSelection={currentRowSelection}
                     onSelectionChange={handleSelectionChange}
                     footer={{}}
@@ -485,7 +590,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 )}
               </Section>
 
-              {isAdmin && (
+              {canEditPermissions && (
                 <GroupPermissionsSection
                   enabledPermissions={enabledPermissions}
                   onPermissionsChange={setEnabledPermissions}
@@ -504,27 +609,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
               <TokenLimitSection
                 limits={tokenLimits}
                 onLimitsChange={setTokenLimits}
-                disabled={!isEnterpriseTier}
+                disabled={!isEnterpriseTier || !canEditTokenLimits}
                 disabledTooltip={tokenLimitsDisabledTooltip}
               />
 
-              {/* Delete This Group */}
-              <Card>
-                <InputHorizontal
-                  title="Delete This Group"
-                  description="Members will lose access to any resources shared with this group."
-                  center
-                >
-                  <Button
-                    variant="danger"
-                    prominence="secondary"
-                    icon={SvgTrash}
-                    onClick={() => setShowDeleteModal(true)}
+              {canDelete && (
+                <Card>
+                  <InputHorizontal
+                    title="Delete This Group"
+                    description="Members will lose access to any resources shared with this group."
+                    center
                   >
-                    Delete Group
-                  </Button>
-                </InputHorizontal>
-              </Card>
+                    <Button
+                      variant="danger"
+                      prominence="secondary"
+                      icon={SvgTrash}
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Delete Group
+                    </Button>
+                  </InputHorizontal>
+                </Card>
+              )}
             </>
           )}
         </SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -18,6 +18,7 @@ import { renameGroup } from "./svc";
 import { toast } from "@/hooks/useToast";
 import { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface GroupCardProps {
   group: UserGroup;
@@ -30,6 +31,7 @@ function GroupCard({ group }: GroupCardProps) {
   const isAdmin = group.name === "Admin";
   const isBasic = group.name === "Basic";
   const isSyncing = !group.is_up_to_date;
+  const canManage = can(group, "manage");
 
   async function handleRename(newName: string) {
     try {
@@ -51,8 +53,10 @@ function GroupCard({ group }: GroupCardProps) {
         sizePreset="main-content"
         variant="section"
         tag={isBasic ? { title: "Default" } : undefined}
-        editable={!builtIn && !isSyncing}
-        onTitleChange={!builtIn && !isSyncing ? handleRename : undefined}
+        editable={!builtIn && !isSyncing && canManage}
+        onTitleChange={
+          !builtIn && !isSyncing && canManage ? handleRename : undefined
+        }
         rightChildren={
           <Section flexDirection="row" alignItems="start" gap={0}>
             <div className="py-1">
@@ -62,13 +66,17 @@ function GroupCard({ group }: GroupCardProps) {
                 )}
               </Text>
             </div>
-            <Button
-              icon={SvgChevronRight}
-              prominence="tertiary"
-              tooltip="View group"
-              aria-label="View group"
-              onClick={() => router.push(`/admin/groups/${group.id}` as Route)}
-            />
+            {canManage && (
+              <Button
+                icon={SvgChevronRight}
+                prominence="tertiary"
+                tooltip="View group"
+                aria-label="View group"
+                onClick={() =>
+                  router.push(`/admin/groups/${group.id}` as Route)
+                }
+              />
+            )}
           </Section>
         }
       />

--- a/web/src/refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx
@@ -30,11 +30,8 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type { PermissionRegistryEntry } from "@/refresh-pages/admin/GroupsPage/interfaces";
 
-// ---------------------------------------------------------------------------
-// Icon mapping — the only permission metadata maintained in the frontend.
-// The `id` keys must match the backend PERMISSION_REGISTRY entries.
-// ---------------------------------------------------------------------------
-
+// Icon mapping — the only permission metadata kept in the frontend.
+// `id` keys must match the backend PERMISSION_REGISTRY entries.
 const ICON_MAP: Record<string, IconFunctionComponent> = {
   manage_llms: SvgCpu,
   manage_connectors_and_document_sets: SvgFiles,
@@ -48,10 +45,6 @@ const ICON_MAP: Record<string, IconFunctionComponent> = {
   view_query_history: SvgHistory,
   create_user_access_token: SvgKey,
 };
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
 
 interface GroupPermissionsSectionProps {
   enabledPermissions: Set<string>;

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Route } from "next";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { SvgExternalLink, SvgUsers, SvgSimpleLoader } from "@opal/icons";
@@ -9,7 +9,11 @@ import { Button, MessageCard } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
+import { Permission } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 import GroupsList from "./GroupsList";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
 import { IllustrationContent } from "@opal/layouts";
@@ -18,12 +22,27 @@ import SvgNoResult from "@opal/illustrations/no-result";
 function GroupsPage() {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
+  const { user } = useUser();
+
+  // Create is global-only (route has no allow_scope); gate on the global token, not
+  // admin_capabilities, which would show it to scoped managers who'd then 403.
+  const canCreateGroup = hasPermission(
+    user?.effective_permissions ?? [],
+    Permission.MANAGE_USER_GROUPS
+  );
 
   const {
     data: groups,
     error,
     isLoading,
   } = useSWR<UserGroup[]>(SWR_KEYS.adminUserGroups, errorHandlingFetcher);
+
+  // The list is READ_USER_GROUPS-scoped (implied by MANAGE_LLMS etc.), so filter to
+  // manageable groups — else a read-only holder sees groups with no open action.
+  const manageableGroups = useMemo(
+    () => (groups ?? []).filter((group) => can(group, "manage")),
+    [groups]
+  );
 
   return (
     <SettingsLayouts.Root>
@@ -53,13 +72,17 @@ function GroupsPage() {
 
       <SettingsLayouts.Body>
         <AdminListHeader
-          hasItems={!isLoading && !error && (groups?.length ?? 0) > 0}
+          hasItems={!isLoading && !error && manageableGroups.length > 0}
           searchQuery={searchQuery}
           onSearchQueryChange={setSearchQuery}
           placeholder="Search groups..."
           emptyStateText="Create groups to organize users and manage access."
-          onAction={() => router.push("/admin/groups/create" as Route)}
-          actionLabel="New Group"
+          onAction={
+            canCreateGroup
+              ? () => router.push("/admin/groups/create" as Route)
+              : undefined
+          }
+          actionLabel={canCreateGroup ? "New Group" : undefined}
         />
 
         {isLoading && <SvgSimpleLoader />}
@@ -73,7 +96,7 @@ function GroupsPage() {
         )}
 
         {!isLoading && !error && groups && (
-          <GroupsList groups={groups} searchQuery={searchQuery} />
+          <GroupsList groups={manageableGroups} searchQuery={searchQuery} />
         )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>

--- a/web/src/refresh-pages/admin/GroupsPage/svc.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/svc.ts
@@ -228,7 +228,7 @@ async function saveTokenLimits(
     const limit = validLimits[i]!;
     const existingLimit = existing[i]!;
     const updateRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -270,7 +270,7 @@ async function saveTokenLimits(
   for (let i = toUpdate; i < existing.length; i++) {
     const existingLimit = existing[i]!;
     const deleteRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       { method: "DELETE" }
     );
     if (!deleteRes.ok) {
@@ -302,6 +302,24 @@ async function saveGroupPermissions(
   }
 }
 
+async function setGroupManager(
+  groupId: number,
+  userId: string,
+  isManager: boolean
+): Promise<void> {
+  const res = await fetch(`${USER_GROUP_URL}/${groupId}/manager`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId, is_manager: isManager }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(
+      detail?.detail ?? `Failed to update group manager: ${res.statusText}`
+    );
+  }
+}
+
 export {
   renameGroup,
   createGroup,
@@ -311,4 +329,5 @@ export {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 };

--- a/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
@@ -12,6 +12,7 @@ import {
 } from "@opal/icons";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,13 @@ export default function CustomSkillRowActions({
 }: CustomSkillRowActionsProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
+  const canEdit = can(skill, "edit");
+  const canManageAccess = can(skill, "manage_access");
+  const canDelete = can(skill, "delete");
+  const hasItems = canEdit || canManageAccess || canDelete;
+
+  if (!hasItems) return null;
+
   return (
     <div className="flex items-center gap-0.5">
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
@@ -55,47 +63,55 @@ export default function CustomSkillRowActions({
         <Popover.Content align="end" width="sm">
           <PopoverMenu>
             {[
-              <LineItem
-                key="share"
-                icon={SvgShare}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onShare();
-                }}
-              >
-                Edit visibility
-              </LineItem>,
-              <LineItem
-                key="replace"
-                icon={SvgUploadCloud}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onReplaceBundle();
-                }}
-              >
-                Replace bundle
-              </LineItem>,
-              <LineItem
-                key="enabled"
-                icon={skill.enabled ? SvgEyeOff : SvgEye}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onToggleEnabled();
-                }}
-              >
-                {skill.enabled ? "Disable" : "Re-enable"}
-              </LineItem>,
-              <LineItem
-                key="delete"
-                icon={SvgTrash}
-                danger
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onDelete();
-                }}
-              >
-                Delete
-              </LineItem>,
+              canManageAccess ? (
+                <LineItem
+                  key="share"
+                  icon={SvgShare}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onShare();
+                  }}
+                >
+                  Edit visibility
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="replace"
+                  icon={SvgUploadCloud}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onReplaceBundle();
+                  }}
+                >
+                  Replace bundle
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="enabled"
+                  icon={skill.enabled ? SvgEyeOff : SvgEye}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onToggleEnabled();
+                  }}
+                >
+                  {skill.enabled ? "Disable" : "Re-enable"}
+                </LineItem>
+              ) : undefined,
+              canDelete ? (
+                <LineItem
+                  key="delete"
+                  icon={SvgTrash}
+                  danger
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onDelete();
+                  }}
+                >
+                  Delete
+                </LineItem>
+              ) : undefined,
             ]}
           </PopoverMenu>
         </Popover.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
@@ -9,6 +9,7 @@ import SkillSharePicker from "@/refresh-pages/admin/SkillsPage/SkillSharePicker"
 import { patchCustomSkill, replaceCustomSkillGrants } from "@/lib/skills/api";
 import { toast } from "@/hooks/useToast";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface ShareSkillModalProps {
   skill: CustomSkill | null;
@@ -104,6 +105,7 @@ export default function ShareSkillModal({
               onIsPublicChange={setIsPublic}
               groupIds={groupIds}
               onGroupIdsChange={setGroupIds}
+              canPublish={can(skill, "publish")}
             />
             {skill.is_personal && (isPublic || groupIds.length > 0) && (
               <MessageCard

--- a/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
@@ -17,6 +17,8 @@ interface SkillSharePickerProps {
   onIsPublicChange: (isPublic: boolean) => void;
   groupIds: number[];
   onGroupIdsChange: (groupIds: number[]) => void;
+  // Org-wide publish is admin-only; fail closed so an omitted value disables the switch.
+  canPublish?: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ export default function SkillSharePicker({
   onIsPublicChange,
   groupIds,
   onGroupIdsChange,
+  canPublish = false,
 }: SkillSharePickerProps) {
   const {
     data: groupsData,
@@ -137,7 +140,11 @@ export default function SkillSharePicker({
               description="Make this skill available to everyone in your organization."
               withLabel
             >
-              <Switch checked={isPublic} onCheckedChange={onIsPublicChange} />
+              <Switch
+                checked={isPublic}
+                onCheckedChange={onIsPublicChange}
+                disabled={!canPublish}
+              />
             </InputHorizontal>
           </Section>
         </Tabs.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.test.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@tests/setup/test-utils";
+import UploadSkillModal from "./UploadSkillModal";
+import { Permission } from "@/lib/types";
+import { useUser } from "@/providers/UserProvider";
+
+jest.mock("@/providers/UserProvider", () => ({
+  useUser: jest.fn(),
+}));
+
+jest.mock("@/hooks/useShareableGroups", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [] })),
+}));
+
+jest.mock("@/lib/skills/api", () => ({
+  createCustomSkill: jest.fn(),
+}));
+
+const mockUseUser = useUser as jest.Mock;
+
+function noop() {}
+
+describe("UploadSkillModal publish default", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("opens public-by-default for an admin whose permissions load after mount", async () => {
+    // Mount closed while permissions are still loading (empty set) — the stale-capture case.
+    mockUseUser.mockReturnValue({ permissions: [] });
+    const { rerender } = render(
+      <UploadSkillModal open={false} onClose={noop} onUploaded={noop} />
+    );
+
+    // Permissions resolve (global skill admin) and the dialog opens.
+    mockUseUser.mockReturnValue({ permissions: [Permission.MANAGE_SKILLS] });
+    rerender(<UploadSkillModal open onClose={noop} onUploaded={noop} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("tab", { name: "Your Organization" })
+      ).toHaveAttribute("data-state", "active")
+    );
+  });
+
+  it("opens private for a scoped manager without publish permission", async () => {
+    mockUseUser.mockReturnValue({ permissions: [] });
+    render(<UploadSkillModal open onClose={noop} onUploaded={noop} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Groups" })).toHaveAttribute(
+        "data-state",
+        "active"
+      )
+    );
+  });
+});

--- a/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.tsx
@@ -9,6 +9,9 @@ import { Section } from "@/layouts/general-layouts";
 import SkillSharePicker from "@/refresh-pages/admin/SkillsPage/SkillSharePicker";
 import { createCustomSkill } from "@/lib/skills/api";
 import { toast } from "@/hooks/useToast";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { Permission } from "@/lib/types";
 
 interface UploadSkillModalProps {
   open: boolean;
@@ -22,15 +25,33 @@ export default function UploadSkillModal({
   onClose,
   onUploaded,
 }: UploadSkillModalProps) {
+  // Publish is global MANAGE_SKILLS; read effective (global) permissions, not
+  // adminCapabilities — the scoped bundle would over-grant a group manager.
+  const { permissions } = useUser();
+  const canPublish = hasPermission(permissions, Permission.MANAGE_SKILLS);
+
   const [file, setFile] = useState<File | null>(null);
-  const [isPublic, setIsPublic] = useState(true);
+  // Default private for scoped managers; the server 403s their public create.
+  const [isPublic, setIsPublic] = useState(canPublish);
   const [groupIds, setGroupIds] = useState<number[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Always-mounted modal: the useState above can capture a stale canPublish while permissions
+  // are still loading. Re-sync the default each time the dialog opens (by then permissions have
+  // loaded). Done during render, not in an effect, so the picker's tab mounts from the corrected
+  // value instead of a frame late.
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setIsPublic(canPublish);
+    }
+  }
+
   function reset() {
     setFile(null);
-    setIsPublic(true);
+    setIsPublic(canPublish);
     setGroupIds([]);
   }
 
@@ -117,6 +138,7 @@ export default function UploadSkillModal({
                 onIsPublicChange={setIsPublic}
                 groupIds={groupIds}
                 onGroupIdsChange={setGroupIds}
+                canPublish={canPublish}
               />
             </Section>
           </Section>

--- a/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
+++ b/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
@@ -43,6 +43,8 @@ export interface CustomSkill {
   created_at: string | null;
   updated_at: string | null;
   granted_group_ids: number[];
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export interface SkillsList {

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -19,6 +19,7 @@ import {
   MCPServer,
 } from "@/lib/tools/interfaces";
 import useServerTools from "@/hooks/useServerTools";
+import { can } from "@/lib/permissions/resource-actions";
 import { KeyedMutator } from "swr";
 import type { IconProps } from "@opal/types";
 import {
@@ -110,6 +111,11 @@ export default function MCPActionCard({
   const [showOnlyEnabled, setShowOnlyEnabled] = useState(false);
   const [isToolsRefreshing, setIsToolsRefreshing] = useState(false);
   const deleteModal = useCreateModal();
+
+  const canEdit = can(server, "edit");
+  const canDelete = can(server, "delete");
+  const canAuthenticate = can(server, "authenticate");
+  const canManageStatus = can(server, "manage_status");
 
   // Update expanded state when initialExpanded changes
   const hasInitializedExpansion = useRef(false);
@@ -206,17 +212,23 @@ export default function MCPActionCard({
       <Actions
         status={status}
         serverName={title}
-        onDisconnect={onDisconnect}
-        onManage={onManage}
-        onAuthenticate={onAuthenticate}
-        onReconnect={onReconnect}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={canManageStatus ? onDisconnect : undefined}
+        onManage={canEdit ? onManage : undefined}
+        onAuthenticate={canAuthenticate ? onAuthenticate : undefined}
+        onReconnect={canManageStatus ? onReconnect : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
         toolCount={toolCount}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={handleToggleTools}
       />
     ),
     [
+      canAuthenticate,
+      canDelete,
+      canEdit,
+      canManageStatus,
       deleteModal,
       handleToggleTools,
       isToolsExpanded,
@@ -251,13 +263,15 @@ export default function MCPActionCard({
 
     return (
       <div className="flex items-center gap-2">
-        <Button
-          icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
-          prominence="internal"
-          onClick={handleRefreshTools}
-          tooltip="Refresh tools"
-          aria-label="Refresh tools"
-        />
+        {canManageStatus && (
+          <Button
+            icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
+            prominence="internal"
+            onClick={handleRefreshTools}
+            tooltip="Refresh tools"
+            aria-label="Refresh tools"
+          />
+        )}
         {lastRefreshedText && (
           <Text as="p" text03 mainUiBody className="whitespace-nowrap">
             Tools last refreshed {lastRefreshedText}
@@ -266,6 +280,7 @@ export default function MCPActionCard({
       </div>
     );
   }, [
+    canManageStatus,
     server.last_refreshed_at,
     serverId,
     mutate,
@@ -281,8 +296,8 @@ export default function MCPActionCard({
         icon={icon}
         status={status}
         actions={actionsComponent}
-        onEdit={onEdit}
-        onRename={handleRename}
+        onEdit={canEdit ? onEdit : undefined}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}
@@ -300,10 +315,16 @@ export default function MCPActionCard({
           enabledCount={tools.filter((tool) => tool.isEnabled).length}
           showOnlyEnabled={showOnlyEnabled}
           onToggleShowOnlyEnabled={handleToggleShowOnlyEnabled}
-          onUpdateToolsStatus={(enabled) => {
-            const toolIds = tools.map((tool) => parseInt(tool.id));
-            onUpdateToolsStatus?.(serverId, toolIds, enabled, mutate);
-          }}
+          onUpdateToolsStatus={
+            // Bulk toggles all tools; the status route 403s the whole batch unless every
+            // tool is manageable, so only offer it when the user can toggle each one.
+            tools.length > 0 && tools.every((tool) => can(tool, "toggle"))
+              ? (enabled) => {
+                  const toolIds = tools.map((tool) => parseInt(tool.id));
+                  onUpdateToolsStatus?.(serverId, toolIds, enabled, mutate);
+                }
+              : undefined
+          }
           isEmpty={filteredTools.length === 0}
           searchQuery={searchQuery}
           emptyMessage="No tools available"
@@ -318,6 +339,7 @@ export default function MCPActionCard({
               icon={tool.icon}
               isAvailable={tool.isAvailable}
               isEnabled={tool.isEnabled}
+              canToggle={can(tool, "toggle")}
               onToggle={(enabled) =>
                 onToolToggle?.(serverId, tool.id, enabled, mutate)
               }

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -10,6 +10,7 @@ import { ToolSnapshot, ActionStatus, MethodSpec } from "@/lib/tools/interfaces";
 import ToolItem from "@/sections/actions/ToolItem";
 import { extractMethodSpecsFromDefinition } from "@/lib/tools/openApiService";
 import { updateToolStatus } from "@/lib/tools/mcpService";
+import { can } from "@/lib/permissions/resource-actions";
 import { SvgServer, SvgTrash } from "@opal/icons";
 import Modal from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { Button } from "@opal/components";
@@ -39,6 +40,13 @@ export default function OpenApiActionCard({
   const [searchQuery, setSearchQuery] = useState("");
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const deleteModal = useCreateModal();
+
+  const canEdit = can(tool, "edit");
+  const canDelete = can(tool, "delete");
+  const canToggle = can(tool, "toggle");
+  // Authenticate manages the OAuth config (owner-or-admin) — gate on the server capability,
+  // not canEdit, so a scoped non-owner isn't shown a 403 button.
+  const canAuthenticate = can(tool, "authenticate");
 
   const methodSpecs = useMemo<MethodSpec[]>(() => {
     try {
@@ -121,16 +129,24 @@ export default function OpenApiActionCard({
         toolCount={methodSpecs.length}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={methodSpecs.length ? handleToggleTools : undefined}
-        onDisconnect={() => onOpenDisconnectModal?.(tool)}
-        onManage={onManage ? () => onManage(tool) : undefined}
-        onAuthenticate={() => {
-          onAuthenticate(tool);
-        }}
-        onReconnect={() => handleConnectionUpdate(true)}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={
+          canToggle ? () => onOpenDisconnectModal?.(tool) : undefined
+        }
+        onManage={canEdit && onManage ? () => onManage(tool) : undefined}
+        onAuthenticate={
+          canAuthenticate ? () => onAuthenticate(tool) : undefined
+        }
+        onReconnect={canToggle ? () => handleConnectionUpdate(true) : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
       />
     ),
     [
+      canAuthenticate,
+      canDelete,
+      canEdit,
+      canToggle,
       deleteModal,
       handleConnectionUpdate,
       handleToggleTools,
@@ -159,7 +175,7 @@ export default function OpenApiActionCard({
         icon={SvgServer}
         status={status}
         actions={actionsComponent}
-        onRename={handleRename}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}

--- a/web/src/sections/actions/ToolItem.tsx
+++ b/web/src/sections/actions/ToolItem.tsx
@@ -73,6 +73,7 @@ export interface ToolItemProps {
 
   // Handlers
   onToggle?: (enabled: boolean) => void;
+  canToggle?: boolean;
 
   // Optional styling
   className?: string;
@@ -87,6 +88,7 @@ const ToolItem: React.FC<ToolItemProps> = ({
   variant = "mcp",
   openApiMetadata,
   onToggle,
+  canToggle = true,
   className,
 }) => {
   const isMcpVariant = variant === "mcp";
@@ -226,7 +228,7 @@ const ToolItem: React.FC<ToolItemProps> = ({
             <Switch
               checked={isEnabled}
               onCheckedChange={onToggle}
-              disabled={!isAvailable}
+              disabled={!isAvailable || !canToggle}
               aria-label={`tool-toggle-${name}`}
             />
           </div>

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -11,6 +11,7 @@ import { CopyButton } from "@opal/components";
 import { Button, Divider } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { MethodSpec, ToolSnapshot } from "@/lib/tools/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import {
   validateToolDefinition,
   createCustomTool,
@@ -91,6 +92,11 @@ function FormContent({
   const [url, setUrl] = useState<string | undefined>(undefined);
 
   const isEditMode = Boolean(existingTool);
+  // Editing auth manages the action's OAuth config (owner-or-admin); gate on the same
+  // server-stamped capability as the card.
+  const canEditAuthentication = existingTool
+    ? can(existingTool, "authenticate")
+    : false;
 
   const handleFormat = useCallback(() => {
     if (!values.definition.trim()) {
@@ -370,7 +376,12 @@ function FormContent({
                 }}
               />
               <Button
-                disabled={!onEditAuthentication}
+                disabled={!onEditAuthentication || !canEditAuthentication}
+                tooltip={
+                  !canEditAuthentication
+                    ? "Only the action's creator or an admin can manage authentication"
+                    : undefined
+                }
                 prominence="secondary"
                 type="button"
                 onClick={handleEditAuthenticationClick}

--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -16,10 +16,10 @@ interface AdminListHeaderProps {
   placeholder?: string;
   /** Text shown in the empty-state card when no items exist. */
   emptyStateText: string;
-  /** Called when the action button is clicked. */
-  onAction: () => void;
-  /** Label for the action button. */
-  actionLabel: string;
+  /** Action button click handler. Omit (with actionLabel) to hide the button. */
+  onAction?: () => void;
+  /** Label for the action button. Omit (with onAction) to hide it. */
+  actionLabel?: string;
 }
 
 /**
@@ -59,11 +59,12 @@ export default function AdminListHeader({
   onAction,
   actionLabel,
 }: AdminListHeaderProps) {
-  const actionButton = (
-    <Button rightIcon={SvgPlusCircle} onClick={onAction}>
-      {actionLabel}
-    </Button>
-  );
+  const actionButton =
+    onAction && actionLabel ? (
+      <Button rightIcon={SvgPlusCircle} onClick={onAction}>
+        {actionLabel}
+      </Button>
+    ) : null;
 
   if (!hasItems) {
     return (

--- a/web/src/sections/agents/AgentCard.tsx
+++ b/web/src/sections/agents/AgentCard.tsx
@@ -11,7 +11,7 @@ import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
-import { checkUserOwnsAgent } from "@/lib/agents/utils";
+import { can } from "@/lib/permissions/resource-actions";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
 import {
@@ -19,8 +19,6 @@ import {
   updateAgentFeaturedStatus,
 } from "@/lib/agents/svc";
 import { useUser } from "@/providers/UserProvider";
-import { hasPermission } from "@/lib/permissions";
-import { Permission } from "@/lib/types";
 import {
   SvgActions,
   SvgBarChart,
@@ -52,16 +50,14 @@ export default function AgentCard({ agent }: AgentCardProps) {
     () => pinnedAgents.some((pinnedAgent) => pinnedAgent.id === agent.id),
     [agent.id, pinnedAgents]
   );
-  const { user, isAdmin, permissions } = useUser();
+  const { isAdmin } = useUser();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
-    Permission.MANAGE_AGENTS
-  );
-  const isOwnedByUser = checkUserOwnsAgent(user, agent);
   const shareAgentModal = useCreateModal();
   const agentViewerModal = useCreateModal();
   const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
+  // Affordances read the map the list endpoint stamped on `agent`, so icons render with
+  // the card instead of popping in after the per-card fullAgent fetch resolves.
+  const canUpdateFeaturedStatus = can(agent, "feature");
 
   // Start chat and auto-pin unpinned agents to the sidebar
   const handleStartChat = useCallback(() => {
@@ -146,7 +142,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
               description={agent.description}
               rightChildren={
                 <>
-                  {isOwnedByUser && businessTier && (
+                  {can(agent, "view_stats") && businessTier && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgBarChart}
@@ -158,7 +154,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {can(agent, "edit") && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgEdit}
@@ -170,7 +166,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {can(agent, "share") && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgShare}

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -41,7 +41,7 @@ export default function AdminSidebar() {
   }, [focusSearch, folded]);
   const pathname = usePathname();
   const { customAnalyticsEnabled } = useCustomAnalyticsEnabled();
-  const { permissions } = useUser();
+  const { adminCapabilities } = useUser();
   const settings = useSettingsContext();
   const tier = settings?.settings.tier;
   const { data: billingData, isLoading: billingLoading } =
@@ -69,7 +69,7 @@ export default function AdminSidebar() {
       !settings?.settings.hide_query_history_from_admin_panel,
   };
 
-  const allItems = buildItems(permissions, flags, settings);
+  const allItems = buildItems(adminCapabilities, flags, settings);
 
   const itemExtractor = useCallback((item: SidebarItemEntry) => item.name, []);
 

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -470,7 +470,7 @@ const AppSidebar = memo(function AppSidebarInner() {
     ]
   );
 
-  const { isAdmin, hasAdminAccess, permissions, user } = useUser();
+  const { isAdmin, hasAdminAccess, adminCapabilities, user } = useUser();
   const activeSidebarTab = useAppFocus();
   const createProjectModal = useCreateModal();
   const showLogoWhenFolded = useShowLogoWhenFolded();
@@ -578,7 +578,7 @@ const AppSidebar = memo(function AppSidebarInner() {
       <div>
         {hasAdminAccess && (
           <SidebarTab
-            href={getFirstPermittedAdminRoute(permissions)}
+            href={getFirstPermittedAdminRoute(adminCapabilities)}
             icon={SvgSettings}
             folded={folded}
           >
@@ -596,7 +596,7 @@ const AppSidebar = memo(function AppSidebarInner() {
     [
       folded,
       hasAdminAccess,
-      permissions,
+      adminCapabilities,
       handleShowBuildIntro,
       isOnyxCraftEnabled,
     ]

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -73,7 +73,6 @@ test.describe("Permission gating — MANAGE_AGENTS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a custom agent
     const agentName = `E2E Manage Agent ${Date.now()}`;
     const agentId = await adminClient.createAgent(agentName, "Test agent");
 
@@ -114,7 +113,6 @@ test.describe("Permission gating — MANAGE_AGENTS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the agent
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -139,7 +137,6 @@ test.describe("Permission gating — MANAGE_LLMS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates an LLM provider
     const providerName = `E2E Manage LLM ${Date.now()}`;
     const providerId = await adminClient.createProvider(providerName);
 
@@ -182,7 +179,6 @@ test.describe("Permission gating — MANAGE_LLMS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the provider
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -207,7 +203,6 @@ test.describe("Permission gating — MANAGE_CONNECTORS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a file connector
     const connectorName = `E2E Manage Connector ${Date.now()}`;
     const ccPairId = await adminClient.createFileConnector(connectorName);
 
@@ -261,7 +256,6 @@ test.describe("Permission gating — MANAGE_CONNECTORS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the connector
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -286,7 +280,6 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a public file connector
     const connectorName = `E2E DocSet Connector ${Date.now()}`;
     const ccPairId = await adminClient.createFileConnector(
       connectorName,
@@ -340,17 +333,17 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
         page.getByLabel("admin-page-title").getByText("New Document Set")
       ).toBeVisible({ timeout: 10000 });
 
-      // Open the connector dropdown and verify the admin-created connector is listed
+      // Open the connector dropdown
       const connectorSearchInput = page.getByTestId("connector-search-input");
       await expect(connectorSearchInput).toBeVisible({ timeout: 10000 });
       await connectorSearchInput.click();
 
-      // Verify the connector is visible (proves implied READ_CONNECTORS)
+      // Connector visible proves implied READ_CONNECTORS
       await expect(page.getByText(connectorName)).toBeVisible({
         timeout: 10000,
       });
 
-      // Verify group selector loaded successfully (proves implied READ_USER_GROUPS)
+      // Group selector loaded proves implied READ_USER_GROUPS
       await expect(
         page.getByText("Assign group access for this document set")
       ).toBeVisible({ timeout: 10000 });
@@ -381,7 +374,6 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the connector and extra group
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -407,7 +399,6 @@ test.describe("Permission gating — MANAGE_ACTIONS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates an OpenAPI custom tool and an MCP server
     const toolName = `E2E Manage Tool ${Date.now()}`;
     const toolId = await adminClient.createCustomTool(toolName);
 
@@ -473,7 +464,6 @@ test.describe("Permission gating — MANAGE_ACTIONS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the tool and MCP server
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -499,7 +489,6 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a service account
     const accountName = `E2E Service Account ${Date.now()}`;
     const apiKeyId = await adminClient.createServiceAccount(accountName);
 
@@ -561,7 +550,6 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the service account and extra group
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -647,7 +635,6 @@ test.describe("Permission gating — MANAGE_BOTS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the Discord guild
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -713,7 +700,6 @@ test.describe("Permission gating — READ_QUERY_HISTORY", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the chat session
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -803,7 +789,7 @@ test.describe("Permission gating — CREATE_USER_API_KEYS", () => {
       await expect(newTokenButton).toBeVisible({ timeout: 10000 });
       await expect(newTokenButton).toBeDisabled();
     } finally {
-      // Cleanup: delete the PAT (only requires BASIC_ACCESS)
+      // Delete the PAT (only requires BASIC_ACCESS)
       if (createdPatId !== undefined) {
         await page.context().clearCookies();
         await apiLogin(page, email, password);
@@ -910,7 +896,7 @@ test.describe("Permission gating — MANAGE_USER_GROUPS", () => {
         timeout: 10000,
       });
 
-      // Dismiss the connectors popover by pressing Escape before opening agents
+      // Dismiss the connectors popover before opening agents
       await page.keyboard.press("Escape");
 
       // Open agents popover and verify item (proves READ_AGENTS)
@@ -932,7 +918,7 @@ test.describe("Permission gating — MANAGE_USER_GROUPS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete resources (doc set before connector since it references it)
+      // Delete doc set before connector since it references it
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);

--- a/web/tests/e2e/admin/permissions/permission_system.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_system.spec.ts
@@ -50,8 +50,8 @@ test("group permissions apply immediately when a user is added to the group", as
       Permission.MANAGE_LLMS,
     ]);
 
-    // This is intentionally not followed by waitForGroupSync. Auth permission
-    // recomputation is expected to complete before add-users returns.
+    // Intentionally no waitForGroupSync: auth permission recomputation
+    // is expected to complete before add-users returns.
     await adminClient.addUsersToGroup(groupId, [user.id]);
 
     await page.context().clearCookies();

--- a/web/tests/e2e/utils/onyxApiClient.ts
+++ b/web/tests/e2e/utils/onyxApiClient.ts
@@ -776,10 +776,11 @@ export class OnyxApiClient {
 
   async getCurrentUserPermissions(): Promise<string[]> {
     const response = await this.get("/me/permissions");
-    return await this.handleResponse(
+    const body = await this.handleResponse<{ permissions: string[] }>(
       response,
       "Failed to fetch current user permissions"
     );
+    return body.permissions;
   }
 
   async addUserToAdminGroup(email: string): Promise<void> {


### PR DESCRIPTION
## Description

PR5 of the group-manager scoped-permissions series (stacked on PR4). Completes the backend: lets admins and in-group managers create managers, scopes group membership edits, and exposes the manager flag to clients.

- Add a manager-assignment endpoint (`PUT /admin/user-group/{group_id}/manager`) plus `make_group_manager`/`revoke_group_manager` — admins assign anywhere, a scoped manager only within a group they manage; non-member targets are rejected.
- Scope group membership edits (patch, add-users, rename) so a manager can only edit a group they manage.
- Close the junction-rewrite escalation vector: a newly-attached connector must be private and within the manager's managed scope (authorized against `is_current` junction rows only, so a removed-but-not-yet-swept pair can't slip past).
- Scope the admin group list so a manager sees only the groups they manage (admins keep the full list).
- Expose `is_manager` + `managed_group_ids` on `/me/permissions` so the frontend can reveal manager nav.
- Group create, delete, and set-permissions stay admin-only.

## How Has This Been Tested?

Added an integration escalation suite (`test_group_manager_membership.py`, 22 tests) covering the assignment endpoint, membership/rename gates, the cc_pair re-attach gate (incl. a stale-junction-row regression), the scoped group list, `/me/permissions` flags, and the admin-only carve-outs. Verified with ruff + ty + the `has_permission` unit suite + `pytest --collect-only`; the integration suite needs a live EE deployment to run (pending, same as PR3/PR4).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
