### PR TITLE
chore(deployment): stop advertising env-based SSO setup in templates and installers

### DIFF
--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -23,7 +23,8 @@
 #    - Replace env_file with explicit environment variables
 #
 # 4. AUTHENTICATION:
-#    - Select an authentication method like Basic, Google OAuth, OIDC, or SAML
+#    - Email/password auth works out of the box. SSO (Google, OIDC, SAML) is
+#      configured from the admin panel: Admin Panel > Organization > SSO Providers
 #
 # 5. CA CERTIFICATES:
 #    - Uncomment custom CA certificate volumes if needed

--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -15,19 +15,26 @@ WEB_DOMAIN=http://localhost:3000
 # from and where data can be sent. Off by default.
 # WEB_STRICT_CSP_ENABLED=true
 
-# The following are for configuring User Authentication, supported flows are:
-# disabled
-# basic (standard username / password)
-# google_oauth (login with google/gmail account)
-# oidc
-# saml
-AUTH_TYPE=google_oauth
+# User authentication is always enabled. Email/password login works out of the
+# box, and the first user to sign up becomes an admin.
+# SSO (Google / OIDC / SAML) and its per-provider options are configured in the
+# admin panel (Admin Panel > Organization > SSO Providers), no env vars needed.
+# See https://docs.onyx.app/deployment/authentication for details.
 
-# Set the values below to use with Google OAuth
-GOOGLE_OAUTH_CLIENT_ID=
-GOOGLE_OAUTH_CLIENT_SECRET=
+# Legacy pre-v4.4 SSO configuration. Imported into an SSO provider entry on
+# upgrade, so keep these set through the upgrade. Planned for removal in v4.5.
+#AUTH_TYPE=
+#GOOGLE_OAUTH_CLIENT_ID=
+#GOOGLE_OAUTH_CLIENT_SECRET=
+#OAUTH_CLIENT_ID=
+#OAUTH_CLIENT_SECRET=
+#OPENID_CONFIG_URL=
+# Forces PKCE on for every provider. Superseded by the per-provider setting.
+#OIDC_PKCE_ENABLED=
+# SAML config directory for pre-v4.4 OneLogin compatible setups
+#SAML_CONF_DIR=
 
-# if using basic auth and you want to require email verification, 
+# if you want to require email verification,
 # then uncomment / set the following
 #REQUIRE_EMAIL_VERIFICATION=true
 #SMTP_USER=your-email@company.com
@@ -41,19 +48,11 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 # Optional comma-separated BCC archive recipients for all emails
 #EMAIL_ARCHIVE_BCC_ADDRESSES=
 
-# OpenID Connect (OIDC)
-#OPENID_CONFIG_URL=
-#OIDC_PKCE_ENABLED=
-
-# SAML config directory for OneLogin compatible setups
-#SAML_CONF_DIR=
-
-
 # How long before user needs to reauthenticate, default to 7 days. (cookie expiration time)
 SESSION_EXPIRE_TIME_SECONDS=604800
 
 
-# Use the below to specify a list of allowed user domains, only checked if user Auth is turned on
+# Use the below to specify a list of allowed user domains
 # e.g. `VALID_EMAIL_DOMAINS=example.com,example.org` will only allow users
 # with an @example.com or an @example.org email
 #VALID_EMAIL_DOMAINS=

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -52,7 +52,8 @@ IMAGE_TAG=latest
 
 ## Auth Settings
 ### https://docs.onyx.app/deployment/authentication
-AUTH_TYPE=basic
+### Authentication is always enabled. SSO (Google / OIDC / SAML) is configured
+### in the admin panel (Admin Panel > Organization > SSO Providers).
 # SESSION_EXPIRE_TIME_SECONDS=
 ### Signs password reset, email verification, OAuth login state, and captcha cookies.
 ### REQUIRED: the API server refuses to start with an empty value (secure by default).
@@ -265,8 +266,6 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # ONYX_BOT_MAX_WAIT_TIME=
 
 ## Advanced Auth Settings
-# GOOGLE_OAUTH_CLIENT_ID=
-# GOOGLE_OAUTH_CLIENT_SECRET=
 # REQUIRE_EMAIL_VERIFICATION=
 # SMTP_SERVER=
 # SMTP_PORT=
