### PR TITLE
refactor(mcp): polymorphic gated_app identity for gated targets

### DIFF
--- a/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
+++ b/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
@@ -1,0 +1,256 @@
+"""replace external-app approval targets with a polymorphic gated_app
+
+The approval pipeline (per-action policy, approval rows, scheduled-task
+pre-approvals) attributed a gated request to an ``external_app`` row. Introduce a
+polymorphic ``gated_app`` identity table — one row per external app or MCP
+server — and repoint every consumer at a single ``gated_app_id`` FK, so a new
+gated-target catalog adds one column to ``gated_app`` instead of a column to
+every consumer table. ``external_app_policy`` becomes ``gated_action_policy``.
+
+Revision ID: bc9e56f2fb96
+Revises: 1e0a3e4226f7
+Create Date: 2026-07-17 14:10:36.718336
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+from onyx.db.enums import GatedAppKind
+
+
+# revision identifiers, used by Alembic.
+revision = "bc9e56f2fb96"
+down_revision = "1e0a3e4226f7"
+branch_labels = None
+depends_on = None
+
+_EXTERNAL_APP = GatedAppKind.EXTERNAL_APP.value
+_MCP_SERVER = GatedAppKind.MCP_SERVER.value
+
+
+def upgrade() -> None:
+    # --- polymorphic identity table -------------------------------------
+    op.create_table(
+        "gated_app",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.Enum(GatedAppKind, native_enum=False), nullable=False),
+        sa.Column("external_app_id", sa.Integer(), nullable=True),
+        sa.Column("mcp_server_id", sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["external_app_id"], ["external_app.id"], ondelete="CASCADE"
+        ),
+        sa.ForeignKeyConstraint(
+            ["mcp_server_id"], ["mcp_server.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("external_app_id", name="uq_gated_app_external_app"),
+        sa.UniqueConstraint("mcp_server_id", name="uq_gated_app_mcp_server"),
+        sa.CheckConstraint(
+            "num_nonnulls(external_app_id, mcp_server_id) = 1",
+            name="ck_gated_app_single_target",
+        ),
+    )
+    # One identity row per existing target so current policy / approval /
+    # pre-approval rows can be repointed. New targets get theirs lazily.
+    op.execute(
+        f"INSERT INTO gated_app (kind, external_app_id) "
+        f"SELECT '{_EXTERNAL_APP}', id FROM external_app"
+    )
+    op.execute(
+        f"INSERT INTO gated_app (kind, mcp_server_id) "
+        f"SELECT '{_MCP_SERVER}', id FROM mcp_server"
+    )
+
+    # --- external_app_policy -> gated_action_policy ---------------------
+    op.rename_table("external_app_policy", "gated_action_policy")
+    op.add_column(
+        "gated_action_policy",
+        sa.Column("gated_app_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        "UPDATE gated_action_policy p SET gated_app_id = g.id "
+        "FROM gated_app g WHERE g.external_app_id = p.external_app_id"
+    )
+    op.alter_column("gated_action_policy", "gated_app_id", nullable=False)
+    op.drop_constraint(
+        "uq_external_app_policy_app_action", "gated_action_policy", type_="unique"
+    )
+    op.drop_constraint(
+        "external_app_policy_external_app_id_fkey",
+        "gated_action_policy",
+        type_="foreignkey",
+    )
+    op.drop_column("gated_action_policy", "external_app_id")
+    op.create_foreign_key(
+        "gated_action_policy_gated_app_id_fkey",
+        "gated_action_policy",
+        "gated_app",
+        ["gated_app_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_gated_action_policy",
+        "gated_action_policy",
+        ["gated_app_id", "action_id"],
+    )
+
+    # --- action_approval ------------------------------------------------
+    op.add_column(
+        "action_approval", sa.Column("gated_app_id", sa.Integer(), nullable=True)
+    )
+    op.execute(
+        "UPDATE action_approval a SET gated_app_id = g.id "
+        "FROM gated_app g WHERE g.external_app_id = a.external_app_id"
+    )
+    op.drop_constraint(
+        "fk_action_approval_external_app_id", "action_approval", type_="foreignkey"
+    )
+    op.drop_column("action_approval", "external_app_id")
+    op.create_foreign_key(
+        "fk_action_approval_gated_app_id",
+        "action_approval",
+        "gated_app",
+        ["gated_app_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # --- scheduled_task_pre_approved_app --------------------------------
+    op.add_column(
+        "scheduled_task_pre_approved_app",
+        sa.Column("gated_app_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        "UPDATE scheduled_task_pre_approved_app s SET gated_app_id = g.id "
+        "FROM gated_app g WHERE g.external_app_id = s.external_app_id"
+    )
+    op.alter_column("scheduled_task_pre_approved_app", "gated_app_id", nullable=False)
+    op.drop_constraint(
+        "uq_scheduled_task_pre_approved_app",
+        "scheduled_task_pre_approved_app",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "scheduled_task_pre_approved_app_external_app_id_fkey",
+        "scheduled_task_pre_approved_app",
+        type_="foreignkey",
+    )
+    op.drop_column("scheduled_task_pre_approved_app", "external_app_id")
+    op.create_foreign_key(
+        "scheduled_task_pre_approved_app_gated_app_id_fkey",
+        "scheduled_task_pre_approved_app",
+        "gated_app",
+        ["gated_app_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_scheduled_task_pre_approved_app",
+        "scheduled_task_pre_approved_app",
+        ["scheduled_task_id", "gated_app_id"],
+    )
+
+
+def downgrade() -> None:
+    # Backfills read from gated_app, so it is dropped last. MCP-server targets
+    # have no pre-gated representation: their approval rows null out, their
+    # policy / pre-approval rows are dropped.
+
+    # --- scheduled_task_pre_approved_app --------------------------------
+    op.add_column(
+        "scheduled_task_pre_approved_app",
+        sa.Column("external_app_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        "UPDATE scheduled_task_pre_approved_app s SET external_app_id = "
+        "g.external_app_id FROM gated_app g WHERE g.id = s.gated_app_id"
+    )
+    op.drop_constraint(
+        "uq_scheduled_task_pre_approved_app",
+        "scheduled_task_pre_approved_app",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "scheduled_task_pre_approved_app_gated_app_id_fkey",
+        "scheduled_task_pre_approved_app",
+        type_="foreignkey",
+    )
+    op.drop_column("scheduled_task_pre_approved_app", "gated_app_id")
+    op.execute(
+        "DELETE FROM scheduled_task_pre_approved_app WHERE external_app_id IS NULL"
+    )
+    op.alter_column(
+        "scheduled_task_pre_approved_app", "external_app_id", nullable=False
+    )
+    op.create_foreign_key(
+        "scheduled_task_pre_approved_app_external_app_id_fkey",
+        "scheduled_task_pre_approved_app",
+        "external_app",
+        ["external_app_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_scheduled_task_pre_approved_app",
+        "scheduled_task_pre_approved_app",
+        ["scheduled_task_id", "external_app_id"],
+    )
+
+    # --- action_approval ------------------------------------------------
+    op.add_column(
+        "action_approval",
+        sa.Column("external_app_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        "UPDATE action_approval a SET external_app_id = g.external_app_id "
+        "FROM gated_app g WHERE g.id = a.gated_app_id"
+    )
+    op.drop_constraint(
+        "fk_action_approval_gated_app_id", "action_approval", type_="foreignkey"
+    )
+    op.drop_column("action_approval", "gated_app_id")
+    op.create_foreign_key(
+        "fk_action_approval_external_app_id",
+        "action_approval",
+        "external_app",
+        ["external_app_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+
+    # --- gated_action_policy -> external_app_policy ---------------------
+    op.add_column(
+        "gated_action_policy",
+        sa.Column("external_app_id", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        "UPDATE gated_action_policy p SET external_app_id = g.external_app_id "
+        "FROM gated_app g WHERE g.id = p.gated_app_id"
+    )
+    op.drop_constraint("uq_gated_action_policy", "gated_action_policy", type_="unique")
+    op.drop_constraint(
+        "gated_action_policy_gated_app_id_fkey",
+        "gated_action_policy",
+        type_="foreignkey",
+    )
+    op.drop_column("gated_action_policy", "gated_app_id")
+    op.execute("DELETE FROM gated_action_policy WHERE external_app_id IS NULL")
+    op.alter_column("gated_action_policy", "external_app_id", nullable=False)
+    op.create_foreign_key(
+        "external_app_policy_external_app_id_fkey",
+        "gated_action_policy",
+        "external_app",
+        ["external_app_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_unique_constraint(
+        "uq_external_app_policy_app_action",
+        "gated_action_policy",
+        ["external_app_id", "action_id"],
+    )
+    op.rename_table("gated_action_policy", "external_app_policy")
+
+    op.drop_table("gated_app")

--- a/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
+++ b/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
@@ -8,7 +8,7 @@ gated-target catalog adds one column to ``gated_app`` instead of a column to
 every consumer table. ``external_app_policy`` becomes ``gated_action_policy``.
 
 Revision ID: bc9e56f2fb96
-Revises: eec4fc85ef28
+Revises: 565c5b57a573
 Create Date: 2026-07-17 14:10:36.718336
 
 """
@@ -18,7 +18,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "bc9e56f2fb96"
-down_revision = "eec4fc85ef28"
+down_revision = "565c5b57a573"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
+++ b/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
@@ -47,7 +47,10 @@ def upgrade() -> None:
         sa.UniqueConstraint("external_app_id", name="uq_gated_app_external_app"),
         sa.UniqueConstraint("mcp_server_id", name="uq_gated_app_mcp_server"),
         sa.CheckConstraint(
-            "num_nonnulls(external_app_id, mcp_server_id) = 1",
+            "(kind = 'EXTERNAL_APP' AND external_app_id IS NOT NULL "
+            "AND mcp_server_id IS NULL) OR "
+            "(kind = 'MCP_SERVER' AND mcp_server_id IS NOT NULL "
+            "AND external_app_id IS NULL)",
             name="ck_gated_app_single_target",
         ),
     )

--- a/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
+++ b/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
@@ -16,25 +16,20 @@ Create Date: 2026-07-17 14:10:36.718336
 import sqlalchemy as sa
 from alembic import op
 
-from onyx.db.enums import GatedAppKind
-
-
 # revision identifiers, used by Alembic.
 revision = "bc9e56f2fb96"
 down_revision = "1e0a3e4226f7"
 branch_labels = None
 depends_on = None
 
-_EXTERNAL_APP = GatedAppKind.EXTERNAL_APP.value
-_MCP_SERVER = GatedAppKind.MCP_SERVER.value
-
 
 def upgrade() -> None:
     # --- polymorphic identity table -------------------------------------
