### PR TITLE
feat(auth): per-provider account linking for SSO, and verify Google emails

### DIFF
--- a/backend/alembic/versions/48589afda2aa_add_allow_email_link_to_sso_provider.py
+++ b/backend/alembic/versions/48589afda2aa_add_allow_email_link_to_sso_provider.py
@@ -1,0 +1,33 @@
+"""add allow_email_link to sso_provider
+
+Revision ID: 48589afda2aa
+Revises: e2875ce6454b
+Create Date: 2026-07-21 12:50:50.134166
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "48589afda2aa"
+down_revision = "e2875ce6454b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sso_provider",
+        sa.Column(
+            "allow_email_link",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sso_provider", "allow_email_link")

--- a/backend/onyx/auth/oidc_client.py
+++ b/backend/onyx/auth/oidc_client.py
@@ -4,8 +4,10 @@ verified, and the discovery document's issuer must own the configured
 discovery URL, so one provider's tokens cannot be replayed against another
 provider's callback (OIDC mix-up defense)."""
 
+from typing import Any
 from urllib.parse import unquote, urlsplit
 
+from httpx_oauth.clients.google import GoogleOAuth2
 from httpx_oauth.clients.openid import BASE_SCOPES, OpenID
 from httpx_oauth.exceptions import GetIdEmailError
 
@@ -141,3 +143,67 @@ class VerifiedEmailOpenID(OpenID):
                 )
 
             return sub, email
+
+
+class VerifiedEmailGoogleOAuth2(GoogleOAuth2):
+    """Google login client that returns the primary email only when Google marks
+    it verified, and rejects a malformed People API body with a controlled login
+    error. The stock client trusts the email unconditionally, the same
+    unverified-email takeover vector VerifiedEmailOpenID guards against."""
+
+    async def get_id_email(self, token: str) -> tuple[str, str | None]:
+        async with self.get_httpx_client() as client:
+            response = await client.get(
+                "https://people.googleapis.com/v1/people/me",
+                params={"personFields": "emailAddresses"},
+                headers={**self.request_headers, "Authorization": f"Bearer {token}"},
+            )
+
+            if response.status_code >= 400:
+                raise GetIdEmailError(response=response)
+
+            try:
+                data = response.json()
+            except ValueError as e:
+                raise GetIdEmailError(
+                    "People API response was not valid JSON", response=response
+                ) from e
+            if not isinstance(data, dict):
+                raise GetIdEmailError(
+                    "People API response was not a JSON object", response=response
+                )
+
+            user_id = data.get("resourceName")
+            if not isinstance(user_id, str) or not user_id:
+                raise GetIdEmailError(
+                    "People API response missing a string 'resourceName'",
+                    response=response,
+                )
+
+            emails = data.get("emailAddresses")
+            if not isinstance(emails, list):
+                raise GetIdEmailError(
+                    "People API response missing 'emailAddresses'", response=response
+                )
+
+            primary_email = _select_primary_verified_email(emails)
+            if primary_email is None:
+                raise GetIdEmailError(
+                    "Google did not return a primary verified email",
+                    response=response,
+                )
+
+            return user_id, primary_email
+
+
+def _select_primary_verified_email(emails: list[Any]) -> str | None:
+    for entry in emails:
+        if not isinstance(entry, dict):
+            continue
+        metadata = entry.get("metadata")
+        value = entry.get("value")
+        if not isinstance(metadata, dict) or not isinstance(value, str) or not value:
+            continue
+        if metadata.get("primary") is True and metadata.get("verified") is True:
+            return value
+    return None

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -6649,6 +6649,12 @@ class SSOProvider(Base):
         postgresql.ARRAY(String), nullable=False, default=list
     )
     enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # When true, a login through this provider may adopt an existing account
+    # with the same IdP-verified email. Safe only because linking is gated on
+    # allowed_email_domains and email verification, both enforced before linking.
+    allow_email_link: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
     time_created: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -111,6 +111,16 @@ def _normalize_domains(domains: list[str]) -> list[str]:
     return sorted({domain.strip().lower() for domain in domains if domain.strip()})
 
 