@@ -276,10 +275,6 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # ENABLE_EMAIL_INVITES=
 # EMAIL_FROM=                   # Required when SMTP_USER is not set
 # EMAIL_ARCHIVE_BCC_ADDRESSES=  # Optional comma-separated BCC archive recipients for all emails
-# OAUTH_CLIENT_ID=
-# OAUTH_CLIENT_SECRET=
-# OPENID_CONFIG_URL=
-# OIDC_PKCE_ENABLED=
 # TRACK_EXTERNAL_IDP_EXPIRY=
 # Opt-in: capture IdP directory claims at OAuth/OIDC login to enrich chat
 # prompts and resolve {{user.<key>}} agent placeholders. Sends directory data
@@ -288,6 +283,15 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # Optional JSON overriding directory claim aliases per field, e.g.
 # '{"department": ["dept", "division"], "country": ["c"]}'.
 # IDP_PROFILE_CLAIM_MAP=
+### Legacy pre-v4.4 SSO vars. Imported into an SSO provider entry on upgrade.
+### Planned for removal in v4.5.
+# AUTH_TYPE=
+# GOOGLE_OAUTH_CLIENT_ID=
+# GOOGLE_OAUTH_CLIENT_SECRET=
+# OAUTH_CLIENT_ID=
+# OAUTH_CLIENT_SECRET=
+# OPENID_CONFIG_URL=
+# SAML_CONF_DIR=
 # Comma-separated list of origins allowed to make cross-origin (CORS) requests,
 # e.g. "https://onyx.example.com". When unset, all origins are allowed but
 # credentialed (cookie-authenticated) cross-origin requests are disabled.

