### PR TITLE
feat(ods): run bun install when desktop workspace deps are missing

### DIFF
--- a/tools/ods/cmd/desktop.go
+++ b/tools/ods/cmd/desktop.go
@@ -48,6 +48,26 @@ func runDesktopScript(args []string) {
 		log.Fatalf("Failed to find desktop directory: %v", err)
 	}
 
+	// desktop is a member of the root bun workspace (see the root package.json
+	// "workspaces" field), so its dependencies are hoisted to and installed from
+	// the repo root rather than desktop/node_modules.
+	root, err := paths.GitRoot()
+	if err != nil {
+		log.Fatalf("Failed to find repo root: %v", err)
+	}
+	rootNodeModules := filepath.Join(root, "node_modules")
+	if needsInstall, reason := nodeModulesNeedsInstall(rootNodeModules); needsInstall {
+		log.Infof("%s, running bun install --frozen-lockfile...", reason)
+		installCmd := exec.Command("bun", "install", "--frozen-lockfile")
+		installCmd.Dir = root
+		installCmd.Stdout = os.Stdout
+		installCmd.Stderr = os.Stderr
+		installCmd.Stdin = os.Stdin
+		if err := installCmd.Run(); err != nil {
+			log.Fatalf("Failed to run bun install: %v", err)
+		}
+	}
+
 	scriptName := args[0]
 	scriptArgs := args[1:]
 	if len(scriptArgs) > 0 && scriptArgs[0] == "--" {


### PR DESCRIPTION
## Summary

`ods web` already installs deps when they are missing. This applies the same behavior to `ods desktop` so `ods desktop <script>` works on a fresh checkout without a manual install step.

Unlike `web/` (which is standalone with its own `web/bun.lock`), **`desktop/` is a member of the root bun workspace** (root `package.json` `"workspaces": [..., "desktop"]`). Its deps are hoisted to and installed from the repo root against the root `bun.lock`, per the desktop README ("install once at the repo root: `bun install`"). So:

- The presence check looks at the **root** `node_modules` (where hoisted deps land), not `desktop/node_modules`.
- The install runs **`bun install --frozen-lockfile` at the repo root** — consistent with the repo's bun tooling, and `--frozen-lockfile` works because the root lockfile exists.
- Reuses the existing `nodeModulesNeedsInstall` helper (shared in the `cmd` package).

## Test plan

- `go build ./...` and `go vet ./cmd/` pass.
- On a checkout with no root `node_modules`, `ods desktop <script>` now runs `bun install --frozen-lockfile` at the repo root before the script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)