### PR TITLE
chore(deps): upgrade litellm 1.89.4 -> 1.93.0

### DIFF
--- a/backend/onyx/llm/litellm_singleton/config.py
+++ b/backend/onyx/llm/litellm_singleton/config.py
@@ -15,7 +15,7 @@ def configure_litellm_settings() -> None:
     litellm.telemetry = False  # ty: ignore[invalid-assignment]
     litellm.modify_params = True
     litellm.add_function_to_prompt = False
-    litellm.suppress_debug_info = True  # ty: ignore[invalid-assignment]
+    litellm.suppress_debug_info = True
 
 
 # TODO: We might not need to register ollama_chat in addition to ollama but let's just do it for good measure for now.

--- a/backend/onyx/llm/litellm_singleton/monkey_patches.py
+++ b/backend/onyx/llm/litellm_singleton/monkey_patches.py
@@ -3,7 +3,7 @@ LiteLLM Monkey Patches
 
 This module addresses the following issues in LiteLLM:
 
-Status checked against LiteLLM v1.85.1 (2026-05-26):
+Status checked against LiteLLM v1.93.0 (2026-07-20):
 
 1. Ollama Streaming Reasoning Content (_patch_ollama_chunk_parser):
    - LiteLLM's chunk_parser doesn't properly handle reasoning content in streaming
@@ -54,7 +54,7 @@ Status checked against LiteLLM v1.85.1 (2026-05-26):
    - This replaces the proper ResponseAPIUsage object with a dict, causing Pydantic
      serialization warnings
    STATUS: STILL NEEDED - Upstream still mutates result.response.usage in place via
-         setattr in v1.85.1. Our patch rebuilds the response via model_construct so the
+         setattr in v1.93.0. Our patch rebuilds the response via model_construct so the
          original ResponseAPIUsage object is preserved. Handles ResponseCompletedEvent,
          ResponseIncompleteEvent, and ResponseFailedEvent (matching upstream).
 """
@@ -430,12 +430,12 @@ def _patch_responses_api_usage_format() -> None:
     This patch wraps model_construct to transform usage before construction, ensuring
     the correct type regardless of which code path calls model_construct.
 
-    Affected locations in LiteLLM v1.85.1:
-    - litellm/llms/openai/responses/transformation.py (lines 215, 574)
-    - litellm/llms/chatgpt/responses/transformation.py (line 147)
-    - litellm/llms/manus/responses/transformation.py (lines 157, 224)
-    - litellm/llms/volcengine/responses/transformation.py (lines 225, 277)
-    - litellm/completion_extras/litellm_responses_transformation/handler.py (line 51)
+    Affected locations in LiteLLM v1.93.0:
+    - litellm/llms/openai/responses/transformation.py (lines 268, 635)
+    - litellm/llms/chatgpt/responses/transformation.py (line 212)
+    - litellm/llms/manus/responses/transformation.py (lines 223, 311)
+    - litellm/llms/volcengine/responses/transformation.py (line 262)
+    - litellm/completion_extras/litellm_responses_transformation/handler.py (line 57)
     """
     from litellm.types.llms.openai import ResponseAPIUsage, ResponsesAPIResponse
 

--- a/backend/requirements/default.txt
+++ b/backend/requirements/default.txt
@@ -1357,9 +1357,12 @@ ldap3==2.9.1 \
 libpass==1.9.3 \
     --hash=sha256:3cbeb14d22086660e92c30d787ea981973d67394e81c8c870e1a83cfe1c84353 \
     --hash=sha256:7830b9323d9ba96a841ad698a8dec1d43a2b0b7f1c855c76772e7972c1c6d959
-litellm==1.89.4 \
-    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
-    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
+litellm==1.93.0 \
+    --hash=sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec \
+    --hash=sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b \
+    --hash=sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5 \
+    --hash=sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb \
+    --hash=sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada
     # via onyx
 locket==1.0.0 \
     --hash=sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632 \

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -943,9 +943,12 @@ kiwisolver==1.4.9 \
     --hash=sha256:efb3a45b35622bb6c16dbfab491a8f5a391fe0e9d45ef32f4df85658232ca0e2 \
     --hash=sha256:f68e4f3eeca8fb22cc3d731f9715a13b652795ef657a13df1ad0c7dc0e9731df
     # via matplotlib
-litellm==1.89.4 \
-    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
-    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
+litellm==1.93.0 \
+    --hash=sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec \
+    --hash=sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b \
+    --hash=sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5 \
+    --hash=sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb \
+    --hash=sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada
     # via onyx
 mako==1.3.12 \
     --hash=sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9 \

--- a/backend/requirements/ee.txt
+++ b/backend/requirements/ee.txt
@@ -682,9 +682,12 @@ jsonschema-specifications==2025.9.1 \
     --hash=sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe \
     --hash=sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d
     # via jsonschema
-litellm==1.89.4 \
-    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
-    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
+litellm==1.93.0 \
+    --hash=sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec \
+    --hash=sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b \
+    --hash=sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5 \
+    --hash=sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb \
+    --hash=sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada
     # via onyx
 markupsafe==3.0.3 \
     --hash=sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf \

