### PR TITLE
feat(skills): support duplicate skill names

### DIFF
--- a/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
+++ b/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
@@ -38,15 +38,13 @@ def upgrade() -> None:
     )
 
     op.drop_constraint("uq_skill_slug", "skill", type_="unique")
-    op.execute("UPDATE skill SET name = slug")
     op.alter_column(
         "skill",
         "name",
         existing_type=sa.String(),
         type_=sa.String(length=64),
-        nullable=False,
+        postgresql_using="slug",
     )
-    op.create_index("ix_skill_name", "skill", ["name"])
 
     op.add_column(
         "user_skill_preference",
@@ -66,7 +64,7 @@ def upgrade() -> None:
         existing_type=sa.String(length=64),
         nullable=False,
     )
-    op.create_unique_constraint("uq_skill_id_name", "skill", ["id", "name"])
+    op.create_unique_constraint("uq_skill_name_id", "skill", ["name", "id"])
     op.drop_constraint(
         "user_skill_preference_skill_id_fkey",
         "user_skill_preference",
@@ -76,8 +74,8 @@ def upgrade() -> None:
         "fk_user_skill_preference_skill_name",
         "user_skill_preference",
         "skill",
-        ["skill_id", "name"],
-        ["id", "name"],
+        ["name", "skill_id"],
+        ["name", "id"],
         ondelete="CASCADE",
     )
     op.create_index(
@@ -102,19 +100,7 @@ def downgrade() -> None:
         existing_type=sa.String(length=64),
         nullable=False,
     )
-    op.execute(
-        """
-        DO $$
-        BEGIN
-            IF EXISTS (
-                SELECT 1 FROM skill GROUP BY slug HAVING count(*) > 1
-            ) THEN
-                RAISE EXCEPTION
-                    'Cannot downgrade while duplicate skill names exist';
-            END IF;
-        END$$
-        """
-    )
+    op.create_unique_constraint("uq_skill_slug", "skill", ["slug"])
     op.drop_index(
         "uq_user_skill_preference_enabled_name",
         table_name="user_skill_preference",
@@ -132,15 +118,13 @@ def downgrade() -> None:
         ["id"],
         ondelete="CASCADE",
     )
-    op.drop_constraint("uq_skill_id_name", "skill", type_="unique")
+    op.drop_constraint("uq_skill_name_id", "skill", type_="unique")
     op.drop_column("user_skill_preference", "name")
-    op.drop_index("ix_skill_name", table_name="skill")
     op.alter_column(
         "skill",
         "name",
         existing_type=sa.String(length=64),
         type_=sa.String(),
-        nullable=False,
     )
     op.execute(
         """
@@ -150,5 +134,4 @@ def downgrade() -> None:
         WHERE external_app.skill_id = skill.id
         """
     )
-    op.create_unique_constraint("uq_skill_slug", "skill", ["slug"])
     op.drop_column("external_app", "name")

--- a/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
+++ b/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
@@ -1,5 +1,17 @@
 """Allow duplicate skill names.
 
+Before this migration, ``Skill.slug`` was the unique canonical Agent Skills
+name, while ``Skill.name`` also held editable display metadata. External apps
+stored their display names on the linked skill, and user preferences identified
+skills by ``(user_id, skill_id)`` plus an ``enabled`` boolean.
+
+After the upgrade, ``Skill.name`` is the sole canonical skill name and may be
+shared by multiple skill rows. External-app display names live independently on
+``ExternalApp.name``. ``UserSkillPreference.name`` mirrors the referenced skill
+name through a composite foreign key. A preference row now means the skill is
+enabled, and a unique index enforces at most one selection per ``(user_id,
+name)`` while preserving UUID-based skill identity.
+
 Revision ID: b72c72cd6ef6
 Revises: eec4fc85ef28
 Create Date: 2026-07-20 16:32:40.354227
@@ -78,12 +90,13 @@ def upgrade() -> None:
         ["name", "id"],
         ondelete="CASCADE",
     )
+    op.execute("DELETE FROM user_skill_preference WHERE NOT enabled")
+    op.drop_column("user_skill_preference", "enabled")
     op.create_index(
-        "uq_user_skill_preference_enabled_name",
+        "uq_user_skill_preference_name",
         "user_skill_preference",
         ["user_id", "name"],
         unique=True,
-        postgresql_where=sa.column("enabled").is_(True),
     )
     op.drop_column("skill", "slug")
 
@@ -102,7 +115,7 @@ def downgrade() -> None:
     )
     op.create_unique_constraint("uq_skill_slug", "skill", ["slug"])
     op.drop_index(
-        "uq_user_skill_preference_enabled_name",
+        "uq_user_skill_preference_name",
         table_name="user_skill_preference",
     )
     op.drop_constraint(
@@ -119,6 +132,16 @@ def downgrade() -> None:
         ondelete="CASCADE",
     )
     op.drop_constraint("uq_skill_name_id", "skill", type_="unique")
+    op.add_column(
+        "user_skill_preference",
+        sa.Column(
+            "enabled",
+            sa.Boolean(),
+            server_default=sa.true(),
+            nullable=False,
+        ),
+    )
+    op.alter_column("user_skill_preference", "enabled", server_default=None)
     op.drop_column("user_skill_preference", "name")
     op.alter_column(
         "skill",

--- a/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
+++ b/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
@@ -102,6 +102,12 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    duplicate_names = op.get_bind().scalar(
+        sa.text("SELECT count(*) != count(DISTINCT name) FROM skill")
+    )
+    if duplicate_names:
+        raise RuntimeError("Cannot downgrade while multiple skills share a name.")
+
     op.add_column(
         "skill",
         sa.Column("slug", sa.String(length=64), nullable=True),

--- a/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
+++ b/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
@@ -1,0 +1,154 @@
+"""Allow duplicate skill names.
+
+Revision ID: b72c72cd6ef6
+Revises: eec4fc85ef28
+Create Date: 2026-07-20 16:32:40.354227
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "b72c72cd6ef6"
+down_revision = "eec4fc85ef28"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "external_app",
+        sa.Column("name", sa.String(), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE external_app
+        SET name = skill.name
+        FROM skill
+        WHERE skill.id = external_app.skill_id
+        """
+    )
+    op.alter_column(
+        "external_app",
+        "name",
+        existing_type=sa.String(),
+        nullable=False,
+    )
+
+    op.drop_constraint("uq_skill_slug", "skill", type_="unique")
+    op.execute("UPDATE skill SET name = slug")
+    op.alter_column(
+        "skill",
+        "name",
+        existing_type=sa.String(),
+        type_=sa.String(length=64),
+        nullable=False,
+    )
+    op.create_index("ix_skill_name", "skill", ["name"])
+
+    op.add_column(
+        "user_skill_preference",
+        sa.Column("name", sa.String(length=64), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE user_skill_preference
+        SET name = skill.name
+        FROM skill
+        WHERE skill.id = user_skill_preference.skill_id
+        """
+    )
+    op.alter_column(
+        "user_skill_preference",
+        "name",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )
+    op.create_unique_constraint("uq_skill_id_name", "skill", ["id", "name"])
+    op.drop_constraint(
+        "user_skill_preference_skill_id_fkey",
+        "user_skill_preference",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "fk_user_skill_preference_skill_name",
+        "user_skill_preference",
+        "skill",
+        ["skill_id", "name"],
+        ["id", "name"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "uq_user_skill_preference_enabled_name",
+        "user_skill_preference",
+        ["user_id", "name"],
+        unique=True,
+        postgresql_where=sa.column("enabled").is_(True),
+    )
+    op.drop_column("skill", "slug")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "skill",
+        sa.Column("slug", sa.String(length=64), nullable=True),
+    )
+    op.execute("UPDATE skill SET slug = name")
+    op.alter_column(
+        "skill",
+        "slug",
+        existing_type=sa.String(length=64),
+        nullable=False,
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM skill GROUP BY slug HAVING count(*) > 1
+            ) THEN
+                RAISE EXCEPTION
+                    'Cannot downgrade while duplicate skill names exist';
+            END IF;
+        END$$
+        """
+    )
+    op.drop_index(
+        "uq_user_skill_preference_enabled_name",
+        table_name="user_skill_preference",
+    )
+    op.drop_constraint(
+        "fk_user_skill_preference_skill_name",
+        "user_skill_preference",
+        type_="foreignkey",
+    )
+    op.create_foreign_key(
+        "user_skill_preference_skill_id_fkey",
+        "user_skill_preference",
+        "skill",
+        ["skill_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.drop_constraint("uq_skill_id_name", "skill", type_="unique")
+    op.drop_column("user_skill_preference", "name")
+    op.drop_index("ix_skill_name", table_name="skill")
+    op.alter_column(
+        "skill",
+        "name",
+        existing_type=sa.String(length=64),
+        type_=sa.String(),
+        nullable=False,
+    )
+    op.execute(
+        """
+        UPDATE skill
+        SET name = external_app.name
+        FROM external_app
+        WHERE external_app.skill_id = skill.id
+        """
+    )
+    op.create_unique_constraint("uq_skill_slug", "skill", ["slug"])
+    op.drop_column("external_app", "name")

--- a/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
+++ b/backend/alembic/versions/b72c72cd6ef6_allow_duplicate_skill_names.py
@@ -13,7 +13,7 @@ enabled, and a unique index enforces at most one selection per ``(user_id,
 name)`` while preserving UUID-based skill identity.
 
 Revision ID: b72c72cd6ef6
-Revises: eec4fc85ef28
+Revises: bc9e56f2fb96
 Create Date: 2026-07-20 16:32:40.354227
 
 """
@@ -24,7 +24,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "b72c72cd6ef6"
-down_revision = "eec4fc85ef28"
+down_revision = "bc9e56f2fb96"
 branch_labels = None
 depends_on = None
 

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -287,10 +287,7 @@ def create_external_app(
     ``DUPLICATE_RESOURCE``. CUSTOM apps get a bundle-backed skill using
     ``skill_name``, or a generated ``custom-<uuid>`` name when omitted.
     """
-    from onyx.db.skill import (
-        add_skill__no_commit,
-        create_skill__no_commit,
-    )
+    from onyx.db.skill import add_new_skill__no_commit
 
     # No existing app to restore from on create, so a masked value is rejected.
     organization_credentials = resolve_masked_credentials(
@@ -299,7 +296,7 @@ def create_external_app(
 
     built_in_skill_id = EXTERNAL_APP_BUILT_IN_SKILL_IDS.get(app_type)
     if built_in_skill_id is not None:
-        skill = add_skill__no_commit(
+        skill = add_new_skill__no_commit(
             Skill(
                 name=built_in_skill_id,
                 description=description,
@@ -317,14 +314,17 @@ def create_external_app(
         # CUSTOM: use the bundle's canonical name supplied by ingestion, falling
         # back to a generated name when no bundle is supplied.
         custom_skill_name = skill_name or f"{app_type.value.lower()}-{uuid4().hex[:8]}"
-        skill = create_skill__no_commit(
-            name=custom_skill_name,
-            description=description,
-            bundle_file_id=bundle_file_id,
-            bundle_sha256=bundle_sha256,
-            public_permission=(SkillSharePermission.VIEWER if is_public else None),
-            author_user_id=author_user_id,
-            db_session=db_session,
+        skill = add_new_skill__no_commit(
+            Skill(
+                name=custom_skill_name,
+                description=description,
+                bundle_file_id=bundle_file_id,
+                bundle_sha256=bundle_sha256,
+                is_valid=True,
+                public_permission=(SkillSharePermission.VIEWER if is_public else None),
+                author_user_id=author_user_id,
+            ),
+            db_session,
             is_external_app_backing=True,
         )
     app = ExternalApp(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -215,10 +215,10 @@ def get_built_in_external_app(
 ) -> ExternalApp | None:
     """The tenant's built-in external app of the given type, or None.
 
-    Built-in apps are unique per type per tenant (enforced via the built-in
-    skill slug — see ``create_built_in_skill_row__no_commit``), so at most one
-    row matches. ``CUSTOM`` is rejected: it can repeat, so "the app of this
-    type" is meaningless — callers must pass a built-in type.
+    Built-in apps are unique per type per tenant (enforced when their backing
+    skill is created), so at most one row matches. ``CUSTOM`` is rejected: it
+    can repeat, so "the app of this type" is meaningless — callers must pass a
+    built-in type.
     """
     if not app_type.is_built_in:
         raise OnyxError(
@@ -273,22 +273,22 @@ def create_external_app(
     organization_credentials: dict[str, str],
     is_public: bool = False,
     author_user_id: UUID | None = None,
-    slug: str | None = None,
+    skill_name: str | None = None,
     action_policies: dict[str, EndpointPolicy] | None = None,
 ) -> ExternalApp:
     """Create the backing Skill row and the ExternalApp that references it (flush
     only — the caller commits after pushing, so a push failure rolls back). The
-    the linked skill currently owns display and bundle metadata; the external app
-    owns gateway state and availability.
+    linked skill owns bundle metadata and its canonical Agent Skills name; the
+    external app owns display metadata, gateway state, and availability.
 
     Built-in providers (``EXTERNAL_APP_BUILT_IN_SKILL_IDS``) get a built-in
-    skill row whose slug is the provider id, so slug uniqueness means one
-    instance per provider per tenant (duplicate raises ``DUPLICATE_RESOURCE``).
-    CUSTOM apps get a bundle-backed skill using ``slug``, or a generated
-    ``custom-<uuid>`` slug when omitted.
+    skill row whose name is the provider id. App-backed skill names remain
+    exclusive until app content is decoupled from skills, so a duplicate raises
+    ``DUPLICATE_RESOURCE``. CUSTOM apps get a bundle-backed skill using
+    ``skill_name``, or a generated ``custom-<uuid>`` name when omitted.
     """
     from onyx.db.skill import (
-        create_built_in_skill_row__no_commit,
+        add_skill__no_commit,
         create_skill__no_commit,
     )
 
@@ -299,30 +299,37 @@ def create_external_app(
 
     built_in_skill_id = EXTERNAL_APP_BUILT_IN_SKILL_IDS.get(app_type)
     if built_in_skill_id is not None:
-        skill = create_built_in_skill_row__no_commit(
-            built_in_skill_id=built_in_skill_id,
-            name=name,
-            description=description,
-            public_permission=(SkillSharePermission.VIEWER if is_public else None),
-            author_user_id=author_user_id,
-            db_session=db_session,
+        skill = add_skill__no_commit(
+            Skill(
+                name=built_in_skill_id,
+                description=description,
+                built_in_skill_id=built_in_skill_id,
+                bundle_file_id=None,
+                bundle_sha256=None,
+                is_valid=True,
+                public_permission=(SkillSharePermission.VIEWER if is_public else None),
+                author_user_id=author_user_id,
+            ),
+            db_session,
+            is_external_app_backing=True,
         )
     else:
         # CUSTOM: use the bundle's canonical name supplied by ingestion, falling
-        # back to a generated slug when no bundle is supplied.
-        custom_slug = slug or f"{app_type.value.lower()}-{uuid4().hex[:8]}"
+        # back to a generated name when no bundle is supplied.
+        custom_skill_name = skill_name or f"{app_type.value.lower()}-{uuid4().hex[:8]}"
         skill = create_skill__no_commit(
-            slug=custom_slug,
-            name=name,
+            name=custom_skill_name,
             description=description,
             bundle_file_id=bundle_file_id,
             bundle_sha256=bundle_sha256,
             public_permission=(SkillSharePermission.VIEWER if is_public else None),
             author_user_id=author_user_id,
             db_session=db_session,
+            is_external_app_backing=True,
         )
     app = ExternalApp(
         skill_id=skill.id,
+        name=name,
         app_type=app_type,
         upstream_url_patterns=upstream_url_patterns,
         auth_template=auth_template,
@@ -357,7 +364,7 @@ def update_external_app(
     Patch fields default to ``UNSET`` (left untouched); pass a value to set one.
     ``app_type`` is required and immutable — a mismatch raises, blocking
     cross-editing built-in vs custom. Passing ``new_bundle_file_id`` swaps the
-    bundle (slug unchanged) and returns the previous blob id for post-commit
+    bundle (skill name unchanged) and returns the previous blob id for post-commit
     cleanup, else ``None``.
 
     Raises ``OnyxError(NOT_FOUND)`` if absent, or ``INVALID_INPUT`` on app_type
@@ -382,12 +389,12 @@ def update_external_app(
     if is_set(enabled):
         app.enabled = enabled
     if is_set(name):
-        app.skill.name = name
+        app.name = name
     if is_set(description):
         app.skill.description = description
     old_bundle_file_id: str | None = None
     if new_bundle_file_id is not None:
-        # Keep the slug; only the bundle bytes change.
+        # Keep the skill name; only the bundle bytes change.
         old_bundle_file_id = app.skill.bundle_file_id
         app.skill.bundle_file_id = new_bundle_file_id
         app.skill.bundle_sha256 = new_bundle_sha256

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -687,8 +687,8 @@ class UserSkillPreference(Base):
 
     __table_args__ = (
         ForeignKeyConstraint(
-            ["skill_id", "name"],
-            ["skill.id", "skill.name"],
+            ["name", "skill_id"],
+            ["skill.name", "skill.id"],
             name="fk_user_skill_preference_skill_name",
             ondelete="CASCADE",
         ),
@@ -4580,8 +4580,7 @@ class Skill(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("id", "name", name="uq_skill_id_name"),
-        Index("ix_skill_name", "name"),
+        UniqueConstraint("name", "id", name="uq_skill_name_id"),
         CheckConstraint(
             "(built_in_skill_id IS NULL) <> (bundle_file_id IS NULL)",
             name="ck_skill_definition_source",

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -679,12 +679,28 @@ class UserSkillPreference(Base):
     )
     skill_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
-        ForeignKey("skill.id", ondelete="CASCADE"),
         primary_key=True,
     )
+    # Denormalized for the enabled-name index; the composite FK keeps it exact.
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False)
 
-    __table_args__ = (Index("ix_user_skill_preference_skill_id", "skill_id"),)
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["skill_id", "name"],
+            ["skill.id", "skill.name"],
+            name="fk_user_skill_preference_skill_name",
+            ondelete="CASCADE",
+        ),
+        Index("ix_user_skill_preference_skill_id", "skill_id"),
+        Index(
+            "uq_user_skill_preference_enabled_name",
+            "user_id",
+            "name",
+            unique=True,
+            postgresql_where=enabled.is_(True),
+        ),
+    )
 
 
 class DocumentSet__User(Base):
@@ -4498,9 +4514,8 @@ class Skill(Base):
         PGUUID(as_uuid=True), primary_key=True, default=uuid4
     )
 
-    # Admin-controlled metadata (editable post-creation via PATCH).
-    slug: Mapped[str] = mapped_column(String(64), nullable=False)
-    name: Mapped[str] = mapped_column(String, nullable=False)
+    # Immutable Agent Skills name and sandbox directory name.
+    name: Mapped[str] = mapped_column(String(64), nullable=False)
     description: Mapped[str] = mapped_column(Text, nullable=False)
 
     # Discriminator: when set, definition (source files, has_template, etc.)
@@ -4565,7 +4580,8 @@ class Skill(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("slug", name="uq_skill_slug"),
+        UniqueConstraint("id", "name", name="uq_skill_id_name"),
+        Index("ix_skill_name", "name"),
         CheckConstraint(
             "(built_in_skill_id IS NULL) <> (bundle_file_id IS NULL)",
             name="ck_skill_definition_source",
@@ -6453,8 +6469,8 @@ class ExternalApp(Base):
     __tablename__ = "external_app"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    # Display and bundle metadata currently live on the linked Skill row.
-    # App availability is independent of user skill preferences.
+    # App display metadata is independent of the linked skill's canonical name.
+    name: Mapped[str] = mapped_column(String, nullable=False)
     skill_id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True),
         ForeignKey("skill.id", ondelete="CASCADE"),

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -681,9 +681,8 @@ class UserSkillPreference(Base):
         PGUUID(as_uuid=True),
         primary_key=True,
     )
-    # Denormalized for the enabled-name index; the composite FK keeps it exact.
+    # Denormalized for name uniqueness; the composite FK keeps it exact.
     name: Mapped[str] = mapped_column(String(64), nullable=False)
-    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False)
 
     __table_args__ = (
         ForeignKeyConstraint(
@@ -694,11 +693,10 @@ class UserSkillPreference(Base):
         ),
         Index("ix_user_skill_preference_skill_id", "skill_id"),
         Index(
-            "uq_user_skill_preference_enabled_name",
+            "uq_user_skill_preference_name",
             "user_id",
             "name",
             unique=True,
-            postgresql_where=enabled.is_(True),
         ),
     )
 

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -486,6 +486,7 @@ def set_skill_enabled_for_user(
         policy=SkillAccessPolicy.VIEW,
         user=user,
         db_session=db_session,
+        lock_for_update=True,
     )
     if skill is None:
         raise OnyxError(

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -348,7 +348,7 @@ def fetch_skill(
     return db_session.scalars(stmt).one_or_none()
 
 
-def add_skill__no_commit(
+def add_new_skill__no_commit(
     skill: Skill,
     db_session: Session,
     *,
@@ -376,31 +376,23 @@ def add_skill__no_commit(
     return skill
 
 
-def create_skill__no_commit(
-    *,
-    name: str,
-    description: str,
-    bundle_file_id: str,
-    bundle_sha256: str,
-    public_permission: SkillSharePermission | None = None,
-    author_user_id: UUID | None,
+def enable_new_skill_if_name_available__no_commit(
+    skill: Skill,
+    user_id: UUID,
     db_session: Session,
-    is_external_app_backing: bool = False,
-) -> Skill:
-    skill = Skill(
-        name=name,
-        description=description,
-        bundle_file_id=bundle_file_id,
-        bundle_sha256=bundle_sha256,
-        is_valid=True,
-        public_permission=public_permission,
-        author_user_id=author_user_id,
+) -> bool:
+    inserted_user_id = db_session.scalar(
+        insert(UserSkillPreference)
+        .values(user_id=user_id, skill_id=skill.id, name=skill.name)
+        .on_conflict_do_nothing(
+            index_elements=[
+                UserSkillPreference.user_id,
+                UserSkillPreference.name,
+            ]
+        )
+        .returning(UserSkillPreference.user_id)
     )
-    return add_skill__no_commit(
-        skill,
-        db_session,
-        is_external_app_backing=is_external_app_backing,
-    )
+    return inserted_user_id is not None
 
 
 def replace_skill_bundle(
@@ -493,7 +485,7 @@ def set_skill_enabled_for_user(
     db_session.execute(
         select(User)
         .where(User.id == user.id)  # ty: ignore[invalid-argument-type]
-        .with_for_update()
+        .with_for_update(of=User)
     )
     skill = fetch_skill(
         skill_id,

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -33,6 +33,7 @@ from sqlalchemy import (
     func,
     or_,
     select,
+    true,
     update,
 )
 from sqlalchemy.dialects.postgresql import insert
@@ -480,13 +481,6 @@ def set_skill_enabled_for_user(
     user: User,
     db_session: Session,
 ) -> Skill:
-    # Serialize selection changes so a confirmed same-name replacement is
-    # atomic even when requests arrive concurrently.
-    db_session.execute(
-        select(User)
-        .where(User.id == user.id)  # ty: ignore[invalid-argument-type]
-        .with_for_update(of=User)
-    )
     skill = fetch_skill(
         skill_id,
         policy=SkillAccessPolicy.VIEW,
@@ -515,42 +509,30 @@ def set_skill_enabled_for_user(
         )
         return skill
 
-    conflicting_skill_id = db_session.scalar(
-        select(UserSkillPreference.skill_id)
-        .where(
-            UserSkillPreference.user_id == user.id,
-            UserSkillPreference.name == skill.name,
-            UserSkillPreference.skill_id != skill.id,
-        )
-        .limit(1)
+    preference_insert = insert(UserSkillPreference).values(
+        user_id=user.id,
+        skill_id=skill.id,
+        name=skill.name,
     )
-    if conflicting_skill_id is not None and not replace_conflict:
+    enabled_skill_id = db_session.scalar(
+        preference_insert.on_conflict_do_update(
+            index_elements=[
+                UserSkillPreference.user_id,
+                UserSkillPreference.name,
+            ],
+            set_={"skill_id": preference_insert.excluded.skill_id},
+            where=(
+                true()
+                if replace_conflict
+                else UserSkillPreference.skill_id == preference_insert.excluded.skill_id
+            ),
+        ).returning(UserSkillPreference.skill_id)
+    )
+    if enabled_skill_id is None:
         raise OnyxError(
             OnyxErrorCode.SKILL_NAME_CONFLICT,
             f"Another skill named '{skill.name}' is already enabled.",
         )
-    if conflicting_skill_id is not None:
-        db_session.execute(
-            delete(UserSkillPreference).where(
-                UserSkillPreference.user_id == user.id,
-                UserSkillPreference.name == skill.name,
-            )
-        )
-
-    db_session.execute(
-        insert(UserSkillPreference)
-        .values(
-            user_id=user.id,
-            skill_id=skill.id,
-            name=skill.name,
-        )
-        .on_conflict_do_nothing(
-            index_elements=[
-                UserSkillPreference.user_id,
-                UserSkillPreference.skill_id,
-            ],
-        )
-    )
     return skill
 
 

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -53,12 +53,10 @@ from onyx.db.models import (
     User__UserGroup,
     UserSkillPreference,
 )
-from onyx.db.utils import is_fk_violation, is_unique_violation
+from onyx.db.utils import is_fk_violation
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import BUILT_IN_SKILLS
-
-SKILL_SLUG_UNIQUE_CONSTRAINT = "uq_skill_slug"
 
 
 class SkillAccessPolicy(str, Enum):
@@ -217,7 +215,7 @@ def _skill_select_with_eager_load(*, order_by_name: bool) -> Select[tuple[Skill]
         selectinload(Skill.group_shares).selectinload(Skill__UserGroup.user_group),
     )
     if order_by_name:
-        stmt = stmt.order_by(Skill.name)
+        stmt = stmt.order_by(Skill.name, Skill.id)
     return stmt
 
 
@@ -357,23 +355,36 @@ def fetch_skill(
     return db_session.scalars(stmt).one_or_none()
 
 
-def _add_skill(skill: Skill, db_session: Session) -> Skill:
+def add_skill__no_commit(
+    skill: Skill,
+    db_session: Session,
+    *,
+    is_external_app_backing: bool = False,
+) -> Skill:
+    # App-backed skills share the sandbox directory namespace until their
+    # lifecycle is decoupled, so they cannot share a name with another skill.
+    existing_name = select(Skill.id).where(Skill.name == skill.name)
+    if not is_external_app_backing:
+        existing_name = existing_name.join(
+            ExternalApp,
+            ExternalApp.skill_id == Skill.id,
+        )
+    if db_session.scalar(existing_name.limit(1)) is not None:
+        conflicting_resource = (
+            "another skill" if is_external_app_backing else "an external app"
+        )
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"The skill name '{skill.name}' is already used by {conflicting_resource}.",
+        )
+
     db_session.add(skill)
-    try:
-        db_session.flush()
-    except IntegrityError as exc:
-        if is_unique_violation(exc, SKILL_SLUG_UNIQUE_CONSTRAINT):
-            raise OnyxError(
-                OnyxErrorCode.DUPLICATE_RESOURCE,
-                f"A skill with slug '{skill.slug}' already exists.",
-            ) from exc
-        raise
+    db_session.flush()
     return skill
 
 
 def create_skill__no_commit(
     *,
-    slug: str,
     name: str,
     description: str,
     bundle_file_id: str,
@@ -381,9 +392,9 @@ def create_skill__no_commit(
     public_permission: SkillSharePermission | None = None,
     author_user_id: UUID | None,
     db_session: Session,
+    is_external_app_backing: bool = False,
 ) -> Skill:
     skill = Skill(
-        slug=slug,
         name=name,
         description=description,
         bundle_file_id=bundle_file_id,
@@ -392,31 +403,11 @@ def create_skill__no_commit(
         public_permission=public_permission,
         author_user_id=author_user_id,
     )
-    return _add_skill(skill, db_session)
-
-
-def create_built_in_skill_row__no_commit(
-    *,
-    built_in_skill_id: str,
-    name: str,
-    description: str,
-    author_user_id: UUID | None = None,
-    public_permission: SkillSharePermission | None = None,
-    db_session: Session,
-) -> Skill:
-    """Create an on-demand built-in row without bundle storage."""
-    skill = Skill(
-        slug=built_in_skill_id,
-        name=name,
-        description=description,
-        built_in_skill_id=built_in_skill_id,
-        bundle_file_id=None,
-        bundle_sha256=None,
-        is_valid=True,
-        public_permission=public_permission,
-        author_user_id=author_user_id,
+    return add_skill__no_commit(
+        skill,
+        db_session,
+        is_external_app_backing=is_external_app_backing,
     )
-    return _add_skill(skill, db_session)
 
 
 def replace_skill_bundle(
@@ -437,7 +428,7 @@ def replace_skill_bundle(
     if skill.built_in_skill_id is not None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"Skill '{skill.slug}' is a built-in and has no bundle.",
+            f"Skill '{skill.name}' is a built-in and has no bundle.",
         )
 
     # Custom rows always have a bundle (XOR check constraint), but guard
@@ -445,7 +436,7 @@ def replace_skill_bundle(
     if skill.bundle_file_id is None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"Skill '{skill.slug}' has no bundle to replace.",
+            f"Skill '{skill.name}' has no bundle to replace.",
         )
 
     old_bundle_file_id = skill.bundle_file_id
@@ -496,6 +487,14 @@ def skill_user_states(
     }
 
 
+def _lock_user_skill_preferences(user_id: UUID, db_session: Session) -> None:
+    db_session.execute(
+        select(User)
+        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
+        .with_for_update()
+    )
+
+
 def set_skill_enabled_for_user(
     *,
     skill_id: UUID,
@@ -503,12 +502,15 @@ def set_skill_enabled_for_user(
     user: User,
     db_session: Session,
 ) -> Skill:
+    # Serialize preference mutations for this user. This makes disabling the
+    # previous same-name selection and enabling the requested row one atomic
+    # switch even when requests arrive concurrently.
+    _lock_user_skill_preferences(user.id, db_session)
     skill = fetch_skill(
         skill_id,
         policy=SkillAccessPolicy.VIEW,
         user=user,
         db_session=db_session,
-        lock_for_update=True,
     )
     if skill is None:
         raise OnyxError(
@@ -523,11 +525,24 @@ def set_skill_enabled_for_user(
             "This skill cannot be enabled or disabled.",
         )
 
+    if enabled:
+        db_session.execute(
+            update(UserSkillPreference)
+            .where(
+                UserSkillPreference.user_id == user.id,
+                UserSkillPreference.name == skill.name,
+                UserSkillPreference.skill_id != skill.id,
+                UserSkillPreference.enabled.is_(True),
+            )
+            .values(enabled=False)
+        )
+
     preference_upsert = (
         insert(UserSkillPreference)
         .values(
             user_id=user.id,
             skill_id=skill.id,
+            name=skill.name,
             enabled=enabled,
         )
         .on_conflict_do_update(
@@ -549,12 +564,23 @@ def set_skill_enabled_for_user(
 def enable_skill_for_user_if_unset__no_commit(
     skill: Skill, user_id: UUID, db_session: Session
 ) -> None:
+    _lock_user_skill_preferences(user_id, db_session)
+    same_name_is_enabled = db_session.scalar(
+        select(UserSkillPreference.user_id)
+        .where(
+            UserSkillPreference.user_id == user_id,
+            UserSkillPreference.name == skill.name,
+            UserSkillPreference.enabled.is_(True),
+        )
+        .limit(1)
+    )
     db_session.execute(
         insert(UserSkillPreference)
         .values(
             user_id=user_id,
             skill_id=skill.id,
-            enabled=True,
+            name=skill.name,
+            enabled=same_name_is_enabled is None,
         )
         .on_conflict_do_nothing(
             index_elements=[
@@ -613,7 +639,7 @@ def transfer_skill_ownership(
     if skill.built_in_skill_id is not None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"Skill '{skill.slug}' is a built-in and cannot have its ownership transferred.",
+            f"Skill '{skill.name}' is a built-in and cannot have its ownership transferred.",
         )
 
     previous_owner_user_id = skill.author_user_id

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -170,20 +170,13 @@ def _is_editable_by_user(user: User) -> ColumnElement[bool]:
 
 
 def _is_enabled_for_user(user: User) -> ColumnElement[bool]:
-    explicit_preference = (
-        select(UserSkillPreference.enabled)
-        .where(
-            UserSkillPreference.user_id == user.id,
-            UserSkillPreference.skill_id == Skill.id,
-        )
-        .correlate(Skill)
-        .scalar_subquery()
-    )
     return or_(
-        explicit_preference.is_(True),
-        and_(
-            explicit_preference.is_(None),
-            Skill.built_in_skill_id.isnot(None),
+        Skill.built_in_skill_id.isnot(None),
+        exists(
+            select(UserSkillPreference.user_id).where(
+                UserSkillPreference.user_id == user.id,
+                UserSkillPreference.skill_id == Skill.id,
+            )
         ),
     )
 
@@ -487,25 +480,21 @@ def skill_user_states(
     }
 
 
-def _lock_user_skill_preferences(user_id: UUID, db_session: Session) -> None:
-    db_session.execute(
-        select(User)
-        .where(User.id == user_id)  # ty: ignore[invalid-argument-type]
-        .with_for_update()
-    )
-
-
 def set_skill_enabled_for_user(
     *,
     skill_id: UUID,
     enabled: bool,
+    replace_conflict: bool = False,
     user: User,
     db_session: Session,
 ) -> Skill:
-    # Serialize preference mutations for this user. This makes disabling the
-    # previous same-name selection and enabling the requested row one atomic
-    # switch even when requests arrive concurrently.
-    _lock_user_skill_preferences(user.id, db_session)
+    # Serialize selection changes so a confirmed same-name replacement is
+    # atomic even when requests arrive concurrently.
+    db_session.execute(
+        select(User)
+        .where(User.id == user.id)  # ty: ignore[invalid-argument-type]
+        .with_for_update()
+    )
     skill = fetch_skill(
         skill_id,
         policy=SkillAccessPolicy.VIEW,
@@ -525,70 +514,52 @@ def set_skill_enabled_for_user(
             "This skill cannot be enabled or disabled.",
         )
 
-    if enabled:
+    if not enabled:
         db_session.execute(
-            update(UserSkillPreference)
-            .where(
+            delete(UserSkillPreference).where(
+                UserSkillPreference.user_id == user.id,
+                UserSkillPreference.skill_id == skill.id,
+            )
+        )
+        return skill
+
+    conflicting_skill_id = db_session.scalar(
+        select(UserSkillPreference.skill_id)
+        .where(
+            UserSkillPreference.user_id == user.id,
+            UserSkillPreference.name == skill.name,
+            UserSkillPreference.skill_id != skill.id,
+        )
+        .limit(1)
+    )
+    if conflicting_skill_id is not None and not replace_conflict:
+        raise OnyxError(
+            OnyxErrorCode.SKILL_NAME_CONFLICT,
+            f"Another skill named '{skill.name}' is already enabled.",
+        )
+    if conflicting_skill_id is not None:
+        db_session.execute(
+            delete(UserSkillPreference).where(
                 UserSkillPreference.user_id == user.id,
                 UserSkillPreference.name == skill.name,
-                UserSkillPreference.skill_id != skill.id,
-                UserSkillPreference.enabled.is_(True),
             )
-            .values(enabled=False)
         )
 
-    preference_upsert = (
+    db_session.execute(
         insert(UserSkillPreference)
         .values(
             user_id=user.id,
             skill_id=skill.id,
             name=skill.name,
-            enabled=enabled,
-        )
-        .on_conflict_do_update(
-            index_elements=[
-                UserSkillPreference.user_id,
-                UserSkillPreference.skill_id,
-            ],
-            set_={"enabled": enabled},
-        )
-        .returning(UserSkillPreference)
-    )
-    db_session.scalars(
-        preference_upsert,
-        execution_options={"populate_existing": True},
-    ).one()
-    return skill
-
-
-def enable_skill_for_user_if_unset__no_commit(
-    skill: Skill, user_id: UUID, db_session: Session
-) -> None:
-    _lock_user_skill_preferences(user_id, db_session)
-    same_name_is_enabled = db_session.scalar(
-        select(UserSkillPreference.user_id)
-        .where(
-            UserSkillPreference.user_id == user_id,
-            UserSkillPreference.name == skill.name,
-            UserSkillPreference.enabled.is_(True),
-        )
-        .limit(1)
-    )
-    db_session.execute(
-        insert(UserSkillPreference)
-        .values(
-            user_id=user_id,
-            skill_id=skill.id,
-            name=skill.name,
-            enabled=same_name_is_enabled is None,
         )
         .on_conflict_do_nothing(
             index_elements=[
                 UserSkillPreference.user_id,
                 UserSkillPreference.skill_id,
-            ]
+            ],
         )
     )
+    return skill
 
 
 def _flush_shares(db_session: Session, fk_violation_detail: str) -> None:
@@ -648,11 +619,6 @@ def transfer_skill_ownership(
 
     try:
         skill.author_user_id = new_owner_user_id
-        enable_skill_for_user_if_unset__no_commit(
-            skill,
-            new_owner_user_id,
-            db_session,
-        )
         db_session.execute(
             delete(Skill__User).where(
                 Skill__User.skill_id == skill.id,

--- a/backend/onyx/error_handling/error_codes.py
+++ b/backend/onyx/error_handling/error_codes.py
@@ -67,6 +67,7 @@ class OnyxErrorCode(Enum):
     # --------------------------------------------------------------------------
     CONFLICT = ("CONFLICT", 409)
     DUPLICATE_RESOURCE = ("DUPLICATE_RESOURCE", 409)
+    SKILL_NAME_CONFLICT = ("SKILL_NAME_CONFLICT", 409)
 
     # --------------------------------------------------------------------------
     # Rate Limiting / Quotas (429 / 402)

--- a/backend/onyx/external_apps/matching/engine.py
+++ b/backend/onyx/external_apps/matching/engine.py
@@ -122,9 +122,9 @@ def _app_name(app: ExternalApp) -> str:
     provider = get_provider_for_app(app)
     if provider is not None:
         return provider.spec.app_name
-    # CUSTOM apps have no provider; their human name lives on the linked skill.
+    # CUSTOM apps have no provider; use their independently editable display name.
     if app.app_type == ExternalAppType.CUSTOM:
-        return app.skill.name
+        return app.name
     return app.app_type.value
 
 

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -91,7 +91,7 @@ def _to_admin_response(
     managed = MULTI_TENANT and get_onyx_managed_provider(app.app_type) is not None
     return ExternalAppAdminResponse(
         id=app.id,
-        name=app.skill.name,
+        name=app.name,
         description=app.skill.description,
         app_type=app.app_type,
         # Managed built-ins: hide Onyx-owned config/creds. Else mask secrets — the
@@ -131,9 +131,9 @@ def _to_user_response(
 
     return ExternalAppUserResponse(
         id=app.id,
-        name=app.skill.name,
+        name=app.name,
         description=app.skill.description,
-        slug=app.skill.slug,
+        slug=app.skill.name,
         app_type=app.app_type,
         credential_keys=required_keys,
         credential_values=credential_values,
@@ -317,7 +317,7 @@ def create_custom_external_app(
             auth_template=parsed_auth_template,
             organization_credentials=parsed_org_credentials,
             is_public=True,
-            slug=ingested.canonical_name,
+            skill_name=ingested.canonical_name,
         )
         # Push before commit so a failure rolls back the create + orphaned blob.
         push_skill_to_affected_sandboxes(app.skill, db_session)
@@ -334,7 +334,7 @@ def replace_custom_app_bundle(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> ExternalAppAdminResponse:
-    """Replace a CUSTOM app's bundle bytes, keeping its slug. Multipart-only
+    """Replace a CUSTOM app's bundle bytes, keeping its skill name. Multipart-only
     channel for bundle swaps; field edits use ``PATCH /admin/apps/{id}``. 404 if
     absent; rejects built-in apps (no bundle).
     """
@@ -350,7 +350,7 @@ def replace_custom_app_bundle(
         read_bundle_file(bundle.file),
         bundle.filename,
         file_store,
-        expected_name=app.skill.slug,
+        expected_name=app.skill.name,
     ) as ingested:
         app, old_bundle_file_id = update_external_app(
             db_session=db_session,

--- a/backend/onyx/server/features/build/external_apps/models.py
+++ b/backend/onyx/server/features/build/external_apps/models.py
@@ -17,7 +17,7 @@ class CreateBuiltInExternalAppRequest(BaseModel):
     transaction). ``upstream_url_patterns`` is a list of regex patterns matched
     by the egress proxy against outbound request URLs.
 
-    Skill identity (slug, bundle bytes, sharing scope) is derived server-side
+    Skill identity (name, bundle bytes, sharing scope) is derived server-side
     from ``app_type``; admins don't supply it. New apps are enabled by default.
     """
 

--- a/backend/onyx/server/features/build/external_apps/oauth.py
+++ b/backend/onyx/server/features/build/external_apps/oauth.py
@@ -52,7 +52,7 @@ def _oauth_client_credentials(app: ExternalApp) -> tuple[str, str]:
     if not client_id or not client_secret:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"{app.skill.name} is missing client_id or client_secret — "
+            f"{app.name} is missing client_id or client_secret — "
             "ask an admin to fill them in on the Manage Apps page.",
         )
     return client_id, client_secret
@@ -69,7 +69,7 @@ def _oauth_provider_or_raise(app: ExternalApp) -> OAuthExternalAppProvider:
     if not isinstance(provider, OAuthExternalAppProvider):
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"App '{app.skill.name}' does not use an OAuth flow.",
+            f"App '{app.name}' does not use an OAuth flow.",
         )
     return provider
 
@@ -194,13 +194,13 @@ def handle_external_app_oauth_callback(
     except requests.RequestException as exc:
         logger.warning(
             "%s OAuth token exchange network error for app %d: %s",
-            app.skill.name,
+            app.name,
             app.id,
             exc,
         )
         raise OnyxError(
             OnyxErrorCode.BAD_GATEWAY,
-            f"Could not reach {app.skill.name} to complete OAuth.",
+            f"Could not reach {app.name} to complete OAuth.",
         )
 
     try:
@@ -208,12 +208,12 @@ def handle_external_app_oauth_callback(
     except ValueError:
         logger.warning(
             "%s OAuth token response was not JSON (status=%d)",
-            app.skill.name,
+            app.name,
             response.status_code,
         )
         raise OnyxError(
             OnyxErrorCode.BAD_GATEWAY,
-            f"{app.skill.name} returned a non-JSON response during OAuth.",
+            f"{app.name} returned a non-JSON response during OAuth.",
             status_code_override=response.status_code,
         )
 
@@ -221,14 +221,14 @@ def handle_external_app_oauth_callback(
     if error:
         logger.warning(
             "%s OAuth token exchange failed for user %s, app %d: %s",
-            app.skill.name,
+            app.name,
             user.id,
             app.id,
             error,
         )
         raise OnyxError(
             OnyxErrorCode.BAD_GATEWAY,
-            f"{app.skill.name} OAuth failed: {error}",
+            f"{app.name} OAuth failed: {error}",
         )
 
     # Stamp an absolute `expires_at` now so the lazy-refresh path can later

--- a/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
+++ b/backend/onyx/server/features/build/sandbox/util/agent_instructions.py
@@ -87,7 +87,7 @@ def build_connectable_apps_list(apps: Iterable[ExternalApp]) -> str:
     yet. The heading and explanatory prose live in AGENTS.template.md; this only
     supplies the dynamic ``{{CONNECTABLE_APPS_LIST}}`` value, with a fallback
     line when there are no apps."""
-    entries = sorted((app.skill.slug, _truncate(app.skill.description)) for app in apps)
+    entries = sorted((app.skill.name, _truncate(app.skill.description)) for app in apps)
     if not entries:
         return "No connectable apps available."
     return "\n".join(f"- **{slug}**: {desc}" for slug, desc in entries)

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -222,17 +222,16 @@ def create_custom_skill(
             ),
             db_session,
         )
