### PR TITLE
fix(image-gen): stream keepalives so LB idle timeouts don't kill slow generations

### DIFF
--- a/backend/onyx/image_gen/generation.py
+++ b/backend/onyx/image_gen/generation.py
@@ -110,6 +110,12 @@ def _default_provider_and_model(
     return llm_provider.provider, config.model_configuration.name, credentials
 
 
+def ensure_image_generation_configured() -> None:
+    """Raises ImageGenerationNotConfiguredError if no default provider is set up."""
+    with get_session_with_current_tenant() as db_session:
+        _default_provider_and_model(db_session)
+
+
 def is_image_generation_configured(db_session: Session) -> bool:
     try:
         _default_provider_and_model(db_session)

--- a/backend/onyx/server/features/image_generation/api.py
+++ b/backend/onyx/server/features/image_generation/api.py
@@ -44,6 +44,10 @@ _MAX_STREAM_DURATION_S = 10 * 60.0
 _generation_executor = ThreadPoolExecutor(
     max_workers=32, thread_name_prefix="image-gen"
 )
+# max_workers bounds execution, not admission — without this a burst would
+# queue unbounded 10-minute runs (each retaining its decoded reference images).
+_MAX_PENDING_GENERATIONS = 64
+_admission_semaphore = threading.BoundedSemaphore(_MAX_PENDING_GENERATIONS)
 
 
 class ReferenceImagePayload(BaseModel):
@@ -91,9 +95,9 @@ def _decode_reference_images(
         if len(data) > _MAX_REFERENCE_IMAGE_BYTES:
             raise size_error
         try:
-            mime_type = payload.mime_type or get_image_type_from_bytes(data)
+            mime_type = get_image_type_from_bytes(data)
         except ValueError:
-            mime_type = "image/png"
+            mime_type = payload.mime_type or "image/png"
         references.append(ReferenceImage(data=data, mime_type=mime_type))
     return references
 
@@ -153,13 +157,21 @@ class _GenerationRun:
         self.error: Exception | None = None
 
     def start(self) -> None:
-        _generation_executor.submit(self._run)
+        if not _admission_semaphore.acquire(blocking=False):
+            raise OnyxError(
+                OnyxErrorCode.RATE_LIMITED,
+                "Too many image generations in progress; try again shortly.",
+            )
+        try:
+            _generation_executor.submit(self._run)
+        except BaseException:
+            _admission_semaphore.release()
+            raise
 
     def _run(self) -> None:
-        if self.abandoned.is_set():
-            self.done.set()
-            return
         try:
+            if self.abandoned.is_set():
+                return
             self.images = self._context.run(
                 generate_images_with_default_config,
                 prompt=self._prompt,
@@ -172,6 +184,7 @@ class _GenerationRun:
             self.error = e
         finally:
             self.done.set()
+            _admission_semaphore.release()
 
 
 def _keepalive_stream(run: _GenerationRun) -> Iterator[bytes]:

--- a/backend/onyx/server/features/image_generation/api.py
+++ b/backend/onyx/server/features/image_generation/api.py
@@ -146,6 +146,9 @@ class _GenerationRun:
         self._reference_images = reference_images
         self._context = contextvars.copy_context()
         self.done = threading.Event()
+        # Set when the stream gives up; a run still queued in the executor
+        # skips the provider call instead of generating for a dead client.
+        self.abandoned = threading.Event()
         self.images: list[GeneratedImageData] | None = None
         self.error: Exception | None = None
 
@@ -153,6 +156,9 @@ class _GenerationRun:
         _generation_executor.submit(self._run)
 
     def _run(self) -> None:
+        if self.abandoned.is_set():
+            self.done.set()
+            return
         try:
             self.images = self._context.run(
                 generate_images_with_default_config,
@@ -177,6 +183,7 @@ def _keepalive_stream(run: _GenerationRun) -> Iterator[bytes]:
                 "Image generation exceeded %ss; abandoning stream",
                 _MAX_STREAM_DURATION_S,
             )
+            run.abandoned.set()
             yield _error_envelope(
                 OnyxError(OnyxErrorCode.GATEWAY_TIMEOUT, "Image generation timed out.")
             )

--- a/backend/onyx/server/features/image_generation/api.py
+++ b/backend/onyx/server/features/image_generation/api.py
@@ -39,7 +39,7 @@ _MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024
 _KEEPALIVE_INTERVAL_S = 15.0
 # The keepalives defeat the LB idle timeout that used to reap hung provider
 # calls, so the stream needs its own ceiling.
-_MAX_STREAM_DURATION_S = 10 * 60.0
+_MAX_STREAM_DURATION_S = 5 * 60.0
 
 _generation_executor = ThreadPoolExecutor(
     max_workers=32, thread_name_prefix="image-gen"

--- a/backend/onyx/server/features/image_generation/api.py
+++ b/backend/onyx/server/features/image_generation/api.py
@@ -23,7 +23,7 @@ from onyx.image_gen.generation import (
     generate_images_with_default_config,
 )
 from onyx.image_gen.interfaces import ImageShape, ReferenceImage
-from onyx.utils.b64 import get_image_type
+from onyx.utils.b64 import get_image_type, get_image_type_from_bytes
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -72,8 +72,15 @@ class ImageGenerationResponse(BaseModel):
 def _decode_reference_images(
     payloads: list[ReferenceImagePayload],
 ) -> list[ReferenceImage]:
+    size_error = OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        f"reference image exceeds {_MAX_REFERENCE_IMAGE_BYTES // (1024 * 1024)} MB",
+    )
     references: list[ReferenceImage] = []
     for payload in payloads:
+        # base64 inflates by 4/3; reject before allocating the decoded copy.
+        if len(payload.data_base64) > _MAX_REFERENCE_IMAGE_BYTES * 4 // 3 + 4:
+            raise size_error
         try:
             data = base64.b64decode(payload.data_base64, validate=True)
         except (binascii.Error, ValueError):
@@ -82,12 +89,9 @@ def _decode_reference_images(
                 "reference image is not valid base64",
             )
         if len(data) > _MAX_REFERENCE_IMAGE_BYTES:
-            raise OnyxError(
-                OnyxErrorCode.INVALID_INPUT,
-                f"reference image exceeds {_MAX_REFERENCE_IMAGE_BYTES // (1024 * 1024)} MB",
-            )
+            raise size_error
         try:
-            mime_type = payload.mime_type or get_image_type(payload.data_base64)
+            mime_type = payload.mime_type or get_image_type_from_bytes(data)
         except ValueError:
             mime_type = "image/png"
         references.append(ReferenceImage(data=data, mime_type=mime_type))
@@ -166,8 +170,9 @@ class _GenerationRun:
 
 def _keepalive_stream(run: _GenerationRun) -> Iterator[bytes]:
     deadline = time.monotonic() + _MAX_STREAM_DURATION_S
-    while not run.done.wait(_KEEPALIVE_INTERVAL_S):
-        if time.monotonic() > deadline:
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
             logger.error(
                 "Image generation exceeded %ss; abandoning stream",
                 _MAX_STREAM_DURATION_S,
@@ -176,6 +181,8 @@ def _keepalive_stream(run: _GenerationRun) -> Iterator[bytes]:
                 OnyxError(OnyxErrorCode.GATEWAY_TIMEOUT, "Image generation timed out.")
             )
             return
+        if run.done.wait(min(_KEEPALIVE_INTERVAL_S, remaining)):
+            break
         yield b" "
     if run.error is not None:
         yield _error_envelope(_map_generation_error(run.error))

--- a/backend/onyx/server/features/image_generation/api.py
+++ b/backend/onyx/server/features/image_generation/api.py
@@ -1,7 +1,14 @@
 import base64
 import binascii
+import contextvars
+import json
+import threading
+import time
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
 
 from fastapi import APIRouter, Depends
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from onyx.auth.permissions import require_permission
@@ -10,7 +17,11 @@ from onyx.db.models import User
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.image_gen.exceptions import ImageGenerationNotConfiguredError
-from onyx.image_gen.generation import generate_images_with_default_config
+from onyx.image_gen.generation import (
+    GeneratedImageData,
+    ensure_image_generation_configured,
+    generate_images_with_default_config,
+)
 from onyx.image_gen.interfaces import ImageShape, ReferenceImage
 from onyx.utils.b64 import get_image_type
 from onyx.utils.logger import setup_logger
@@ -21,6 +32,18 @@ router = APIRouter(prefix="/image-generation")
 
 _MAX_IMAGES = 4
 _MAX_REFERENCE_IMAGES = 16
+_MAX_REFERENCE_IMAGE_BYTES = 20 * 1024 * 1024
+
+# Keepalives stop LB idle timeouts (e.g. ALB's 60s default) from killing
+# slow generations; leading whitespace is valid JSON, so clients are unaffected.
+_KEEPALIVE_INTERVAL_S = 15.0
+# The keepalives defeat the LB idle timeout that used to reap hung provider
+# calls, so the stream needs its own ceiling.
+_MAX_STREAM_DURATION_S = 10 * 60.0
+
+_generation_executor = ThreadPoolExecutor(
+    max_workers=32, thread_name_prefix="image-gen"
+)
 
 
 class ReferenceImagePayload(BaseModel):
@@ -58,6 +81,11 @@ def _decode_reference_images(
                 OnyxErrorCode.INVALID_INPUT,
                 "reference image is not valid base64",
             )
+        if len(data) > _MAX_REFERENCE_IMAGE_BYTES:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                f"reference image exceeds {_MAX_REFERENCE_IMAGE_BYTES // (1024 * 1024)} MB",
+            )
         try:
             mime_type = payload.mime_type or get_image_type(payload.data_base64)
         except ValueError:
@@ -66,45 +94,19 @@ def _decode_reference_images(
     return references
 
 
-@router.post("/generate")
-def generate_image(
-    request: ImageGenerationRequest,
-    _user: User = Depends(require_permission(Permission.GENERATE_IMAGE)),
-) -> ImageGenerationResponse:
-    if not request.prompt.strip():
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "prompt must not be empty")
-    if not 1 <= request.n <= _MAX_IMAGES:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            f"n must be between 1 and {_MAX_IMAGES}",
-        )
-    if len(request.reference_images) > _MAX_REFERENCE_IMAGES:
-        raise OnyxError(
-            OnyxErrorCode.INVALID_INPUT,
-            f"at most {_MAX_REFERENCE_IMAGES} reference images are allowed",
-        )
+def _map_generation_error(error: BaseException) -> OnyxError:
+    if isinstance(error, ImageGenerationNotConfiguredError):
+        return OnyxError(OnyxErrorCode.NOT_FOUND, str(error))
+    if isinstance(error, ValueError):
+        return OnyxError(OnyxErrorCode.INVALID_INPUT, str(error))
+    logger.error("Image generation failed", exc_info=error)
+    return OnyxError(
+        OnyxErrorCode.LLM_PROVIDER_ERROR,
+        "Image generation failed.",
+    )
 
-    reference_images = _decode_reference_images(request.reference_images)
 
-    try:
-        generated = generate_images_with_default_config(
-            prompt=request.prompt,
-            shape=request.shape,
-            n=request.n,
-            quality=request.quality,
-            reference_images=reference_images or None,
-        )
-    except ImageGenerationNotConfiguredError as e:
-        raise OnyxError(OnyxErrorCode.NOT_FOUND, str(e))
-    except ValueError as e:
-        raise OnyxError(OnyxErrorCode.INVALID_INPUT, str(e))
-    except Exception:
-        logger.exception("Image generation failed")
-        raise OnyxError(
-            OnyxErrorCode.LLM_PROVIDER_ERROR,
-            "Image generation failed.",
-        )
-
+def _build_response(generated: list[GeneratedImageData]) -> ImageGenerationResponse:
     images: list[GeneratedImagePayload] = []
     for item in generated:
         try:
@@ -118,5 +120,106 @@ def generate_image(
                 revised_prompt=item.revised_prompt,
             )
         )
