### PR TITLE
fix(onboarding): make flow scrollable and responsive at small viewports

### DIFF
--- a/web/lib/opal/src/components/shadow-div/components.tsx
+++ b/web/lib/opal/src/components/shadow-div/components.tsx
@@ -30,6 +30,12 @@ interface ShadowDivProps extends React.HTMLAttributes<HTMLDivElement> {
    * Show only top shadow
    */
   topOnly?: boolean;
+
+  /**
+   * Fade the content itself via mask-image instead of painting gradient
+   * overlays. Use over non-flat backgrounds the gradients can't match.
+   */
+  mask?: boolean;
 }
 
 /**
@@ -59,8 +65,10 @@ function ShadowDiv({
   scrollContainerRef,
   bottomOnly = false,
   topOnly = false,
+  mask = false,
   className,
   children,
+  style,
   ...props
 }: ShadowDivProps) {
   const [showTopShadow, setShowTopShadow] = useState(false);
@@ -104,18 +112,25 @@ function ShadowDiv({
     };
   }, [containerRef, checkScroll]);
 
+  const topFade = !bottomOnly && showTopShadow ? shadowHeight : "0px";
+  const bottomFade = !topOnly && showBottomShadow ? shadowHeight : "0px";
+  const maskImage = `linear-gradient(to bottom, transparent 0, black ${topFade}, black calc(100% - ${bottomFade}), transparent 100%)`;
+
   return (
     <div className="relative min-h-0 flex flex-col">
       <div
         ref={containerRef}
         className={cn("overflow-y-auto", className)}
+        style={
+          mask ? { ...style, maskImage, WebkitMaskImage: maskImage } : style
+        }
         {...props}
       >
         {children}
       </div>
 
       {/* Top scroll shadow indicator */}
