### PR TITLE
fix(auth): admin modal shows the SAML ACS the flow actually validates (#13147) to release v4.4

### DIFF
--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -87,8 +87,11 @@ def sso_login_callback_uri(
     operator must allowlist at the IdP. Rows migrated from single-provider env
     config keep the legacy URI their IdP client already allowlists."""
     if provider.provider_type is SSOProviderType.SAML:
-        # Single issuer-resolved ACS for every SAML row.
-        return f"{web_domain}/api/auth/saml/callback"
+        # Single issuer-resolved ACS for every SAML row. No /api prefix: the
+        # AuthnRequest advertises this exact URL, nginx routes /auth/saml to
+        # the backend directly, and strict Destination validation compares
+        # against the stripped path.
+        return f"{web_domain}/auth/saml/callback"
     if config.get("legacy_callback"):
         if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
             return f"{web_domain}/auth/oauth/callback"

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -282,8 +282,9 @@ def test_create_saml_provider(
     provider_names.append(name)
     body = response.json()
     assert body["provider_type"] == SSOProviderType.SAML.value
-    # Single issuer-resolved ACS for every SAML row.
-    assert body["redirect_uri"] == f"{WEB_DOMAIN}/api/auth/saml/callback"
+    # Single issuer-resolved ACS for every SAML row, no /api prefix (the
+    # AuthnRequest advertises this exact URL).
+    assert body["redirect_uri"] == f"{WEB_DOMAIN}/auth/saml/callback"
     assert is_masked_credential(body["config"]["sp_private_key"]) is True
 
     raw = _stored_config(db_session, body["id"])

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -278,7 +278,7 @@ def test_login_callback_uri_saml_is_fixed_acs() -> None:
 
     provider = _provider(name="corp-saml", provider_type=SSOProviderType.SAML)
     uri = sso_login_callback_uri(provider, {}, "https://onyx.example.com")
-    assert uri == "https://onyx.example.com/api/auth/saml/callback"
+    assert uri == "https://onyx.example.com/auth/saml/callback"
 
 
 def test_fixed_callback_rejects_missing_state() -> None:


### PR DESCRIPTION
Cherry-pick of commit 6ec94f7ea2da4389890b7ce585b243e265f30dd6 to release/v4.4 branch.

Original PR: #13147

- [x] [Optional] Override Linear Check
