### PR TITLE
fix(scripts): make tenant cleanup toolkit safe to run concurrently

### DIFF
--- a/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
+++ b/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
@@ -54,14 +54,28 @@ kubectl get po | grep celery-worker-user-file-processing | grep Running
 ## Important Notes
 
 1. **Step 2 triggers background deletion** - the actual document deletion happens asynchronously via Celery workers
-2. **You MUST wait** between Step 2 and Step 3 for deletion to complete (can take 6+ hours)
+2. **You MUST wait** between Step 2 and Step 3 for deletion to complete (can take 6+ hours).
+   Tenants with no documents drain within minutes, since there is nothing to delete.
 3. **Monitor deletion progress** with: `kubectl logs -f <celery-worker-pod>`
 4. **All scripts verify tenant status** - they'll refuse to process active (non-GATED_ACCESS) tenants
+5. **Pods are resolved once per run.** If that pod restarts mid-run, every remaining tenant fails.
+   Prefer batches of ~1000 over one enormous run.
+6. **Set the namespace on your kubectl contexts.** Pod discovery runs `kubectl get po` with no
+   `-n`, so it only sees the context's default namespace.
+7. **Verify against the database afterwards, not against the summary.** A tenant counted as
+   successful can still leave rows behind if a later step failed. Check `pg_namespace`,
+   `public.user_tenant_mapping`, and the control plane `tenant` table.
+8. **Search indices are not cleaned up.** In multi-tenant deployments all tenants share indices
+   and are separated by a `tenant_id` field, so dropping a schema leaves that tenant's chunks
+   behind. They can be swept later by selecting on `tenant_id` - keep `cleaned_tenants.csv`.
 
 ## Files Generated
 
+- `tenant_data_YYYYMMDD_HHMMSS.json` - Raw per-tenant data. **Contains real user chat message
+  text** (`last_query_text`); keep it out of the repo and off shared storage.
 - `gated_tenants_no_query_3mo_YYYYMMDD_HHMMSS.csv` - List of tenants to clean
-- `cleaned_tenants.csv` - Successfully cleaned tenants with timestamps
+- `cleaned_tenants.csv` - Successfully cleaned tenants with timestamps. Appended across runs, and
+  the only record of what was deleted - needed for any later search-index sweep.
 
 ## Safety First
 

--- a/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
+++ b/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
@@ -68,25 +68,41 @@ kubectl get po | grep celery-worker-user-file-processing | grep Running
 8. **Search indices are not cleaned up.** In multi-tenant deployments all tenants share indices
    and are separated by a `tenant_id` field, so dropping a schema leaves that tenant's chunks
    behind. They can be swept later by selecting on `tenant_id` - keep `cleaned_tenants.csv`.
-9. **To go faster, spread across pods - do not just raise `--concurrency`.** Every operation is a
-   `kubectl exec` against the one pod the run picked, so that pod is the bottleneck. Running two
-   batches at once without pinning gains nothing: pod selection is random over a small set, so
-   both runs usually land on the same pod, and it ends up saturated while its replicas idle.
-   Pin distinct pods per run instead:
+9. **The database writer is the real limit. Do not tune for throughput.**
+   Dropping a tenant schema deletes on the order of 500 relations, so cleanup is a sustained
+   burst of catalog writes against the cluster writer. On a live cluster this is the constraint
+   that matters, well before pod CPU is.
 
-   ```bash
-   # terminal 1
-   ... --csv batch_a.csv --concurrency 8 \
-       --data-plane-pod <worker-pod-1> --control-plane-pod <control-pod-1>
-   # terminal 2
-   ... --csv batch_b.csv --concurrency 8 \
-       --data-plane-pod <worker-pod-2> --control-plane-pod <control-pod-2>
-   ```
+   Measured on a real cleanup, and the reason this note exists:
 
