### PR TITLE
feat(skills): review uploads before creation

### DIFF
--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { use, useState, useEffect, useCallback, useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { cn } from "@opal/utils";
 import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { PageLoader } from "@opal/layouts";
@@ -26,6 +27,8 @@ import { DiscordChannelsTable } from "@/app/admin/discord-bot/[guild-id]/Discord
 import { DiscordChannelConfig } from "@/app/admin/discord-bot/types";
 import { useAdminAgents } from "@/lib/agents/hooks";
 import { Agent } from "@/lib/agents/types";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
+import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
 
 interface Props {
   params: Promise<{ "guild-id": string }>;
@@ -150,6 +153,7 @@ function GuildDetailContent({
 }
 
 export default function Page({ params }: Props) {
+  const router = useRouter();
   const unwrappedParams = use(params);
   const guildId = Number(unwrappedParams["guild-id"]);
   const { data: guild, refreshGuild } = useDiscordGuild(guildId);
@@ -200,6 +204,9 @@ export default function Page({ params }: Props) {
     }
     return false;
   }, [localChannels, originalChannels]);
+  const unsavedChanges = useUnsavedChangesGuard({
+    isDirty: hasUnsavedChanges,
+  });
 
   // Get list of changed channels for bulk update
   const getChangedChannels = useCallback(() => {
@@ -339,7 +346,7 @@ export default function Page({ params }: Props) {
         icon={SvgServer}
         title={guild?.guild_name || `Server #${guildId}`}
         description={registeredText}
-        backButton
+        backButton={() => unsavedChanges.requestLeave(() => router.back())}
         rightChildren={
           <Button disabled={isUpdateDisabled} onClick={handleSaveChanges}>
             Update Configuration
@@ -412,6 +419,11 @@ export default function Page({ params }: Props) {
           />
         </div>
       </SettingsLayouts.Body>
+      <UnsavedChangesModal
+        open={unsavedChanges.confirmationOpen}
+        onCancel={unsavedChanges.cancelLeave}
+        onDiscard={unsavedChanges.discardAndLeave}
+      />
     </SettingsLayouts.Root>
   );
 }

--- a/web/src/app/admin/discord-bot/[guild-id]/page.tsx
+++ b/web/src/app/admin/discord-bot/[guild-id]/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { use, useState, useEffect, useCallback, useMemo } from "react";
-import { useRouter } from "next/navigation";
 import { cn } from "@opal/utils";
 import SvgSimpleLoader from "@opal/icons/simple-loader";
 import { PageLoader } from "@opal/layouts";
@@ -27,8 +26,6 @@ import { DiscordChannelsTable } from "@/app/admin/discord-bot/[guild-id]/Discord
 import { DiscordChannelConfig } from "@/app/admin/discord-bot/types";
 import { useAdminAgents } from "@/lib/agents/hooks";
 import { Agent } from "@/lib/agents/types";
-import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
-import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
 
 interface Props {
   params: Promise<{ "guild-id": string }>;
@@ -153,7 +150,6 @@ function GuildDetailContent({
 }
 
 export default function Page({ params }: Props) {
-  const router = useRouter();
   const unwrappedParams = use(params);
   const guildId = Number(unwrappedParams["guild-id"]);
   const { data: guild, refreshGuild } = useDiscordGuild(guildId);
@@ -204,9 +200,6 @@ export default function Page({ params }: Props) {
     }
     return false;
   }, [localChannels, originalChannels]);
-  const unsavedChanges = useUnsavedChangesGuard({
-    isDirty: hasUnsavedChanges,
-  });
 
   // Get list of changed channels for bulk update
   const getChangedChannels = useCallback(() => {
@@ -346,7 +339,7 @@ export default function Page({ params }: Props) {
         icon={SvgServer}
         title={guild?.guild_name || `Server #${guildId}`}
         description={registeredText}
-        backButton={() => unsavedChanges.requestLeave(() => router.back())}
+        backButton
         rightChildren={
           <Button disabled={isUpdateDisabled} onClick={handleSaveChanges}>
             Update Configuration
@@ -419,11 +412,6 @@ export default function Page({ params }: Props) {
           />
         </div>
       </SettingsLayouts.Body>
-      <UnsavedChangesModal
-        open={unsavedChanges.confirmationOpen}
-        onCancel={unsavedChanges.cancelLeave}
-        onDiscard={unsavedChanges.discardAndLeave}
-      />
     </SettingsLayouts.Root>
   );
 }

--- a/web/src/app/craft/components/SideBar.tsx
+++ b/web/src/app/craft/components/SideBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { memo, useMemo, useCallback, useState, useEffect, useRef } from "react";
+import type { Route } from "next";
 import { useRouter, usePathname } from "next/navigation";
 import { useBuildContext } from "@/app/craft/contexts/BuildContext";
 import {
@@ -53,6 +54,7 @@ import {
   CRAFT_APPS_PATH,
   CRAFT_TASKS_PATH,
 } from "@/app/craft/v1/constants";
+import { useUnsavedChangesNavigation } from "@/providers/UnsavedChangesNavigationProvider";
 
 // ============================================================================
 // Fun Deleting Messages
@@ -329,6 +331,7 @@ function BuildSessionButton({
 const MemoizedBuildSidebarInner = memo(() => {
   const { folded } = useSidebarState();
   const router = useRouter();
+  const { requestNavigation } = useUnsavedChangesNavigation();
   const pathname = usePathname();
   const session = useSession();
   const sessionHistory = useSessionHistory();
@@ -362,20 +365,25 @@ const MemoizedBuildSidebarInner = memo(() => {
   }, [isEnabled, limits]);
 
   // Navigate to new build - session controller handles setCurrentSession and pre-provisioning
-  const handleNewBuild = useCallback(() => {
-    router.push(CRAFT_PATH);
-  }, [router]);
+  const navigate = useCallback(
+    (destination: Route) => requestNavigation(() => router.push(destination)),
+    [requestNavigation, router]
+  );
+
+  const handleNewBuild = useCallback(() => navigate(CRAFT_PATH), [navigate]);
 
   const handleLoadSession = useCallback(
     (sessionId: string) => {
       // Clicking a session in the sidebar always lands on the main-agent view
       // (one click back from any subagent transcript you were viewing).
-      returnToMainAgent(sessionId);
-      router.push(
-        `${CRAFT_PATH}?${CRAFT_SEARCH_PARAM_NAMES.SESSION_ID}=${sessionId}`
-      );
+      requestNavigation(() => {
+        returnToMainAgent(sessionId);
+        router.push(
+          `${CRAFT_PATH}?${CRAFT_SEARCH_PARAM_NAMES.SESSION_ID}=${sessionId}`
+        );
+      });
     },
-    [router, returnToMainAgent]
+    [requestNavigation, router, returnToMainAgent]
   );
 
   const newBuildButton = useMemo(
@@ -392,13 +400,13 @@ const MemoizedBuildSidebarInner = memo(() => {
       <SidebarTab
         icon={SvgClock}
         folded={folded}
-        href={CRAFT_TASKS_PATH}
+        onClick={() => navigate(CRAFT_TASKS_PATH)}
         selected={pathname.startsWith(CRAFT_TASKS_PATH)}
       >
         Scheduled Tasks
       </SidebarTab>
     ),
-    [folded, pathname]
+    [folded, navigate, pathname]
   );
 
   const appsTab = useMemo(
@@ -406,13 +414,13 @@ const MemoizedBuildSidebarInner = memo(() => {
       <SidebarTab
         icon={SvgPlug}
         folded={folded}
-        href={CRAFT_APPS_PATH}
+        onClick={() => navigate(CRAFT_APPS_PATH)}
         selected={pathname.startsWith(CRAFT_APPS_PATH)}
       >
         Apps
       </SidebarTab>
     ),
-    [folded, pathname]
+    [folded, navigate, pathname]
   );
 
   const skillsPanel = useMemo(
@@ -420,22 +428,26 @@ const MemoizedBuildSidebarInner = memo(() => {
       <SidebarTab
         icon={SvgBlocks}
         folded={folded}
-        href={CRAFT_SKILLS_PATH}
+        onClick={() => navigate(CRAFT_SKILLS_PATH)}
         selected={pathname.startsWith(CRAFT_SKILLS_PATH)}
       >
         Skills
       </SidebarTab>
     ),
-    [folded, pathname]
+    [folded, navigate, pathname]
   );
 
   const backToChatButton = useMemo(
     () => (
-      <SidebarTab icon={SvgArrowLeft} folded={folded} href="/app">
+      <SidebarTab
+        icon={SvgArrowLeft}
+        folded={folded}
+        onClick={() => navigate("/app")}
+      >
         Back to Chat
       </SidebarTab>
     ),
-    [folded]
+    [folded, navigate]
   );
 
   const footer = useMemo(
@@ -492,7 +504,7 @@ const MemoizedBuildSidebarInner = memo(() => {
                   onDelete={() => deleteBuildSession(historyItem.id)}
                   onDeleteActiveSession={
                     session?.id === historyItem.id
-                      ? () => router.push(CRAFT_PATH)
+                      ? () => navigate(CRAFT_PATH)
                       : undefined
                   }
                 />

--- a/web/src/app/craft/v1/skills/new/page.tsx
+++ b/web/src/app/craft/v1/skills/new/page.tsx
@@ -1,5 +1,14 @@
 import SkillEditorPage from "@/views/SkillEditorPage";
 
-export default function CreateSkillPage() {
-  return <SkillEditorPage />;
+interface CreateSkillPageProps {
+  searchParams: Promise<{ draft?: string | string[] }>;
+}
+
+export default async function CreateSkillPage({
+  searchParams,
+}: CreateSkillPageProps) {
+  const { draft } = await searchParams;
+  return (
+    <SkillEditorPage draftId={typeof draft === "string" ? draft : undefined} />
+  );
 }

--- a/web/src/hooks/useUnsavedChangesGuard.test.tsx
+++ b/web/src/hooks/useUnsavedChangesGuard.test.tsx
@@ -1,0 +1,109 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
+import {
+  UnsavedChangesNavigationProvider,
+  useUnsavedChangesNavigation,
+} from "@/providers/UnsavedChangesNavigationProvider";
+
+const mockPush = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+describe("useUnsavedChangesGuard", () => {
+  afterEach(() => {
+    cleanup();
+    jest.restoreAllMocks();
+    mockPush.mockReset();
+    document.body.replaceChildren();
+  });
+
+  it("warns before unloading only while dirty", () => {
+    const { rerender } = renderHook(
+      ({ isDirty }) => useUnsavedChangesGuard({ isDirty }),
+      { initialProps: { isDirty: true } }
+    );
+
+    const dirtyEvent = new Event("beforeunload", { cancelable: true });
+    act(() => window.dispatchEvent(dirtyEvent));
+    expect(dirtyEvent.defaultPrevented).toBe(true);
+
+    rerender({ isDirty: false });
+    const cleanEvent = new Event("beforeunload", { cancelable: true });
+    act(() => window.dispatchEvent(cleanEvent));
+    expect(cleanEvent.defaultPrevented).toBe(false);
+  });
+
+  it("defers requested navigation until discard is confirmed", () => {
+    const navigate = jest.fn();
+    const onDiscard = jest.fn();
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, onDiscard })
+    );
+
+    act(() => result.current.requestLeave(navigate));
+    expect(result.current.confirmationOpen).toBe(true);
+    expect(navigate).not.toHaveBeenCalled();
+
+    act(() => result.current.discardAndLeave());
+    expect(onDiscard).toHaveBeenCalledTimes(1);
+    expect(navigate).toHaveBeenCalledTimes(1);
+    expect(result.current.confirmationOpen).toBe(false);
+  });
+
+  it("guards navigation requested by another component", () => {
+    const navigate = jest.fn();
+    const { result } = renderHook(
+      () => ({
+        guard: useUnsavedChangesGuard({ isDirty: true }),
+        navigation: useUnsavedChangesNavigation(),
+      }),
+      { wrapper: UnsavedChangesNavigationProvider }
+    );
+
+    act(() => result.current.navigation.requestNavigation(navigate));
+    expect(result.current.guard.confirmationOpen).toBe(true);
+    expect(navigate).not.toHaveBeenCalled();
+
+    act(() => result.current.guard.discardAndLeave());
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels pending navigation without discarding changes", () => {
+    const navigate = jest.fn();
+    const onDiscard = jest.fn();
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true, onDiscard })
+    );
+
+    act(() => result.current.requestLeave(navigate));
+    act(() => result.current.cancelLeave());
+    expect(result.current.confirmationOpen).toBe(false);
+    expect(onDiscard).not.toHaveBeenCalled();
+    expect(navigate).not.toHaveBeenCalled();
+  });
+
+  it("guards unmodified internal link clicks", () => {
+    const { result } = renderHook(() =>
+      useUnsavedChangesGuard({ isDirty: true })
+    );
+    const link = document.createElement("a");
+    link.href = "/target?tab=one#section";
+    document.body.append(link);
+
+    const event = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    });
+    act(() => link.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(result.current.confirmationOpen).toBe(true);
+    expect(mockPush).not.toHaveBeenCalled();
+
+    act(() => result.current.discardAndLeave());
+    expect(mockPush).toHaveBeenCalledWith("/target?tab=one#section");
+  });
+});

--- a/web/src/hooks/useUnsavedChangesGuard.ts
+++ b/web/src/hooks/useUnsavedChangesGuard.ts
@@ -1,0 +1,115 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Route } from "next";
+import { useRouter } from "next/navigation";
+import { useUnsavedChangesNavigation } from "@/providers/UnsavedChangesNavigationProvider";
+
+interface UnsavedChangesGuardOptions {
+  isDirty: boolean;
+  onDiscard?: () => void;
+}
+
+export default function useUnsavedChangesGuard({
+  isDirty,
+  onDiscard,
+}: UnsavedChangesGuardOptions) {
+  const router = useRouter();
+  const { registerGuard } = useUnsavedChangesNavigation();
+  const [confirmationOpen, setConfirmationOpen] = useState(false);
+  const pendingNavigation = useRef<(() => void) | null>(null);
+  const onDiscardRef = useRef(onDiscard);
+  onDiscardRef.current = onDiscard;
+
+  const requestLeave = useCallback(
+    (navigate: () => void) => {
+      if (!isDirty) {
+        navigate();
+        return;
+      }
+      pendingNavigation.current = navigate;
+      setConfirmationOpen(true);
+    },
+    [isDirty]
+  );
+
+  const cancelLeave = useCallback(() => {
+    pendingNavigation.current = null;
+    setConfirmationOpen(false);
+  }, []);
+
+  const discardAndLeave = useCallback(() => {
+    const navigate = pendingNavigation.current;
+    pendingNavigation.current = null;
+    setConfirmationOpen(false);
+    onDiscardRef.current?.();
+    navigate?.();
+  }, []);
+
+  useEffect(() => {
+    if (!isDirty) return;
+    return registerGuard(requestLeave);
+  }, [isDirty, registerGuard, requestLeave]);
+
+  useEffect(() => {
+    if (isDirty) return;
+    pendingNavigation.current = null;
+    setConfirmationOpen(false);
+  }, [isDirty]);
+
+  useEffect(() => {
+    if (!isDirty) return;
+
+    function warnBeforeUnload(event: BeforeUnloadEvent) {
+      event.preventDefault();
+    }
+
+    function guardInternalLink(event: MouseEvent) {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      const target = event.target;
+      if (!(target instanceof Element)) return;
+      const anchor = target.closest<HTMLAnchorElement>("a[href]");
+      if (!anchor || anchor.target || anchor.hasAttribute("download")) return;
+
+      const destination = new URL(anchor.href, window.location.href);
+      const current = new URL(window.location.href);
+      if (
+        destination.origin !== current.origin ||
+        (destination.pathname === current.pathname &&
+          destination.search === current.search)
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      requestLeave(() =>
+        router.push(
+          `${destination.pathname}${destination.search}${destination.hash}` as Route
+        )
+      );
+    }
+
+    window.addEventListener("beforeunload", warnBeforeUnload);
+    document.addEventListener("click", guardInternalLink, true);
+    return () => {
+      window.removeEventListener("beforeunload", warnBeforeUnload);
+      document.removeEventListener("click", guardInternalLink, true);
+    };
+  }, [isDirty, requestLeave, router]);
+
+  return {
+    confirmationOpen,
+    requestLeave,
+    cancelLeave,
+    discardAndLeave,
+  };
+}

--- a/web/src/lib/skills/api.test.ts
+++ b/web/src/lib/skills/api.test.ts
@@ -1,5 +1,4 @@
 import {
-  createCustomSkill,
   createCustomSkillFromEditor,
   isSkillNameConflict,
 } from "@/lib/skills/api";
@@ -17,8 +16,7 @@ describe("skills API", () => {
     global.fetch = fetchMock;
   });
 
-  it("sends the confirmed disabled state through both creation APIs", async () => {
-    await createCustomSkill(new File(["bundle"], "skill.zip"), false);
+  it("sends the confirmed disabled state through editor creation", async () => {
     await createCustomSkillFromEditor({
       name: "report-writer",
       description: "Writes reports",
@@ -26,12 +24,11 @@ describe("skills API", () => {
       auto_enable: false,
     });
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(fetchMock.mock.calls[0]![0]).toBe("/api/skills/custom");
-    expect(fetchMock.mock.calls[1]![0]).toBe("/api/skills/custom/editor");
-    for (const [, request] of fetchMock.mock.calls) {
-      expect((request!.body as FormData).get("auto_enable")).toBe("false");
-    }
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]![0]).toBe("/api/skills/custom/editor");
+    expect(
+      (fetchMock.mock.calls[0]![1]!.body as FormData).get("auto_enable")
+    ).toBe("false");
   });
 
   it("recognizes only the dedicated skill-name conflict", () => {

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -44,21 +44,6 @@ async function handle<T>(res: Response): Promise<T> {
 // Mutations
 // ---------------------------------------------------------------------------
 
-export async function createCustomSkill(
-  bundle: File,
-  autoEnable = true
-): Promise<CustomSkill> {
-  const form = new FormData();
-  form.append("bundle", bundle);
-  form.append("auto_enable", String(autoEnable));
-
-  const res = await fetch("/api/skills/custom", {
-    method: "POST",
-    body: form,
-  });
-  return handle<CustomSkill>(res);
-}
-
 export interface CreateCustomSkillInput {
   name: string;
   description: string;

--- a/web/src/lib/skills/creationDraft.test.ts
+++ b/web/src/lib/skills/creationDraft.test.ts
@@ -1,0 +1,42 @@
+import {
+  discardSkillCreationDraft,
+  getSkillCreationDraft,
+  stageSkillCreationDraft,
+  type SkillCreationDraft,
+} from "@/lib/skills/creationDraft";
+
+function draft(name: string): SkillCreationDraft {
+  const file = new File([name], `${name}.zip`);
+  return {
+    contents: {
+      name,
+      description: `${name} description`,
+      instructions_markdown: `${name} instructions`,
+      files: [{ path: "SKILL.md", size: file.size }],
+    },
+    upload: {
+      file,
+      displayName: file.name,
+      entries: [{ path: "SKILL.md", size: file.size }],
+      containsSkillMd: true,
+    },
+  };
+}
+
+describe("skill creation draft", () => {
+  it("retains only the current draft within a tab", () => {
+    const firstDraft = draft("first");
+    const secondDraft = draft("second");
+    const firstId = stageSkillCreationDraft(firstDraft);
+    const secondId = stageSkillCreationDraft(secondDraft);
+
+    expect(getSkillCreationDraft(firstId)).toBeUndefined();
+    expect(getSkillCreationDraft(secondId)).toBe(secondDraft);
+
+    discardSkillCreationDraft(firstId);
+    expect(getSkillCreationDraft(secondId)).toBe(secondDraft);
+
+    discardSkillCreationDraft(secondId);
+    expect(getSkillCreationDraft(secondId)).toBeUndefined();
+  });
+});

--- a/web/src/lib/skills/creationDraft.ts
+++ b/web/src/lib/skills/creationDraft.ts
@@ -1,0 +1,30 @@
+import type { PreparedSkillFilesUpload } from "@/lib/skills/bundleUpload";
+import type { SkillBundleContents } from "@/lib/skills/types";
+
+export interface SkillCreationDraft {
+  contents: SkillBundleContents;
+  upload: PreparedSkillFilesUpload;
+}
+
+interface PendingSkillCreationDraft {
+  id: string;
+  draft: SkillCreationDraft;
+}
+
+let pendingDraft: PendingSkillCreationDraft | undefined;
+
+export function stageSkillCreationDraft(draft: SkillCreationDraft): string {
+  const id = crypto.randomUUID();
+  pendingDraft = { id, draft };
+  return id;
+}
+
+export function getSkillCreationDraft(
+  id: string
+): SkillCreationDraft | undefined {
+  return pendingDraft?.id === id ? pendingDraft.draft : undefined;
+}
+
+export function discardSkillCreationDraft(id: string): void {
+  if (pendingDraft?.id === id) pendingDraft = undefined;
+}

--- a/web/src/providers/AppProvider.tsx
+++ b/web/src/providers/AppProvider.tsx
@@ -19,6 +19,7 @@
  * 5. **ModalProvider** - Global modal state management
  * 6. **SidebarStateProvider** - Sidebar open/closed state
  * 7. **QueryControllerProvider** - Search/Chat mode + query lifecycle
+ * 8. **UnsavedChangesNavigationProvider** - Cross-layout navigation guards
  */
 
 "use client";
@@ -34,6 +35,7 @@ import { AppBackgroundProvider } from "@/providers/AppBackgroundProvider";
 import { QueryControllerProvider } from "@/providers/QueryControllerProvider";
 import { NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK } from "@/lib/constants";
 import { FullWidthChatProvider } from "@/providers/FullWidthChatProvider";
+import { UnsavedChangesNavigationProvider } from "@/providers/UnsavedChangesNavigationProvider";
 
 interface SidebarPersistenceProviderProps {
   children: React.ReactNode;
@@ -80,15 +82,17 @@ export default function AppProvider({ children }: AppProviderProps) {
               <SidebarPersistenceProvider>
                 <QueryControllerProvider>
                   <FullWidthChatProvider>
-                    <ToastProvider
-                      errorAppendix={
-                        NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK
-                          ? "Need help? Join our community at https://discord.gg/4NA5SbzrWb for support!"
-                          : undefined
-                      }
-                    >
-                      {children}
-                    </ToastProvider>
+                    <UnsavedChangesNavigationProvider>
+                      <ToastProvider
+                        errorAppendix={
+                          NEXT_PUBLIC_INCLUDE_ERROR_POPUP_SUPPORT_LINK
+                            ? "Need help? Join our community at https://discord.gg/4NA5SbzrWb for support!"
+                            : undefined
+                        }
+                      >
+                        {children}
+                      </ToastProvider>
+                    </UnsavedChangesNavigationProvider>
                   </FullWidthChatProvider>
                 </QueryControllerProvider>
               </SidebarPersistenceProvider>

--- a/web/src/providers/UnsavedChangesNavigationProvider.tsx
+++ b/web/src/providers/UnsavedChangesNavigationProvider.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from "react";
+
+type Navigate = () => void;
+type NavigationGuard = (navigate: Navigate) => void;
+
+interface UnsavedChangesNavigationContextValue {
+  registerGuard: (guard: NavigationGuard) => () => void;
+  requestNavigation: NavigationGuard;
+}
+
+const UnsavedChangesNavigationContext =
+  createContext<UnsavedChangesNavigationContextValue>({
+    registerGuard: () => () => undefined,
+    requestNavigation: (navigate) => navigate(),
+  });
+
+export function UnsavedChangesNavigationProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const guards = useRef(new Map<symbol, NavigationGuard>());
+
+  const registerGuard = useCallback((guard: NavigationGuard) => {
+    const id = Symbol();
+    guards.current.set(id, guard);
+    return () => guards.current.delete(id);
+  }, []);
+
+  const requestNavigation = useCallback((navigate: Navigate) => {
+    const activeGuard = Array.from(guards.current.values()).at(-1);
+    if (activeGuard) activeGuard(navigate);
+    else navigate();
+  }, []);
+
+  const value = useMemo(
+    () => ({ registerGuard, requestNavigation }),
+    [registerGuard, requestNavigation]
+  );
+
+  return (
+    <UnsavedChangesNavigationContext.Provider value={value}>
+      {children}
+    </UnsavedChangesNavigationContext.Provider>
+  );
+}
+
+export function useUnsavedChangesNavigation() {
+  return useContext(UnsavedChangesNavigationContext);
+}

--- a/web/src/providers/UnsavedChangesNavigationProvider.tsx
+++ b/web/src/providers/UnsavedChangesNavigationProvider.tsx
@@ -33,7 +33,9 @@ export function UnsavedChangesNavigationProvider({
   const registerGuard = useCallback((guard: NavigationGuard) => {
     const id = Symbol();
     guards.current.set(id, guard);
-    return () => guards.current.delete(id);
+    return () => {
+      guards.current.delete(id);
+    };
   }, []);
 
   const requestNavigation = useCallback((navigate: Navigate) => {

--- a/web/src/sections/modals/UnsavedChangesModal.tsx
+++ b/web/src/sections/modals/UnsavedChangesModal.tsx
@@ -1,0 +1,32 @@
+import { Button } from "@opal/components";
+import { SvgAlertTriangle } from "@opal/icons";
+import { ConfirmationModalLayout } from "@opal/layouts";
+
+interface UnsavedChangesModalProps {
+  open: boolean;
+  onCancel: () => void;
+  onDiscard: () => void;
+}
+
+export default function UnsavedChangesModal({
+  open,
+  onCancel,
+  onDiscard,
+}: UnsavedChangesModalProps) {
+  if (!open) return null;
+
+  return (
+    <ConfirmationModalLayout
+      icon={SvgAlertTriangle}
+      title="Discard unsaved changes?"
+      onClose={onCancel}
+      submit={
+        <Button type="button" variant="danger" onClick={onDiscard}>
+          Discard changes
+        </Button>
+      }
+    >
+      Your changes have not been saved. If you leave now, they will be lost.
+    </ConfirmationModalLayout>
+  );
+}

--- a/web/src/sections/modals/skills/CreateSkillModal.test.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.test.tsx
@@ -49,6 +49,8 @@ describe("CreateSkillModal", () => {
     mockInspectSkillBundle.mockReset();
   });
 
+  afterEach(() => jest.restoreAllMocks());
+
   it("inspects the upload and passes an unsaved editor draft onward", async () => {
     const user = setupUser();
     const onContinue = jest.fn();
@@ -77,6 +79,7 @@ describe("CreateSkillModal", () => {
   it("keeps the modal open and reports inspection failures", async () => {
     const user = setupUser();
     const onContinue = jest.fn();
+    const consoleError = jest.spyOn(console, "error").mockImplementation();
     mockInspectSkillBundle.mockRejectedValue(
       new Error("SKILL.md is missing its description")
     );
@@ -92,6 +95,10 @@ describe("CreateSkillModal", () => {
     );
     expect(onContinue).not.toHaveBeenCalled();
     expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to inspect skill bundle",
+      expect.any(Error)
+    );
   });
 
   it("prevents duplicate review submissions while inspection is pending", async () => {

--- a/web/src/sections/modals/skills/CreateSkillModal.test.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.test.tsx
@@ -1,13 +1,18 @@
-import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import {
+  act,
+  deferred,
+  render,
+  screen,
+  setupUser,
+  waitFor,
+} from "@tests/setup/test-utils";
 import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
-import type { CustomSkill } from "@/lib/skills/types";
+import type { SkillBundleContents } from "@/lib/skills/types";
 
-const mockCreateCustomSkill = jest.fn();
 const mockInspectSkillBundle = jest.fn();
 
 jest.mock("@/lib/skills/api", () => ({
   ...jest.requireActual("@/lib/skills/api"),
-  createCustomSkill: (...args: unknown[]) => mockCreateCustomSkill(...args),
   inspectSkillBundle: (...args: unknown[]) => mockInspectSkillBundle(...args),
 }));
 
@@ -29,104 +34,83 @@ jest.mock("@/sections/skills/SkillBundlePicker", () => ({
   ),
 }));
 
+const inspectedContents: SkillBundleContents = {
+  name: "report-writer",
+  description: "Writes polished reports",
+  instructions_markdown: "# Report writer\n\nWrite the requested report.",
+  files: [
+    { path: "SKILL.md", size: 128 },
+    { path: "references/style.md", size: 64 },
+  ],
+};
+
 describe("CreateSkillModal", () => {
   beforeEach(() => {
-    mockCreateCustomSkill.mockReset();
     mockInspectSkillBundle.mockReset();
   });
 
-  it("confirms before creating a same-name skill disabled", async () => {
+  it("inspects the upload and passes an unsaved editor draft onward", async () => {
     const user = setupUser();
-    const onCreated = jest.fn();
-    const conflict = Object.assign(new Error("Name conflict"), {
-      errorCode: "SKILL_NAME_CONFLICT",
-    });
-    const created = {
-      id: "new-skill-id",
-      name: "report-writer",
-      enabled: false,
-    } as CustomSkill;
-    mockInspectSkillBundle.mockResolvedValue({ name: "report-writer" });
-    mockCreateCustomSkill
-      .mockRejectedValueOnce(conflict)
-      .mockResolvedValueOnce(created);
+    const onContinue = jest.fn();
+    mockInspectSkillBundle.mockResolvedValue(inspectedContents);
 
-    render(<CreateSkillModal open onClose={jest.fn()} onCreated={onCreated} />);
+    render(
+      <CreateSkillModal open onClose={jest.fn()} onContinue={onContinue} />
+    );
     await user.click(screen.getByRole("button", { name: "Select bundle" }));
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(screen.getByRole("button", { name: "Review skill" }));
 
-    expect(
-      await screen.findByText("Create another “report-writer” skill?")
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(
-        "The new skill will start disabled. You can switch which one is active from the Skills page."
-      )
-    ).toBeInTheDocument();
-    expect(mockCreateCustomSkill).toHaveBeenCalledTimes(1);
-    expect(mockCreateCustomSkill).toHaveBeenCalledWith(expect.any(File), true);
-    expect(onCreated).not.toHaveBeenCalled();
-
-    await user.click(screen.getByRole("button", { name: "Create anyway" }));
-
-    await waitFor(() => {
-      expect(mockCreateCustomSkill).toHaveBeenNthCalledWith(
-        1,
-        expect.any(File),
-        true
-      );
-      expect(mockCreateCustomSkill).toHaveBeenNthCalledWith(
-        2,
-        expect.any(File),
-        false
-      );
-      expect(onCreated).toHaveBeenCalledWith(created);
-    });
-    expect(mockInspectSkillBundle).toHaveBeenCalledTimes(1);
-  });
-
-  it("returns to the upload without creating when confirmation is canceled", async () => {
-    const user = setupUser();
-    const onCreated = jest.fn();
-    mockInspectSkillBundle.mockResolvedValue({ name: "report-writer" });
-    mockCreateCustomSkill.mockRejectedValue(
-      Object.assign(new Error("Name conflict"), {
-        errorCode: "SKILL_NAME_CONFLICT",
+    await waitFor(() => expect(onContinue).toHaveBeenCalledTimes(1));
+    const draft = onContinue.mock.calls[0]![0];
+    expect(draft.contents).toEqual(inspectedContents);
+    expect(draft.upload).toEqual(
+      expect.objectContaining({
+        displayName: "skill.zip",
+        entries: inspectedContents.files,
+        containsSkillMd: true,
       })
     );
-
-    render(<CreateSkillModal open onClose={jest.fn()} onCreated={onCreated} />);
-    await user.click(screen.getByRole("button", { name: "Select bundle" }));
-    await user.click(screen.getByRole("button", { name: "Create" }));
-    await screen.findByText("Create another “report-writer” skill?");
-
-    await user.click(screen.getByRole("button", { name: "Cancel" }));
-
-    expect(screen.getByRole("button", { name: "Create" })).toBeInTheDocument();
-    expect(mockCreateCustomSkill).toHaveBeenCalledTimes(1);
-    expect(onCreated).not.toHaveBeenCalled();
+    expect(draft.upload.file).toBeInstanceOf(File);
+    expect(mockInspectSkillBundle).toHaveBeenCalledWith(draft.upload.file);
   });
 
-  it("creates immediately when the name is available", async () => {
+  it("keeps the modal open and reports inspection failures", async () => {
     const user = setupUser();
-    const onCreated = jest.fn();
-    const created = {
-      id: "new-skill-id",
-      name: "available-skill",
-      enabled: true,
-    } as CustomSkill;
-    mockInspectSkillBundle.mockResolvedValue({ name: "available-skill" });
-    mockCreateCustomSkill.mockResolvedValue(created);
+    const onContinue = jest.fn();
+    mockInspectSkillBundle.mockRejectedValue(
+      new Error("SKILL.md is missing its description")
+    );
 
-    render(<CreateSkillModal open onClose={jest.fn()} onCreated={onCreated} />);
+    render(
+      <CreateSkillModal open onClose={jest.fn()} onContinue={onContinue} />
+    );
     await user.click(screen.getByRole("button", { name: "Select bundle" }));
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(screen.getByRole("button", { name: "Review skill" }));
 
-    await waitFor(() => expect(onCreated).toHaveBeenCalledWith(created));
-    expect(mockCreateCustomSkill).toHaveBeenCalledTimes(1);
-    expect(mockCreateCustomSkill).toHaveBeenCalledWith(expect.any(File), true);
-    expect(
-      screen.queryByText(/Create another .* skill\?/)
-    ).not.toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "SKILL.md is missing its description"
+    );
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled();
+  });
+
+  it("prevents duplicate review submissions while inspection is pending", async () => {
+    const user = setupUser();
+    const inspection = deferred<SkillBundleContents>();
+    mockInspectSkillBundle.mockReturnValue(inspection.promise);
+
+    render(
+      <CreateSkillModal open onClose={jest.fn()} onContinue={jest.fn()} />
+    );
+    await user.click(screen.getByRole("button", { name: "Select bundle" }));
+    await user.click(screen.getByRole("button", { name: "Review skill" }));
+
+    expect(screen.getByRole("button", { name: "Opening…" })).toBeDisabled();
+    expect(mockInspectSkillBundle).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      inspection.resolve(inspectedContents);
+      await inspection.promise;
+    });
   });
 });

--- a/web/src/sections/modals/skills/CreateSkillModal.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.tsx
@@ -3,157 +3,130 @@
 import { useState } from "react";
 import { Button, Modal, Text } from "@opal/components";
 import { SvgUploadCloud } from "@opal/icons";
-import { toast } from "@opal/layouts";
-import {
-  createCustomSkill,
-  inspectSkillBundle,
-  isSkillNameConflict,
-} from "@/lib/skills/api";
+import { inspectSkillBundle } from "@/lib/skills/api";
 import type { PreparedSkillBundle } from "@/lib/skills/bundleUpload";
-import type { CustomSkill } from "@/lib/skills/types";
+import type { SkillCreationDraft } from "@/lib/skills/creationDraft";
 import SkillBundlePicker from "@/sections/skills/SkillBundlePicker";
-import SkillNameConflictModal from "@/sections/modals/skills/SkillNameConflictModal";
 
 interface CreateSkillModalProps {
   open: boolean;
   onClose: () => void;
-  onCreated: (skill: CustomSkill) => void;
+  onContinue: (draft: SkillCreationDraft) => void;
 }
 
 export default function CreateSkillModal({
   open,
   onClose,
-  onCreated,
+  onContinue,
 }: CreateSkillModalProps) {
   const [bundle, setBundle] = useState<PreparedSkillBundle | null>(null);
   const [preparing, setPreparing] = useState(false);
-  const [submitting, setSubmitting] = useState(false);
+  const [inspecting, setInspecting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [conflictingSkillName, setConflictingSkillName] = useState<
-    string | null
-  >(null);
 
   function reset() {
     setBundle(null);
     setErrorMessage(null);
-    setConflictingSkillName(null);
   }
 
   function handleClose() {
-    if (preparing || submitting) return;
+    if (preparing || inspecting) return;
     reset();
     onClose();
   }
 
-  async function handleSubmit(autoEnable = true, knownSkillName?: string) {
+  async function handleContinue() {
     if (!bundle) return;
-    setSubmitting(true);
+    setInspecting(true);
     setErrorMessage(null);
-    let skillName = knownSkillName;
     try {
-      skillName ??= (await inspectSkillBundle(bundle.file)).name;
-      const created = await createCustomSkill(bundle.file, autoEnable);
-      toast.success(`Created "${created.name}"`);
+      const contents = await inspectSkillBundle(bundle.file);
+      const draft: SkillCreationDraft = {
+        contents,
+        upload: {
+          file: bundle.file,
+          displayName: bundle.displayName,
+          entries: contents.files,
+          containsSkillMd: true,
+        },
+      };
       reset();
-      onCreated(created);
-      onClose();
+      onContinue(draft);
     } catch (error) {
-      if (autoEnable && skillName && isSkillNameConflict(error)) {
-        setConflictingSkillName(skillName);
-        return;
-      }
-      console.error("Failed to create skill", error);
-      setConflictingSkillName(null);
+      console.error("Failed to inspect skill bundle", error);
       setErrorMessage(
-        error instanceof Error ? error.message : "Failed to create skill"
+        error instanceof Error ? error.message : "Failed to read skill"
       );
     } finally {
-      setSubmitting(false);
+      setInspecting(false);
     }
   }
 
   return (
-    <>
-      <Modal
-        open={open && conflictingSkillName === null}
-        onOpenChange={(isOpen) => !isOpen && handleClose()}
-      >
-        <Modal.Content width="sm">
-          <Modal.Header
-            icon={SvgUploadCloud}
-            title="Create skill"
-            description="Upload a SKILL.md file, ZIP file, or skill folder. New skills are private until you choose to share them."
-            onClose={handleClose}
-          />
-          <Modal.Body>
-            <SkillBundlePicker
-              value={bundle}
-              disabled={submitting}
-              onPreparingChange={setPreparing}
-              onChange={(nextBundle) => {
-                setBundle(nextBundle);
-                setErrorMessage(null);
-              }}
-              onError={(message) => {
-                setBundle(null);
-                setErrorMessage(message);
-              }}
-            />
-            <div className="mt-3">
-              <Text as="p" font="main-ui-body" color="text-02">
-                File requirements
-              </Text>
-              <ul className="mt-1 list-disc space-y-1 pl-5">
-                <Text as="li" font="secondary-body" color="text-03">
-                  SKILL.md must include valid frontmatter with a name and
-                  description.
-                </Text>
-                <Text as="li" font="secondary-body" color="text-03">
-                  ZIP files must contain a SKILL.md file.
-                </Text>
-                <Text as="li" font="secondary-body" color="text-03">
-                  Upload one skill at a time.
-                </Text>
-              </ul>
-            </div>
-            {errorMessage && (
-              <div className="mt-2">
-                <Text as="p" font="secondary-body" color="status-error-05">
-                  {errorMessage}
-                </Text>
-              </div>
-            )}
-          </Modal.Body>
-          <Modal.Footer>
-            <Button
-              prominence="secondary"
-              disabled={preparing || submitting}
-              onClick={handleClose}
-            >
-              Cancel
-            </Button>
-            <Button
-              disabled={preparing || submitting || !bundle}
-              onClick={() => void handleSubmit()}
-              icon={SvgUploadCloud}
-            >
-              {submitting ? "Creating…" : "Create"}
-            </Button>
-          </Modal.Footer>
-        </Modal.Content>
-      </Modal>
-
-      {open && conflictingSkillName && (
-        <SkillNameConflictModal
-          skillName={conflictingSkillName}
-          onClose={() => setConflictingSkillName(null)}
-          onConfirm={() => {
-            const skillName = conflictingSkillName;
-            setConflictingSkillName(null);
-            void handleSubmit(false, skillName);
-          }}
+    <Modal open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
+      <Modal.Content width="sm">
+        <Modal.Header
+          icon={SvgUploadCloud}
+          title="Upload skill"
+          description="Upload a SKILL.md file, ZIP file, or skill folder. You can review and edit its details before saving."
+          onClose={handleClose}
         />
-      )}
-    </>
+        <Modal.Body>
+          <SkillBundlePicker
+            value={bundle}
+            disabled={inspecting}
+            onPreparingChange={setPreparing}
+            onChange={(nextBundle) => {
+              setBundle(nextBundle);
+              setErrorMessage(null);
+            }}
+            onError={(message) => {
+              setBundle(null);
+              setErrorMessage(message);
+            }}
+          />
+          <div className="mt-3">
+            <Text as="p" font="main-ui-body" color="text-02">
+              File requirements
+            </Text>
+            <ul className="mt-1 list-disc space-y-1 pl-5">
+              <Text as="li" font="secondary-body" color="text-03">
+                SKILL.md must include valid frontmatter with a name and
+                description.
+              </Text>
+              <Text as="li" font="secondary-body" color="text-03">
+                ZIP files must contain a SKILL.md file.
+              </Text>
+              <Text as="li" font="secondary-body" color="text-03">
+                Upload one skill at a time.
+              </Text>
+            </ul>
+          </div>
+          {errorMessage && (
+            <div role="alert" className="mt-2">
+              <Text as="p" font="secondary-body" color="status-error-05">
+                {errorMessage}
+              </Text>
+            </div>
+          )}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button
+            prominence="secondary"
+            disabled={preparing || inspecting}
+            onClick={handleClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            disabled={preparing || inspecting || !bundle}
+            onClick={() => void handleContinue()}
+            icon={SvgUploadCloud}
+          >
+            {inspecting ? "Opening…" : "Review skill"}
+          </Button>
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
   );
 }

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -15,6 +15,8 @@ const mockRouterPush = jest.fn();
 const mockGetSkillCreationDraft = jest.fn();
 const mockDiscardSkillCreationDraft = jest.fn();
 const mockMutate = jest.fn();
+const mockRefreshSkill = jest.fn();
+const mockUseSWR = jest.fn();
 
 async function fillRequiredFields(user: ReturnType<typeof setupUser>) {
   await user.type(
@@ -42,6 +44,7 @@ jest.mock("next/navigation", () => ({
 jest.mock("swr", () => ({
   __esModule: true,
   ...jest.requireActual("swr"),
+  default: (...args: unknown[]) => mockUseSWR(...args),
   useSWRConfig: () => ({ mutate: mockMutate }),
 }));
 
@@ -68,7 +71,7 @@ jest.mock("@/sections/skills/SkillFilesPicker", () => ({
   default: () => null,
 }));
 
-describe("SkillEditorPage creation", () => {
+describe("SkillEditorPage", () => {
   beforeEach(() => {
     mockCreateCustomSkillFromEditor.mockReset();
     mockRouterReplace.mockReset();
@@ -77,7 +80,17 @@ describe("SkillEditorPage creation", () => {
     mockDiscardSkillCreationDraft.mockReset();
     mockMutate.mockReset();
     mockMutate.mockResolvedValue(undefined);
+    mockRefreshSkill.mockReset();
+    mockUseSWR.mockReset();
+    mockUseSWR.mockReturnValue({
+      data: undefined,
+      error: undefined,
+      isLoading: false,
+      mutate: mockRefreshSkill,
+    });
   });
+
+  afterEach(() => jest.restoreAllMocks());
 
   it("navigates after creation even when the skill-list refresh fails", async () => {
     const user = setupUser();
@@ -181,6 +194,55 @@ describe("SkillEditorPage creation", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/craft/v1/skills");
   });
 
+  it("confirms before leaving an existing skill with unsaved changes", async () => {
+    const user = setupUser();
+    const skill: SkillEditableDetail = {
+      source: "custom",
+      id: "existing-id",
+      name: "report-writer",
+      description: "Writes reports",
+      instructions_markdown: "Write the requested report.",
+      files: [],
+      is_available: true,
+      unavailable_reason: null,
+      is_valid: true,
+      is_personal: true,
+      enabled: true,
+      can_toggle: true,
+      author_user_id: "author-id",
+      author_email: "author@example.com",
+      owner: { id: "author-id", email: "author@example.com" },
+      ownership_vacant: false,
+      created_at: null,
+      updated_at: null,
+      user_shares: [],
+      group_shares: [],
+      public_permission: null,
+      user_permission: "OWNER",
+    };
+    mockUseSWR.mockReturnValue({
+      data: skill,
+      error: undefined,
+      isLoading: false,
+      mutate: mockRefreshSkill,
+    });
+
+    render(<SkillEditorPage skillId={skill.id} />);
+    const description = screen.getByPlaceholderText(
+      "What does this skill help with?"
+    );
+    await user.clear(description);
+    await user.type(description, "Writes detailed reports");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByText("Discard unsaved changes?")).toBeInTheDocument();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Discard changes" }));
+    expect(mockRouterPush).toHaveBeenCalledWith("/craft/v1/skills");
+    expect(mockDiscardSkillCreationDraft).not.toHaveBeenCalled();
+  });
+
   it("requires confirmation before retrying a same-name creation disabled", async () => {
     const user = setupUser();
     const conflict = Object.assign(new Error("Name conflict"), {
@@ -232,6 +294,7 @@ describe("SkillEditorPage creation", () => {
 
   it("keeps the confirmation open when disabled creation fails", async () => {
     const user = setupUser();
+    const consoleError = jest.spyOn(console, "error").mockImplementation();
     const conflict = Object.assign(new Error("Name conflict"), {
       errorCode: "SKILL_NAME_CONFLICT",
     });
@@ -266,5 +329,9 @@ describe("SkillEditorPage creation", () => {
       screen.getByText("Create another “report-writer” skill?")
     ).toBeInTheDocument();
     expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to save skill",
+      expect.any(Error)
+    );
   });
 });

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -181,38 +181,6 @@ describe("SkillEditorPage creation", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/craft/v1/skills");
   });
 
-  it("warns before unloading a create page with unsaved changes", async () => {
-    const user = setupUser();
-    render(<SkillEditorPage />);
-    await user.type(screen.getByPlaceholderText("Name your skill"), "draft");
-
-    const event = new Event("beforeunload", { cancelable: true });
-    act(() => window.dispatchEvent(event));
-
-    expect(event.defaultPrevented).toBe(true);
-  });
-
-  it("restores browser history when discarding is canceled", async () => {
-    const user = setupUser();
-    const confirm = jest.spyOn(window, "confirm").mockReturnValue(false);
-    const forward = jest
-      .spyOn(window.history, "forward")
-      .mockImplementation(() => undefined);
-    render(<SkillEditorPage />);
-    await user.type(screen.getByPlaceholderText("Name your skill"), "draft");
-
-    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
-
-    expect(confirm).toHaveBeenCalledWith("Discard unsaved changes?");
-    expect(forward).toHaveBeenCalledTimes(1);
-
-    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
-    expect(confirm).toHaveBeenCalledTimes(1);
-
-    confirm.mockRestore();
-    forward.mockRestore();
-  });
-
   it("requires confirmation before retrying a same-name creation disabled", async () => {
     const user = setupUser();
     const conflict = Object.assign(new Error("Name conflict"), {

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -181,6 +181,38 @@ describe("SkillEditorPage creation", () => {
     expect(mockRouterPush).toHaveBeenCalledWith("/craft/v1/skills");
   });
 
+  it("warns before unloading a create page with unsaved changes", async () => {
+    const user = setupUser();
+    render(<SkillEditorPage />);
+    await user.type(screen.getByPlaceholderText("Name your skill"), "draft");
+
+    const event = new Event("beforeunload", { cancelable: true });
+    act(() => window.dispatchEvent(event));
+
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it("restores browser history when discarding is canceled", async () => {
+    const user = setupUser();
+    const confirm = jest.spyOn(window, "confirm").mockReturnValue(false);
+    const forward = jest
+      .spyOn(window.history, "forward")
+      .mockImplementation(() => undefined);
+    render(<SkillEditorPage />);
+    await user.type(screen.getByPlaceholderText("Name your skill"), "draft");
+
+    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
+
+    expect(confirm).toHaveBeenCalledWith("Discard unsaved changes?");
+    expect(forward).toHaveBeenCalledTimes(1);
+
+    act(() => window.dispatchEvent(new PopStateEvent("popstate")));
+    expect(confirm).toHaveBeenCalledTimes(1);
+
+    confirm.mockRestore();
+    forward.mockRestore();
+  });
+
   it("requires confirmation before retrying a same-name creation disabled", async () => {
     const user = setupUser();
     const conflict = Object.assign(new Error("Name conflict"), {

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -11,6 +11,10 @@ import type { SkillEditableDetail } from "@/lib/skills/types";
 
 const mockCreateCustomSkillFromEditor = jest.fn();
 const mockRouterReplace = jest.fn();
+const mockRouterPush = jest.fn();
+const mockGetSkillCreationDraft = jest.fn();
+const mockDiscardSkillCreationDraft = jest.fn();
+const mockMutate = jest.fn();
 
 async function fillRequiredFields(user: ReturnType<typeof setupUser>) {
   await user.type(
@@ -30,9 +34,22 @@ async function fillRequiredFields(user: ReturnType<typeof setupUser>) {
 jest.mock("next/navigation", () => ({
   usePathname: () => "/craft/v1/skills/new",
   useRouter: () => ({
-    push: jest.fn(),
+    push: mockRouterPush,
     replace: mockRouterReplace,
   }),
+}));
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  ...jest.requireActual("swr"),
+  useSWRConfig: () => ({ mutate: mockMutate }),
+}));
+
+jest.mock("@/lib/skills/creationDraft", () => ({
+  getSkillCreationDraft: (...args: unknown[]) =>
+    mockGetSkillCreationDraft(...args),
+  discardSkillCreationDraft: (...args: unknown[]) =>
+    mockDiscardSkillCreationDraft(...args),
 }));
 
 jest.mock("@/sections/modals/skills/ShareSkillModal", () => ({
@@ -55,6 +72,113 @@ describe("SkillEditorPage creation", () => {
   beforeEach(() => {
     mockCreateCustomSkillFromEditor.mockReset();
     mockRouterReplace.mockReset();
+    mockRouterPush.mockReset();
+    mockGetSkillCreationDraft.mockReset();
+    mockDiscardSkillCreationDraft.mockReset();
+    mockMutate.mockReset();
+    mockMutate.mockResolvedValue(undefined);
+  });
+
+  it("navigates after creation even when the skill-list refresh fails", async () => {
+    const user = setupUser();
+    const consoleError = jest.spyOn(console, "error").mockImplementation();
+    mockCreateCustomSkillFromEditor.mockResolvedValue({
+      id: "created-id",
+      name: "report-writer",
+      enabled: true,
+    } as SkillEditableDetail);
+    mockMutate.mockRejectedValue(new Error("Refresh failed"));
+
+    render(<SkillEditorPage />);
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockRouterReplace).toHaveBeenCalledWith("/craft/v1/skills")
+    );
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        "Failed to refresh skill list after creation",
+        expect.any(Error)
+      )
+    );
+    expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
+  });
+
+  it("prefills an uploaded draft without creating it until Save", async () => {
+    const user = setupUser();
+    const upload = new File(["bundle"], "report-writer.zip");
+    mockGetSkillCreationDraft.mockReturnValue({
+      contents: {
+        name: "report-writer",
+        description: "Writes reports",
+        instructions_markdown: "Write the requested report.",
+        files: [{ path: "SKILL.md", size: 64 }],
+      },
+      upload: {
+        file: upload,
+        displayName: upload.name,
+        entries: [{ path: "SKILL.md", size: 64 }],
+        containsSkillMd: true,
+      },
+    });
+    const created = {
+      id: "created-id",
+      name: "report-writer",
+      enabled: true,
+    } as SkillEditableDetail;
+    mockCreateCustomSkillFromEditor.mockResolvedValue(created);
+
+    render(<SkillEditorPage draftId="draft-id" />);
+
+    expect(screen.getByDisplayValue("report-writer")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Writes reports")).toBeInTheDocument();
+    expect(
+      screen.getByDisplayValue("Write the requested report.")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("Have an existing skill?")
+    ).not.toBeInTheDocument();
+    expect(mockCreateCustomSkillFromEditor).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledWith(
+        {
+          name: "report-writer",
+          description: "Writes reports",
+          instructions_markdown: "Write the requested report.",
+          auto_enable: true,
+        },
+        upload
+      )
+    );
+    expect(mockDiscardSkillCreationDraft).toHaveBeenCalledWith("draft-id");
+    expect(mockRouterReplace).toHaveBeenCalledWith("/craft/v1/skills");
+  });
+
+  it("confirms before canceling a create page with unsaved changes", async () => {
+    const user = setupUser();
+    render(<SkillEditorPage />);
+
+    expect(screen.getByText("Have an existing skill?")).toBeInTheDocument();
+    await user.type(screen.getByPlaceholderText("Name your skill"), "draft");
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByText("Discard unsaved changes?")).toBeInTheDocument();
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.queryByText("Discard unsaved changes?")
+    ).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("draft")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+    await user.click(screen.getByRole("button", { name: "Discard changes" }));
+    expect(mockRouterPush).toHaveBeenCalledWith("/craft/v1/skills");
   });
 
   it("requires confirmation before retrying a same-name creation disabled", async () => {
@@ -73,7 +197,7 @@ describe("SkillEditorPage creation", () => {
 
     render(<SkillEditorPage />);
     await fillRequiredFields(user);
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
 
     expect(
       await screen.findByText("Create another “report-writer” skill?")
@@ -99,9 +223,7 @@ describe("SkillEditorPage creation", () => {
         }),
         undefined
       );
-      expect(mockRouterReplace).toHaveBeenCalledWith(
-        "/craft/v1/skills/edit/created-id"
-      );
+      expect(mockRouterReplace).toHaveBeenCalledWith("/craft/v1/skills");
     });
     expect(
       screen.queryByText("Create another “report-writer” skill?")
@@ -120,7 +242,7 @@ describe("SkillEditorPage creation", () => {
 
     render(<SkillEditorPage />);
     await fillRequiredFields(user);
-    await user.click(screen.getByRole("button", { name: "Create" }));
+    await user.click(screen.getByRole("button", { name: "Save" }));
     await user.click(
       await screen.findByRole("button", { name: "Create anyway" })
     );

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -49,6 +49,10 @@ import {
 } from "@/lib/skills/api";
 import type { SkillEditableDetail } from "@/lib/skills/types";
 import type { PreparedSkillFilesUpload } from "@/lib/skills/bundleUpload";
+import {
+  discardSkillCreationDraft,
+  getSkillCreationDraft,
+} from "@/lib/skills/creationDraft";
 import InstructionsDisplayModeToggle, {
   type InstructionsDisplayMode,
 } from "@/sections/skills/InstructionsDisplayModeToggle";
@@ -61,6 +65,7 @@ import { ConfirmationModalLayout } from "@opal/layouts";
 
 interface SkillEditorPageProps {
   skillId?: string;
+  draftId?: string;
 }
 
 function getSharingStatus(skill: SkillEditableDetail): {
@@ -97,9 +102,16 @@ function getSharingStatus(skill: SkillEditableDetail): {
   };
 }
 
-export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
+export default function SkillEditorPage({
+  skillId,
+  draftId,
+}: SkillEditorPageProps) {
   const isCreating = skillId === undefined;
   const router = useRouter();
+  const creationDraft = useMemo(
+    () => (isCreating && draftId ? getSkillCreationDraft(draftId) : undefined),
+    [draftId, isCreating]
+  );
   const { mutate } = useSWRConfig();
   const {
     data: skill,
@@ -111,9 +123,13 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
     errorHandlingFetcher
   );
 
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
-  const [instructionsMarkdown, setInstructionsMarkdown] = useState("");
+  const [name, setName] = useState(creationDraft?.contents.name ?? "");
+  const [description, setDescription] = useState(
+    creationDraft?.contents.description ?? ""
+  );
+  const [instructionsMarkdown, setInstructionsMarkdown] = useState(
+    creationDraft?.contents.instructions_markdown ?? ""
+  );
   const [instructionsDisplayMode, setInstructionsDisplayMode] =
     useState<InstructionsDisplayMode>("raw");
   const [hydratedSkillId, setHydratedSkillId] = useState<string | null>(null);
@@ -123,7 +139,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
   const [isPreparingFiles, setIsPreparingFiles] = useState(false);
   const [isUploadingFiles, setIsUploadingFiles] = useState(false);
   const [pendingFilesUpload, setPendingFilesUpload] =
-    useState<PreparedSkillFilesUpload | null>(null);
+    useState<PreparedSkillFilesUpload | null>(creationDraft?.upload ?? null);
   const [filesUploadToConfirm, setFilesUploadToConfirm] =
     useState<PreparedSkillFilesUpload | null>(null);
   const [removingFilePath, setRemovingFilePath] = useState<string | null>(null);
@@ -131,6 +147,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
   const [conflictingSkillName, setConflictingSkillName] = useState<
     string | null
   >(null);
+  const [discardOpen, setDiscardOpen] = useState(false);
 
   const syncEditableFields = useCallback((nextSkill: SkillEditableDetail) => {
     setName(nextSkill.name);
@@ -159,6 +176,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
     description,
     instructionsMarkdown,
     isCreating,
+    name,
     pendingFilesUpload,
     skill,
   ]);
@@ -185,8 +203,18 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
     !!instructionsMarkdown.trim() &&
     !isSaving;
 
-  function navigateBack() {
+  function leaveEditor() {
+    if (draftId) discardSkillCreationDraft(draftId);
     router.push("/craft/v1/skills" as Route);
+  }
+
+  function handleCancel() {
+    if (isSaving || isPreparingFiles || isUploadingFiles) return;
+    if (isCreating && isDirty) {
+      setDiscardOpen(true);
+      return;
+    }
+    leaveEditor();
   }
 
   async function refreshSkillList() {
@@ -212,9 +240,12 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
           pendingFilesUpload?.file
         );
         setConflictingSkillName(null);
-        await refreshSkillList();
+        if (draftId) discardSkillCreationDraft(draftId);
+        void refreshSkillList().catch((error: unknown) => {
+          console.error("Failed to refresh skill list after creation", error);
+        });
         toast.success(`Created "${created.name}"`);
-        router.replace(`/craft/v1/skills/edit/${created.id}` as Route);
+        router.replace("/craft/v1/skills" as Route);
         return;
       }
 
@@ -356,7 +387,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
 
   const saveTooltip = isSaving
     ? isCreating
-      ? "Creating skill..."
+      ? "Saving skill..."
       : "Saving changes..."
     : !isCreating && !skill
       ? undefined
@@ -411,24 +442,19 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
               <Button
                 prominence="secondary"
                 type="button"
-                onClick={navigateBack}
+                disabled={isSaving || isPreparingFiles || isUploadingFiles}
+                onClick={handleCancel}
               >
                 Cancel
               </Button>
               <Tooltip tooltip={saveTooltip} side="bottom">
                 <Button disabled={!canSave} type="submit">
-                  {isSaving
-                    ? isCreating
-                      ? "Creating..."
-                      : "Saving..."
-                    : isCreating
-                      ? "Create"
-                      : "Save"}
+                  {isSaving ? "Saving..." : "Save"}
                 </Button>
               </Tooltip>
             </div>
           }
-          backButton
+          backButton={handleCancel}
           divider
         />
 
@@ -449,7 +475,7 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
 
           {(isCreating || skill) && !isLoading && !error && (
             <>
-              {isCreating && (
+              {isCreating && !creationDraft && (
                 <>
                   <Section gap={0.5} alignItems="stretch" height="auto">
                     <Card border="solid" rounding="lg" padding="sm">
@@ -738,6 +764,22 @@ export default function SkillEditorPage({ skillId }: SkillEditorPageProps) {
           onConfirm={() => void handleSave(undefined, true)}
           pending={isSaving}
         />
+      )}
+
+      {discardOpen && (
+        <ConfirmationModalLayout
+          icon={SvgAlertTriangle}
+          title="Discard unsaved changes?"
+          onClose={() => setDiscardOpen(false)}
+          submit={
+            <Button type="button" variant="danger" onClick={leaveEditor}>
+              Discard changes
+            </Button>
+          }
+        >
+          This skill has not been saved. If you leave now, your changes will be
+          lost.
+        </ConfirmationModalLayout>
       )}
 
       {skill && deleteOpen && (

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -4,7 +4,6 @@ import {
   useCallback,
   useEffect,
   useMemo,
-  useRef,
   useState,
   type FormEvent,
 } from "react";
@@ -54,12 +53,14 @@ import {
   discardSkillCreationDraft,
   getSkillCreationDraft,
 } from "@/lib/skills/creationDraft";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
 import InstructionsDisplayModeToggle, {
   type InstructionsDisplayMode,
 } from "@/sections/skills/InstructionsDisplayModeToggle";
 import ShareSkillModal from "@/sections/modals/skills/ShareSkillModal";
 import SkillNameConflictModal from "@/sections/modals/skills/SkillNameConflictModal";
 import { ConfirmEntityModal } from "@/sections/modals/ConfirmEntityModal";
+import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
 import SkillFileTree from "@/sections/skills/SkillFileTree";
 import SkillFilesPicker from "@/sections/skills/SkillFilesPicker";
 import { ConfirmationModalLayout } from "@opal/layouts";
@@ -148,8 +149,6 @@ export default function SkillEditorPage({
   const [conflictingSkillName, setConflictingSkillName] = useState<
     string | null
   >(null);
-  const [discardOpen, setDiscardOpen] = useState(false);
-  const restoringHistory = useRef(false);
 
   const syncEditableFields = useCallback((nextSkill: SkillEditableDetail) => {
     setName(nextSkill.name);
@@ -183,6 +182,14 @@ export default function SkillEditorPage({
     skill,
   ]);
 
+  const discardCreationDraft = useCallback(() => {
+    if (draftId) discardSkillCreationDraft(draftId);
+  }, [draftId]);
+  const unsavedChanges = useUnsavedChangesGuard({
+    isDirty: isCreating && isDirty,
+    onDiscard: discardCreationDraft,
+  });
+
   const canManageSkill =
     isCreating ||
     skill?.user_permission === "OWNER" ||
@@ -205,46 +212,13 @@ export default function SkillEditorPage({
     !!instructionsMarkdown.trim() &&
     !isSaving;
 
-  useEffect(() => {
-    if (!isCreating || !isDirty) return;
-
-    function warnBeforeUnload(event: BeforeUnloadEvent) {
-      event.preventDefault();
-    }
-
-    function confirmBrowserBack() {
-      if (restoringHistory.current) {
-        restoringHistory.current = false;
-        return;
-      }
-      if (window.confirm("Discard unsaved changes?")) {
-        if (draftId) discardSkillCreationDraft(draftId);
-        return;
-      }
-      restoringHistory.current = true;
-      window.history.forward();
-    }
-
-    window.addEventListener("beforeunload", warnBeforeUnload);
-    window.addEventListener("popstate", confirmBrowserBack);
-    return () => {
-      window.removeEventListener("beforeunload", warnBeforeUnload);
-      window.removeEventListener("popstate", confirmBrowserBack);
-    };
-  }, [draftId, isCreating, isDirty]);
-
   function leaveEditor() {
-    if (draftId) discardSkillCreationDraft(draftId);
     router.push("/craft/v1/skills" as Route);
   }
 
   function handleCancel() {
     if (isSaving || isPreparingFiles || isUploadingFiles) return;
-    if (isCreating && isDirty) {
-      setDiscardOpen(true);
-      return;
-    }
-    leaveEditor();
+    unsavedChanges.requestLeave(leaveEditor);
   }
 
   async function refreshSkillList() {
@@ -796,21 +770,11 @@ export default function SkillEditorPage({
         />
       )}
 
-      {discardOpen && (
-        <ConfirmationModalLayout
-          icon={SvgAlertTriangle}
-          title="Discard unsaved changes?"
-          onClose={() => setDiscardOpen(false)}
-          submit={
-            <Button type="button" variant="danger" onClick={leaveEditor}>
-              Discard changes
-            </Button>
-          }
-        >
-          This skill has not been saved. If you leave now, your changes will be
-          lost.
-        </ConfirmationModalLayout>
-      )}
+      <UnsavedChangesModal
+        open={unsavedChanges.confirmationOpen}
+        onCancel={unsavedChanges.cancelLeave}
+        onDiscard={unsavedChanges.discardAndLeave}
+      />
 
       {skill && deleteOpen && (
         <ConfirmEntityModal

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -4,6 +4,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type FormEvent,
 } from "react";
@@ -148,6 +149,7 @@ export default function SkillEditorPage({
     string | null
   >(null);
   const [discardOpen, setDiscardOpen] = useState(false);
+  const restoringHistory = useRef(false);
 
   const syncEditableFields = useCallback((nextSkill: SkillEditableDetail) => {
     setName(nextSkill.name);
@@ -202,6 +204,34 @@ export default function SkillEditorPage({
     !!description.trim() &&
     !!instructionsMarkdown.trim() &&
     !isSaving;
+
+  useEffect(() => {
+    if (!isCreating || !isDirty) return;
+
+    function warnBeforeUnload(event: BeforeUnloadEvent) {
+      event.preventDefault();
+    }
+
+    function confirmBrowserBack() {
+      if (restoringHistory.current) {
+        restoringHistory.current = false;
+        return;
+      }
+      if (window.confirm("Discard unsaved changes?")) {
+        if (draftId) discardSkillCreationDraft(draftId);
+        return;
+      }
+      restoringHistory.current = true;
+      window.history.forward();
+    }
+
+    window.addEventListener("beforeunload", warnBeforeUnload);
+    window.addEventListener("popstate", confirmBrowserBack);
+    return () => {
+      window.removeEventListener("beforeunload", warnBeforeUnload);
+      window.removeEventListener("popstate", confirmBrowserBack);
+    };
+  }, [draftId, isCreating, isDirty]);
 
   function leaveEditor() {
     if (draftId) discardSkillCreationDraft(draftId);

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -182,12 +182,9 @@ export default function SkillEditorPage({
     skill,
   ]);
 
-  const discardCreationDraft = useCallback(() => {
-    if (draftId) discardSkillCreationDraft(draftId);
-  }, [draftId]);
   const unsavedChanges = useUnsavedChangesGuard({
-    isDirty: isCreating && isDirty,
-    onDiscard: discardCreationDraft,
+    isDirty,
+    onDiscard: draftId ? () => discardSkillCreationDraft(draftId) : undefined,
   });
 
   const canManageSkill =

--- a/web/src/views/SkillsPage.test.tsx
+++ b/web/src/views/SkillsPage.test.tsx
@@ -14,6 +14,7 @@ const mockRefresh = jest.fn();
 const mockToastError = jest.fn();
 const mockRouterPush = jest.fn();
 const mockUseUserSkills = jest.fn();
+const mockStageSkillCreationDraft = jest.fn();
 
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush }),
@@ -60,9 +61,25 @@ jest.mock("@/sections/cards/SkillCard", () => ({
   ),
 }));
 
+jest.mock("@/lib/skills/creationDraft", () => ({
+  stageSkillCreationDraft: (...args: unknown[]) =>
+    mockStageSkillCreationDraft(...args),
+}));
+
 jest.mock("@/sections/modals/skills/CreateSkillModal", () => ({
   __esModule: true,
-  default: () => null,
+  default: ({
+    open,
+    onContinue,
+  }: {
+    open: boolean;
+    onContinue: (draft: object) => void;
+  }) =>
+    open ? (
+      <button type="button" onClick={() => onContinue({ draft: true })}>
+        Continue upload
+      </button>
+    ) : null,
 }));
 
 jest.mock("@/sections/modals/SkillPreviewModal", () => ({
@@ -126,6 +143,24 @@ describe("SkillsPage preference toggles", () => {
       }
       return skillsData;
     });
+    mockRouterPush.mockReset();
+    mockStageSkillCreationDraft.mockReset();
+    mockStageSkillCreationDraft.mockReturnValue("draft-id");
+  });
+
+  it("routes an uploaded skill draft to the editor without creating it", async () => {
+    const user = setupUser();
+    render(<SkillsPage />);
+
+    await user.click(screen.getByRole("button", { name: "Create skill" }));
+    await user.click(screen.getAllByText("Upload a skill")[0]!);
+    await user.click(screen.getByRole("button", { name: "Continue upload" }));
+
+    expect(mockStageSkillCreationDraft).toHaveBeenCalledWith({ draft: true });
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/craft/v1/skills/new?draft=draft-id"
+    );
+    expect(mockRefresh).not.toHaveBeenCalled();
   });
 
   it("optimistically enables and disables only the pending skill switch", async () => {

--- a/web/src/views/SkillsPage.tsx
+++ b/web/src/views/SkillsPage.tsx
@@ -35,6 +35,7 @@ import SkillCard, {
 import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
 import SkillPreviewModal from "@/sections/modals/SkillPreviewModal";
 import type { BuiltinSkill, CustomSkill } from "@/lib/skills/types";
+import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import { isSkillNameConflict, setSkillEnabled } from "@/lib/skills/api";
 
@@ -350,9 +351,10 @@ export default function SkillsPage() {
       <CreateSkillModal
         open={createOpen}
         onClose={() => setCreateOpen(false)}
-        onCreated={(created) => {
-          refresh();
-          router.push(`/craft/v1/skills/edit/${created.id}` as Route);
+        onContinue={(draft) => {
+          const draftId = stageSkillCreationDraft(draft);
+          setCreateOpen(false);
+          router.push(`/craft/v1/skills/new?draft=${draftId}` as Route);
         }}
       />
 

--- a/web/src/views/admin/CraftInstructionsPage/index.tsx
+++ b/web/src/views/admin/CraftInstructionsPage/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import useSWR, { mutate } from "swr";
 import { Button, Card, Text } from "@opal/components";
 import {
@@ -21,6 +21,8 @@ import { ADMIN_ROUTES } from "@/lib/admin-routes";
 import { useSettings } from "@/lib/settings/hooks";
 import { toSettings } from "@/lib/settings/types";
 import { updateAdminSettings } from "@/lib/settings/svc";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
+import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
 
 const MAX_INSTRUCTIONS_LENGTH = 4000;
 
@@ -65,15 +67,7 @@ export default function CraftInstructionsPage() {
   // null until the user edits — render the saved value until then.
   const value = draft ?? savedInstructions;
   const isDirty = value !== savedInstructions;
-
-  useEffect(() => {
-    if (!isDirty) return;
-    function warn(event: BeforeUnloadEvent) {
-      event.preventDefault();
-    }
-    window.addEventListener("beforeunload", warn);
-    return () => window.removeEventListener("beforeunload", warn);
-  }, [isDirty]);
+  const unsavedChanges = useUnsavedChangesGuard({ isDirty });
 
   async function save(instructions: string): Promise<boolean> {
     if (!settings) return false;
@@ -235,6 +229,11 @@ export default function CraftInstructionsPage() {
           removes your workspace instructions for everyone.
         </ConfirmationModalLayout>
       )}
+      <UnsavedChangesModal
+        open={unsavedChanges.confirmationOpen}
+        onCancel={unsavedChanges.cancelLeave}
+        onDiscard={unsavedChanges.discardAndLeave}
+      />
     </SettingsLayouts.Root>
   );
 }


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/a65a36d4-f87f-464f-becd-63d72bc8556e


Uploading an existing skill now opens the skill editor with the parsed name, description, instructions, and files instead of immediately creating the skill.

The editor saves the reviewed skill explicitly, returns to the skills list after creation, and warns before discarding unsaved creation changes. Upload-based drafts are kept in memory per browser tab so separate tabs do not overwrite each other.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uploading a skill now opens the editor to review and edit details before saving. Added a cross-app unsaved-changes guard that prompts on refresh/back and internal navigation.

- **New Features**
  - Upload opens the editor prefilled; clicking Save creates the skill and returns to the skills list (refresh attempted in the background). Per-tab upload drafts are routed via `?draft=...` and discarded on save/exit.
  - Create modal inspects the bundle, shows inline errors, and uses a “Review skill” action to pass the draft to the editor.
  - Unsaved changes are guarded across the app: editor Cancel/back, Craft sidebar tab switches, and Admin Craft Instructions prompt to discard; beforeunload and unmodified internal link clicks are intercepted.

- **Refactors**
  - Removed `createCustomSkill`; all creation flows use `createCustomSkillFromEditor`.
  - Added `@/lib/skills/creationDraft` and `draftId` support in `SkillEditorPage`.
  - Introduced `useUnsavedChangesGuard`, `UnsavedChangesNavigationProvider` (in `AppProvider`), and `UnsavedChangesModal`; Craft sidebar now requests guarded navigation.

<sup>Written for commit 505d2cc7ea1ddf0a2c3534d8ef294f0d36b5e49d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



