### PR TITLE
fix: canvas start date

### DIFF
--- a/backend/ee/onyx/external_permissions/canvas/group_sync.py
+++ b/backend/ee/onyx/external_permissions/canvas/group_sync.py
@@ -13,6 +13,7 @@ from onyx.connectors.canvas.connector import (
 from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.db.models import ConnectorCredentialPair
 from onyx.error_handling.exceptions import OnyxError
+from onyx.utils.datetime import datetime_to_utc
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -76,7 +77,7 @@ def canvas_group_sync(
     connector = CanvasConnector(**cc_pair.connector.connector_specific_config)
     connector.load_credentials(credential_json(cc_pair))
     indexing_start = (
-        cc_pair.connector.indexing_start.timestamp()
+        datetime_to_utc(cc_pair.connector.indexing_start).timestamp()
         if cc_pair.connector.indexing_start is not None
         else None
     )

--- a/backend/ee/onyx/external_permissions/canvas/group_sync.py
+++ b/backend/ee/onyx/external_permissions/canvas/group_sync.py
@@ -10,6 +10,7 @@ from onyx.connectors.canvas.connector import (
     canvas_group_group_id,
     canvas_section_group_id,
 )
+from onyx.connectors.interfaces import SecondsSinceUnixEpoch
 from onyx.db.models import ConnectorCredentialPair
 from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
@@ -47,6 +48,7 @@ def _fetch_canvas_group_emails(
 def _referenced_group_and_section_ids(
     connector: CanvasConnector,
     course_id: int,
+    indexing_start: SecondsSinceUnixEpoch | None,
 ) -> tuple[set[int], set[int]]:
     group_ids: set[int] = set()
     section_ids: set[int] = set()
@@ -57,7 +59,10 @@ def _referenced_group_and_section_ids(
             if override.course_section_id is not None:
                 section_ids.add(override.course_section_id)
 
-    for announcement in connector._list_announcements(course_id):
+    for announcement in connector._list_announcements(
+        course_id,
+        start=indexing_start,
+    ):
         for section in announcement.sections:
             section_ids.add(section.id)
 
@@ -70,6 +75,11 @@ def canvas_group_sync(
 ) -> Generator[ExternalUserGroup, None, None]:
     connector = CanvasConnector(**cc_pair.connector.connector_specific_config)
     connector.load_credentials(credential_json(cc_pair))
+    indexing_start = (
+        cc_pair.connector.indexing_start.timestamp()
+        if cc_pair.connector.indexing_start is not None
+        else None
+    )
 
     should_emit_all_users = False
     for course in connector._list_courses():
@@ -81,7 +91,9 @@ def canvas_group_sync(
         )
 
         group_ids, referenced_section_ids = _referenced_group_and_section_ids(
-            connector, course.id
+            connector,
+            course.id,
+            indexing_start,
         )
         section_ids = set(context.section_id_to_emails) | referenced_section_ids
         for section_id in section_ids:

--- a/backend/onyx/connectors/canvas/connector.py
+++ b/backend/onyx/connectors/canvas/connector.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timezone
 from enum import StrEnum
 from typing import Any, NoReturn, cast
@@ -416,15 +417,25 @@ class CanvasConnector(
         return assignments
 
     @retry_builder(tries=3, delay=1, backoff=2)
-    def _list_announcements(self, course_id: int) -> list[CanvasAnnouncement]:
+    def _list_announcements(
+        self,
+        course_id: int,
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
+    ) -> list[CanvasAnnouncement]:
         """Fetch all announcements for a given course."""
         logger.debug("Fetching announcements for course %s", course_id)
 
         announcements: list[CanvasAnnouncement] = []
         config = _STAGE_CONFIG[CanvasStage.ANNOUNCEMENTS]
+        params = _format_stage_params(config["params"], course_id)
+        params["start_date"] = _unix_to_canvas_time(start if start is not None else 0.0)
+        params["end_date"] = _unix_to_canvas_time(
+            end if end is not None else time.time()
+        )
         for page in self.canvas_client.paginate(
             config["endpoint"].format(course_id=course_id),
-            params=_format_stage_params(config["params"], course_id),
+            params=params,
         ):
             announcements.extend(
                 CanvasAnnouncement.from_api(a, course_id=course_id) for a in page
@@ -976,14 +987,18 @@ class CanvasConnector(
     @override
     def retrieve_all_slim_docs_perm_sync(
         self,
-        start: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
-        end: SecondsSinceUnixEpoch | None = None,  # noqa: ARG002
+        start: SecondsSinceUnixEpoch | None = None,
+        end: SecondsSinceUnixEpoch | None = None,
         callback: IndexingHeartbeatInterface | None = None,
     ) -> GenerateSlimDocumentOutput:
         slim_doc_batch: list[SlimDocument | HierarchyNode] = []
 
         for course in self._list_courses():
-            for slim_doc in self._retrieve_course_slim_docs(course.id):
+            for slim_doc in self._retrieve_course_slim_docs(
+                course.id,
+                start,
+                end,
+            ):
                 slim_doc_batch.append(slim_doc)
                 if len(slim_doc_batch) < self.batch_size:
                     continue
@@ -1003,6 +1018,8 @@ class CanvasConnector(
     def _retrieve_course_slim_docs(
         self,
         course_id: int,
+        start: SecondsSinceUnixEpoch | None,
+        end: SecondsSinceUnixEpoch | None,
     ) -> list[SlimDocument]:
         slim_docs: list[SlimDocument] = []
 
@@ -1024,7 +1041,7 @@ class CanvasConnector(
                 )
             )
 
-        for announcement in self._list_announcements(course_id):
+        for announcement in self._list_announcements(course_id, start, end):
             slim_docs.append(
                 SlimDocument(
                     id=f"canvas-announcement-{announcement.course_id}-{announcement.id}",

--- a/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
+++ b/backend/tests/unit/onyx/connectors/canvas/test_canvas_connector.py
@@ -1087,6 +1087,36 @@ class TestListAnnouncements:
         assert result[0].id == 30
         assert result[1].id == 31
 
+    @patch("onyx.connectors.canvas.connector.time.time", return_value=86400.0)
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_defaults_to_complete_time_range(
+        self,
+        mock_requests: MagicMock,
+        mock_time: MagicMock,
+    ) -> None:
+        mock_requests.get.return_value = _mock_response(json_data=[])
+        connector = _build_connector()
+
+        connector._list_announcements(course_id=1)
+
+        _, kwargs = mock_requests.get.call_args
+        assert kwargs["params"]["start_date"] == "1970-01-01T00:00:00Z"
+        assert kwargs["params"]["end_date"] == "1970-01-02T00:00:00Z"
+        mock_time.assert_called_once_with()
+
+    @patch("onyx.connectors.canvas.client.rl_requests")
+    def test_uses_explicit_time_range(self, mock_requests: MagicMock) -> None:
+        mock_requests.get.return_value = _mock_response(json_data=[])
+        connector = _build_connector()
+        start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        end = datetime(2025, 7, 1, tzinfo=timezone.utc).timestamp()
+
+        connector._list_announcements(course_id=1, start=start, end=end)
+
+        _, kwargs = mock_requests.get.call_args
+        assert kwargs["params"]["start_date"] == "2025-06-01T00:00:00Z"
+        assert kwargs["params"]["end_date"] == "2025-07-01T00:00:00Z"
+
     @patch("onyx.connectors.canvas.client.rl_requests")
     def test_empty_response(self, mock_requests: MagicMock) -> None:
         mock_requests.get.return_value = _mock_response(json_data=[])
@@ -1809,6 +1839,17 @@ class TestRetrieveAllSlimDocsPermSync:
             "canvas-assignment-1-20",
             "canvas-announcement-1-30",
         }
+        announcement_call = next(
+            call
+            for call in mock_requests.get.call_args_list
+            if call.args[0].endswith("/announcements")
+        )
+        assert announcement_call.kwargs["params"]["start_date"] == (
+            "2025-07-01T00:00:00Z"
+        )
+        assert announcement_call.kwargs["params"]["end_date"] == (
+            "2025-07-02T00:00:00Z"
+        )
 
     @patch("onyx.connectors.canvas.client.rl_requests")
     def test_permission_error_fails_sync(self, mock_requests: MagicMock) -> None:
@@ -1860,12 +1901,20 @@ class TestCanvasGroupSyncHelpers:
             )
         ]
 
-        group_ids, section_ids = _referenced_group_and_section_ids(connector, 1)
+        indexing_start = datetime(2025, 6, 1, tzinfo=timezone.utc).timestamp()
+        group_ids, section_ids = _referenced_group_and_section_ids(
+            connector,
+            1,
+            indexing_start,
+        )
 
         assert group_ids == {99}
         assert section_ids == {10, 11}
         connector._list_assignments.assert_called_once_with(1)
-        connector._list_announcements.assert_called_once_with(1)
+        connector._list_announcements.assert_called_once_with(
+            1,
+            start=indexing_start,
+        )
 
 
 class TestCanvasPermissionMapping:


### PR DESCRIPTION
## Description

Canvas defaults to a 14 day window on its content requests unless you explicitly pass a time range in, so now we do that.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly set a UTC time range for Canvas announcements to avoid the 14-day default window, ensuring we index the full history or the requested window. This also prevents misses from timezone drift.

- **Bug Fixes**
  - Pass start/end to the announcements API; default to epoch→now (UTC).
  - Normalize `indexing_start` to UTC and propagate start/end through `retrieve_all_slim_docs_perm_sync` and `_retrieve_course_slim_docs`.
  - In group sync, pass `indexing_start` when fetching announcements to include older referenced sections.
  - Added unit tests for default and explicit ranges, UTC formatting, and group sync behavior.

<sup>Written for commit 4adefde8fdaf10b9eb8e86b09e63c78a4fdbe89f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13254?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

