### PR TITLE
fix(desktop): respect configured window_title

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -440,8 +440,11 @@ fn trigger_new_chat(app: &AppHandle) {
 }
 
 fn trigger_new_window(app: &AppHandle) {
-    let state = app.state::<ConfigState>();
-    let server_url = state.config.read().unwrap().server_url.clone();
+    let (server_url, window_title) = {
+        let state = app.state::<ConfigState>();
+        let config = state.config.read().unwrap();
+        (config.server_url.clone(), config.window_title.clone())
+    };
     let handle = app.clone();
 
     tauri::async_runtime::spawn(async move {
@@ -451,7 +454,7 @@ fn trigger_new_window(app: &AppHandle) {
             &window_label,
             WebviewUrl::External(server_url.parse().unwrap()),
         )
-        .title("Onyx")
+        .title(window_title)
         .inner_size(1232.0, 800.0)
         .min_inner_size(800.0, 600.0);
 
@@ -809,7 +812,10 @@ fn go_forward(window: tauri::WebviewWindow) {
 /// Open a new window
 #[tauri::command]
 async fn new_window(app: AppHandle, state: tauri::State<'_, ConfigState>) -> Result<(), String> {
-    let server_url = state.config.read().unwrap().server_url.clone();
+    let (server_url, window_title) = {
+        let config = state.config.read().unwrap();
+        (config.server_url.clone(), config.window_title.clone())
+    };
     let window_label = format!("onyx-{}", uuid::Uuid::new_v4());
 
     let builder = WebviewWindowBuilder::new(
@@ -821,7 +827,7 @@ async fn new_window(app: AppHandle, state: tauri::State<'_, ConfigState>) -> Res
                 .map_err(|e| format!("Invalid URL: {}", e))?,
         ),
     )
-    .title("Onyx")
+    .title(window_title)
     .inner_size(1232.0, 800.0)
     .min_inner_size(800.0, 600.0);
 
@@ -905,11 +911,15 @@ fn find_check_menu_item(
 }
 
 fn apply_settings_to_window(app: &AppHandle, window: &tauri::WebviewWindow) {
+    let state = app.state::<ConfigState>();
+    let config = state.config.read().unwrap();
+
+    let _ = window.set_title(&config.window_title);
+
+    // Menu-bar visibility and window decorations are only configurable off macOS.
     if cfg!(target_os = "macos") {
         return;
     }
-    let state = app.state::<ConfigState>();
-    let config = state.config.read().unwrap();
     if !config.show_menu_bar {
         let _ = window.hide_menu();
     }


### PR DESCRIPTION
## Problem

`desktop/src-tauri/src/main.rs` defines a `window_title` field on `AppConfig` (with a `"Onyx"` default, read from `config.json`), but it was never actually used:

- The **main window** takes its title straight from `tauri.conf.json` (`"title": "Onyx"`).
- `trigger_new_window` and `new_window` **hardcoded** `.title("Onyx")`.

So a user setting `"window_title": "..."` in their `config.json` saw no effect.

## Fix

- Set the title from `config.window_title` in `apply_settings_to_window`, which is the central per-window settings applier invoked for the main window during `setup` (all platforms) and for newly created windows. This wires up the main window without touching `tauri.conf.json`.
- Use the configured title in the `trigger_new_window` and `new_window` builders so new windows open with the right title immediately (no flash of the default).

The title is applied on all platforms. On macOS the visible titlebar is a custom empty draggable strip (`hiddenTitle` + injected `titlebar.js`), so the native title still matters for the Window menu, Mission Control, and tabbing.

## Notes

- No behavior change for anyone who hasn't customized `window_title` — the default remains `"Onyx"`.
- No new config/UI surface: `window_title` was already a config field, edited via `config.json` (`open_config_file`).

## Testing

Reasoned through statically; this container has no Rust toolchain so `cargo check` couldn't be run here. Changes are limited to swapping the hardcoded title string for the existing config value and moving the config read above the macOS early-return in `apply_settings_to_window`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use the configured `window_title` from `config.json` for the main window and all new windows on every platform. Set the title in `apply_settings_to_window` and new-window builders to replace the hardcoded "Onyx" and prevent a default-title flash.

<sup>Written for commit 1f7add99d21db76187ccedf05b5ec34d536f4c8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