-
     return ImageGenerationResponse(images=images)
+
+
+def _error_envelope(error: OnyxError) -> bytes:
+    return json.dumps(
+        {"error_code": error.error_code.code, "detail": error.detail}
+    ).encode()
+
+
+class _GenerationRun:
+    def __init__(
+        self,
+        request: ImageGenerationRequest,
+        reference_images: list[ReferenceImage],
+    ) -> None:
+        self._prompt = request.prompt
+        self._shape = request.shape
+        self._n = request.n
+        self._quality = request.quality
+        self._reference_images = reference_images
+        self._context = contextvars.copy_context()
+        self.done = threading.Event()
+        self.images: list[GeneratedImageData] | None = None
+        self.error: Exception | None = None
+
+    def start(self) -> None:
+        _generation_executor.submit(self._run)
+
+    def _run(self) -> None:
+        try:
+            self.images = self._context.run(
+                generate_images_with_default_config,
+                prompt=self._prompt,
+                shape=self._shape,
+                n=self._n,
+                quality=self._quality,
+                reference_images=self._reference_images or None,
+            )
+        except Exception as e:
+            self.error = e
+        finally:
+            self.done.set()
+
+
+def _keepalive_stream(run: _GenerationRun) -> Iterator[bytes]:
+    deadline = time.monotonic() + _MAX_STREAM_DURATION_S
+    while not run.done.wait(_KEEPALIVE_INTERVAL_S):
+        if time.monotonic() > deadline:
+            logger.error(
+                "Image generation exceeded %ss; abandoning stream",
+                _MAX_STREAM_DURATION_S,
+            )
+            yield _error_envelope(
+                OnyxError(OnyxErrorCode.GATEWAY_TIMEOUT, "Image generation timed out.")
+            )
+            return
+        yield b" "
+    if run.error is not None:
+        yield _error_envelope(_map_generation_error(run.error))
+        return
+    if run.images is None:
+        yield _error_envelope(
+            OnyxError(OnyxErrorCode.LLM_PROVIDER_ERROR, "Image generation failed.")
+        )
+        return
+    yield _build_response(run.images).model_dump_json().encode()
+
+
+@router.post("/generate", responses={200: {"model": ImageGenerationResponse}})
+def generate_image(
+    request: ImageGenerationRequest,
+    _user: User = Depends(require_permission(Permission.GENERATE_IMAGE)),
+) -> StreamingResponse:
+    if not request.prompt.strip():
+        raise OnyxError(OnyxErrorCode.INVALID_INPUT, "prompt must not be empty")
+    if not 1 <= request.n <= _MAX_IMAGES:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"n must be between 1 and {_MAX_IMAGES}",
+        )
+    if len(request.reference_images) > _MAX_REFERENCE_IMAGES:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"at most {_MAX_REFERENCE_IMAGES} reference images are allowed",
+        )
+    reference_images = _decode_reference_images(request.reference_images)
+
+    # Fail with a real 404 before the 200 is committed — older CLIs can't read
+    # the in-band envelope, and this is the most common generation error.
+    try:
+        ensure_image_generation_configured()
+    except ImageGenerationNotConfiguredError as e:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, str(e))
+
+    run = _GenerationRun(request, reference_images)
+    run.start()
+
+    return StreamingResponse(
+        _keepalive_stream(run),
+        media_type="application/json",
+        # Without this nginx buffers the keepalive bytes and the LB still sees an idle connection.
+        headers={"X-Accel-Buffering": "no"},
+    )

