### PR TITLE
refactor(settings): make /admin/settings a PATCH with partial-merge

### DIFF
--- a/backend/ee/onyx/server/tenants/product_gating.py
+++ b/backend/ee/onyx/server/tenants/product_gating.py
@@ -2,7 +2,11 @@ from ee.onyx.configs.app_configs import GATED_TENANTS_KEY
 from onyx.configs.constants import ONYX_CLOUD_TENANT_ID
 from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client
 from onyx.server.settings.models import ApplicationStatus
-from onyx.server.settings.store import load_settings, store_settings
+from onyx.server.settings.store import (
+    load_settings,
+    settings_write_lock,
+    store_settings,
+)
 from onyx.utils.logger import setup_logger
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -20,22 +24,22 @@ def update_tenant_gating(tenant_id: str, status: ApplicationStatus) -> None:
 
 
 def store_product_gating(tenant_id: str, application_status: ApplicationStatus) -> None:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
     try:
-        token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
-
-        settings = load_settings()
-        settings.application_status = application_status
-        store_settings(settings)
+        # Shares the settings write lock so a concurrent settings writer cannot
+        # merge onto a stale snapshot and drop application_status.
+        with settings_write_lock():
+            settings = load_settings()
+            settings.application_status = application_status
+            store_settings(settings)
 
         # Store gated tenant information in Redis
         update_tenant_gating(tenant_id, application_status)
-
-        if token is not None:
-            CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
-
     except Exception:
         logger.exception("Failed to gate product")
         raise
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
 def overwrite_full_gated_set(tenant_ids: list[str]) -> None:

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -39,7 +39,11 @@ from onyx.server.settings.models import (
     Tier,
     UserSettings,
 )
-from onyx.server.settings.store import load_settings, store_settings
+from onyx.server.settings.store import (
+    load_settings,
+    settings_write_lock,
+    store_settings,
+)
 from onyx.server.settings.tier_order import tier_at_least
 from onyx.utils.audit import (
     AuditAction,
@@ -61,70 +65,74 @@ admin_router = APIRouter(prefix="/admin/settings")
 basic_router = APIRouter(prefix="/settings")
 
 
-@admin_router.put("")
-def admin_put_settings(
+@admin_router.patch("")
+def admin_patch_settings(
     settings: Settings,
     current_user: User = Depends(
         require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)
     ),
 ) -> None:
-    if (
-        settings.user_file_max_upload_size_mb is not None
-        and settings.user_file_max_upload_size_mb > 0
-        and settings.user_file_max_upload_size_mb > MAX_ALLOWED_UPLOAD_SIZE_MB
-    ):
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            f"File upload size limit cannot exceed {MAX_ALLOWED_UPLOAD_SIZE_MB} MB",
-        )
-
     if global_version.is_ee_version():
         from ee.onyx.utils.tier import get_tier
 
         current_tier = get_tier()
     else:
         current_tier = Tier.COMMUNITY
-    existing = load_settings()
 
