### PR TITLE
fix(connectors): preserve BookStack timestamp filters

### DIFF
--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -51,7 +51,7 @@ class BookstackConnector(LoadConnector, PollConnector):
     def _format_bookstack_datetime(timestamp: SecondsSinceUnixEpoch) -> str:
         return (
             datetime.fromtimestamp(timestamp, tz=timezone.utc)
-            .isoformat(timespec="seconds")
+            .isoformat(timespec="microseconds")
             .replace("+00:00", "Z")
         )
 

--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -48,6 +48,14 @@ class BookstackConnector(LoadConnector, PollConnector):
         return None
 
     @staticmethod
+    def _format_bookstack_datetime(timestamp: SecondsSinceUnixEpoch) -> str:
+        return (
+            datetime.fromtimestamp(timestamp, tz=timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z")
+        )
+
+    @staticmethod
     def _get_doc_batch(
         batch_size: int,
         bookstack_client: BookStackApiClient,
@@ -63,15 +71,15 @@ class BookstackConnector(LoadConnector, PollConnector):
             "sort": "+id",
         }
 
-        if start:
-            params["filter[updated_at:gte]"] = datetime.fromtimestamp(
-                start, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+        if start is not None:
+            params["filter[updated_at:gte]"] = (
+                BookstackConnector._format_bookstack_datetime(start)
+            )
 
-        if end:
-            params["filter[updated_at:lte]"] = datetime.fromtimestamp(
-                end, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+        if end is not None:
+            params["filter[updated_at:lte]"] = (
+                BookstackConnector._format_bookstack_datetime(end)
+            )
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])
         doc_batch: list[Document | HierarchyNode] = [

--- a/backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py
+++ b/backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py
@@ -24,7 +24,7 @@ def test_get_doc_batch_uses_datetime_updated_at_filters() -> None:
         transformer=_unused_transformer,
         start_ind=20,
         start=0,
-        end=1711974896,
+        end=1711974896.789123,
     )
 
     assert docs == []
@@ -35,8 +35,8 @@ def test_get_doc_batch_uses_datetime_updated_at_filters() -> None:
             "count": "10",
             "offset": "20",
             "sort": "+id",
-            "filter[updated_at:gte]": "1970-01-01T00:00:00Z",
-            "filter[updated_at:lte]": "2024-04-01T12:34:56Z",
+            "filter[updated_at:gte]": "1970-01-01T00:00:00.000000Z",
+            "filter[updated_at:lte]": "2024-04-01T12:34:56.789123Z",
         },
     )
 

--- a/backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py
+++ b/backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py
@@ -1,0 +1,60 @@
+from typing import Any
+from typing import cast
+from unittest.mock import MagicMock
+
+from onyx.connectors.bookstack.client import BookStackApiClient
+from onyx.connectors.bookstack.connector import BookstackConnector
+from onyx.connectors.models import Document
+
+
+def _unused_transformer(
+    bookstack_client: BookStackApiClient, item: dict[str, Any]
+) -> Document:
+    del bookstack_client, item
+    return cast(Document, MagicMock())
+
+
+def test_get_doc_batch_uses_datetime_updated_at_filters() -> None:
+    bookstack_client = MagicMock()
+    bookstack_client.get.return_value = {"data": []}
+
+    docs, num_results = BookstackConnector._get_doc_batch(
+        batch_size=10,
+        bookstack_client=bookstack_client,
+        endpoint="/pages",
+        transformer=_unused_transformer,
+        start_ind=20,
+        start=0,
+        end=1711974896,
+    )
+
+    assert docs == []
+    assert num_results == 0
+    bookstack_client.get.assert_called_once_with(
+        "/pages",
+        params={
+            "count": "10",
+            "offset": "20",
+            "sort": "+id",
+            "filter[updated_at:gte]": "1970-01-01T00:00:00Z",
+            "filter[updated_at:lte]": "2024-04-01T12:34:56Z",
+        },
+    )
+
+
+def test_get_doc_batch_omits_updated_at_filters_without_poll_window() -> None:
+    bookstack_client = MagicMock()
+    bookstack_client.get.return_value = {"data": []}
+
+    BookstackConnector._get_doc_batch(
+        batch_size=5,
+        bookstack_client=bookstack_client,
+        endpoint="/books",
+        transformer=_unused_transformer,
+        start_ind=0,
+    )
+
+    _, kwargs = bookstack_client.get.call_args
+    params: dict[str, Any] = kwargs["params"]
+    assert "filter[updated_at:gte]" not in params
+    assert "filter[updated_at:lte]" not in params

--- a/backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py
+++ b/backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py
@@ -1,5 +1,4 @@
-from typing import Any
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 from onyx.connectors.bookstack.client import BookStackApiClient


### PR DESCRIPTION
## Description

This PR fixes BookStack connector polling so documents updated during the current day are not missed by incremental indexing.

The root cause was that the connector sent day-level update boundaries to BookStack. BookStack interprets those boundaries at midnight, which can exclude documents updated later on the same day. This change keeps full timestamp precision for polling windows, formats filter bounds as explicit UTC timestamps, and preserves epoch-start windows instead of treating them as absent.

Closes #11913.

## How Has This Been Tested?

- `git diff --check origin/main...HEAD`
- `.venv\Scripts\python.exe -m py_compile backend/onyx/connectors/bookstack/connector.py backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py`
- `.venv\Scripts\python.exe -m pytest backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py` (`2 passed` on Python 3.13.14)
- `.venv\Scripts\python.exe -m ruff check backend/onyx/connectors/bookstack/connector.py backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py`
- `.venv\Scripts\python.exe -m ruff format --check backend/onyx/connectors/bookstack/connector.py backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py`
- `.venv\Scripts\python.exe -m ty check backend/onyx/connectors/bookstack/connector.py backend/tests/unit/onyx/connectors/bookstack/test_bookstack_connector.py`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes BookStack incremental polling so we don’t miss documents updated later the same day. Uses microsecond-precision UTC timestamps and preserves zero-epoch windows.

- **Bug Fixes**
  - Send `updated_at` filters as microsecond-precision UTC ISO 8601 (`Z`) and always include bounds when set (including `start=0`); omit filters only when no poll window is provided.
  - Added unit tests for timestamp formatting and filter omission.

<sup>Written for commit 9ed4a3d16eb4d16594cc6d5d18229312c97c5538. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