--- a/backend/tests/unit/onyx/server/features/image_generation/test_image_generation_endpoint.py
+++ b/backend/tests/unit/onyx/server/features/image_generation/test_image_generation_endpoint.py
@@ -135,6 +135,16 @@ def test_oversized_reference_rejected() -> None:
     assert exc.value.error_code == OnyxErrorCode.INVALID_INPUT
 
 
+def test_admission_limit_rejects_with_rate_limited() -> None:
+    with patch(
+        "onyx.server.features.image_generation.api._admission_semaphore",
+        threading.BoundedSemaphore(0),
+    ):
+        with pytest.raises(OnyxError) as exc:
+            generate_image(ImageGenerationRequest(prompt="a cat"))
+    assert exc.value.error_code == OnyxErrorCode.RATE_LIMITED
+
+
 def test_not_configured_raises_before_stream() -> None:
     with patch(_ENSURE, side_effect=ImageGenerationNotConfiguredError("none")):
         with pytest.raises(OnyxError) as exc:

--- a/backend/tests/unit/onyx/server/features/image_generation/test_image_generation_endpoint.py
+++ b/backend/tests/unit/onyx/server/features/image_generation/test_image_generation_endpoint.py
@@ -1,7 +1,13 @@
+import asyncio
 import base64
+import json
+import threading
+from collections.abc import Iterator
+from typing import Any
 from unittest.mock import patch
 
 import pytest
