### PR TITLE
fix: sharepoint role names localization (#13167) to release v4.3

### DIFF
--- a/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/permission_utils.py
@@ -3,6 +3,7 @@ import time
 from collections import deque
 from collections.abc import Callable
 from collections.abc import Generator
+from collections.abc import Iterable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -12,6 +13,7 @@ from office365.graph_client import GraphClient
 from office365.onedrive.driveitems.driveItem import DriveItem
 from office365.runtime.client_request import ClientRequestException
 from office365.sharepoint.client_context import ClientContext
+from office365.sharepoint.permissions.roles.definitions.definition import RoleDefinition
 from office365.sharepoint.permissions.securable_object import RoleAssignmentCollection
 from office365.sharepoint.principal.users.collection import UserCollection
 from pydantic import BaseModel
@@ -38,9 +40,9 @@ AZURE_AD_GROUP_PRINCIPAL_TYPE = 4  # Azure Active Directory security groups
 SHAREPOINT_GROUP_PRINCIPAL_TYPE = 8  # SharePoint site groups (local to the site)
 MICROSOFT_DOMAIN = ".onmicrosoft"
 SHAREPOINT_GROUP_SCOPE_SEPARATOR = "::"
-# Limited Access role type, limited access is a travel through permission not a actual permission
-LIMITED_ACCESS_ROLE_TYPES = [1, 9]
-LIMITED_ACCESS_ROLE_NAMES = ["Limited Access", "Web-Only Limited Access"]
+# PnP RoleType defines Guest=1 and RestrictedGuest=9:
+# https://github.com/pnp/pnpcore/blob/4e4f58fcac797f2957bfcd14fedcecd690dfe7ee/src/sdk/PnP.Core/Model/SharePoint/Core/Public/Enums/RoleType.cs
+LIMITED_ACCESS_ROLE_TYPES = frozenset({1, 9})
 
 
 AD_GROUP_ENUMERATION_THRESHOLD = 100_000
@@ -54,6 +56,15 @@ AD_GROUP_ENUMERATION_THRESHOLD = 100_000
 # paged collections and keeps each page well under typical proxy buffer
 # limits while not making the round-trip count overwhelming.
 ROLE_ASSIGNMENTS_PAGE_SIZE = 100
+
+
+def _has_only_limited_access(
+    role_definition_bindings: Iterable[RoleDefinition],
+) -> bool:
+    return all(
+        binding.role_type_kind in LIMITED_ACCESS_ROLE_TYPES
+        for binding in role_definition_bindings
+    )
 
 
 def _graph_api_get(
@@ -527,23 +538,11 @@ def get_external_access_from_sharepoint(
         # callback and recurses until Python hits its max recursion depth.
         for assignment in role_assignments.current_page:
             logger.debug("Assignment: %s", assignment.to_json())
-            if assignment.role_definition_bindings:
-                is_limited_access = True
-                for role_definition_binding in assignment.role_definition_bindings:
-                    if (
-                        role_definition_binding.role_type_kind
-                        not in LIMITED_ACCESS_ROLE_TYPES
-                        or role_definition_binding.name not in LIMITED_ACCESS_ROLE_NAMES
-                    ):
-                        is_limited_access = False
-                        break
-
-                # Skip if the role is only Limited Access, because this is not a actual permission its a travel through permission
-                if is_limited_access:
-                    logger.info(
-                        "Skipping assignment because it has only Limited Access role"
-                    )
-                    continue
+            if assignment.role_definition_bindings and _has_only_limited_access(
+                assignment.role_definition_bindings
+            ):
+                logger.info("Skipping Limited Access-only assignment")
+                continue
             if assignment.member:
                 member = assignment.member
                 if member.principal_type == USER_PRINCIPAL_TYPE and hasattr(
@@ -723,24 +722,11 @@ def get_sharepoint_external_groups(
         # via `_get_next().execute_query()`, which re-fires this `page_loaded`
         # callback and recurses until Python hits its max recursion depth.
         for assignment in role_assignments.current_page:
-            if assignment.role_definition_bindings:
-                is_limited_access = True
-                for role_definition_binding in assignment.role_definition_bindings:
-                    if (
-                        role_definition_binding.role_type_kind
-                        not in LIMITED_ACCESS_ROLE_TYPES
-                        or role_definition_binding.name not in LIMITED_ACCESS_ROLE_NAMES
-                    ):
-                        is_limited_access = False
-                        break
-
-                # Skip if the role assignment is only Limited Access, because this is not a actual permission its
-                #  a travel through permission
-                if is_limited_access:
-                    logger.info(
-                        "Skipping assignment because it has only Limited Access role"
-                    )
-                    continue
+            if assignment.role_definition_bindings and _has_only_limited_access(
+                assignment.role_definition_bindings
+            ):
+                logger.info("Skipping Limited Access-only assignment")
+                continue
             if assignment.member:
                 member = assignment.member
                 if member.principal_type in [

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -9,6 +9,9 @@ from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _enumerate_ad_groups_paginated,
 )
 from ee.onyx.external_permissions.sharepoint.permission_utils import _get_azuread_groups
+from ee.onyx.external_permissions.sharepoint.permission_utils import (
+    _has_only_limited_access,
+)
 from ee.onyx.external_permissions.sharepoint.permission_utils import _is_public_item
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
     _iter_graph_collection,
@@ -211,6 +214,33 @@ def test_azuread_group_owners_are_not_treated_as_members(
 
     assert user_emails == {"member@contoso.com"}
     group.owners.get_all.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("role_type_kind", "localized_name"),
+    [
+        (1, "Beschränkter Zugriff"),
+        (9, "Nur Web – beschränkter Zugriff"),
+    ],
+)
+def test_limited_access_detection_uses_numeric_role_type(
+    role_type_kind: int,
+    localized_name: str,
+) -> None:
+    binding = MagicMock()
+    binding.role_type_kind = role_type_kind
+    binding.name = localized_name
+
+    assert _has_only_limited_access([binding])
+
+
+def test_limited_access_detection_rejects_mixed_roles() -> None:
+    limited_access = MagicMock()
+    limited_access.role_type_kind = 1
+    read_access = MagicMock()
+    read_access.role_type_kind = 2
+
+    assert not _has_only_limited_access([limited_access, read_access])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Cherry-pick of commit 4fe09b28d76ccbcdb9a52f1e5ac8c08081dc4dab to release/v4.3 branch.

Original PR: #13167

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SharePoint Limited Access detection to be locale-agnostic by using numeric role types (1, 9) instead of role names. Prevents Limited Access-only assignments from being treated as real permissions in non-English tenants.

- Bug Fixes
  - Added `_has_only_limited_access` and used it when processing user and group role assignments.
  - Replaced name-based checks with `role_type_kind` and a `frozenset` of Limited Access types.
  - Added tests for localized role names and mixed role bindings.

<sup>Written for commit f893d59e460a93cffbc61e84e5af738a09b12901. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13174?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

