### PR TITLE
fix(auth): harden SSO callbacks, invite-only toggle, and error surfacing

### DIFF
--- a/backend/onyx/auth/sso_web_error.py
+++ b/backend/onyx/auth/sso_web_error.py
@@ -1,0 +1,49 @@
+"""Render SSO callback failures as a readable page for browsers.
+
+Non-legacy OIDC provider rows and all SAML callbacks terminate directly in
+FastAPI (no Next.js wrapper), so an ``OnyxError`` from those handlers would
+reach the browser as raw JSON. This decorator converts it into a redirect to
+the ``/auth/error`` page for browser navigations, while non-browser callers
+(mobile, API, tests) still get the JSON error via content negotiation.
+"""
+
+import enum
+import functools
+from collections.abc import Awaitable, Callable
+from typing import Any
+from urllib.parse import quote
+
+from fastapi import Request
+from fastapi.responses import RedirectResponse
+from starlette.responses import Response
+
+from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.error_handling.exceptions import OnyxError
+
+
+def redirect_sso_errors_to_web(
+    handler: Callable[..., Awaitable[Response]],
+) -> Callable[..., Awaitable[Response]]:
+    @functools.wraps(handler)
+    async def wrapper(*args: Any, **kwargs: Any) -> Response:
+        try:
+            return await handler(*args, **kwargs)
+        except OnyxError as error:
+            request = kwargs.get("request")
+            accept = (
+                request.headers.get("accept", "")
+                if isinstance(request, Request)
+                else ""
+            )
+            # Only browser navigations get the page. Mobile and API clients keep
+            # the JSON error they can parse.
+            if "text/html" not in accept.lower():
+                raise
+            detail = error.detail
+            detail_str = detail.value if isinstance(detail, enum.Enum) else str(detail)
+            return RedirectResponse(
+                f"{WEB_DOMAIN}/auth/error?error={quote(detail_str)}",
+                status_code=302,
+            )
+
+    return wrapper

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -288,7 +288,13 @@ def anonymous_user_enabled(*, tenant_id: str | None = None) -> bool:
 
 
 def workspace_invite_only_enabled() -> bool:
-    settings = load_settings()
+    try:
+        settings = load_settings(raise_on_error=True)
+    except Exception:
+        # Fail closed: if the setting can't be read, treat the workspace as
+        # invite-only rather than silently admitting uninvited users.
+        logger.error("Could not load invite-only setting; failing closed (invite-only)")
+        return True
     return settings.invite_only_enabled
 
 

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -21,6 +21,7 @@ from httpx_oauth.oauth2 import BaseOAuth2, GetAccessTokenError
 from sqlalchemy.orm import Session
 
 from onyx.auth.oidc_client import VerifiedEmailOpenID
