### PR TITLE
fix(file-processing): respect UNSTRUCTURED_API_URL

### DIFF
--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -116,6 +116,7 @@ SLACK_SERVICE_ACCOUNT_EMAIL = (
 # Key-Value store keys
 KV_REINDEX_KEY = "needs_reindexing"
 KV_UNSTRUCTURED_API_KEY = "unstructured_api_key"
+UNSTRUCTURED_API_URL = os.environ.get("UNSTRUCTURED_API_URL", "")
 KV_USER_STORE_KEY = "INVITED_USERS"
 KV_PENDING_USERS_KEY = "PENDING_USERS"
 KV_ANONYMOUS_USER_PREFERENCES_KEY = "anonymous_user_preferences"

--- a/backend/onyx/file_processing/unstructured.py
+++ b/backend/onyx/file_processing/unstructured.py
@@ -1,6 +1,6 @@
 from typing import IO, TYPE_CHECKING, Any, cast
 
-from onyx.configs.constants import KV_UNSTRUCTURED_API_KEY
+from onyx.configs.constants import KV_UNSTRUCTURED_API_KEY, UNSTRUCTURED_API_URL
 from onyx.key_value_store.factory import get_kv_store
 from onyx.key_value_store.interface import KvKeyNotFoundError
 from onyx.utils.logger import setup_logger
@@ -10,6 +10,13 @@ if TYPE_CHECKING:
 
 
 logger = setup_logger()
+
+
+def _unstructured_client_kwargs() -> dict[str, str | None]:
+    kwargs: dict[str, str | None] = {"api_key_auth": get_unstructured_api_key()}
+    if UNSTRUCTURED_API_URL:
+        kwargs["server_url"] = UNSTRUCTURED_API_URL
+    return kwargs
 
 
 def get_unstructured_api_key() -> str | None:
@@ -58,7 +65,7 @@ def unstructured_to_text(file: IO[Any], file_name: str) -> str:
     logger.debug("Starting to read file: %s", file_name)
     req = _sdk_partition_request(file, file_name, strategy="fast")
 
-    unstructured_client = UnstructuredClient(api_key_auth=get_unstructured_api_key())
+    unstructured_client = UnstructuredClient(**_unstructured_client_kwargs())
 
     response = unstructured_client.general.partition(request=req)
 

--- a/backend/tests/unit/onyx/file_processing/test_unstructured.py
+++ b/backend/tests/unit/onyx/file_processing/test_unstructured.py
@@ -1,0 +1,26 @@
+from unittest.mock import patch
+
+from onyx.file_processing import unstructured
+
+
+def test_unstructured_client_kwargs_omits_server_url_when_unset() -> None:
+    with (
+        patch.object(unstructured, "UNSTRUCTURED_API_URL", ""),
+        patch.object(unstructured, "get_unstructured_api_key", return_value="test-key"),
+    ):
+        kwargs = unstructured._unstructured_client_kwargs()
+
+    assert kwargs == {"api_key_auth": "test-key"}
+
+
+def test_unstructured_client_kwargs_uses_configured_server_url() -> None:
+    with (
+        patch.object(unstructured, "UNSTRUCTURED_API_URL", "http://unstructured:8000"),
+        patch.object(unstructured, "get_unstructured_api_key", return_value="test-key"),
+    ):
+        kwargs = unstructured._unstructured_client_kwargs()
+
+    assert kwargs == {
+        "api_key_auth": "test-key",
+        "server_url": "http://unstructured:8000",
+    }


### PR DESCRIPTION
## Summary
- Add UNSTRUCTURED_API_URL as an env-backed config constant.
- Pass server_url to UnstructuredClient when UNSTRUCTURED_API_URL is configured, while preserving SDK defaults when it is unset.
- Add focused unit coverage for both constructor-kwargs paths.

Fixes #12427.

## Validation
- Inspected pinned unstructured-client==0.42.6 constructor and verified it supports server_url.
- .venv\\Scripts\\python.exe -m pytest -q backend/tests/unit/onyx/file_processing/test_unstructured.py
- .venv\\Scripts\\python.exe -m pytest -q backend/tests/unit/onyx/file_processing
- .venv\\Scripts\\ruff.exe check backend/onyx/file_processing/unstructured.py backend/tests/unit/onyx/file_processing/test_unstructured.py

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Respect `UNSTRUCTURED_API_URL` in file processing by passing it as `server_url` to `UnstructuredClient` when set. Defaults apply when unset.

- **Bug Fixes**
  - Add `UNSTRUCTURED_API_URL` env-backed constant and use it via `_unstructured_client_kwargs()` with `UnstructuredClient` (`unstructured-client==0.42.6`).
  - Preserve defaults when the env var is empty.
  - Add unit tests for both configured and unset cases.

<sup>Written for commit 5042653fea814de0ec1432978785b2f0b5e6896c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

