### PR TITLE
chore(db): migrate python tool db name to run_python, drop code-side resolution

### DIFF
--- a/backend/alembic/versions/e2875ce6454b_rename_python_tool_llm_facing_name.py
+++ b/backend/alembic/versions/e2875ce6454b_rename_python_tool_llm_facing_name.py
@@ -1,0 +1,41 @@
+"""rename python tool llm facing name
+
+OpenAI reserves the function name "python" for its own harness and rejects
+requests that define a tool with that name (400 invalid_request_error,
+enforced server-side since 2026-07-21). The LLM-facing name of the Code
+Interpreter tool moves to "run_python"; display_name and in_code_tool_id
+are unchanged.
+
+Revision ID: e2875ce6454b
+Revises: eec4fc85ef28
+Create Date: 2026-07-21 08:33:15.857244
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e2875ce6454b"
+down_revision = "eec4fc85ef28"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE tool SET name = 'run_python' "
+            "WHERE in_code_tool_id = 'PythonTool' AND name = 'python'"
+        )
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE tool SET name = 'python' "
+            "WHERE in_code_tool_id = 'PythonTool' AND name = 'run_python'"
+        )
+    )

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -33,7 +33,6 @@ from onyx.prompts.compression_prompts import (
     SUMMARIZATION_PROMPT,
     USER_REMINDER,
 )
-from onyx.tools.built_in_tools import llm_tool_name
 from onyx.tracing.flows import LLMFlow
 from onyx.tracing.framework.create import ensure_trace
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
@@ -403,8 +402,7 @@ def compress_chat_history(
                 )
                 all_tools = get_tools(read_session)
                 tool_id_to_name: dict[int, str] = {
-                    tool.id: llm_tool_name(tool.in_code_tool_id, tool.name)
-                    for tool in all_tools
+                    tool.id: tool.name for tool in all_tools
                 }
 
             summary_content = get_messages_to_summarize(

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -130,7 +130,6 @@ from onyx.server.query_and_chat.streaming_models import (
 from onyx.server.settings.store import load_settings
 from onyx.server.usage_limits import check_llm_cost_limit_for_provider
 from onyx.server.utils import get_json_line
-from onyx.tools.built_in_tools import llm_tool_name
 from onyx.tools.constants import FILE_READER_TOOL_ID, SEARCH_TOOL_ID
 from onyx.tools.models import ChatFile, SearchToolUsage
 from onyx.tools.tool_constructor import (
@@ -879,11 +878,7 @@ def build_chat_turn(
                 available_files.user_file_ids.append(uf.id)
 
     all_tools = get_tools(db_session)
-    # Resolve built-in tool names from code, not the DB name column — replayed
-    # history must use the same function names the live tools advertise.
-    tool_id_to_name_map = {
-        tool.id: llm_tool_name(tool.in_code_tool_id, tool.name) for tool in all_tools
-    }
+    tool_id_to_name_map = {tool.id: tool.name for tool in all_tools}
 
     search_tool_id = next(
         (tool.id for tool in all_tools if tool.in_code_tool_id == SEARCH_TOOL_ID), None

--- a/backend/onyx/tools/built_in_tools.py
+++ b/backend/onyx/tools/built_in_tools.py
@@ -78,24 +78,3 @@ def _build_tool_name_to_class() -> dict[str, Type[BUILT_IN_TOOL_TYPES]]:
 
 
 TOOL_NAME_TO_CLASS: dict[str, Type[BUILT_IN_TOOL_TYPES]] = _build_tool_name_to_class()
-
-_IN_CODE_TOOL_ID_TO_LLM_NAME: dict[str, str] = {
-    in_code_tool_id: _tool_llm_name(cls)
-    for in_code_tool_id, cls in BUILT_IN_TOOL_MAP.items()
-}
-
-
-def llm_tool_name(in_code_tool_id: str | None, db_name: str) -> str:
-    """LLM-facing name for a tool table row.
-
-    For built-in tools the class constant is the source of truth: the DB name
-    column is seeded once by migration and may lag code renames (e.g. the
-    Code Interpreter's "python" -> "run_python" rename after OpenAI reserved
-    the name "python"). Custom/MCP tools have no in-code class, so their DB
-    name is authoritative.
-    """
-    if in_code_tool_id is not None:
-        llm_name = _IN_CODE_TOOL_ID_TO_LLM_NAME.get(in_code_tool_id)
-        if llm_name is not None:
-            return llm_name
-    return db_name

--- a/backend/tests/integration/tests/migrations/test_assistant_consolidation_migration.py
+++ b/backend/tests/integration/tests/migrations/test_assistant_consolidation_migration.py
@@ -67,7 +67,7 @@ def test_cold_startup_default_assistant() -> None:
         assert "read_file" in tool_names, (
             "Default assistant should have FileReaderTool attached"
         )
-        assert "python" in tool_names, (
+        assert "run_python" in tool_names, (
             "Default assistant should have PythonTool attached"
         )
 

--- a/backend/tests/integration/tests/migrations/test_tool_seeding.py
+++ b/backend/tests/integration/tests/migrations/test_tool_seeding.py
@@ -39,7 +39,7 @@ EXPECTED_TOOLS = {
         user_id=None,
     ),
     "PythonTool": ToolSeedingExpectedResult(
-        name="python",
+        name="run_python",
         display_name="Code Interpreter",
         in_code_tool_id="PythonTool",
         user_id=None,

--- a/backend/tests/unit/onyx/tools/test_tool_llm_names.py
+++ b/backend/tests/unit/onyx/tools/test_tool_llm_names.py
@@ -7,11 +7,7 @@ server-side since 2026-07-21. A collision breaks every chat that has the tool
 attached, across all GPT models served via api.openai.com.
 """
 
