### PR TITLE
fix(confluence): skip a page's attachments on 5xx instead of failing the index attempt

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -23,6 +23,7 @@ from onyx.connectors.confluence.access import (
     get_page_restrictions_with_per_ancestor_fetch,
 )
 from onyx.connectors.confluence.onyx_confluence import (
+    _SERVER_ERROR_CODES,
     Confcloud77618Error,
     OnyxConfluence,
     extract_text_from_confluence_html,
@@ -780,14 +781,16 @@ class ConfluenceConnector(
                         )
                     )
         except HTTPError as e:
-            # If we get a 403 after all retries, the user likely doesn't have permission
-            # to access attachments on this page. Log and skip rather than failing the whole job.
+            # Auth (401/403) or server (5xx) errors while listing a page's
+            # attachments skip just that page's attachments rather than failing
+            # the whole index attempt. Other statuses propagate.
             page_id = _get_page_id(page, allow_missing=True)
             page_title = page.get("title", "unknown")
-            if e.response and e.response.status_code in [401, 403]:
+            status_code = e.response.status_code if e.response else None
+            if status_code in (401, 403):
                 failure_message_prefix = (
                     "Invalid credentials (401)"
-                    if e.response.status_code == 401
+                    if status_code == 401
                     else "Permission denied (403)"
                 )
                 failure_message = (
@@ -795,28 +798,34 @@ class ConfluenceConnector(
                     f"(ID: {page_id}). The user may not have permission to query attachments on this page. "
                     "Skipping attachments for this page."
                 )
-                logger.warning(failure_message)
-
-                # Build the page URL for the failure record
-                try:
-                    page_url = build_confluence_document_id(
-                        self.wiki_base, page["_links"]["webui"], self.is_cloud
-                    )
-                except Exception:
-                    page_url = f"page_id:{page_id}"
-
-                return [], [
-                    ConnectorFailure(
-                        failed_document=DocumentFailure(
-                            document_id=page_id,
-                            document_link=page_url,
-                        ),
-                        failure_message=failure_message,
-                        exception=e,
-                    )
-                ]
+            elif status_code in _SERVER_ERROR_CODES:
+                failure_message = (
+                    f"Server error ({status_code}) when fetching attachments for page "
+                    f"'{page_title}' (ID: {page_id}). Skipping attachments for this page."
+                )
             else:
                 raise
+
+            logger.warning(failure_message)
+
+            # Build the page URL for the failure record
+            try:
+                page_url = build_confluence_document_id(
+                    self.wiki_base, page["_links"]["webui"], self.is_cloud
+                )
+            except Exception:
+                page_url = f"page_id:{page_id}"
+
+            return [], [
+                ConnectorFailure(
+                    failed_document=DocumentFailure(
+                        document_id=page_id,
+                        document_link=page_url,
+                    ),
+                    failure_message=failure_message,
+                    exception=e,
+                )
+            ]
 
         return attachment_docs, attachment_failures
 

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -786,7 +786,9 @@ class ConfluenceConnector(
             # the whole index attempt. Other statuses propagate.
             page_id = _get_page_id(page, allow_missing=True)
             page_title = page.get("title", "unknown")
-            status_code = e.response.status_code if e.response else None
+            # requests.Response is falsy for error statuses (bool == .ok), so
+            # test for existence explicitly to preserve 4xx/5xx status codes.
+            status_code = e.response.status_code if e.response is not None else None
             if status_code in (401, 403):
                 failure_message_prefix = (
                     "Invalid credentials (401)"
@@ -1269,7 +1271,9 @@ class ConfluenceConnector(
             )
             first_space = next(spaces_iter, None)
         except HTTPError as e:
-            status_code = e.response.status_code if e.response else None
+            # requests.Response is falsy for error statuses (bool == .ok), so
+            # test for existence explicitly to preserve the 401/403 status code.
+            status_code = e.response.status_code if e.response is not None else None
             if status_code == 401:
                 raise CredentialExpiredError(
                     "Invalid or expired Confluence credentials (HTTP 401)."

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
@@ -212,6 +212,29 @@ def test_load_from_checkpoint_happy_path(
     assert not checkpoint_output2.next_checkpoint.has_more
 
 
+def test_fetch_page_attachments_skips_on_server_error(
+    confluence_connector: ConfluenceConnector,
+    create_mock_page: Callable[..., dict[str, Any]],
+) -> None:
+    """A 5xx while listing a page's attachments should skip that page's
+    attachments (recording a ConnectorFailure) rather than failing the whole
+    index attempt."""
+    page = create_mock_page(id="1", title="Page 1")
+    confluence_client = confluence_connector._confluence_client
+    assert confluence_client is not None, "bad test setup"
+
+    confluence_client.paginated_cql_retrieval = MagicMock(  # ty: ignore[invalid-assignment]
+        side_effect=HTTPError(response=MagicMock(status_code=500))
+    )
+
+    docs, failures = confluence_connector._fetch_page_attachments(page)
+
+    assert docs == []
+    assert len(failures) == 1
+    assert isinstance(failures[0], ConnectorFailure)
+    assert "500" in failures[0].failure_message
+
+
 def test_load_from_checkpoint_with_page_processing_error(
     confluence_connector: ConfluenceConnector,
     create_mock_page: Callable[..., dict[str, Any]],

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_checkpointing.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
+from requests import Response
 from requests.exceptions import HTTPError
 
 from onyx.configs.constants import DocumentSource
@@ -218,13 +219,16 @@ def test_fetch_page_attachments_skips_on_server_error(
 ) -> None:
     """A 5xx while listing a page's attachments should skip that page's
     attachments (recording a ConnectorFailure) rather than failing the whole
-    index attempt."""
+    index attempt. Uses a real Response because requests.Response is falsy for
+    error statuses (bool(resp) == resp.ok), which a truthy MagicMock hides."""
     page = create_mock_page(id="1", title="Page 1")
     confluence_client = confluence_connector._confluence_client
     assert confluence_client is not None, "bad test setup"
 
+    error_response = Response()
+    error_response.status_code = 500
     confluence_client.paginated_cql_retrieval = MagicMock(  # ty: ignore[invalid-assignment]
-        side_effect=HTTPError(response=MagicMock(status_code=500))
+        side_effect=HTTPError(response=error_response)
     )
 
     docs, failures = confluence_connector._fetch_page_attachments(page)
@@ -409,7 +413,9 @@ def test_validate_connector_settings_errors(
     expected_message: str,
 ) -> None:
     """Test validation with various error scenarios"""
-    error = HTTPError(response=MagicMock(status_code=status_code))
+    error_response = Response()
+    error_response.status_code = status_code
+    error = HTTPError(response=error_response)
 
     with patch(
         "onyx.connectors.confluence.onyx_confluence.OnyxConfluence.retrieve_confluence_spaces"


### PR DESCRIPTION
## Description

When Atlassian returns a server error (500/502/503/504) while listing a page's
attachments, `_fetch_page_attachments` re-raised the `HTTPError`, which fails the
entire index attempt. On a large Confluence Cloud crawl this is fatal in practice:
every attempt re-crawls the full window, so a single 5xx on one page's attachment
query near the end of the run dooms the whole attempt and can lock the connector in
a repeated-error loop.

The connector already skips a page's attachments non-fatally on `401`/`403`
(recording a `ConnectorFailure` and continuing). This extends that same handling to
server errors (`_SERVER_ERROR_CODES` = `{500, 502, 503, 504}`): skip that page's
attachments and continue the crawl. The page body is still indexed and the skip is
surfaced as a `ConnectorFailure` in the errors tab; any other status still propagates.

Note `_paginate_url` already shrinks the page size on 5xx before giving up, so
genuinely transient server errors get several retries first and usually recover
without any skip — this handler only catches the case where those retries are
exhausted.

## How Has This Been Tested?

Added a unit test (`test_fetch_page_attachments_skips_on_server_error`) asserting a
500 while listing a page's attachments returns a `ConnectorFailure` and does not
raise. The full Confluence unit suite passes (60 tests); `ruff` and `ty` are clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Confluence connector now skips a page’s attachments on Atlassian 5xx instead of failing the index attempt. Also fixes response handling so 4xx/5xx skips and validation errors trigger reliably in production.

- **Bug Fixes**
  - On 500/502/503/504 while listing attachments, skip that page’s attachments, log, and record a `ConnectorFailure`; the page body is still indexed and other statuses still raise.
  - Check `e.response is not None` before reading `status_code` in `_fetch_page_attachments` and `validate_connector_settings` (since `requests.Response` is falsy on error). Tests now use a real `requests.Response` and include `test_fetch_page_attachments_skips_on_server_error`.

<sup>Written for commit 76bb119f19db1ff4b18e2ad1f5d75f1e4325bdbc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