+from fastapi.responses import StreamingResponse
 
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -17,10 +23,42 @@ from onyx.server.features.image_generation.api import (
 _HELPER = (
     "onyx.server.features.image_generation.api.generate_images_with_default_config"
 )
+_ENSURE = "onyx.server.features.image_generation.api.ensure_image_generation_configured"
+_KEEPALIVE = "onyx.server.features.image_generation.api._KEEPALIVE_INTERVAL_S"
+_MAX_DURATION = "onyx.server.features.image_generation.api._MAX_STREAM_DURATION_S"
 
 _PNG_B64 = base64.b64encode(b"\x89PNG\r\n\x1a\n").decode()
 _JPEG_B64 = base64.b64encode(b"\xff\xd8\xff\xe0jpegbody").decode()
 _NON_IMAGE_B64 = base64.b64encode(b"not an image at all").decode()
+
+
+@pytest.fixture(autouse=True)
+def _configured() -> Iterator[None]:
+    with patch(_ENSURE):
+        yield
+
+
+def _as_bytes(chunk: str | bytes | memoryview) -> bytes:
+    if isinstance(chunk, str):
+        return chunk.encode()
+    return bytes(chunk)
+
+
+def _drain_stream(resp: Any) -> tuple[bytes, dict]:
+    """Returns (keepalive bytes, final decoded JSON) from a StreamingResponse."""
+    assert isinstance(resp, StreamingResponse)
+    assert resp.headers["x-accel-buffering"] == "no"
+    assert resp.headers["content-type"].startswith("application/json")
+
+    async def _collect() -> bytes:
+        body = b""
+        async for chunk in resp.body_iterator:
+            body += _as_bytes(chunk)
+        return body
+
+    body = asyncio.run(_collect())
+    stripped = body.lstrip()
+    return body[: len(body) - len(stripped)], json.loads(stripped)
 
 
 def test_generate_success_detects_mime() -> None:
@@ -28,11 +66,14 @@ def test_generate_success_detects_mime() -> None:
         _HELPER,
         return_value=[GeneratedImageData(b64_data=_PNG_B64, revised_prompt="revised")],
     ):
-        resp = generate_image(ImageGenerationRequest(prompt="a cat"))
-    assert len(resp.images) == 1
-    assert resp.images[0].mime_type == "image/png"
-    assert resp.images[0].revised_prompt == "revised"
-    assert resp.images[0].data_base64 == _PNG_B64
+        _, parsed = _drain_stream(
+            generate_image(ImageGenerationRequest(prompt="a cat"))
+        )
+    images = parsed["images"]
+    assert len(images) == 1
+    assert images[0]["mime_type"] == "image/png"
+    assert images[0]["revised_prompt"] == "revised"
+    assert images[0]["data_base64"] == _PNG_B64
 
 
 def test_generate_detects_jpeg_mime() -> None:
@@ -40,8 +81,10 @@ def test_generate_detects_jpeg_mime() -> None:
         _HELPER,
         return_value=[GeneratedImageData(b64_data=_JPEG_B64, revised_prompt="r")],
     ):
-        resp = generate_image(ImageGenerationRequest(prompt="a cat"))
-    assert resp.images[0].mime_type == "image/jpeg"
+        _, parsed = _drain_stream(
+            generate_image(ImageGenerationRequest(prompt="a cat"))
+        )
+    assert parsed["images"][0]["mime_type"] == "image/jpeg"
 
 
 def test_generate_unrecognized_bytes_fall_back_to_png() -> None:
@@ -49,8 +92,10 @@ def test_generate_unrecognized_bytes_fall_back_to_png() -> None:
         _HELPER,
         return_value=[GeneratedImageData(b64_data=_NON_IMAGE_B64, revised_prompt="r")],
     ):
-        resp = generate_image(ImageGenerationRequest(prompt="a cat"))
-    assert resp.images[0].mime_type == "image/png"
+        _, parsed = _drain_stream(
+            generate_image(ImageGenerationRequest(prompt="a cat"))
+        )
+    assert parsed["images"][0]["mime_type"] == "image/png"
 
 
 def test_empty_prompt_rejected() -> None:
@@ -76,15 +121,10 @@ def test_invalid_base64_reference_rejected() -> None:
     assert exc.value.error_code == OnyxErrorCode.INVALID_INPUT
 
 
-def test_not_configured_maps_to_not_found() -> None:
-    with patch(_HELPER, side_effect=ImageGenerationNotConfiguredError("none")):
-        with pytest.raises(OnyxError) as exc:
-            generate_image(ImageGenerationRequest(prompt="a cat"))
-    assert exc.value.error_code == OnyxErrorCode.NOT_FOUND
-
-
-def test_reference_unsupported_maps_to_invalid_input() -> None:
-    with patch(_HELPER, side_effect=ValueError("no edits")):
+def test_oversized_reference_rejected() -> None:
+    with patch(
+        "onyx.server.features.image_generation.api._MAX_REFERENCE_IMAGE_BYTES", 4
+    ):
         with pytest.raises(OnyxError) as exc:
             generate_image(
                 ImageGenerationRequest(
@@ -95,11 +135,43 @@ def test_reference_unsupported_maps_to_invalid_input() -> None:
     assert exc.value.error_code == OnyxErrorCode.INVALID_INPUT
 
 
-def test_provider_error_maps_to_llm_provider_error() -> None:
-    with patch(_HELPER, side_effect=RuntimeError("boom")):
+def test_not_configured_raises_before_stream() -> None:
+    with patch(_ENSURE, side_effect=ImageGenerationNotConfiguredError("none")):
         with pytest.raises(OnyxError) as exc:
             generate_image(ImageGenerationRequest(prompt="a cat"))
-    assert exc.value.error_code == OnyxErrorCode.LLM_PROVIDER_ERROR
+    assert exc.value.error_code == OnyxErrorCode.NOT_FOUND
+
+
+def test_not_configured_mid_generation_maps_to_not_found_envelope() -> None:
+    with patch(_HELPER, side_effect=ImageGenerationNotConfiguredError("none")):
+        _, parsed = _drain_stream(
+            generate_image(ImageGenerationRequest(prompt="a cat"))
+        )
+    assert parsed["error_code"] == OnyxErrorCode.NOT_FOUND.code
+    assert parsed["detail"] == "none"
+
+
+def test_reference_unsupported_maps_to_invalid_input_envelope() -> None:
+    with patch(_HELPER, side_effect=ValueError("no edits")):
+        _, parsed = _drain_stream(
+            generate_image(
+                ImageGenerationRequest(
+                    prompt="a cat",
+                    reference_images=[ReferenceImagePayload(data_base64=_PNG_B64)],
+                ),
+            )
+        )
+    assert parsed["error_code"] == OnyxErrorCode.INVALID_INPUT.code
+    assert parsed["detail"] == "no edits"
+
+
+def test_provider_error_maps_to_llm_provider_error_envelope() -> None:
+    with patch(_HELPER, side_effect=RuntimeError("boom")):
+        _, parsed = _drain_stream(
+            generate_image(ImageGenerationRequest(prompt="a cat"))
+        )
+    assert parsed["error_code"] == OnyxErrorCode.LLM_PROVIDER_ERROR.code
+    assert parsed["detail"] == "Image generation failed."
 
 
 def test_reference_images_decoded_and_forwarded() -> None:
@@ -110,16 +182,100 @@ def test_reference_images_decoded_and_forwarded() -> None:
         return [GeneratedImageData(b64_data=_PNG_B64, revised_prompt="r")]
 
     with patch(_HELPER, side_effect=_capture):
-        generate_image(
-            ImageGenerationRequest(
-                prompt="a cat",
-                shape=ImageShape.LANDSCAPE,
-                quality="high",
-                reference_images=[ReferenceImagePayload(data_base64=_PNG_B64)],
-            ),
+        _drain_stream(
+            generate_image(
+                ImageGenerationRequest(
+                    prompt="a cat",
+                    shape=ImageShape.LANDSCAPE,
+                    quality="high",
+                    reference_images=[ReferenceImagePayload(data_base64=_PNG_B64)],
+                ),
+            )
         )
     refs = captured["reference_images"]
     assert refs is not None and len(refs) == 1
     assert refs[0].data == base64.b64decode(_PNG_B64)
     assert captured["shape"] == ImageShape.LANDSCAPE
     assert captured["quality"] == "high"
+
+
+def test_slow_generation_streams_repeated_keepalives_then_result() -> None:
+    release = threading.Event()
+
+    def _slow(**_: object) -> list[GeneratedImageData]:
+        release.wait(10)
+        return [GeneratedImageData(b64_data=_PNG_B64, revised_prompt="r")]
+
+    with patch(_HELPER, side_effect=_slow), patch(_KEEPALIVE, 0.02):
+        resp = generate_image(ImageGenerationRequest(prompt="a cat"))
+        assert isinstance(resp, StreamingResponse)
+        assert resp.headers["x-accel-buffering"] == "no"
+
+        async def _consume() -> tuple[bytes, bytes]:
+            iterator = resp.body_iterator.__aiter__()
+            # Multiple keepalives before releasing proves the loop re-fires
+            # rather than pinging once and blocking.
+            keepalives = b""
+            for _ in range(3):
+                keepalives += _as_bytes(await iterator.__anext__())
+            release.set()
+            rest_bytes = b""
+            async for chunk in iterator:
+                rest_bytes += _as_bytes(chunk)
+            return keepalives, rest_bytes
+
+        first, rest = asyncio.run(_consume())
+        assert first == b"   "
+    parsed = json.loads(rest.lstrip())
+    assert parsed["images"][0]["data_base64"] == _PNG_B64
+    # Whitespace-prefixed body must still be decodable as a whole.
+    assert json.loads((first + rest).decode()) == parsed
+
+
+def test_slow_generation_error_streams_error_envelope() -> None:
+    release = threading.Event()
+
+    def _slow_fail(**_: object) -> list[GeneratedImageData]:
+        release.wait(10)
+        raise RuntimeError("boom")
+
+    with patch(_HELPER, side_effect=_slow_fail), patch(_KEEPALIVE, 0.02):
+        resp = generate_image(ImageGenerationRequest(prompt="a cat"))
+
+        async def _consume() -> tuple[bytes, bytes]:
+            iterator = resp.body_iterator.__aiter__()
+            first_bytes = _as_bytes(await iterator.__anext__())
+            release.set()
+            rest_bytes = b""
+            async for chunk in iterator:
+                rest_bytes += _as_bytes(chunk)
+            return first_bytes, rest_bytes
+
+        keepalive, rest = asyncio.run(_consume())
+    assert keepalive == b" "
+    parsed = json.loads(rest.lstrip())
+    assert parsed["error_code"] == OnyxErrorCode.LLM_PROVIDER_ERROR.code
+    assert parsed["detail"] == "Image generation failed."
+
+
+def test_stream_deadline_yields_timeout_envelope() -> None:
+    release = threading.Event()
+
+    def _hung(**_: object) -> list[GeneratedImageData]:
+        release.wait(10)
+        return [GeneratedImageData(b64_data=_PNG_B64, revised_prompt="r")]
+
+    try:
+        with (
+            patch(_HELPER, side_effect=_hung),
+            patch(_KEEPALIVE, 0.02),
+            patch(_MAX_DURATION, 0.05),
+        ):
+            keepalive, parsed = _drain_stream(
+                generate_image(ImageGenerationRequest(prompt="a cat"))
+            )
+    finally:
+        release.set()
+    assert parsed["error_code"] == OnyxErrorCode.GATEWAY_TIMEOUT.code
+    assert parsed["detail"] == "Image generation timed out."
+    assert keepalive

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -175,6 +175,8 @@ func (c *Client) GenerateImage(ctx context.Context, req models.ImageGenerationRe
 			statusCode = 404
 		case "INVALID_INPUT":
 			statusCode = 400
+		case "GATEWAY_TIMEOUT":
+			statusCode = 504
 		default:
 			statusCode = 502
 		}

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -32,6 +32,7 @@ type Client struct {
 	httpClient          *http.Client
 	searchHTTPClient    *http.Client
 	streamingHTTPClient *http.Client
+	imageHTTPClient     *http.Client
 }
 
 // NewClient creates a new API client from config.
@@ -57,6 +58,12 @@ func NewClient(cfg config.OnyxCliConfig) *Client {
 		},
 		streamingHTTPClient: &http.Client{
 			Timeout:   5 * time.Minute,
+			Transport: transport,
+		},
+		// Must exceed the server's 10-minute image-generation stream ceiling,
+		// or the client gives up before the server's timeout envelope arrives.
+		imageHTTPClient: &http.Client{
+			Timeout:   11 * time.Minute,
 			Transport: transport,
 		},
 	}
@@ -153,8 +160,7 @@ func (c *Client) Search(ctx context.Context, req models.SearchRequest) (*models.
 }
 
 // GenerateImage calls POST /image-generation/generate, which generates
-// image(s) using the workspace's default image-gen provider. Uses the 5min
-// client since high-res generation can be slow.
+// image(s) using the workspace's default image-gen provider.
 //
 // The server streams keepalive whitespace before the JSON body (which
 // json.Decoder skips) and reports errors in-band on a 200, since the status
@@ -165,7 +171,7 @@ func (c *Client) GenerateImage(ctx context.Context, req models.ImageGenerationRe
 		ErrorCode string `json:"error_code"`
 		Detail    string `json:"detail"`
 	}
-	if err := c.doJSONWith(ctx, c.streamingHTTPClient, "POST", "/image-generation/generate", req, &resp); err != nil {
+	if err := c.doJSONWith(ctx, c.imageHTTPClient, "POST", "/image-generation/generate", req, &resp); err != nil {
 		return nil, err
 	}
 	if resp.ErrorCode != "" {

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -155,12 +155,35 @@ func (c *Client) Search(ctx context.Context, req models.SearchRequest) (*models.
 // GenerateImage calls POST /image-generation/generate, which generates
 // image(s) using the workspace's default image-gen provider. Uses the 5min
 // client since high-res generation can be slow.
+//
+// The server streams keepalive whitespace before the JSON body (which
+// json.Decoder skips) and reports errors in-band on a 200, since the status
+// line is already committed when a slow generation fails.
 func (c *Client) GenerateImage(ctx context.Context, req models.ImageGenerationRequest) (*models.ImageGenerationResponse, error) {
-	var resp models.ImageGenerationResponse
+	var resp struct {
+		models.ImageGenerationResponse
+		ErrorCode string `json:"error_code"`
+		Detail    string `json:"detail"`
+	}
 	if err := c.doJSONWith(ctx, c.streamingHTTPClient, "POST", "/image-generation/generate", req, &resp); err != nil {
 		return nil, err
 	}
-	return &resp, nil
+	if resp.ErrorCode != "" {
+		var statusCode int
+		switch resp.ErrorCode {
+		case "NOT_FOUND":
+			statusCode = 404
+		case "INVALID_INPUT":
+			statusCode = 400
+		default:
+			statusCode = 502
+		}
+		return nil, &OnyxAPIError{StatusCode: statusCode, Detail: resp.Detail}
+	}
+	if len(resp.Images) == 0 {
+		return nil, &OnyxAPIError{StatusCode: 502, Detail: "server returned no images"}
+	}
+	return &resp.ImageGenerationResponse, nil
 }
 
 // TestConnection checks if the server is reachable and credentials are valid.

--- a/cli/internal/api/client.go
+++ b/cli/internal/api/client.go
@@ -60,10 +60,10 @@ func NewClient(cfg config.OnyxCliConfig) *Client {
 			Timeout:   5 * time.Minute,
 			Transport: transport,
 		},
-		// Must exceed the server's 10-minute image-generation stream ceiling,
+		// Must exceed the server's 5-minute image-generation stream ceiling,
 		// or the client gives up before the server's timeout envelope arrives.
 		imageHTTPClient: &http.Client{
-			Timeout:   11 * time.Minute,
+			Timeout:   6 * time.Minute,
 			Transport: transport,
 		},
 	}

--- a/cli/internal/api/image_test.go
+++ b/cli/internal/api/image_test.go
@@ -101,6 +101,24 @@ func TestGenerateImage_InBandNotFoundEnvelope(t *testing.T) {
 	}
 }
 
+func TestGenerateImage_InBandTimeoutEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`  {"error_code": "GATEWAY_TIMEOUT", "detail": "Image generation timed out."}`))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	_, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	var apiErr *api.OnyxAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *OnyxAPIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 504 {
+		t.Errorf("status = %d, want 504", apiErr.StatusCode)
+	}
+}
+
 func TestGenerateImage_EmptyBodyIsError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/cli/internal/api/image_test.go
