### PR TITLE
fix(auth): invite-only gates SSO signups, and placeholder claims stop 500ing

### DIFF
--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -292,13 +292,7 @@ def workspace_invite_only_enabled() -> bool:
     return settings.invite_only_enabled
 
 
-def verify_email_is_invited(email: str, *, sso_managed: bool = False) -> None:
-    # An SSO provider manages membership for users it provisions, and its
-    # allowed_email_domains is the admin's per-provider control, so the
-    # workspace invite list does not apply.
-    if sso_managed:
-        return
-
+def verify_email_is_invited(email: str) -> None:
     if not workspace_invite_only_enabled():
         return
 
@@ -333,12 +327,14 @@ def verify_email_is_invited(email: str, *, sso_managed: bool = False) -> None:
     )
 
 
-def verify_email_in_whitelist(
-    email: str, tenant_id: str, *, sso_managed: bool = False
-) -> None:
+def verify_email_in_whitelist(email: str, tenant_id: str) -> None:
     with get_session_with_tenant(tenant_id=tenant_id) as db_session:
-        if not get_user_by_email(email, db_session):
-            verify_email_is_invited(email, sso_managed=sso_managed)
+        user = get_user_by_email(email, db_session)
+        # A permission-sync placeholder is not a member: appearing in a
+        # connector's ACLs must not satisfy invite-only, so the invite check
+        # applies until the person actually joins.
+        if user is None or not user.account_type.is_web_login():
+            verify_email_is_invited(email)
 
 
 def verify_email_domain(
@@ -560,8 +556,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         user_create: schemas.UC | UserCreate,
         safe: bool = False,
         request: Optional[Request] = None,
-        *,
-        sso_managed: bool = False,
     ) -> User:
         # Check for disposable emails FIRST so obvious throwaway domains are
         # rejected before hitting Google's siteverify API. Cheap local check.
@@ -646,13 +640,10 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                     user_count = await get_user_count()
                     if user_count > 0:
                         # Tenant already has users - require invite for new users
-                        verify_email_is_invited(
-                            user_create.email, sso_managed=sso_managed
-                        )
+                        verify_email_is_invited(user_create.email)
                 else:
