### PR TITLE
feat: efficient token tracking

### DIFF
--- a/backend/ee/onyx/server/query_and_chat/token_limit.py
+++ b/backend/ee/onyx/server/query_and_chat/token_limit.py
@@ -1,19 +1,13 @@
 from collections import defaultdict
-from collections.abc import Sequence
 from datetime import datetime
-from itertools import groupby
-from typing import Dict, List, Tuple
 from uuid import UUID
 
-from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.db.api_key import is_api_key_email_address
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.models import (
-    ChatMessage,
-    ChatSession,
     TokenRateLimit,
     TokenRateLimit__UserGroup,
     User,
@@ -21,6 +15,13 @@ from onyx.db.models import (
     UserGroup,
 )
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.user_usage import (
+    TokenUsageBucket,
+    get_group_token_buckets_since,
+    get_user_token_buckets_since,
+)
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import (
     _get_cutoff_time,
     _is_rate_limited,
@@ -64,29 +65,16 @@ def _user_is_rate_limited(user_id: UUID) -> None:
             user_usage = _fetch_user_usage(user_id, user_cutoff_time, db_session)
 
             if _is_rate_limited(user_rate_limits, user_usage):
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for user. Try again later.",
+                raise OnyxError(
+                    OnyxErrorCode.RATE_LIMITED,
+                    "Token budget exceeded for user. Try again later.",
                 )
 
 
 def _fetch_user_usage(
     user_id: UUID, cutoff_time: datetime, db_session: Session
-) -> Sequence[tuple[datetime, int]]:
-    """
-    Fetch user usage within the cutoff time, grouped by minute
-    """
-    result = db_session.execute(
-        select(
-            func.date_trunc("minute", ChatMessage.time_sent),
-            func.sum(ChatMessage.token_count),
-        )
-        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
-        .where(ChatSession.user_id == user_id, ChatMessage.time_sent >= cutoff_time)
-        .group_by(func.date_trunc("minute", ChatMessage.time_sent))
-    ).all()
-
-    return [(row[0], row[1]) for row in result]
+) -> list[TokenUsageBucket]:
+    return get_user_token_buckets_since(db_session, str(user_id), cutoff_time)
 
 
 """
@@ -120,15 +108,15 @@ def _user_is_rate_limited_by_group(user_id: UUID) -> None:
                     break
 
             if not has_at_least_one_untriggered_limit:
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for user's groups. Try again later.",
+                raise OnyxError(
+                    OnyxErrorCode.RATE_LIMITED,
+                    "Token budget exceeded for user's groups. Try again later.",
                 )
 
 
 def _fetch_all_user_group_rate_limits(
     user_id: UUID, db_session: Session
-) -> Dict[int, List[TokenRateLimit]]:
+) -> dict[int, list[TokenRateLimit]]:
     group_limits = (
         select(TokenRateLimit, User__UserGroup.user_group_id)
         .join(
@@ -160,26 +148,5 @@ def _fetch_all_user_group_rate_limits(
 
 def _fetch_user_group_usage(
     user_group_ids: list[int], cutoff_time: datetime, db_session: Session
-) -> dict[int, list[Tuple[datetime, int]]]:
-    """
-    Fetch user group usage within the cutoff time, grouped by minute
-    """
-    user_group_usage = db_session.execute(
-        select(
-            func.sum(ChatMessage.token_count),
-            func.date_trunc("minute", ChatMessage.time_sent),
-            UserGroup.id,
-        )
-        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
-        .join(User__UserGroup, User__UserGroup.user_id == ChatSession.user_id)
-        .join(UserGroup, UserGroup.id == User__UserGroup.user_group_id)
-        .filter(UserGroup.id.in_(user_group_ids), ChatMessage.time_sent >= cutoff_time)
-        .group_by(func.date_trunc("minute", ChatMessage.time_sent), UserGroup.id)
-    ).all()
-
-    return {
-        user_group_id: [(usage, time_sent) for time_sent, usage, _ in group_usage]
-        for user_group_id, group_usage in groupby(
-            user_group_usage, key=lambda row: row[2]
-        )
-    }
+) -> dict[int, list[TokenUsageBucket]]:
+    return get_group_token_buckets_since(db_session, user_group_ids, cutoff_time)

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2122,12 +2122,16 @@ async def current_limited_user(
 
 async def current_chat_accessible_user(
     user: User | None = Depends(optional_user),
-) -> User:
+) -> AsyncGenerator[User, None]:
     tenant_id = get_current_tenant_id()
-
-    return await double_check_user(
+    user = await double_check_user(
         user, allow_anonymous_access=anonymous_user_enabled(tenant_id=tenant_id)
     )
+    token = CURRENT_USER_ID_CONTEXTVAR.set(str(user.id))
+    try:
+        yield user
+    finally:
+        CURRENT_USER_ID_CONTEXTVAR.reset(token)
 
 
 async def current_user(

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -4,7 +4,8 @@ A window rollup: rows accumulate in place per (user, window,
 model, flow, provider), not an append-only per-call ledger."""
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
+from math import ceil
 
 from pydantic import BaseModel
 from sqlalchemy import func, select
@@ -18,7 +19,30 @@ from onyx.utils.logger import setup_logger
 logger = setup_logger()
 
 USER_USAGE_BUCKET_SECONDS = 24 * 60 * 60
+USER_USAGE_BUCKET_HOURS = USER_USAGE_BUCKET_SECONDS // (60 * 60)
+TOKEN_BUDGET_PERIOD_ERROR = "Token budget periods must be whole UTC days"
 _CONFLICT_COLS = ["user_id", "window_start", "model", "flow", "provider"]
+
+
+class TokenUsageBucket(BaseModel):
+    window_start: datetime
+    tokens: int
+
+
+def normalize_token_period_hours(period_hours: int) -> int:
+    """Round legacy periods up to whole UTC days."""
+    return max(
+        USER_USAGE_BUCKET_HOURS,
+        ceil(period_hours / USER_USAGE_BUCKET_HOURS) * USER_USAGE_BUCKET_HOURS,
+    )
+
+
+def get_token_window_start(now: datetime, period_hours: int) -> datetime:
+    period_hours = normalize_token_period_hours(period_hours)
+    current_bucket = datetime_to_utc(now).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    return current_bucket - timedelta(hours=period_hours - USER_USAGE_BUCKET_HOURS)
 
 
 class UserUsageByDay(BaseModel):
@@ -291,4 +315,73 @@ def get_group_cost_cents_buckets_since(
     result: dict[int, list[tuple[datetime, float]]] = defaultdict(list)
     for group_id, window_start, cost in rows:
         result[group_id].append((datetime_to_utc(window_start), float(cost)))
+    return result
+
+
+def get_user_token_buckets_since(
+    db_session: Session,
+    user_id: str,
+    cutoff: datetime,
+) -> list[TokenUsageBucket]:
+    rows = db_session.execute(
+        select(
+            UserUsage.window_start,
+            func.sum(UserUsage.input_tokens + UserUsage.output_tokens),
+        )
+        .where(UserUsage.user_id == user_id, UserUsage.window_start >= cutoff)
+        .group_by(UserUsage.window_start)
+        .order_by(UserUsage.window_start)
+    ).all()
+    return [
+        TokenUsageBucket(window_start=datetime_to_utc(window_start), tokens=int(tokens))
+        for window_start, tokens in rows
+    ]
+
+
+def get_total_token_buckets_since(
+    db_session: Session,
+    cutoff: datetime,
+) -> list[TokenUsageBucket]:
+    rows = db_session.execute(
+        select(
+            UserUsage.window_start,
+            func.sum(UserUsage.input_tokens + UserUsage.output_tokens),
+        )
+        .where(UserUsage.window_start >= cutoff)
+        .group_by(UserUsage.window_start)
+        .order_by(UserUsage.window_start)
+    ).all()
+    return [
+        TokenUsageBucket(window_start=datetime_to_utc(window_start), tokens=int(tokens))
+        for window_start, tokens in rows
+    ]
+
+
+def get_group_token_buckets_since(
+    db_session: Session,
+    user_group_ids: list[int],
+    cutoff: datetime,
+) -> dict[int, list[TokenUsageBucket]]:
+    rows = db_session.execute(
+        select(
+            User__UserGroup.user_group_id,
+            UserUsage.window_start,
+            func.sum(UserUsage.input_tokens + UserUsage.output_tokens),
+        )
+        .join(User__UserGroup, User__UserGroup.user_id == UserUsage.user_id)
+        .where(
+            User__UserGroup.user_group_id.in_(user_group_ids),
+            UserUsage.window_start >= cutoff,
+        )
+        .group_by(User__UserGroup.user_group_id, UserUsage.window_start)
+        .order_by(User__UserGroup.user_group_id, UserUsage.window_start)
+    ).all()
+
+    result: dict[int, list[TokenUsageBucket]] = defaultdict(list)
+    for group_id, window_start, tokens in rows:
+        result[group_id].append(
+            TokenUsageBucket(
+                window_start=datetime_to_utc(window_start), tokens=int(tokens)
+            )
+        )
     return result

--- a/backend/onyx/db/user_usage.py
+++ b/backend/onyx/db/user_usage.py
@@ -323,6 +323,7 @@ def get_user_token_buckets_since(
     user_id: str,
     cutoff: datetime,
 ) -> list[TokenUsageBucket]:
+    """Provider input + output tokens across all recorded flows for one user."""
     rows = db_session.execute(
         select(
             UserUsage.window_start,
@@ -342,6 +343,7 @@ def get_total_token_buckets_since(
     db_session: Session,
     cutoff: datetime,
 ) -> list[TokenUsageBucket]:
+    """Tenant-wide provider input + output tokens across all recorded flows."""
     rows = db_session.execute(
         select(
             UserUsage.window_start,
@@ -362,6 +364,7 @@ def get_group_token_buckets_since(
     user_group_ids: list[int],
     cutoff: datetime,
 ) -> dict[int, list[TokenUsageBucket]]:
+    """Provider input + output tokens across all recorded flows per group."""
     rows = db_session.execute(
         select(
             User__UserGroup.user_group_id,

--- a/backend/onyx/server/query_and_chat/token_limit.py
+++ b/backend/onyx/server/query_and_chat/token_limit.py
@@ -1,17 +1,23 @@
 from collections.abc import Sequence
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from threading import RLock
 
 from cachetools import TTLCache
-from dateutil import tz
-from fastapi import Depends, HTTPException
-from sqlalchemy import func, select
+from fastapi import Depends
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.users import current_chat_accessible_user
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
-from onyx.db.models import ChatMessage, ChatSession, TokenRateLimit, User
+from onyx.db.models import TokenRateLimit, User
 from onyx.db.token_limit import fetch_all_global_token_rate_limits
+from onyx.db.user_usage import (
+    TokenUsageBucket,
+    get_token_window_start,
+    get_total_token_buckets_since,
+)
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 from onyx.utils.variable_functionality import fetch_versioned_implementation
 from shared_configs.contextvars import get_current_tenant_id
@@ -56,31 +62,16 @@ def _user_is_rate_limited_by_global() -> None:
             global_usage = _fetch_global_usage(global_cutoff_time, db_session)
 
             if _is_rate_limited(global_rate_limits, global_usage):
-                raise HTTPException(
-                    status_code=429,
-                    detail="Token budget exceeded for organization. Try again later.",
+                raise OnyxError(
+                    OnyxErrorCode.RATE_LIMITED,
+                    "Token budget exceeded for organization. Try again later.",
                 )
 
 
 def _fetch_global_usage(
     cutoff_time: datetime, db_session: Session
-) -> Sequence[tuple[datetime, int]]:
-    """
-    Fetch global token usage within the cutoff time, grouped by minute
-    """
-    result = db_session.execute(
-        select(
-            func.date_trunc("minute", ChatMessage.time_sent),
-            func.sum(ChatMessage.token_count),
-        )
-        .join(ChatSession, ChatMessage.chat_session_id == ChatSession.id)
-        .filter(
-            ChatMessage.time_sent >= cutoff_time,
-        )
-        .group_by(func.date_trunc("minute", ChatMessage.time_sent))
-    ).all()
-
-    return [(row[0], row[1]) for row in result]
+) -> list[TokenUsageBucket]:
+    return get_total_token_buckets_since(db_session, cutoff_time)
 
 
 """
@@ -90,24 +81,24 @@ Common functions
 
 def _get_cutoff_time(rate_limits: Sequence[TokenRateLimit]) -> datetime:
     max_period_hours = max(rate_limit.period_hours for rate_limit in rate_limits)
-    return datetime.now(tz=timezone.utc) - timedelta(hours=max_period_hours)
+    return get_token_window_start(
+        datetime.now(timezone.utc),
+        max_period_hours,
+    )
 
 
 def _is_rate_limited(
-    rate_limits: Sequence[TokenRateLimit], usage: Sequence[tuple[datetime, int]]
+    rate_limits: Sequence[TokenRateLimit], usage: Sequence[TokenUsageBucket]
 ) -> bool:
-    """
-    If at least one rate limit is exceeded, return True
-    """
+    """Whether any provider-token budget is exceeded."""
+    now = datetime.now(timezone.utc)
     for rate_limit in rate_limits:
         if rate_limit.token_budget is None:
             continue
 
+        cutoff = get_token_window_start(now, rate_limit.period_hours)
         tokens_used = sum(
-            u_token_count
-            for u_date, u_token_count in usage
-            if u_date
-            >= datetime.now(tz=tz.UTC) - timedelta(hours=rate_limit.period_hours)
+            bucket.tokens for bucket in usage if bucket.window_start >= cutoff
         )
 
         if tokens_used >= rate_limit.token_budget * TOKEN_BUDGET_UNIT:

--- a/backend/onyx/server/token_rate_limits/models.py
+++ b/backend/onyx/server/token_rate_limits/models.py
@@ -1,6 +1,10 @@
 from pydantic import BaseModel, Field, model_validator
 
 from onyx.db.models import TokenRateLimit
+from onyx.db.user_usage import (
+    TOKEN_BUDGET_PERIOD_ERROR,
+    normalize_token_period_hours,
+)
 
 
 class TokenRateLimitArgs(BaseModel):
@@ -14,6 +18,11 @@ class TokenRateLimitArgs(BaseModel):
     def validate_budget_set(self) -> "TokenRateLimitArgs":
         if self.token_budget is None and self.cost_budget_cents is None:
             raise ValueError("Either token_budget or cost_budget_cents must be set")
+        if (
+            self.token_budget is not None
+            and self.period_hours != normalize_token_period_hours(self.period_hours)
+        ):
+            raise ValueError(TOKEN_BUDGET_PERIOD_ERROR)
         return self
 
 
@@ -26,10 +35,13 @@ class TokenRateLimitDisplay(BaseModel):
 
     @classmethod
     def from_db(cls, token_rate_limit: TokenRateLimit) -> "TokenRateLimitDisplay":
+        period_hours = token_rate_limit.period_hours
+        if token_rate_limit.token_budget is not None:
+            period_hours = normalize_token_period_hours(period_hours)
         return cls(
             token_id=token_rate_limit.id,
             enabled=token_rate_limit.enabled,
             token_budget=token_rate_limit.token_budget,
-            period_hours=token_rate_limit.period_hours,
+            period_hours=period_hours,
             cost_budget_cents=token_rate_limit.cost_budget_cents,
         )

--- a/backend/tests/unit/onyx/db/test_user_usage.py
+++ b/backend/tests/unit/onyx/db/test_user_usage.py
@@ -21,16 +21,36 @@ from sqlalchemy.orm import Session, sessionmaker
 
 from onyx.db.models import User__UserGroup, UserUsage
 from onyx.db.user_usage import (
+    TokenUsageBucket,
     UserUsageByDay,
     get_group_cost_cents_since,
+    get_group_token_buckets_since,
+    get_token_window_start,
     get_total_cost_cents_buckets_since,
     get_total_cost_cents_since,
+    get_total_token_buckets_since,
     get_user_cost_cents_buckets_since,
     get_user_cost_cents_in_window,
     get_user_cost_cents_since,
+    get_user_token_buckets_since,
     get_user_usage_by_day_and_model,
+    normalize_token_period_hours,
     record_user_usage,
 )
+
+
+def test_token_periods_use_whole_utc_days() -> None:
+    now = datetime.datetime(2026, 7, 21, 13, 30, tzinfo=datetime.timezone.utc)
+
+    assert normalize_token_period_hours(1) == 24
+    assert normalize_token_period_hours(24) == 24
+    assert normalize_token_period_hours(25) == 48
+    assert get_token_window_start(now, 24) == datetime.datetime(
+        2026, 7, 21, tzinfo=datetime.timezone.utc
+    )
+    assert get_token_window_start(now, 48) == datetime.datetime(
+        2026, 7, 20, tzinfo=datetime.timezone.utc
+    )
 
 
 @compiles(PGUUID, "sqlite")
@@ -307,6 +327,32 @@ class TestTotalCostBucketsSince:
         assert buckets[w2] == pytest.approx(9.0)
 
 
+class TestTokenBuckets:
+    def test_user_tokens_are_provider_input_plus_output(
+        self, db_session: Session
+    ) -> None:
+        user_id, other_id = str(uuid4()), str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        _seed_usage(db_session, user_id, "m", "CHAT", None, 100, 20, 80, 1.0, window)
+        _seed_usage(db_session, user_id, "n", "CHAT", None, 50, 10, 0, 1.0, window)
+        _seed_usage(db_session, other_id, "m", "CHAT", None, 999, 1, 0, 1.0, window)
+
+        assert get_user_token_buckets_since(db_session, user_id, window) == [
+            TokenUsageBucket(window_start=window, tokens=180)
+        ]
+
+    def test_total_tokens_sum_across_users(self, db_session: Session) -> None:
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        _seed_usage(
+            db_session, str(uuid4()), "m", "CHAT", None, 100, 20, 0, 1.0, window
+        )
+        _seed_usage(db_session, str(uuid4()), "m", "CHAT", None, 50, 10, 0, 1.0, window)
+
+        assert get_total_token_buckets_since(db_session, window) == [
+            TokenUsageBucket(window_start=window, tokens=180)
+        ]
+
+
 @pytest.fixture
 def db_session_with_groups() -> Generator[Session, None, None]:
     engine: Engine = create_engine("sqlite://")
@@ -338,3 +384,18 @@ class TestGroupCostSince:
         _seed_usage(s, outsider, "m", "CHAT", None, 1, 1, 0, 99.0, window)
 
         assert get_group_cost_cents_since(s, 10, window) == pytest.approx(7.0)
+
+    def test_token_buckets_sum_group_members(
+        self, db_session_with_groups: Session
+    ) -> None:
+        session = db_session_with_groups
+        member, outsider = str(uuid4()), str(uuid4())
+        window = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        session.add(User__UserGroup(user_group_id=10, user_id=member))
+        session.flush()
+        _seed_usage(session, member, "m", "CHAT", None, 100, 25, 0, 1.0, window)
+        _seed_usage(session, outsider, "m", "CHAT", None, 999, 1, 0, 1.0, window)
+
+        assert get_group_token_buckets_since(session, [10], window) == {
+            10: [TokenUsageBucket(window_start=window, tokens=125)]
+        }

--- a/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
+++ b/backend/tests/unit/onyx/server/test_token_rate_limit_budget_models.py
@@ -5,6 +5,7 @@ from pydantic import ValidationError
 
 from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.models import TokenRateLimit
+from onyx.db.user_usage import TokenUsageBucket
 from onyx.server.query_and_chat.token_limit import _is_rate_limited
 from onyx.server.token_rate_limits.models import (
     TokenRateLimitArgs,
@@ -26,13 +27,19 @@ def _rate_limit(
 
 
 def test_cost_only_rate_limit_skips_token_enforcement() -> None:
-    usage = [(datetime.datetime.now(datetime.UTC), 1_000_000)]
+    usage = [
+        TokenUsageBucket(
+            window_start=datetime.datetime.now(datetime.UTC), tokens=1_000_000
+        )
+    ]
 
     assert not _is_rate_limited([_rate_limit(None, cost_budget_cents=1.0)], usage)
 
 
 def test_token_budget_still_enforces_tokens() -> None:
-    usage = [(datetime.datetime.now(datetime.UTC), 1_000)]
+    usage = [
+        TokenUsageBucket(window_start=datetime.datetime.now(datetime.UTC), tokens=1_000)
+    ]
 
     assert _is_rate_limited([_rate_limit(1)], usage)
 
@@ -41,7 +48,26 @@ def test_token_rate_limit_args_requires_a_budget() -> None:
     with pytest.raises(
         ValidationError, match="Either token_budget or cost_budget_cents"
     ):
-        TokenRateLimitArgs(enabled=True, period_hours=1)
+        TokenRateLimitArgs(enabled=True, period_hours=24)
+
+
+def test_token_rate_limit_args_requires_whole_utc_days() -> None:
+    with pytest.raises(ValidationError, match="whole UTC days"):
+        TokenRateLimitArgs(enabled=True, token_budget=1, period_hours=25)
+
+
+def test_token_rate_limit_uses_current_utc_day() -> None:
+    now = datetime.datetime.now(datetime.UTC)
+    current_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    previous_day = current_day - datetime.timedelta(days=1)
+    limit = _rate_limit(1)
+
+    assert _is_rate_limited(
+        [limit], [TokenUsageBucket(window_start=current_day, tokens=1_000)]
+    )
+    assert not _is_rate_limited(
+        [limit], [TokenUsageBucket(window_start=previous_day, tokens=1_000)]
+    )
 
 
 def test_token_rate_limit_display_allows_cost_only_limit() -> None:
@@ -49,3 +75,9 @@ def test_token_rate_limit_display_allows_cost_only_limit() -> None:
 
     assert display.token_budget is None
     assert display.cost_budget_cents == 2.5
+
+
+def test_token_rate_limit_display_normalizes_legacy_period() -> None:
+    display = TokenRateLimitDisplay.from_db(_rate_limit(1))
+
+    assert display.period_hours == 24

--- a/backend/tests/unit/shared_configs/test_user_id_contextvar.py
+++ b/backend/tests/unit/shared_configs/test_user_id_contextvar.py
@@ -9,11 +9,13 @@ from fastapi.testclient import TestClient
 
 from onyx.auth import users
 from onyx.auth.users import (
+    current_chat_accessible_user,
     current_user_from_websocket,
     get_user_manager,
     optional_fastapi_current_user,
     optional_user,
 )
+from onyx.configs.constants import ANONYMOUS_USER_UUID
 from onyx.db.engine.async_sql_engine import get_async_session
 from shared_configs.contextvars import CURRENT_USER_ID_CONTEXTVAR, get_current_user_id
 
@@ -37,12 +39,12 @@ def test_reset_restores_previous_value() -> None:
     assert get_current_user_id() is None
 
 
-def _authenticated_app(user_id: Any) -> FastAPI:
+def _authenticated_app(user_id: Any | None) -> FastAPI:
     class _FakeUser:
         id = user_id
 
-    async def fake_auth() -> _FakeUser:
-        return _FakeUser()
+    async def fake_auth() -> _FakeUser | None:
+        return _FakeUser() if user_id is not None else None
 
     async def skip_oauth_refresh(*_: Any) -> None:
         return None
@@ -112,6 +114,35 @@ def test_optional_user_context_is_set_for_endpoint_body(
 
     assert resp.status_code == 200
     assert resp.json() == {"user_id": str(user_id)}
+    assert get_current_user_id() is None
+
+
+def test_anonymous_chat_context_propagates_to_streamed_chunks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _authenticated_app(None)
+    monkeypatch.setattr(users, "anonymous_user_enabled", lambda **_: True)
+    reads: list[str | None] = []
+
+    def chat_gate(
+        _user: Any = Depends(current_chat_accessible_user),
+    ) -> None:
+        return None
+
+    @app.post("/anonymous-stream")
+    def stream_ep(
+        _gate: None = Depends(chat_gate),
+    ) -> StreamingResponse:
+        def gen() -> Generator[str, None, None]:
+            reads.append(get_current_user_id())
+            yield "chunk\n"
+
+        return StreamingResponse(gen(), media_type="text/plain")
+
+    response = TestClient(app).post("/anonymous-stream")
+
+    assert response.status_code == 200
+    assert reads == [ANONYMOUS_USER_UUID]
     assert get_current_user_id() is None
 
 

--- a/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
+++ b/web/src/app/admin/token-rate-limits/CreateRateLimitModal.tsx
@@ -10,6 +10,9 @@ import { UserGroup } from "@/lib/types";
 import { Scope } from "./types";
 import { toast } from "@opal/layouts";
 import { SvgSettings } from "@opal/icons";
+
+const HOURS_PER_DAY = 24;
+
 interface CreateRateLimitModalProps {
   isOpen: boolean;
   setIsOpen: (isOpen: boolean) => void;
@@ -67,15 +70,16 @@ export default function CreateRateLimitModal({
         <Formik
           initialValues={{
             enabled: true,
-            period_hours: "",
+            period_days: "",
             token_budget: "",
             target_scope: forSpecificScope || Scope.GLOBAL,
             user_group_id: forSpecificUserGroup,
           }}
           validationSchema={Yup.object().shape({
-            period_hours: Yup.number()
+            period_days: Yup.number()
               .required("Time Window is a required field")
-              .min(1, "Time Window must be at least 1 hour"),
+              .integer("Time Window must be a whole number of days")
+              .min(1, "Time Window must be at least 1 day"),
             token_budget: Yup.number()
               .required("Token Budget is a required field")
               .min(1, "Token Budget must be at least 1"),
@@ -98,7 +102,7 @@ export default function CreateRateLimitModal({
             formikHelpers.setSubmitting(true);
             onSubmit(
               values.target_scope,
-              Number(values.period_hours),
+              Number(values.period_days) * HOURS_PER_DAY,
               Number(values.token_budget),
               Number(values.user_group_id)
             );
@@ -136,8 +140,8 @@ export default function CreateRateLimitModal({
                     />
                   )}
                 <TextFormField
-                  name="period_hours"
-                  label="Time Window (Hours)"
+                  name="period_days"
+                  label="Time Window (UTC Days)"
                   type="number"
                   placeholder=""
                 />

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -19,6 +19,8 @@ import { TableHeader } from "@/components/ui/table";
 import { Text } from "@opal/components";
 import { Spacer } from "@opal/components";
 
+const HOURS_PER_DAY = 24;
+
 type TokenRateLimitTableArgs = {
   tokenRateLimits: TokenRateLimitDisplay[];
   title?: string;
@@ -101,7 +103,7 @@ export const TokenRateLimitTable = ({
           <TableRow>
             <TableHead>Enabled</TableHead>
             {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
-            <TableHead>Time Window (Hours)</TableHead>
+            <TableHead>Time Window (UTC Days)</TableHead>
             <TableHead>Token Budget (Thousands)</TableHead>
             {isAdmin && <TableHead>Delete</TableHead>}
           </TableRow>
@@ -147,9 +149,9 @@ export const TokenRateLimitTable = ({
                   </TableCell>
                 )}
                 <TableCell>
-                  {tokenRateLimit.period_hours +
-                    " hour" +
-                    (tokenRateLimit.period_hours > 1 ? "s" : "")}
+                  {tokenRateLimit.period_hours / HOURS_PER_DAY +
+                    " day" +
+                    (tokenRateLimit.period_hours > HOURS_PER_DAY ? "s" : "")}
                 </TableCell>
                 <TableCell>
                   {tokenRateLimit.token_budget + " thousand tokens"}

--- a/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
+++ b/web/src/app/admin/token-rate-limits/TokenRateLimitTables.tsx
@@ -20,6 +20,18 @@ import { Text } from "@opal/components";
 import { Spacer } from "@opal/components";
 
 const HOURS_PER_DAY = 24;
+const UTC_DAY_LABEL = "UTC day";
+const HOUR_LABEL = "hour";
+const COST_ONLY_LABEL = "Cost only";
+
+function formatPeriod(tokenRateLimit: TokenRateLimitDisplay): string {
+  const isTokenBudget = tokenRateLimit.token_budget !== null;
+  const value = isTokenBudget
+    ? tokenRateLimit.period_hours / HOURS_PER_DAY
+    : tokenRateLimit.period_hours;
+  const unit = isTokenBudget ? UTC_DAY_LABEL : HOUR_LABEL;
+  return `${value} ${unit}${value === 1 ? "" : "s"}`;
+}
 
 type TokenRateLimitTableArgs = {
   tokenRateLimits: TokenRateLimitDisplay[];
@@ -103,7 +115,7 @@ export const TokenRateLimitTable = ({
           <TableRow>
             <TableHead>Enabled</TableHead>
             {shouldRenderGroupName() && <TableHead>Group Name</TableHead>}
-            <TableHead>Time Window (UTC Days)</TableHead>
+            <TableHead>Time Window</TableHead>
             <TableHead>Token Budget (Thousands)</TableHead>
             {isAdmin && <TableHead>Delete</TableHead>}
           </TableRow>
@@ -148,13 +160,11 @@ export const TokenRateLimitTable = ({
                     {tokenRateLimit.group_name}
                   </TableCell>
                 )}
+                <TableCell>{formatPeriod(tokenRateLimit)}</TableCell>
                 <TableCell>
-                  {tokenRateLimit.period_hours / HOURS_PER_DAY +
-                    " day" +
-                    (tokenRateLimit.period_hours > HOURS_PER_DAY ? "s" : "")}
-                </TableCell>
-                <TableCell>
-                  {tokenRateLimit.token_budget + " thousand tokens"}
+                  {tokenRateLimit.token_budget === null
+                    ? COST_ONLY_LABEL
+                    : `${tokenRateLimit.token_budget} thousand tokens`}
                 </TableCell>
                 {isAdmin && (
                   <TableCell>

--- a/web/src/app/admin/token-rate-limits/types.ts
+++ b/web/src/app/admin/token-rate-limits/types.ts
@@ -6,14 +6,14 @@ export enum Scope {
 
 export interface TokenRateLimitArgs {
   enabled: boolean;
-  token_budget: number;
+  token_budget: number | null;
   period_hours: number;
 }
 
 export interface TokenRateLimit {
   token_id: number;
   enabled: boolean;
-  token_budget: number;
+  token_budget: number | null;
   period_hours: number;
 }
 

--- a/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/CreateGroupPage.tsx
@@ -32,7 +32,7 @@ function CreateGroupPage() {
   const [selectedDocSetIds, setSelectedDocSetIds] = useState<number[]>([]);
   const [selectedAgentIds, setSelectedAgentIds] = useState<number[]>([]);
   const [tokenLimits, setTokenLimits] = useState<TokenLimit[]>([
-    { tokenBudget: null, periodHours: null },
+    { tokenBudget: null, periodDays: null },
   ]);
 
   const { rows: allRows, isLoading, error } = useGroupMemberCandidates();

--- a/web/src/views/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/views/admin/GroupsPage/EditGroupPage.tsx
@@ -42,6 +42,7 @@ import SharedGroupResources from "@/views/admin/GroupsPage/SharedGroupResources"
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
 
+const HOURS_PER_DAY = 24;
 const addModeColumns = memberTableColumns;
 
 // ---------------------------------------------------------------------------
@@ -100,7 +101,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const [selectedDocSetIds, setSelectedDocSetIds] = useState<number[]>([]);
   const [selectedAgentIds, setSelectedAgentIds] = useState<number[]>([]);
   const [tokenLimits, setTokenLimits] = useState<TokenLimit[]>([
-    { tokenBudget: null, periodHours: null },
+    { tokenBudget: null, periodDays: null },
   ]);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
@@ -141,7 +142,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       setTokenLimits(
         tokenRateLimits.map((trl) => ({
           tokenBudget: trl.token_budget,
-          periodHours: trl.period_hours,
+          periodDays: trl.period_hours / HOURS_PER_DAY,
         }))
       );
     }

--- a/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
+++ b/web/src/views/admin/GroupsPage/TokenLimitSection.tsx
@@ -19,7 +19,7 @@ import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 
 export interface TokenLimit {
   tokenBudget: number | null;
-  periodHours: number | null;
+  periodDays: number | null;
 }
 
 interface TokenLimitSectionProps {
@@ -54,12 +54,12 @@ function TokenLimitSection({
 
   function addLimit() {
     const emptyIndex = limits.findIndex(
-      (l) => l.tokenBudget === null && l.periodHours === null
+      (l) => l.tokenBudget === null && l.periodDays === null
     );
     if (emptyIndex !== -1) return;
     const key = nextKeyRef.current++;
     keysRef.current = [...keysRef.current, key];
-    onLimitsChange([...limits, { tokenBudget: null, periodHours: null }]);
+    onLimitsChange([...limits, { tokenBudget: null, periodDays: null }]);
   }
 
   function removeLimit(index: number) {
@@ -111,7 +111,7 @@ function TokenLimitSection({
                     Time Window
                   </Text>
                   <Text mainUiMuted text03 className="ml-0.5">
-                    (hours)
+                    (UTC days)
                   </Text>
                 </div>
               </div>
@@ -132,10 +132,10 @@ function TokenLimitSection({
                   </div>
                   <div className="flex-1">
                     <InputNumber
-                      value={limit.periodHours}
-                      onChange={(v) => updateLimit(i, "periodHours", v)}
+                      value={limit.periodDays}
+                      onChange={(v) => updateLimit(i, "periodDays", v)}
                       min={1}
-                      placeholder="24"
+                      placeholder="1"
                     />
                   </div>
                   <IconButton

--- a/web/src/views/admin/GroupsPage/svc.ts
+++ b/web/src/views/admin/GroupsPage/svc.ts
@@ -199,9 +199,11 @@ async function updateDocSetGroupSharing(
 // Token rate limits — create / update / delete
 // ---------------------------------------------------------------------------
 
+const HOURS_PER_DAY = 24;
+
 interface TokenLimitPayload {
   tokenBudget: number | null;
-  periodHours: number | null;
+  periodDays: number | null;
 }
 
 interface ExistingTokenLimit {
@@ -218,8 +220,8 @@ async function saveTokenLimits(
 ): Promise<void> {
   // Filter to only valid (non-null) limits
   const validLimits = limits.filter(
-    (l): l is { tokenBudget: number; periodHours: number } =>
-      l.tokenBudget != null && l.periodHours != null
+    (l): l is { tokenBudget: number; periodDays: number } =>
+      l.tokenBudget != null && l.periodDays != null
   );
 
   // Update existing limits (match by index position)
@@ -235,7 +237,7 @@ async function saveTokenLimits(
         body: JSON.stringify({
           enabled: existingLimit.enabled,
           token_budget: limit.tokenBudget,
-          period_hours: limit.periodHours,
+          period_hours: limit.periodDays * HOURS_PER_DAY,
         }),
       }
     );
@@ -257,7 +259,7 @@ async function saveTokenLimits(
         body: JSON.stringify({
           enabled: true,
           token_budget: limit.tokenBudget,
-          period_hours: limit.periodHours,
+          period_hours: limit.periodDays * HOURS_PER_DAY,
         }),
       }
     );


### PR DESCRIPTION
## Description

Switch from the old approach to token tracking (un-indexed scan over chat message filtering chat message time) to use the new UserUsage. This forces us to use only per-day limits, which is an accepted limitation.

## How Has This Been Tested?

added tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched token budget enforcement to daily `UserUsage` buckets and moved all token windows to whole UTC days. Also set the current user context during chat (including anonymous) so streaming responses carry the correct user and rate limits.

- **New Features**
  - Use daily `UserUsage` buckets for tokens at user/group/org levels (`get_user_token_buckets_since`, `get_group_token_buckets_since`, `get_total_token_buckets_since`).
  - Token windows now use whole UTC days; `period_hours` is normalized to 24×N and validated. Legacy limits are shown normalized in `TokenRateLimitDisplay`.
  - Cutoff logic uses `get_token_window_start` for correct UTC-day windows.
  - Consistent rate-limit errors via `OnyxError` with `RATE_LIMITED`.
  - Admin UI shows “Time Window (UTC Days)” and submits days (service converts to hours). Group editor and tables updated; tables show “Cost only” when no token budget.
  - Chat endpoints set `CURRENT_USER_ID_CONTEXTVAR` via `current_chat_accessible_user`, so user context (including anonymous) is available during streaming.

- **Migration**
  - All token budgets apply to whole UTC days. Previous hour-based limits are rounded up: 1–24h → 1 day, 25–48h → 2 days, etc.
  - Update any scripts/clients setting `period_hours` to use 24×N hours. In the UI, enter days.
  - No data migration required.

<sup>Written for commit 90bb498b5861b406cb1a08d38b5733cc55c7478c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