-        auto_enabled = auto_enable and enable_new_skill_if_name_available__no_commit(
+        if auto_enable and not enable_new_skill_if_name_available__no_commit(
             skill, user.id, db_session
-        )
-        if auto_enable and not auto_enabled:
+        ):
             raise OnyxError(
                 OnyxErrorCode.SKILL_NAME_CONFLICT,
                 f"A skill named '{skill.name}' is already enabled.",
             )
         db_session.commit()
 
-    if auto_enabled:
+    if auto_enable:
         push_skill_to_affected_sandboxes(skill, db_session)
         db_session.commit()
 
@@ -304,17 +303,16 @@ def create_custom_skill_from_editor(
             ),
             db_session,
         )
-        auto_enabled = auto_enable and enable_new_skill_if_name_available__no_commit(
+        if auto_enable and not enable_new_skill_if_name_available__no_commit(
             skill, user.id, db_session
-        )
-        if auto_enable and not auto_enabled:
+        ):
             raise OnyxError(
                 OnyxErrorCode.SKILL_NAME_CONFLICT,
                 f"A skill named '{skill.name}' is already enabled.",
             )
         db_session.commit()
 
-    if auto_enabled:
+    if auto_enable:
         push_skill_to_affected_sandboxes(skill, db_session)
         db_session.commit()
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -17,7 +17,6 @@ from onyx.db.skill import (
     affected_user_ids_for_skill,
     create_skill__no_commit,
     delete_skill,
-    enable_skill_for_user_if_unset__no_commit,
     fetch_skill,
     list_skills,
     replace_skill_bundle,
@@ -154,6 +153,7 @@ def set_skill_enabled_for_current_user(
     skill = set_skill_enabled_for_user(
         skill_id=skill_id,
         enabled=request.enabled,
+        replace_conflict=request.replace_conflict,
         user=user,
         db_session=db_session,
     )
@@ -217,11 +217,8 @@ def create_custom_skill(
             author_user_id=user.id,
             db_session=db_session,
         )
-        enable_skill_for_user_if_unset__no_commit(skill, user.id, db_session)
         db_session.commit()
 
-    push_skill_to_affected_sandboxes(skill, db_session)
-    db_session.commit()
     return skill_response_for_user(
         skill,
         user,
@@ -286,11 +283,8 @@ def create_custom_skill_from_editor(
             author_user_id=user.id,
             db_session=db_session,
         )
-        enable_skill_for_user_if_unset__no_commit(skill, user.id, db_session)
         db_session.commit()
 
-    push_skill_to_affected_sandboxes(skill, db_session)
-    db_session.commit()
     return _editable_skill_response(skill, user, db_session)
 
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -14,9 +14,10 @@ from onyx.db.enums import AccountType, Permission, SkillSharePermission
 from onyx.db.models import Skill, User
 from onyx.db.skill import (
     SkillAccessPolicy,
+    add_new_skill__no_commit,
     affected_user_ids_for_skill,
-    create_skill__no_commit,
     delete_skill,
+    enable_new_skill_if_name_available__no_commit,
     fetch_skill,
     list_skills,
     replace_skill_bundle,
@@ -200,6 +201,7 @@ def preview_skill_for_current_user(
 @user_router.post("/custom")
 def create_custom_skill(
     bundle: UploadFile = File(...),
+    auto_enable: Annotated[bool, Form()] = True,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SkillResponse:
@@ -209,14 +211,29 @@ def create_custom_skill(
         bundle.filename,
         file_store,
     ) as ingested:
-        skill = create_skill__no_commit(
-            name=ingested.canonical_name,
-            description=ingested.description,
-            bundle_file_id=ingested.bundle_file_id,
-            bundle_sha256=ingested.bundle_sha256,
-            author_user_id=user.id,
-            db_session=db_session,
+        skill = add_new_skill__no_commit(
+            Skill(
+                name=ingested.canonical_name,
+                description=ingested.description,
+                bundle_file_id=ingested.bundle_file_id,
+                bundle_sha256=ingested.bundle_sha256,
+                is_valid=True,
+                author_user_id=user.id,
+            ),
+            db_session,
         )
+        auto_enabled = auto_enable and enable_new_skill_if_name_available__no_commit(
+            skill, user.id, db_session
+        )
+        if auto_enable and not auto_enabled:
+            raise OnyxError(
+                OnyxErrorCode.SKILL_NAME_CONFLICT,
+                f"A skill named '{skill.name}' is already enabled.",
+            )
+        db_session.commit()
+
+    if auto_enabled:
+        push_skill_to_affected_sandboxes(skill, db_session)
         db_session.commit()
 
     return skill_response_for_user(
@@ -233,6 +250,7 @@ def create_custom_skill_from_editor(
     description: Annotated[str, Form(min_length=1)],
     instructions_markdown: Annotated[str, Form(min_length=1)],
     upload: Annotated[UploadFile | None, File()] = None,
+    auto_enable: Annotated[bool, Form()] = True,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SkillEditableDetailResponse:
@@ -275,14 +293,29 @@ def create_custom_skill_from_editor(
         file_store,
         expected_name=canonical_name,
     ) as ingested:
-        skill = create_skill__no_commit(
-            name=ingested.canonical_name,
-            description=ingested.description,
-            bundle_file_id=ingested.bundle_file_id,
-            bundle_sha256=ingested.bundle_sha256,
-            author_user_id=user.id,
-            db_session=db_session,
+        skill = add_new_skill__no_commit(
+            Skill(
+                name=ingested.canonical_name,
+                description=ingested.description,
+                bundle_file_id=ingested.bundle_file_id,
+                bundle_sha256=ingested.bundle_sha256,
+                is_valid=True,
+                author_user_id=user.id,
+            ),
+            db_session,
         )
+        auto_enabled = auto_enable and enable_new_skill_if_name_available__no_commit(
+            skill, user.id, db_session
+        )
+        if auto_enable and not auto_enabled:
+            raise OnyxError(
+                OnyxErrorCode.SKILL_NAME_CONFLICT,
+                f"A skill named '{skill.name}' is already enabled.",
+            )
+        db_session.commit()
+
+    if auto_enabled:
+        push_skill_to_affected_sandboxes(skill, db_session)
         db_session.commit()
 
     return _editable_skill_response(skill, user, db_session)

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -111,9 +111,9 @@ def _replace_skill_bundle_from_editor(
     file_store = get_default_file_store()
     with ingested_skill_bundle(
         bundle_bytes,
-        f"{skill.slug}.zip",
+        f"{skill.name}.zip",
         file_store,
-        expected_name=skill.slug,
+        expected_name=skill.name,
     ) as ingested:
         old_file_id = replace_skill_bundle(
             skill=skill,
@@ -210,7 +210,6 @@ def create_custom_skill(
         file_store,
     ) as ingested:
         skill = create_skill__no_commit(
-            slug=ingested.canonical_name,
             name=ingested.canonical_name,
             description=ingested.description,
             bundle_file_id=ingested.bundle_file_id,
@@ -280,7 +279,6 @@ def create_custom_skill_from_editor(
         expected_name=canonical_name,
     ) as ingested:
         skill = create_skill__no_commit(
-            slug=ingested.canonical_name,
             name=ingested.canonical_name,
             description=ingested.description,
             bundle_file_id=ingested.bundle_file_id,
@@ -368,7 +366,7 @@ def replace_current_user_skill_bundle(
         read_bundle_file(bundle.file),
         bundle.filename,
         file_store,
-        expected_name=skill.slug,
+        expected_name=skill.name,
     ) as ingested:
         old_file_id = replace_skill_bundle(
             skill=skill,
@@ -494,13 +492,13 @@ def patch_current_user_skill(
                 )
             new_bundle_bytes = rewrite_custom_bundle_skill_md(
                 old_bundle_bytes,
-                canonical_name=skill.slug,
+                canonical_name=skill.name,
                 description=description,
                 instructions_markdown=instructions_markdown,
             )
             new_bundle_file_id = save_skill_bundle_bytes(
                 new_bundle_bytes,
-                display_name=f"{skill.slug}.zip",
+                display_name=f"{skill.name}.zip",
                 file_store=file_store,
             )
             old_bundle_file_id = replace_skill_bundle(
@@ -640,7 +638,7 @@ def transfer_current_user_skill_ownership(
     if skill.built_in_skill_id is not None:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
-            f"Skill '{skill.slug}' is a built-in and cannot change ownership.",
+            f"Skill '{skill.name}' is a built-in and cannot change ownership.",
         )
 
     ownership_vacant = (

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -189,6 +189,7 @@ class SkillBundleInspectResponse(BaseModel):
 
 class SkillEnableRequest(BaseModel):
     enabled: bool
+    replace_conflict: bool = False
 
 
 class SkillCreateRequest(BaseModel):

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -28,7 +28,6 @@ class SkillGroupShare(BaseModel):
 class SkillResponse(BaseModel):
     source: Literal["builtin", "custom"]
     id: UUID
-    slug: str
     name: str
     description: str
 
@@ -62,7 +61,6 @@ class SkillResponse(BaseModel):
         return cls(
             source="builtin",
             id=skill.id,
-            slug=skill.slug,
             name=skill.name,
             description=skill.description,
             is_available=definition.is_available(db_session),
@@ -104,7 +102,6 @@ class SkillResponse(BaseModel):
         return cls(
             source="custom",
             id=skill.id,
-            slug=skill.slug,
             name=skill.name,
             description=skill.description,
             is_valid=skill.is_valid,

--- a/backend/onyx/server/features/skill/response_helpers.py
+++ b/backend/onyx/server/features/skill/response_helpers.py
@@ -142,7 +142,7 @@ def skills_list_response_for_user(
         ):
             logger.warning(
                 "Skill row %s references unknown built-in %s; hiding from listing",
-                skill.slug,
+                skill.name,
                 skill.built_in_skill_id,
             )
             continue

--- a/backend/onyx/skills/content.py
+++ b/backend/onyx/skills/content.py
@@ -46,7 +46,7 @@ def read_custom_skill_bundle_bytes(
     if skill.bundle_file_id is None:
         raise OnyxError(
             OnyxErrorCode.INTERNAL_ERROR,
-            f"Custom skill '{skill.slug}' has no bundle.",
+            f"Custom skill '{skill.name}' has no bundle.",
         )
     store = file_store or get_default_file_store()
     try:
@@ -54,6 +54,6 @@ def read_custom_skill_bundle_bytes(
     except Exception as exc:
         raise OnyxError(
             OnyxErrorCode.INTERNAL_ERROR,
-            f"Failed to read bundle for skill '{skill.slug}'.",
+            f"Failed to read bundle for skill '{skill.name}'.",
         ) from exc
     return bundle_bytes

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -21,6 +21,8 @@ from onyx.db.skill import (
     list_skills,
     persist_skill_validity,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.build.db.sandbox import (
     get_sandbox_user_map,
@@ -91,7 +93,7 @@ def _add_static_builtin(
         if not path.is_file() or _is_excluded(path, source_dir):
             continue
         rel = path.relative_to(source_dir)
-        files[f"{skill.slug}/{rel.as_posix()}"] = path.read_bytes()
+        files[f"{skill.name}/{rel.as_posix()}"] = path.read_bytes()
 
 
 def _render_template(
@@ -101,14 +103,14 @@ def _render_template(
     db_session: Session,
     user: User,
 ) -> None:
-    """Overwrite ``{slug}/SKILL.md`` with a per-user rendering. company-search
+    """Overwrite ``{name}/SKILL.md`` with a per-user rendering. company-search
     and external-app built-ins have renderers; any other templated built-in logs
     a warning and ships the static siblings as-is."""
     if definition.built_in_skill_id == COMPANY_SEARCH.built_in_skill_id:
         rendered = render_company_search_skill(
             db_session, user, definition.source_dir.parent
         )
-        files[f"{skill.slug}/SKILL.md"] = rendered.encode("utf-8")
+        files[f"{skill.name}/SKILL.md"] = rendered.encode("utf-8")
         return
 
     app_type = EXTERNAL_APP_SKILL_ID_TO_APP_TYPE.get(definition.built_in_skill_id)
@@ -120,7 +122,7 @@ def _render_template(
             external_app,
             definition.source_dir,
         )
-        files[f"{skill.slug}/SKILL.md"] = rendered.encode("utf-8")
+        files[f"{skill.name}/SKILL.md"] = rendered.encode("utf-8")
         return
 
     logger.warning(
@@ -135,12 +137,12 @@ def _add_bundle_bytes(files: FileSet, skill: Skill, bundle_bytes: bytes) -> None
             for info in zf.infolist():
                 if info.is_dir():
                     continue
-                bundle_files[f"{skill.slug}/{info.filename}"] = zf.read(info)
+                bundle_files[f"{skill.name}/{info.filename}"] = zf.read(info)
         files.update(bundle_files)
     except Exception:
         logger.warning(
             "Failed to unpack bundle for skill %s (%s), skipping",
-            skill.slug,
+            skill.name,
             skill.bundle_file_id,
             exc_info=True,
         )
@@ -157,6 +159,16 @@ def _assemble_fileset(
     validation before their FileStore bundle is unpacked. Invalid,
     indeterminate, and unknown built-in rows are skipped.
     """
+    skills = list(skills)
+    seen_names: set[str] = set()
+    for skill in skills:
+        if skill.name in seen_names:
+            raise OnyxError(
+                OnyxErrorCode.INTERNAL_ERROR,
+                f"Multiple enabled skills are named '{skill.name}'.",
+            )
+        seen_names.add(skill.name)
+
     files: FileSet = {}
     validity_updates: list[SkillValidityUpdate] = []
     file_store = get_default_file_store()
@@ -206,7 +218,7 @@ def _assemble_fileset(
         if definition is None:
             logger.warning(
                 "Skill row %s references unknown built-in %s; skipping",
-                skill.slug,
+                skill.name,
                 skill.built_in_skill_id,
             )
             continue

--- a/backend/onyx/skills/validation.py
+++ b/backend/onyx/skills/validation.py
@@ -61,13 +61,13 @@ def validate_stored_custom_skill(
     skill: Skill,
     file_store: FileStore,
 ) -> SkillValidationResult:
-    if len(skill.slug) > 64 or not SKILL_NAME_PATTERN.fullmatch(skill.slug):
+    if len(skill.name) > 64 or not SKILL_NAME_PATTERN.fullmatch(skill.name):
         return SkillValidationResult(
             is_valid=False,
             normalized_bundle=None,
             detail="persisted skill name does not match the canonical grammar",
         )
-    if skill.slug in BUILT_IN_SKILLS:
+    if skill.name in BUILT_IN_SKILLS:
         return SkillValidationResult(
             is_valid=False,
             normalized_bundle=None,
@@ -119,7 +119,7 @@ def validate_stored_custom_skill(
             detail=f"stored bundle is invalid: {detail}",
         )
 
-    if document.metadata.name != skill.slug:
+    if document.metadata.name != skill.name:
         return SkillValidationResult(
             is_valid=False,
             normalized_bundle=None,

--- a/backend/tests/external_dependency_unit/craft/conftest.py
+++ b/backend/tests/external_dependency_unit/craft/conftest.py
@@ -277,7 +277,7 @@ def seeded_skill(
     request.addfinalizer(_cleanup)
 
     def _make(
-        slug: str,
+        name: str,
         public: bool = False,
         groups: Iterable[UserGroup] | None = None,
         bundle_files: dict[str, bytes | str] | None = None,
@@ -286,7 +286,7 @@ def seeded_skill(
         if bundle_files is None:
             bundle_files = {
                 "SKILL.md": (
-                    f"---\nname: {slug}\ndescription: Seeded skill {slug}\n---\n"
+                    f"---\nname: {name}\ndescription: Seeded skill {name}\n---\n"
                 ),
             }
         bundle_bytes = _build_zip(bundle_files)
@@ -294,7 +294,7 @@ def seeded_skill(
 
         bundle_file_id = file_store.save_file(
             content=io.BytesIO(bundle_bytes),
-            display_name=f"{slug}.zip",
+            display_name=f"{name}.zip",
             file_origin=FileOrigin.SKILL_BUNDLE,
             file_type="application/zip",
         )
@@ -302,9 +302,8 @@ def seeded_skill(
 
         skill = Skill(
             id=uuid4(),
-            slug=slug,
-            name=slug,
-            description=f"Seeded skill {slug}",
+            name=name,
+            description=f"Seeded skill {name}",
             bundle_file_id=bundle_file_id,
             bundle_sha256=bundle_sha256,
             public_permission=SkillSharePermission.VIEWER if public else None,

--- a/backend/tests/external_dependency_unit/craft/db_helpers.py
+++ b/backend/tests/external_dependency_unit/craft/db_helpers.py
@@ -131,7 +131,7 @@ def make_sandbox(
 def make_skill(
     db_session: Session,
     *,
-    slug: str | None = None,
+    name: str | None = None,
     is_public: bool = False,
     public_permission: SkillSharePermission = SkillSharePermission.VIEWER,
     author_user_id: UUID | None = None,
@@ -144,8 +144,7 @@ def make_skill(
     """
     skill = Skill(
         id=uuid4(),
-        slug=slug or f"helper-skill-{uuid4().hex[:8]}",
-        name=slug or "helper-skill",
+        name=name or f"helper-skill-{uuid4().hex[:8]}",
         description="d",
         bundle_file_id=f"bundle-{uuid4().hex[:8]}",
         bundle_sha256="0" * 64,
@@ -161,19 +160,17 @@ def make_built_in_skill_row(
     db_session: Session,
     *,
     built_in_skill_id: str,
-    slug: str | None = None,
     name: str | None = None,
     description: str = "test built-in",
     is_public: bool = True,
 ) -> Skill:
     """Insert a built-in-style ``Skill`` row pointing at a
-    ``built_in_skill_id``. Slug defaults to ``built_in_skill_id`` (the
+    ``built_in_skill_id``. Name defaults to ``built_in_skill_id`` (the
     default seeder convention), but can be overridden to test the
     multi-row case where several skills share the same built-in id.
     Bundle fields stay NULL (required by the XOR check constraint)."""
     skill = Skill(
         id=uuid4(),
-        slug=slug or built_in_skill_id,
         name=name or built_in_skill_id,
         description=description,
         built_in_skill_id=built_in_skill_id,
@@ -190,24 +187,22 @@ def reset_built_in_skill_row(
     db_session: Session,
     *,
     built_in_skill_id: str,
-    slug: str | None = None,
     name: str | None = None,
     description: str = "test built-in",
     is_public: bool = True,
 ) -> Skill:
     """Idempotently (re)create a built-in row for ``built_in_skill_id``.
 
-    Deletes any existing row with the same slug first, so tests stay
+    Deletes any existing row with the same name first, so tests stay
     robust whether or not the migration-seeded canonical row is present
     (it always is on a migrated DB, but another test's teardown may have
     removed it). Returns the freshly inserted row.
     """
-    target_slug = slug or built_in_skill_id
-    db_session.execute(delete(Skill).where(Skill.slug == target_slug))
+    target_name = name or built_in_skill_id
+    db_session.execute(delete(Skill).where(Skill.name == target_name))
     return make_built_in_skill_row(
         db_session,
         built_in_skill_id=built_in_skill_id,
-        slug=slug,
         name=name,
         description=description,
         is_public=is_public,
@@ -229,6 +224,7 @@ def make_external_app(
     policy overrides in ``action_policies`` (``{action_id: policy}``)."""
     app = ExternalApp(
         skill_id=skill.id,
+        name=skill.name,
         app_type=app_type,
         enabled=enabled,
         upstream_url_patterns=upstream_url_patterns or [],

--- a/backend/tests/external_dependency_unit/craft/test_action_matching.py
+++ b/backend/tests/external_dependency_unit/craft/test_action_matching.py
@@ -402,5 +402,5 @@ def test_external_app_matcher_credentialless_app_is_gated(
     assert matched_actions.actions[0].action_type == WHOLE_DOMAIN_ACTION_TYPE
     assert matched_actions.actions[0].policy == EndpointPolicy.ASK
     assert matched_actions.target.key == (GatedAppKind.EXTERNAL_APP, app.id)
-    # CUSTOM apps have no provider; the name comes from the linked skill.
-    assert matched_actions.app_name == skill.name
+    # CUSTOM apps have no provider; the name comes from app display metadata.
+    assert matched_actions.app_name == app.name

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -45,14 +45,14 @@ def _isolate_built_in_skill_rows(
 
 def _seed_canonical(db_session: Session) -> None:
     """Insert one default row per codified built-in, mirroring what the
-    migration seeds (slug == built_in_skill_id, public, enabled)."""
+    migration seeds (name == built_in_skill_id, public, enabled)."""
     for built_in_skill_id in BUILT_IN_SKILLS:
         make_built_in_skill_row(db_session, built_in_skill_id=built_in_skill_id)
     db_session.commit()
 
 
 def _row(db_session: Session, built_in_skill_id: str) -> Skill:
-    row = db_session.scalar(select(Skill).where(Skill.slug == built_in_skill_id))
+    row = db_session.scalar(select(Skill).where(Skill.name == built_in_skill_id))
     assert row is not None, f"expected built-in row for {built_in_skill_id}"
     return row
 
@@ -200,7 +200,7 @@ class TestBuiltInIsImmutable:
         db_session: Session,
         test_user: User,
     ) -> None:
-        custom = make_skill(db_session, slug=f"custom-{uuid4().hex[:8]}")
+        custom = make_skill(db_session, name=f"custom-{uuid4().hex[:8]}")
         custom.author_user_id = test_user.id
         db_session.commit()
 
@@ -219,14 +219,12 @@ class TestNonUniqueBuiltInId:
         self, db_session: Session
     ) -> None:
         """``built_in_skill_id`` is not unique — a single built-in can
-        back multiple rows (different slugs / sharing scopes). Slug
-        remains the natural unique key."""
+        back multiple rows with different canonical names and sharing scopes."""
         make_built_in_skill_row(db_session, built_in_skill_id="pptx")
         make_built_in_skill_row(
             db_session,
             built_in_skill_id="pptx",
-            slug="pptx-team-a",
-            name="pptx (team A)",
+            name="pptx-team-a",
             is_public=False,
         )
         db_session.commit()
@@ -235,7 +233,7 @@ class TestNonUniqueBuiltInId:
             db_session.scalars(select(Skill).where(Skill.built_in_skill_id == "pptx"))
         )
         assert len(matches) == 2
-        assert {s.slug for s in matches} == {"pptx", "pptx-team-a"}
+        assert {s.name for s in matches} == {"pptx", "pptx-team-a"}
 
 
 class TestDefinitionSourceInvariant:

--- a/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_connectable_apps.py
@@ -26,13 +26,13 @@ def test_lists_only_unconnected_apps_and_renders_them(
     # Connectable: public, needs a user token the org hasn't pre-filled.
     make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="needs-setup", is_public=True),
+        skill=make_skill(db_session, name="needs-setup", is_public=True),
         auth_template=_USER_TOKEN_TEMPLATE,
     )
     # Connected: the user already stored the token.
     connected = make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="already-connected", is_public=True),
+        skill=make_skill(db_session, name="already-connected", is_public=True),
         auth_template=_USER_TOKEN_TEMPLATE,
     )
     make_user_credential(
@@ -41,7 +41,7 @@ def test_lists_only_unconnected_apps_and_renders_them(
     # Org-credentialed: org pre-fills the token, so there's nothing to set up.
     make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="org-filled", is_public=True),
+        skill=make_skill(db_session, name="org-filled", is_public=True),
         auth_template=_USER_TOKEN_TEMPLATE,
         organization_credentials={"token": "shared"},
     )
@@ -49,24 +49,24 @@ def test_lists_only_unconnected_apps_and_renders_them(
     # the user would connect a skill that never injects into their sandbox.
     make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="hidden-app", is_public=False),
+        skill=make_skill(db_session, name="hidden-app", is_public=False),
         auth_template=_USER_TOKEN_TEMPLATE,
     )
     make_external_app(
         db_session,
-        skill=make_skill(db_session, slug="disabled-app", is_public=True),
+        skill=make_skill(db_session, name="disabled-app", is_public=True),
         auth_template=_USER_TOKEN_TEMPLATE,
         enabled=False,
     )
     db_session.commit()
 
-    slugs = {app.skill.slug for app in get_connectable_apps_for_user(db_session, user)}
+    names = {app.skill.name for app in get_connectable_apps_for_user(db_session, user)}
 
-    assert "needs-setup" in slugs
-    assert "already-connected" not in slugs
-    assert "org-filled" not in slugs
-    assert "hidden-app" not in slugs
-    assert "disabled-app" not in slugs
+    assert "needs-setup" in names
+    assert "already-connected" not in names
+    assert "org-filled" not in names
+    assert "hidden-app" not in names
+    assert "disabled-app" not in names
 
     apps_list = build_connectable_apps_list(
         get_connectable_apps_for_user(db_session, user)

--- a/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
+++ b/backend/tests/external_dependency_unit/craft/test_custom_external_app_create.py
@@ -72,7 +72,7 @@ def _upload(
 def _create(
     db_session: Session,
     test_user: User,
-    slug: str,
+    skill_name: str,
     *,
     auth_template: str = json.dumps(_AUTH_TEMPLATE),
     organization_credentials: str = json.dumps({"api_key": "sk-test"}),
@@ -84,7 +84,7 @@ def _create(
         upstream_url_patterns=json.dumps(_UPSTREAM),
         auth_template=auth_template,
         organization_credentials=organization_credentials,
-        bundle=_upload(f"{slug}.zip"),
+        bundle=_upload(f"{skill_name}.zip"),
         _=test_user,
         db_session=db_session,
     )
@@ -105,32 +105,34 @@ def test_create_persists_skill_and_app(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
 
-    resp = _create(db_session, test_user, slug)
+    resp = _create(db_session, test_user, skill_name)
 
-    # Form name overrides the bundle's SKILL.md name; blank description falls
-    # back to the bundle's parsed description.
+    # The form name is app display metadata; the bundle frontmatter supplies the
+    # linked skill's canonical name. Blank description falls back to the
+    # bundle's parsed description.
     assert resp.app_type == ExternalAppType.CUSTOM
     assert resp.name == "My Form Name"
     assert resp.description == "Bundle description"
     assert resp.upstream_url_patterns == _UPSTREAM
 
-    skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+    skill = db_session.scalar(select(Skill).where(Skill.name == skill_name))
     assert skill is not None
     assert skill.built_in_skill_id is None
     assert skill.bundle_file_id  # bundle was stored
-    assert skill.name == "My Form Name"
+    assert skill.name == skill_name
 
     app = db_session.scalar(select(ExternalApp).where(ExternalApp.skill_id == skill.id))
     assert app is not None
+    assert app.name == "My Form Name"
     assert app.auth_template == _AUTH_TEMPLATE
     # organization_credentials is encrypted at rest -> decrypt to compare.
     assert app.organization_credentials.get_value(apply_mask=False) == {
         "api_key": "sk-test"
     }
 
-    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.execute(delete(Skill).where(Skill.name == skill_name))
     db_session.commit()
 
 
@@ -148,9 +150,9 @@ def test_custom_app_glob_matches_deep_path(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
 
-    resp = _create(db_session, test_user, slug)
+    resp = _create(db_session, test_user, skill_name)
     # The glob is stored and round-tripped verbatim — no regex stored at rest.
     assert resp.upstream_url_patterns == _UPSTREAM
 
@@ -161,7 +163,7 @@ def test_custom_app_glob_matches_deep_path(
     assert resolve_app_for_url("https://api.example.com/v10/users/@me", [app]) is app
     assert resolve_app_for_url("https://other.example.com/x", [app]) is None
 
-    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.execute(delete(Skill).where(Skill.name == skill_name))
     db_session.commit()
 
 
@@ -174,7 +176,7 @@ def test_create_rejects_wildcard_host_glob(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
 
     with pytest.raises(OnyxError):
         create_custom_external_app(
@@ -183,12 +185,12 @@ def test_create_rejects_wildcard_host_glob(
             upstream_url_patterns=json.dumps(["https://*.example.com/*"]),
             auth_template=json.dumps(_AUTH_TEMPLATE),
             organization_credentials=json.dumps({"api_key": "sk-test"}),
-            bundle=_upload(f"{slug}.zip"),
+            bundle=_upload(f"{skill_name}.zip"),
             _=test_user,
             db_session=db_session,
         )
     # Rejected before persistence — no skill row created.
-    assert db_session.scalar(select(Skill).where(Skill.slug == slug)) is None
+    assert db_session.scalar(select(Skill).where(Skill.name == skill_name)) is None
 
 
 def test_create_with_no_credentials(
@@ -200,21 +202,21 @@ def test_create_with_no_credentials(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
 
     resp = _create(
         db_session,
         test_user,
-        slug,
+        skill_name,
         auth_template=json.dumps({}),
         organization_credentials=json.dumps({}),
     )
 
     assert resp.auth_template == {}
     assert resp.organization_credentials == {}
-    assert db_session.scalar(select(Skill).where(Skill.slug == slug)) is not None
+    assert db_session.scalar(select(Skill).where(Skill.name == skill_name)) is not None
 
-    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.execute(delete(Skill).where(Skill.name == skill_name))
     db_session.commit()
 
 
@@ -227,10 +229,10 @@ def test_edit_updates_config_and_replaces_bundle(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
 
-    created = _create(db_session, test_user, slug)
-    skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+    created = _create(db_session, test_user, skill_name)
+    skill = db_session.scalar(select(Skill).where(Skill.name == skill_name))
     assert skill is not None
     original_bundle_id = skill.bundle_file_id
 
@@ -255,7 +257,7 @@ def test_edit_updates_config_and_replaces_bundle(
 
     rebundled = replace_custom_app_bundle(
         external_app_id=created.id,
-        bundle=_upload(f"{slug}.zip", marker="v2"),
+        bundle=_upload(f"{skill_name}.zip", marker="v2"),
         _=test_user,
         db_session=db_session,
     )
@@ -263,14 +265,18 @@ def test_edit_updates_config_and_replaces_bundle(
     assert rebundled.name == "Renamed App"
 
     db_session.expire_all()
-    skill = db_session.scalar(select(Skill).where(Skill.slug == slug))
+    skill = db_session.scalar(select(Skill).where(Skill.name == skill_name))
     assert skill is not None
-    # Slug is stable across a bundle swap, but the blob changed.
-    assert skill.name == "Renamed App"
+    # The skill name is stable across app edits and bundle swaps, but the blob
+    # changed.
+    assert skill.name == skill_name
+    app = db_session.scalar(select(ExternalApp).where(ExternalApp.id == created.id))
+    assert app is not None
+    assert app.name == "Renamed App"
     assert skill.bundle_file_id
     assert skill.bundle_file_id != original_bundle_id
 
-    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.execute(delete(Skill).where(Skill.name == skill_name))
     db_session.commit()
 
 
@@ -286,13 +292,13 @@ def test_admin_response_masks_secret_and_edit_preserves_it(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
     raw_secret = "super-secret-client-value-1234567890"
 
     created = _create(
         db_session,
         test_user,
-        slug,
+        skill_name,
         organization_credentials=json.dumps({"api_key": raw_secret}),
     )
 
@@ -324,7 +330,7 @@ def test_admin_response_masks_secret_and_edit_preserves_it(
         "api_key": raw_secret
     }
 
-    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.execute(delete(Skill).where(Skill.name == skill_name))
     db_session.commit()
 
 
@@ -337,7 +343,7 @@ def test_create_rejects_bundle_without_skill_md(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
 
     with pytest.raises(OnyxError):
         create_custom_external_app(
@@ -346,12 +352,12 @@ def test_create_rejects_bundle_without_skill_md(
             upstream_url_patterns=json.dumps(_UPSTREAM),
             auth_template=json.dumps(_AUTH_TEMPLATE),
             organization_credentials=json.dumps({}),
-            bundle=_upload(f"{slug}.zip", with_skill_md=False),
+            bundle=_upload(f"{skill_name}.zip", with_skill_md=False),
             _=test_user,
             db_session=db_session,
         )
 
-    assert db_session.scalar(select(Skill).where(Skill.slug == slug)) is None
+    assert db_session.scalar(select(Skill).where(Skill.name == skill_name)) is None
 
 
 def test_create_requires_bundle(
@@ -386,7 +392,7 @@ def test_create_rejects_bundle_over_skill_upload_size_limit(
         _noop,
     )
     monkeypatch.setattr("onyx.skills.bundle.DEFAULT_TOTAL_MAX_BYTES", 1)
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
 
     with pytest.raises(OnyxError) as exc:
         create_custom_external_app(
@@ -395,13 +401,13 @@ def test_create_rejects_bundle_over_skill_upload_size_limit(
             upstream_url_patterns=json.dumps(_UPSTREAM),
             auth_template=json.dumps(_AUTH_TEMPLATE),
             organization_credentials=json.dumps({}),
-            bundle=_upload(f"{slug}.zip"),
+            bundle=_upload(f"{skill_name}.zip"),
             _=test_user,
             db_session=db_session,
         )
 
     assert exc.value.error_code == OnyxErrorCode.PAYLOAD_TOO_LARGE
-    assert db_session.scalar(select(Skill).where(Skill.slug == slug)) is None
+    assert db_session.scalar(select(Skill).where(Skill.name == skill_name)) is None
 
 
 def test_replace_rejects_bundle_over_skill_upload_size_limit(
@@ -413,22 +419,22 @@ def test_replace_rejects_bundle_over_skill_upload_size_limit(
         "onyx.server.features.build.external_apps.api.push_skill_to_affected_sandboxes",
         _noop,
     )
-    slug = f"custom-test-{uuid4().hex[:8]}"
-    created = _create(db_session, test_user, slug)
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
+    created = _create(db_session, test_user, skill_name)
 
     monkeypatch.setattr("onyx.skills.bundle.DEFAULT_TOTAL_MAX_BYTES", 1)
 
     with pytest.raises(OnyxError) as exc:
         replace_custom_app_bundle(
             external_app_id=created.id,
-            bundle=_upload(f"{slug}.zip", marker="v2"),
+            bundle=_upload(f"{skill_name}.zip", marker="v2"),
             _=test_user,
             db_session=db_session,
         )
 
     assert exc.value.error_code == OnyxErrorCode.PAYLOAD_TOO_LARGE
 
-    db_session.execute(delete(Skill).where(Skill.slug == slug))
+    db_session.execute(delete(Skill).where(Skill.name == skill_name))
     db_session.commit()
 
 
@@ -456,9 +462,9 @@ def test_create_cleans_up_blob_on_failure(
         lambda _fs, file_id: deleted.append(file_id),
     )
 
-    slug = f"custom-test-{uuid4().hex[:8]}"
+    skill_name = f"custom-test-{uuid4().hex[:8]}"
     with pytest.raises(OnyxError):
-        _create(db_session, test_user, slug)
+        _create(db_session, test_user, skill_name)
 
     # The bundle was stored during ingest, so the post-failure cleanup must run.
     assert len(deleted) == 1

--- a/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
@@ -31,16 +31,16 @@ def _noop(*_args: object, **_kwargs: object) -> None:
 
 @pytest.fixture(autouse=True)
 def _clean_slack_rows(db_session: Session) -> Generator[None, None, None]:
-    db_session.execute(delete(Skill).where(Skill.slug == "slack"))
+    db_session.execute(delete(Skill).where(Skill.name == "slack"))
     db_session.commit()
     yield
-    db_session.execute(delete(Skill).where(Skill.slug == "slack"))
+    db_session.execute(delete(Skill).where(Skill.name == "slack"))
     db_session.commit()
 
 
 def _slack_app(db_session: Session) -> ExternalApp:
     skill = reset_built_in_skill_row(
-        db_session, built_in_skill_id="slack", name="Slack", is_public=True
+        db_session, built_in_skill_id="slack", is_public=True
     )
     app = make_external_app(
         db_session,
@@ -85,6 +85,8 @@ def test_patch_updates_config_on_non_managed_built_in(
     db_session.expire_all()
     stored = get_external_app_by_id(db_session, app_id)
     assert stored is not None
+    assert stored.name == "Slack — Eng"
+    assert stored.skill.name == "slack"
     assert list(stored.upstream_url_patterns) == new_patterns
     assert stored.auth_template == new_auth
     assert stored.organization_credentials.get_value(apply_mask=False) == {

--- a/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_fileset.py
@@ -32,11 +32,11 @@ from tests.external_dependency_unit.craft.db_helpers import (
 # Slack ships on-disk skill content; require a single user-supplied key.
 _AUTH_TEMPLATE = {"Authorization": "Bearer {token}"}
 _FULL_CREDS = {"token": "xoxp-test"}
-_SLACK_ID = SLACK.built_in_skill_id  # == slug == on-disk dir ("slack")
+_SLACK_ID = SLACK.built_in_skill_id  # Also the skill name and on-disk directory.
 
 
 def _slack_skill(db_session: Session) -> Skill:
-    """A built-in Slack skill row (slug == built_in_skill_id), mirroring what
+    """A built-in Slack skill row (name == built_in_skill_id), mirroring what
     ``create_external_app`` makes for a connected Slack app. ``reset_*`` keeps
     it independent of the migration-seeded built-in rows."""
     return reset_built_in_skill_row(

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
@@ -75,8 +75,8 @@ def test_admin_view_hides_external_apps(
     test_user: User,  # noqa: ARG001
 ) -> None:
     admin = make_user(db_session, role=UserRole.ADMIN)
-    regular = make_skill(db_session, is_public=True, slug="plain-admin-skill")
-    external = make_skill(db_session, is_public=True, slug="ext-admin-hidden")
+    regular = make_skill(db_session, is_public=True, name="plain-admin-skill")
+    external = make_skill(db_session, is_public=True, name="ext-admin-hidden")
     make_external_app(db_session, skill=external, auth_template={})
 
     visible = _skill_ids(admin, db_session, SkillAccessPolicy.VIEW)
@@ -165,13 +165,13 @@ def test_use_includes_external_app_with_no_user_credentials_required(
     empty_template_skill = make_skill(
         db_session,
         is_public=True,
-        slug="ext-empty-template",
+        name="ext-empty-template",
     )
     make_external_app(db_session, skill=empty_template_skill, auth_template={})
     org_filled_skill = make_skill(
         db_session,
         is_public=True,
-        slug="ext-org-fills-all",
+        name="ext-org-fills-all",
     )
     make_external_app(
         db_session,
@@ -190,7 +190,7 @@ def test_regular_shared_skill_still_requires_enabled_preference(
     test_user: User,  # noqa: ARG001
 ) -> None:
     user = make_user(db_session)
-    skill = make_skill(db_session, is_public=True, slug="plain-skill")
+    skill = make_skill(db_session, is_public=True, name="plain-skill")
 
     assert skill.id in _skill_ids(user, db_session, SkillAccessPolicy.VIEW)
     assert skill.id not in _skill_ids(user, db_session, SkillAccessPolicy.USE)

--- a/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
+++ b/backend/tests/external_dependency_unit/craft/test_managed_external_apps.py
@@ -50,7 +50,7 @@ def _noop(*_args: object, **_kwargs: object) -> None:
 
 def _cleanup(db_session: Session) -> None:
     # Deleting the built-in skill cascades to its external_app + credential rows.
-    db_session.execute(delete(Skill).where(Skill.slug.in_(_BUILT_IN_SLUGS)))
+    db_session.execute(delete(Skill).where(Skill.name.in_(_BUILT_IN_SLUGS)))
     db_session.commit()
 
 

--- a/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
@@ -142,7 +142,6 @@ def test_preference_commit_succeeds_when_sandbox_push_fails(
     )
     assert response.enabled is True
     assert preference is not None
-    assert preference.enabled is True
 
 
 def test_create_reserved_name_rejects_from_bundle_metadata(

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -4,13 +4,17 @@ from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
 from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill__User, Skill__UserGroup, UserSkillPreference
 from onyx.db.skill import (
+    SkillAccessPolicy,
+    list_skills,
     replace_skill_shares,
+    set_skill_enabled_for_user,
     skill_user_states,
     transfer_skill_ownership,
 )
@@ -54,7 +58,7 @@ def test_skill_user_states_resolve_defaults_and_visibility(
     invalid_custom = make_skill(
         db_session,
         is_public=True,
-        slug=f"invalid-{uuid4().hex[:8]}",
+        name=f"invalid-{uuid4().hex[:8]}",
     )
     invalid_custom.is_valid = False
     built_in = make_built_in_skill_row(
@@ -255,6 +259,7 @@ def test_transfer_skill_ownership_preserves_new_owner_explicit_disable(
     preference = UserSkillPreference(
         user_id=new_owner.id,
         skill_id=skill.id,
+        name=skill.name,
         enabled=False,
     )
     db_session.add(preference)
@@ -268,6 +273,111 @@ def test_transfer_skill_ownership_preserves_new_owner_explicit_disable(
 
     assert skill.author_user_id == new_owner.id
     assert preference.enabled is False
+
+
+def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> None:
+    first_user = make_user(db_session)
+    second_user = make_user(db_session)
+    name = f"shared-name-{uuid4().hex[:8]}"
+    first_skill = make_skill(db_session, name=name, is_public=True)
+    second_skill = make_skill(db_session, name=name, is_public=True)
+
+    set_skill_enabled_for_user(
+        skill_id=first_skill.id,
+        enabled=True,
+        user=first_user,
+        db_session=db_session,
+    )
+    set_skill_enabled_for_user(
+        skill_id=second_skill.id,
+        enabled=True,
+        user=second_user,
+        db_session=db_session,
+    )
+
+    assert {
+        skill.id
+        for skill in list_skills(
+            policy=SkillAccessPolicy.USE,
+            user=first_user,
+            db_session=db_session,
+        )
+        if skill.name == name
+    } == {first_skill.id}
+    assert {
+        skill.id
+        for skill in list_skills(
+            policy=SkillAccessPolicy.USE,
+            user=second_user,
+            db_session=db_session,
+        )
+        if skill.name == name
+    } == {second_skill.id}
+
+    set_skill_enabled_for_user(
+        skill_id=second_skill.id,
+        enabled=True,
+        user=first_user,
+        db_session=db_session,
+    )
+
+    preferences = list(
+        db_session.scalars(
+            select(UserSkillPreference)
+            .where(UserSkillPreference.user_id == first_user.id)
+            .where(UserSkillPreference.name == name)
+        )
+    )
+    assert {
+        preference.skill_id for preference in preferences if preference.enabled
+    } == {second_skill.id}
+
+
+def test_database_rejects_two_enabled_same_name_preferences(
+    db_session: Session,
+) -> None:
+    user = make_user(db_session)
+    name = f"constrained-name-{uuid4().hex[:8]}"
+    first_skill = make_skill(db_session, name=name, is_public=True)
+    second_skill = make_skill(db_session, name=name, is_public=True)
+    db_session.add(
+        UserSkillPreference(
+            user_id=user.id,
+            skill_id=first_skill.id,
+            name=name,
+            enabled=True,
+        )
+    )
+    db_session.flush()
+
+    with pytest.raises(IntegrityError):
+        with db_session.begin_nested():
+            db_session.add(
+                UserSkillPreference(
+                    user_id=user.id,
+                    skill_id=second_skill.id,
+                    name=name,
+                    enabled=True,
+                )
+            )
+            db_session.flush()
+
+
+def test_preference_name_must_match_skill_name(db_session: Session) -> None:
+    user = make_user(db_session)
+    skill = make_skill(db_session, is_public=True)
+
+    with pytest.raises(IntegrityError):
+        with db_session.begin_nested():
+            db_session.add(
+                UserSkillPreference(
+                    user_id=user.id,
+                    skill_id=skill.id,
+                    name="different-name",
+                    enabled=True,
+                )
+            )
+            db_session.flush()
 
 
 def test_transfer_skill_ownership_self_transfer_preserves_direct_share(

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -222,7 +222,7 @@ def test_transfer_skill_ownership_removes_new_owner_direct_share_and_upgrades_pr
     assert direct_shares == {previous_owner.id: SkillSharePermission.EDITOR}
 
 
-def test_transfer_skill_ownership_adds_previous_owner_editor_share(
+def test_transfer_skill_ownership_does_not_enable_skill_for_new_owner(
     db_session: Session,
 ) -> None:
     previous_owner = make_user(db_session)
@@ -242,11 +242,10 @@ def test_transfer_skill_ownership_adds_previous_owner_editor_share(
         UserSkillPreference,
         {"user_id": new_owner.id, "skill_id": skill.id},
     )
-    assert preference is not None
-    assert preference.enabled is True
+    assert preference is None
 
 
-def test_transfer_skill_ownership_preserves_new_owner_explicit_disable(
+def test_transfer_skill_ownership_preserves_new_owner_selection(
     db_session: Session,
 ) -> None:
     previous_owner = make_user(db_session)
@@ -260,7 +259,6 @@ def test_transfer_skill_ownership_preserves_new_owner_explicit_disable(
         user_id=new_owner.id,
         skill_id=skill.id,
         name=skill.name,
-        enabled=False,
     )
     db_session.add(preference)
     db_session.flush()
@@ -272,7 +270,13 @@ def test_transfer_skill_ownership_preserves_new_owner_explicit_disable(
     )
 
     assert skill.author_user_id == new_owner.id
-    assert preference.enabled is False
+    assert (
+        db_session.get(
+            UserSkillPreference,
+            {"user_id": new_owner.id, "skill_id": skill.id},
+        )
+        is preference
+    )
 
 
 def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> None:
@@ -314,9 +318,19 @@ def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> Non
         if skill.name == name
     } == {second_skill.id}
 
+    with pytest.raises(OnyxError) as exc_info:
+        set_skill_enabled_for_user(
+            skill_id=second_skill.id,
+            enabled=True,
+            user=first_user,
+            db_session=db_session,
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.SKILL_NAME_CONFLICT
+
     set_skill_enabled_for_user(
         skill_id=second_skill.id,
         enabled=True,
+        replace_conflict=True,
         user=first_user,
         db_session=db_session,
     )
@@ -328,12 +342,36 @@ def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> Non
             .where(UserSkillPreference.name == name)
         )
     )
-    assert {
-        preference.skill_id for preference in preferences if preference.enabled
-    } == {second_skill.id}
+    assert {preference.skill_id for preference in preferences} == {second_skill.id}
 
 
-def test_database_rejects_two_enabled_same_name_preferences(
+def test_disabling_skill_deletes_selection(db_session: Session) -> None:
+    user = make_user(db_session)
+    skill = make_skill(db_session, is_public=True)
+    set_skill_enabled_for_user(
+        skill_id=skill.id,
+        enabled=True,
+        user=user,
+        db_session=db_session,
+    )
+
+    set_skill_enabled_for_user(
+        skill_id=skill.id,
+        enabled=False,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert (
+        db_session.get(
+            UserSkillPreference,
+            {"user_id": user.id, "skill_id": skill.id},
+        )
+        is None
+    )
+
+
+def test_database_rejects_two_same_name_preferences(
     db_session: Session,
 ) -> None:
     user = make_user(db_session)
@@ -345,7 +383,6 @@ def test_database_rejects_two_enabled_same_name_preferences(
             user_id=user.id,
             skill_id=first_skill.id,
             name=name,
-            enabled=True,
         )
     )
     db_session.flush()
@@ -357,7 +394,6 @@ def test_database_rejects_two_enabled_same_name_preferences(
                     user_id=user.id,
                     skill_id=second_skill.id,
                     name=name,
-                    enabled=True,
                 )
             )
             db_session.flush()
@@ -374,7 +410,6 @@ def test_preference_name_must_match_skill_name(db_session: Session) -> None:
                     user_id=user.id,
                     skill_id=skill.id,
                     name="different-name",
-                    enabled=True,
                 )
             )
             db_session.flush()

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -318,6 +318,12 @@ def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> Non
         db_session=db_session,
     )
     set_skill_enabled_for_user(
+        skill_id=first_skill.id,
+        enabled=True,
+        user=first_user,
+        db_session=db_session,
+    )
+    set_skill_enabled_for_user(
         skill_id=second_skill.id,
         enabled=True,
         user=second_user,
@@ -351,6 +357,15 @@ def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> Non
             db_session=db_session,
         )
     assert exc_info.value.error_code == OnyxErrorCode.SKILL_NAME_CONFLICT
+    assert (
+        db_session.scalar(
+            select(UserSkillPreference.skill_id).where(
+                UserSkillPreference.user_id == first_user.id,
+                UserSkillPreference.name == name,
+            )
+        )
+        == first_skill.id
+    )
 
     set_skill_enabled_for_user(
         skill_id=second_skill.id,

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -12,6 +12,7 @@ from onyx.db.enums import SkillSharePermission
 from onyx.db.models import Skill__User, Skill__UserGroup, UserSkillPreference
 from onyx.db.skill import (
     SkillAccessPolicy,
+    enable_new_skill_if_name_available__no_commit,
     list_skills,
     replace_skill_shares,
     set_skill_enabled_for_user,
@@ -78,6 +79,30 @@ def test_skill_user_states_resolve_defaults_and_visibility(
     assert states[invalid_custom.id].can_toggle is False
     assert states[built_in.id].enabled is True
     assert states[built_in.id].can_toggle is False
+
+
+def test_new_skill_is_enabled_only_when_name_is_available(
+    db_session: Session,
+) -> None:
+    user = make_user(db_session)
+    name = f"auto-enable-{uuid4().hex[:8]}"
+    first_skill = make_skill(db_session, name=name, is_public=True)
+    second_skill = make_skill(db_session, name=name, is_public=True)
+
+    assert enable_new_skill_if_name_available__no_commit(
+        first_skill, user.id, db_session
+    )
+    assert not enable_new_skill_if_name_available__no_commit(
+        second_skill, user.id, db_session
+    )
+    assert set(
+        db_session.scalars(
+            select(UserSkillPreference.skill_id).where(
+                UserSkillPreference.user_id == user.id,
+                UserSkillPreference.name == name,
+            )
+        )
+    ) == {first_skill.id}
 
 
 def test_orphaned_private_skill_has_boolean_admin_state(

--- a/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
@@ -67,7 +67,7 @@ def test_one_failing_sandbox_does_not_abort_push_to_others(
     )
 
     seeded_skill(
-        slug=f"partial-{uuid4().hex[:6]}",
+        name=f"partial-{uuid4().hex[:6]}",
         public=True,
         bundle_files={"SKILL.md": "p\n"},
     )

--- a/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
+++ b/backend/tests/external_dependency_unit/craft/test_skills_fileset.py
@@ -23,7 +23,7 @@ from tests.external_dependency_unit.craft.db_helpers import (
 )
 from tests.external_dependency_unit.indexing_helpers import make_cc_pair
 
-_FRONTMATTER = "---\nname: {slug}\ndescription: {slug}\n---\n"
+_FRONTMATTER = "---\nname: {name}\ndescription: {name}\n---\n"
 
 
 def _write_skill_dir(
@@ -44,7 +44,7 @@ def _write_skill_dir(
         (source_dir / "SKILL.md.template").write_text(template_body, encoding="utf-8")
     else:
         (source_dir / "SKILL.md").write_text(
-            _FRONTMATTER.format(slug=skill_id), encoding="utf-8"
+            _FRONTMATTER.format(name=skill_id), encoding="utf-8"
         )
     for rel, content in (extra_files or {}).items():
         path = source_dir / rel
@@ -63,7 +63,7 @@ def _register_built_in(
     """Register a fresh synthetic built-in (definition + Skill row) whose
     content lives under ``skills_root/<id>``, redirecting ``BUILTIN_SKILLS_PATH``
     so its computed ``source_dir`` resolves there. Returns the synthetic
-    ``built_in_skill_id`` (also the slug and on-disk dir name).
+    ``built_in_skill_id`` (also the name and on-disk dir name).
     """
     monkeypatch.setattr(built_in_module, "BUILTIN_SKILLS_PATH", skills_root)
     built_in_skill_id = f"test-builtin-{uuid4().hex[:8]}"
@@ -84,14 +84,14 @@ def _register_built_in(
 
 
 class TestBuiltInFromDisk:
-    def test_static_built_in_files_are_included_under_slug_prefix(
+    def test_static_built_in_files_are_included_under_name_prefix(
         self,
         tmp_path: Path,
         db_session: Session,
         test_user: User,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        slug = _register_built_in(
+        name = _register_built_in(
             monkeypatch,
             db_session,
             tmp_path,
@@ -100,8 +100,8 @@ class TestBuiltInFromDisk:
 
         files = build_skills_fileset_for_user(test_user, db_session)
 
-        assert f"name: {slug}".encode() in files[f"{slug}/SKILL.md"]
-        assert files[f"{slug}/scripts/preview.py"] == b"print('hi')"
+        assert f"name: {name}".encode() in files[f"{name}/SKILL.md"]
+        assert files[f"{name}/scripts/preview.py"] == b"print('hi')"
 
     def test_excluded_dirs_and_dotfiles_are_skipped(
         self,
@@ -110,7 +110,7 @@ class TestBuiltInFromDisk:
         test_user: User,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        slug = _register_built_in(
+        name = _register_built_in(
             monkeypatch,
             db_session,
             tmp_path,
@@ -123,16 +123,16 @@ class TestBuiltInFromDisk:
 
         files = build_skills_fileset_for_user(test_user, db_session)
 
-        assert f"{slug}/SKILL.md" in files
-        assert f"{slug}/__pycache__/cached.pyc" not in files
-        assert f"{slug}/.DS_Store" not in files
-        assert f"{slug}/scripts/.hidden" not in files
+        assert f"{name}/SKILL.md" in files
+        assert f"{name}/__pycache__/cached.pyc" not in files
+        assert f"{name}/.DS_Store" not in files
+        assert f"{name}/scripts/.hidden" not in files
 
 
 class TestBuiltInTemplate:
     """Templated built-ins (company-search) get their SKILL.md rendered
     per-user. The renderer dispatches on ``built_in_skill_id``, so the
-    synthetic slug needs to match a known renderer — here we point at
+    synthetic name needs to match a known renderer — here we point at
     ``company-search`` by directly seeding that row instead of a synthetic."""
 
     def test_template_built_in_is_rendered_per_user(
@@ -143,7 +143,7 @@ class TestBuiltInTemplate:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         template_body = (
-            f"{_FRONTMATTER.format(slug='company-search')}"
+            f"{_FRONTMATTER.format(name='company-search')}"
             "Sources:\n{{AVAILABLE_SOURCES_SECTION}}\n"
         )
         # Redirect BUILTIN_SKILLS_PATH at tmp_path and write the template under
@@ -170,7 +170,7 @@ class TestBuiltInTemplate:
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         template_body = (
-            f"{_FRONTMATTER.format(slug='company-search')}"
+            f"{_FRONTMATTER.format(name='company-search')}"
             "{{AVAILABLE_SOURCES_SECTION}}\n"
         )
         monkeypatch.setattr(built_in_module, "BUILTIN_SKILLS_PATH", tmp_path)
@@ -194,7 +194,7 @@ class TestBuiltInTemplate:
 
 
 class TestCustomSkillFileset:
-    def test_custom_bundle_entries_are_added_under_their_slug(
+    def test_custom_bundle_entries_are_added_under_their_name(
         self,
         db_session: Session,
         test_user: User,
@@ -202,19 +202,19 @@ class TestCustomSkillFileset:
     ) -> None:
         # Custom skills require both visibility and per-user enablement. Set up:
         # user is in group ``team``; skill is granted to ``team`` and explicitly
-        # enabled for the user; the bundle holds two files. A uniquified slug
+        # enabled for the user; the bundle holds two files. A uniquified name
         # avoids collisions with leftover rows from prior partial runs.
-        slug = f"my-custom-{uuid4().hex[:8]}"
+        name = f"my-custom-{uuid4().hex[:8]}"
         team_group: UserGroup = make_group(db_session)
         add_user_to_group(db_session, test_user, team_group)
         db_session.commit()
 
         skill = seeded_skill(
-            slug=slug,
+            name=name,
             public=False,
             groups=[team_group],
             bundle_files={
-                "SKILL.md": f"---\nname: {slug}\ndescription: c\n---\ncustom body",
+                "SKILL.md": f"---\nname: {name}\ndescription: c\n---\ncustom body",
                 "nested/file.txt": "nested body",
             },
         )
@@ -228,8 +228,8 @@ class TestCustomSkillFileset:
 
         files = build_skills_fileset_for_user(test_user, db_session)
 
-        assert b"custom body" in files[f"{slug}/SKILL.md"]
-        assert files[f"{slug}/nested/file.txt"] == b"nested body"
+        assert b"custom body" in files[f"{name}/SKILL.md"]
+        assert files[f"{name}/nested/file.txt"] == b"nested body"
 
 
 class TestUnknownBuiltInRowIsSkipped:

--- a/backend/tests/integration/common_utils/managers/external_app.py
+++ b/backend/tests/integration/common_utils/managers/external_app.py
@@ -162,8 +162,7 @@ class ExternalAppManager:
             "auth_template": json.dumps(auth_template),
             "organization_credentials": json.dumps(organization_credentials),
         }
-        # Each bundle needs a unique canonical name while slug uniqueness is
-        # still enforced by the current persistence model.
+        # Keep app-backed skill names unique so independent tests cannot collide.
         skill_name = f"custom-{uuid4().hex[:8]}"
         files: dict[str, tuple[str, bytes, str]] = {
             "bundle": (

--- a/backend/tests/integration/common_utils/managers/skill.py
+++ b/backend/tests/integration/common_utils/managers/skill.py
@@ -35,24 +35,21 @@ def _response_model(
 
 
 def build_minimal_bundle(
-    slug: str,
+    name: str,
     *,
-    name: str | None = None,
     description: str | None = None,
 ) -> bytes:
     """Build a minimal valid skill bundle zip with SKILL.md.
 
-    `name` / `description` are written into the bundle's frontmatter — that's
-    now the canonical source for those fields on the backend, so tests that
-    care about them should pass them here instead of as separate API args.
+    ``name`` and ``description`` are written into the bundle's frontmatter,
+    which is the canonical metadata source.
     """
-    fm_name = name or slug
-    fm_desc = description or f"Description for {slug}"
+    description = description or f"Description for {name}"
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(
             "SKILL.md",
-            f"---\nname: {fm_name}\ndescription: {fm_desc}\n---\n\nSkill instructions.",
+            f"---\nname: {name}\ndescription: {description}\n---\n\nSkill instructions.",
         )
     return buf.getvalue()
 
@@ -97,7 +94,6 @@ class SkillManager:
     def create_custom(
         user_performing_action: DATestUser,
         *,
-        slug: str | None = None,
         name: str | None = None,
         description: str | None = None,
         is_public: bool = False,
@@ -105,11 +101,9 @@ class SkillManager:
         bundle_bytes: bytes | None = None,
         filename: str | None = None,
     ) -> SkillResponse:
-        slug = slug or f"test-skill-{uuid4().hex[:8]}"
+        name = name or f"test-skill-{uuid4().hex[:8]}"
         if bundle_bytes is None:
-            bundle_bytes = build_minimal_bundle(
-                slug, name=name, description=description
-            )
+            bundle_bytes = build_minimal_bundle(name, description=description)
 
         headers = dict(user_performing_action.headers)
         headers.pop("Content-Type", None)
@@ -118,7 +112,7 @@ class SkillManager:
             f"{API_SERVER_URL}/skills/custom",
             files={
                 "bundle": (
-                    filename or f"{slug}.zip",
+                    filename or f"{name}.zip",
                     io.BytesIO(bundle_bytes),
                     "application/zip",
                 )
@@ -179,7 +173,7 @@ class SkillManager:
             f"{API_SERVER_URL}/skills/custom/{skill.id}/bundle",
             files={
                 "bundle": (
-                    f"{skill.slug}.zip",
+                    f"{skill.name}.zip",
                     io.BytesIO(bundle_bytes),
                     "application/zip",
                 )
@@ -391,17 +385,14 @@ class SkillManager:
     def create_personal(
         user_performing_action: DATestUser,
         *,
-        slug: str | None = None,
         name: str | None = None,
         description: str | None = None,
         bundle_bytes: bytes | None = None,
         filename: str | None = None,
     ) -> SkillResponse:
-        slug = slug or f"personal-skill-{uuid4().hex[:8]}"
+        name = name or f"personal-skill-{uuid4().hex[:8]}"
         if bundle_bytes is None:
-            bundle_bytes = build_minimal_bundle(
-                slug, name=name, description=description
-            )
+            bundle_bytes = build_minimal_bundle(name, description=description)
 
         headers = dict(user_performing_action.headers)
         headers.pop("Content-Type", None)
@@ -410,7 +401,7 @@ class SkillManager:
             f"{API_SERVER_URL}/skills/custom",
             files={
                 "bundle": (
-                    filename or f"{slug}.zip",
+                    filename or f"{name}.zip",
                     io.BytesIO(bundle_bytes),
                     "application/zip",
                 )
@@ -433,7 +424,7 @@ class SkillManager:
             f"{API_SERVER_URL}/skills/custom/{skill.id}/bundle",
             files={
                 "bundle": (
-                    f"{skill.slug}.zip",
+                    f"{skill.name}.zip",
                     io.BytesIO(bundle_bytes),
                     "application/zip",
                 )

--- a/backend/tests/integration/common_utils/managers/skill.py
+++ b/backend/tests/integration/common_utils/managers/skill.py
@@ -282,10 +282,11 @@ class SkillManager:
         skill: SkillResponse,
         user_performing_action: DATestUser,
         enabled: bool,
+        replace_conflict: bool = False,
     ) -> SkillResponse:
         response = client.put(
             f"{API_SERVER_URL}/skills/{skill.id}/enabled",
-            json={"enabled": enabled},
+            json={"enabled": enabled, "replace_conflict": replace_conflict},
             headers=user_performing_action.headers,
         )
         response.raise_for_status()

--- a/backend/tests/integration/common_utils/managers/skill.py
+++ b/backend/tests/integration/common_utils/managers/skill.py
@@ -64,6 +64,7 @@ class SkillManager:
         instructions_markdown: str,
         upload_bytes: bytes | None = None,
         upload_filename: str = "supporting-file.txt",
+        auto_enable: bool = True,
     ) -> SkillResponse:
         create_request = SkillCreateRequest(
             name=name,
@@ -76,6 +77,7 @@ class SkillManager:
         files: dict[str, tuple[str | None, object, str | None]] = {
             field: (None, value, None) for field, value in form_fields.items()
         }
+        files["auto_enable"] = (None, str(auto_enable).lower(), None)
         if upload_bytes is not None:
             files["upload"] = (
                 upload_filename,
@@ -100,6 +102,7 @@ class SkillManager:
         group_ids: list[int] | None = None,
         bundle_bytes: bytes | None = None,
         filename: str | None = None,
+        auto_enable: bool = True,
     ) -> SkillResponse:
         name = name or f"test-skill-{uuid4().hex[:8]}"
         if bundle_bytes is None:
@@ -111,11 +114,12 @@ class SkillManager:
         response = client.post(
             f"{API_SERVER_URL}/skills/custom",
             files={
+                "auto_enable": (None, str(auto_enable).lower(), None),
                 "bundle": (
                     filename or f"{name}.zip",
                     io.BytesIO(bundle_bytes),
                     "application/zip",
-                )
+                ),
             },
             headers=headers,
         )
@@ -390,6 +394,7 @@ class SkillManager:
         description: str | None = None,
         bundle_bytes: bytes | None = None,
         filename: str | None = None,
+        auto_enable: bool = True,
     ) -> SkillResponse:
         name = name or f"personal-skill-{uuid4().hex[:8]}"
         if bundle_bytes is None:
@@ -401,11 +406,12 @@ class SkillManager:
         response = client.post(
             f"{API_SERVER_URL}/skills/custom",
             files={
+                "auto_enable": (None, str(auto_enable).lower(), None),
                 "bundle": (
                     filename or f"{name}.zip",
                     io.BytesIO(bundle_bytes),
                     "application/zip",
-                )
+                ),
             },
             headers=headers,
         )

--- a/backend/tests/integration/tests/craft/k8s/test_skill_push.py
+++ b/backend/tests/integration/tests/craft/k8s/test_skill_push.py
@@ -351,7 +351,7 @@ class TestSkillPush:
         )
         try:
             user_app = ExternalAppManager.get_for_user(user, app.id)
-            skill_file = _skill_file_path(workspace, user_app.name)
+            skill_file = _skill_file_path(workspace, user_app.slug)
             skill_file.wait_for_absent()
 
             ExternalAppManager.upsert_user_credentials(

--- a/backend/tests/integration/tests/craft/k8s/test_skill_push.py
+++ b/backend/tests/integration/tests/craft/k8s/test_skill_push.py
@@ -55,23 +55,23 @@ pytestmark = [
 
 
 def _skill_file_path(
-    workspace: WorkspaceProxy, slug: str, name: str = "SKILL.md"
+    workspace: WorkspaceProxy, skill_name: str, file_name: str = "SKILL.md"
 ) -> WorkspaceProxy:
-    return workspace / "managed" / "skills" / slug / name
+    return workspace / "managed" / "skills" / skill_name / file_name
 
 
 def _skills_dir(workspace: WorkspaceProxy) -> WorkspaceProxy:
     return workspace / "managed" / "skills"
 
 
-def _bundle(slug: str, body: bytes | str, **extra_files: bytes | str) -> bytes:
+def _bundle(name: str, body: bytes | str, **extra_files: bytes | str) -> bytes:
     body_bytes = body.encode("utf-8") if isinstance(body, str) else body
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(
             "SKILL.md",
             b"---\n"
-            + f"name: {slug}\ndescription: {slug} integration test\n".encode("utf-8")
+            + f"name: {name}\ndescription: {name} integration test\n".encode("utf-8")
             + b"---\n"
             + body_bytes,
         )
@@ -83,7 +83,7 @@ def _bundle(slug: str, body: bytes | str, **extra_files: bytes | str) -> bytes:
 
 def _create_skill(
     admin: DATestUser,
-    slug: str,
+    name: str,
     *,
     body: bytes | str,
     is_public: bool = False,
@@ -91,11 +91,11 @@ def _create_skill(
 ) -> SkillResponse:
     return SkillManager.create_custom(
         admin,
-        slug=slug,
+        name=name,
         is_public=is_public,
         group_ids=group_ids or [],
-        bundle_bytes=_bundle(slug, body),
-        filename=f"{slug}.zip",
+        bundle_bytes=_bundle(name, body),
+        filename=f"{name}.zip",
     )
 
 
@@ -107,7 +107,7 @@ def _replace_bundle(
 ) -> SkillResponse:
     return SkillManager.replace_bundle(
         skill,
-        _bundle(skill.slug, body),
+        _bundle(skill.name, body),
         admin,
     )
 
@@ -211,7 +211,6 @@ def _make_private_cc_pair(
 def _make_built_in_skill_row(db_session: Session, *, built_in_skill_id: str) -> Skill:
     skill = Skill(
         id=uuid4(),
-        slug=built_in_skill_id,
         name=built_in_skill_id,
         description="test built-in",
         built_in_skill_id=built_in_skill_id,
@@ -227,14 +226,14 @@ def _make_built_in_skill_row(db_session: Session, *, built_in_skill_id: str) -> 
 def _reset_built_in_skill_row(db_session: Session, *, built_in_skill_id: str) -> Skill:
     from sqlalchemy import delete
 
-    db_session.execute(delete(Skill).where(Skill.slug == built_in_skill_id))
+    db_session.execute(delete(Skill).where(Skill.name == built_in_skill_id))
     return _make_built_in_skill_row(db_session, built_in_skill_id=built_in_skill_id)
 
 
 def _seed_custom_skill(
     db_session: Session,
     *,
-    slug: str,
+    name: str,
     public: bool,
     body: str,
     group: UserGroup | None = None,
@@ -245,20 +244,19 @@ def _seed_custom_skill(
     from onyx.db.models import Skill__UserGroup
     from onyx.file_store.file_store import get_default_file_store
 
-    bundle_bytes = _bundle(slug, body)
+    bundle_bytes = _bundle(name, body)
     file_store = get_default_file_store()
     file_store.initialize()
     bundle_file_id = file_store.save_file(
         content=io.BytesIO(bundle_bytes),
-        display_name=f"{slug}.zip",
+        display_name=f"{name}.zip",
         file_origin=FileOrigin.SKILL_BUNDLE,
         file_type="application/zip",
     )
     skill = Skill(
         id=uuid4(),
-        slug=slug,
-        name=slug,
-        description=f"Seeded skill {slug}",
+        name=name,
+        description=f"Seeded skill {name}",
         bundle_file_id=bundle_file_id,
         bundle_sha256=hashlib.sha256(bundle_bytes).hexdigest(),
         public_permission=SkillSharePermission.VIEWER if public else None,
@@ -353,7 +351,7 @@ class TestSkillPush:
         )
         try:
             user_app = ExternalAppManager.get_for_user(user, app.id)
-            skill_file = _skill_file_path(workspace, user_app.slug)
+            skill_file = _skill_file_path(workspace, user_app.name)
             skill_file.wait_for_absent()
 
             ExternalAppManager.upsert_user_credentials(
@@ -375,18 +373,18 @@ class TestSkillPush:
         users = _create_users(3)
         workspaces = handle.provision_api_users(users)
 
-        slug = f"public-skill-{uuid4().hex[:6]}"
+        name = f"public-skill-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=True,
             body="public skill body\n",
         )
 
         for user, workspace in zip(users, workspaces, strict=True):
-            _skill_file_path(workspace, skill.slug).wait_for_absent()
+            _skill_file_path(workspace, skill.name).wait_for_absent()
             SkillManager.set_enabled(skill, user, True)
-            _skill_file_path(workspace, skill.slug).wait_for_bytes(
+            _skill_file_path(workspace, skill.name).wait_for_bytes(
                 b"public skill body\n",
             )
 
@@ -404,20 +402,20 @@ class TestSkillPush:
             [user_a.id],
         )
 
-        slug = f"eng-only-{uuid4().hex[:6]}"
+        name = f"eng-only-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=False,
             group_ids=[group.id],
             body="engineering only\n",
         )
 
-        _skill_file_path(ws_a, skill.slug).wait_for_absent()
-        _skill_file_path(ws_b, skill.slug).wait_for_absent()
-        _skill_file_path(ws_c, skill.slug).wait_for_absent()
+        _skill_file_path(ws_a, skill.name).wait_for_absent()
+        _skill_file_path(ws_b, skill.name).wait_for_absent()
+        _skill_file_path(ws_c, skill.name).wait_for_absent()
         SkillManager.set_enabled(skill, user_a, True)
-        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"engineering only\n")
+        _skill_file_path(ws_a, skill.name).wait_for_bytes(b"engineering only\n")
 
     def test_disable_skill_removes_files_from_affected_sandboxes(
         self,
@@ -433,20 +431,20 @@ class TestSkillPush:
             [user.id],
         )
 
-        slug = f"disable-me-{uuid4().hex[:6]}"
+        name = f"disable-me-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=False,
             group_ids=[group.id],
             body="to be disabled\n",
         )
         SkillManager.set_enabled(skill, user, True)
-        _skill_file_path(workspace, skill.slug).wait_for_bytes(b"to be disabled\n")
+        _skill_file_path(workspace, skill.name).wait_for_bytes(b"to be disabled\n")
 
         SkillManager.set_enabled(skill, user, False)
 
-        (_skills_dir(workspace) / skill.slug).wait_for_absent()
+        (_skills_dir(workspace) / skill.name).wait_for_absent()
 
     def test_group_share_change_revokes_old_user_and_new_user_starts_disabled(
         self,
@@ -466,25 +464,25 @@ class TestSkillPush:
             [user_b.id],
         )
 
-        slug = f"shares-flip-{uuid4().hex[:6]}"
+        name = f"shares-flip-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=False,
             group_ids=[group_x.id],
             body="shifting shares\n",
         )
-        _skill_file_path(ws_a, skill.slug).wait_for_absent()
-        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+        _skill_file_path(ws_a, skill.name).wait_for_absent()
+        _skill_file_path(ws_b, skill.name).wait_for_absent()
         SkillManager.set_enabled(skill, user_a, True)
-        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"shifting shares\n")
+        _skill_file_path(ws_a, skill.name).wait_for_bytes(b"shifting shares\n")
 
         SkillManager.replace_group_shares(skill, [group_y.id], k8s_admin_user)
 
-        _skill_file_path(ws_a, skill.slug).wait_for_absent()
-        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+        _skill_file_path(ws_a, skill.name).wait_for_absent()
+        _skill_file_path(ws_b, skill.name).wait_for_absent()
         SkillManager.set_enabled(skill, user_b, True)
-        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"shifting shares\n")
+        _skill_file_path(ws_b, skill.name).wait_for_bytes(b"shifting shares\n")
 
     def test_direct_share_change_revokes_old_user_and_new_user_starts_disabled(
         self,
@@ -495,15 +493,15 @@ class TestSkillPush:
         user_a, user_b = _create_users(2)
         [ws_a, ws_b] = handle.provision_api_users([user_a, user_b])
 
-        slug = f"direct-shares-flip-{uuid4().hex[:6]}"
+        name = f"direct-shares-flip-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=False,
             body="direct shifting shares\n",
         )
-        _skill_file_path(ws_a, skill.slug).wait_for_absent()
-        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+        _skill_file_path(ws_a, skill.name).wait_for_absent()
+        _skill_file_path(ws_b, skill.name).wait_for_absent()
 
         skill = SkillManager.share(
             skill,
@@ -516,10 +514,10 @@ class TestSkillPush:
             ],
         )
         assert [str(share.user.id) for share in skill.user_shares] == [user_a.id]
-        _skill_file_path(ws_a, skill.slug).wait_for_absent()
-        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+        _skill_file_path(ws_a, skill.name).wait_for_absent()
+        _skill_file_path(ws_b, skill.name).wait_for_absent()
         SkillManager.set_enabled(skill, user_a, True)
-        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"direct shifting shares\n")
+        _skill_file_path(ws_a, skill.name).wait_for_bytes(b"direct shifting shares\n")
 
         skill = SkillManager.share(
             skill,
@@ -533,10 +531,10 @@ class TestSkillPush:
         )
         assert [str(share.user.id) for share in skill.user_shares] == [user_b.id]
 
-        _skill_file_path(ws_a, skill.slug).wait_for_absent()
-        _skill_file_path(ws_b, skill.slug).wait_for_absent()
+        _skill_file_path(ws_a, skill.name).wait_for_absent()
+        _skill_file_path(ws_b, skill.name).wait_for_absent()
         SkillManager.set_enabled(skill, user_b, True)
-        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"direct shifting shares\n")
+        _skill_file_path(ws_b, skill.name).wait_for_bytes(b"direct shifting shares\n")
 
     def test_replace_bundle_propagates_new_content(
         self,
@@ -547,19 +545,19 @@ class TestSkillPush:
         [user] = _create_users(1)
         [workspace] = handle.provision_api_users([user])
 
-        slug = f"versioned-{uuid4().hex[:6]}"
+        name = f"versioned-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=True,
             body="version one\n",
         )
         SkillManager.set_enabled(skill, user, True)
-        _skill_file_path(workspace, skill.slug).wait_for_bytes(b"version one\n")
+        _skill_file_path(workspace, skill.name).wait_for_bytes(b"version one\n")
 
         _replace_bundle(k8s_admin_user, skill, body="version two\n")
 
-        _skill_file_path(workspace, skill.slug).wait_for_bytes(b"version two\n")
+        _skill_file_path(workspace, skill.name).wait_for_bytes(b"version two\n")
 
     def test_owner_file_removal_propagates_to_shared_users_sandbox(
         self,
@@ -569,22 +567,22 @@ class TestSkillPush:
         shared_user, owner = _create_users(2)
         [workspace] = handle.provision_api_users([shared_user])
 
-        slug = f"remove-file-{uuid4().hex[:6]}"
+        name = f"remove-file-{uuid4().hex[:6]}"
         skill = SkillManager.create_custom(
             owner,
-            slug=slug,
+            name=name,
             bundle_bytes=_bundle(
-                slug,
+                name,
                 "keep these instructions\n",
                 **{"references/context.md": "remove this context\n"},
             ),
-            filename=f"{slug}.zip",
+            filename=f"{name}.zip",
         )
         skill = _share_directly(owner, skill, shared_user)
         SkillManager.set_enabled(skill, shared_user, True)
 
-        skill_md = _skill_file_path(workspace, skill.slug)
-        context_file = _skill_file_path(workspace, skill.slug, "references/context.md")
+        skill_md = _skill_file_path(workspace, skill.name)
+        context_file = _skill_file_path(workspace, skill.name, "references/context.md")
         skill_md.wait_for_bytes(b"keep these instructions\n")
         context_file.wait_for_bytes(b"remove this context\n")
 
@@ -601,13 +599,13 @@ class TestSkillPush:
         shared_user, owner = _create_users(2)
         [workspace] = handle.provision_api_users([shared_user])
 
-        slug = f"upload-file-{uuid4().hex[:6]}"
-        skill = _create_skill(owner, slug, body="keep these instructions\n")
+        name = f"upload-file-{uuid4().hex[:6]}"
+        skill = _create_skill(owner, name, body="keep these instructions\n")
         skill = _share_directly(owner, skill, shared_user)
         SkillManager.set_enabled(skill, shared_user, True)
 
-        skill_md = _skill_file_path(workspace, skill.slug)
-        context_file = _skill_file_path(workspace, skill.slug, "references/context.md")
+        skill_md = _skill_file_path(workspace, skill.name)
+        context_file = _skill_file_path(workspace, skill.name, "references/context.md")
         skill_md.wait_for_bytes(b"keep these instructions\n")
         context_file.wait_for_absent()
 
@@ -629,30 +627,30 @@ class TestSkillPush:
         shared_user, owner = _create_users(2)
         [workspace] = handle.provision_api_users([shared_user])
 
-        slug = f"replace-files-{uuid4().hex[:6]}"
+        name = f"replace-files-{uuid4().hex[:6]}"
         skill = SkillManager.create_custom(
             owner,
-            slug=slug,
+            name=name,
             bundle_bytes=_bundle(
-                slug,
+                name,
                 "old instructions\n",
                 **{"references/stale.md": "stale context\n"},
             ),
-            filename=f"{slug}.zip",
+            filename=f"{name}.zip",
         )
         skill = _share_directly(owner, skill, shared_user)
         SkillManager.set_enabled(skill, shared_user, True)
 
-        skill_md = _skill_file_path(workspace, skill.slug)
-        stale_file = _skill_file_path(workspace, skill.slug, "references/stale.md")
+        skill_md = _skill_file_path(workspace, skill.name)
+        stale_file = _skill_file_path(workspace, skill.name, "references/stale.md")
         replacement_file = _skill_file_path(
-            workspace, skill.slug, "references/current.md"
+            workspace, skill.name, "references/current.md"
         )
         skill_md.wait_for_bytes(b"old instructions\n")
         stale_file.wait_for_bytes(b"stale context\n")
 
         replacement = _bundle(
-            slug,
+            name,
             "new instructions\n",
             **{"references/current.md": "current context\n"},
         )
@@ -671,22 +669,22 @@ class TestSkillPush:
         user_a, user_b = _create_users(2)
         [ws_a, ws_b] = handle.provision_api_users([user_a, user_b])
 
-        slug = f"to-delete-{uuid4().hex[:6]}"
+        name = f"to-delete-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=True,
             body="will be deleted\n",
         )
         SkillManager.set_enabled(skill, user_a, True)
         SkillManager.set_enabled(skill, user_b, True)
-        _skill_file_path(ws_a, skill.slug).wait_for_bytes(b"will be deleted\n")
-        _skill_file_path(ws_b, skill.slug).wait_for_bytes(b"will be deleted\n")
+        _skill_file_path(ws_a, skill.name).wait_for_bytes(b"will be deleted\n")
+        _skill_file_path(ws_b, skill.name).wait_for_bytes(b"will be deleted\n")
 
         SkillManager.delete_custom(skill, k8s_admin_user)
 
-        (_skills_dir(ws_a) / skill.slug).wait_for_absent()
-        (_skills_dir(ws_b) / skill.slug).wait_for_absent()
+        (_skills_dir(ws_a) / skill.name).wait_for_absent()
+        (_skills_dir(ws_b) / skill.name).wait_for_absent()
 
     def test_user_with_overlapping_shares_receives_skill_once(
         self,
@@ -706,18 +704,18 @@ class TestSkillPush:
             [user.id],
         )
 
-        slug = f"dup-shares-{uuid4().hex[:6]}"
+        name = f"dup-shares-{uuid4().hex[:6]}"
         skill = _create_skill(
             k8s_admin_user,
-            slug,
+            name,
             is_public=False,
             group_ids=[group_x.id, group_y.id],
             body="dedup\n",
         )
 
         SkillManager.set_enabled(skill, user, True)
-        _skill_file_path(workspace, skill.slug).wait_for_bytes(b"dedup\n")
-        skill_dir = _skills_dir(workspace) / skill.slug
+        _skill_file_path(workspace, skill.name).wait_for_bytes(b"dedup\n")
+        skill_dir = _skills_dir(workspace) / skill.name
         skill_files = [p for p in skill_dir.rglob("*") if p.is_file()]
         assert len(skill_files) == 1
         assert skill_files[0].name == "SKILL.md"
@@ -742,7 +740,7 @@ class TestSkillPushLowLevel:
 
         skill = _seed_custom_skill(
             db_session,
-            slug=f"sleeping-{uuid4().hex[:6]}",
+            name=f"sleeping-{uuid4().hex[:6]}",
             public=True,
             body="anything\n",
         )
@@ -750,7 +748,7 @@ class TestSkillPushLowLevel:
         push_skill_to_affected_sandboxes(skill, db_session)
 
         assert workspace.exists()
-        assert not (_skills_dir(workspace) / skill.slug).exists()
+        assert not (_skills_dir(workspace) / skill.name).exists()
 
     def test_push_skips_terminated_sandboxes(
         self,
@@ -768,7 +766,7 @@ class TestSkillPushLowLevel:
 
         skill = _seed_custom_skill(
             db_session,
-            slug=f"terminated-{uuid4().hex[:6]}",
+            name=f"terminated-{uuid4().hex[:6]}",
             public=True,
             body="anything\n",
         )
@@ -776,7 +774,7 @@ class TestSkillPushLowLevel:
         push_skill_to_affected_sandboxes(skill, db_session)
 
         assert workspace.exists()
-        assert not (_skills_dir(workspace) / skill.slug).exists()
+        assert not (_skills_dir(workspace) / skill.name).exists()
 
     def test_company_search_skill_rendered_per_user(
         self,
@@ -824,14 +822,14 @@ class TestSkillPushLowLevel:
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        slug = f"excl-builtin-{uuid4().hex[:6]}"
+        name = f"excl-builtin-{uuid4().hex[:6]}"
         skills_root = tmp_path / "builtin_src"
-        source_dir = skills_root / slug
+        source_dir = skills_root / name
         source_dir.mkdir(parents=True)
 
         # Files the exclusion rule must keep IN.
         (source_dir / "SKILL.md").write_text(
-            f"---\nname: {slug}\ndescription: exclusion test\n---\n# body\n"
+            f"---\nname: {name}\ndescription: exclusion test\n---\n# body\n"
         )
         (source_dir / "script.py").write_text("print('hello')\n")
 
@@ -845,21 +843,21 @@ class TestSkillPushLowLevel:
         monkeypatch.setattr("onyx.skills.built_in.BUILTIN_SKILLS_PATH", skills_root)
         monkeypatch.setitem(
             BUILT_IN_SKILLS,
-            slug,
-            BuiltInSkillDefinition(built_in_skill_id=slug),
+            name,
+            BuiltInSkillDefinition(built_in_skill_id=name),
         )
-        _make_built_in_skill_row(db_session, built_in_skill_id=slug)
+        _make_built_in_skill_row(db_session, built_in_skill_id=name)
 
         [api_user] = _create_users(1)
         user = _orm_user(db_session, api_user)
         db_session.commit()
 
         fileset = build_skills_fileset_for_user(user, db_session)
-        shipped = {Path(rel).name for rel in fileset if rel.startswith(f"{slug}/")}
+        shipped = {Path(rel).name for rel in fileset if rel.startswith(f"{name}/")}
 
         assert "SKILL.md" in shipped
         assert "script.py" in shipped
         assert "notes.template" not in shipped
         assert ".hidden" not in shipped
         assert "foo.pyc" not in shipped
-        assert not any(rel.startswith(f"{slug}/__pycache__/") for rel in fileset)
+        assert not any(rel.startswith(f"{name}/__pycache__/") for rel in fileset)

--- a/backend/tests/integration/tests/craft/k8s/test_snapshot_restore.py
+++ b/backend/tests/integration/tests/craft/k8s/test_snapshot_restore.py
@@ -245,7 +245,7 @@ def test_restore_re_pushes_skills(
 
     skill = SkillManager.create_custom(
         k8s_admin_user,
-        slug=f"restore-repush-{uuid4().hex[:6]}",
+        name=f"restore-repush-{uuid4().hex[:6]}",
         is_public=True,
     )
     try:
@@ -278,7 +278,7 @@ def test_restore_re_pushes_skills(
             k8s_client,
             pod_name,
             SANDBOX_NAMESPACE,
-            f"ls -1 /workspace/managed/skills/{skill.slug}/",
+            f"ls -1 /workspace/managed/skills/{skill.name}/",
         )
         assert "SKILL.md" in listing, (
             f"API restore should rehydrate skills after snapshot restore. Got: {listing}"
@@ -288,7 +288,7 @@ def test_restore_re_pushes_skills(
             k8s_client,
             pod_name,
             SANDBOX_NAMESPACE,
-            f"ls -1 /workspace/sessions/{session_id}/.opencode/skills/{skill.slug}/",
+            f"ls -1 /workspace/sessions/{session_id}/.opencode/skills/{skill.name}/",
         )
         assert "SKILL.md" in resolved
     finally:

--- a/backend/tests/integration/tests/external_apps/test_external_apps.py
+++ b/backend/tests/integration/tests/external_apps/test_external_apps.py
@@ -189,8 +189,8 @@ def test_external_app_is_excluded_from_skill_management_apis(
         SkillManager.list_for_user(basic_user),
         SkillManager.list_all(admin_user),
     ):
-        listed_slugs = {skill.slug for skill in [*skills.builtins, *skills.customs]}
-        assert user_app.slug not in listed_slugs
+        listed_names = {skill.name for skill in [*skills.builtins, *skills.customs]}
+        assert user_app.slug not in listed_names
 
 
 # =============================================================================

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -203,13 +203,15 @@ def test_create_skill_rejects_reserved_name(admin_user: DATestUser) -> None:
     )
 
 
-def test_create_skill_allows_duplicate_names(admin_user: DATestUser) -> None:
+def test_create_skill_allows_disabled_duplicate_name(admin_user: DATestUser) -> None:
     name = f"duplicate-{uuid4().hex[:8]}"
 
     first = SkillManager.create_custom(admin_user, name=name)
-    second = SkillManager.create_custom(admin_user, name=name)
+    second = SkillManager.create_custom(admin_user, name=name, auto_enable=False)
 
     assert first.id != second.id
+    assert first.enabled is True
+    assert second.enabled is False
     matching = [
         skill
         for skill in SkillManager.list_all(admin_user).customs

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -12,7 +12,7 @@ from onyx.auth.schemas import UserRole
 from onyx.configs.constants import FileOrigin
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import SkillSharePermission
-from onyx.db.models import FileRecord, Skill
+from onyx.db.models import Skill
 from onyx.file_store.file_store import get_default_file_store
 from onyx.server.features.skill.models import SkillPatchRequest
 from tests.integration.common_utils.constants import API_SERVER_URL
@@ -53,39 +53,24 @@ def _bundle_blob_exists(bundle_file_id: str) -> bool:
     )
 
 
-def _skill_bundle_blob_ids() -> set[str]:
-    """Return the set of all file IDs for SKILL_BUNDLE blobs in the file store."""
-    with get_session_with_current_tenant() as db_session:
-        rows = (
-            db_session.execute(
-                select(FileRecord.file_id).where(
-                    FileRecord.file_origin == FileOrigin.SKILL_BUNDLE
-                )
-            )
-            .scalars()
-            .all()
-        )
-    return set(rows)
-
-
 # ---------------------------------------------------------------------------
 # Existing tests preserved
 # ---------------------------------------------------------------------------
 
 
 def test_create_and_list_skill(admin_user: DATestUser) -> None:
-    slug = f"test-create-{uuid4().hex[:6]}"
-    skill = SkillManager.create_custom(admin_user, slug=slug)
-    assert skill.slug == slug
+    name = f"test-create-{uuid4().hex[:6]}"
+    skill = SkillManager.create_custom(admin_user, name=name)
+    assert skill.name == name
     assert skill.enabled is True
 
     skills_list = SkillManager.list_all(admin_user)
-    custom_slugs = [skill.slug for skill in skills_list.customs]
-    assert slug in custom_slugs
+    custom_names = [skill.name for skill in skills_list.customs]
+    assert name in custom_names
 
 
 def test_patch_skill_metadata(admin_user: DATestUser) -> None:
-    skill = SkillManager.create_custom(admin_user, slug=f"patch-test-{uuid4().hex[:6]}")
+    skill = SkillManager.create_custom(admin_user, name=f"patch-test-{uuid4().hex[:6]}")
 
     public = SkillManager.patch_custom(
         skill,
@@ -100,7 +85,7 @@ def test_invalid_skill_is_manageable_but_not_toggleable(
 ) -> None:
     skill = SkillManager.create_custom(
         admin_user,
-        slug=f"invalid-toggle-{uuid4().hex[:6]}",
+        name=f"invalid-toggle-{uuid4().hex[:6]}",
     )
     _mark_skill_invalid(skill.id)
 
@@ -119,27 +104,26 @@ def test_invalid_skill_is_manageable_but_not_toggleable(
 
 
 def test_replace_bundle_updates_metadata(admin_user: DATestUser) -> None:
-    slug = f"bundle-test-{uuid4().hex[:6]}"
+    name = f"bundle-test-{uuid4().hex[:6]}"
     skill = SkillManager.create_custom(
         admin_user,
-        slug=slug,
+        name=name,
         description="Original desc",
     )
-    new_bundle = build_minimal_bundle(slug, description="Updated desc")
+    new_bundle = build_minimal_bundle(name, description="Updated desc")
     updated = SkillManager.replace_bundle(skill, new_bundle, admin_user)
-    assert updated.slug == slug
-    assert updated.name == slug
+    assert updated.name == name
     assert updated.description == "Updated desc"
 
 
 def test_delete_skill(admin_user: DATestUser) -> None:
-    slug = f"delete-test-{uuid4().hex[:6]}"
-    skill = SkillManager.create_custom(admin_user, slug=slug)
+    name = f"delete-test-{uuid4().hex[:6]}"
+    skill = SkillManager.create_custom(admin_user, name=name)
     SkillManager.delete_custom(skill, admin_user)
 
     skills_list = SkillManager.list_all(admin_user)
-    custom_slugs = [skill.slug for skill in skills_list.customs]
-    assert slug not in custom_slugs
+    custom_names = [skill.name for skill in skills_list.customs]
+    assert name not in custom_names
 
 
 def test_bundle_missing_skill_md(admin_user: DATestUser) -> None:
@@ -150,14 +134,14 @@ def test_bundle_missing_skill_md(admin_user: DATestUser) -> None:
 
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
         SkillManager.create_custom(
-            admin_user, slug=f"bad-bundle-{uuid4().hex[:6]}", bundle_bytes=bad_bundle
+            admin_user, name=f"bad-bundle-{uuid4().hex[:6]}", bundle_bytes=bad_bundle
         )
     assert exc_info.value.response.status_code == 400
 
 
 def test_group_shares_replace(admin_user: DATestUser) -> None:
     skill = SkillManager.create_custom(
-        admin_user, slug=f"group-shares-test-{uuid4().hex[:6]}", is_public=False
+        admin_user, name=f"group-shares-test-{uuid4().hex[:6]}", is_public=False
     )
     updated = SkillManager.replace_group_shares(skill, [], admin_user)
     assert updated.group_shares == []
@@ -166,7 +150,7 @@ def test_group_shares_replace(admin_user: DATestUser) -> None:
 def test_metadata_from_bundle_frontmatter(admin_user: DATestUser) -> None:
     bundle = build_minimal_bundle("from-frontmatter", description="From bundle desc")
     skill = SkillManager.create_custom(
-        admin_user, slug="from-frontmatter", bundle_bytes=bundle
+        admin_user, name="from-frontmatter", bundle_bytes=bundle
     )
     assert skill.name == "from-frontmatter"
     assert skill.description == "From bundle desc"
@@ -183,10 +167,10 @@ def test_create_skill_201_persists_row_group_shares_bundle(
     """POST -> row persisted with bundle blob and group shares visible in DB."""
     group = UserGroupManager.create(admin_user, name="create-shares-group")
 
-    slug = f"persist-{uuid4().hex[:8]}"
+    name = f"persist-{uuid4().hex[:8]}"
     skill = SkillManager.create_custom(
         admin_user,
-        slug=slug,
+        name=name,
         is_public=False,
         group_ids=[group.id],
     )
@@ -195,7 +179,7 @@ def test_create_skill_201_persists_row_group_shares_bundle(
 
     row = _fetch_skill_row(skill.id)
     assert row is not None, "skill row missing after create"
-    assert row.slug == slug
+    assert row.name == name
     assert row.public_permission is None
     assert row.bundle_file_id, "skill row has no bundle_file_id"
     assert _bundle_blob_exists(row.bundle_file_id), (
@@ -203,25 +187,32 @@ def test_create_skill_201_persists_row_group_shares_bundle(
     )
 
 
-def test_create_skill_rejects_reserved_slug(admin_user: DATestUser) -> None:
+def test_create_skill_rejects_reserved_name(admin_user: DATestUser) -> None:
     reserved = "company-search"
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_custom(admin_user, slug=reserved)
+        SkillManager.create_custom(admin_user, name=reserved)
     response = exc_info.value.response
     assert response.status_code == 400
     body = response.json()
     detail = str(body.get("detail") or body)
     assert reserved in detail, (
-        f"error message must name the reserved slug; got {detail!r}"
+        f"error message must name the reserved name; got {detail!r}"
     )
 
 
-def test_create_skill_409_on_duplicate_slug(admin_user: DATestUser) -> None:
-    slug = f"dup-409-{uuid4().hex[:8]}"
-    SkillManager.create_custom(admin_user, slug=slug)
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_custom(admin_user, slug=slug)
-    assert exc_info.value.response.status_code == 409
+def test_create_skill_allows_duplicate_names(admin_user: DATestUser) -> None:
+    name = f"duplicate-{uuid4().hex[:8]}"
+
+    first = SkillManager.create_custom(admin_user, name=name)
+    second = SkillManager.create_custom(admin_user, name=name)
+
+    assert first.id != second.id
+    matching = [
+        skill
+        for skill in SkillManager.list_all(admin_user).customs
+        if skill.name == name
+    ]
+    assert {skill.id for skill in matching} == {first.id, second.id}
 
 
 def test_create_skill_413_on_oversized_bundle(admin_user: DATestUser) -> None:
@@ -247,70 +238,10 @@ def test_create_skill_413_on_oversized_bundle(admin_user: DATestUser) -> None:
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
         SkillManager.create_custom(
             admin_user,
-            slug=f"too-big-{uuid4().hex[:8]}",
+            name=f"too-big-{uuid4().hex[:8]}",
             bundle_bytes=big_bundle,
         )
     assert exc_info.value.response.status_code == 413
-
-
-def test_create_skill_failure_cleans_up_orphan_blob(
-    admin_user: DATestUser,
-) -> None:
-    """Force the DB step to fail post-blob-write; verify the blob is gone.
-
-    The cheapest reproducible "DB fails after blob written" is a duplicate
-    slug: the first create succeeds (and persists a blob), the second create
-    is forced to validate + write its own blob and *then* hits the unique
-    constraint on slug at the DB layer — the rollback path must delete the
-    new blob (regression for SHA `d45bbe1b15`).
-
-    We observe the orphan-cleanup by snapshotting the file store before and
-    after the failing call, asserting the set of skill-bundle file ids did
-    not grow.
-    """
-    slug = f"orphan-{uuid4().hex[:8]}"
-
-    # First create — succeeds and saves blob #1.
-    first = SkillManager.create_custom(admin_user, slug=slug)
-    first_row = _fetch_skill_row(first.id)
-    assert first_row is not None
-    first_blob_id = first_row.bundle_file_id
-    assert first_blob_id is not None  # custom skills always have a bundle
-
-    # Snapshot file store blobs before the failing create.
-    blobs_before = _skill_bundle_blob_ids()
-
-    # Second create — bundle is fine, but the DB insert fails on the
-    # unique-slug check after the blob has already been written. The except
-    # branch should delete the just-written blob before re-raising.
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_custom(admin_user, slug=slug)
-    assert exc_info.value.response.status_code == 409
-
-    # First skill's blob is untouched.
-    assert _bundle_blob_exists(first_blob_id), (
-        "first skill's blob should be intact after the failing duplicate create"
-    )
-
-    # The orphan blob was cleaned up from the file store: no new blob IDs
-    # appeared after the failing create.
-    blobs_after = _skill_bundle_blob_ids()
-    orphan_blobs = blobs_after - blobs_before
-    assert not orphan_blobs, (
-        f"Orphan blob(s) leaked into the file store: {orphan_blobs}"
-    )
-
-    # And the failing create's blob was cleaned up: the only skill row for
-    # this slug is the original, and its blob is the only one tied to it.
-    # We assert by counting Skill rows with this slug.
-    with get_session_with_current_tenant() as db_session:
-        rows = (
-            db_session.execute(select(Skill).where(Skill.slug == slug)).scalars().all()
-        )
-    assert len(rows) == 1, (
-        f"expected exactly one skill row with slug {slug}; got {len(rows)}"
-    )
-    assert rows[0].bundle_file_id == first_blob_id
 
 
 # ---------------------------------------------------------------------------
@@ -327,7 +258,7 @@ def test_replace_group_shares_400_on_unknown_group_id(
     INVALID_INPUT, not a 500.
     """
     skill = SkillManager.create_custom(
-        admin_user, slug=f"unknown-grp-{uuid4().hex[:8]}", is_public=False
+        admin_user, name=f"unknown-grp-{uuid4().hex[:8]}", is_public=False
     )
 
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
@@ -363,7 +294,7 @@ def test_delete_skill_404_for_nonexistent(admin_user: DATestUser) -> None:
 
 def test_basic_user_can_create_private_skill(basic_user: DATestUser) -> None:
     skill = SkillManager.create_custom(
-        basic_user, slug=f"basic-create-{uuid4().hex[:6]}"
+        basic_user, name=f"basic-create-{uuid4().hex[:6]}"
     )
     assert skill.public_permission is None
     assert skill.user_permission == "OWNER"
@@ -382,7 +313,7 @@ def test_curator_can_post_skill(
     )
     try:
         skill = SkillManager.create_custom(
-            curator, slug=f"curator-create-{uuid4().hex[:6]}"
+            curator, name=f"curator-create-{uuid4().hex[:6]}"
         )
         assert skill.enabled is True
     finally:

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -62,7 +62,7 @@ def test_create_and_list_skill(admin_user: DATestUser) -> None:
     name = f"test-create-{uuid4().hex[:6]}"
     skill = SkillManager.create_custom(admin_user, name=name)
     assert skill.name == name
-    assert skill.enabled is True
+    assert skill.enabled is False
 
     skills_list = SkillManager.list_all(admin_user)
     custom_names = [skill.name for skill in skills_list.customs]
@@ -315,7 +315,7 @@ def test_curator_can_post_skill(
         skill = SkillManager.create_custom(
             curator, name=f"curator-create-{uuid4().hex[:6]}"
         )
-        assert skill.enabled is True
+        assert skill.enabled is False
     finally:
         # restore so module-shared basic_user fixture stays BASIC
         UserManager.set_role(

--- a/backend/tests/integration/tests/skills/test_skills_admin.py
+++ b/backend/tests/integration/tests/skills/test_skills_admin.py
@@ -62,11 +62,14 @@ def test_create_and_list_skill(admin_user: DATestUser) -> None:
     name = f"test-create-{uuid4().hex[:6]}"
     skill = SkillManager.create_custom(admin_user, name=name)
     assert skill.name == name
-    assert skill.enabled is False
+    assert skill.enabled is True
 
     skills_list = SkillManager.list_all(admin_user)
-    custom_names = [skill.name for skill in skills_list.customs]
-    assert name in custom_names
+    [listed_skill] = [
+        candidate for candidate in skills_list.customs if candidate.id == skill.id
+    ]
+    assert listed_skill.name == name
+    assert listed_skill.enabled is True
 
 
 def test_patch_skill_metadata(admin_user: DATestUser) -> None:
@@ -315,7 +318,7 @@ def test_curator_can_post_skill(
         skill = SkillManager.create_custom(
             curator, name=f"curator-create-{uuid4().hex[:6]}"
         )
-        assert skill.enabled is False
+        assert skill.enabled is True
     finally:
         # restore so module-shared basic_user fixture stays BASIC
         UserManager.set_role(

--- a/backend/tests/integration/tests/skills/test_skills_management.py
+++ b/backend/tests/integration/tests/skills/test_skills_management.py
@@ -47,7 +47,7 @@ def test_edit_fetch_returns_instructions_and_share_details(
     stranger = UserManager.create(name=f"skill_stranger_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"edit-fetch-{uuid4().hex[:6]}",
+        name=f"edit-fetch-{uuid4().hex[:6]}",
     )
     skill_id = _skill_id(skill)
 
@@ -91,7 +91,7 @@ def test_preview_returns_instructions_without_share_details(
     viewer = UserManager.create(name=f"skill_preview_viewer_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"preview-custom-{uuid4().hex[:6]}",
+        name=f"preview-custom-{uuid4().hex[:6]}",
         description="Preview description",
     )
     skill_id = _skill_id(skill)
@@ -132,10 +132,10 @@ def test_builtin_preview_returns_instructions(basic_user: DATestUser) -> None:
 def test_patch_details_rewrites_bundle_without_changing_slug(
     basic_user: DATestUser,
 ) -> None:
-    slug = f"patch-details-{uuid4().hex[:6]}"
+    name = f"patch-details-{uuid4().hex[:6]}"
     skill = SkillManager.create_custom(
         basic_user,
-        slug=slug,
+        name=name,
         description="Original description",
     )
     skill_id = _skill_id(skill)
@@ -149,19 +149,19 @@ def test_patch_details_rewrites_bundle_without_changing_slug(
         ),
     )
 
-    assert updated.slug == slug
-    assert updated.name == slug
+    assert updated.name == name
+    assert updated.name == name
     assert updated.description == "Updated description"
 
     editable = SkillManager.get_editable(skill_id, basic_user)
-    assert editable.name == slug
+    assert editable.name == name
     assert editable.description == "Updated description"
     assert editable.instructions_markdown == (
         "# Updated instructions\n\nUse the revised workflow."
     )
 
     preview = SkillManager.preview(skill_id, basic_user)
-    assert preview.name == slug
+    assert preview.name == name
     assert preview.description == "Updated description"
     assert preview.instructions_markdown == (
         "# Updated instructions\n\nUse the revised workflow."
@@ -175,7 +175,7 @@ def test_direct_viewer_share_grants_view_not_edit(
     viewer = UserManager.create(name=f"skill_direct_viewer_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"direct-viewer-{uuid4().hex[:6]}",
+        name=f"direct-viewer-{uuid4().hex[:6]}",
     )
     skill_id = _skill_id(skill)
 
@@ -207,7 +207,7 @@ def test_direct_share_restores_existing_enabled_preference(
     recipient = UserManager.create(name=f"skill_recipient_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"preference-restore-{uuid4().hex[:6]}",
+        name=f"preference-restore-{uuid4().hex[:6]}",
     )
     share = SkillUserShareRequest(
         user_id=UUID(recipient.id),
@@ -234,7 +234,7 @@ def test_org_wide_editor_permission_grants_edit(
     other_user = UserManager.create(name=f"skill_org_editor_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"org-editor-{uuid4().hex[:6]}",
+        name=f"org-editor-{uuid4().hex[:6]}",
     )
     skill_id = _skill_id(skill)
 
@@ -269,7 +269,7 @@ def test_switching_from_org_wide_to_scoped_share_removes_org_visibility(
     unshared_user = UserManager.create(name=f"skill_unscoped_user_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"scoped-share-{uuid4().hex[:6]}",
+        name=f"scoped-share-{uuid4().hex[:6]}",
     )
     skill_id = _skill_id(skill)
 
@@ -301,7 +301,7 @@ def test_owner_transfer_demotes_previous_owner_and_promotes_new_owner(
     new_owner = UserManager.create(name=f"skill_new_owner_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"transfer-owner-{uuid4().hex[:6]}",
+        name=f"transfer-owner-{uuid4().hex[:6]}",
     )
     skill_id = _skill_id(skill)
     SkillManager.share(
@@ -348,7 +348,7 @@ def test_sharee_cannot_transfer_ownership(
     target = UserManager.create(name=f"skill_transfer_target_{uuid4().hex[:8]}")
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"transfer-deny-{permission.lower()}-{uuid4().hex[:6]}",
+        name=f"transfer-deny-{permission.lower()}-{uuid4().hex[:6]}",
     )
     SkillManager.share(
         skill,
@@ -378,7 +378,7 @@ def test_transfer_rejects_missing_and_inactive_targets(
     )
     skill = SkillManager.create_custom(
         basic_user,
-        slug=f"transfer-target-{uuid4().hex[:6]}",
+        name=f"transfer-target-{uuid4().hex[:6]}",
     )
     skill_id = _skill_id(skill)
 
@@ -402,7 +402,7 @@ def test_admin_transfers_vacant_skill_but_not_owned_skill(
     target = UserManager.create(name=f"skill_admin_target_{uuid4().hex[:8]}")
     owned_skill = SkillManager.create_custom(
         owner,
-        slug=f"admin-owned-transfer-{uuid4().hex[:6]}",
+        name=f"admin-owned-transfer-{uuid4().hex[:6]}",
     )
     owned_skill_id = _skill_id(owned_skill)
 

--- a/backend/tests/integration/tests/skills/test_skills_management.py
+++ b/backend/tests/integration/tests/skills/test_skills_management.py
@@ -332,7 +332,7 @@ def test_owner_transfer_demotes_previous_owner_and_promotes_new_owner(
     new_owner_response = SkillManager.get_for_user(str(skill_id), new_owner)
     assert new_owner_response.author_user_id == UUID(new_owner.id)
     assert new_owner_response.user_permission == SkillAccessLevel.OWNER
-    assert new_owner_response.enabled is True
+    assert new_owner_response.enabled is False
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/integration/tests/skills/test_skills_personal.py
+++ b/backend/tests/integration/tests/skills/test_skills_personal.py
@@ -223,8 +223,30 @@ def test_duplicate_name_across_users(
     second = SkillManager.create_personal(other_basic_user, name=name)
 
     assert first.id != second.id
-    assert first.enabled is True
-    assert second.enabled is True
+    assert first.enabled is False
+    assert second.enabled is False
+
+
+def test_same_name_enable_requires_explicit_replacement(
+    basic_user: DATestUser,
+) -> None:
+    name = f"personal-switch-{uuid4().hex[:6]}"
+    first = SkillManager.create_personal(basic_user, name=name)
+    second = SkillManager.create_personal(basic_user, name=name)
+    SkillManager.set_enabled(first, basic_user, True)
+
+    with pytest.raises(httpx.HTTPStatusError) as exc_info:
+        SkillManager.set_enabled(second, basic_user, True)
+    assert exc_info.value.response.status_code == 409
+    assert exc_info.value.response.json()["error_code"] == "SKILL_NAME_CONFLICT"
+
+    SkillManager.set_enabled(second, basic_user, True, replace_conflict=True)
+    matching = [
+        skill
+        for skill in SkillManager.list_for_user(basic_user).customs
+        if skill.name == name
+    ]
+    assert [skill.id for skill in matching if skill.enabled] == [second.id]
 
 
 def test_personal_and_shared_skills_can_have_the_same_name(
@@ -242,7 +264,7 @@ def test_personal_and_shared_skills_can_have_the_same_name(
         if skill.name == name
     ]
     assert {skill.id for skill in visible} == {shared.id, personal.id}
-    assert [skill.id for skill in visible if skill.enabled] == [personal.id]
+    assert not [skill for skill in visible if skill.enabled]
 
 
 def test_admin_can_hard_delete_personal_skill(
@@ -295,6 +317,8 @@ def test_owner_can_toggle_personal_skill(
     name = f"personal-toggle-{uuid4().hex[:6]}"
     skill = SkillManager.create_personal(basic_user, name=name)
 
+    toggled = SkillManager.set_enabled(skill, basic_user, True)
+    assert toggled.enabled is True
     toggled = SkillManager.set_enabled(skill, basic_user, False)
     assert toggled.enabled is False
     assert toggled.is_personal is True
@@ -331,6 +355,7 @@ def test_user_enablement_is_independent(
         SkillPatchRequest(public_permission=SkillSharePermission.VIEWER),
     )
 
+    SkillManager.set_enabled(skill, basic_user, True)
     SkillManager.set_enabled(skill, admin_user, False)
     own = [
         skill

--- a/backend/tests/integration/tests/skills/test_skills_personal.py
+++ b/backend/tests/integration/tests/skills/test_skills_personal.py
@@ -223,8 +223,8 @@ def test_duplicate_name_across_users(
     second = SkillManager.create_personal(other_basic_user, name=name)
 
     assert first.id != second.id
-    assert first.enabled is False
-    assert second.enabled is False
+    assert first.enabled is True
+    assert second.enabled is True
 
 
 def test_same_name_enable_requires_explicit_replacement(
@@ -232,8 +232,26 @@ def test_same_name_enable_requires_explicit_replacement(
 ) -> None:
     name = f"personal-switch-{uuid4().hex[:6]}"
     first = SkillManager.create_personal(basic_user, name=name)
-    second = SkillManager.create_personal(basic_user, name=name)
-    SkillManager.set_enabled(first, basic_user, True)
+    with pytest.raises(httpx.HTTPStatusError) as create_exc_info:
+        SkillManager.create_personal(basic_user, name=name)
+    assert create_exc_info.value.response.status_code == 409
+    assert create_exc_info.value.response.json()["error_code"] == "SKILL_NAME_CONFLICT"
+    after_rejection = [
+        skill
+        for skill in SkillManager.list_for_user(basic_user).customs
+        if skill.name == name
+    ]
+    assert [(skill.id, skill.enabled) for skill in after_rejection] == [
+        (first.id, True)
+    ]
+
+    second = SkillManager.create_personal(
+        basic_user,
+        name=name,
+        auto_enable=False,
+    )
+    assert first.enabled is True
+    assert second.enabled is False
 
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
         SkillManager.set_enabled(second, basic_user, True)
@@ -246,6 +264,7 @@ def test_same_name_enable_requires_explicit_replacement(
         for skill in SkillManager.list_for_user(basic_user).customs
         if skill.name == name
     ]
+    assert len(matching) == 2
     assert [skill.id for skill in matching if skill.enabled] == [second.id]
 
 
@@ -264,7 +283,7 @@ def test_personal_and_shared_skills_can_have_the_same_name(
         if skill.name == name
     ]
     assert {skill.id for skill in visible} == {shared.id, personal.id}
-    assert not [skill for skill in visible if skill.enabled]
+    assert [skill.id for skill in visible if skill.enabled] == [personal.id]
 
 
 def test_admin_can_hard_delete_personal_skill(
@@ -317,8 +336,7 @@ def test_owner_can_toggle_personal_skill(
     name = f"personal-toggle-{uuid4().hex[:6]}"
     skill = SkillManager.create_personal(basic_user, name=name)
 
-    toggled = SkillManager.set_enabled(skill, basic_user, True)
-    assert toggled.enabled is True
+    assert skill.enabled is True
     toggled = SkillManager.set_enabled(skill, basic_user, False)
     assert toggled.enabled is False
     assert toggled.is_personal is True
@@ -355,7 +373,6 @@ def test_user_enablement_is_independent(
         SkillPatchRequest(public_permission=SkillSharePermission.VIEWER),
     )
 
-    SkillManager.set_enabled(skill, basic_user, True)
     SkillManager.set_enabled(skill, admin_user, False)
     own = [
         skill

--- a/backend/tests/integration/tests/skills/test_skills_personal.py
+++ b/backend/tests/integration/tests/skills/test_skills_personal.py
@@ -2,7 +2,7 @@
 
 Covers the user-facing ``POST /skills/custom``,
 ``PUT /skills/custom/{id}/bundle``, and ``DELETE /skills/custom/{id}``
-endpoints: ownership/visibility rules, reserved slugs, duplicate slugs,
+endpoints: ownership/visibility rules, reserved names, duplicate names,
 promotion to org-wide, and admin disable as a reversible mute.
 """
 
@@ -33,8 +33,8 @@ def other_basic_user(admin_user: DATestUser) -> DATestUser:  # noqa: ARG001
     return UserManager.create(name=f"other_basic_{uuid4().hex[:8]}")
 
 
-def _user_custom_slugs(user: DATestUser) -> list[str]:
-    return [skill.slug for skill in SkillManager.list_for_user(user).customs]
+def _user_custom_names(user: DATestUser) -> list[str]:
+    return [skill.name for skill in SkillManager.list_for_user(user).customs]
 
 
 def test_create_personal_skill_visibility(
@@ -42,17 +42,17 @@ def test_create_personal_skill_visibility(
     basic_user: DATestUser,
     other_basic_user: DATestUser,
 ) -> None:
-    slug = f"personal-vis-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-vis-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
     assert skill.is_personal is True
     assert skill.public_permission is None
 
     own_list = SkillManager.list_for_user(basic_user).customs
-    mine = [skill for skill in own_list if skill.slug == slug]
+    mine = [skill for skill in own_list if skill.name == name]
     assert len(mine) == 1
     assert mine[0].is_personal is True
 
-    assert slug not in _user_custom_slugs(other_basic_user)
+    assert name not in _user_custom_names(other_basic_user)
 
     response = client.get(
         f"{API_SERVER_URL}/skills/{skill.id}",
@@ -61,7 +61,7 @@ def test_create_personal_skill_visibility(
     assert response.status_code == 404
 
     admin_customs = SkillManager.list_all(admin_user).customs
-    admin_match = [skill for skill in admin_customs if skill.slug == slug]
+    admin_match = [skill for skill in admin_customs if skill.name == name]
     assert len(admin_match) == 1
     assert admin_match[0].is_personal is True
 
@@ -80,7 +80,7 @@ def test_create_personal_skill_from_editor(basic_user: DATestUser) -> None:
     )
 
     editable = SkillManager.get_editable(skill.id, basic_user)
-    assert skill.slug == f"editor-skill-{suffix}"
+    assert skill.name == f"editor-skill-{suffix}"
     assert skill.is_personal is True
     assert editable.instructions_markdown == "# Workflow\n\nFollow these steps."
     assert [file.path for file in editable.files] == ["context.txt"]
@@ -140,56 +140,56 @@ def test_upload_supporting_files_merges_and_bundle_upload_replaces(
 def test_create_personal_skill_accepts_wrapped_directory(
     basic_user: DATestUser,
 ) -> None:
-    slug = f"personal-wrapped-{uuid4().hex[:6]}"
+    name = f"personal-wrapped-{uuid4().hex[:6]}"
     bundle = io.BytesIO()
     with zipfile.ZipFile(bundle, "w", zipfile.ZIP_DEFLATED) as zf:
         zf.writestr(
-            f"{slug}/SKILL.md",
-            f"---\nname: {slug}\ndescription: Wrapped directory\n---\n\n"
+            f"{name}/SKILL.md",
+            f"---\nname: {name}\ndescription: Wrapped directory\n---\n\n"
             "Use the supporting script.",
         )
 
     skill = SkillManager.create_personal(
         basic_user,
-        slug=slug,
+        name=name,
         bundle_bytes=bundle.getvalue(),
     )
 
-    assert skill.name == slug
+    assert skill.name == name
     assert skill.description == "Wrapped directory"
 
 
 def test_owner_can_fetch_own_personal_skill(basic_user: DATestUser) -> None:
-    slug = f"personal-fetch-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-fetch-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
 
     fetched = SkillManager.get_for_user(str(skill.id), basic_user)
-    assert fetched.slug == slug
+    assert fetched.name == name
     assert fetched.is_personal is True
 
 
 def test_owner_can_replace_bundle_and_delete(basic_user: DATestUser) -> None:
-    slug = f"personal-mutate-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-mutate-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
 
-    new_bundle = build_minimal_bundle(slug, description="Updated personal desc")
+    new_bundle = build_minimal_bundle(name, description="Updated personal desc")
     updated = SkillManager.replace_personal_bundle(skill, new_bundle, basic_user)
-    assert updated.name == slug
+    assert updated.name == name
     assert updated.description == "Updated personal desc"
     assert updated.is_personal is True
 
     SkillManager.delete_personal(skill, basic_user)
-    assert slug not in _user_custom_slugs(basic_user)
+    assert name not in _user_custom_names(basic_user)
 
 
 def test_other_user_cannot_mutate_personal_skill(
     basic_user: DATestUser,
     other_basic_user: DATestUser,
 ) -> None:
-    slug = f"personal-guard-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-guard-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
 
-    new_bundle = build_minimal_bundle(slug)
+    new_bundle = build_minimal_bundle(name)
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
         SkillManager.replace_personal_bundle(skill, new_bundle, other_basic_user)
     assert exc_info.value.response.status_code == 404
@@ -199,14 +199,14 @@ def test_other_user_cannot_mutate_personal_skill(
     assert exc_info.value.response.status_code == 404
 
     # still intact for the owner
-    assert slug in _user_custom_slugs(basic_user)
+    assert name in _user_custom_names(basic_user)
 
 
 def test_create_personal_skill_rejects_reserved_slug(
     basic_user: DATestUser,
 ) -> None:
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_personal(basic_user, slug="slack")
+        SkillManager.create_personal(basic_user, name="slack")
     response = exc_info.value.response
     assert response.status_code == 400
     body = response.json()
@@ -214,33 +214,35 @@ def test_create_personal_skill_rejects_reserved_slug(
     assert "reserved" in detail.lower()
 
 
-def test_duplicate_slug_across_users_409(
+def test_duplicate_name_across_users(
     basic_user: DATestUser,
     other_basic_user: DATestUser,
 ) -> None:
-    slug = f"personal-dup-{uuid4().hex[:6]}"
-    SkillManager.create_personal(basic_user, slug=slug)
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_personal(other_basic_user, slug=slug)
-    assert exc_info.value.response.status_code == 409
+    name = f"personal-dup-{uuid4().hex[:6]}"
+    first = SkillManager.create_personal(basic_user, name=name)
+    second = SkillManager.create_personal(other_basic_user, name=name)
+
+    assert first.id != second.id
+    assert first.enabled is True
+    assert second.enabled is True
 
 
-def test_personal_slug_collides_with_admin_skill_both_directions(
+def test_personal_and_shared_skills_can_have_the_same_name(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    # personal slug shares one namespace with admin/org-wide skills
-    admin_slug = f"admin-collide-{uuid4().hex[:6]}"
-    SkillManager.create_custom(admin_user, slug=admin_slug, is_public=True)
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_personal(basic_user, slug=admin_slug)
-    assert exc_info.value.response.status_code == 409
+    name = f"personal-shared-collision-{uuid4().hex[:6]}"
+    shared = SkillManager.create_custom(admin_user, name=name, is_public=True)
+    personal = SkillManager.create_personal(basic_user, name=name)
 
-    personal_slug = f"personal-collide-{uuid4().hex[:6]}"
-    SkillManager.create_personal(basic_user, slug=personal_slug)
-    with pytest.raises(httpx.HTTPStatusError) as exc_info:
-        SkillManager.create_custom(admin_user, slug=personal_slug, is_public=True)
-    assert exc_info.value.response.status_code == 409
+    assert shared.id != personal.id
+    visible = [
+        skill
+        for skill in SkillManager.list_for_user(basic_user).customs
+        if skill.name == name
+    ]
+    assert {skill.id for skill in visible} == {shared.id, personal.id}
+    assert [skill.id for skill in visible if skill.enabled] == [personal.id]
 
 
 def test_admin_can_hard_delete_personal_skill(
@@ -248,22 +250,22 @@ def test_admin_can_hard_delete_personal_skill(
     basic_user: DATestUser,
 ) -> None:
     """Admins can hard-delete any custom skill, mirroring agents/personas."""
-    slug = f"personal-admin-delete-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-admin-delete-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
 
     SkillManager.delete_custom(skill, admin_user)
 
-    assert slug not in _user_custom_slugs(basic_user)
-    admin_slugs = [skill.slug for skill in SkillManager.list_all(admin_user).customs]
-    assert slug not in admin_slugs
+    assert name not in _user_custom_names(basic_user)
+    admin_names = [skill.name for skill in SkillManager.list_all(admin_user).customs]
+    assert name not in admin_names
 
 
 def test_owner_can_share_org_wide_and_retain_edit_permissions(
     basic_user: DATestUser,
     other_basic_user: DATestUser,
 ) -> None:
-    slug = f"personal-promote-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-promote-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
 
     promoted = SkillManager.patch_personal(
         skill,
@@ -274,13 +276,13 @@ def test_owner_can_share_org_wide_and_retain_edit_permissions(
     assert promoted.is_personal is False
 
     other_list = SkillManager.list_for_user(other_basic_user).customs
-    visible = [skill for skill in other_list if skill.slug == slug]
+    visible = [skill for skill in other_list if skill.name == name]
     assert len(visible) == 1
     assert visible[0].is_personal is False
 
-    new_bundle = build_minimal_bundle(slug, description="Owner can still edit")
+    new_bundle = build_minimal_bundle(name, description="Owner can still edit")
     updated = SkillManager.replace_personal_bundle(skill, new_bundle, basic_user)
-    assert updated.name == slug
+    assert updated.name == name
 
     disabled = SkillManager.set_enabled(skill, basic_user, False)
     assert disabled.enabled is False
@@ -290,8 +292,8 @@ def test_owner_can_toggle_personal_skill(
     basic_user: DATestUser,
     other_basic_user: DATestUser,
 ) -> None:
-    slug = f"personal-toggle-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-toggle-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
 
     toggled = SkillManager.set_enabled(skill, basic_user, False)
     assert toggled.enabled is False
@@ -301,13 +303,13 @@ def test_owner_can_toggle_personal_skill(
     own = [
         skill
         for skill in SkillManager.list_for_user(basic_user).customs
-        if skill.slug == slug
+        if skill.name == name
     ]
     assert len(own) == 1
     assert own[0].enabled is False
 
     # still invisible to everyone else
-    assert slug not in _user_custom_slugs(other_basic_user)
+    assert name not in _user_custom_names(other_basic_user)
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
         SkillManager.set_enabled(skill, other_basic_user, True)
     assert exc_info.value.response.status_code == 404
@@ -321,8 +323,8 @@ def test_user_enablement_is_independent(
     basic_user: DATestUser,
 ) -> None:
     """One user's preference does not change another user's preference."""
-    slug = f"personal-admin-toggle-{uuid4().hex[:6]}"
-    skill = SkillManager.create_personal(basic_user, slug=slug)
+    name = f"personal-admin-toggle-{uuid4().hex[:6]}"
+    skill = SkillManager.create_personal(basic_user, name=name)
     SkillManager.patch_personal(
         skill,
         basic_user,
@@ -333,7 +335,7 @@ def test_user_enablement_is_independent(
     own = [
         skill
         for skill in SkillManager.list_for_user(basic_user).customs
-        if skill.slug == slug
+        if skill.name == name
     ]
     assert len(own) == 1 and own[0].enabled is True
 

--- a/backend/tests/integration/tests/skills/test_skills_user.py
+++ b/backend/tests/integration/tests/skills/test_skills_user.py
@@ -29,7 +29,7 @@ def test_get_skills_returns_builtins_plus_accessible_customs(
 ) -> None:
     """The user listing returns both built-ins and visible customs."""
     SkillManager.create_custom(
-        admin_user, slug=f"mixed-public-{uuid4().hex[:6]}", is_public=True
+        admin_user, name=f"mixed-public-{uuid4().hex[:6]}", is_public=True
     )
 
     user_skills = SkillManager.list_for_user(basic_user)
@@ -54,10 +54,10 @@ def test_newly_shared_skill_is_visible_but_disabled(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    slug = f"disabled-{uuid4().hex[:6]}"
-    SkillManager.create_custom(admin_user, slug=slug, is_public=True)
+    name = f"disabled-{uuid4().hex[:6]}"
+    SkillManager.create_custom(admin_user, name=name, is_public=True)
     user_skills = SkillManager.list_for_user(basic_user)
-    [shared_skill] = [skill for skill in user_skills.customs if skill.slug == slug]
+    [shared_skill] = [skill for skill in user_skills.customs if skill.name == name]
     assert shared_skill.enabled is False
     assert shared_skill.can_toggle is True
 
@@ -66,12 +66,12 @@ def test_user_does_not_see_private_skill_without_share(
     admin_user: DATestUser,
     basic_user: DATestUser,
 ) -> None:
-    slug = f"private-unshared-{uuid4().hex[:6]}"
-    SkillManager.create_custom(admin_user, slug=slug, is_public=False)
+    name = f"private-unshared-{uuid4().hex[:6]}"
+    SkillManager.create_custom(admin_user, name=name, is_public=False)
 
     user_skills = SkillManager.list_for_user(basic_user)
-    custom_slugs = [skill.slug for skill in user_skills.customs]
-    assert slug not in custom_slugs
+    custom_names = [skill.name for skill in user_skills.customs]
+    assert name not in custom_names
 
 
 @pytest.mark.skipif(
@@ -94,16 +94,16 @@ def test_user_sees_private_skill_with_group_share(
     )
     UserGroupManager.add_users(group, [basic_user.id], admin_user)
 
-    slug = f"private-shared-{uuid4().hex[:6]}"
+    name = f"private-shared-{uuid4().hex[:6]}"
     SkillManager.create_custom(
         admin_user,
-        slug=slug,
+        name=name,
         is_public=False,
         group_ids=[group.id],
     )
 
     user_skills = SkillManager.list_for_user(basic_user)
-    [shared_skill] = [skill for skill in user_skills.customs if skill.slug == slug]
+    [shared_skill] = [skill for skill in user_skills.customs if skill.name == name]
     assert shared_skill.enabled is False
     assert shared_skill.can_toggle is True
 
@@ -113,8 +113,8 @@ def test_get_skill_by_id_404_when_not_visible(
     basic_user: DATestUser,
 ) -> None:
     """Direct lookup by UUID obeys the same visibility filter as listing."""
-    slug = f"hidden-id-{uuid4().hex[:6]}"
-    skill = SkillManager.create_custom(admin_user, slug=slug, is_public=False)
+    name = f"hidden-id-{uuid4().hex[:6]}"
+    skill = SkillManager.create_custom(admin_user, name=name, is_public=False)
 
     response = client.get(
         f"{API_SERVER_URL}/skills/{skill.id}",
@@ -128,7 +128,7 @@ def test_non_owner_cannot_delete_skill(
     basic_user: DATestUser,
 ) -> None:
     """Users without edit permissions cannot delete another user's skill."""
-    skill = SkillManager.create_custom(admin_user, slug=f"no-del-{uuid4().hex[:6]}")
+    skill = SkillManager.create_custom(admin_user, name=f"no-del-{uuid4().hex[:6]}")
     response = client.delete(
         f"{API_SERVER_URL}/skills/custom/{skill.id}",
         headers=basic_user.headers,

--- a/backend/tests/unit/external_apps/matching/test_engine.py
+++ b/backend/tests/unit/external_apps/matching/test_engine.py
@@ -32,7 +32,7 @@ def test_rejects_empty_actions() -> None:
 
 
 def _app(app_type: ExternalAppType = ExternalAppType.SLACK) -> ExternalApp:
-    app = ExternalApp(app_type=app_type)
+    app = ExternalApp(name="Slack", app_type=app_type)
     app.id = 1
     return app
 
@@ -68,6 +68,16 @@ def test_apply_gate_serveable_no_catalog_synthesizes_whole_domain_ask() -> None:
     assert matched_actions.governing_action.policy == EndpointPolicy.ASK
     assert matched_actions.app_name == "Slack"
     assert matched_actions.target.key == (GatedAppKind.EXTERNAL_APP, 1)
+
+
+def test_apply_gate_uses_custom_app_display_name() -> None:
+    app = _app(ExternalAppType.CUSTOM)
+    app.name = "Customer CRM"
+
+    matched_actions = apply_credential_gate(app, _request(), None, is_available=True)
+
+    assert matched_actions is not None
+    assert matched_actions.app_name == "Customer CRM"
 
 
 def test_apply_gate_not_serveable_no_catalog_forwards_bare() -> None:

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -272,7 +272,7 @@ def _setup(
     the lock)."""
     provider = GoogleCalendarProvider()
     app = MagicMock()
-    app.skill.name = "Google Calendar"
+    app.name = "Google Calendar"
 
     monkeypatch.setattr(tr, "redis_shared_lock", _noop_cm)
     monkeypatch.setattr(tr, "get_session_with_tenant", _noop_cm)

--- a/backend/tests/unit/onyx/server/features/build/external_apps/test_api_bundle_cleanup.py
+++ b/backend/tests/unit/onyx/server/features/build/external_apps/test_api_bundle_cleanup.py
@@ -67,7 +67,7 @@ def test_replace_custom_app_bundle_cleans_new_bundle_on_failure(
         ExternalApp,
         SimpleNamespace(
             app_type=ExternalAppType.CUSTOM,
-            skill=SimpleNamespace(slug="helper-skill"),
+            skill=SimpleNamespace(name="helper-skill"),
         ),
     )
     monkeypatch.setattr(external_apps_api, "get_default_file_store", lambda: file_store)

--- a/backend/tests/unit/onyx/server/features/build/external_apps/test_api_user_response.py
+++ b/backend/tests/unit/onyx/server/features/build/external_apps/test_api_user_response.py
@@ -29,10 +29,10 @@ def _external_app(
         ExternalApp,
         SimpleNamespace(
             id=1,
+            name="Test App",
             skill=SimpleNamespace(
-                name="Test App",
+                name="test-app",
                 description="Test description",
-                slug="test-app",
             ),
             app_type=app_type,
             auth_template=auth_template,

--- a/backend/tests/unit/onyx/skills/test_content.py
+++ b/backend/tests/unit/onyx/skills/test_content.py
@@ -62,7 +62,7 @@ def test_read_custom_skill_bundle_instructions_reads_bundle_from_file_store() ->
     file_store.read_file.return_value = io.BytesIO(zip_bytes)
 
     instructions = read_custom_skill_bundle_instructions(
-        Skill(slug="preview-test", bundle_file_id="bundle-file-id"),
+        Skill(name="preview-test", bundle_file_id="bundle-file-id"),
         file_store,
     )
 

--- a/backend/tests/unit/onyx/skills/test_push.py
+++ b/backend/tests/unit/onyx/skills/test_push.py
@@ -11,6 +11,8 @@ import pytest
 from sqlalchemy.orm import Session
 
 from onyx.db.models import Skill, User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import FileStore
 from onyx.skills import push
 
@@ -32,15 +34,14 @@ def _bundle(name: str, *, wrapper: str | None = None) -> bytes:
 
 def _skill(
     *,
-    slug: str = "canonical-name",
+    name: str = "canonical-name",
     is_valid: bool | None = None,
 ) -> Skill:
     return cast(
         Skill,
         SimpleNamespace(
             id=uuid4(),
-            slug=slug,
-            name=slug,
+            name=name,
             bundle_file_id="bundle-id",
             built_in_skill_id=None,
             is_valid=is_valid,
@@ -60,6 +61,16 @@ def test_skill_runtime_hash_covers_files_and_connectable_apps() -> None:
     assert push.compute_skill_runtime_hash(
         files, "apps"
     ) != push.compute_skill_runtime_hash(files, "different apps")
+
+
+def test_assemble_rejects_duplicate_names() -> None:
+    user = cast(User, SimpleNamespace())
+    skills = [_skill(is_valid=True), _skill(is_valid=True)]
+
+    with pytest.raises(OnyxError) as exc_info:
+        push._assemble_fileset(skills, user, MagicMock(spec=Session))
+
+    assert exc_info.value.error_code == OnyxErrorCode.INTERNAL_ERROR
 
 
 def test_assemble_classifies_and_hydrates_valid_unclassified_skill(
@@ -203,7 +214,7 @@ def test_user_payload_returns_hydrated_files_and_connectable_apps(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     valid_skill = _skill(is_valid=True)
-    invalid_skill = _skill(slug="invalid-skill", is_valid=False)
+    invalid_skill = _skill(name="invalid-skill", is_valid=False)
     user = cast(User, SimpleNamespace())
     db_session = MagicMock(spec=Session)
     monkeypatch.setattr(

--- a/backend/tests/unit/onyx/skills/test_skill_access.py
+++ b/backend/tests/unit/onyx/skills/test_skill_access.py
@@ -22,8 +22,7 @@ def _skill(
 ) -> Skill:
     return Skill(
         id=uuid4(),
-        slug=f"skill-{uuid4().hex}",
-        name="Skill",
+        name=f"skill-{uuid4().hex}",
         description="Description",
         author_user_id=author.id,
         public_permission=public_permission if is_public else None,

--- a/backend/tests/unit/onyx/skills/test_validation.py
+++ b/backend/tests/unit/onyx/skills/test_validation.py
@@ -12,12 +12,12 @@ from onyx.file_store.file_store import FileStore
 from onyx.skills.validation import validate_stored_custom_skill
 
 
-def _skill(slug: str = "canonical-name") -> Skill:
+def _skill(name: str = "canonical-name") -> Skill:
     return cast(
         Skill,
         SimpleNamespace(
             id=uuid4(),
-            slug=slug,
+            name=name,
             bundle_file_id="bundle-id",
         ),
     )

--- a/backend/tests/unit/sandbox_proxy/test_request_evaluator.py
+++ b/backend/tests/unit/sandbox_proxy/test_request_evaluator.py
@@ -17,7 +17,11 @@ def _app(
     patterns: list[str],
     app_type: ExternalAppType = ExternalAppType.CUSTOM,
 ) -> ExternalApp:
-    return ExternalApp(app_type=app_type, upstream_url_patterns=patterns)
+    return ExternalApp(
+        name=app_type.value,
+        app_type=app_type,
+        upstream_url_patterns=patterns,
+    )
 
 
 def test_custom_glob_matches_deep_path() -> None:

--- a/web/src/app/craft/components/CraftInputBar.stories.tsx
+++ b/web/src/app/craft/components/CraftInputBar.stories.tsx
@@ -24,7 +24,7 @@ const SWR_NO_FETCH = {
 };
 
 const skillsList: SkillsList = {
-  builtins: [builtinFixture(), builtinFixture({ slug: "pdf", name: "PDF" })],
+  builtins: [builtinFixture(), builtinFixture({ name: "pdf" })],
   customs: [customFixture()],
 };
 

--- a/web/src/app/craft/services/externalAppsService.ts
+++ b/web/src/app/craft/services/externalAppsService.ts
@@ -55,7 +55,7 @@ interface CreateCustomExternalAppInput {
   upstream_url_patterns: string[];
   auth_template: Record<string, string>;
   organization_credentials: Record<string, string>;
-  /** Required — the skill bundle whose filename becomes the app slug. */
+  /** Required skill bundle; its SKILL.md defines the linked skill name. */
   bundle: File;
 }
 
@@ -94,7 +94,7 @@ export async function createCustomExternalApp(
 }
 
 /**
- * Replace a custom app's bundle bytes, keeping its slug
+ * Replace a custom app's bundle bytes, keeping its skill name
  * (`PUT /admin/apps/{id}/bundle`). The only multipart channel for edits; all
  * other field edits go through {@link updateExternalApp}.
  */

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -256,8 +256,8 @@ export default function CreateCustomAppModal({
               </Text>
               <Text font="secondary-body" color="text-03">
                 {isEdit
-                  ? "Optional — upload a new zip to replace the current bundle. Leave empty to keep it. The slug stays the same."
-                  : "A zip containing SKILL.md plus any other files. The filename becomes the app slug."}
+                  ? "Optional — upload a new zip to replace the current bundle. Leave empty to keep it. The skill name stays the same."
+                  : "A zip containing SKILL.md plus any other files. The linked skill name comes from SKILL.md."}
               </Text>
               <div className="flex items-center gap-2">
                 <input

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -114,7 +114,7 @@ export interface ExternalAppUserResponse {
 
 /**
  * Built-in descriptors still available to add. Only one app per `app_type` is
- * allowed (server-enforced via the built-in skill's unique slug), so configured
+ * allowed (server-enforced through its backing skill name), so configured
  * types are dropped to avoid a duplicate-resource error. Cloud managed built-ins
  * are pre-provisioned (always configured) and never show here. CUSTOM apps have
  * no descriptor, so they never match and are left untouched.

--- a/web/src/lib/skills/__fixtures__/picker.ts
+++ b/web/src/lib/skills/__fixtures__/picker.ts
@@ -8,8 +8,7 @@ export function builtinFixture(over: Partial<BuiltinSkill> = {}): BuiltinSkill {
   return {
     source: "builtin",
     id: "builtin-1",
-    slug: "pptx",
-    name: "PPTX",
+    name: "pptx",
     description: "Build PowerPoint decks.",
     is_available: true,
     unavailable_reason: null,
@@ -35,8 +34,7 @@ export function customFixture(over: Partial<CustomSkill> = {}): CustomSkill {
   return {
     source: "custom",
     id: "custom-1",
-    slug: "report-writer",
-    name: "Report Writer",
+    name: "report-writer",
     description: "Draft a structured report from notes.",
     is_available: null,
     unavailable_reason: null,

--- a/web/src/lib/skills/__tests__/picker.test.ts
+++ b/web/src/lib/skills/__tests__/picker.test.ts
@@ -56,8 +56,8 @@ describe("toPickerSections", () => {
   it("places plain built-ins in `skills`", () => {
     const data = skillsList({
       builtins: [
-        builtinFixture({ slug: "pptx" }),
-        builtinFixture({ slug: "image-gen" }),
+        builtinFixture({ name: "pptx" }),
+        builtinFixture({ name: "image-gen" }),
       ],
     });
     const result = toPickerSections(data, []);
@@ -68,8 +68,8 @@ describe("toPickerSections", () => {
   it("filters out unavailable built-ins", () => {
     const data = skillsList({
       builtins: [
-        builtinFixture({ slug: "pptx" }),
-        builtinFixture({ slug: "image-gen", is_available: false }),
+        builtinFixture({ name: "pptx" }),
+        builtinFixture({ name: "image-gen", is_available: false }),
       ],
     });
     expect(toPickerSections(data, []).skills.map((s) => s.slug)).toEqual([
@@ -79,10 +79,10 @@ describe("toPickerSections", () => {
 
   it("appends enabled customs to `skills`", () => {
     const data = skillsList({
-      builtins: [builtinFixture({ slug: "pptx" })],
+      builtins: [builtinFixture({ name: "pptx" })],
       customs: [
-        customFixture({ slug: "my-custom" }),
-        customFixture({ slug: "disabled-one", enabled: false }),
+        customFixture({ name: "my-custom" }),
+        customFixture({ name: "disabled-one", enabled: false }),
       ],
     });
     expect(toPickerSections(data, []).skills.map((s) => s.slug)).toEqual([
@@ -94,8 +94,8 @@ describe("toPickerSections", () => {
   it("filters out invalid customs", () => {
     const data = skillsList({
       customs: [
-        customFixture({ slug: "valid-skill" }),
-        customFixture({ slug: "invalid-skill", is_valid: false }),
+        customFixture({ name: "valid-skill" }),
+        customFixture({ name: "invalid-skill", is_valid: false }),
       ],
     });
     expect(toPickerSections(data, []).skills.map((s) => s.slug)).toEqual([

--- a/web/src/lib/skills/api.test.ts
+++ b/web/src/lib/skills/api.test.ts
@@ -1,0 +1,54 @@
+import {
+  createCustomSkill,
+  createCustomSkillFromEditor,
+  isSkillNameConflict,
+} from "@/lib/skills/api";
+
+describe("skills API", () => {
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ id: "created-skill" }),
+    } as Response);
+    global.fetch = fetchMock;
+  });
+
+  it("sends the confirmed disabled state through both creation APIs", async () => {
+    await createCustomSkill(new File(["bundle"], "skill.zip"), false);
+    await createCustomSkillFromEditor({
+      name: "report-writer",
+      description: "Writes reports",
+      instructions_markdown: "Write the report.",
+      auto_enable: false,
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/skills/custom");
+    expect(fetchMock.mock.calls[1]![0]).toBe("/api/skills/custom/editor");
+    for (const [, request] of fetchMock.mock.calls) {
+      expect((request!.body as FormData).get("auto_enable")).toBe("false");
+    }
+  });
+
+  it("recognizes only the dedicated skill-name conflict", () => {
+    expect(
+      isSkillNameConflict(
+        Object.assign(new Error("Conflict"), {
+          errorCode: "SKILL_NAME_CONFLICT",
+        })
+      )
+    ).toBe(true);
+    expect(
+      isSkillNameConflict(
+        Object.assign(new Error("Different conflict"), {
+          errorCode: "DUPLICATE_RESOURCE",
+        })
+      )
+    ).toBe(false);
+    expect(isSkillNameConflict(new Error("No structured code"))).toBe(false);
+  });
+});

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -14,21 +14,25 @@ import type {
   SkillSharePermission,
 } from "@/lib/skills/types";
 
-async function readErrorDetail(res: Response): Promise<string> {
-  try {
-    const body = await res.json();
-    if (typeof body?.detail === "string") return body.detail;
-    if (Array.isArray(body?.detail) && body.detail[0]?.msg)
-      return body.detail[0].msg;
-  } catch {
-    // fall through
-  }
-  return `Request failed (${res.status})`;
-}
-
 async function handle<T>(res: Response): Promise<T> {
   if (!res.ok) {
-    throw new Error(await readErrorDetail(res));
+    let errorCode: string | undefined;
+    let detail = `Request failed (${res.status})`;
+    try {
+      const body = await res.json();
+      if (typeof body?.error_code === "string") errorCode = body.error_code;
+      if (typeof body?.detail === "string") detail = body.detail;
+      else if (Array.isArray(body?.detail) && body.detail[0]?.msg) {
+        detail = body.detail[0].msg;
+      }
+    } catch {
+      // Use the generic status message.
+    }
+    const error = new Error(detail) as Error & {
+      errorCode: string | undefined;
+    };
+    error.errorCode = errorCode;
+    throw error;
   }
   if (res.status === 204) {
     return undefined as T;
@@ -82,12 +86,13 @@ export interface PatchCustomSkillInput {
 
 export async function setSkillEnabled(
   skillId: string,
-  enabled: boolean
+  enabled: boolean,
+  replaceConflict = false
 ): Promise<Skill> {
   const res = await fetch(`/api/skills/${skillId}/enabled`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ enabled }),
+    body: JSON.stringify({ enabled, replace_conflict: replaceConflict }),
   });
   return handle<Skill>(res);
 }

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -44,9 +44,13 @@ async function handle<T>(res: Response): Promise<T> {
 // Mutations
 // ---------------------------------------------------------------------------
 
-export async function createCustomSkill(bundle: File): Promise<CustomSkill> {
+export async function createCustomSkill(
+  bundle: File,
+  autoEnable = true
+): Promise<CustomSkill> {
   const form = new FormData();
   form.append("bundle", bundle);
+  form.append("auto_enable", String(autoEnable));
 
   const res = await fetch("/api/skills/custom", {
     method: "POST",
@@ -59,6 +63,7 @@ export interface CreateCustomSkillInput {
   name: string;
   description: string;
   instructions_markdown: string;
+  auto_enable?: boolean;
 }
 
 export async function createCustomSkillFromEditor(
@@ -69,6 +74,7 @@ export async function createCustomSkillFromEditor(
   form.append("name", input.name);
   form.append("description", input.description);
   form.append("instructions_markdown", input.instructions_markdown);
+  form.append("auto_enable", String(input.auto_enable ?? true));
   if (upload) form.append("upload", upload);
 
   const res = await fetch("/api/skills/custom/editor", {
@@ -76,6 +82,14 @@ export async function createCustomSkillFromEditor(
     body: form,
   });
   return handle<SkillEditableDetail>(res);
+}
+
+export function isSkillNameConflict(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    "errorCode" in error &&
+    error.errorCode === "SKILL_NAME_CONFLICT"
+  );
 }
 
 export interface PatchCustomSkillInput {

--- a/web/src/lib/skills/picker.ts
+++ b/web/src/lib/skills/picker.ts
@@ -43,7 +43,7 @@ export function toPickerSections(
     if (!b.is_available || !b.enabled) continue;
     skills.push({
       kind: "skill",
-      slug: b.slug,
+      slug: b.name,
       name: b.name,
       description: b.description,
     });
@@ -53,7 +53,7 @@ export function toPickerSections(
     if (!c.enabled || c.is_valid === false) continue;
     skills.push({
       kind: "skill",
-      slug: c.slug,
+      slug: c.name,
       name: c.name,
       description: c.description,
     });

--- a/web/src/lib/skills/types.ts
+++ b/web/src/lib/skills/types.ts
@@ -24,7 +24,6 @@ export interface SkillGroupShare {
 export interface Skill {
   source: SkillSource;
   id: string;
-  slug: string;
   name: string;
   description: string;
 

--- a/web/src/sections/cards/SkillCard.test.tsx
+++ b/web/src/sections/cards/SkillCard.test.tsx
@@ -28,7 +28,6 @@ function custom(overrides: Partial<CustomSkill> = {}): CustomSkillCardItem {
   const skill: CustomSkill = {
     source: "custom",
     id: "custom-skill-id",
-    slug: "report-writer",
     name: "Report Writer",
     description: "Draft reports",
     is_available: null,
@@ -65,7 +64,6 @@ function custom(overrides: Partial<CustomSkill> = {}): CustomSkillCardItem {
 function invalidCustom(): CustomSkillCardItem {
   return custom({
     id: "invalid-skill-id",
-    slug: "invalid-skill",
     name: "Invalid skill",
     description: "Invalid bundle",
     is_valid: false,

--- a/web/src/sections/modals/skills/CreateSkillModal.test.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
+import type { CustomSkill } from "@/lib/skills/types";
+
+const mockCreateCustomSkill = jest.fn();
+const mockInspectSkillBundle = jest.fn();
+
+jest.mock("@/lib/skills/api", () => ({
+  ...jest.requireActual("@/lib/skills/api"),
+  createCustomSkill: (...args: unknown[]) => mockCreateCustomSkill(...args),
+  inspectSkillBundle: (...args: unknown[]) => mockInspectSkillBundle(...args),
+}));
+
+jest.mock("@/sections/skills/SkillBundlePicker", () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (bundle: object) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onChange({
+          file: new File(["bundle"], "skill.zip"),
+          displayName: "skill.zip",
+          source: "zip",
+        })
+      }
+    >
+      Select bundle
+    </button>
+  ),
+}));
+
+describe("CreateSkillModal", () => {
+  beforeEach(() => {
+    mockCreateCustomSkill.mockReset();
+    mockInspectSkillBundle.mockReset();
+  });
+
+  it("confirms before creating a same-name skill disabled", async () => {
+    const user = setupUser();
+    const onCreated = jest.fn();
+    const conflict = Object.assign(new Error("Name conflict"), {
+      errorCode: "SKILL_NAME_CONFLICT",
+    });
+    const created = {
+      id: "new-skill-id",
+      name: "report-writer",
+      enabled: false,
+    } as CustomSkill;
+    mockInspectSkillBundle.mockResolvedValue({ name: "report-writer" });
+    mockCreateCustomSkill
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce(created);
+
+    render(<CreateSkillModal open onClose={jest.fn()} onCreated={onCreated} />);
+    await user.click(screen.getByRole("button", { name: "Select bundle" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(
+      await screen.findByText("Create another “report-writer” skill?")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The new skill will start disabled. You can switch which one is active from the Skills page."
+      )
+    ).toBeInTheDocument();
+    expect(mockCreateCustomSkill).toHaveBeenCalledTimes(1);
+    expect(mockCreateCustomSkill).toHaveBeenCalledWith(expect.any(File), true);
+    expect(onCreated).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Create anyway" }));
+
+    await waitFor(() => {
+      expect(mockCreateCustomSkill).toHaveBeenNthCalledWith(
+        1,
+        expect.any(File),
+        true
+      );
+      expect(mockCreateCustomSkill).toHaveBeenNthCalledWith(
+        2,
+        expect.any(File),
+        false
+      );
+      expect(onCreated).toHaveBeenCalledWith(created);
+    });
+    expect(mockInspectSkillBundle).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns to the upload without creating when confirmation is canceled", async () => {
+    const user = setupUser();
+    const onCreated = jest.fn();
+    mockInspectSkillBundle.mockResolvedValue({ name: "report-writer" });
+    mockCreateCustomSkill.mockRejectedValue(
+      Object.assign(new Error("Name conflict"), {
+        errorCode: "SKILL_NAME_CONFLICT",
+      })
+    );
+
+    render(<CreateSkillModal open onClose={jest.fn()} onCreated={onCreated} />);
+    await user.click(screen.getByRole("button", { name: "Select bundle" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    await screen.findByText("Create another “report-writer” skill?");
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
+    expect(mockCreateCustomSkill).toHaveBeenCalledTimes(1);
+    expect(onCreated).not.toHaveBeenCalled();
+  });
+
+  it("creates immediately when the name is available", async () => {
+    const user = setupUser();
+    const onCreated = jest.fn();
+    const created = {
+      id: "new-skill-id",
+      name: "available-skill",
+      enabled: true,
+    } as CustomSkill;
+    mockInspectSkillBundle.mockResolvedValue({ name: "available-skill" });
+    mockCreateCustomSkill.mockResolvedValue(created);
+
+    render(<CreateSkillModal open onClose={jest.fn()} onCreated={onCreated} />);
+    await user.click(screen.getByRole("button", { name: "Select bundle" }));
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(created));
+    expect(mockCreateCustomSkill).toHaveBeenCalledTimes(1);
+    expect(mockCreateCustomSkill).toHaveBeenCalledWith(expect.any(File), true);
+    expect(
+      screen.queryByText(/Create another .* skill\?/)
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/sections/modals/skills/CreateSkillModal.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 import { useState } from "react";
-import { Button, Text } from "@opal/components";
+import { Button, Modal, Text } from "@opal/components";
 import { SvgUploadCloud } from "@opal/icons";
 import { toast } from "@opal/layouts";
-import { createCustomSkill } from "@/lib/skills/api";
+import {
+  createCustomSkill,
+  inspectSkillBundle,
+  isSkillNameConflict,
+} from "@/lib/skills/api";
 import type { PreparedSkillBundle } from "@/lib/skills/bundleUpload";
 import type { CustomSkill } from "@/lib/skills/types";
-import { Modal } from "@opal/components";
 import SkillBundlePicker from "@/sections/skills/SkillBundlePicker";
+import SkillNameConflictModal from "@/sections/modals/skills/SkillNameConflictModal";
 
 interface CreateSkillModalProps {
   open: boolean;
@@ -25,10 +29,14 @@ export default function CreateSkillModal({
   const [preparing, setPreparing] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [conflictingSkillName, setConflictingSkillName] = useState<
+    string | null
+  >(null);
 
   function reset() {
     setBundle(null);
     setErrorMessage(null);
+    setConflictingSkillName(null);
   }
 
   function handleClose() {
@@ -37,18 +45,25 @@ export default function CreateSkillModal({
     onClose();
   }
 
-  async function handleSubmit() {
+  async function handleSubmit(autoEnable = true, knownSkillName?: string) {
     if (!bundle) return;
     setSubmitting(true);
     setErrorMessage(null);
+    let skillName = knownSkillName;
     try {
-      const created = await createCustomSkill(bundle.file);
+      skillName ??= (await inspectSkillBundle(bundle.file)).name;
+      const created = await createCustomSkill(bundle.file, autoEnable);
       toast.success(`Created "${created.name}"`);
       reset();
       onCreated(created);
       onClose();
     } catch (error) {
+      if (autoEnable && skillName && isSkillNameConflict(error)) {
+        setConflictingSkillName(skillName);
+        return;
+      }
       console.error("Failed to create skill", error);
+      setConflictingSkillName(null);
       setErrorMessage(
         error instanceof Error ? error.message : "Failed to create skill"
       );
@@ -58,70 +73,87 @@ export default function CreateSkillModal({
   }
 
   return (
-    <Modal open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
-      <Modal.Content width="sm">
-        <Modal.Header
-          icon={SvgUploadCloud}
-          title="Create skill"
-          description="Upload a SKILL.md file, ZIP file, or skill folder. New skills are private until you choose to share them."
-          onClose={handleClose}
-        />
-        <Modal.Body>
-          <SkillBundlePicker
-            value={bundle}
-            disabled={submitting}
-            onPreparingChange={setPreparing}
-            onChange={(nextBundle) => {
-              setBundle(nextBundle);
-              setErrorMessage(null);
-            }}
-            onError={(message) => {
-              setBundle(null);
-              setErrorMessage(message);
-            }}
-          />
-          <div className="mt-3">
-            <Text as="p" font="main-ui-body" color="text-02">
-              File requirements
-            </Text>
-            <ul className="mt-1 list-disc space-y-1 pl-5">
-              <Text as="li" font="secondary-body" color="text-03">
-                SKILL.md must include valid frontmatter with a name and
-                description.
-              </Text>
-              <Text as="li" font="secondary-body" color="text-03">
-                ZIP files must contain a SKILL.md file.
-              </Text>
-              <Text as="li" font="secondary-body" color="text-03">
-                Upload one skill at a time.
-              </Text>
-            </ul>
-          </div>
-          {errorMessage && (
-            <div className="mt-2">
-              <Text as="p" font="secondary-body" color="status-error-05">
-                {errorMessage}
-              </Text>
-            </div>
-          )}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button
-            prominence="secondary"
-            disabled={preparing || submitting}
-            onClick={handleClose}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={preparing || submitting || !bundle}
-            onClick={handleSubmit}
+    <>
+      <Modal
+        open={open && conflictingSkillName === null}
+        onOpenChange={(isOpen) => !isOpen && handleClose()}
+      >
+        <Modal.Content width="sm">
+          <Modal.Header
             icon={SvgUploadCloud}
-          >
-            {submitting ? "Creating…" : "Create"}
-          </Button>
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal>
+            title="Create skill"
+            description="Upload a SKILL.md file, ZIP file, or skill folder. New skills are private until you choose to share them."
+            onClose={handleClose}
+          />
+          <Modal.Body>
+            <SkillBundlePicker
+              value={bundle}
+              disabled={submitting}
+              onPreparingChange={setPreparing}
+              onChange={(nextBundle) => {
+                setBundle(nextBundle);
+                setErrorMessage(null);
+              }}
+              onError={(message) => {
+                setBundle(null);
+                setErrorMessage(message);
+              }}
+            />
+            <div className="mt-3">
+              <Text as="p" font="main-ui-body" color="text-02">
+                File requirements
+              </Text>
+              <ul className="mt-1 list-disc space-y-1 pl-5">
+                <Text as="li" font="secondary-body" color="text-03">
+                  SKILL.md must include valid frontmatter with a name and
+                  description.
+                </Text>
+                <Text as="li" font="secondary-body" color="text-03">
+                  ZIP files must contain a SKILL.md file.
+                </Text>
+                <Text as="li" font="secondary-body" color="text-03">
+                  Upload one skill at a time.
+                </Text>
+              </ul>
+            </div>
+            {errorMessage && (
+              <div className="mt-2">
+                <Text as="p" font="secondary-body" color="status-error-05">
+                  {errorMessage}
+                </Text>
+              </div>
+            )}
+          </Modal.Body>
+          <Modal.Footer>
+            <Button
+              prominence="secondary"
+              disabled={preparing || submitting}
+              onClick={handleClose}
+            >
+              Cancel
+            </Button>
+            <Button
+              disabled={preparing || submitting || !bundle}
+              onClick={() => void handleSubmit()}
+              icon={SvgUploadCloud}
+            >
+              {submitting ? "Creating…" : "Create"}
+            </Button>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+
+      {open && conflictingSkillName && (
+        <SkillNameConflictModal
+          skillName={conflictingSkillName}
+          onClose={() => setConflictingSkillName(null)}
+          onConfirm={() => {
+            const skillName = conflictingSkillName;
+            setConflictingSkillName(null);
+            void handleSubmit(false, skillName);
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/web/src/sections/modals/skills/SkillNameConflictModal.tsx
+++ b/web/src/sections/modals/skills/SkillNameConflictModal.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Button } from "@opal/components";
+import { SvgAlertTriangle } from "@opal/icons";
+import { ConfirmationModalLayout } from "@opal/layouts";
+
+interface SkillNameConflictModalProps {
+  skillName: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export default function SkillNameConflictModal({
+  skillName,
+  onClose,
+  onConfirm,
+}: SkillNameConflictModalProps) {
+  return (
+    <ConfirmationModalLayout
+      icon={SvgAlertTriangle}
+      title={`Create another “${skillName}” skill?`}
+      description="You already have an enabled skill with this name."
+      onClose={onClose}
+      submit={<Button onClick={onConfirm}>Create anyway</Button>}
+    >
+      The new skill will start disabled. You can switch which one is active from
+      the Skills page.
+    </ConfirmationModalLayout>
+  );
+}

--- a/web/src/sections/modals/skills/SkillNameConflictModal.tsx
+++ b/web/src/sections/modals/skills/SkillNameConflictModal.tsx
@@ -8,20 +8,26 @@ interface SkillNameConflictModalProps {
   skillName: string;
   onClose: () => void;
   onConfirm: () => void;
+  pending?: boolean;
 }
 
 export default function SkillNameConflictModal({
   skillName,
   onClose,
   onConfirm,
+  pending = false,
 }: SkillNameConflictModalProps) {
   return (
     <ConfirmationModalLayout
       icon={SvgAlertTriangle}
       title={`Create another “${skillName}” skill?`}
       description="You already have an enabled skill with this name."
-      onClose={onClose}
-      submit={<Button onClick={onConfirm}>Create anyway</Button>}
+      onClose={pending ? undefined : onClose}
+      submit={
+        <Button onClick={onConfirm} disabled={pending}>
+          {pending ? "Creating..." : "Create anyway"}
+        </Button>
+      }
     >
       The new skill will start disabled. You can switch which one is active from
       the Skills page.

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -1,9 +1,31 @@
-import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import {
+  act,
+  deferred,
+  render,
+  screen,
+  setupUser,
+  waitFor,
+} from "@tests/setup/test-utils";
 import SkillEditorPage from "@/views/SkillEditorPage";
 import type { SkillEditableDetail } from "@/lib/skills/types";
 
 const mockCreateCustomSkillFromEditor = jest.fn();
 const mockRouterReplace = jest.fn();
+
+async function fillRequiredFields(user: ReturnType<typeof setupUser>) {
+  await user.type(
+    screen.getByPlaceholderText("Name your skill"),
+    "report-writer"
+  );
+  await user.type(
+    screen.getByPlaceholderText("What does this skill help with?"),
+    "Writes reports"
+  );
+  await user.type(
+    screen.getByPlaceholderText("Write the skill instructions."),
+    "Write the requested report."
+  );
+}
 
 jest.mock("next/navigation", () => ({
   usePathname: () => "/craft/v1/skills/new",
@@ -50,18 +72,7 @@ describe("SkillEditorPage creation", () => {
       .mockResolvedValueOnce(created);
 
     render(<SkillEditorPage />);
-    await user.type(
-      screen.getByPlaceholderText("Name your skill"),
-      "report-writer"
-    );
-    await user.type(
-      screen.getByPlaceholderText("What does this skill help with?"),
-      "Writes reports"
-    );
-    await user.type(
-      screen.getByPlaceholderText("Write the skill instructions."),
-      "Write the requested report."
-    );
+    await fillRequiredFields(user);
     await user.click(screen.getByRole("button", { name: "Create" }));
 
     expect(
@@ -92,5 +103,46 @@ describe("SkillEditorPage creation", () => {
         "/craft/v1/skills/edit/created-id"
       );
     });
+    expect(
+      screen.queryByText("Create another “report-writer” skill?")
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the confirmation open when disabled creation fails", async () => {
+    const user = setupUser();
+    const conflict = Object.assign(new Error("Name conflict"), {
+      errorCode: "SKILL_NAME_CONFLICT",
+    });
+    const retry = deferred<SkillEditableDetail>();
+    mockCreateCustomSkillFromEditor
+      .mockRejectedValueOnce(conflict)
+      .mockReturnValueOnce(retry.promise);
+
+    render(<SkillEditorPage />);
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(
+      await screen.findByRole("button", { name: "Create anyway" })
+    );
+
+    expect(screen.getByRole("button", { name: "Creating..." })).toBeDisabled();
+    expect(
+      screen.getByText("Create another “report-writer” skill?")
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      retry.reject(new Error("Creation failed"));
+      await retry.promise.catch(() => undefined);
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", { name: "Create anyway" })
+      ).toBeEnabled()
+    );
+    expect(
+      screen.getByText("Create another “report-writer” skill?")
+    ).toBeInTheDocument();
+    expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(2);
   });
 });

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import SkillEditorPage from "@/views/SkillEditorPage";
+import type { SkillEditableDetail } from "@/lib/skills/types";
+
+const mockCreateCustomSkillFromEditor = jest.fn();
+const mockRouterReplace = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/craft/v1/skills/new",
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: mockRouterReplace,
+  }),
+}));
+
+jest.mock("@/sections/modals/skills/ShareSkillModal", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock("@/lib/skills/api", () => ({
+  ...jest.requireActual("@/lib/skills/api"),
+  createCustomSkillFromEditor: (...args: unknown[]) =>
+    mockCreateCustomSkillFromEditor(...args),
+}));
+
+jest.mock("@/sections/skills/SkillFilesPicker", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+describe("SkillEditorPage creation", () => {
+  beforeEach(() => {
+    mockCreateCustomSkillFromEditor.mockReset();
+    mockRouterReplace.mockReset();
+  });
+
+  it("requires confirmation before retrying a same-name creation disabled", async () => {
+    const user = setupUser();
+    const conflict = Object.assign(new Error("Name conflict"), {
+      errorCode: "SKILL_NAME_CONFLICT",
+    });
+    const created = {
+      id: "created-id",
+      name: "report-writer",
+      enabled: false,
+    } as SkillEditableDetail;
+    mockCreateCustomSkillFromEditor
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce(created);
+
+    render(<SkillEditorPage />);
+    await user.type(
+      screen.getByPlaceholderText("Name your skill"),
+      "report-writer"
+    );
+    await user.type(
+      screen.getByPlaceholderText("What does this skill help with?"),
+      "Writes reports"
+    );
+    await user.type(
+      screen.getByPlaceholderText("Write the skill instructions."),
+      "Write the requested report."
+    );
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    expect(
+      await screen.findByText("Create another “report-writer” skill?")
+    ).toBeInTheDocument();
+    expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(1);
+    expect(mockCreateCustomSkillFromEditor).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        name: "report-writer",
+        auto_enable: true,
+      }),
+      undefined
+    );
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Create anyway" }));
+
+    await waitFor(() => {
+      expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(2);
+      expect(mockCreateCustomSkillFromEditor).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          name: "report-writer",
+          auto_enable: false,
+        }),
+        undefined
+      );
+      expect(mockRouterReplace).toHaveBeenCalledWith(
+        "/craft/v1/skills/edit/created-id"
+      );
+    });
+  });
+});

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -211,6 +211,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
           },
           pendingFilesUpload?.file
         );
+        setConflictingSkillName(null);
         await refreshSkillList();
         toast.success(`Created "${created.name}"`);
         router.replace(`/craft/v1/skills/edit/${created.id}` as Route);
@@ -236,7 +237,6 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
         setConflictingSkillName(name.trim());
         return;
       }
-      if (createDisabled) setConflictingSkillName(null);
       console.error("Failed to save skill", err);
       toast.error(err instanceof Error ? err.message : "Failed to save skill");
     } finally {
@@ -735,10 +735,8 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
         <SkillNameConflictModal
           skillName={conflictingSkillName}
           onClose={() => setConflictingSkillName(null)}
-          onConfirm={() => {
-            setConflictingSkillName(null);
-            void handleSave(undefined, true);
-          }}
+          onConfirm={() => void handleSave(undefined, true)}
+          pending={isSaving}
         />
       )}
 

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -42,6 +42,7 @@ import {
   createCustomSkillFromEditor,
   deleteUserSkill,
   inspectSkillBundle,
+  isSkillNameConflict,
   patchUserSkill,
   removeUserSkillFile,
   uploadUserSkillFiles,
@@ -52,6 +53,7 @@ import InstructionsDisplayModeToggle, {
   type InstructionsDisplayMode,
 } from "@/sections/skills/InstructionsDisplayModeToggle";
 import ShareSkillModal from "@/sections/modals/skills/ShareSkillModal";
+import SkillNameConflictModal from "@/sections/modals/skills/SkillNameConflictModal";
 import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
 import SkillFileTree from "@/sections/skills/SkillFileTree";
 import SkillFilesPicker from "@/sections/skills/SkillFilesPicker";
@@ -126,6 +128,9 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
     useState<PreparedSkillFilesUpload | null>(null);
   const [removingFilePath, setRemovingFilePath] = useState<string | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [conflictingSkillName, setConflictingSkillName] = useState<
+    string | null
+  >(null);
 
   const syncEditableFields = useCallback((nextSkill: SkillEditableDetail) => {
     setName(nextSkill.name);
@@ -188,7 +193,10 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
     await mutate(SWR_KEYS.userSkills);
   }
 
-  async function handleSave(event?: FormEvent<HTMLFormElement>) {
+  async function handleSave(
+    event?: FormEvent<HTMLFormElement>,
+    createDisabled = false
+  ) {
     event?.preventDefault();
     if (!canSave) return;
     setIsSaving(true);
@@ -199,6 +207,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
             name,
             description,
             instructions_markdown: instructionsMarkdown,
+            auto_enable: !createDisabled,
           },
           pendingFilesUpload?.file
         );
@@ -223,6 +232,11 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
       await refreshSkillList();
       toast.success(`Saved "${updated.name}"`);
     } catch (err) {
+      if (isCreating && !createDisabled && isSkillNameConflict(err)) {
+        setConflictingSkillName(name.trim());
+        return;
+      }
+      if (createDisabled) setConflictingSkillName(null);
       console.error("Failed to save skill", err);
       toast.error(err instanceof Error ? err.message : "Failed to save skill");
     } finally {
@@ -715,6 +729,17 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
             ? "This upload includes SKILL.md. Continuing will replace the current name, description, instructions, and files with the uploaded bundle."
             : "This upload must use the same skill name. Continuing will replace the description, instructions, and files with the uploaded bundle."}
         </ConfirmationModalLayout>
+      )}
+
+      {conflictingSkillName && (
+        <SkillNameConflictModal
+          skillName={conflictingSkillName}
+          onClose={() => setConflictingSkillName(null)}
+          onConfirm={() => {
+            setConflictingSkillName(null);
+            void handleSave(undefined, true);
+          }}
+        />
       )}
 
       {skill && deleteOpen && (

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -128,7 +128,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
   const [isDeleting, setIsDeleting] = useState(false);
 
   const syncEditableFields = useCallback((nextSkill: SkillEditableDetail) => {
-    setName(nextSkill.slug);
+    setName(nextSkill.name);
     setDescription(nextSkill.description);
     setInstructionsMarkdown(nextSkill.instructions_markdown);
   }, []);

--- a/web/src/views/SkillsPage.test.tsx
+++ b/web/src/views/SkillsPage.test.tsx
@@ -7,7 +7,6 @@ import {
 } from "@tests/setup/test-utils";
 import SkillsPage from "@/views/SkillsPage";
 import type { CustomSkill, SkillsList } from "@/lib/skills/types";
-import { builtinFixture } from "@/lib/skills/__fixtures__/picker";
 
 const mockSetSkillEnabled = jest.fn();
 const mockRefresh = jest.fn();
@@ -246,14 +245,12 @@ describe("SkillsPage preference toggles", () => {
 
   it("confirms before switching between skills with the same name", async () => {
     const user = setupUser();
-    const first = builtinFixture({
-      id: "first-id",
-      name: "report-writer",
+    const first = {
+      ...customSkill("first-id", "report-writer"),
       enabled: true,
-      can_toggle: true,
-    });
+    };
     const second = customSkill("second-id", "report-writer");
-    skillsData = { builtins: [first], customs: [second] };
+    skillsData = { builtins: [], customs: [first, second] };
     mockSetSkillEnabled.mockResolvedValueOnce({ ...second, enabled: true });
     render(<SkillsPage />);
 
@@ -275,11 +272,36 @@ describe("SkillsPage preference toggles", () => {
     await user.click(screen.getByRole("button", { name: "Switch skill" }));
 
     await waitFor(() =>
-      expect(mockSetSkillEnabled).toHaveBeenCalledWith("second-id", true)
+      expect(mockSetSkillEnabled).toHaveBeenCalledWith("second-id", true, true)
     );
     await waitFor(() => {
       expect(switches[0]).toHaveAttribute("aria-checked", "false");
       expect(switches[1]).toHaveAttribute("aria-checked", "true");
     });
+  });
+
+  it("confirms a conflict reported by the server", async () => {
+    const user = setupUser();
+    const conflict = Object.assign(new Error("A conflict exists"), {
+      errorCode: "SKILL_NAME_CONFLICT",
+    });
+    mockSetSkillEnabled
+      .mockRejectedValueOnce(conflict)
+      .mockResolvedValueOnce(enabledCustomAt(0));
+    render(<SkillsPage />);
+
+    await user.click(screen.getByRole("switch", { name: "first-skill" }));
+
+    expect(await screen.findByText("Switch active skill?")).toBeInTheDocument();
+    expect(mockToastError).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Switch skill" }));
+    await waitFor(() =>
+      expect(mockSetSkillEnabled).toHaveBeenLastCalledWith(
+        "first-id",
+        true,
+        true
+      )
+    );
   });
 });

--- a/web/src/views/SkillsPage.test.tsx
+++ b/web/src/views/SkillsPage.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tests/setup/test-utils";
 import SkillsPage from "@/views/SkillsPage";
 import type { CustomSkill, SkillsList } from "@/lib/skills/types";
+import { builtinFixture } from "@/lib/skills/__fixtures__/picker";
 
 const mockSetSkillEnabled = jest.fn();
 const mockRefresh = jest.fn();
@@ -16,6 +17,7 @@ const mockUseUserSkills = jest.fn();
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush }),
+  usePathname: () => "/craft/v1/skills",
 }));
 
 jest.mock("@/hooks/useUserSkills", () => ({
@@ -71,7 +73,6 @@ function customSkill(id: string, name: string): CustomSkill {
   return {
     source: "custom",
     id,
-    slug: name.toLowerCase().replaceAll(" ", "-"),
     name,
     description: `${name} description`,
     is_available: null,
@@ -118,8 +119,8 @@ describe("SkillsPage preference toggles", () => {
     skillsData = {
       builtins: [],
       customs: [
-        customSkill("first-id", "First Skill"),
-        customSkill("second-id", "Second Skill"),
+        customSkill("first-id", "first-skill"),
+        customSkill("second-id", "second-skill"),
       ],
     };
     mockUseUserSkills.mockImplementation(() => ({
@@ -142,10 +143,10 @@ describe("SkillsPage preference toggles", () => {
     mockSetSkillEnabled.mockReturnValueOnce(mutation.promise);
     render(<SkillsPage />);
 
-    await user.click(screen.getByRole("switch", { name: "First Skill" }));
+    await user.click(screen.getByRole("switch", { name: "first-skill" }));
 
-    const firstSwitch = screen.getByRole("switch", { name: "First Skill" });
-    const secondSwitch = screen.getByRole("switch", { name: "Second Skill" });
+    const firstSwitch = screen.getByRole("switch", { name: "first-skill" });
+    const secondSwitch = screen.getByRole("switch", { name: "second-skill" });
     expect(firstSwitch).toHaveAttribute("aria-checked", "true");
     expect(firstSwitch).toBeDisabled();
     expect(secondSwitch).toHaveAttribute("aria-checked", "false");
@@ -167,11 +168,11 @@ describe("SkillsPage preference toggles", () => {
       .mockReturnValueOnce(secondMutation.promise);
     render(<SkillsPage />);
 
-    await user.click(screen.getByRole("switch", { name: "First Skill" }));
-    await user.click(screen.getByRole("switch", { name: "Second Skill" }));
+    await user.click(screen.getByRole("switch", { name: "first-skill" }));
+    await user.click(screen.getByRole("switch", { name: "second-skill" }));
 
-    const firstSwitch = screen.getByRole("switch", { name: "First Skill" });
-    const secondSwitch = screen.getByRole("switch", { name: "Second Skill" });
+    const firstSwitch = screen.getByRole("switch", { name: "first-skill" });
+    const secondSwitch = screen.getByRole("switch", { name: "second-skill" });
     expect(firstSwitch).toHaveAttribute("aria-checked", "true");
     expect(firstSwitch).toBeDisabled();
     expect(secondSwitch).toHaveAttribute("aria-checked", "true");
@@ -196,8 +197,8 @@ describe("SkillsPage preference toggles", () => {
     mockSetSkillEnabled.mockReturnValueOnce(mutation.promise);
     render(<SkillsPage />);
 
-    await user.click(screen.getByRole("switch", { name: "First Skill" }));
-    const firstSwitch = screen.getByRole("switch", { name: "First Skill" });
+    await user.click(screen.getByRole("switch", { name: "first-skill" }));
+    const firstSwitch = screen.getByRole("switch", { name: "first-skill" });
     expect(firstSwitch).toHaveAttribute("aria-checked", "true");
 
     await act(async () => {
@@ -226,20 +227,59 @@ describe("SkillsPage preference toggles", () => {
       .mockRejectedValueOnce(new Error("Refresh failed"));
     render(<SkillsPage />);
 
-    await user.click(screen.getByRole("switch", { name: "First Skill" }));
+    await user.click(screen.getByRole("switch", { name: "first-skill" }));
 
-    const firstSwitch = screen.getByRole("switch", { name: "First Skill" });
+    const firstSwitch = screen.getByRole("switch", { name: "first-skill" });
     await waitFor(() => {
       expect(firstSwitch).toHaveAttribute("aria-checked", "true");
       expect(firstSwitch).toBeEnabled();
     });
     await waitFor(() =>
       expect(mockToastError).toHaveBeenCalledWith(
-        "First Skill was updated, but the skill list could not be refreshed."
+        "first-skill was updated, but the skill list could not be refreshed."
       )
     );
     expect(mockToastError).not.toHaveBeenCalledWith(
       expect.stringContaining("Failed to enable")
     );
+  });
+
+  it("confirms before switching between skills with the same name", async () => {
+    const user = setupUser();
+    const first = builtinFixture({
+      id: "first-id",
+      name: "report-writer",
+      enabled: true,
+      can_toggle: true,
+    });
+    const second = customSkill("second-id", "report-writer");
+    skillsData = { builtins: [first], customs: [second] };
+    mockSetSkillEnabled.mockResolvedValueOnce({ ...second, enabled: true });
+    render(<SkillsPage />);
+
+    const switches = screen.getAllByRole("switch", { name: "report-writer" });
+    await user.click(switches[1]!);
+
+    expect(mockSetSkillEnabled).not.toHaveBeenCalled();
+    expect(screen.getByText("Switch active skill?")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(
+        "Only one skill named “report-writer” can be active at a time."
+      )
+    ).not.toHaveLength(0);
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockSetSkillEnabled).not.toHaveBeenCalled();
+
+    await user.click(switches[1]!);
+    await user.click(screen.getByRole("button", { name: "Switch skill" }));
+
+    await waitFor(() =>
+      expect(mockSetSkillEnabled).toHaveBeenCalledWith("second-id", true)
+    );
+    await waitFor(() => {
+      expect(switches[0]).toHaveAttribute("aria-checked", "false");
+      expect(switches[1]).toHaveAttribute("aria-checked", "true");
+    });
   });
 });

--- a/web/src/views/SkillsPage.test.tsx
+++ b/web/src/views/SkillsPage.test.tsx
@@ -1,5 +1,6 @@
 import {
   act,
+  deferred,
   render,
   screen,
   setupUser,
@@ -92,16 +93,6 @@ function customSkill(id: string, name: string): CustomSkill {
     public_permission: "VIEWER",
     user_permission: "VIEWER",
   };
-}
-
-function deferred<T>() {
-  let resolve!: (value: T) => void;
-  let reject!: (reason: unknown) => void;
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
-    resolve = resolvePromise;
-    reject = rejectPromise;
-  });
-  return { promise, resolve, reject };
 }
 
 describe("SkillsPage preference toggles", () => {
@@ -279,6 +270,39 @@ describe("SkillsPage preference toggles", () => {
       expect(switches[0]).toHaveAttribute("aria-checked", "false");
       expect(switches[1]).toHaveAttribute("aria-checked", "true");
     });
+    expect(screen.queryByText("Switch active skill?")).not.toBeInTheDocument();
+  });
+
+  it("keeps the switch confirmation open when replacement fails", async () => {
+    const user = setupUser();
+    const first = {
+      ...customSkill("first-id", "report-writer"),
+      enabled: true,
+    };
+    const second = customSkill("second-id", "report-writer");
+    const mutation = deferred<CustomSkill>();
+    skillsData = { builtins: [], customs: [first, second] };
+    mockSetSkillEnabled.mockReturnValueOnce(mutation.promise);
+    render(<SkillsPage />);
+
+    await user.click(
+      screen.getAllByRole("switch", { name: "report-writer" })[1]!
+    );
+    await user.click(screen.getByRole("button", { name: "Switch skill" }));
+
+    expect(screen.getByRole("button", { name: "Switching..." })).toBeDisabled();
+    expect(screen.getByText("Switch active skill?")).toBeInTheDocument();
+
+    await act(async () => {
+      mutation.reject(new Error("Replacement failed"));
+      await mutation.promise.catch(() => undefined);
+    });
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Switch skill" })).toBeEnabled()
+    );
+    expect(screen.getByText("Switch active skill?")).toBeInTheDocument();
+    expect(mockToastError).toHaveBeenCalledWith("Replacement failed");
   });
 
   it("confirms a conflict reported by the server", async () => {
@@ -303,6 +327,9 @@ describe("SkillsPage preference toggles", () => {
         true,
         true
       )
+    );
+    await waitFor(() =>
+      expect(screen.queryByText("Switch active skill?")).not.toBeInTheDocument()
     );
   });
 });

--- a/web/src/views/SkillsPage.test.tsx
+++ b/web/src/views/SkillsPage.test.tsx
@@ -25,6 +25,7 @@ jest.mock("@/hooks/useUserSkills", () => ({
 }));
 
 jest.mock("@/lib/skills/api", () => ({
+  ...jest.requireActual("@/lib/skills/api"),
   setSkillEnabled: (...args: unknown[]) => mockSetSkillEnabled(...args),
 }));
 

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -10,16 +10,21 @@ import {
   Popover,
   Text,
 } from "@opal/components";
-import { IllustrationContent } from "@opal/layouts";
+import {
+  ConfirmationModalLayout,
+  IllustrationContent,
+  SettingsLayouts,
+  toast,
+} from "@opal/layouts";
 import SvgNoResult from "@opal/illustrations/no-result";
 import {
+  SvgAlertTriangle,
   SvgBlocks,
   SvgEdit,
   SvgPlus,
   SvgSimpleLoader,
   SvgUploadCloud,
 } from "@opal/icons";
-import { SettingsLayouts, toast } from "@opal/layouts";
 import TextSeparator from "@/refresh-components/TextSeparator";
 import useOnMount from "@/hooks/useOnMount";
 import useUserSkills from "@/hooks/useUserSkills";
@@ -52,6 +57,8 @@ export default function SkillsPage() {
   const [optimisticEnabledById, setOptimisticEnabledById] = useState<
     Map<string, boolean>
   >(new Map());
+  const [pendingSwitchTarget, setPendingSwitchTarget] =
+    useState<SkillCardItem | null>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   useOnMount(() => {
@@ -62,23 +69,76 @@ export default function SkillsPage() {
     router.push(`/craft/v1/skills/edit/${item.id}` as Route);
   }
 
-  async function handleEnabledChange(item: SkillCardItem, enabled: boolean) {
-    setPendingSkillIds((current) => new Set(current).add(item.id));
-    setOptimisticEnabledById((current) =>
-      new Map(current).set(item.id, enabled)
-    );
+  async function updateSkillEnabled(
+    item: SkillCardItem,
+    enabled: boolean,
+    confirmed = false
+  ) {
+    if (
+      enabled &&
+      !confirmed &&
+      items.some(
+        (candidate) =>
+          candidate.id !== item.id &&
+          candidate.name === item.name &&
+          candidate.enabled
+      )
+    ) {
+      setPendingSwitchTarget(item);
+      return;
+    }
+
+    const affectedItems = enabled
+      ? items.filter((candidate) => candidate.name === item.name)
+      : [item];
+    const affectedIds = new Set(affectedItems.map(({ id }) => id));
+    setPendingSkillIds((current) => {
+      const next = new Set(current);
+      affectedIds.forEach((id) => next.add(id));
+      return next;
+    });
+    setOptimisticEnabledById((current) => {
+      const next = new Map(current);
+      if (enabled) {
+        affectedItems.forEach((candidate) =>
+          next.set(candidate.id, candidate.id === item.id)
+        );
+      } else {
+        next.set(item.id, false);
+      }
+      return next;
+    });
     try {
       const updatedSkill = await setSkillEnabled(item.id, enabled);
       await refresh(
         (current) => {
           if (!current) return current;
-          const key =
-            updatedSkill.source === "builtin" ? "builtins" : "customs";
           return {
             ...current,
-            [key]: current[key].map((skill) =>
-              skill.id === updatedSkill.id ? updatedSkill : skill
-            ),
+            builtins: current.builtins.map((skill) => {
+              if (
+                updatedSkill.source === "builtin" &&
+                skill.id === updatedSkill.id
+              ) {
+                return updatedSkill;
+              }
+              if (enabled && skill.name === updatedSkill.name) {
+                return { ...skill, enabled: false };
+              }
+              return skill;
+            }),
+            customs: current.customs.map((skill) => {
+              if (
+                updatedSkill.source === "custom" &&
+                skill.id === updatedSkill.id
+              ) {
+                return updatedSkill;
+              }
+              if (enabled && skill.name === updatedSkill.name) {
+                return { ...skill, enabled: false };
+              }
+              return skill;
+            }),
           };
         },
         { revalidate: false }
@@ -97,12 +157,12 @@ export default function SkillsPage() {
     } finally {
       setOptimisticEnabledById((current) => {
         const next = new Map(current);
-        next.delete(item.id);
+        affectedIds.forEach((id) => next.delete(id));
         return next;
       });
       setPendingSkillIds((current) => {
         const next = new Set(current);
-        next.delete(item.id);
+        affectedIds.forEach((id) => next.delete(id));
         return next;
       });
     }
@@ -258,7 +318,9 @@ export default function SkillsPage() {
                         item={item}
                         onEdit={handleEdit}
                         onClick={setPreviewTarget}
-                        onEnabledChange={handleEnabledChange}
+                        onEnabledChange={(skill, enabled) =>
+                          void updateSkillEnabled(skill, enabled)
+                        }
                         enablementPending={pendingSkillIds.has(item.id)}
                       />
                     ))}
@@ -290,6 +352,28 @@ export default function SkillsPage() {
         unavailableReason={previewUnavailableReason}
         onClose={() => setPreviewTarget(null)}
       />
+
+      {pendingSwitchTarget && (
+        <ConfirmationModalLayout
+          icon={SvgAlertTriangle}
+          title="Switch active skill?"
+          description={`Only one skill named “${pendingSwitchTarget.name}” can be active at a time.`}
+          onClose={() => setPendingSwitchTarget(null)}
+          submit={
+            <Button
+              onClick={() => {
+                const target = pendingSwitchTarget;
+                setPendingSwitchTarget(null);
+                void updateSkillEnabled(target, true, true);
+              }}
+            >
+              Switch skill
+            </Button>
+          }
+        >
+          Continuing will disable the active skill and enable the selected one.
+        </ConfirmationModalLayout>
+      )}
     </SettingsLayouts.Root>
   );
 }

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -36,7 +36,7 @@ import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
 import SkillPreviewModal from "@/sections/modals/SkillPreviewModal";
 import type { BuiltinSkill, CustomSkill } from "@/lib/skills/types";
 import LineItem from "@/refresh-components/buttons/LineItem";
-import { setSkillEnabled } from "@/lib/skills/api";
+import { isSkillNameConflict, setSkillEnabled } from "@/lib/skills/api";
 
 // ---------------------------------------------------------------------------
 // Page
@@ -153,13 +153,7 @@ export default function SkillsPage() {
         );
       });
     } catch (error) {
-      if (
-        enabled &&
-        !replaceConflict &&
-        error instanceof Error &&
-        "errorCode" in error &&
-        error.errorCode === "SKILL_NAME_CONFLICT"
-      ) {
+      if (enabled && !replaceConflict && isSkillNameConflict(error)) {
         setPendingSwitchTarget(item);
         return;
       }

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -114,6 +114,7 @@ export default function SkillsPage() {
         enabled,
         replaceConflict
       );
+      if (replaceConflict) setPendingSwitchTarget(null);
       await refresh(
         (current) => {
           if (!current) return current;
@@ -236,6 +237,8 @@ export default function SkillsPage() {
       ? (previewTarget.unavailable_reason ??
         "This skill is currently unavailable.")
       : null;
+  const switchPending =
+    pendingSwitchTarget !== null && pendingSkillIds.has(pendingSwitchTarget.id);
 
   return (
     <SettingsLayouts.Root data-testid="SkillsPage/container">
@@ -366,16 +369,18 @@ export default function SkillsPage() {
           icon={SvgAlertTriangle}
           title="Switch active skill?"
           description={`Only one skill named “${pendingSwitchTarget.name}” can be active at a time.`}
-          onClose={() => setPendingSwitchTarget(null)}
+          onClose={
+            switchPending ? undefined : () => setPendingSwitchTarget(null)
+          }
           submit={
             <Button
+              disabled={switchPending}
               onClick={() => {
                 const target = pendingSwitchTarget;
-                setPendingSwitchTarget(null);
                 void updateSkillEnabled(target, true, true);
               }}
             >
-              Switch skill
+              {switchPending ? "Switching..." : "Switch skill"}
             </Button>
           }
         >

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -72,11 +72,11 @@ export default function SkillsPage() {
   async function updateSkillEnabled(
     item: SkillCardItem,
     enabled: boolean,
-    confirmed = false
+    replaceConflict = false
   ) {
     if (
       enabled &&
-      !confirmed &&
+      !replaceConflict &&
       items.some(
         (candidate) =>
           candidate.id !== item.id &&
@@ -109,7 +109,11 @@ export default function SkillsPage() {
       return next;
     });
     try {
-      const updatedSkill = await setSkillEnabled(item.id, enabled);
+      const updatedSkill = await setSkillEnabled(
+        item.id,
+        enabled,
+        replaceConflict
+      );
       await refresh(
         (current) => {
           if (!current) return current;
@@ -149,6 +153,16 @@ export default function SkillsPage() {
         );
       });
     } catch (error) {
+      if (
+        enabled &&
+        !replaceConflict &&
+        error instanceof Error &&
+        "errorCode" in error &&
+        error.errorCode === "SKILL_NAME_CONFLICT"
+      ) {
+        setPendingSwitchTarget(item);
+        return;
+      }
       toast.error(
         error instanceof Error
           ? error.message

--- a/web/tests/setup/test-utils.tsx
+++ b/web/tests/setup/test-utils.tsx
@@ -82,6 +82,16 @@ export { userEvent };
 // Override render with our custom render
 export { customRender as render };
 
+export function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
 /**
  * Override jsdom's document visibility (always "visible" by default) so tests
  * can exercise hidden-tab behavior. Dispatch a "visibilitychange" event after


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/deb3a93c-f8ed-4482-a541-e0d8a0d55195


- Consolidate each skill's canonical Agent Skills identity into `Skill.name`, remove the legacy `Skill.slug` field, and move editable external-app labels to `ExternalApp.name`.
- Allow independently addressable skills to share a name while enforcing that each user can enable only one record with that name at a time.
- Add atomic backend switching, sandbox collision protection, and a confirmation modal that explains enabling one same-name skill disables the currently active one.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows duplicate skill names by making `Skill.name` the canonical identity and removing `Skill.slug`. Adds conflict-safe create/enable flows with modal confirmations, and switches external app display/OAuth to `ExternalApp.name`.

- **New Features**
  - Multiple skills can share a name; users can enable only one per name via a single `UserSkillPreference` row per `(user_id, name)` (row existence = enabled). Enabling supports atomic switching with `replace_conflict`.
  - Creation (bundle and editor) detects `SKILL_NAME_CONFLICT`; UI shows a confirm modal and creates the new skill disabled on confirm. Enabling a same‑name skill prompts to switch.
  - External apps use `ExternalApp.name` for display/matching/OAuth; admin/user responses read `app.name` (user response returns `slug` as the skill name for compatibility).

- **Migration**
  - DB: add `external_app.name`; constrain `skill.name` to 64 chars; add `UserSkillPreference.name` with a composite FK and a unique `(user_id, name)` index; drop `UserSkillPreference.enabled`; remove the unique `skill.slug`.
  - API/UI: remove `slug` from skill responses; clients should use `name`. Skill enable toggles accept `replace_conflict`. Errors include `error_code` so clients can detect `SKILL_NAME_CONFLICT`. Creation/editor flows send the confirmed disabled state.
  - Filesystem/runtime: skill bundle/workspace paths use `name`; runtime assembly rejects duplicate names.

<sup>Written for commit ac56d6ec7c15bee9d97884e5afb36121c620aa98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