+def _validate_email_link_scope(
+    allow_email_link: bool, allowed_email_domains: list[str]
+) -> None:
+    """allow_email_link lets a login claim an existing same-email account, so it
+    must be scoped to domains the provider is authoritative for. Without a domain
+    allowlist any verified email could adopt any account, so refuse the combo."""
+    if allow_email_link and not allowed_email_domains:
+        raise ValueError("allow_email_link requires at least one allowed email domain")
+
+
 def fetch_sso_providers(
     db_session: Session, enabled_only: bool = False
 ) -> list[SSOProvider]:
@@ -139,14 +149,18 @@ def create_sso_provider(
     provider_type: SSOProviderType,
     config: dict[str, Any],
     allowed_email_domains: list[str],
+    allow_email_link: bool = False,
 ) -> SSOProvider:
     validate_sso_provider_name(name)
+    normalized_domains = _normalize_domains(allowed_email_domains)
+    _validate_email_link_scope(allow_email_link, normalized_domains)
     provider = SSOProvider(
         name=name,
         display_name=display_name,
         provider_type=provider_type,
         config=validate_sso_config(provider_type, config),
-        allowed_email_domains=_normalize_domains(allowed_email_domains),
+        allowed_email_domains=normalized_domains,
+        allow_email_link=allow_email_link,
     )
     db_session.add(provider)
     db_session.commit()