+    # The target's kind is derived from which FK is populated; no stored
+    # discriminator to keep consistent.
     op.create_table(
         "gated_app",
         sa.Column("id", sa.Integer(), nullable=False),
-        sa.Column("kind", sa.Enum(GatedAppKind, native_enum=False), nullable=False),
         sa.Column("external_app_id", sa.Integer(), nullable=True),
         sa.Column("mcp_server_id", sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(
@@ -47,23 +42,14 @@ def upgrade() -> None:
         sa.UniqueConstraint("external_app_id", name="uq_gated_app_external_app"),
         sa.UniqueConstraint("mcp_server_id", name="uq_gated_app_mcp_server"),
         sa.CheckConstraint(
-            "(kind = 'EXTERNAL_APP' AND external_app_id IS NOT NULL "
-            "AND mcp_server_id IS NULL) OR "
-            "(kind = 'MCP_SERVER' AND mcp_server_id IS NOT NULL "
-            "AND external_app_id IS NULL)",
+            "num_nonnulls(external_app_id, mcp_server_id) = 1",
             name="ck_gated_app_single_target",
         ),
     )
     # One identity row per existing target so current policy / approval /
     # pre-approval rows can be repointed. New targets get theirs lazily.
-    op.execute(
-        f"INSERT INTO gated_app (kind, external_app_id) "
-        f"SELECT '{_EXTERNAL_APP}', id FROM external_app"
-    )
-    op.execute(
-        f"INSERT INTO gated_app (kind, mcp_server_id) "
-        f"SELECT '{_MCP_SERVER}', id FROM mcp_server"
-    )
+    op.execute("INSERT INTO gated_app (external_app_id) SELECT id FROM external_app")
+    op.execute("INSERT INTO gated_app (mcp_server_id) SELECT id FROM mcp_server")
 
     # --- external_app_policy -> gated_action_policy ---------------------
     op.rename_table("external_app_policy", "gated_action_policy")

--- a/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
+++ b/backend/alembic/versions/bc9e56f2fb96_polymorphic_gated_app.py
@@ -8,7 +8,7 @@ gated-target catalog adds one column to ``gated_app`` instead of a column to
 every consumer table. ``external_app_policy`` becomes ``gated_action_policy``.
 
 Revision ID: bc9e56f2fb96
-Revises: 1e0a3e4226f7
+Revises: eec4fc85ef28
 Create Date: 2026-07-17 14:10:36.718336
 
 """
@@ -18,7 +18,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "bc9e56f2fb96"
-down_revision = "1e0a3e4226f7"
+down_revision = "eec4fc85ef28"
 branch_labels = None
 depends_on = None
 

--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -469,6 +469,19 @@ POLICY_SEVERITY: dict[EndpointPolicy, int] = {
 }
 
 
+class GatedAppKind(str, PyEnum):
+    """Which catalog a gated egress action belongs to.
+
+    The approval pipeline (matched actions, approval rows, per-tool policy,
+    pre-approvals, session grants) is shared across surfaces; this discriminates
+    whether the target id refers to an ``external_app`` or an ``mcp_server`` row,
+    since the two live in separate tables under a single approval flow.
+    """
+
+    EXTERNAL_APP = "EXTERNAL_APP"
+    MCP_SERVER = "MCP_SERVER"
+
+
 class PatType(str, PyEnum):
     USER = "USER"
     CRAFT = "CRAFT"

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -331,9 +331,10 @@ def create_external_app(
         organization_credentials=organization_credentials,
     )
     db_session.add(app)
+    # Policies key off the gated_app identity row, which needs app.id.
+    db_session.flush()
     if action_policies is not None:
         _write_policies__no_commit(db_session, app, action_policies)
-    db_session.flush()
     return app
 
 

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -13,7 +13,6 @@ from onyx.db.enums import (
     SkillSharePermission,
 )
 from onyx.db.gated_app import (
-    get_action_policies,
     get_or_create_gated_app_id,
     replace_action_policies__no_commit,
 )
@@ -140,7 +139,7 @@ def get_external_app_by_skill_id(
 ) -> ExternalApp | None:
     """The external-app gateway backing ``skill_id``, or None if the skill isn't
     an external app. Returns just the row — callers that need its policies fetch
-    them via ``get_policies``."""
+    them via ``get_action_policies``."""
     stmt = select(ExternalApp).where(ExternalApp.skill_id == skill_id)
     return db_session.scalar(stmt)
 
@@ -425,15 +424,6 @@ def set_external_app_organization_credentials(
     # assignment shape as update_external_app's masked-credential restore).
     app.organization_credentials = organization_credentials  # ty: ignore[invalid-assignment]
     db_session.flush()
-
-
-def get_policies(
-    db_session: Session, external_app_ids: list[int]
-) -> dict[int, dict[str, EndpointPolicy]]:
-    """The apps' stored per-action policy overrides as
-    ``{external_app_id: {action_id: policy}}``. Sparse — only actions the admin
-    has set; apps with no overrides are absent. One query regardless of count."""
-    return get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app_ids)
 
 
 def _write_policies__no_commit(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -6,14 +6,18 @@ from sqlalchemy import and_, delete, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session, selectinload
 
-from onyx.db.enums import EndpointPolicy, ExternalAppType, SkillSharePermission
-from onyx.db.models import (
-    ExternalApp,
-    ExternalAppPolicy,
-    ExternalAppUserCredential,
-    Skill,
-    User,
+from onyx.db.enums import (
+    EndpointPolicy,
+    ExternalAppType,
+    GatedAppKind,
+    SkillSharePermission,
 )
+from onyx.db.gated_app import (
+    get_action_policies,
+    get_or_create_gated_app_id,
+    replace_action_policies__no_commit,
+)
+from onyx.db.models import ExternalApp, ExternalAppUserCredential, Skill, User
 from onyx.db.utils import UNSET, UnsetType, is_set
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -124,10 +128,7 @@ def get_external_app_by_id(
 ) -> ExternalApp | None:
     stmt = (
         select(ExternalApp)
-        .options(
-            selectinload(ExternalApp.skill),
-            selectinload(ExternalApp.policies),
-        )
+        .options(selectinload(ExternalApp.skill))
         .where(ExternalApp.id == external_app_id)
     )
     return db_session.scalar(stmt)
@@ -201,10 +202,7 @@ def get_external_apps(
 ) -> list[ExternalApp]:
     stmt = (
         select(ExternalApp)
-        .options(
-            selectinload(ExternalApp.skill),
-            selectinload(ExternalApp.policies),
-        )
+        .options(selectinload(ExternalApp.skill))
         .order_by(ExternalApp.id)
     )
     if enabled_only:
@@ -231,10 +229,7 @@ def get_built_in_external_app(
         )
     stmt = (
         select(ExternalApp)
-        .options(
-            selectinload(ExternalApp.skill),
-            selectinload(ExternalApp.policies),
-        )
+        .options(selectinload(ExternalApp.skill))
         .where(ExternalApp.app_type == app_type)
     )
     return db_session.scalars(stmt).one_or_none()
@@ -437,12 +432,7 @@ def get_policies(
 ) -> dict[str, EndpointPolicy]:
     """Return the app's stored per-action policy overrides as
     ``{action_id: policy}``. Sparse — only actions the admin has set."""
-    rows = db_session.scalars(
-        select(ExternalAppPolicy).where(
-            ExternalAppPolicy.external_app_id == external_app_id
-        )
-    ).all()
-    return {row.action_id: row.policy for row in rows}
+    return get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app_id)
 
 
 def _write_policies__no_commit(
@@ -450,19 +440,14 @@ def _write_policies__no_commit(
     app: ExternalApp,
     policies: dict[str, EndpointPolicy],
 ) -> None:
-    """Replace ``app``'s per-action policy rows with exactly ``policies``.
-
-    Clears the existing rows and flushes the DELETEs before inserting the new
-    set. The flush is required: within a single flush the ORM emits INSERTs
-    before DELETEs, so a re-inserted ``action_id`` would collide with its
-    not-yet-deleted row on the ``(external_app_id, action_id)`` unique
-    constraint. No commit — runs inside the caller's transaction. ``action_id``
-    validation is the caller's responsibility.
+    """Replace ``app``'s per-action policy rows with exactly ``policies``. No
+    commit — runs inside the caller's transaction. ``action_id`` validation is
+    the caller's responsibility.
     """
-    app.policies.clear()  # delete-orphan cascade deletes the rows on flush
-    db_session.flush()
-    for action_id, policy in policies.items():
-        app.policies.append(ExternalAppPolicy(action_id=action_id, policy=policy))
+    gated_app_id = get_or_create_gated_app_id(
+        db_session, GatedAppKind.EXTERNAL_APP, app.id
+    )
+    replace_action_policies__no_commit(db_session, gated_app_id, policies)
 
 
 def delete_external_app(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -14,6 +14,7 @@ from onyx.db.enums import (
 )
 from onyx.db.gated_app import (
     get_action_policies,
+    get_action_policies_by_target,
     get_or_create_gated_app_id,
     replace_action_policies__no_commit,
 )
@@ -433,6 +434,17 @@ def get_policies(
     """Return the app's stored per-action policy overrides as
     ``{action_id: policy}``. Sparse — only actions the admin has set."""
     return get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app_id)
+
+
+def get_policies_for_apps(
+    db_session: Session, external_app_ids: list[int]
+) -> dict[int, dict[str, EndpointPolicy]]:
+    """Batched :func:`get_policies` for many apps, as
+    ``{external_app_id: {action_id: policy}}``. Apps with no overrides are
+    absent. One query — use to avoid a per-app policy lookup when listing."""
+    return get_action_policies_by_target(
+        db_session, GatedAppKind.EXTERNAL_APP, external_app_ids
+    )
 
 
 def _write_policies__no_commit(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -14,7 +14,6 @@ from onyx.db.enums import (
 )
 from onyx.db.gated_app import (
     get_action_policies,
-    get_action_policies_by_target,
     get_or_create_gated_app_id,
     replace_action_policies__no_commit,
 )
@@ -429,23 +428,12 @@ def set_external_app_organization_credentials(
 
 
 def get_policies(
-    db_session: Session,
-    external_app_id: int,
-) -> dict[str, EndpointPolicy]:
-    """Return the app's stored per-action policy overrides as
-    ``{action_id: policy}``. Sparse — only actions the admin has set."""
-    return get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app_id)
-
-
-def get_policies_for_apps(
     db_session: Session, external_app_ids: list[int]
 ) -> dict[int, dict[str, EndpointPolicy]]:
-    """Batched :func:`get_policies` for many apps, as
-    ``{external_app_id: {action_id: policy}}``. Apps with no overrides are
-    absent. One query — use to avoid a per-app policy lookup when listing."""
-    return get_action_policies_by_target(
-        db_session, GatedAppKind.EXTERNAL_APP, external_app_ids
-    )
+    """The apps' stored per-action policy overrides as
+    ``{external_app_id: {action_id: policy}}``. Sparse — only actions the admin
+    has set; apps with no overrides are absent. One query regardless of count."""
+    return get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app_ids)
 
 
 def _write_policies__no_commit(

--- a/backend/onyx/db/gated_app.py
+++ b/backend/onyx/db/gated_app.py
@@ -45,17 +45,11 @@ def get_or_create_gated_app_id(
     existing = get_gated_app_id(db_session, kind, target_id)
     if existing is not None:
         return existing
-    values: dict[str, object] = {"kind": kind}
-    if kind is GatedAppKind.EXTERNAL_APP:
-        values["external_app_id"] = target_id
-        conflict_column = "external_app_id"
-    else:
-        values["mcp_server_id"] = target_id
-        conflict_column = "mcp_server_id"
+    target_column = _target_column(kind).key
     db_session.execute(
         pg_insert(GatedApp)
-        .values(**values)
-        .on_conflict_do_nothing(index_elements=[conflict_column])
+        .values({target_column: target_id})
+        .on_conflict_do_nothing(index_elements=[target_column])
     )
     db_session.flush()
     created = get_gated_app_id(db_session, kind, target_id)

--- a/backend/onyx/db/gated_app.py
+++ b/backend/onyx/db/gated_app.py
@@ -60,29 +60,15 @@ def get_or_create_gated_app_id(
 
 
 def get_action_policies(
-    db_session: Session, kind: GatedAppKind, target_id: int
-) -> dict[str, EndpointPolicy]:
-    """The target's stored per-action policy overrides as ``{action_id: policy}``.
-    Sparse — only actions an admin has explicitly set.
-
-    Single query: joins ``gated_action_policy`` to ``gated_app`` so resolving the
-    identity row and reading its policies is one round trip (this runs on the
-    request matching path).
-    """
-    rows = db_session.execute(
-        select(GatedActionPolicy.action_id, GatedActionPolicy.policy)
-        .join(GatedApp, GatedApp.id == GatedActionPolicy.gated_app_id)
-        .where(_target_column(kind) == target_id)
-    ).all()
-    return {action_id: policy for action_id, policy in rows}
-
-
-def get_action_policies_by_target(
     db_session: Session, kind: GatedAppKind, target_ids: list[int]
 ) -> dict[int, dict[str, EndpointPolicy]]:
-    """Batched :func:`get_action_policies` for many targets of one kind, as
-    ``{target_id: {action_id: policy}}``. Targets with no stored overrides are
-    absent from the result. One query regardless of target count."""
+    """The targets' stored per-action policy overrides as
+    ``{target_id: {action_id: policy}}``. Sparse — only actions an admin has
+    explicitly set; targets with no stored overrides are absent.
+
+    Single query regardless of target count: joins ``gated_action_policy`` to
+    ``gated_app`` so resolving the identity rows and reading their policies is
+    one round trip (this runs on the request matching path)."""
     if not target_ids:
         return {}
     target_column = _target_column(kind)

--- a/backend/onyx/db/gated_app.py
+++ b/backend/onyx/db/gated_app.py
@@ -1,0 +1,101 @@
+"""The ``gated_app`` identity row: get-or-create, lookup, and the per-action
+policy read/write shared by every gated target (external app or MCP server).
+
+All mapping between a gated target ``(kind, target_id)`` and its ``gated_app``
+row lives here; consumers reference ``gated_app_id`` only, never the per-catalog
+columns.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import delete, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import InstrumentedAttribute, Session
+
+from onyx.db.enums import EndpointPolicy, GatedAppKind
+from onyx.db.models import GatedActionPolicy, GatedApp
+
+
+def _target_column(kind: GatedAppKind) -> InstrumentedAttribute[int | None]:
+    return (
+        GatedApp.external_app_id
+        if kind is GatedAppKind.EXTERNAL_APP
+        else GatedApp.mcp_server_id
+    )
+
+
+def get_gated_app_id(
+    db_session: Session, kind: GatedAppKind, target_id: int
+) -> int | None:
+    """The ``gated_app`` row id for ``(kind, target_id)``, or ``None`` when the
+    target has no identity row yet (nothing has policied/approved it)."""
+    return db_session.scalar(
+        select(GatedApp.id).where(_target_column(kind) == target_id)
+    )
+
+
+def get_or_create_gated_app_id(
+    db_session: Session, kind: GatedAppKind, target_id: int
+) -> int:
+    """The ``gated_app`` row id for ``(kind, target_id)``, creating it if absent.
+
+    Race-safe: a concurrent insert is absorbed by ON CONFLICT DO NOTHING on the
+    target's unique index, then re-selected. Flushes but does not commit.
+    """
+    existing = get_gated_app_id(db_session, kind, target_id)
+    if existing is not None:
+        return existing
+    values: dict[str, object] = {"kind": kind}
+    if kind is GatedAppKind.EXTERNAL_APP:
+        values["external_app_id"] = target_id
+        conflict_column = "external_app_id"
+    else:
+        values["mcp_server_id"] = target_id
+        conflict_column = "mcp_server_id"
+    db_session.execute(
+        pg_insert(GatedApp)
+        .values(**values)
+        .on_conflict_do_nothing(index_elements=[conflict_column])
+    )
+    db_session.flush()
+    created = get_gated_app_id(db_session, kind, target_id)
+    assert created is not None  # just inserted, or a concurrent writer did
+    return created
+
+
+def get_action_policies(
+    db_session: Session, kind: GatedAppKind, target_id: int
+) -> dict[str, EndpointPolicy]:
+    """The target's stored per-action policy overrides as ``{action_id: policy}``.
+    Sparse — only actions an admin has explicitly set."""
+    gated_app_id = get_gated_app_id(db_session, kind, target_id)
+    if gated_app_id is None:
+        return {}
+    rows = db_session.scalars(
+        select(GatedActionPolicy).where(GatedActionPolicy.gated_app_id == gated_app_id)
+    ).all()
+    return {row.action_id: row.policy for row in rows}
+
+
+def replace_action_policies__no_commit(
+    db_session: Session,
+    gated_app_id: int,
+    policies: dict[str, EndpointPolicy],
+) -> None:
+    """Replace ``gated_app_id``'s per-action policy rows with exactly ``policies``.
+
+    DELETEs and flushes before inserting so a re-set action can't collide with
+    its not-yet-deleted row on ``uq_gated_action_policy``. No commit — runs
+    inside the caller's transaction.
+    """
+    db_session.execute(
+        delete(GatedActionPolicy).where(GatedActionPolicy.gated_app_id == gated_app_id)
+    )
+    db_session.flush()
+    for action_id, policy in policies.items():
+        db_session.add(
+            GatedActionPolicy(
+                gated_app_id=gated_app_id, action_id=action_id, policy=policy
+            )
+        )
+    db_session.flush()

--- a/backend/onyx/db/gated_app.py
+++ b/backend/onyx/db/gated_app.py
@@ -8,24 +8,12 @@ columns.
 
 from __future__ import annotations
 
-from pydantic import BaseModel
 from sqlalchemy import delete, insert, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
 from onyx.db.enums import EndpointPolicy, GatedAppKind
 from onyx.db.models import GatedActionPolicy, GatedApp
-
-
-class StoredActionPolicies(BaseModel):
-    """Stored per-action policy overrides as ``{target_id: {action_id: policy}}``.
-    Sparse — only actions an admin has explicitly set; targets with no stored
-    overrides are absent."""
-
-    by_target_id: dict[int, dict[str, EndpointPolicy]]
-
-    def for_target(self, target_id: int) -> dict[str, EndpointPolicy]:
-        return self.by_target_id.get(target_id, {})
 
 
 def _target_column(kind: GatedAppKind) -> InstrumentedAttribute[int | None]:
@@ -75,33 +63,18 @@ def get_or_create_gated_app_id(
 
 
 def get_action_policies(
-    db_session: Session, kind: GatedAppKind, target_ids: list[int]
-) -> StoredActionPolicies:
-    """The targets' stored per-action policy overrides.
-
-    Single query regardless of target count: joins ``gated_action_policy`` to
-    ``gated_app`` so resolving the identity rows and reading their policies is
-    one round trip (this runs on the request matching path)."""
-    if not target_ids:
-        return StoredActionPolicies(by_target_id={})
-    target_column = _target_column(kind)
-    rows = db_session.execute(
-        select(target_column, GatedActionPolicy.action_id, GatedActionPolicy.policy)
-        .join(GatedApp, GatedApp.id == GatedActionPolicy.gated_app_id)
-        .where(target_column.in_(target_ids))
-    ).all()
-    by_target_id: dict[int, dict[str, EndpointPolicy]] = {}
-    for target_id, action_id, policy in rows:
-        by_target_id.setdefault(target_id, {})[action_id] = policy
-    return StoredActionPolicies(by_target_id=by_target_id)
-
-
-def get_action_policies_for_target(
     db_session: Session, kind: GatedAppKind, target_id: int
 ) -> dict[str, EndpointPolicy]:
-    """Single-target convenience over ``get_action_policies``: the target's
-    stored ``{action_id: policy}`` overrides, ``{}`` when none are set."""
-    return get_action_policies(db_session, kind, [target_id]).for_target(target_id)
+    """The target's stored per-action policy overrides as
+    ``{action_id: policy}``; ``{}`` when none are set. Sparse — only actions an
+    admin has explicitly set. One query: joins ``gated_action_policy`` to
+    ``gated_app`` (this runs on the request matching path)."""
+    rows = db_session.execute(
+        select(GatedActionPolicy.action_id, GatedActionPolicy.policy)
+        .join(GatedApp, GatedApp.id == GatedActionPolicy.gated_app_id)
+        .where(_target_column(kind) == target_id)
+    ).all()
+    return {action_id: policy for action_id, policy in rows}
 
 
 def replace_action_policies__no_commit(

--- a/backend/onyx/db/gated_app.py
+++ b/backend/onyx/db/gated_app.py
@@ -8,12 +8,24 @@ columns.
 
 from __future__ import annotations
 
-from sqlalchemy import delete, select
+from pydantic import BaseModel
+from sqlalchemy import delete, insert, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import InstrumentedAttribute, Session
 
 from onyx.db.enums import EndpointPolicy, GatedAppKind
 from onyx.db.models import GatedActionPolicy, GatedApp
+
+
+class StoredActionPolicies(BaseModel):
+    """Stored per-action policy overrides as ``{target_id: {action_id: policy}}``.
+    Sparse — only actions an admin has explicitly set; targets with no stored
+    overrides are absent."""
+
+    by_target_id: dict[int, dict[str, EndpointPolicy]]
+
+    def for_target(self, target_id: int) -> dict[str, EndpointPolicy]:
+        return self.by_target_id.get(target_id, {})
 
 
 def _target_column(kind: GatedAppKind) -> InstrumentedAttribute[int | None]:
@@ -29,8 +41,6 @@ def get_gated_app_id(
 ) -> int | None:
     """The ``gated_app`` row id for ``(kind, target_id)``, or ``None`` when the
     target has no identity row yet (nothing has policied/approved it)."""
-    # A None id renders as IS NULL and would match a row of the *other* kind.
-    assert target_id is not None, "target must be flushed before gating"
     return db_session.scalar(
         select(GatedApp.id).where(_target_column(kind) == target_id)
     )
@@ -55,32 +65,43 @@ def get_or_create_gated_app_id(
     )
     db_session.flush()
     created = get_gated_app_id(db_session, kind, target_id)
-    assert created is not None  # just inserted, or a concurrent writer did
+    if created is None:
+        # Unreachable barring a concurrent delete: we just inserted, or a
+        # concurrent writer did.
+        raise RuntimeError(
+            f"gated_app row missing after insert for kind {kind} target_id {target_id}"
+        )
     return created
 
 
 def get_action_policies(
     db_session: Session, kind: GatedAppKind, target_ids: list[int]
-) -> dict[int, dict[str, EndpointPolicy]]:
-    """The targets' stored per-action policy overrides as
-    ``{target_id: {action_id: policy}}``. Sparse — only actions an admin has
-    explicitly set; targets with no stored overrides are absent.
+) -> StoredActionPolicies:
+    """The targets' stored per-action policy overrides.
 
     Single query regardless of target count: joins ``gated_action_policy`` to
     ``gated_app`` so resolving the identity rows and reading their policies is
     one round trip (this runs on the request matching path)."""
     if not target_ids:
-        return {}
+        return StoredActionPolicies(by_target_id={})
     target_column = _target_column(kind)
     rows = db_session.execute(
         select(target_column, GatedActionPolicy.action_id, GatedActionPolicy.policy)
         .join(GatedApp, GatedApp.id == GatedActionPolicy.gated_app_id)
         .where(target_column.in_(target_ids))
     ).all()
-    result: dict[int, dict[str, EndpointPolicy]] = {}
+    by_target_id: dict[int, dict[str, EndpointPolicy]] = {}
     for target_id, action_id, policy in rows:
-        result.setdefault(target_id, {})[action_id] = policy
-    return result
+        by_target_id.setdefault(target_id, {})[action_id] = policy
+    return StoredActionPolicies(by_target_id=by_target_id)
+
+
+def get_action_policies_for_target(
+    db_session: Session, kind: GatedAppKind, target_id: int
+) -> dict[str, EndpointPolicy]:
+    """Single-target convenience over ``get_action_policies``: the target's
+    stored ``{action_id: policy}`` overrides, ``{}`` when none are set."""
+    return get_action_policies(db_session, kind, [target_id]).for_target(target_id)
 
 
 def replace_action_policies__no_commit(
@@ -90,18 +111,18 @@ def replace_action_policies__no_commit(
 ) -> None:
     """Replace ``gated_app_id``'s per-action policy rows with exactly ``policies``.
 
-    DELETEs and flushes before inserting so a re-set action can't collide with
-    its not-yet-deleted row on ``uq_gated_action_policy``. No commit — runs
+    DELETE then one bulk INSERT, emitted in order so a re-set action can't
+    collide with its old row on ``uq_gated_action_policy``. No commit — runs
     inside the caller's transaction.
     """
     db_session.execute(
         delete(GatedActionPolicy).where(GatedActionPolicy.gated_app_id == gated_app_id)
     )
-    db_session.flush()
-    for action_id, policy in policies.items():
-        db_session.add(
-            GatedActionPolicy(
-                gated_app_id=gated_app_id, action_id=action_id, policy=policy
-            )
+    if policies:
+        db_session.execute(
+            insert(GatedActionPolicy),
+            [
+                {"gated_app_id": gated_app_id, "action_id": action_id, "policy": policy}
+                for action_id, policy in policies.items()
+            ],
         )
-    db_session.flush()

--- a/backend/onyx/db/gated_app.py
+++ b/backend/onyx/db/gated_app.py
@@ -29,6 +29,8 @@ def get_gated_app_id(
 ) -> int | None:
     """The ``gated_app`` row id for ``(kind, target_id)``, or ``None`` when the
     target has no identity row yet (nothing has policied/approved it)."""
+    # A None id renders as IS NULL and would match a row of the *other* kind.
+    assert target_id is not None, "target must be flushed before gating"
     return db_session.scalar(
         select(GatedApp.id).where(_target_column(kind) == target_id)
     )

--- a/backend/onyx/db/gated_app.py
+++ b/backend/onyx/db/gated_app.py
@@ -67,14 +67,38 @@ def get_action_policies(
     db_session: Session, kind: GatedAppKind, target_id: int
 ) -> dict[str, EndpointPolicy]:
     """The target's stored per-action policy overrides as ``{action_id: policy}``.
-    Sparse — only actions an admin has explicitly set."""
-    gated_app_id = get_gated_app_id(db_session, kind, target_id)
-    if gated_app_id is None:
-        return {}
-    rows = db_session.scalars(
-        select(GatedActionPolicy).where(GatedActionPolicy.gated_app_id == gated_app_id)
+    Sparse — only actions an admin has explicitly set.
+
+    Single query: joins ``gated_action_policy`` to ``gated_app`` so resolving the
+    identity row and reading its policies is one round trip (this runs on the
+    request matching path).
+    """
+    rows = db_session.execute(
+        select(GatedActionPolicy.action_id, GatedActionPolicy.policy)
+        .join(GatedApp, GatedApp.id == GatedActionPolicy.gated_app_id)
+        .where(_target_column(kind) == target_id)
     ).all()
-    return {row.action_id: row.policy for row in rows}
+    return {action_id: policy for action_id, policy in rows}
+
+
+def get_action_policies_by_target(
+    db_session: Session, kind: GatedAppKind, target_ids: list[int]
+) -> dict[int, dict[str, EndpointPolicy]]:
+    """Batched :func:`get_action_policies` for many targets of one kind, as
+    ``{target_id: {action_id: policy}}``. Targets with no stored overrides are
+    absent from the result. One query regardless of target count."""
+    if not target_ids:
+        return {}
+    target_column = _target_column(kind)
+    rows = db_session.execute(
+        select(target_column, GatedActionPolicy.action_id, GatedActionPolicy.policy)
+        .join(GatedApp, GatedApp.id == GatedActionPolicy.gated_app_id)
+        .where(target_column.in_(target_ids))
+    ).all()
+    result: dict[int, dict[str, EndpointPolicy]] = {}
+    for target_id, action_id, policy in rows:
+        result.setdefault(target_id, {})[action_id] = policy
+    return result
 
 
 def replace_action_policies__no_commit(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6095,7 +6095,7 @@ class ScheduledTask(Base):
         excluded — their target ids live in a different id space, and this
         property backs the API's external-app-id field (the gate reads all
         grants regardless of kind via ``get_running_scheduled_run_grants``).
-        Set via ``onyx.db.scheduled_task.set_pre_approved_external_apps``."""
+        Set via ``onyx.db.scheduled_task.set_pre_approved_apps``."""
         return [
             grant.gated_app.external_app_id
             for grant in self.pre_approved_apps
@@ -6222,9 +6222,9 @@ class ScheduledTaskPreApprovedApp(Base):
     task: Mapped[ScheduledTask] = relationship(
         "ScheduledTask", back_populates="pre_approved_apps"
     )
-    # selectin: pre_approved_external_app_ids and set_pre_approved_external_apps
-    # read gated_app for every grant, so batch them in one SELECT rather than
-    # one per grant.
+    # selectin: pre_approved_external_app_ids and set_pre_approved_apps read
+    # gated_app for every grant, so batch them in one SELECT rather than one
+    # per grant.
     gated_app: Mapped["GatedApp"] = relationship("GatedApp", lazy="selectin")
 
     __table_args__ = (

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6090,9 +6090,12 @@ class ScheduledTask(Base):
     )
 
     @property
-    def pre_approved_app_ids(self) -> list[int]:
+    def pre_approved_external_app_ids(self) -> list[int]:
         """Granted external-app ids in grant order. MCP-server grants are
-        excluded. Set via ``onyx.db.scheduled_task.set_pre_approved_apps``."""
+        excluded — their target ids live in a different id space, and this
+        property backs the API's external-app-id field (the gate reads all
+        grants regardless of kind via ``get_running_scheduled_run_grants``).
+        Set via ``onyx.db.scheduled_task.set_pre_approved_external_apps``."""
         return [
             grant.gated_app.external_app_id
             for grant in self.pre_approved_apps
@@ -6219,8 +6222,9 @@ class ScheduledTaskPreApprovedApp(Base):
     task: Mapped[ScheduledTask] = relationship(
         "ScheduledTask", back_populates="pre_approved_apps"
     )
-    # selectin: pre_approved_app_ids and set_pre_approved_apps read gated_app for
-    # every grant, so batch them in one SELECT rather than one per grant.
+    # selectin: pre_approved_external_app_ids and set_pre_approved_external_apps
+    # read gated_app for every grant, so batch them in one SELECT rather than
+    # one per grant.
     gated_app: Mapped["GatedApp"] = relationship("GatedApp", lazy="selectin")
 
     __table_args__ = (

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6589,7 +6589,9 @@ class GatedApp(Base):
     pre-approvals) references this single id instead of a per-catalog FK, so a
     new target type adds one nullable column here rather than a column on every
     consumer table. Rows are created lazily via
-    ``onyx.db.gated_app.get_or_create_gated_app_id``.
+    ``onyx.db.gated_app.get_or_create_gated_app_id`` (the migration backfilled
+    pre-existing targets), so a row's existence doesn't imply the target was
+    ever policied or approved.
 
     Exactly one of ``external_app_id`` / ``mcp_server_id`` is set; ``kind`` is
     derived from which. Deleting the underlying target CASCADEs this row away,
@@ -6603,16 +6605,17 @@ class GatedApp(Base):
         Integer,
         ForeignKey("external_app.id", ondelete="CASCADE"),
         nullable=True,
-        unique=True,
     )
     mcp_server_id: Mapped[int | None] = mapped_column(
         Integer,
         ForeignKey("mcp_server.id", ondelete="CASCADE"),
         nullable=True,
-        unique=True,
     )
 
+    # Constraints are named to match the live schema created by the migration.
     __table_args__ = (
+        UniqueConstraint("external_app_id", name="uq_gated_app_external_app"),
+        UniqueConstraint("mcp_server_id", name="uq_gated_app_mcp_server"),
         CheckConstraint(
             "num_nonnulls(external_app_id, mcp_server_id) = 1",
             name="ck_gated_app_single_target",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -75,6 +75,7 @@ from onyx.db.enums import (
     EmbeddingPrecision,
     EndpointPolicy,
     ExternalAppType,
+    GatedAppKind,
     GrantSource,
     HierarchyNodeType,
     HookFailStrategy,
@@ -6009,13 +6010,15 @@ class ActionApproval(Base):
         Enum(ApprovalDecidedVia, native_enum=False, name="approvaldecidedvia"),
         nullable=True,
     )
-    # Lookups key off this id, not ``app_name``: the latter isn't unique
-    # across instances (self-hosted GitLab/Jira share an app_type).
-    external_app_id: Mapped[int | None] = mapped_column(
+    # The gated target (external app or MCP server) this request hit, via the
+    # polymorphic ``gated_app`` identity row. Goes NULL when that target is
+    # deleted (SET NULL) — the decided row stays as an audit record.
+    gated_app_id: Mapped[int | None] = mapped_column(
         Integer,
-        ForeignKey("external_app.id", ondelete="SET NULL"),
+        ForeignKey("gated_app.id", ondelete="SET NULL"),
         nullable=True,
     )
+    gated_app: Mapped["GatedApp | None"] = relationship("GatedApp")
 
 
 class ScheduledTask(Base):
@@ -6088,9 +6091,14 @@ class ScheduledTask(Base):
 
     @property
     def pre_approved_app_ids(self) -> list[int]:
-        """Granted external-app ids in grant order. Set via
-        ``onyx.db.scheduled_task.set_pre_approved_apps``."""
-        return [grant.external_app_id for grant in self.pre_approved_apps]
+        """Granted external-app ids in grant order. MCP-server grants are
+        excluded. Set via ``onyx.db.scheduled_task.set_pre_approved_apps``."""
+        return [
+            grant.gated_app.external_app_id
+            for grant in self.pre_approved_apps
+            if grant.gated_app is not None
+            and grant.gated_app.external_app_id is not None
+        ]
 
     __table_args__ = (
         # Dispatcher hot path: WHERE status='active' AND deleted=false
@@ -6183,12 +6191,13 @@ class ScheduledTaskRun(Base):
 
 
 class ScheduledTaskPreApprovedApp(Base):
-    """One (task, app) pre-approval grant: the matched app's ASK-gated
+    """One (task, target) pre-approval grant: the matched target's ASK-gated
     actions skip the approval park for the task's RUNNING runs.
 
-    Deleting the task (CASCADE) or the app (CASCADE) drops the grant; a
-    stale grant on a removed app is meaningless. The unique constraint
-    keeps grants idempotent and its index serves the per-task lookup.
+    The target is a ``gated_app`` row (external app or MCP server). Deleting the
+    task or the target (both CASCADE) drops the grant; a stale grant on a removed
+    target is meaningless. The unique constraint keeps grants idempotent and its
+    index serves the per-task lookup.
     """
 
     __tablename__ = "scheduled_task_pre_approved_app"
@@ -6199,9 +6208,9 @@ class ScheduledTaskPreApprovedApp(Base):
         ForeignKey("scheduled_task.id", ondelete="CASCADE"),
         nullable=False,
     )
-    external_app_id: Mapped[int] = mapped_column(
+    gated_app_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("external_app.id", ondelete="CASCADE"),
+        ForeignKey("gated_app.id", ondelete="CASCADE"),
         nullable=False,
     )
     created_at: Mapped[datetime.datetime] = mapped_column(
@@ -6211,11 +6220,12 @@ class ScheduledTaskPreApprovedApp(Base):
     task: Mapped[ScheduledTask] = relationship(
         "ScheduledTask", back_populates="pre_approved_apps"
     )
+    gated_app: Mapped["GatedApp"] = relationship("GatedApp")
 
     __table_args__ = (
         UniqueConstraint(
             "scheduled_task_id",
-            "external_app_id",
+            "gated_app_id",
             name="uq_scheduled_task_pre_approved_app",
         ),
     )
@@ -6504,11 +6514,6 @@ class ExternalApp(Base):
         back_populates="external_app",
         cascade="all, delete-orphan",
     )
-    policies: Mapped[list["ExternalAppPolicy"]] = relationship(
-        "ExternalAppPolicy",
-        back_populates="external_app",
-        cascade="all, delete-orphan",
-    )
 
     @property
     def upstream_url_regexes(self) -> list[str]:
@@ -6575,26 +6580,79 @@ class ExternalAppUserCredential(Base):
     )
 
 
-class ExternalAppPolicy(Base):
-    """Admin's per-action policy override for an external app.
+class GatedApp(Base):
+    """Polymorphic identity for a gated egress target — one row per external app
+    or MCP server.
+
+    The approval pipeline (per-action policy, approval rows, scheduled-task
+    pre-approvals) references this single id instead of a per-catalog FK, so a
+    new target type adds one nullable column here rather than a column on every
+    consumer table. Rows are created lazily via
+    ``onyx.db.gated_app.get_or_create_gated_app_id``.
+
+    Exactly one of ``external_app_id`` / ``mcp_server_id`` is set; ``kind`` names
+    which. Deleting the underlying target CASCADEs this row away, which in turn
+    CASCADEs its policies and pre-approvals.
+    """
+
+    __tablename__ = "gated_app"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    kind: Mapped[GatedAppKind] = mapped_column(
+        Enum(GatedAppKind, native_enum=False),
+        nullable=False,
+    )
+    external_app_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("external_app.id", ondelete="CASCADE"),
+        nullable=True,
+        unique=True,
+    )
+    mcp_server_id: Mapped[int | None] = mapped_column(
+        Integer,
+        ForeignKey("mcp_server.id", ondelete="CASCADE"),
+        nullable=True,
+        unique=True,
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "num_nonnulls(external_app_id, mcp_server_id) = 1",
+            name="ck_gated_app_single_target",
+        ),
+    )
+
+    @property
+    def target_id(self) -> int:
+        """Id of the underlying target row named by ``kind``."""
+        tid = (
+            self.external_app_id
+            if self.kind is GatedAppKind.EXTERNAL_APP
+            else self.mcp_server_id
+        )
+        assert tid is not None  # guaranteed by ck_gated_app_single_target
+        return tid
+
+
+class GatedActionPolicy(Base):
+    """Admin's per-action policy override for a gated target, keyed by the
+    ``gated_app`` identity row.
 
     Sparse: only actions the admin has set are stored; an action without a row
     resolves to ``ASK`` (the default ask-approval behaviour).
 
-    ``action_id`` is a catalog id; display (name/description) comes from the code
-    catalog. Admin-authored custom-app rules will add their own action
-    name/description/match columns when that feature lands.
+    ``action_id`` is a catalog id (external apps) or a tool name (MCP servers);
+    display (name/description) comes from the code catalog / discovered tools.
     """
 
-    __tablename__ = "external_app_policy"
+    __tablename__ = "gated_action_policy"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    external_app_id: Mapped[int] = mapped_column(
+    gated_app_id: Mapped[int] = mapped_column(
         Integer,
-        ForeignKey("external_app.id", ondelete="CASCADE"),
+        ForeignKey("gated_app.id", ondelete="CASCADE"),
         nullable=False,
     )
-    # Hierarchical action id, e.g. "slack.messages.read".
     action_id: Mapped[str] = mapped_column(Text, nullable=False)
     policy: Mapped[EndpointPolicy] = mapped_column(
         Enum(EndpointPolicy, native_enum=False),
@@ -6612,15 +6670,11 @@ class ExternalAppPolicy(Base):
         nullable=False,
     )
 
-    external_app: Mapped["ExternalApp"] = relationship(
-        "ExternalApp", back_populates="policies"
-    )
-
     __table_args__ = (
         UniqueConstraint(
-            "external_app_id",
+            "gated_app_id",
             "action_id",
-            name="uq_external_app_policy_app_action",
+            name="uq_gated_action_policy",
         ),
     )
 

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6096,8 +6096,7 @@ class ScheduledTask(Base):
         return [
             grant.gated_app.external_app_id
             for grant in self.pre_approved_apps
-            if grant.gated_app is not None
-            and grant.gated_app.external_app_id is not None
+            if grant.gated_app.external_app_id is not None
         ]
 
     __table_args__ = (
@@ -6592,18 +6591,14 @@ class GatedApp(Base):
     consumer table. Rows are created lazily via
     ``onyx.db.gated_app.get_or_create_gated_app_id``.
 
-    Exactly one of ``external_app_id`` / ``mcp_server_id`` is set; ``kind`` names
-    which. Deleting the underlying target CASCADEs this row away, which in turn
-    CASCADEs its policies and pre-approvals.
+    Exactly one of ``external_app_id`` / ``mcp_server_id`` is set; ``kind`` is
+    derived from which. Deleting the underlying target CASCADEs this row away,
+    which in turn CASCADEs its policies and pre-approvals.
     """
 
     __tablename__ = "gated_app"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    kind: Mapped[GatedAppKind] = mapped_column(
-        Enum(GatedAppKind, native_enum=False),
-        nullable=False,
-    )
     external_app_id: Mapped[int | None] = mapped_column(
         Integer,
         ForeignKey("external_app.id", ondelete="CASCADE"),
@@ -6618,28 +6613,37 @@ class GatedApp(Base):
     )
 
     __table_args__ = (
-        # Exactly one target column is populated AND it matches ``kind`` — a
-        # mismatched pair (kind=EXTERNAL_APP with only mcp_server_id set) would
-        # make ``target_id`` assert and resolve policies against the wrong row.
         CheckConstraint(
-            "(kind = 'EXTERNAL_APP' AND external_app_id IS NOT NULL "
-            "AND mcp_server_id IS NULL) OR "
-            "(kind = 'MCP_SERVER' AND mcp_server_id IS NOT NULL "
-            "AND external_app_id IS NULL)",
+            "num_nonnulls(external_app_id, mcp_server_id) = 1",
             name="ck_gated_app_single_target",
         ),
     )
+
+    @property
+    def kind(self) -> GatedAppKind:
+        """Which catalog the target lives in, derived from the populated FK so a
+        kind/column mismatch is unrepresentable."""
+        return (
+            GatedAppKind.EXTERNAL_APP
+            if self.external_app_id is not None
+            else GatedAppKind.MCP_SERVER
+        )
 
     @property
     def target_id(self) -> int:
         """Id of the underlying target row named by ``kind``."""
         tid = (
             self.external_app_id
-            if self.kind is GatedAppKind.EXTERNAL_APP
+            if self.external_app_id is not None
             else self.mcp_server_id
         )
         assert tid is not None  # guaranteed by ck_gated_app_single_target
         return tid
+
+    @property
+    def target_key(self) -> tuple[GatedAppKind, int]:
+        """The ``(kind, target_id)`` pair consumers key grants and lookups off."""
+        return self.kind, self.target_id
 
 
 class GatedActionPolicy(Base):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6220,7 +6220,9 @@ class ScheduledTaskPreApprovedApp(Base):
     task: Mapped[ScheduledTask] = relationship(
         "ScheduledTask", back_populates="pre_approved_apps"
     )
-    gated_app: Mapped["GatedApp"] = relationship("GatedApp")
+    # selectin: pre_approved_app_ids and set_pre_approved_apps read gated_app for
+    # every grant, so batch them in one SELECT rather than one per grant.
+    gated_app: Mapped["GatedApp"] = relationship("GatedApp", lazy="selectin")
 
     __table_args__ = (
         UniqueConstraint(
@@ -6616,8 +6618,14 @@ class GatedApp(Base):
     )
 
     __table_args__ = (
+        # Exactly one target column is populated AND it matches ``kind`` — a
+        # mismatched pair (kind=EXTERNAL_APP with only mcp_server_id set) would
+        # make ``target_id`` assert and resolve policies against the wrong row.
         CheckConstraint(
-            "num_nonnulls(external_app_id, mcp_server_id) = 1",
+            "(kind = 'EXTERNAL_APP' AND external_app_id IS NOT NULL "
+            "AND mcp_server_id IS NULL) OR "
+            "(kind = 'MCP_SERVER' AND mcp_server_id IS NOT NULL "
+            "AND external_app_id IS NULL)",
             name="ck_gated_app_single_target",
         ),
     )

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -107,8 +107,7 @@ def set_pre_approved_apps(
     mcp_grants = [
         grant
         for grant in task.pre_approved_apps
-        if grant.gated_app is not None
-        and grant.gated_app.kind is GatedAppKind.MCP_SERVER
+        if grant.gated_app.kind is GatedAppKind.MCP_SERVER
     ]
     task.pre_approved_apps = [
         existing.get(gated_app_id)
@@ -541,7 +540,7 @@ def get_live_scheduled_run_grants(
         )
         .where(ScheduledTaskPreApprovedApp.scheduled_task_id == task_id)
     ).all()
-    granted: set[GrantedTarget] = {(ga.kind, ga.target_id) for ga in gated_apps}
+    granted: set[GrantedTarget] = {ga.target_key for ga in gated_apps}
     return run_id, granted
 
 

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -84,38 +84,42 @@ def create_scheduled_task(
         status=status,
         next_run_at=next_run_at,
     )
-    set_pre_approved_external_apps(
-        db_session, task, pre_approved_external_app_ids or []
+    set_pre_approved_apps(
+        db_session,
+        task,
+        GatedAppKind.EXTERNAL_APP,
+        pre_approved_external_app_ids or [],
     )
     db_session.add(task)
     db_session.flush()
     return task
 
 
-def set_pre_approved_external_apps(
-    db_session: Session, task: ScheduledTask, app_ids: list[int]
+def set_pre_approved_apps(
+    db_session: Session,
+    task: ScheduledTask,
+    kind: GatedAppKind,
+    target_ids: list[int],
 ) -> None:
-    """Replace a task's EXTERNAL-APP pre-approval grants with ``app_ids``
-    (deduped); MCP-server grants are preserved. Reuses existing grant rows so
-    re-submitting a granted app is a no-op — recreating it would orphan+reinsert
+    """Replace a task's ``kind`` pre-approval grants with ``target_ids``
+    (deduped); grants of other kinds are preserved. Reuses existing grant rows so
+    re-submitting a granted target is a no-op — recreating it would orphan+reinsert
     the same unique key in one flush, which Postgres rejects. Removed grants drop
     via the ``delete-orphan`` cascade.
     """
     wanted_gated_app_ids = [
-        get_or_create_gated_app_id(db_session, GatedAppKind.EXTERNAL_APP, app_id)
-        for app_id in dict.fromkeys(app_ids)
+        get_or_create_gated_app_id(db_session, kind, target_id)
+        for target_id in dict.fromkeys(target_ids)
     ]
     existing = {grant.gated_app_id: grant for grant in task.pre_approved_apps}
-    mcp_grants = [
-        grant
-        for grant in task.pre_approved_apps
-        if grant.gated_app.kind is GatedAppKind.MCP_SERVER
+    other_kind_grants = [
+        grant for grant in task.pre_approved_apps if grant.gated_app.kind is not kind
     ]
     task.pre_approved_apps = [
         existing.get(gated_app_id)
         or ScheduledTaskPreApprovedApp(gated_app_id=gated_app_id)
         for gated_app_id in wanted_gated_app_ids
-    ] + mcp_grants
+    ] + other_kind_grants
 
 
 def get_scheduled_task(
@@ -197,7 +201,9 @@ def update_scheduled_task(
     if prompt is not None:
         task.prompt = prompt
     if pre_approved_external_app_ids is not None:
-        set_pre_approved_external_apps(db_session, task, pre_approved_external_app_ids)
+        set_pre_approved_apps(
+            db_session, task, GatedAppKind.EXTERNAL_APP, pre_approved_external_app_ids
+        )
     if editor_mode is not None:
         task.editor_mode = editor_mode
     if cron_expression is not None and cron_expression != task.cron_expression:

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -20,13 +20,20 @@ from sqlalchemy import and_, desc, literal, select
 from sqlalchemy.orm import Session, selectinload
 
 from onyx.db.enums import (
+    GatedAppKind,
     ScheduledTaskErrorClass,
     ScheduledTaskRunStatus,
     ScheduledTaskSkipReason,
     ScheduledTaskStatus,
     ScheduledTaskTriggerSource,
 )
-from onyx.db.models import ScheduledTask, ScheduledTaskPreApprovedApp, ScheduledTaskRun
+from onyx.db.gated_app import get_or_create_gated_app_id
+from onyx.db.models import (
+    GatedApp,
+    ScheduledTask,
+    ScheduledTaskPreApprovedApp,
+    ScheduledTaskRun,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.scheduled_tasks.schedule import (
@@ -77,23 +84,37 @@ def create_scheduled_task(
         status=status,
         next_run_at=next_run_at,
     )
-    set_pre_approved_apps(task, pre_approved_app_ids or [])
+    set_pre_approved_apps(db_session, task, pre_approved_app_ids or [])
     db_session.add(task)
     db_session.flush()
     return task
 
 
-def set_pre_approved_apps(task: ScheduledTask, app_ids: list[int]) -> None:
-    """Replace a task's pre-approval grants with ``app_ids`` (deduped). Reuses
-    existing rows so re-submitting a granted app is a no-op — recreating it
-    would orphan+reinsert the same unique key in one flush, which Postgres
-    rejects. Removed grants drop via the ``delete-orphan`` cascade.
+def set_pre_approved_apps(
+    db_session: Session, task: ScheduledTask, app_ids: list[int]
+) -> None:
+    """Replace a task's EXTERNAL-APP pre-approval grants with ``app_ids``
+    (deduped); MCP-server grants are preserved. Reuses existing grant rows so
+    re-submitting a granted app is a no-op — recreating it would orphan+reinsert
+    the same unique key in one flush, which Postgres rejects. Removed grants drop
+    via the ``delete-orphan`` cascade.
     """
-    existing = {grant.external_app_id: grant for grant in task.pre_approved_apps}
-    task.pre_approved_apps = [
-        existing.get(app_id) or ScheduledTaskPreApprovedApp(external_app_id=app_id)
+    wanted_gated_app_ids = [
+        get_or_create_gated_app_id(db_session, GatedAppKind.EXTERNAL_APP, app_id)
         for app_id in dict.fromkeys(app_ids)
     ]
+    existing = {grant.gated_app_id: grant for grant in task.pre_approved_apps}
+    mcp_grants = [
+        grant
+        for grant in task.pre_approved_apps
+        if grant.gated_app is not None
+        and grant.gated_app.kind is GatedAppKind.MCP_SERVER
+    ]
+    task.pre_approved_apps = [
+        existing.get(gated_app_id)
+        or ScheduledTaskPreApprovedApp(gated_app_id=gated_app_id)
+        for gated_app_id in wanted_gated_app_ids
+    ] + mcp_grants
 
 
 def get_scheduled_task(
@@ -175,7 +196,7 @@ def update_scheduled_task(
     if prompt is not None:
         task.prompt = prompt
     if pre_approved_app_ids is not None:
-        set_pre_approved_apps(task, pre_approved_app_ids)
+        set_pre_approved_apps(db_session, task, pre_approved_app_ids)
     if editor_mode is not None:
         task.editor_mode = editor_mode
     if cron_expression is not None and cron_expression != task.cron_expression:
@@ -485,8 +506,10 @@ def find_stuck_runs(
 # Egress-gate pre-approval lookup
 # ---------------------------------------------------------------------------
 
-# (run_id, granted external-app ids) for a RUNNING scheduled run, else None.
-ScheduledRunGrants = tuple[UUID, list[int]] | None
+# (run_id, granted gated targets) for a RUNNING scheduled run, else None. A
+# target is a (kind, id) pair spanning external apps and MCP servers.
+GrantedTarget = tuple[GatedAppKind, int]
+ScheduledRunGrants = tuple[UUID, set[GrantedTarget]] | None
 
 
 def get_live_scheduled_run_grants(
@@ -494,7 +517,7 @@ def get_live_scheduled_run_grants(
     db_session: Session,
     session_id: UUID,
 ) -> ScheduledRunGrants:
-    """``(run_id, pre_approved_app_ids)`` when ``session_id`` is a currently
+    """``(run_id, granted_targets)`` when ``session_id`` is a currently
     RUNNING scheduled run; ``None`` otherwise.
 
     The ``scheduled_task_run`` lookup subsumes the session-origin check
@@ -510,14 +533,16 @@ def get_live_scheduled_run_grants(
     if run is None:
         return None
     run_id, task_id = run
-    app_ids = list(
-        db_session.execute(
-            select(ScheduledTaskPreApprovedApp.external_app_id)
-            .where(ScheduledTaskPreApprovedApp.scheduled_task_id == task_id)
-            .order_by(ScheduledTaskPreApprovedApp.id)
-        ).scalars()
-    )
-    return run_id, app_ids
+    gated_apps = db_session.scalars(
+        select(GatedApp)
+        .join(
+            ScheduledTaskPreApprovedApp,
+            ScheduledTaskPreApprovedApp.gated_app_id == GatedApp.id,
+        )
+        .where(ScheduledTaskPreApprovedApp.scheduled_task_id == task_id)
+    ).all()
+    granted: set[GrantedTarget] = {(ga.kind, ga.target_id) for ga in gated_apps}
+    return run_id, granted
 
 
 # ---------------------------------------------------------------------------

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -59,7 +59,7 @@ def create_scheduled_task(
     cron_expression: str,
     editor_mode: EditorMode,
     status: ScheduledTaskStatus = ScheduledTaskStatus.ACTIVE,
-    pre_approved_app_ids: list[int] | None = None,
+    pre_approved_external_app_ids: list[int] | None = None,
     now: datetime | None = None,
 ) -> ScheduledTask:
     """Insert a new ``ScheduledTask``.
@@ -84,13 +84,15 @@ def create_scheduled_task(
         status=status,
         next_run_at=next_run_at,
     )
-    set_pre_approved_apps(db_session, task, pre_approved_app_ids or [])
+    set_pre_approved_external_apps(
+        db_session, task, pre_approved_external_app_ids or []
+    )
     db_session.add(task)
     db_session.flush()
     return task
 
 
-def set_pre_approved_apps(
+def set_pre_approved_external_apps(
     db_session: Session, task: ScheduledTask, app_ids: list[int]
 ) -> None:
     """Replace a task's EXTERNAL-APP pre-approval grants with ``app_ids``
@@ -168,7 +170,7 @@ def update_scheduled_task(
     cron_expression: str | None = None,
     editor_mode: EditorMode | None = None,
     status: ScheduledTaskStatus | None = None,
-    pre_approved_app_ids: list[int] | None = None,
+    pre_approved_external_app_ids: list[int] | None = None,
     now: datetime | None = None,
 ) -> ScheduledTask:
     """Apply a partial update to a scheduled task.
@@ -178,7 +180,7 @@ def update_scheduled_task(
         ``next_run_at`` is recomputed from ``now``.
       - If ``status`` transitions to PAUSED, ``next_run_at`` is set to NULL.
       - If ``status`` transitions to ACTIVE, ``next_run_at`` is recomputed.
-      - ``pre_approved_app_ids`` follows normal patch semantics: supplied
+      - ``pre_approved_external_app_ids`` follows normal patch semantics: supplied
         replaces the set, omitted leaves it unchanged.
 
     Raises:
@@ -194,8 +196,8 @@ def update_scheduled_task(
         task.name = name
     if prompt is not None:
         task.prompt = prompt
-    if pre_approved_app_ids is not None:
-        set_pre_approved_apps(db_session, task, pre_approved_app_ids)
+    if pre_approved_external_app_ids is not None:
+        set_pre_approved_external_apps(db_session, task, pre_approved_external_app_ids)
     if editor_mode is not None:
         task.editor_mode = editor_mode
     if cron_expression is not None and cron_expression != task.cron_expression:

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import POLICY_SEVERITY, EndpointPolicy, ExternalAppType, GatedAppKind
-from onyx.db.gated_app import get_action_policies_for_target
+from onyx.db.gated_app import get_action_policies
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.request import MatchContext, ProxiedRequest
 from onyx.external_apps.matching.rules import rule_matches
@@ -86,20 +86,6 @@ class AllMatchedActions(BaseModel):
     def app_name(self) -> str:
         return self.target.app_name
 
-    @property
-    def external_app_id(self) -> int | None:
-        """The external-app row id, or ``None`` for a non-external-app target."""
-        if self.target.kind is GatedAppKind.EXTERNAL_APP:
-            return self.target.id
-        return None
-
-    @property
-    def mcp_server_id(self) -> int | None:
-        """The mcp_server row id, or ``None`` for a non-MCP target."""
-        if self.target.kind is GatedAppKind.MCP_SERVER:
-            return self.target.id
-        return None
-
 
 PersistedMatchedAction = Mapping[str, Any]
 ActionLike = MatchedAction | PersistedMatchedAction
@@ -158,9 +144,7 @@ def recognize_actions(
     it via ``model_copy``.
     """
     context = MatchContext(request)
-    stored = get_action_policies_for_target(
-        db_session, GatedAppKind.EXTERNAL_APP, app.id
-    )
+    stored = get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, app.id)
     catalog = get_endpoint_catalog(app.app_type)
     matched = [
         MatchedAction(

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -158,7 +158,7 @@ def recognize_actions(
     it via ``model_copy``.
     """
     context = MatchContext(request)
-    stored = get_policies(db_session, app.id)
+    stored = get_policies(db_session, [app.id]).get(app.id, {})
     catalog = get_endpoint_catalog(app.app_type)
     matched = [
         MatchedAction(

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -7,7 +7,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import POLICY_SEVERITY, EndpointPolicy, ExternalAppType
+from onyx.db.enums import POLICY_SEVERITY, EndpointPolicy, ExternalAppType, GatedAppKind
 from onyx.db.external_app import get_policies
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.request import MatchContext, ProxiedRequest
@@ -34,19 +34,35 @@ class MatchedAction(BaseModel):
     policy: EndpointPolicy
 
 
+class GatedTarget(BaseModel):
+    """The connected app/server a gated request is attributed to.
+
+    ``id`` indexes the table named by ``kind`` — ``external_app`` or
+    ``mcp_server``. Lookups key off ``(kind, id)``, never ``app_name``: the
+    latter isn't unique across instances (self-hosted GitLab/Jira share an
+    app_type, and two MCP servers can share a display name).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    kind: GatedAppKind
+    id: int
+    app_name: str
+
+
 class AllMatchedActions(BaseModel):
     """Every catalog action the request matched within the resolved app.
 
     ``actions`` is sorted strictest-policy-first; ``governing_action`` returns the
     head, whose policy drives the gate's verdict. A batched GraphQL POST is
-    the canonical multi-action case.
+    the canonical multi-action case. ``target`` names the connected app/server
+    the whole approval pipeline attributes the request to.
     """
 
     model_config = ConfigDict(frozen=True)
 
     actions: tuple[MatchedAction, ...]
-    app_name: str
-    external_app_id: int
+    target: GatedTarget
     payload: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="after")
@@ -59,6 +75,24 @@ class AllMatchedActions(BaseModel):
     def governing_action(self) -> MatchedAction:
         """The action whose policy drove the verdict (head of the sorted list)."""
         return self.actions[0]
+
+    @property
+    def app_name(self) -> str:
+        return self.target.app_name
+
+    @property
+    def external_app_id(self) -> int | None:
+        """The external-app row id, or ``None`` for a non-external-app target."""
+        if self.target.kind is GatedAppKind.EXTERNAL_APP:
+            return self.target.id
+        return None
+
+    @property
+    def mcp_server_id(self) -> int | None:
+        """The mcp_server row id, or ``None`` for a non-MCP target."""
+        if self.target.kind is GatedAppKind.MCP_SERVER:
+            return self.target.id
+        return None
 
 
 PersistedMatchedAction = Mapping[str, Any]
@@ -135,8 +169,9 @@ def recognize_actions(
     matched.sort(key=lambda a: POLICY_SEVERITY[a.policy], reverse=True)
     return AllMatchedActions(
         actions=tuple(matched),
-        app_name=_app_name(app),
-        external_app_id=app.id,
+        target=GatedTarget(
+            kind=GatedAppKind.EXTERNAL_APP, id=app.id, app_name=_app_name(app)
+        ),
     )
 
 
@@ -174,6 +209,7 @@ def apply_credential_gate(
                 policy=EndpointPolicy.ASK,
             ),
         ),
-        app_name=_app_name(app),
-        external_app_id=app.id,
+        target=GatedTarget(
+            kind=GatedAppKind.EXTERNAL_APP, id=app.id, app_name=_app_name(app)
+        ),
     )

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import POLICY_SEVERITY, EndpointPolicy, ExternalAppType, GatedAppKind
-from onyx.db.external_app import get_policies
+from onyx.db.gated_app import get_action_policies_for_target
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.request import MatchContext, ProxiedRequest
 from onyx.external_apps.matching.rules import rule_matches
@@ -158,7 +158,9 @@ def recognize_actions(
     it via ``model_copy``.
     """
     context = MatchContext(request)
-    stored = get_policies(db_session, [app.id]).get(app.id, {})
+    stored = get_action_policies_for_target(
+        db_session, GatedAppKind.EXTERNAL_APP, app.id
+    )
     catalog = get_endpoint_catalog(app.app_type)
     matched = [
         MatchedAction(

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -49,6 +49,12 @@ class GatedTarget(BaseModel):
     id: int
     app_name: str
 
+    @property
+    def key(self) -> tuple[GatedAppKind, int]:
+        """The ``(kind, id)`` pair — same shape as ``GatedApp.target_key``, so
+        live matches compare directly against persisted grants."""
+        return self.kind, self.id
+
 
 class AllMatchedActions(BaseModel):
     """Every catalog action the request matched within the resolved app.

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -26,6 +26,7 @@ from onyx.cache.interface import CACHE_TRANSIENT_ERRORS, CacheBackend
 from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, EndpointPolicy
+from onyx.db.gated_app import get_gated_app_id
 from onyx.db.notification import create_notification
 from onyx.db.scheduled_task import ScheduledRunGrants, get_live_scheduled_run_grants
 from onyx.external_apps.matching.engine import (
@@ -777,8 +778,7 @@ class GateAddon:
         grant_source_rows = action_approval.list_session_grant_action_approvals(
             db,
             session_id=ctx.session_id,
-            kind=target.kind,
-            target_id=target.id,
+            gated_app_id=get_gated_app_id(db, target.kind, target.id),
         )
         granted_action_types = approval_cache.hydrate_session_grants(
             session_id=ctx.session_id,
@@ -919,14 +919,15 @@ class GateAddon:
 
         logger.info(
             "approval_requested tenant=%s sandbox=%s session=%s approval=%s "
-            "app_name=%r external_app_id=%s action_type=%s action_count=%s "
+            "app_name=%r target=%s:%s action_type=%s action_count=%s "
             "proxy_instance=%s session_id=%s approval_id=%s",
             ctx.tenant_id,
             sandbox_log_label(ctx),
             short_log_id(ctx.session_id),
             short_log_id(approval_id),
             matched_actions.app_name,
-            matched_actions.external_app_id,
+            matched_actions.target.kind.value,
+            matched_actions.target.id,
             matched_actions.governing_action.action_type,
             len(matched_actions.actions),
             self._proxy_instance_id,

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -730,7 +730,7 @@ class GateAddon:
             return None
         run_id, granted_targets = grants
         target = matched_actions.target
-        if (target.kind, target.id) not in granted_targets:
+        if target.key not in granted_targets:
             return None
         return _ApprovalGrant(
             decided_via=ApprovalDecidedVia.PRE_APPROVAL,
@@ -780,38 +780,15 @@ class GateAddon:
             kind=target.kind,
             target_id=target.id,
         )
-        granted_action_types: set[str] = set()
-        for grant_source_row in grant_source_rows:
-            granted_action_types.update(
-                actions_requiring_approval(grant_source_row.actions)
-            )
+        granted_action_types = approval_cache.hydrate_session_grants(
+            session_id=ctx.session_id,
+            kind=target.kind,
+            target_id=target.id,
+            rows=grant_source_rows,
+            cache=cache,
+        )
         if not set(action_types).issubset(granted_action_types):
             return None
-
-        if cache is not None:
-            try:
-                for grant_source_row in grant_source_rows:
-                    approval_cache.cache_session_grant_actions(
-                        session_id=ctx.session_id,
-                        kind=target.kind,
-                        target_id=target.id,
-                        action_types=actions_requiring_approval(
-                            grant_source_row.actions
-                        ),
-                        source_approval_id=grant_source_row.approval_id,
-                        cache=cache,
-                    )
-            except CACHE_TRANSIENT_ERRORS as e:
-                logger.warning(
-                    "approval_grant_cache_error tenant=%s session=%s "
-                    "target=%s:%s operation=%s error=%r",
-                    ctx.tenant_id,
-                    short_log_id(ctx.session_id),
-                    target.kind.value,
-                    target.id,
-                    "hydrate",
-                    str(e),
-                )
         return _ApprovalGrant(decided_via=ApprovalDecidedVia.SESSION_GRANT)
 
     async def _apply_approval_grant(
@@ -864,8 +841,7 @@ class GateAddon:
                     ],
                     app_name=matched_actions.app_name,
                     payload=matched_actions.payload,
-                    kind=matched_actions.target.kind,
-                    target_id=matched_actions.target.id,
+                    target=matched_actions.target.key,
                     decision=ApprovalDecision.APPROVED,
                     decided_via=grant.decided_via,
                 )
@@ -921,8 +897,7 @@ class GateAddon:
                 actions=actions_payload,
                 app_name=matched_actions.app_name,
                 payload=matched_actions.payload,
-                kind=matched_actions.target.kind,
-                target_id=matched_actions.target.id,
+                target=matched_actions.target.key,
             )
             approval_id = row.approval_id
             db.commit()

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -728,8 +728,9 @@ class GateAddon:
         grants = self._live_grants(db, ctx.session_id)
         if grants is None:
             return None
-        run_id, granted_app_ids = grants
-        if matched_actions.external_app_id not in granted_app_ids:
+        run_id, granted_targets = grants
+        target = matched_actions.target
+        if (target.kind, target.id) not in granted_targets:
             return None
         return _ApprovalGrant(
             decided_via=ApprovalDecidedVia.PRE_APPROVAL,
@@ -737,7 +738,8 @@ class GateAddon:
             notification_title=f"Scheduled task used {matched_actions.app_name} (pre-approved)",
             notification_data={
                 "run_id": str(run_id),
-                "external_app_id": matched_actions.external_app_id,
+                "target_kind": target.kind.value,
+                "target_id": target.id,
             },
         )
 
@@ -748,12 +750,14 @@ class GateAddon:
         action_types = actions_requiring_approval(matched_actions.actions)
         if not action_types:
             return None
+        target = matched_actions.target
         cache: CacheBackend | None = None
         try:
             cache = self._cache_factory(ctx.tenant_id)
             if approval_cache.cached_session_grants_cover(
                 session_id=ctx.session_id,
-                external_app_id=matched_actions.external_app_id,
+                kind=target.kind,
+                target_id=target.id,
                 action_types=action_types,
                 cache=cache,
             ):
@@ -761,10 +765,11 @@ class GateAddon:
         except CACHE_TRANSIENT_ERRORS as e:
             logger.warning(
                 "approval_grant_cache_error tenant=%s session=%s "
-                "external_app_id=%s operation=%s error=%r",
+                "target=%s:%s operation=%s error=%r",
                 ctx.tenant_id,
                 short_log_id(ctx.session_id),
-                matched_actions.external_app_id,
+                target.kind.value,
+                target.id,
                 "check",
                 str(e),
             )
@@ -772,7 +777,8 @@ class GateAddon:
         grant_source_rows = action_approval.list_session_grant_action_approvals(
             db,
             session_id=ctx.session_id,
-            external_app_id=matched_actions.external_app_id,
+            kind=target.kind,
+            target_id=target.id,
         )
         granted_action_types: set[str] = set()
         for grant_source_row in grant_source_rows:
@@ -787,7 +793,8 @@ class GateAddon:
                 for grant_source_row in grant_source_rows:
                     approval_cache.cache_session_grant_actions(
                         session_id=ctx.session_id,
-                        external_app_id=matched_actions.external_app_id,
+                        kind=target.kind,
+                        target_id=target.id,
                         action_types=actions_requiring_approval(
                             grant_source_row.actions
                         ),
@@ -797,10 +804,11 @@ class GateAddon:
             except CACHE_TRANSIENT_ERRORS as e:
                 logger.warning(
                     "approval_grant_cache_error tenant=%s session=%s "
-                    "external_app_id=%s operation=%s error=%r",
+                    "target=%s:%s operation=%s error=%r",
                     ctx.tenant_id,
                     short_log_id(ctx.session_id),
-                    matched_actions.external_app_id,
+                    target.kind.value,
+                    target.id,
                     "hydrate",
                     str(e),
                 )
@@ -856,7 +864,8 @@ class GateAddon:
                     ],
                     app_name=matched_actions.app_name,
                     payload=matched_actions.payload,
-                    external_app_id=matched_actions.external_app_id,
+                    kind=matched_actions.target.kind,
+                    target_id=matched_actions.target.id,
                     decision=ApprovalDecision.APPROVED,
                     decided_via=grant.decided_via,
                 )
@@ -912,7 +921,8 @@ class GateAddon:
                 actions=actions_payload,
                 app_name=matched_actions.app_name,
                 payload=matched_actions.payload,
-                external_app_id=matched_actions.external_app_id,
+                kind=matched_actions.target.kind,
+                target_id=matched_actions.target.id,
             )
             approval_id = row.approval_id
             db.commit()

--- a/backend/onyx/sandbox_proxy/approval_cache.py
+++ b/backend/onyx/sandbox_proxy/approval_cache.py
@@ -16,7 +16,7 @@ from collections.abc import Iterable
 from uuid import UUID
 
 from onyx.cache.interface import CacheBackend
-from onyx.db.enums import ApprovalDecision
+from onyx.db.enums import ApprovalDecision, GatedAppKind
 
 # Only need to outlive the gap between RPUSH and the consumer's BLPOP.
 ANNOUNCE_TTL_S = 60
@@ -35,8 +35,10 @@ def _wake_key(approval_id: UUID) -> str:
     return f"approval:wake:{approval_id}"
 
 
-def _session_grant_key(session_id: UUID, external_app_id: int, action_type: str) -> str:
-    return f"approval:session-grant:{session_id}:{external_app_id}:{action_type}"
+def _session_grant_key(
+    session_id: UUID, kind: GatedAppKind, target_id: int, action_type: str
+) -> str:
+    return f"approval:session-grant:{session_id}:{kind.value}:{target_id}:{action_type}"
 
 
 def announce_approval(approval_id: UUID, session_id: UUID, cache: CacheBackend) -> None:
@@ -47,12 +49,13 @@ def announce_approval(approval_id: UUID, session_id: UUID, cache: CacheBackend) 
 def cache_session_grant_actions(
     *,
     session_id: UUID,
-    external_app_id: int,
+    kind: GatedAppKind,
+    target_id: int,
     action_types: Iterable[str],
     source_approval_id: UUID,
     cache: CacheBackend,
 ) -> None:
-    """Cache the same app/action types for this BuildSession.
+    """Cache the same target/action types for this BuildSession.
 
     One key per action keeps matching simple and conservative: a future
     multi-action request is auto-approved only when every ASK action it invokes
@@ -60,7 +63,7 @@ def cache_session_grant_actions(
     """
     for action_type in set(action_types):
         cache.set(
-            _session_grant_key(session_id, external_app_id, action_type),
+            _session_grant_key(session_id, kind, target_id, action_type),
             str(source_approval_id),
             ex=SESSION_GRANT_TTL_S,
         )
@@ -69,7 +72,8 @@ def cache_session_grant_actions(
 def cached_session_grants_cover(
     *,
     session_id: UUID,
-    external_app_id: int,
+    kind: GatedAppKind,
+    target_id: int,
     action_types: Iterable[str],
     cache: CacheBackend,
 ) -> bool:
@@ -82,7 +86,7 @@ def cached_session_grants_cover(
     if not unique_action_types:
         return False
     keys = [
-        _session_grant_key(session_id, external_app_id, action_type)
+        _session_grant_key(session_id, kind, target_id, action_type)
         for action_type in unique_action_types
     ]
     for key in keys:

--- a/backend/onyx/sandbox_proxy/approval_cache.py
+++ b/backend/onyx/sandbox_proxy/approval_cache.py
@@ -13,10 +13,18 @@ here is best-effort over `CacheBackend`. Two lists:
 import asyncio
 import time
 from collections.abc import Iterable
+from typing import TYPE_CHECKING
 from uuid import UUID
 
-from onyx.cache.interface import CacheBackend
+from onyx.cache.interface import CACHE_TRANSIENT_ERRORS, CacheBackend
 from onyx.db.enums import ApprovalDecision, GatedAppKind
+from onyx.external_apps.matching.engine import actions_requiring_approval
+from onyx.utils.logger import setup_logger
+
+if TYPE_CHECKING:
+    from onyx.db.models import ActionApproval
+
+logger = setup_logger()
 
 # Only need to outlive the gap between RPUSH and the consumer's BLPOP.
 ANNOUNCE_TTL_S = 60
@@ -67,6 +75,50 @@ def cache_session_grant_actions(
             str(source_approval_id),
             ex=SESSION_GRANT_TTL_S,
         )
+
+
+def hydrate_session_grants(
+    *,
+    session_id: UUID,
+    kind: GatedAppKind,
+    target_id: int,
+    rows: Iterable["ActionApproval"],
+    cache: CacheBackend | None,
+) -> set[str]:
+    """Union of ASK action types across persisted grant ``rows``, hydrating each
+    row's per-action grant keys as a side effect.
+
+    Hydration is best-effort: skipped when ``cache`` is ``None`` and
+    warned-and-continued on transient cache errors, so callers always get the
+    union back.
+    """
+    granted: set[str] = set()
+    per_row: list[tuple[UUID, list[str]]] = []
+    for row in rows:
+        action_types = actions_requiring_approval(row.actions)
+        granted.update(action_types)
+        per_row.append((row.approval_id, action_types))
+    if cache is not None:
+        try:
+            for source_approval_id, action_types in per_row:
+                cache_session_grant_actions(
+                    session_id=session_id,
+                    kind=kind,
+                    target_id=target_id,
+                    action_types=action_types,
+                    source_approval_id=source_approval_id,
+                    cache=cache,
+                )
+        except CACHE_TRANSIENT_ERRORS as e:
+            logger.warning(
+                "approval.session_grant_cache_hydrate_failed session_id=%s "
+                "target=%s:%s error=%s",
+                session_id,
+                kind.value,
+                target_id,
+                str(e),
+            )
+    return granted
 
 
 def cached_session_grants_cover(

--- a/backend/onyx/sandbox_proxy/logging_utils.py
+++ b/backend/onyx/sandbox_proxy/logging_utils.py
@@ -13,9 +13,9 @@ _EGRESS_CONTEXT_FIELDS = "tenant=%s sandbox=%s"
 _EGRESS_SESSION_FIELDS = f"{_EGRESS_CONTEXT_FIELDS} session=%s"
 _EGRESS_APPROVAL_FIELDS = f"{_EGRESS_SESSION_FIELDS} approval=%s"
 _EGRESS_REQUEST_FIELDS = "host=%s method=%s"
-_EGRESS_ACTION_FIELDS = "app_name=%r external_app_id=%s action_type=%s policy=%s"
+_EGRESS_ACTION_FIELDS = "app_name=%r target=%s:%s action_type=%s policy=%s"
 APPROVAL_DECIDED_FIELDS = (
-    f"{_EGRESS_APPROVAL_FIELDS} app_name=%r external_app_id=%s action_type=%s "
+    f"{_EGRESS_APPROVAL_FIELDS} app_name=%r target=%s:%s action_type=%s "
     "decision=%s wake=%s source=%s session_id=%s approval_id=%s"
 )
 
@@ -80,7 +80,8 @@ def _egress_action_args(
 ) -> tuple[object, ...]:
     return (
         matched_actions.app_name,
-        matched_actions.external_app_id,
+        matched_actions.target.kind.value,
+        matched_actions.target.id,
         matched_actions.governing_action.action_type,
         _policy_label(policy),
     )
@@ -151,7 +152,8 @@ def approval_decided_args(
         short_log_id(ctx.session_id),
         short_log_id(approval_id),
         matched_actions.app_name,
-        matched_actions.external_app_id,
+        matched_actions.target.kind.value,
+        matched_actions.target.id,
         matched_actions.governing_action.action_type,
         decision,
         wake,

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from mitmproxy import http
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
+from onyx.db.enums import GatedAppKind
 from onyx.external_apps.credentials import resolve_injection_headers
 from onyx.external_apps.token_refresh import ensure_fresh_credentials
 from onyx.sandbox_proxy.credential_injection import (
@@ -34,17 +35,20 @@ class ExternalAppResolver(CredentialResolver):
         # The matcher has already proven URL→app attribution; host is unused. An
         # MCP-server target is another resolver's — external app only here.
         actions = ctx.matched_actions
-        return actions is not None and actions.external_app_id is not None
+        return actions is not None and actions.target.kind is GatedAppKind.EXTERNAL_APP
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
         matched_actions = ctx.matched_actions
-        external_app_id = matched_actions.external_app_id if matched_actions else None
-        if external_app_id is None:
+        if (
+            matched_actions is None
+            or matched_actions.target.kind is not GatedAppKind.EXTERNAL_APP
+        ):
             # `claims` guarantees this is unreachable; explicit raise so a
             # broken Protocol contract surfaces as a 403, not a NoneType crash.
             raise CredentialUnavailableError(
                 "ExternalAppResolver invoked without an external-app request"
             )
+        external_app_id = matched_actions.target.id
 
         # Lazily refresh an expired/expiring OAuth token before rendering, so the
         # injected `Bearer` is live. A no-op for fresh or non-OAuth credentials,

--- a/backend/onyx/sandbox_proxy/resolvers/external_app.py
+++ b/backend/onyx/sandbox_proxy/resolvers/external_app.py
@@ -31,16 +31,19 @@ class ExternalAppResolver(CredentialResolver):
         request: http.Request,  # noqa: ARG002
         ctx: InjectionContext,
     ) -> bool:
-        # The matcher has already proven URL→app attribution; host is unused.
-        return ctx.matched_actions is not None
+        # The matcher has already proven URL→app attribution; host is unused. An
+        # MCP-server target is another resolver's — external app only here.
+        actions = ctx.matched_actions
+        return actions is not None and actions.external_app_id is not None
 
     def resolve(self, request: http.Request, ctx: InjectionContext) -> dict[str, str]:
         matched_actions = ctx.matched_actions
-        if matched_actions is None:
+        external_app_id = matched_actions.external_app_id if matched_actions else None
+        if external_app_id is None:
             # `claims` guarantees this is unreachable; explicit raise so a
             # broken Protocol contract surfaces as a 403, not a NoneType crash.
             raise CredentialUnavailableError(
-                "ExternalAppResolver invoked without a matched request"
+                "ExternalAppResolver invoked without an external-app request"
             )
 
         # Lazily refresh an expired/expiring OAuth token before rendering, so the
@@ -50,13 +53,13 @@ class ExternalAppResolver(CredentialResolver):
         # clears the credential, which renders as empty headers below).
         ensure_fresh_credentials(
             ctx.sandbox.tenant_id,
-            matched_actions.external_app_id,
+            external_app_id,
             ctx.sandbox.user_id,
         )
 
         with get_session_with_tenant(tenant_id=ctx.sandbox.tenant_id) as db:
             headers = resolve_injection_headers(
-                db, matched_actions.external_app_id, ctx.sandbox.user_id
+                db, external_app_id, ctx.sandbox.user_id
             )
 
         # Per-app debug line so `external_app_id` survives in logs even when
@@ -67,7 +70,7 @@ class ExternalAppResolver(CredentialResolver):
         logger.debug(
             "external_app_resolver.resolved external_app_id=%s host=%s "
             "header_count=%s header_names=%s",
-            matched_actions.external_app_id,
+            external_app_id,
             request.host,
             len(headers),
             header_names,

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -269,8 +269,7 @@ def submit_session_grant(
     grant_source_rows = action_approval.list_session_grant_action_approvals(
         db_session,
         session_id=session_id,
-        kind=target_kind,
-        target_id=target_id,
+        gated_app_id=current.gated_app_id,
     )
     cache: CacheBackend | None = None
     try:

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
 from onyx.cache.factory import get_cache_backend
-from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
+from onyx.cache.interface import CACHE_TRANSIENT_ERRORS, CacheBackend
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, GatedAppKind, Permission
 from onyx.db.models import ActionApproval, User
@@ -82,9 +82,7 @@ class ApprovalListResponse(BaseModel):
 def _row_target(row: ActionApproval) -> tuple[GatedAppKind, int] | None:
     """The gated target ``(kind, id)`` a row is attributed to, or ``None`` when
     its ``gated_app`` was cleared (parent app/server deleted — SET NULL)."""
-    if row.gated_app is None:
-        return None
-    return row.gated_app.kind, row.gated_app.target_id
+    return row.gated_app.target_key if row.gated_app is not None else None
 
 
 def _send_wake_best_effort(approval_id: UUID, decision: ApprovalDecision) -> None:
@@ -274,23 +272,9 @@ def submit_session_grant(
         kind=target_kind,
         target_id=target_id,
     )
-    granted_action_types: set[str] = set()
-    for grant_source_row in grant_source_rows:
-        granted_action_types.update(
-            actions_requiring_approval(grant_source_row.actions)
-        )
-
+    cache: CacheBackend | None = None
     try:
         cache = get_cache_backend(tenant_id=get_current_tenant_id())
-        for grant_source_row in grant_source_rows:
-            approval_cache.cache_session_grant_actions(
-                session_id=session_id,
-                kind=target_kind,
-                target_id=target_id,
-                action_types=actions_requiring_approval(grant_source_row.actions),
-                source_approval_id=grant_source_row.approval_id,
-                cache=cache,
-            )
     except CACHE_TRANSIENT_ERRORS as e:
         logger.warning(
             "approval.session_grant_cache_failed approval_id=%s session_id=%s error=%s",
@@ -298,6 +282,13 @@ def submit_session_grant(
             session_id,
             str(e),
         )
+    granted_action_types = approval_cache.hydrate_session_grants(
+        session_id=session_id,
+        kind=target_kind,
+        target_id=target_id,
+        rows=grant_source_rows,
+        cache=cache,
+    )
 
     pending_rows = action_approval.list_session_pending_action_approvals(
         db_session, session_id, created_after=cutoff, load_target=True

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -300,7 +300,7 @@ def submit_session_grant(
         )
 
     pending_rows = action_approval.list_session_pending_action_approvals(
-        db_session, session_id, created_after=cutoff
+        db_session, session_id, created_after=cutoff, load_target=True
     )
     for row in pending_rows:
         if row.approval_id == approval_id:

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -18,8 +18,8 @@ from onyx.auth.permissions import require_permission
 from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, Permission
-from onyx.db.models import User
+from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, GatedAppKind, Permission
+from onyx.db.models import ActionApproval, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.matching.engine import MatchedAction, actions_requiring_approval
@@ -77,6 +77,14 @@ class ApprovalView(BaseModel):
 
 class ApprovalListResponse(BaseModel):
     items: list[ApprovalView]
+
+
+def _row_target(row: ActionApproval) -> tuple[GatedAppKind, int] | None:
+    """The gated target ``(kind, id)`` a row is attributed to, or ``None`` when
+    its ``gated_app`` was cleared (parent app/server deleted — SET NULL)."""
+    if row.gated_app is None:
+        return None
+    return row.gated_app.kind, row.gated_app.target_id
 
 
 def _send_wake_best_effort(approval_id: UUID, decision: ApprovalDecision) -> None:
@@ -205,12 +213,13 @@ def submit_session_grant(
     if current is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "approval request not found")
     session_id = current.session_id
-    external_app_id = current.external_app_id
-    if external_app_id is None:
+    target = _row_target(current)
+    if target is None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             "approval request cannot be granted for a session",
         )
+    target_kind, target_id = target
     if current.decision is not None:
         raise OnyxError(
             OnyxErrorCode.CONFLICT,
@@ -262,7 +271,8 @@ def submit_session_grant(
     grant_source_rows = action_approval.list_session_grant_action_approvals(
         db_session,
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=target_kind,
+        target_id=target_id,
     )
     granted_action_types: set[str] = set()
     for grant_source_row in grant_source_rows:
@@ -275,7 +285,8 @@ def submit_session_grant(
         for grant_source_row in grant_source_rows:
             approval_cache.cache_session_grant_actions(
                 session_id=session_id,
-                external_app_id=external_app_id,
+                kind=target_kind,
+                target_id=target_id,
                 action_types=actions_requiring_approval(grant_source_row.actions),
                 source_approval_id=grant_source_row.approval_id,
                 cache=cache,
@@ -294,7 +305,7 @@ def submit_session_grant(
     for row in pending_rows:
         if row.approval_id == approval_id:
             continue
-        if row.external_app_id != external_app_id:
+        if _row_target(row) != target:
             continue
         row_action_types = set(actions_requiring_approval(row.actions))
         covered = bool(row_action_types) and row_action_types.issubset(
@@ -320,11 +331,12 @@ def submit_session_grant(
 
     logger.info(
         "approval.session_grant_recorded approval_id=%s session_id=%s "
-        "user_id=%s external_app_id=%s action_types=%s approved_count=%s",
+        "user_id=%s target=%s:%s action_types=%s approved_count=%s",
         approval_id,
         session_id,
         user.id,
-        external_app_id,
+        target_kind.value,
+        target_id,
         grant_action_types,
         len(approved_ids),
     )

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -8,7 +8,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select, update
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.db.enums import (
     POLICY_SEVERITY,
@@ -133,17 +133,24 @@ def list_session_pending_action_approvals(
     session_id: UUID,
     *,
     created_after: datetime | None = None,
+    load_target: bool = False,
 ) -> list[ActionApproval]:
     """Undecided rows for the session.
 
     `created_after` excludes rows older than the proxy's wait window
     (likely orphaned by a crashed proxy that couldn't write EXPIRED).
+
+    `load_target` eager-loads each row's ``gated_app`` in one batched SELECT —
+    set it when the caller inspects the target per row (else it stays lazy and a
+    caller that never touches it pays nothing).
     """
     stmt = (
         select(ActionApproval)
         .where(ActionApproval.session_id == session_id)
         .where(ActionApproval.decision.is_(None))
     )
+    if load_target:
+        stmt = stmt.options(selectinload(ActionApproval.gated_app))
     if created_after is not None:
         stmt = stmt.where(ActionApproval.created_at >= created_after)
     stmt = stmt.order_by(ActionApproval.created_at.desc())

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -15,7 +15,9 @@ from onyx.db.enums import (
     ApprovalDecidedVia,
     ApprovalDecision,
     EndpointPolicy,
+    GatedAppKind,
 )
+from onyx.db.gated_app import get_gated_app_id, get_or_create_gated_app_id
 from onyx.db.models import ActionApproval, BuildSession
 from onyx.utils.logger import setup_logger
 
@@ -29,13 +31,17 @@ def insert_action_approval(
     actions: list[dict[str, Any]],
     app_name: str,
     payload: dict[str, Any],
-    external_app_id: int | None = None,
+    kind: GatedAppKind | None = None,
+    target_id: int | None = None,
     decision: ApprovalDecision | None = None,
     decided_via: ApprovalDecidedVia | None = None,
 ) -> ActionApproval:
     """Commit an approval row. ``actions`` is the JSONB list of
     ``MatchedAction``-shaped dicts; must be non-empty. Re-sorted
     strictest-policy-first so every reader can rely on ``actions[0]``.
+    ``(kind, target_id)``, when both given, attribute the row to a gated target
+    via its ``gated_app`` identity row; a target-less row (e.g. a bash gate)
+    leaves ``gated_app_id`` NULL.
 
     Defaults to a pending row (``decision IS NULL``). Passing ``decision``
     inserts it pre-decided — safe to bypass ``try_record_decision``'s
@@ -48,12 +54,17 @@ def insert_action_approval(
         key=lambda a: POLICY_SEVERITY[EndpointPolicy(a["policy"])],
         reverse=True,
     )
+    gated_app_id = (
+        get_or_create_gated_app_id(db_session, kind, target_id)
+        if kind is not None and target_id is not None
+        else None
+    )
     row = ActionApproval(
         session_id=session_id,
         actions=sorted_actions,
         app_name=app_name,
         payload=payload,
-        external_app_id=external_app_id,
+        gated_app_id=gated_app_id,
         decision=decision,
         decided_at=datetime.now(timezone.utc) if decision is not None else None,
         decided_via=decided_via,
@@ -142,13 +153,18 @@ def list_session_pending_action_approvals(
 def list_session_grant_action_approvals(
     db_session: Session,
     session_id: UUID,
-    external_app_id: int,
+    *,
+    kind: GatedAppKind,
+    target_id: int,
 ) -> list[ActionApproval]:
-    """Approved rows covered by a durable session-scope grant."""
+    """Approved rows covered by a durable session-scope grant for one target."""
+    gated_app_id = get_gated_app_id(db_session, kind, target_id)
+    if gated_app_id is None:
+        return []
     stmt = (
         select(ActionApproval)
         .where(ActionApproval.session_id == session_id)
-        .where(ActionApproval.external_app_id == external_app_id)
+        .where(ActionApproval.gated_app_id == gated_app_id)
         .where(ActionApproval.decision == ApprovalDecision.APPROVED)
         .where(ActionApproval.decided_via == ApprovalDecidedVia.SESSION_GRANT)
         .order_by(ActionApproval.decided_at.desc())

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -31,17 +31,16 @@ def insert_action_approval(
     actions: list[dict[str, Any]],
     app_name: str,
     payload: dict[str, Any],
-    kind: GatedAppKind | None = None,
-    target_id: int | None = None,
+    target: tuple[GatedAppKind, int] | None = None,
     decision: ApprovalDecision | None = None,
     decided_via: ApprovalDecidedVia | None = None,
 ) -> ActionApproval:
     """Commit an approval row. ``actions`` is the JSONB list of
     ``MatchedAction``-shaped dicts; must be non-empty. Re-sorted
     strictest-policy-first so every reader can rely on ``actions[0]``.
-    ``(kind, target_id)``, when both given, attribute the row to a gated target
-    via its ``gated_app`` identity row; a target-less row (e.g. a bash gate)
-    leaves ``gated_app_id`` NULL.
+    ``target`` attributes the row to a gated ``(kind, target_id)`` via its
+    ``gated_app`` identity row; a target-less row (e.g. a bash gate) leaves
+    ``gated_app_id`` NULL.
 
     Defaults to a pending row (``decision IS NULL``). Passing ``decision``
     inserts it pre-decided — safe to bypass ``try_record_decision``'s
@@ -55,9 +54,7 @@ def insert_action_approval(
         reverse=True,
     )
     gated_app_id = (
-        get_or_create_gated_app_id(db_session, kind, target_id)
-        if kind is not None and target_id is not None
-        else None
+        get_or_create_gated_app_id(db_session, *target) if target is not None else None
     )
     row = ActionApproval(
         session_id=session_id,

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -17,7 +17,7 @@ from onyx.db.enums import (
     EndpointPolicy,
     GatedAppKind,
 )
-from onyx.db.gated_app import get_gated_app_id, get_or_create_gated_app_id
+from onyx.db.gated_app import get_or_create_gated_app_id
 from onyx.db.models import ActionApproval, BuildSession
 from onyx.utils.logger import setup_logger
 
@@ -158,11 +158,10 @@ def list_session_grant_action_approvals(
     db_session: Session,
     session_id: UUID,
     *,
-    kind: GatedAppKind,
-    target_id: int,
+    gated_app_id: int | None,
 ) -> list[ActionApproval]:
-    """Approved rows covered by a durable session-scope grant for one target."""
-    gated_app_id = get_gated_app_id(db_session, kind, target_id)
+    """Approved rows covered by a durable session-scope grant for one gated app.
+    ``None`` means the target was never gated — no identity row, so no grants."""
     if gated_app_id is None:
         return []
     stmt = (

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -7,13 +7,14 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.cache.factory import get_cache_backend
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import ExternalAppType, Permission, SandboxStatus
+from onyx.db.enums import EndpointPolicy, ExternalAppType, Permission, SandboxStatus
 from onyx.db.external_app import (
     create_external_app,
     delete_external_app,
     get_external_app_by_id,
     get_external_apps,
     get_policies,
+    get_policies_for_apps,
     get_user_credentials_by_app_id,
     required_user_credential_keys,
     update_external_app,
@@ -77,9 +78,15 @@ def _get_app_or_404(db_session: Session, external_app_id: int) -> ExternalApp:
 
 
 def _to_admin_response(
-    db_session: Session, app: ExternalApp
+    db_session: Session,
+    app: ExternalApp,
+    *,
+    stored: dict[str, EndpointPolicy] | None = None,
 ) -> ExternalAppAdminResponse:
-    stored = get_policies(db_session, app.id)
+    # ``stored`` lets a list caller pass policies fetched in one batched query
+    # instead of paying a per-app lookup here.
+    if stored is None:
+        stored = get_policies(db_session, app.id)
     managed = MULTI_TENANT and get_onyx_managed_provider(app.app_type) is not None
     return ExternalAppAdminResponse(
         id=app.id,
@@ -366,7 +373,11 @@ def list_external_apps_admin(
 ) -> list[ExternalAppAdminResponse]:
     """List all external apps with admin-only fields (org credentials, auth template)."""
     apps = get_external_apps(db_session=db_session)
-    return [_to_admin_response(db_session, app) for app in apps]
+    policies_by_app = get_policies_for_apps(db_session, [app.id for app in apps])
+    return [
+        _to_admin_response(db_session, app, stored=policies_by_app.get(app.id, {}))
+        for app in apps
+    ]
 
 
 @admin_router.get("/apps/built-in/options")

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -76,8 +76,10 @@ def _get_app_or_404(db_session: Session, external_app_id: int) -> ExternalApp:
     return app
 
 
-def _to_admin_response(app: ExternalApp) -> ExternalAppAdminResponse:
-    stored = {policy.action_id: policy.policy for policy in app.policies}
+def _to_admin_response(
+    db_session: Session, app: ExternalApp
+) -> ExternalAppAdminResponse:
+    stored = get_policies(db_session, app.id)
     managed = MULTI_TENANT and get_onyx_managed_provider(app.app_type) is not None
     return ExternalAppAdminResponse(
         id=app.id,
@@ -182,7 +184,7 @@ def create_built_in_external_app(
     # Push before commit so a push failure rolls back the create.
     push_skill_to_affected_sandboxes(app.skill, db_session)
     db_session.commit()
-    return _to_admin_response(app)
+    return _to_admin_response(db_session, app)
 
 
 @admin_router.patch("/apps/{external_app_id}")
@@ -235,7 +237,7 @@ def update_external_app_admin(
     # Push before commit so a push failure rolls back the change.
     push_skill_to_affected_sandboxes(app.skill, db_session)
     db_session.commit()
-    return _to_admin_response(app)
+    return _to_admin_response(db_session, app)
 
 
 @admin_router.post("/apps/custom")
@@ -311,7 +313,7 @@ def create_custom_external_app(
         push_skill_to_affected_sandboxes(app.skill, db_session)
         db_session.commit()
 
-    return _to_admin_response(app)
+    return _to_admin_response(db_session, app)
 
 
 @admin_router.put("/apps/{external_app_id}/bundle")
@@ -354,7 +356,7 @@ def replace_custom_app_bundle(
     if old_bundle_file_id:
         delete_bundle_blob(file_store, old_bundle_file_id)
 
-    return _to_admin_response(app)
+    return _to_admin_response(db_session, app)
 
 
 @admin_router.get("/apps")
@@ -364,7 +366,7 @@ def list_external_apps_admin(
 ) -> list[ExternalAppAdminResponse]:
     """List all external apps with admin-only fields (org credentials, auth template)."""
     apps = get_external_apps(db_session=db_session)
-    return [_to_admin_response(app) for app in apps]
+    return [_to_admin_response(db_session, app) for app in apps]
 
 
 @admin_router.get("/apps/built-in/options")

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -14,7 +14,6 @@ from onyx.db.external_app import (
     get_external_app_by_id,
     get_external_apps,
     get_policies,
-    get_policies_for_apps,
     get_user_credentials_by_app_id,
     required_user_credential_keys,
     update_external_app,
@@ -188,7 +187,8 @@ def create_built_in_external_app(
     # Push before commit so a push failure rolls back the create.
     push_skill_to_affected_sandboxes(app.skill, db_session)
     db_session.commit()
-    return _to_admin_response(app, stored=get_policies(db_session, app.id))
+    # ``action_policies`` is exactly what was persisted — no need to re-read.
+    return _to_admin_response(app, stored=action_policies)
 
 
 @admin_router.patch("/apps/{external_app_id}")
@@ -219,7 +219,7 @@ def update_external_app_admin(
     action_policies = resolve_action_overrides(
         app.app_type,
         request.action_policies,
-        get_policies(db_session, external_app_id),
+        get_policies(db_session, [external_app_id]).get(external_app_id, {}),
     )
     app, _old = update_external_app(
         db_session=db_session,
@@ -241,7 +241,8 @@ def update_external_app_admin(
     # Push before commit so a push failure rolls back the change.
     push_skill_to_affected_sandboxes(app.skill, db_session)
     db_session.commit()
-    return _to_admin_response(app, stored=get_policies(db_session, app.id))
+    # ``action_policies`` is exactly what was persisted — no need to re-read.
+    return _to_admin_response(app, stored=action_policies)
 
 
 @admin_router.post("/apps/custom")
@@ -317,7 +318,8 @@ def create_custom_external_app(
         push_skill_to_affected_sandboxes(app.skill, db_session)
         db_session.commit()
 
-    return _to_admin_response(app, stored=get_policies(db_session, app.id))
+    # A freshly created custom app has no stored policy overrides.
+    return _to_admin_response(app, stored={})
 
 
 @admin_router.put("/apps/{external_app_id}/bundle")
@@ -360,7 +362,9 @@ def replace_custom_app_bundle(
     if old_bundle_file_id:
         delete_bundle_blob(file_store, old_bundle_file_id)
 
-    return _to_admin_response(app, stored=get_policies(db_session, app.id))
+    return _to_admin_response(
+        app, stored=get_policies(db_session, [app.id]).get(app.id, {})
+    )
 
 
 @admin_router.get("/apps")
@@ -370,7 +374,7 @@ def list_external_apps_admin(
 ) -> list[ExternalAppAdminResponse]:
     """List all external apps with admin-only fields (org credentials, auth template)."""
     apps = get_external_apps(db_session=db_session)
-    policies_by_app = get_policies_for_apps(db_session, [app.id for app in apps])
+    policies_by_app = get_policies(db_session, [app.id for app in apps])
     return [
         _to_admin_response(app, stored=policies_by_app.get(app.id, {})) for app in apps
     ]

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -25,7 +25,7 @@ from onyx.db.external_app import (
     upsert_external_app_user_credential,
     validate_auth_template,
 )
-from onyx.db.gated_app import get_action_policies, get_action_policies_for_target
+from onyx.db.gated_app import get_action_policies
 from onyx.db.models import ExternalApp, ExternalAppUserCredential, User
 from onyx.db.skill import affected_user_ids_for_skill
 from onyx.db.utils import UNSET, none_as_unset
@@ -87,8 +87,7 @@ def _to_admin_response(
     *,
     stored: dict[str, EndpointPolicy],
 ) -> ExternalAppAdminResponse:
-    # ``stored`` is the app's per-action policy overrides; list callers fetch
-    # them for all apps in one batched query instead of per app.
+    # ``stored`` is the app's per-action policy overrides.
     managed = MULTI_TENANT and get_onyx_managed_provider(app.app_type) is not None
     return ExternalAppAdminResponse(
         id=app.id,
@@ -225,9 +224,7 @@ def update_external_app_admin(
     action_policies = resolve_action_overrides(
         app.app_type,
         request.action_policies,
-        get_action_policies_for_target(
-            db_session, GatedAppKind.EXTERNAL_APP, external_app_id
-        ),
+        get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app_id),
     )
     app, _old = update_external_app(
         db_session=db_session,
@@ -372,9 +369,7 @@ def replace_custom_app_bundle(
 
     return _to_admin_response(
         app,
-        stored=get_action_policies_for_target(
-            db_session, GatedAppKind.EXTERNAL_APP, app.id
-        ),
+        stored=get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, app.id),
     )
 
 
@@ -385,11 +380,12 @@ def list_external_apps_admin(
 ) -> list[ExternalAppAdminResponse]:
     """List all external apps with admin-only fields (org credentials, auth template)."""
     apps = get_external_apps(db_session=db_session)
-    policies_by_app = get_action_policies(
-        db_session, GatedAppKind.EXTERNAL_APP, [app.id for app in apps]
-    )
+    # One policy query per app; admin app lists are small.
     return [
-        _to_admin_response(app, stored=policies_by_app.for_target(app.id))
+        _to_admin_response(
+            app,
+            stored=get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, app.id),
+        )
         for app in apps
     ]
 

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -78,15 +78,12 @@ def _get_app_or_404(db_session: Session, external_app_id: int) -> ExternalApp:
 
 
 def _to_admin_response(
-    db_session: Session,
     app: ExternalApp,
     *,
-    stored: dict[str, EndpointPolicy] | None = None,
+    stored: dict[str, EndpointPolicy],
 ) -> ExternalAppAdminResponse:
-    # ``stored`` lets a list caller pass policies fetched in one batched query
-    # instead of paying a per-app lookup here.
-    if stored is None:
-        stored = get_policies(db_session, app.id)
+    # ``stored`` is the app's per-action policy overrides; list callers fetch
+    # them for all apps in one batched query instead of per app.
     managed = MULTI_TENANT and get_onyx_managed_provider(app.app_type) is not None
     return ExternalAppAdminResponse(
         id=app.id,
@@ -191,7 +188,7 @@ def create_built_in_external_app(
     # Push before commit so a push failure rolls back the create.
     push_skill_to_affected_sandboxes(app.skill, db_session)
     db_session.commit()
-    return _to_admin_response(db_session, app)
+    return _to_admin_response(app, stored=get_policies(db_session, app.id))
 
 
 @admin_router.patch("/apps/{external_app_id}")
@@ -244,7 +241,7 @@ def update_external_app_admin(
     # Push before commit so a push failure rolls back the change.
     push_skill_to_affected_sandboxes(app.skill, db_session)
     db_session.commit()
-    return _to_admin_response(db_session, app)
+    return _to_admin_response(app, stored=get_policies(db_session, app.id))
 
 
 @admin_router.post("/apps/custom")
@@ -320,7 +317,7 @@ def create_custom_external_app(
         push_skill_to_affected_sandboxes(app.skill, db_session)
         db_session.commit()
 
-    return _to_admin_response(db_session, app)
+    return _to_admin_response(app, stored=get_policies(db_session, app.id))
 
 
 @admin_router.put("/apps/{external_app_id}/bundle")
@@ -363,7 +360,7 @@ def replace_custom_app_bundle(
     if old_bundle_file_id:
         delete_bundle_blob(file_store, old_bundle_file_id)
 
-    return _to_admin_response(db_session, app)
+    return _to_admin_response(app, stored=get_policies(db_session, app.id))
 
 
 @admin_router.get("/apps")
@@ -375,8 +372,7 @@ def list_external_apps_admin(
     apps = get_external_apps(db_session=db_session)
     policies_by_app = get_policies_for_apps(db_session, [app.id for app in apps])
     return [
-        _to_admin_response(db_session, app, stored=policies_by_app.get(app.id, {}))
-        for app in apps
+        _to_admin_response(app, stored=policies_by_app.get(app.id, {})) for app in apps
     ]
 
 

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -7,19 +7,25 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.cache.factory import get_cache_backend
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.enums import EndpointPolicy, ExternalAppType, Permission, SandboxStatus
+from onyx.db.enums import (
+    EndpointPolicy,
+    ExternalAppType,
+    GatedAppKind,
+    Permission,
+    SandboxStatus,
+)
 from onyx.db.external_app import (
     create_external_app,
     delete_external_app,
     get_external_app_by_id,
     get_external_apps,
-    get_policies,
     get_user_credentials_by_app_id,
     required_user_credential_keys,
     update_external_app,
     upsert_external_app_user_credential,
     validate_auth_template,
 )
+from onyx.db.gated_app import get_action_policies, get_action_policies_for_target
 from onyx.db.models import ExternalApp, ExternalAppUserCredential, User
 from onyx.db.skill import affected_user_ids_for_skill
 from onyx.db.utils import UNSET, none_as_unset
@@ -219,7 +225,9 @@ def update_external_app_admin(
     action_policies = resolve_action_overrides(
         app.app_type,
         request.action_policies,
-        get_policies(db_session, [external_app_id]).get(external_app_id, {}),
+        get_action_policies_for_target(
+            db_session, GatedAppKind.EXTERNAL_APP, external_app_id
+        ),
     )
     app, _old = update_external_app(
         db_session=db_session,
@@ -363,7 +371,10 @@ def replace_custom_app_bundle(
         delete_bundle_blob(file_store, old_bundle_file_id)
 
     return _to_admin_response(
-        app, stored=get_policies(db_session, [app.id]).get(app.id, {})
+        app,
+        stored=get_action_policies_for_target(
+            db_session, GatedAppKind.EXTERNAL_APP, app.id
+        ),
     )
 
 
@@ -374,9 +385,12 @@ def list_external_apps_admin(
 ) -> list[ExternalAppAdminResponse]:
     """List all external apps with admin-only fields (org credentials, auth template)."""
     apps = get_external_apps(db_session=db_session)
-    policies_by_app = get_policies(db_session, [app.id for app in apps])
+    policies_by_app = get_action_policies(
+        db_session, GatedAppKind.EXTERNAL_APP, [app.id for app in apps]
+    )
     return [
-        _to_admin_response(app, stored=policies_by_app.get(app.id, {})) for app in apps
+        _to_admin_response(app, stored=policies_by_app.for_target(app.id))
+        for app in apps
     ]
 
 

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -301,7 +301,7 @@ def _detail(
         next_run_at=task.next_run_at,
         next_runs=next_runs,
         last_run=RunSummary.from_model(last_run) if last_run is not None else None,
-        pre_approved_app_ids=task.pre_approved_app_ids,
+        pre_approved_app_ids=task.pre_approved_external_app_ids,
         created_at=task.created_at,
         updated_at=task.updated_at,
     )
@@ -405,7 +405,7 @@ def create_task(
         cron_expression=cron_expression,
         editor_mode=request.editor_mode,
         status=request.status,
-        pre_approved_app_ids=_validated_app_ids(
+        pre_approved_external_app_ids=_validated_app_ids(
             db_session, request.pre_approved_app_ids
         ),
     )
@@ -468,7 +468,7 @@ def patch_task(
         cron_expression=cron_expression,
         editor_mode=request.editor_mode,
         status=request.status,
-        pre_approved_app_ids=(
+        pre_approved_external_app_ids=(
             _validated_app_ids(db_session, request.pre_approved_app_ids)
             if request.pre_approved_app_ids is not None
             else None

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -7,8 +7,8 @@ from sqlalchemy.orm import Session
 from onyx.configs.constants import DocumentSource, DocumentSourceDescription
 from onyx.db.connector import _INTERNAL_ONLY_SOURCES
 from onyx.db.connector_credential_pair import get_connector_credential_pairs_for_user
-from onyx.db.enums import EndpointPolicy, ExternalAppType
-from onyx.db.external_app import get_policies
+from onyx.db.enums import EndpointPolicy, ExternalAppType, GatedAppKind
+from onyx.db.gated_app import get_action_policies_for_target
 from onyx.db.models import ExternalApp, User
 from onyx.external_apps.providers.registry import action_policy_views
 from onyx.utils.logger import setup_logger
@@ -113,7 +113,9 @@ def render_external_app_skill(
     """
     template = (skill_dir / "SKILL.md.template").read_text()
     stored = (
-        get_policies(db_session, [external_app.id]).get(external_app.id, {})
+        get_action_policies_for_target(
+            db_session, GatedAppKind.EXTERNAL_APP, external_app.id
+        )
         if external_app
         else {}
     )

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -8,7 +8,7 @@ from onyx.configs.constants import DocumentSource, DocumentSourceDescription
 from onyx.db.connector import _INTERNAL_ONLY_SOURCES
 from onyx.db.connector_credential_pair import get_connector_credential_pairs_for_user
 from onyx.db.enums import EndpointPolicy, ExternalAppType, GatedAppKind
-from onyx.db.gated_app import get_action_policies_for_target
+from onyx.db.gated_app import get_action_policies
 from onyx.db.models import ExternalApp, User
 from onyx.external_apps.providers.registry import action_policy_views
 from onyx.utils.logger import setup_logger
@@ -113,9 +113,7 @@ def render_external_app_skill(
     """
     template = (skill_dir / "SKILL.md.template").read_text()
     stored = (
-        get_action_policies_for_target(
-            db_session, GatedAppKind.EXTERNAL_APP, external_app.id
-        )
+        get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app.id)
         if external_app
         else {}
     )

--- a/backend/onyx/skills/rendering.py
+++ b/backend/onyx/skills/rendering.py
@@ -112,7 +112,11 @@ def render_external_app_skill(
     ``skill_dir`` is the skill's on-disk directory (holds ``SKILL.md.template``).
     """
     template = (skill_dir / "SKILL.md.template").read_text()
-    stored = get_policies(db_session, external_app.id) if external_app else {}
+    stored = (
+        get_policies(db_session, [external_app.id]).get(external_app.id, {})
+        if external_app
+        else {}
+    )
     section = build_action_availability_section(app_type, stored)
     if section:
         return template.replace(ACTION_AVAILABILITY_PLACEHOLDER, section)

--- a/backend/tests/common/craft/skill_table_isolation.py
+++ b/backend/tests/common/craft/skill_table_isolation.py
@@ -9,8 +9,9 @@ from sqlalchemy.orm import Session, class_mapper
 
 from onyx.db.models import (
     ExternalApp,
-    ExternalAppPolicy,
     ExternalAppUserCredential,
+    GatedActionPolicy,
+    GatedApp,
     Skill,
     Skill__User,
     Skill__UserGroup,
@@ -21,9 +22,10 @@ from onyx.db.models import (
 _SKILL_ISOLATION_MODELS: tuple[type[Any], ...] = (
     Skill,
     ExternalApp,
+    GatedApp,
     Skill__User,
     Skill__UserGroup,
-    ExternalAppPolicy,
+    GatedActionPolicy,
     ExternalAppUserCredential,
 )
 

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -31,17 +31,19 @@ from onyx.db.enums import (
     ConnectorCredentialPairStatus,
     EndpointPolicy,
     ExternalAppType,
+    GatedAppKind,
     SandboxStatus,
     SkillSharePermission,
 )
+from onyx.db.gated_app import get_or_create_gated_app_id
 from onyx.db.models import (
     ActionApproval,
     Connector,
     ConnectorCredentialPair,
     Credential,
     ExternalApp,
-    ExternalAppPolicy,
     ExternalAppUserCredential,
+    GatedActionPolicy,
     Sandbox,
     Skill,
     Skill__User,
@@ -235,15 +237,19 @@ def make_external_app(
     )
     db_session.add(app)
     db_session.flush()
-    for action_id, policy in (action_policies or {}).items():
-        db_session.add(
-            ExternalAppPolicy(
-                external_app_id=app.id,
-                action_id=action_id,
-                policy=policy,
-            )
+    if action_policies:
+        gated_app_id = get_or_create_gated_app_id(
+            db_session, GatedAppKind.EXTERNAL_APP, app.id
         )
-    db_session.flush()
+        for action_id, policy in action_policies.items():
+            db_session.add(
+                GatedActionPolicy(
+                    gated_app_id=gated_app_id,
+                    action_id=action_id,
+                    policy=policy,
+                )
+            )
+        db_session.flush()
     return app
 
 

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -313,7 +313,7 @@ def test_external_app_matcher_resolves_app_and_verdict(
     assert [a.action_type for a in matched_actions.actions] == ["slack.messages.write"]
     assert matched_actions.actions[0].policy == EndpointPolicy.DENY
     assert matched_actions.app_name == "Slack"
-    assert matched_actions.external_app_id == app.id
+    assert matched_actions.target.key == (GatedAppKind.EXTERNAL_APP, app.id)
     assert matched_actions.payload == {"channel": "C1", "text": "hi"}
 
 
@@ -372,7 +372,7 @@ def test_external_app_matcher_off_catalog_synthesizes_whole_domain(
     assert matched_actions is not None
     assert matched_actions.actions[0].action_type == WHOLE_DOMAIN_ACTION_TYPE
     assert matched_actions.actions[0].policy == EndpointPolicy.ASK
-    assert matched_actions.external_app_id == app.id
+    assert matched_actions.target.key == (GatedAppKind.EXTERNAL_APP, app.id)
 
 
 def test_external_app_matcher_credentialless_app_is_gated(
@@ -401,6 +401,6 @@ def test_external_app_matcher_credentialless_app_is_gated(
     assert matched_actions is not None
     assert matched_actions.actions[0].action_type == WHOLE_DOMAIN_ACTION_TYPE
     assert matched_actions.actions[0].policy == EndpointPolicy.ASK
-    assert matched_actions.external_app_id == app.id
+    assert matched_actions.target.key == (GatedAppKind.EXTERNAL_APP, app.id)
     # CUSTOM apps have no provider; the name comes from the linked skill.
     assert matched_actions.app_name == skill.name

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -26,13 +26,15 @@ import pytest
 from mitmproxy import http
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import EndpointPolicy, ExternalAppType
-from onyx.db.models import ExternalApp, ExternalAppPolicy, User
+from onyx.db.enums import EndpointPolicy, ExternalAppType, GatedAppKind
+from onyx.db.gated_app import get_or_create_gated_app_id
+from onyx.db.models import ExternalApp, GatedActionPolicy, User
 from onyx.external_apps.credentials import app_is_available
 from onyx.external_apps.matching import engine as matching_engine
 from onyx.external_apps.matching.engine import (
     WHOLE_DOMAIN_ACTION_TYPE,
     AllMatchedActions,
+    GatedTarget,
     MatchedAction,
     recognize_actions,
 )
@@ -73,9 +75,12 @@ def _set_policy(
     action_id: str,
     policy: EndpointPolicy,
 ) -> None:
+    gated_app_id = get_or_create_gated_app_id(
+        db_session, GatedAppKind.EXTERNAL_APP, app.id
+    )
     db_session.add(
-        ExternalAppPolicy(
-            external_app_id=app.id,
+        GatedActionPolicy(
+            gated_app_id=gated_app_id,
             action_id=action_id,
             policy=policy,
         )
@@ -103,8 +108,7 @@ def test_match_stored_override_wins(
                 policy=EndpointPolicy.ALWAYS,
             ),
         ),
-        app_name="Slack",
-        external_app_id=app.id,
+        target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=app.id, app_name="Slack"),
     )
 
 

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -362,8 +362,7 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send, always_read],
         app_name="Slack",
         payload={"text": "current"},
-        kind=GatedAppKind.EXTERNAL_APP,
-        target_id=app.id,
+        target=(GatedAppKind.EXTERNAL_APP, app.id),
     )
     matching = insert_action_approval(
         db_session,
@@ -371,8 +370,7 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send],
         app_name="Slack",
         payload={"text": "matching"},
-        kind=GatedAppKind.EXTERNAL_APP,
-        target_id=app.id,
+        target=(GatedAppKind.EXTERNAL_APP, app.id),
     )
     broader = insert_action_approval(
         db_session,
@@ -380,8 +378,7 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send, ask_upload],
         app_name="Slack",
         payload={"text": "broader"},
-        kind=GatedAppKind.EXTERNAL_APP,
-        target_id=app.id,
+        target=(GatedAppKind.EXTERNAL_APP, app.id),
     )
     other = insert_action_approval(
         db_session,
@@ -389,8 +386,7 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send],
         app_name="Other",
         payload={"text": "other"},
-        kind=GatedAppKind.EXTERNAL_APP,
-        target_id=other_app.id,
+        target=(GatedAppKind.EXTERNAL_APP, other_app.id),
     )
     db_session.commit()
 

--- a/backend/tests/external_dependency_unit/craft/test_approvals_api.py
+++ b/backend/tests/external_dependency_unit/craft/test_approvals_api.py
@@ -12,7 +12,12 @@ import redis
 from sqlalchemy.orm import Session
 
 from onyx.cache.factory import get_cache_backend
-from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, EndpointPolicy
+from onyx.db.enums import (
+    ApprovalDecidedVia,
+    ApprovalDecision,
+    EndpointPolicy,
+    GatedAppKind,
+)
 from onyx.db.models import BuildSession
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -357,7 +362,8 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send, always_read],
         app_name="Slack",
         payload={"text": "current"},
-        external_app_id=app.id,
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app.id,
     )
     matching = insert_action_approval(
         db_session,
@@ -365,7 +371,8 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send],
         app_name="Slack",
         payload={"text": "matching"},
-        external_app_id=app.id,
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app.id,
     )
     broader = insert_action_approval(
         db_session,
@@ -373,7 +380,8 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send, ask_upload],
         app_name="Slack",
         payload={"text": "broader"},
-        external_app_id=app.id,
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app.id,
     )
     other = insert_action_approval(
         db_session,
@@ -381,7 +389,8 @@ def test_submit_session_grant_approves_matching_pending_rows(
         actions=[ask_send],
         app_name="Other",
         payload={"text": "other"},
-        external_app_id=other_app.id,
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=other_app.id,
     )
     db_session.commit()
 
@@ -421,13 +430,15 @@ def test_submit_session_grant_approves_matching_pending_rows(
     cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     assert approval_cache.cached_session_grants_cover(
         session_id=session.id,
-        external_app_id=app.id,
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app.id,
         action_types=["slack.chat.post"],
         cache=cache,
     )
     assert not approval_cache.cached_session_grants_cover(
         session_id=session.id,
-        external_app_id=app.id,
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app.id,
         action_types=["slack.files.upload"],
         cache=cache,
     )

--- a/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
@@ -212,7 +212,7 @@ def test_self_hosted_built_in_response_shows_config_and_masked_creds(
     assert gmail is not None
 
     monkeypatch.setattr(api, "MULTI_TENANT", False)
-    resp = api._to_admin_response(gmail)
+    resp = api._to_admin_response(db_session, gmail)
 
     assert resp.upstream_url_patterns  # config visible
     # Creds are present but masked — not the same raw values, not blanked away.

--- a/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
@@ -24,7 +24,7 @@ from onyx.db.external_app import (
     create_external_app,
     get_built_in_external_app,
 )
-from onyx.db.gated_app import get_action_policies_for_target
+from onyx.db.gated_app import get_action_policies
 from onyx.db.models import Skill, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -218,9 +218,7 @@ def test_self_hosted_built_in_response_shows_config_and_masked_creds(
     monkeypatch.setattr(api, "MULTI_TENANT", False)
     resp = api._to_admin_response(
         gmail,
-        stored=get_action_policies_for_target(
-            db_session, GatedAppKind.EXTERNAL_APP, gmail.id
-        ),
+        stored=get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, gmail.id),
     )
 
     assert resp.upstream_url_patterns  # config visible

--- a/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
@@ -216,7 +216,9 @@ def test_self_hosted_built_in_response_shows_config_and_masked_creds(
     assert gmail is not None
 
     monkeypatch.setattr(api, "MULTI_TENANT", False)
-    resp = api._to_admin_response(gmail, stored=get_policies(db_session, gmail.id))
+    resp = api._to_admin_response(
+        gmail, stored=get_policies(db_session, [gmail.id]).get(gmail.id, {})
+    )
 
     assert resp.upstream_url_patterns  # config visible
     # Creds are present but masked — not the same raw values, not blanked away.

--- a/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
@@ -20,7 +20,11 @@ from sqlalchemy.orm import Session
 
 import onyx.server.features.build.external_apps.api as api
 from onyx.db.enums import ExternalAppType
-from onyx.db.external_app import create_external_app, get_built_in_external_app
+from onyx.db.external_app import (
+    create_external_app,
+    get_built_in_external_app,
+    get_policies,
+)
 from onyx.db.models import Skill, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -212,7 +216,7 @@ def test_self_hosted_built_in_response_shows_config_and_masked_creds(
     assert gmail is not None
 
     monkeypatch.setattr(api, "MULTI_TENANT", False)
-    resp = api._to_admin_response(db_session, gmail)
+    resp = api._to_admin_response(gmail, stored=get_policies(db_session, gmail.id))
 
     assert resp.upstream_url_patterns  # config visible
     # Creds are present but masked — not the same raw values, not blanked away.

--- a/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
@@ -19,12 +19,12 @@ from sqlalchemy import delete
 from sqlalchemy.orm import Session
 
 import onyx.server.features.build.external_apps.api as api
-from onyx.db.enums import ExternalAppType
+from onyx.db.enums import ExternalAppType, GatedAppKind
 from onyx.db.external_app import (
     create_external_app,
     get_built_in_external_app,
-    get_policies,
 )
+from onyx.db.gated_app import get_action_policies_for_target
 from onyx.db.models import Skill, User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -217,7 +217,10 @@ def test_self_hosted_built_in_response_shows_config_and_masked_creds(
 
     monkeypatch.setattr(api, "MULTI_TENANT", False)
     resp = api._to_admin_response(
-        gmail, stored=get_policies(db_session, [gmail.id]).get(gmail.id, {})
+        gmail,
+        stored=get_action_policies_for_target(
+            db_session, GatedAppKind.EXTERNAL_APP, gmail.id
+        ),
     )
 
     assert resp.upstream_url_patterns  # config visible

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import (
     ApprovalDecidedVia,
     ApprovalDecision,
+    GatedAppKind,
     ScheduledTaskRunStatus,
     ScheduledTaskStatus,
     ScheduledTaskTriggerSource,
@@ -106,9 +107,12 @@ def test_grants_returned_for_running_run(
     grants = get_live_scheduled_run_grants(db_session=db_session, session_id=bs.id)
 
     assert grants is not None
-    run_id, app_ids = grants
+    run_id, granted = grants
     assert run_id == run.id
-    assert app_ids == [app_a, app_b]
+    assert granted == {
+        (GatedAppKind.EXTERNAL_APP, app_a),
+        (GatedAppKind.EXTERNAL_APP, app_b),
+    }
 
 
 @pytest.mark.parametrize(
@@ -174,6 +178,7 @@ def test_insert_pre_decided_row(
 ) -> None:
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
+    app_id = _make_app(db_session)
 
     row = insert_action_approval(
         db_session,
@@ -181,6 +186,8 @@ def test_insert_pre_decided_row(
         actions=default_action_entries(),
         app_name="Slack",
         payload={"text": "hi"},
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app_id,
         decision=ApprovalDecision.APPROVED,
         decided_via=ApprovalDecidedVia.PRE_APPROVAL,
     )
@@ -200,6 +207,7 @@ def test_insert_default_row_stays_pending(
 ) -> None:
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
+    app_id = _make_app(db_session)
 
     row = insert_action_approval(
         db_session,
@@ -207,6 +215,8 @@ def test_insert_default_row_stays_pending(
         actions=default_action_entries(),
         app_name="Slack",
         payload={},
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app_id,
     )
     db_session.commit()
     db_session.refresh(row)
@@ -214,7 +224,7 @@ def test_insert_default_row_stays_pending(
     assert row.decision is None
     assert row.decided_at is None
     assert row.decided_via is None
-    assert row.external_app_id is None
+    assert row.gated_app_id is not None
 
 
 # ---------------------------------------------------------------------------
@@ -337,8 +347,9 @@ def test_deleting_app_nulls_action_approval_fk(
     tenant_context: None,  # noqa: ARG001
     build_session_with_user: Callable[..., BuildSession],
 ) -> None:
-    """``action_approval.external_app_id`` is ``ON DELETE SET NULL``: an audit
-    row survives app deletion with the FK cleared, not cascaded away."""
+    """``action_approval.gated_app_id`` is ``ON DELETE SET NULL``: an audit row
+    survives app deletion with the FK cleared, not cascaded away. Deleting the
+    app cascades its gated_app row away, which nulls the approval's FK."""
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
     app_id = _make_app(db_session)
@@ -348,18 +359,19 @@ def test_deleting_app_nulls_action_approval_fk(
         actions=default_action_entries(),
         app_name="Slack",
         payload={},
-        external_app_id=app_id,
+        kind=GatedAppKind.EXTERNAL_APP,
+        target_id=app_id,
         decision=ApprovalDecision.APPROVED,
         decided_via=ApprovalDecidedVia.PRE_APPROVAL,
     )
     db_session.commit()
-    assert row.external_app_id == app_id
+    assert row.gated_app_id is not None
 
     db_session.execute(delete(ExternalApp).where(ExternalApp.id == app_id))
     db_session.commit()
     db_session.refresh(row)
 
-    assert row.external_app_id is None
+    assert row.gated_app_id is None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -62,7 +62,7 @@ def _seed_task(
     db_session: Session,
     user: User,
     *,
-    pre_approved_app_ids: list[int] | None = None,
+    pre_approved_external_app_ids: list[int] | None = None,
     prompt: str = "Summarise yesterday's events",
 ) -> ScheduledTask:
     task = create_scheduled_task(
@@ -73,7 +73,7 @@ def _seed_task(
         cron_expression="0 9 * * *",
         editor_mode="advanced",
         status=ScheduledTaskStatus.ACTIVE,
-        pre_approved_app_ids=pre_approved_app_ids,
+        pre_approved_external_app_ids=pre_approved_external_app_ids,
     )
     db_session.commit()
     db_session.refresh(task)
@@ -93,7 +93,7 @@ def test_grants_returned_for_running_run(
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
     app_a, app_b = _make_app(db_session), _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a, app_b])
+    task = _seed_task(db_session, user, pre_approved_external_app_ids=[app_a, app_b])
     run = insert_run(
         db_session=db_session,
         task_id=task.id,
@@ -136,7 +136,9 @@ def test_no_grants_for_non_running_run(
     usual — the RUNNING filter is the load-bearing scope guard."""
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[_make_app(db_session)])
+    task = _seed_task(
+        db_session, user, pre_approved_external_app_ids=[_make_app(db_session)]
+    )
     run = insert_run(
         db_session=db_session,
         task_id=task.id,
@@ -238,10 +240,12 @@ def test_prompt_change_preserves_grants(
     tenant_context: None,  # noqa: ARG001
 ) -> None:
     """Grants are explicit state surfaced as checkboxes in the editor: a
-    prompt edit that omits ``pre_approved_app_ids`` leaves them untouched."""
+    prompt edit that omits ``pre_approved_external_app_ids`` leaves them untouched."""
     user = make_user(db_session)
     app = _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app], prompt="orig")
+    task = _seed_task(
+        db_session, user, pre_approved_external_app_ids=[app], prompt="orig"
+    )
 
     updated = update_scheduled_task(
         db_session=db_session,
@@ -251,28 +255,28 @@ def test_prompt_change_preserves_grants(
     )
     db_session.commit()
 
-    assert updated.pre_approved_app_ids == [app]
+    assert updated.pre_approved_external_app_ids == [app]
 
 
 def test_supplied_grants_replace_existing(
     db_session: Session,
     tenant_context: None,  # noqa: ARG001
 ) -> None:
-    """Supplying ``pre_approved_app_ids`` replaces the set wholesale —
+    """Supplying ``pre_approved_external_app_ids`` replaces the set wholesale —
     dropping omitted apps and adding new ones."""
     user = make_user(db_session)
     app_a, app_b = _make_app(db_session), _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a])
+    task = _seed_task(db_session, user, pre_approved_external_app_ids=[app_a])
 
     updated = update_scheduled_task(
         db_session=db_session,
         task_id=task.id,
         user_id=user.id,
-        pre_approved_app_ids=[app_b],
+        pre_approved_external_app_ids=[app_b],
     )
     db_session.commit()
 
-    assert updated.pre_approved_app_ids == [app_b]
+    assert updated.pre_approved_external_app_ids == [app_b]
 
 
 def test_resubmitting_existing_grant_is_idempotent(
@@ -284,17 +288,17 @@ def test_resubmitting_existing_grant_is_idempotent(
     re-sends current grants on every save, so this is the common path."""
     user = make_user(db_session)
     app_a, app_b = _make_app(db_session), _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a])
+    task = _seed_task(db_session, user, pre_approved_external_app_ids=[app_a])
 
     updated = update_scheduled_task(
         db_session=db_session,
         task_id=task.id,
         user_id=user.id,
-        pre_approved_app_ids=[app_a, app_b],  # app_a already granted
+        pre_approved_external_app_ids=[app_a, app_b],  # app_a already granted
     )
     db_session.commit()
 
-    assert set(updated.pre_approved_app_ids) == {app_a, app_b}
+    assert set(updated.pre_approved_external_app_ids) == {app_a, app_b}
 
 
 def test_mcp_grants_survive_external_app_replacement(
@@ -302,15 +306,15 @@ def test_mcp_grants_survive_external_app_replacement(
     tenant_context: None,  # noqa: ARG001
     build_session_with_user: Callable[..., BuildSession],
 ) -> None:
-    """``set_pre_approved_apps`` manages only EXTERNAL_APP grants: an MCP-server
+    """``set_pre_approved_external_apps`` manages only EXTERNAL_APP grants: an MCP-server
     grant (seeded directly — no API writes these yet) survives a wholesale
-    external-app replacement, stays out of ``pre_approved_app_ids``, and reaches
+    external-app replacement, stays out of ``pre_approved_external_app_ids``, and reaches
     the gate through ``get_live_scheduled_run_grants`` as its (kind, id) target.
     """
     user = make_user(db_session)
     bs = build_session_with_user(user=user)
     app_a, app_b = _make_app(db_session), _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a])
+    task = _seed_task(db_session, user, pre_approved_external_app_ids=[app_a])
 
     server = MCPServer(
         owner=user.email,
@@ -334,11 +338,11 @@ def test_mcp_grants_survive_external_app_replacement(
         db_session=db_session,
         task_id=task.id,
         user_id=user.id,
-        pre_approved_app_ids=[app_b],
+        pre_approved_external_app_ids=[app_b],
     )
     db_session.commit()
 
-    assert updated.pre_approved_app_ids == [app_b]  # MCP grant excluded
+    assert updated.pre_approved_external_app_ids == [app_b]  # MCP grant excluded
     assert {g.gated_app.target_key for g in updated.pre_approved_apps} == {
         (GatedAppKind.EXTERNAL_APP, app_b),
         (GatedAppKind.MCP_SERVER, server.id),
@@ -373,11 +377,11 @@ def test_create_persists_grants(
     app_a, app_b = _make_app(db_session), _make_app(db_session)
     assert app_a < app_b  # ids autoincrement, so the higher id is created last
     # Insertion order is preserved (not sorted): pass the higher id first.
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app_b, app_a])
-    assert task.pre_approved_app_ids == [app_b, app_a]
+    task = _seed_task(db_session, user, pre_approved_external_app_ids=[app_b, app_a])
+    assert task.pre_approved_external_app_ids == [app_b, app_a]
 
     bare = _seed_task(db_session, user)
-    assert bare.pre_approved_app_ids == []
+    assert bare.pre_approved_external_app_ids == []
 
 
 # ---------------------------------------------------------------------------
@@ -393,8 +397,8 @@ def test_deleting_app_drops_grants(
     grant rows — a grant on a removed app is meaningless."""
     user = make_user(db_session)
     app_id = _make_app(db_session)
-    task = _seed_task(db_session, user, pre_approved_app_ids=[app_id])
-    assert task.pre_approved_app_ids == [app_id]
+    task = _seed_task(db_session, user, pre_approved_external_app_ids=[app_id])
+    assert task.pre_approved_external_app_ids == [app_id]
 
     db_session.execute(delete(ExternalApp).where(ExternalApp.id == app_id))
     db_session.commit()

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -306,7 +306,7 @@ def test_mcp_grants_survive_external_app_replacement(
     tenant_context: None,  # noqa: ARG001
     build_session_with_user: Callable[..., BuildSession],
 ) -> None:
-    """``set_pre_approved_external_apps`` manages only EXTERNAL_APP grants: an MCP-server
+    """``set_pre_approved_apps`` replaces only the given kind's grants: an MCP-server
     grant (seeded directly — no API writes these yet) survives a wholesale
     external-app replacement, stays out of ``pre_approved_external_app_ids``, and reaches
     the gate through ``get_live_scheduled_run_grants`` as its (kind, id) target.

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -9,6 +9,7 @@ this file pins the queries those stubs stand in for.
 from __future__ import annotations
 
 from typing import Callable
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import delete, select
@@ -22,9 +23,11 @@ from onyx.db.enums import (
     ScheduledTaskStatus,
     ScheduledTaskTriggerSource,
 )
+from onyx.db.gated_app import get_or_create_gated_app_id
 from onyx.db.models import (
     BuildSession,
     ExternalApp,
+    MCPServer,
     ScheduledTask,
     ScheduledTaskPreApprovedApp,
     User,
@@ -292,6 +295,74 @@ def test_resubmitting_existing_grant_is_idempotent(
     db_session.commit()
 
     assert set(updated.pre_approved_app_ids) == {app_a, app_b}
+
+
+def test_mcp_grants_survive_external_app_replacement(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+    build_session_with_user: Callable[..., BuildSession],
+) -> None:
+    """``set_pre_approved_apps`` manages only EXTERNAL_APP grants: an MCP-server
+    grant (seeded directly — no API writes these yet) survives a wholesale
+    external-app replacement, stays out of ``pre_approved_app_ids``, and reaches
+    the gate through ``get_live_scheduled_run_grants`` as its (kind, id) target.
+    """
+    user = make_user(db_session)
+    bs = build_session_with_user(user=user)
+    app_a, app_b = _make_app(db_session), _make_app(db_session)
+    task = _seed_task(db_session, user, pre_approved_app_ids=[app_a])
+
+    server = MCPServer(
+        owner=user.email,
+        name=f"pre_approval_mcp_{uuid4().hex[:8]}",
+        server_url="https://example.com/mcp",
+        is_public=False,
+    )
+    db_session.add(server)
+    db_session.flush()
+    mcp_gated_app_id = get_or_create_gated_app_id(
+        db_session, GatedAppKind.MCP_SERVER, server.id
+    )
+    db_session.add(
+        ScheduledTaskPreApprovedApp(
+            scheduled_task_id=task.id, gated_app_id=mcp_gated_app_id
+        )
+    )
+    db_session.commit()
+
+    updated = update_scheduled_task(
+        db_session=db_session,
+        task_id=task.id,
+        user_id=user.id,
+        pre_approved_app_ids=[app_b],
+    )
+    db_session.commit()
+
+    assert updated.pre_approved_app_ids == [app_b]  # MCP grant excluded
+    assert {g.gated_app.target_key for g in updated.pre_approved_apps} == {
+        (GatedAppKind.EXTERNAL_APP, app_b),
+        (GatedAppKind.MCP_SERVER, server.id),
+    }
+
+    run = insert_run(
+        db_session=db_session,
+        task_id=task.id,
+        trigger_source=ScheduledTaskTriggerSource.SCHEDULED,
+    )
+    mark_run_status(
+        db_session=db_session,
+        run_id=run.id,
+        status=ScheduledTaskRunStatus.RUNNING,
+        session_id=bs.id,
+    )
+    db_session.commit()
+
+    grants = get_live_scheduled_run_grants(db_session=db_session, session_id=bs.id)
+    assert grants is not None
+    assert grants[1] == {
+        (GatedAppKind.EXTERNAL_APP, app_b),
+        (GatedAppKind.MCP_SERVER, server.id),
+    }
 
 
 def test_create_persists_grants(

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_pre_approvals.py
@@ -186,8 +186,7 @@ def test_insert_pre_decided_row(
         actions=default_action_entries(),
         app_name="Slack",
         payload={"text": "hi"},
-        kind=GatedAppKind.EXTERNAL_APP,
-        target_id=app_id,
+        target=(GatedAppKind.EXTERNAL_APP, app_id),
         decision=ApprovalDecision.APPROVED,
         decided_via=ApprovalDecidedVia.PRE_APPROVAL,
     )
@@ -215,8 +214,7 @@ def test_insert_default_row_stays_pending(
         actions=default_action_entries(),
         app_name="Slack",
         payload={},
-        kind=GatedAppKind.EXTERNAL_APP,
-        target_id=app_id,
+        target=(GatedAppKind.EXTERNAL_APP, app_id),
     )
     db_session.commit()
     db_session.refresh(row)
@@ -359,8 +357,7 @@ def test_deleting_app_nulls_action_approval_fk(
         actions=default_action_entries(),
         app_name="Slack",
         payload={},
-        kind=GatedAppKind.EXTERNAL_APP,
-        target_id=app_id,
+        target=(GatedAppKind.EXTERNAL_APP, app_id),
         decision=ApprovalDecision.APPROVED,
         decided_via=ApprovalDecidedVia.PRE_APPROVAL,
     )

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_approval_cache.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from onyx.cache.factory import get_cache_backend
-from onyx.db.enums import ApprovalDecision
+from onyx.db.enums import ApprovalDecision, GatedAppKind
 from onyx.sandbox_proxy.approval_cache import (
     _wake_key,
     announce_approval,
@@ -124,18 +124,21 @@ def test_cached_session_grants_cover_requires_every_action() -> None:
     cache = get_cache_backend(tenant_id=POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE)
     session_id = uuid4()
     approval_id = uuid4()
-    external_app_id = 42
+    kind = GatedAppKind.EXTERNAL_APP
+    target_id = 42
 
     assert not cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post"],
         cache=cache,
     )
 
     cache_session_grant_actions(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post"],
         source_approval_id=approval_id,
         cache=cache,
@@ -143,19 +146,23 @@ def test_cached_session_grants_cover_requires_every_action() -> None:
 
     assert cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post"],
         cache=cache,
     )
     assert not cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post", "slack.files.upload"],
         cache=cache,
     )
+    # A different catalog (MCP) at the same numeric id must not satisfy the grant.
     assert not cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id + 1,
+        kind=GatedAppKind.MCP_SERVER,
+        target_id=target_id,
         action_types=["slack.chat.post"],
         cache=cache,
     )

--- a/backend/tests/unit/external_apps/matching/test_engine.py
+++ b/backend/tests/unit/external_apps/matching/test_engine.py
@@ -6,11 +6,12 @@ from __future__ import annotations
 import pytest
 from pydantic import ValidationError
 
-from onyx.db.enums import EndpointPolicy, ExternalAppType
+from onyx.db.enums import EndpointPolicy, ExternalAppType, GatedAppKind
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.engine import (
     WHOLE_DOMAIN_ACTION_TYPE,
     AllMatchedActions,
+    GatedTarget,
     MatchedAction,
     apply_credential_gate,
 )
@@ -21,7 +22,10 @@ def test_rejects_empty_actions() -> None:
     """An AllMatchedActions with no actions is a programmer error — every gate
     consumer reads ``actions[0]``."""
     with pytest.raises(ValidationError, match="actions must be non-empty"):
-        AllMatchedActions(actions=(), app_name="X", external_app_id=1)
+        AllMatchedActions(
+            actions=(),
+            target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=1, app_name="X"),
+        )
 
 
 # ── apply_credential_gate: the pure credential/synthesize fork ─────────
@@ -45,8 +49,7 @@ def _matched_actions(*policies: EndpointPolicy) -> AllMatchedActions:
             )
             for i, p in enumerate(policies)
         ),
-        app_name="Slack",
-        external_app_id=1,
+        target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=1, app_name="Slack"),
     )
 
 

--- a/backend/tests/unit/external_apps/matching/test_engine.py
+++ b/backend/tests/unit/external_apps/matching/test_engine.py
@@ -67,7 +67,7 @@ def test_apply_gate_serveable_no_catalog_synthesizes_whole_domain_ask() -> None:
     assert matched_actions.governing_action.action_type == WHOLE_DOMAIN_ACTION_TYPE
     assert matched_actions.governing_action.policy == EndpointPolicy.ASK
     assert matched_actions.app_name == "Slack"
-    assert matched_actions.external_app_id == 1
+    assert matched_actions.target.key == (GatedAppKind.EXTERNAL_APP, 1)
 
 
 def test_apply_gate_not_serveable_no_catalog_forwards_bare() -> None:

--- a/backend/tests/unit/sandbox_proxy/conftest.py
+++ b/backend/tests/unit/sandbox_proxy/conftest.py
@@ -16,8 +16,12 @@ from uuid import UUID, uuid4
 
 from mitmproxy import http
 
-from onyx.db.enums import EndpointPolicy
-from onyx.external_apps.matching.engine import AllMatchedActions, MatchedAction
+from onyx.db.enums import EndpointPolicy, GatedAppKind
+from onyx.external_apps.matching.engine import (
+    AllMatchedActions,
+    GatedTarget,
+    MatchedAction,
+)
 from onyx.sandbox_proxy.addons.gate import _IdentityResolver
 from onyx.sandbox_proxy.credential_injection import CredentialResolver, InjectionContext
 from onyx.sandbox_proxy.identity import (
@@ -218,7 +222,8 @@ def make_matched_actions(
                 policy=policy,
             ),
         ),
-        app_name=app_name,
-        external_app_id=external_app_id,
+        target=GatedTarget(
+            kind=GatedAppKind.EXTERNAL_APP, id=external_app_id, app_name=app_name
+        ),
         payload=payload if payload is not None else {},
     )

--- a/backend/tests/unit/sandbox_proxy/test_approval_cache.py
+++ b/backend/tests/unit/sandbox_proxy/test_approval_cache.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 import pytest
 
 from onyx.cache.interface import CacheBackend, CacheLock
-from onyx.db.enums import ApprovalDecision
+from onyx.db.enums import ApprovalDecision, GatedAppKind
 from onyx.sandbox_proxy.approval_cache import (
     _wake_key,
     cache_session_grant_actions,
@@ -74,18 +74,21 @@ def test_cached_session_grants_cover_requires_every_action() -> None:
     cache = _MemoryCache()
     session_id = uuid4()
     approval_id = uuid4()
-    external_app_id = 42
+    kind = GatedAppKind.EXTERNAL_APP
+    target_id = 42
 
     assert not cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post"],
         cache=cache,
     )
 
     cache_session_grant_actions(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post"],
         source_approval_id=approval_id,
         cache=cache,
@@ -93,19 +96,22 @@ def test_cached_session_grants_cover_requires_every_action() -> None:
 
     assert cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post"],
         cache=cache,
     )
     assert not cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id,
+        kind=kind,
+        target_id=target_id,
         action_types=["slack.chat.post", "slack.files.upload"],
         cache=cache,
     )
     assert not cached_session_grants_cover(
         session_id=session_id,
-        external_app_id=external_app_id + 1,
+        kind=kind,
+        target_id=target_id + 1,
         action_types=["slack.chat.post"],
         cache=cache,
     )

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -27,8 +27,17 @@ from mitmproxy import connection, http
 from mitmproxy.proxy import server_hooks
 from redis.exceptions import RedisError
 
-from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, EndpointPolicy
-from onyx.external_apps.matching.engine import AllMatchedActions, MatchedAction
+from onyx.db.enums import (
+    ApprovalDecidedVia,
+    ApprovalDecision,
+    EndpointPolicy,
+    GatedAppKind,
+)
+from onyx.external_apps.matching.engine import (
+    AllMatchedActions,
+    GatedTarget,
+    MatchedAction,
+)
 from onyx.sandbox_proxy.addons import gate
 from onyx.sandbox_proxy.addons.gate import GateAddon, ParkedApprovals
 from onyx.sandbox_proxy.credential_injection import (
@@ -105,7 +114,7 @@ def _patch_gate_session(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         gate.action_approval,
         "list_session_grant_action_approvals",
-        lambda _db, *, session_id, external_app_id: [],  # noqa: ARG005
+        lambda _db, *, session_id, kind, target_id: [],  # noqa: ARG005
     )
 
 
@@ -153,8 +162,7 @@ _MATCH_MULTI_ASK = AllMatchedActions(
             policy=EndpointPolicy.ASK,
         ),
     ),
-    app_name="Slack",
-    external_app_id=42,
+    target=GatedTarget(kind=GatedAppKind.EXTERNAL_APP, id=42, app_name="Slack"),
     payload={"text": "hi"},
 )
 _MATCH_ALWAYS = make_matched_actions(
@@ -552,14 +560,24 @@ def _stub_grants(
     monkeypatch: pytest.MonkeyPatch,
     result: tuple[UUID, list[int]] | None | Exception,
 ) -> list[UUID]:
-    """Stub the gate's grant lookup; returns the recorded session_ids."""
+    """Stub the gate's grant lookup; returns the recorded session_ids.
+
+    Callers pass granted external-app ids; the stub wraps them as the
+    ``(kind, id)`` targets the real lookup now returns."""
     calls: list[UUID] = []
 
-    def _lookup(*, db_session: Any, session_id: UUID) -> tuple[UUID, list[int]] | None:  # noqa: ARG001
+    def _lookup(
+        *,
+        db_session: Any,  # noqa: ARG001
+        session_id: UUID,
+    ) -> tuple[UUID, set[tuple[GatedAppKind, int]]] | None:
         calls.append(session_id)
         if isinstance(result, Exception):
             raise result
-        return result
+        if result is None:
+            return None
+        run_id, app_ids = result
+        return run_id, {(GatedAppKind.EXTERNAL_APP, app_id) for app_id in app_ids}
 
     monkeypatch.setattr(gate, "get_live_scheduled_run_grants", _lookup)
     return calls
@@ -643,12 +661,14 @@ async def test_pre_approved_scheduled_run_skips_park(
     assert len(inserted) == 1
     assert inserted[0]["decision"] == ApprovalDecision.APPROVED
     assert inserted[0]["decided_via"] == ApprovalDecidedVia.PRE_APPROVAL
-    assert inserted[0]["external_app_id"] == _GRANTED_APP_ID
+    assert inserted[0]["kind"] == GatedAppKind.EXTERNAL_APP
+    assert inserted[0]["target_id"] == _GRANTED_APP_ID
     # Dedup contract: additional_data is exactly the stable (run, app) pair.
     assert len(notified) == 1
     assert notified[0]["additional_data"] == {
         "run_id": str(_RUN_ID),
-        "external_app_id": _GRANTED_APP_ID,
+        "target_kind": GatedAppKind.EXTERNAL_APP.value,
+        "target_id": _GRANTED_APP_ID,
     }
 
 
@@ -710,7 +730,7 @@ async def test_session_grant_db_fallback_hydrates_cache(
     monkeypatch.setattr(
         gate.action_approval,
         "list_session_grant_action_approvals",
-        lambda _db, *, session_id, external_app_id: [grant_source],  # noqa: ARG005
+        lambda _db, *, session_id, kind, target_id: [grant_source],  # noqa: ARG005
     )
     flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 
@@ -1516,7 +1536,8 @@ def test_persist_approval_row_commits_announces_notifies(
         "actions": [a.model_dump(mode="json") for a in _MATCH.actions],
         "app_name": _MATCH.app_name,
         "payload": _MATCH.payload,
-        "external_app_id": _MATCH.external_app_id,
+        "kind": _MATCH.target.kind,
+        "target_id": _MATCH.target.id,
     }
 
     # insert -> commit -> rpush: announce must not precede the commit,

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -111,10 +111,12 @@ def _patch_gate_session(monkeypatch: pytest.MonkeyPatch) -> None:
     Default it to a dummy MagicMock-yielding session; tests asserting on
     session-open ordering re-patch it with `_recorder_db_factory(ops)`."""
     monkeypatch.setattr(gate, "get_session_with_tenant", _recorder_db_factory([]))
+    # The stub sessions can't answer the target → gated_app_id lookup.
+    monkeypatch.setattr(gate, "get_gated_app_id", lambda _db, _kind, _target_id: 1)
     monkeypatch.setattr(
         gate.action_approval,
         "list_session_grant_action_approvals",
-        lambda _db, *, session_id, kind, target_id: [],  # noqa: ARG005
+        lambda _db, *, session_id, gated_app_id: [],  # noqa: ARG005
     )
 
 
@@ -729,7 +731,7 @@ async def test_session_grant_db_fallback_hydrates_cache(
     monkeypatch.setattr(
         gate.action_approval,
         "list_session_grant_action_approvals",
-        lambda _db, *, session_id, kind, target_id: [grant_source],  # noqa: ARG005
+        lambda _db, *, session_id, gated_app_id: [grant_source],  # noqa: ARG005
     )
     flow = make_flow(proxy_auth=_basic_auth(_TAG_UUID))
 

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -661,8 +661,7 @@ async def test_pre_approved_scheduled_run_skips_park(
     assert len(inserted) == 1
     assert inserted[0]["decision"] == ApprovalDecision.APPROVED
     assert inserted[0]["decided_via"] == ApprovalDecidedVia.PRE_APPROVAL
-    assert inserted[0]["kind"] == GatedAppKind.EXTERNAL_APP
-    assert inserted[0]["target_id"] == _GRANTED_APP_ID
+    assert inserted[0]["target"] == (GatedAppKind.EXTERNAL_APP, _GRANTED_APP_ID)
     # Dedup contract: additional_data is exactly the stable (run, app) pair.
     assert len(notified) == 1
     assert notified[0]["additional_data"] == {
@@ -1536,8 +1535,7 @@ def test_persist_approval_row_commits_announces_notifies(
         "actions": [a.model_dump(mode="json") for a in _MATCH.actions],
         "app_name": _MATCH.app_name,
         "payload": _MATCH.payload,
-        "kind": _MATCH.target.kind,
-        "target_id": _MATCH.target.id,
+        "target": _MATCH.target.key,
     }
 
     # insert -> commit -> rpush: announce must not precede the commit,


### PR DESCRIPTION
## What

Pure refactor with **no behavior change**: generalize the sandbox-proxy approval pipeline's target from "external app only" to a polymorphic `gated_app` identity — one row per external app *or* MCP server. This is the schema foundation the MCP per-tool approvals feature stacks on, split out so it can be reviewed (and land) on its own.

## Why

The approval pipeline (per-action policy, approval rows, scheduled-task pre-approvals) attributed every gated request to an `external_app` row. Rather than sprinkling `(external_app_id?, mcp_server_id?)` companion columns + CHECK constraints across every consumer table when MCP arrives, the target concept moves into a single polymorphic table. A future gated-target catalog then adds one nullable column to `gated_app` — nothing to the consumers.

## Changes

- **`gated_app`** — `kind` + nullable `external_app_id`/`mcp_server_id` (each unique, `ON DELETE CASCADE`) + `num_nonnulls(...) = 1` CHECK. The single-target invariant lives here alone.
- **`external_app_policy` → `gated_action_policy`**, keyed by `gated_app_id`.
- **`action_approval`** / **`scheduled_task_pre_approved_app`** — repointed at a single `gated_app_id` (`SET NULL` / `CASCADE`).
- **`onyx/db/gated_app.py`** — centralizes `(kind, id) ↔ gated_app_id` mapping (race-safe get-or-create) and the shared per-action policy read/write.
- Consumers (`external_app`, `scheduled_task`, `action_approval`, approvals API, external-apps admin API, matching engine `GatedTarget`, approval cache, external-app resolver) route through `gated_app`.

The `MCP_SERVER` kind and `gated_app.mcp_server_id` column ship here but stay **unused** until the MCP approvals PR lands on top.

## Migration

Creates + backfills `gated_app` (one row per existing external app + MCP server), repoints the three consumer tables, renames the policy table. Validated with a full base→head upgrade **and** downgrade round-trip on a fresh DB.

## Tests

No new behavior, so this is covered by the existing external-app suites — updated for the renamed model / new call signatures:
- ext-dep: `test_action_matching`, `test_approvals_api`, `test_scheduled_task_pre_approvals`, `test_managed_external_apps`, `test_approval_cache` — **56 passed**
- unit: `test_gate`, `test_approval_cache`, `matching/test_engine` — **80 passed**
- ruff / ruff-format / `ty` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactor the approval pipeline to use a polymorphic `gated_app` identity shared by external apps and MCP servers, unifying policy/approval/pre-approval targets and enabling target-aware session grants. External-app behavior is unchanged; matching, caching, and queries are more efficient.

- **Refactors**
  - Added `gated_app` with nullable `external_app_id`/`mcp_server_id` (each unique, `ON DELETE CASCADE`) and a single-target CHECK; kind is derived from the populated FK.
  - Renamed `external_app_policy` → `gated_action_policy`, keyed by `gated_app_id`; centralized per-action policy read/write and `(kind, id) ↔ gated_app_id` mapping in `onyx/db/gated_app.py`; admin responses pass stored policies explicitly (removed `ExternalApp.policies` relationship).
  - Repointed `action_approval` and `scheduled_task_pre_approved_app` to `gated_app_id` (`SET NULL` / `CASCADE`). `ScheduledTask.pre_approved_external_app_ids` exposes external-app ids only; `set_pre_approved_apps(db, task, kind, target_ids)` replaces grants for the given kind and preserves others; live scheduled-run grants return a set of `(kind, id)` targets.
  - Matching returns `GatedTarget`; the gate, approval cache, session grants, and notifications key by `(kind, id)`. Added `approval_cache.hydrate_session_grants` to union ASK actions and hydrate cache; pending-rows query can eager-load targets (`load_target=True`) to avoid N+1s.

- **Bug Fixes**
  - Flush the app before writing action policies in `create_external_app` so the `gated_app` identity is created/found correctly.

<sup>Written for commit 89ba910783ecebf9309bdc1ae72c17911b51280f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13169?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





