### PR TITLE
fix(deployment): avoid MCP nginx enable flag

### DIFF
--- a/deployment/data/nginx/app.conf.template
+++ b/deployment/data/nginx/app.conf.template
@@ -23,9 +23,6 @@ upstream web_server {
     server ${ONYX_WEB_SERVER_HOST}:3000 fail_timeout=0;
 }
 
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
-
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -39,7 +36,6 @@ server {
 
     access_log /var/log/nginx/access.log custom_main;
 
-    # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
 
     # First-party health probe served directly by nginx (no upstreams),

--- a/deployment/data/nginx/app.conf.template.no-letsencrypt
+++ b/deployment/data/nginx/app.conf.template.no-letsencrypt
@@ -23,9 +23,6 @@ upstream web_server {
     server web_server:3000 fail_timeout=0;
 }
 
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
-
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -39,7 +36,6 @@ server {
 
     access_log /var/log/nginx/access.log custom_main;
 
-    # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
 
     # First-party health probe served directly by nginx (no upstreams),

--- a/deployment/data/nginx/app.conf.template.prod
+++ b/deployment/data/nginx/app.conf.template.prod
@@ -23,9 +23,6 @@ upstream web_server {
     server ${ONYX_WEB_SERVER_HOST}:3000 fail_timeout=0;
 }
 
-# Conditionally include MCP upstream configuration
-include /etc/nginx/conf.d/mcp_upstream.conf.inc;
-
 # WebSocket support: only set Connection "upgrade" for actual upgrade requests
 map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -39,7 +36,6 @@ server {
 
     access_log /var/log/nginx/access.log custom_main;
 
-    # Conditionally include MCP location configuration
     include /etc/nginx/conf.d/mcp.conf.inc;
 
     # First-party health probe served directly by nginx (no upstreams),

--- a/deployment/data/nginx/mcp.conf.inc.template
+++ b/deployment/data/nginx/mcp.conf.inc.template
@@ -34,5 +34,7 @@ location ~ ^/mcp(/.*)?$ {
     proxy_redirect off;
     rewrite ^/mcp(/.*)$ $1 break;
     rewrite ^/mcp/?$ / break;
-    proxy_pass http://mcp_server;
+    resolver 127.0.0.11 ipv6=off valid=30s;
+    set $mcp_server "http://${ONYX_MCP_SERVER_HOST}:8090";
+    proxy_pass $mcp_server;
 }

--- a/deployment/data/nginx/mcp_upstream.conf.inc.template
+++ b/deployment/data/nginx/mcp_upstream.conf.inc.template
@@ -1,3 +1,0 @@
-upstream mcp_server {
-    server ${ONYX_MCP_SERVER_HOST}:8090 fail_timeout=0;
-}

--- a/deployment/data/nginx/run-nginx.sh
+++ b/deployment/data/nginx/run-nginx.sh
@@ -20,20 +20,8 @@ echo "Using nginx proxy timeouts - connect: ${NGINX_PROXY_CONNECT_TIMEOUT}s, sen
 # shellcheck disable=SC2016
 envsubst '$DOMAIN $SSL_CERT_FILE_NAME $SSL_CERT_KEY_FILE_NAME $ONYX_BACKEND_API_HOST $ONYX_WEB_SERVER_HOST $ONYX_MCP_SERVER_HOST $NGINX_PROXY_CONNECT_TIMEOUT $NGINX_PROXY_SEND_TIMEOUT $NGINX_PROXY_READ_TIMEOUT' < "/etc/nginx/conf.d/$1" > /etc/nginx/conf.d/app.conf
 
-# Conditionally create MCP server configuration
-if [ "${MCP_SERVER_ENABLED}" = "True" ] || [ "${MCP_SERVER_ENABLED}" = "true" ]; then
-  echo "MCP server is enabled, creating MCP configuration..."
-  # shellcheck disable=SC2016
-  envsubst '$ONYX_MCP_SERVER_HOST' < "/etc/nginx/conf.d/mcp_upstream.conf.inc.template" > /etc/nginx/conf.d/mcp_upstream.conf.inc
-  # shellcheck disable=SC2016
-  envsubst '$ONYX_MCP_SERVER_HOST' < "/etc/nginx/conf.d/mcp.conf.inc.template" > /etc/nginx/conf.d/mcp.conf.inc
-else
-  echo "MCP server is disabled, removing MCP configuration..."
-  # Leave empty placeholder files so nginx includes do not fail
-  # These files are empty because MCP server is disabled
-  echo "# Empty file - MCP server is disabled" > /etc/nginx/conf.d/mcp_upstream.conf.inc
-  echo "# Empty file - MCP server is disabled" > /etc/nginx/conf.d/mcp.conf.inc
-fi
+# shellcheck disable=SC2016
+envsubst '$ONYX_MCP_SERVER_HOST' < "/etc/nginx/conf.d/mcp.conf.inc.template" > /etc/nginx/conf.d/mcp.conf.inc
 
 # Start nginx and reload every 6 hours
 while :; do sleep 6h & wait; nginx -s reload; done & nginx -g "daemon off;"


### PR DESCRIPTION
## Description

Fixes #11612.

## Objective

Avoid requiring production Docker Compose nginx services to receive `MCP_SERVER_ENABLED` while still allowing `/mcp` traffic to route correctly when the MCP server is enabled.

## Summary

- Remove nginx's conditional `MCP_SERVER_ENABLED` handling.
- Always generate the MCP nginx location include.
- Remove the separate MCP upstream include and use Docker DNS lazy resolution for the MCP proxy target so nginx can start even when the optional `mcp_server` service is not running.
- Leave production compose files as configuration-light as they were before this PR.

## How Has This Been Tested?

- `git diff --check`
- With temporary dummy production secret values and a temporary ignored `.env.nginx` generated from `env.nginx.template`:
  - `docker compose -f docker-compose.prod.yml config --quiet`
  - `docker compose -f docker-compose.prod-no-letsencrypt.yml config --quiet`
  - `docker compose -f docker-compose.prod-cloud.yml config --quiet`

Note: I attempted to run `nginx -t` in the nginx container, but Docker Desktop is not running in this local environment, so containerized nginx syntax validation could not be executed here.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check