### PR TITLE
feat: mcp shared api key header

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5387,6 +5387,8 @@ class MCPConnectionConfig(Base):
     #   "refresh_token": "<token>",  # OAuth only
     #   "access_token": "<token>",   # OAuth only
     #   "headers": {"key": "value", "key2": "value2"},
+    #   "header_template": {"Authorization": "Bearer {api_key}"}, # shared API-token config
+    #   "api_token": "<token>",  # shared API-token config
     #   "header_substitutions": {"<key>": "<value>"}, # stored header template substitutions
     #   "request_body": ["path/in/body:value", "path2/in2/body2:value2"] # TBD
     #   "client_id": "<id>",  # For dynamically registered OAuth clients

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -330,7 +330,7 @@ def _resolve_shared_api_token_template(
         return request_template
 
     if existing_config:
-        stored_template = existing_config.get("header_template")
+        stored_template: dict[str, str] | None = existing_config.get("header_template")
         if stored_template:
             return MCPAuthTemplate(
                 headers=stored_template,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -264,6 +264,61 @@ def _resolve_admin_credentials(
     return resolved
 
 
+def _default_shared_api_token_template() -> MCPAuthTemplate:
+    """Return the legacy shared API-token template."""
+    return MCPAuthTemplate(
+        headers={"Authorization": "Bearer {api_key}"},
+        required_fields=["api_key"],
+    )
+
+
+def _extract_shared_api_token(config_data: MCPConnectionData) -> str:
+    """Read the encrypted shared token, with compatibility for old configs."""
+    if api_token := config_data.get("api_token"):
+        return api_token
+
+    authorization = config_data.get("headers", {}).get("Authorization", "")
+    if authorization:
+        return authorization.rsplit(" ", 1)[-1]
+
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        "Existing shared MCP API token could not be recovered; please re-enter it.",
+    )
+
+
+def _resolve_shared_api_token(
+    *,
+    request_api_token: str | None,
+    request_api_token_changed: bool,
+    existing_config: MCPConnectionData | None,
+) -> str | None:
+    """Preserve masked shared tokens when only configuration is edited."""
+    if not request_api_token_changed and existing_config:
+        return _extract_shared_api_token(existing_config)
+
+    if request_api_token:
+        reject_masked_credentials({"api_token": request_api_token})
+    return request_api_token
+
+
+def _build_shared_api_token_config_data(
+    *,
+    api_token: str,
+    auth_template: MCPAuthTemplate | None,
+    user_email: str,
+) -> MCPConnectionData:
+    """Render and persist a shared API-token header template."""
+    template = auth_template or _default_shared_api_token_template()
+    return MCPConnectionData(
+        headers=_build_headers_from_template(
+            template, {"api_key": api_token}, user_email
+        ),
+        header_template=template.headers,
+        api_token=api_token,
+    )
+
+
 def _build_oauth_admin_config_data(
     *,
     client_id: str | None,
@@ -1117,9 +1172,7 @@ def _db_mcp_server_to_api_mcp_server(
                 db_server.admin_connection_config, apply_mask=False
             )
             if db_server.auth_type == MCPAuthenticationType.API_TOKEN:
-                raw_api_key = admin_config_dict["headers"]["Authorization"].split(" ")[
-                    -1
-                ]
+                raw_api_key = _extract_shared_api_token(admin_config_dict)
                 admin_credentials = {
                     "api_key": mask_string(raw_api_key),
                 }
@@ -1187,24 +1240,24 @@ def _db_mcp_server_to_api_mcp_server(
                 admin_credentials = {}
                 logger.warning("No client info found for server %s", db_server.name)
 
-    # The header template is only meaningful for per-user API_TOKEN
-    # servers, where it surfaces placeholder strings (e.g.
-    # `Bearer {API_KEY}`) for the user-side credential prompt. OAuth
-    # per-user servers do not get an `auth_template`: OAuth uses the
-    # handshake URL (`/oauth/connect`) rather than a header template,
-    # so the frontend never consumes one for OAuth flows.
+    # Surface the placeholder header template without exposing rendered
+    # credentials. OAuth servers do not get an auth_template because OAuth
+    # uses the handshake URL rather than a header template.
     auth_template = None
-    if (
-        auth_performer == MCPAuthenticationPerformer.PER_USER
-        and db_server.auth_type != MCPAuthenticationType.OAUTH
-    ):
+    if db_server.auth_type != MCPAuthenticationType.OAUTH:
         try:
             template_config = db_server.admin_connection_config
             if template_config:
                 template_config_dict = extract_connection_data(
                     template_config, apply_mask=False
                 )
-                headers = template_config_dict.get("headers", {})
+                if auth_performer == MCPAuthenticationPerformer.ADMIN:
+                    headers = (
+                        template_config_dict.get("header_template")
+                        or _default_shared_api_token_template().headers
+                    )
+                else:
+                    headers = template_config_dict.get("headers", {})
                 # Prefer the explicitly persisted list; fall back to deriving
                 # from header placeholders for servers created before
                 # `required_fields` was persisted.
@@ -1716,9 +1769,28 @@ def _upsert_mcp_server(
         # against the admin's stored per-user row
         existing_admin_per_user_creds: dict[str, str] = {}
         existing_template_headers: dict[str, str] = {}
+        existing_shared_template_headers: dict[str, str] = {}
         if mcp_server.admin_connection_config:
             existing_template_headers = (
                 existing_admin_config_dict.get("headers", {}) or {}
+            )
+            existing_shared_template_headers = (
+                existing_admin_config_dict.get("header_template")
+                or _default_shared_api_token_template().headers
+            )
+
+        if (
+            request.auth_type == MCPAuthenticationType.API_TOKEN
+            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+        ):
+            request.api_token = _resolve_shared_api_token(
+                request_api_token=request.api_token,
+                request_api_token_changed=request.api_token_changed,
+                existing_config=(
+                    existing_admin_config_dict
+                    if mcp_server.admin_connection_config
+                    else None
+                ),
             )
         if (
             request.auth_type == MCPAuthenticationType.API_TOKEN
@@ -1752,6 +1824,12 @@ def _upsert_mcp_server(
             and request.auth_performer == MCPAuthenticationPerformer.PER_USER
             and request.auth_template is not None
             and request.auth_template.headers != existing_template_headers
+        )
+        shared_api_token_template_changed = (
+            request.auth_type == MCPAuthenticationType.API_TOKEN
+            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            and request.auth_template is not None
+            and request.auth_template.headers != existing_shared_template_headers
         )
         api_token_scheme_changed = (
             request.auth_type == MCPAuthenticationType.API_TOKEN
@@ -1793,6 +1871,11 @@ def _upsert_mcp_server(
                 and (
                     api_token_creds_changed
                     or api_token_template_changed
+                    or shared_api_token_template_changed
+                    or (
+                        request.auth_performer == MCPAuthenticationPerformer.ADMIN
+                        and request.api_token_changed
+                    )
                     or api_token_scheme_changed
                 )
             )
@@ -1898,8 +1981,10 @@ def _upsert_mcp_server(
     if request.auth_performer == MCPAuthenticationPerformer.ADMIN and request.api_token:
         # Admin-managed server: create admin config with API token
         admin_config = create_connection_config(
-            config_data=MCPConnectionData(
-                headers={"Authorization": f"Bearer {request.api_token}"},
+            config_data=_build_shared_api_token_config_data(
+                api_token=request.api_token,
+                auth_template=request.auth_template,
+                user_email=user.email,
             ),
             mcp_server_id=mcp_server.id,
             db_session=db_session,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -108,7 +108,11 @@ from onyx.server.features.mcp.oauth import (
 )
 from onyx.server.features.mcp.ssrf import validate_mcp_outbound_url
 from onyx.server.features.tool.models import ToolSnapshot
-from onyx.utils.encryption import mask_string, reject_masked_credentials
+from onyx.utils.encryption import (
+    is_masked_credential,
+    mask_string,
+    reject_masked_credentials,
+)
 from onyx.utils.logger import setup_logger
 from onyx.utils.url import BLOCKED_HOSTNAMES, SSRFException
 from onyx.utils.variable_functionality import (
@@ -295,12 +299,45 @@ def _resolve_shared_api_token(
     existing_config: MCPConnectionData | None,
 ) -> str | None:
     """Preserve masked shared tokens when only configuration is edited."""
-    if not request_api_token_changed and existing_config:
+    if request_api_token_changed:
+        if request_api_token:
+            reject_masked_credentials({"api_token": request_api_token})
+        return request_api_token
+
+    # A real token in the request takes precedence during auth-mode
+    # conversion, even when older clients omit the changed flag.
+    if request_api_token and not is_masked_credential(request_api_token):
+        return request_api_token
+
+    if existing_config and (
+        "api_token" in existing_config
+        or "Authorization" in existing_config.get("headers", {})
+    ):
         return _extract_shared_api_token(existing_config)
 
     if request_api_token:
         reject_masked_credentials({"api_token": request_api_token})
     return request_api_token
+
+
+def _resolve_shared_api_token_template(
+    *,
+    request_template: MCPAuthTemplate | None,
+    existing_config: MCPConnectionData | None,
+) -> MCPAuthTemplate | None:
+    """Preserve an existing shared header template when omitted on update."""
+    if request_template is not None:
+        return request_template
+
+    if existing_config:
+        stored_template = existing_config.get("header_template")
+        if stored_template:
+            return MCPAuthTemplate(
+                headers=stored_template,
+                required_fields=["api_key"],
+            )
+
+    return None
 
 
 def _build_shared_api_token_config_data(
@@ -1803,6 +1840,14 @@ def _upsert_mcp_server(
             request.auth_type == MCPAuthenticationType.API_TOKEN
             and request.auth_performer == MCPAuthenticationPerformer.ADMIN
         ):
+            request.auth_template = _resolve_shared_api_token_template(
+                request_template=request.auth_template,
+                existing_config=(
+                    existing_admin_config_dict
+                    if mcp_server.admin_connection_config
+                    else None
+                ),
+            )
             request.api_token = _resolve_shared_api_token(
                 request_api_token=request.api_token,
                 request_api_token_changed=request.api_token_changed,

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -17,6 +17,8 @@ from onyx.db.enums import (
 
 # Matches `{placeholder_name}` inside header value templates.
 _PLACEHOLDER_RE = re.compile(r"\{([^}]+)\}")
+# RFC 9110 field-name syntax: a non-empty sequence of HTTP token characters.
+_HTTP_FIELD_NAME_RE = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 
 
 def _build_auto_substitution_map(*, user_email: str) -> dict[str, str]:
@@ -250,12 +252,12 @@ class MCPToolCreateRequest(BaseModel):
             # server is created. Do not materialize that default here, since
             # doing so makes an omitted template look like an explicit edit.
             if self.auth_template is not None:
-                placeholders = {
+                placeholders: set[str] = {
                     match
                     for value in self.auth_template.headers.values()
                     for match in _PLACEHOLDER_RE.findall(value)
                 }
-                unsupported_placeholders = placeholders - {"api_key"}
+                unsupported_placeholders: set[str] = placeholders - {"api_key"}
                 if unsupported_placeholders:
                     raise ValueError(
                         "Shared API-token header templates only support the "
@@ -270,8 +272,7 @@ class MCPToolCreateRequest(BaseModel):
                         "Shared API-token header templates must include the {api_key} placeholder"
                     )
                 if any(
-                    not name.strip()
-                    or any(char in name for char in "\r\n")
+                    _HTTP_FIELD_NAME_RE.fullmatch(name) is None
                     or name.strip().lower() in DENYLISTED_MCP_HEADERS
                     for name in self.auth_template.headers
                 ):

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -74,6 +74,12 @@ class MCPConnectionData(TypedDict):
     in Postgres"""
 
     headers: dict[str, str]
+    # The placeholder form of shared API-token headers. The rendered headers
+    # above remain the source used for outbound requests.
+    header_template: NotRequired[dict[str, str]]
+    # Stored in the encrypted connection config so an admin can edit the
+    # header template without re-entering the masked API token.
+    api_token: NotRequired[str]
     header_substitutions: NotRequired[dict[str, str]]
     # Names of fields the user must supply for header substitution. Persisted
     # only on the per-user template config (the admin's connection config that
@@ -136,6 +142,13 @@ class MCPToolCreateRequest(BaseModel):
     api_token: Optional[str] = Field(
         None, description="API token for api_token auth type"
     )
+    api_token_changed: bool = Field(
+        default=False,
+        description=(
+            "True if the shared API token was edited. When False on an update, "
+            "the stored token is reused instead of the masked request value."
+        ),
+    )
     oauth_client_id: Optional[str] = Field(None, description="OAuth client ID")
     oauth_client_secret: Optional[str] = Field(None, description="OAuth client secret")
     oauth_provider_mode: MCPOAuthProviderMode = Field(
@@ -178,7 +191,11 @@ class MCPToolCreateRequest(BaseModel):
         None, description="MCP transport type (STREAMABLE_HTTP or SSE)"
     )
     auth_template: Optional[MCPAuthTemplate] = Field(
-        None, description="Template configuration for per-user authentication"
+        None,
+        description=(
+            "Authentication header template for API-token authentication. "
+            "Shared templates support the {api_key} placeholder."
+        ),
     )
     admin_credentials: Optional[dict[str, str]] = Field(
         None,
@@ -223,6 +240,43 @@ class MCPToolCreateRequest(BaseModel):
             raise ValueError(
                 "api_token is required when auth_type is 'api_token' and auth_performer is 'admin'"
             )
+
+        if (
+            self.auth_type == MCPAuthenticationType.API_TOKEN
+            and self.auth_performer == MCPAuthenticationPerformer.ADMIN
+        ):
+            if self.auth_template is None:
+                self.auth_template = MCPAuthTemplate(
+                    headers={"Authorization": "Bearer {api_key}"},
+                    required_fields=["api_key"],
+                )
+
+            placeholders = {
+                match
+                for value in self.auth_template.headers.values()
+                for match in _PLACEHOLDER_RE.findall(value)
+            }
+            unsupported_placeholders = placeholders - {"api_key"}
+            if unsupported_placeholders:
+                raise ValueError(
+                    "Shared API-token header templates only support the "
+                    f"{{api_key}} placeholder; unsupported placeholders: "
+                    f"{', '.join(sorted(unsupported_placeholders))}"
+                )
+            if not any(
+                "{api_key}" in value for value in self.auth_template.headers.values()
+            ):
+                raise ValueError(
+                    "Shared API-token header templates must include the {api_key} placeholder"
+                )
+            if any(
+                not name.strip() or name.strip().lower() in DENYLISTED_MCP_HEADERS
+                for name in self.auth_template.headers
+            ):
+                raise ValueError(
+                    "Shared API-token header templates contain an invalid header name"
+                )
+            self.auth_template.required_fields = ["api_key"]
 
         # Validate that API token is not provided for per-user auth
         if (

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -245,38 +245,40 @@ class MCPToolCreateRequest(BaseModel):
             self.auth_type == MCPAuthenticationType.API_TOKEN
             and self.auth_performer == MCPAuthenticationPerformer.ADMIN
         ):
-            if self.auth_template is None:
-                self.auth_template = MCPAuthTemplate(
-                    headers={"Authorization": "Bearer {api_key}"},
-                    required_fields=["api_key"],
-                )
-
-            placeholders = {
-                match
-                for value in self.auth_template.headers.values()
-                for match in _PLACEHOLDER_RE.findall(value)
-            }
-            unsupported_placeholders = placeholders - {"api_key"}
-            if unsupported_placeholders:
-                raise ValueError(
-                    "Shared API-token header templates only support the "
-                    f"{{api_key}} placeholder; unsupported placeholders: "
-                    f"{', '.join(sorted(unsupported_placeholders))}"
-                )
-            if not any(
-                "{api_key}" in value for value in self.auth_template.headers.values()
-            ):
-                raise ValueError(
-                    "Shared API-token header templates must include the {api_key} placeholder"
-                )
-            if any(
-                not name.strip() or name.strip().lower() in DENYLISTED_MCP_HEADERS
-                for name in self.auth_template.headers
-            ):
-                raise ValueError(
-                    "Shared API-token header templates contain an invalid header name"
-                )
-            self.auth_template.required_fields = ["api_key"]
+            # An omitted template is resolved against the existing server
+            # configuration during an update, or defaults to Bearer when a
+            # server is created. Do not materialize that default here, since
+            # doing so makes an omitted template look like an explicit edit.
+            if self.auth_template is not None:
+                placeholders = {
+                    match
+                    for value in self.auth_template.headers.values()
+                    for match in _PLACEHOLDER_RE.findall(value)
+                }
+                unsupported_placeholders = placeholders - {"api_key"}
+                if unsupported_placeholders:
+                    raise ValueError(
+                        "Shared API-token header templates only support the "
+                        f"{{api_key}} placeholder; unsupported placeholders: "
+                        f"{', '.join(sorted(unsupported_placeholders))}"
+                    )
+                if not any(
+                    "{api_key}" in value
+                    for value in self.auth_template.headers.values()
+                ):
+                    raise ValueError(
+                        "Shared API-token header templates must include the {api_key} placeholder"
+                    )
+                if any(
+                    not name.strip()
+                    or any(char in name for char in "\r\n")
+                    or name.strip().lower() in DENYLISTED_MCP_HEADERS
+                    for name in self.auth_template.headers
+                ):
+                    raise ValueError(
+                        "Shared API-token header templates contain an invalid header name"
+                    )
+                self.auth_template.required_fields = ["api_key"]
 
         # Validate that API token is not provided for per-user auth
         if (

--- a/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
@@ -1,0 +1,79 @@
+import pytest
+
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.server.features.mcp.api import (
+    _build_shared_api_token_config_data,
+    _resolve_shared_api_token,
+)
+from onyx.server.features.mcp.models import (
+    MCPAuthTemplate,
+    MCPConnectionData,
+    MCPToolCreateRequest,
+)
+
+
+def _shared_request(
+    auth_template: MCPAuthTemplate | None = None,
+) -> MCPToolCreateRequest:
+    return MCPToolCreateRequest(
+        name="Semrush",
+        description="Shared API-token MCP server",
+        server_url="https://mcp.semrush.com/v2/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        api_token="shared-secret",
+        auth_template=auth_template,
+        transport=MCPTransport.STREAMABLE_HTTP,
+    )
+
+
+def test_shared_api_token_template_renders_and_persists_template() -> None:
+    template = MCPAuthTemplate(
+        headers={"Authorization": "Apikey {api_key}"},
+        required_fields=["api_key"],
+    )
+
+    config_data = _build_shared_api_token_config_data(
+        api_token="shared-secret",
+        auth_template=template,
+        user_email="admin@example.com",
+    )
+
+    assert config_data["headers"] == {"Authorization": "Apikey shared-secret"}
+    assert config_data["header_template"] == {"Authorization": "Apikey {api_key}"}
+    assert config_data["api_token"] == "shared-secret"
+
+
+def test_shared_api_token_template_defaults_to_bearer() -> None:
+    request = _shared_request()
+
+    assert request.auth_template is not None
+    assert request.auth_template.headers == {"Authorization": "Bearer {api_key}"}
+
+
+def test_shared_api_token_template_rejects_non_api_key_placeholders() -> None:
+    with pytest.raises(ValueError, match=r"only support the \{api_key\}"):
+        _shared_request(
+            MCPAuthTemplate(
+                headers={"Authorization": "Apikey {user_email}"},
+                required_fields=[],
+            )
+        )
+
+
+def test_shared_api_token_update_reuses_existing_token() -> None:
+    existing = MCPConnectionData(
+        headers={"Authorization": "Bearer shared-secret"},
+    )
+
+    token = _resolve_shared_api_token(
+        request_api_token="••••••••••••",
+        request_api_token_changed=False,
+        existing_config=existing,
+    )
+
+    assert token == "shared-secret"

--- a/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
@@ -73,11 +73,22 @@ def test_shared_api_token_template_rejects_non_api_key_placeholders() -> None:
         )
 
 
-def test_shared_api_token_template_rejects_crlf_in_header_name() -> None:
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        "X-API-Key\r\nInjected",
+        "X API-Key",
+        "X:API-Key",
+        "X-API-Kéy",
+    ],
+)
+def test_shared_api_token_template_rejects_invalid_header_name(
+    header_name: str,
+) -> None:
     with pytest.raises(ValueError, match="invalid header name"):
         _shared_request(
             MCPAuthTemplate(
-                headers={"X-API-Key\r\nInjected": "{api_key}"},
+                headers={header_name: "{api_key}"},
                 required_fields=[],
             )
         )

--- a/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
@@ -8,6 +8,7 @@ from onyx.db.enums import (
 from onyx.server.features.mcp.api import (
     _build_shared_api_token_config_data,
     _resolve_shared_api_token,
+    _resolve_shared_api_token_template,
 )
 from onyx.server.features.mcp.models import (
     MCPAuthTemplate,
@@ -51,8 +52,15 @@ def test_shared_api_token_template_renders_and_persists_template() -> None:
 def test_shared_api_token_template_defaults_to_bearer() -> None:
     request = _shared_request()
 
-    assert request.auth_template is not None
-    assert request.auth_template.headers == {"Authorization": "Bearer {api_key}"}
+    assert request.auth_template is None
+
+    config_data = _build_shared_api_token_config_data(
+        api_token="shared-secret",
+        auth_template=request.auth_template,
+        user_email="admin@example.com",
+    )
+
+    assert config_data["headers"] == {"Authorization": "Bearer shared-secret"}
 
 
 def test_shared_api_token_template_rejects_non_api_key_placeholders() -> None:
@@ -60,6 +68,16 @@ def test_shared_api_token_template_rejects_non_api_key_placeholders() -> None:
         _shared_request(
             MCPAuthTemplate(
                 headers={"Authorization": "Apikey {user_email}"},
+                required_fields=[],
+            )
+        )
+
+
+def test_shared_api_token_template_rejects_crlf_in_header_name() -> None:
+    with pytest.raises(ValueError, match="invalid header name"):
+        _shared_request(
+            MCPAuthTemplate(
+                headers={"X-API-Key\r\nInjected": "{api_key}"},
                 required_fields=[],
             )
         )
@@ -77,3 +95,34 @@ def test_shared_api_token_update_reuses_existing_token() -> None:
     )
 
     assert token == "shared-secret"
+
+
+def test_shared_api_token_prefers_new_token_during_auth_mode_conversion() -> None:
+    existing = MCPConnectionData(
+        headers={},
+        client_info={"client_id": "oauth-client"},
+    )
+
+    token = _resolve_shared_api_token(
+        request_api_token="new-shared-secret",
+        request_api_token_changed=False,
+        existing_config=existing,
+    )
+
+    assert token == "new-shared-secret"
+
+
+def test_shared_api_token_template_update_preserves_omitted_template() -> None:
+    existing = MCPConnectionData(
+        headers={"X-API-Key": "shared-secret"},
+        header_template={"X-API-Key": "{api_key}"},
+        api_token="shared-secret",
+    )
+
+    template = _resolve_shared_api_token_template(
+        request_template=None,
+        existing_config=existing,
+    )
+
+    assert template is not None
+    assert template.headers == {"X-API-Key": "{api_key}"}

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -33,7 +33,7 @@ export interface MCPServer {
   oauth_additional_auth_params?: Record<string, string>;
   is_authenticated: boolean;
   user_authenticated?: boolean;
-  auth_template?: any;
+  auth_template?: MCPAuthTemplate;
   admin_credentials?: Record<string, string>;
   user_credentials?: Record<string, string>;
   status: MCPServerStatus;
@@ -42,6 +42,11 @@ export interface MCPServer {
   users: string[];
   last_refreshed_at?: string;
   tool_count: number;
+}
+
+export interface MCPAuthTemplate {
+  headers: Record<string, string>;
+  required_fields: string[];
 }
 
 export interface AgentEditorMCPServer extends MCPServer {

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -33,7 +33,7 @@ export interface MCPServer {
   oauth_additional_auth_params?: Record<string, string>;
   is_authenticated: boolean;
   user_authenticated?: boolean;
-  auth_template?: MCPAuthTemplate;
+  auth_template?: MCPAuthTemplate | null;
   admin_credentials?: Record<string, string>;
   user_credentials?: Record<string, string>;
   status: MCPServerStatus;

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -12,6 +12,7 @@ import {
   MCPAuthenticationType,
   MCPAuthenticationPerformer,
   MCPOAuthProviderMode,
+  MCPAuthTemplate,
 } from "@/lib/tools/interfaces";
 export interface ToolStatusUpdateRequest {
   tool_ids: number[];
@@ -187,6 +188,7 @@ export async function upsertMCPServer(serverData: {
   auth_type: MCPAuthenticationType;
   auth_performer: MCPAuthenticationPerformer;
   api_token?: string;
+  api_token_changed?: boolean;
   oauth_client_id?: string;
   oauth_client_secret?: string;
   oauth_provider_mode?: MCPOAuthProviderMode;
@@ -199,7 +201,7 @@ export async function upsertMCPServer(serverData: {
   // overwrite stored values with masked placeholders on resubmit.
   oauth_client_id_changed?: boolean;
   oauth_client_secret_changed?: boolean;
-  auth_template?: any;
+  auth_template?: MCPAuthTemplate;
   admin_credentials?: Record<string, string>;
   // Per-key analogue of `oauth_client_*_changed` for `admin_credentials`.
   admin_credentials_changed?: Record<string, boolean>;

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -17,11 +17,13 @@ interface PerUserAuthConfigProps {
     field: keyof MCPAuthFormValues | string,
     value: unknown
   ) => void;
+  mode?: "per-user" | "shared";
 }
 
 export function PerUserAuthConfig({
   values,
   setFieldValue,
+  mode = "per-user",
 }: PerUserAuthConfigProps) {
   // Use draft state for KeyValue array (like in LLMConnectionFieldsCustom)
   const [headersDraft, setHeadersDraft] = useState<KeyValue[]>(
@@ -117,22 +119,28 @@ export function PerUserAuthConfig({
           />
         </FormField.Control>
         <FormField.Description>
-          Format headers for each user to fill in their individual credentials.
+          {mode === "per-user"
+            ? "Format headers for each user to fill in their individual credentials."
+            : "Format the headers sent with your organization's shared credentials."}{" "}
           Use placeholders like{" "}
           <Text text03 secondaryMono className="inline">
             {"{api_key}"}
           </Text>{" "}
-          or{" "}
-          <Text text03 secondaryMono className="inline">
-            {"{user_email}"}
-          </Text>
-          . Users will be prompted to provide values for placeholders (except
-          user_email).
+          {mode === "per-user" && (
+            <>
+              or{" "}
+              <Text text03 secondaryMono className="inline">
+                {"{user_email}"}
+              </Text>
+              . Users will be prompted to provide values for placeholders
+              (except user_email).
+            </>
+          )}
         </FormField.Description>
       </FormField>
 
       {/* Only show user credentials section if there are required fields */}
-      {requiredFields.length > 0 && (
+      {mode === "per-user" && requiredFields.length > 0 && (
         <>
           <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -31,6 +31,7 @@ import {
   MCPServerStatus,
   MCPServer,
   MCPServersResponse,
+  MCPAuthTemplate,
 } from "@/lib/tools/interfaces";
 import { PerUserAuthConfig } from "@/sections/actions/PerUserAuthConfig";
 import { updateMCPServerStatus, upsertMCPServer } from "@/lib/tools/mcpService";
@@ -43,11 +44,6 @@ interface MCPAuthenticationModalProps {
   skipOverlay?: boolean;
   onTriggerFetchTools?: (serverId: number) => Promise<void> | void;
   mutateMcpServers: KeyedMutator<MCPServersResponse>;
-}
-
-interface MCPAuthTemplate {
-  headers: Record<string, string>;
-  required_fields: string[];
 }
 
 export interface MCPAuthFormValues {
@@ -303,6 +299,9 @@ export default function MCPAuthenticationModal({
     const isPerUserApiToken =
       values.auth_performer === MCPAuthenticationPerformer.PER_USER &&
       authType === MCPAuthenticationType.API_TOKEN;
+    const isAdminApiToken =
+      values.auth_performer === MCPAuthenticationPerformer.ADMIN &&
+      authType === MCPAuthenticationType.API_TOKEN;
     const isKnownProviderOauth =
       authType === MCPAuthenticationType.OAUTH &&
       values.oauth_provider_mode === MCPOAuthProviderMode.KNOWN_PROVIDER;
@@ -342,12 +341,14 @@ export default function MCPAuthenticationModal({
       transport: values.transport,
       auth_type: values.auth_type,
       auth_performer: values.auth_performer,
-      api_token:
-        authType === MCPAuthenticationType.API_TOKEN &&
-        values.auth_performer === MCPAuthenticationPerformer.ADMIN
-          ? values.api_token
+      api_token: isAdminApiToken ? values.api_token : undefined,
+      api_token_changed: isAdminApiToken
+        ? values.api_token !== initialValues.api_token
+        : false,
+      auth_template:
+        authType === MCPAuthenticationType.API_TOKEN
+          ? values.auth_template
           : undefined,
-      auth_template: isPerUserApiToken ? values.auth_template : undefined,
       admin_credentials: isPerUserApiToken
         ? values.user_credentials || {}
         : undefined,
@@ -892,7 +893,12 @@ export default function MCPAuthenticationModal({
 
                         {/* Admin Tab Content */}
                         <Tabs.Content value="admin">
-                          <div className="flex flex-col gap-4 px-2 py-2 bg-background-tint-00 rounded-12">
+                          <div className="flex flex-col gap-4">
+                            <PerUserAuthConfig
+                              values={values}
+                              setFieldValue={setFieldValue}
+                              mode="shared"
+                            />
                             <FormField
                               name="api_token"
                               state={


### PR DESCRIPTION
## What

Adds configurable authentication header templates for shared MCP API tokens.

- Supports custom shared API-token headers and schemes.
- Preserves the existing Bearer-token default.
- Stores the header template separately from the rendered credential.
- Preserves existing tokens when masked values are submitted unchanged.
- Adds validation for supported placeholders and restricted headers.
- Aligns the shared-key authentication UI with the per-user layout.
- Adds unit coverage for rendering, defaults, validation, and token preservation.

## Why

MCP servers do not all accept API tokens through the same header format. Shared authentication currently assumes Bearer authorization, preventing administrators from configuring servers that require custom headers or API-key schemes.

This change extends the existing template-based authentication model without introducing provider-specific behavior.

## How to Review

Review the shared API-token request validation and configuration-building logic in the MCP API and models. Confirm that:

- `{api_key}` substitution is limited to shared credentials.
- Existing shared tokens are not overwritten by masked values.
- Legacy Bearer-token configurations remain compatible.
- The shared-key UI uses the same spacing and structure as the per-user configuration.

## Testing

- Focused backend unit tests pass.
- Frontend formatting, linting, and TypeScript checks pass.
- Applicable pre-commit backend and security checks pass.

## Risks / Impact

Low risk. The default behavior remains unchanged for existing shared API-token configurations. No database migration is required. The main behavioral change is that administrators can customize the headers used for shared API-token authentication.

## Related

[Issue #13277](https://github.com/onyx-dot-app/onyx/issues/13277)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable header templates for shared (admin-managed) MCP API tokens, enabling non-Bearer schemes with a Bearer default. Preserves stored tokens on edit and surfaces header templates for both shared and per-user flows.

- Shared header templates with the {api_key} placeholder; default is Authorization: Bearer {api_key}. Templates must include {api_key}; other placeholders are rejected. Invalid or restricted header names are blocked.
- Template and encrypted api_token are stored separately; `api_token_changed` preserves the existing token on template-only edits. Legacy configs auto-recover the token from Authorization.
- API returns an `auth_template` for admin-managed API-token servers (stored `header_template` or the Bearer default) and for per-user flows; headers render from templates without exposing secrets.
- Frontend: typed MCPAuthTemplate, `api_token_changed` wiring, and a shared-mode header editor with updated copy.
- Added unit tests; no migration required; existing configs remain compatible.

<sup>Written for commit 538b2b5fdf4d5c7066705bdc7646bc8acf1febb6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13278?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