--- a/backend/requirements/model_server.txt
+++ b/backend/requirements/model_server.txt
@@ -733,9 +733,12 @@ kombu==5.5.4 \
     --hash=sha256:886600168275ebeada93b888e831352fe578168342f0d1d5833d88ba0d847363 \
     --hash=sha256:a12ed0557c238897d8e518f1d1fdf84bd1516c5e305af2dacd85c2015115feb8
     # via celery
-litellm==1.89.4 \
-    --hash=sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5 \
-    --hash=sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757
+litellm==1.93.0 \
+    --hash=sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec \
+    --hash=sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b \
+    --hash=sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5 \
+    --hash=sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb \
+    --hash=sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada
     # via onyx
 markupsafe==3.0.3 \
     --hash=sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "cohere==7.0.5",
     "fastapi==0.133.1",
     "google-genai==1.52.0",
-    "litellm[google]==1.89.4",
+    "litellm[google]==1.93.0",
     "openai==2.38.0",
     "pydantic==2.11.7",
     # Shared so structured JSON logging (LOG_FORMAT=json) works in the

--- a/uv.lock
+++ b/uv.lock
@@ -3196,7 +3196,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.89.4"
+version = "1.93.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -3212,9 +3212,12 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/e1/ce008da0be1515b025f1b008d0664e3d2b2ffdbece2913d71baefc9887f4/litellm-1.89.4.tar.gz", hash = "sha256:ab551a8d52cb703c738b4db7cb6f350c4bb2ff146f0d3cc3986fd879a1eecac5", size = 14061816, upload-time = "2026-06-25T02:35:40.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/93/e1/4f05ca4cbb4efb739c9e66a182ecd5c816bc05bf3665ec8e0fb4ab408379/litellm-1.93.0.tar.gz", hash = "sha256:140bf215e264c71601bca9c06d2436c5451bb59e1e195ea23fc2d3d87b6929ec", size = 15948866, upload-time = "2026-07-19T03:01:24.389Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/cc/6fc72581a3ad22b7a53e8dddcc4ccc3ac679795d2200629f0fab35cb6d34/litellm-1.89.4-py3-none-any.whl", hash = "sha256:c3a19961b9e3576d4aafb6d27a0a8e1d06c370784b2d88631a9ba0d027cfd757", size = 15472272, upload-time = "2026-06-25T02:35:37.523Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/e1/eabe3f13d9c8b853a01377b59e78a295f34c24c36b09e5fc1c60c0167f19/litellm-1.93.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:23b8eea4fb8b3b6ade05e7b6085ec9ca12daffcfb38d033d0bbce9c1d5894da5", size = 20164863, upload-time = "2026-07-19T03:01:12.035Z" },
+    { url = "https://files.pythonhosted.org/packages/64/49/2db5757f7e284eb12618b547cb62dab49687ffaf1d749ca048210e3d0dbd/litellm-1.93.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:98c15e84d32e922a821c105308bf9ddae8700de9ed396530bee2cbb1cacf4cbb", size = 20157288, upload-time = "2026-07-19T03:01:15.395Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/7f/b48d88cb32055b4ba7e51cd67e4ea13a589d4a568d33c3d0dc6994d13b83/litellm-1.93.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1a476ebc340c070c982eab15b4673fa63a70f5936935f9f20e4d2acb5f35d23b", size = 20165502, upload-time = "2026-07-19T03:01:18.425Z" },
+    { url = "https://files.pythonhosted.org/packages/45/6c/65a7f916326daa151131f1fce5e254d4834127a95d53a18f1c4d238dd5c3/litellm-1.93.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:cd70ccd4ba3ef1a395535c287bce72d30c7d937ecca4290c0db37a00738f7ada", size = 20159007, upload-time = "2026-07-19T03:01:21.704Z" },
 ]
 
 [package.optional-dependencies]