-                    # Single-tenant: the gate self-skips for SSO-managed users
-                    # and when invite-only is off
-                    verify_email_is_invited(user_create.email, sso_managed=sso_managed)
+                    # Single-tenant: the gate self-skips when invite-only is off
+                    verify_email_is_invited(user_create.email)
                 if MULTI_TENANT:
                     tenant_user_db = SQLAlchemyUserAdminDB[User, uuid.UUID](
                         db_session, User, OAuthAccount
@@ -884,7 +875,6 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         associate_by_email: bool = False,
         is_verified_by_default: bool = False,
         allowed_email_domains_override: Sequence[str] | None = None,
-        sso_managed: bool = False,
     ) -> User:
         referral_source = (
             getattr(request.state, "referral_source", None) if request else None
@@ -908,7 +898,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         async with get_async_session_context_manager(tenant_id) as db_session:
             token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-            verify_email_in_whitelist(account_email, tenant_id, sso_managed=sso_managed)
+            verify_email_in_whitelist(account_email, tenant_id)
             oauth_security_settings = get_security_settings()
             effective_valid_email_domains = (
                 allowed_email_domains_override
@@ -1058,8 +1048,12 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
 
                 # Refresh the async user object so downstream code
                 # (e.g. oidc_expiry check) sees the updated fields.
+                # Cache id before expire. Accessing attrs on an expired object
+                # triggers a sync lazy-load which raises MissingGreenlet in this
+                # async context.
+                refreshed_user_id = user.id
                 self.user_db.session.expire(user)
-                user = await self.user_db.get(user.id)
+                user = await self.user_db.get(refreshed_user_id)
                 assert user is not None
 
             # this is needed if an organization toggles track_external_idp_expiry from
@@ -2388,7 +2382,6 @@ async def complete_login_flow(
     associate_by_email: bool,
     is_verified_by_default: bool,
     allowed_email_domains_override: Sequence[str] | None = None,
-    sso_managed: bool = False,
 ) -> RedirectResponse:
     """Shared post-token OAuth/OIDC login: read the verified identity, create or
     authenticate the user, and return a web or mobile redirect."""
@@ -2438,7 +2431,6 @@ async def complete_login_flow(
             associate_by_email=associate_by_email,
             is_verified_by_default=is_verified_by_default,
             allowed_email_domains_override=allowed_email_domains_override,  # ty: ignore[unknown-argument]
-            sso_managed=sso_managed,  # ty: ignore[unknown-argument]
         )
     except UserAlreadyExists:
         raise OnyxError(

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -350,8 +350,6 @@ async def oidc_login_callback_for_provider(
         associate_by_email=_ALLOW_AUTO_LINK,
         is_verified_by_default=True,
         allowed_email_domains_override=provider.allowed_email_domains,
-        # Provider rows delegate membership to the IdP.
-        sso_managed=True,
     )
 
     if OIDC_PKCE_ENABLED:

--- a/backend/onyx/server/saml.py
+++ b/backend/onyx/server/saml.py
@@ -98,7 +98,6 @@ async def upsert_saml_user(email: str) -> User:
                         role=role,
                         is_verified=True,  # SAML users are pre-verified by their IdP
                     ),
-                    sso_managed=True,
                 )
 
                 return user

--- a/backend/tests/unit/onyx/auth/test_user_registration.py
+++ b/backend/tests/unit/onyx/auth/test_user_registration.py
@@ -241,9 +241,7 @@ class TestMultiTenantInviteLogic:
             pass
 
         # Verify invite check WAS called (user_count > 0)
-        mock_verify_invited.assert_called_once_with(
-            mock_user_create.email, sso_managed=False
-        )
+        mock_verify_invited.assert_called_once_with(mock_user_create.email)
 
 
 class TestSingleTenantInviteLogic:
@@ -293,9 +291,7 @@ class TestSingleTenantInviteLogic:
             pass
 
         # Verify invite check was called
-        mock_verify_invited.assert_called_once_with(
-            mock_user_create.email, sso_managed=False
-        )
+        mock_verify_invited.assert_called_once_with(mock_user_create.email)
 
 
 class TestWhitelistBehavior:
@@ -697,7 +693,6 @@ class TestOAuthPlaceholderPromotion:
             account_email="synced@corp.com",
             associate_by_email=False,
             is_verified_by_default=True,
-            sso_managed=True,
         )
 
         # The oauth account attaches instead of UserAlreadyExists, and the
@@ -742,7 +737,6 @@ class TestOAuthPlaceholderPromotion:
                 account_id="acct-2",
                 account_email="taken@corp.com",
                 associate_by_email=False,
-                sso_managed=True,
             )
 
         cast(AsyncMock, user_manager.user_db.add_oauth_account).assert_not_awaited()

--- a/backend/tests/unit/onyx/auth/test_verify_email_invite.py
+++ b/backend/tests/unit/onyx/auth/test_verify_email_invite.py
@@ -1,11 +1,20 @@
+"""Invite-only gating: when the toggle is on, the invite list governs every
+signup regardless of login method, and a permission-sync placeholder never
+counts as an existing member."""
+
+from contextlib import contextmanager
+from typing import Any, Iterator
+from unittest.mock import MagicMock
+
 import pytest
 
 import onyx.auth.users as users
-from onyx.auth.users import verify_email_is_invited
+from onyx.auth.users import verify_email_in_whitelist, verify_email_is_invited
+from onyx.db.enums import AccountType
 from onyx.error_handling.exceptions import OnyxError
 
 
