### PR TITLE
fix(image-generation): sanitize test endpoint errors (#13151) to release v4.4

### DIFF
--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -100,9 +100,14 @@ from onyx.hooks.points.query_processing import (
 )
 from onyx.llm.factory import get_llm_for_persona, get_llm_token_counter
 from onyx.llm.interfaces import LLM, LLMUserIdentity
+from onyx.llm.models import LLMErrorInfo
 from onyx.llm.override_models import LLMOverride
 from onyx.llm.request_context import reset_llm_mock_response, set_llm_mock_response
-from onyx.llm.utils import litellm_exception_to_error_msg
+from onyx.llm.utils import (
+    collect_credential_values,
+    litellm_exception_to_safe_error,
+    scrub_sensitive_values,
+)
 from onyx.onyxbot.slack.models import SlackContext
 from onyx.prompts.prompt_utils import substitute_user_placeholders
 from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
@@ -1118,9 +1123,9 @@ def _run_models(
     # Set to True when a model raises an exception (distinct from "still running").
     # Used in the stop-button path to avoid calling completion for errored models.
     model_errored: list[bool] = [False] * n_models
-    # Per-model classified (message, error_code, is_retryable), set in _run_model
-    # and reused by the streamed packet and the persisted message.
-    model_error_info: list[tuple[str, str, bool] | None] = [None] * n_models
+    # Per-model classification set in _run_model and reused by the streamed
+    # packet and the persisted message.
+    model_error_info: list[LLMErrorInfo | None] = [None] * n_models
     persist_lock = threading.Lock()
     persisted: list[bool] = [False] * n_models
     post_steps_done = threading.Event()
@@ -1304,16 +1309,9 @@ def _run_models(
 
         except Exception as e:
             model_errored[model_idx] = True
-            message, error_code, is_retryable = litellm_exception_to_error_msg(
+            model_error_info[model_idx] = litellm_exception_to_safe_error(
                 e, model_llm, fallback_to_error_msg=True
             )
-            # Redact here so both the streamed and persisted error are safe:
-            # the fallback path returns str(e) verbatim, which can embed the key.
-            if model_llm.config.api_key and len(model_llm.config.api_key) > 2:
-                message = message.replace(
-                    model_llm.config.api_key, "[REDACTED_API_KEY]"
-                )
-            model_error_info[model_idx] = (message, error_code, is_retryable)
             merged_queue.put((model_idx, e))
 
         finally:
@@ -1330,7 +1328,7 @@ def _run_models(
                 if msg is not None:
                     info = model_error_info[model_idx]
                     detail = (
-                        info[0]
+                        info.message
                         if info is not None
                         else "model encountered an error during generation."
                     )
@@ -1418,30 +1416,26 @@ def _run_models(
                     model_llm = setup.llms[model_idx]
                     # Classified in _run_model; fall back to a generic error.
                     info = model_error_info[model_idx]
-                    if info is not None:
-                        error_msg, err_code, err_retryable = info
-                    else:
-                        error_msg, err_code, err_retryable = (
-                            str(item),
-                            "MODEL_ERROR",
-                            True,
+                    if info is None:
+                        info = LLMErrorInfo(
+                            message=str(item),
+                            error_code="MODEL_ERROR",
+                            is_retryable=True,
                         )
                     stack_trace = "".join(
                         traceback.format_exception(type(item), item, item.__traceback__)
                     )
-                    if model_llm.config.api_key and len(model_llm.config.api_key) > 2:
-                        error_msg = error_msg.replace(
-                            model_llm.config.api_key, "[REDACTED_API_KEY]"
-                        )
-                        stack_trace = stack_trace.replace(
-                            model_llm.config.api_key, "[REDACTED_API_KEY]"
-                        )
+                    secrets = collect_credential_values(
+                        model_llm.config.api_key, model_llm.config.custom_config
+                    )
+                    error_msg = scrub_sensitive_values(info.message, secrets)
+                    stack_trace = scrub_sensitive_values(stack_trace, secrets)
                     _publish(
                         StreamingError(
                             error=error_msg,
                             stack_trace=stack_trace,
-                            error_code=err_code,
-                            is_retryable=err_retryable,
+                            error_code=info.error_code,
+                            is_retryable=info.is_retryable,
                             details={
                                 "model": model_llm.config.model_name,
                                 "provider": model_llm.config.model_provider,
@@ -1705,21 +1699,16 @@ def _stream_chat_turn(
 
         llm = setup.llms[0] if setup else None
         if llm:
-            client_error_msg, error_code, is_retryable = litellm_exception_to_error_msg(
-                e, llm
+            error_info = litellm_exception_to_safe_error(e, llm)
+            stack_trace = scrub_sensitive_values(
+                stack_trace,
+                collect_credential_values(llm.config.api_key, llm.config.custom_config),
             )
-            if llm.config.api_key and len(llm.config.api_key) > 2:
-                client_error_msg = client_error_msg.replace(
-                    llm.config.api_key, "[REDACTED_API_KEY]"
-                )
-                stack_trace = stack_trace.replace(
-                    llm.config.api_key, "[REDACTED_API_KEY]"
-                )
             yield StreamingError(
-                error=client_error_msg,
+                error=error_info.message,
                 stack_trace=stack_trace,
-                error_code=error_code,
-                is_retryable=is_retryable,
+                error_code=error_info.error_code,
+                is_retryable=error_info.is_retryable,
                 details={
                     "model": llm.config.model_name,
                     "provider": llm.config.model_provider,

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -4,6 +4,12 @@ from typing import Literal
 from pydantic import BaseModel
 
 
+class LLMErrorInfo(BaseModel):
+    message: str
+    error_code: str
+    is_retryable: bool
+
+
 class ToolChoiceOptions(str, Enum):
     REQUIRED = "required"
     AUTO = "auto"

--- a/backend/onyx/llm/utils.py
+++ b/backend/onyx/llm/utils.py
@@ -21,7 +21,7 @@ from onyx.llm.model_capabilities import (
     litellm_thinks_model_supports_image_input,
 )
 from onyx.llm.model_response import ModelResponse
-from onyx.llm.models import UserMessage
+from onyx.llm.models import LLMErrorInfo, UserMessage
 from onyx.prompts.contextual_retrieval import (
     CONTEXTUAL_RAG_TOKEN_ESTIMATE,
     DOCUMENT_SUMMARY_TOKEN_ESTIMATE,
@@ -363,9 +363,8 @@ def scrub_sensitive_values(message: str, secrets: Iterable[str | None]) -> str:
     already maps known LiteLLM exception types to friendly messages and
     swallows unknown ones, but a few branches (`RateLimitError`, `APIError`,
     `ServiceUnavailableError`) still embed `str(core_exception)`. This pass
-    strips any credential we already know about (typically the values pulled
-    off `llm.config` via `collect_llm_credential_values`) before the message
-    is surfaced to a client.
+    strips any credential we already know about before the message is surfaced
+    to a client.
 
     Short / empty secrets are ignored so we don't accidentally eat common
     substrings.
@@ -375,28 +374,52 @@ def scrub_sensitive_values(message: str, secrets: Iterable[str | None]) -> str:
 
     scrubbed = message
     for secret in secrets:
-        if not secret or len(secret) < 4:
+        if not secret or len(secret) < 3:
             continue
         scrubbed = scrubbed.replace(secret, _SCRUB_PLACEHOLDER)
 
     return scrubbed
 
 
-def collect_llm_credential_values(llm: LLM | None) -> list[str]:
-    """Pull every credential-looking value out of an LLM's config.
+def collect_credential_values(
+    api_key: str | None, custom_config: dict[str, str] | None
+) -> list[str]:
+    """Collect credential-bearing values from a provider configuration."""
+    credential_values = [api_key] if api_key else []
+    for key, value in (custom_config or {}).items():
+        if value and is_sensitive_custom_config_key(key):
+            credential_values.append(value)
+    return credential_values
 
-    Used to build the `secrets` argument for `scrub_sensitive_values`.
-    """
-    if llm is None:
-        return []
-    config_secrets: list[str] = []
-    if llm.config.api_key:
-        config_secrets.append(llm.config.api_key)
-    custom_config = llm.config.custom_config or {}
-    for key, value in custom_config.items():
-        if isinstance(value, str) and value and is_sensitive_custom_config_key(key):
-            config_secrets.append(value)
-    return config_secrets
+
+def litellm_exception_to_safe_error(
+    e: Exception,
+    llm: LLM | None = None,
+    *,
+    fallback_to_error_msg: bool = False,
+    custom_error_msg_mappings: (
+        dict[str, str] | None
+    ) = LITELLM_CUSTOM_ERROR_MESSAGE_MAPPINGS,
+    secrets: Iterable[str | None] = (),
+) -> LLMErrorInfo:
+    """Classify a LiteLLM exception and redact secrets from its message."""
+    message, error_code, is_retryable = litellm_exception_to_error_msg(
+        e,
+        llm,
+        fallback_to_error_msg=fallback_to_error_msg,
+        custom_error_msg_mappings=custom_error_msg_mappings,
+    )
+    llm_secrets = (
+        collect_credential_values(llm.config.api_key, llm.config.custom_config)
+        if llm is not None
+        else []
+    )
+    safe_message = scrub_sensitive_values(message, [*llm_secrets, *secrets])
+    return LLMErrorInfo(
+        message=safe_message,
+        error_code=error_code,
+        is_retryable=is_retryable,
+    )
 
 
 def test_llm(llm: LLM) -> str | None:
@@ -411,7 +434,6 @@ def test_llm(llm: LLM) -> str | None:
 
     The full raw error is still logged at WARNING for ops debugging.
     """
-    secrets = collect_llm_credential_values(llm)
     error_msg: str | None = None
     # try for up to 2 timeouts (e.g. 10 seconds in total)
     for _ in range(2):
@@ -420,10 +442,7 @@ def test_llm(llm: LLM) -> str | None:
             return None
         except Exception as e:
             logger.warning("Failed to call LLM with the following error: %s", e)
-            safe_msg, _, _ = litellm_exception_to_error_msg(
-                e, llm, fallback_to_error_msg=False
-            )
-            error_msg = scrub_sensitive_values(safe_msg, secrets)
+            error_msg = litellm_exception_to_safe_error(e, llm).message
 
     return error_msg
 

--- a/backend/onyx/server/manage/image_generation/api.py
+++ b/backend/onyx/server/manage/image_generation/api.py
@@ -15,10 +15,13 @@ from onyx.db.image_generation import (
 from onyx.db.llm import remove_llm_provider
 from onyx.db.models import LLMProvider as LLMProviderModel
 from onyx.db.models import ModelConfiguration, User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.image_gen.exceptions import ImageProviderCredentialsError
 from onyx.image_gen.factory import get_image_generation_provider, validate_credentials
 from onyx.image_gen.interfaces import ImageGenerationProviderCredentials
 from onyx.llm.model_capabilities import get_max_input_tokens
+from onyx.llm.utils import collect_credential_values, litellm_exception_to_safe_error
 from onyx.server.manage.image_generation.models import (
     ImageGenerationConfigCreate,
     ImageGenerationConfigUpdate,
@@ -293,13 +296,11 @@ def test_image_generation(
     except HTTPException:
         raise
     except Exception as e:
-        # Log only exception type to avoid exposing sensitive data
-        # (LiteLLM errors may contain URLs with API keys or auth tokens)
         logger.warning("Image generation test failed: %s", type(e).__name__)
-        raise HTTPException(
-            status_code=400,
-            detail=f"Image generation test failed: {type(e).__name__}",
+        safe_error = litellm_exception_to_safe_error(
+            e, secrets=collect_credential_values(api_key, custom_config)
         )
+        raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, safe_error.message)
 
 
 @admin_router.post("/config")

--- a/backend/tests/unit/onyx/llm/test_llm_utils_scrub.py
+++ b/backend/tests/unit/onyx/llm/test_llm_utils_scrub.py
@@ -8,8 +8,9 @@ from typing import Any
 
 from onyx.llm.interfaces import LLM, LLMConfig
 from onyx.llm.utils import (
-    collect_llm_credential_values,
+    collect_credential_values,
     is_sensitive_custom_config_key,
+    litellm_exception_to_safe_error,
     scrub_sensitive_values,
 )
 from onyx.llm.utils import (
@@ -111,6 +112,10 @@ def test_scrub_ignores_empty_and_short_secrets() -> None:
     assert scrubbed == msg
 
 
+def test_scrub_replaces_three_character_secrets() -> None:
+    assert scrub_sensitive_values("key=abc", ["abc"]) == "key=[REDACTED]"
+
+
 def test_scrub_replaces_multiple_occurrences_of_same_secret() -> None:
     msg = f"sent {_SECRET_KEY} then retried with {_SECRET_KEY}"
 
@@ -140,21 +145,19 @@ def test_scrub_accepts_iterable_secrets() -> None:
 
 
 # ---------------------------------------------------------------------------
-# collect_llm_credential_values
+# collect_credential_values
 # ---------------------------------------------------------------------------
 
 
-def test_collect_llm_credential_values_includes_api_key_and_sensitive_config() -> None:
-    config = _make_config(
-        custom_config={
+def test_collect_credential_values_includes_api_key_and_sensitive_config() -> None:
+    values = collect_credential_values(
+        _SECRET_KEY,
+        {
             "api_base": "https://api.example.com",
             "vertex_credentials": _SECRET_VERTEX_BLOB,
             "aws_secret_access_key": "AWSSECRET123456",
         },
     )
-    llm = _StubLLM(config)
-
-    values = collect_llm_credential_values(llm)
 
     assert _SECRET_KEY in values
     assert _SECRET_VERTEX_BLOB in values
@@ -162,15 +165,26 @@ def test_collect_llm_credential_values_includes_api_key_and_sensitive_config() -
     assert "https://api.example.com" not in values
 
 
-def test_collect_llm_credential_values_returns_empty_for_none() -> None:
-    assert collect_llm_credential_values(None) == []
+def test_collect_credential_values_skips_missing_credentials() -> None:
+    assert collect_credential_values(None, {"region": "us-east-1"}) == []
 
 
-def test_collect_llm_credential_values_skips_missing_api_key() -> None:
-    config = _make_config(api_key=None, custom_config={"region": "us-east-1"})
-    llm = _StubLLM(config)
+def test_safe_error_preserves_classification_and_redacts_fallback() -> None:
+    custom_secret = "custom-config-secret"
+    llm = _StubLLM(_make_config(custom_config={"auth_token": custom_secret}))
+    error = RuntimeError(f"provider rejected {_SECRET_KEY} and {custom_secret}")
 
-    assert collect_llm_credential_values(llm) == []
+    error_info = litellm_exception_to_safe_error(
+        error,
+        llm,
+        fallback_to_error_msg=True,
+    )
+
+    assert error_info.message.count("[REDACTED]") == 2
+    assert _SECRET_KEY not in error_info.message
+    assert custom_secret not in error_info.message
+    assert error_info.error_code == "UNKNOWN_ERROR"
+    assert error_info.is_retryable is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/onyx/server/manage/image_generation/test_image_generation_api.py
+++ b/backend/tests/unit/onyx/server/manage/image_generation/test_image_generation_api.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from litellm.exceptions import BadRequestError
+
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.manage.image_generation.api import (
+    test_image_generation as run_test_image_generation,
+)
+from onyx.server.manage.image_generation.models import (
+    TestImageGenerationRequest as ImageGenerationTestRequest,
+)
+
+_API_KEY = "sk-image-generation-secret"
+_CUSTOM_SECRET = "custom-config-secret"
+
+
+def test_image_generation_error_is_actionable_and_redacts_credentials() -> None:
+    upstream_error = BadRequestError(
+        message=(
+            f"Unsupported image size. api_key={_API_KEY} custom_token={_CUSTOM_SECRET}"
+        ),
+        model="gpt-image-1",
+        llm_provider="openai",
+    )
+    image_provider = MagicMock()
+    image_provider.generate_image.side_effect = upstream_error
+    request = ImageGenerationTestRequest(
+        model_name="gpt-image-1",
+        provider="openai",
+        api_key=_API_KEY,
+        custom_config={"custom_token": _CUSTOM_SECRET},
+    )
+
+    with (
+        patch(
+            "onyx.server.manage.image_generation.api.get_image_generation_provider",
+            return_value=image_provider,
+        ),
+        pytest.raises(OnyxError) as exc_info,
+    ):
+        run_test_image_generation(request, MagicMock(), MagicMock())
+
+    assert exc_info.value.error_code is OnyxErrorCode.VALIDATION_ERROR
+    assert "Unsupported image size" in exc_info.value.detail
+    assert exc_info.value.detail.count("[REDACTED]") == 2
+    assert _API_KEY not in exc_info.value.detail
+    assert _CUSTOM_SECRET not in exc_info.value.detail


### PR DESCRIPTION
Cherry-pick of commit 6f411f9 to release/v4.4 branch.

Original PR: #13151

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes errors from the image generation test endpoint by redacting credentials and returning clear validation messages. Also standardizes LLM error handling to scrub secrets in streamed errors and logs.

- **Bug Fixes**
  - Test endpoint now raises `VALIDATION_ERROR` with redacted detail using `collect_credential_values` and `litellm_exception_to_safe_error`.
  - Streamed chat errors and stack traces are scrubbed to remove API keys and custom tokens.

- **Refactors**
  - Added `LLMErrorInfo`, `litellm_exception_to_safe_error`, and `collect_credential_values`; removed ad-hoc redaction and direct `litellm` messages.
  - `scrub_sensitive_values` now redacts secrets of length ≥3; updated unit tests and added image generation API redaction test.

<sup>Written for commit f3404aa043944b1a4a5dcfd802be74612b8e8c17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13262?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

