### PR TITLE
feat(craft): add external app admin disablement

### DIFF
--- a/backend/alembic/versions/fd006e57c868_add_external_app_enablement.py
+++ b/backend/alembic/versions/fd006e57c868_add_external_app_enablement.py
@@ -1,0 +1,33 @@
+"""Add external app enablement.
+
+Revision ID: fd006e57c868
+Revises: 9cc89a7b96de
+Create Date: 2026-07-17 13:24:43.117490
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "fd006e57c868"
+down_revision = "9cc89a7b96de"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "external_app",
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            server_default=sa.true(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("external_app", "enabled")

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -164,7 +164,7 @@ def get_connectable_apps_for_user(
     user_creds_by_app = get_user_credentials_by_app_id(db_session, user.id)
     return [
         app
-        for app in get_external_apps(db_session)
+        for app in get_external_apps(db_session, enabled_only=True)
         if app.skill_id in visible_skill_ids
         and not is_user_authenticated_for_app(app, user_creds_by_app.get(app.id))
     ]
@@ -176,7 +176,8 @@ def available_external_app_skill_ids_for_user(
 ) -> list[UUID]:
     """Return app-backed skill IDs whose credentials are ready for this user."""
     rows = db_session.execute(
-        select(ExternalApp, ExternalAppUserCredential).join(
+        select(ExternalApp, ExternalAppUserCredential)
+        .join(
             ExternalAppUserCredential,
             and_(
                 ExternalAppUserCredential.external_app_id == ExternalApp.id,
@@ -184,6 +185,7 @@ def available_external_app_skill_ids_for_user(
             ),
             isouter=True,
         )
+        .where(ExternalApp.enabled.is_(True))
     ).all()
     return [
         app.skill_id
@@ -194,6 +196,8 @@ def available_external_app_skill_ids_for_user(
 
 def get_external_apps(
     db_session: Session,
+    *,
+    enabled_only: bool = False,
 ) -> list[ExternalApp]:
     stmt = (
         select(ExternalApp)
@@ -203,6 +207,8 @@ def get_external_apps(
         )
         .order_by(ExternalApp.id)
     )
+    if enabled_only:
+        stmt = stmt.where(ExternalApp.enabled.is_(True))
     return list(db_session.scalars(stmt).all())
 
 
@@ -339,6 +345,7 @@ def update_external_app(
     db_session: Session,
     external_app_id: int,
     app_type: ExternalAppType,
+    enabled: bool | UnsetType = UNSET,
     name: str | UnsetType = UNSET,
     description: str | UnsetType = UNSET,
     upstream_url_patterns: list[str] | UnsetType = UNSET,
@@ -377,6 +384,8 @@ def update_external_app(
             f"'{app.app_type.value}' to '{app_type.value}'.",
         )
 
+    if is_set(enabled):
+        app.enabled = enabled
     if is_set(name):
         app.skill.name = name
     if is_set(description):

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6463,6 +6463,12 @@ class ExternalApp(Base):
         default=ExternalAppType.CUSTOM,
         server_default=ExternalAppType.CUSTOM.value,
     )
+    enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=True,
+        server_default=true(),
+    )
     # CUSTOM apps store URL globs here (translated to regexes at match time).
     upstream_url_patterns: Mapped[list[str]] = mapped_column(
         postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"

--- a/backend/onyx/external_apps/credentials.py
+++ b/backend/onyx/external_apps/credentials.py
@@ -43,13 +43,13 @@ def resolve_injection_headers(
     """Auth headers the egress proxy should inject for a *verified* request to
     ``external_app_id`` on behalf of ``user_id``.
 
-    Returns ``{}`` when the app is gone or when no header's placeholders can be
-    filled. Merges the app's organization credentials with
+    Returns ``{}`` when the app is gone or disabled, or when no header's
+    placeholders can be filled. Merges the app's organization credentials with
     the user's stored credentials (the user's win on key conflicts), then
     renders the ``auth_template`` via :func:`build_auth_headers`.
     """
     app = get_external_app_by_id(db_session, external_app_id)
-    if app is None:
+    if app is None or not app.enabled:
         return {}
 
     credentials: dict[str, Any] = dict(
@@ -74,6 +74,8 @@ def app_is_available(db_session: Session, app: ExternalApp, user_id: UUID) -> bo
     Injection re-resolves later with an OAuth refresh, so this verdict-time render is the
     cheap presence check, not the final one.
     """
+    if not app.enabled:
+        return False
     if not app.auth_template:
         return True
     return bool(resolve_injection_headers(db_session, app.id, user_id))

--- a/backend/onyx/sandbox_proxy/request_evaluator.py
+++ b/backend/onyx/sandbox_proxy/request_evaluator.py
@@ -73,7 +73,7 @@ class ExternalAppRequestEvaluator(RequestEvaluator):
         self, request: http.Request, tenant_id: str, user_id: UUID
     ) -> AllMatchedActions | None:
         with get_session_with_tenant(tenant_id=tenant_id) as db:
-            apps = get_external_apps(db)
+            apps = get_external_apps(db, enabled_only=True)
             app = resolve_app_for_url(request.url, apps)
             if app is None:
                 return None

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -99,7 +99,7 @@ def set_sandbox_skills_hashes__no_commit(
     db_session: Session,
     skills_hashes: dict[UUID, str],
 ) -> None:
