### PR TITLE
fix(desktop): match default window width to large breakpoint (#13194) to release v4.4

### DIFF
--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -452,7 +452,7 @@ fn trigger_new_window(app: &AppHandle) {
             WebviewUrl::External(server_url.parse().unwrap()),
         )
         .title("Onyx")
-        .inner_size(1200.0, 800.0)
+        .inner_size(1232.0, 800.0)
         .min_inner_size(800.0, 600.0);
 
         // Windows draws its own title bar in the system theme; a transparent
@@ -822,7 +822,7 @@ async fn new_window(app: AppHandle, state: tauri::State<'_, ConfigState>) -> Res
         ),
     )
     .title("Onyx")
-    .inner_size(1200.0, 800.0)
+    .inner_size(1232.0, 800.0)
     .min_inner_size(800.0, 600.0);
 
     #[cfg(not(target_os = "windows"))]

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -15,7 +15,7 @@
         "title": "Onyx",
         "label": "main",
         "url": "index.html",
-        "width": 1200,
+        "width": 1232,
         "height": 800,
         "minWidth": 800,
         "minHeight": 600,

--- a/desktop/src-tauri/tauri.windows.conf.json
+++ b/desktop/src-tauri/tauri.windows.conf.json
@@ -6,7 +6,7 @@
         "title": "Onyx",
         "label": "main",
         "url": "index.html",
-        "width": 1200,
+        "width": 1232,
         "height": 800,
         "minWidth": 800,
         "minHeight": 600,


### PR DESCRIPTION
Cherry-pick of commit bd513498c118d19df25f289dd356235d63988928 to release/v4.4 branch.

Original PR: #13194

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the desktop app’s default window width from 1200 to 1232 to match the large breakpoint, so the UI renders at the intended layout on first open. Adjusted the Tauri window initialization and config (`tauri.conf.json`, `tauri.windows.conf.json`).

<sup>Written for commit 24a4a6013f6af135fcff69f47a0d5181c5744718. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13199?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

