### PR TITLE
fix(desktop): show Onyx icon in the Linux About dialog

### DIFF
--- a/desktop/src-tauri/src/menu.rs
+++ b/desktop/src-tauri/src/menu.rs
@@ -2,6 +2,8 @@ use crate::config::ConfigState;
 use crate::debug_log::{log_backend_error, MENU_OPEN_DEBUG_LOG_ID, MENU_TOGGLE_DEVTOOLS_ID};
 use crate::window::{focus_main_window, open_chat_window};
 use tauri::image::Image;
+#[cfg(not(target_os = "macos"))]
+use tauri::menu::AboutMetadataBuilder;
 use tauri::menu::{
     CheckMenuItem, Menu, MenuBuilder, MenuItem, PredefinedMenuItem, SubmenuBuilder, HELP_SUBMENU_ID,
 };
@@ -10,6 +12,10 @@ use tauri::{AppHandle, Manager, Wry};
 
 const TRAY_ID: &str = "onyx-tray";
 const TRAY_ICON_BYTES: &[u8] = include_bytes!("../icons/tray-icon.png");
+// GTK's AboutDialog renders the logo at the image's native size (muda does no
+// scaling), so embed the 128px asset rather than the 256px @2x one.
+#[cfg(not(target_os = "macos"))]
+const ABOUT_ICON_BYTES: &[u8] = include_bytes!("../icons/128x128.png");
 const TRAY_MENU_OPEN_APP_ID: &str = "tray_open_app";
 const TRAY_MENU_OPEN_CHAT_ID: &str = "tray_open_chat";
 const TRAY_MENU_SHOW_IN_BAR_ID: &str = "tray_show_in_menu_bar";
@@ -146,6 +152,26 @@ fn build_help_menu(app: &AppHandle, menu: &Menu<Wry>) -> tauri::Result<()> {
         .get(HELP_SUBMENU_ID)
         .and_then(|item| item.as_submenu().cloned())
     {
+        // Off macOS, `Menu::default` seeds this Help menu with a predefined
+        // "About" item (at index 0) whose metadata carries no icon, so the
+        // About dialog shows no logo. Rebuild that metadata -- keeping the name,
+        // version, and copyright `Menu::default` set -- with the Onyx icon added.
+        // (On macOS the About item lives in the app menu, not Help.)
+        #[cfg(not(target_os = "macos"))]
+        {
+            let pkg_info = app.package_info();
+            let config = app.config();
+            let about_metadata = AboutMetadataBuilder::new()
+                .name(Some(pkg_info.name.clone()))
+                .version(Some(pkg_info.version.to_string()))
+                .copyright(config.bundle.copyright.clone())
+                .authors(config.bundle.publisher.clone().map(|p| vec![p]))
+                .icon(Image::from_bytes(ABOUT_ICON_BYTES).ok())
+                .build();
+            let about_item = PredefinedMenuItem::about(app, None, Some(about_metadata))?;
+            help_menu.remove_at(0)?;
+            help_menu.insert(&about_item, 0)?;
+        }
         help_menu.append(&docs_item)?;
     } else {
         let help_menu = SubmenuBuilder::with_id(app, HELP_SUBMENU_ID, "Help")


### PR DESCRIPTION
## Problem

On Linux, the desktop app's **Help → About Onyx** dialog showed no logo. The menu is built from Tauri's `Menu::default()`, which — on every non-macOS platform — seeds the Help menu with a predefined About item whose `AboutMetadata` has name/version/copyright but **no icon**. muda's GTK backend only sets the About dialog's logo when `AboutMetadata.icon` is present (`gtk/mod.rs`: `builder.logo(...)`), so it rendered blank.

## Fix

In `build_help_menu` (`menu.rs`), when the pre-existing Help submenu is found, replace its index-0 About item with an equivalent one that carries the Onyx icon. The replacement metadata is rebuilt to **preserve** the name, version, and copyright that `Menu::default` set, and adds `icon(Image::from_bytes(...))` from the embedded `icons/128x128@2x.png`.

Gated `#[cfg(not(target_os = "macos"))]` — that's exactly where `Menu::default` places the Help-menu About item (Linux + Windows). On macOS the About item lives in the app menu and the native panel already uses the bundle icon, so it's left untouched.

## Verification

- `cargo check` passes on **Linux** — and because this code path is `not(macos)`, the native build actually compiles and type-checks the fix (not just the surrounding code).
- `cargo fmt --check` clean.
- API validated against the pinned crate sources (`tauri` 2.11.1 / `muda` 0.19.1): the `AboutMetadataBuilder` methods, `PredefinedMenuItem::about`, `Submenu::remove_at`/`insert`, and that `Menu::default` seeds Help's About at index 0 on non-macOS. muda's GTK backend wires `AboutMetadata.icon` into the dialog logo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1264" height="2085" alt="20260721_16h00m38s_grim" src="https://github.com/user-attachments/assets/d5974744-4d99-433f-80db-46e440a548c3" />