-    """Record the contents successfully hydrated into each sandbox."""
+    """Record the skill runtime state successfully synchronized to each sandbox."""
     if not skills_hashes:
         return
     sandboxes = db_session.scalars(

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -91,6 +91,7 @@ def _to_admin_response(app: ExternalApp) -> ExternalAppAdminResponse:
         organization_credentials=(
             {} if managed else app.organization_credentials.get_value(apply_mask=True)
         ),
+        enabled=app.enabled,
         actions=action_policy_views(app.app_type, stored),
         is_onyx_managed=managed,
     )
@@ -193,7 +194,7 @@ def update_external_app_admin(
 ) -> ExternalAppAdminResponse:
     """Partial update of any app (404 if absent). ``None`` fields are left
     untouched. For Onyx-managed built-ins (cloud) the gateway-config fields
-    are Onyx-owned and ignored — only ``action_policies`` apply.
+    are Onyx-owned and ignored — only ``enabled`` and ``action_policies`` apply.
     A custom app's bundle bytes are swapped via ``PUT /admin/apps/{id}/bundle``.
     """
     app = _get_app_or_404(db_session, external_app_id)
@@ -218,6 +219,7 @@ def update_external_app_admin(
         db_session=db_session,
         external_app_id=external_app_id,
         app_type=app.app_type,
+        enabled=none_as_unset(request.enabled),
         name=none_as_unset(request.name),
         description=none_as_unset(request.description),
         # Gateway config is Onyx-owned for managed built-ins; leave it untouched.
@@ -414,6 +416,13 @@ def upsert_user_credentials(
 
     Returns 404 if no app with `external_app_id` exists.
     """
+    app = _get_app_or_404(db_session, external_app_id)
+    if not app.enabled:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "This app is currently disabled by an admin.",
+        )
+
     upsert_external_app_user_credential(
         db_session=db_session,
         external_app_id=external_app_id,
@@ -432,12 +441,12 @@ def list_external_apps(
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> list[ExternalAppUserResponse]:
-    """List external apps with the calling user's credential state: the
+    """List enabled external apps with the calling user's credential state: the
     keys the user must supply, the values already stored, and an
     ``authenticated`` flag. Org credentials and the raw auth template aren't
     exposed.
     """
-    apps = get_external_apps(db_session=db_session)
+    apps = get_external_apps(db_session=db_session, enabled_only=True)
     user_creds_by_app = get_user_credentials_by_app_id(
         db_session=db_session, user_id=user.id
     )

--- a/backend/onyx/server/features/build/external_apps/models.py
+++ b/backend/onyx/server/features/build/external_apps/models.py
@@ -18,7 +18,7 @@ class CreateBuiltInExternalAppRequest(BaseModel):
     by the egress proxy against outbound request URLs.
 
     Skill identity (slug, bundle bytes, sharing scope) is derived server-side
-    from ``app_type``; admins don't supply it.
+    from ``app_type``; admins don't supply it. New apps are enabled by default.
     """
 
     name: str
@@ -40,11 +40,12 @@ class UpdateExternalAppRequest(BaseModel):
     This is the single update path for built-in apps. For Onyx-managed built-ins
     (cloud) the gateway-config fields (``upstream_url_patterns``,
     ``auth_template``, ``organization_credentials``) are Onyx-owned and ignored —
-    only ``action_policies`` take effect. Custom-app field edits
+    only ``enabled`` and ``action_policies`` take effect. Custom-app field edits
     (and bundle replacement) go through ``POST /admin/apps/custom`` instead, since
     that path is multipart.
     """
 
+    enabled: bool | None = None
     name: str | None = None
     description: str | None = None
     upstream_url_patterns: list[str] | None = None
@@ -64,10 +65,11 @@ class ExternalAppAdminResponse(BaseModel):
     upstream_url_patterns: list[str]
     auth_template: dict[str, Any]
     organization_credentials: dict[str, Any]
+    enabled: bool
     # The merged per-action policy view (built-in apps; empty for custom).
     actions: list[ActionPolicyView]
     # Onyx-managed built-in (cloud): creds/config Onyx-owned and blanked above;
-    # admin may only set policies. UI hides the rest.
+    # admin may only set availability and policies. UI hides the rest.
     is_onyx_managed: bool = False
 
 
@@ -89,7 +91,7 @@ class ExternalAppUserResponse(BaseModel):
     `credential_keys`.
 
     Admin-only fields (``organization_credentials``, ``auth_template``,
-    ``upstream_url_patterns``) are intentionally omitted.
+    ``upstream_url_patterns``, ``enabled``) are intentionally omitted.
     ``app_type`` is included — it's the non-sensitive provider
     discriminator the UI needs to render the app.
     """

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -93,6 +93,11 @@ def start_external_app_oauth(
             OnyxErrorCode.NOT_FOUND,
             f"External app with id {external_app_id} not found.",
         )
+    if not app.enabled:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "This app is currently disabled by an admin.",
+        )
     provider = _oauth_provider_or_raise(app)
     client_id, _client_secret = _oauth_client_credentials(app)
 
@@ -163,6 +168,11 @@ def handle_external_app_oauth_callback(
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND,
             f"External app with id {record.external_app_id} no longer exists.",
+        )
+    if not app.enabled:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "This app is currently disabled by an admin.",
         )
 
     provider = _oauth_provider_or_raise(app)

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -470,6 +470,7 @@ def restore_session(
                     sandbox.id,
                     user,
                     db_session,
+                    connectable_apps_section=connectable_apps_section,
                     skills_files=skills_files,
                 )
                 if snapshot:

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -306,7 +306,7 @@ class SessionManager:
                     )
                     raise OnyxError(
                         OnyxErrorCode.BAD_GATEWAY,
-                        "Failed to reload session skills.",
+                        "Failed to reload session.",
                     ) from exc
 
             session.skills_hash = skills_hash
@@ -465,6 +465,7 @@ class SessionManager:
             sandbox.id,
             user,
             self._db_session,
+            connectable_apps_section=connectable_apps_section,
             skills_files=skills_files,
         )
         self._sandbox_manager.setup_session_workspace(

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -42,8 +42,8 @@ from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.skills.push import (
-    build_skills_fileset_for_user,
-    compute_skills_hash,
+    build_user_skills_payload,
+    compute_skill_runtime_hash,
     hydrate_sandbox_skills,
 )
 from onyx.utils.logger import setup_logger
@@ -146,6 +146,8 @@ def hydrate_managed_content(
     sandbox_id: UUID,
     user: User,
     db_session: DBSession,
+    *,
+    connectable_apps_section: str | None = None,
     skills_files: FileSet | None = None,
 ) -> bool:
     """Push managed skills + user library into a sandbox.
@@ -153,13 +155,22 @@ def hydrate_managed_content(
     Must complete before the sandbox is reported RUNNING: turns dispatch as
     soon as RUNNING is visible, and opencode scans the skills directory once
     per instance, so a turn started mid-push permanently misses managed
-    skills. Each push is best-effort — failures are logged, never raised.
+    skills. The persisted hash also covers the connectable-app guidance used
+    to regenerate ``AGENTS.md`` on reload. Each push is best-effort — failures
+    are logged, never raised.
     """
+    if (connectable_apps_section is None) != (skills_files is None):
+        raise ValueError(
+            "connectable_apps_section and skills_files must be provided together"
+        )
+    if connectable_apps_section is None or skills_files is None:
+        connectable_apps_section, skills_files = build_user_skills_payload(
+            user, db_session
+        )
+
     skills_hydrated = False
     try:
-        if skills_files is None:
-            skills_files = build_skills_fileset_for_user(user, db_session)
-        skills_hash = compute_skills_hash(skills_files)
+        skills_hash = compute_skill_runtime_hash(skills_files, connectable_apps_section)
         result = hydrate_sandbox_skills(
             sandbox_id,
             user,

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -156,8 +156,11 @@ def hydrate_managed_content(
     soon as RUNNING is visible, and opencode scans the skills directory once
     per instance, so a turn started mid-push permanently misses managed
     skills. The persisted hash also covers the connectable-app guidance used
-    to regenerate ``AGENTS.md`` on reload. Each push is best-effort — failures
-    are logged, never raised.
+    to regenerate ``AGENTS.md`` on reload.
+
+    ``connectable_apps_section`` and ``skills_files`` must be supplied together
+    or both omitted; mismatched nullity is a programmer error and raises
+    ``ValueError`` eagerly. Runtime push failures are logged, never raised.
     """
     if (connectable_apps_section is None) != (skills_files is None):
         raise ValueError(

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -53,9 +53,15 @@ SKILLS_MOUNT_PATH = "/workspace/managed/skills"
 _EXCLUDED_DIR_NAMES: frozenset[str] = frozenset({"__pycache__"})
 
 
-def compute_skills_hash(files: FileSet) -> str:
-    """Return a deterministic digest of the hydrated paths and contents."""
+def compute_skill_runtime_hash(
+    files: FileSet,
+    connectable_apps_section: str,
+) -> str:
+    """Digest skill files and the app guidance rendered into ``AGENTS.md``."""
     digest = hashlib.sha256()
+    connectable_apps_bytes = connectable_apps_section.encode()
+    digest.update(len(connectable_apps_bytes).to_bytes(8))
+    digest.update(connectable_apps_bytes)
     for path in sorted(files):
         path_bytes = path.encode()
         content = files[path]
@@ -268,23 +274,29 @@ def push_skill_to_affected_sandboxes(skill: Skill, db_session: Session) -> None:
 
 
 def push_skills_for_users(user_ids: set[UUID], db_session: Session) -> None:
-    """Rebuild and push the full skills fileset for each user's sandbox."""
+    """Push skill state changes and mark affected sessions for reload."""
     if not user_ids:
         return
     try:
         sandbox_map = get_sandbox_user_map(list(user_ids), db_session)
         current_hashes = lock_sandbox_skills_hashes(db_session, set(sandbox_map))
-        sandbox_files = {
-            sid: build_skills_fileset_for_user(user, db_session)
-            for sid, user in sandbox_map.items()
+        sandbox_payloads = {
+            sandbox_id: build_user_skills_payload(user, db_session)
+            for sandbox_id, user in sandbox_map.items()
         }
         desired_hashes = {
-            sandbox_id: compute_skills_hash(files)
-            for sandbox_id, files in sandbox_files.items()
+            sandbox_id: compute_skill_runtime_hash(files, connectable_apps_section)
+            for sandbox_id, (
+                connectable_apps_section,
+                files,
+            ) in sandbox_payloads.items()
         }
         changed_files = {
             sandbox_id: files
-            for sandbox_id, files in sandbox_files.items()
+            for sandbox_id, (
+                _connectable_apps_section,
+                files,
+            ) in sandbox_payloads.items()
             if current_hashes.get(sandbox_id) != desired_hashes[sandbox_id]
         }
         if not changed_files:

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -221,12 +221,14 @@ def make_external_app(
     app_type: ExternalAppType = ExternalAppType.CUSTOM,
     upstream_url_patterns: list[str] | None = None,
     action_policies: dict[str, EndpointPolicy] | None = None,
+    enabled: bool = True,
 ) -> ExternalApp:
     """Insert an ``ExternalApp`` row backing ``skill``, plus any per-action
     policy overrides in ``action_policies`` (``{action_id: policy}``)."""
     app = ExternalApp(
         skill_id=skill.id,
         app_type=app_type,
+        enabled=enabled,
         upstream_url_patterns=upstream_url_patterns or [],
         auth_template=auth_template,
         organization_credentials=organization_credentials or {},

--- a/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
@@ -52,6 +52,12 @@ def test_lists_only_unconnected_apps_and_renders_them(
         skill=make_skill(db_session, slug="hidden-app", is_public=False),
         auth_template=_USER_TOKEN_TEMPLATE,
     )
+    make_external_app(
+        db_session,
+        skill=make_skill(db_session, slug="disabled-app", is_public=True),
+        auth_template=_USER_TOKEN_TEMPLATE,
+        enabled=False,
+    )
     db_session.commit()
 
     slugs = {app.skill.slug for app in get_connectable_apps_for_user(db_session, user)}
@@ -60,9 +66,11 @@ def test_lists_only_unconnected_apps_and_renders_them(
     assert "already-connected" not in slugs
     assert "org-filled" not in slugs
     assert "hidden-app" not in slugs
+    assert "disabled-app" not in slugs
 
     apps_list = build_connectable_apps_list(
         get_connectable_apps_for_user(db_session, user)
     )
     assert "- **needs-setup**" in apps_list
     assert "hidden-app" not in apps_list
+    assert "disabled-app" not in apps_list

--- a/backend/tests/external_dependency_unit/craft/test_credential_injection.py
+++ b/backend/tests/external_dependency_unit/craft/test_credential_injection.py
@@ -84,6 +84,22 @@ def test_missing_user_credential_omits_header(
     assert resolve_injection_headers(db_session, app.id, user.id) == {}
 
 
+def test_disabled_app_does_not_inject_credentials(
+    db_session: Session,
+    test_user: object,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    app = make_external_app(
+        db_session,
+        skill=make_skill(db_session),
+        auth_template=_BEARER,
+        organization_credentials={"access_token": "org-token"},
+        enabled=False,
+    )
+
+    assert resolve_injection_headers(db_session, app.id, user.id) == {}
+
+
 def test_unknown_app_returns_empty(
     db_session: Session,
     test_user: object,  # noqa: ARG001

--- a/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
@@ -10,6 +10,7 @@ from onyx.db.enums import ExternalAppType
 from onyx.db.models import User
 from onyx.server.features.build.external_apps.models import (
     CreateBuiltInExternalAppRequest,
+    UpdateExternalAppRequest,
     UpsertUserCredentialsRequest,
 )
 from tests.external_dependency_unit.craft.db_helpers import (
@@ -92,6 +93,44 @@ def test_create_refreshes_the_created_skill(
         db_session=db_session,
     )
 
+    assert pushed_skill_ids == [skill.id]
+
+
+def test_admin_toggle_updates_app_and_refreshes_affected_sandboxes(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    skill = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id=f"toggle-push-{uuid4().hex[:8]}",
+        is_public=True,
+    )
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.SLACK,
+        auth_template={"Authorization": "Bearer {token}"},
+    )
+    db_session.commit()
+
+    pushed_skill_ids: list[UUID] = []
+    monkeypatch.setattr(api, "MULTI_TENANT", False)
+    monkeypatch.setattr(
+        api,
+        "push_skill_to_affected_sandboxes",
+        lambda pushed_skill, _db: pushed_skill_ids.append(pushed_skill.id),
+    )
+
+    response = api.update_external_app_admin(
+        external_app_id=app.id,
+        request=UpdateExternalAppRequest(enabled=False),
+        _=test_user,
+        db_session=db_session,
+    )
+
+    assert response.enabled is False
+    assert app.enabled is False
     assert pushed_skill_ids == [skill.id]
 
 

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
@@ -114,6 +114,28 @@ def test_use_includes_authenticated_external_app_without_preference(
     assert skill.id in _skill_ids(user, db_session, SkillAccessPolicy.USE)
 
 
+def test_use_excludes_disabled_external_app(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    skill = make_skill(db_session, is_public=True)
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        auth_template=_AUTH_TEMPLATE,
+        enabled=False,
+    )
+    make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
+
+    assert skill.id not in _skill_ids(user, db_session, SkillAccessPolicy.USE)
+
+    app.enabled = True
+    db_session.flush()
+
+    assert skill.id in _skill_ids(user, db_session, SkillAccessPolicy.USE)
+
+
 def test_use_excludes_unauthenticated_or_partially_authenticated_external_app(
     db_session: Session,
     test_user: User,  # noqa: ARG001

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -68,6 +68,7 @@ def test_warm_skill_hydration_changes_only_live_session_staleness(
         sandbox_row.id,
         test_user,
         db_session,
+        connectable_apps_section="first apps",
         skills_files={"first/SKILL.md": b"first"},
     )
     db_session.commit()
@@ -93,7 +94,8 @@ def test_warm_skill_hydration_changes_only_live_session_staleness(
         sandbox_row.id,
         test_user,
         db_session,
-        skills_files={"second/SKILL.md": b"second"},
+        connectable_apps_section="second apps",
+        skills_files={"first/SKILL.md": b"first"},
     )
     db_session.commit()
     db_session.refresh(sandbox_row)

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -54,7 +54,7 @@ from tests.external_dependency_unit.craft.redis_helpers import (
 # =============================================================================
 
 
-def test_warm_skill_hydration_changes_only_live_session_staleness(
+def test_warm_content_hash_change_marks_only_live_session_stale(
     db_session: Session,
     test_user: User,
     sandbox: Callable[..., Sandbox],

--- a/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
@@ -13,7 +13,7 @@ from onyx.db.enums import BuildSessionStatus, SandboxStatus, SessionOrigin
 from onyx.db.models import BuildSession, Skill, User
 from onyx.server.features.build.db.build_session import skills_are_stale
 from onyx.server.features.build.sandbox.models import FatalWriteError
-from onyx.skills.push import compute_skills_hash, push_skills_for_users
+from onyx.skills.push import compute_skill_runtime_hash, push_skills_for_users
 from tests.common.craft.stubs import StubSandboxManager
 from tests.external_dependency_unit.craft.db_helpers import make_sandbox, make_user
 
@@ -104,7 +104,7 @@ def test_one_failing_sandbox_does_not_abort_push_to_others(
         assert not skills_are_stale(session, sandbox)
 
 
-def test_only_changed_skill_files_are_pushed_and_hashes_self_heal(
+def test_connectable_app_change_pushes_and_hashes_self_heal(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -127,19 +127,21 @@ def test_only_changed_skill_files_are_pushed_and_hashes_self_heal(
         opencode_session_id="changed-runtime",
     )
 
-    contents = {
-        unchanged_user.id: b"content",
-        changed_user.id: b"changed",
+    def files_for(user: User, _db_session: Session) -> dict[str, bytes]:
+        return {f"{user.id}/SKILL.md": b"content"}
+
+    connectable_apps_sections = {
+        unchanged_user.id: "",
+        changed_user.id: "new apps",
     }
 
-    def files_for(user: User, _db_session: Session) -> dict[str, bytes]:
-        return {f"{user.id}/SKILL.md": contents[user.id]}
-
-    unchanged_sandbox.skills_hash = compute_skills_hash(
-        files_for(unchanged_user, db_session)
+    unchanged_sandbox.skills_hash = compute_skill_runtime_hash(
+        files_for(unchanged_user, db_session),
+        "",
     )
-    changed_sandbox.skills_hash = compute_skills_hash(
-        {f"{changed_user.id}/SKILL.md": b"original"}
+    changed_sandbox.skills_hash = compute_skill_runtime_hash(
+        files_for(changed_user, db_session),
+        "old apps",
     )
     unchanged_session.skills_hash = unchanged_sandbox.skills_hash
     changed_session.skills_hash = changed_sandbox.skills_hash
@@ -149,7 +151,13 @@ def test_only_changed_skill_files_are_pushed_and_hashes_self_heal(
     stub = StubSandboxManager()
     stub.write_files_to_sandbox_silent = True
     monkeypatch.setattr("onyx.skills.push.get_sandbox_manager", lambda: stub)
-    monkeypatch.setattr("onyx.skills.push.build_skills_fileset_for_user", files_for)
+    monkeypatch.setattr(
+        "onyx.skills.push.build_user_skills_payload",
+        lambda user, session: (
+            connectable_apps_sections[user.id],
+            files_for(user, session),
+        ),
+    )
 
     push_skills_for_users({unchanged_user.id, changed_user.id}, db_session)
 
@@ -161,7 +169,7 @@ def test_only_changed_skill_files_are_pushed_and_hashes_self_heal(
     assert not skills_are_stale(unchanged_session, unchanged_sandbox)
     assert skills_are_stale(changed_session, changed_sandbox)
 
-    contents[changed_user.id] = b"original"
+    connectable_apps_sections[changed_user.id] = "old apps"
     push_skills_for_users({changed_user.id}, db_session)
 
     db_session.refresh(changed_sandbox)

--- a/backend/tests/integration/common_utils/managers/external_app.py
+++ b/backend/tests/integration/common_utils/managers/external_app.py
@@ -198,6 +198,21 @@ class ExternalAppManager:
         return [ExternalAppAdminResponse.model_validate(row) for row in response.json()]
 
     @staticmethod
+    def set_enabled(
+        user_performing_action: DATestUser,
+        app_id: int,
+        enabled: bool,
+    ) -> ExternalAppAdminResponse:
+        response = client.patch(
+            f"{_BUILD_PREFIX}/admin/apps/{app_id}",
+            json={"enabled": enabled},
+            headers=user_performing_action.headers,
+            cookies=user_performing_action.cookies,
+        )
+        response.raise_for_status()
+        return ExternalAppAdminResponse.model_validate(response.json())
+
+    @staticmethod
     def delete(user_performing_action: DATestUser, app_id: int) -> None:
         response = client.delete(
             f"{_BUILD_PREFIX}/admin/apps/{app_id}",

--- a/backend/tests/integration/tests/external_apps/test_external_apps.py
+++ b/backend/tests/integration/tests/external_apps/test_external_apps.py
@@ -109,6 +109,7 @@ def test_admin_creates_app_user_configures_credentials(
     assert admin_app.description == "An app for testing"
     assert admin_app.upstream_url_patterns == ["https://api.example.com/*"]
     assert admin_app.auth_template == _AUTH_TEMPLATE
+    assert admin_app.enabled is True
     # Org credentials are masked in the admin response so secrets are never
     # returned to the client.
     assert admin_app.organization_credentials == mask_credential_dict(_ORG_CREDENTIALS)
@@ -140,6 +141,39 @@ def test_admin_creates_app_user_configures_credentials(
     assert admin_apps_after[0].organization_credentials == mask_credential_dict(
         _ORG_CREDENTIALS
     )
+
+
+def test_admin_disablement_hides_app_without_deleting_user_credentials(
+    reset: None,  # noqa: ARG001
+    admin_user: DATestUser,
+    basic_user: DATestUser,
+) -> None:
+    created = _create_test_app(admin_user)
+    ExternalAppManager.upsert_user_credentials(
+        user_performing_action=basic_user,
+        app_id=created.id,
+        credentials=_USER_CREDENTIALS,
+    )
+
+    disabled = ExternalAppManager.set_enabled(admin_user, created.id, False)
+
+    assert disabled.enabled is False
+    assert all(
+        app.id != created.id for app in ExternalAppManager.list_for_user(basic_user)
+    )
+    with pytest.raises(httpx.HTTPStatusError) as exc:
+        ExternalAppManager.upsert_user_credentials(
+            user_performing_action=basic_user,
+            app_id=created.id,
+            credentials=_USER_CREDENTIALS,
+        )
+    assert exc.value.response.status_code == 400
+
+    enabled = ExternalAppManager.set_enabled(admin_user, created.id, True)
+    restored = ExternalAppManager.get_for_user(basic_user, created.id)
+
+    assert enabled.enabled is True
+    assert restored.authenticated is True
 
 
 def test_external_app_is_excluded_from_skill_management_apis(

--- a/backend/tests/unit/external_apps/test_hubspot_provider.py
+++ b/backend/tests/unit/external_apps/test_hubspot_provider.py
@@ -83,8 +83,9 @@ def test_authorize_url_carries_optional_scope(monkeypatch: pytest.MonkeyPatch) -
     oauth = _provider().spec.oauth
     app = SimpleNamespace(
         id=1,
+        enabled=True,
         app_type=ExternalAppType.HUBSPOT,
-        skill=SimpleNamespace(name="HubSpot", enabled=True),
+        skill=SimpleNamespace(name="HubSpot"),
         organization_credentials=SimpleNamespace(
             get_value=lambda **_: {
                 "client_id": "client-id",

--- a/backend/tests/unit/onyx/skills/test_push.py
+++ b/backend/tests/unit/onyx/skills/test_push.py
@@ -48,15 +48,18 @@ def _skill(
     )
 
 
-def test_compute_skills_hash_is_order_independent_and_content_sensitive() -> None:
+def test_skill_runtime_hash_covers_files_and_connectable_apps() -> None:
     files = {"b/SKILL.md": b"second", "a/SKILL.md": b"first"}
 
-    assert push.compute_skills_hash(files) == push.compute_skills_hash(
-        dict(reversed(files.items()))
-    )
-    assert push.compute_skills_hash(files) != push.compute_skills_hash(
-        {**files, "a/SKILL.md": b"changed"}
-    )
+    assert push.compute_skill_runtime_hash(
+        files, "apps"
+    ) == push.compute_skill_runtime_hash(dict(reversed(files.items())), "apps")
+    assert push.compute_skill_runtime_hash(
+        files, "apps"
+    ) != push.compute_skill_runtime_hash({**files, "a/SKILL.md": b"changed"}, "apps")
+    assert push.compute_skill_runtime_hash(
+        files, "apps"
+    ) != push.compute_skill_runtime_hash(files, "different apps")
 
 
 def test_assemble_classifies_and_hydrates_valid_unclassified_skill(

--- a/web/src/app/craft/components/SkillsStaleNotice.test.tsx
+++ b/web/src/app/craft/components/SkillsStaleNotice.test.tsx
@@ -26,7 +26,7 @@ describe("SkillsStaleNotice", () => {
   it("reloads only this session and clears its stale state", async () => {
     render(<SkillsStaleNotice sessionId={SESSION_ID} turnActive={false} />);
 
-    fireEvent.click(screen.getByRole("button", { name: "Reload skills" }));
+    fireEvent.click(screen.getByRole("button", { name: "Reload" }));
 
     await waitFor(() => {
       expect(api.reloadSessionSkills).toHaveBeenCalledWith(SESSION_ID);
@@ -39,8 +39,6 @@ describe("SkillsStaleNotice", () => {
   it("disables reload while a turn is active", () => {
     render(<SkillsStaleNotice sessionId={SESSION_ID} turnActive />);
 
-    expect(
-      screen.getByRole("button", { name: "Reload skills" })
-    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Reload" })).toBeDisabled();
   });
 });

--- a/web/src/app/craft/components/SkillsStaleNotice.tsx
+++ b/web/src/app/craft/components/SkillsStaleNotice.tsx
@@ -27,9 +27,7 @@ export default function SkillsStaleNotice({
       updateSessionData(sessionId, { skillsStale: state.skills_stale });
     } catch (error) {
       toast.error(
-        error instanceof Error
-          ? error.message
-          : "Failed to reload session skills"
+        error instanceof Error ? error.message : "Failed to reload session"
       );
     } finally {
       setReloading(false);
@@ -39,8 +37,8 @@ export default function SkillsStaleNotice({
   return (
     <MessageCard
       variant="warning"
-      title="Your skills have changed"
-      description="Reload this session to update skills."
+      title="Your agent’s capabilities have changed"
+      description="Reload this session to apply the latest skills and app access."
       rightChildren={
         <Button
           icon={SvgRefreshCw}
@@ -50,7 +48,7 @@ export default function SkillsStaleNotice({
             turnActive ? "Wait for the current turn to finish." : undefined
           }
         >
-          {reloading ? "Reloading…" : "Reload skills"}
+          {reloading ? "Reloading…" : "Reload"}
         </Button>
       }
     />

--- a/web/src/app/craft/services/apiServices.ts
+++ b/web/src/app/craft/services/apiServices.ts
@@ -155,7 +155,7 @@ export async function reloadSessionSkills(
   );
 
   if (!res.ok) {
-    throw new Error(await errorDetail(res, "Failed to reload session skills"));
+    throw new Error(await errorDetail(res, "Failed to reload session"));
   }
 
   return res.json();

--- a/web/src/app/craft/services/externalAppsService.ts
+++ b/web/src/app/craft/services/externalAppsService.ts
@@ -117,6 +117,7 @@ export async function replaceCustomAppBundle(
 
 interface UpdateExternalAppBody {
   // Every field is optional; omit to leave the stored value untouched.
+  enabled?: boolean;
   name?: string;
   description?: string;
   upstream_url_patterns?: string[];

--- a/web/src/app/craft/v1/apps/__tests__/registry.test.ts
+++ b/web/src/app/craft/v1/apps/__tests__/registry.test.ts
@@ -30,6 +30,7 @@ function configuredApp(
     upstream_url_patterns: [],
     auth_template: {},
     organization_credentials: {},
+    enabled: true,
     actions: [],
     is_onyx_managed: false,
     ...overrides,

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -92,9 +92,10 @@ export interface ExternalAppAdminResponse {
   upstream_url_patterns: string[];
   auth_template: Record<string, string>;
   organization_credentials: Record<string, string>;
+  enabled: boolean;
   actions: ActionPolicyView[];
   // Onyx-managed built-in (cloud): creds/config Onyx-owned and blanked here; the
-  // admin may only set policies (the UI hides the rest).
+  // admin may only set availability and policies (the UI hides the rest).
   is_onyx_managed: boolean;
 }
 

--- a/web/src/views/admin/ExternalAppsPage.test.tsx
+++ b/web/src/views/admin/ExternalAppsPage.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@tests/setup/test-utils";
+import useSWR from "swr";
+import ExternalAppsPage from "@/views/admin/ExternalAppsPage";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
+import * as externalAppsService from "@/app/craft/services/externalAppsService";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  ...jest.requireActual("swr"),
+  default: jest.fn(),
+}));
+
+jest.mock("@/app/craft/services/externalAppsService");
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockMutateApps = jest.fn();
+
+const APP: ExternalAppAdminResponse = {
+  id: 1,
+  name: "Custom app",
+  description: "",
+  app_type: "CUSTOM",
+  upstream_url_patterns: [],
+  auth_template: {},
+  organization_credentials: {},
+  enabled: true,
+  actions: [],
+  is_onyx_managed: false,
+};
+
+describe("ExternalAppsPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseSWR.mockImplementation((key) => {
+      if (key === SWR_KEYS.buildExternalAppsAdmin) {
+        return {
+          data: [APP],
+          error: undefined,
+          isLoading: false,
+          isValidating: false,
+          mutate: mockMutateApps,
+        } as ReturnType<typeof useSWR>;
+      }
+      return {
+        data: [],
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: jest.fn(),
+      } as ReturnType<typeof useSWR>;
+    });
+    jest.mocked(externalAppsService.updateExternalApp).mockResolvedValue(APP);
+  });
+
+  it("keeps app controls disabled until the refreshed app state arrives", async () => {
+    let finishRefresh: (() => void) | undefined;
+    mockMutateApps.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishRefresh = resolve;
+      })
+    );
+
+    render(<ExternalAppsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Disable" }));
+
+    await waitFor(() => {
+      expect(externalAppsService.updateExternalApp).toHaveBeenCalledWith(1, {
+        enabled: false,
+      });
+    });
+    expect(screen.getByRole("button", { name: "Disable" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Edit" })).toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: "Delete Custom app" })
+    ).toBeDisabled();
+
+    await act(async () => finishRefresh?.());
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Disable" })).toBeEnabled();
+    });
+  });
+});

--- a/web/src/views/admin/ExternalAppsPage.tsx
+++ b/web/src/views/admin/ExternalAppsPage.tsx
@@ -17,7 +17,10 @@ import {
 } from "@/app/craft/v1/apps/registry";
 import ConfigureProviderModal from "@/app/craft/v1/apps/admin/ConfigureProviderModal";
 import CreateCustomAppModal from "@/app/craft/v1/apps/admin/CreateCustomAppModal";
-import { deleteExternalApp } from "@/app/craft/services/externalAppsService";
+import {
+  deleteExternalApp,
+  updateExternalApp,
+} from "@/app/craft/services/externalAppsService";
 
 interface ModalState {
   descriptor: BuiltInExternalAppDescriptor;
@@ -188,6 +191,22 @@ function ConfiguredAppCard({
   const [isMutating, setIsMutating] = useState(false);
   const Logo = getAppTypeLogo(app.app_type);
 
+  async function toggleEnabled() {
+    setIsMutating(true);
+    try {
+      await updateExternalApp(app.id, { enabled: !app.enabled });
+      onChange();
+    } catch (e) {
+      toast.error(
+        e instanceof Error
+          ? e.message
+          : `Failed to ${app.enabled ? "disable" : "enable"} "${app.name}"`
+      );
+    } finally {
+      setIsMutating(false);
+    }
+  }
+
   async function remove() {
     setIsMutating(true);
     try {
@@ -209,7 +228,9 @@ function ConfiguredAppCard({
         <div className="flex-1 flex flex-col gap-0.5">
           <Text font="main-ui-action">{app.name}</Text>
           <Text font="secondary-body" color="text-03">
-            Users connect this app on the Apps page to make its skill available
+            {app.enabled
+              ? "Users connect this app on the Apps page to make its skill available"
+              : "Disabled — unavailable to users"}
           </Text>
         </div>
         <div className="flex items-center gap-2">
@@ -232,6 +253,13 @@ function ConfiguredAppCard({
               </Button>
             )
           )}
+          <Button
+            prominence="secondary"
+            onClick={toggleEnabled}
+            disabled={isMutating}
+          >
+            {app.enabled ? "Disable" : "Enable"}
+          </Button>
           {/* Onyx-managed built-ins are provisioned by Onyx. */}
           {!app.is_onyx_managed && (
             <Button

--- a/web/src/views/admin/ExternalAppsPage.tsx
+++ b/web/src/views/admin/ExternalAppsPage.tsx
@@ -178,7 +178,7 @@ interface ConfiguredAppCardProps {
   onEdit: (descriptor: BuiltInExternalAppDescriptor) => void;
   /** Edit a custom app (no descriptor — config is on the row itself). */
   onEditCustom: (app: ExternalAppAdminResponse) => void;
-  onChange: () => void;
+  onChange: () => Promise<unknown>;
 }
 
 function ConfiguredAppCard({
@@ -195,7 +195,7 @@ function ConfiguredAppCard({
     setIsMutating(true);
     try {
       await updateExternalApp(app.id, { enabled: !app.enabled });
-      onChange();
+      await onChange();
     } catch (e) {
       toast.error(
         e instanceof Error
@@ -211,7 +211,7 @@ function ConfiguredAppCard({
     setIsMutating(true);
     try {
       await deleteExternalApp(app.id);
-      onChange();
+      await onChange();
     } catch (e) {
       toast.error(
         e instanceof Error ? e.message : `Failed to delete "${app.name}"`


### PR DESCRIPTION
## Description

Restore administrator enablement controls for Craft external apps using an `ExternalApp.enabled` field independent of skill preferences.

Disabled apps are excluded from credential injection, sandbox proxy access, connectable-app guidance, and linked skill hydration. Admin enable/disable and deletion changes refresh affected sandboxes, and the runtime content hash now includes connectable-app guidance so existing Craft sessions prompt users to reload when app availability changes.

The admin External Apps page exposes the restored toggle, while existing apps remain enabled by default through the accompanying migration.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add admin enable/disable controls to Craft external apps and wire availability across APIs, proxying, and sessions. Disabled apps are hidden from users, blocked from OAuth and credential injection, and sessions prompt a reload when availability changes.

- New Features
  - Added `ExternalApp.enabled` (default true) and admin PATCH to toggle; Onyx‑managed built‑ins allow only availability and policies. Admin UI adds an Enable/Disable button and disables controls during refresh.
  - User-facing lists and the proxy consider only enabled apps; resolving injection returns empty for disabled apps; upserting credentials and OAuth start/callback return an error when the app is disabled.
  - Connectable‑app guidance excludes disabled apps; the session runtime hash now includes this guidance so toggles mark affected sessions stale and show a “Reload” notice. Updated copy: “Your agent’s capabilities have changed…”, button “Reload”, error “Failed to reload session”.

- Migration
  - Alembic migration adds `enabled` to `external_app`; existing apps stay enabled by default. No manual action needed.

<sup>Written for commit 40828746ee68717015fce8f1428278133c1d0dee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

