### PR TITLE
fix(desktop): match default window width to large breakpoint

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -452,7 +452,7 @@ fn trigger_new_window(app: &AppHandle) {
             WebviewUrl::External(server_url.parse().unwrap()),
         )
         .title("Onyx")
-        .inner_size(1200.0, 800.0)
+        .inner_size(1232.0, 800.0)
         .min_inner_size(800.0, 600.0);
 
         // Windows draws its own title bar in the system theme; a transparent
@@ -822,7 +822,7 @@ async fn new_window(app: AppHandle, state: tauri::State<'_, ConfigState>) -> Res
         ),
     )
     .title("Onyx")
-    .inner_size(1200.0, 800.0)
+    .inner_size(1232.0, 800.0)
     .min_inner_size(800.0, 600.0);
 
     #[cfg(not(target_os = "windows"))]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
         "title": "Onyx",
         "label": "main",
         "url": "index.html",
-        "width": 1200,
+        "width": 1232,
         "height": 800,
         "minWidth": 800,
         "minHeight": 600,

--- a/desktop/src-tauri/tauri.windows.conf.json
+++ b/desktop/src-tauri/tauri.windows.conf.json
@@ -6,7 +6,7 @@
         "title": "Onyx",
         "label": "main",
         "url": "index.html",
-        "width": 1200,
+        "width": 1232,
         "height": 800,
         "minWidth": 800,
         "minHeight": 600,


### PR DESCRIPTION
## Summary
- Update the desktop app's default window width from `1200` to `1232` in `tauri.conf.json`, `tauri.windows.conf.json`, and `main.rs` (both `new_window` and `trigger_new_window`) to match `LARGE_BREAKPOINT_PX` introduced in 3097498e89.
- Keeps the desktop app's default window size at or above the breakpoint that gates container-relative modal centering and desktop sidebar/layout behavior, rather than opening slightly below it.

## Test plan
- [ ] `cd desktop/src-tauri && cargo check` to confirm the Rust changes compile
- [ ] Launch the desktop app and confirm the default window opens at 1232x800
- [ ] Open a new window (File > New Window) and confirm it also opens at 1232x800

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Increase the desktop app’s default window width to 1232px to match the large breakpoint, ensuring modals center correctly and the desktop sidebar/layout loads in the right state for new and additional windows.

- Bug Fixes
  - Set default width to 1232 in `desktop/src-tauri/tauri.conf.json` and `desktop/src-tauri/tauri.windows.conf.json`.
  - Updated `desktop/src-tauri/src/main.rs` to use 1232px for both `new_window` and `trigger_new_window`.

<sup>Written for commit 8b5efd5069245d80aec17fef1fdc1b5ac9fa2c2c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13194?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