@@ -4060,7 +4063,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -4071,7 +4074,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -4098,9 +4101,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -4111,7 +4114,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -4394,7 +4397,7 @@ requires-dist = [
     { name = "cohere", specifier = "==7.0.5" },
     { name = "fastapi", specifier = "==0.133.1" },
     { name = "google-genai", specifier = "==1.52.0" },
-    { name = "litellm", extras = ["google"], specifier = "==1.89.4" },
+    { name = "litellm", extras = ["google"], specifier = "==1.93.0" },
     { name = "openai", specifier = "==2.38.0" },
     { name = "prometheus-client", specifier = ">=0.21.1" },
     { name = "prometheus-fastapi-instrumentator", specifier = "==8.0.0" },
@@ -4915,7 +4918,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -6520,8 +6523,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Closes #13131
Closes #12847

Upgrades `litellm[google]` from 1.89.4 to 1.93.0. Because we carry six monkey patches against litellm internals (`backend/onyx/llm/litellm_singleton/monkey_patches.py`), every patched code path was diff-audited against the 1.93.0 source.

## Monkey patch audit (1.89.4 → 1.93.0)

All six patches **still apply cleanly and are all still needed** — upstream has not fixed any of the underlying issues:

| Patch | Target | 1.93.0 status |
|---|---|---|
| 1. Ollama streaming reasoning | `OllamaChatCompletionResponseIterator.chunk_parser` | Upstream diff is reformatting only; still no `<think>` tag-boundary tracking |
| 2. Reasoning summary newlines | `OpenAiResponsesToChatCompletionStreamIterator.chunk_parser` | Upstream still passes `reasoning_summary_text.delta` through with no separator between `summary_index` sections |
| 3. Non-streaming summary join | `LiteLLMResponsesTransformationHandler.transform_response` | Upstream still uses `" ".join()`; signature unchanged |
| 4. Azure fake streaming | `AzureOpenAIResponsesAPIConfig.should_fake_stream` | Azure config still doesn't override it; unknown models still fake-stream via `supports_native_streaming` returning False |
| 5. `model_construct` usage format | `ResponsesAPIResponse.model_construct` | All 7 fallback call sites still present (locations refreshed in docstring); `ResponseAPIUsage` field set unchanged |
| 6. Logging usage mutation | `LiteLLMLoggingObj._get_assembled_streaming_response` | Upstream body behaviorally identical (still mutates `usage` in place); caller kwargs unchanged |

The audit header in `monkey_patches.py` is updated from v1.85.1 to v1.93.0.

## Issues fixed by the new model metadata

The 1.93.0 model map adds the GPT-5.6 entries (absent in 1.89.4) that both issues trace to. Verified against Onyx's own resolution functions running on this branch:

- **#13131** (OpenAI GPT-5.6 falls back to 32K context): `gpt-5.6`, `gpt-5.6-sol`, `gpt-5.6-terra`, and `gpt-5.6-luna` all resolve to `max_input_tokens=1050000` / `max_output_tokens=128000`. `get_max_input_tokens(name, "openai")` returns **1,048,976** for all four — exactly the value the issue's expected-behavior section specifies — instead of the 32K fallback.
- **#12847** (Azure GPT-5.6 missing capabilities / wrong API routing): all three Azure variants now report `model_is_reasoning_model=True`, `litellm_thinks_model_supports_image_input=True`, and `is_true_openai_model()=True`. The last one is the gate `LitellmLLM` uses to route through the Responses API bridge (`multi_llm.py`), so Azure GPT-5.6 requests now take the Responses path instead of Chat Completions. Metadata and routing-gate verified locally; a live Azure call needs the nightly credentials.

## Upstream changes worth knowing about

- **Rust native extension (since 1.92.0)**: litellm now builds with maturin/PyO3 and publishes **only manylinux wheels** (cp310–cp314, x86_64/aarch64) plus an sdist — no macOS or universal wheels. On macOS, `uv sync` builds the sdist, which **requires a Rust toolchain (cargo)**. The native module is an optional OCR bridge (`litellm.rust_bridge`) with a graceful `None` fallback at runtime; Onyx doesn't use litellm OCR. Linux Docker/CI are unaffected.
- **Streamed tool-call IDs**: function-call chunks now derive `id` via `_tool_call_id_from_responses_item` (falls back to the unique item `id` when `call_id` is the degenerate Bedrock-Mantle `call_<N>` form). No change for OpenAI/Azure-style `call_<alphanum>` IDs.
- **`register_model` warnings**: 1.93.0 warns at startup for registered models with no cache-cost fields and no builtin prefix match — 4 benign log lines for our Ollama `-cloud` entries.
- **`litellm.suppress_debug_info` is now typed** — removed the stale `ty: ignore` in `config.py`.

## Verification

- Diff-audited all six patched modules plus `types/llms/openai.py`, `responses/utils.py`, and top-level signatures (`completion`, `aembedding`, `image_generation`, `get_model_info`, `get_max_tokens`, `cost_per_token`) between the two versions
- Smoke script asserts every litellm symbol Onyx imports resolves in 1.93.0, all six patches land after `import onyx.llm.litellm_singleton`, and the patched `model_construct` round-trips chat-format usage into `ResponseAPIUsage`
- Full backend unit suite: 6113 passed (1 unrelated flaky Confluence checkpointing test; passes in isolation)
- Non-nightly external-dependency LLM provider tests: 47 passed
- `ty check`: clean; pre-commit (incl. uv-lock/uv-export consistency): all pass
- Not run here (need nightly CI secrets): live Ollama Cloud streaming, live OpenAI Responses API, Bedrock — these run in the nightly matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `litellm[google]` from 1.89.4 to 1.93.0 and re-audit our six LiteLLM monkey patches; all still required and apply cleanly. No behavior changes expected; removed a stale type ignore for `litellm.suppress_debug_info`.

- **Migration**
  - On macOS, `uv sync` will build `litellm` from sdist and requires a Rust toolchain (`cargo`) due to the new optional native module added in 1.92.0. Linux/CI images are unaffected.

<sup>Written for commit c3d459e4fa14928ef4765e902f8ae4b17c23fa97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13192?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


