### PR TITLE
feat(ollama): store API key in api_key field instead of custom_config

### DIFF
--- a/backend/alembic/versions/1e0a3e4226f7_move_ollama_api_key_from_custom_config_.py
+++ b/backend/alembic/versions/1e0a3e4226f7_move_ollama_api_key_from_custom_config_.py
@@ -1,0 +1,114 @@
+"""move ollama api key from custom_config to api_key
+
+Revision ID: 1e0a3e4226f7
+Revises: fd006e57c868
+Create Date: 2026-07-20 12:28:16.748159
+
+Moves the optional Ollama Cloud bearer token out of the plaintext
+``custom_config`` JSONB and into the encrypted ``api_key`` column, matching how
+every other provider stores its credential.
+
+Encryption goes through ``onyx.utils.encryption`` (as revisions ``0a98909f2757``
+and ``3c9a65f1207f`` do) rather than a local reimplementation: that helper
+dispatches on EE-vs-MIT, so the value we write is exactly what the running app
+reads back. Reimplementing AES here would ignore that gate and corrupt values on
+MIT deployments that happen to have ENCRYPTION_KEY_SECRET set (where the app
+stores plaintext).
+
+The downgrade restores ``custom_config.OLLAMA_API_KEY`` (what older code reads)
+but deliberately leaves ``api_key`` in place rather than nulling it. Once
+upgraded, a row with a set ``api_key`` is indistinguishable from one whose
+``api_key`` predated this migration, so clearing it could wipe an unrelated
+credential. Repopulating ``custom_config`` while keeping ``api_key`` is safe:
+worst case a row ends up with the same key in both places, which is harmless.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from onyx.utils.encryption import decrypt_bytes_to_string
+from onyx.utils.encryption import encrypt_string_to_bytes
+
+# revision identifiers, used by Alembic.
+revision = "1e0a3e4226f7"
+down_revision = "fd006e57c868"
+branch_labels = None
+depends_on = None
+
+
+OLLAMA_PROVIDER = "ollama_chat"
+OLLAMA_API_KEY_CONFIG_KEY = "OLLAMA_API_KEY"
+
+
+def _llm_provider_table(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "llm_provider",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("provider", sa.String),
+        sa.Column("api_key", sa.LargeBinary),
+        sa.Column("custom_config", postgresql.JSONB),
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    table = _llm_provider_table(sa.MetaData())
+
+    rows = bind.execute(
+        sa.select(table.c.id, table.c.api_key, table.c.custom_config).where(
+            table.c.provider == OLLAMA_PROVIDER
+        )
+    ).all()
+
+    for row_id, api_key, custom_config in rows:
+        if not custom_config or OLLAMA_API_KEY_CONFIG_KEY not in custom_config:
+            continue
+
+        stored_key = custom_config.get(OLLAMA_API_KEY_CONFIG_KEY)
+        remaining_config = {
+            k: v for k, v in custom_config.items() if k != OLLAMA_API_KEY_CONFIG_KEY
+        }
+        new_custom_config = remaining_config or None
+
+        # Don't clobber an existing api_key; just drop the legacy config value.
+        new_api_key = api_key
+        if api_key is None and stored_key:
+            new_api_key = encrypt_string_to_bytes(stored_key)
+
+        bind.execute(
+            table.update()
+            .where(table.c.id == row_id)
+            .values(api_key=new_api_key, custom_config=new_custom_config)
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    table = _llm_provider_table(sa.MetaData())
+
+    rows = bind.execute(
+        sa.select(table.c.id, table.c.api_key, table.c.custom_config).where(
+            table.c.provider == OLLAMA_PROVIDER
+        )
+    ).all()
+
+    for row_id, api_key, custom_config in rows:
+        if api_key is None:
+            continue
+
+        # Restore the legacy config value; leave api_key untouched so we never
+        # clear a credential that may have predated this migration.
+        new_custom_config = dict(custom_config or {})
+        new_custom_config[OLLAMA_API_KEY_CONFIG_KEY] = decrypt_bytes_to_string(
+            bytes(api_key)
+        )
+
+        bind.execute(
+            table.update()
+            .where(table.c.id == row_id)
+            .values(custom_config=new_custom_config)
+        )

--- a/backend/onyx/llm/factory.py
+++ b/backend/onyx/llm/factory.py
@@ -403,9 +403,8 @@ def get_llm(
 
     extra_headers = build_llm_extra_headers(additional_headers)
 
-    # NOTE: this is needed since Ollama API key is optional
-    # User may access Ollama cloud via locally hosted instance (logged in)
-    # or just via the cloud API (not logged in, using API key)
+    # Some providers (e.g. LM Studio) carry an optional Bearer token in
+    # custom_config that must be turned into an Authorization header.
     provider_extra_headers = _build_provider_extra_headers(provider, custom_config)
     if provider_extra_headers:
         extra_headers.update(provider_extra_headers)

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -45,7 +45,6 @@ from onyx.llm.well_known_providers.constants import (
     AWS_SECRET_ACCESS_KEY_KWARG,
     AWS_SECRET_ACCESS_KEY_KWARG_ENV_VAR_FORMAT,
     LM_STUDIO_API_KEY_CONFIG_KEY,
-    OLLAMA_API_KEY_CONFIG_KEY,
     VERTEX_AUTH_METHOD_KWARG,
     VERTEX_AUTH_METHOD_WORKLOAD_IDENTITY,
     VERTEX_CREDENTIALS_FILE_KWARG,
@@ -374,9 +373,6 @@ class LitellmLLM(LLM):
                         model_kwargs[k] = v
                     elif k == VERTEX_PROJECT_KWARG:
                         model_kwargs[k] = v
-                elif model_provider == LlmProviderNames.OLLAMA_CHAT:
-                    if k == OLLAMA_API_KEY_CONFIG_KEY:
-                        model_kwargs["api_key"] = v
                 elif model_provider == LlmProviderNames.LM_STUDIO:
                     if k == LM_STUDIO_API_KEY_CONFIG_KEY:
                         model_kwargs["api_key"] = v

--- a/backend/onyx/llm/well_known_providers/constants.py
+++ b/backend/onyx/llm/well_known_providers/constants.py
@@ -6,7 +6,6 @@ BEDROCK_PROVIDER_NAME = "bedrock"
 
 
 OLLAMA_PROVIDER_NAME = "ollama_chat"
-OLLAMA_API_KEY_CONFIG_KEY = "OLLAMA_API_KEY"
 
 LM_STUDIO_PROVIDER_NAME = "lm_studio"
 LM_STUDIO_API_KEY_CONFIG_KEY = "LM_STUDIO_API_KEY"
@@ -21,7 +20,6 @@ NEBIUS_TOKENFACTORY_PROVIDER_NAME = "nebius_tokenfactory"
 
 # Providers that use optional Bearer auth from custom_config
 PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING: dict[str, str] = {
-    LlmProviderNames.OLLAMA_CHAT: OLLAMA_API_KEY_CONFIG_KEY,
     LlmProviderNames.LM_STUDIO: LM_STUDIO_API_KEY_CONFIG_KEY,
 }
 

--- a/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
+++ b/backend/tests/integration/tests/llm_workflows/test_nightly_provider_chat_workflow.py
@@ -153,9 +153,6 @@ def _load_provider_config() -> NightlyProviderConfig:
             provider=provider, raw_custom_config=parsed
         )
 
-    if provider == "ollama_chat" and api_key and not custom_config:
-        custom_config = {"OLLAMA_API_KEY": api_key}
-
     return NightlyProviderConfig(
         provider=provider,
         model_names=model_names,

--- a/backend/tests/unit/onyx/llm/test_factory.py
+++ b/backend/tests/unit/onyx/llm/test_factory.py
@@ -2,14 +2,14 @@ from unittest.mock import patch
 
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.factory import _build_provider_extra_headers, get_llm, llm_from_provider
-from onyx.llm.well_known_providers.constants import OLLAMA_API_KEY_CONFIG_KEY
+from onyx.llm.well_known_providers.constants import LM_STUDIO_API_KEY_CONFIG_KEY
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 
 
-def test_build_provider_extra_headers_adds_bearer_for_ollama_api_key() -> None:
+def test_build_provider_extra_headers_adds_bearer_for_lm_studio_api_key() -> None:
     headers = _build_provider_extra_headers(
-        LlmProviderNames.OLLAMA_CHAT,
-        {OLLAMA_API_KEY_CONFIG_KEY: "  test-key  "},
+        LlmProviderNames.LM_STUDIO,
+        {LM_STUDIO_API_KEY_CONFIG_KEY: "  test-key  "},
     )
 
     assert headers == {"Authorization": "Bearer test-key"}
@@ -17,17 +17,28 @@ def test_build_provider_extra_headers_adds_bearer_for_ollama_api_key() -> None:
 
 def test_build_provider_extra_headers_keeps_existing_bearer_prefix() -> None:
     headers = _build_provider_extra_headers(
-        LlmProviderNames.OLLAMA_CHAT,
-        {OLLAMA_API_KEY_CONFIG_KEY: "bearer test-key"},
+        LlmProviderNames.LM_STUDIO,
+        {LM_STUDIO_API_KEY_CONFIG_KEY: "bearer test-key"},
     )
 
     assert headers == {"Authorization": "bearer test-key"}
 
 
-def test_build_provider_extra_headers_ignores_empty_ollama_api_key() -> None:
+def test_build_provider_extra_headers_ignores_empty_lm_studio_api_key() -> None:
+    headers = _build_provider_extra_headers(
+        LlmProviderNames.LM_STUDIO,
+        {LM_STUDIO_API_KEY_CONFIG_KEY: "   "},
+    )
+
+    assert headers == {}
+
+
+def test_build_provider_extra_headers_ignores_legacy_ollama_custom_config() -> None:
+    # Ollama now carries its key in the standard api_key field, which LiteLLM
+    # turns into a Bearer header itself; custom_config must not add one.
     headers = _build_provider_extra_headers(
         LlmProviderNames.OLLAMA_CHAT,
-        {OLLAMA_API_KEY_CONFIG_KEY: "   "},
+        {"OLLAMA_API_KEY": "test-key"},
     )
 
     assert headers == {}

--- a/web/src/sections/modals/languageModels/OllamaModal.tsx
+++ b/web/src/sections/modals/languageModels/OllamaModal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import * as Yup from "yup";
 import { Dispatch, SetStateAction, useMemo, useState } from "react";
 import { useSWRConfig } from "swr";
 import { useFormikContext } from "formik";
@@ -41,9 +40,6 @@ enum Tab {
 
 interface OllamaModalValues extends BaseLLMFormValues {
   api_base: string;
-  custom_config: {
-    OLLAMA_API_KEY?: string;
-  };
 }
 
 interface OllamaModalInternalsProps {
@@ -66,13 +62,13 @@ function OllamaModalInternals({
     () =>
       tab === Tab.TAB_SELF_HOSTED
         ? !formikProps.values.api_base
-        : !formikProps.values.custom_config.OLLAMA_API_KEY,
+        : !formikProps.values.api_key,
     [tab, formikProps]
   );
 
   const handleFetchModels = async (signal?: AbortSignal) => {
     // Only Ollama cloud accepts API key
-    const apiBase = formikProps.values.custom_config?.OLLAMA_API_KEY
+    const apiBase = formikProps.values.api_key
       ? CLOUD_API_BASE
       : formikProps.values.api_base;
     const { models, error } = await fetchOllamaModels({
@@ -125,12 +121,12 @@ function OllamaModalInternals({
 
             <Tabs.Content value={Tab.TAB_CLOUD}>
               <InputVertical
-                withLabel="custom_config.OLLAMA_API_KEY"
+                withLabel="api_key"
                 title="API Key"
                 subDescription="Your Ollama Cloud API key."
               >
                 <PasswordInputTypeInField
-                  name="custom_config.OLLAMA_API_KEY"
+                  name="api_key"
                   placeholder="API Key"
                 />
               </InputVertical>
@@ -176,7 +172,7 @@ export default function OllamaModal({
   const defaultApiBase = settings.is_containerized
     ? "http://host.docker.internal:11434"
     : "http://127.0.0.1:11434";
-  const apiKey = existingLlmProvider?.custom_config?.OLLAMA_API_KEY;
+  const apiKey = existingLlmProvider?.api_key;
   const defaultTab =
     existingLlmProvider && !!apiKey ? Tab.TAB_CLOUD : Tab.TAB_SELF_HOSTED;
   const [tab, setTab] = useState<Tab>(defaultTab);
@@ -190,23 +186,13 @@ export default function OllamaModal({
       existingLlmProvider
     ),
     api_base: existingLlmProvider?.api_base ?? defaultApiBase,
-    custom_config: {
-      OLLAMA_API_KEY: apiKey,
-    },
   } as OllamaModalValues;
 
   const validationSchema = useMemo(
     () =>
       buildValidationSchema(isOnboarding, {
         apiBase: tab === Tab.TAB_SELF_HOSTED,
-        extra:
-          tab === Tab.TAB_CLOUD
-            ? {
-                custom_config: Yup.object({
-                  OLLAMA_API_KEY: Yup.string().required("API Key is required"),
-                }),
-              }
-            : undefined,
+        apiKey: tab === Tab.TAB_CLOUD,
       }),
     [tab, isOnboarding]
   );
@@ -219,19 +205,10 @@ export default function OllamaModal({
       initialValues={initialValues}
       validationSchema={validationSchema}
       onSubmit={async (values, { setSubmitting, setStatus }) => {
-        const filteredCustomConfig = Object.fromEntries(
-          Object.entries(values.custom_config || {}).filter(([, v]) => v !== "")
-        );
-
         const submitValues = {
           ...values,
-          api_base: filteredCustomConfig.OLLAMA_API_KEY
-            ? CLOUD_API_BASE
-            : values.api_base,
-          custom_config:
-            Object.keys(filteredCustomConfig).length > 0
-              ? filteredCustomConfig
-              : undefined,
+          // Ollama Cloud is reached via a fixed base URL; the API key implies it.
+          api_base: values.api_key ? CLOUD_API_BASE : values.api_base,
         };
 
         await submitProvider({


### PR DESCRIPTION
## Summary

Ollama's optional Bearer token was stored in `custom_config.OLLAMA_API_KEY`, which required special-case handling in `factory.py` and `multi_llm.py` and sat **unencrypted** in the JSONB `custom_config` column. 

This was done because it is an optional api_key and at the time the db enforced api_key. Now that the db has loosened this requirement to make api_key optional, we can migrate it.

This is also a small security improvement: `api_key` is `EncryptedString` (encrypted at rest) whereas `custom_config` is plain JSONB, and moving the key lets the sandbox egress proxy protect it like every other provider credential (the proxy swaps `api_key`, never `custom_config`).

## Changes

- **Backend**: drop Ollama from `PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING` and remove the `custom_config -> model_kwargs["api_key"]` branch in `multi_llm.py`; `self._api_key` now flows to LiteLLM natively (only LM Studio still uses the special path).
- **Frontend**: `OllamaModal` cloud tab writes the standard `api_key` form field; tab detection, validation, model-fetch, and submit updated to match.
- **Migration** `1e0a3e4226f7`: moves existing `ollama_chat` keys from `custom_config.OLLAMA_API_KEY` into the encrypted `api_key` column (only when `api_key` is NULL, so nothing is clobbered), then strips the legacy key. Uses `onyx.utils.encryption` so the EE/MIT encryption dispatch matches what the app reads back — following the pattern in `0a98909f2757` / `3c9a65f1207f`.

## Testing

- Unit: `test_factory.py` (repointed Bearer-header tests to LM Studio + added a guard that Ollama's legacy `custom_config` produces no header).
- Migration manually verified end-to-end on a throwaway DB (before → upgrade → downgrade) across three row shapes (cloud key, self-hosted no-key, pre-existing `api_key` + extra config), in **both** MIT (plaintext) and EE (AES) modes — confirmed the app's own decrypt path reads back the migrated value.
- Runtime `api_key` path already covered by nightly `test_ollama_streaming.py` (constructs `LitellmLLM(api_key=..., provider=ollama_chat, api_base="https://ollama.com")` against real Ollama Cloud); its `api_key -> custom_config` shim is removed.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Store Ollama’s API key in the encrypted `api_key` field instead of `custom_config.OLLAMA_API_KEY`. This removes special-case handling, improves security, and aligns `ollama_chat` with other providers.

- **Refactors**
  - Dropped Ollama from `PROVIDERS_WITH_SPECIAL_API_KEY_HANDLING`; removed the `custom_config -> api_key` path in `multi_llm`. Factory now only builds Bearer headers for providers that use custom-config tokens (e.g. `lm_studio`).
  - Web `OllamaModal` cloud tab writes `api_key`; validation, model fetch, and submit infer the cloud base when `api_key` is set.
  - Tests repointed header checks to `lm_studio` and added a guard that legacy Ollama `custom_config` produces no header; nightly workflow removes the Ollama shim.

- **Migration**
  - Moves existing `ollama_chat` keys from `custom_config.OLLAMA_API_KEY` into encrypted `api_key` when empty, then removes the legacy key (via `onyx.utils.encryption` for correct EE/MIT behavior).
  - Downgrade restores the legacy config value but keeps `api_key`. No manual action needed.

<sup>Written for commit 0ecc9041e2fdb1afbcb95c315f13741f5add42ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