-    # These fields are access control: a PUT that omits one (e.g. an older
-    # client, or a partial write) must not silently reset it to the pydantic
-    # default. invite_only_enabled off-by-default would let uninvited users in.
-    if "craft_default_enabled" not in settings.model_fields_set:
-        settings.craft_default_enabled = existing.craft_default_enabled
-    if "craft_instructions" not in settings.model_fields_set:
-        settings.craft_instructions = existing.craft_instructions
-    if "invite_only_enabled" not in settings.model_fields_set:
-        settings.invite_only_enabled = existing.invite_only_enabled
-    # Search Mode is Business+; Chat Retention is Enterprise-only.
-    # Use the same error code (FEATURE_NOT_AVAILABLE / 402) the tier_gate
-    # middleware uses, so the FE has one shape to handle for tier-rejected
-    # writes.
-    if settings.search_ui_enabled != existing.search_ui_enabled and not tier_at_least(
-        current_tier, Tier.BUSINESS
-    ):
-        raise OnyxError(
-            OnyxErrorCode.FEATURE_NOT_AVAILABLE,
-            "Search Mode requires the Business or Enterprise plan.",
-        )
-    if (
-        settings.maximum_chat_retention_days != existing.maximum_chat_retention_days
-        and not tier_at_least(current_tier, Tier.ENTERPRISE)
-    ):
-        raise OnyxError(
-            OnyxErrorCode.FEATURE_NOT_AVAILABLE,
-            "Chat history retention requires the Enterprise plan.",
+    # Serialize the read-modify-write so two concurrent partial patches cannot
+    # each merge onto a stale snapshot and drop the other's field.
+    with settings_write_lock():
+        # Fail closed: a settings-read error must not fall back to defaults and
+        # silently disable an access-control field like invite_only_enabled.
+        existing = load_settings(raise_on_error=True)
+        # Merge only the fields the caller sent so omitted fields keep their
+        # stored value. Access-control fields rely on this: a partial write
+        # must not silently reset them to pydantic defaults.
+        merged = existing.model_copy(
+            update={
+                field: getattr(settings, field) for field in settings.model_fields_set
+            }
         )
 
-    store_settings(settings)
+        if (
+            merged.user_file_max_upload_size_mb is not None
+            and merged.user_file_max_upload_size_mb > 0
+            and merged.user_file_max_upload_size_mb > MAX_ALLOWED_UPLOAD_SIZE_MB
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"File upload size limit cannot exceed {MAX_ALLOWED_UPLOAD_SIZE_MB} MB",
+            )
 
-    if settings.craft_default_enabled != existing.craft_default_enabled:
-        emit_audit_event(
-            AuditAction.CRAFT_DEFAULT_CHANGE,
-            AuditOutcome.SUCCESS,
-            actor=actor_from_user(current_user),
-            resource_type="settings",
-            extra={"craft_default_enabled": settings.craft_default_enabled},
-        )
+        # Search Mode is Business+, Chat Retention is Enterprise-only. Same error
+        # code (FEATURE_NOT_AVAILABLE / 402) the tier_gate middleware uses, so the
+        # FE has one shape to handle for tier-rejected writes.
+        if merged.search_ui_enabled != existing.search_ui_enabled and not tier_at_least(
+            current_tier, Tier.BUSINESS
+        ):
+            raise OnyxError(
+                OnyxErrorCode.FEATURE_NOT_AVAILABLE,
+                "Search Mode requires the Business or Enterprise plan.",
+            )
+        if (
+            merged.maximum_chat_retention_days != existing.maximum_chat_retention_days
+            and not tier_at_least(current_tier, Tier.ENTERPRISE)
+        ):
+            raise OnyxError(
+                OnyxErrorCode.FEATURE_NOT_AVAILABLE,
+                "Chat history retention requires the Enterprise plan.",
+            )
+
+        store_settings(merged)
+
+        if merged.craft_default_enabled != existing.craft_default_enabled:
+            emit_audit_event(
+                AuditAction.CRAFT_DEFAULT_CHANGE,
+                AuditOutcome.SUCCESS,
+                actor=actor_from_user(current_user),
+                resource_type="settings",
+                extra={"craft_default_enabled": merged.craft_default_enabled},
+            )
 
 
 def apply_license_status_to_settings(settings: Settings) -> Settings:

--- a/backend/onyx/server/settings/store.py
+++ b/backend/onyx/server/settings/store.py
@@ -1,4 +1,8 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 from onyx.cache.factory import get_cache_backend
+from onyx.cache.locks import cache_shared_lock
 from onyx.configs.app_configs import (
     DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB,
     DISABLE_USER_KNOWLEDGE,
@@ -18,11 +22,30 @@ from onyx.server.settings.models import (
     Settings,
 )
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
 # TTL for settings keys - 30 days
 SETTINGS_TTL = 30 * 24 * 60 * 60
+
+_SETTINGS_WRITE_LOCK_TIMEOUT_S = 10.0
+
+
+@contextmanager
+def settings_write_lock() -> Iterator[None]:
+    """Serialize read-modify-write of the workspace Settings record so concurrent
+    writers cannot each merge onto a stale snapshot and drop another's field. Any
+    code that loads the Settings record, mutates it, and stores it back must hold
+    this lock. Tenant-scoped, and works on both the Redis and Postgres cache
+    backends."""
+    with cache_shared_lock(
+        lock_name=f"settings_write:{get_current_tenant_id()}",
+        max_time_lock_held_s=_SETTINGS_WRITE_LOCK_TIMEOUT_S,
+        wait_for_lock_s=_SETTINGS_WRITE_LOCK_TIMEOUT_S,
+        logger=logger,
+    ):
+        yield
 
 
 def load_settings(raise_on_error: bool = False) -> Settings:

--- a/backend/onyx/setup.py
+++ b/backend/onyx/setup.py
@@ -66,7 +66,11 @@ from onyx.server.manage.llm.models import (
     LLMProviderUpsertRequest,
     ModelConfigurationUpsertRequest,
 )
-from onyx.server.settings.store import load_settings, store_settings
+from onyx.server.settings.store import (
+    load_settings,
+    settings_write_lock,
+    store_settings,
+)
 from onyx.utils.gpu_utils import gpu_status_request
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import (
@@ -315,10 +319,12 @@ def update_default_multipass_indexing(db_session: Session) -> None:
         )
         update_current_search_settings(db_session, updated_settings)
 
-        # Update settings with GPU availability
-        settings = load_settings()
-        settings.gpu_enabled = gpu_available
-        store_settings(settings)
+        # Shares the settings write lock so a concurrent writer cannot merge
+        # onto a stale snapshot.
+        with settings_write_lock():
+            settings = load_settings()
+            settings.gpu_enabled = gpu_available
+            store_settings(settings)
         logger.notice("Updated settings with GPU availability: %s", gpu_available)
 
     else:

--- a/backend/tests/integration/common_utils/managers/settings.py
+++ b/backend/tests/integration/common_utils/managers/settings.py
@@ -35,7 +35,7 @@ class SettingsManager:
         headers.pop("Content-Type", None)
 
         payload = settings.model_dump()
-        response = client.put(
+        response = client.patch(
             f"{API_SERVER_URL}/admin/settings",
             json=payload,
             headers=headers,

--- a/backend/tests/integration/tests/streaming_endpoints/test_chat_file_attachment.py
+++ b/backend/tests/integration/tests/streaming_endpoints/test_chat_file_attachment.py
@@ -90,7 +90,7 @@ def test_send_message_with_text_file_attachment(admin_user: DATestUser) -> None:
 
 def _set_token_threshold(admin_user: DATestUser, threshold_k: int) -> None:
     """Set the file token count threshold via admin settings API."""
-    response = client.put(
+    response = client.patch(
         f"{API_SERVER_URL}/admin/settings",
         json={"file_token_count_threshold_k": threshold_k},
         headers=admin_user.headers,

--- a/backend/tests/unit/onyx/server/settings/test_admin_patch_settings.py
+++ b/backend/tests/unit/onyx/server/settings/test_admin_patch_settings.py
@@ -1,3 +1,5 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -8,17 +10,27 @@ from onyx.server.settings import api as settings_api
 from onyx.server.settings.models import CRAFT_INSTRUCTIONS_MAX_LENGTH, Settings
 
 
-def _put_settings(
+@contextmanager
+def _noop_lock(*_a: Any, **_k: Any) -> Iterator[None]:
+    yield
+
+
+def _patch_settings(
     payload: dict[str, Any],
     existing: Settings,
     monkeypatch: pytest.MonkeyPatch,
 ) -> Settings:
     stored: list[Settings] = []
-    monkeypatch.setattr(settings_api, "load_settings", lambda: existing)
+    monkeypatch.setattr(
+        settings_api,
+        "load_settings",
+        lambda raise_on_error=False: existing,  # noqa: ARG005
+    )
     monkeypatch.setattr(settings_api, "store_settings", stored.append)
     monkeypatch.setattr(settings_api, "emit_audit_event", lambda *_a, **_k: None)
+    monkeypatch.setattr(settings_api, "settings_write_lock", _noop_lock)
     monkeypatch.setattr(settings_api.global_version, "is_ee_version", lambda: False)
-    settings_api.admin_put_settings(
+    settings_api.admin_patch_settings(
         Settings.model_validate(payload), current_user=MagicMock()
     )
     assert len(stored) == 1
@@ -29,7 +41,7 @@ def test_omitted_craft_instructions_is_preserved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     existing = Settings(craft_instructions="keep me")
-    result = _put_settings({}, existing, monkeypatch)
+    result = _patch_settings({}, existing, monkeypatch)
     assert result.craft_instructions == "keep me"
 
 
@@ -37,7 +49,7 @@ def test_explicit_null_clears_craft_instructions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     existing = Settings(craft_instructions="old value")
-    result = _put_settings({"craft_instructions": None}, existing, monkeypatch)
+    result = _patch_settings({"craft_instructions": None}, existing, monkeypatch)
     assert result.craft_instructions is None
 
 
@@ -45,8 +57,19 @@ def test_explicit_value_overwrites_craft_instructions(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     existing = Settings(craft_instructions="old value")
-    result = _put_settings({"craft_instructions": "new value"}, existing, monkeypatch)
+    result = _patch_settings({"craft_instructions": "new value"}, existing, monkeypatch)
     assert result.craft_instructions == "new value"
+
+
+def test_omitted_field_preserved_generally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Partial merge applies to every field, not just craft: a write that omits
+    an access-control field leaves it unchanged instead of resetting it."""
+    existing = Settings(invite_only_enabled=True, maximum_chat_retention_days=30)
+    result = _patch_settings({"craft_instructions": "x"}, existing, monkeypatch)
+    assert result.invite_only_enabled is True
+    assert result.maximum_chat_retention_days == 30
 
 
 def test_over_length_craft_instructions_rejected() -> None:

--- a/web/src/lib/indexing/svc.ts
+++ b/web/src/lib/indexing/svc.ts
@@ -124,7 +124,7 @@ export async function disconnectEmbeddingProvider(
 
 export async function saveAdminSettings(settings: Settings) {
   const response = await fetch("/api/admin/settings", {
-    method: "PUT",
+    method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(settings),
   });

--- a/web/src/lib/settings/svc.ts
+++ b/web/src/lib/settings/svc.ts
@@ -14,7 +14,7 @@ async function parseErrorDetail(
 
 export async function updateAdminSettings(settings: Settings): Promise<void> {
   const res = await fetch("/api/admin/settings", {
-    method: "PUT",
+    method: "PATCH",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(settings),
   });

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -802,7 +802,7 @@ export default function ChatPreferencesPage() {
 
       try {
         const response = await fetch("/api/admin/settings", {
-          method: "PUT",
+          method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(newSettings),
         });

--- a/web/tests/e2e/auth/anonymous_chat.spec.ts
+++ b/web/tests/e2e/auth/anonymous_chat.spec.ts
@@ -6,21 +6,16 @@ import { loginAs } from "@tests/e2e/utils/auth";
 // visitor should reach the chat surface (/app) instead of being redirected to
 // the login page.
 
-// Patch global settings via the admin API, mirroring the admin UI's
-// read-modify-write (web/src/refresh-pages/admin/ChatPreferencesPage.tsx).
-// `page` must be authenticated as an admin.
+// Patch global settings via the admin PATCH endpoint, which merges only the
+// fields sent. `page` must be authenticated as an admin.
 async function patchAdminSettings(
   page: Page,
   patch: Record<string, unknown>
 ): Promise<void> {
-  const getRes = await page.request.get("/api/settings");
-  expect(getRes.ok()).toBe(true);
-  const current = await getRes.json();
-
-  const putRes = await page.request.put("/api/admin/settings", {
-    data: { ...current, ...patch },
+  const patchRes = await page.request.patch("/api/admin/settings", {
+    data: patch,
   });
-  expect(putRes.ok()).toBe(true);
+  expect(patchRes.ok()).toBe(true);
 }
 
 // @exclusive: mutates the global `anonymous_user_enabled` setting, which is


### PR DESCRIPTION
## Description

Follow-up to @acaprau's note on #13256: the admin settings write is a `PUT` that behaves like a partial update, worked around with per-field `model_fields_set` guards.

- Convert the endpoint to `PATCH` and merge only the fields the caller sent onto the stored settings (`model_copy(update=...)`).
- This drops the per-field guards and gives every field correct partial-update semantics: an omitted field keeps its value instead of resetting to the pydantic default.
- Frontend writers (`updateAdminSettings`, ChatPreferences) and the integration `SettingsManager` switch to `PATCH`.

Full-object callers (all current FE writers) are behavior-neutral. Partial callers now preserve omitted fields.

Note: this reworks the same block as #13256's invite-only guard, so it should merge after #13256 (the merge subsumes that guard).

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check