-from onyx.tools.built_in_tools import (
-    BUILT_IN_TOOL_MAP,
-    TOOL_NAME_TO_CLASS,
-    llm_tool_name,
-)
+from onyx.tools.built_in_tools import BUILT_IN_TOOL_MAP, TOOL_NAME_TO_CLASS
 
 # Names OpenAI is known to reserve. Extend if OpenAI reserves more of its
 # harness tool names (e.g. "browser", "bash") and starts rejecting them.
@@ -31,16 +27,3 @@ def test_tool_name_map_covers_all_builtin_tools() -> None:
     # Every built-in tool must resolve to an LLM-facing name — a missing entry
     # would silently skip the reserved-name check above.
     assert len(TOOL_NAME_TO_CLASS) == len(BUILT_IN_TOOL_MAP)
-
-
-def test_llm_tool_name_resolves_builtins_from_code() -> None:
-    # The tool table's name column is seeded by migration and still says
-    # "python" on existing deployments; the code constant must win so history
-    # replay never sends the reserved name to OpenAI.
-    assert llm_tool_name("PythonTool", "python") == "run_python"
-
-
-def test_llm_tool_name_passes_through_custom_tools() -> None:
-    # Custom/MCP tools have no in-code class; their DB name is authoritative.
-    assert llm_tool_name(None, "my_custom_tool") == "my_custom_tool"
-    assert llm_tool_name("NotARealBuiltin", "my_custom_tool") == "my_custom_tool"


### PR DESCRIPTION
## Description

Follow-up to #13235, per team discussion: now that the fleet is unblocked by the code-side fix, this restores the single-source-of-truth architecture on main.

- **Alembic migration** `e2875ce6454b`: `tool.name` `python` → `run_python` (idempotent, one row). Fresh installs get the new name via the chain; seeding test expectation updated.
- **Reverts the `llm_tool_name()` code-side resolution** added in #13235: with the DB migrated, the indirection is unnecessary on main — `tool_id_to_name_map` reads `tool.name` directly again. Migration + revert are in one PR deliberately so there is never a commit where the map reads an unmigrated DB.
- Keeps the reserved-name guard tests from #13235.

**Stacked on #13235 — merge that first.** Release-branch backports take only #13235 (code-side resolution, no migration) since frozen branches can't cleanly carry alembic revisions; main ends up abstraction-free with the DB migrated.

## How Has This Been Tested?

- `pytest backend/tests/unit/onyx/tools backend/tests/unit/onyx/chat` — 918 passed
- `alembic heads` — single head (`e2875ce6454b`); migration SQL dry-run transactionally against a live DB (updates exactly the one `PythonTool` row, clean rollback)
- Pre-commit (ruff, ty) clean

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)