### PR TITLE
feat: per-user usage + cost tracking — enforcement (3/4) [edit of #11888]

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.api_key import is_api_key_email_address
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.models import TokenRateLimit, User
+from onyx.db.models import User
 from onyx.db.token_limit import (
     fetch_all_user_token_rate_limits,
     fetch_user_group_token_rate_limits,
@@ -20,14 +20,12 @@ from onyx.db.user_usage import (
     get_user_token_buckets_since,
 )
 from onyx.server.query_and_chat.token_limit import (
-    _cost_reset_at,
+    _cost_budget_reset,
     _get_cutoff_time,
     _has_token_budget,
     _raise_for_latest_reset,
-    _token_reset_at,
+    _token_budget_reset,
     _user_is_rate_limited_by_global,
-    _worst_triggered_cost_limit,
-    _worst_triggered_limit,
     raise_rate_limited,
 )
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
@@ -65,7 +63,7 @@ def _user_is_rate_limited(user_id: UUID) -> None:
         if not user_rate_limits:
             return
 
-        token_triggered: TokenRateLimit | None = None
+        token_reset: datetime | None = None
         token_limits = [
             limit
             for limit in user_rate_limits
@@ -74,9 +72,9 @@ def _user_is_rate_limited(user_id: UUID) -> None:
         if token_limits:
             user_cutoff_time = _get_cutoff_time(token_limits)
             user_usage = _fetch_user_usage(user_id, user_cutoff_time, db_session)
-            token_triggered = _worst_triggered_limit(user_rate_limits, user_usage)
+            token_reset = _token_budget_reset(user_rate_limits, user_usage)
 
-        cost_triggered: TokenRateLimit | None = None
+        cost_reset: datetime | None = None
         cost_limits = [
             limit for limit in user_rate_limits if limit.cost_budget_cents is not None
         ]
@@ -88,13 +86,9 @@ def _user_is_rate_limited(user_id: UUID) -> None:
             cost_buckets = get_user_cost_cents_buckets_since(
                 db_session, str(user_id), cost_cutoff
             )
-            cost_triggered = _worst_triggered_cost_limit(user_rate_limits, cost_buckets)
+            cost_reset = _cost_budget_reset(user_rate_limits, cost_buckets)
 
-        _raise_for_latest_reset(
-            TokenRateLimitScope.USER.value,
-            _token_reset_at(token_triggered),
-            _cost_reset_at(cost_triggered),
-        )
+        _raise_for_latest_reset(TokenRateLimitScope.USER, token_reset, cost_reset)
 
 
 def _fetch_user_usage(
@@ -146,25 +140,19 @@ def _user_is_rate_limited_by_group(user_id: UUID) -> None:
 
         group_resets: list[datetime] = []
         for user_group_id, rate_limits in group_rate_limits.items():
-            token_triggered = _worst_triggered_limit(
+            token_reset = _token_budget_reset(
                 rate_limits, group_token_usage.get(user_group_id, [])
             )
-            cost_triggered = _worst_triggered_cost_limit(
+            cost_reset = _cost_budget_reset(
                 rate_limits, group_cost_usage.get(user_group_id, [])
             )
-            if token_triggered is None and cost_triggered is None:
+            # A group the user is under (no exceeded budget) unblocks them entirely.
+            if token_reset is None and cost_reset is None:
                 return
-            resets = [
-                reset
-                for reset in (
-                    _token_reset_at(token_triggered),
-                    _cost_reset_at(cost_triggered),
-                )
-                if reset is not None
-            ]
+            resets = [reset for reset in (token_reset, cost_reset) if reset is not None]
             group_resets.append(max(resets))
 
-        raise_rate_limited(TokenRateLimitScope.USER_GROUP.value, min(group_resets))
+        raise_rate_limited(TokenRateLimitScope.USER_GROUP, min(group_resets))
 
 
 def _fetch_user_group_usage(

--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from sqlalchemy.orm import Session
@@ -13,19 +13,22 @@ from onyx.db.token_limit import (
 )
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    get_cost_window_start,
     get_group_cost_cents_buckets_since,
     get_group_token_buckets_since,
     get_user_cost_cents_buckets_since,
     get_user_token_buckets_since,
 )
 from onyx.server.query_and_chat.token_limit import (
-    _LEDGER_GRID,
+    _cost_reset_at,
     _get_cutoff_time,
     _has_token_budget,
-    _raise_for_longest_window,
+    _raise_for_latest_reset,
+    _token_reset_at,
     _user_is_rate_limited_by_global,
     _worst_triggered_cost_limit,
     _worst_triggered_limit,
+    raise_rate_limited,
 )
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 
@@ -78,16 +81,19 @@ def _user_is_rate_limited(user_id: UUID) -> None:
             limit for limit in user_rate_limits if limit.cost_budget_cents is not None
         ]
         if cost_limits:
-            cost_cutoff = _get_cutoff_time(cost_limits) - _LEDGER_GRID
+            cost_cutoff = get_cost_window_start(
+                datetime.now(timezone.utc),
+                max(limit.period_hours for limit in cost_limits),
+            )
             cost_buckets = get_user_cost_cents_buckets_since(
                 db_session, str(user_id), cost_cutoff
             )
             cost_triggered = _worst_triggered_cost_limit(user_rate_limits, cost_buckets)
 
-        _raise_for_longest_window(
+        _raise_for_latest_reset(
             TokenRateLimitScope.USER.value,
-            token_triggered.period_hours if token_triggered else None,
-            cost_triggered.period_hours if cost_triggered else None,
+            _token_reset_at(token_triggered),
+            _cost_reset_at(cost_triggered),
         )
 
 
@@ -130,12 +136,15 @@ def _user_is_rate_limited_by_group(user_id: UUID) -> None:
             limit for limit in all_rate_limits if limit.cost_budget_cents is not None
         ]
         if cost_limits:
-            cost_cutoff = _get_cutoff_time(cost_limits) - _LEDGER_GRID
+            cost_cutoff = get_cost_window_start(
+                datetime.now(timezone.utc),
+                max(limit.period_hours for limit in cost_limits),
+            )
             group_cost_usage = get_group_cost_cents_buckets_since(
                 db_session, user_group_ids, cost_cutoff
             )
 
-        triggered_periods: list[int] = []
+        group_resets: list[datetime] = []
         for user_group_id, rate_limits in group_rate_limits.items():
             token_triggered = _worst_triggered_limit(
                 rate_limits, group_token_usage.get(user_group_id, [])
@@ -145,14 +154,17 @@ def _user_is_rate_limited_by_group(user_id: UUID) -> None:
             )
             if token_triggered is None and cost_triggered is None:
                 return
-            if token_triggered:
-                triggered_periods.append(token_triggered.period_hours)
-            if cost_triggered:
-                triggered_periods.append(cost_triggered.period_hours)
+            resets = [
+                reset
+                for reset in (
+                    _token_reset_at(token_triggered),
+                    _cost_reset_at(cost_triggered),
+                )
+                if reset is not None
+            ]
+            group_resets.append(max(resets))
 
-        _raise_for_longest_window(
-            TokenRateLimitScope.USER_GROUP.value, *triggered_periods
-        )
+        raise_rate_limited(TokenRateLimitScope.USER_GROUP.value, min(group_resets))
 
 
 def _fetch_user_group_usage(

--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -1,31 +1,31 @@
-from collections import defaultdict
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.api_key import is_api_key_email_address
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.models import (
-    TokenRateLimit,
-    TokenRateLimit__UserGroup,
-    User,
-    User__UserGroup,
-    UserGroup,
+from onyx.db.models import TokenRateLimit, User
+from onyx.db.token_limit import (
+    fetch_all_user_token_rate_limits,
+    fetch_user_group_token_rate_limits,
 )
-from onyx.db.token_limit import fetch_all_user_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    get_group_cost_cents_buckets_since,
     get_group_token_buckets_since,
+    get_user_cost_cents_buckets_since,
     get_user_token_buckets_since,
 )
-from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import (
+    _LEDGER_GRID,
     _get_cutoff_time,
-    _is_rate_limited,
+    _has_token_budget,
+    _raise_for_longest_window,
     _user_is_rate_limited_by_global,
+    _worst_triggered_cost_limit,
+    _worst_triggered_limit,
 )
 from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
 
@@ -59,16 +59,36 @@ def _user_is_rate_limited(user_id: UUID) -> None:
         user_rate_limits = fetch_all_user_token_rate_limits(
             db_session=db_session, enabled_only=True, ordered=False
         )
+        if not user_rate_limits:
+            return
 
-        if user_rate_limits:
-            user_cutoff_time = _get_cutoff_time(user_rate_limits)
+        token_triggered: TokenRateLimit | None = None
+        token_limits = [
+            limit
+            for limit in user_rate_limits
+            if limit.token_budget is not None and limit.token_budget > 0
+        ]
+        if token_limits:
+            user_cutoff_time = _get_cutoff_time(token_limits)
             user_usage = _fetch_user_usage(user_id, user_cutoff_time, db_session)
+            token_triggered = _worst_triggered_limit(user_rate_limits, user_usage)
 
-            if _is_rate_limited(user_rate_limits, user_usage):
-                raise OnyxError(
-                    OnyxErrorCode.RATE_LIMITED,
-                    "Token budget exceeded for user. Try again later.",
-                )
+        cost_triggered: TokenRateLimit | None = None
+        cost_limits = [
+            limit for limit in user_rate_limits if limit.cost_budget_cents is not None
+        ]
+        if cost_limits:
+            cost_cutoff = _get_cutoff_time(cost_limits) - _LEDGER_GRID
+            cost_buckets = get_user_cost_cents_buckets_since(
+                db_session, str(user_id), cost_cutoff
+            )
+            cost_triggered = _worst_triggered_cost_limit(user_rate_limits, cost_buckets)
+
+        _raise_for_longest_window(
+            TokenRateLimitScope.USER.value,
+            token_triggered.period_hours if token_triggered else None,
+            cost_triggered.period_hours if cost_triggered else None,
+        )
 
 
 def _fetch_user_usage(
@@ -84,66 +104,55 @@ User Group rate limits
 
 def _user_is_rate_limited_by_group(user_id: UUID) -> None:
     with get_session_with_current_tenant() as db_session:
-        group_rate_limits = _fetch_all_user_group_rate_limits(user_id, db_session)
+        group_rate_limits = fetch_user_group_token_rate_limits(db_session, user_id)
+        if not group_rate_limits:
+            return
 
-        if group_rate_limits:
-            # Group cutoff time is the same for all groups.
-            # This could be optimized to only fetch the maximum cutoff time for
-            # a specific group, but seems unnecessary for now.
-            group_cutoff_time = _get_cutoff_time(
-                [e for sublist in group_rate_limits.values() for e in sublist]
+        all_rate_limits = [
+            limit for limits in group_rate_limits.values() for limit in limits
+        ]
+        user_group_ids = list(group_rate_limits)
+
+        group_token_usage: dict[int, list[TokenUsageBucket]] = {}
+        if _has_token_budget(all_rate_limits):
+            token_limits = [
+                limit
+                for limit in all_rate_limits
+                if limit.token_budget is not None and limit.token_budget > 0
+            ]
+            token_cutoff = _get_cutoff_time(token_limits)
+            group_token_usage = _fetch_user_group_usage(
+                user_group_ids, token_cutoff, db_session
             )
 
-            user_group_ids = list(group_rate_limits.keys())
-            group_usage = _fetch_user_group_usage(
-                user_group_ids, group_cutoff_time, db_session
+        group_cost_usage: dict[int, list[tuple[datetime, float]]] = {}
+        cost_limits = [
+            limit for limit in all_rate_limits if limit.cost_budget_cents is not None
+        ]
+        if cost_limits:
+            cost_cutoff = _get_cutoff_time(cost_limits) - _LEDGER_GRID
+            group_cost_usage = get_group_cost_cents_buckets_since(
+                db_session, user_group_ids, cost_cutoff
             )
 
-            has_at_least_one_untriggered_limit = False
-            for user_group_id, rate_limits in group_rate_limits.items():
-                usage = group_usage.get(user_group_id, [])
+        triggered_periods: list[int] = []
+        for user_group_id, rate_limits in group_rate_limits.items():
+            token_triggered = _worst_triggered_limit(
+                rate_limits, group_token_usage.get(user_group_id, [])
+            )
+            cost_triggered = _worst_triggered_cost_limit(
+                rate_limits, group_cost_usage.get(user_group_id, [])
+            )
+            if token_triggered is None and cost_triggered is None:
+                return
+            if token_triggered:
+                triggered_periods.append(token_triggered.period_hours)
+            if cost_triggered:
+                triggered_periods.append(cost_triggered.period_hours)
 
-                if not _is_rate_limited(rate_limits, usage):
-                    has_at_least_one_untriggered_limit = True
-                    break
-
-            if not has_at_least_one_untriggered_limit:
-                raise OnyxError(
-                    OnyxErrorCode.RATE_LIMITED,
-                    "Token budget exceeded for user's groups. Try again later.",
-                )
-
-
-def _fetch_all_user_group_rate_limits(
-    user_id: UUID, db_session: Session
-) -> dict[int, list[TokenRateLimit]]:
-    group_limits = (
-        select(TokenRateLimit, User__UserGroup.user_group_id)
-        .join(
-            TokenRateLimit__UserGroup,
-            TokenRateLimit.id == TokenRateLimit__UserGroup.rate_limit_id,
+        _raise_for_longest_window(
+            TokenRateLimitScope.USER_GROUP.value, *triggered_periods
         )
-        .join(
-            UserGroup,
-            UserGroup.id == TokenRateLimit__UserGroup.user_group_id,
-        )
-        .join(
-            User__UserGroup,
-            User__UserGroup.user_group_id == UserGroup.id,
-        )
-        .where(
-            User__UserGroup.user_id == user_id,
-            TokenRateLimit.enabled.is_(True),
-        )
-    )
-
-    raw_rate_limits = db_session.execute(group_limits).all()
-
-    group_rate_limits = defaultdict(list)
-    for rate_limit, user_group_id in raw_rate_limits:
-        group_rate_limits[user_group_id].append(rate_limit)
-
-    return group_rate_limits
 
 
 def _fetch_user_group_usage(

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -61,7 +61,7 @@ def get_cost_window_start(now: datetime, period_hours: int) -> datetime:
     )
 
 
-def get_next_cost_bucket_start(now: datetime) -> datetime:
+def get_next_usage_bucket_start(now: datetime) -> datetime:
     return get_window_start(now, USER_USAGE_BUCKET_SECONDS) + timedelta(
         seconds=USER_USAGE_BUCKET_SECONDS
     )

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -46,25 +46,35 @@ def get_token_window_start(now: datetime, period_hours: int) -> datetime:
     return current_bucket - timedelta(hours=period_hours - USER_USAGE_BUCKET_HOURS)
 
 
-def get_cost_window_start(now: datetime, period_hours: int) -> datetime:
-    """Start of the UTC-day buckets in a cost-budget window."""
+def _get_cost_period_seconds(period_hours: int) -> int:
     period_seconds = period_hours * 60 * 60
     if (
         period_seconds < USER_USAGE_BUCKET_SECONDS
         or period_seconds % USER_USAGE_BUCKET_SECONDS
     ):
         raise ValueError(COST_BUDGET_PERIOD_ERROR)
+    return period_seconds
 
+
+def get_cost_window_start(now: datetime, period_hours: int) -> datetime:
+    """Start of the UTC-day buckets in a cost-budget window."""
+    period_seconds = _get_cost_period_seconds(period_hours)
     current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
     return current_bucket - timedelta(
         seconds=period_seconds - USER_USAGE_BUCKET_SECONDS
     )
 
 
-def get_next_usage_bucket_start(now: datetime) -> datetime:
-    return get_window_start(now, USER_USAGE_BUCKET_SECONDS) + timedelta(
-        seconds=USER_USAGE_BUCKET_SECONDS
-    )
+def get_token_window_reset(now: datetime, period_hours: int) -> datetime:
+    period_hours = normalize_token_period_hours(period_hours)
+    current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
+    return current_bucket + timedelta(hours=period_hours)
+
+
+def get_cost_window_reset(now: datetime, period_hours: int) -> datetime:
+    period_seconds = _get_cost_period_seconds(period_hours)
+    current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
+    return current_bucket + timedelta(seconds=period_seconds)
 
 
 class UserUsageByDay(BaseModel):

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -4,6 +4,7 @@ A window rollup: rows accumulate in place per (user, window,
 model, flow, provider), not an append-only per-call ledger."""
 
 from collections import defaultdict
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from math import ceil
 
@@ -40,9 +41,7 @@ def normalize_token_period_hours(period_hours: int) -> int:
 
 def get_token_window_start(now: datetime, period_hours: int) -> datetime:
     period_hours = normalize_token_period_hours(period_hours)
-    current_bucket = datetime_to_utc(now).replace(
-        hour=0, minute=0, second=0, microsecond=0
-    )
+    current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
     return current_bucket - timedelta(hours=period_hours - USER_USAGE_BUCKET_HOURS)
 
 
@@ -75,6 +74,33 @@ def get_cost_window_reset(now: datetime, period_hours: int) -> datetime:
     period_seconds = _get_cost_period_seconds(period_hours)
     current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
     return current_bucket + timedelta(seconds=period_seconds)
+
+
+def earliest_window_reset(
+    now: datetime,
+    period_hours: int,
+    buckets: Sequence[tuple[datetime, float]],
+    threshold: float,
+) -> datetime:
+    """First future UTC-day boundary at which the trailing-window sum drops below
+    `threshold`, assuming no further usage.
+
+    Usage is bucketed by whole UTC days and the window slides forward one day at
+    a time, so the reset is always a midnight. As each day rolls off, the trailing
+    sum can only drop; this returns the first boundary where it clears. Equals the
+    full-window expiry when even the current day alone is over threshold.
+    `period_hours` must be a whole number of days.
+    """
+    day = timedelta(seconds=USER_USAGE_BUCKET_SECONDS)
+    today = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
+    period_days = period_hours // USER_USAGE_BUCKET_HOURS
+    window_start = today - day * (period_days - 1)
+    for days_elapsed in range(1, period_days + 1):
+        cutoff = window_start + day * days_elapsed
+        remaining = sum(amount for ws, amount in buckets if ws >= cutoff)
+        if remaining < threshold:
+            return today + day * days_elapsed
+    return today + day * period_days
 
 
 class UserUsageByDay(BaseModel):

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -13,7 +13,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.orm import Session
 
 from onyx.db.models import User, User__UserGroup, UserUsage
-from onyx.utils.datetime import datetime_to_utc
+from onyx.utils.datetime import datetime_to_utc, get_window_start
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -21,6 +21,7 @@ logger = setup_logger()
 USER_USAGE_BUCKET_SECONDS = 24 * 60 * 60
 USER_USAGE_BUCKET_HOURS = USER_USAGE_BUCKET_SECONDS // (60 * 60)
 TOKEN_BUDGET_PERIOD_ERROR = "Token budget periods must be whole UTC days"
+COST_BUDGET_PERIOD_ERROR = "Cost budget periods must be whole UTC days"
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider"]
 
 
@@ -43,6 +44,27 @@ def get_token_window_start(now: datetime, period_hours: int) -> datetime:
         hour=0, minute=0, second=0, microsecond=0
     )
     return current_bucket - timedelta(hours=period_hours - USER_USAGE_BUCKET_HOURS)
+
+
+def get_cost_window_start(now: datetime, period_hours: int) -> datetime:
+    """Start of the UTC-day buckets in a cost-budget window."""
+    period_seconds = period_hours * 60 * 60
+    if (
+        period_seconds < USER_USAGE_BUCKET_SECONDS
+        or period_seconds % USER_USAGE_BUCKET_SECONDS
+    ):
+        raise ValueError(COST_BUDGET_PERIOD_ERROR)
+
+    current_bucket = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
+    return current_bucket - timedelta(
+        seconds=period_seconds - USER_USAGE_BUCKET_SECONDS
+    )
+
+
+def get_next_cost_bucket_start(now: datetime) -> datetime:
+    return get_window_start(now, USER_USAGE_BUCKET_SECONDS) + timedelta(
+        seconds=USER_USAGE_BUCKET_SECONDS
+    )
 
 
 class UserUsageByDay(BaseModel):

--- a/backend/onyx/error_handling/exceptions.py
+++ b/backend/onyx/error_handling/exceptions.py
@@ -46,6 +46,7 @@ class OnyxError(Exception):
         detail: str | None = None,
         *,
         status_code_override: int | None = None,
+        extra: dict[str, object] | None = None,
         headers: dict[str, str] | None = None,
     ) -> None:
         resolved_detail = detail or error_code.code
@@ -53,6 +54,9 @@ class OnyxError(Exception):
         self.error_code = error_code
         self.detail = resolved_detail
         self._status_code_override = status_code_override
+        # extra: machine-readable fields merged into the JSON body (e.g. reset_at).
+        # headers: response headers the FE/clients need (e.g. Retry-After).
+        self.extra = extra
         self.headers = headers
 
     @property
@@ -70,9 +74,13 @@ def log_onyx_error(exc: OnyxError) -> None:
 
 
 def onyx_error_to_json_response(exc: OnyxError) -> JSONResponse:
+    content = exc.error_code.detail(exc.detail)
+    if exc.extra:
+        # extra first so the canonical error_code/detail can't be overwritten.
+        content = {**exc.extra, **content}
     return JSONResponse(
         status_code=exc.status_code,
-        content=exc.error_code.detail(exc.detail),
+        content=content,
         headers=exc.headers,
     )
 

--- a/backend/onyx/server/features/build/session/messages.py
+++ b/backend/onyx/server/features/build/session/messages.py
@@ -46,6 +46,7 @@ from onyx.server.features.build.session.models import (
     MessageRequest,
     MessageResponse,
 )
+from onyx.server.query_and_chat.token_limit import check_token_rate_limits
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -140,6 +141,9 @@ def send_message(
             SessionManager(db_session).reload_session_skills(session_id, user)
 
         check_build_rate_limits(user=user, db_session=db_session)
+        # Craft turns also respect the org/user token + cost budgets. No-op when
+        # none are configured; raises the structured 429 when over budget.
+        check_token_rate_limits(user)
 
         turn_index = count_user_messages(session_id, db_session)
         if request.provider and request.model:
@@ -203,6 +207,8 @@ def send_subagent_message(
     request: MessageRequest,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     _rate_limit_check: None = Depends(check_build_rate_limits),
+    # Craft turns also respect the org/user token + cost budgets (no-op when none).
+    _token_rate_limit_check: None = Depends(check_token_rate_limits),
 ) -> StreamingResponse:
     """
     Send a follow-up message to a subagent's child opencode session and

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -22,7 +22,7 @@ from onyx.db.token_limit import (
     fetch_user_group_token_rate_limits,
 )
 from onyx.db.user_usage import (
-    USER_USAGE_BUCKET_SECONDS,
+    get_cost_window_start,
     get_group_cost_cents_buckets_since,
     get_total_cost_cents_buckets_since,
     get_usage_export,
@@ -56,9 +56,6 @@ from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 # Default trailing range for the export when no start is given.
 _DEFAULT_EXPORT_DAYS = 30
 
-# Relax budget cutoffs to include the partially overlapping ledger bucket.
-_LEDGER_GRID = timedelta(seconds=USER_USAGE_BUCKET_SECONDS)
-
 
 def _used_from_buckets(
     buckets: list[tuple[datetime, float]], cutoff: datetime
@@ -78,7 +75,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
         for rl in limits:
             if rl.cost_budget_cents is None:
                 continue
-            cutoff = now - timedelta(hours=rl.period_hours) - _LEDGER_GRID
+            cutoff = get_cost_window_start(now, rl.period_hours)
             used = _used_from_buckets(buckets, cutoff)
             candidates.append(
                 EffectiveCostBudget(
@@ -92,7 +89,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
     user_cost_rls = [rl for rl in user_rls if rl.cost_budget_cents is not None]
     if user_cost_rls:
         broadest = max(rl.period_hours for rl in user_cost_rls)
-        fetch_cutoff = now - timedelta(hours=broadest) - _LEDGER_GRID
+        fetch_cutoff = get_cost_window_start(now, broadest)
         _add_from_limits(
             user_cost_rls,
             get_user_cost_cents_buckets_since(db_session, user_id, fetch_cutoff),
@@ -102,7 +99,7 @@ def _user_cost_budget(db_session: Session, user_id: str) -> EffectiveCostBudget 
     global_cost_rls = [rl for rl in global_rls if rl.cost_budget_cents is not None]
     if global_cost_rls:
         broadest = max(rl.period_hours for rl in global_cost_rls)
-        fetch_cutoff = now - timedelta(hours=broadest) - _LEDGER_GRID
+        fetch_cutoff = get_cost_window_start(now, broadest)
         _add_from_limits(
             global_cost_rls,
             get_total_cost_cents_buckets_since(db_session, fetch_cutoff),
@@ -142,7 +139,7 @@ def _group_cost_budget_candidate(
 
     # One batched query for every group's cost buckets, then window in Python.
     broadest = max(rl.period_hours for rl in cost_rls)
-    fetch_cutoff = now - timedelta(hours=broadest) - _LEDGER_GRID
+    fetch_cutoff = get_cost_window_start(now, broadest)
     buckets = get_group_cost_cents_buckets_since(
         db_session, list(group_limits.keys()), fetch_cutoff
     )
@@ -154,7 +151,7 @@ def _group_cost_budget_candidate(
         for rl in limits:
             if rl.cost_budget_cents is None:
                 continue
-            cutoff = now - timedelta(hours=rl.period_hours) - _LEDGER_GRID
+            cutoff = get_cost_window_start(now, rl.period_hours)
             used = _used_from_buckets(group_buckets, cutoff)
             remaining = rl.cost_budget_cents - used
             if group_binding is None or remaining < group_binding.remaining_cents:

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -9,17 +9,18 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_chat_accessible_user
+from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
-    get_cost_window_reset,
+    earliest_window_reset,
     get_cost_window_start,
-    get_token_window_reset,
     get_token_window_start,
     get_total_cost_cents_buckets_since,
     get_total_token_buckets_since,
+    normalize_token_period_hours,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -63,41 +64,36 @@ def _user_is_rate_limited_by_global() -> None:
             db_session=db_session, enabled_only=True, ordered=False
         )
 
-        if global_rate_limits:
-            # Skip the token-usage aggregation when every limit is cost-only.
-            triggered = None
-            if _has_token_budget(global_rate_limits):
-                # Scan the token table only as far back as the widest *token*
-                # window — a longer cost-only window must not widen the scan.
-                token_limits = [
-                    rl
-                    for rl in global_rate_limits
-                    if rl.token_budget is not None and rl.token_budget > 0
-                ]
-                global_cutoff_time = _get_cutoff_time(token_limits)
-                global_usage = _fetch_global_usage(global_cutoff_time, db_session)
-                triggered = _worst_triggered_limit(global_rate_limits, global_usage)
+        if not global_rate_limits:
+            return
 
-            cost_limits = [
-                rl for rl in global_rate_limits if rl.cost_budget_cents is not None
+        # Skip the token-usage aggregation when every limit is cost-only.
+        token_reset: datetime | None = None
+        if _has_token_budget(global_rate_limits):
+            # Scan the token table only as far back as the widest *token*
+            # window — a longer cost-only window must not widen the scan.
+            token_limits = [
+                rl
+                for rl in global_rate_limits
+                if rl.token_budget is not None and rl.token_budget > 0
             ]
-            cost_buckets: list[tuple[datetime, float]] = []
-            if cost_limits:
-                cost_cutoff = get_cost_window_start(
-                    datetime.now(timezone.utc),
-                    max(rl.period_hours for rl in cost_limits),
-                )
-                cost_buckets = get_total_cost_cents_buckets_since(
-                    db_session, cost_cutoff
-                )
-            cost_triggered = _worst_triggered_cost_limit(
-                global_rate_limits, cost_buckets
+            global_cutoff_time = _get_cutoff_time(token_limits)
+            global_usage = _fetch_global_usage(global_cutoff_time, db_session)
+            token_reset = _token_budget_reset(global_rate_limits, global_usage)
+
+        cost_reset: datetime | None = None
+        cost_limits = [
+            rl for rl in global_rate_limits if rl.cost_budget_cents is not None
+        ]
+        if cost_limits:
+            cost_cutoff = get_cost_window_start(
+                datetime.now(timezone.utc),
+                max(rl.period_hours for rl in cost_limits),
             )
-            _raise_for_latest_reset(
-                "organization",
-                _token_reset_at(triggered),
-                _cost_reset_at(cost_triggered),
-            )
+            cost_buckets = get_total_cost_cents_buckets_since(db_session, cost_cutoff)
+            cost_reset = _cost_budget_reset(global_rate_limits, cost_buckets)
+
+        _raise_for_latest_reset(TokenRateLimitScope.GLOBAL, token_reset, cost_reset)
 
 
 def _fetch_global_usage(
@@ -127,15 +123,20 @@ def _has_token_budget(rate_limits: Sequence[TokenRateLimit]) -> bool:
     )
 
 
-def _worst_triggered_limit(
+def _token_budget_reset(
     rate_limits: Sequence[TokenRateLimit], usage: Sequence[TokenUsageBucket]
-) -> TokenRateLimit | None:
-    """Among the exceeded token limits, return the one with the longest window
-    (or None). Picking the longest period_hours makes the reported reset
-    deterministic and conservative: a client that waits it out won't immediately
-    re-trip a still-exceeded longer limit. Carries period_hours for the reset."""
+) -> datetime | None:
+    """The latest exact reset among the exceeded token budgets, or None.
+
+    Each limit's reset is the earliest UTC-day boundary at which its trailing
+    window drops back under budget (see `earliest_window_reset`) — not the full
+    window expiry. Taking the max across all exceeded limits keeps the reported
+    reset safe: a client that waits it out won't immediately re-trip a limit that
+    clears later.
+    """
     now = datetime.now(timezone.utc)
-    worst: TokenRateLimit | None = None
+    buckets = [(bucket.window_start, float(bucket.tokens)) for bucket in usage]
+    resets: list[datetime] = []
     for rate_limit in rate_limits:
         # A null (cost-only) or non-positive token_budget is token-exempt — skip
         # the token check. Guarding <= 0 means a 0 (new cost-only rows store null,
@@ -143,41 +144,35 @@ def _worst_triggered_limit(
         if rate_limit.token_budget is None or rate_limit.token_budget <= 0:
             continue
 
-        cutoff = get_token_window_start(now, rate_limit.period_hours)
-        tokens_used = sum(
-            bucket.tokens for bucket in usage if bucket.window_start >= cutoff
-        )
-
         # The admin enters the budget in THOUSANDS of tokens (Onyx convention),
         # so the stored value is scaled up to the real token count here.
-        if tokens_used >= rate_limit.token_budget * TOKEN_BUDGET_UNIT:
-            if worst is None or rate_limit.period_hours > worst.period_hours:
-                worst = rate_limit
+        budget = rate_limit.token_budget * TOKEN_BUDGET_UNIT
+        cutoff = get_token_window_start(now, rate_limit.period_hours)
+        used = sum(tokens for window_start, tokens in buckets if window_start >= cutoff)
+        if used >= budget:
+            resets.append(
+                earliest_window_reset(
+                    now,
+                    normalize_token_period_hours(rate_limit.period_hours),
+                    buckets,
+                    budget,
+                )
+            )
 
-    return worst
+    return max(resets) if resets else None
 
 
-def _is_rate_limited(
-    rate_limits: Sequence[TokenRateLimit],
-    usage: Sequence[TokenUsageBucket],
-) -> bool:
-    """Whether any provider-token budget is exceeded."""
-    return _worst_triggered_limit(rate_limits, usage) is not None
-
-
-def _worst_triggered_cost_limit(
+def _cost_budget_reset(
     rate_limits: Sequence[TokenRateLimit],
     cost_buckets: Sequence[tuple[datetime, float]],
-) -> TokenRateLimit | None:
-    """Among rows whose cost_budget_cents is set and exceeded, return the one
-    with the longest window (or None) — longest period_hours so the reset is
-    deterministic and conservative, matching _worst_triggered_limit.
+) -> datetime | None:
+    """The latest exact reset among the exceeded cost budgets, or None.
 
-    Cost windows contain whole UTC-day buckets, including the current day.
-    Rows without a cost_budget_cents are cost-exempt.
+    Mirrors `_token_budget_reset`. Cost windows contain whole UTC-day buckets;
+    rows without a cost_budget_cents are cost-exempt.
     """
-    now = datetime.now(tz=timezone.utc)
-    worst: TokenRateLimit | None = None
+    now = datetime.now(timezone.utc)
+    resets: list[datetime] = []
     for rate_limit in rate_limits:
         budget = rate_limit.cost_budget_cents
         if budget is None:
@@ -188,13 +183,25 @@ def _worst_triggered_cost_limit(
             cents for window_start, cents in cost_buckets if window_start >= cutoff
         )
         if cost >= budget:
-            if worst is None or rate_limit.period_hours > worst.period_hours:
-                worst = rate_limit
+            resets.append(
+                earliest_window_reset(
+                    now, rate_limit.period_hours, cost_buckets, budget
+                )
+            )
 
-    return worst
+    return max(resets) if resets else None
 
 
-def raise_rate_limited(scope: str, reset_at: datetime) -> None:
+# Human-readable subject for each scope, used only in the fallback message text.
+# The machine-readable scope value goes in the structured `extra` payload.
+_SCOPE_LABELS: dict[TokenRateLimitScope, str] = {
+    TokenRateLimitScope.GLOBAL: "your organization",
+    TokenRateLimitScope.USER: "your account",
+    TokenRateLimitScope.USER_GROUP: "your user group",
+}
+
+
+def raise_rate_limited(scope: TokenRateLimitScope, reset_at: datetime) -> None:
     """Raise a structured 429 with the next relevant budget reset."""
     retry_after_seconds = max(
         1, ceil((reset_at - datetime.now(timezone.utc)).total_seconds())
@@ -204,9 +211,9 @@ def raise_rate_limited(scope: str, reset_at: datetime) -> None:
         OnyxErrorCode.RATE_LIMITED,
         # Neutral wording, no raw timestamp — the FE renders a friendly reset
         # time from reset_at / retry_after_seconds below.
-        f"You've reached the usage budget for {scope}.",
+        f"You've reached the usage budget for {_SCOPE_LABELS[scope]}.",
         extra={
-            "scope": scope,
+            "scope": scope.value,
             "reset_at": reset_at_iso,
             "retry_after_seconds": retry_after_seconds,
         },
@@ -214,25 +221,9 @@ def raise_rate_limited(scope: str, reset_at: datetime) -> None:
     )
 
 
-def _token_reset_at(limit: TokenRateLimit | None) -> datetime | None:
-    if limit is None:
-        return None
-    return get_token_window_reset(
-        datetime.now(timezone.utc),
-        limit.period_hours,
-    )
-
-
-def _cost_reset_at(limit: TokenRateLimit | None) -> datetime | None:
-    if limit is None:
-        return None
-    return get_cost_window_reset(
-        datetime.now(timezone.utc),
-        limit.period_hours,
-    )
-
-
-def _raise_for_latest_reset(scope: str, *reset_times: datetime | None) -> None:
+def _raise_for_latest_reset(
+    scope: TokenRateLimitScope, *reset_times: datetime | None
+) -> None:
     """Raise after evaluating independent limits that must all recover."""
     resets = [reset for reset in reset_times if reset is not None]
     if resets:

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
+from math import ceil
 from threading import RLock
 
 from cachetools import TTLCache
@@ -13,6 +14,8 @@ from onyx.db.models import TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    get_cost_window_start,
+    get_next_cost_bucket_start,
     get_token_window_start,
     get_total_cost_cents_buckets_since,
     get_total_token_buckets_since,
@@ -21,7 +24,6 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
-from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
@@ -29,10 +31,6 @@ logger = setup_logger()
 # Admin token budgets are entered in thousands of tokens; the stored value is
 # multiplied by this to get the real token count enforced.
 TOKEN_BUDGET_UNIT = 1000
-
-# The cost ledger buckets at this fixed grid; the cost cutoff is relaxed by one
-# grid to capture partially-overlapping buckets (see _worst_triggered_cost_limit).
-_LEDGER_GRID = timedelta(seconds=USAGE_LIMIT_WINDOW_SECONDS)
 
 
 def check_token_rate_limits(
@@ -79,21 +77,25 @@ def _user_is_rate_limited_by_global() -> None:
                 global_usage = _fetch_global_usage(global_cutoff_time, db_session)
                 triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
+            cost_limits = [
+                rl for rl in global_rate_limits if rl.cost_budget_cents is not None
+            ]
             cost_buckets: list[tuple[datetime, float]] = []
-            if any(rl.cost_budget_cents is not None for rl in global_rate_limits):
-                # One bucket fetch for the widest window; _worst_triggered_cost_limit
-                # sums per-limit in Python (no query per cost limit).
-                cost_cutoff = _get_cutoff_time(global_rate_limits) - _LEDGER_GRID
+            if cost_limits:
+                cost_cutoff = get_cost_window_start(
+                    datetime.now(timezone.utc),
+                    max(rl.period_hours for rl in cost_limits),
+                )
                 cost_buckets = get_total_cost_cents_buckets_since(
                     db_session, cost_cutoff
                 )
             cost_triggered = _worst_triggered_cost_limit(
                 global_rate_limits, cost_buckets
             )
-            _raise_for_longest_window(
+            _raise_for_latest_reset(
                 "organization",
-                triggered.period_hours if triggered else None,
-                cost_triggered.period_hours if cost_triggered else None,
+                _token_reset_at(triggered),
+                _cost_reset_at(cost_triggered),
             )
 
 
@@ -170,14 +172,8 @@ def _worst_triggered_cost_limit(
     with the longest window (or None) — longest period_hours so the reset is
     deterministic and conservative, matching _worst_triggered_limit.
 
-    Cost comes from the UserUsage ledger (not ChatMessage.token_count), bucketed
-    at a coarse fixed grid (_LEDGER_GRID) and fetched once upstream; we sum the
-    buckets per window in Python (no query per limit). A bucket has no sub-grid
-    timing, so to mirror the token sliding window over [now - period_hours, now]
-    we count every bucket that *overlaps* it: window_start >= now - period_hours
-    - grid. This is conservative (a budget period finer than the grid can pull in
-    one adjacent bucket) — fail-CLOSED, the safe direction for a budget gate.
-    Rows without a cost_budget_cents are cost-exempt (token-only).
+    Cost windows contain whole UTC-day buckets, including the current day.
+    Rows without a cost_budget_cents are cost-exempt.
     """
     now = datetime.now(tz=timezone.utc)
     worst: TokenRateLimit | None = None
@@ -186,7 +182,7 @@ def _worst_triggered_cost_limit(
         if budget is None:
             continue
 
-        cutoff = now - timedelta(hours=rate_limit.period_hours) - _LEDGER_GRID
+        cutoff = get_cost_window_start(now, rate_limit.period_hours)
         cost = sum(
             cents for window_start, cents in cost_buckets if window_start >= cutoff
         )
@@ -197,14 +193,11 @@ def _worst_triggered_cost_limit(
     return worst
 
 
-def raise_rate_limited(scope: str, period_hours: int) -> None:
-    """Raise a structured 429 carrying the offending scope + when its window rolls over.
-
-    Sliding-window enforcement has no single fixed reset instant; we report a full
-    period from now as the conservative "try again after" so the FE banner can count down.
-    """
-    retry_after_seconds = period_hours * 3600
-    reset_at = datetime.now(tz=timezone.utc) + timedelta(seconds=retry_after_seconds)
+def raise_rate_limited(scope: str, reset_at: datetime) -> None:
+    """Raise a structured 429 with the next relevant budget reset."""
+    retry_after_seconds = max(
+        1, ceil((reset_at - datetime.now(timezone.utc)).total_seconds())
+    )
     reset_at_iso = reset_at.isoformat()
     raise OnyxError(
         OnyxErrorCode.RATE_LIMITED,
@@ -220,14 +213,23 @@ def raise_rate_limited(scope: str, period_hours: int) -> None:
     )
 
 
-def _raise_for_longest_window(scope: str, *period_hours: int | None) -> None:
-    """Raise once for the longest of the given reset windows (Nones skipped).
-    The token and cost gates are independent; evaluating both before raising
-    avoids reporting a too-early reset when a short token window and a long cost
-    window are both exceeded."""
-    periods = [p for p in period_hours if p is not None]
-    if periods:
-        raise_rate_limited(scope, max(periods))
+def _token_reset_at(limit: TokenRateLimit | None) -> datetime | None:
+    if limit is None:
+        return None
+    return datetime.now(timezone.utc) + timedelta(hours=limit.period_hours)
+
+
+def _cost_reset_at(limit: TokenRateLimit | None) -> datetime | None:
+    if limit is None:
+        return None
+    return get_next_cost_bucket_start(datetime.now(timezone.utc))
+
+
+def _raise_for_latest_reset(scope: str, *reset_times: datetime | None) -> None:
+    """Raise after evaluating independent limits that must all recover."""
+    resets = [reset for reset in reset_times if reset is not None]
+    if resets:
+        raise_rate_limited(scope, max(resets))
 
 
 _ANY_RATE_LIMIT_EXISTS_CACHE_TTL_SECONDS = 60

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,5 +1,5 @@
 from collections.abc import Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from math import ceil
 from threading import RLock
 
@@ -15,7 +15,7 @@ from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
     get_cost_window_start,
-    get_next_cost_bucket_start,
+    get_next_usage_bucket_start,
     get_token_window_start,
     get_total_cost_cents_buckets_since,
     get_total_token_buckets_since,
@@ -216,13 +216,13 @@ def raise_rate_limited(scope: str, reset_at: datetime) -> None:
 def _token_reset_at(limit: TokenRateLimit | None) -> datetime | None:
     if limit is None:
         return None
-    return datetime.now(timezone.utc) + timedelta(hours=limit.period_hours)
+    return get_next_usage_bucket_start(datetime.now(timezone.utc))
 
 
 def _cost_reset_at(limit: TokenRateLimit | None) -> datetime | None:
     if limit is None:
         return None
-    return get_next_cost_bucket_start(datetime.now(timezone.utc))
+    return get_next_usage_bucket_start(datetime.now(timezone.utc))
 
 
 def _raise_for_latest_reset(scope: str, *reset_times: datetime | None) -> None:

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,5 +1,6 @@
+from collections.abc import Callable
 from collections.abc import Sequence
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from threading import RLock
 
 from cachetools import TTLCache
@@ -14,18 +15,25 @@ from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
     get_token_window_start,
+    get_total_cost_cents_since,
     get_total_token_buckets_since,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
+# Admin token budgets are entered in thousands of tokens; the stored value is
+# multiplied by this to get the real token count enforced.
+TOKEN_BUDGET_UNIT = 1000
 
-TOKEN_BUDGET_UNIT = 1_000
+# The cost ledger buckets at this fixed grid; the cost cutoff is relaxed by one
+# grid to capture partially-overlapping buckets (see _worst_triggered_cost_limit).
+_LEDGER_GRID = timedelta(seconds=USAGE_LIMIT_WINDOW_SECONDS)
 
 
 def check_token_rate_limits(
@@ -58,14 +66,22 @@ def _user_is_rate_limited_by_global() -> None:
         )
 
         if global_rate_limits:
-            global_cutoff_time = _get_cutoff_time(global_rate_limits)
-            global_usage = _fetch_global_usage(global_cutoff_time, db_session)
+            # Skip the token-usage aggregation when every limit is cost-only.
+            triggered = None
+            if _has_token_budget(global_rate_limits):
+                global_cutoff_time = _get_cutoff_time(global_rate_limits)
+                global_usage = _fetch_global_usage(global_cutoff_time, db_session)
+                triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
-            if _is_rate_limited(global_rate_limits, global_usage):
-                raise OnyxError(
-                    OnyxErrorCode.RATE_LIMITED,
-                    "Token budget exceeded for organization. Try again later.",
-                )
+            cost_triggered = _worst_triggered_cost_limit(
+                global_rate_limits,
+                lambda cutoff: get_total_cost_cents_since(db_session, cutoff),
+            )
+            _raise_for_longest_window(
+                "organization",
+                triggered.period_hours if triggered else None,
+                cost_triggered.period_hours if cost_triggered else None,
+            )
 
 
 def _fetch_global_usage(
@@ -87,13 +103,28 @@ def _get_cutoff_time(rate_limits: Sequence[TokenRateLimit]) -> datetime:
     )
 
 
-def _is_rate_limited(
+def _has_token_budget(rate_limits: Sequence[TokenRateLimit]) -> bool:
+    """Whether any limit sets a positive token budget. If not (cost-only limits),
+    the caller skips the token-usage aggregation query entirely."""
+    return any(
+        rl.token_budget is not None and rl.token_budget > 0 for rl in rate_limits
+    )
+
+
+def _worst_triggered_limit(
     rate_limits: Sequence[TokenRateLimit], usage: Sequence[TokenUsageBucket]
-) -> bool:
-    """Whether any provider-token budget is exceeded."""
+) -> TokenRateLimit | None:
+    """Among the exceeded token limits, return the one with the longest window
+    (or None). Picking the longest period_hours makes the reported reset
+    deterministic and conservative: a client that waits it out won't immediately
+    re-trip a still-exceeded longer limit. Carries period_hours for the reset."""
     now = datetime.now(timezone.utc)
+    worst: TokenRateLimit | None = None
     for rate_limit in rate_limits:
-        if rate_limit.token_budget is None:
+        # A null (cost-only) or non-positive token_budget is token-exempt — skip
+        # the token check. Guarding <= 0 means a 0 (new cost-only rows store null,
+        # but legacy/edge rows may hold 0) can never block every request.
+        if rate_limit.token_budget is None or rate_limit.token_budget <= 0:
             continue
 
         cutoff = get_token_window_start(now, rate_limit.period_hours)
@@ -101,10 +132,84 @@ def _is_rate_limited(
             bucket.tokens for bucket in usage if bucket.window_start >= cutoff
         )
 
+        # The admin enters the budget in THOUSANDS of tokens (Onyx convention),
+        # so the stored value is scaled up to the real token count here.
         if tokens_used >= rate_limit.token_budget * TOKEN_BUDGET_UNIT:
-            return True
+            if worst is None or rate_limit.period_hours > worst.period_hours:
+                worst = rate_limit
 
-    return False
+    return worst
+
+
+def _is_rate_limited(
+    rate_limits: Sequence[TokenRateLimit],
+    usage: Sequence[TokenUsageBucket],
+) -> bool:
+    return _worst_triggered_limit(rate_limits, usage) is not None
+
+
+def _worst_triggered_cost_limit(
+    rate_limits: Sequence[TokenRateLimit],
+    cost_since: Callable[[datetime], float],
+) -> TokenRateLimit | None:
+    """Among rows whose cost_budget_cents is set and exceeded, return the one
+    with the longest window (or None) — longest period_hours so the reset is
+    deterministic and conservative, matching _worst_triggered_limit.
+
+    Cost comes from the UserUsage ledger (not ChatMessage.token_count), which
+    buckets spend at a coarse fixed grid (_LEDGER_GRID). A bucket has no sub-grid
+    timing, so to mirror the token sliding window over [now - period_hours, now]
+    we count every bucket that *overlaps* it: window_start >= now - period_hours
+    - grid. This is conservative (a budget period finer than the grid can pull in
+    one adjacent bucket) — fail-CLOSED, the safe direction for a budget gate.
+    Rows without a cost_budget_cents are cost-exempt (token-only).
+    """
+    now = datetime.now(tz=timezone.utc)
+    worst: TokenRateLimit | None = None
+    for rate_limit in rate_limits:
+        budget = rate_limit.cost_budget_cents
+        if budget is None:
+            continue
+
+        cutoff = now - timedelta(hours=rate_limit.period_hours) - _LEDGER_GRID
+        if cost_since(cutoff) >= budget:
+            if worst is None or rate_limit.period_hours > worst.period_hours:
+                worst = rate_limit
+
+    return worst
+
+
+def raise_rate_limited(scope: str, period_hours: int) -> None:
+    """Raise a structured 429 carrying the offending scope + when its window rolls over.
+
+    Sliding-window enforcement has no single fixed reset instant; we report a full
+    period from now as the conservative "try again after" so the FE banner can count down.
+    """
+    retry_after_seconds = period_hours * 3600
+    reset_at = datetime.now(tz=timezone.utc) + timedelta(seconds=retry_after_seconds)
+    reset_at_iso = reset_at.isoformat()
+    raise OnyxError(
+        OnyxErrorCode.RATE_LIMITED,
+        # Neutral wording, no raw timestamp — the FE renders a friendly reset
+        # time from reset_at / retry_after_seconds below.
+        f"You've reached the usage budget for {scope}.",
+        extra={
+            "scope": scope,
+            "reset_at": reset_at_iso,
+            "retry_after_seconds": retry_after_seconds,
+        },
+        headers={"Retry-After": str(retry_after_seconds)},
+    )
+
+
+def _raise_for_longest_window(scope: str, *period_hours: int | None) -> None:
+    """Raise once for the longest of the given reset windows (Nones skipped).
+    The token and cost gates are independent; evaluating both before raising
+    avoids reporting a too-early reset when a short token window and a long cost
+    window are both exceeded."""
+    periods = [p for p in period_hours if p is not None]
+    if periods:
+        raise_rate_limited(scope, max(periods))
 
 
 _ANY_RATE_LIMIT_EXISTS_CACHE_TTL_SECONDS = 60

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -68,7 +68,14 @@ def _user_is_rate_limited_by_global() -> None:
             # Skip the token-usage aggregation when every limit is cost-only.
             triggered = None
             if _has_token_budget(global_rate_limits):
-                global_cutoff_time = _get_cutoff_time(global_rate_limits)
+                # Scan the token table only as far back as the widest *token*
+                # window — a longer cost-only window must not widen the scan.
+                token_limits = [
+                    rl
+                    for rl in global_rate_limits
+                    if rl.token_budget is not None and rl.token_budget > 0
+                ]
+                global_cutoff_time = _get_cutoff_time(token_limits)
                 global_usage = _fetch_global_usage(global_cutoff_time, db_session)
                 triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
@@ -151,6 +158,7 @@ def _is_rate_limited(
     rate_limits: Sequence[TokenRateLimit],
     usage: Sequence[TokenUsageBucket],
 ) -> bool:
+    """Whether any provider-token budget is exceeded."""
     return _worst_triggered_limit(rate_limits, usage) is not None
 
 

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -14,8 +14,9 @@ from onyx.db.models import TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    get_cost_window_reset,
     get_cost_window_start,
-    get_next_usage_bucket_start,
+    get_token_window_reset,
     get_token_window_start,
     get_total_cost_cents_buckets_since,
     get_total_token_buckets_since,
@@ -216,13 +217,19 @@ def raise_rate_limited(scope: str, reset_at: datetime) -> None:
 def _token_reset_at(limit: TokenRateLimit | None) -> datetime | None:
     if limit is None:
         return None
-    return get_next_usage_bucket_start(datetime.now(timezone.utc))
+    return get_token_window_reset(
+        datetime.now(timezone.utc),
+        limit.period_hours,
+    )
 
 
 def _cost_reset_at(limit: TokenRateLimit | None) -> datetime | None:
     if limit is None:
         return None
-    return get_next_usage_bucket_start(datetime.now(timezone.utc))
+    return get_cost_window_reset(
+        datetime.now(timezone.utc),
+        limit.period_hours,
+    )
 
 
 def _raise_for_latest_reset(scope: str, *reset_times: datetime | None) -> None:

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,4 +1,3 @@
-from collections.abc import Callable
 from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 from threading import RLock
@@ -15,7 +14,7 @@ from onyx.db.token_limit import fetch_all_global_token_rate_limits
 from onyx.db.user_usage import (
     TokenUsageBucket,
     get_token_window_start,
-    get_total_cost_cents_since,
+    get_total_cost_cents_buckets_since,
     get_total_token_buckets_since,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -73,9 +72,16 @@ def _user_is_rate_limited_by_global() -> None:
                 global_usage = _fetch_global_usage(global_cutoff_time, db_session)
                 triggered = _worst_triggered_limit(global_rate_limits, global_usage)
 
+            cost_buckets: list[tuple[datetime, float]] = []
+            if any(rl.cost_budget_cents is not None for rl in global_rate_limits):
+                # One bucket fetch for the widest window; _worst_triggered_cost_limit
+                # sums per-limit in Python (no query per cost limit).
+                cost_cutoff = _get_cutoff_time(global_rate_limits) - _LEDGER_GRID
+                cost_buckets = get_total_cost_cents_buckets_since(
+                    db_session, cost_cutoff
+                )
             cost_triggered = _worst_triggered_cost_limit(
-                global_rate_limits,
-                lambda cutoff: get_total_cost_cents_since(db_session, cutoff),
+                global_rate_limits, cost_buckets
             )
             _raise_for_longest_window(
                 "organization",
@@ -150,14 +156,15 @@ def _is_rate_limited(
 
 def _worst_triggered_cost_limit(
     rate_limits: Sequence[TokenRateLimit],
-    cost_since: Callable[[datetime], float],
+    cost_buckets: Sequence[tuple[datetime, float]],
 ) -> TokenRateLimit | None:
     """Among rows whose cost_budget_cents is set and exceeded, return the one
     with the longest window (or None) — longest period_hours so the reset is
     deterministic and conservative, matching _worst_triggered_limit.
 
-    Cost comes from the UserUsage ledger (not ChatMessage.token_count), which
-    buckets spend at a coarse fixed grid (_LEDGER_GRID). A bucket has no sub-grid
+    Cost comes from the UserUsage ledger (not ChatMessage.token_count), bucketed
+    at a coarse fixed grid (_LEDGER_GRID) and fetched once upstream; we sum the
+    buckets per window in Python (no query per limit). A bucket has no sub-grid
     timing, so to mirror the token sliding window over [now - period_hours, now]
     we count every bucket that *overlaps* it: window_start >= now - period_hours
     - grid. This is conservative (a budget period finer than the grid can pull in
@@ -172,7 +179,10 @@ def _worst_triggered_cost_limit(
             continue
 
         cutoff = now - timedelta(hours=rate_limit.period_hours) - _LEDGER_GRID
-        if cost_since(cutoff) >= budget:
+        cost = sum(
+            cents for window_start, cents in cost_buckets if window_start >= cutoff
+        )
+        if cost >= budget:
             if worst is None or rate_limit.period_hours > worst.period_hours:
                 worst = rate_limit
 

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -2,7 +2,9 @@ from pydantic import BaseModel, Field, model_validator
 
 from onyx.db.models import TokenRateLimit
 from onyx.db.user_usage import (
+    COST_BUDGET_PERIOD_ERROR,
     TOKEN_BUDGET_PERIOD_ERROR,
+    USER_USAGE_BUCKET_SECONDS,
     normalize_token_period_hours,
 )
 
@@ -23,6 +25,11 @@ class TokenRateLimitArgs(BaseModel):
             and self.period_hours != normalize_token_period_hours(self.period_hours)
         ):
             raise ValueError(TOKEN_BUDGET_PERIOD_ERROR)
+        if (
+            self.cost_budget_cents is not None
+            and (self.period_hours * 60 * 60) % USER_USAGE_BUCKET_SECONDS != 0
+        ):
+            raise ValueError(COST_BUDGET_PERIOD_ERROR)
         return self
 
 

--- a/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
@@ -17,12 +17,15 @@ from onyx.db.models import (
     User__UserGroup,
     UserGroup,
 )
-from onyx.db.user_usage import record_user_usage
+from onyx.db.user_usage import (
+    TokenUsageBucket,
+    get_cost_window_start,
+    get_next_cost_bucket_start,
+    record_user_usage,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.tracing.flows import LLMFlow
-from onyx.utils.datetime import get_window_start
-from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 from tests.external_dependency_unit.conftest import create_test_user
 
 pytestmark = pytest.mark.usefixtures("tenant_context")
@@ -30,7 +33,7 @@ pytestmark = pytest.mark.usefixtures("tenant_context")
 _TEST_MODEL = "cost-budget-test-model"
 
 
-def _cost_limit(scope: TokenRateLimitScope, period_hours: int = 1) -> TokenRateLimit:
+def _cost_limit(scope: TokenRateLimitScope, period_hours: int = 24) -> TokenRateLimit:
     return TokenRateLimit(
         enabled=True,
         token_budget=None,
@@ -41,9 +44,7 @@ def _cost_limit(scope: TokenRateLimitScope, period_hours: int = 1) -> TokenRateL
 
 
 def _record_cost(db_session: Session, user: User, cost_cents: float) -> None:
-    window_start = get_window_start(
-        datetime.now(timezone.utc), USAGE_LIMIT_WINDOW_SECONDS
-    )
+    window_start = get_cost_window_start(datetime.now(timezone.utc), 24)
     record_user_usage(
         db_session=db_session,
         user_id=str(user.id),
@@ -63,13 +64,18 @@ def _fail_token_query(*_args: object) -> NoReturn:
     raise AssertionError("cost-only enforcement queried token usage")
 
 
-def _assert_rate_limited(
-    error: OnyxError, scope: TokenRateLimitScope, period_hours: int
-) -> None:
+def _assert_rate_limited(error: OnyxError, scope: TokenRateLimitScope) -> None:
     assert error.error_code is OnyxErrorCode.RATE_LIMITED
     assert error.extra is not None
     assert error.extra["scope"] == scope.value
-    assert error.extra["retry_after_seconds"] == period_hours * 3600
+
+
+def _assert_cost_rate_limited(error: OnyxError, scope: TokenRateLimitScope) -> None:
+    _assert_rate_limited(error, scope)
+    assert error.extra is not None
+    assert datetime.fromisoformat(str(error.extra["reset_at"])) == (
+        get_next_cost_bucket_start(datetime.now(timezone.utc))
+    )
 
 
 def test_user_cost_isolated_and_longest_window_reported(
@@ -78,8 +84,8 @@ def test_user_cost_isolated_and_longest_window_reported(
     user = create_test_user(db_session, "cost_budget_user")
     other_user = create_test_user(db_session, "cost_budget_other")
     limits = [
-        _cost_limit(TokenRateLimitScope.USER, period_hours=1),
         _cost_limit(TokenRateLimitScope.USER, period_hours=24),
+        _cost_limit(TokenRateLimitScope.USER, period_hours=48),
     ]
     monkeypatch.setattr(
         ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: limits
@@ -93,7 +99,7 @@ def test_user_cost_isolated_and_longest_window_reported(
     _record_cost(db_session, user, 50.0)
     with pytest.raises(OnyxError) as exc_info:
         ee_token_limit._user_is_rate_limited(user.id)
-    _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER, 24)
+    _assert_cost_rate_limited(exc_info.value, TokenRateLimitScope.USER)
 
 
 def _create_group(db_session: Session, name: str) -> UserGroup:
@@ -131,8 +137,8 @@ def test_group_blocks_only_when_every_group_is_over_budget(
             User__UserGroup(user_id=spender.id, user_group_id=over_budget_group.id),
         ]
     )
-    _add_group_limit(db_session, over_budget_group, period_hours=5)
-    _add_group_limit(db_session, under_budget_group, period_hours=1)
+    _add_group_limit(db_session, over_budget_group, period_hours=48)
+    _add_group_limit(db_session, under_budget_group, period_hours=24)
     db_session.commit()
     _record_cost(db_session, spender, 150.0)
     monkeypatch.setattr(ee_token_limit, "_fetch_user_group_usage", _fail_token_query)
@@ -148,7 +154,7 @@ def test_group_blocks_only_when_every_group_is_over_budget(
     db_session.commit()
     with pytest.raises(OnyxError) as exc_info:
         ee_token_limit._user_is_rate_limited_by_group(user.id)
-    _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER_GROUP, 5)
+    _assert_cost_rate_limited(exc_info.value, TokenRateLimitScope.USER_GROUP)
 
 
 def test_user_token_limit_behavior_is_unchanged(
@@ -170,9 +176,18 @@ def test_user_token_limit_behavior_is_unchanged(
     monkeypatch.setattr(
         ee_token_limit,
         "_fetch_user_usage",
-        lambda *_: [(datetime.now(timezone.utc), 1_000)],
+        lambda *_: [
+            TokenUsageBucket(
+                window_start=datetime.now(timezone.utc),
+                tokens=1_000,
+            )
+        ],
     )
 
     with pytest.raises(OnyxError) as exc_info:
         ee_token_limit._user_is_rate_limited(user.id)
-    _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER, 2)
+    _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER)
+    assert exc_info.value.extra is not None
+    retry_after_seconds = exc_info.value.extra["retry_after_seconds"]
+    assert isinstance(retry_after_seconds, int)
+    assert abs(retry_after_seconds - 2 * 60 * 60) <= 1

--- a/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
@@ -1,0 +1,178 @@
+"""Enterprise user and group budget enforcement against the usage ledger."""
+
+from datetime import datetime, timezone
+from typing import NoReturn
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete
+from sqlalchemy.orm import Session
+
+import ee.onyx.server.query_and_chat.token_limit as ee_token_limit
+from onyx.configs.constants import TokenRateLimitScope
+from onyx.db.models import (
+    TokenRateLimit,
+    TokenRateLimit__UserGroup,
+    User,
+    User__UserGroup,
+    UserGroup,
+)
+from onyx.db.user_usage import record_user_usage
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.tracing.flows import LLMFlow
+from onyx.utils.datetime import get_window_start
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
+from tests.external_dependency_unit.conftest import create_test_user
+
+pytestmark = pytest.mark.usefixtures("tenant_context")
+
+_TEST_MODEL = "cost-budget-test-model"
+
+
+def _cost_limit(scope: TokenRateLimitScope, period_hours: int = 1) -> TokenRateLimit:
+    return TokenRateLimit(
+        enabled=True,
+        token_budget=None,
+        cost_budget_cents=100.0,
+        period_hours=period_hours,
+        scope=scope,
+    )
+
+
+def _record_cost(db_session: Session, user: User, cost_cents: float) -> None:
+    window_start = get_window_start(
+        datetime.now(timezone.utc), USAGE_LIMIT_WINDOW_SECONDS
+    )
+    record_user_usage(
+        db_session=db_session,
+        user_id=str(user.id),
+        model=_TEST_MODEL,
+        flow=LLMFlow.CHAT_RESPONSE.value,
+        provider=None,
+        input_tokens=1,
+        output_tokens=1,
+        cache_read_tokens=0,
+        cost_cents=cost_cents,
+        window_start=window_start,
+    )
+    db_session.commit()
+
+
+def _fail_token_query(*_args: object) -> NoReturn:
+    raise AssertionError("cost-only enforcement queried token usage")
+
+
+def _assert_rate_limited(
+    error: OnyxError, scope: TokenRateLimitScope, period_hours: int
+) -> None:
+    assert error.error_code is OnyxErrorCode.RATE_LIMITED
+    assert error.extra is not None
+    assert error.extra["scope"] == scope.value
+    assert error.extra["retry_after_seconds"] == period_hours * 3600
+
+
+def test_user_cost_isolated_and_longest_window_reported(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user = create_test_user(db_session, "cost_budget_user")
+    other_user = create_test_user(db_session, "cost_budget_other")
+    limits = [
+        _cost_limit(TokenRateLimitScope.USER, period_hours=1),
+        _cost_limit(TokenRateLimitScope.USER, period_hours=24),
+    ]
+    monkeypatch.setattr(
+        ee_token_limit, "fetch_all_user_token_rate_limits", lambda **_: limits
+    )
+    monkeypatch.setattr(ee_token_limit, "_fetch_user_usage", _fail_token_query)
+
+    _record_cost(db_session, user, 50.0)
+    _record_cost(db_session, other_user, 1_000.0)
+    ee_token_limit._user_is_rate_limited(user.id)
+
+    _record_cost(db_session, user, 50.0)
+    with pytest.raises(OnyxError) as exc_info:
+        ee_token_limit._user_is_rate_limited(user.id)
+    _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER, 24)
+
+
+def _create_group(db_session: Session, name: str) -> UserGroup:
+    group = UserGroup(name=f"{name}-{uuid4().hex}", is_up_to_date=True)
+    db_session.add(group)
+    db_session.flush()
+    return group
+
+
+def _add_group_limit(
+    db_session: Session, group: UserGroup, period_hours: int = 1
+) -> None:
+    limit = _cost_limit(TokenRateLimitScope.USER_GROUP, period_hours)
+    db_session.add(limit)
+    db_session.flush()
+    db_session.add(
+        TokenRateLimit__UserGroup(
+            rate_limit_id=limit.id,
+            user_group_id=group.id,
+        )
+    )
+
+
+def test_group_blocks_only_when_every_group_is_over_budget(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user = create_test_user(db_session, "group_budget_user")
+    spender = create_test_user(db_session, "group_budget_spender")
+    over_budget_group = _create_group(db_session, "over-budget")
+    under_budget_group = _create_group(db_session, "under-budget")
+    db_session.add_all(
+        [
+            User__UserGroup(user_id=user.id, user_group_id=over_budget_group.id),
+            User__UserGroup(user_id=user.id, user_group_id=under_budget_group.id),
+            User__UserGroup(user_id=spender.id, user_group_id=over_budget_group.id),
+        ]
+    )
+    _add_group_limit(db_session, over_budget_group, period_hours=5)
+    _add_group_limit(db_session, under_budget_group, period_hours=1)
+    db_session.commit()
+    _record_cost(db_session, spender, 150.0)
+    monkeypatch.setattr(ee_token_limit, "_fetch_user_group_usage", _fail_token_query)
+
+    ee_token_limit._user_is_rate_limited_by_group(user.id)
+
+    db_session.execute(
+        delete(User__UserGroup).where(
+            User__UserGroup.user_id == user.id,
+            User__UserGroup.user_group_id == under_budget_group.id,
+        )
+    )
+    db_session.commit()
+    with pytest.raises(OnyxError) as exc_info:
+        ee_token_limit._user_is_rate_limited_by_group(user.id)
+    _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER_GROUP, 5)
+
+
+def test_user_token_limit_behavior_is_unchanged(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user = create_test_user(db_session, "token_budget_user")
+    limit = TokenRateLimit(
+        enabled=True,
+        token_budget=1,
+        cost_budget_cents=None,
+        period_hours=2,
+        scope=TokenRateLimitScope.USER,
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "fetch_all_user_token_rate_limits",
+        lambda **_: [limit],
+    )
+    monkeypatch.setattr(
+        ee_token_limit,
+        "_fetch_user_usage",
+        lambda *_: [(datetime.now(timezone.utc), 1_000)],
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        ee_token_limit._user_is_rate_limited(user.id)
+    _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER, 2)

--- a/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
@@ -20,7 +20,7 @@ from onyx.db.models import (
 from onyx.db.user_usage import (
     TokenUsageBucket,
     get_cost_window_start,
-    get_next_cost_bucket_start,
+    get_next_usage_bucket_start,
     record_user_usage,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -74,7 +74,7 @@ def _assert_cost_rate_limited(error: OnyxError, scope: TokenRateLimitScope) -> N
     _assert_rate_limited(error, scope)
     assert error.extra is not None
     assert datetime.fromisoformat(str(error.extra["reset_at"])) == (
-        get_next_cost_bucket_start(datetime.now(timezone.utc))
+        get_next_usage_bucket_start(datetime.now(timezone.utc))
     )
 
 
@@ -188,6 +188,6 @@ def test_user_token_limit_behavior_is_unchanged(
         ee_token_limit._user_is_rate_limited(user.id)
     _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER)
     assert exc_info.value.extra is not None
-    retry_after_seconds = exc_info.value.extra["retry_after_seconds"]
-    assert isinstance(retry_after_seconds, int)
-    assert abs(retry_after_seconds - 2 * 60 * 60) <= 1
+    assert datetime.fromisoformat(str(exc_info.value.extra["reset_at"])) == (
+        get_next_usage_bucket_start(datetime.now(timezone.utc))
+    )

--- a/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
+++ b/backend/tests/external_dependency_unit/ee/onyx/server/query_and_chat/test_user_group_cost_budget_enforcement.py
@@ -19,8 +19,9 @@ from onyx.db.models import (
 )
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    get_cost_window_reset,
     get_cost_window_start,
-    get_next_usage_bucket_start,
+    get_token_window_reset,
     record_user_usage,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -70,11 +71,18 @@ def _assert_rate_limited(error: OnyxError, scope: TokenRateLimitScope) -> None:
     assert error.extra["scope"] == scope.value
 
 
-def _assert_cost_rate_limited(error: OnyxError, scope: TokenRateLimitScope) -> None:
+def _assert_cost_rate_limited(
+    error: OnyxError,
+    scope: TokenRateLimitScope,
+    period_hours: int,
+) -> None:
     _assert_rate_limited(error, scope)
     assert error.extra is not None
     assert datetime.fromisoformat(str(error.extra["reset_at"])) == (
-        get_next_usage_bucket_start(datetime.now(timezone.utc))
+        get_cost_window_reset(
+            datetime.now(timezone.utc),
+            period_hours,
+        )
     )
 
 
@@ -99,7 +107,11 @@ def test_user_cost_isolated_and_longest_window_reported(
     _record_cost(db_session, user, 50.0)
     with pytest.raises(OnyxError) as exc_info:
         ee_token_limit._user_is_rate_limited(user.id)
-    _assert_cost_rate_limited(exc_info.value, TokenRateLimitScope.USER)
+    _assert_cost_rate_limited(
+        exc_info.value,
+        TokenRateLimitScope.USER,
+        period_hours=48,
+    )
 
 
 def _create_group(db_session: Session, name: str) -> UserGroup:
@@ -154,7 +166,11 @@ def test_group_blocks_only_when_every_group_is_over_budget(
     db_session.commit()
     with pytest.raises(OnyxError) as exc_info:
         ee_token_limit._user_is_rate_limited_by_group(user.id)
-    _assert_cost_rate_limited(exc_info.value, TokenRateLimitScope.USER_GROUP)
+    _assert_cost_rate_limited(
+        exc_info.value,
+        TokenRateLimitScope.USER_GROUP,
+        period_hours=48,
+    )
 
 
 def test_user_token_limit_behavior_is_unchanged(
@@ -189,5 +205,8 @@ def test_user_token_limit_behavior_is_unchanged(
     _assert_rate_limited(exc_info.value, TokenRateLimitScope.USER)
     assert exc_info.value.extra is not None
     assert datetime.fromisoformat(str(exc_info.value.extra["reset_at"])) == (
-        get_next_usage_bucket_start(datetime.now(timezone.utc))
+        get_token_window_reset(
+            datetime.now(timezone.utc),
+            2,
+        )
     )

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -23,6 +23,7 @@ from onyx.db.models import User__UserGroup, UserUsage
 from onyx.db.user_usage import (
     TokenUsageBucket,
     UserUsageByDay,
+    get_cost_window_start,
     get_group_cost_cents_since,
     get_group_token_buckets_since,
     get_token_window_start,
@@ -49,6 +50,17 @@ def test_token_periods_use_whole_utc_days() -> None:
         2026, 7, 21, tzinfo=datetime.timezone.utc
     )
     assert get_token_window_start(now, 48) == datetime.datetime(
+        2026, 7, 20, tzinfo=datetime.timezone.utc
+    )
+
+
+def test_cost_window_uses_whole_utc_day_buckets() -> None:
+    now = datetime.datetime(2026, 7, 21, 13, 30, tzinfo=datetime.timezone.utc)
+
+    assert get_cost_window_start(now, 24) == datetime.datetime(
+        2026, 7, 21, tzinfo=datetime.timezone.utc
+    )
+    assert get_cost_window_start(now, 48) == datetime.datetime(
         2026, 7, 20, tzinfo=datetime.timezone.utc
     )
 

--- a/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.session import messages as messages_api
 from onyx.server.features.build.session.models import MessageRequest
@@ -82,6 +83,7 @@ def test_send_message_starts_background_turn(monkeypatch: pytest.MonkeyPatch) ->
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(
         messages_api,
         "create_message",
@@ -131,6 +133,7 @@ def test_send_message_rejects_second_active_turn(
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
     monkeypatch.setattr(messages_api, "start_interactive_turn_runner", MagicMock())
 
@@ -206,6 +209,7 @@ def test_send_message_is_idempotent_for_same_client_request(
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", rate_limit_check)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(
         messages_api,
         "create_message",
@@ -254,6 +258,7 @@ def test_send_message_leaves_turn_active_if_runner_cannot_start(
     _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", get_session_stub)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
     monkeypatch.setattr(
         messages_api,
@@ -276,3 +281,38 @@ def test_send_message_leaves_turn_active_if_runner_cannot_start(
     assert response.status == "QUEUED"
     assert active is not None
     assert active.turn_id == UUID(response.turn_id)
+
+
+def test_send_message_blocked_when_over_token_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A user over their token/cost budget can't start a Craft turn: the gate
+    raises a structured 429 before any turn is created or scheduled."""
+    cache = FakeCache()
+    session_id = uuid4()
+    user_id = uuid4()
+    session = SimpleNamespace(id=session_id)
+    start_runner = MagicMock()
+
+    monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    monkeypatch.setattr(messages_api, "get_build_session", lambda *_, **__: session)
+    monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
+    monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
+    monkeypatch.setattr(messages_api, "start_interactive_turn_runner", start_runner)
+
+    def _over_budget(_user: object) -> None:
+        raise OnyxError(OnyxErrorCode.RATE_LIMITED, "You've reached the usage budget.")
+
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", _over_budget)
+
+    with pytest.raises(OnyxError) as ei:
+        messages_api.send_message(
+            session_id=session_id,
+            request=MessageRequest(content="hello", client_request_id="req-1"),
+            user=cast(User, SimpleNamespace(id=user_id)),
+            db_session=cast(Session, _FakeDbSession(user_message_count=0)),
+        )
+
+    assert ei.value.error_code is OnyxErrorCode.RATE_LIMITED
+    start_runner.assert_not_called()  # no turn scheduled when over budget

--- a/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
@@ -168,6 +168,7 @@ def test_send_message_reloads_stale_skills(
     monkeypatch.setattr(messages_api, "get_build_session", lambda *_: session)
     monkeypatch.setattr(messages_api, "SessionManager", lambda _: session_manager)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
+    monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)
     monkeypatch.setattr(messages_api, "create_message", _create_message_noop)
     monkeypatch.setattr(messages_api, "start_interactive_turn_runner", MagicMock())
     user = cast(User, SimpleNamespace(id=user_id))
@@ -295,6 +296,7 @@ def test_send_message_blocked_when_over_token_budget(
     start_runner = MagicMock()
 
     monkeypatch.setattr(messages_api, "get_cache_backend", lambda: cache)
+    _patch_skill_state(monkeypatch)
     monkeypatch.setattr(messages_api, "get_build_session", lambda *_, **__: session)
     monkeypatch.setattr(messages_api, "check_build_rate_limits", lambda **_: None)
     monkeypatch.setattr(messages_api, "check_token_rate_limits", lambda *_: None)

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -247,13 +247,18 @@ def _cost_limit(
     return limit
 
 
+def _recent_cost_buckets(total: float) -> list[tuple[datetime.datetime, float]]:
+    """A single just-now cost bucket, so it lands inside any limit's window."""
+    return [(datetime.datetime.now(datetime.timezone.utc), total)]
+
+
 class TestWorstTriggeredCostLimit:
-    """Unit of the shared cost evaluator (no DB; cost is injected)."""
+    """Unit of the shared cost evaluator (no DB; cost buckets are injected)."""
 
     def test_over_cost_budget_returns_row(self) -> None:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         triggered = token_limit._worst_triggered_cost_limit(
-            [limit], cost_since=lambda _cutoff: 150.0
+            [limit], _recent_cost_buckets(150.0)
         )
         assert triggered is limit
 
@@ -261,7 +266,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 99.99
+                [limit], _recent_cost_buckets(99.99)
             )
             is None
         )
@@ -270,7 +275,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 100.0
+                [limit], _recent_cost_buckets(100.0)
             )
             is limit
         )
@@ -280,7 +285,7 @@ class TestWorstTriggeredCostLimit:
         limit = _cost_limit(None, TokenRateLimitScope.USER)
         assert (
             token_limit._worst_triggered_cost_limit(
-                [limit], cost_since=lambda _cutoff: 10**9
+                [limit], _recent_cost_buckets(10**9)
             )
             is None
         )
@@ -299,7 +304,11 @@ class TestGlobalCostRejectionPath:
         )
         # under token budget so only cost can trigger
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 600.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(600.0),
+        )
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
@@ -316,7 +325,11 @@ class TestGlobalCostRejectionPath:
             token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
         )
         monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
 
         token_limit._user_is_rate_limited_by_global()  # no raise
 
@@ -342,7 +355,11 @@ class TestGlobalCostRejectionPath:
             raise AssertionError("token aggregation ran for a cost-only limit")
 
         monkeypatch.setattr(token_limit, "_fetch_global_usage", _boom)
-        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+        monkeypatch.setattr(
+            token_limit,
+            "get_total_cost_cents_buckets_since",
+            lambda *_: _recent_cost_buckets(100.0),
+        )
 
         token_limit._user_is_rate_limited_by_global()  # no raise, no token query
 

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -1,0 +1,465 @@
+"""Unit tests for token-rate-limit enforcement (in-memory SQLite).
+
+Guards the admin-facing unit: a stored ``token_budget`` of N is in thousands,
+so it enforces at N * 1000 tokens (the Onyx convention).
+"""
+
+import datetime
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.engine import Engine
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+
+import onyx.server.query_and_chat.token_limit as token_limit
+from onyx.db.models import TokenRateLimit
+from onyx.db.models import TokenRateLimitScope
+from onyx.db.models import UserUsage
+from onyx.db.user_usage import get_window_start
+from onyx.db.user_usage import record_user_usage
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.query_and_chat.token_limit import _worst_triggered_limit
+
+
+def _is_rate_limited(
+    rate_limits: list[TokenRateLimit],
+    usage: list[tuple[datetime.datetime, int]],
+) -> bool:
+    return _worst_triggered_limit(rate_limits, usage) is not None
+
+
+# Postgres-only column types -> SQLite equivalents so the real UserUsage table
+# can back the real cost-source query path.
+@compiles(PGUUID, "sqlite")
+def _compile_pguuid_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "CHAR(36)"
+
+
+@compiles(PGJSONB, "sqlite")
+def _compile_jsonb_sqlite(_e: object, _c: object, **_kw: object) -> str:
+    return "JSON"
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    # Only the table under test; user-group FK is not exercised here.
+    cast(Table, TokenRateLimit.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_limit(token_budget: int) -> TokenRateLimit:
+    return TokenRateLimit(
+        enabled=True,
+        token_budget=token_budget,
+        period_hours=1,
+        scope=TokenRateLimitScope.GLOBAL,
+    )
+
+
+def _usage(token_count: int) -> list[tuple[datetime.datetime, int]]:
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    return [(now, token_count)]
+
+
+class TestIsRateLimitedUnit:
+    def test_budget_is_in_thousands(self) -> None:
+        # token_budget=12 means 12,000 tokens (the Onyx thousands convention).
+        limit = _make_limit(token_budget=12)
+        assert _is_rate_limited([limit], _usage(11_999)) is False
+        assert _is_rate_limited([limit], _usage(12_000)) is True
+        assert _is_rate_limited([limit], _usage(12_001)) is True
+
+    def test_below_budget_not_limited(self) -> None:
+        limit = _make_limit(token_budget=1000)  # 1,000,000 tokens
+        assert _is_rate_limited([limit], _usage(999_999)) is False
+
+    def test_at_budget_is_limited(self) -> None:
+        limit = _make_limit(token_budget=1000)  # 1,000,000 tokens
+        assert _is_rate_limited([limit], _usage(1_000_000)) is True
+
+    def test_cost_only_limit_is_token_exempt(self) -> None:
+        # A cost-only limit (token_budget=None) must NOT block on tokens — a 0
+        # would make tokens_used >= 0 always true and block every request.
+        cost_only = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        assert _is_rate_limited([cost_only], _usage(10_000_000)) is False
+
+    def test_zero_token_budget_does_not_block(self) -> None:
+        # A legacy/edge token_budget of 0 must be treated as no token limit, not
+        # "block at 0 tokens" (which would reject every request).
+        zero = TokenRateLimit(
+            enabled=True,
+            token_budget=0,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        assert _is_rate_limited([zero], _usage(10_000_000)) is False
+
+    def test_longest_window_among_exceeded_wins(self) -> None:
+        # When several limits are exceeded the reset must be deterministic and
+        # conservative: report the longest window so a retry can't immediately
+        # re-trip a still-exceeded longer limit. Order must not matter.
+        short = TokenRateLimit(
+            enabled=True,
+            token_budget=1,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        long_ = TokenRateLimit(
+            enabled=True,
+            token_budget=1,
+            period_hours=24,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        for order in ([short, long_], [long_, short]):
+            worst = _worst_triggered_limit(order, _usage(10_000))
+            assert worst is not None and worst.period_hours == 24
+
+
+def _assert_structured_429(exc: OnyxError, scope: str, period_hours: int) -> None:
+    """The 429 the FE banner binds to: RATE_LIMITED + scope + reset fields + header."""
+    assert exc.error_code is OnyxErrorCode.RATE_LIMITED
+    assert exc.status_code == 429
+    assert scope in exc.detail
+
+    extra = exc.extra or {}
+    assert extra["scope"] == scope
+    assert extra["retry_after_seconds"] == period_hours * 3600
+
+    reset_at = datetime.datetime.fromisoformat(cast(str, extra["reset_at"]))
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    expected = now + datetime.timedelta(hours=period_hours)
+    # Allow a few seconds of execution slop.
+    assert abs((reset_at - expected).total_seconds()) < 60
+
+    assert exc.headers == {"Retry-After": str(period_hours * 3600)}
+
+
+class TestRaiseRateLimited:
+    def test_global_scope_shape(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit.raise_rate_limited("organization", period_hours=2)
+        _assert_structured_429(ei.value, "organization", 2)
+
+
+class TestRaiseForLongestWindow:
+    """Token + cost gates are evaluated together; the reported reset is the
+    longest window, so a short token limit can't mask a longer cost reset."""
+
+    def test_longest_of_token_and_cost_wins(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit._raise_for_longest_window("user", 1, 24)
+        _assert_structured_429(ei.value, "user", 24)
+
+    def test_skips_none_windows(self) -> None:
+        with pytest.raises(OnyxError) as ei:
+            token_limit._raise_for_longest_window("user", None, 5)
+        _assert_structured_429(ei.value, "user", 5)
+
+    def test_no_trigger_does_not_raise(self) -> None:
+        token_limit._raise_for_longest_window("user", None, None)  # no raise
+
+
+class _SessionCtx:
+    """Minimal stand-in for get_session_with_current_tenant (only the limit fetch is patched)."""
+
+    def __enter__(self) -> object:
+        return object()
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class TestGlobalRejectionPath:
+    """CE path: a global limit over budget raises the structured 429."""
+
+    def test_over_global_budget_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        limit = _make_limit(token_budget=1000)
+        limit.period_hours = 3
+
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "fetch_all_global_token_rate_limits",
+            lambda **_: [limit],
+        )
+        # date_trunc isn't valid on SQLite; stub usage directly.
+        monkeypatch.setattr(
+            token_limit, "_fetch_global_usage", lambda *_: _usage(1_500_000)
+        )
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 3)
+
+    def test_under_global_budget_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        limit = _make_limit(token_budget=1000)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "fetch_all_global_token_rate_limits",
+            lambda **_: [limit],
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(10))
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+def _cost_limit(
+    cost_budget_cents: float | None,
+    scope: TokenRateLimitScope,
+    period_hours: int = 1,
+    token_budget: int = 10**12,  # effectively unbounded so only cost can trigger
+) -> TokenRateLimit:
+    limit = TokenRateLimit(
+        enabled=True,
+        token_budget=token_budget,
+        period_hours=period_hours,
+        scope=scope,
+    )
+    limit.cost_budget_cents = cost_budget_cents
+    return limit
+
+
+class TestWorstTriggeredCostLimit:
+    """Unit of the shared cost evaluator (no DB; cost is injected)."""
+
+    def test_over_cost_budget_returns_row(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        triggered = token_limit._worst_triggered_cost_limit(
+            [limit], cost_since=lambda _cutoff: 150.0
+        )
+        assert triggered is limit
+
+    def test_under_cost_budget_returns_none(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 99.99
+            )
+            is None
+        )
+
+    def test_at_cost_budget_triggers(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 100.0
+            )
+            is limit
+        )
+
+    def test_row_without_cost_budget_is_exempt(self) -> None:
+        # token-only row (cost_budget_cents is None) is never cost-limited
+        limit = _cost_limit(None, TokenRateLimitScope.USER)
+        assert (
+            token_limit._worst_triggered_cost_limit(
+                [limit], cost_since=lambda _cutoff: 10**9
+            )
+            is None
+        )
+
+
+class TestGlobalCostRejectionPath:
+    """CE global path: a global cost budget summed across the tenant raises."""
+
+    def test_over_global_cost_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL, period_hours=3)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        # under token budget so only cost can trigger
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 600.0)
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 3)
+
+    def test_under_global_cost_does_not_raise(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL)
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+    def test_cost_only_skips_token_aggregation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A cost-only limit (token_budget=None) must not run the token-usage query.
+        limit = TokenRateLimit(
+            enabled=True,
+            token_budget=None,
+            cost_budget_cents=500.0,
+            period_hours=1,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+
+        def _boom(*_a: object) -> object:
+            raise AssertionError("token aggregation ran for a cost-only limit")
+
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", _boom)
+        monkeypatch.setattr(token_limit, "get_total_cost_cents_since", lambda *_: 100.0)
+
+        token_limit._user_is_rate_limited_by_global()  # no raise, no token query
+
+
+class _RealLedgerSessionCtx:
+    """Yields a real SQLite session backing the actual UserUsage cost query."""
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+
+    def __enter__(self) -> Session:
+        return self._session
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+@pytest.fixture
+def ledger_session() -> Generator[Session, None, None]:
+    engine: Engine = create_engine("sqlite://")
+    cast(Table, UserUsage.__table__).create(bind=engine)
+    session = sessionmaker(bind=engine)()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+class TestCostEnforcementRealLedgerPath:
+    """The global cost gate, end-to-end through the real cost source — the
+    regression that the prior exact-window read fail-opened on a sub-grid
+    budget period."""
+
+    def test_sub_grid_period_blocks_against_real_ledger(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        # Ledger row written at the weekly grid (as the real processor does),
+        # but the admin's budget period is 24h. The sliding cutoff still reads it.
+        import uuid
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        ledger_window = get_window_start(now, period_hours=168)
+        record_user_usage(
+            ledger_session,
+            str(uuid.uuid4()),
+            "m",
+            "CHAT",
+            None,
+            1,
+            1,
+            0,
+            500.0,
+            ledger_window,
+        )
+
+        limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)
+        monkeypatch.setattr(
+            token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+
+        with pytest.raises(OnyxError) as ei:
+            token_limit._user_is_rate_limited_by_global()
+        _assert_structured_429(ei.value, "organization", 24)
+
+    def test_window_rollover_does_not_count(
+        self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
+    ) -> None:
+        import uuid
+
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
+        current = get_window_start(now, period_hours=168)
+        # Two grids back: always before the (period + one-grid) relaxed cutoff,
+        # regardless of weekday. A 24h budget must not see last-period spend.
+        prior = current - datetime.timedelta(days=14)
+        record_user_usage(
+            ledger_session, str(uuid.uuid4()), "m", "CHAT", None, 1, 1, 0, 9999.0, prior
+        )
+
+        limit = _cost_limit(100.0, TokenRateLimitScope.GLOBAL, period_hours=24)
+        monkeypatch.setattr(
+            token_limit,
+            "get_session_with_current_tenant",
+            lambda: _RealLedgerSessionCtx(ledger_session),
+        )
+        monkeypatch.setattr(
+            token_limit, "fetch_all_global_token_rate_limits", lambda **_: [limit]
+        )
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", lambda *_: _usage(1))
+
+        token_limit._user_is_rate_limited_by_global()  # no raise
+
+
+class TestTokenRateLimitArgsValidation:
+    """A limit must carry a token budget, a cost budget, or both — never neither."""
+
+    def test_neither_budget_rejected(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        with pytest.raises(ValueError):
+            TokenRateLimitArgs(enabled=True, token_budget=None, period_hours=24)
+
+    def test_cost_only_accepted(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        args = TokenRateLimitArgs(
+            enabled=True, token_budget=None, period_hours=24, cost_budget_cents=500.0
+        )
+        assert args.token_budget is None and args.cost_budget_cents == 500.0
+
+    def test_token_only_accepted(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+        assert args.token_budget == 1000 and args.cost_budget_cents is None

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -21,7 +21,7 @@ from onyx.db.models import TokenRateLimit, TokenRateLimitScope, UserUsage
 from onyx.db.user_usage import (
     TokenUsageBucket,
     get_cost_window_start,
-    get_next_cost_bucket_start,
+    get_next_usage_bucket_start,
     get_token_window_start,
     record_user_usage,
 )
@@ -172,16 +172,16 @@ def _structured_reset_at(exc: OnyxError, scope: str) -> datetime.datetime:
     return reset_at
 
 
-def _assert_token_reset(exc: OnyxError, scope: str, period_hours: int) -> None:
+def _assert_token_reset(exc: OnyxError, scope: str) -> None:
     reset_at = _structured_reset_at(exc, scope)
-    now = datetime.datetime.now(tz=datetime.timezone.utc)
-    expected = now + datetime.timedelta(hours=period_hours)
-    assert abs((reset_at - expected).total_seconds()) < 60
+    assert reset_at == get_next_usage_bucket_start(
+        datetime.datetime.now(tz=datetime.timezone.utc)
+    )
 
 
 def _assert_cost_reset(exc: OnyxError, scope: str) -> None:
     reset_at = _structured_reset_at(exc, scope)
-    expected = get_next_cost_bucket_start(
+    expected = get_next_usage_bucket_start(
         datetime.datetime.now(tz=datetime.timezone.utc)
     )
     assert reset_at == expected
@@ -253,7 +253,7 @@ class TestGlobalRejectionPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_token_reset(ei.value, "organization", 3)
+        _assert_token_reset(ei.value, "organization")
 
     def test_under_global_budget_does_not_raise(
         self, monkeypatch: pytest.MonkeyPatch
@@ -449,7 +449,7 @@ class TestGlobalCostRejectionPath:
         with pytest.raises(OnyxError) as exc_info:
             token_limit._user_is_rate_limited_by_global()
 
-        _assert_token_reset(exc_info.value, "organization", 30 * 24)
+        _assert_token_reset(exc_info.value, "organization")
         assert token_cutoffs == [get_token_window_start(now, 30 * 24)]
         assert cost_cutoffs == [get_cost_window_start(now, 24)]
 

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -20,8 +20,9 @@ import onyx.server.query_and_chat.token_limit as token_limit
 from onyx.db.models import TokenRateLimit, TokenRateLimitScope, UserUsage
 from onyx.db.user_usage import (
     TokenUsageBucket,
+    get_cost_window_reset,
     get_cost_window_start,
-    get_next_usage_bucket_start,
+    get_token_window_reset,
     get_token_window_start,
     record_user_usage,
 )
@@ -172,17 +173,23 @@ def _structured_reset_at(exc: OnyxError, scope: str) -> datetime.datetime:
     return reset_at
 
 
-def _assert_token_reset(exc: OnyxError, scope: str) -> None:
+def _assert_token_reset(exc: OnyxError, scope: str, period_hours: int) -> None:
     reset_at = _structured_reset_at(exc, scope)
-    assert reset_at == get_next_usage_bucket_start(
-        datetime.datetime.now(tz=datetime.timezone.utc)
+    assert reset_at == get_token_window_reset(
+        datetime.datetime.now(tz=datetime.timezone.utc),
+        period_hours,
     )
 
 
-def _assert_cost_reset(exc: OnyxError, scope: str) -> None:
+def _assert_cost_reset(
+    exc: OnyxError,
+    scope: str,
+    period_hours: int = 24,
+) -> None:
     reset_at = _structured_reset_at(exc, scope)
-    expected = get_next_usage_bucket_start(
-        datetime.datetime.now(tz=datetime.timezone.utc)
+    expected = get_cost_window_reset(
+        datetime.datetime.now(tz=datetime.timezone.utc),
+        period_hours,
     )
     assert reset_at == expected
 
@@ -253,7 +260,7 @@ class TestGlobalRejectionPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_token_reset(ei.value, "organization")
+        _assert_token_reset(ei.value, "organization", 3)
 
     def test_under_global_budget_does_not_raise(
         self, monkeypatch: pytest.MonkeyPatch
@@ -295,6 +302,18 @@ def _recent_cost_buckets(total: float) -> list[tuple[datetime.datetime, float]]:
 
 class TestWorstTriggeredCostLimit:
     """Unit of the shared cost evaluator (no DB; cost buckets are injected)."""
+
+    def test_multi_day_reset_expires_all_current_buckets(self) -> None:
+        limit = _cost_limit(
+            100.0,
+            TokenRateLimitScope.USER,
+            period_hours=48,
+        )
+
+        assert token_limit._cost_reset_at(limit) == get_cost_window_reset(
+            datetime.datetime.now(datetime.timezone.utc),
+            48,
+        )
 
     def test_over_cost_budget_returns_row(self) -> None:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
@@ -449,7 +468,7 @@ class TestGlobalCostRejectionPath:
         with pytest.raises(OnyxError) as exc_info:
             token_limit._user_is_rate_limited_by_global()
 
-        _assert_token_reset(exc_info.value, "organization")
+        _assert_token_reset(exc_info.value, "organization", 30 * 24)
         assert token_cutoffs == [get_token_window_start(now, 30 * 24)]
         assert cost_cutoffs == [get_cost_window_start(now, 24)]
 

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -9,24 +9,21 @@ from collections.abc import Generator
 from typing import cast
 
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy import Table
+from sqlalchemy import Table, create_engine
 from sqlalchemy.dialects.postgresql import JSONB as PGJSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.engine import Engine
 from sqlalchemy.ext.compiler import compiles
-from sqlalchemy.orm import Session
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 
 import onyx.server.query_and_chat.token_limit as token_limit
-from onyx.db.models import TokenRateLimit
-from onyx.db.models import TokenRateLimitScope
-from onyx.db.models import UserUsage
-from onyx.db.user_usage import get_window_start
+from onyx.db.models import TokenRateLimit, TokenRateLimitScope, UserUsage
 from onyx.db.user_usage import record_user_usage
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import _worst_triggered_limit
+from onyx.utils.datetime import get_window_start
+from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 
 
 def _is_rate_limited(
@@ -401,7 +398,7 @@ class TestCostEnforcementRealLedgerPath:
         import uuid
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        ledger_window = get_window_start(now, period_hours=168)
+        ledger_window = get_window_start(now, USAGE_LIMIT_WINDOW_SECONDS)
         record_user_usage(
             ledger_session,
             str(uuid.uuid4()),
@@ -436,7 +433,7 @@ class TestCostEnforcementRealLedgerPath:
         import uuid
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        current = get_window_start(now, period_hours=168)
+        current = get_window_start(now, USAGE_LIMIT_WINDOW_SECONDS)
         # Two grids back: always before the (period + one-grid) relaxed cutoff,
         # regardless of weekday. A 24h budget must not see last-period spend.
         prior = current - datetime.timedelta(days=14)

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -28,14 +28,14 @@ from onyx.db.user_usage import (
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
-from onyx.server.query_and_chat.token_limit import _worst_triggered_limit
+from onyx.server.query_and_chat.token_limit import _token_budget_reset
 
 
 def _is_rate_limited(
     rate_limits: list[TokenRateLimit],
     usage: list[TokenUsageBucket],
 ) -> bool:
-    return _worst_triggered_limit(rate_limits, usage) is not None
+    return _token_budget_reset(rate_limits, usage) is not None
 
 
 # Postgres-only column types -> SQLite equivalents so the real UserUsage table
@@ -117,25 +117,28 @@ class TestIsRateLimitedUnit:
         )
         assert _is_rate_limited([zero], _usage(10_000_000)) is False
 
-    def test_longest_window_among_exceeded_wins(self) -> None:
-        # When several limits are exceeded the reset must be deterministic and
-        # conservative: report the longest window so a retry can't immediately
-        # re-trip a still-exceeded longer limit. Order must not matter.
+    def test_latest_reset_among_exceeded_wins(self) -> None:
+        # When several limits are exceeded the reported reset is the max across
+        # them, so a retry can't immediately re-trip a limit that clears later.
+        # Usage lands in today's bucket, so each limit clears only when its whole
+        # window rolls off: the 48h limit binds. Order must not matter.
+        now = datetime.datetime.now(datetime.timezone.utc)
         short = TokenRateLimit(
-            enabled=True,
-            token_budget=1,
-            period_hours=1,
-            scope=TokenRateLimitScope.GLOBAL,
-        )
-        long_ = TokenRateLimit(
             enabled=True,
             token_budget=1,
             period_hours=24,
             scope=TokenRateLimitScope.GLOBAL,
         )
+        long_ = TokenRateLimit(
+            enabled=True,
+            token_budget=1,
+            period_hours=48,
+            scope=TokenRateLimitScope.GLOBAL,
+        )
         for order in ([short, long_], [long_, short]):
-            worst = _worst_triggered_limit(order, _usage(10_000))
-            assert worst is not None and worst.period_hours == 24
+            assert _token_budget_reset(order, _usage(10_000)) == get_token_window_reset(
+                now, 48
+            )
 
     def test_thirty_day_token_window_is_unchanged(self) -> None:
         limit = _make_limit(token_budget=1)
@@ -160,20 +163,24 @@ class TestIsRateLimitedUnit:
         )
 
 
-def _structured_reset_at(exc: OnyxError, scope: str) -> datetime.datetime:
+def _structured_reset_at(
+    exc: OnyxError, scope: TokenRateLimitScope
+) -> datetime.datetime:
     assert exc.error_code is OnyxErrorCode.RATE_LIMITED
     assert exc.status_code == 429
-    assert scope in exc.detail
+    assert "usage budget" in exc.detail
 
     extra = exc.extra or {}
-    assert extra["scope"] == scope
+    assert extra["scope"] == scope.value
     reset_at = datetime.datetime.fromisoformat(cast(str, extra["reset_at"]))
     retry_after_seconds = cast(int, extra["retry_after_seconds"])
     assert exc.headers == {"Retry-After": str(retry_after_seconds)}
     return reset_at
 
 
-def _assert_token_reset(exc: OnyxError, scope: str, period_hours: int) -> None:
+def _assert_token_reset(
+    exc: OnyxError, scope: TokenRateLimitScope, period_hours: int
+) -> None:
     reset_at = _structured_reset_at(exc, scope)
     assert reset_at == get_token_window_reset(
         datetime.datetime.now(tz=datetime.timezone.utc),
@@ -183,7 +190,7 @@ def _assert_token_reset(exc: OnyxError, scope: str, period_hours: int) -> None:
 
 def _assert_cost_reset(
     exc: OnyxError,
-    scope: str,
+    scope: TokenRateLimitScope,
     period_hours: int = 24,
 ) -> None:
     reset_at = _structured_reset_at(exc, scope)
@@ -200,8 +207,8 @@ class TestRaiseRateLimited:
             hours=2
         )
         with pytest.raises(OnyxError) as ei:
-            token_limit.raise_rate_limited("organization", reset_at)
-        assert _structured_reset_at(ei.value, "organization") == reset_at
+            token_limit.raise_rate_limited(TokenRateLimitScope.GLOBAL, reset_at)
+        assert _structured_reset_at(ei.value, TokenRateLimitScope.GLOBAL) == reset_at
 
 
 class TestRaiseForLatestReset:
@@ -212,20 +219,22 @@ class TestRaiseForLatestReset:
         latest = now + datetime.timedelta(hours=24)
         with pytest.raises(OnyxError) as ei:
             token_limit._raise_for_latest_reset(
-                "user", now + datetime.timedelta(hours=1), latest
+                TokenRateLimitScope.USER, now + datetime.timedelta(hours=1), latest
             )
-        assert _structured_reset_at(ei.value, "user") == latest
+        assert _structured_reset_at(ei.value, TokenRateLimitScope.USER) == latest
 
     def test_skips_none_resets(self) -> None:
         reset_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
             hours=5
         )
         with pytest.raises(OnyxError) as ei:
-            token_limit._raise_for_latest_reset("user", None, reset_at)
-        assert _structured_reset_at(ei.value, "user") == reset_at
+            token_limit._raise_for_latest_reset(
+                TokenRateLimitScope.USER, None, reset_at
+            )
+        assert _structured_reset_at(ei.value, TokenRateLimitScope.USER) == reset_at
 
     def test_no_trigger_does_not_raise(self) -> None:
-        token_limit._raise_for_latest_reset("user", None, None)
+        token_limit._raise_for_latest_reset(TokenRateLimitScope.USER, None, None)
 
 
 class _SessionCtx:
@@ -260,7 +269,7 @@ class TestGlobalRejectionPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_token_reset(ei.value, "organization", 3)
+        _assert_token_reset(ei.value, TokenRateLimitScope.GLOBAL, 3)
 
     def test_under_global_budget_does_not_raise(
         self, monkeypatch: pytest.MonkeyPatch
@@ -300,54 +309,53 @@ def _recent_cost_buckets(total: float) -> list[tuple[datetime.datetime, float]]:
     return [(datetime.datetime.now(datetime.timezone.utc), total)]
 
 
-class TestWorstTriggeredCostLimit:
+class TestCostBudgetReset:
     """Unit of the shared cost evaluator (no DB; cost buckets are injected)."""
 
-    def test_multi_day_reset_expires_all_current_buckets(self) -> None:
-        limit = _cost_limit(
-            100.0,
-            TokenRateLimitScope.USER,
-            period_hours=48,
-        )
-
-        assert token_limit._cost_reset_at(limit) == get_cost_window_reset(
-            datetime.datetime.now(datetime.timezone.utc),
-            48,
-        )
-
-    def test_over_cost_budget_returns_row(self) -> None:
-        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
-        triggered = token_limit._worst_triggered_cost_limit(
+    def test_current_day_usage_expires_at_full_window(self) -> None:
+        # Usage sits in today's (newest) bucket, so a 2-day window only clears
+        # once today itself rolls off — the full-window expiry.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER, period_hours=48)
+        assert token_limit._cost_budget_reset(
             [limit], _recent_cost_buckets(150.0)
+        ) == get_cost_window_reset(now, 48)
+
+    def test_stale_day_usage_expires_early(self) -> None:
+        # The overage is entirely in the oldest day of a 2-day window, so it ages
+        # out tomorrow — the exact reset, well before the full-window expiry.
+        now = datetime.datetime.now(datetime.timezone.utc)
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER, period_hours=48)
+        oldest_day = [(get_cost_window_start(now, 48), 150.0)]
+        assert token_limit._cost_budget_reset(
+            [limit], oldest_day
+        ) == get_cost_window_reset(now, 24)
+
+    def test_over_cost_budget_returns_reset(self) -> None:
+        limit = _cost_limit(100.0, TokenRateLimitScope.USER)
+        assert (
+            token_limit._cost_budget_reset([limit], _recent_cost_buckets(150.0))
+            is not None
         )
-        assert triggered is limit
 
     def test_under_cost_budget_returns_none(self) -> None:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
-            token_limit._worst_triggered_cost_limit(
-                [limit], _recent_cost_buckets(99.99)
-            )
-            is None
+            token_limit._cost_budget_reset([limit], _recent_cost_buckets(99.99)) is None
         )
 
     def test_at_cost_budget_triggers(self) -> None:
         limit = _cost_limit(100.0, TokenRateLimitScope.USER)
         assert (
-            token_limit._worst_triggered_cost_limit(
-                [limit], _recent_cost_buckets(100.0)
-            )
-            is limit
+            token_limit._cost_budget_reset([limit], _recent_cost_buckets(100.0))
+            is not None
         )
 
     def test_row_without_cost_budget_is_exempt(self) -> None:
         # token-only row (cost_budget_cents is None) is never cost-limited
         limit = _cost_limit(None, TokenRateLimitScope.USER)
         assert (
-            token_limit._worst_triggered_cost_limit(
-                [limit], _recent_cost_buckets(10**9)
-            )
-            is None
+            token_limit._cost_budget_reset([limit], _recent_cost_buckets(10**9)) is None
         )
 
 
@@ -372,7 +380,7 @@ class TestGlobalCostRejectionPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_cost_reset(ei.value, "organization")
+        _assert_cost_reset(ei.value, TokenRateLimitScope.GLOBAL)
 
     def test_under_global_cost_does_not_raise(
         self, monkeypatch: pytest.MonkeyPatch
@@ -448,9 +456,10 @@ class TestGlobalCostRejectionPath:
             cutoff: datetime.datetime, _session: object
         ) -> list[TokenUsageBucket]:
             token_cutoffs.append(cutoff)
+            # Oldest day in the 30-day window: over budget now, ages out tomorrow.
             return [
                 TokenUsageBucket(
-                    window_start=now - datetime.timedelta(days=29), tokens=1_000
+                    window_start=get_token_window_start(now, 30 * 24), tokens=1_000
                 )
             ]
 
@@ -468,7 +477,10 @@ class TestGlobalCostRejectionPath:
         with pytest.raises(OnyxError) as exc_info:
             token_limit._user_is_rate_limited_by_global()
 
-        _assert_token_reset(exc_info.value, "organization", 30 * 24)
+        reset_at = _structured_reset_at(exc_info.value, TokenRateLimitScope.GLOBAL)
+        # The lone token bucket is the oldest day in the 30-day window, so it ages
+        # out tomorrow: the exact reset, not the 30-day full-window expiry.
+        assert reset_at == get_token_window_reset(now, 24)
         assert token_cutoffs == [get_token_window_start(now, 30 * 24)]
         assert cost_cutoffs == [get_cost_window_start(now, 24)]
 
@@ -533,7 +545,7 @@ class TestCostEnforcementRealLedgerPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_cost_reset(ei.value, "organization")
+        _assert_cost_reset(ei.value, TokenRateLimitScope.GLOBAL)
 
     def test_window_rollover_does_not_count(
         self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session

--- a/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_token_limit.py
@@ -18,17 +18,21 @@ from sqlalchemy.orm import Session, sessionmaker
 
 import onyx.server.query_and_chat.token_limit as token_limit
 from onyx.db.models import TokenRateLimit, TokenRateLimitScope, UserUsage
-from onyx.db.user_usage import record_user_usage
+from onyx.db.user_usage import (
+    TokenUsageBucket,
+    get_cost_window_start,
+    get_next_cost_bucket_start,
+    get_token_window_start,
+    record_user_usage,
+)
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import _worst_triggered_limit
-from onyx.utils.datetime import get_window_start
-from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 
 
 def _is_rate_limited(
     rate_limits: list[TokenRateLimit],
-    usage: list[tuple[datetime.datetime, int]],
+    usage: list[TokenUsageBucket],
 ) -> bool:
     return _worst_triggered_limit(rate_limits, usage) is not None
 
@@ -67,9 +71,9 @@ def _make_limit(token_budget: int) -> TokenRateLimit:
     )
 
 
-def _usage(token_count: int) -> list[tuple[datetime.datetime, int]]:
+def _usage(token_count: int) -> list[TokenUsageBucket]:
     now = datetime.datetime.now(tz=datetime.timezone.utc)
-    return [(now, token_count)]
+    return [TokenUsageBucket(window_start=now, tokens=token_count)]
 
 
 class TestIsRateLimitedUnit:
@@ -132,49 +136,89 @@ class TestIsRateLimitedUnit:
             worst = _worst_triggered_limit(order, _usage(10_000))
             assert worst is not None and worst.period_hours == 24
 
+    def test_thirty_day_token_window_is_unchanged(self) -> None:
+        limit = _make_limit(token_budget=1)
+        limit.period_hours = 30 * 24
+        now = datetime.datetime.now(datetime.timezone.utc)
 
-def _assert_structured_429(exc: OnyxError, scope: str, period_hours: int) -> None:
-    """The 429 the FE banner binds to: RATE_LIMITED + scope + reset fields + header."""
+        assert _is_rate_limited(
+            [limit],
+            [
+                TokenUsageBucket(
+                    window_start=now - datetime.timedelta(days=29), tokens=1_000
+                )
+            ],
+        )
+        assert not _is_rate_limited(
+            [limit],
+            [
+                TokenUsageBucket(
+                    window_start=now - datetime.timedelta(days=31), tokens=1_000
+                )
+            ],
+        )
+
+
+def _structured_reset_at(exc: OnyxError, scope: str) -> datetime.datetime:
     assert exc.error_code is OnyxErrorCode.RATE_LIMITED
     assert exc.status_code == 429
     assert scope in exc.detail
 
     extra = exc.extra or {}
     assert extra["scope"] == scope
-    assert extra["retry_after_seconds"] == period_hours * 3600
-
     reset_at = datetime.datetime.fromisoformat(cast(str, extra["reset_at"]))
+    retry_after_seconds = cast(int, extra["retry_after_seconds"])
+    assert exc.headers == {"Retry-After": str(retry_after_seconds)}
+    return reset_at
+
+
+def _assert_token_reset(exc: OnyxError, scope: str, period_hours: int) -> None:
+    reset_at = _structured_reset_at(exc, scope)
     now = datetime.datetime.now(tz=datetime.timezone.utc)
     expected = now + datetime.timedelta(hours=period_hours)
-    # Allow a few seconds of execution slop.
     assert abs((reset_at - expected).total_seconds()) < 60
 
-    assert exc.headers == {"Retry-After": str(period_hours * 3600)}
+
+def _assert_cost_reset(exc: OnyxError, scope: str) -> None:
+    reset_at = _structured_reset_at(exc, scope)
+    expected = get_next_cost_bucket_start(
+        datetime.datetime.now(tz=datetime.timezone.utc)
+    )
+    assert reset_at == expected
 
 
 class TestRaiseRateLimited:
     def test_global_scope_shape(self) -> None:
+        reset_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+            hours=2
+        )
         with pytest.raises(OnyxError) as ei:
-            token_limit.raise_rate_limited("organization", period_hours=2)
-        _assert_structured_429(ei.value, "organization", 2)
+            token_limit.raise_rate_limited("organization", reset_at)
+        assert _structured_reset_at(ei.value, "organization") == reset_at
 
 
-class TestRaiseForLongestWindow:
-    """Token + cost gates are evaluated together; the reported reset is the
-    longest window, so a short token limit can't mask a longer cost reset."""
+class TestRaiseForLatestReset:
+    """Independent limits report the latest relevant reset."""
 
-    def test_longest_of_token_and_cost_wins(self) -> None:
+    def test_latest_reset_wins(self) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        latest = now + datetime.timedelta(hours=24)
         with pytest.raises(OnyxError) as ei:
-            token_limit._raise_for_longest_window("user", 1, 24)
-        _assert_structured_429(ei.value, "user", 24)
+            token_limit._raise_for_latest_reset(
+                "user", now + datetime.timedelta(hours=1), latest
+            )
+        assert _structured_reset_at(ei.value, "user") == latest
 
-    def test_skips_none_windows(self) -> None:
+    def test_skips_none_resets(self) -> None:
+        reset_at = datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(
+            hours=5
+        )
         with pytest.raises(OnyxError) as ei:
-            token_limit._raise_for_longest_window("user", None, 5)
-        _assert_structured_429(ei.value, "user", 5)
+            token_limit._raise_for_latest_reset("user", None, reset_at)
+        assert _structured_reset_at(ei.value, "user") == reset_at
 
     def test_no_trigger_does_not_raise(self) -> None:
-        token_limit._raise_for_longest_window("user", None, None)  # no raise
+        token_limit._raise_for_latest_reset("user", None, None)
 
 
 class _SessionCtx:
@@ -209,7 +253,7 @@ class TestGlobalRejectionPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_structured_429(ei.value, "organization", 3)
+        _assert_token_reset(ei.value, "organization", 3)
 
     def test_under_global_budget_does_not_raise(
         self, monkeypatch: pytest.MonkeyPatch
@@ -231,8 +275,8 @@ class TestGlobalRejectionPath:
 def _cost_limit(
     cost_budget_cents: float | None,
     scope: TokenRateLimitScope,
-    period_hours: int = 1,
-    token_budget: int = 10**12,  # effectively unbounded so only cost can trigger
+    period_hours: int = 24,
+    token_budget: int | None = 10**12,
 ) -> TokenRateLimit:
     limit = TokenRateLimit(
         enabled=True,
@@ -292,7 +336,7 @@ class TestGlobalCostRejectionPath:
     """CE global path: a global cost budget summed across the tenant raises."""
 
     def test_over_global_cost_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL, period_hours=3)
+        limit = _cost_limit(500.0, TokenRateLimitScope.GLOBAL)
         monkeypatch.setattr(
             token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
         )
@@ -309,7 +353,7 @@ class TestGlobalCostRejectionPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_structured_429(ei.value, "organization", 3)
+        _assert_cost_reset(ei.value, "organization")
 
     def test_under_global_cost_does_not_raise(
         self, monkeypatch: pytest.MonkeyPatch
@@ -338,7 +382,7 @@ class TestGlobalCostRejectionPath:
             enabled=True,
             token_budget=None,
             cost_budget_cents=500.0,
-            period_hours=1,
+            period_hours=24,
             scope=TokenRateLimitScope.GLOBAL,
         )
         monkeypatch.setattr(
@@ -359,6 +403,55 @@ class TestGlobalCostRejectionPath:
         )
 
         token_limit._user_is_rate_limited_by_global()  # no raise, no token query
+
+    def test_long_token_window_does_not_widen_cost_query(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+        token_limit_row = _make_limit(token_budget=1)
+        token_limit_row.period_hours = 30 * 24
+        cost_limit_row = _cost_limit(
+            500.0, TokenRateLimitScope.GLOBAL, token_budget=None
+        )
+        token_cutoffs: list[datetime.datetime] = []
+        cost_cutoffs: list[datetime.datetime] = []
+
+        monkeypatch.setattr(
+            token_limit, "get_session_with_current_tenant", lambda: _SessionCtx()
+        )
+        monkeypatch.setattr(
+            token_limit,
+            "fetch_all_global_token_rate_limits",
+            lambda **_: [token_limit_row, cost_limit_row],
+        )
+
+        def _fetch_tokens(
+            cutoff: datetime.datetime, _session: object
+        ) -> list[TokenUsageBucket]:
+            token_cutoffs.append(cutoff)
+            return [
+                TokenUsageBucket(
+                    window_start=now - datetime.timedelta(days=29), tokens=1_000
+                )
+            ]
+
+        def _fetch_cost(
+            _session: object, cutoff: datetime.datetime
+        ) -> list[tuple[datetime.datetime, float]]:
+            cost_cutoffs.append(cutoff)
+            return [(get_cost_window_start(now, 24), 1.0)]
+
+        monkeypatch.setattr(token_limit, "_fetch_global_usage", _fetch_tokens)
+        monkeypatch.setattr(
+            token_limit, "get_total_cost_cents_buckets_since", _fetch_cost
+        )
+
+        with pytest.raises(OnyxError) as exc_info:
+            token_limit._user_is_rate_limited_by_global()
+
+        _assert_token_reset(exc_info.value, "organization", 30 * 24)
+        assert token_cutoffs == [get_token_window_start(now, 30 * 24)]
+        assert cost_cutoffs == [get_cost_window_start(now, 24)]
 
 
 class _RealLedgerSessionCtx:
@@ -386,19 +479,15 @@ def ledger_session() -> Generator[Session, None, None]:
 
 
 class TestCostEnforcementRealLedgerPath:
-    """The global cost gate, end-to-end through the real cost source — the
-    regression that the prior exact-window read fail-opened on a sub-grid
-    budget period."""
+    """The global cost gate reads UTC-day buckets from the real ledger query."""
 
-    def test_sub_grid_period_blocks_against_real_ledger(
+    def test_current_day_blocks_against_real_ledger(
         self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
     ) -> None:
-        # Ledger row written at the weekly grid (as the real processor does),
-        # but the admin's budget period is 24h. The sliding cutoff still reads it.
         import uuid
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        ledger_window = get_window_start(now, USAGE_LIMIT_WINDOW_SECONDS)
+        ledger_window = get_cost_window_start(now, 24)
         record_user_usage(
             ledger_session,
             str(uuid.uuid4()),
@@ -425,7 +514,7 @@ class TestCostEnforcementRealLedgerPath:
 
         with pytest.raises(OnyxError) as ei:
             token_limit._user_is_rate_limited_by_global()
-        _assert_structured_429(ei.value, "organization", 24)
+        _assert_cost_reset(ei.value, "organization")
 
     def test_window_rollover_does_not_count(
         self, monkeypatch: pytest.MonkeyPatch, ledger_session: Session
@@ -433,10 +522,8 @@ class TestCostEnforcementRealLedgerPath:
         import uuid
 
         now = datetime.datetime.now(tz=datetime.timezone.utc)
-        current = get_window_start(now, USAGE_LIMIT_WINDOW_SECONDS)
-        # Two grids back: always before the (period + one-grid) relaxed cutoff,
-        # regardless of weekday. A 24h budget must not see last-period spend.
-        prior = current - datetime.timedelta(days=14)
+        current = get_cost_window_start(now, 24)
+        prior = current - datetime.timedelta(days=1)
         record_user_usage(
             ledger_session, str(uuid.uuid4()), "m", "CHAT", None, 1, 1, 0, 9999.0, prior
         )
@@ -471,6 +558,17 @@ class TestTokenRateLimitArgsValidation:
             enabled=True, token_budget=None, period_hours=24, cost_budget_cents=500.0
         )
         assert args.token_budget is None and args.cost_budget_cents == 500.0
+
+    def test_cost_period_must_be_whole_days(self) -> None:
+        from onyx.server.token_rate_limits.models import TokenRateLimitArgs
+
+        with pytest.raises(ValueError, match="whole UTC days"):
+            TokenRateLimitArgs(
+                enabled=True,
+                token_budget=None,
+                period_hours=25,
+                cost_budget_cents=500.0,
+            )
 
     def test_token_only_accepted(self) -> None:
         from onyx.server.token_rate_limits.models import TokenRateLimitArgs

--- a/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
+++ b/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
@@ -6,11 +6,18 @@ from pydantic import ValidationError
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit
 from onyx.db.user_usage import TokenUsageBucket
-from onyx.server.query_and_chat.token_limit import _is_rate_limited
+from onyx.server.query_and_chat.token_limit import _token_budget_reset
 from onyx.server.token_rate_limits.models import (
     TokenRateLimitArgs,
     TokenRateLimitDisplay,
 )
+
+
+def _is_rate_limited(
+    rate_limits: list[TokenRateLimit],
+    usage: list[TokenUsageBucket],
+) -> bool:
+    return _token_budget_reset(rate_limits, usage) is not None
 
 
 def _rate_limit(

--- a/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
+++ b/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
@@ -1,0 +1,89 @@
+"""Global token-rate-limit create/read round-trips cost_budget_cents (cents at
+the API boundary), and a limit may carry only a cost budget (no token budget)."""
+
+from collections.abc import Generator
+from typing import cast
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy import Table
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from onyx.auth.users import current_user
+from onyx.db.engine.sql_engine import get_session
+from onyx.db.enums import Permission
+from onyx.db.models import TokenRateLimit
+from onyx.error_handling.exceptions import register_onyx_exception_handlers
+from onyx.server.token_rate_limits.api import router as token_rate_limit_router
+
+
+class _StubUser:
+    def __init__(self, permissions: list[str]) -> None:
+        self.id = "00000000-0000-0000-0000-000000000001"
+        self.effective_permissions = permissions
+
+
+_ADMIN = _StubUser([Permission.FULL_ADMIN_PANEL_ACCESS.value])
+
+
+@pytest.fixture
+def db_session() -> Generator[Session, None, None]:
+    # StaticPool keeps the table alive across the endpoint's commit().
+    engine: Engine = create_engine(
+        "sqlite://", poolclass=StaticPool, connect_args={"check_same_thread": False}
+    )
+    cast(Table, TokenRateLimit.__table__).create(bind=engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def _make_app(db_session: Session) -> FastAPI:
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    app.include_router(token_rate_limit_router)
+    app.dependency_overrides[get_session] = lambda: db_session
+    app.dependency_overrides[current_user] = lambda: _ADMIN
+    return app
+
+
+def test_create_persists_cost_budget_and_get_returns_it(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session))
+
+    created = client.post(
+        "/admin/token-rate-limits/global",
+        json={
+            "enabled": True,
+            "token_budget": 1000,
+            "period_hours": 24,
+            "cost_budget_cents": 500.0,
+        },
+    )
+    assert created.status_code == 200
+    assert created.json()["cost_budget_cents"] == 500.0
+
+    listing = client.get("/admin/token-rate-limits/global")
+    assert listing.status_code == 200
+    rows = listing.json()
+    assert len(rows) == 1
+    assert rows[0]["cost_budget_cents"] == 500.0
+    assert rows[0]["token_budget"] == 1000
+
+
+def test_cost_budget_optional_defaults_null(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session))
+
+    created = client.post(
+        "/admin/token-rate-limits/global",
+        json={"enabled": True, "token_budget": 1000, "period_hours": 24},
+    )
+    assert created.status_code == 200
+    assert created.json()["cost_budget_cents"] is None

--- a/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
+++ b/backend/tests/unit/onyx/server/token_rate_limits/test_cost_budget_api.py
@@ -7,11 +7,9 @@ from typing import cast
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import create_engine
-from sqlalchemy import Table
+from sqlalchemy import Table, create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
 from onyx.auth.users import current_user
@@ -87,3 +85,19 @@ def test_cost_budget_optional_defaults_null(db_session: Session) -> None:
     )
     assert created.status_code == 200
     assert created.json()["cost_budget_cents"] is None
+
+
+def test_cost_budget_rejects_partial_day_period(db_session: Session) -> None:
+    client = TestClient(_make_app(db_session))
+
+    response = client.post(
+        "/admin/token-rate-limits/global",
+        json={
+            "enabled": True,
+            "token_budget": None,
+            "period_hours": 25,
+            "cost_budget_cents": 500.0,
+        },
+    )
+
+    assert response.status_code == 422


### PR DESCRIPTION
## Description

See #11888 , this is our version so we can make edits and get it merged.

## How Has This Been Tested?

see original PR, added tests and will test E2E

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds enforcement for token and cost budgets at the org, user, and user‑group scopes, returning a structured 429 with precise reset timing. Craft (Build Mode) turns are now blocked when over budget.

- **New Features**
  - Optional cost budgets (cents) alongside token budgets; limits can be token‑only, cost‑only, or both; cost periods must be whole UTC days.
  - Enforce budgets globally and (EE) per user and per user‑group; a user in groups is blocked only if all their groups are over; 429 includes `scope`, `reset_at`, `retry_after_seconds`, and a `Retry-After` header. Reset is the latest exceeded window for org/user, and the earliest group reset when all groups are over.
  - Craft send‑message and subagent endpoints call `check_token_rate_limits` before starting a turn.

- **Refactors**
  - Compute exact resets from UTC‑day buckets (earliest window boundary via `earliest_window_reset`); token budgets are enforced in thousands of tokens; `retry_after_seconds` is calculated precisely.
  - Skip token scans for cost‑only limits; scan tokens only to the widest token window among token limits; fetch cost buckets once for the widest cost window (batched per group).
  - `OnyxError` supports `extra` fields merged into the JSON response and response headers; the 429 uses this to return structured budget metadata.

<sup>Written for commit e81baf1fbf7cdaf50d57ff359a0309f395007900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13222?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

