### PR TITLE
fix(sidebar): scroll-aware edge fades, hide native scrollbar

### DIFF
--- a/web/lib/opal/src/components/shadow-div/components.tsx
+++ b/web/lib/opal/src/components/shadow-div/components.tsx
@@ -36,6 +36,11 @@ interface ShadowDivProps extends React.HTMLAttributes<HTMLDivElement> {
    * overlays. Use over non-flat backgrounds the gradients can't match.
    */
   mask?: boolean;
+
+  /**
+   * Class for the outer wrapper (e.g. flex sizing within a parent column).
+   */
+  containerClassName?: string;
 }
 
 /**
@@ -66,6 +71,7 @@ function ShadowDiv({
   bottomOnly = false,
   topOnly = false,
   mask = false,
+  containerClassName,
   className,
   children,
   style,
@@ -117,7 +123,7 @@ function ShadowDiv({
   const maskImage = `linear-gradient(to bottom, transparent 0, black ${topFade}, black calc(100% - ${bottomFade}), transparent 100%)`;
 
   return (
-    <div className="relative min-h-0 flex flex-col">
+    <div className={cn("relative min-h-0 flex flex-col", containerClassName)}>
       <div
         ref={containerRef}
         className={cn("overflow-y-auto", className)}

--- a/web/lib/opal/src/layouts/sidebar/components.tsx
+++ b/web/lib/opal/src/layouts/sidebar/components.tsx
@@ -11,7 +11,7 @@ import {
   useRef,
 } from "react";
 import { usePathname } from "next/navigation";
-import { Button, Spacer, Text } from "@opal/components";
+import { Button, ShadowDiv, Spacer, Text } from "@opal/components";
 import { Disabled, Hoverable } from "@opal/core";
 import { SvgSidebar } from "@opal/icons";
 import type { IconFunctionComponent, RichStr } from "@opal/types";
@@ -231,18 +231,17 @@ function SidebarBody({ scrollKey, children }: SidebarBodyProps) {
   }, [pathname, scrollKey]);
 
   return (
-    <div className="opal-sidebar-body">
-      <div ref={scrollRef} className="opal-sidebar-body__scroll">
-        <div
-          className="opal-sidebar-body__content"
-          data-folded={String(folded)}
-        >
-          {children}
-        </div>
-        <div className="opal-sidebar-body__spacer" />
+    <ShadowDiv
+      mask
+      scrollContainerRef={scrollRef}
+      containerClassName="opal-sidebar-body"
+      className="opal-sidebar-body__scroll"
+    >
+      <div className="opal-sidebar-body__content" data-folded={String(folded)}>
+        {children}
       </div>
-      <div className="opal-sidebar-body__fade" />
-    </div>
+      <div className="opal-sidebar-body__spacer" />
+    </ShadowDiv>
   );
 }
 

--- a/web/lib/opal/src/layouts/sidebar/styles.css
+++ b/web/lib/opal/src/layouts/sidebar/styles.css
@@ -128,12 +128,18 @@
    SidebarBody
    --------------------------------------------------------------------------- */
 
+/* Applied to the ShadowDiv wrapper, which provides positioning and column flow */
 .opal-sidebar-body {
-  @apply relative flex-1 min-h-0 overflow-y-hidden flex flex-col;
+  @apply flex-1;
 }
 
+/* Applied to the ShadowDiv scroll container, which provides overflow-y-auto */
 .opal-sidebar-body__scroll {
-  @apply flex-1 min-h-0 overflow-y-auto flex flex-col;
+  @apply flex-1 min-h-0 flex flex-col;
+  scrollbar-width: none;
+}
+.opal-sidebar-body__scroll::-webkit-scrollbar {
+  display: none;
 }
 
 .opal-sidebar-body__content {
@@ -145,15 +151,6 @@
 
 .opal-sidebar-body__spacer {
   min-height: 2rem;
-}
-
-.opal-sidebar-body__fade {
-  @apply absolute bottom-0 left-0 right-0 h-4 z-20 pointer-events-none;
-  background: linear-gradient(
-    to bottom,
-    transparent,
-    var(--background-tint-02)
-  );
 }
 
 /* ---------------------------------------------------------------------------

--- a/web/lib/opal/src/layouts/sidebar/styles.css
+++ b/web/lib/opal/src/layouts/sidebar/styles.css
@@ -133,13 +133,12 @@
   @apply flex-1;
 }
 
-/* Applied to the ShadowDiv scroll container, which provides overflow-y-auto */
+/* Applied to the ShadowDiv scroll container, which provides overflow-y-auto.
+   Thin themed scrollbar keeps position/drag affordance without the default bar. */
 .opal-sidebar-body__scroll {
   @apply flex-1 min-h-0 flex flex-col;
-  scrollbar-width: none;
-}
-.opal-sidebar-body__scroll::-webkit-scrollbar {
-  display: none;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-02) transparent;
 }
 
 .opal-sidebar-body__content {


### PR DESCRIPTION
## Description

Design feedback on the sidebar scroll area: the top was a straight cutoff with no fade, the bottom fade was a static painted gradient that sat above the actual scroll boundary (a 2rem tail spacer pushed content past it), and the native scrollbar rendered with visual artifacts.

Fix, all inside `SidebarLayouts.Body`:
- Compose `ShadowDiv mask` (added in #13228): the list fades under the sticky header only once scrolled, and fades at the true bottom edge only while more content remains. At full scroll no fade renders.
- Delete the always-on painted bottom gradient.
- Hide the native scrollbar on the sidebar scroller (`scrollbar-width: none` + webkit fallback); wheel/trackpad/keyboard scrolling unchanged.
- `ShadowDiv` gains a `containerClassName` prop so consumers can size the wrapper without an extra div.

Applies to all three consumers: app sidebar, admin sidebar, connector-step sidebar.

## How Has This Been Tested?

<img width="300"  alt="2026-07-21 09 37 23" src="https://github.com/user-attachments/assets/4c353eb3-c2e3-4361-8605-84537f34091e" />


- Manually on dev1: admin + app sidebars mid-scroll (both fades), at full scroll (no fade, clean gap above the separator), scrollbar gone.
- `tsgo --noEmit` clean; full web jest suite 849/849 after rebasing onto main; oxlint/oxfmt via pre-commit.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check