### PR TITLE
fix(gdrive): stream folders during group sync to bound memory

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/external_group_syncing/tasks.py
@@ -590,7 +590,7 @@ def _timed_perform_external_group_sync(
                 # Track progress
                 total_groups_processed += 1
                 total_group_memberships_synced += len(external_user_group.user_emails)
-                seen_users = seen_users.union(external_user_group.user_emails)
+                seen_users.update(external_user_group.user_emails)
 
                 if len(external_user_group_batch) >= _EXTERNAL_GROUP_BATCH_SIZE:
                     logger.debug(

--- a/backend/ee/onyx/external_permissions/google_drive/group_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/group_sync.py
@@ -42,22 +42,24 @@ class FolderInfo(BaseModel):
 
 def _get_all_folders(
     google_drive_connector: GoogleDriveConnector, skip_folders_without_permissions: bool
-) -> list[FolderInfo]:
+) -> Generator[FolderInfo, None, None]:
     """Have to get all folders since the group syncing system assumes all groups
     are returned every time.
+
+    Folders are yielded as they are discovered rather than accumulated into a
+    list, so the full folder/permission graph is never resident at once.
 
     TODO: tweak things so we can fetch deltas.
     """
     MAX_FAILED_PERCENTAGE = 0.5
 
-    all_folders: list[FolderInfo] = []
     seen_folder_ids: set[str] = set()
 
     def _get_all_folders_for_user(
         google_drive_connector: GoogleDriveConnector,
         skip_folders_without_permissions: bool,
         user_email: str,
-    ) -> None:
+    ) -> Generator[FolderInfo, None, None]:
         """Helper to get folders for a specific user + update shared seen_folder_ids"""
         drive_service = get_drive_service(
             google_drive_connector.creds,
@@ -101,18 +103,16 @@ def _get_all_folders(
                 logger.debug("Folder %s has no permissions. Skipping.", folder_id)
                 continue
 
-            all_folders.append(
-                FolderInfo(
-                    id=folder_id,
-                    permissions=permissions,
-                )
+            yield FolderInfo(
+                id=folder_id,
+                permissions=permissions,
             )
 
     failed_count = 0
     user_emails = google_drive_connector._get_all_user_emails()
     for user_email in user_emails:
         try:
-            _get_all_folders_for_user(
+            yield from _get_all_folders_for_user(
                 google_drive_connector, skip_folders_without_permissions, user_email
             )
         except Exception as e:
@@ -130,8 +130,6 @@ def _get_all_folders(
 
             if failed_count > MAX_FAILED_PERCENTAGE * len(user_emails):
                 raise RuntimeError("Too many failed folder fetches during group sync")
-
-    return all_folders
 
 
 def _drive_folder_to_onyx_group(

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_all_folders_streaming.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_all_folders_streaming.py
@@ -1,0 +1,125 @@
+import inspect
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ee.onyx.external_permissions.google_drive.group_sync import _get_all_folders
+
+
+def _folder(folder_id: str) -> dict[str, Any]:
+    """A Drive folder payload carrying one non-inherited permission.
+
+    No "permissionDetails" means inherited_from is None, so the permission
+    survives the inherited-permission filter and the folder is kept.
+    """
+    permission_id = f"perm-{folder_id}"
+    return {
+        "id": folder_id,
+        "name": folder_id,
+        "permissionIds": [permission_id],
+        "permissions": [
+            {
+                "id": permission_id,
+                "type": "user",
+                "emailAddress": f"{folder_id}@example.com",
+            }
+        ],
+    }
+
+
+def _make_connector(user_emails: list[str]) -> MagicMock:
+    connector = MagicMock()
+    connector.creds = MagicMock()
+    connector._get_all_user_emails.return_value = user_emails
+    return connector
+
+
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_modified_folders")
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_drive_service")
+def test_get_all_folders_streams_without_materializing(
+    mock_get_drive_service: MagicMock,
+    mock_get_modified_folders: MagicMock,
+) -> None:
+    """Folders must be yielded as they are found, not accumulated into a list.
+
+    Building the full list before returning is what pinned the entire
+    folder/permission graph in memory and OOM-killed the heavy worker. This
+    asserts the generator emits its first folder after touching only the first
+    user, so a regression back to list-building fails here.
+    """
+    assert inspect.isgeneratorfunction(_get_all_folders)
+
+    mock_get_drive_service.return_value = MagicMock()
+    mock_get_modified_folders.side_effect = [
+        [_folder("a1"), _folder("a2")],
+        [_folder("b1")],
+        [_folder("c1")],
+    ]
+    connector = _make_connector(["a@example.com", "b@example.com", "c@example.com"])
+
+    generator = _get_all_folders(
+        google_drive_connector=connector, skip_folders_without_permissions=True
+    )
+
+    # Merely calling the function must not perform any work.
+    assert mock_get_drive_service.call_count == 0
+
+    first = next(generator)
+
+    # One folder pulled => only the first user has been enumerated.
+    assert first.id == "a1"
+    assert mock_get_drive_service.call_count == 1
+
+    # Draining the rest reaches the remaining users.
+    remaining = [folder.id for folder in generator]
+    assert remaining == ["a2", "b1", "c1"]
+    assert mock_get_drive_service.call_count == 3
+
+
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_modified_folders")
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_drive_service")
+def test_get_all_folders_dedupes_across_users(
+    mock_get_drive_service: MagicMock,
+    mock_get_modified_folders: MagicMock,
+) -> None:
+    """Every user re-enumerates the whole domain, so the shared seen-set must
+    still collapse duplicates now that folders are streamed rather than
+    appended to a shared list."""
+    mock_get_drive_service.return_value = MagicMock()
+    mock_get_modified_folders.side_effect = [
+        [_folder("shared"), _folder("only-a")],
+        [_folder("shared"), _folder("only-b")],
+    ]
+    connector = _make_connector(["a@example.com", "b@example.com"])
+
+    folder_ids = [
+        folder.id
+        for folder in _get_all_folders(
+            google_drive_connector=connector, skip_folders_without_permissions=True
+        )
+    ]
+
+    assert folder_ids == ["shared", "only-a", "only-b"]
+
+
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_modified_folders")
+@patch("ee.onyx.external_permissions.google_drive.group_sync.get_drive_service")
+def test_get_all_folders_aborts_after_too_many_user_failures(
+    mock_get_drive_service: MagicMock,
+    mock_get_modified_folders: MagicMock,
+) -> None:
+    """Failure accounting must still abort mid-stream. With yield from, the
+    per-user exception surfaces when the consumer pulls, so the guard has to
+    keep working from inside the generator."""
+    mock_get_drive_service.return_value = MagicMock()
+    mock_get_modified_folders.side_effect = RuntimeError("drive unavailable")
+    connector = _make_connector([f"u{i}@example.com" for i in range(4)])
+
+    with pytest.raises(RuntimeError, match="Too many failed folder fetches"):
+        list(
+            _get_all_folders(
+                google_drive_connector=connector,
+                skip_folders_without_permissions=True,
+            )
+        )


### PR DESCRIPTION
## Description

`celery-worker-heavy` pods were repeatedly OOMKilled (exit 137) against their 5Gi limit. Memory tracked pod uptime while CPU stayed low — pods holding ~4.7GB at <50m CPU.

Root cause is `_get_all_folders` in `ee/onyx/external_permissions/google_drive/group_sync.py`: it accumulated the entire Drive folder/permission graph into a `list[FolderInfo]` and only returned once every folder for every user had been enumerated. Each `FolderInfo` carries a full `list[GoogleDrivePermission]`, so the whole graph was resident at once.

A live heap census on an affected worker measured it directly:

- **902,244** `GoogleDrivePermission` objects retaining **1.099 GB**
- `FolderInfo` (+ transitively their permissions) retaining **1.124 GB** of a **2.17 GB** RSS — ~52% of the process
- Heap `FolderInfo` count (30,143) exactly matched the sum of the two live in-flight `all_folders` lists (12,131 + 18,012), confirming those lists were the sole owner

This is **single-task peak memory** driven by domain size (users × folders), not cross-task accumulation and not multi-tenant-specific — a single deployment syncing a large Drive domain hits the same wall. Concurrency amplifies it: the heavy worker uses a threads pool, so up to `CELERY_WORKER_HEAVY_CONCURRENCY` full graphs share one heap with no process boundary to reclaim on task completion.

### Fix

Yield each `FolderInfo` as it is discovered. The consumer in `external_group_syncing/tasks.py` already iterates the generator and upserts in batches of 100 (resetting the batch each flush), so peak retention drops from the whole graph to one folder's permissions plus the seen-folder id set (ids only, single-digit MB).

Also swaps `seen_users = seen_users.union(...)` for `seen_users.update(...)` in the same loop — the former reallocated the entire set on every group, O(n²) allocation churn feeding the same RSS high-water.

### Not in scope

`_get_all_folders` is still O(users × folders): every user re-enumerates the whole domain and >99% of results are discarded as already-seen. That is the docstring's existing "fetch deltas" TODO and is the bigger win for runtime and Google API quota, but it is a separate change. This PR fixes memory only.

### Behavior change to note

The consumer enforces `JOB_TIMEOUT` (default 6h) per yielded group. Because the folder phase previously never yielded, it was effectively **exempt** from that timeout — a sync could run well past it. It is now covered, which is the code's stated intent (Celery's `soft_time_limit` is inert under a threads pool). A domain whose folder phase legitimately exceeds 6h would now fail with `External group sync task timed out` rather than grinding on. Those syncs are being OOMKilled today anyway, and should run faster without multi-GB GC pressure, but worth watching post-deploy.

### Age

Not a regression. `_get_all_folders` has returned a materialized list since it was introduced (#4672, 2025-05-07). #4678 the following day targeted the same symptom but only added the `skip_folders_without_permissions` filter, reducing the constant factor rather than the accumulation.

## How Has This Been Tested?

New unit tests in `backend/tests/unit/ee/onyx/external_permissions/google_drive/test_get_all_folders_streaming.py`:

- **Laziness (regression guard)** — asserts the generator emits its first folder after touching only the first user. Verified this **fails against the previous implementation** and passes with the fix.
- **Dedup equivalence** — the shared seen-set still collapses folders seen by multiple users.
- **Failure accounting** — `MAX_FAILED_PERCENTAGE` still aborts mid-stream now that per-user exceptions surface at the consumer's pull point via `yield from`.

`pre-commit` clean (`ty`, `ruff`, `ruff format`, lazy-import check). Full local unit run for the module passes; 3 unrelated failures in `test_gdrive_domain_permission_scoping.py` are a stale-venv `ModuleNotFoundError: readerwriterlock` and reproduce on unmodified `main`.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stream Google Drive folders during group sync to bound memory and prevent OOMs. Also enforces the job timeout and removes a set reallocation hot path.

- **Bug Fixes**
  - `_get_all_folders` now yields `FolderInfo` as discovered instead of building a full list, cutting peak memory to one folder’s permissions plus a shared seen-id set.
  - Replaced `seen_users.union(...)` with `seen_users.update(...)` to avoid whole-set reallocations each batch.
  - The folder phase now respects `JOB_TIMEOUT` since results are streamed.

<sup>Written for commit a69474cb86d99757a94d43d946cd16f0db3f748c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

