### PR TITLE
feat(image-gen): add Gemini 3 Pro Image (GA), hide discontinued preview (#13284) to release v4.1

### DIFF
--- a/backend/onyx/skills/builtin/image-generation/scripts/generate.py
+++ b/backend/onyx/skills/builtin/image-generation/scripts/generate.py
@@ -41,7 +41,7 @@ def load_image_as_base64(image_path: str) -> tuple[str, str]:
 def generate_image(
     prompt: str,
     output_path: str,
-    model: str = "gemini-3-pro-image-preview",
+    model: str = "gemini-3-pro-image",
     input_image: str | None = None,
     aspect_ratio: str | None = None,  # noqa: ARG001
     num_images: int = 1,
@@ -181,8 +181,8 @@ Examples:
         "--model",
         "-m",
         type=str,
-        default="gemini-3-pro-image-preview",
-        help="Model to use (default: gemini-3-pro-image-preview).",
+        default="gemini-3-pro-image",
+        help="Model to use (default: gemini-3-pro-image).",
     )
     parser.add_argument(
         "--input-image",

--- a/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/ImageGenerationContent.tsx
@@ -69,6 +69,17 @@ export default function ImageGenerationContent() {
     return new Set(configs.map((c) => c.image_provider_id));
   }, [configs]);
 
+  // Deprecated models stay visible only for admins who already connected them,
+  // so they can still disconnect or switch away.
+  const visibleGroups = useMemo(() => {
+    return IMAGE_PROVIDER_GROUPS.map((group) => ({
+      ...group,
+      providers: group.providers.filter(
+        (p) => !p.deprecated || connectedProviderIds.has(p.image_provider_id)
+      ),
+    })).filter((g) => g.providers.length > 0);
+  }, [connectedProviderIds]);
+
   const defaultConfig = useMemo(() => {
     return configs.find((c) => c.is_default);
   }, [configs]);
@@ -218,7 +229,7 @@ export default function ImageGenerationContent() {
         )}
 
         {/* Provider Groups */}
-        {IMAGE_PROVIDER_GROUPS.map((group) => (
+        {visibleGroups.map((group) => (
           <div key={group.name} className="flex flex-col gap-2">
             <Content title={group.name} sizePreset="secondary" variant="body" />
             {group.providers.map((provider) => {

--- a/web/src/refresh-pages/admin/ImageGenerationPage/constants.ts
+++ b/web/src/refresh-pages/admin/ImageGenerationPage/constants.ts
@@ -4,6 +4,7 @@ export interface ImageProvider {
   provider_name: string;
   title: string;
   description: string;
+  deprecated?: boolean; // Hidden unless already connected (model no longer offered upstream)
 }
 
 export interface ProviderGroup {
@@ -81,12 +82,21 @@ export const IMAGE_PROVIDER_GROUPS: ProviderGroup[] = [
           "Gemini 2.5 Flash Image (Nano Banana) model is designed for speed and efficiency.",
       },
       {
+        image_provider_id: "gemini-3-pro-image",
+        model_name: "gemini-3-pro-image",
+        provider_name: "vertex_ai",
+        title: "Gemini 3 Pro Image",
+        description:
+          "Gemini 3 Pro Image (Nano Banana Pro) is designed for professional asset production.",
+      },
+      {
         image_provider_id: "gemini-3-pro-image-preview",
         model_name: "gemini-3-pro-image-preview",
         provider_name: "vertex_ai",
         title: "Gemini 3 Pro Image Preview",
         description:
-          "Gemini 3 Pro Image Preview (Nano Banana Pro) is designed for professional asset production.",
+          "Discontinued by Google Cloud on July 17, 2026. Switch to Gemini 3 Pro Image.",
+        deprecated: true,
       },
     ],
   },


### PR DESCRIPTION
## Description

Backport of #13284 to release/v4.1 (cherry-pick of squash commit d103f963; git rename detection mapped `web/src/views/admin/ImageGenerationPage/` → `web/src/refresh-pages/admin/ImageGenerationPage/`, no conflicts). A v4.1.x tag will be cut from this for a customer pinned on v4.1.8.

Google Cloud discontinued `gemini-3-pro-image-preview` on Vertex AI on July 17, 2026; the GA model id is `gemini-3-pro-image`. Adds the GA model to the Vertex AI image provider list and hides the deprecated preview entry unless already connected.

Extra commit vs main: `backend/onyx/skills/builtin/image-generation/scripts/generate.py` (deleted on main, still present on this branch) defaulted `--model` to the discontinued preview id — bumped to the GA id.

Linear: https://linear.app/onyx-app/issue/CS-77

## How Has This Been Tested?

- `tsc --noEmit` passes on `web/` with this branch's own dependencies.
- Verified hunks landed in the refresh-pages path (`deprecated` flag + `visibleGroups` filter wired).
- Verified the pinned litellm 1.85.1 routes `vertex_ai/gemini-3-pro-image` to the gemini image path by name pattern (GA id missing from its cost map only affects cost-tracking metadata).
- Main PR #13284 passed CI.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backport to v4.1: add the GA `gemini-3-pro-image` to Vertex AI image providers and hide the discontinued `gemini-3-pro-image-preview` unless already connected. Update the image-generation script default to `gemini-3-pro-image` to prevent failures; fulfills Linear CS-77.

<sup>Written for commit 17dcd0acf1153bc032be50ac8590df43612ec880. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13289?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