@@ -159,6 +173,7 @@ def update_sso_provider(
     display_name: str | None = None,
     config: dict[str, Any] | None = None,
     allowed_email_domains: list[str] | None = None,
+    allow_email_link: bool | None = None,
 ) -> SSOProvider:
     """Partial update. Name and provider_type are immutable: linked login
     accounts and the login URL reference the name, and the type fixes the config
@@ -168,6 +183,18 @@ def update_sso_provider(
     if provider is None:
         raise ValueError(f"SSO provider {provider_id} does not exist")
 
+    # Validate the resulting combination against whichever of the two coupled
+    # fields the caller is changing, falling back to the stored value.
+    effective_domains = (
+        _normalize_domains(allowed_email_domains)
+        if allowed_email_domains is not None
+        else provider.allowed_email_domains
+    )
+    effective_link = (
+        allow_email_link if allow_email_link is not None else provider.allow_email_link
+    )
+    _validate_email_link_scope(effective_link, effective_domains)
+
     if display_name is not None:
         provider.display_name = display_name
     if config is not None:
@@ -175,7 +202,9 @@ def update_sso_provider(
             provider.provider_type, config
         )
     if allowed_email_domains is not None:
-        provider.allowed_email_domains = _normalize_domains(allowed_email_domains)
+        provider.allowed_email_domains = effective_domains
+    if allow_email_link is not None:
+        provider.allow_email_link = effective_link
 
     db_session.commit()
     return provider

--- a/backend/onyx/server/manage/sso/api.py
+++ b/backend/onyx/server/manage/sso/api.py
@@ -85,6 +85,7 @@ def create_sso_provider_endpoint(
             provider_type=request.provider_type,
             config=request.config,
             allowed_email_domains=request.allowed_email_domains,
+            allow_email_link=request.allow_email_link,
         )
     except IntegrityError as e:
         db_session.rollback()
@@ -128,6 +129,7 @@ def update_sso_provider_endpoint(
             display_name=request.display_name,
             config=merged_config,
             allowed_email_domains=request.allowed_email_domains,
+            allow_email_link=request.allow_email_link,
         )
     except ValueError as e:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e)) from e

--- a/backend/onyx/server/manage/sso/models.py
+++ b/backend/onyx/server/manage/sso/models.py
@@ -15,12 +15,14 @@ class SSOProviderCreateRequest(BaseModel):
     provider_type: SSOProviderType
     config: dict[str, Any]
     allowed_email_domains: list[str]
+    allow_email_link: bool = False
 
 
 class SSOProviderUpdateRequest(BaseModel):
     display_name: str | None = None
     allowed_email_domains: list[str] | None = None
     config: dict[str, Any] | None = None
+    allow_email_link: bool | None = None
 
 
 class SSOProviderEnabledRequest(BaseModel):
@@ -34,6 +36,7 @@ class SSOProviderResponse(BaseModel):
     provider_type: SSOProviderType
     enabled: bool
     allowed_email_domains: list[str]
+    allow_email_link: bool
     config: dict[str, Any]
     redirect_uri: str
 
@@ -51,6 +54,7 @@ class SSOProviderResponse(BaseModel):
             provider_type=provider.provider_type,
             enabled=provider.enabled,
             allowed_email_domains=provider.allowed_email_domains,
+            allow_email_link=provider.allow_email_link,
             config=config,
             redirect_uri=redirect_uri,
         )

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -15,12 +15,11 @@ from fastapi import APIRouter, Depends, Request, Response
 from fastapi.concurrency import run_in_threadpool
 from fastapi.responses import JSONResponse
 from fastapi_users.authentication import Strategy
-from httpx_oauth.clients.google import GoogleOAuth2
 from httpx_oauth.clients.openid import BASE_SCOPES
 from httpx_oauth.oauth2 import BaseOAuth2, GetAccessTokenError
 from sqlalchemy.orm import Session
 
-from onyx.auth.oidc_client import VerifiedEmailOpenID
+from onyx.auth.oidc_client import VerifiedEmailGoogleOAuth2, VerifiedEmailOpenID
 from onyx.auth.users import (
     CSRF_TOKEN_COOKIE_NAME,
     CSRF_TOKEN_KEY,
@@ -60,9 +59,6 @@ from shared_configs.contextvars import get_current_tenant_id
 router = APIRouter(prefix="/auth/oidc")
 
 _CLIENT_CACHE_TTL_SECONDS = 600
-# Hardcoded off: linking a second IdP to an existing account by verified email is
-# an account-takeover vector when two IdPs can assert one domain.
-_ALLOW_AUTO_LINK = False
 
 _CLIENT_CACHE: TTLCache[tuple[str, str, SSOProviderType, str], BaseOAuth2[Any]] = (
     TTLCache(maxsize=128, ttl=_CLIENT_CACHE_TTL_SECONDS)
@@ -96,6 +92,13 @@ def _resolve_oidc_provider(
     return provider, config
 
 
+def _should_link_by_email(provider: SSOProvider) -> bool:
+    """Whether a login through this provider may claim an existing same-email
+    account. Gated on the admin enabling it AND scoping the provider to email
+    domains, so a provider can only adopt accounts in domains it owns."""
+    return provider.allow_email_link and bool(provider.allowed_email_domains)
+
+
 def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
     if provider.provider_type is SSOProviderType.OIDC:
         # Env override lets deployments request extra API scopes (e.g. MS Graph
@@ -111,7 +114,7 @@ def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[A
             base_scopes=scopes,
         )
     if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
-        return GoogleOAuth2(
+        return VerifiedEmailGoogleOAuth2(
             config["client_id"],
             config["client_secret"],
             scopes=list(GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES),
@@ -347,7 +350,7 @@ async def oidc_login_callback_for_provider(
         user_manager=user_manager,
         backend=auth_backend,
         strategy=strategy,
-        associate_by_email=_ALLOW_AUTO_LINK,
+        associate_by_email=_should_link_by_email(provider),
         is_verified_by_default=True,
         allowed_email_domains_override=provider.allowed_email_domains,
         # Provider rows delegate membership to the IdP.

--- a/backend/tests/unit/onyx/auth/test_sso_email_linking.py
+++ b/backend/tests/unit/onyx/auth/test_sso_email_linking.py
@@ -1,0 +1,124 @@
+"""Per-provider email linking: a provider may claim an existing same-email
+account only when the admin enabled it and scoped the provider to domains, and
+only for an IdP-verified email. Google's People API email must be marked
+verified, matching the OIDC client's guarantee."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from httpx_oauth.exceptions import GetIdEmailError
+
+from onyx.auth.oidc_client import (
+    VerifiedEmailGoogleOAuth2,
+    _select_primary_verified_email,
+)
+from onyx.db.enums import SSOProviderType
+from onyx.db.models import SSOProvider
+from onyx.db.sso_provider import _validate_email_link_scope
+from onyx.server.oidc_multi import _should_link_by_email
+
+
+def _provider(allow: bool, domains: list[str]) -> SSOProvider:
+    return SSOProvider(
+        name="p",
+        display_name="P",
+        provider_type=SSOProviderType.OIDC,
+        config=None,
+        allowed_email_domains=domains,
+        allow_email_link=allow,
+    )
+
+
+def test_link_gate_requires_flag_and_domains() -> None:
+    assert _should_link_by_email(_provider(True, ["corp.com"])) is True
+    assert _should_link_by_email(_provider(False, ["corp.com"])) is False
+    assert _should_link_by_email(_provider(True, [])) is False
+
+
+def test_validate_scope_rejects_link_without_domains() -> None:
+    with pytest.raises(ValueError):
+        _validate_email_link_scope(True, [])
+
+
+def test_validate_scope_allows_link_with_domains() -> None:
+    _validate_email_link_scope(True, ["corp.com"])
+    _validate_email_link_scope(False, [])
+
+
+def test_select_primary_verified_email() -> None:
+    assert (
+        _select_primary_verified_email(
+            [{"value": "a@corp.com", "metadata": {"primary": True, "verified": True}}]
+        )
+        == "a@corp.com"
+    )
+    # Unverified, non-primary, and malformed entries never match.
+    assert (
+        _select_primary_verified_email(
+            [{"value": "a@corp.com", "metadata": {"primary": True, "verified": False}}]
+        )
+        is None
+    )
+    assert (
+        _select_primary_verified_email(
+            [{"value": "a@corp.com", "metadata": {"primary": False, "verified": True}}]
+        )
+        is None
+    )
+    assert _select_primary_verified_email(["garbage", {}]) is None
+
+
+def _google_client_with_response(
+    payload: Any, status: int = 200
+) -> VerifiedEmailGoogleOAuth2:
+    client = VerifiedEmailGoogleOAuth2("cid", "secret")
+    response = MagicMock()
+    response.status_code = status
+    response.json.return_value = payload
+    httpx_client = AsyncMock()
+    httpx_client.get.return_value = response
+    ctx = MagicMock()
+    ctx.__aenter__.return_value = httpx_client
+    ctx.__aexit__.return_value = None
+    client.get_httpx_client = MagicMock(return_value=ctx)  # ty: ignore[invalid-assignment]
+    return client
+
+
+@pytest.mark.asyncio
+async def test_google_returns_verified_primary_email() -> None:
+    client = _google_client_with_response(
+        {
+            "resourceName": "people/123",
+            "emailAddresses": [
+                {"value": "a@corp.com", "metadata": {"primary": True, "verified": True}}
+            ],
+        }
+    )
+    user_id, email = await client.get_id_email("tok")
+    assert user_id == "people/123"
+    assert email == "a@corp.com"
+
+
+@pytest.mark.asyncio
+async def test_google_rejects_unverified_email() -> None:
+    client = _google_client_with_response(
+        {
+            "resourceName": "people/123",
+            "emailAddresses": [
+                {
+                    "value": "a@corp.com",
+                    "metadata": {"primary": True, "verified": False},
+                }
+            ],
+        }
+    )
+    with pytest.raises(GetIdEmailError):
+        await client.get_id_email("tok")
+
+
+@pytest.mark.asyncio
+async def test_google_rejects_malformed_body() -> None:
+    client = _google_client_with_response({"unexpected": "shape"})
+    with pytest.raises(GetIdEmailError):
+        await client.get_id_email("tok")

