### PR TITLE
feat: daily cost usage buckets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,8 +58,8 @@ node_modules
 # MCP configs
 .playwright-mcp
 
-# plans
-plans/
+# plans (include symlinked plans dir too)
+plans
 
 # Added context for LLMs
 .claude/CLAUDE.md

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5624,14 +5624,9 @@ class TenantUsage(Base):
 
 class UserUsage(Base):
     """
-    Per-user LLM usage rollup within a time window — the source of truth for
-    per-user cost/token attribution and budget checks. Mirrors TenantUsage's
-    window-rollup model (one accumulating row per window+dims, not a per-call
-    ledger).
+    Hourly per-user LLM usage rollup for cost/token attribution and budget checks.
 
-    One row per (user, window, model, flow, provider), accumulated in place;
-    windows match the tenant-usage alignment so per-user and per-tenant totals
-    reconcile.
+    One accumulating row per (user, window, model, flow, provider), not per call.
     """
 
     __tablename__ = "user_usage"

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5624,7 +5624,7 @@ class TenantUsage(Base):
 
 class UserUsage(Base):
     """
-    Hourly per-user LLM usage rollup for cost/token attribution and budget checks.
+    Daily per-user LLM usage rollup for cost/token attribution and budget checks.
 
     One accumulating row per (user, window, model, flow, provider), not per call.
     """

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -1,4 +1,4 @@
-"""Hourly per-user LLM usage rollup for cost/token attribution.
+"""Daily per-user LLM usage rollup for cost/token attribution.
 
 A window rollup: rows accumulate in place per (user, window,
 model, flow, provider), not an append-only per-call ledger."""
@@ -17,7 +17,7 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-USER_USAGE_BUCKET_SECONDS = 60 * 60
+USER_USAGE_BUCKET_SECONDS = 24 * 60 * 60
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider"]
 
 

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -1,6 +1,6 @@
-"""Per-user LLM usage rollup — the source of truth for cost/token attribution.
+"""Hourly per-user LLM usage rollup for cost/token attribution.
 
-A window-rollup like TenantUsage: rows accumulate in place per (user, window,
+A window rollup: rows accumulate in place per (user, window,
 model, flow, provider), not an append-only per-call ledger."""
 
 from collections import defaultdict
@@ -17,6 +17,7 @@ from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
+USER_USAGE_BUCKET_SECONDS = 60 * 60
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider"]
 
 
@@ -32,11 +33,11 @@ class UserUsageByDay(BaseModel):
 
 
 class UsageExportRow(BaseModel):
-    """Tenant-wide usage row: email + model + window-start day."""
+    """Tenant-wide usage row by email, model, and UTC day."""
 
     email: str
     model: str
-    day: str  # YYYY-MM-DD — window start day, not call calendar day
+    day: str  # YYYY-MM-DD
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
@@ -129,8 +130,7 @@ def get_usage_export(
     end: datetime,
     model: str | None = None,
 ) -> list[UsageExportRow]:
-    """Tenant-wide usage by email/model/window-day.
-    day = window start (weekly grid), not call calendar day."""
+    """Tenant-wide usage by email, model, and UTC day."""
     utc_day = func.date(func.timezone("UTC", UserUsage.window_start))
     query = (
         # User.email comes from the fastapi-users base; ty mis-resolves it as a

--- a/backend/onyx/server/features/usage/api.py
+++ b/backend/onyx/server/features/usage/api.py
@@ -22,11 +22,12 @@ from onyx.db.token_limit import (
     fetch_user_group_token_rate_limits,
 )
 from onyx.db.user_usage import (
+    USER_USAGE_BUCKET_SECONDS,
     get_group_cost_cents_buckets_since,
     get_total_cost_cents_buckets_since,
     get_usage_export,
     get_user_cost_cents_buckets_since,
-    get_user_cost_cents_in_window,
+    get_user_cost_cents_since,
     get_user_usage_by_day_and_model,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -55,8 +56,8 @@ from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 # Default trailing range for the export when no start is given.
 _DEFAULT_EXPORT_DAYS = 30
 
-# Ledger grid; relax cutoff like cost gate so UI matches enforcement.
-_LEDGER_GRID = timedelta(seconds=USAGE_LIMIT_WINDOW_SECONDS)
+# Relax budget cutoffs to include the partially overlapping ledger bucket.
+_LEDGER_GRID = timedelta(seconds=USER_USAGE_BUCKET_SECONDS)
 
 
 def _used_from_buckets(
@@ -196,7 +197,7 @@ def get_my_usage(
     per_day = get_user_usage_by_day_and_model(
         db_session, user_id, since=since, until=now
     )
-    window_cost_cents = get_user_cost_cents_in_window(db_session, user_id, window_start)
+    window_cost_cents = get_user_cost_cents_since(db_session, user_id, window_start)
 
     # Price tenant default chat model (no per-user model selection yet).
     default_model = fetch_default_llm_model(db_session)
@@ -235,7 +236,7 @@ def export_usage(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> UsageExportResponse:
-    """Company-wide usage export by email; day = window start, not call calendar day."""
+    """Company-wide daily usage export by email."""
     end_date = end or datetime.now(timezone.utc).date()
     start_date = start or (end_date - timedelta(days=_DEFAULT_EXPORT_DAYS))
     if start_date > end_date:

--- a/backend/onyx/server/features/usage/models.py
+++ b/backend/onyx/server/features/usage/models.py
@@ -40,7 +40,7 @@ class CostOverride(BaseModel):
 
 class UsageExportRecord(BaseModel):
     model: str
-    day: str  # YYYY-MM-DD — the usage window's start day (see UsageExportUser)
+    day: str  # YYYY-MM-DD
     input_tokens: int
     output_tokens: int
     cache_read_tokens: int
@@ -61,7 +61,7 @@ class UsageExportUser(BaseModel):
 
 
 class UsageExportResponse(BaseModel):
-    """Nested per-user export; day = window start (weekly grid)."""
+    """Nested per-user daily usage export."""
 
     start: str
     end: str

--- a/backend/onyx/tracing/processors/user_usage_processor.py
+++ b/backend/onyx/tracing/processors/user_usage_processor.py
@@ -13,7 +13,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
-from onyx.db.user_usage import record_user_usage
+from onyx.db.user_usage import USER_USAGE_BUCKET_SECONDS, record_user_usage
 from onyx.llm.cost import compute_cost_cents
 from onyx.tracing.flows import IMAGE_FLOWS
 from onyx.tracing.framework.processor_interface import TracingProcessor
@@ -22,7 +22,6 @@ from onyx.tracing.framework.spans import Span
 from onyx.tracing.framework.traces import Trace
 from onyx.utils.datetime import get_window_start
 from onyx.utils.logger import setup_logger
-from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 from shared_configs.contextvars import (
     CURRENT_TENANT_ID_CONTEXTVAR,
     get_current_tenant_id,
@@ -131,7 +130,7 @@ class UserUsageTracingProcessor(TracingProcessor):
         provider = model_config.get("model_provider")
 
         window_start = get_window_start(
-            datetime.now(timezone.utc), period_seconds=USAGE_LIMIT_WINDOW_SECONDS
+            datetime.now(timezone.utc), period_seconds=USER_USAGE_BUCKET_SECONDS
         )
 
         return _UsageRecord(

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -149,6 +149,18 @@ class TestAggregation:
             db_session, user_id, "model-a", "CHAT", "anthropic", 100, 50, 0, 1.0, day1
         )
         _seed_usage(
+            db_session,
+            user_id,
+            "model-a",
+            "CHAT",
+            "anthropic",
+            25,
+            10,
+            0,
+            0.5,
+            day1 + datetime.timedelta(hours=1),
+        )
+        _seed_usage(
             db_session, user_id, "model-b", "CHAT", "anthropic", 200, 60, 0, 2.0, day1
         )
         _seed_usage(
@@ -165,10 +177,10 @@ class TestAggregation:
             UserUsageByDay(
                 day="2026-06-01",
                 model="model-a",
-                input_tokens=100,
-                output_tokens=50,
+                input_tokens=125,
+                output_tokens=60,
                 cache_read_tokens=0,
-                cost_cents=1.0,
+                cost_cents=1.5,
             ),
             UserUsageByDay(
                 day="2026-06-01",

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -149,18 +149,6 @@ class TestAggregation:
             db_session, user_id, "model-a", "CHAT", "anthropic", 100, 50, 0, 1.0, day1
         )
         _seed_usage(
-            db_session,
-            user_id,
-            "model-a",
-            "CHAT",
-            "anthropic",
-            25,
-            10,
-            0,
-            0.5,
-            day1 + datetime.timedelta(hours=1),
-        )
-        _seed_usage(
             db_session, user_id, "model-b", "CHAT", "anthropic", 200, 60, 0, 2.0, day1
         )
         _seed_usage(
@@ -177,10 +165,10 @@ class TestAggregation:
             UserUsageByDay(
                 day="2026-06-01",
                 model="model-a",
-                input_tokens=125,
-                output_tokens=60,
+                input_tokens=100,
+                output_tokens=50,
                 cache_read_tokens=0,
-                cost_cents=1.5,
+                cost_cents=1.0,
             ),
             UserUsageByDay(
                 day="2026-06-01",

--- a/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
+++ b/backend/tests/unit/onyx/server/features/usage/test_user_usage_api.py
@@ -124,11 +124,11 @@ def _seed_usage(
 
 
 def _seed_current_window(db_session: Session, user_id: str) -> datetime.datetime:
+    from onyx.db.user_usage import USER_USAGE_BUCKET_SECONDS
     from onyx.utils.datetime import get_window_start
-    from shared_configs.configs import USAGE_LIMIT_WINDOW_SECONDS
 
     now = datetime.datetime.now(datetime.timezone.utc)
-    window = get_window_start(now, USAGE_LIMIT_WINDOW_SECONDS)
+    window = get_window_start(now, USER_USAGE_BUCKET_SECONDS)
     _seed_usage(
         db_session, user_id, "gpt-4o", "CHAT", "openai", 100, 50, 0, 1.25, window
     )

--- a/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections.abc import Generator
 from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 from unittest.mock import MagicMock
 from uuid import uuid4
@@ -112,6 +113,9 @@ def test_records_usage_when_user_id_set(
     assert call["provider"] == "openai"
     assert call["flow"] == "chat_response"
     assert call["cost_cents"] == pytest.approx(3.0)  # 1.0 input + 2.0 output
+    window_start = call["window_start"]
+    assert window_start.minute == window_start.second == window_start.microsecond == 0
+    assert datetime.now(timezone.utc) - window_start < timedelta(hours=1)
 
 
 def test_normalizes_prompt_completion_token_aliases(

--- a/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
+++ b/backend/tests/unit/onyx/tracing/test_user_usage_processor.py
@@ -114,8 +114,14 @@ def test_records_usage_when_user_id_set(
     assert call["flow"] == "chat_response"
     assert call["cost_cents"] == pytest.approx(3.0)  # 1.0 input + 2.0 output
     window_start = call["window_start"]
-    assert window_start.minute == window_start.second == window_start.microsecond == 0
-    assert datetime.now(timezone.utc) - window_start < timedelta(hours=1)
+    assert (
+        window_start.hour
+        == window_start.minute
+        == window_start.second
+        == window_start.microsecond
+        == 0
+    )
+    assert datetime.now(timezone.utc) - window_start < timedelta(days=1)
 
 
 def test_normalizes_prompt_completion_token_aliases(


### PR DESCRIPTION
## Description

increases the granularity of per usage cost buckets to make daily limits reasonable

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch per-user LLM usage rollups to daily UTC buckets to make daily limits accurate and simplify exports. API, processor, and exports now align to midnight UTC and group usage by day.

- **New Features**
  - Added `USER_USAGE_BUCKET_SECONDS = 86400` and moved cost/ledger grids and rollups to daily UTC buckets.
  - Replaced `get_user_cost_cents_in_window` with `get_user_cost_cents_since`; budget cutoffs include the partially overlapping daily bucket.
  - Export and API models report usage by UTC day; tracing processor and tests assert midnight alignment and daily accumulation.

<sup>Written for commit 6a81c42c6c6cd1e9942a6b0dd1b8eb164c8c9701. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

