### PR TITLE
chore(deps): upgrade celery-types to 0.26.0

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -28,8 +28,8 @@ from shared_configs.configs import (
 )
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 from onyx.db.models import Base
-from celery.backends.database.session import (  # ty: ignore[unresolved-import]
-    ResultModelBase,
+from celery.backends.database.session import (
+    ResultModelBase,  # ty: ignore[unresolved-import]
 )
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.variable_functionality import set_is_ee_based_on_env_variable

--- a/backend/onyx/background/celery/apps/app_base.py
+++ b/backend/onyx/background/celery/apps/app_base.py
@@ -7,15 +7,15 @@ from typing import Any, cast
 
 from celery import (
     Task,
-    bootsteps,  # ty: ignore[unresolved-import]
+    bootsteps,
 )
-from celery.app import trace  # ty: ignore[unresolved-import]
+from celery.app import trace
 from celery.exceptions import WorkerShutdown
 from celery.signals import before_task_publish, task_postrun, task_prerun
 from celery.states import READY_STATES
 from celery.utils.log import get_task_logger
-from celery.worker import strategy  # ty: ignore[unresolved-import]
-from celery.worker.control import control_command  # ty: ignore[unresolved-import]
+from celery.worker import strategy
+from celery.worker.control import control_command
 from redis.lock import Lock as RedisLock
 from sentry_sdk.integrations.celery import CeleryIntegration
 from sqlalchemy import text
@@ -99,7 +99,7 @@ def clear_revoked(state: Any, **kwargs: Any) -> dict[str, Any]:  # noqa: ARG001
     Intentionally ungated, like Celery's built-in shutdown/terminate/revoke control
     commands: the trust boundary is broker access, not a per-command check.
     """
-    from celery.worker import state as worker_state  # ty: ignore[unresolved-import]
+    from celery.worker import state as worker_state
 
     count = len(worker_state.revoked)
     worker_state.revoked.clear()
@@ -699,7 +699,7 @@ class LivenessProbe(bootsteps.StartStopStep):
         self.task_tref = None
         self.path = make_probe_path("liveness", worker.hostname)
 
-    def start(self, worker: Any) -> None:
+    def start(self, worker: Any) -> None:  # ty: ignore[invalid-method-override]
         self.task_tref = worker.timer.call_repeatedly(
             15.0,
             self.update_liveness_file,
@@ -707,7 +707,7 @@ class LivenessProbe(bootsteps.StartStopStep):
             priority=10,
         )
 
-    def stop(self, worker: Any) -> None:  # noqa: ARG002
+    def stop(self, worker: Any) -> None:  # noqa: ARG002  # ty: ignore[invalid-method-override]
         self.path.unlink(missing_ok=True)
         if self.task_tref:
             self.task_tref.cancel()

--- a/backend/onyx/background/celery/apps/beat.py
+++ b/backend/onyx/background/celery/apps/beat.py
@@ -1,8 +1,9 @@
+from collections.abc import ItemsView
 from datetime import timedelta
 from typing import Any
 
 from celery import Celery, signals
-from celery.beat import PersistentScheduler  # ty: ignore[unresolved-import]
+from celery.beat import PersistentScheduler
 from celery.signals import beat_init
 from celery.utils.log import get_task_logger
 
@@ -56,7 +57,7 @@ class DynamicTenantScheduler(PersistentScheduler):
     def setup_schedule(self) -> None:
         super().setup_schedule()
 
-    def tick(self) -> float:
+    def tick(self) -> float:  # ty: ignore[invalid-method-override]
         retval = super().tick()
         now = self.app.now()
         if (
@@ -236,7 +237,9 @@ class DynamicTenantScheduler(PersistentScheduler):
         self.last_beat_multiplier = beat_multiplier
 
     @staticmethod
-    def _compare_schedules(schedule1: dict, schedule2: dict) -> bool:
+    def _compare_schedules(
+        schedule1: ItemsView[str, Any], schedule2: dict[str, Any]
+    ) -> bool:
         """Compare schedules by task name only to determine if an update is needed.
         True if equivalent, False if not."""
         current_tasks = set(name for name, _ in schedule1)

--- a/backend/onyx/background/celery/apps/primary.py
+++ b/backend/onyx/background/celery/apps/primary.py
@@ -5,7 +5,7 @@ from typing import Any, cast
 from celery import (
     Celery,
     Task,
-    bootsteps,  # ty: ignore[unresolved-import]
+    bootsteps,
     signals,
 )
 from celery.apps.worker import Worker
@@ -280,7 +280,7 @@ class HubPeriodicTask(bootsteps.StartStopStep):
         self.interval = CELERY_PRIMARY_WORKER_LOCK_TIMEOUT / 8  # Interval in seconds
         self.task_tref = None
 
-    def start(self, worker: Any) -> None:
+    def start(self, worker: Any) -> None:  # ty: ignore[invalid-method-override]
         if not celery_is_worker_primary(worker):
             return
 
@@ -331,7 +331,7 @@ class HubPeriodicTask(bootsteps.StartStopStep):
         except Exception:
             task_logger.exception("Periodic task failed.")
 
-    def stop(self, worker: Any) -> None:  # noqa: ARG002
+    def stop(self, worker: Any) -> None:  # noqa: ARG002  # ty: ignore[invalid-method-override]
         # Cancel the scheduled task when the worker stops
         if self.task_tref:
             self.task_tref.cancel()

--- a/backend/onyx/background/celery/celery_redis.py
+++ b/backend/onyx/background/celery/celery_redis.py
@@ -212,9 +212,7 @@ def celery_inspect_get_reserved(worker_names: list[str], app: Celery) -> set[str
     inspect = app.control.inspect(destination=worker_names)
 
     # get the list of reserved tasks
-    reserved_tasks: dict[str, list] | None = (  # ty: ignore[invalid-assignment]
-        inspect.reserved()
-    )
+    reserved_tasks: dict[str, list] | None = inspect.reserved()
     if reserved_tasks:
         for _, task_list in reserved_tasks.items():
             for task in task_list:
@@ -235,9 +233,7 @@ def celery_inspect_get_active(worker_names: list[str], app: Celery) -> set[str]:
     inspect = app.control.inspect(destination=worker_names)
 
     # get the list of reserved tasks
-    active_tasks: dict[str, list] | None = (  # ty: ignore[invalid-assignment]
-        inspect.active()
-    )
+    active_tasks: dict[str, list] | None = inspect.active()
     if active_tasks:
         for _, task_list in active_tasks.items():
             for task in task_list:

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -178,9 +178,9 @@ brotli==1.2.0 \
     --hash=sha256:e7c0af964e0b4e3412a0ebf341ea26ec767fa0b4cf81abb5e897c9338b5ad6a3 \
     --hash=sha256:fc1530af5c3c275b8524f2e24841cbe2599d74462455e9bae5109e9ff42e9361
     # via onyx
-celery-types==0.19.0 \
-    --hash=sha256:3d3b54fa115aba1798c341d01cb156d5ccbfbebdae0a57dfa9b4b6a726271d80 \
-    --hash=sha256:d4e2d4271b2ec46fec08a0f12a25388bba391f26897485bcacfa3c5287cc236f
+celery-types==0.26.0 \
+    --hash=sha256:eb9da76f461786091970df466ec647d9a27956399852542cb6cab9309970f950 \
+    --hash=sha256:fa318136fdad83f83f1531deecd9fe664b5dfffff29f3c31e9120a46b8e3908f
 certifi==2025.11.12 \
     --hash=sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b \
     --hash=sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316

--- a/backend/scripts/dev_celery_reload.py
+++ b/backend/scripts/dev_celery_reload.py
@@ -37,7 +37,7 @@ _SANDBOX_IMAGE_DIR = str(
 
 
 def _run(argv: list[str]) -> None:
-    from celery.__main__ import main  # ty: ignore[unresolved-import]
+    from celery.__main__ import main
 
     sys.argv[:] = argv
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ backend = [
 # Dev tools
 dev = [
     "boto3-stubs[s3]==1.39.11",
-    "celery-types==0.19.0",
+    "celery-types==0.26.0",
     "faker==40.1.2",
     "hatchling==1.28.0",
     "ipykernel==6.29.5",

--- a/uv.lock
+++ b/uv.lock
@@ -829,14 +829,14 @@ wheels = [
 
 [[package]]
 name = "celery-types"
-version = "0.19.0"
+version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/a6/9923b3cb1902613d0aeeb561249f20ef0a58d6e173eed11149f7214ba693/celery-types-0.19.0.tar.gz", hash = "sha256:d4e2d4271b2ec46fec08a0f12a25388bba391f26897485bcacfa3c5287cc236f", size = 24945, upload-time = "2023-08-06T22:52:29.158Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/38/813dd7534e41682684d3a5c2cc4a8710e3acc51b364920b9c4d747c7b18f/celery_types-0.26.0.tar.gz", hash = "sha256:fa318136fdad83f83f1531deecd9fe664b5dfffff29f3c31e9120a46b8e3908f", size = 106210, upload-time = "2026-03-12T23:06:49.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/7b/c91fabc3c67ce28634d079b70ec0e7a2e7469c8435e690d14bff1709432e/celery_types-0.19.0-py3-none-any.whl", hash = "sha256:3d3b54fa115aba1798c341d01cb156d5ccbfbebdae0a57dfa9b4b6a726271d80", size = 38129, upload-time = "2023-08-06T22:52:30.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e5/c5ec98f7fd7817d077c9a5a5e705d54f74d4ca08ee3f14dee881c93c0511/celery_types-0.26.0-py3-none-any.whl", hash = "sha256:eb9da76f461786091970df466ec647d9a27956399852542cb6cab9309970f950", size = 211260, upload-time = "2026-03-12T23:06:48.588Z" },
 ]
 
 [[package]]
@@ -4502,7 +4502,7 @@ backend = [
 ]
 dev = [
     { name = "boto3-stubs", extras = ["s3"], specifier = "==1.39.11" },
-    { name = "celery-types", specifier = "==0.19.0" },
+    { name = "celery-types", specifier = "==0.26.0" },
     { name = "faker", specifier = "==40.1.2" },
     { name = "hatchling", specifier = "==1.28.0" },
     { name = "ipykernel", specifier = "==6.29.5" },


### PR DESCRIPTION
## What

Upgrades `celery-types` from **0.19.0 → 0.26.0** (latest), which properly targets our `celery==5.5.1`.

The pinned 0.19.0 predated celery 5.5's API and shipped incomplete stubs, which is why the celery worker modules were littered with `# ty: ignore[unresolved-import]` suppressions for real celery symbols. 0.26.0 dev-deps `celery>=5.0,<6` and now types the previously-unresolved symbols.

## Changes

**Dependency bump** (source of truth is `pyproject.toml`):
- `celery-types==0.19.0` → `0.26.0`
- Regenerated `uv.lock` and re-exported `backend/requirements/{default,dev,ee,model_server}.txt` via the same commands the `uv-export` pre-commit hooks use. Only `celery-types` changed in the resolution.

**Type fixes** — the fuller stubs surfaced 18 diagnostics, all resolved (`ty check` clean, ruff clean):
- **11 now-obsolete suppressions removed** — the new stubs resolve `bootsteps`, `celery.app.trace`, `celery.worker.strategy`/`control`/`state`, `celery.beat.PersistentScheduler`, `celery.__main__.main`, and the `inspect.reserved()/active()` assignments. Under `all = "error"`, unused `# ty: ignore` directives are themselves errors, so they had to go.
- **`alembic/env.py`** — `ResultModelBase` exists at runtime but 0.26.0 omits it from the stub's `__all__`, so the `[unresolved-import]` suppression moved onto that member line.
- **5 `invalid-method-override`** on the bootstep `start`/`stop` (`LivenessProbe`, `HubPeriodicTask`) and `DynamicTenantScheduler.tick` overrides — the stubs now type the celery base methods, exposing the signature narrowing. Suppressed with `# ty: ignore[invalid-method-override]` (the established pattern in this repo) rather than renaming params, keeping runtime behavior identical.
- **`_compare_schedules`** — genuine annotation fix: `schedule.items()` is now typed `ItemsView`, revealing that the `schedule1: dict` annotation was always inaccurate (it's only ever passed `.items()`). Corrected to `ItemsView[str, Any]`.

## Testing

- `ty check` → All checks passed
- `ruff format` / `ruff check` → clean
- Smoke-imported the touched celery app modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `celery-types` to 0.26.0 to match `celery==5.5.1`, cleaning up Celery typings and removing stale ignores across workers and beat. Also fixed a few annotations to align with the typed APIs.

- **Dependencies**
  - Bump `celery-types` 0.19.0 → 0.26.0.
  - Regenerated `uv.lock` and `backend/requirements/*.txt`.

- **Refactors**
  - Removed 11 obsolete `# ty: ignore` across `bootsteps`, `celery.app.trace`, `celery.worker.strategy/control/state`, and `celery.__main__.main`.
  - Moved the unresolved-import suppression to `ResultModelBase` in Alembic env.
  - Added targeted `# ty: ignore[invalid-method-override]` for bootstep `start/stop` and scheduler `tick`.
  - Fixed types: `_compare_schedules` now takes `ItemsView[str, Any]`; dropped `invalid-assignment` ignores for `inspect.reserved()` and `inspect.active()`.

<sup>Written for commit 44c1e460e7e2227f340f07fa5cc48813f335ac57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

