### PR TITLE
feat(sharepoint): support OneDrive for Business and personal SharePoint site indexing

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1258,10 +1258,10 @@ class SharepointConnector(
         # Ensure sites are sharepoint urls
         for site_url in self.sites:
             if not site_url.startswith("https://") or not (
-                "/sites/" in site_url or "/teams/" in site_url
+                "/sites/" in site_url or "/teams/" in site_url or "/personal/" in site_url
             ):
                 raise ConnectorValidationError(
-                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site or https://your-tenant.sharepoint.com/teams/your-team)"
+                    "Site URLs must be full Sharepoint/OneDrive URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site, https://your-tenant.sharepoint.com/teams/your-team or https://your-tenant-my.sharepoint.com/personal/your-user)"
                 )
             try:
                 validate_outbound_http_url(site_url, https_only=True)
@@ -1491,14 +1491,14 @@ class SharepointConnector(
 
             lower_parts = [part.lower() for part in parts]
             site_type_index = None
-            for site_token in ("sites", "teams"):
+            for site_token in ("sites", "teams", "personal"):
                 if site_token in lower_parts:
                     site_type_index = lower_parts.index(site_token)
                     break
 
             if site_type_index is None or len(parts) <= site_type_index + 1:
                 logger.warning(
-                    "Site URL '%s' is not a valid Sharepoint URL (must contain /sites/<name> or /teams/<name>)",
+                    "Site URL '%s' is not a valid Sharepoint URL (must contain /sites/<name>, /teams/<name>, or /personal/<name>)",
                     url,
                 )
                 continue
@@ -1551,6 +1551,21 @@ class SharepointConnector(
                 and SHARED_DOCUMENTS_MAP[d.name] == drive_name
             )
         ]
+        if not matched and drives:
+            # Fallback for OneDrive for Business personal sites:
+            # Graph API returns the drive name as "OneDrive" or "documentLibrary",
+            # but the browser/SharePoint URL uses "Documents".
+            if "/personal/" in site_descriptor.url.lower():
+                matched = [drives[0]]
+            else:
+                onedrive_matches = [
+                    d
+                    for d in drives
+                    if d.name and d.name.lower() in ("onedrive", "onedrive for business", "documentlibrary")
+                ]
+                if onedrive_matches:
+                    matched = [onedrive_matches[0]]
+
         if not matched:
             logger.warning("Drive '%s' not found", drive_name)
             return None


### PR DESCRIPTION
### Summary
This PR adds support for indexing OneDrive for Business and personal SharePoint site URLs (containing `/personal/`) using the existing SharePoint connector.
---
### The Problem
When users attempt to index a personal OneDrive for Business site (e.g., `https://yourtenant-my.sharepoint.com/personal/username_domain_com`):
1. **Validation & Token Parsing Block:** The connector validation and URL-segment parser expected only `/sites/` or `/teams/` structures. This blocked `/personal/` site URLs from being validated or parsed correctly.
2. **Drive Naming Mismatch:** On OneDrive for Business personal sites, the default drive is often returned by the API as `"OneDrive"`, `"OneDrive for Business"`, or `"documentLibrary"`. If a URL-specified folder path is used (which typically contains `"Documents"` in the browser path), the drive resolver failed to match the drive and indexed 0 files.
---
### The Solution
1. **URL & Validation Updates:** Extended `validate_connector_settings` and `_extract_site_and_drive_info` to allow and parse `/personal/` SharePoint site structures.
2. **Robust Drive Fallback Resolution:** Updated `_resolve_drive` so that on personal OneDrive sites, if no exact match is found for the browser-parsed drive name (e.g., `"Documents"`), it falls back to the **primary/first drive** returned by the API (since personal OneDrive sites always contain exactly one primary library).
This allows users to seamlessly index their personal OneDrive sites using their personal base URLs.
---
### How Was This Tested?
- Verified with OneDrive personal base URLs (`https://nasa-my.sharepoint.com/:f:/r/personal/username_domain_com`).
- Verified that the connector successfully validates, authenticates, and indexes files on personal SharePoint/OneDrive collections.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for indexing OneDrive for Business personal SharePoint sites (`/personal/`) using the existing SharePoint connector. This enables validation of personal URLs and reliably selects the correct drive so files index as expected.

- New Features
  - Allow `/personal/` URLs in `validate_connector_settings` and `_extract_site_and_drive_info`.
  - Improve drive resolution: fall back to the primary drive on personal sites and handle common names like "OneDrive" and "documentLibrary" when no exact match is found.

<sup>Written for commit a54aa9486b7787317a88ffd7845c3c279c845a8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13253?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

