### PR TITLE
fix(tools): rename Code Interpreter LLM function name off OpenAI-reserved "python" (v3.2 backport)

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -120,6 +120,7 @@ from onyx.server.query_and_chat.streaming_models import CitationInfo
 from onyx.server.query_and_chat.streaming_models import OverallStop
 from onyx.server.query_and_chat.streaming_models import Packet
 from onyx.server.usage_limits import check_llm_cost_limit_for_provider
+from onyx.tools.built_in_tools import llm_tool_name
 from onyx.tools.constants import FILE_READER_TOOL_ID
 from onyx.tools.constants import SEARCH_TOOL_ID
 from onyx.tools.models import ChatFile
@@ -968,7 +969,11 @@ def build_chat_turn(
                 available_files.user_file_ids.append(uf.id)
 
     all_tools = get_tools(db_session)
-    tool_id_to_name_map = {tool.id: tool.name for tool in all_tools}
+    # Resolve built-in tool names from code, not the DB name column — replayed
+    # history must use the same function names the live tools advertise.
+    tool_id_to_name_map = {
+        tool.id: llm_tool_name(tool.in_code_tool_id, tool.name) for tool in all_tools
+    }
 
     search_tool_id = next(
         (tool.id for tool in all_tools if tool.in_code_tool_id == SEARCH_TOOL_ID), None
@@ -1780,7 +1785,10 @@ def llm_loop_completion_handle(
     if compression_params.should_compress:
         # Build tool mapping for formatting messages
         all_tools = get_tools(db_session)
-        tool_id_to_name = {tool.id: tool.name for tool in all_tools}
+        tool_id_to_name = {
+            tool.id: llm_tool_name(tool.in_code_tool_id, tool.name)
+            for tool in all_tools
+        }
 
         compress_chat_history(
             db_session=db_session,

--- a/backend/onyx/prompts/tool_prompts.py
+++ b/backend/onyx/prompts/tool_prompts.py
@@ -52,8 +52,8 @@ You should almost always use open_url after a web_search call. Use this tool whe
 """.lstrip()
 
 PYTHON_TOOL_GUIDANCE = """
-## python
-Use the `python` tool to execute Python code in an isolated sandbox. The tool will respond with the output of the execution or time out after 60.0 seconds.
+## run_python
+Use the `run_python` tool to execute Python code in an isolated sandbox. The tool will respond with the output of the execution or time out after 60.0 seconds.
 Any files uploaded to the chat will be automatically be available in the execution environment's current directory. \
 The current directory in the file system can be used to save and persist user files. Files written to the current directory will be returned with a `file_link`. \
 Use this to give the user a way to download the file OR to display generated images.

--- a/backend/onyx/tools/built_in_tools.py
+++ b/backend/onyx/tools/built_in_tools.py
@@ -58,21 +58,42 @@ def get_built_in_tool_by_id(in_code_tool_id: str) -> Type[BUILT_IN_TOOL_TYPES]:
     return BUILT_IN_TOOL_MAP[in_code_tool_id]
 
 
+def _tool_llm_name(cls: Type[BUILT_IN_TOOL_TYPES]) -> str:
+    """Extract the LLM-facing tool name from a tool class."""
+    name_attr = cls.__dict__.get("name")
+    if isinstance(name_attr, property) and name_attr.fget is not None:
+        return name_attr.fget(cls)
+    if isinstance(name_attr, str):
+        return name_attr
+    raise ValueError(
+        f"Built-in tool {cls.__name__} must define a valid LLM-facing tool name"
+    )
+
+
 def _build_tool_name_to_class() -> dict[str, Type[BUILT_IN_TOOL_TYPES]]:
     """Build a mapping from LLM-facing tool name to tool class."""
-    result: dict[str, Type[BUILT_IN_TOOL_TYPES]] = {}
-    for cls in BUILT_IN_TOOL_MAP.values():
-        name_attr = cls.__dict__.get("name")
-        if isinstance(name_attr, property) and name_attr.fget is not None:
-            tool_name = name_attr.fget(cls)
-        elif isinstance(name_attr, str):
-            tool_name = name_attr
-        else:
-            raise ValueError(
-                f"Built-in tool {cls.__name__} must define a valid LLM-facing tool name"
-            )
-        result[tool_name] = cls
-    return result
+    return {_tool_llm_name(cls): cls for cls in BUILT_IN_TOOL_MAP.values()}
 
 
 TOOL_NAME_TO_CLASS: dict[str, Type[BUILT_IN_TOOL_TYPES]] = _build_tool_name_to_class()
+
+_IN_CODE_TOOL_ID_TO_LLM_NAME: dict[str, str] = {
+    in_code_tool_id: _tool_llm_name(cls)
+    for in_code_tool_id, cls in BUILT_IN_TOOL_MAP.items()
+}
+
+
+def llm_tool_name(in_code_tool_id: str | None, db_name: str) -> str:
+    """LLM-facing name for a tool table row.
+
+    For built-in tools the class constant is the source of truth: the DB name
+    column is seeded once by migration and may lag code renames (e.g. the
+    Code Interpreter's "python" -> "run_python" rename after OpenAI reserved
+    the name "python"). Custom/MCP tools have no in-code class, so their DB
+    name is authoritative.
+    """
+    if in_code_tool_id is not None:
+        llm_name = _IN_CODE_TOOL_ID_TO_LLM_NAME.get(in_code_tool_id)
+        if llm_name is not None:
+            return llm_name
+    return db_name

--- a/backend/onyx/tools/tool_implementations/python/python_tool.py
+++ b/backend/onyx/tools/tool_implementations/python/python_tool.py
@@ -77,7 +77,10 @@ class PythonTool(Tool[PythonToolOverrideKwargs]):
     It supports uploading files from the chat session and downloading generated files.
     """
 
-    NAME = "python"
+    # OpenAI reserves the function name "python" for its own harness and
+    # rejects requests that define a tool with that name (400 invalid_request_error,
+    # enforced server-side since 2026-07-21) — never rename this back to "python".
+    NAME = "run_python"
     DISPLAY_NAME = "Code Interpreter"
     DESCRIPTION = "Execute Python code in an isolated sandbox environment."
 

--- a/backend/tests/external_dependency_unit/tools/test_python_tool.py
+++ b/backend/tests/external_dependency_unit/tools/test_python_tool.py
@@ -1202,7 +1202,7 @@ def test_code_interpreter_receives_chat_files(
     ):
         mock_llm.add_response(
             LLMToolCallResponse(
-                tool_name="python",
+                tool_name="run_python",
                 tool_call_id="call_test_1",
                 tool_call_argument_tokens=[json.dumps({"code": code})],
             )
@@ -1289,7 +1289,7 @@ def test_code_interpreter_replay_packets_include_code_and_output(
             # Phase 1: LLM requests python tool execution.
             handler.add_response(
                 LLMToolCallResponse(
-                    tool_name="python",
+                    tool_name="run_python",
                     tool_call_id="call_replay_test",
                     tool_call_argument_tokens=[json.dumps({"code": code})],
                 )
@@ -1297,7 +1297,7 @@ def test_code_interpreter_replay_packets_include_code_and_output(
                 Packet(
                     placement=create_placement(0),
                     obj=ToolCallArgumentDelta(
-                        tool_type="python",
+                        tool_type="run_python",
                         argument_deltas={"code": code},
                     ),
                 ),
@@ -1416,7 +1416,7 @@ def test_code_interpreter_streaming_fallback_to_batch(
     ):
         mock_llm.add_response(
             LLMToolCallResponse(
-                tool_name="python",
+                tool_name="run_python",
                 tool_call_id="call_fallback",
                 tool_call_argument_tokens=[json.dumps({"code": code})],
             )

--- a/backend/tests/unit/onyx/chat/test_argument_delta_streaming.py
+++ b/backend/tests/unit/onyx/chat/test_argument_delta_streaming.py
@@ -85,7 +85,7 @@ class TestMaybeEmitArgumentDeltaGuards:
         mock_get_tool.return_value = _mock_tool_class(emit=False)
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": '{"code": "x'}
+            0: {"id": "tc_1", "name": "run_python", "arguments": '{"code": "x'}
         }
         assert _collect(tc_map, _make_tool_call_delta(arguments="x")) == []
 
@@ -107,7 +107,7 @@ class TestMaybeEmitArgumentDeltaGuards:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": '{"code": "x'}
+            0: {"id": "tc_1", "name": "run_python", "arguments": '{"code": "x'}
         }
         assert _collect(tc_map, _make_tool_call_delta(arguments=None)) == []
 
@@ -119,7 +119,7 @@ class TestMaybeEmitArgumentDeltaGuards:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": '{"code":'}
+            0: {"id": "tc_1", "name": "run_python", "arguments": '{"code":'}
         }
         assert _collect(tc_map, _make_tool_call_delta(arguments=":")) == []
 
@@ -129,7 +129,7 @@ class TestMaybeEmitArgumentDeltaGuards:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": "{"}
+            0: {"id": "tc_1", "name": "run_python", "arguments": "{"}
         }
         assert _collect(tc_map, _make_tool_call_delta(arguments="{")) == []
 
@@ -142,7 +142,7 @@ class TestMaybeEmitArgumentDeltaBasic:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "', "print(1)", '"}']
 
@@ -160,7 +160,7 @@ class TestMaybeEmitArgumentDeltaBasic:
         # Verify packet structure
         obj = all_packets[0].obj
         assert isinstance(obj, ToolCallArgumentDelta)
-        assert obj.tool_type == "python"
+        assert obj.tool_type == "run_python"
         # All emitted content should reconstruct the value
         full_code = ""
         for p in all_packets:
@@ -177,7 +177,7 @@ class TestMaybeEmitArgumentDeltaBasic:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         parsers: dict[int, Parser] = {}
         pl = _make_placement()
@@ -210,7 +210,7 @@ class TestMaybeEmitArgumentDeltaBasic:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"code": "x',
@@ -229,7 +229,7 @@ class TestMaybeEmitArgumentDeltaBasic:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"code": "x',
@@ -248,7 +248,7 @@ class TestMaybeEmitArgumentDeltaBasic:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         # Opening quote just arrived, value is empty
         tc_map[0]["arguments"] = '{"code": "'
@@ -267,7 +267,7 @@ class TestMaybeEmitArgumentDeltaDecoding:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "line1\\nline2"}']
 
@@ -279,7 +279,7 @@ class TestMaybeEmitArgumentDeltaDecoding:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "\\tindented"}']
 
@@ -291,7 +291,7 @@ class TestMaybeEmitArgumentDeltaDecoding:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "say \\"hi\\""}']
 
@@ -303,7 +303,7 @@ class TestMaybeEmitArgumentDeltaDecoding:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "path\\\\dir"}']
 
@@ -315,7 +315,7 @@ class TestMaybeEmitArgumentDeltaDecoding:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "\\u0041"}']
 
@@ -330,7 +330,7 @@ class TestMaybeEmitArgumentDeltaDecoding:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "hello\\', 'n"}']
 
@@ -345,7 +345,7 @@ class TestMaybeEmitArgumentDeltaDecoding:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"code": "hello\\u00', '41"}']
 
@@ -363,7 +363,7 @@ class TestArgumentDeltaStreamingE2E:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"',
@@ -386,7 +386,7 @@ class TestArgumentDeltaStreamingE2E:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"code": "',
@@ -407,7 +407,7 @@ class TestArgumentDeltaStreamingE2E:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"code": "hello',
@@ -425,7 +425,7 @@ class TestArgumentDeltaStreamingE2E:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"code": "',
@@ -448,7 +448,7 @@ class TestArgumentDeltaStreamingE2E:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"code": "',
@@ -472,7 +472,7 @@ class TestArgumentDeltaStreamingE2E:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         # The LLM sends: {"code": "x = {\"key\": \"val\"}"}
         # The inner quotes are escaped as \" in the JSON value.
@@ -495,7 +495,7 @@ class TestArgumentDeltaStreamingE2E:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = [
             '{"code": "',
@@ -517,7 +517,7 @@ class TestMaybeEmitArgumentDeltaEdgeCases:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": '{"code": "x'}
+            0: {"id": "tc_1", "name": "run_python", "arguments": '{"code": "x'}
         }
         delta = _make_tool_call_delta(arguments=None, function_is_none=True)
         assert _collect(tc_map, delta) == []
@@ -528,8 +528,8 @@ class TestMaybeEmitArgumentDeltaEdgeCases:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""},
-            1: {"id": "tc_2", "name": "python", "arguments": ""},
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""},
+            1: {"id": "tc_2", "name": "run_python", "arguments": ""},
         }
 
         parsers: dict[int, Parser] = {}
@@ -570,7 +570,7 @@ class TestMaybeEmitArgumentDeltaEdgeCases:
 
         full = '{"a": "one", "b": "two", "c": "three", "d": "four"}'
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         tc_map[0]["arguments"] = full
         parsers: dict[int, Parser] = {}
@@ -600,7 +600,7 @@ class TestMaybeEmitArgumentDeltaEdgeCases:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
 
         fragments = [
@@ -621,7 +621,7 @@ class TestMaybeEmitArgumentDeltaEdgeCases:
         mock_get_tool.return_value = _mock_tool_class()
 
         tc_map: dict[int, dict[str, Any]] = {
-            0: {"id": "tc_1", "name": "python", "arguments": ""}
+            0: {"id": "tc_1", "name": "run_python", "arguments": ""}
         }
         fragments = ['{"timeout": 30, "code": "hello"}']
 

--- a/backend/tests/unit/onyx/chat/test_save_chat.py
+++ b/backend/tests/unit/onyx/chat/test_save_chat.py
@@ -16,7 +16,7 @@ from onyx.tools.models import ToolCallInfo
 
 def _make_tool_call_info(
     generated_files: list[PythonExecutionFile] | None = None,
-    tool_name: str = "python",
+    tool_name: str = "run_python",
 ) -> ToolCallInfo:
     return ToolCallInfo(
         parent_tool_call_id=None,

--- a/backend/tests/unit/onyx/tools/test_tool_llm_names.py
+++ b/backend/tests/unit/onyx/tools/test_tool_llm_names.py
@@ -7,11 +7,9 @@ server-side since 2026-07-21. A collision breaks every chat that has the tool
 attached, across all GPT models served via api.openai.com.
 """
 
-from onyx.tools.built_in_tools import (
-    BUILT_IN_TOOL_MAP,
-    TOOL_NAME_TO_CLASS,
-    llm_tool_name,
-)
+from onyx.tools.built_in_tools import BUILT_IN_TOOL_MAP
+from onyx.tools.built_in_tools import llm_tool_name
+from onyx.tools.built_in_tools import TOOL_NAME_TO_CLASS
 
 # Names OpenAI is known to reserve. Extend if OpenAI reserves more of its
 # harness tool names (e.g. "browser", "bash") and starts rejecting them.

--- a/backend/tests/unit/onyx/tools/test_tool_llm_names.py
+++ b/backend/tests/unit/onyx/tools/test_tool_llm_names.py
@@ -1,0 +1,46 @@
+"""Guards built-in tool LLM-facing names against OpenAI's reserved function names.
+
+OpenAI reserves certain function names for its own model harness and rejects any
+request whose tools array defines one of them (400 invalid_request_error:
+"The function name 'python' is reserved for use by this model."), enforced
+server-side since 2026-07-21. A collision breaks every chat that has the tool
+attached, across all GPT models served via api.openai.com.
+"""
+
+from onyx.tools.built_in_tools import (
+    BUILT_IN_TOOL_MAP,
+    TOOL_NAME_TO_CLASS,
+    llm_tool_name,
+)
+
+# Names OpenAI is known to reserve. Extend if OpenAI reserves more of its
+# harness tool names (e.g. "browser", "bash") and starts rejecting them.
+OPENAI_RESERVED_FUNCTION_NAMES = {"python"}
+
+
+def test_builtin_tool_names_avoid_openai_reserved_names() -> None:
+    for tool_name in TOOL_NAME_TO_CLASS:
+        assert tool_name not in OPENAI_RESERVED_FUNCTION_NAMES, (
+            f"Built-in tool name {tool_name!r} collides with an OpenAI-reserved "
+            "function name; OpenAI rejects requests defining it. Rename the "
+            "tool's NAME (and migrate the tool table's name column)."
+        )
+
+
+def test_tool_name_map_covers_all_builtin_tools() -> None:
+    # Every built-in tool must resolve to an LLM-facing name — a missing entry
+    # would silently skip the reserved-name check above.
+    assert len(TOOL_NAME_TO_CLASS) == len(BUILT_IN_TOOL_MAP)
+
+
+def test_llm_tool_name_resolves_builtins_from_code() -> None:
+    # The tool table's name column is seeded by migration and still says
+    # "python" on existing deployments; the code constant must win so history
+    # replay never sends the reserved name to OpenAI.
+    assert llm_tool_name("PythonTool", "python") == "run_python"
+
+
+def test_llm_tool_name_passes_through_custom_tools() -> None:
+    # Custom/MCP tools have no in-code class; their DB name is authoritative.
+    assert llm_tool_name(None, "my_custom_tool") == "my_custom_tool"
+    assert llm_tool_name("NotARealBuiltin", "my_custom_tool") == "my_custom_tool"

--- a/backend/tests/unit/onyx/tools/test_tool_runner.py
+++ b/backend/tests/unit/onyx/tools/test_tool_runner.py
@@ -135,12 +135,12 @@ class TestMergeToolCalls:
         """Non-mergeable tools (e.g., python) are returned as separate calls."""
         calls = [
             _make_tool_call(
-                tool_name="python",
+                tool_name="run_python",
                 tool_args={"code": "print(1)"},
                 tool_call_id="call_1",
             ),
             _make_tool_call(
-                tool_name="python",
+                tool_name="run_python",
                 tool_args={"code": "print(2)"},
                 tool_call_id="call_2",
             ),
@@ -160,7 +160,7 @@ class TestMergeToolCalls:
                 tool_call_id="search_1",
             ),
             _make_tool_call(
-                tool_name="python",
+                tool_name="run_python",
                 tool_args={"code": "x = 1"},
                 tool_call_id="python_1",
             ),
@@ -176,12 +176,12 @@ class TestMergeToolCalls:
         assert len(result) == 2
 
         tool_names = {r.tool_name for r in result}
-        assert tool_names == {"internal_search", "python"}
+        assert tool_names == {"internal_search", "run_python"}
 
         search_result = next(r for r in result if r.tool_name == "internal_search")
         assert search_result.tool_args["queries"] == ["q1", "q2"]
 
-        python_result = next(r for r in result if r.tool_name == "python")
+        python_result = next(r for r in result if r.tool_name == "run_python")
         assert python_result.tool_args["code"] == "x = 1"
 
     def test_multiple_different_mergeable_tools(self) -> None:

--- a/web/src/app/app/message/messageComponents/renderMessageComponent.tsx
+++ b/web/src/app/app/message/messageComponents/renderMessageComponent.tsx
@@ -1,7 +1,7 @@
 import React, { JSX, memo } from "react";
 import {
   ChatPacket,
-  CODE_INTERPRETER_TOOL_TYPES,
+  isCodeInterpreterToolType,
   ImageGenerationToolPacket,
   Packet,
   PacketType,
@@ -61,8 +61,9 @@ function isPythonToolPacket(packet: Packet) {
   return (
     packet.obj.type === PacketType.PYTHON_TOOL_START ||
     (packet.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
-      (packet.obj as ToolCallArgumentDelta).tool_type ===
-        CODE_INTERPRETER_TOOL_TYPES.PYTHON)
+      isCodeInterpreterToolType(
+        (packet.obj as ToolCallArgumentDelta).tool_type
+      ))
   );
 }
 

--- a/web/src/app/app/message/messageComponents/timeline/hooks/packetProcessor.ts
+++ b/web/src/app/app/message/messageComponents/timeline/hooks/packetProcessor.ts
@@ -11,7 +11,7 @@ import {
   ImageGenerationToolDelta,
   MessageStart,
   ToolCallArgumentDelta,
-  CODE_INTERPRETER_TOOL_TYPES,
+  isCodeInterpreterToolType,
 } from "@/app/app/services/streamingModels";
 import { CitationMap } from "@/app/app/interfaces";
 import { OnyxDocument } from "@/lib/search/interfaces";
@@ -155,9 +155,8 @@ function hasContentPackets(packets: Packet[]): boolean {
   return packets.some((packet) => {
     const type = packet.obj.type as PacketType;
     if (type === PacketType.TOOL_CALL_ARGUMENT_DELTA) {
-      return (
-        (packet.obj as ToolCallArgumentDelta).tool_type ===
-        CODE_INTERPRETER_TOOL_TYPES.PYTHON
+      return isCodeInterpreterToolType(
+        (packet.obj as ToolCallArgumentDelta).tool_type
       );
     }
     return CONTENT_PACKET_TYPES_SET.has(type);

--- a/web/src/app/app/message/messageComponents/timeline/packetHelpers.ts
+++ b/web/src/app/app/message/messageComponents/timeline/packetHelpers.ts
@@ -1,5 +1,5 @@
 import {
-  CODE_INTERPRETER_TOOL_TYPES,
+  isCodeInterpreterToolType,
   Packet,
   PacketType,
   ToolCallArgumentDelta,
@@ -32,8 +32,7 @@ export const isPythonToolPackets = (packets: Packet[]): boolean =>
     (p) =>
       p.obj.type === PacketType.PYTHON_TOOL_START ||
       (p.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
-        (p.obj as ToolCallArgumentDelta).tool_type ===
-          CODE_INTERPRETER_TOOL_TYPES.PYTHON)
+        isCodeInterpreterToolType((p.obj as ToolCallArgumentDelta).tool_type))
   );
 
 // Check if packets belong to reasoning
@@ -46,8 +45,7 @@ export const stepSupportsCollapsedStreaming = (packets: Packet[]): boolean =>
     (p) =>
       COLLAPSED_STREAMING_PACKET_TYPES.has(p.obj.type as PacketType) ||
       (p.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
-        (p.obj as ToolCallArgumentDelta).tool_type ===
-          CODE_INTERPRETER_TOOL_TYPES.PYTHON)
+        isCodeInterpreterToolType((p.obj as ToolCallArgumentDelta).tool_type))
   );
 
 // Check if packets have content worth rendering in collapsed streaming mode.
@@ -88,8 +86,7 @@ export const stepHasCollapsedStreamingContent = (
     packets.some(
       (p) =>
         p.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
-        (p.obj as ToolCallArgumentDelta).tool_type ===
-          CODE_INTERPRETER_TOOL_TYPES.PYTHON
+        isCodeInterpreterToolType((p.obj as ToolCallArgumentDelta).tool_type)
     )
   ) {
     return true;

--- a/web/src/app/app/message/messageComponents/timeline/renderers/code/PythonToolRenderer.tsx
+++ b/web/src/app/app/message/messageComponents/timeline/renderers/code/PythonToolRenderer.tsx
@@ -6,7 +6,7 @@ import {
   PythonToolDelta,
   ToolCallArgumentDelta,
   SectionEnd,
-  CODE_INTERPRETER_TOOL_TYPES,
+  isCodeInterpreterToolType,
 } from "@/app/app/services/streamingModels";
 import {
   MessageRenderer,
@@ -46,8 +46,9 @@ function constructCurrentPythonState(packets: PythonToolPacket[]) {
     .filter(
       (packet) =>
         packet.obj.type === PacketType.TOOL_CALL_ARGUMENT_DELTA &&
-        (packet.obj as ToolCallArgumentDelta).tool_type ===
-          CODE_INTERPRETER_TOOL_TYPES.PYTHON
+        isCodeInterpreterToolType(
+          (packet.obj as ToolCallArgumentDelta).tool_type
+        )
     )
     .map((packet) =>
       String((packet.obj as ToolCallArgumentDelta).argument_deltas.code ?? "")

--- a/web/src/app/app/services/streamingModels.ts
+++ b/web/src/app/app/services/streamingModels.ts
@@ -64,8 +64,14 @@ export enum PacketType {
 }
 
 export const CODE_INTERPRETER_TOOL_TYPES = {
+  // Legacy LLM-facing name; still present in sessions persisted before the
+  // rename (OpenAI reserves the function name "python" and rejects it).
   PYTHON: "python",
+  RUN_PYTHON: "run_python",
 } as const;
+
+export const isCodeInterpreterToolType = (toolType: string): boolean =>
+  (Object.values(CODE_INTERPRETER_TOOL_TYPES) as string[]).includes(toolType);
 
 // Basic Message Packets
 export interface MessageStart extends BaseObj {


### PR DESCRIPTION
## Description

Backport of #13235 (merged to main as dac9941cc0) to release/v3.2, adapted like the v3.3 backport (#13245): import styles, both `tool_id_to_name` map constructions in `process_message.py` patched with `llm_tool_name()` (compression takes the map as a parameter on this branch), frontend helpers without call sites omitted. No migration.

OpenAI rejects function tools named `python` since 2026-07-21; this branch ships the Code Interpreter, so v3.2 deployments with a direct OpenAI provider are affected.

## How Has This Been Tested?

Verified on main (#13235); adapted hunks syntax-checked; CI on this PR validates the branch.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename the Code Interpreter tool function from "python" to "run_python" to avoid OpenAI’s reserved-name rejection. Backend resolves built-in tool names from code, and the UI accepts both names so old chats continue to render; no migration needed.

- **Bug Fixes**
  - Set Code Interpreter NAME to "run_python"; updated prompt guidance.
  - Added `llm_tool_name(...)` and resolve built-in tool names from code; custom tools still use the DB name.
  - Updated history/compression mapping so we never emit "python".
  - Frontend adds `isCodeInterpreterToolType` and accepts both "python" and "run_python".
  - Updated tests and added a guard against OpenAI-reserved names.

<sup>Written for commit a65ef1f342fcb5d395bf9a3796540d6b41e20ba5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13246?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

