### PR TITLE
fix(chat): restore 24px welcome-to-input gap per design spec

### DIFF
--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -922,7 +922,7 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                           />
                         )}
                     </Section>
-                    <Spacer rem={1} />
+                    <Spacer rem={1.5} />
                   </Fade>
                 </div>
 
@@ -971,9 +971,9 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       # Note (@raunakab)
 
                       `shadow-box-01` on AppInputBar extends ~14px below the element
-                      (2px offset + 12px blur). Because the content area in `Root`
-                      (app-layouts.tsx) uses `overflow-auto`, shadows that exceed
-                      the container bounds are clipped.
+                      (2px offset + 12px blur). Because the content area in
+                      `RootLayout` (@opal/layouts) uses `overflow-auto`, shadows
+                      that exceed the container bounds are clipped.
 
                       The animated spacer divs above and below the AppInputBar
                       provide 14px of breathing room so the shadow renders fully.
@@ -981,11 +981,11 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                       the classification is "search" (spacer above) or "chat"
                       (spacer below).
 
-                      There is a corresponding note inside `app-layouts.tsx`
-                      (Footer) that explains why the Footer removes its top
-                      padding during chat to compensate for this extra space.
+                      There is a corresponding note inside the Footer in
+                      `AppChrome.tsx` that explains why the Footer removes its
+                      top padding during chat to compensate for this extra space.
                     */}
-                    <div className={cn(onboardingVisible && "shrink-0 pt-4")}>
+                    <div className={cn(onboardingVisible && "shrink-0 pt-6")}>
                       <div
                         className={cn(
                           "transition-all duration-150 ease-in-out overflow-hidden",


### PR DESCRIPTION
## Description

The empty-state greeting shifted down 8px (caught by the persona-chat-welcome visual regression). Cause: #13228 tightened the welcome-to-input spacer from 1.5rem to 1rem to equalize the onboarding gaps, which also changed the normal empty state.

Figma (node 5136-191265) specifies the title-to-input gap as `--spacing/block/6x-main` = 24px.

Fix:
- Restore the empty-state spacer to 1.5rem (24px), matching the spec and the visual-regression baseline.
- Bump the onboarding input gap from `pt-4` to `pt-6` so the onboarding top/bottom gaps stay equal, now at the same 24px token.
- Fix two stale `app-layouts.tsx` references in the adjacent spacer note (file was removed in #11688; content area is `RootLayout`, the Footer note lives in `AppChrome.tsx`).

## How Has This Been Tested?

- Gap value verified against the Figma node via MCP (`--spacing/block/6x-main`, 24px).
- `tsgo --noEmit` clean; full web jest suite 849/849 after rebasing onto main; oxlint/oxfmt via pre-commit.
- Manually on dev1: empty-state greeting back at spec height.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check