### PR TITLE
fix(fe): align header items at `flex-start`

### DIFF
--- a/web/src/layouts/chromes/AppChrome.tsx
+++ b/web/src/layouts/chromes/AppChrome.tsx
@@ -360,7 +360,7 @@ function Header() {
         isMobile) &&
         !appFocus.isSharedChat() && (
           <RootLayout.Header>
-            <div className="w-full h-full flex flex-row flex-wrap justify-center items-center p-2 sm:px-4">
+            <div className="w-full h-full flex flex-row flex-wrap justify-center items-start p-2 sm:px-4">
               {/*
           Left:
           - (mobile) sidebar toggle


### PR DESCRIPTION
## Description

When the custom header text wraps, it expands the size of the header causing the center to shift down slightly.

 Instead align everything at the `flex-start` so the Search/Chat button is always inline with the sidebar header.

## How Has This Been Tested?

**before**
<img width="1900" height="2085" alt="20260720_16h01m06s_grim" src="https://github.com/user-attachments/assets/43a3f9b3-0f3d-41dc-8fd3-3f1260962fe0" />

**after**
<img width="1900" height="2085" alt="20260720_16h01m11s_grim" src="https://github.com/user-attachments/assets/34538cde-8771-4607-a0ae-4e39ec745b83" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Align header items at flex-start to prevent vertical shift when custom header text wraps, keeping the Search/Chat button inline with the sidebar header.
Changed the header flex container from items-center to items-start.

<sup>Written for commit 8a9bb4c7ef58a997da4a83486d0a5889d57edd2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

