### PR TITLE
chore(fmt): remove `order-by-type` to release 4.1

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/ee/onyx/background/celery/tasks/beat_schedule.py
@@ -3,11 +3,11 @@ from typing import Any
 
 from ee.onyx.configs.app_configs import CHECK_TTL_MANAGEMENT_TASK_FREQUENCY_IN_HOURS
 from onyx.background.celery.tasks.beat_schedule import (
-    beat_cloud_tasks as base_beat_system_tasks,
-)
-from onyx.background.celery.tasks.beat_schedule import (
     BEAT_EXPIRES_DEFAULT,
     generate_cloud_tasks,
+)
+from onyx.background.celery.tasks.beat_schedule import (
+    beat_cloud_tasks as base_beat_system_tasks,
 )
 from onyx.background.celery.tasks.beat_schedule import (
     beat_task_templates as base_beat_task_templates,

--- a/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/cloud/tasks.py
@@ -1,6 +1,6 @@
 import time
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from redis.lock import Lock as RedisLock
 

--- a/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/doc_permission_syncing/tasks.py
@@ -5,7 +5,7 @@ from time import sleep
 from typing import Any, cast
 from uuid import uuid4
 
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from pydantic import ValidationError
 from redis import Redis
@@ -76,7 +76,7 @@ from onyx.db.permission_sync_attempt import (
 )
 from onyx.db.sync_record import insert_sync_record, update_sync_record_status
 from onyx.db.users import batch_add_ext_perm_user_if_not_exists
-from onyx.db.utils import DocumentRow, is_retryable_sqlalchemy_error, SortOrder
+from onyx.db.utils import DocumentRow, SortOrder, is_retryable_sqlalchemy_error
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_connector_doc_perm_sync import (
@@ -98,12 +98,12 @@ from onyx.server.metrics.perm_sync_metrics import (
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 from onyx.server.utils import make_short_id
 from onyx.utils.logger import (
+    LoggerContextVars,
     doc_permission_sync_ctx,
     format_error_for_logging,
-    LoggerContextVars,
     setup_logger,
 )
-from onyx.utils.telemetry import optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, optional_telemetry
 from shared_configs.configs import MULTI_TENANT
 
 logger = setup_logger()

--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 from uuid import uuid4
 
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from pydantic import ValidationError
 from redis import Redis

--- a/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/query_history/tasks.py
@@ -2,11 +2,11 @@ import csv
 import io
 from datetime import datetime
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 
 from ee.onyx.server.query_history.api import (
-    fetch_and_process_chat_session_history,
     ONYX_ANONYMIZED_EMAIL,
+    fetch_and_process_chat_session_history,
 )
 from ee.onyx.server.query_history.models import QuestionAnswerPairSnapshot
 from onyx.background.task_utils import construct_query_history_report_name

--- a/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/tenant_provisioning/tasks.py
@@ -6,7 +6,7 @@ import asyncio
 import datetime
 import uuid
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 from redis.lock import Lock as RedisLock
 
 from ee.onyx.server.tenants.provisioning import setup_tenant

--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 
 from ee.onyx.background.celery_utils import should_perform_chat_ttl_check
 from onyx.configs.app_configs import JOB_TIMEOUT

--- a/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/usage_reporting/tasks.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 
 from ee.onyx.server.reporting.usage_export_generation import create_new_usage_report
 from onyx.configs.app_configs import JOB_TIMEOUT

--- a/backend/ee/onyx/db/analytics.py
+++ b/backend/ee/onyx/db/analytics.py
@@ -2,7 +2,7 @@ import datetime
 from collections.abc import Sequence
 from uuid import UUID
 
-from sqlalchemy import and_, case, cast, Date, func, or_, select
+from sqlalchemy import Date, and_, case, cast, func, or_, select
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import MessageType

--- a/backend/ee/onyx/db/hierarchy.py
+++ b/backend/ee/onyx/db/hierarchy.py
@@ -4,7 +4,7 @@ This module provides permission-aware hierarchy node access for Enterprise Editi
 It filters hierarchy nodes based on user email and external group membership.
 """
 
-from sqlalchemy import any_, cast, or_, select, String
+from sqlalchemy import String, any_, cast, or_, select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement

--- a/backend/ee/onyx/db/query_history.py
+++ b/backend/ee/onyx/db/query_history.py
@@ -1,10 +1,10 @@
 from collections.abc import Sequence
 from datetime import datetime
 
-from sqlalchemy import asc, BinaryExpression, ColumnElement, desc, distinct
-from sqlalchemy.orm import contains_eager, joinedload, Session
+from sqlalchemy import BinaryExpression, ColumnElement, asc, desc, distinct
+from sqlalchemy.orm import Session, contains_eager, joinedload
 from sqlalchemy.sql import case, func, select
-from sqlalchemy.sql.expression import literal, UnaryExpression
+from sqlalchemy.sql.expression import UnaryExpression, literal
 
 from ee.onyx.background.task_name_builders import QUERY_HISTORY_TASK_NAME_PREFIX
 from onyx.configs.constants import QAFeedbackType

--- a/backend/ee/onyx/db/saml.py
+++ b/backend/ee/onyx/db/saml.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
 from onyx.db.models import SamlAccount

--- a/backend/ee/onyx/db/scim.py
+++ b/backend/ee/onyx/db/scim.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 
 from uuid import UUID
 
+from sqlalchemy import Select, SQLColumnExpression, func, select
 from sqlalchemy import delete as sa_delete
-from sqlalchemy import func, Select, select, SQLColumnExpression
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 from ee.onyx.server.scim.filtering import ScimFilter, ScimFilterOperator

--- a/backend/ee/onyx/db/token_limit.py
+++ b/backend/ee/onyx/db/token_limit.py
@@ -1,7 +1,7 @@
 from collections.abc import Sequence
 
-from sqlalchemy import exists, Row, Select, select
-from sqlalchemy.orm import aliased, Session
+from sqlalchemy import Row, Select, exists, select
+from sqlalchemy.orm import Session, aliased
 
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import (

--- a/backend/ee/onyx/db/user_group.py
+++ b/backend/ee/onyx/db/user_group.py
@@ -3,9 +3,9 @@ from operator import and_
 from uuid import UUID
 
 from fastapi import HTTPException
-from sqlalchemy import delete, func, Select, select, update
+from sqlalchemy import Select, delete, func, select, update
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from ee.onyx.server.user_group.models import (
     SetCuratorRequest,

--- a/backend/ee/onyx/external_permissions/confluence/group_sync.py
+++ b/backend/ee/onyx/external_permissions/confluence/group_sync.py
@@ -5,8 +5,8 @@ from ee.onyx.external_permissions.confluence.constants import ALL_CONF_EMAILS_GR
 from onyx.background.error_logging import emit_background_error
 from onyx.configs.app_configs import CONFLUENCE_USE_ONYX_USERS_FOR_GROUP_SYNC
 from onyx.connectors.confluence.onyx_confluence import (
-    get_user_email_from_username__server,
     OnyxConfluence,
+    get_user_email_from_username__server,
 )
 from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
 from onyx.db.engine.sql_engine import get_session_with_current_tenant

--- a/backend/ee/onyx/external_permissions/confluence/page_access.py
+++ b/backend/ee/onyx/external_permissions/confluence/page_access.py
@@ -5,8 +5,8 @@ from onyx.access.models import ExternalAccess
 from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.confluence.onyx_confluence import (
-    get_user_email_from_username__server,
     OnyxConfluence,
+    get_user_email_from_username__server,
 )
 from onyx.utils.logger import setup_logger
 

--- a/backend/ee/onyx/external_permissions/confluence/space_access.py
+++ b/backend/ee/onyx/external_permissions/confluence/space_access.py
@@ -13,9 +13,9 @@ from onyx.access.utils import build_ext_group_name_for_onyx
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.confluence.onyx_confluence import (
     ConfluenceRestSpacePermissionsNotAvailableError,
+    OnyxConfluence,
     get_user_email_from_userkey__server,
     get_user_email_from_username__server,
-    OnyxConfluence,
 )
 from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.utils.logger import setup_logger

--- a/backend/ee/onyx/external_permissions/github/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/github/doc_sync.py
@@ -5,13 +5,13 @@ from github import Github
 from github.Repository import Repository
 
 from ee.onyx.external_permissions.github.utils import (
+    GitHubVisibility,
     fetch_repository_team_slugs,
     form_collaborators_group_id,
     form_organization_group_id,
     form_outside_collaborators_group_id,
     get_external_access_permission,
     get_repository_visibility,
-    GitHubVisibility,
 )
 from ee.onyx.external_permissions.perm_sync_types import (
     FetchAllDocumentsFunction,

--- a/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
+++ b/backend/ee/onyx/external_permissions/sharepoint/group_sync.py
@@ -8,8 +8,8 @@ from ee.onyx.external_permissions.sharepoint.permission_utils import (
 )
 from onyx.configs.app_configs import SHAREPOINT_EXHAUSTIVE_AD_ENUMERATION
 from onyx.connectors.sharepoint.connector import (
-    acquire_token_for_rest,
     SharepointConnector,
+    acquire_token_for_rest,
 )
 from onyx.db.models import ConnectorCredentialPair
 from onyx.utils.logger import setup_logger

--- a/backend/ee/onyx/external_permissions/slack/channel_access.py
+++ b/backend/ee/onyx/external_permissions/slack/channel_access.py
@@ -2,7 +2,7 @@ from slack_sdk import WebClient
 
 from onyx.access.models import ExternalAccess
 from onyx.connectors.models import BasicExpertInfo
-from onyx.connectors.slack.connector import channel_team_ids, ChannelType
+from onyx.connectors.slack.connector import ChannelType, channel_team_ids
 from onyx.connectors.slack.utils import (
     expert_info_from_slack_id,
     make_paginated_slack_api_call,

--- a/backend/ee/onyx/external_permissions/slack/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/slack/doc_sync.py
@@ -16,11 +16,11 @@ from onyx.connectors.credentials_provider import OnyxDBCredentialsProvider
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.connectors.models import HierarchyNode
 from onyx.connectors.slack.connector import (
+    SlackConnector,
     get_channels,
     get_channels_across_teams,
     list_grid_team_ids,
     make_paginated_slack_api_call,
-    SlackConnector,
 )
 from onyx.db.models import ConnectorCredentialPair
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface

--- a/backend/ee/onyx/external_permissions/sync_params.py
+++ b/backend/ee/onyx/external_permissions/sync_params.py
@@ -1,5 +1,5 @@
 from collections.abc import Generator
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import BaseModel
 

--- a/backend/ee/onyx/server/auth_check.py
+++ b/backend/ee/onyx/server/auth_check.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 
-from onyx.server.auth_check import check_router_auth, PUBLIC_ENDPOINT_SPECS
+from onyx.server.auth_check import PUBLIC_ENDPOINT_SPECS, check_router_auth
 
 EE_PUBLIC_ENDPOINT_SPECS = PUBLIC_ENDPOINT_SPECS + [
     # SCIM 2.0 service discovery — unauthenticated so IdPs can probe

--- a/backend/ee/onyx/server/enterprise_settings/api.py
+++ b/backend/ee/onyx/server/enterprise_settings/api.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Response, status, UploadFile
+from fastapi import APIRouter, Depends, HTTPException, Response, UploadFile, status
 from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
@@ -29,9 +29,9 @@ from ee.onyx.server.scim.models import (
 from ee.onyx.utils.tier import get_tier
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import (
+    UserManager,
     current_user_with_expired_token,
     get_user_manager,
-    UserManager,
 )
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission

--- a/backend/ee/onyx/server/enterprise_settings/store.py
+++ b/backend/ee/onyx/server/enterprise_settings/store.py
@@ -1,6 +1,6 @@
 import os
 from io import BytesIO
-from typing import Any, cast, IO
+from typing import IO, Any, cast
 
 from fastapi import HTTPException, UploadFile
 
@@ -9,10 +9,10 @@ from ee.onyx.server.enterprise_settings.models import (
     EnterpriseSettings,
 )
 from onyx.configs.constants import (
-    FileOrigin,
     KV_CUSTOM_ANALYTICS_SCRIPT_KEY,
     KV_ENTERPRISE_SETTINGS_KEY,
     ONYX_DEFAULT_APPLICATION_NAME,
+    FileOrigin,
 )
 from onyx.file_store.file_store import get_default_file_store
 from onyx.key_value_store.factory import get_kv_store

--- a/backend/ee/onyx/server/query_history/api.py
+++ b/backend/ee/onyx/server/query_history/api.py
@@ -26,13 +26,13 @@ from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.background.task_utils import construct_query_history_report_name
 from onyx.chat.chat_utils import create_chat_history_chain
 from onyx.configs.constants import (
+    PUBLIC_API_TAGS,
     FileOrigin,
     FileType,
     MessageType,
     OnyxCeleryPriority,
     OnyxCeleryQueues,
     OnyxCeleryTask,
-    PUBLIC_API_TAGS,
     QAFeedbackType,
     QueryHistoryType,
     SessionType,

--- a/backend/ee/onyx/server/reporting/usage_export_api.py
+++ b/backend/ee/onyx/server/reporting/usage_export_api.py
@@ -7,9 +7,9 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.usage_export import (
+    UsageReportMetadata,
     get_all_usage_reports,
     get_usage_report_data,
-    UsageReportMetadata,
 )
 from onyx.auth.permissions import require_permission
 from onyx.background.celery.versioned_apps.client import app as client_app

--- a/backend/ee/onyx/server/scim/api.py
+++ b/backend/ee/onyx/server/scim/api.py
@@ -37,13 +37,13 @@ from ee.onyx.server.scim.models import (
     ScimUserResource,
 )
 from ee.onyx.server.scim.patch import (
+    ScimPatchError,
     apply_group_patch,
     apply_user_patch,
-    ScimPatchError,
 )
 from ee.onyx.server.scim.providers.base import (
-    get_default_provider,
     ScimProvider,
+    get_default_provider,
     serialize_emails,
 )
 from ee.onyx.server.scim.schema_definitions import (

--- a/backend/ee/onyx/server/tenants/admin_api.py
+++ b/backend/ee/onyx/server/tenants/admin_api.py
@@ -4,7 +4,7 @@ from fastapi_users import exceptions
 from ee.onyx.auth.users import current_cloud_superuser
 from ee.onyx.server.tenants.models import ImpersonateRequest
 from ee.onyx.server.tenants.user_mapping import get_tenant_id_for_email
-from onyx.auth.users import auth_backend, get_redis_strategy, User
+from onyx.auth.users import User, auth_backend, get_redis_strategy
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.users import get_user_by_email

--- a/backend/ee/onyx/server/tenants/anonymous_users_api.py
+++ b/backend/ee/onyx/server/tenants/anonymous_users_api.py
@@ -10,7 +10,7 @@ from ee.onyx.server.tenants.anonymous_user_path import (
 )
 from ee.onyx.server.tenants.models import AnonymousUserPath
 from onyx.auth.permissions import require_permission
-from onyx.auth.users import anonymous_user_enabled, User
+from onyx.auth.users import User, anonymous_user_enabled
 from onyx.configs.constants import (
     ANONYMOUS_USER_COOKIE_NAME,
     FASTAPI_USERS_AUTH_COOKIE_NAME,

--- a/backend/ee/onyx/server/tenants/billing.py
+++ b/backend/ee/onyx/server/tenants/billing.py
@@ -1,5 +1,5 @@
 from enum import Enum as PyEnum
-from typing import cast, Literal
+from typing import Literal, cast
 
 import requests
 import stripe

--- a/backend/ee/onyx/server/tenants/tier_management.py
+++ b/backend/ee/onyx/server/tenants/tier_management.py
@@ -6,7 +6,7 @@ Value at TENANT_TIER_KEY is a JSON blob:
 
 import json
 from datetime import datetime
-from typing import cast, NamedTuple
+from typing import NamedTuple, cast
 
 from ee.onyx.server.license.models import CustomerTier
 from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client

--- a/backend/ee/onyx/utils/encryption.py
+++ b/backend/ee/onyx/utils/encryption.py
@@ -3,7 +3,7 @@ from os import urandom
 
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import padding
-from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 from onyx.configs.app_configs import ENCRYPTION_KEY_SECRET
 from onyx.utils.logger import setup_logger

--- a/backend/ee/onyx/utils/license_notifications.py
+++ b/backend/ee/onyx/utils/license_notifications.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 from ee.onyx.utils.license_expiry import ExpiryWarningStage, get_grace_days_remaining
 from onyx.auth.email_utils import build_html_email, send_email
 from onyx.configs.app_configs import EMAIL_CONFIGURED
-from onyx.configs.constants import NotificationType, ONYX_DEFAULT_APPLICATION_NAME
+from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME, NotificationType
 from onyx.db.notification import batch_create_notifications
 from onyx.db.users import get_active_admin_users
 from onyx.utils.logger import setup_logger

--- a/backend/model_server/encoders.py
+++ b/backend/model_server/encoders.py
@@ -1,6 +1,6 @@
 import asyncio
 import time
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException, Request
 

--- a/backend/model_server/utils.py
+++ b/backend/model_server/utils.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Callable, Generator, Iterator
 from functools import wraps
 from pathlib import Path
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
 import torch
 

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 
 from onyx.access.models import DocumentAccess
 from onyx.access.utils import prefix_user_email
-from onyx.configs.constants import DocumentSource, FileOrigin, PUBLIC_DOC_PAT
+from onyx.configs.constants import PUBLIC_DOC_PAT, DocumentSource, FileOrigin
 from onyx.db.document import get_access_info_for_document, get_access_info_for_documents
 from onyx.db.models import (
     ChatMessage,

--- a/backend/onyx/auth/email_utils.py
+++ b/backend/onyx/auth/email_utils.py
@@ -32,9 +32,9 @@ from onyx.configs.app_configs import (
     WEB_DOMAIN,
 )
 from onyx.configs.constants import (
-    AuthType,
     ONYX_DEFAULT_APPLICATION_NAME,
     ONYX_DISCORD_URL,
+    AuthType,
 )
 from onyx.db.models import User
 from onyx.server.runtime.onyx_runtime import OnyxRuntime

--- a/backend/onyx/auth/jwt.py
+++ b/backend/onyx/auth/jwt.py
@@ -6,8 +6,8 @@ from typing import Any, cast
 import jwt
 import requests
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
-from jwt import decode as jwt_decode
 from jwt import InvalidTokenError, PyJWTError
+from jwt import decode as jwt_decode
 from jwt.algorithms import RSAAlgorithm  # ty: ignore[possibly-missing-import]
 
 from onyx.configs.app_configs import JWT_PUBLIC_KEY_URL

--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -3,7 +3,7 @@ import os
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, cast, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 import httpx
 from fastapi_users.manager import BaseUserManager

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -8,7 +8,7 @@ import string
 import uuid
 from collections.abc import AsyncGenerator, Sequence
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast, Dict, List, Literal, Optional, Protocol, Tuple, TypeVar
+from typing import Any, Dict, List, Literal, Optional, Protocol, Tuple, TypeVar, cast
 from urllib.parse import urlparse
 
 import jwt
@@ -20,19 +20,19 @@ from fastapi import (
     Query,
     Request,
     Response,
-    status,
     WebSocket,
+    status,
 )
 from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.routing import APIRoute
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import (
     BaseUserManager,
-    exceptions,
     FastAPIUsers,
+    UUIDIDMixin,
+    exceptions,
     models,
     schemas,
-    UUIDIDMixin,
 )
 from fastapi_users.authentication import (
     AuthenticationBackend,
@@ -46,7 +46,7 @@ from fastapi_users.authentication.strategy.db import (
     DatabaseStrategy,
 )
 from fastapi_users.exceptions import UserAlreadyExists
-from fastapi_users.jwt import decode_jwt, generate_jwt, SecretType
+from fastapi_users.jwt import SecretType, decode_jwt, generate_jwt
 from fastapi_users.manager import UserManagerDependency
 from fastapi_users.openapi import OpenAPIResponseType
 from fastapi_users.router.common import ErrorCode, ErrorModel
@@ -89,22 +89,22 @@ from onyx.configs.constants import (
     ANONYMOUS_USER_COOKIE_NAME,
     ANONYMOUS_USER_EMAIL,
     ANONYMOUS_USER_UUID,
-    AuthType,
     DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN,
     DANSWER_API_KEY_PREFIX,
     FASTAPI_USERS_AUTH_COOKIE_NAME,
-    MilestoneRecordType,
-    OnyxRedisLocks,
     PASSWORD_SPECIAL_CHARS,
     UNNAMED_KEY_PLACEHOLDER,
+    AuthType,
+    MilestoneRecordType,
+    OnyxRedisLocks,
 )
 from onyx.db.api_key import fetch_user_for_api_key
 from onyx.db.auth import (
+    SQLAlchemyUserAdminDB,
     get_access_token_db,
     get_default_admin_user_emails,
     get_user_count,
     get_user_db,
-    SQLAlchemyUserAdminDB,
 )
 from onyx.db.engine.async_sql_engine import (
     get_async_session,
@@ -124,9 +124,9 @@ from onyx.db.users import (
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import (
+    OnyxError,
     log_onyx_error,
     onyx_error_to_json_response,
-    OnyxError,
 )
 from onyx.redis.redis_pool import get_async_redis_connection, retrieve_ws_token_data
 from onyx.server.security.store import get_security_settings
@@ -134,20 +134,20 @@ from onyx.server.settings.store import load_settings
 from onyx.server.utils import BasicAuthenticationError
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import (
+    RecordType,
     mt_cloud_alias,
     mt_cloud_get_anon_id,
     mt_cloud_identify,
     mt_cloud_telemetry,
     optional_telemetry,
-    RecordType,
 )
 from onyx.utils.timing import log_function_time
 from onyx.utils.url import add_url_params
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 from shared_configs.configs import (
-    async_return_default_schema,
     MULTI_TENANT,
     POSTGRES_DEFAULT_SCHEMA,
+    async_return_default_schema,
 )
 from shared_configs.contextvars import (
     CURRENT_TENANT_ID_CONTEXTVAR,

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -7,8 +7,8 @@ from typing import Any, cast
 
 import sentry_sdk
 from celery import (
-    bootsteps,  # ty: ignore[unresolved-import]
     Task,
+    bootsteps,  # ty: ignore[unresolved-import]
 )
 from celery.app import trace  # ty: ignore[unresolved-import]
 from celery.exceptions import WorkerShutdown
@@ -56,10 +56,10 @@ from onyx.redis.redis_usergroup import RedisUserGroup
 from onyx.tracing.setup import setup_tracing
 from onyx.utils.logger import (
     ColoredFormatter,
-    get_json_formatter,
-    get_log_level_from_str,
     LoggerContextVars,
     PlainFormatter,
+    get_json_formatter,
+    get_log_level_from_str,
     setup_logger,
 )
 from shared_configs.configs import (

--- a/backend/onyx/background/celery/apps/docfetching.py
+++ b/backend/onyx/background/celery/apps/docfetching.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 
-from celery import Celery, signals, Task
+from celery import Celery, Task, signals
 from celery.apps.worker import Worker
 from celery.signals import celeryd_init, worker_init, worker_ready, worker_shutdown
 

--- a/backend/onyx/background/celery/apps/docprocessing.py
+++ b/backend/onyx/background/celery/apps/docprocessing.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 
-from celery import Celery, signals, Task
+from celery import Celery, Task, signals
 from celery.apps.worker import Worker
 from celery.signals import (
     celeryd_init,

--- a/backend/onyx/background/celery/apps/heavy.py
+++ b/backend/onyx/background/celery/apps/heavy.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 
-from celery import Celery, signals, Task
+from celery import Celery, Task, signals
 from celery.apps.worker import Worker
 from celery.signals import celeryd_init, worker_init, worker_ready, worker_shutdown
 

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from celery import Celery, signals, Task
+from celery import Celery, Task, signals
 from celery.apps.worker import Worker
 from celery.signals import celeryd_init, worker_init, worker_ready, worker_shutdown
 

--- a/backend/onyx/background/celery/apps/monitoring.py
+++ b/backend/onyx/background/celery/apps/monitoring.py
@@ -1,7 +1,7 @@
 import multiprocessing
 from typing import Any
 
-from celery import Celery, signals, Task
+from celery import Celery, Task, signals
 from celery.signals import celeryd_init, worker_init, worker_ready, worker_shutdown
 
 import onyx.background.celery.apps.app_base as app_base

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -3,10 +3,10 @@ import os
 from typing import Any, cast
 
 from celery import (
-    bootsteps,  # ty: ignore[unresolved-import]
     Celery,
-    signals,
     Task,
+    bootsteps,  # ty: ignore[unresolved-import]
+    signals,
 )
 from celery.apps.worker import Worker
 from celery.exceptions import WorkerShutdown
@@ -21,11 +21,11 @@ from onyx.background.celery.tasks.vespa.document_sync import reset_document_sync
 from onyx.configs.app_configs import CELERY_WORKER_PRIMARY_POOL_OVERFLOW
 from onyx.configs.constants import (
     CELERY_PRIMARY_WORKER_LOCK_TIMEOUT,
+    POSTGRES_CELERY_WORKER_PRIMARY_APP_NAME,
     OnyxRedisConstants,
     OnyxRedisLocks,
-    POSTGRES_CELERY_WORKER_PRIMARY_APP_NAME,
 )
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.index_attempt import get_index_attempt, mark_attempt_canceled
 from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector_delete import RedisConnectorDelete

--- a/backend/onyx/background/celery/apps/scheduled_tasks.py
+++ b/backend/onyx/background/celery/apps/scheduled_tasks.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 
-from celery import Celery, signals, Task
+from celery import Celery, Task, signals
 from celery.apps.worker import Worker
 from celery.signals import celeryd_init, worker_init, worker_ready, worker_shutdown
 

--- a/backend/onyx/background/celery/apps/task_formatters.py
+++ b/backend/onyx/background/celery/apps/task_formatters.py
@@ -2,7 +2,7 @@ import logging
 
 from celery import current_task
 
-from onyx.utils.logger import ColoredFormatter, get_json_formatter, PlainFormatter
+from onyx.utils.logger import ColoredFormatter, PlainFormatter, get_json_formatter
 
 
 class CeleryTaskJsonFormatter(logging.Formatter):

--- a/backend/onyx/background/celery/apps/user_file_processing.py
+++ b/backend/onyx/background/celery/apps/user_file_processing.py
@@ -1,6 +1,6 @@
 from typing import Any, cast
 
-from celery import Celery, signals, Task
+from celery import Celery, Task, signals
 from celery.apps.worker import Worker
 from celery.signals import (
     celeryd_init,

--- a/backend/onyx/background/celery/celery_redis.py
+++ b/backend/onyx/background/celery/celery_redis.py
@@ -8,7 +8,7 @@ from redis import Redis
 
 from onyx.background.celery.configs.base import CELERY_SEPARATOR
 from onyx.configs.app_configs import REDIS_HEALTH_CHECK_INTERVAL
-from onyx.configs.constants import OnyxCeleryPriority, REDIS_SOCKET_KEEPALIVE_OPTIONS
+from onyx.configs.constants import REDIS_SOCKET_KEEPALIVE_OPTIONS, OnyxCeleryPriority
 
 _broker_client: Redis | None = None
 _broker_url: str | None = None

--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -2,7 +2,7 @@ import time
 from collections.abc import Generator, Iterator, Sequence
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
 import httpx
 from pydantic import BaseModel

--- a/backend/onyx/background/celery/configs/base.py
+++ b/backend/onyx/background/celery/configs/base.py
@@ -15,7 +15,7 @@ from onyx.configs.app_configs import (
     REDIS_SSL_CERT_REQS,
     USE_REDIS_IAM_AUTH,
 )
-from onyx.configs.constants import OnyxCeleryPriority, REDIS_SOCKET_KEEPALIVE_OPTIONS
+from onyx.configs.constants import REDIS_SOCKET_KEEPALIVE_OPTIONS, OnyxCeleryPriority
 
 CELERY_SEPARATOR = ":"
 

--- a/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
+++ b/backend/onyx/background/celery/tasks/connector_deletion/tasks.py
@@ -2,7 +2,7 @@ import traceback
 from datetime import datetime, timezone
 from typing import Any, cast
 
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from pydantic import ValidationError
 from redis import Redis

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -5,7 +5,7 @@ import traceback
 from time import sleep
 
 import sentry_sdk
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 
 from onyx import __version__
 from onyx.background.celery.apps.app_base import task_logger

--- a/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/targeted_reindex_task.py
@@ -10,7 +10,7 @@ connector invocation + indexing pipeline plumbing live in
 import datetime
 import logging
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.indexing.run_targeted_reindex import (

--- a/backend/onyx/background/celery/tasks/docprocessing/tasks.py
+++ b/backend/onyx/background/celery/tasks/docprocessing/tasks.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from celery import Celery, current_app, shared_task, Task
+from celery import Celery, Task, current_app, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from pydantic import BaseModel
 from redis.lock import Lock as RedisLock
@@ -55,9 +55,9 @@ from onyx.configs.app_configs import (
     VESPA_CLOUD_KEY_PATH,
 )
 from onyx.configs.constants import (
-    AuthType,
     CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
     CELERY_INDEXING_LOCK_TIMEOUT,
+    AuthType,
     DocumentSource,
     MilestoneRecordType,
     NotificationType,
@@ -85,11 +85,11 @@ from onyx.db.enums import (
     SwitchoverType,
 )
 from onyx.db.index_attempt import (
+    IndexAttemptError,
     create_index_attempt_error,
     get_index_attempt,
     get_index_attempt_errors_for_cc_pair,
     get_stale_not_started_index_attempts,
-    IndexAttemptError,
     mark_attempt_canceled,
     mark_attempt_failed,
     mark_attempt_partially_succeeded,
@@ -132,10 +132,10 @@ from onyx.natural_language_processing.search_nlp_models import (
 from onyx.redis.redis_connector import RedisConnector
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_pool import (
+    SCAN_ITER_COUNT_DEFAULT,
     get_redis_client,
     get_redis_replica_client,
     redis_lock_dump,
-    SCAN_ITER_COUNT_DEFAULT,
 )
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.redis.redis_utils import is_fence
@@ -148,7 +148,7 @@ from onyx.server.metrics.connector_health_metrics import (
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 from onyx.utils.logger import setup_logger
 from onyx.utils.middleware import make_randomized_onyx_request_id
-from onyx.utils.telemetry import mt_cloud_telemetry, optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, mt_cloud_telemetry, optional_telemetry
 from shared_configs.configs import (
     INDEXING_MODEL_SERVER_HOST,
     INDEXING_MODEL_SERVER_PORT,
@@ -1864,7 +1864,7 @@ def _docprocessing_task(
         # Track chunk indexing usage for cloud usage limits
         if USAGE_LIMITS_ENABLED and index_pipeline_result.total_chunks > 0:
             try:
-                from onyx.db.usage import increment_usage, UsageType
+                from onyx.db.usage import UsageType, increment_usage
 
                 with get_session_with_current_tenant() as usage_db_session:
                     increment_usage(

--- a/backend/onyx/background/celery/tasks/evals/tasks.py
+++ b/backend/onyx/background/celery/tasks/evals/tasks.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 from typing import Any
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 
 from onyx.configs.app_configs import (
     BRAINTRUST_API_KEY,

--- a/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/hierarchyfetching/tasks.py
@@ -12,7 +12,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session
 
@@ -46,9 +46,9 @@ from onyx.db.hierarchy import (
 )
 from onyx.db.models import ConnectorCredentialPair
 from onyx.redis.redis_hierarchy import (
+    HierarchyNodeCacheEntry,
     cache_hierarchy_nodes_batch,
     ensure_source_node_exists,
-    HierarchyNodeCacheEntry,
 )
 from onyx.redis.redis_pool import get_redis_client
 from onyx.redis.tenant_redis_client import TenantRedisClient

--- a/backend/onyx/background/celery/tasks/llm_model_update/tasks.py
+++ b/backend/onyx/background/celery/tasks/llm_model_update/tasks.py
@@ -1,4 +1,4 @@
-from celery import shared_task, Task
+from celery import Task, shared_task
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.app_configs import AUTO_LLM_CONFIG_URL

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -2,10 +2,10 @@ import json
 import time
 from datetime import timedelta
 from itertools import islice
-from typing import Any, cast, Literal
+from typing import Any, Literal, cast
 
 import psutil
-from celery import shared_task, Task
+from celery import Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from pydantic import BaseModel
 from redis import Redis
@@ -45,7 +45,7 @@ from onyx.db.search_settings import get_active_search_settings_list
 from onyx.redis.redis_pool import get_redis_client, redis_lock_dump
 from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.utils.platform_utils import is_running_in_container, is_running_in_kubernetes
-from onyx.utils.telemetry import optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, optional_telemetry
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 

--- a/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
+++ b/backend/onyx/background/celery/tasks/opensearch_migration/tasks.py
@@ -3,7 +3,7 @@
 import time
 import traceback
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 from redis.lock import Lock as RedisLock
 
 from onyx.background.celery.apps.app_base import task_logger

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 from uuid import uuid4
 
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from pydantic import ValidationError
 from redis import Redis
@@ -70,12 +70,12 @@ from onyx.redis.redis_connector_prune import (
     RedisConnectorPrunePayload,
 )
 from onyx.redis.redis_hierarchy import (
+    HierarchyNodeCacheEntry,
     cache_hierarchy_nodes_batch,
     ensure_source_node_exists,
     evict_hierarchy_nodes_from_cache,
     get_node_id_from_raw_id,
     get_source_node_id_from_cache,
-    HierarchyNodeCacheEntry,
 )
 from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
@@ -84,8 +84,8 @@ from onyx.server.metrics.pruning_metrics import observe_pruning_diff_duration
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 from onyx.server.utils import make_short_id
 from onyx.utils.logger import (
-    format_error_for_logging,
     LoggerContextVars,
+    format_error_for_logging,
     pruning_ctx,
     setup_logger,
 )

--- a/backend/onyx/background/celery/tasks/scheduled_tasks/tasks.py
+++ b/backend/onyx/background/celery/tasks/scheduled_tasks/tasks.py
@@ -31,7 +31,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.configs.constants import OnyxCeleryPriority, OnyxCeleryQueues, OnyxCeleryTask

--- a/backend/onyx/background/celery/tasks/shared/tasks.py
+++ b/backend/onyx/background/celery/tasks/shared/tasks.py
@@ -3,7 +3,7 @@ from enum import Enum
 from http import HTTPStatus
 
 import httpx
-from celery import shared_task, Task
+from celery import Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from tenacity import RetryError
 

--- a/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
+++ b/backend/onyx/background/celery/tasks/user_file_processing/tasks.py
@@ -5,7 +5,7 @@ from uuid import UUID
 
 import httpx
 import sqlalchemy as sa
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 from redis.lock import Lock as RedisLock
 from retry import retry
 from sqlalchemy import select
@@ -32,14 +32,14 @@ from onyx.configs.constants import (
     CELERY_USER_FILE_PROCESSING_TASK_EXPIRES,
     CELERY_USER_FILE_PROJECT_SYNC_LOCK_TIMEOUT,
     CELERY_USER_FILE_PROJECT_SYNC_TASK_EXPIRES,
+    USER_FILE_DELETE_MAX_QUEUE_DEPTH,
+    USER_FILE_PROCESSING_MAX_QUEUE_DEPTH,
+    USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
     DocumentSource,
     OnyxCeleryPriority,
     OnyxCeleryQueues,
     OnyxCeleryTask,
     OnyxRedisLocks,
-    USER_FILE_DELETE_MAX_QUEUE_DEPTH,
-    USER_FILE_PROCESSING_MAX_QUEUE_DEPTH,
-    USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
 )
 from onyx.connectors.file.connector import LocalFileConnector
 from onyx.connectors.models import Document, HierarchyNode

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -4,7 +4,7 @@ from http import HTTPStatus
 from typing import Any, cast
 
 import httpx
-from celery import Celery, shared_task, Task
+from celery import Celery, Task, shared_task
 from celery.exceptions import SoftTimeLimitExceeded
 from redis.lock import Lock as RedisLock
 from sqlalchemy.orm import Session

--- a/backend/onyx/background/indexing/checkpointing_utils.py
+++ b/backend/onyx/background/indexing/checkpointing_utils.py
@@ -4,7 +4,7 @@ from io import BytesIO
 from sqlalchemy import and_
 from sqlalchemy.orm import Session
 
-from onyx.configs.constants import FileOrigin, NUM_DAYS_TO_KEEP_CHECKPOINTS
+from onyx.configs.constants import NUM_DAYS_TO_KEEP_CHECKPOINTS, FileOrigin
 from onyx.connectors.interfaces import BaseConnector, CheckpointedConnector
 from onyx.connectors.models import ConnectorCheckpoint
 from onyx.db.engine.time_utils import get_db_current_time

--- a/backend/onyx/background/indexing/run_docfetching.py
+++ b/backend/onyx/background/indexing/run_docfetching.py
@@ -79,18 +79,18 @@ from onyx.file_store.document_batch_storage import (
     get_document_batch_storage,
 )
 from onyx.file_store.staging import (
-    build_raw_file_callback,
     RawFileCallback,
+    build_raw_file_callback,
     reap_prior_attempt_staged_files,
 )
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_hierarchy import (
+    HierarchyNodeCacheEntry,
     cache_hierarchy_nodes_batch,
     ensure_source_node_exists,
     get_node_id_from_raw_id,
     get_source_node_id_from_cache,
-    HierarchyNodeCacheEntry,
 )
 from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/background/indexing/run_targeted_reindex.py
+++ b/backend/onyx/background/indexing/run_targeted_reindex.py
@@ -51,8 +51,8 @@ from onyx.indexing.adapters.document_indexing_adapter import (
 from onyx.indexing.embedder import DefaultIndexingEmbedder
 from onyx.indexing.indexing_pipeline import run_indexing_pipeline
 from onyx.redis.redis_hierarchy import (
-    cache_hierarchy_nodes_batch,
     HierarchyNodeCacheEntry,
+    cache_hierarchy_nodes_batch,
 )
 from onyx.redis.redis_pool import get_redis_client
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/cache/postgres_backend.py
+++ b/backend/onyx/cache/postgres_backend.py
@@ -16,10 +16,10 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from onyx.cache.interface import (
-    CacheBackend,
-    CacheLock,
     TTL_KEY_NOT_FOUND,
     TTL_NO_EXPIRY,
+    CacheBackend,
+    CacheLock,
 )
 from onyx.db.models import CacheStore
 

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -17,9 +17,9 @@ from onyx.chat.models import (
 )
 from onyx.configs.constants import (
     DEFAULT_PERSONA_ID,
+    TMP_DRALPHA_PERSONA_NAME,
     FileOrigin,
     MessageType,
-    TMP_DRALPHA_PERSONA_NAME,
 )
 from onyx.context.search.models import SearchDoc
 from onyx.context.search.utils import sandbox_filename_for_document

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -39,7 +39,7 @@ from onyx.configs.constants import DocumentSource, MessageType
 from onyx.configs.model_configs import GEN_AI_INPUT_TOKEN_SAFETY_MARGIN
 from onyx.context.search.models import SearchDoc, SearchDocsResponse
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.memory import add_memory, update_memory_at_index, UserMemoryContext
+from onyx.db.memory import UserMemoryContext, add_memory, update_memory_at_index
 from onyx.db.models import Persona
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM, LLMUserIdentity, ToolChoiceOptions

--- a/backend/onyx/chat/llm_step.py
+++ b/backend/onyx/chat/llm_step.py
@@ -21,8 +21,8 @@ from onyx.context.search.models import SearchDoc
 from onyx.file_store.models import ChatFileType
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import (
-    LanguageModelInput,
     LLM,
+    LanguageModelInput,
     LLMConfig,
     LLMUserIdentity,
     ToolChoiceOptions,

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -84,7 +84,7 @@ from onyx.db.projects import get_user_files_from_project
 from onyx.db.tools import get_tools
 from onyx.deep_research.dr_loop import run_deep_research_llm_loop
 from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import log_onyx_error, OnyxError
+from onyx.error_handling.exceptions import OnyxError, log_onyx_error
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_store.models import ChatFileType, InMemoryChatFile
 from onyx.file_store.utils import (
@@ -92,7 +92,7 @@ from onyx.file_store.utils import (
     load_in_memory_chat_files,
     verify_user_files,
 )
-from onyx.hooks.executor import execute_hook, HookSkipped, HookSoftFailed
+from onyx.hooks.executor import HookSkipped, HookSoftFailed, execute_hook
 from onyx.hooks.points.query_processing import (
     QueryProcessingPayload,
     QueryProcessingResponse,
@@ -124,10 +124,10 @@ from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.tools.constants import FILE_READER_TOOL_ID, SEARCH_TOOL_ID
 from onyx.tools.models import ChatFile, SearchToolUsage
 from onyx.tools.tool_constructor import (
-    construct_tools,
     CustomToolConfig,
     FileReaderToolConfig,
     SearchToolConfig,
+    construct_tools,
 )
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -2,7 +2,7 @@ import os
 import platform
 import re
 import socket
-from enum import auto, Enum
+from enum import Enum, auto
 
 ONYX_DEFAULT_APPLICATION_NAME = "Onyx"
 ONYX_DISCORD_URL = "https://discord.gg/4NA5SbzrWb"

--- a/backend/onyx/connectors/airtable/airtable_connector.py
+++ b/backend/onyx/connectors/airtable/airtable_connector.py
@@ -1,6 +1,6 @@
 import contextvars
 import re
-from concurrent.futures import as_completed, Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from io import BytesIO
 from typing import Any, cast
 

--- a/backend/onyx/connectors/bitbucket/connector.py
+++ b/backend/onyx/connectors/bitbucket/connector.py
@@ -3,19 +3,19 @@ from __future__ import annotations
 import copy
 from collections.abc import Callable, Iterator
 from datetime import datetime, timezone
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE, REQUEST_TIMEOUT_SECONDS
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.bitbucket.utils import (
+    PR_LIST_RESPONSE_FIELDS,
+    SLIM_PR_LIST_RESPONSE_FIELDS,
     build_auth_client,
     list_repositories,
     map_pr_to_document,
     paginate,
-    PR_LIST_RESPONSE_FIELDS,
-    SLIM_PR_LIST_RESPONSE_FIELDS,
 )
 from onyx.connectors.exceptions import (
     CredentialExpiredError,

--- a/backend/onyx/connectors/blob/connector.py
+++ b/backend/onyx/connectors/blob/connector.py
@@ -5,7 +5,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 from io import BytesIO
 from numbers import Integral
-from typing import Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 from urllib.parse import quote
 
 import boto3

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Any, cast, NoReturn
+from typing import Any, NoReturn, cast
 
 from pydantic import BaseModel
 from retry import retry

--- a/backend/onyx/connectors/coda/connector.py
+++ b/backend/onyx/connectors/coda/connector.py
@@ -1,7 +1,7 @@
 import os
 from collections.abc import Generator
 from datetime import datetime, timezone
-from typing import Any, cast, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from pydantic import BaseModel
 from retry import retry

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -24,8 +24,8 @@ from onyx.connectors.confluence.access import (
 )
 from onyx.connectors.confluence.onyx_confluence import (
     Confcloud77618Error,
-    extract_text_from_confluence_html,
     OnyxConfluence,
+    extract_text_from_confluence_html,
 )
 from onyx.connectors.confluence.utils import (
     build_confluence_document_id,

--- a/backend/onyx/connectors/confluence/onyx_confluence.py
+++ b/backend/onyx/connectors/confluence/onyx_confluence.py
@@ -16,7 +16,7 @@ import json
 import time
 from collections.abc import Callable, Generator, Iterator
 from datetime import datetime, timedelta, timezone
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 from urllib.parse import quote
 
 import bs4

--- a/backend/onyx/connectors/confluence/utils.py
+++ b/backend/onyx/connectors/confluence/utils.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
 from io import BytesIO
 from pathlib import Path
-from typing import Any, cast, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 from urllib.parse import parse_qs, quote, urljoin, urlparse
 
 import requests

--- a/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
+++ b/backend/onyx/connectors/cross_connector_utils/miscellaneous_utils.py
@@ -9,7 +9,7 @@ import requests
 from dateutil.parser import parse
 
 from onyx.configs.app_configs import CONNECTOR_LOCALHOST_OVERRIDE
-from onyx.configs.constants import DocumentSource, IGNORE_FOR_QA
+from onyx.configs.constants import IGNORE_FOR_QA, DocumentSource
 from onyx.connectors.models import BasicExpertInfo, OnyxMetadata
 from onyx.utils.logger import setup_logger
 from onyx.utils.text_processing import is_valid_email

--- a/backend/onyx/connectors/cross_connector_utils/rate_limit_wrapper.py
+++ b/backend/onyx/connectors/cross_connector_utils/rate_limit_wrapper.py
@@ -1,7 +1,7 @@
 import time
 from collections.abc import Callable
 from functools import wraps
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
 import requests
 

--- a/backend/onyx/connectors/egnyte/connector.py
+++ b/backend/onyx/connectors/egnyte/connector.py
@@ -2,7 +2,7 @@ import io
 import os
 from collections.abc import Generator
 from datetime import datetime, timezone
-from typing import Any, IO
+from typing import IO, Any
 from urllib.parse import quote
 
 from pydantic import Field

--- a/backend/onyx/connectors/file/connector.py
+++ b/backend/onyx/connectors/file/connector.py
@@ -3,7 +3,7 @@ import os
 from datetime import datetime, timezone
 from io import BytesIO
 from pathlib import Path
-from typing import Any, IO
+from typing import IO, Any
 
 from onyx.configs.app_configs import INDEX_BATCH_SIZE
 from onyx.configs.constants import DocumentSource, FileOrigin

--- a/backend/onyx/connectors/fireflies/connector.py
+++ b/backend/onyx/connectors/fireflies/connector.py
@@ -1,7 +1,7 @@
 import time
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from typing import cast, List
+from typing import List, cast
 
 import requests
 

--- a/backend/onyx/connectors/gmail/connector.py
+++ b/backend/onyx/connectors/gmail/connector.py
@@ -1,6 +1,6 @@
 from base64 import urlsafe_b64decode
 from collections.abc import Callable, Iterator
-from typing import Any, cast, Dict
+from typing import Any, Dict, cast
 
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
@@ -12,15 +12,15 @@ from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.google_utils.google_auth import get_google_creds
 from onyx.connectors.google_utils.google_utils import (
+    PAGE_TOKEN_KEY,
     execute_paginated_retrieval,
     execute_paginated_retrieval_with_max_pages,
     execute_single_retrieval,
-    PAGE_TOKEN_KEY,
 )
 from onyx.connectors.google_utils.resources import (
+    GmailService,
     get_admin_service,
     get_gmail_service,
-    GmailService,
 )
 from onyx.connectors.google_utils.shared_constants import (
     DB_CREDENTIALS_PRIMARY_ADMIN_KEY,

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -6,7 +6,7 @@ import threading
 from collections.abc import Callable, Generator, Iterator
 from datetime import datetime
 from enum import Enum
-from typing import Any, cast, Protocol
+from typing import Any, Protocol, cast
 from urllib.parse import parse_qs, urlparse, urlunparse
 
 from google.auth.exceptions import RefreshError
@@ -28,14 +28,14 @@ from onyx.connectors.exceptions import (
     InsufficientPermissionsError,
 )
 from onyx.connectors.google_drive.doc_conversion import (
+    PermissionSyncContext,
     build_slim_document,
     convert_drive_item_to_document,
     onyx_document_id_from_drive_file,
-    PermissionSyncContext,
 )
 from onyx.connectors.google_drive.file_retrieval import (
-    crawl_folders_for_files,
     DriveFileFieldType,
+    crawl_folders_for_files,
     get_all_files_for_oauth,
     get_all_files_in_my_drive_and_shared,
     get_external_access_for_folder,
@@ -55,15 +55,15 @@ from onyx.connectors.google_drive.models import (
 )
 from onyx.connectors.google_utils.google_auth import get_google_creds
 from onyx.connectors.google_utils.google_utils import (
+    GoogleFields,
     execute_paginated_retrieval,
     get_file_owners,
-    GoogleFields,
 )
 from onyx.connectors.google_utils.resources import (
-    get_admin_service,
-    get_drive_service,
     GoogleDriveService,
     ImpersonationError,
+    get_admin_service,
+    get_drive_service,
     make_user_removal_checker,
 )
 from onyx.connectors.google_utils.shared_constants import (
@@ -97,10 +97,10 @@ from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from onyx.utils.logger import setup_logger
 from onyx.utils.retry_wrapper import retry_builder
 from onyx.utils.threadpool_concurrency import (
-    parallel_yield,
-    run_functions_tuples_in_parallel,
     ThreadSafeDict,
     ThreadSafeSet,
+    parallel_yield,
+    run_functions_tuples_in_parallel,
 )
 
 logger = setup_logger()

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -21,14 +21,14 @@ from onyx.connectors.google_drive.constants import (
 )
 from onyx.connectors.google_drive.models import GDriveMimeType, GoogleDriveFileType
 from onyx.connectors.google_drive.section_extraction import (
-    get_document_sections,
     HEADING_DELIMITER,
+    get_document_sections,
 )
 from onyx.connectors.google_utils.resources import (
-    get_drive_service,
-    get_google_docs_service,
     GoogleDocsService,
     GoogleDriveService,
+    get_drive_service,
+    get_google_docs_service,
 )
 from onyx.connectors.models import (
     ConnectorFailure,
@@ -47,10 +47,10 @@ from onyx.file_processing.extract_file_text import (
     read_pptx_file,
 )
 from onyx.file_processing.file_types import (
-    OnyxFileExtensions,
-    OnyxMimeTypes,
     PRESENTATION_MIME_TYPE,
     SPREADSHEET_MIME_TYPE,
+    OnyxFileExtensions,
+    OnyxMimeTypes,
 )
 from onyx.file_processing.image_utils import (
     make_image_callback,

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -20,11 +20,11 @@ from onyx.connectors.google_drive.models import (
     RetrievedDriveFile,
 )
 from onyx.connectors.google_utils.google_utils import (
-    execute_paginated_retrieval,
-    execute_paginated_retrieval_with_max_pages,
-    GoogleFields,
     ORDER_BY_KEY,
     PAGE_TOKEN_KEY,
+    GoogleFields,
+    execute_paginated_retrieval,
+    execute_paginated_retrieval_with_max_pages,
 )
 from onyx.connectors.google_utils.resources import GoogleDriveService
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch

--- a/backend/onyx/connectors/google_utils/google_kv.py
+++ b/backend/onyx/connectors/google_utils/google_kv.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any, cast
-from urllib.parse import parse_qs, ParseResult, urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -8,12 +8,12 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import (
-    DocumentSource,
     KV_CRED_KEY,
     KV_GMAIL_CRED_KEY,
     KV_GMAIL_SERVICE_ACCOUNT_KEY,
     KV_GOOGLE_DRIVE_CRED_KEY,
     KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY,
+    DocumentSource,
 )
 from onyx.connectors.google_utils.resources import get_drive_service, get_gmail_service
 from onyx.connectors.google_utils.shared_constants import (
@@ -22,9 +22,9 @@ from onyx.connectors.google_utils.shared_constants import (
     DB_CREDENTIALS_DICT_TOKEN_KEY,
     DB_CREDENTIALS_PRIMARY_ADMIN_KEY,
     GOOGLE_SCOPES,
-    GoogleOAuthAuthenticationMethod,
     MISSING_SCOPES_ERROR_STR,
     ONYX_SCOPE_INSTRUCTIONS,
+    GoogleOAuthAuthenticationMethod,
 )
 from onyx.db.credentials import update_credential_json
 from onyx.db.models import User

--- a/backend/onyx/connectors/google_utils/resources.py
+++ b/backend/onyx/connectors/google_utils/resources.py
@@ -3,7 +3,7 @@ from collections.abc import Callable
 from google.auth.exceptions import RefreshError
 from google.oauth2.credentials import Credentials as OAuthCredentials
 from google.oauth2.service_account import Credentials as ServiceAccountCredentials
-from googleapiclient.discovery import build, Resource
+from googleapiclient.discovery import Resource, build
 
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/connectors/hubspot/connector.py
+++ b/backend/onyx/connectors/hubspot/connector.py
@@ -2,7 +2,7 @@ import re
 import time
 from collections.abc import Callable, Generator
 from datetime import datetime, timezone
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
 import requests
 from hubspot import HubSpot

--- a/backend/onyx/connectors/hubspot/rate_limit.py
+++ b/backend/onyx/connectors/hubspot/rate_limit.py
@@ -5,8 +5,8 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from onyx.connectors.cross_connector_utils.rate_limit_wrapper import (
-    rate_limit_builder,
     RateLimitTriedTooManyTimesError,
+    rate_limit_builder,
 )
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/connectors/jira/connector.py
+++ b/backend/onyx/connectors/jira/connector.py
@@ -38,13 +38,13 @@ from onyx.connectors.interfaces import (
 )
 from onyx.connectors.jira.access import get_project_permissions
 from onyx.connectors.jira.utils import (
+    JIRA_CLOUD_API_VERSION,
     best_effort_basic_expert_info,
     best_effort_get_field_from_issue,
     build_jira_client,
     build_jira_url,
     extract_text_from_adf,
     get_comment_strs,
-    JIRA_CLOUD_API_VERSION,
 )
 from onyx.connectors.models import (
     ConnectorCheckpoint,

--- a/backend/onyx/connectors/mediawiki/wiki.py
+++ b/backend/onyx/connectors/mediawiki/wiki.py
@@ -4,7 +4,7 @@ import datetime
 import itertools
 import tempfile
 from collections.abc import Iterator
-from typing import Any, cast, ClassVar
+from typing import Any, ClassVar, cast
 
 import pywikibot.config
 import pywikibot.time

--- a/backend/onyx/connectors/models.py
+++ b/backend/onyx/connectors/models.py
@@ -4,12 +4,12 @@ import sys
 from collections.abc import Sequence
 from datetime import datetime
 from enum import Enum
-from typing import Any, cast, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from onyx.access.models import ExternalAccess
-from onyx.configs.constants import DocumentSource, INDEX_SEPARATOR, RETURN_SEPARATOR
+from onyx.configs.constants import INDEX_SEPARATOR, RETURN_SEPARATOR, DocumentSource
 from onyx.db.enums import HierarchyNodeType, IndexModelStatus
 from onyx.utils.text_processing import make_url_compatible
 

--- a/backend/onyx/connectors/notion/connector.py
+++ b/backend/onyx/connectors/notion/connector.py
@@ -1,7 +1,7 @@
 import re
 from collections.abc import Generator
 from datetime import datetime, timezone
-from typing import Any, cast, Optional
+from typing import Any, Optional, cast
 from urllib.parse import parse_qs, urlparse
 
 import requests

--- a/backend/onyx/connectors/salesforce/connector.py
+++ b/backend/onyx/connectors/salesforce/connector.py
@@ -29,9 +29,9 @@ from onyx.connectors.models import (
     TextSection,
 )
 from onyx.connectors.salesforce.doc_conversion import (
+    ID_PREFIX,
     convert_sf_object_to_doc,
     convert_sf_query_result_to_doc,
-    ID_PREFIX,
 )
 from onyx.connectors.salesforce.onyx_salesforce import OnyxSalesforce
 from onyx.connectors.salesforce.salesforce_calls import fetch_all_csvs_in_parallel

--- a/backend/onyx/connectors/salesforce/sqlite_functions.py
+++ b/backend/onyx/connectors/salesforce/sqlite_functions.py
@@ -12,9 +12,9 @@ from onyx.connectors.salesforce.utils import (
     ACCOUNT_OBJECT_TYPE,
     ID_FIELD,
     NAME_FIELD,
-    remove_sqlite_db_files,
-    SalesforceObject,
     USER_OBJECT_TYPE,
+    SalesforceObject,
+    remove_sqlite_db_files,
     validate_salesforce_id,
 )
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -3,7 +3,7 @@ import copy
 import itertools
 import re
 from collections.abc import Callable, Generator
-from concurrent.futures import as_completed, Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from enum import Enum
 from http.client import IncompleteRead, RemoteDisconnected
@@ -60,11 +60,11 @@ from onyx.connectors.slack.models import ChannelType, MessageType, ThreadType
 from onyx.connectors.slack.onyx_retry_handler import OnyxRedisSlackRetryHandler
 from onyx.connectors.slack.onyx_slack_web_client import OnyxSlackWebClient
 from onyx.connectors.slack.utils import (
+    SlackTextCleaner,
     expert_info_from_slack_id,
     fetch_team_user_emails,
     get_message_link,
     make_paginated_slack_api_call,
-    SlackTextCleaner,
 )
 from onyx.db.enums import HierarchyNodeType
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface

--- a/backend/onyx/db/api_key.py
+++ b/backend/onyx/db/api_key.py
@@ -3,7 +3,7 @@ import uuid
 from fastapi_users.password import PasswordHelper
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import joinedload, Session
+from sqlalchemy.orm import Session, joinedload
 
 from onyx.auth.api_key import (
     ApiKeyDescriptor,

--- a/backend/onyx/db/auth.py
+++ b/backend/onyx/db/auth.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 from fastapi_users.models import ID, UP
 from fastapi_users_db_sqlalchemy import SQLAlchemyUserDatabase
 from fastapi_users_db_sqlalchemy.access_token import SQLAlchemyAccessTokenDatabase
-from sqlalchemy import func, Select
+from sqlalchemy import Select, func
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 from sqlalchemy.orm import Session

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -4,9 +4,9 @@ from typing import Tuple
 from uuid import UUID
 
 from fastapi import HTTPException
-from sqlalchemy import delete, desc, func, nullsfirst, or_, Row, select, update
+from sqlalchemy import Row, delete, desc, func, nullsfirst, or_, select, update
 from sqlalchemy.exc import MultipleResultsFound
-from sqlalchemy.orm import joinedload, selectinload, Session
+from sqlalchemy.orm import Session, joinedload, selectinload
 
 from onyx.configs.chat_configs import HARD_DELETE_CHATS
 from onyx.configs.constants import MessageType

--- a/backend/onyx/db/chat_search.py
+++ b/backend/onyx/db/chat_search.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple
 from uuid import UUID
 
 from sqlalchemy import column, desc, func, select
-from sqlalchemy.orm import joinedload, Session
+from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.sql.expression import ColumnClause
 
 from onyx.db.models import ChatMessage, ChatSession

--- a/backend/onyx/db/connector.py
+++ b/backend/onyx/db/connector.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from sqlalchemy import and_, exists, func, select
-from sqlalchemy.orm import aliased, Session
+from sqlalchemy.orm import Session, aliased
 
 from onyx.configs.app_configs import DEFAULT_PRUNING_FREQ
 from onyx.configs.constants import DocumentSource

--- a/backend/onyx/db/connector_credential_pair.py
+++ b/backend/onyx/db/connector_credential_pair.py
@@ -3,8 +3,8 @@ from enum import Enum
 from typing import TypeVarTuple
 
 from fastapi import HTTPException
-from sqlalchemy import delete, desc, exists, Select, select, update
-from sqlalchemy.orm import aliased, joinedload, selectinload, Session
+from sqlalchemy import Select, delete, desc, exists, select, update
+from sqlalchemy.orm import Session, aliased, joinedload, selectinload
 
 from onyx.configs.constants import DocumentSource
 from onyx.db.connector import fetch_connector_by_id

--- a/backend/onyx/db/credentials.py
+++ b/backend/onyx/db/credentials.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from sqlalchemy import exists, Select, select, update
+from sqlalchemy import Select, exists, select, update
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.expression import and_, or_
 

--- a/backend/onyx/db/discord_bot.py
+++ b/backend/onyx/db/discord_bot.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 from sqlalchemy import delete, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import joinedload, Session
+from sqlalchemy.orm import Session, joinedload
 
 from onyx.auth.api_key import build_displayable_api_key, generate_api_key, hash_api_key
 from onyx.auth.schemas import UserRole

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, delete, exists, func, or_, Select, select, tuple_, update
+from sqlalchemy import Select, and_, delete, exists, func, or_, select, tuple_, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine.util import TransactionalContext
 from sqlalchemy.exc import OperationalError
@@ -38,7 +38,7 @@ from onyx.db.relationships import (
     delete_from_kg_relationships_extraction_staging__no_commit,
 )
 from onyx.db.tag import delete_document_tags_for_documents__no_commit
-from onyx.db.utils import DocumentRow, model_to_dict, SortOrder
+from onyx.db.utils import DocumentRow, SortOrder, model_to_dict
 from onyx.document_index.document_metadata import DocumentMetadata
 from onyx.file_store.staging import delete_files_best_effort
 from onyx.kg.models import KGStage

--- a/backend/onyx/db/document_access.py
+++ b/backend/onyx/db/document_access.py
@@ -10,7 +10,7 @@ This module provides reusable access filtering logic for documents based on:
 This is a standalone module to avoid circular imports between document.py and persona.py.
 """
 
-from sqlalchemy import and_, any_, cast, or_, Select, select, String
+from sqlalchemy import Select, String, and_, any_, cast, or_, select
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import Session
 from sqlalchemy.sql.elements import ColumnElement

--- a/backend/onyx/db/document_set.py
+++ b/backend/onyx/db/document_set.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 from typing import cast
 from uuid import UUID
 
-from sqlalchemy import and_, delete, exists, func, or_, Select, select
-from sqlalchemy.orm import aliased, selectinload, Session
+from sqlalchemy import Select, and_, delete, exists, func, or_, select
+from sqlalchemy.orm import Session, aliased, selectinload
 
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.db.connector_credential_pair import (

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -20,10 +20,10 @@ from onyx.configs.app_configs import (
 from onyx.db.engine.iam_auth import create_ssl_context_if_iam, get_iam_auth_token
 from onyx.db.engine.sql_engine import (
     ASYNC_DB_API,
+    USE_IAM_AUTH,
+    SqlEngine,
     build_connection_string,
     is_valid_schema_name,
-    SqlEngine,
-    USE_IAM_AUTH,
 )
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from shared_configs.contextvars import get_current_tenant_id

--- a/backend/onyx/db/engine/sql_engine.py
+++ b/backend/onyx/db/engine/sql_engine.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from fastapi import HTTPException
 from sqlalchemy import event, pool
-from sqlalchemy.engine import create_engine, Engine
+from sqlalchemy.engine import Engine, create_engine
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -2,7 +2,7 @@ import re
 
 from sqlalchemy import text
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
 from shared_configs.configs import (
     MULTI_TENANT,
     POSTGRES_DEFAULT_SCHEMA,

--- a/backend/onyx/db/entities.py
+++ b/backend/onyx/db/entities.py
@@ -3,8 +3,8 @@ from datetime import datetime, timezone
 from typing import List
 
 from sqlalchemy import func, literal, select, update
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 import onyx.db.document as dbdocument

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -4,11 +4,11 @@ from uuid import UUID, uuid4
 
 from sqlalchemy import delete, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.db.enums import EndpointPolicy, ExternalAppType
 from onyx.db.models import ExternalApp, ExternalAppPolicy, ExternalAppUserCredential
-from onyx.db.utils import is_set, UNSET, UnsetType
+from onyx.db.utils import UNSET, UnsetType, is_set
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import EXTERNAL_APP_BUILT_IN_SKILL_IDS

--- a/backend/onyx/db/federated.py
+++ b/backend/onyx/db/federated.py
@@ -3,7 +3,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload, selectinload, Session
+from sqlalchemy.orm import Session, joinedload, selectinload
 
 from onyx.configs.constants import FederatedConnectorSource
 from onyx.db.engine.sql_engine import get_session_with_current_tenant

--- a/backend/onyx/db/feedback.py
+++ b/backend/onyx/db/feedback.py
@@ -2,8 +2,8 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from fastapi import HTTPException
-from sqlalchemy import and_, asc, delete, desc, exists, Select, select
-from sqlalchemy.orm import aliased, Session
+from sqlalchemy import Select, and_, asc, delete, desc, exists, select
+from sqlalchemy.orm import Session, aliased
 
 from onyx.configs.constants import MessageType, SearchFeedbackType
 from onyx.db.chat import get_chat_message

--- a/backend/onyx/db/file_record.py
+++ b/backend/onyx/db/file_record.py
@@ -1,4 +1,4 @@
-from sqlalchemy import and_, cast, select, String
+from sqlalchemy import String, and_, cast, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 

--- a/backend/onyx/db/hook.py
+++ b/backend/onyx/db/hook.py
@@ -4,7 +4,7 @@ from uuid import UUID
 from sqlalchemy import delete, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.db.constants import UNSET, UnsetType
 from onyx.db.enums import HookFailStrategy, HookPoint

--- a/backend/onyx/db/image_generation.py
+++ b/backend/onyx/db/image_generation.py
@@ -1,5 +1,5 @@
 from sqlalchemy import select, update
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.db.models import ImageGenerationConfig, LLMProvider, ModelConfiguration
 from onyx.llm.utils import get_max_input_tokens

--- a/backend/onyx/db/index_attempt.py
+++ b/backend/onyx/db/index_attempt.py
@@ -2,8 +2,8 @@ from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from typing import TypeVarTuple
 
-from sqlalchemy import and_, delete, desc, func, Select, select, update
-from sqlalchemy.orm import joinedload, Session
+from sqlalchemy import Select, and_, delete, desc, func, select, update
+from sqlalchemy.orm import Session, joinedload
 
 from onyx.connectors.models import ConnectorFailure
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -22,7 +22,7 @@ from onyx.redis.redis_docprocessing import RedisDocprocessing
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.documents.models import ConnectorCredentialPairIdentifier
 from onyx.utils.logger import setup_logger
-from onyx.utils.telemetry import optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, optional_telemetry
 
 logger = setup_logger()
 

--- a/backend/onyx/db/index_attempt_metrics.py
+++ b/backend/onyx/db/index_attempt_metrics.py
@@ -20,7 +20,7 @@ import time
 from collections.abc import Generator
 from contextlib import contextmanager
 
-from sqlalchemy import case, cast, Float, func, select
+from sqlalchemy import Float, case, cast, func, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 

--- a/backend/onyx/db/input_prompt.py
+++ b/backend/onyx/db/input_prompt.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException
 from sqlalchemy import or_, select
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import aliased, Session
+from sqlalchemy.orm import Session, aliased
 
 from onyx.db.models import InputPrompt, InputPrompt__User, User
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -1,6 +1,6 @@
 from sqlalchemy import delete, or_, select, update
 from sqlalchemy.dialects.postgresql import insert
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.db.enums import LLMModelFlowType
 from onyx.db.models import CloudEmbeddingProvider as CloudEmbeddingProviderModel

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -15,22 +15,22 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     DateTime,
-    desc,
     Enum,
-    event,
     Float,
     ForeignKey,
     ForeignKeyConstraint,
-    func,
     Index,
     Integer,
     PrimaryKeyConstraint,
     Sequence,
     String,
     Text,
+    UniqueConstraint,
+    desc,
+    event,
+    func,
     text,
     true,
-    UniqueConstraint,
 )
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
@@ -39,8 +39,8 @@ from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.orm import (
     DeclarativeBase,
     Mapped,
-    mapped_column,
     Mapper,
+    mapped_column,
     relationship,
     validates,
 )

--- a/backend/onyx/db/pat.py
+++ b/backend/onyx/db/pat.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import contains_eager, Session
+from sqlalchemy.orm import Session, contains_eager
 
 from onyx.auth.pat import (
     build_displayable_pat,

--- a/backend/onyx/db/permission_sync_attempt.py
+++ b/backend/onyx/db/permission_sync_attempt.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.engine.cursor import CursorResult
-from sqlalchemy.orm import joinedload, Session
+from sqlalchemy.orm import Session, joinedload
 
 from onyx.configs.constants import DocumentSource
 from onyx.db.enums import PermissionSyncStatus
@@ -19,7 +19,7 @@ from onyx.db.models import (
     ExternalGroupPermissionSyncAttempt,
 )
 from onyx.utils.logger import setup_logger
-from onyx.utils.telemetry import optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, optional_telemetry
 from onyx.utils.variable_functionality import fetch_ee_implementation_or_noop
 
 logger = setup_logger()

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -4,8 +4,8 @@ from enum import Enum
 from uuid import UUID
 
 from fastapi import HTTPException
-from sqlalchemy import exists, func, not_, or_, Select, select, update
-from sqlalchemy.orm import aliased, selectinload, Session
+from sqlalchemy import Select, exists, func, not_, or_, select, update
+from sqlalchemy.orm import Session, aliased, selectinload
 
 from onyx.access.hierarchy_access import get_user_external_group_ids
 from onyx.auth.schemas import UserRole

--- a/backend/onyx/db/projects.py
+++ b/backend/onyx/db/projects.py
@@ -21,8 +21,8 @@ from onyx.db.enums import UserFileStatus
 from onyx.db.models import Project__UserFile, User, UserFile, UserProject
 from onyx.server.documents.connector import upload_files
 from onyx.server.features.projects.projects_file_utils import (
-    categorize_uploaded_files,
     RejectedFile,
+    categorize_uploaded_files,
 )
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id

--- a/backend/onyx/db/release_notes.py
+++ b/backend/onyx/db/release_notes.py
@@ -8,8 +8,8 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import INSTANCE_TYPE
 from onyx.configs.constants import (
     DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN,
-    NotificationType,
     ONYX_UTM_SOURCE,
+    NotificationType,
 )
 from onyx.db.enums import AccountType
 from onyx.db.models import User

--- a/backend/onyx/db/saml.py
+++ b/backend/onyx/db/saml.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.configs.app_configs import SESSION_EXPIRE_TIME_SECONDS
 from onyx.db.models import SamlAccount

--- a/backend/onyx/db/scheduled_task.py
+++ b/backend/onyx/db/scheduled_task.py
@@ -30,8 +30,8 @@ from onyx.db.models import ScheduledTask, ScheduledTaskPreApprovedApp, Scheduled
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.scheduled_tasks.schedule import (
-    compute_next_run_at,
     EditorMode,
+    compute_next_run_at,
 )
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -19,9 +19,9 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from uuid import UUID
 
-from sqlalchemy import and_, delete, or_, Select, select
+from sqlalchemy import Select, and_, delete, or_, select
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.auth.schemas import UserRole
 from onyx.db.enums import SandboxStatus
@@ -35,7 +35,7 @@ from onyx.db.models import (
     User,
     User__UserGroup,
 )
-from onyx.db.utils import is_fk_violation, is_unique_violation, UNSET, UnsetType
+from onyx.db.utils import UNSET, UnsetType, is_fk_violation, is_unique_violation
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import BUILT_IN_SKILLS

--- a/backend/onyx/db/slack_channel_config.py
+++ b/backend/onyx/db/slack_channel_config.py
@@ -2,7 +2,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from sqlalchemy import select
-from sqlalchemy.orm import joinedload, Session
+from sqlalchemy.orm import Session, joinedload
 
 from onyx.db.constants import (
     DEFAULT_PERSONA_SLACK_CHANNEL_NAME,

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Type, cast
 from uuid import UUID
 
 from sqlalchemy import func, or_, select

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -2,7 +2,7 @@ import datetime
 from uuid import UUID
 
 from sqlalchemy import func, select
-from sqlalchemy.orm import joinedload, selectinload, Session
+from sqlalchemy.orm import Session, joinedload, selectinload
 
 from onyx.db.models import Persona, Project__UserFile, UserFile
 

--- a/backend/onyx/db/utils.py
+++ b/backend/onyx/db/utils.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Any, Final, TypeGuard, TypeVar
 
-from psycopg2 import errorcodes, OperationalError
+from psycopg2 import OperationalError, errorcodes
 from psycopg2.errors import ForeignKeyViolation, UniqueViolation
 from pydantic import BaseModel
 from sqlalchemy import inspect

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -26,11 +26,11 @@ from onyx.configs.constants import MessageType
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.tools import get_tool_by_name
 from onyx.deep_research.dr_mock_tools import (
-    get_clarification_tool_definitions,
-    get_orchestrator_tools,
     RESEARCH_AGENT_TOOL_NAME,
     THINK_TOOL_RESPONSE_MESSAGE,
     THINK_TOOL_RESPONSE_TOKEN_COUNT,
+    get_clarification_tool_definitions,
+    get_orchestrator_tools,
 )
 from onyx.deep_research.utils import (
     check_special_tool_calls,

--- a/backend/onyx/document_index/opensearch/opensearch_document_index.py
+++ b/backend/onyx/document_index/opensearch/opensearch_document_index.py
@@ -9,7 +9,7 @@ from onyx.configs.app_configs import (
     MAX_CHUNKS_PER_DOC_BATCH,
     VERIFY_CREATE_OPENSEARCH_INDEX_ON_INIT_MT,
 )
-from onyx.configs.constants import OnyxRedisLocks, PUBLIC_DOC_PAT
+from onyx.configs.constants import PUBLIC_DOC_PAT, OnyxRedisLocks
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     get_experts_stores_representations,
 )
@@ -45,14 +45,14 @@ from onyx.document_index.opensearch.schema import (
     ACCESS_CONTROL_LIST_FIELD_NAME,
     CONTENT_FIELD_NAME,
     DOCUMENT_SETS_FIELD_NAME,
-    DocumentChunk,
-    DocumentChunkWithoutVectors,
-    DocumentSchema,
-    get_opensearch_doc_chunk_id,
     GLOBAL_BOOST_FIELD_NAME,
     HIDDEN_FIELD_NAME,
     PERSONAS_FIELD_NAME,
     USER_PROJECTS_FIELD_NAME,
+    DocumentChunk,
+    DocumentChunkWithoutVectors,
+    DocumentSchema,
+    get_opensearch_doc_chunk_id,
 )
 from onyx.document_index.opensearch.search import (
     DocumentQuery,

--- a/backend/onyx/document_index/opensearch/schema.py
+++ b/backend/onyx/document_index/opensearch/schema.py
@@ -5,11 +5,11 @@ from typing import Any, Self
 from pydantic import (
     BaseModel,
     Field,
+    SerializerFunctionWrapHandler,
     field_serializer,
     field_validator,
     model_serializer,
     model_validator,
-    SerializerFunctionWrapHandler,
 )
 
 from onyx.configs.app_configs import (
@@ -26,9 +26,9 @@ from onyx.document_index.opensearch.constants import (
     M,
 )
 from onyx.document_index.opensearch.string_filtering import (
+    MAX_DOCUMENT_ID_ENCODED_LENGTH,
     DocumentIDTooLongError,
     filter_and_validate_document_id,
-    MAX_DOCUMENT_ID_ENCODED_LENGTH,
 )
 from onyx.utils.tenant import get_tenant_id_short_string
 from shared_configs.configs import MULTI_TENANT

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -8,7 +8,7 @@ from onyx.configs.app_configs import (
     OPENSEARCH_MATCH_HIGHLIGHTS_DISABLED,
     OPENSEARCH_PROFILING_DISABLED,
 )
-from onyx.configs.constants import DocumentSource, INDEX_SEPARATOR
+from onyx.configs.constants import INDEX_SEPARATOR, DocumentSource
 from onyx.context.search.models import IndexFilters, Tag
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.constants import (
@@ -34,12 +34,12 @@ from onyx.document_index.opensearch.schema import (
     METADATA_LIST_FIELD_NAME,
     PERSONAS_FIELD_NAME,
     PUBLIC_FIELD_NAME,
-    set_or_convert_timezone_to_utc,
     SOURCE_TYPE_FIELD_NAME,
     TENANT_ID_FIELD_NAME,
     TITLE_FIELD_NAME,
     TITLE_VECTOR_FIELD_NAME,
     USER_PROJECTS_FIELD_NAME,
+    set_or_convert_timezone_to_utc,
 )
 
 # See https://docs.opensearch.org/latest/query-dsl/term/terms/.

--- a/backend/onyx/document_index/vespa/vespa_document_index.py
+++ b/backend/onyx/document_index/vespa/vespa_document_index.py
@@ -56,11 +56,11 @@ from onyx.document_index.vespa.chunk_retrieval import (
 from onyx.document_index.vespa.deletion import delete_vespa_chunks
 from onyx.document_index.vespa.indexing_utils import (
     BaseHTTPXClientContext,
+    GlobalHTTPXClientContext,
+    TemporaryHTTPXClientContext,
     batch_index_vespa_chunks,
     check_for_final_chunk_existence,
     clean_chunk_id_copy,
-    GlobalHTTPXClientContext,
-    TemporaryHTTPXClientContext,
 )
 from onyx.document_index.vespa.internal_types import (
     EnrichedDocumentIndexingInfo,

--- a/backend/onyx/evals/providers/braintrust.py
+++ b/backend/onyx/evals/providers/braintrust.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import Any, Union
 
-from braintrust import Eval, EvalCase, init_dataset, Score
+from braintrust import Eval, EvalCase, Score, init_dataset
 
 from onyx.configs.app_configs import BRAINTRUST_MAX_CONCURRENCY, BRAINTRUST_PROJECT
 from onyx.evals.models import (

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -6,7 +6,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy.orm import Session
 
-from onyx.db.enums import EndpointPolicy, ExternalAppType, POLICY_SEVERITY
+from onyx.db.enums import POLICY_SEVERITY, EndpointPolicy, ExternalAppType
 from onyx.db.external_app import get_policies
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.request import MatchContext, ProxiedRequest

--- a/backend/onyx/external_apps/matching/rules.py
+++ b/backend/onyx/external_apps/matching/rules.py
@@ -5,14 +5,14 @@ the dispatch in ``rule_matches`` never changes (open/closed).
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, ClassVar, Generic, get_args, TypeVar
+from typing import Any, ClassVar, Generic, TypeVar, get_args
 
 from onyx.external_apps.matching.request import MatchContext
 from onyx.external_apps.providers.actions import (
     GraphQLOp,
     MatchRule,
-    path_matches,
     RestRoute,
+    path_matches,
 )
 
 RuleT = TypeVar("RuleT")

--- a/backend/onyx/external_apps/providers/actions.py
+++ b/backend/onyx/external_apps/providers/actions.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, InstanceOf
+from pydantic import BaseModel, ConfigDict, Field, InstanceOf, field_validator
 
 from onyx.db.enums import EndpointPolicy
 

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -29,7 +29,7 @@ from onyx.external_apps.providers.base import (
 )
 from onyx.external_apps.providers.registry import get_provider_for_app
 from onyx.external_apps.token_utils import needs_refresh, stamp_expires_at
-from onyx.redis.lock_context import redis_shared_lock, RedisSharedLockAcquisitionError
+from onyx.redis.lock_context import RedisSharedLockAcquisitionError, redis_shared_lock
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -9,7 +9,7 @@ from collections.abc import Callable, Iterator, Sequence
 from email.parser import Parser as EmailParser
 from io import BytesIO
 from pathlib import Path
-from typing import Any, cast, IO, NamedTuple, Optional, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any, NamedTuple, Optional, cast
 from zipfile import BadZipFile
 
 import chardet
@@ -24,10 +24,10 @@ from onyx.configs.app_configs import (
 from onyx.configs.constants import ONYX_METADATA_FILENAME
 from onyx.configs.llm_configs import get_image_extraction_and_analysis_enabled
 from onyx.file_processing.file_types import (
-    OnyxFileExtensions,
-    OnyxMimeTypes,
     PRESENTATION_MIME_TYPE,
     WORD_PROCESSING_MIME_TYPE,
+    OnyxFileExtensions,
+    OnyxMimeTypes,
 )
 from onyx.file_processing.html_utils import parse_html_page_basic
 from onyx.file_processing.unstructured import (

--- a/backend/onyx/file_processing/password_validation.py
+++ b/backend/onyx/file_processing/password_validation.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
-from typing import Any, IO
+from typing import IO, Any
 
 from onyx.file_processing.extract_file_text import get_file_ext
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/file_processing/unstructured.py
+++ b/backend/onyx/file_processing/unstructured.py
@@ -1,4 +1,4 @@
-from typing import Any, cast, IO, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any, cast
 
 from onyx.configs.constants import KV_UNSTRUCTURED_API_KEY
 from onyx.key_value_store.factory import get_kv_store

--- a/backend/onyx/file_store/file_store.py
+++ b/backend/onyx/file_store/file_store.py
@@ -3,7 +3,7 @@ import tempfile
 import uuid
 from abc import ABC, abstractmethod
 from io import BytesIO
-from typing import Any, cast, IO, NotRequired, TYPE_CHECKING, TypedDict
+from typing import IO, TYPE_CHECKING, Any, NotRequired, TypedDict, cast
 
 import boto3
 import puremagic

--- a/backend/onyx/file_store/gcs_file_store.py
+++ b/backend/onyx/file_store/gcs_file_store.py
@@ -4,7 +4,7 @@ import json
 import tempfile
 import uuid
 from io import BytesIO
-from typing import Any, cast, IO, TYPE_CHECKING
+from typing import IO, TYPE_CHECKING, Any, cast
 
 import puremagic
 from sqlalchemy.orm import Session

--- a/backend/onyx/file_store/postgres_file_store.py
+++ b/backend/onyx/file_store/postgres_file_store.py
@@ -7,7 +7,7 @@ eliminating the need for an external S3/MinIO service.
 import tempfile
 import uuid
 from io import BytesIO
-from typing import Any, cast, IO
+from typing import IO, Any, cast
 
 import puremagic
 from psycopg2.extensions import connection as Psycopg2Connection

--- a/backend/onyx/file_store/staging.py
+++ b/backend/onyx/file_store/staging.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from typing import Any, IO
+from typing import IO, Any
 
 from sqlalchemy.orm import Session
 

--- a/backend/onyx/hooks/models.py
+++ b/backend/onyx/hooks/models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum
 from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, field_validator, model_validator, SecretStr
+from pydantic import BaseModel, Field, SecretStr, field_validator, model_validator
 
 from onyx.db.enums import HookFailStrategy, HookPoint
 

--- a/backend/onyx/image_gen/interfaces.py
+++ b/backend/onyx/image_gen/interfaces.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 

--- a/backend/onyx/image_gen/providers/azure_img_gen.py
+++ b/backend/onyx/image_gen/providers/azure_img_gen.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from onyx.image_gen.interfaces import (
     ImageGenerationProvider,

--- a/backend/onyx/image_gen/providers/openai_img_gen.py
+++ b/backend/onyx/image_gen/providers/openai_img_gen.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from onyx.image_gen.interfaces import (
     ImageGenerationProvider,

--- a/backend/onyx/image_gen/providers/vertex_img_gen.py
+++ b/backend/onyx/image_gen/providers/vertex_img_gen.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 import json
 from datetime import datetime
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 

--- a/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
+++ b/backend/onyx/indexing/adapters/user_file_indexing_adapter.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.access.access import get_access_for_user_files
 from onyx.access.models import DocumentAccess

--- a/backend/onyx/indexing/chunker.py
+++ b/backend/onyx/indexing/chunker.py
@@ -9,7 +9,7 @@ from onyx.configs.app_configs import (
     USE_CHUNK_SUMMARY,
     USE_DOCUMENT_SUMMARY,
 )
-from onyx.configs.constants import DocumentSource, RETURN_SEPARATOR, SECTION_SEPARATOR
+from onyx.configs.constants import RETURN_SEPARATOR, SECTION_SEPARATOR, DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import (
     get_metadata_keys_to_ignore,
 )

--- a/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
+++ b/backend/onyx/indexing/chunking/tabular_section_chunker/tabular_section_chunker.py
@@ -21,7 +21,7 @@ from onyx.natural_language_processing.utils import (
     count_tokens,
     split_text_by_tokens,
 )
-from onyx.utils.csv_utils import parse_csv_string, ParsedRow, read_csv_header
+from onyx.utils.csv_utils import ParsedRow, parse_csv_string, read_csv_header
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -61,7 +61,7 @@ from onyx.document_index.interfaces_new import (
 from onyx.file_processing.image_summarization import summarize_image_with_error_handling
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.staging import promote_staged_file
-from onyx.hooks.executor import execute_hook, HookSkipped, HookSoftFailed
+from onyx.hooks.executor import HookSkipped, HookSoftFailed, execute_hook
 from onyx.hooks.points.document_ingestion import (
     DocumentIngestionOwner,
     DocumentIngestionPayload,
@@ -71,7 +71,7 @@ from onyx.hooks.points.document_ingestion import (
 from onyx.hooks.points.document_push import DocumentPushPayload, DocumentPushResponse
 from onyx.indexing.chunk_batch_store import ChunkBatchStore
 from onyx.indexing.chunker import Chunker
-from onyx.indexing.embedder import embed_chunks_with_failure_handling, IndexingEmbedder
+from onyx.indexing.embedder import IndexingEmbedder, embed_chunks_with_failure_handling
 from onyx.indexing.models import (
     DocAwareChunk,
     DocMetadataAwareIndexChunk,
@@ -83,7 +83,7 @@ from onyx.llm.factory import get_default_llm_with_vision, get_llm_for_contextual
 from onyx.llm.interfaces import LLM
 from onyx.llm.models import UserMessage
 from onyx.llm.multi_llm import LLMRateLimitError
-from onyx.llm.utils import llm_response_to_string, MAX_CONTEXT_TOKENS
+from onyx.llm.utils import MAX_CONTEXT_TOKENS, llm_response_to_string
 from onyx.natural_language_processing.utils import (
     BaseTokenizer,
     get_tokenizer,

--- a/backend/onyx/indexing/models.py
+++ b/backend/onyx/indexing/models.py
@@ -1,6 +1,6 @@
 import contextlib
 from collections.abc import Generator
-from typing import Optional, Protocol, TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, Protocol
 
 from pydantic import BaseModel, Field
 

--- a/backend/onyx/kg/clustering/normalizations.py
+++ b/backend/onyx/kg/clustering/normalizations.py
@@ -4,7 +4,7 @@ from typing import cast
 
 import numpy as np
 from rapidfuzz.distance.DamerauLevenshtein import normalized_similarity
-from sqlalchemy import desc, Float, func, MetaData, select, String, Table
+from sqlalchemy import Float, MetaData, String, Table, desc, func, select
 from sqlalchemy.dialects.postgresql import ARRAY
 
 from onyx.configs.kg_configs import (

--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -61,7 +61,7 @@ Status checked against LiteLLM v1.85.1 (2026-05-26):
 
 import time
 import uuid
-from typing import Any, cast, List, Optional
+from typing import Any, List, Optional, cast
 
 from litellm.completion_extras.litellm_responses_transformation.transformation import (
     LiteLLMResponsesTransformationHandler,

--- a/backend/onyx/llm/model_name_parser.py
+++ b/backend/onyx/llm/model_name_parser.py
@@ -23,10 +23,10 @@ from pydantic import BaseModel
 from onyx.llm.constants import (
     AGGREGATOR_PROVIDERS,
     HYPHENATED_MODEL_NAMES,
-    LlmProviderNames,
     MODEL_PREFIX_TO_VENDOR,
     PROVIDER_DISPLAY_NAMES,
     VENDOR_BRAND_NAMES,
+    LlmProviderNames,
 )
 
 

--- a/backend/onyx/llm/model_response.py
+++ b/backend/onyx/llm/model_response.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, List
 
 from pydantic import BaseModel, Field
 

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -3,7 +3,7 @@ import os
 import threading
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
-from typing import Any, cast, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union, cast
 
 from onyx.configs.app_configs import (
     MOCK_LLM_RESPONSE,
@@ -17,8 +17,8 @@ from onyx.configs.model_configs import GEN_AI_TEMPERATURE, LITELLM_EXTRA_BODY
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.cost import calculate_llm_cost_cents
 from onyx.llm.interfaces import (
-    LanguageModelInput,
     LLM,
+    LanguageModelInput,
     LLMConfig,
     LLMUserIdentity,
     ReasoningEffort,
@@ -460,7 +460,7 @@ class LitellmLLM(LLM):
             return
         # Import here to avoid circular imports
         from onyx.db.engine.sql_engine import get_session_with_current_tenant
-        from onyx.db.usage import increment_usage, UsageType
+        from onyx.db.usage import UsageType, increment_usage
 
         # Calculate cost in cents
         cost_cents = calculate_llm_cost_cents(

--- a/backend/onyx/llm/tracing_wrap.py
+++ b/backend/onyx/llm/tracing_wrap.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import functools
 import inspect
 from collections.abc import Callable, Iterator
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from onyx.llm.model_response import ChatCompletionDeltaToolCall, Usage
 from onyx.llm.model_response import FunctionCall as DeltaFunctionCall

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -2,7 +2,7 @@ import copy
 import re
 from collections.abc import Callable, Iterable
 from functools import lru_cache
-from typing import Any, cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from sqlalchemy import select
 

--- a/backend/onyx/llm/well_known_providers/llm_provider_options.py
+++ b/backend/onyx/llm/well_known_providers/llm_provider_options.py
@@ -4,9 +4,9 @@ import threading
 import time
 
 from onyx.llm.constants import (
-    LlmProviderNames,
     PROVIDER_DISPLAY_NAMES,
     WELL_KNOWN_PROVIDER_NAMES,
+    LlmProviderNames,
 )
 from onyx.llm.utils import get_max_input_tokens, model_supports_image_input
 from onyx.llm.well_known_providers.auto_update_models import LLMRecommendations

--- a/backend/onyx/main.py
+++ b/backend/onyx/main.py
@@ -53,13 +53,13 @@ from onyx.configs.app_configs import (
     USER_AUTH_SECRET,
     WEB_DOMAIN,
 )
-from onyx.configs.constants import AuthType, POSTGRES_WEB_APP_NAME
+from onyx.configs.constants import POSTGRES_WEB_APP_NAME, AuthType
 from onyx.db.engine.async_sql_engine import (
     get_sqlalchemy_async_engine,
     reset_sqlalchemy_async_engine,
 )
 from onyx.db.engine.connection_warmup import warm_up_connections
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.error_handling.exceptions import register_onyx_exception_handlers
 from onyx.file_store.file_store import get_default_file_store
 from onyx.hooks.registry import validate_registry
@@ -134,9 +134,9 @@ from onyx.server.metrics.postgres_connection_pool import (
 from onyx.server.metrics.prometheus_setup import setup_prometheus_metrics
 from onyx.server.middleware.latency_logging import add_latency_logging_middleware
 from onyx.server.middleware.rate_limiting import (
+    RATE_LIMITING_ENABLED,
     close_auth_limiter,
     get_auth_rate_limiters,
-    RATE_LIMITING_ENABLED,
     setup_auth_limiter,
 )
 from onyx.server.onyx_api.ingestion import router as onyx_api_router
@@ -158,7 +158,7 @@ from onyx.utils.middleware import (
     add_endpoint_context_middleware,
     add_onyx_request_id_middleware,
 )
-from onyx.utils.telemetry import get_or_generate_uuid, optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, get_or_generate_uuid, optional_telemetry
 from onyx.utils.variable_functionality import (
     fetch_ee_implementation_or_noop,
     fetch_versioned_implementation,

--- a/backend/onyx/natural_language_processing/query_embedding_cache.py
+++ b/backend/onyx/natural_language_processing/query_embedding_cache.py
@@ -21,10 +21,10 @@ import struct
 from onyx.cache.factory import get_cache_backend
 from onyx.cache.interface import CACHE_TRANSIENT_ERRORS
 from onyx.server.metrics.embedding import (
-    observe_query_embedding_cache_lookup,
-    observe_query_embedding_cache_write,
     QueryEmbeddingCacheLookupOutcome,
     QueryEmbeddingCacheWriteOutcome,
+    observe_query_embedding_cache_lookup,
+    observe_query_embedding_cache_write,
 )
 from onyx.utils.logger import setup_logger
 from shared_configs.enums import EmbeddingProvider

--- a/backend/onyx/natural_language_processing/search_nlp_models.py
+++ b/backend/onyx/natural_language_processing/search_nlp_models.py
@@ -4,7 +4,7 @@ import os
 import threading
 import time
 from collections.abc import Callable
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import wraps
 from types import TracebackType
 from typing import Any, cast

--- a/backend/onyx/onyxbot/slack/formatting.py
+++ b/backend/onyx/onyxbot/slack/formatting.py
@@ -2,7 +2,7 @@ import re
 from collections.abc import Callable
 from typing import Any
 
-from mistune import create_markdown, HTMLRenderer
+from mistune import HTMLRenderer, create_markdown
 
 # Tags that should be replaced with a newline (line-break and block-level elements)
 _HTML_NEWLINE_TAG_PATTERN = re.compile(

--- a/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_buttons.py
@@ -25,11 +25,11 @@ from onyx.onyxbot.slack.blocks import (
 from onyx.onyxbot.slack.config import get_slack_channel_config_for_bot_and_channel
 from onyx.onyxbot.slack.constants import (
     DISLIKE_BLOCK_ACTION_ID,
-    FeedbackVisibility,
     KEEP_TO_YOURSELF_ACTION_ID,
     LIKE_BLOCK_ACTION_ID,
     SHOW_EVERYONE_ACTION_ID,
     VIEW_DOC_FEEDBACK_ID,
+    FeedbackVisibility,
 )
 from onyx.onyxbot.slack.handlers.handle_message import (
     remove_scheduled_feedback_reminder,
@@ -37,6 +37,7 @@ from onyx.onyxbot.slack.handlers.handle_message import (
 from onyx.onyxbot.slack.handlers.handle_regular_answer import handle_regular_answer
 from onyx.onyxbot.slack.models import SlackMessageInfo
 from onyx.onyxbot.slack.utils import (
+    TenantSocketModeClient,
     build_feedback_id,
     decompose_action_id,
     fetch_group_ids_from_names,
@@ -45,7 +46,6 @@ from onyx.onyxbot.slack.utils import (
     get_feedback_visibility,
     read_slack_thread,
     respond_in_thread_or_channel,
-    TenantSocketModeClient,
     update_emote_react,
 )
 from onyx.server.query_and_chat.models import ChatMessageDetail

--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -24,10 +24,10 @@ from onyx.onyxbot.slack.blocks import build_slack_response_blocks
 from onyx.onyxbot.slack.constants import SLACK_CHANNEL_REF_PATTERN
 from onyx.onyxbot.slack.models import SlackMessageInfo, ThreadMessage
 from onyx.onyxbot.slack.utils import (
+    SlackRateLimiter,
     get_channel_from_id,
     get_channel_name_from_id,
     respond_in_thread_or_channel,
-    SlackRateLimiter,
     update_emote_react,
 )
 from onyx.server.query_and_chat.models import (

--- a/backend/onyx/onyxbot/slack/listener.py
+++ b/backend/onyx/onyxbot/slack/listener.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from contextvars import Token
 from threading import Event
 from types import FrameType
-from typing import Any, cast, Dict
+from typing import Any, Dict, cast
 
 import psycopg2.errors
 from prometheus_client import Gauge, start_http_server
@@ -31,9 +31,9 @@ from onyx.configs.constants import MessageType, OnyxRedisLocks
 from onyx.configs.onyxbot_configs import NOTIFY_SLACKBOT_NO_ANSWER
 from onyx.connectors.slack.utils import expert_info_from_slack_id
 from onyx.db.engine.sql_engine import (
+    SqlEngine,
     get_session_with_current_tenant,
     get_session_with_tenant,
-    SqlEngine,
 )
 from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.db.models import SlackBot
@@ -45,12 +45,12 @@ from onyx.natural_language_processing.search_nlp_models import (
     warm_up_bi_encoder,
 )
 from onyx.onyxbot.slack.config import (
-    get_slack_channel_config_for_bot_and_channel,
     MAX_TENANTS_PER_POD,
     TENANT_ACQUISITION_INTERVAL,
     TENANT_HEARTBEAT_EXPIRATION,
     TENANT_HEARTBEAT_INTERVAL,
     TENANT_LOCK_EXPIRATION,
+    get_slack_channel_config_for_bot_and_channel,
 )
 from onyx.onyxbot.slack.constants import (
     DISLIKE_BLOCK_ACTION_ID,
@@ -79,6 +79,7 @@ from onyx.onyxbot.slack.handlers.handle_message import (
 )
 from onyx.onyxbot.slack.models import SlackContext, SlackMessageInfo, ThreadMessage
 from onyx.onyxbot.slack.utils import (
+    TenantSocketModeClient,
     check_message_limit,
     decompose_action_id,
     get_channel_name_from_id,
@@ -87,7 +88,6 @@ from onyx.onyxbot.slack.utils import (
     read_slack_thread,
     remove_onyx_bot_tag,
     respond_in_thread_or_channel,
-    TenantSocketModeClient,
 )
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.manage.models import SlackBotTokens

--- a/backend/onyx/onyxbot/slack/utils.py
+++ b/backend/onyx/onyxbot/slack/utils.py
@@ -32,7 +32,7 @@ from onyx.db.users import get_user_by_email
 from onyx.onyxbot.slack.constants import FeedbackVisibility
 from onyx.onyxbot.slack.models import ChannelType, ThreadMessage
 from onyx.utils.logger import setup_logger
-from onyx.utils.telemetry import optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, optional_telemetry
 from onyx.utils.text_processing import replace_whitespaces_w_space
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 

--- a/backend/onyx/redis/redis_connector_doc_perm_sync.py
+++ b/backend/onyx/redis/redis_connector_doc_perm_sync.py
@@ -1,7 +1,7 @@
 import time
 from datetime import datetime
 from logging import Logger
-from typing import Any, cast, NamedTuple
+from typing import Any, NamedTuple, cast
 
 from pydantic import BaseModel
 from redis.lock import Lock as RedisLock

--- a/backend/onyx/redis/redis_hierarchy.py
+++ b/backend/onyx/redis/redis_hierarchy.py
@@ -16,7 +16,7 @@ Cache Strategy:
   using only the SOURCE-type node as the ancestor
 """
 
-from typing import cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from pydantic import BaseModel
 from redis.lock import Lock as RedisLock

--- a/backend/onyx/redis/redis_pool.py
+++ b/backend/onyx/redis/redis_pool.py
@@ -2,7 +2,7 @@ import asyncio
 import json
 import ssl
 import threading
-from typing import Any, cast, Optional
+from typing import Any, Optional, cast
 
 import redis
 from fastapi import Request

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Protocol
 from uuid import UUID
 
-from cachetools import cachedmethod, TTLCache
+from cachetools import TTLCache, cachedmethod
 from mitmproxy import http
 from sqlalchemy.orm import Session
 
@@ -23,14 +23,14 @@ from onyx.configs.constants import NotificationType
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, EndpointPolicy
 from onyx.db.notification import create_notification
-from onyx.db.scheduled_task import get_live_scheduled_run_grants, ScheduledRunGrants
+from onyx.db.scheduled_task import ScheduledRunGrants, get_live_scheduled_run_grants
 from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy import approval_cache
 from onyx.sandbox_proxy.credential_injection import (
     CredentialInjectionDispatcher,
     InjectionContext,
 )
-from onyx.sandbox_proxy.errors import http_403, SandboxProxyError
+from onyx.sandbox_proxy.errors import SandboxProxyError, http_403
 from onyx.sandbox_proxy.identity import ResolvedSandbox, SessionContext
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy

--- a/backend/onyx/sandbox_proxy/credential_injection.py
+++ b/backend/onyx/sandbox_proxy/credential_injection.py
@@ -19,7 +19,7 @@ from typing import Protocol
 from mitmproxy import http
 
 from onyx.external_apps.matching.engine import AllMatchedActions
-from onyx.sandbox_proxy.errors import http_403, SandboxProxyError
+from onyx.sandbox_proxy.errors import SandboxProxyError, http_403
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/server/api_key_usage.py
+++ b/backend/onyx/server/api_key_usage.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.api_key import get_hashed_api_key_from_request
 from onyx.auth.pat import get_hashed_pat_from_request
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.usage import increment_usage, UsageType
+from onyx.db.usage import UsageType, increment_usage
 from onyx.server.usage_limits import check_usage_and_raise, is_usage_limits_enabled
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import get_current_tenant_id

--- a/backend/onyx/server/auth/captcha_api.py
+++ b/backend/onyx/server/auth/captcha_api.py
@@ -33,7 +33,7 @@ from onyx.configs.app_configs import (
 )
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import onyx_error_to_json_response, OnyxError
+from onyx.error_handling.exceptions import OnyxError, onyx_error_to_json_response
 from onyx.utils.client_ip import get_client_ip
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -13,10 +13,10 @@ from onyx.background.celery.tasks.pruning.tasks import try_creating_prune_genera
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.background.indexing.models import IndexAttemptErrorPydantic
 from onyx.configs.constants import (
+    PUBLIC_API_TAGS,
     DocumentSource,
     OnyxCeleryPriority,
     OnyxCeleryTask,
-    PUBLIC_API_TAGS,
 )
 from onyx.connectors.exceptions import ValidationError
 from onyx.connectors.factory import identify_connector_class, validate_ccpair_for_user

--- a/backend/onyx/server/documents/connector.py
+++ b/backend/onyx/server/documents/connector.py
@@ -33,13 +33,13 @@ from onyx.configs.app_configs import (
     MOCK_CONNECTOR_FILE_PATH,
 )
 from onyx.configs.constants import (
+    ONYX_METADATA_FILENAME,
+    PUBLIC_API_TAGS,
     DocumentSource,
     FileOrigin,
     MilestoneRecordType,
-    ONYX_METADATA_FILENAME,
     OnyxCeleryPriority,
     OnyxCeleryTask,
-    PUBLIC_API_TAGS,
 )
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.factory import validate_ccpair_for_user

--- a/backend/onyx/server/documents/credential.py
+++ b/backend/onyx/server/documents/credential.py
@@ -8,10 +8,10 @@ from onyx.auth.users import current_curator_or_admin_user
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.connectors.factory import validate_ccpair_for_user
 from onyx.db.credentials import (
+    CREDENTIAL_PERMISSIONS_TO_IGNORE,
     alter_credential,
     cleanup_gmail_credentials,
     create_credential,
-    CREDENTIAL_PERMISSIONS_TO_IGNORE,
     delete_credential,
     delete_credential_for_user,
     fetch_credential_by_id_for_user,

--- a/backend/onyx/server/documents/models.py
+++ b/backend/onyx/server/documents/models.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime, timezone, UTC
+from datetime import UTC, datetime, timezone
 from enum import Enum
 from typing import Any, Generic, TypeVar
 from uuid import UUID
@@ -15,8 +15,8 @@ from onyx.db.enums import (
     ProcessingMode,
 )
 from onyx.db.index_attempt_metrics_models import (
-    IndexAttemptStage,
     STAGE_SCOPE,
+    IndexAttemptStage,
     StageScope,
 )
 from onyx.db.models import (

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -25,12 +25,12 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import IndexingStatus
 from onyx.db.models import User
 from onyx.db.targeted_reindex import (
+    MAX_TARGETS_PER_REQUEST,
+    TargetSpec,
     count_targets_for_job,
     create_targeted_reindex_job,
     get_targeted_reindex_job,
-    MAX_TARGETS_PER_REQUEST,
     resolve_error_ids_to_targets,
-    TargetSpec,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError

--- a/backend/onyx/server/features/build/api/external_apps_api.py
+++ b/backend/onyx/server/features/build/api/external_apps_api.py
@@ -19,7 +19,7 @@ from onyx.db.external_app import (
 )
 from onyx.db.models import ExternalApp, ExternalAppUserCredential, User
 from onyx.db.skill import affected_user_ids_for_skill
-from onyx.db.utils import none_as_unset, UNSET
+from onyx.db.utils import UNSET, none_as_unset
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.registry import (

--- a/backend/onyx/server/features/build/api/models.py
+++ b/backend/onyx/server/features/build/api/models.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Any, Union
 
 from pydantic import BaseModel
 

--- a/backend/onyx/server/features/build/approvals/api.py
+++ b/backend/onyx/server/features/build/approvals/api.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 from uuid import UUID
 
 from fastapi import APIRouter, Depends
-from pydantic import BaseModel, computed_field, ConfigDict
+from pydantic import BaseModel, ConfigDict, computed_field
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission

--- a/backend/onyx/server/features/build/db/action_approval.py
+++ b/backend/onyx/server/features/build/db/action_approval.py
@@ -11,10 +11,10 @@ from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import (
+    POLICY_SEVERITY,
     ApprovalDecidedVia,
     ApprovalDecision,
     EndpointPolicy,
-    POLICY_SEVERITY,
 )
 from onyx.db.models import ActionApproval, BuildSession
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from sqlalchemy import desc, exists, select
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import selectinload, Session
+from sqlalchemy.orm import Session, selectinload
 
 from onyx.auth.schemas import UserRole
 from onyx.configs.constants import MessageType

--- a/backend/onyx/server/features/build/db/user_library.py
+++ b/backend/onyx/server/features/build/db/user_library.py
@@ -8,7 +8,7 @@ import hashlib
 import io
 from uuid import UUID
 
-from sqlalchemy import and_, cast, func, Integer, select
+from sqlalchemy import Integer, and_, cast, func, select
 from sqlalchemy.orm import Session
 
 from onyx.configs.constants import DocumentSource, FileOrigin

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/extract.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/extract.py
@@ -3,7 +3,7 @@ import os
 import shutil
 import tarfile
 import threading
-from datetime import datetime, UTC
+from datetime import UTC, datetime
 from pathlib import Path
 
 MAX_FILE_BYTES = 25 * 1024 * 1024  # 25 MiB per entry

--- a/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
+++ b/backend/onyx/server/features/build/sandbox/image/sandbox_daemon/server.py
@@ -16,7 +16,7 @@ from sandbox_daemon.models import (
     SnapshotCreateResponse,
     SnapshotRestoreRequest,
 )
-from sandbox_daemon.snapshot import create_snapshot, restore_snapshot, SnapshotError
+from sandbox_daemon.snapshot import SnapshotError, create_snapshot, restore_snapshot
 
 app = FastAPI(title="sandbox-sidecar", docs_url=None, redoc_url=None)
 

--- a/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
+++ b/backend/onyx/server/features/build/sandbox/opencode/serve_client.py
@@ -37,9 +37,9 @@ from onyx.server.features.build.sandbox.event_schema import (
     ToolCallStart,
 )
 from onyx.server.features.build.sandbox.opencode.event_bus import (
-    _Subscription,
     BUS_CLOSED_SENTINEL,
     PodEventBus,
+    _Subscription,
 )
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -37,8 +37,8 @@ from onyx.server.features.build.sandbox.opencode.event_bus import (
     PodEventBus,
 )
 from onyx.server.features.build.sandbox.opencode.serve_client import (
-    _TurnState,
     OpencodeServeClient,
+    _TurnState,
     translate_opencode_event,
 )
 from onyx.server.features.build.sandbox.sse import SSEKeepalive

--- a/backend/onyx/server/features/build/sandbox/tasks/tasks.py
+++ b/backend/onyx/server/features/build/sandbox/tasks/tasks.py
@@ -1,6 +1,6 @@
 """Celery tasks for sandbox operations (cleanup, etc.)."""
 
-from celery import shared_task, Task
+from celery import Task, shared_task
 from redis.lock import Lock as RedisLock
 
 from onyx.background.celery.apps.app_base import task_logger

--- a/backend/onyx/server/features/build/scheduled_tasks/api.py
+++ b/backend/onyx/server/features/build/scheduled_tasks/api.py
@@ -45,10 +45,10 @@ from onyx.db.scheduled_task import (
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.scheduled_tasks.schedule import (
-    compile_to_cron,
     EDITOR_PAYLOAD_MODELS,
     EditorMode,
     EditorPayload,
+    compile_to_cron,
     human_readable,
     next_n_fires,
 )

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -19,9 +19,9 @@ from pydantic import AnyUrl, BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import (
+    OAuthFlowParams,
     build_oauth_authorization_url,
     exchange_oauth_code_for_token,
-    OAuthFlowParams,
     validate_oauth_endpoint_url,
 )
 from onyx.auth.permissions import require_permission
@@ -65,7 +65,6 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.mcp.models import (
-    apply_auto_substitutions,
     MCPApiKeyResponse,
     MCPAuthTemplate,
     MCPConnectionData,
@@ -83,6 +82,7 @@ from onyx.server.features.mcp.models import (
     MCPUserCredentialsRequest,
     MCPUserOAuthConnectRequest,
     MCPUserOAuthConnectResponse,
+    apply_auto_substitutions,
 )
 from onyx.server.features.tool.models import ToolSnapshot
 from onyx.tools.tool_implementations.mcp.mcp_client import (

--- a/backend/onyx/server/features/password/api.py
+++ b/backend/onyx/server/features/password/api.py
@@ -3,7 +3,7 @@ from fastapi_users.exceptions import InvalidPasswordException
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import require_permission
-from onyx.auth.users import get_user_manager, User, UserManager
+from onyx.auth.users import User, UserManager, get_user_manager
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.users import get_user_by_email

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -21,7 +21,7 @@ from onyx.auth.users import (
     current_limited_user,
 )
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
-from onyx.configs.constants import FileOrigin, MilestoneRecordType, PUBLIC_API_TAGS
+from onyx.configs.constants import PUBLIC_API_TAGS, FileOrigin, MilestoneRecordType
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.file_record import get_filerecord_by_file_id_optional

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -17,11 +17,11 @@ from sqlalchemy.orm import Session
 from onyx.auth.permissions import require_permission
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import (
+    PUBLIC_API_TAGS,
+    USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
     OnyxCeleryPriority,
     OnyxCeleryQueues,
     OnyxCeleryTask,
-    PUBLIC_API_TAGS,
-    USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
 )
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission, UserFileStatus

--- a/backend/onyx/server/manage/administrative.py
+++ b/backend/onyx/server/manage/administrative.py
@@ -10,11 +10,11 @@ from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.background.indexing.models import IndexAttemptErrorPydantic
 from onyx.configs.app_configs import GENERATIVE_MODEL_ACCESS_CHECK_FREQ
 from onyx.configs.constants import (
-    DocumentSource,
     KV_GEN_AI_KEY_CHECK_TIME,
+    PUBLIC_API_TAGS,
+    DocumentSource,
     OnyxCeleryPriority,
     OnyxCeleryTask,
-    PUBLIC_API_TAGS,
 )
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pair_for_user,

--- a/backend/onyx/server/manage/get_state.py
+++ b/backend/onyx/server/manage/get_state.py
@@ -8,10 +8,10 @@ from onyx import __version__
 from onyx.auth.users import anonymous_user_enabled, user_needs_to_be_verified
 from onyx.configs.app_configs import AUTH_TYPE, OAUTH_ENABLED
 from onyx.configs.constants import (
-    AuthType,
     DEV_VERSION_PATTERN,
     PUBLIC_API_TAGS,
     STABLE_VERSION_PATTERN,
+    AuthType,
 )
 from onyx.db.auth import get_user_count
 from onyx.server.manage.models import (

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -38,9 +38,9 @@ from onyx.db.persona import user_can_access_persona
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.llm.constants import (
-    LlmProviderNames,
     PROVIDER_DISPLAY_NAMES,
     WELL_KNOWN_PROVIDER_NAMES,
+    LlmProviderNames,
 )
 from onyx.llm.factory import (
     get_default_llm,
@@ -66,8 +66,8 @@ from onyx.llm.well_known_providers.constants import (
     VERTEX_PROJECT_KWARG,
 )
 from onyx.llm.well_known_providers.llm_provider_options import (
-    fetch_available_well_known_llms,
     WellKnownLLMProviderDescriptor,
+    fetch_available_well_known_llms,
 )
 from onyx.server.manage.llm.models import (
     BedrockFinalModelResponse,
@@ -105,13 +105,13 @@ from onyx.server.manage.llm.provider_cache import (
     invalidate_provider_listing_cache,
 )
 from onyx.server.manage.llm.utils import (
+    ModelMetadata,
     generate_bedrock_display_name,
     generate_ollama_display_name,
     infer_vision_support,
     is_embedding_model,
     is_reasoning_model,
     is_valid_bedrock_model,
-    ModelMetadata,
     strip_openrouter_vendor_prefix,
 )
 from onyx.utils.encryption import mask_string as mask_with_ellipsis

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import cached_property
-from typing import Any, Generic, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 from pydantic import BaseModel, Field, field_validator
 

--- a/backend/onyx/server/manage/llm/utils.py
+++ b/backend/onyx/server/manage/llm/utils.py
@@ -12,11 +12,11 @@ from typing import TypedDict
 
 from onyx.llm.constants import (
     BEDROCK_MODEL_NAME_MAPPINGS,
-    LlmProviderNames,
     MODEL_PREFIX_TO_VENDOR,
     OLLAMA_MODEL_NAME_MAPPINGS,
     OLLAMA_MODEL_TO_VENDOR,
     PROVIDER_DISPLAY_NAMES,
+    LlmProviderNames,
 )
 
 # Dynamic providers fetch models directly from source APIs (not LiteLLM)

--- a/backend/onyx/server/manage/models.py
+++ b/backend/onyx/server/manage/models.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 

--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -32,7 +32,6 @@ from onyx.auth.users import (
 from onyx.configs.app_configs import (
     AUTH_BACKEND,
     AUTH_TYPE,
-    AuthBackend,
     DEV_MODE,
     EMAIL_CONFIGURED,
     ENABLE_EMAIL_INVITES,
@@ -40,6 +39,7 @@ from onyx.configs.app_configs import (
     REDIS_AUTH_KEY_PREFIX,
     SESSION_EXPIRE_TIME_SECONDS,
     USER_AUTH_SECRET,
+    AuthBackend,
 )
 from onyx.configs.constants import FASTAPI_USERS_AUTH_COOKIE_NAME, PUBLIC_API_TAGS
 from onyx.db.api_key import is_api_key_email_address

--- a/backend/onyx/server/manage/voice/user_api.py
+++ b/backend/onyx/server/manage/voice/user_api.py
@@ -18,7 +18,7 @@ from onyx.db.voice import (
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.redis.redis_pool import store_ws_token, WsTokenRateLimitExceeded
+from onyx.redis.redis_pool import WsTokenRateLimitExceeded, store_ws_token
 from onyx.server.manage.models import VoiceSettingsUpdateRequest
 from onyx.server.manage.voice.text_utils import strip_markdown_for_tts
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/server/metrics/postgres_connection_pool.py
+++ b/backend/onyx/server/metrics/postgres_connection_pool.py
@@ -18,7 +18,7 @@ from fastapi import Request
 from fastapi.responses import JSONResponse
 from prometheus_client import Counter, Gauge, Histogram
 from prometheus_client.core import GaugeMetricFamily
-from prometheus_client.registry import Collector, REGISTRY
+from prometheus_client.registry import REGISTRY, Collector
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
 from sqlalchemy.engine.interfaces import DBAPIConnection

--- a/backend/onyx/server/middleware/rate_limiting.py
+++ b/backend/onyx/server/middleware/rate_limiting.py
@@ -1,4 +1,4 @@
-from fastapi import Depends, params, Request, Response
+from fastapi import Depends, Request, Response, params
 from fastapi_limiter import FastAPILimiter
 from fastapi_limiter.depends import RateLimiter
 

--- a/backend/onyx/server/pat/api.py
+++ b/backend/onyx/server/pat/api.py
@@ -11,10 +11,10 @@ from onyx.db.pat import create_pat, list_user_pats, revoke_pat
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.pat.models import (
+    SELECTABLE_PAT_SCOPES,
     CreatedTokenResponse,
     CreateTokenRequest,
     PatScopeOption,
-    SELECTABLE_PAT_SCOPES,
     TokenResponse,
 )
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/server/pat/models.py
+++ b/backend/onyx/server/pat/models.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, computed_field, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, field_validator
 
 from onyx.auth.permissions import resolve_effective_permissions
 from onyx.db.enums import Permission

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -33,7 +33,7 @@ from onyx.chat.prompt_utils import get_default_base_system_prompt
 from onyx.chat.stop_signal_checker import set_fence
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.chat_configs import HARD_DELETE_CHATS
-from onyx.configs.constants import MessageType, MilestoneRecordType, PUBLIC_API_TAGS
+from onyx.configs.constants import PUBLIC_API_TAGS, MessageType, MilestoneRecordType
 from onyx.configs.model_configs import LITELLM_PASS_THROUGH_HEADERS
 from onyx.db.chat import (
     add_chats_to_session_from_slack_thread,
@@ -55,7 +55,7 @@ from onyx.db.enums import Permission
 from onyx.db.feedback import create_chat_message_feedback, remove_chat_message_feedback
 from onyx.db.models import ChatSessionSharedStatus, Persona, User
 from onyx.db.persona import get_persona_by_id
-from onyx.db.usage import increment_usage, UsageType
+from onyx.db.usage import UsageType, increment_usage
 from onyx.db.user_file import get_file_id_by_user_file_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError

--- a/backend/onyx/server/query_and_chat/session_loading.py
+++ b/backend/onyx/server/query_and_chat/session_loading.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from typing import Any, cast, Literal
+from typing import Any, Literal, cast
 
 from pydantic import ValidationError
 from sqlalchemy.orm import Session

--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -12,7 +12,7 @@ from onelogin.saml2.auth import OneLogin_Saml2_Auth
 from pydantic import BaseModel
 
 from onyx.auth.schemas import UserCreate, UserRole
-from onyx.auth.users import auth_backend, fastapi_users, get_user_manager, UserManager
+from onyx.auth.users import UserManager, auth_backend, fastapi_users, get_user_manager
 from onyx.configs.app_configs import (
     REQUIRE_EMAIL_VERIFICATION,
     SAML_CONF_DIR,

--- a/backend/onyx/server/usage_limits.py
+++ b/backend/onyx/server/usage_limits.py
@@ -10,7 +10,7 @@ from onyx.configs.app_configs import (
     OPENAI_DEFAULT_API_KEY,
     OPENROUTER_DEFAULT_API_KEY,
 )
-from onyx.db.usage import check_usage_limit, UsageLimitExceededError, UsageType
+from onyx.db.usage import UsageLimitExceededError, UsageType, check_usage_limit
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.tenant_usage_limits import (

--- a/backend/onyx/skills/built_in.py
+++ b/backend/onyx/skills/built_in.py
@@ -25,7 +25,7 @@ from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Final, Literal
 
-from pydantic import BaseModel, computed_field, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import ExternalAppType

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -20,9 +20,9 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
 )
 from onyx.skills.built_in import (
     BUILT_IN_SKILLS,
-    BuiltInSkillDefinition,
     COMPANY_SEARCH,
     EXTERNAL_APP_SKILL_ID_TO_APP_TYPE,
+    BuiltInSkillDefinition,
 )
 from onyx.skills.rendering import render_company_search_skill, render_external_app_skill
 from onyx.utils.logger import setup_logger

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -22,10 +22,10 @@ from onyx.configs.chat_configs import DR_REPORT_LLM_TIMEOUT_S
 from onyx.configs.constants import MessageType
 from onyx.context.search.models import SearchDocsResponse
 from onyx.deep_research.dr_mock_tools import (
-    get_research_agent_additional_tool_definitions,
     RESEARCH_AGENT_TASK_KEY,
     THINK_TOOL_RESPONSE_MESSAGE,
     THINK_TOOL_RESPONSE_TOKEN_COUNT,
+    get_research_agent_additional_tool_definitions,
 )
 from onyx.deep_research.models import (
     CombinedResearchAgentCallResult,
@@ -720,7 +720,7 @@ if __name__ == "__main__":
     from uuid import uuid4
 
     from onyx.chat.chat_state import ChatStateContainer
-    from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+    from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
     from onyx.db.models import User
     from onyx.db.persona import get_default_behavior_persona
     from onyx.llm.factory import get_default_llm, get_llm_token_counter

--- a/backend/onyx/tools/tool_implementations/custom/custom_tool.py
+++ b/backend/onyx/tools/tool_implementations/custom/custom_tool.py
@@ -22,23 +22,23 @@ from onyx.server.query_and_chat.streaming_models import (
 from onyx.tools.interface import Tool
 from onyx.tools.models import (
     CHAT_SESSION_ID_PLACEHOLDER,
+    MESSAGE_ID_PLACEHOLDER,
+    USER_EMAIL_PLACEHOLDER,
+    USER_ID_PLACEHOLDER,
     CustomToolCallSummary,
     CustomToolUserFileSnapshot,
     DynamicSchemaInfo,
-    MESSAGE_ID_PLACEHOLDER,
     ToolCallException,
     ToolResponse,
-    USER_EMAIL_PLACEHOLDER,
-    USER_ID_PLACEHOLDER,
 )
 from onyx.tools.tool_implementations.custom.openapi_parsing import (
+    REQUEST_BODY,
     MethodSpec,
     openapi_to_method_specs,
     openapi_to_url,
-    REQUEST_BODY,
     validate_openapi_schema,
 )
-from onyx.utils.headers import header_list_to_header_dict, HeaderItemDict
+from onyx.utils.headers import HeaderItemDict, header_list_to_header_dict
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -231,8 +231,8 @@ class MCPTool(Tool[None]):
                     )
                 else:
                     from onyx.server.features.mcp.api import (
-                        make_oauth_provider,
                         UNUSED_RETURN_PATH,
+                        make_oauth_provider,
                     )
 
                     # user_id is the requesting user's UUID; safe here because

--- a/backend/onyx/tools/tool_implementations/memory/memory_tool.py
+++ b/backend/onyx/tools/tool_implementations/memory/memory_tool.py
@@ -6,7 +6,7 @@ The memories are passed in via override_kwargs which contains the current list o
 memories that exist for the user.
 """
 
-from typing import Any, cast, Literal
+from typing import Any, Literal, cast
 
 from pydantic import BaseModel
 from typing_extensions import override

--- a/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
+++ b/backend/onyx/tools/tool_implementations/open_url/onyx_web_crawler.py
@@ -15,11 +15,11 @@ from onyx.tools.tool_implementations.open_url.models import (
 )
 from onyx.utils.logger import setup_logger
 from onyx.utils.playwright_fetch import (
+    RenderedPage,
     fetch_rendered_html,
     looks_like_cloudflare_challenge,
-    RenderedPage,
 )
-from onyx.utils.url import ssrf_safe_get, SSRFException
+from onyx.utils.url import SSRFException, ssrf_safe_get
 from onyx.utils.web_content import (
     decode_html_bytes,
     extract_pdf_text,

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -47,8 +47,8 @@ from onyx.tools.tool_implementations.web_search.providers import (
     get_default_content_provider,
 )
 from onyx.tools.tool_implementations.web_search.utils import (
-    inference_section_from_internet_page_scrape,
     MAX_CHARS_PER_URL,
+    inference_section_from_internet_page_scrape,
 )
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from onyx.utils.logger import setup_logger
 

--- a/backend/onyx/tracing/framework/processor_interface.py
+++ b/backend/onyx/tracing/framework/processor_interface.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .spans import Span

--- a/backend/onyx/tracing/framework/scope.py
+++ b/backend/onyx/tracing/framework/scope.py
@@ -1,5 +1,5 @@
 import contextvars
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from .spans import Span

--- a/backend/onyx/tracing/framework/traces.py
+++ b/backend/onyx/tracing/framework/traces.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import abc
 import contextvars
 from types import TracebackType
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from . import util
 from .scope import Scope

--- a/backend/onyx/utils/jsonriver/__init__.py
+++ b/backend/onyx/utils/jsonriver/__init__.py
@@ -9,8 +9,8 @@ Copyright (c) 2024 jsonriver-python contributors (Python port)
 SPDX-License-Identifier: BSD-3-Clause
 """
 
-from .parse import _Parser as Parser
 from .parse import JsonObject, JsonValue
+from .parse import _Parser as Parser
 
 __all__ = ["Parser", "JsonValue", "JsonObject"]
 __version__ = "0.0.1"

--- a/backend/onyx/utils/jsonriver/parse.py
+++ b/backend/onyx/utils/jsonriver/parse.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import copy
 from enum import IntEnum
-from typing import cast, Union
+from typing import Union, cast
 
-from .tokenize import _Input, json_token_type_to_string, JsonTokenType, Tokenizer
+from .tokenize import JsonTokenType, Tokenizer, _Input, json_token_type_to_string
 
 # Type definitions for JSON values
 JsonValue = Union[None, bool, float, str, list["JsonValue"], dict[str, "JsonValue"]]

--- a/backend/onyx/utils/retry_wrapper.py
+++ b/backend/onyx/utils/retry_wrapper.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from logging import Logger
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
 import requests
 from retry import retry

--- a/backend/onyx/utils/threadpool_concurrency.py
+++ b/backend/onyx/utils/threadpool_concurrency.py
@@ -7,13 +7,13 @@ import threading
 import uuid
 from collections.abc import Callable, Coroutine, Iterator, MutableMapping, Sequence
 from concurrent.futures import (
-    as_completed,
     FIRST_COMPLETED,
     Future,
     ThreadPoolExecutor,
+    as_completed,
     wait,
 )
-from typing import Any, cast, Generic, overload, Protocol, TypeVar
+from typing import Any, Generic, Protocol, TypeVar, cast, overload
 
 from pydantic import GetCoreSchemaHandler
 from pydantic.types import T

--- a/backend/onyx/utils/timing.py
+++ b/backend/onyx/utils/timing.py
@@ -2,10 +2,10 @@ import time
 from collections.abc import Callable, Generator, Iterator
 from functools import wraps
 from inspect import signature
-from typing import Any, cast, TypeVar
+from typing import Any, TypeVar, cast
 
 from onyx.utils.logger import setup_logger
-from onyx.utils.telemetry import optional_telemetry, RecordType
+from onyx.utils.telemetry import RecordType, optional_telemetry
 
 logger = setup_logger()
 

--- a/backend/onyx/voice/providers/openai.py
+++ b/backend/onyx/voice/providers/openai.py
@@ -12,7 +12,7 @@ import io
 import json
 from collections.abc import AsyncIterator
 from enum import StrEnum
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aiohttp
 

--- a/backend/scripts/coding_agent_test.py
+++ b/backend/scripts/coding_agent_test.py
@@ -30,7 +30,7 @@ from onyx.coding_agent.mock_tools import (
     CODING_AGENT_REPO_KEY,
     CODING_AGENT_TOOL_NAME,
 )
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.models import User
 from onyx.llm.factory import get_default_llm, get_llm_token_counter
 from onyx.server.query_and_chat.placement import Placement

--- a/backend/scripts/debugging/onyx_db.py
+++ b/backend/scripts/debugging/onyx_db.py
@@ -14,11 +14,11 @@ if True:  # noqa: E402
     from sqlalchemy import func
 
     from onyx.db.engine.sql_engine import (
-        build_connection_string,
-        get_session_with_tenant,
-        SqlEngine,
         SYNC_DB_API,
         USE_IAM_AUTH,
+        SqlEngine,
+        build_connection_string,
+        get_session_with_tenant,
     )
     from onyx.db.engine.tenant_utils import get_all_tenant_ids
     from onyx.db.models import Document, User

--- a/backend/scripts/debugging/opensearch/benchmark_retrieval.py
+++ b/backend/scripts/debugging/opensearch/benchmark_retrieval.py
@@ -18,7 +18,7 @@ from scripts.debugging.opensearch.embedding_io import load_query_embedding_from_
 from onyx.configs.chat_configs import NUM_RETURNED_HITS
 from onyx.context.search.enums import QueryType
 from onyx.context.search.models import IndexFilters
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.search_settings import get_current_search_settings
 from onyx.document_index.interfaces_new import TenantState
 from onyx.document_index.opensearch.opensearch_document_index import (

--- a/backend/scripts/debugging/opensearch/embed_and_save.py
+++ b/backend/scripts/debugging/opensearch/embed_and_save.py
@@ -15,7 +15,7 @@ from scripts.debugging.opensearch.constants import DEV_TENANT_ID
 from scripts.debugging.opensearch.embedding_io import save_query_embedding_to_file
 
 from onyx.context.search.utils import get_query_embedding
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from shared_configs.configs import MULTI_TENANT
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 

--- a/backend/scripts/hard_delete_chats.py
+++ b/backend/scripts/hard_delete_chats.py
@@ -8,8 +8,8 @@ sys.path.append(parent_dir)
 
 from onyx.db.chat import delete_chat_session  # noqa: E402
 from onyx.db.engine.sql_engine import (  # noqa: E402
-    get_session_with_current_tenant,
     SqlEngine,
+    get_session_with_current_tenant,
 )
 from onyx.db.models import ChatSession  # noqa: E402
 

--- a/backend/scripts/reencrypt_secrets.py
+++ b/backend/scripts/reencrypt_secrets.py
@@ -25,8 +25,8 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(parent_dir)
 
 from onyx.db.engine.sql_engine import (  # noqa: E402
-    get_session_with_tenant,
     SqlEngine,
+    get_session_with_tenant,
 )
 from onyx.db.engine.tenant_utils import get_all_tenant_ids  # noqa: E402
 from onyx.db.rotate_encryption_key import rotate_encryption_key  # noqa: E402

--- a/backend/scripts/rotate_llm_provider_keys.py
+++ b/backend/scripts/rotate_llm_provider_keys.py
@@ -41,8 +41,8 @@ sys.path.append(parent_dir)
 from sqlalchemy import select  # noqa: E402
 
 from onyx.db.engine.sql_engine import (  # noqa: E402
-    get_session_with_tenant,
     SqlEngine,
+    get_session_with_tenant,
 )
 from onyx.db.engine.tenant_utils import get_all_tenant_ids  # noqa: E402
 from onyx.db.models import (  # noqa: E402

--- a/backend/scripts/seed_dev_license.py
+++ b/backend/scripts/seed_dev_license.py
@@ -19,8 +19,8 @@ sys.path.append(parent_dir)
 from ee.onyx.db.license import upsert_license  # noqa: E402
 from ee.onyx.utils.license import verify_license_signature  # noqa: E402
 from onyx.db.engine.sql_engine import (  # noqa: E402
-    get_session_with_current_tenant,
     SqlEngine,
+    get_session_with_current_tenant,
 )
 
 _PEM_BEGIN = "-----BEGIN ONYX LICENSE-----"

--- a/backend/scripts/tenant_cleanup/cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/cleanup_tenants.py
@@ -30,12 +30,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from scripts.tenant_cleanup.cleanup_utils import (
+    TenantNotFoundInControlPlaneError,
     confirm_step,
     execute_control_plane_query,
     find_worker_pod,
     get_tenant_status,
     read_tenant_ids_from_csv,
-    TenantNotFoundInControlPlaneError,
 )
 
 

--- a/backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py
+++ b/backend/scripts/tenant_cleanup/mark_connectors_for_deletion.py
@@ -27,7 +27,7 @@ Examples:
 
 import subprocess
 import sys
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock
 from typing import Any

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -17,19 +17,19 @@ import json
 import signal
 import subprocess
 import sys
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from pathlib import Path
 from threading import Lock
 
 from scripts.tenant_cleanup.no_bastion_cleanup_utils import (
+    TenantNotFoundInControlPlaneError,
     confirm_step,
     execute_control_plane_delete,
     find_background_pod,
     find_worker_pod,
     get_tenant_status,
     read_tenant_ids_from_csv,
-    TenantNotFoundInControlPlaneError,
 )
 
 # Global lock for thread-safe operations

--- a/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
@@ -14,18 +14,18 @@ Usage:
 
 import subprocess
 import sys
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock
 from typing import Any
 
 from scripts.tenant_cleanup.no_bastion_cleanup_utils import (
+    TenantNotFoundInControlPlaneError,
     confirm_step,
     find_background_pod,
     find_worker_pod,
     get_tenant_status,
     read_tenant_ids_from_csv,
-    TenantNotFoundInControlPlaneError,
 )
 
 # Global lock for thread-safe printing

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/check_documents_deleted.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/check_documents_deleted.py
@@ -15,7 +15,7 @@ import sys
 
 from sqlalchemy import func, select
 
-from onyx.db.engine.sql_engine import get_session_with_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_tenant
 from onyx.db.models import ConnectorCredentialPair, Document
 
 

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
@@ -12,7 +12,7 @@ import sys
 
 from sqlalchemy import text
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
 
 
 def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/execute_connector_deletion.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/execute_connector_deletion.py
@@ -37,7 +37,7 @@ from onyx.db.connector_credential_pair import (
     get_connector_credential_pairs,
     update_connector_credential_pair_from_id,
 )
-from onyx.db.engine.sql_engine import get_session_with_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_tenant
 from onyx.db.enums import ConnectorCredentialPairStatus
 from onyx.db.index_attempt import cancel_indexing_attempts_for_ccpair
 

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_connectors.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_connectors.py
@@ -29,7 +29,7 @@ import sys
 
 from sqlalchemy import select
 
-from onyx.db.engine.sql_engine import get_session_with_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_tenant
 from onyx.db.models import ConnectorCredentialPair
 
 

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_index_name.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_index_name.py
@@ -10,7 +10,7 @@ Usage:
 import json
 import sys
 
-from onyx.db.engine.sql_engine import get_session_with_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_tenant
 from onyx.db.search_settings import get_current_search_settings
 
 

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_users.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/get_tenant_users.py
@@ -15,7 +15,7 @@ import sys
 
 from sqlalchemy import select
 
-from onyx.db.engine.sql_engine import get_session_with_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_tenant
 from onyx.db.models import User
 
 

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/understand_tenants.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/understand_tenants.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import get_session_with_shared_schema, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
 
 
 def get_tenant_activity_summary(session: Session) -> list[dict[str, Any]]:

--- a/backend/scripts/update_connector_prune_freq.py
+++ b/backend/scripts/update_connector_prune_freq.py
@@ -23,8 +23,8 @@ from sqlalchemy.engine import CursorResult  # noqa: E402
 from sqlalchemy.exc import ProgrammingError  # noqa: E402
 
 from onyx.db.engine.sql_engine import (  # noqa: E402
-    get_session_with_tenant,
     SqlEngine,
+    get_session_with_tenant,
 )
 from onyx.db.engine.tenant_utils import get_all_tenant_ids  # noqa: E402
 from onyx.db.models import Connector  # noqa: E402

--- a/backend/tests/daily/connectors/google_drive/test_admin_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_admin_oauth.py
@@ -5,13 +5,10 @@ import pytest
 
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from tests.daily.connectors.google_drive.consts_and_utils import (
-    _pick,
     ADMIN_EMAIL,
     ADMIN_FILE_IDS,
     ADMIN_FOLDER_3_FILE_IDS,
     ADMIN_MY_DRIVE_ID,
-    assert_expected_docs_in_retrieved_docs,
-    assert_hierarchy_nodes_match_expected,
     FOLDER_1_1_FILE_IDS,
     FOLDER_1_1_URL,
     FOLDER_1_2_FILE_IDS,
@@ -25,8 +22,6 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     FOLDER_2_URL,
     FOLDER_3_ID,
     FOLDER_3_URL,
-    get_expected_hierarchy_for_shared_drives,
-    load_connector_outputs,
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_A_ID,
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_B_ID,
     PERM_SYNC_DRIVE_ADMIN_ONLY_ID,
@@ -40,6 +35,11 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     TEST_USER_1_EXTRA_DRIVE_1_ID,
     TEST_USER_1_EXTRA_DRIVE_2_ID,
     TEST_USER_1_EXTRA_FOLDER_ID,
+    _pick,
+    assert_expected_docs_in_retrieved_docs,
+    assert_hierarchy_nodes_match_expected,
+    get_expected_hierarchy_for_shared_drives,
+    load_connector_outputs,
 )
 from tests.utils.secret_names import TestSecret
 

--- a/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
+++ b/backend/tests/daily/connectors/google_drive/test_drive_perm_sync.py
@@ -15,15 +15,11 @@ from onyx.db.models import ConnectorCredentialPair
 from onyx.db.utils import DocumentRow, SortOrder
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
 from tests.daily.connectors.google_drive.consts_and_utils import (
-    _pick,
     ACCESS_MAPPING,
     ADMIN_EMAIL,
     ADMIN_MY_DRIVE_ID,
-    assert_hierarchy_nodes_match_expected,
     EXTERNAL_SHARED_FOLDER_ID,
     FOLDER_3_ID,
-    get_expected_hierarchy_for_shared_drives,
-    load_connector_outputs,
     PERM_SYNC_DRIVE_ACCESS_MAPPING,
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_A_ID,
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_B_ID,
@@ -40,6 +36,10 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     TEST_USER_1_MY_DRIVE_ID,
     TEST_USER_2_MY_DRIVE,
     TEST_USER_3_MY_DRIVE_ID,
+    _pick,
+    assert_hierarchy_nodes_match_expected,
+    get_expected_hierarchy_for_shared_drives,
+    load_connector_outputs,
 )
 from tests.utils.secret_names import TestSecret
 

--- a/backend/tests/daily/connectors/google_drive/test_map_test_ids.py
+++ b/backend/tests/daily/connectors/google_drive/test_map_test_ids.py
@@ -10,7 +10,6 @@ from tests.daily.connectors.google_drive.conftest import build_credentials
 from tests.daily.connectors.google_drive.consts_and_utils import (
     ADMIN_EMAIL,
     ADMIN_FILE_IDS,
-    file_name_template,
     FOLDER_1_1_FILE_IDS,
     FOLDER_1_2_FILE_IDS,
     FOLDER_1_FILE_IDS,
@@ -18,12 +17,13 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     FOLDER_2_2_FILE_IDS,
     FOLDER_2_FILE_IDS,
     FOLDER_3_FILE_IDS,
-    load_connector_outputs,
     SHARED_DRIVE_1_FILE_IDS,
     SHARED_DRIVE_2_FILE_IDS,
     TEST_USER_1_FILE_IDS,
     TEST_USER_2_FILE_IDS,
     TEST_USER_3_FILE_IDS,
+    file_name_template,
+    load_connector_outputs,
 )
 from tests.utils.secret_names import TestSecret
 

--- a/backend/tests/daily/connectors/google_drive/test_sections.py
+++ b/backend/tests/daily/connectors/google_drive/test_sections.py
@@ -6,8 +6,8 @@ import pytest
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from tests.daily.connectors.google_drive.consts_and_utils import (
     ADMIN_EMAIL,
-    load_connector_outputs,
     SECTIONS_FOLDER_URL,
+    load_connector_outputs,
 )
 from tests.utils.secret_names import TestSecret
 

--- a/backend/tests/daily/connectors/google_drive/test_service_acct.py
+++ b/backend/tests/daily/connectors/google_drive/test_service_acct.py
@@ -7,13 +7,10 @@ import pytest
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.google_utils.google_utils import execute_paginated_retrieval
 from tests.daily.connectors.google_drive.consts_and_utils import (
-    _pick,
     ADMIN_EMAIL,
     ADMIN_FILE_IDS,
     ADMIN_FOLDER_3_FILE_IDS,
     ADMIN_MY_DRIVE_ID,
-    assert_expected_docs_in_retrieved_docs,
-    assert_hierarchy_nodes_match_expected,
     EXTERNAL_SHARED_DOC_SINGLETON,
     EXTERNAL_SHARED_DOCS_IN_FOLDER,
     EXTERNAL_SHARED_FOLDER_ID,
@@ -31,9 +28,6 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     FOLDER_2_URL,
     FOLDER_3_ID,
     FOLDER_3_URL,
-    get_expected_hierarchy_for_shared_drives,
-    id_to_name,
-    load_connector_outputs,
     MISC_SHARED_DRIVE_FNAMES,
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_A_ID,
     PERM_SYNC_DRIVE_ADMIN_AND_USER_1_B_ID,
@@ -61,6 +55,12 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     TEST_USER_3_EMAIL,
     TEST_USER_3_FILE_IDS,
     TEST_USER_3_MY_DRIVE_ID,
+    _pick,
+    assert_expected_docs_in_retrieved_docs,
+    assert_hierarchy_nodes_match_expected,
+    get_expected_hierarchy_for_shared_drives,
+    id_to_name,
+    load_connector_outputs,
 )
 from tests.utils.secret_names import TestSecret
 

--- a/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
+++ b/backend/tests/daily/connectors/google_drive/test_user_1_oauth.py
@@ -6,11 +6,7 @@ import pytest
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
 from onyx.connectors.models import Document
 from tests.daily.connectors.google_drive.consts_and_utils import (
-    _clear_parents,
-    _pick,
     ADMIN_FOLDER_3_FILE_IDS,
-    assert_expected_docs_in_retrieved_docs,
-    assert_hierarchy_nodes_match_expected,
     DONWLOAD_REVOKED_FILE_ID,
     FOLDER_1_1_FILE_IDS,
     FOLDER_1_1_ID,
@@ -21,15 +17,19 @@ from tests.daily.connectors.google_drive.consts_and_utils import (
     FOLDER_1_URL,
     FOLDER_3_ID,
     FOLDER_3_URL,
+    SHARED_DRIVE_1_FILE_IDS,
+    SHARED_DRIVE_1_ID,
+    TEST_USER_1_EMAIL,
+    TEST_USER_1_FILE_IDS,
+    _clear_parents,
+    _pick,
+    assert_expected_docs_in_retrieved_docs,
+    assert_hierarchy_nodes_match_expected,
     get_expected_hierarchy_for_test_user_1,
     get_expected_hierarchy_for_test_user_1_my_drive_only,
     get_expected_hierarchy_for_test_user_1_shared_drives_only,
     get_expected_hierarchy_for_test_user_1_shared_with_me_only,
     load_connector_outputs,
-    SHARED_DRIVE_1_FILE_IDS,
-    SHARED_DRIVE_1_ID,
-    TEST_USER_1_EMAIL,
-    TEST_USER_1_FILE_IDS,
 )
 from tests.daily.connectors.utils import ConnectorOutput
 from tests.utils.secret_names import TestSecret

--- a/backend/tests/daily/targeted_reindex/conftest.py
+++ b/backend/tests/daily/targeted_reindex/conftest.py
@@ -16,7 +16,7 @@ from collections.abc import Generator
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 

--- a/backend/tests/external_dependency_unit/background/test_periodic_task_claim.py
+++ b/backend/tests/external_dependency_unit/background/test_periodic_task_claim.py
@@ -10,7 +10,7 @@ the task runs, so long-running tasks don't hold connections.
 
 import time
 from collections.abc import Generator
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -18,12 +18,12 @@ from uuid import uuid4
 import pytest
 
 from onyx.background.periodic_poller import (
+    PERIODIC_TASK_KV_PREFIX,
     _PeriodicTaskDef,
     _try_claim_task,
     _try_run_periodic_task,
-    PERIODIC_TASK_KV_PREFIX,
 )
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.models import KVStore
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from tests.external_dependency_unit.constants import TEST_TENANT_ID

--- a/backend/tests/external_dependency_unit/cache/test_cache_backend_parity.py
+++ b/backend/tests/external_dependency_unit/cache/test_cache_backend_parity.py
@@ -8,7 +8,7 @@ in conftest.py.
 import time
 from uuid import uuid4
 
-from onyx.cache.interface import CacheBackend, TTL_KEY_NOT_FOUND, TTL_NO_EXPIRY
+from onyx.cache.interface import TTL_KEY_NOT_FOUND, TTL_NO_EXPIRY, CacheBackend
 
 
 def _key() -> str:

--- a/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
+++ b/backend/tests/external_dependency_unit/cache/test_kv_store_cache_layer.py
@@ -20,7 +20,7 @@ from onyx.cache.postgres_backend import PostgresCacheBackend
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import CacheStore, KVStore
 from onyx.key_value_store.interface import KvKeyNotFoundError
-from onyx.key_value_store.store import PgRedisKVStore, REDIS_KEY_PREFIX
+from onyx.key_value_store.store import REDIS_KEY_PREFIX, PgRedisKVStore
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 
 

--- a/backend/tests/external_dependency_unit/cache/test_postgres_cache_backend.py
+++ b/backend/tests/external_dependency_unit/cache/test_postgres_cache_backend.py
@@ -12,8 +12,8 @@ from sqlalchemy import select
 
 from onyx.cache.interface import TTL_KEY_NOT_FOUND, TTL_NO_EXPIRY
 from onyx.cache.postgres_backend import (
-    cleanup_expired_cache_entries,
     PostgresCacheBackend,
+    cleanup_expired_cache_entries,
 )
 from onyx.db.models import CacheStore
 

--- a/backend/tests/external_dependency_unit/celery/test_persona_file_sync.py
+++ b/backend/tests/external_dependency_unit/celery/test_persona_file_sync.py
@@ -20,7 +20,7 @@ since we only need to verify the arguments passed to update_single.
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import uuid4
 
 from sqlalchemy.orm import Session

--- a/backend/tests/external_dependency_unit/celery/test_user_file_delete_queue.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_delete_queue.py
@@ -25,7 +25,7 @@ on the task class so no real broker is needed.
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import uuid4
 
 from sqlalchemy.orm import Session
@@ -38,9 +38,9 @@ from onyx.background.celery.tasks.user_file_processing.tasks import (
 )
 from onyx.configs.constants import (
     CELERY_USER_FILE_DELETE_TASK_EXPIRES,
+    USER_FILE_DELETE_MAX_QUEUE_DEPTH,
     OnyxCeleryQueues,
     OnyxCeleryTask,
-    USER_FILE_DELETE_MAX_QUEUE_DEPTH,
 )
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile

--- a/backend/tests/external_dependency_unit/celery/test_user_file_processing_queue.py
+++ b/backend/tests/external_dependency_unit/celery/test_user_file_processing_queue.py
@@ -25,7 +25,7 @@ on the task class so no real broker is needed.
 from collections.abc import Generator
 from contextlib import contextmanager
 from typing import Any
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 from uuid import uuid4
 
 from sqlalchemy.orm import Session
@@ -38,9 +38,9 @@ from onyx.background.celery.tasks.user_file_processing.tasks import (
 )
 from onyx.configs.constants import (
     CELERY_USER_FILE_PROCESSING_TASK_EXPIRES,
+    USER_FILE_PROCESSING_MAX_QUEUE_DEPTH,
     OnyxCeleryQueues,
     OnyxCeleryTask,
-    USER_FILE_PROCESSING_MAX_QUEUE_DEPTH,
 )
 from onyx.db.enums import UserFileStatus
 from onyx.db.models import UserFile

--- a/backend/tests/external_dependency_unit/conftest.py
+++ b/backend/tests/external_dependency_unit/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from fastapi_users.password import PasswordHelper
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.enums import AccountType
 from onyx.db.models import User, UserRole
 from onyx.file_store.file_store import get_default_file_store

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -15,11 +15,11 @@ import threading
 import time
 import zipfile
 from collections.abc import Callable, Generator, Iterable, Sequence
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 import pytest
@@ -29,10 +29,10 @@ if TYPE_CHECKING:
     from kubernetes import client as k8s_client_module
 from redis import Redis
 from sqlalchemy import select, text
-from sqlalchemy.orm import class_mapper, Session
+from sqlalchemy.orm import Session, class_mapper
 
 from onyx.configs.constants import FileOrigin
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.enums import AccountType, BuildSessionStatus, SandboxStatus
 from onyx.db.llm import (
     fetch_default_llm_model,

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -31,10 +31,10 @@ from onyx.db.models import ExternalApp, ExternalAppPolicy, User
 from onyx.external_apps.credentials import app_is_available
 from onyx.external_apps.matching import engine as matching_engine
 from onyx.external_apps.matching.engine import (
+    WHOLE_DOMAIN_ACTION_TYPE,
     AllMatchedActions,
     MatchedAction,
     recognize_actions,
-    WHOLE_DOMAIN_ACTION_TYPE,
 )
 from onyx.external_apps.matching.request import ProxiedRequest
 from onyx.sandbox_proxy import request_evaluator as request_evaluator_mod

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import CheckConstraint, delete, select, Table, text
+from sqlalchemy import CheckConstraint, Table, delete, select, text
 from sqlalchemy.orm import Session
 
 from onyx.db.models import Skill, User

--- a/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
+++ b/backend/tests/external_dependency_unit/craft/test_docker_sandbox_serve_streaming.py
@@ -49,8 +49,8 @@ from onyx.server.features.build.configs import (
     SandboxBackend,
 )
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
-    _sandbox_container_name,
     DockerSandboxManager,
+    _sandbox_container_name,
 )
 from onyx.server.features.build.sandbox.event_schema import (
     AgentMessageChunk,

--- a/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
+++ b/backend/tests/external_dependency_unit/craft/test_ensure_sandbox_running.py
@@ -28,7 +28,7 @@ from onyx.server.features.build.db.sandbox import (
     create_sandbox__no_commit,
     update_sandbox_status__no_commit,
 )
-from onyx.server.features.build.sandbox.base import get_sandbox_manager, SandboxManager
+from onyx.server.features.build.sandbox.base import SandboxManager, get_sandbox_manager
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.server.features.build.session.manager import SessionManager

--- a/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
+++ b/backend/tests/external_dependency_unit/craft/test_kubernetes_sandbox.py
@@ -37,8 +37,8 @@ from onyx.server.features.build.configs import (
     SandboxBackend,
 )
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-    KubernetesSandboxManager,
     PUSH_DAEMON_PORT,
+    KubernetesSandboxManager,
 )
 from onyx.server.features.build.sandbox.models import LLMProviderConfig
 from onyx.utils.logger import setup_logger

--- a/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
@@ -26,10 +26,10 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.external_apps.providers.base import OnyxManagedExtApp
 from onyx.external_apps.providers.registry import (
+    PROVIDERS,
     action_policy_views,
     fetch_onyx_managed_built_in_apps,
     get_endpoint_catalog,
-    PROVIDERS,
 )
 from onyx.server.features.build.api.models import (
     CreateBuiltInExternalAppRequest,

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import datetime
 import threading
 from typing import Any
-from unittest.mock import patch, PropertyMock
+from unittest.mock import PropertyMock, patch
 from uuid import UUID
 
 import pytest

--- a/backend/tests/external_dependency_unit/craft/test_skill_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push.py
@@ -32,12 +32,12 @@ from onyx.configs.constants import DocumentSource, FileOrigin
 from onyx.db.enums import AccessType, SandboxStatus
 from onyx.db.models import Sandbox, Skill, User, UserGroup
 from onyx.db.skill import (
+    SkillPatch,
     affected_user_ids_for_skill,
     delete_skill,
     patch_skill,
     replace_skill_bundle,
     replace_skill_grants,
-    SkillPatch,
 )
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.sandbox.models import FatalWriteError

--- a/backend/tests/external_dependency_unit/db/test_index_attempt_stage_metrics.py
+++ b/backend/tests/external_dependency_unit/db/test_index_attempt_stage_metrics.py
@@ -21,7 +21,7 @@ Validates the upsert + Chan-combination logic against real Postgres:
 import math
 import statistics
 from collections.abc import Generator
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import pytest
 from sqlalchemy import select
@@ -30,9 +30,9 @@ from sqlalchemy.orm import Session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import IndexingStatus
 from onyx.db.index_attempt_metrics import (
+    StageEventBuffer,
     record_single_event,
     record_stage_aggregate,
-    StageEventBuffer,
 )
 from onyx.db.index_attempt_metrics_models import IndexAttemptStage
 from onyx.db.models import (

--- a/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
+++ b/backend/tests/external_dependency_unit/db/test_run_targeted_reindex.py
@@ -40,10 +40,10 @@ from onyx.db.models import (
 )
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.targeted_reindex import (
+    TargetSpec,
     create_targeted_reindex_job,
     resolve_error_ids_to_targets,
     targets_to_connector_failures,
-    TargetSpec,
 )
 from tests.external_dependency_unit.constants import TEST_TENANT_ID
 from tests.external_dependency_unit.indexing_helpers import (

--- a/backend/tests/external_dependency_unit/db/test_tag_race_condition.py
+++ b/backend/tests/external_dependency_unit/db/test_tag_race_condition.py
@@ -6,7 +6,7 @@ UniqueViolation errors, which would occur if the upsert logic
 isn't properly implemented.
 """
 
-from concurrent.futures import as_completed, Future, ThreadPoolExecutor
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from typing import Union
 from uuid import uuid4
 

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_create.py
@@ -25,11 +25,11 @@ from onyx.db.models import (
 )
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.targeted_reindex import (
+    MAX_TARGETS_PER_REQUEST,
+    TargetSpec,
     create_targeted_reindex_job,
     get_targeted_reindex_job,
-    MAX_TARGETS_PER_REQUEST,
     resolve_error_ids_to_targets,
-    TargetSpec,
 )
 from tests.external_dependency_unit.indexing_helpers import (
     cleanup_cc_pair,

--- a/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
+++ b/backend/tests/external_dependency_unit/db/test_targeted_reindex_task.py
@@ -34,9 +34,9 @@ from onyx.db.models import (
 )
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.targeted_reindex import (
+    TargetSpec,
     create_targeted_reindex_job,
     resolve_error_ids_to_targets,
-    TargetSpec,
 )
 from tests.external_dependency_unit.indexing_helpers import (
     cleanup_cc_pair,

--- a/backend/tests/external_dependency_unit/discord_bot/conftest.py
+++ b/backend/tests/external_dependency_unit/discord_bot/conftest.py
@@ -7,7 +7,7 @@ import discord
 import pytest
 from sqlalchemy.orm import Session
 
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 TEST_TENANT_ID: str = "public"

--- a/backend/tests/external_dependency_unit/ee/onyx/db/test_license_cache.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/db/test_license_cache.py
@@ -13,9 +13,9 @@ import pytest
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.license import (
-    get_cached_license_metadata,
     LICENSE_CACHE_TTL_SECONDS,
     LICENSE_METADATA_KEY,
+    get_cached_license_metadata,
     update_license_cache,
 )
 from ee.onyx.server.license.models import (

--- a/backend/tests/external_dependency_unit/ee/onyx/utils/test_trial_promotion.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/utils/test_trial_promotion.py
@@ -16,8 +16,8 @@ import pytest
 from ee.onyx.server.license.models import CustomerTier
 from ee.onyx.server.tenants.models import BillingInformation, SubscriptionStatusResponse
 from ee.onyx.server.tenants.tier_management import (
-    get_cached_tier,
     TENANT_TIER_KEY,
+    get_cached_tier,
     update_tenant_tier,
 )
 from ee.onyx.utils import tier as tier_module

--- a/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_file_store_non_mocked.py
@@ -2,9 +2,9 @@ import os
 import time
 import uuid
 from collections.abc import Generator
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from io import BytesIO
-from typing import Any, cast, Dict, List, Tuple, TypedDict
+from typing import Any, Dict, List, Tuple, TypedDict, cast
 from unittest.mock import patch
 
 import pytest

--- a/backend/tests/external_dependency_unit/file_store/test_postgres_file_store_non_mocked.py
+++ b/backend/tests/external_dependency_unit/file_store/test_postgres_file_store_non_mocked.py
@@ -21,10 +21,10 @@ from onyx.db.file_content import (
     get_file_content_by_file_id_optional,
 )
 from onyx.file_store.postgres_file_store import (
-    _get_raw_connection,
-    _read_large_object,
     POSTGRES_BUCKET_SENTINEL,
     PostgresBackedFileStore,
+    _get_raw_connection,
+    _read_large_object,
 )
 from onyx.utils.logger import setup_logger
 

--- a/backend/tests/external_dependency_unit/full_setup.py
+++ b/backend/tests/external_dependency_unit/full_setup.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import Optional
 
-from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
 from onyx.db.search_settings import get_active_search_settings
 from onyx.document_index.factory import (
     get_all_document_indices,

--- a/backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py
+++ b/backend/tests/external_dependency_unit/indexing/test_get_old_index_attempt_ids.py
@@ -19,8 +19,8 @@ from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from onyx.background.indexing.index_attempt_utils import (
-    get_old_index_attempt_ids,
     NUM_RECENT_INDEX_ATTEMPTS_TO_KEEP,
+    get_old_index_attempt_ids,
 )
 from onyx.configs.constants import NUM_DAYS_TO_KEEP_INDEX_ATTEMPTS
 from onyx.db.engine.time_utils import get_db_current_time

--- a/backend/tests/external_dependency_unit/mock_llm.py
+++ b/backend/tests/external_dependency_unit/mock_llm.py
@@ -6,14 +6,14 @@ import time
 from collections.abc import Generator, Iterator
 from contextlib import contextmanager
 from enum import Enum
-from typing import Any, cast, Generic, Literal, TypeVar
+from typing import Any, Generic, Literal, TypeVar, cast
 from unittest.mock import patch
 
 from pydantic import BaseModel
 
 from onyx.llm.interfaces import (
-    LanguageModelInput,
     LLM,
+    LanguageModelInput,
     LLMConfig,
     LLMUserIdentity,
     ReasoningEffort,

--- a/backend/tests/external_dependency_unit/redis/test_lock_context.py
+++ b/backend/tests/external_dependency_unit/redis/test_lock_context.py
@@ -9,7 +9,7 @@ from collections.abc import Generator
 
 import pytest
 
-from onyx.redis.lock_context import redis_shared_lock, RedisSharedLockAcquisitionError
+from onyx.redis.lock_context import RedisSharedLockAcquisitionError, redis_shared_lock
 from onyx.redis.redis_pool import get_shared_redis_client
 from onyx.utils.logger import setup_logger
 

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_gate_claim_arbiter.py
@@ -15,7 +15,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.enums import ApprovalDecision, BuildSessionStatus
 from onyx.db.models import ActionApproval, BuildSession
-from onyx.sandbox_proxy.addons.gate import _IdentityResolver, GateAddon
+from onyx.sandbox_proxy.addons.gate import GateAddon, _IdentityResolver
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator

--- a/backend/tests/external_dependency_unit/sandbox_proxy/test_identity_docker_lookup.py
+++ b/backend/tests/external_dependency_unit/sandbox_proxy/test_identity_docker_lookup.py
@@ -22,8 +22,8 @@ from docker.errors import APIError, NotFound
 from docker.models.containers import Container
 
 from onyx.sandbox_proxy.identity_docker import (
-    _identity_from_container,
     DockerEventsLookup,
+    _identity_from_container,
 )
 
 _DOCKER_SOCKET = os.environ.get("SANDBOX_DOCKER_SOCKET", "/var/run/docker.sock")

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_per_user_api_token_credentials.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_per_user_api_token_credentials.py
@@ -20,8 +20,8 @@ from onyx.db.enums import (
 from onyx.db.mcp import extract_connection_data, get_user_connection_config
 from onyx.db.models import User
 from onyx.server.features.mcp.api import (
-    _upsert_mcp_server,
     HEADER_SUBSTITUTIONS,
+    _upsert_mcp_server,
     save_user_credentials,
 )
 from onyx.server.features.mcp.models import (

--- a/backend/tests/external_dependency_unit/tier/test_tier_order.py
+++ b/backend/tests/external_dependency_unit/tier/test_tier_order.py
@@ -5,7 +5,7 @@ import pytest
 from ee.onyx.configs.license_enforcement_config import PATH_PREFIX_MIN_TIER
 from ee.onyx.server.middleware.tier_gate import _required_tier
 from onyx.server.settings.models import Tier
-from onyx.server.settings.tier_order import tier_at_least, TIER_RANK
+from onyx.server.settings.tier_order import TIER_RANK, tier_at_least
 
 
 class TestTierOrdering:

--- a/backend/tests/external_dependency_unit/tools/test_mcp_passthrough_oauth.py
+++ b/backend/tests/external_dependency_unit/tools/test_mcp_passthrough_oauth.py
@@ -32,7 +32,7 @@ from onyx.db.models import OAuthAccount, Persona, Tool, User
 from onyx.llm.factory import get_default_llm
 from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import CustomToolCallSummary
-from onyx.tools.tool_constructor import construct_tools, SearchToolConfig
+from onyx.tools.tool_constructor import SearchToolConfig, construct_tools
 from onyx.tools.tool_implementations.mcp.mcp_tool import MCPTool
 from tests.external_dependency_unit.answer.conftest import ensure_default_llm_provider
 from tests.external_dependency_unit.conftest import create_test_user

--- a/backend/tests/external_dependency_unit/tools/test_memory_tool_integration.py
+++ b/backend/tests/external_dependency_unit/tools/test_memory_tool_integration.py
@@ -5,9 +5,9 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.memory import (
+    MAX_MEMORIES_PER_USER,
     add_memory,
     get_memories,
-    MAX_MEMORIES_PER_USER,
     update_memory_at_index,
 )
 from onyx.db.models import Memory, User

--- a/backend/tests/external_dependency_unit/tools/test_oauth_token_manager.py
+++ b/backend/tests/external_dependency_unit/tools/test_oauth_token_manager.py
@@ -16,10 +16,10 @@ from requests import HTTPError, Response
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import (
-    build_oauth_authorization_url,
-    exchange_oauth_code_for_token,
     OAuthFlowParams,
     OAuthTokenManager,
+    build_oauth_authorization_url,
+    exchange_oauth_code_for_token,
 )
 from onyx.db.models import OAuthConfig
 from onyx.db.oauth_config import create_oauth_config, upsert_user_oauth_token

--- a/backend/tests/external_dependency_unit/tools/test_oauth_tool_integration.py
+++ b/backend/tests/external_dependency_unit/tools/test_oauth_tool_integration.py
@@ -20,7 +20,7 @@ from onyx.chat.emitter import Emitter
 from onyx.db.models import OAuthAccount, OAuthConfig, Persona, Tool, User
 from onyx.db.oauth_config import create_oauth_config, upsert_user_oauth_token
 from onyx.llm.factory import get_default_llm
-from onyx.tools.tool_constructor import construct_tools, SearchToolConfig
+from onyx.tools.tool_constructor import SearchToolConfig, construct_tools
 from onyx.tools.tool_implementations.custom.custom_tool import CustomTool
 from tests.external_dependency_unit.answer.conftest import ensure_default_llm_provider
 from tests.external_dependency_unit.conftest import create_test_user

--- a/backend/tests/integration/common_utils/managers/chat.py
+++ b/backend/tests/integration/common_utils/managers/chat.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, cast, Literal, TypedDict
+from typing import Any, Literal, TypedDict, cast
 from uuid import UUID
 
 import httpx

--- a/backend/tests/integration/common_utils/managers/file.py
+++ b/backend/tests/integration/common_utils/managers/file.py
@@ -1,6 +1,6 @@
 import io
 import mimetypes
-from typing import cast, IO, List, Tuple
+from typing import IO, List, Tuple, cast
 
 from onyx.file_store.models import FileDescriptor
 from onyx.server.documents.models import FileUploadResponse

--- a/backend/tests/integration/common_utils/reset.py
+++ b/backend/tests/integration/common_utils/reset.py
@@ -14,9 +14,9 @@ from onyx.configs.app_configs import (
     POSTGRES_USER,
 )
 from onyx.db.engine.sql_engine import (
+    SYNC_DB_API,
     build_connection_string,
     get_session_with_current_tenant,
-    SYNC_DB_API,
 )
 from onyx.db.swap_index import check_and_perform_index_swap
 from onyx.file_store.file_store import get_default_file_store

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -54,8 +54,8 @@ from onyx.auth.schemas import UserRole  # noqa: E402
 from onyx.background.celery.apps.client import celery_app  # noqa: E402
 from onyx.configs.constants import DocumentSource  # noqa: E402
 from onyx.db.engine.sql_engine import (  # noqa: E402
-    get_session_with_current_tenant,
     SqlEngine,
+    get_session_with_current_tenant,
 )
 from onyx.db.search_settings import get_current_search_settings  # noqa: E402
 from onyx.utils.variable_functionality import (  # noqa: E402
@@ -78,9 +78,9 @@ from tests.integration.common_utils.managers.llm_provider import (  # noqa: E402
     LLMProviderManager,
 )
 from tests.integration.common_utils.managers.user import (  # noqa: E402
-    build_email,
     DEFAULT_PASSWORD,
     UserManager,
+    build_email,
 )
 from tests.integration.common_utils.reset import (  # noqa: E402
     _seed_dev_license_if_set,

--- a/backend/tests/integration/connector_job_tests/google/google_drive_api_utils.py
+++ b/backend/tests/integration/connector_job_tests/google/google_drive_api_utils.py
@@ -4,10 +4,10 @@ from uuid import uuid4
 from google.oauth2.service_account import Credentials
 
 from onyx.connectors.google_utils.resources import (
-    get_drive_service,
-    get_google_docs_service,
     GoogleDocsService,
     GoogleDriveService,
+    get_drive_service,
+    get_google_docs_service,
 )
 
 GOOGLE_SCOPES = {

--- a/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
+++ b/backend/tests/integration/multitenant_tests/discord_bot/test_discord_bot_multitenant.py
@@ -15,9 +15,9 @@ from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.models import UserRole
 from onyx.onyxbot.discord.cache import DiscordCacheManager
 from onyx.server.manage.discord_bot.utils import (
+    REGISTRATION_KEY_PREFIX,
     generate_discord_registration_key,
     parse_discord_registration_key,
-    REGISTRATION_KEY_PREFIX,
 )
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client

--- a/backend/tests/integration/tests/chat/test_chat_session_access.py
+++ b/backend/tests/integration/tests/chat/test_chat_session_access.py
@@ -8,9 +8,9 @@ from tests.integration.common_utils.constants import API_SERVER_URL, GENERAL_HEA
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.chat import ChatSessionManager
 from tests.integration.common_utils.managers.user import (
-    build_email,
     DEFAULT_PASSWORD,
     UserManager,
+    build_email,
 )
 from tests.integration.common_utils.reset import reset_all
 from tests.integration.common_utils.test_models import DATestUser

--- a/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
+++ b/backend/tests/integration/tests/discord_bot/test_discord_bot_db.py
@@ -714,7 +714,7 @@ class TestServiceApiKeyAPI:
 @pytest.fixture
 def db_session() -> Generator[Session, None, None]:
     """Create database session for tests."""
-    from onyx.db.engine.sql_engine import get_session_with_current_tenant, SqlEngine
+    from onyx.db.engine.sql_engine import SqlEngine, get_session_with_current_tenant
     from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
     SqlEngine.init_engine(pool_size=10, max_overflow=5)

--- a/backend/tests/integration/tests/migrations/conftest.py
+++ b/backend/tests/integration/tests/migrations/conftest.py
@@ -24,7 +24,7 @@ from onyx.configs.app_configs import (
     POSTGRES_PORT,
     POSTGRES_USER,
 )
-from onyx.db.engine.sql_engine import build_connection_string, SYNC_DB_API
+from onyx.db.engine.sql_engine import SYNC_DB_API, build_connection_string
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
 
 # Override the parent integration conftest's autouse session fixtures.

--- a/backend/tests/integration/tests/migrations/test_alembic_tenants.py
+++ b/backend/tests/integration/tests/migrations/test_alembic_tenants.py
@@ -30,7 +30,7 @@ from onyx.configs.app_configs import (
     POSTGRES_PORT,
     POSTGRES_USER,
 )
-from onyx.db.engine.sql_engine import build_connection_string, SYNC_DB_API
+from onyx.db.engine.sql_engine import SYNC_DB_API, build_connection_string
 
 
 @pytest.fixture

--- a/backend/tests/integration/tests/query_history/utils.py
+++ b/backend/tests/integration/tests/query_history/utils.py
@@ -1,4 +1,4 @@
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from onyx.configs.constants import QAFeedbackType
 from tests.integration.common_utils.managers.api_key import APIKeyManager

--- a/backend/tests/integration/tests/scim/test_scim_groups.py
+++ b/backend/tests/integration/tests/scim/test_scim_groups.py
@@ -30,9 +30,9 @@ from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.scim_client import ScimClient
 from tests.integration.common_utils.managers.scim_token import ScimTokenManager
 from tests.integration.common_utils.managers.user import (
-    build_email,
     DEFAULT_PASSWORD,
     UserManager,
+    build_email,
 )
 from tests.integration.common_utils.test_models import DATestUser
 

--- a/backend/tests/integration/tests/scim/test_scim_users.py
+++ b/backend/tests/integration/tests/scim/test_scim_users.py
@@ -35,9 +35,9 @@ from tests.integration.common_utils.constants import ADMIN_USER_NAME, GENERAL_HE
 from tests.integration.common_utils.managers.scim_client import ScimClient
 from tests.integration.common_utils.managers.scim_token import ScimTokenManager
 from tests.integration.common_utils.managers.user import (
-    build_email,
     DEFAULT_PASSWORD,
     UserManager,
+    build_email,
 )
 from tests.integration.common_utils.test_models import DATestUser
 
@@ -69,9 +69,9 @@ def scim_token(idp_style: str) -> str:
         GENERAL_HEADERS,
     )
     from tests.integration.common_utils.managers.user import (
-        build_email,
         DEFAULT_PASSWORD,
         UserManager,
+        build_email,
     )
     from tests.integration.common_utils.test_models import DATestUser
 

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -16,8 +16,8 @@ from onyx.file_store.file_store import get_default_file_store
 from tests.integration.common_utils.constants import API_SERVER_URL
 from tests.integration.common_utils.http_client import client
 from tests.integration.common_utils.managers.skill import (
-    build_minimal_bundle,
     SkillManager,
+    build_minimal_bundle,
 )
 from tests.integration.common_utils.managers.user import UserManager
 from tests.integration.common_utils.managers.user_group import UserGroupManager

--- a/backend/tests/regression/search_quality/run_search_eval.py
+++ b/backend/tests/regression/search_quality/run_search_eval.py
@@ -4,7 +4,7 @@ import os
 import sys
 import time
 from collections import defaultdict
-from concurrent.futures import as_completed, ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from pathlib import Path
 from threading import Event, Lock, Semaphore
@@ -43,7 +43,7 @@ from onyx.configs.app_configs import (
     POSTGRES_API_SERVER_POOL_SIZE,
 )
 from onyx.context.search.models import BaseFilters, SavedSearchDoc
-from onyx.db.engine.sql_engine import get_session_with_tenant, SqlEngine
+from onyx.db.engine.sql_engine import SqlEngine, get_session_with_tenant
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT, POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.regression.search_quality.models import (
@@ -54,10 +54,10 @@ from tests.regression.search_quality.models import (
     TestQuery,
 )
 from tests.regression.search_quality.utils import (
+    LazyJsonWriter,
     compute_overall_scores,
     find_document_id,
     get_federated_sources,
-    LazyJsonWriter,
     ragas_evaluate,
     search_docs_to_doc_contexts,
 )

--- a/backend/tests/regression/search_quality/utils.py
+++ b/backend/tests/regression/search_quality/utils.py
@@ -2,12 +2,12 @@ import json
 import re
 from pathlib import Path
 from textwrap import indent
-from typing import Any, cast, TextIO
+from typing import Any, TextIO, cast
 
 from ragas import (  # ty: ignore[unresolved-import]
-    evaluate,
     EvaluationDataset,
     SingleTurnSample,
+    evaluate,
 )
 from ragas.dataset_schema import EvaluationResult  # ty: ignore[unresolved-import]
 from ragas.metrics import (  # ty: ignore[unresolved-import]

--- a/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/sharepoint/test_permission_utils.py
@@ -5,16 +5,16 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from ee.onyx.external_permissions.sharepoint.permission_utils import (
+    AD_GROUP_ENUMERATION_THRESHOLD,
+    SHAREPOINT_GROUP_PRINCIPAL_TYPE,
+    GroupsResult,
     _enumerate_ad_groups_paginated,
     _get_azuread_groups,
     _is_public_item,
     _iter_graph_collection,
     _normalize_email,
-    AD_GROUP_ENUMERATION_THRESHOLD,
     get_external_access_from_sharepoint,
     get_sharepoint_external_groups,
-    GroupsResult,
-    SHAREPOINT_GROUP_PRINCIPAL_TYPE,
 )
 
 MODULE = "ee.onyx.external_permissions.sharepoint.permission_utils"

--- a/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_billing_seat_enforcement.py
@@ -13,10 +13,10 @@ import pytest
 import stripe
 
 from ee.onyx.server.tenants.billing import (
+    SeatBillingDeclineReason,
     _seat_billing_idempotency_key,
     attempt_seat_billing_increase,
     enforce_cloud_seat_limit,
-    SeatBillingDeclineReason,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError

--- a/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
+++ b/backend/tests/unit/ee/onyx/utils/test_license_expiry.py
@@ -4,11 +4,11 @@ from unittest.mock import patch
 import pytest
 
 from ee.onyx.utils.license_expiry import (
+    LICENSE_GRACE_PERIOD_DAYS,
     ExpiryWarningStage,
     get_expiry_warning_stage,
     get_grace_days_remaining,
     get_grace_period_end,
-    LICENSE_GRACE_PERIOD_DAYS,
 )
 
 NOW = datetime(2026, 5, 1, 12, 0, 0, tzinfo=timezone.utc)

--- a/backend/tests/unit/external_apps/matching/test_engine.py
+++ b/backend/tests/unit/external_apps/matching/test_engine.py
@@ -9,10 +9,10 @@ from pydantic import ValidationError
 from onyx.db.enums import EndpointPolicy, ExternalAppType
 from onyx.db.models import ExternalApp
 from onyx.external_apps.matching.engine import (
-    AllMatchedActions,
-    apply_credential_gate,
-    MatchedAction,
     WHOLE_DOMAIN_ACTION_TYPE,
+    AllMatchedActions,
+    MatchedAction,
+    apply_credential_gate,
 )
 from onyx.external_apps.matching.request import ProxiedRequest
 

--- a/backend/tests/unit/external_apps/test_gmail_catalog.py
+++ b/backend/tests/unit/external_apps/test_gmail_catalog.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import pytest
 
 from onyx.db.enums import EndpointPolicy, ExternalAppType
-from onyx.external_apps.providers.actions import path_matches, RestRoute
+from onyx.external_apps.providers.actions import RestRoute, path_matches
 from onyx.external_apps.providers.gmail import GmailAction
 from onyx.external_apps.providers.registry import get_endpoint_catalog
 

--- a/backend/tests/unit/external_apps/test_google_drive_provider.py
+++ b/backend/tests/unit/external_apps/test_google_drive_provider.py
@@ -5,7 +5,7 @@ calls. Reads are auto-approved (ALWAYS); mutations default to ASK."""
 from __future__ import annotations
 
 from onyx.db.enums import EndpointPolicy, ExternalAppType
-from onyx.external_apps.providers.actions import path_matches, RestRoute
+from onyx.external_apps.providers.actions import RestRoute, path_matches
 from onyx.external_apps.providers.base import OnyxManagedExtApp
 from onyx.external_apps.providers.google_drive import (
     GoogleDriveAction,

--- a/backend/tests/unit/external_apps/test_managed_credentials.py
+++ b/backend/tests/unit/external_apps/test_managed_credentials.py
@@ -8,7 +8,7 @@ import pytest
 
 from onyx.db.enums import ExternalAppType
 from onyx.external_apps.providers.base import OnyxManagedExtApp
-from onyx.external_apps.providers.registry import get_onyx_managed_provider, PROVIDERS
+from onyx.external_apps.providers.registry import PROVIDERS, get_onyx_managed_provider
 
 
 def _gmail() -> OnyxManagedExtApp:

--- a/backend/tests/unit/external_apps/test_path_matching.py
+++ b/backend/tests/unit/external_apps/test_path_matching.py
@@ -3,7 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
-from onyx.external_apps.providers.actions import path_matches, RestRoute
+from onyx.external_apps.providers.actions import RestRoute, path_matches
 
 
 def test_non_trailing_wildcard_rejected_at_construction() -> None:

--- a/backend/tests/unit/file_store/test_file_store.py
+++ b/backend/tests/unit/file_store/test_file_store.py
@@ -6,12 +6,12 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from sqlalchemy import create_engine, DateTime, Enum, String
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, Session, sessionmaker
+from sqlalchemy import DateTime, Enum, String, create_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, Session, mapped_column, sessionmaker
 from sqlalchemy.sql import func
 
 from onyx.configs.constants import FileOrigin
-from onyx.file_store.file_store import get_default_file_store, S3BackedFileStore
+from onyx.file_store.file_store import S3BackedFileStore, get_default_file_store
 from onyx.file_store.gcs_file_store import GCSBackedFileStore
 
 

--- a/backend/tests/unit/onyx/auth/test_captcha_replay.py
+++ b/backend/tests/unit/onyx/auth/test_captcha_replay.py
@@ -7,10 +7,10 @@ import pytest
 
 from onyx.auth import captcha as captcha_module
 from onyx.auth.captcha import (
-    _replay_cache_key,
-    _reserve_token_or_raise,
     CaptchaAction,
     CaptchaVerificationError,
+    _replay_cache_key,
+    _reserve_token_or_raise,
     verify_captcha_token,
 )
 

--- a/backend/tests/unit/onyx/auth/test_email.py
+++ b/backend/tests/unit/onyx/auth/test_email.py
@@ -1,7 +1,7 @@
 import pytest
 
 from onyx.auth.email_utils import build_user_email_invite, send_email
-from onyx.configs.constants import AuthType, ONYX_DEFAULT_APPLICATION_NAME
+from onyx.configs.constants import ONYX_DEFAULT_APPLICATION_NAME, AuthType
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 

--- a/backend/tests/unit/onyx/auth/test_oidc_pkce.py
+++ b/backend/tests/unit/onyx/auth/test_oidc_pkce.py
@@ -11,10 +11,10 @@ from httpx_oauth.oauth2 import BaseOAuth2, GetAccessTokenError
 from onyx.auth.users import (
     CSRF_TOKEN_COOKIE_NAME,
     CSRF_TOKEN_KEY,
-    get_oauth_router,
-    get_pkce_cookie_name,
     PKCE_COOKIE_NAME_PREFIX,
     STATE_TOKEN_AUDIENCE,
+    get_oauth_router,
+    get_pkce_cookie_name,
 )
 from onyx.error_handling.exceptions import register_onyx_exception_handlers
 

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -11,9 +11,9 @@ from fastapi import Request
 
 from onyx.auth.permissions import (
     ALL_PERMISSIONS,
-    get_effective_permissions,
     IMPLIED_PERMISSIONS,
     NON_TOGGLEABLE_PERMISSIONS,
+    get_effective_permissions,
     require_permission,
     resolve_effective_permissions,
 )

--- a/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
+++ b/backend/tests/unit/onyx/auth/test_signup_rate_limit.py
@@ -7,9 +7,9 @@ from fastapi import Request
 
 from onyx.auth import signup_rate_limit as rl
 from onyx.auth.signup_rate_limit import (
+    _PER_IP_PER_HOUR,
     _bucket_key,
     _client_ip,
-    _PER_IP_PER_HOUR,
     enforce_signup_rate_limit,
 )
 from onyx.error_handling.exceptions import OnyxError

--- a/backend/tests/unit/onyx/background/celery/tasks/test_user_file_project_sync_queue.py
+++ b/backend/tests/unit/onyx/background/celery/tasks/test_user_file_project_sync_queue.py
@@ -11,10 +11,10 @@ from onyx.background.celery.tasks.user_file_processing.tasks import (
 )
 from onyx.configs.constants import (
     CELERY_USER_FILE_PROJECT_SYNC_TASK_EXPIRES,
+    USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
     OnyxCeleryPriority,
     OnyxCeleryQueues,
     OnyxCeleryTask,
-    USER_FILE_PROJECT_SYNC_MAX_QUEUE_DEPTH,
 )
 
 

--- a/backend/tests/unit/onyx/chat/test_compression.py
+++ b/backend/tests/unit/onyx/chat/test_compression.py
@@ -4,12 +4,12 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 from onyx.chat.compression import (
+    SummaryContent,
     _build_llm_messages_for_summarization,
     find_summary_for_branch,
     generate_summary,
     get_compression_params,
     get_messages_to_summarize,
-    SummaryContent,
 )
 from onyx.configs.constants import MessageType
 from onyx.llm.models import AssistantMessage, SystemMessage, UserMessage

--- a/backend/tests/unit/onyx/chat/test_llm_loop.py
+++ b/backend/tests/unit/onyx/chat/test_llm_loop.py
@@ -6,10 +6,10 @@ from unittest.mock import Mock
 import pytest
 
 from onyx.chat.llm_loop import (
+    EmptyLLMResponseError,
     _build_empty_llm_response_error,
     _try_fallback_tool_extraction,
     construct_message_history,
-    EmptyLLMResponseError,
     select_reminder_text,
 )
 from onyx.chat.models import (

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -10,12 +10,12 @@ from onyx.access.models import ExternalAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.canvas.client import CanvasApiClient
 from onyx.connectors.canvas.connector import (
-    _in_time_window,
-    _parse_canvas_dt,
-    _unix_to_canvas_time,
     CanvasConnector,
     CanvasConnectorCheckpoint,
     CanvasStage,
+    _in_time_window,
+    _parse_canvas_dt,
+    _unix_to_canvas_time,
 )
 from onyx.connectors.exceptions import (
     CredentialExpiredError,

--- a/backend/tests/unit/onyx/connectors/confluence/test_confcloud_77618_fallback.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confcloud_77618_fallback.py
@@ -20,9 +20,9 @@ from onyx.connectors.confluence.access import (
 )
 from onyx.connectors.confluence.connector import ConfluenceConnector
 from onyx.connectors.confluence.onyx_confluence import (
-    _is_confcloud_77618_response,
     Confcloud77618Error,
     OnyxConfluence,
+    _is_confcloud_77618_response,
 )
 from onyx.connectors.interfaces import CredentialsProviderInterface
 

--- a/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_onyx_confluence.py
@@ -11,8 +11,8 @@ from onyx.connectors.confluence.onyx_confluence import (
     _DEFAULT_PAGINATION_LIMIT,
     _MINIMUM_PAGINATION_LIMIT,
     ConfluenceRestSpacePermissionsNotAvailableError,
-    get_user_email_from_userkey__server,
     OnyxConfluence,
+    get_user_email_from_userkey__server,
 )
 from onyx.connectors.exceptions import (
     ConnectorValidationError,

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -9,7 +9,7 @@ from github.GithubException import UnknownObjectException
 from github.RateLimit import RateLimit
 from github.Requester import Requester
 
-from onyx.connectors.github.connector import _is_indexable_path, GithubConnector
+from onyx.connectors.github.connector import GithubConnector, _is_indexable_path
 from onyx.connectors.github.models import SerializedRepository
 from onyx.connectors.models import ConnectorFailure, Document
 from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector

--- a/backend/tests/unit/onyx/connectors/github/test_github_slim_connector.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_slim_connector.py
@@ -4,7 +4,7 @@ correctly, and that pruning uses the cheap slim path (no lazy loading).
 """
 
 from collections.abc import Generator
-from unittest.mock import MagicMock, patch, PropertyMock
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 

--- a/backend/tests/unit/onyx/connectors/gmail/test_connector.py
+++ b/backend/tests/unit/onyx/connectors/gmail/test_connector.py
@@ -8,9 +8,9 @@ from unittest.mock import MagicMock, patch
 from onyx.access.models import ExternalAccess
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.gmail.connector import (
-    _build_time_range_query,
     GmailCheckpoint,
     GmailConnector,
+    _build_time_range_query,
     thread_to_document,
 )
 from onyx.connectors.models import Document, TextSection

--- a/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_google_credential_storage.py
@@ -3,9 +3,9 @@ from typing import Any
 import pytest
 
 from onyx.configs.constants import (
-    DocumentSource,
     KV_GOOGLE_DRIVE_CRED_KEY,
     KV_GOOGLE_DRIVE_SERVICE_ACCOUNT_KEY,
+    DocumentSource,
 )
 from onyx.connectors.google_utils.google_kv import (
     get_auth_url,

--- a/backend/tests/unit/onyx/connectors/google_utils/test_impersonation_guard.py
+++ b/backend/tests/unit/onyx/connectors/google_utils/test_impersonation_guard.py
@@ -5,8 +5,8 @@ from google.auth.exceptions import RefreshError
 
 from onyx.connectors.google_utils.resources import (
     ImpersonationError,
-    make_user_removal_checker,
     UserRemovedError,
+    make_user_removal_checker,
 )
 from onyx.connectors.google_utils.shared_constants import MISSING_SCOPES_ERROR_STR
 

--- a/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_custom_config.py
+++ b/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_custom_config.py
@@ -10,8 +10,8 @@ import json
 from typing import Any
 
 from onyx.connectors.salesforce.connector import (
-    _validate_custom_query_config,
     SalesforceConnector,
+    _validate_custom_query_config,
 )
 from onyx.connectors.salesforce.utils import ACCOUNT_OBJECT_TYPE, MODIFIED_FIELD
 

--- a/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_sqlite.py
+++ b/backend/tests/unit/onyx/connectors/salesforce/test_salesforce_sqlite.py
@@ -14,7 +14,7 @@ import pytest
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.cross_connector_utils.miscellaneous_utils import time_str_to_utc
 from onyx.connectors.models import BasicExpertInfo, Document, ImageSection, TextSection
-from onyx.connectors.salesforce.doc_conversion import _extract_section, ID_PREFIX
+from onyx.connectors.salesforce.doc_conversion import ID_PREFIX, _extract_section
 from onyx.connectors.salesforce.onyx_salesforce import OnyxSalesforce
 from onyx.connectors.salesforce.salesforce_calls import (
     _bulk_retrieve_from_salesforce,

--- a/backend/tests/unit/onyx/connectors/salesforce/test_yield_doc_batches.py
+++ b/backend/tests/unit/onyx/connectors/salesforce/test_yield_doc_batches.py
@@ -8,8 +8,8 @@ import pytest
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.models import Document
 from onyx.connectors.salesforce.connector import (
-    _convert_to_metadata_value,
     SalesforceConnector,
+    _convert_to_metadata_value,
 )
 from onyx.connectors.salesforce.utils import (
     ID_FIELD,

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_denylist.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_denylist.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import pytest
 
 from onyx.connectors.sharepoint.connector import (
-    _build_item_relative_path,
-    _is_path_excluded,
-    _is_site_excluded,
     DriveItemData,
     SharepointConnector,
     SiteDescriptor,
+    _build_item_relative_path,
+    _is_path_excluded,
+    _is_site_excluded,
 )
 
 

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -9,8 +9,8 @@ import pytest
 
 from onyx.connectors.models import Document, DocumentSource, TextSection
 from onyx.connectors.sharepoint.connector import (
-    DriveItemData,
     SHARED_DOCUMENTS_MAP,
+    DriveItemData,
     SharepointConnector,
     SharepointConnectorCheckpoint,
     SiteDescriptor,

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_fetch_site_pages.py
@@ -19,11 +19,11 @@ from requests import Response
 from requests.exceptions import HTTPError
 
 from onyx.connectors.sharepoint.connector import (
-    _is_per_site_graph_failure,
     GRAPH_INVALID_REQUEST_CODE,
     PER_SITE_GRAPH_FAILURE_STATUSES,
     SharepointConnector,
     SiteDescriptor,
+    _is_per_site_graph_failure,
 )
 
 SITE_URL = "https://tenant.sharepoint.com/sites/ClassicSite"

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_streaming_download_retry.py
@@ -17,10 +17,10 @@ import requests
 
 from onyx.connectors.sharepoint import connector as sp_connector
 from onyx.connectors.sharepoint.connector import (
+    SizeCapExceeded,
     _download_via_graph_api,
     _download_with_cap,
     _redact_url_for_logging,
-    SizeCapExceeded,
 )
 
 CAP = 10 * 1024 * 1024  # 10 MiB cap; well above the byte payloads used in tests

--- a/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
@@ -11,13 +11,13 @@ import pytest
 from slack_sdk.errors import SlackApiError
 
 from onyx.connectors.slack.connector import (
+    SlackConnector,
     _channel_team_id,
     _channel_to_hierarchy_node,
     channel_team_ids,
     fetch_team_url,
     get_channels_across_teams,
     list_grid_team_ids,
-    SlackConnector,
 )
 from onyx.connectors.slack.models import ChannelType, MessageType
 from onyx.connectors.slack.utils import get_message_link

--- a/backend/tests/unit/onyx/connectors/slack/test_message_filtering.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_message_filtering.py
@@ -1,10 +1,10 @@
 import pytest
 
 from onyx.connectors.slack.connector import (
-    _bot_inclusive_msg_filter,
-    default_msg_filter,
     SlackConnector,
     SlackMessageFilterReason,
+    _bot_inclusive_msg_filter,
+    default_msg_filter,
 )
 from onyx.connectors.slack.models import MessageType
 

--- a/backend/tests/unit/onyx/connectors/teams/test_execute_query_with_retry.py
+++ b/backend/tests/unit/onyx/connectors/teams/test_execute_query_with_retry.py
@@ -13,9 +13,9 @@ import pytest
 from office365.runtime.client_request_exception import ClientRequestException
 
 from onyx.connectors.teams.utils import (
+    GRAPH_API_RETRYABLE_STATUSES,
     _backoff_seconds,
     execute_query_with_retry,
-    GRAPH_API_RETRYABLE_STATUSES,
 )
 
 

--- a/backend/tests/unit/onyx/connectors/teams/test_retry_request.py
+++ b/backend/tests/unit/onyx/connectors/teams/test_retry_request.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from requests.exceptions import HTTPError
 
-from onyx.connectors.teams.utils import _retry, GRAPH_API_RETRYABLE_STATUSES
+from onyx.connectors.teams.utils import GRAPH_API_RETRYABLE_STATUSES, _retry
 
 
 def _response(

--- a/backend/tests/unit/onyx/connectors/test_connector_factory.py
+++ b/backend/tests/unit/onyx/connectors/test_connector_factory.py
@@ -13,9 +13,9 @@ import pytest
 
 from onyx.configs.constants import DocumentSource
 from onyx.connectors.factory import (
+    ConnectorMissingException,
     _connector_cache,
     _load_connector_class,
-    ConnectorMissingException,
     identify_connector_class,
     instantiate_connector,
 )

--- a/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
+++ b/backend/tests/unit/onyx/connectors/web/test_ssrf_protection.py
@@ -15,10 +15,10 @@ import pytest
 from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.web import connector as web_connector
 from onyx.connectors.web.connector import (
-    check_internet_connection,
-    extract_urls_from_sitemap,
     WEB_CONNECTOR_VALID_SETTINGS,
     WebConnector,
+    check_internet_connection,
+    extract_urls_from_sitemap,
 )
 from onyx.server.security.models import SSRFProtectionLevel
 

--- a/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/zendesk/test_zendesk_checkpointing.py
@@ -1,7 +1,7 @@
 import time
 from collections.abc import Callable, Generator
 from typing import Any, cast
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from requests.exceptions import HTTPError

--- a/backend/tests/unit/onyx/context/search/federated/test_slack_thread_context.py
+++ b/backend/tests/unit/onyx/context/search/federated/test_slack_thread_context.py
@@ -8,10 +8,10 @@ from slack_sdk.errors import SlackApiError
 
 from onyx.context.search.federated.models import SlackMessage
 from onyx.context.search.federated.slack_search import (
-    _fetch_thread_context,
-    fetch_thread_contexts_with_rate_limit_handling,
     SlackRateLimitError,
     ThreadContextResult,
+    _fetch_thread_context,
+    fetch_thread_contexts_with_rate_limit_handling,
 )
 
 

--- a/backend/tests/unit/onyx/db/test_chat_message_cleanup.py
+++ b/backend/tests/unit/onyx/db/test_chat_message_cleanup.py
@@ -4,7 +4,7 @@ Verifies that user-owned files (those with user_file_id) are never deleted
 during chat session cleanup — only chat-only files should be removed.
 """
 
-from unittest.mock import call, MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 from uuid import uuid4
 
 from onyx.db.chat import delete_messages_and_files_from_chat_session

--- a/backend/tests/unit/onyx/db/test_usage.py
+++ b/backend/tests/unit/onyx/db/test_usage.py
@@ -6,14 +6,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from onyx.db.usage import (
+    TenantUsageStats,
+    UsageLimitExceededError,
+    UsageType,
     check_usage_limit,
     get_current_window_start,
     get_or_create_tenant_usage,
     get_tenant_usage_stats,
     increment_usage,
-    TenantUsageStats,
-    UsageLimitExceededError,
-    UsageType,
 )
 
 

--- a/backend/tests/unit/onyx/db/test_voice.py
+++ b/backend/tests/unit/onyx/db/test_voice.py
@@ -7,6 +7,8 @@ import pytest
 
 from onyx.db.models import VoiceProvider
 from onyx.db.voice import (
+    MAX_VOICE_PLAYBACK_SPEED,
+    MIN_VOICE_PLAYBACK_SPEED,
     deactivate_stt_provider,
     deactivate_tts_provider,
     delete_voice_provider,
@@ -15,8 +17,6 @@ from onyx.db.voice import (
     fetch_voice_provider_by_id,
     fetch_voice_provider_by_type,
     fetch_voice_providers,
-    MAX_VOICE_PLAYBACK_SPEED,
-    MIN_VOICE_PLAYBACK_SPEED,
     set_default_stt_provider,
     set_default_tts_provider,
     update_user_voice_settings,

--- a/backend/tests/unit/onyx/document_index/test_disabled_document_index.py
+++ b/backend/tests/unit/onyx/document_index/test_disabled_document_index.py
@@ -12,7 +12,7 @@ import pytest
 from onyx.context.search.enums import QueryType
 from onyx.context.search.models import IndexFilters
 from onyx.db.enums import EmbeddingPrecision
-from onyx.document_index.disabled import DisabledDocumentIndex, VECTOR_DB_DISABLED_ERROR
+from onyx.document_index.disabled import VECTOR_DB_DISABLED_ERROR, DisabledDocumentIndex
 from onyx.document_index.interfaces_new import IndexingMetadata, MetadataUpdateRequest
 
 ESCAPED_ERROR = re.escape(VECTOR_DB_DISABLED_ERROR)

--- a/backend/tests/unit/onyx/federated_connectors/test_federated_connector_factory.py
+++ b/backend/tests/unit/onyx/federated_connectors/test_federated_connector_factory.py
@@ -13,9 +13,9 @@ import pytest
 
 from onyx.configs.constants import FederatedConnectorSource
 from onyx.federated_connectors.factory import (
+    FederatedConnectorMissingException,
     _federated_connector_cache,
     _load_federated_connector_class,
-    FederatedConnectorMissingException,
     get_federated_connector_cls,
 )
 from onyx.federated_connectors.interfaces import FederatedConnector

--- a/backend/tests/unit/onyx/federated_connectors/test_oauth_utils.py
+++ b/backend/tests/unit/onyx/federated_connectors/test_oauth_utils.py
@@ -11,9 +11,9 @@ import pytest
 
 from onyx.cache.interface import CacheBackend, CacheLock
 from onyx.federated_connectors.oauth_utils import (
-    generate_oauth_state,
     OAUTH_STATE_TTL,
     OAuthSession,
+    generate_oauth_state,
     verify_oauth_state,
 )
 

--- a/backend/tests/unit/onyx/indexing/test_document_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_document_chunker.py
@@ -1,7 +1,7 @@
 import pytest
 from chonkie import SentenceChunker
 
-from onyx.configs.constants import DocumentSource, SECTION_SEPARATOR
+from onyx.configs.constants import SECTION_SEPARATOR, DocumentSource
 from onyx.connectors.models import IndexingDocument, Section, SectionType
 from onyx.indexing.chunking import DocumentChunker
 from onyx.indexing.chunking import text_section_chunker as text_chunker_module

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -2,7 +2,7 @@ import random
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Any, cast, List
+from typing import Any, List, cast
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest

--- a/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
+++ b/backend/tests/unit/onyx/indexing/test_tabular_section_chunker.py
@@ -19,8 +19,8 @@ from onyx.indexing.chunking.tabular_section_chunker.sheet_descriptor import (
     build_sheet_descriptor_chunks,
 )
 from onyx.indexing.chunking.tabular_section_chunker.total_descriptor import (
-    build_total_descriptor_chunks,
     TOTALS_HEADER,
+    build_total_descriptor_chunks,
 )
 from onyx.natural_language_processing.utils import BaseTokenizer
 from onyx.utils.csv_utils import parse_csv_string, read_csv_header

--- a/backend/tests/unit/onyx/llm/test_model_response.py
+++ b/backend/tests/unit/onyx/llm/test_model_response.py
@@ -1,16 +1,16 @@
 from __future__ import annotations
 
-from typing import cast, TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 
 from onyx.llm.model_response import (
     ChatCompletionDeltaToolCall,
-    from_litellm_model_response,
-    from_litellm_model_response_stream,
     FunctionCall,
     ModelResponse,
     ModelResponseStream,
+    from_litellm_model_response,
+    from_litellm_model_response_stream,
 )
 
 if TYPE_CHECKING:

--- a/backend/tests/unit/onyx/onyxbot/discord/test_discord_utils.py
+++ b/backend/tests/unit/onyx/onyxbot/discord/test_discord_utils.py
@@ -9,9 +9,9 @@ from unittest.mock import MagicMock, patch
 
 from onyx.onyxbot.discord.utils import get_bot_token
 from onyx.server.manage.discord_bot.utils import (
+    REGISTRATION_KEY_PREFIX,
     generate_discord_registration_key,
     parse_discord_registration_key,
-    REGISTRATION_KEY_PREFIX,
 )
 
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_manager_config.py
@@ -22,18 +22,18 @@ from onyx.server.features.build.sandbox.docker.dev_mode_serve import (
     OPENCODE_SERVE_HOST_BIND_IP,
 )
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
+    LABEL_COMPONENT,
+    LABEL_COMPONENT_VALUE,
+    LABEL_SANDBOX_ID,
+    LABEL_TENANT_ID,
+    LABEL_USER_ID,
+    ContainerCreateKwargs,
     _sandbox_container_name,
     _sandbox_volume_name,
     _sanitize_relative_path,
     _validate_strict_path,
     build_container_create_kwargs,
     build_sandbox_labels,
-    ContainerCreateKwargs,
-    LABEL_COMPONENT,
-    LABEL_COMPONENT_VALUE,
-    LABEL_SANDBOX_ID,
-    LABEL_TENANT_ID,
-    LABEL_USER_ID,
 )
 from onyx.server.features.build.sandbox.labels import (
     LABEL_K8S_MANAGED_BY,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_event_bus.py
@@ -22,10 +22,10 @@ import pytest
 
 from onyx.server.features.build.sandbox.opencode import event_bus as event_bus_mod
 from onyx.server.features.build.sandbox.opencode.event_bus import (
-    _extract_session_id,
-    _parse_sse_block,
     BUS_CLOSED_SENTINEL,
     PodEventBus,
+    _extract_session_id,
+    _parse_sse_block,
 )
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -26,8 +26,8 @@ from cryptography.hazmat.primitives.serialization import (
 from kubernetes.client.rest import ApiException
 
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-    _build_targz,
     KubernetesSandboxManager,
+    _build_targz,
 )
 from onyx.server.features.build.sandbox.models import (
     FatalWriteError,

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_pod_spec.py
@@ -28,8 +28,8 @@ from kubernetes import client
 import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
 from onyx.server.features.build.configs import SANDBOX_PROXY_INJECTED_PLACEHOLDER
 from onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager import (
-    KubernetesSandboxManager,
     PUSH_DAEMON_PORT,
+    KubernetesSandboxManager,
 )
 
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_serve_readiness_probe.py
@@ -15,8 +15,8 @@ import pytest
 
 from onyx.server.features.build.sandbox.opencode.serve_client import OpencodeServeClient
 from onyx.server.features.build.sandbox.serve_transport import (
-    _ServeMixin,
     ServeConnectionInfo,
+    _ServeMixin,
 )
 
 _SBX = UUID("12345678-1234-1234-1234-1234567890ab")

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_snapshot_manager_streams.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_snapshot_manager_streams.py
@@ -9,7 +9,7 @@ must stay stable, so we assert it here against a fake ``FileStore``.
 from __future__ import annotations
 
 import io
-from typing import Any, cast, IO
+from typing import IO, Any, cast
 
 import pytest
 

--- a/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
+++ b/backend/tests/unit/onyx/server/manage/voice/test_chunked_transcriber.py
@@ -10,11 +10,11 @@ from unittest.mock import AsyncMock
 import pytest
 
 from onyx.server.manage.voice.websocket_api import (
-    ChunkedTranscriber,
-    pcm16_rms,
     PCM_BYTES_PER_SECOND,
     PCM_SAMPLE_RATE,
     SILENCE_RMS_THRESHOLD,
+    ChunkedTranscriber,
+    pcm16_rms,
     trim_pcm16_silence,
 )
 

--- a/backend/tests/unit/onyx/server/scim/test_auth.py
+++ b/backend/tests/unit/onyx/server/scim/test_auth.py
@@ -3,10 +3,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from ee.onyx.server.scim.auth import (
-    _hash_scim_token,
-    generate_scim_token,
     SCIM_TOKEN_PREFIX,
     ScimAuthError,
+    _hash_scim_token,
+    generate_scim_token,
     verify_scim_token,
 )
 

--- a/backend/tests/unit/onyx/server/scim/test_entra.py
+++ b/backend/tests/unit/onyx/server/scim/test_entra.py
@@ -16,6 +16,7 @@ import pytest
 from fastapi import Response
 
 from ee.onyx.server.scim.api import (
+    ScimJSONResponse,
     create_user,
     delete_user,
     get_group,
@@ -28,7 +29,6 @@ from ee.onyx.server.scim.api import (
     patch_group,
     patch_user,
     replace_user,
-    ScimJSONResponse,
 )
 from ee.onyx.server.scim.models import (
     SCIM_ENTERPRISE_USER_SCHEMA,

--- a/backend/tests/unit/onyx/server/scim/test_filtering.py
+++ b/backend/tests/unit/onyx/server/scim/test_filtering.py
@@ -1,9 +1,9 @@
 import pytest
 
 from ee.onyx.server.scim.filtering import (
-    parse_scim_filter,
     ScimFilter,
     ScimFilterOperator,
+    parse_scim_filter,
 )
 
 

--- a/backend/tests/unit/onyx/server/scim/test_patch.py
+++ b/backend/tests/unit/onyx/server/scim/test_patch.py
@@ -13,9 +13,9 @@ from ee.onyx.server.scim.models import (
     ScimUserResource,
 )
 from ee.onyx.server.scim.patch import (
+    ScimPatchError,
     apply_group_patch,
     apply_user_patch,
-    ScimPatchError,
 )
 from ee.onyx.server.scim.providers.entra import EntraProvider
 from ee.onyx.server.scim.providers.okta import OktaProvider

--- a/backend/tests/unit/onyx/server/security/test_models.py
+++ b/backend/tests/unit/onyx/server/security/test_models.py
@@ -6,15 +6,15 @@ import pytest
 from pydantic import ValidationError
 
 from onyx.server.security.models import (
-    _derive_operator_locked_fields,
-    _operator_locked,
-    _tenant_editable,
     OPERATOR_LOCKED_FIELDS,
     PASSWORD_LENGTH_CAP,
     PASSWORD_MAX_LENGTH_FLOOR,
     SecuritySettings,
     SecuritySettingsOverrides,
     SSRFProtectionLevel,
+    _derive_operator_locked_fields,
+    _operator_locked,
+    _tenant_editable,
 )
 
 _VALID_EFFECTIVE_KWARGS: dict[str, Any] = {

--- a/backend/tests/unit/onyx/server/test_pool_metrics.py
+++ b/backend/tests/unit/onyx/server/test_pool_metrics.py
@@ -7,8 +7,8 @@ from fastapi import FastAPI
 from sqlalchemy.pool import NullPool
 
 from onyx.server.metrics.postgres_connection_pool import (
-    _register_pool_events,
     PoolStateCollector,
+    _register_pool_events,
     setup_postgres_connection_pool_metrics,
 )
 from onyx.utils.middleware import _build_route_map, _match_route

--- a/backend/tests/unit/onyx/skills/test_bundle_safety.py
+++ b/backend/tests/unit/onyx/skills/test_bundle_safety.py
@@ -17,8 +17,8 @@ import pytest
 
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.bundle import (
-    _safe_unzip,
     _ZIP_UNIX_CREATE_SYSTEM,
+    _safe_unzip,
     validate_custom_bundle,
 )
 

--- a/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
+++ b/backend/tests/unit/onyx/tools/custom/test_custom_tools.py
@@ -8,8 +8,8 @@ import pytest
 from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import DynamicSchemaInfo, ToolResponse
 from onyx.tools.tool_implementations.custom.custom_tool import (
-    build_custom_tools_from_openapi_schema_and_headers,
     CustomToolCallSummary,
+    build_custom_tools_from_openapi_schema_and_headers,
     validate_openapi_schema,
 )
 from onyx.tools.tool_implementations.custom.openapi_parsing import (

--- a/backend/tests/unit/onyx/tools/test_file_reader_tool.py
+++ b/backend/tests/unit/onyx/tools/test_file_reader_tool.py
@@ -18,10 +18,10 @@ from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import ToolCallException
 from onyx.tools.tool_implementations.file_reader.file_reader_tool import (
     FILE_ID_FIELD,
-    FileReaderTool,
     MAX_NUM_CHARS,
     NUM_CHARS_FIELD,
     START_CHAR_FIELD,
+    FileReaderTool,
 )
 
 TOOL_MODULE = "onyx.tools.tool_implementations.file_reader.file_reader_tool"

--- a/backend/tests/unit/onyx/tools/test_image_generation_reference_resolution.py
+++ b/backend/tests/unit/onyx/tools/test_image_generation_reference_resolution.py
@@ -14,8 +14,8 @@ import pytest
 
 from onyx.tools.models import ToolCallException
 from onyx.tools.tool_implementations.images.image_generation_tool import (
-    ImageGenerationTool,
     REFERENCE_IMAGE_FILE_IDS_FIELD,
+    ImageGenerationTool,
 )
 
 

--- a/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
+++ b/backend/tests/unit/onyx/tools/test_mcp_tool_schema.py
@@ -15,8 +15,8 @@ from unittest.mock import MagicMock
 import pytest
 
 from onyx.tools.tool_implementations.mcp.mcp_tool import (
-    _normalize_parameters_schema,
     MCPTool,
+    _normalize_parameters_schema,
 )
 
 

--- a/backend/tests/unit/onyx/tools/test_search_llm_json.py
+++ b/backend/tests/unit/onyx/tools/test_search_llm_json.py
@@ -8,8 +8,8 @@ from onyx.configs.constants import DocumentSource
 from onyx.context.search.models import InferenceChunk, InferenceSection
 from onyx.context.search.utils import sandbox_filename_for_document
 from onyx.tools.tool_implementations.utils import (
-    convert_inference_sections_to_llm_string,
     FILE_ASSOCIATED_GUIDANCE,
+    convert_inference_sections_to_llm_string,
 )
 
 FID = "550e8400-e29b-41d4-a716-446655440000"

--- a/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/bash/test_bash_tool.py
@@ -26,9 +26,9 @@ from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import BashToolDelta, BashToolStart
 from onyx.tools.models import ToolCallException
 from onyx.tools.tool_implementations.bash.bash_tool import (
+    CMD_FIELD,
     BashTool,
     BashToolOverrideKwargs,
-    CMD_FIELD,
 )
 from onyx.tools.tool_implementations.python.code_interpreter_client import (
     BashExecResponse,

--- a/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_ssrf.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/mcp/test_mcp_ssrf.py
@@ -11,7 +11,7 @@ import httpx
 import pytest
 
 from onyx.auth import oauth_token_manager
-from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token, OAuthFlowParams
+from onyx.auth.oauth_token_manager import OAuthFlowParams, exchange_oauth_code_for_token
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.mcp import api

--- a/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/python/test_python_tool_upload_cache.py
@@ -13,10 +13,10 @@ from onyx.tools.tool_implementations.python.code_interpreter_client import (
     StreamResultEvent,
 )
 from onyx.tools.tool_implementations.python.python_tool import (
+    PythonTool,
     _build_staging_notice,
     _code_references_file,
     _select_files_for_staging,
-    PythonTool,
 )
 
 TOOL_MODULE = "onyx.tools.tool_implementations.python.python_tool"

--- a/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/websearch/test_web_search_tool_run.py
@@ -9,8 +9,8 @@ from onyx.server.query_and_chat.placement import Placement
 from onyx.tools.models import ToolCallException, WebSearchToolOverrideKwargs
 from onyx.tools.tool_implementations.web_search.models import WebSearchResult
 from onyx.tools.tool_implementations.web_search.web_search_tool import (
-    _normalize_queries_input,
     WebSearchTool,
+    _normalize_queries_input,
 )
 
 

--- a/backend/tests/unit/onyx/utils/test_github.py
+++ b/backend/tests/unit/onyx/utils/test_github.py
@@ -7,8 +7,8 @@ import pytest
 import requests
 
 from onyx.utils.github import (
-    download_github_repo,
     GITHUB_TARBALL_URL,
+    download_github_repo,
     parse_github_repo,
 )
 

--- a/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
+++ b/backend/tests/unit/onyx/utils/test_threadpool_concurrency.py
@@ -7,10 +7,10 @@ from concurrent.futures import ThreadPoolExecutor
 import pytest
 
 from onyx.utils.threadpool_concurrency import (
+    ThreadSafeDict,
     parallel_yield,
     run_in_background,
     run_with_timeout,
-    ThreadSafeDict,
     wait_on_background,
 )
 

--- a/backend/tests/unit/onyx/utils/test_url_ssrf.py
+++ b/backend/tests/unit/onyx/utils/test_url_ssrf.py
@@ -10,10 +10,10 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from onyx.utils.url import (
+    SSRFException,
     _is_ip_private_or_reserved,
     _validate_and_resolve_url,
     ssrf_safe_get,
-    SSRFException,
     validate_outbound_http_url,
 )
 

--- a/backend/tests/unit/onyx/utils/test_vespa_query.py
+++ b/backend/tests/unit/onyx/utils/test_vespa_query.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta, timezone
 
-from onyx.configs.constants import DocumentSource, INDEX_SEPARATOR
+from onyx.configs.constants import INDEX_SEPARATOR, DocumentSource
 from onyx.context.search.models import IndexFilters, Tag
 from onyx.document_index.vespa.shared_utils.vespa_request_builders import (
     build_vespa_filters,

--- a/backend/tests/unit/onyx/voice/providers/test_elevenlabs_provider.py
+++ b/backend/tests/unit/onyx/voice/providers/test_elevenlabs_provider.py
@@ -1,10 +1,10 @@
 import struct
 
 from onyx.voice.providers.elevenlabs import (
-    _http_to_ws_url,
     DEFAULT_ELEVENLABS_API_BASE,
     ElevenLabsSTTMessageType,
     ElevenLabsVoiceProvider,
+    _http_to_ws_url,
 )
 
 # --- _http_to_ws_url ---

--- a/backend/tests/unit/onyx/voice/providers/test_openai_provider.py
+++ b/backend/tests/unit/onyx/voice/providers/test_openai_provider.py
@@ -3,10 +3,10 @@ import struct
 import wave
 
 from onyx.voice.providers.openai import (
-    _create_wav_header,
-    _http_to_ws_url,
     OpenAIRealtimeMessageType,
     OpenAIVoiceProvider,
+    _create_wav_header,
+    _http_to_ws_url,
 )
 
 # --- _http_to_ws_url ---

--- a/backend/tests/unit/sandbox_proxy/test_credential_injection.py
+++ b/backend/tests/unit/sandbox_proxy/test_credential_injection.py
@@ -18,11 +18,11 @@ from onyx.sandbox_proxy.credential_injection import (
     InjectionOutcome,
 )
 from onyx.sandbox_proxy.errors import SandboxProxyError
-from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import (
-    make_matched_actions,
     RecordingCredentialResolver,
+    make_matched_actions,
 )
+from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
 
 

--- a/backend/tests/unit/sandbox_proxy/test_errors.py
+++ b/backend/tests/unit/sandbox_proxy/test_errors.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 
-from onyx.sandbox_proxy.errors import http_403, SandboxProxyError
+from onyx.sandbox_proxy.errors import SandboxProxyError, http_403
 
 
 @pytest.mark.parametrize("code", list(SandboxProxyError))

--- a/backend/tests/unit/sandbox_proxy/test_gate.py
+++ b/backend/tests/unit/sandbox_proxy/test_gate.py
@@ -29,9 +29,9 @@ from onyx.db.enums import ApprovalDecidedVia, ApprovalDecision, EndpointPolicy
 from onyx.external_apps.matching.engine import AllMatchedActions
 from onyx.sandbox_proxy.addons import gate as gate_mod
 from onyx.sandbox_proxy.addons.gate import (
+    PARSER_MAX_BODY_BYTES,
     GateAddon,
     ParkedApprovals,
-    PARSER_MAX_BODY_BYTES,
 )
 from onyx.sandbox_proxy.credential_injection import (
     CredentialInjectionDispatcher,
@@ -42,13 +42,13 @@ from onyx.sandbox_proxy.errors import SandboxProxyError
 from onyx.sandbox_proxy.identity import ResolvedSandbox, SessionContext
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.sandbox_proxy.snapshot_egress import SnapshotEgressPolicy
-from tests.unit.sandbox_proxy.conftest import make_flow as _flow
 from tests.unit.sandbox_proxy.conftest import (
-    make_matched_actions,
     RecordingCredentialResolver,
+    make_matched_actions,
 )
-from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
 from tests.unit.sandbox_proxy.conftest import StubResolver as _StubResolver
+from tests.unit.sandbox_proxy.conftest import make_flow as _flow
+from tests.unit.sandbox_proxy.conftest import make_resolved_sandbox as _sandbox
 
 # ---------------------------------------------------------------------------
 # Stubs

--- a/backend/tests/unit/sandbox_proxy/test_identity_docker.py
+++ b/backend/tests/unit/sandbox_proxy/test_identity_docker.py
@@ -7,8 +7,8 @@ import pytest
 from docker import DockerClient
 
 from onyx.sandbox_proxy.identity_docker import (
-    _identity_from_container,
     DockerEventsLookup,
+    _identity_from_container,
 )
 
 _DEFAULT_NETWORK = "onyx_craft_sandbox"

--- a/backend/tests/unit/sandbox_proxy/test_informer.py
+++ b/backend/tests/unit/sandbox_proxy/test_informer.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from kubernetes import client
 
-from onyx.sandbox_proxy.identity_k8s import _identity_from_pod, K8sInformerLookup
+from onyx.sandbox_proxy.identity_k8s import K8sInformerLookup, _identity_from_pod
 
 
 def _make_pod(

--- a/backend/tests/unit/sandbox_proxy/test_response_streaming.py
+++ b/backend/tests/unit/sandbox_proxy/test_response_streaming.py
@@ -29,7 +29,7 @@ from mitmproxy import http as mitm_http
 from mitmproxy.options import Options
 from mitmproxy.tools.dump import DumpMaster
 
-from onyx.sandbox_proxy.addons.gate import _IdentityResolver, GateAddon
+from onyx.sandbox_proxy.addons.gate import GateAddon, _IdentityResolver
 from onyx.sandbox_proxy.credential_injection import CredentialInjectionDispatcher
 from onyx.sandbox_proxy.identity import ResolvedSandbox
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator

--- a/backend/tests/unit/server/metrics/test_celery_task_metrics.py
+++ b/backend/tests/unit/server/metrics/test_celery_task_metrics.py
@@ -8,14 +8,14 @@ import pytest
 
 from onyx.background.celery.apps.app_base import on_before_task_publish
 from onyx.server.metrics.celery_task_metrics import (
-    _task_start_times,
-    on_celery_task_postrun,
-    on_celery_task_prerun,
     TASK_COMPLETED,
     TASK_DURATION,
     TASK_QUEUE_WAIT,
     TASK_STARTED,
     TASKS_ACTIVE,
+    _task_start_times,
+    on_celery_task_postrun,
+    on_celery_task_prerun,
 )
 
 

--- a/backend/tests/unit/server/metrics/test_embedding_metrics.py
+++ b/backend/tests/unit/server/metrics/test_embedding_metrics.py
@@ -3,16 +3,16 @@
 from unittest.mock import patch
 
 from onyx.server.metrics.embedding import (
+    LOCAL_PROVIDER_LABEL,
+    PROVIDER_LABEL_NAME,
+    TEXT_TYPE_LABEL_NAME,
     _client_duration,
     _embedding_input_chars_total,
     _embedding_requests_total,
     _embedding_texts_total,
     _embeddings_in_progress,
-    LOCAL_PROVIDER_LABEL,
     observe_embedding_client,
     provider_label,
-    PROVIDER_LABEL_NAME,
-    TEXT_TYPE_LABEL_NAME,
     track_embedding_in_progress,
 )
 from shared_configs.enums import EmbeddingProvider, EmbedTextType

--- a/backend/tests/unit/server/metrics/test_indexing_task_metrics.py
+++ b/backend/tests/unit/server/metrics/test_indexing_task_metrics.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from onyx.server.metrics.indexing_task_metrics import (
-    _connector_cache,
-    _indexing_start_times,
-    ConnectorInfo,
     INDEXING_TASK_COMPLETED,
     INDEXING_TASK_DURATION,
     INDEXING_TASK_STARTED,
+    ConnectorInfo,
+    _connector_cache,
+    _indexing_start_times,
     on_indexing_task_postrun,
     on_indexing_task_prerun,
 )

--- a/backend/tests/unit/server/metrics/test_pruning_metrics.py
+++ b/backend/tests/unit/server/metrics/test_pruning_metrics.py
@@ -3,12 +3,12 @@
 import pytest
 
 from onyx.server.metrics.pruning_metrics import (
-    inc_pruning_rate_limit_error,
-    observe_pruning_diff_duration,
-    observe_pruning_enumeration_duration,
     PRUNING_DIFF_DURATION,
     PRUNING_ENUMERATION_DURATION,
     PRUNING_RATE_LIMIT_ERRORS,
+    inc_pruning_rate_limit_error,
+    observe_pruning_diff_duration,
+    observe_pruning_enumeration_duration,
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -267,7 +267,6 @@ ignore = [
 select = ["ARG", "E", "F", "I", "S", "W"]
 
 [tool.ruff.lint.isort]
-order-by-type = false
 known-first-party = ["onyx", "ee", "tests", "shared_configs", "model_server"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
## Description

Companion change to https://github.com/onyx-dot-app/onyx/pull/13183 applying the change to `release/v4.1` branch.

## How Has This Been Tested?

No-op, captured by existing

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `order-by-type` import sorting and reformatted imports across the backend on `release/v4.1` to align with 4.1 code style. No functional changes.

- **Refactors**
  - Dropped the `order-by-type` rule and standardized import order across Celery tasks, DB modules, servers, and connectors to match the main branch formatting.
  - Improves consistency and reduces future merge noise without affecting runtime behavior.

<sup>Written for commit 0d34a95074801bba5301c44d6e8b02bdb30209b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

