### PR TITLE
fix(desktop): only reserve the title-bar strip on macOS

### DIFF
--- a/web/src/app/css/desktop-titlebar.css
+++ b/web/src/app/css/desktop-titlebar.css
@@ -9,9 +9,12 @@
   update. These rules let the web app reserve the strip itself, so the fix
   reaches every existing install via the remote bundle without a desktop release.
 
-  Activated by the `onyx-desktop` class added to <html> (see the inline detector
-  in app/layout.tsx). All rules are gated on `html.onyx-desktop`, so browser
-  users are completely unaffected. The selectors are deliberately more specific
+  Activated by the `onyx-desktop` class added to <html> on macOS only (see the
+  inline detector in app/layout.tsx) — the overlay title bar is macOS-specific;
+  Linux and Windows keep native window decorations (and, on Linux, an in-window
+  menu bar), so reserving the strip there would just leave a gap above the app.
+  All rules are gated on `html.onyx-desktop`, so browser users are completely
+  unaffected. The selectors are deliberately more specific
   than the shim's (`.onyx-desktop` + element/id), and this sheet is imported
   unlayered, so it deterministically wins over every shim version — producing a
   single inset (never a doubled 72px gap) regardless of which shim is present.

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -77,18 +77,24 @@ export default function Layout({ children }: LayoutProps) {
           content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0, interactive-widget=resizes-content"
         />
 
-        {/* When running inside the Tauri desktop wrapper, tag <html> as desktop
-            so the native title-bar reservation in css/desktop-titlebar.css
-            engages before paint. Tauri injects its IPC globals via an init
-            script that runs before page scripts, so this synchronous check sees
-            them; the class then persists across client-side navigations. No-op
-            in a browser. */}
+        {/* When running inside the Tauri desktop wrapper on macOS, tag <html>
+            as desktop so the native title-bar reservation in
+            css/desktop-titlebar.css engages before paint. macOS is the only
+            platform with an overlay title bar (traffic lights float over the
+            content); Linux and Windows keep native window decorations, so
+            reserving the strip there would only push content down. Tauri
+            injects its IPC globals via an init script that runs before page
+            scripts, so this synchronous check sees them; the class then
+            persists across client-side navigations. No-op in a browser. */}
         <Script
           id="onyx-desktop-detector"
           strategy="beforeInteractive"
           dangerouslySetInnerHTML={{
             __html: `
-              if ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) {
+              if (
+                ('__TAURI_INTERNALS__' in window || '__TAURI__' in window) &&
+                navigator.platform.startsWith('Mac')
+              ) {
                 document.documentElement.classList.add('onyx-desktop');
               }
             `,


### PR DESCRIPTION
## Description

aa3c2d0bc5 (#12534) made the web app reserve a 36px top strip whenever it detects it is running inside the Tauri desktop wrapper, so content stays below the macOS overlay title bar. But the overlay title bar (`titleBarStyle: "Overlay"`, traffic lights floating over the content) is macOS-only — the Rust wrapper already gates the `titlebar.js` shim injection to `#[cfg(target_os = "macos")]`. On Linux the window keeps native decorations plus an in-window menu bar, so the reservation (activated via the CSS fallback literal, since no shim ever sets the height variable) rendered as a needless gap between the app menu and the top of the app.

This gates the `onyx-desktop` class on `navigator.platform.startsWith("Mac")` in addition to the Tauri-globals check, so the strip is only reserved where an overlay title bar actually exists. Also fixes the same latent gap on Windows, which likewise uses native decorations.

## How Has This Been Tested?

Verified against the dev server with Playwright (chromium), injecting Tauri globals via an init script before page load:

- Linux platform + Tauri globals → `onyx-desktop` class absent, `<html>` padding-top `0px` (gap gone)
- `MacIntel` platform + Tauri globals → class present, padding-top `36px` (macOS reservation intact)
- Plain browser, no Tauri globals → class absent, padding-top `0px`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate the `onyx-desktop` class to macOS in the `Tauri` desktop app so the 36px overlay title-bar strip is only reserved where it exists. Fixes the top gap on Linux and Windows.

<sup>Written for commit 5061439155b1c0771a9335e23a2e341999337827. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