--- a/deployment/docker_compose/install.ps1
+++ b/deployment/docker_compose/install.ps1
@@ -996,8 +996,6 @@ function Main {
         Set-EnvFileValue -Path $envFile -Key "IMAGE_TAG" -Value $version
         Print-Success "IMAGE_TAG set to $version"
         if ($script:LiteMode) { Set-EnvFileValue -Path $envFile -Key "COMPOSE_PROFILES" -Value "" }
-        Set-EnvFileValue -Path $envFile -Key "AUTH_TYPE" -Value "basic"
-        Print-Success "Basic authentication enabled"
         Set-EnvFileValue -Path $envFile -Key "USER_AUTH_SECRET" -Value "`"$(New-SecureSecret)`""
         Print-Success "Generated secure USER_AUTH_SECRET"
         if ($script:IncludeCraftMode) {
@@ -1007,7 +1005,7 @@ function Main {
             Print-Info "Onyx Craft disabled (use -IncludeCraft to enable)"
         }
         Print-Success ".env file created"
-        Print-Info "You can customize .env later for OAuth/SAML, AI models, domain settings, and Craft."
+        Print-Info "You can customize .env later for AI models, domain settings, and Craft."
     }
 
     # Clean up stale lite overlay if standard mode was selected

--- a/deployment/docker_compose/install.sh
+++ b/deployment/docker_compose/install.sh
@@ -1066,36 +1066,6 @@ else
         print_info "Selected: $VERSION"
     fi
 
-    # Ask for authentication schema
-    # echo ""
-    # print_info "Which authentication schema would you like to set up?"
-    # echo ""
-    # echo "1) Basic - Username/password authentication"
-    # echo "2) No Auth - Open access (development/testing)"
-    # echo ""
-    # read -p "Choose an option (1) [default 1]: " -r AUTH_CHOICE
-    # echo ""
-
-    # case "${AUTH_CHOICE:-1}" in
-    #     1)
-    #         AUTH_SCHEMA="basic"
-    #         print_info "Selected: Basic authentication"
-    #         ;;
-    #     # 2)
-    #     #     AUTH_SCHEMA="disabled"
-    #     #     print_info "Selected: No authentication"
-    #     #     ;;
-    #     *)
-    #         AUTH_SCHEMA="basic"
-    #         print_info "Invalid choice, using basic authentication"
-    #         ;;
-    # esac
-
-    # TODO (jessica): Uncomment this once no auth users still have an account
-    # Use basic auth by default
-    # shellcheck disable=SC2034  # Referenced by the commented-out auth prompt above.
-    AUTH_SCHEMA="basic"
-
     # Create .env file from template
     print_info "Creating .env file with your selections..."
     cp "$ENV_TEMPLATE" "$ENV_FILE"
@@ -1114,10 +1084,6 @@ else
         sed -i.bak 's/^FILE_STORE_BACKEND=.*/FILE_STORE_BACKEND=postgres/' "$ENV_FILE" 2>/dev/null || true
         print_success "Cleared COMPOSE_PROFILES and set FILE_STORE_BACKEND=postgres for lite mode"
     fi
-
-    # Configure basic authentication (default)
-    sed -i.bak 's/^AUTH_TYPE=.*/AUTH_TYPE=basic/' "$ENV_FILE" 2>/dev/null || true
-    print_success "Basic authentication enabled in configuration"
 
     # Check if openssl is available
     if ! command -v openssl &> /dev/null; then
@@ -1167,7 +1133,6 @@ else
     echo ""
     print_info "IMPORTANT: The .env file has been configured with your selections."
     print_info "You can customize it later for:"
-    echo "  • Advanced authentication (OAuth, SAML, etc.)"
     echo "  • AI model configuration"
     echo "  • Domain settings (for production)"
     echo "  • Onyx Craft (set ENABLE_CRAFT=true)"

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.4
+version: 0.8.5
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1330,6 +1330,8 @@ auth:
       rootUser: ""
       rootPassword: ""
   oauth:
+    # Legacy pre-v4.4 SSO credentials. Imported into an SSO provider entry on
+    # upgrade. Planned for removal in v4.5.
     # -- Enable or disable this secret entirely. Will remove from env var configurations and remove any created secrets.
     enabled: false
     # -- Overwrite the default secret name, ignored if existingSecret is defined
@@ -1471,13 +1473,14 @@ configMap:
   # overridden only if sandboxes must reach a different proxy host.
   # See deployment/helm/README.md for the external-Redis / ElastiCache path.
 
-  # Auth type: "basic" (default), "google_oauth", "oidc", or "saml"
-  # UPGRADE NOTE: Default changed from "disabled" to "basic" in 0.4.34.
+  # Authentication is always enabled (email/password). SSO (Google/OIDC/SAML)
+  # and its per-provider options are configured in the admin panel (Admin
+  # Panel > Organization > SSO Providers), not through environment variables.
+  # AUTH_TYPE stays as an inert default for the pre-v4.4 SSO import on
+  # upgrade. Planned for removal in v4.5.
   # Set auth.userauth.enabled=true and provide auth.userauth.values.user_auth_secret
-  # before enabling flows that require it.
+  # (signs password reset and email verification tokens and OAuth login state).
   AUTH_TYPE: "basic"
-  # Enable PKCE for OIDC login flow. Leave empty/false for backward compatibility.
-  OIDC_PKCE_ENABLED: ""
   # Opt-in: capture IdP directory claims at OAuth/OIDC login and use them to
   # enrich chat prompts and resolve {{user.<key>}} agent placeholders. Sends
   # directory data to the configured LLM, so off by default.


### PR DESCRIPTION
## Description

Since `v4.4.0`, SSO is configured from the admin panel and the legacy env vars no longer enable it. The deployment templates still presented them as the setup path. A fresh-install user set `AUTH_TYPE=google_oauth` + `OAUTH_CLIENT_*` and silently got no Google login (reported on Discord).

- `env.prod.template`: drop the "supported flows" list and active `AUTH_TYPE=google_oauth`. State the current model (auth always on, SSO via admin panel) and keep the legacy vars commented as an upgrade-import group.
- `env.template`: same treatment, drop active `AUTH_TYPE=basic` (inert since v4.4).
- `install.sh` / `install.ps1`: remove the dead "enable basic auth" steps, the orphaned commented-out auth prompt, and the "customize for OAuth/SAML" hints.
- `docker-compose.yml`: fix the stale "select an authentication method" comment.
- Helm: correct the `AUTH_TYPE` and `auth.oauth` comments (import + legacy login/token-refresh only, removal planned in v4.5). Chart 0.7.1 → 0.7.2.

Deliberately unchanged: compose `${AUTH_TYPE:-oidc}` forwarding (pre-v4.4 upgraders relying on the compose default need it to reach the one-time import) and ECS templates.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check