--- a/web/src/lib/sso/interfaces.ts
+++ b/web/src/lib/sso/interfaces.ts
@@ -12,6 +12,7 @@ export interface SSOProviderResponse {
   provider_type: SSOProviderType;
   enabled: boolean;
   allowed_email_domains: string[];
+  allow_email_link: boolean;
   config: Record<string, string>;
   redirect_uri: string;
 }
@@ -22,10 +23,12 @@ export interface SSOProviderCreateRequest {
   provider_type: SSOProviderType;
   config: Record<string, string>;
   allowed_email_domains: string[];
+  allow_email_link: boolean;
 }
 
 export interface SSOProviderUpdateRequest {
   display_name?: string;
   allowed_email_domains?: string[];
   config?: Record<string, string>;
+  allow_email_link?: boolean;
 }

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -24,6 +24,7 @@ import {
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
+import UnlabeledCheckboxField from "@/refresh-components/form/CheckboxField";
 import InputChipField, {
   type ChipItem,
 } from "@/refresh-components/inputs/InputChipField";
@@ -44,6 +45,7 @@ interface SSOProviderFormValues {
   display_name: string;
   config: Record<string, string>;
   allowed_email_domains: string[];
+  allow_email_link: boolean;
 }
 
 // Every config key across all provider types (deduped by name, since provider
@@ -94,6 +96,19 @@ const SSO_VALIDATION_SCHEMA = Yup.object({
     ([type], schema) => CONFIG_SCHEMA_BY_TYPE[type as string] ?? schema
   ),
   allowed_email_domains: Yup.array().of(Yup.string()).optional(),
+  // Mirrors the backend: linking existing accounts by email is only allowed
+  // when the provider is scoped to specific domains it is authoritative for.
+  allow_email_link: Yup.boolean().test(
+    "requires-domains",
+    "Add at least one allowed email domain to enable account linking",
+    function (value) {
+      if (!value) {
+        return true;
+      }
+      const domains = this.parent.allowed_email_domains as string[] | undefined;
+      return Array.isArray(domains) && domains.length > 0;
+    }
+  ),
 });
 
 // The backend masks every config string on read and restores any value sent