-   Measured on a real cleanup: one run at `--concurrency 12` reached ~34 tenants/min and pinned a
-   worker at ~2 cores while its replica sat idle. Two pinned runs at `--concurrency 8` reached
-   ~67 tenants/min with neither worker above ~1.2 cores. Remember these are live workers doing
-   real work, so prefer spreading load over concentrating it.
+   | rate | writer `DiskQueueDepth` | failures |
+   |---|---|---|
+   | ~34 tenants/min | low, occasional spikes | 0 in 500 tenants |
+   | ~67 tenants/min | **50-64 sustained, tripped a >25 alarm** | 39 (`TLS handshake timeout`, `EOF`, failed execs) |
+
+   The faster run paged an on-call engineer and started failing on infrastructure timeouts.
+   `WriteLatency` stayed healthy throughout (2-5 ms), so `DiskQueueDepth` is the signal to watch -
+   by the time latency moves you have gone much too far. **Watch it while running and back off if
+   it approaches the alarm threshold. Prefer off-peak hours.** Roughly 30 tenants/min is a
+   reasonable ceiling; there is no prize for finishing sooner.
+
+10. **`--data-plane-pod` / `--control-plane-pod` are for spreading load, not for going faster.**
+    Every operation is a `kubectl exec` against the one pod a run picked. Two runs without pinning
+    usually land on the *same* pod - selection is random over a small set - saturating one live
+    worker (~2 cores) while its replica idles. Pinning distinct pods per run fixes that
+    distribution problem:
+
+    ```bash
+    # terminal 1
+    ... --csv batch_a.csv --concurrency 8 \
+        --data-plane-pod <worker-pod-1> --control-plane-pod <control-pod-1>
+    # terminal 2
+    ... --csv batch_b.csv --concurrency 8 \
+        --data-plane-pod <worker-pod-2> --control-plane-pod <control-pod-2>
+    ```
+
+    Use this to keep any single worker from being pinned, and keep the *combined* rate under the
+    ceiling in note 9. Running both at full tilt is what produced the failure row above.
 
 ## Files Generated
 

--- a/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
+++ b/backend/scripts/tenant_cleanup/QUICK_START_NO_BASTION.md
@@ -68,6 +68,25 @@ kubectl get po | grep celery-worker-user-file-processing | grep Running
 8. **Search indices are not cleaned up.** In multi-tenant deployments all tenants share indices
    and are separated by a `tenant_id` field, so dropping a schema leaves that tenant's chunks
    behind. They can be swept later by selecting on `tenant_id` - keep `cleaned_tenants.csv`.
+9. **To go faster, spread across pods - do not just raise `--concurrency`.** Every operation is a
+   `kubectl exec` against the one pod the run picked, so that pod is the bottleneck. Running two
+   batches at once without pinning gains nothing: pod selection is random over a small set, so
+   both runs usually land on the same pod, and it ends up saturated while its replicas idle.
+   Pin distinct pods per run instead:
+
+   ```bash
+   # terminal 1
+   ... --csv batch_a.csv --concurrency 8 \
+       --data-plane-pod <worker-pod-1> --control-plane-pod <control-pod-1>
+   # terminal 2
+   ... --csv batch_b.csv --concurrency 8 \
+       --data-plane-pod <worker-pod-2> --control-plane-pod <control-pod-2>
+   ```
+
+   Measured on a real cleanup: one run at `--concurrency 12` reached ~34 tenants/min and pinned a
+   worker at ~2 cores while its replica sat idle. Two pinned runs at `--concurrency 8` reached
+   ~67 tenants/min with neither worker above ~1.2 cores. Remember these are live workers doing
+   real work, so prefer spreading load over concentrating it.
 
 ## Files Generated
 

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -13,7 +13,9 @@ Usage:
 """
 
 import csv
+import fcntl
 import json
+import os
 import signal
 import subprocess
 import sys
@@ -30,6 +32,7 @@ from scripts.tenant_cleanup.no_bastion_cleanup_utils import (
     find_worker_pod,
     get_tenant_status,
     read_tenant_ids_from_csv,
+    validate_tenant_id,
 )
 
 # Global lock for thread-safe operations
@@ -359,6 +362,7 @@ def cleanup_control_plane(
     print(f"Cleaning up control plane data for tenant: {tenant_id}")
 
     # Delete in order respecting foreign key constraints
+    validate_tenant_id(tenant_id)
     delete_queries = [
         (
             "tenant_notification",
@@ -767,12 +771,19 @@ def main() -> None:
     # Append rather than truncate: cleanup runs in batches, and this file is the only
     # record of what was deleted. Opening it "w" silently erased prior batches.
     csv_output_path = "cleaned_tenants.csv"
-    write_header = not Path(csv_output_path).exists()
     with open(csv_output_path, "a", newline="") as csv_file:
         csv_writer = csv.writer(csv_file)
-        if write_header:
-            csv_writer.writerow(["tenant_id", "cleaned_at"])
-        csv_file.flush()
+
+        # Emit the header under an exclusive lock, and decide whether one is needed
+        # while holding it. Two runs starting together would otherwise both see an
+        # absent file and each write a header.
+        fcntl.flock(csv_file.fileno(), fcntl.LOCK_EX)
+        try:
+            if os.fstat(csv_file.fileno()).st_size == 0:
+                csv_writer.writerow(["tenant_id", "cleaned_at"])
+                csv_file.flush()
+        finally:
+            fcntl.flock(csv_file.fileno(), fcntl.LOCK_UN)
 
         print(f"Writing successful cleanups to: {csv_output_path}\n")
 

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -344,7 +344,7 @@ def drop_data_plane_schema(pod_name: str, tenant_id: str, context: str) -> None:
 
 def cleanup_control_plane(
     pod_name: str, tenant_id: str, context: str, force: bool = False
-) -> None:
+) -> bool:
     """Clean up control plane data via pod queries.
 
     Args:
@@ -352,6 +352,9 @@ def cleanup_control_plane(
         tenant_id: Tenant ID to process
         context: kubectl context for control plane cluster
         force: Skip confirmations if True
+
+    Returns:
+        True if every delete succeeded, False if any table still holds rows
     """
     print(f"Cleaning up control plane data for tenant: {tenant_id}")
 
@@ -367,6 +370,7 @@ def cleanup_control_plane(
     ]
 
     try:
+        failed_tables = []
         for table_name, query in delete_queries:
             print(f"  Deleting from {table_name}...")
 
@@ -374,9 +378,19 @@ def cleanup_control_plane(
                 print(f"  Skipping deletion from {table_name}")
                 continue
 
-            execute_control_plane_delete(pod_name, query, context)
+            if not execute_control_plane_delete(pod_name, query, context):
+                failed_tables.append(table_name)
+
+        if failed_tables:
+            print(
+                f"✗ Failed to delete from {', '.join(failed_tables)} for tenant "
+                f"{tenant_id} - control plane rows remain",
+                file=sys.stderr,
+            )
+            return False
 
         print(f"✓ Successfully cleaned up control plane data for tenant: {tenant_id}")
+        return True
 
     except Exception as e:
         print(
@@ -537,15 +551,20 @@ def cleanup_tenant(
         force,
     ):
         try:
-            cleanup_control_plane(
+            if not cleanup_control_plane(
                 control_plane_pod, tenant_id, control_plane_context, force
-            )
+            ):
+                # The schema is already gone at this point, so report the tenant as
+                # failed rather than cleaned - it needs a re-run to drop the leftover
+                # control plane rows.
+                return False
         except Exception as e:
             print(f"✗ Failed at control plane cleanup step: {e}", file=sys.stderr)
             if not force:
                 print("Control plane cleanup failed")
             else:
                 print("[FORCE MODE] Control plane cleanup failed but continuing")
+            return False
     else:
         print("Step 3 skipped by user")
         return False
@@ -745,11 +764,14 @@ def main() -> None:
     successful_tenants = []
     skipped_tenants = []
 
-    # Open CSV file for writing successful cleanups in real-time
+    # Append rather than truncate: cleanup runs in batches, and this file is the only
+    # record of what was deleted. Opening it "w" silently erased prior batches.
     csv_output_path = "cleaned_tenants.csv"
-    with open(csv_output_path, "w", newline="") as csv_file:
+    write_header = not Path(csv_output_path).exists()
+    with open(csv_output_path, "a", newline="") as csv_file:
         csv_writer = csv.writer(csv_file)
-        csv_writer.writerow(["tenant_id", "cleaned_at"])
+        if write_header:
+            csv_writer.writerow(["tenant_id", "cleaned_at"])
         csv_file.flush()
 
         print(f"Writing successful cleanups to: {csv_output_path}\n")

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_tenants.py
@@ -615,6 +615,12 @@ def main() -> None:
         print(
             "  --control-plane-context CTX Kubectl context for control plane cluster (required)"
         )
+        print(
+            "  --data-plane-pod POD        Pin the data plane pod instead of picking one"
+        )
+        print(
+            "  --control-plane-pod POD     Pin the control plane pod instead of picking one"
+        )
         sys.exit(1)
 
     # Parse arguments
@@ -674,6 +680,24 @@ def main() -> None:
             control_plane_context = sys.argv[idx + 1]
         except ValueError:
             pass
+
+    # Pinning pods lets several batches run against different pods instead of all
+    # piling onto whichever one the random pick returns.
+    data_plane_pod_override = None
+    control_plane_pod_override = None
+    for flag, target in (
+        ("--data-plane-pod", "data"),
+        ("--control-plane-pod", "control"),
+    ):
+        if flag in sys.argv:
+            idx = sys.argv.index(flag)
+            if idx + 1 >= len(sys.argv):
+                print(f"Error: {flag} requires a pod name", file=sys.stderr)
+                sys.exit(1)
+            if target == "data":
+                data_plane_pod_override = sys.argv[idx + 1]
+            else:
+                control_plane_pod_override = sys.argv[idx + 1]
 
     # Validate required contexts
     if not data_plane_context:
@@ -747,13 +771,21 @@ def main() -> None:
 
     # Find pods in both clusters before processing
     try:
-        print("Finding data plane worker pod...")
-        data_plane_pod = find_worker_pod(data_plane_context)
-        print(f"✓ Using data plane worker pod: {data_plane_pod}")
+        if data_plane_pod_override:
+            data_plane_pod = data_plane_pod_override
+            print(f"✓ Using pinned data plane worker pod: {data_plane_pod}")
+        else:
+            print("Finding data plane worker pod...")
+            data_plane_pod = find_worker_pod(data_plane_context)
+            print(f"✓ Using data plane worker pod: {data_plane_pod}")
 
-        print("Finding control plane pod...")
-        control_plane_pod = find_background_pod(control_plane_context)
-        print(f"✓ Using control plane pod: {control_plane_pod}\n")
+        if control_plane_pod_override:
+            control_plane_pod = control_plane_pod_override
+            print(f"✓ Using pinned control plane pod: {control_plane_pod}\n")
+        else:
+            print("Finding control plane pod...")
+            control_plane_pod = find_background_pod(control_plane_context)
+            print(f"✓ Using control plane pod: {control_plane_pod}\n")
 
         # Copy all scripts to data plane pod once
         setup_scripts_on_pod(data_plane_pod, data_plane_context)

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_utils.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_utils.py
@@ -5,6 +5,7 @@ Control plane and data plane are in SEPARATE clusters.
 
 import csv
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -12,6 +13,21 @@ from pathlib import Path
 
 class TenantNotFoundInControlPlaneError(Exception):
     """Exception raised when tenant/table is not found in control plane."""
+
+
+# Tenant ids reach SQL through string interpolation, so anything that could carry a
+# quote, semicolon, or whitespace is rejected before it gets there.
+_TENANT_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def validate_tenant_id(tenant_id: str) -> str:
+    """Return the tenant id if it is safe to interpolate, otherwise raise."""
+    if not _TENANT_ID_RE.match(tenant_id):
+        raise ValueError(
+            f"Refusing to use unsafe tenant id: {tenant_id!r}. "
+            "Expected only letters, digits, underscores and dashes."
+        )
+    return tenant_id
 
 
 def find_worker_pod(context: str) -> str:
@@ -217,6 +233,7 @@ def get_tenant_status(pod_name: str, tenant_id: str, context: str) -> str | None
     """
     print(f"Fetching tenant status for tenant: {tenant_id}")
 
+    validate_tenant_id(tenant_id)
     query = f"SELECT application_status FROM tenant WHERE tenant_id = '{tenant_id}'"
 
     result = execute_control_plane_query_from_pod(pod_name, query, context)
@@ -298,7 +315,12 @@ def read_tenant_ids_from_csv(csv_path: str) -> list[str]:
 
         for row in reader:
             tenant_id = row.get("tenant_id", "").strip()
-            if tenant_id:
-                tenant_ids.append(tenant_id)
+            if not tenant_id:
+                continue
+            # cleaned_tenants.csv is appended to across runs, so a repeated header row
+            # is possible. Never treat one as a tenant.
+            if tenant_id == "tenant_id":
+                continue
+            tenant_ids.append(validate_tenant_id(tenant_id))
 
     return tenant_ids

--- a/backend/scripts/tenant_cleanup/no_bastion_cleanup_utils.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_cleanup_utils.py
@@ -171,32 +171,16 @@ with engine.connect() as conn:
     conn.commit()
 '''
 
-    # Write the script to a temp file on the pod
-    script_path = "/tmp/control_plane_query.py"
-
+    # Piped over stdin rather than staged to a file on the pod. Callers run this
+    # concurrently against a single pod, and a shared temp path let one thread's query
+    # overwrite another's before it executed - tenant A could run tenant B's DELETE.
     try:
-        cmd_write = ["kubectl", "exec", "--context", context, pod_name]
-        cmd_write.extend(
-            [
-                "--",
-                "bash",
-                "-c",
-                f"cat > {script_path} << 'EOFQUERY'\n{query_script}\nEOFQUERY",
-            ]
-        )
-
-        subprocess.run(
-            cmd_write,
-            check=True,
-            capture_output=True,
-        )
-
-        # Execute the script
-        cmd_exec = ["kubectl", "exec", "--context", context, pod_name]
-        cmd_exec.extend(["--", "python", script_path])
+        cmd_exec = ["kubectl", "exec", "-i", "--context", context, pod_name]
+        cmd_exec.extend(["--", "python", "-"])
 
         result = subprocess.run(
             cmd_exec,
+            input=query_script,
             capture_output=True,
             text=True,
             check=True,

--- a/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
@@ -40,23 +40,47 @@ def safe_print(*args: Any, **kwargs: Any) -> None:
         print(*args, **kwargs)
 
 
+def _last_json_object(stdout: str) -> Any | None:
+    """Return the last JSON object in stdout, or None if there is none.
+
+    The on-pod script pretty-prints its payload across multiple lines, so this cannot
+    be done line by line.
+    """
+    text = stdout.strip()
+    if not text:
+        return None
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    # Fall back to scanning, in case anything else ever shares stdout.
+    decoder = json.JSONDecoder()
+    found: Any | None = None
+    for idx, char in enumerate(text):
+        if char != "{":
+            continue
+        try:
+            payload, _ = decoder.raw_decode(text, idx)
+        except json.JSONDecodeError:
+            continue
+        found = payload
+    return found
+
+
 def _raise_on_reported_failure(stdout: str, tenant_id: str) -> None:
     """Raise if the on-pod script reported an error in its JSON payload.
 
     The on-pod script exits 0 even when it fails, so its payload is the only signal.
     Unparseable output is left alone - the exit code has already been checked.
     """
-    for line in reversed(stdout.strip().splitlines()):
-        try:
-            payload = json.loads(line)
-        except json.JSONDecodeError:
-            continue
-        if isinstance(payload, dict) and payload.get("status") == "error":
-            raise RuntimeError(
-                f"Connector deletion reported failure for {tenant_id}: "
-                f"{payload.get('message', 'no message')}"
-            )
-        return
+    payload = _last_json_object(stdout)
+    if isinstance(payload, dict) and payload.get("status") == "error":
+        raise RuntimeError(
+            f"Connector deletion reported failure for {tenant_id}: "
+            f"{payload.get('message', 'no message')}"
+        )
 
 
 def run_connector_deletion(pod_name: str, tenant_id: str, context: str) -> None:
@@ -135,6 +159,23 @@ def run_connector_deletion(pod_name: str, tenant_id: str, context: str) -> None:
             file=sys.stderr,
         )
         raise
+
+    finally:
+        # Otherwise a large batch leaves one file per tenant behind on the pod.
+        subprocess.run(
+            [
+                "kubectl",
+                "exec",
+                "--context",
+                context,
+                pod_name,
+                "--",
+                "rm",
+                "-f",
+                remote_script,
+            ],
+            capture_output=True,
+        )
 
 
 def mark_tenant_connectors_for_deletion(

--- a/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
+++ b/backend/scripts/tenant_cleanup/no_bastion_mark_connectors.py
@@ -12,8 +12,10 @@ Usage:
         --data-plane-context <context> --control-plane-context <context> [--force] [--concurrency N]
 """
 
+import json
 import subprocess
 import sys
+import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from threading import Lock
@@ -38,6 +40,25 @@ def safe_print(*args: Any, **kwargs: Any) -> None:
         print(*args, **kwargs)
 
 
+def _raise_on_reported_failure(stdout: str, tenant_id: str) -> None:
+    """Raise if the on-pod script reported an error in its JSON payload.
+
+    The on-pod script exits 0 even when it fails, so its payload is the only signal.
+    Unparseable output is left alone - the exit code has already been checked.
+    """
+    for line in reversed(stdout.strip().splitlines()):
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict) and payload.get("status") == "error":
+            raise RuntimeError(
+                f"Connector deletion reported failure for {tenant_id}: "
+                f"{payload.get('message', 'no message')}"
+            )
+        return
+
+
 def run_connector_deletion(pod_name: str, tenant_id: str, context: str) -> None:
     """Mark all connector credential pairs for deletion.
 
@@ -59,13 +80,17 @@ def run_connector_deletion(pod_name: str, tenant_id: str, context: str) -> None:
             f"execute_connector_deletion.py not found at {mark_deletion_script}"
         )
 
+    # Unique per call: this runs concurrently against a single pod, and concurrent
+    # copies to a shared path can interleave into a corrupt script.
+    remote_script = f"/tmp/execute_connector_deletion_{uuid.uuid4().hex}.py"
+
     try:
         # Copy script to pod
         cmd_cp = ["kubectl", "cp", "--context", context]
         cmd_cp.extend(
             [
                 str(mark_deletion_script),
-                f"{pod_name}:/tmp/execute_connector_deletion.py",
+                f"{pod_name}:{remote_script}",
             ]
         )
 
@@ -81,16 +106,20 @@ def run_connector_deletion(pod_name: str, tenant_id: str, context: str) -> None:
             [
                 "--",
                 "python",
-                "/tmp/execute_connector_deletion.py",
+                remote_script,
                 tenant_id,
                 "--all",
             ]
         )
 
-        result = subprocess.run(cmd_exec)
+        result = subprocess.run(cmd_exec, capture_output=True, text=True)
 
         if result.returncode != 0:
-            raise RuntimeError(result.stderr)
+            raise RuntimeError(result.stderr or result.stdout or "unknown error")
+
+        # The on-pod script reports failures in its JSON payload while still exiting 0,
+        # so a non-zero return code alone is not enough to detect a failed tenant.
+        _raise_on_reported_failure(result.stdout, tenant_id)
 
     except subprocess.CalledProcessError as e:
         safe_print(

--- a/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
+++ b/backend/scripts/tenant_cleanup/on_pod_scripts/cleanup_tenant_schema.py
@@ -48,9 +48,11 @@ def drop_data_plane_schema(tenant_id: str) -> dict[str, str]:
 
             print(f"Successfully dropped schema: {tenant_id}", file=sys.stderr)
 
-            # Delete the tenant mapping from user_tenant_mapping table
+            # Schema-qualified on purpose: schema_translate_map only rewrites SQLAlchemy
+            # Table constructs, not raw text(), so an unqualified name resolves against
+            # whatever search_path the pooled backend happens to carry.
             delete_mapping_query = text("""
-                DELETE FROM user_tenant_mapping
+                DELETE FROM public.user_tenant_mapping
                 WHERE tenant_id = :tenant_id
                 """)
             session.execute(delete_mapping_query, {"tenant_id": tenant_id})


### PR DESCRIPTION
## Description

The no-bastion tenant cleanup scripts are unsafe at `--concurrency > 1`, which is what
`QUICK_START_NO_BASTION.md` told you to use. Found while running a 100-tenant cleanup batch.

Each per-tenant SQL statement was written to a single fixed path on one pod
(`/tmp/control_plane_query.py`) and then executed as a second step. With multiple threads, one
thread's statement overwrites another's in the gap between write and exec, so a tenant executes
someone else's SQL. Measured against a real control plane at `--concurrency 16`, **15 of 16
status lookups returned a different tenant's row**. These same code paths issue the `DELETE`
statements that remove control plane records.

The blast radius is bounded by the input CSV, since only statements for tenants in that CSV are
ever in flight — but within a batch, deletes land on the wrong tenant and are reported as success.

Fixed by piping the script over stdin rather than staging it on disk. That removes the shared
state by construction and drops a round trip per query. The connector deletion script gets a
unique remote path for the same reason.

Three separate defects made these failures invisible, each of which caused a failed cleanup to be
reported as a successful one:

- **`cleanup_tenant_schema.py` deleted from an unqualified `user_tenant_mapping`.**
  `schema_translate_map` only rewrites SQLAlchemy `Table` constructs, not raw `text()`, so the name
  resolved against whatever `search_path` the pooled backend happened to carry. It intermittently
  failed *after* the schema was already dropped, orphaning the mapping row. Hit ~16% of tenants in
  a real run. Now qualified as `public.user_tenant_mapping`.
- **`cleanup_control_plane` discarded `execute_control_plane_delete`'s return value**, so tenants
  whose control plane rows survived were still written to `cleaned_tenants.csv`. Now propagated.
- **`run_connector_deletion` never captured output**, so its `RuntimeError` carried an empty
  message; and the on-pod script reports failures in its JSON payload while still exiting 0. Now
  captures output and checks the payload.

`cleaned_tenants.csv` opened `"w"`, truncating the record of previously deleted tenants on every
run. It is the only record of what was deleted — and the only way to sweep orphaned search index
chunks later — so it now appends.

Docs updated: the `--concurrency 16` guidance, plus notes that pods are resolved once per run,
that contexts need a namespace set, that results should be verified against the database rather
than the run summary, and that `tenant_data_*.json` contains real user chat message text.

### Not fixed here, flagged for a follow-up

- **Search indices are never cleaned up.** `get_tenant_index_name` is defined and copied to the pod
  but never called. In multi-tenant deployments this is less severe than it looks: tenants share
  indices and are separated by a `tenant_id` field, so dropped tenants leave orphaned chunks that
  can be swept later by selecting on `tenant_id` — provided `cleaned_tenants.csv` survives, which
  is now the case. Documented in QUICK_START.
- **`check_documents_deleted` uses `cc_count == 0 or doc_count <= 5`** while its own error message
  says "and". Tightening it to `and` would make the mark-connectors step strictly mandatory, so
  it's left alone pending a decision.

## How Has This Been Tested?

Against a live multi-tenant deployment.

- **Concurrency regression, before:** 16 concurrent status lookups on the old code path, each
  asking for its own tenant id — 1 correct, 15 returned another tenant's row.
- **Concurrency regression, after:** same probe against the fixed code path — 16 of 16 correct.
- **Read path:** verified the stdin-piped query returns correct results for a plain aggregate.
- **End-to-end:** cleaned a 100-tenant batch and reconciled directly against `pg_namespace`,
  `public.user_tenant_mapping`, and the control plane `tenant` table. Final state 100/100 fully
  removed from both planes, with exactly 0 tenants outside the batch affected.
- The `public.` qualification fix addresses the 17 orphaned mapping rows observed in that batch,
  which had to be swept manually.
- `pre-commit run` passes (`ty`, `ruff`, `ruff format`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the no-bastion tenant cleanup toolkit safe to run with concurrency and stop false “success” reports. Adds `--data-plane-pod` and `--control-plane-pod` to spread parallel batches across pods, and updates docs to stress DB writer limits (watch DiskQueueDepth; pin to spread load, not to go faster; ~30 tenants/min ceiling).

- **Bug Fixes**
  - Remove shared on-pod state: pipe control-plane SQL over stdin; use a unique remote path for connector deletion and delete it after execution.
  - Correctly report failures: propagate control-plane delete failures; capture output and parse the JSON payload from connector deletion (multi-line), raising on reported errors even when exit code is 0.
  - Fix schema cleanup: qualify `public.user_tenant_mapping` to avoid `search_path` issues.
  - Preserve cleanup history safely: append to `cleaned_tenants.csv`, write the header once under an exclusive lock, and skip any literal "tenant_id" row when reading.
  - Validate tenant IDs before interpolating into SQL, rejecting values outside `[A-Za-z0-9_-]`.

<sup>Written for commit 736bb5eb0cd08429e3fa9d50f54a5945cf2cd9fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

