### PR TITLE
fix(metrics): bind worker /metrics server on :: for IPv6-only clusters

### DIFF
--- a/backend/onyx/server/metrics/metrics_server.py
+++ b/backend/onyx/server/metrics/metrics_server.py
@@ -80,8 +80,11 @@ def start_metrics_server(worker_type: str) -> int | None:
             )
             return None
 
+        # Bind on "::" so the listener works on IPv6-only clusters. On Linux
+        # this also accepts IPv4 connections via the default v4-mapped-v6
+        # behavior (net.ipv6.bindv6only=0).
         try:
-            start_http_server(port)
+            start_http_server(port, addr="::")
             _server_started = True
             logger.info(
                 "Prometheus metrics server started on :%s for %s", port, worker_type

--- a/backend/tests/unit/server/metrics/test_metrics_server.py
+++ b/backend/tests/unit/server/metrics/test_metrics_server.py
@@ -25,14 +25,14 @@ class TestStartMetricsServer:
     def test_uses_default_port_for_known_worker(self, mock_start: MagicMock) -> None:
         port = start_metrics_server("monitoring")
         assert port == _DEFAULT_PORTS["monitoring"]
-        mock_start.assert_called_once_with(_DEFAULT_PORTS["monitoring"])
+        mock_start.assert_called_once_with(_DEFAULT_PORTS["monitoring"], addr="::")
 
     @patch("onyx.server.metrics.metrics_server.start_http_server")
     @patch.dict("os.environ", {"PROMETHEUS_METRICS_PORT": "9999"})
     def test_env_var_overrides_default(self, mock_start: MagicMock) -> None:
         port = start_metrics_server("monitoring")
         assert port == 9999
-        mock_start.assert_called_once_with(9999)
+        mock_start.assert_called_once_with(9999, addr="::")
 
     @patch("onyx.server.metrics.metrics_server.start_http_server")
     @patch.dict("os.environ", {"PROMETHEUS_METRICS_ENABLED": "false"})


### PR DESCRIPTION
`start_http_server()` defaults to addr="0.0.0.0" , v4-only. On IPv6 single-stack clusters, Prometheus gets `connection refused` scraping worker /metrics, so every KEDA scaler on onyx_queue_depth sits in fallback.

Pass `addr="::"`. Linux default bindv6only=0 means the v6 socket still accepts v4, so no change on dual-stack or v4-only clusters.

Tested

- Unit tests updated + all 7 pass.
- Live scrape from `[::1]` and `127.0.0.1` against a `::`-bound `start_http_server`, both succeed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bind the worker metrics server to IPv6 `::` to fix Prometheus scraping on IPv6-only clusters. On Linux, this also accepts IPv4, so behavior on dual-stack and IPv4-only clusters is unchanged.

- **Bug Fixes**
  - Use `start_http_server(port, addr="::")` and update tests to expect `addr="::"`.

<sup>Written for commit dd7af41c802ca816ec357e12752c4fca22a34acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