@@ -157,6 +172,7 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
     display_name: provider?.display_name ?? "",
     config: initialConfig(provider?.config ?? {}),
     allowed_email_domains: provider?.allowed_email_domains ?? [],
+    allow_email_link: provider?.allow_email_link ?? false,
   };
 
   async function handleSubmit(
@@ -173,6 +189,7 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
           provider_type: providerType,
           config,
           allowed_email_domains: values.allowed_email_domains,
+          allow_email_link: values.allow_email_link,
         };
         await createSSOProvider(request);
         toast.success("SSO provider created");
@@ -181,6 +198,7 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
           display_name: values.display_name.trim(),
           allowed_email_domains: values.allowed_email_domains,
           config,
+          allow_email_link: values.allow_email_link,
         };
         await updateSSOProvider(provider.id, request);
         toast.success("SSO provider updated");
@@ -348,6 +366,14 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                       onChange={setDomainInput}
                       placeholder="Add a domain (e.g. onyx.app)"
                     />
+                  </InputVertical>
+
+                  <InputVertical
+                    title="Link Existing Accounts by Email"
+                    description="Let a user whose account was created another way (a different provider, SAML, or password) sign in through this provider. Requires allowed email domains, since the provider can only claim accounts in domains it is authoritative for."
+                    withLabel="allow_email_link"
+                  >
+                    <UnlabeledCheckboxField name="allow_email_link" />
                   </InputVertical>
 
                   {provider?.redirect_uri && (


### PR DESCRIPTION
## Description

Follow-up to #13256. Unblocks the real SSO-only lockout: an existing account (created by password, SAML, or another provider) could not sign in through a new OIDC/Google provider because auto-link was hardcoded off, and there was no admin or self-service way to link. This blocks IdP migrations.

- **Per-provider `allow_email_link` flag:** when on, a login may claim an existing same-email account instead of being rejected. Gated on the provider having a non-empty `allowed_email_domains`, so it can only adopt accounts in domains it is authoritative for. Create/update refuse the flag without a domain allowlist.
- **Verified email required (fixes M11):** linking is only safe for an IdP-verified email. OIDC already verified via `VerifiedEmailOpenID`; Google now does too via `VerifiedEmailGoogleOAuth2`, which also stops the People API raising raw `KeyError`/`StopIteration` on a malformed body.
- Column + migration, API + admin-modal toggle, unit tests.

Off current main, so overlaps #13256 and the sso_managed removal in `oidc_multi.py` at different lines. Whichever merges last rebases.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check