+++ b/cli/internal/api/image_test.go
@@ -40,6 +40,113 @@ func TestGenerateImage_Success(t *testing.T) {
 	}
 }
 
+func TestGenerateImage_KeepaliveWhitespacePrefix(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`    {
+			"images": [{"data_base64": "YWJj", "mime_type": "image/png", "revised_prompt": "a cat"}]
+		}`))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	resp, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.Images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(resp.Images))
+	}
+}
+
+func TestGenerateImage_InBandErrorEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`  {"error_code": "LLM_PROVIDER_ERROR", "detail": "Image generation failed."}`))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	_, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	if err == nil {
+		t.Fatal("expected error for in-band error envelope")
+	}
+	var apiErr *api.OnyxAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *OnyxAPIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 502 {
+		t.Errorf("status = %d, want 502", apiErr.StatusCode)
+	}
+	if apiErr.Detail != "Image generation failed." {
+		t.Errorf("detail = %q", apiErr.Detail)
+	}
+}
+
+func TestGenerateImage_InBandNotFoundEnvelope(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"error_code": "NOT_FOUND", "detail": "no provider"}`))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	_, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	var apiErr *api.OnyxAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *OnyxAPIError, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 404 {
+		t.Errorf("status = %d, want 404", apiErr.StatusCode)
+	}
+}
+
+func TestGenerateImage_EmptyBodyIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	_, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	var apiErr *api.OnyxAPIError
+	if !errors.As(err, &apiErr) {
+		t.Fatalf("want *OnyxAPIError for empty body, got %T: %v", err, err)
+	}
+	if apiErr.StatusCode != 502 {
+		t.Errorf("status = %d, want 502", apiErr.StatusCode)
+	}
+}
+
+func TestGenerateImage_KeepaliveOnlyStreamIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`   `))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	_, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only body")
+	}
+}
+
+func TestGenerateImage_TruncatedStreamIsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`  {"images": [`))
+	}))
+	defer srv.Close()
+
+	client := testutil.NewClient(srv.URL)
+	_, err := client.GenerateImage(t.Context(), models.ImageGenerationRequest{Prompt: "a cat"})
+	if err == nil {
+		t.Fatal("expected error for truncated body")
+	}
+}
+
 func TestGenerateImage_404(t *testing.T) {
 	srv := testutil.StatusServer(404)
 	defer srv.Close()


### PR DESCRIPTION
## Description

High-quality image generations on Craft (via `onyx-cli image generate`/`edit`) were consistently timing out. Root cause: `POST /image-generation/generate` held a fully silent HTTP connection for the whole provider round-trip, and the AWS ALB in front of the api server kills any connection idle for 60s (its default) — so every generation slower than ~60s died mid-flight, the agent retried, and the server kept generating images nobody received.

This makes the endpoint immune to load-balancer idle timeouts everywhere:

- The endpoint now returns a streamed 200 that emits **one whitespace byte every 15s** while generation runs, then the final JSON. Leading whitespace is valid JSON, so existing clients (including the pinned `onyx-cli==1.2.2` in deployed sandbox images) decode the success body unchanged.
- Generation-time failures arrive as an in-band `{"error_code", "detail"}` envelope (same shape as the global `OnyxError` handler). The CLI maps it back to proper errors (404/400/502).
- Request validation and the "no image provider configured" case still fail **before** the 200 is committed, with real status codes — old CLIs keep their friendly not-configured message.
- Generation runs on a bounded executor (32 workers) with the caller's contextvars; the stream has a 10-minute ceiling (`GATEWAY_TIMEOUT` envelope) since the keepalives deliberately defeat the LB backstop that used to reap hung provider calls.
- Reference images are capped at 20 MB decoded per image.
- `X-Accel-Buffering: no` so nginx doesn't buffer the keepalives.

Follow-up after merge: tag `cli/v1.2.3` and bump the `onyx-cli` pin in the sandbox image so deployed sandboxes get the improved error reporting (successes work with the old CLI as-is).

## How Has This Been Tested?

- 16 unit tests on the endpoint (keepalive cadence, repeated keepalives before result, in-band error envelopes, pre-stream 404s, stream deadline, size caps) + 8 Go CLI tests (whitespace prefix, envelope mapping, empty/truncated/keepalive-only bodies are errors).
- Live end-to-end on a kind cluster through the real nginx hop, with a `socat -T 60` TCP proxy faithfully emulating the ALB idle timeout (negative control: a silent request dies at exactly 60s):
  - a **90-second** generation (slow provider) through the 60s-idle proxy: HTTP 200, six keepalives at exact 15s intervals, valid image; `onyx-cli` saved the PNG and exited 0
  - a 52s real OpenAI `n=4 high` generation through a **20s**-idle proxy (2.6× the idle window): success
  - real OpenAI fast/slow paths, edits with reference images, and provider-error paths verified via CLI

## Known minor items

- Provider failures now ride HTTP 200, so status-code-based monitoring won't see them (inherent to the streaming design; failures are logged server-side).
- The Go CLI maps envelope codes via string literals (`NOT_FOUND`, `INVALID_INPUT`, default 502); an unmapped future code degrades to 502.
- A connection that dies mid-stream surfaces to the CLI as a raw JSON decode error (`unexpected EOF`) rather than a friendlier "stream interrupted" message.
- Client disconnect doesn't cancel the in-flight provider call (parity with the previous blocking implementation).
- `cli/internal/models/image.go` has a pre-existing stale path in a comment (`/build/image-generation/generate`).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams keepalive whitespace from `POST /image-generation/generate` to prevent AWS ALB idle timeouts from killing slow image generations. Errors are sent in-band on the stream, and `onyx-cli` maps them to proper status codes; successes remain backward-compatible.

- **Bug Fixes**
  - Stream one whitespace byte every 15s, then send the final JSON; set `X-Accel-Buffering: no` to avoid nginx buffering.
  - Add a 5-minute stream ceiling with a `GATEWAY_TIMEOUT` envelope; deadline-aware waits; skip provider calls if the stream timed out while queued.
  - Validate requests and return 4xx for “not configured” before streaming so older clients keep their friendly message.
  - Reference images: cap at 20 MB decoded, reject oversize before decode, and sniff MIME from bytes.
  - Bound execution (32 workers) and admission (64 pending); return 429 when the queue is full.
  - Update `onyx-cli` to tolerate leading whitespace, map `{"error_code","detail"}` envelopes to 404/400/504 (others 502), treat empty/truncated/keepalive-only bodies as errors, and use a 6-minute timeout to outlast the server’s 5-minute ceiling.

- **Migration**
  - After merge, bump the sandbox `onyx-cli` pin to `v1.2.3` for improved error reporting; successes work with older `onyx-cli`.

<sup>Written for commit 2b59e6abe1de34f7680ca6367826c356b72f6471. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13282?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

