### PR TITLE
feat(image-gen): add Gemini 3 Pro Image (GA), hide discontinued preview

### DIFF
--- a/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/views/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -68,6 +68,17 @@ export default function ImageGenerationContent() {
     return new Set(configs.map((c) => c.image_provider_id));
   }, [configs]);
 
+  // Deprecated models stay visible only for admins who already connected them,
+  // so they can still disconnect or switch away.
+  const visibleGroups = useMemo(() => {
+    return IMAGE_PROVIDER_GROUPS.map((group) => ({
+      ...group,
+      providers: group.providers.filter(
+        (p) => !p.deprecated || connectedProviderIds.has(p.image_provider_id)
+      ),
+    })).filter((g) => g.providers.length > 0);
+  }, [connectedProviderIds]);
+
   const defaultConfig = useMemo(() => {
     return configs.find((c) => c.is_default);
   }, [configs]);
@@ -217,7 +228,7 @@ export default function ImageGenerationContent() {
         )}
 
         {/* Provider Groups */}
-        {IMAGE_PROVIDER_GROUPS.map((group) => (
+        {visibleGroups.map((group) => (
           <div key={group.name} className="flex flex-col gap-2">
             <Content title={group.name} sizePreset="secondary" variant="body" />
             {group.providers.map((provider) => {

--- a/web/src/views/admin/ImageGenerationPage/constants.ts
+++ b/web/src/views/admin/ImageGenerationPage/constants.ts
@@ -4,6 +4,7 @@ export interface ImageProvider {
   provider_name: string;
   title: string;
   description: string;
+  deprecated?: boolean; // Hidden unless already connected (model no longer offered upstream)
 }
 
 export interface ProviderGroup {
@@ -81,12 +82,21 @@ export const IMAGE_PROVIDER_GROUPS: ProviderGroup[] = [
           "Gemini 2.5 Flash Image (Nano Banana) model is designed for speed and efficiency.",
       },
       {
+        image_provider_id: "gemini-3-pro-image",
+        model_name: "gemini-3-pro-image",
+        provider_name: "vertex_ai",
+        title: "Gemini 3 Pro Image",
+        description:
+          "Gemini 3 Pro Image (Nano Banana Pro) is designed for professional asset production.",
+      },
+      {
         image_provider_id: "gemini-3-pro-image-preview",
         model_name: "gemini-3-pro-image-preview",
         provider_name: "vertex_ai",
         title: "Gemini 3 Pro Image Preview",
         description:
-          "Gemini 3 Pro Image Preview (Nano Banana Pro) is designed for professional asset production.",
+          "Discontinued by Google Cloud on July 17, 2026. Switch to Gemini 3 Pro Image.",
+        deprecated: true,
       },
     ],
   },


### PR DESCRIPTION
## Description

Google Cloud discontinued `gemini-3-pro-image-preview` on Vertex AI on July 17, 2026; the GA model id is `gemini-3-pro-image` (GA since May 28, 2026). Customers with the preview model configured have broken image generation.

- Adds **Gemini 3 Pro Image** (`gemini-3-pro-image`) to the Vertex AI group on the image generation admin page.
- Marks the preview entry `deprecated`: it is hidden unless the admin already has it connected, so existing configs can still be disconnected/switched (removing the entry outright would orphan them in the UI).

No backend changes needed: the model name is passed through to LiteLLM, which routes Vertex `gemini*` models to the generateContent image path by name pattern (verified on litellm 1.93.0 and 1.85.1).

Linear: https://linear.app/onyx-app/issue/CS-77

## How Has This Been Tested?

- `tsc --noEmit` passes on `web/`.
- Verified the Vertex form routes by `provider_name`, so the new entry reuses the existing Vertex credentials form.
- Verified LiteLLM model routing for `vertex_ai/gemini-3-pro-image` (mode `image_generation`, name-based gemini routing) on both the main (1.93.0) and v4.1.8 (1.85.1) pins.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Gemini 3 Pro Image (`gemini-3-pro-image`) to the Vertex provider list and hide the discontinued preview unless already connected. Fixes broken image generation for preview users and aligns with Linear CS-77.

<sup>Written for commit 46e01b9b4f4cbb34c2843bdc1faa0415825e3c91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13284?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