-      {!bottomOnly && (
+      {!mask && !bottomOnly && (
         <div
           className={cn(
             "absolute top-0 left-0 right-0 pointer-events-none transition-opacity duration-150",
@@ -129,7 +144,7 @@ function ShadowDiv({
       )}
 
       {/* Bottom scroll shadow indicator */}
-      {!topOnly && (
+      {!mask && !topOnly && (
         <div
           className={cn(
             "absolute bottom-0 left-0 right-0 pointer-events-none transition-opacity duration-150",

--- a/web/src/sections/onboarding/OnboardingFlow.tsx
+++ b/web/src/sections/onboarding/OnboardingFlow.tsx
@@ -38,7 +38,7 @@ const OnboardingFlowInner = ({
   return user.role === UserRole.ADMIN ? (
     showOnboarding ? (
       <div
-        className="flex flex-col items-center justify-center w-full max-w-(--app-page-main-content-width) gap-2 mb-4"
+        className="flex flex-col items-center justify-center w-full max-w-(--app-page-main-content-width) gap-2"
         aria-label="onboarding-flow"
       >
         <OnboardingHeader

--- a/web/src/sections/onboarding/steps/LLMStep.tsx
+++ b/web/src/sections/onboarding/steps/LLMStep.tsx
@@ -148,7 +148,7 @@ const LLMStep = memo(
               }
             />
             <Divider />
-            <div className="@container/llmcards flex flex-wrap gap-1 w-full max-h-[40vh] overflow-y-auto [&>*:last-child:nth-child(odd)]:basis-full">
+            <div className="@container/llmcards flex flex-wrap gap-1 w-full [&>*:last-child:nth-child(odd)]:basis-full">
               {isLoading ? (
                 Array.from({ length: 8 }).map((_, idx) => (
                   <div

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -62,7 +62,7 @@ import OnboardingFlow from "@/sections/onboarding/OnboardingFlow";
 import { OnboardingStep } from "@/interfaces/onboarding";
 import { useShowOnboarding } from "@/hooks/useShowOnboarding";
 import { SvgChevronDown, SvgFileText } from "@opal/icons";
-import { Button, Spacer } from "@opal/components";
+import { Button, ShadowDiv, Spacer } from "@opal/components";
 import {
   IllustrationContent,
   RootLayout,
@@ -697,19 +697,32 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
   const hasAgentStarterMessages =
     (liveAgent?.starter_messages?.length ?? 0) > 0;
 
+  const isWelcomeFocus =
+    (appFocus.isNewSession() || appFocus.isAgent()) &&
+    (state.phase === "idle" || state.phase === "classifying");
+
+  const onboardingVisible =
+    isWelcomeFocus &&
+    (showOnboarding || !user?.personalization?.name) &&
+    !onboardingDismissed;
+
   const gridStyle = {
     // minmax(0, 1fr) (instead of "1fr") lets the single column shrink to the
     // grid's width. A bare "1fr" is minmax(auto, 1fr), whose auto minimum is
     // the content's min-content — wide content (e.g. the onboarding cards) would
     // otherwise blow the column past the viewport and clip the right edge.
     gridTemplateColumns: "minmax(0, 1fr)",
-    gridTemplateRows: isSearch
-      ? "0fr auto 1fr"
-      : appFocus.isChat()
-        ? "1fr auto 0fr"
-        : appFocus.isProject()
-          ? "auto auto 1fr"
-          : "1fr auto 1fr",
+    // Onboarding: welcome floored at content height, form row compressible
+    // (scrolls), bottom row absorbs slack. Centered when short, pinned when tall.
+    gridTemplateRows: onboardingVisible
+      ? "minmax(min-content, 1fr) minmax(0, max-content) minmax(0, 1fr)"
+      : isSearch
+        ? "0fr auto 1fr"
+        : appFocus.isChat()
+          ? "1fr auto 0fr"
+          : appFocus.isProject()
+            ? "auto auto 1fr"
+            : "1fr auto 1fr",
   };
 
   if (!isReady) return <OnyxInitializingLoader />;
@@ -882,10 +895,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
 
                   {/* WelcomeMessageUI */}
                   <Fade
-                    show={
-                      (appFocus.isNewSession() || appFocus.isAgent()) &&
-                      (state.phase === "idle" || state.phase === "classifying")
-                    }
+                    show={isWelcomeFocus}
                     className="w-full flex-1 flex flex-col items-center justify-end px-2 sm:px-4"
                   >
                     <Section
@@ -902,7 +912,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                         !(
                           state.phase === "idle" && state.appMode === "search"
                         ) &&
-                        liveAgent && (
+                        liveAgent &&
+                        llmManager.hasAnyProvider && (
                           <MultiModelSelector
                             selectedModels={multiModel.selectedModels}
                             onAdd={multiModel.addModel}
@@ -911,7 +922,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                           />
                         )}
                     </Section>
-                    <Spacer rem={1.5} />
+                    <Spacer rem={1} />
                   </Fade>
                 </div>
 
@@ -919,12 +930,14 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                 <div
                   className={cn(
                     "row-start-2 flex flex-col items-center px-2 sm:px-4",
+                    onboardingVisible && "min-h-0",
                     sessionFetchError && "hidden"
                   )}
                 >
                   <div
                     className={cn(
                       "relative w-full flex flex-col",
+                      onboardingVisible && "min-h-0",
                       !fullWidthActive &&
                         "max-w-(--app-page-main-content-width)"
                     )}
@@ -942,11 +955,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                     )}
 
                     {/* OnboardingUI */}
-                    {(appFocus.isNewSession() || appFocus.isAgent()) &&
-                      (state.phase === "idle" ||
-                        state.phase === "classifying") &&
-                      (showOnboarding || !user?.personalization?.name) &&
-                      !onboardingDismissed && (
+                    {onboardingVisible && (
+                      <ShadowDiv mask className="overscroll-contain">
                         <OnboardingFlow
                           showOnboarding={showOnboarding}
                           handleHideOnboarding={hideOnboarding}
@@ -954,7 +964,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                           state={onboardingState}
                           actions={onboardingActions}
                         />
-                      )}
+                      </ShadowDiv>
+                    )}
 
                     {/*
                       # Note (@raunakab)
@@ -974,7 +985,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       (Footer) that explains why the Footer removes its top
                       padding during chat to compensate for this extra space.
                     */}
-                    <div>
+                    <div className={cn(onboardingVisible && "shrink-0 pt-4")}>
                       <div
                         className={cn(
                           "transition-all duration-150 ease-in-out overflow-hidden",


### PR DESCRIPTION
## Description

At small viewports the onboarding flow overflowed the centered app grid: the welcome header clipped at the top, the LLM provider grid clipped mid-card behind the input bar, and there was no way to scroll.

Fix:
- During onboarding the grid rows become `minmax(min-content, 1fr) minmax(0, max-content) minmax(0, 1fr)`: the welcome header can no longer be squeezed below its content height, the form row compresses and scrolls, and the layout stays vertically centered when the form is short.
- Removed the nested `max-h-[40vh]` scroll on the LLM provider grid; the form scrolls as one unit inside a `ShadowDiv`.
- New `mask` prop on Opal `ShadowDiv` fades the scrolled content itself via `mask-image` instead of painting gradient overlays, so the radial page background shows through (default overlay behavior unchanged for existing consumers).
- Welcome → onboarding → input gaps equalized at 1rem.
- The welcome-row model selector is hidden until an LLM provider is configured (design request).

## How Has This Been Tested?

<img width="2084" height="1686" alt="2026-07-20 17 41 07" src="https://github.com/user-attachments/assets/737c123c-fe6c-4663-b71a-07d8aa033991" />


- Manually on dev1 across window sizes: welcome header stays visible, form scrolls with faded edges, input bar stays pinned, Welcome step stays centered.
- `tsgo --noEmit` clean; `useShowOnboarding` jest suite 16/16; oxlint/oxfmt via pre-commit.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check