### PR TITLE
feat(security): LLM env injection toggle on security hardening page

### DIFF
--- a/backend/alembic/versions/eec4fc85ef28_add_llm_custom_config_env_injection_to_.py
+++ b/backend/alembic/versions/eec4fc85ef28_add_llm_custom_config_env_injection_to_.py
@@ -1,0 +1,28 @@
+"""add llm_custom_config_env_injection to security_settings
+
+Revision ID: eec4fc85ef28
+Revises: 1e0a3e4226f7
+Create Date: 2026-07-19 19:14:17.334151
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "eec4fc85ef28"
+down_revision = "1e0a3e4226f7"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "security_settings",
+        sa.Column("llm_custom_config_env_injection", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("security_settings", "llm_custom_config_env_injection")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4405,6 +4405,9 @@ class SecuritySettings(Base):
     mask_credential_prefix: Mapped[bool | None] = mapped_column(
         Boolean, nullable=True, default=None
     )
+    llm_custom_config_env_injection: Mapped[bool | None] = mapped_column(
+        Boolean, nullable=True, default=None
+    )
     valid_email_domains: Mapped[list[str] | None] = mapped_column(
         postgresql.ARRAY(String), nullable=True, default=None
     )

--- a/backend/onyx/server/security/models.py
+++ b/backend/onyx/server/security/models.py
@@ -113,6 +113,9 @@ class SecuritySettingsOverrides(BaseModel):
     mask_credential_prefix: bool | None = Field(
         default=None, json_schema_extra=_operator_locked()
     )
+    llm_custom_config_env_injection: bool | None = Field(
+        default=None, json_schema_extra=_operator_locked()
+    )
     valid_email_domains: list[str] | None = Field(
         default=None, json_schema_extra=_operator_locked()
     )
@@ -181,6 +184,7 @@ class SecuritySettings(BaseModel):
     track_external_idp_expiry: bool
     ssrf_protection_level: SSRFProtectionLevel
     mask_credential_prefix: bool
+    llm_custom_config_env_injection: bool
     valid_email_domains: tuple[str, ...]
     password_min_length: int
     password_max_length: int

--- a/backend/onyx/server/security/store.py
+++ b/backend/onyx/server/security/store.py
@@ -87,6 +87,7 @@ def _build_env_defaults() -> SecuritySettings:
         track_external_idp_expiry=_cfg.TRACK_EXTERNAL_IDP_EXPIRY,
         ssrf_protection_level=_derive_ssrf_level_from_env(),
         mask_credential_prefix=_cfg.MASK_CREDENTIAL_PREFIX,
+        llm_custom_config_env_injection=not MULTI_TENANT,
         valid_email_domains=tuple(_cfg.VALID_EMAIL_DOMAINS),
         password_min_length=_cfg.PASSWORD_MIN_LENGTH,
         password_max_length=_cfg.PASSWORD_MAX_LENGTH,
@@ -113,6 +114,10 @@ def merge_with_env(overrides: SecuritySettingsOverrides) -> SecuritySettings:
             merged[name] = getattr(env, name)
         else:
             merged[name] = override_value
+    # Process-wide env vars are a cross-tenant risk: force injection off on
+    # multi-tenant no matter what any stored or env-derived value says.
+    if MULTI_TENANT:
+        merged["llm_custom_config_env_injection"] = False
     # SecuritySettings types valid_email_domains as tuple; overrides as list.
     if isinstance(merged["valid_email_domains"], list):
         merged["valid_email_domains"] = tuple(merged["valid_email_domains"])

--- a/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
+++ b/backend/tests/external_dependency_unit/server/security/test_security_settings_put.py
@@ -198,6 +198,31 @@ def test_put_multi_tenant_accepts_tenant_editable_field(
     assert _load_row_as_dict() == {"user_directory_admin_only": True}
 
 
+def test_put_multi_tenant_rejects_llm_env_injection_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """llm_custom_config_env_injection cannot be changed on multi-tenant."""
+    monkeypatch.setattr(security_api, "MULTI_TENANT", True)
+    monkeypatch.setattr(security_store, "MULTI_TENANT", True)
+
+    with pytest.raises(OnyxError) as exc_info:
+        _put({"llm_custom_config_env_injection": True})
+    assert exc_info.value.error_code is OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    assert "llm_custom_config_env_injection" in str(exc_info.value)
+
+    assert _load_row_as_dict() is None
+
+
+def test_put_single_tenant_changes_llm_env_injection() -> None:
+    """On single-tenant the setting is editable: off, then back to on."""
+    result = _put({"llm_custom_config_env_injection": False})
+    assert result.llm_custom_config_env_injection is False
+    assert _load_row_as_dict() == {"llm_custom_config_env_injection": False}
+
+    result = _put({"llm_custom_config_env_injection": True})
+    assert result.llm_custom_config_env_injection is True
+
+
 # -----------------------------------------------------------------------------
 # Concurrency: lock serializes writers, both disjoint writes land
 # -----------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
+++ b/backend/tests/unit/onyx/server/manage/test_users_directory_visibility.py
@@ -18,6 +18,7 @@ def _settings(*, user_directory_admin_only: bool) -> SecuritySettings:
         track_external_idp_expiry=base.track_external_idp_expiry,
         ssrf_protection_level=base.ssrf_protection_level,
         mask_credential_prefix=base.mask_credential_prefix,
+        llm_custom_config_env_injection=base.llm_custom_config_env_injection,
         valid_email_domains=base.valid_email_domains,
         password_min_length=base.password_min_length,
         password_max_length=base.password_max_length,

--- a/backend/tests/unit/onyx/server/security/test_models.py
+++ b/backend/tests/unit/onyx/server/security/test_models.py
@@ -22,6 +22,7 @@ _VALID_EFFECTIVE_KWARGS: dict[str, Any] = {
     "track_external_idp_expiry": False,
     "ssrf_protection_level": SSRFProtectionLevel.VALIDATE_LLM,
     "mask_credential_prefix": True,
+    "llm_custom_config_env_injection": True,
     "valid_email_domains": (),
     "password_min_length": 8,
     "password_max_length": 64,

--- a/backend/tests/unit/onyx/server/security/test_store.py
+++ b/backend/tests/unit/onyx/server/security/test_store.py
@@ -7,6 +7,7 @@ derivation reads controlled values instead of the process environment.
 import pytest
 
 from onyx.server.security import store
+from onyx.server.security.models import SecuritySettingsOverrides
 from onyx.server.security.models import SSRFProtectionLevel
 
 
@@ -58,3 +59,22 @@ def test_mcp_private_and_loopback_disables(monkeypatch: pytest.MonkeyPatch) -> N
     """Loopback opt-in wins over the private-network opt-in — it needs DISABLED."""
     _set_env(monkeypatch, mcp_allow_private_network=True, mcp_allow_loopback=True)
     assert store._derive_ssrf_level_from_env() == SSRFProtectionLevel.DISABLED
+
+
+def test_llm_env_injection_forced_off_on_multi_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """merge_with_env forces injection off on multi-tenant even when a stored
+    override says enabled."""
+    monkeypatch.setattr(store, "MULTI_TENANT", True)
+    overrides = SecuritySettingsOverrides(llm_custom_config_env_injection=True)
+    assert store.merge_with_env(overrides).llm_custom_config_env_injection is False
+
+
+def test_llm_env_injection_defaults_on_for_single_tenant() -> None:
+    assert (
+        store.merge_with_env(
+            SecuritySettingsOverrides()
+        ).llm_custom_config_env_injection
+        is True
+    )

--- a/backend/tests/unit/onyx/server/security/test_store.py
+++ b/backend/tests/unit/onyx/server/security/test_store.py
@@ -7,8 +7,7 @@ derivation reads controlled values instead of the process environment.
 import pytest
 
 from onyx.server.security import store
-from onyx.server.security.models import SecuritySettingsOverrides
-from onyx.server.security.models import SSRFProtectionLevel
+from onyx.server.security.models import SecuritySettingsOverrides, SSRFProtectionLevel
 
 
 def _set_env(

--- a/web/src/views/admin/SecurityHardeningPage.tsx
+++ b/web/src/views/admin/SecurityHardeningPage.tsx
@@ -41,6 +41,7 @@ interface SecuritySettings {
   track_external_idp_expiry: boolean;
   ssrf_protection_level: SSRFProtectionLevel;
   mask_credential_prefix: boolean;
+  llm_custom_config_env_injection: boolean;
   valid_email_domains: string[];
   password_min_length: number;
   password_max_length: number;
@@ -63,6 +64,7 @@ interface ToggleRowProps {
   description?: string | RichStr;
   checked: boolean;
   onCheckedChange: (checked: boolean) => void;
+  disabled?: boolean;
 }
 
 function ToggleRow({
@@ -70,10 +72,15 @@ function ToggleRow({
   description,
   checked,
   onCheckedChange,
+  disabled,
 }: ToggleRowProps) {
   return (
     <InputHorizontal title={title} description={description} withLabel>
-      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+      <Switch
+        checked={checked}
+        onCheckedChange={onCheckedChange}
+        disabled={disabled}
+      />
     </InputHorizontal>
   );
 }
@@ -438,18 +445,35 @@ export default function SecurityHardeningPage() {
           </Card>
         </div>
 
-        {/* Network Safety (single-tenant only — SSRF policy is operator-controlled,
-            so it stays env-driven in multi-tenant cloud). */}
-        {!isMultiTenant && (
-          <div className="flex w-full flex-col gap-3">
-            <Content
-              title="Network Safety"
-              sizePreset="main-content"
-              variant="section"
-            />
+        {/* Network Safety. The env-injection toggle is always shown but locked
+            off in multi-tenant cloud; the SSRF policy is single-tenant only
+            (operator-controlled, env-driven in multi-tenant cloud). */}
+        <div className="flex w-full flex-col gap-3">
+          <Content
+            title="Network Safety"
+            sizePreset="main-content"
+            variant="section"
+          />
 
-            <Card border="solid" rounding="lg">
-              <Section>
+          <Card border="solid" rounding="lg">
+            <Section>
+              <ToggleRow
+                title="LLM Environment Variable Injection"
+                description={
+                  isMultiTenant
+                    ? "Custom LLM provider configurations can never set process environment variables on multi-tenant deployments."
+                    : "Allow custom LLM provider configurations to temporarily set process environment variables during calls. Disable to require all provider settings to have a LiteLLM parameter equivalent."
+                }
+                checked={draft.llm_custom_config_env_injection}
+                onCheckedChange={(checked) =>
+                  void saveSettings({
+                    llm_custom_config_env_injection: checked,
+                  })
+                }
+                disabled={isMultiTenant}
+              />
+
+              {!isMultiTenant && (
                 <InputHorizontal
                   title="SSRF Protection"
                   description="Validate outbound requests against private or internal IPs for Server-Side Request Forgery (SSRF) protection."
@@ -498,10 +522,10 @@ export default function SecurityHardeningPage() {
                     </InputSelect>
                   </div>
                 </InputHorizontal>
-              </Section>
-            </Card>
-          </div>
-        )}
+              )}
+            </Section>
+          </Card>
+        </div>
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>
   );


### PR DESCRIPTION
## Summary

Part 1 of 2 (this → #13087). Adds the `llm_custom_config_env_injection` security hardening setting; #13087 makes the LLM stack consume it.

- **Operator-locked setting**: stored as a nullable override column on `security_settings` (schema migration included); `NULL` falls back to the env-derived default of `not MULTI_TENANT` — **default on for self-hosted, off on cloud**.
- **Multi-tenant deployments cannot change it**: the PUT endpoint 403s operator-locked fields, the storage layer strips them, and the env-merge ignores stored overrides for them.
- **UI**: rendered as a toggle in the Security Hardening page's Network Safety section, which is only shown on single-tenant deployments.

This PR only introduces the setting — nothing consumes it yet, so it is safe to merge independently.

Trying to toggle when in cloud

<img width="1140" height="271" alt="Screenshot 2026-07-20 at 10 18 44 AM" src="https://github.com/user-attachments/assets/46db7182-ee53-4619-b24d-129354bec6c9" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

## Test Plan

- `backend/tests/unit/onyx/server/security/test_models.py`: field registered with the operator-locked marker; effective-model validation.
- Existing operator-locked enforcement tests cover the multi-tenant 403/strip behavior generically.