-def test_verify_email_is_invited_enforced_for_basic_auth(
+def test_verify_email_is_invited_enforced_for_uninvited(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
@@ -35,11 +44,22 @@ def test_verify_email_is_invited_skipped_when_invite_only_disabled(
     verify_email_is_invited("newuser@example.com")
 
 
-def test_sso_managed_bypasses_whitelist_under_basic(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A provider-row login on a BASIC deployment is IdP-managed, so the
-    workspace invite list must not block its JIT-provisioned users."""
+@contextmanager
+def _fake_session() -> Iterator[MagicMock]:
+    yield MagicMock()
+
+
+def _patch_whitelist_deps(monkeypatch: pytest.MonkeyPatch, existing_user: Any) -> None:
+    monkeypatch.setattr(
+        users,
+        "get_session_with_tenant",
+        lambda tenant_id: _fake_session(),  # noqa: ARG005
+    )
+    monkeypatch.setattr(
+        users,
+        "get_user_by_email",
+        lambda email, db: existing_user,  # noqa: ARG005
+    )
     monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
     monkeypatch.setattr(
         users,
@@ -48,20 +68,35 @@ def test_sso_managed_bypasses_whitelist_under_basic(
         raising=False,
     )
 
-    verify_email_is_invited("newuser@example.com", sso_managed=True)
 
-
-def test_sso_managed_default_false_keeps_enforcement(
+def test_whitelist_treats_placeholder_as_not_a_member(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Callers that do not declare SSO provenance keep the invite check."""
-    monkeypatch.setattr(users, "workspace_invite_only_enabled", lambda: True)
-    monkeypatch.setattr(
-        users,
-        "get_invited_users",
-        lambda: ["allowed@example.com"],
-        raising=False,
-    )
+    """A permission-sync EXT_PERM_USER row must not satisfy invite-only:
+    ACL visibility is not membership."""
+    placeholder = MagicMock()
+    placeholder.account_type = AccountType.EXT_PERM_USER
+    _patch_whitelist_deps(monkeypatch, placeholder)
 
     with pytest.raises(OnyxError):
-        verify_email_is_invited("newuser@example.com", sso_managed=False)
+        verify_email_in_whitelist("newuser@example.com", "public")
+
+
+def test_whitelist_skips_check_for_real_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An account that has actually joined is never re-gated on login."""
+    member = MagicMock()
+    member.account_type = AccountType.STANDARD
+    _patch_whitelist_deps(monkeypatch, member)
+
+    verify_email_in_whitelist("member@example.com", "public")
+
+
+def test_whitelist_enforces_for_unknown_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_whitelist_deps(monkeypatch, None)
+
+    with pytest.raises(OnyxError):
+        verify_email_in_whitelist("newuser@example.com", "public")


### PR DESCRIPTION
## Description

Fixes two issues reported by a customer running multi-IdP SSO with permission sync.

**Bug 1: invite-only toggle ignored for SSO signups.** SSO and JWT flows passed `sso_managed=True`, which skipped the invite check entirely. On top of that, `verify_email_in_whitelist` treated permission-sync placeholder rows (`EXT_PERM_USER`, no login credentials) as existing members, so any email that appeared in a synced connector ACL could sign up even with open sign-up restricted.

Fix: the `sso_managed` bypass is removed, and the whitelist gate only skips the invite check for accounts that have actually joined (`account_type.is_web_login()`). Appearing in a connector's ACLs is visibility, not membership.

**What this means:** SSO is still how users authenticate. But when "restrict open sign up" is ON, only explicitly invited users can create an account, regardless of login method. When the toggle is OFF, nothing changes. Existing accounts are never re-gated at login.

**Bug 2: 500 on first SSO login for synced users.** The OAuth callback's placeholder-promotion block expired the SQLAlchemy user object and then read `user.id`, triggering a sync lazy-load in an async context (`MissingGreenlet`). The promotion had already committed, which is why a retry worked. The id is now cached before expiring, matching `create()`.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check