+from onyx.auth.sso_web_error import redirect_sso_errors_to_web
 from onyx.auth.users import (
     CSRF_TOKEN_COOKIE_NAME,
     CSRF_TOKEN_KEY,
@@ -285,6 +286,7 @@ async def oidc_login_callback(
 
 
 @router.get("/{provider_name}/callback")
+@redirect_sso_errors_to_web
 async def oidc_login_callback_for_provider(
     provider_name: str,
     request: Request,

--- a/backend/onyx/server/saml_multi.py
+++ b/backend/onyx/server/saml_multi.py
@@ -10,6 +10,7 @@ from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
 from onyx.auth.login_claims_capture import capture_saml_login_claims
+from onyx.auth.sso_web_error import redirect_sso_errors_to_web
 from onyx.auth.users import UserManager, auth_backend, fastapi_users, get_user_manager
 from onyx.configs.app_configs import REQUIRE_EMAIL_VERIFICATION, WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -250,6 +251,7 @@ async def saml_login(
 
 
 @router.get("/callback")
+@redirect_sso_errors_to_web
 async def saml_login_callback_get(
     request: Request,
     db_session: Session = Depends(get_session),
@@ -265,6 +267,7 @@ async def saml_login_callback_get(
 
 
 @router.post("/callback")
+@redirect_sso_errors_to_web
 async def saml_login_callback_post(
     request: Request,
     db_session: Session = Depends(get_session),
@@ -324,6 +327,14 @@ async def _process_saml_callback(
     _enforce_allowed_email_domain(provider, user_email)
 
     user = await upsert_saml_user(email=user_email)
+    # A deactivated account must not receive a session. The OIDC path gates this
+    # in complete_login_flow. SAML gates it here since it logs the user in
+    # directly.
+    if not user.is_active:
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHORIZED,
+            "Your account is deactivated. Contact your workspace admin.",
+        )
     # Best-effort directory-profile capture from the SAML assertion attributes.
     await capture_saml_login_claims(
         user_email, auth.get_attributes(), provider.name or "saml"

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -86,12 +86,15 @@ def admin_put_settings(
         current_tier = Tier.COMMUNITY
     existing = load_settings()
 
-    # craft_default_enabled is access control: a PUT that omits it (e.g. an
-    # older client) must not silently reset it to the pydantic default.
+    # These fields are access control: a PUT that omits one (e.g. an older
+    # client, or a partial write) must not silently reset it to the pydantic
+    # default. invite_only_enabled off-by-default would let uninvited users in.
     if "craft_default_enabled" not in settings.model_fields_set:
         settings.craft_default_enabled = existing.craft_default_enabled
     if "craft_instructions" not in settings.model_fields_set:
         settings.craft_instructions = existing.craft_instructions
+    if "invite_only_enabled" not in settings.model_fields_set:
+        settings.invite_only_enabled = existing.invite_only_enabled
     # Search Mode is Business+; Chat Retention is Enterprise-only.
     # Use the same error code (FEATURE_NOT_AVAILABLE / 402) the tier_gate
     # middleware uses, so the FE has one shape to handle for tier-rejected

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -25,7 +25,7 @@ logger = setup_logger()
 SETTINGS_TTL = 30 * 24 * 60 * 60
 
 
-def load_settings() -> Settings:
+def load_settings(raise_on_error: bool = False) -> Settings:
     kv_store = get_kv_store()
     try:
         stored_settings = kv_store.load(KV_SETTINGS_KEY)
@@ -38,6 +38,10 @@ def load_settings() -> Settings:
         settings = Settings()
     except Exception as e:
         logger.error("Error loading settings from KV store: %s", str(e))
+        # Callers guarding access control (e.g. the invite-only check) opt in to
+        # re-raise so they can fail closed instead of trusting the default.
+        if raise_on_error:
+            raise
         settings = Settings()
 
     cache = get_cache_backend()

--- a/backend/tests/unit/onyx/auth/test_invite_only_failclosed.py
+++ b/backend/tests/unit/onyx/auth/test_invite_only_failclosed.py
@@ -1,0 +1,29 @@
+"""The invite-only check fails closed: a settings-read error is treated as
+invite-only ON so a transient KV/DB failure can't silently admit uninvited
+users."""
+
+import pytest
+
+import onyx.auth.users as users
+from onyx.server.settings.models import Settings
+
+
+def test_returns_setting_value_when_load_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        users,
+        "load_settings",
+        lambda raise_on_error=False: Settings(invite_only_enabled=False),  # noqa: ARG005
+    )
+    assert users.workspace_invite_only_enabled() is False
+
+
+def test_fails_closed_when_load_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(raise_on_error: bool = False) -> Settings:  # noqa: ARG001
+        raise RuntimeError("kv down")
+
+    monkeypatch.setattr(users, "load_settings", _boom)
+    assert users.workspace_invite_only_enabled() is True

--- a/backend/tests/unit/onyx/auth/test_sso_web_error.py
+++ b/backend/tests/unit/onyx/auth/test_sso_web_error.py
@@ -1,0 +1,73 @@
+"""The SSO web-error decorator turns OnyxError into a readable /auth/error
+redirect for browser navigations, while non-browser callers still receive the
+JSON error they can parse."""
+
+import enum
+
+import pytest
+from fastapi import Request
+from fastapi.responses import RedirectResponse
+
+from onyx.auth.sso_web_error import redirect_sso_errors_to_web
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+
+
+def _request_with_accept(accept: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "headers": [(b"accept", accept.encode())],
+        }
+    )
+
+
+@redirect_sso_errors_to_web
+async def _handler(*, request: Request, raise_error: bool) -> RedirectResponse:  # noqa: ARG001
+    if raise_error:
+        raise OnyxError(OnyxErrorCode.UNAUTHORIZED, "invite only")
+    return RedirectResponse("/ok", status_code=302)
+
+
+@pytest.mark.asyncio
+async def test_browser_gets_redirect_to_auth_error() -> None:
+    resp = await _handler(
+        request=_request_with_accept("text/html,application/xhtml+xml"),
+        raise_error=True,
+    )
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 302
+    assert "/auth/error?error=" in resp.headers["location"]
+    assert "invite" in resp.headers["location"]
+
+
+@pytest.mark.asyncio
+async def test_non_browser_still_raises_for_json() -> None:
+    with pytest.raises(OnyxError):
+        await _handler(
+            request=_request_with_accept("application/json"),
+            raise_error=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_success_passes_through_untouched() -> None:
+    resp = await _handler(
+        request=_request_with_accept("text/html"),
+        raise_error=False,
+    )
+    assert resp.headers["location"] == "/ok"
+
+
+@pytest.mark.asyncio
+async def test_enum_detail_uses_value_in_url() -> None:
+    class _Code(str, enum.Enum):
+        SAMPLE = "SAMPLE_CODE"
+
+    @redirect_sso_errors_to_web
+    async def _enum_handler(*, request: Request) -> RedirectResponse:  # noqa: ARG001
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, _Code.SAMPLE)
+
+    resp = await _enum_handler(request=_request_with_accept("text/html"))
+    assert isinstance(resp, RedirectResponse)
+    assert "error=SAMPLE_CODE" in resp.headers["location"]

--- a/web/src/app/auth/error/AuthErrorContent.tsx
+++ b/web/src/app/auth/error/AuthErrorContent.tsx
@@ -9,6 +9,10 @@ import { NEXT_PUBLIC_CLOUD_ENABLED } from "@/lib/constants";
 // Maps raw IdP/OAuth error codes to user-friendly messages.
 // If the message is a known code, we replace it; otherwise show it as-is.
 const ERROR_CODE_MESSAGES: Record<string, string> = {
+  OAUTH_USER_ALREADY_EXISTS:
+    "An account with this email already exists under a different sign-in method. Sign in the way you first did, or ask your admin to link this provider.",
+  LOGIN_BAD_CREDENTIALS:
+    "This account can't sign in. It may be deactivated. Contact your workspace admin.",
   access_denied: "Access was denied by your identity provider.",
   login_required: "You need to log in with your identity provider first.",
   consent_required:


### PR DESCRIPTION
## Description

Four gaps found auditing the multi-IdP SSO surface (OIDC + SAML + permission sync). No auth bypass; these are session-integrity, fail-open, and error-UX fixes. H1's real unblock (per-provider account linking) is a separate follow-up.

- **Deactivated SAML login:** SAML minted a session and logged a SUCCESS audit for a deactivated user. Now gated before login, matching OIDC.
- **Raw-JSON errors:** non-legacy OIDC and all SAML callbacks hit FastAPI directly, so rejections (invite-only, domain, already-exists) rendered as raw JSON. A shared decorator now redirects browsers to `/auth/error`; mobile and API callers still get JSON via content negotiation.
- **Invite-only silently disabled:** a partial settings PUT reset `invite_only_enabled` to `False`, and a settings-read error made the invite gate fail open. Now preserved through partial PUTs and fails closed on read error.
- **Cryptic codes:** `/auth/error` humanizes `OAUTH_USER_ALREADY_EXISTS` and `LOGIN_BAD_CREDENTIALS`.

Note: branches off current main, which predates #13237 (sso_managed removal). Overlaps are non-conflicting; whichever merges second rebases trivially.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check