### PR TITLE
feat(mcp): hot-reload craft MCP servers into running sandboxes

### DIFF
--- a/backend/alembic/versions/fe958f19e42b_add_mcp_config_hash_to_sandbox_and_.py
+++ b/backend/alembic/versions/fe958f19e42b_add_mcp_config_hash_to_sandbox_and_.py
@@ -1,0 +1,33 @@
+"""add mcp_config_hash to sandbox and build_session
+
+Revision ID: fe958f19e42b
+Revises: ea9771dd828c
+Create Date: 2026-07-22 17:36:56.749604
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "fe958f19e42b"
+down_revision = "ea9771dd828c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sandbox",
+        sa.Column("mcp_config_hash", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "build_session",
+        sa.Column("mcp_config_hash", sa.String(length=64), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("build_session", "mcp_config_hash")
+    op.drop_column("sandbox", "mcp_config_hash")

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -153,7 +153,10 @@ def affected_user_ids_for_mcp_server(
     """User IDs with a RUNNING sandbox whose Craft session should be reloaded
     after this server changes (enabled/disabled for craft, tools toggled, URL
     edited). Scoped to running sandboxes so the hot-reload push has somewhere to
-    land; access is public / group / direct / owner (mirrors skills)."""
+    land. Access must match what ``resolve_craft_mcp_servers`` bakes into a
+    session: public / group / direct / owner, plus admins (who bypass the access
+    filter in ``_add_mcp_server_access_filter`` and therefore see every
+    craft-enabled server)."""
     stmt = select(Sandbox.user_id).where(Sandbox.status == SandboxStatus.RUNNING)
     if server.is_public:
         return set(db_session.scalars(stmt))
@@ -172,10 +175,16 @@ def affected_user_ids_for_mcp_server(
     owner_users = select(User.id).where(  # ty: ignore[no-matching-overload]
         User.email == server.owner
     )
+    # Admins see every craft-enabled server (ACL bypass), so any change to a
+    # private server can be baked into an admin's session and must reload it.
+    admin_users = select(User.id).where(  # ty: ignore[no-matching-overload]
+        User.role == UserRole.ADMIN
+    )
     stmt = stmt.where(
         Sandbox.user_id.in_(group_users)
         | Sandbox.user_id.in_(direct_users)
         | Sandbox.user_id.in_(owner_users)
+        | Sandbox.user_id.in_(admin_users)
     )
     return set(db_session.scalars(stmt))
 

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -13,6 +13,7 @@ from onyx.db.enums import (
     MCPOAuthProviderMode,
     MCPServerStatus,
     MCPTransport,
+    SandboxStatus,
 )
 from onyx.db.models import (
     MCPAuthenticationType,
@@ -21,11 +22,13 @@ from onyx.db.models import (
     MCPServer__User,
     MCPServer__UserGroup,
     Persona,
+    Sandbox,
     Tool,
     User,
     User__UserGroup,
     UserRole,
 )
+from onyx.db.users import get_user_by_email
 from onyx.server.features.mcp.models import DENYLISTED_MCP_HEADERS, MCPConnectionData
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
@@ -143,6 +146,49 @@ def user_can_access_mcp_server(user: User, server_id: int, db_session: Session) 
         select(MCPServer.id).where(MCPServer.id == server_id), user
     )
     return db_session.scalar(stmt) is not None
+
+
+def affected_user_ids_for_mcp_server(
+    server: MCPServer, db_session: Session
+) -> set[UUID]:
+    """User IDs with a RUNNING sandbox whose Craft session should be reloaded
+    after this server changes (enabled/disabled for craft, tools toggled, URL
+    edited). Scoped to running sandboxes so the hot-reload push has somewhere to
+    land; access is public / group / direct / owner (mirrors skills)."""
+    if server.is_public:
+        stmt = select(Sandbox.user_id).where(Sandbox.status == SandboxStatus.RUNNING)
+        return set(db_session.scalars(stmt))
+
+    ids: set[UUID] = set()
+    group_stmt = (
+        select(Sandbox.user_id)
+        .join(User__UserGroup, User__UserGroup.user_id == Sandbox.user_id)
+        .join(
+            MCPServer__UserGroup,
+            MCPServer__UserGroup.user_group_id == User__UserGroup.user_group_id,
+        )
+        .where(MCPServer__UserGroup.mcp_server_id == server.id)
+        .where(Sandbox.status == SandboxStatus.RUNNING)
+    )
+    ids |= set(db_session.scalars(group_stmt))
+
+    user_stmt = (
+        select(Sandbox.user_id)
+        .join(MCPServer__User, MCPServer__User.user_id == Sandbox.user_id)
+        .where(MCPServer__User.mcp_server_id == server.id)
+        .where(Sandbox.status == SandboxStatus.RUNNING)
+    )
+    ids |= set(db_session.scalars(user_stmt))
+
+    owner = get_user_by_email(server.owner, db_session)
+    if owner is not None:
+        owner_stmt = (
+            select(Sandbox.user_id)
+            .where(Sandbox.user_id == owner.id)
+            .where(Sandbox.status == SandboxStatus.RUNNING)
+        )
+        ids |= set(db_session.scalars(owner_stmt))
+    return ids
 
 
 def make_mcp_server_private(
@@ -361,6 +407,24 @@ def get_user_connection_config(
             )
         )
     )
+
+
+def get_user_authenticated_server_ids(
+    server_ids: list[int], user_email: str, db_session: Session
+) -> set[int]:
+    """Subset of ``server_ids`` for which ``user_email`` has a stored connection
+    config (per-user credentials / OAuth tokens)."""
+    if not server_ids:
+        return set()
+    rows = db_session.scalars(
+        select(MCPConnectionConfig.mcp_server_id).where(
+            and_(
+                MCPConnectionConfig.mcp_server_id.in_(server_ids),
+                MCPConnectionConfig.user_email == user_email,
+            )
+        )
+    )
+    return {sid for sid in rows if sid is not None}
 
 
 class MCPCredentialsError(Exception):

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -28,7 +28,6 @@ from onyx.db.models import (
     User__UserGroup,
     UserRole,
 )
-from onyx.db.users import get_user_by_email
 from onyx.server.features.mcp.models import DENYLISTED_MCP_HEADERS, MCPConnectionData
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
@@ -155,40 +154,30 @@ def affected_user_ids_for_mcp_server(
     after this server changes (enabled/disabled for craft, tools toggled, URL
     edited). Scoped to running sandboxes so the hot-reload push has somewhere to
     land; access is public / group / direct / owner (mirrors skills)."""
+    stmt = select(Sandbox.user_id).where(Sandbox.status == SandboxStatus.RUNNING)
     if server.is_public:
-        stmt = select(Sandbox.user_id).where(Sandbox.status == SandboxStatus.RUNNING)
         return set(db_session.scalars(stmt))
 
-    ids: set[UUID] = set()
-    group_stmt = (
-        select(Sandbox.user_id)
-        .join(User__UserGroup, User__UserGroup.user_id == Sandbox.user_id)
+    group_users = (
+        select(User__UserGroup.user_id)
         .join(
             MCPServer__UserGroup,
             MCPServer__UserGroup.user_group_id == User__UserGroup.user_group_id,
         )
         .where(MCPServer__UserGroup.mcp_server_id == server.id)
-        .where(Sandbox.status == SandboxStatus.RUNNING)
     )
-    ids |= set(db_session.scalars(group_stmt))
-
-    user_stmt = (
-        select(Sandbox.user_id)
-        .join(MCPServer__User, MCPServer__User.user_id == Sandbox.user_id)
-        .where(MCPServer__User.mcp_server_id == server.id)
-        .where(Sandbox.status == SandboxStatus.RUNNING)
+    direct_users = select(MCPServer__User.user_id).where(
+        MCPServer__User.mcp_server_id == server.id
     )
-    ids |= set(db_session.scalars(user_stmt))
-
-    owner = get_user_by_email(server.owner, db_session)
-    if owner is not None:
-        owner_stmt = (
-            select(Sandbox.user_id)
-            .where(Sandbox.user_id == owner.id)
-            .where(Sandbox.status == SandboxStatus.RUNNING)
-        )
-        ids |= set(db_session.scalars(owner_stmt))
-    return ids
+    owner_users = select(User.id).where(  # ty: ignore[no-matching-overload]
+        User.email == server.owner
+    )
+    stmt = stmt.where(
+        Sandbox.user_id.in_(group_users)
+        | Sandbox.user_id.in_(direct_users)
+        | Sandbox.user_id.in_(owner_users)
+    )
+    return set(db_session.scalars(stmt))
 
 
 def make_mcp_server_private(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5911,6 +5911,7 @@ class BuildSession(Base):
     agent_provider: Mapped[str | None] = mapped_column(String, nullable=True)
     agent_model: Mapped[str | None] = mapped_column(String, nullable=True)
     skills_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    mcp_config_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     # Relationships
     user: Mapped[User | None] = relationship("User", foreign_keys=[user_id])
@@ -5965,6 +5966,7 @@ class Sandbox(Base):
         DateTime(timezone=True), nullable=True
     )
     skills_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    mcp_config_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
     encrypted_pat: Mapped[SensitiveValue[str] | None] = mapped_column(
         EncryptedString(), nullable=True

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -62,6 +62,7 @@ from onyx.server.features.build.configs import (
     MCP_SESSION_TAG_HEADER,
     SANDBOX_API_SERVER_URL,
     SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
+    verify_session_tag,
 )
 from onyx.server.features.build.db import action_approval
 from onyx.utils.logger import setup_logger
@@ -1288,10 +1289,22 @@ class GateAddon:
         direct_auth_header = flow.request.headers.get("Proxy-Authorization")
         direct = _parse_proxy_auth_username(direct_auth_header)
         # opencode's in-process MCP client can't ride the proxy-userinfo tag
-        # (shared process, untagged base proxy), so it carries the session id in
-        # a header stamped by the per-session opencode.json instead.
+        # (shared process, untagged base proxy), so it carries the session id in a
+        # signed header stamped by the per-session opencode.json. Verify the
+        # signature and let it win for MCP requests; a present-but-forged header
+        # fails closed (tag stays None) rather than falling back to a connection
+        # tag it could otherwise override.
         mcp_header = flow.request.headers.get(MCP_SESSION_TAG_HEADER)
-        tag = mcp_header or cached or direct
+        if mcp_header is not None:
+            tag = verify_session_tag(mcp_header)
+            if tag is None:
+                logger.warning(
+                    "mcp_session_tag_invalid conn=%s host=%s",
+                    conn_id or "-",
+                    flow.request.host,
+                )
+        else:
+            tag = cached or direct
 
         logger.debug(
             "session_tag_resolved conn=%s host=%s cached=%s direct=%s "

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -59,6 +59,7 @@ from onyx.sandbox_proxy.logging_utils import (
 )
 from onyx.sandbox_proxy.request_evaluator import RequestEvaluator
 from onyx.server.features.build.configs import (
+    MCP_SESSION_TAG_HEADER,
     SANDBOX_API_SERVER_URL,
     SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
 )
@@ -379,8 +380,9 @@ class GateAddon:
             return
 
         gate_target = await self._resolve_and_match(flow)
-        # Strip the in-band session tag so it never reaches the origin
+        # Strip the in-band session tags so they never reach the origin
         flow.request.headers.pop("Proxy-Authorization", None)
+        flow.request.headers.pop(MCP_SESSION_TAG_HEADER, None)
         if gate_target is None:
             return
         ctx, matched_actions = gate_target
@@ -1285,7 +1287,11 @@ class GateAddon:
         cached = self._conn_session_tags.get(conn_id) if conn_id else None
         direct_auth_header = flow.request.headers.get("Proxy-Authorization")
         direct = _parse_proxy_auth_username(direct_auth_header)
-        tag = cached or direct
+        # opencode's in-process MCP client can't ride the proxy-userinfo tag
+        # (shared process, untagged base proxy), so it carries the session id in
+        # a header stamped by the per-session opencode.json instead.
+        mcp_header = flow.request.headers.get(MCP_SESSION_TAG_HEADER)
+        tag = cached or direct or mcp_header
 
         logger.debug(
             "session_tag_resolved conn=%s host=%s cached=%s direct=%s "

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -1291,7 +1291,7 @@ class GateAddon:
         # (shared process, untagged base proxy), so it carries the session id in
         # a header stamped by the per-session opencode.json instead.
         mcp_header = flow.request.headers.get(MCP_SESSION_TAG_HEADER)
-        tag = cached or direct or mcp_header
+        tag = mcp_header or cached or direct
 
         logger.debug(
             "session_tag_resolved conn=%s host=%s cached=%s direct=%s "

--- a/backend/onyx/sandbox_proxy/addons/gate.py
+++ b/backend/onyx/sandbox_proxy/addons/gate.py
@@ -62,7 +62,6 @@ from onyx.server.features.build.configs import (
     MCP_SESSION_TAG_HEADER,
     SANDBOX_API_SERVER_URL,
     SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS,
-    verify_session_tag,
 )
 from onyx.server.features.build.db import action_approval
 from onyx.utils.logger import setup_logger
@@ -1290,21 +1289,14 @@ class GateAddon:
         direct = _parse_proxy_auth_username(direct_auth_header)
         # opencode's in-process MCP client can't ride the proxy-userinfo tag
         # (shared process, untagged base proxy), so it carries the session id in a
-        # signed header stamped by the per-session opencode.json. Verify the
-        # signature and let it win for MCP requests; a present-but-forged header
-        # fails closed (tag stays None) rather than falling back to a connection
-        # tag it could otherwise override.
+        # header stamped by the per-session opencode.json, which wins for MCP
+        # requests. This is a same-user attribution hint, not a security boundary:
+        # the sandbox is one trust domain per user, so a compromised process can
+        # read any of its sessions' tags and forge this header — signing it buys
+        # nothing (the value is stored in-sandbox in plaintext). Cross-user is
+        # still blocked by the src-IP-pinned sandbox identity in resolve_sandbox.
         mcp_header = flow.request.headers.get(MCP_SESSION_TAG_HEADER)
-        if mcp_header is not None:
-            tag = verify_session_tag(mcp_header)
-            if tag is None:
-                logger.warning(
-                    "mcp_session_tag_invalid conn=%s host=%s",
-                    conn_id or "-",
-                    flow.request.host,
-                )
-        else:
-            tag = cached or direct
+        tag = mcp_header or cached or direct
 
         logger.debug(
             "session_tag_resolved conn=%s host=%s cached=%s direct=%s "

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -1,5 +1,9 @@
+import hashlib
+import hmac
 import os
 from enum import Enum
+
+from onyx.configs.app_configs import ENCRYPTION_KEY_SECRET
 
 
 class SandboxBackend(str, Enum):
@@ -144,6 +148,33 @@ SANDBOX_PROXY_INJECTED_PLACEHOLDER = "replaced_by_egress_proxy"
 # The egress proxy reads it to attribute the tool call to a session for approval,
 # then strips it so it never reaches the MCP origin.
 MCP_SESSION_TAG_HEADER = "X-Onyx-Mcp-Session"
+
+
+def sign_session_tag(session_id: str) -> str:
+    """Value for ``MCP_SESSION_TAG_HEADER``: ``<session_id>.<hmac>``. The session
+    id is not secret (it leaks via deep links / notifications), so the sandbox
+    could otherwise forge a tag for a session it doesn't own. HMAC with the
+    shared ``ENCRYPTION_KEY_SECRET`` (which the sandbox never sees) makes a tag
+    unforgeable without the key."""
+    mac = hmac.new(
+        ENCRYPTION_KEY_SECRET.encode(), session_id.encode(), hashlib.sha256
+    ).hexdigest()
+    return f"{session_id}.{mac}"
+
+
+def verify_session_tag(value: str) -> str | None:
+    """The session id from a signed tag, or ``None`` if the signature is absent
+    or invalid — callers fail closed."""
+    session_id, _, mac = value.partition(".")
+    if not mac:
+        return None
+    expected = hmac.new(
+        ENCRYPTION_KEY_SECRET.encode(), session_id.encode(), hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(mac, expected):
+        return None
+    return session_id
+
 
 # ==============================================================================
 # Docker sandbox (SANDBOX_BACKEND=docker, self-hosted docker-compose)

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -137,6 +137,14 @@ SANDBOX_PROXY_CA_VOLUME_NAME = "sandbox_proxy_ca"
 # never see the raw values.
 SANDBOX_PROXY_INJECTED_PLACEHOLDER = "replaced_by_egress_proxy"
 
+# Header carrying the originating BuildSession id on opencode's in-process MCP
+# client requests. opencode-serve is one process for many sessions and uses the
+# untagged base proxy env, so the shell-env proxy tag can't ride MCP egress;
+# instead the per-session opencode.json stamps this header on each MCP server.
+# The egress proxy reads it to attribute the tool call to a session for approval,
+# then strips it so it never reaches the MCP origin.
+MCP_SESSION_TAG_HEADER = "X-Onyx-Mcp-Session"
+
 # ==============================================================================
 # Docker sandbox (SANDBOX_BACKEND=docker, self-hosted docker-compose)
 # ==============================================================================

--- a/backend/onyx/server/features/build/configs.py
+++ b/backend/onyx/server/features/build/configs.py
@@ -1,9 +1,5 @@
-import hashlib
-import hmac
 import os
 from enum import Enum
-
-from onyx.configs.app_configs import ENCRYPTION_KEY_SECRET
 
 
 class SandboxBackend(str, Enum):
@@ -148,32 +144,6 @@ SANDBOX_PROXY_INJECTED_PLACEHOLDER = "replaced_by_egress_proxy"
 # The egress proxy reads it to attribute the tool call to a session for approval,
 # then strips it so it never reaches the MCP origin.
 MCP_SESSION_TAG_HEADER = "X-Onyx-Mcp-Session"
-
-
-def sign_session_tag(session_id: str) -> str:
-    """Value for ``MCP_SESSION_TAG_HEADER``: ``<session_id>.<hmac>``. The session
-    id is not secret (it leaks via deep links / notifications), so the sandbox
-    could otherwise forge a tag for a session it doesn't own. HMAC with the
-    shared ``ENCRYPTION_KEY_SECRET`` (which the sandbox never sees) makes a tag
-    unforgeable without the key."""
-    mac = hmac.new(
-        ENCRYPTION_KEY_SECRET.encode(), session_id.encode(), hashlib.sha256
-    ).hexdigest()
-    return f"{session_id}.{mac}"
-
-
-def verify_session_tag(value: str) -> str | None:
-    """The session id from a signed tag, or ``None`` if the signature is absent
-    or invalid — callers fail closed."""
-    session_id, _, mac = value.partition(".")
-    if not mac:
-        return None
-    expected = hmac.new(
-        ENCRYPTION_KEY_SECRET.encode(), session_id.encode(), hashlib.sha256
-    ).hexdigest()
-    if not hmac.compare_digest(mac, expected):
-        return None
-    return session_id
 
 
 # ==============================================================================

--- a/backend/onyx/server/features/build/db/build_session.py
+++ b/backend/onyx/server/features/build/db/build_session.py
@@ -104,16 +104,25 @@ def get_orphan_build_session_ids(
     return set(db_session.scalars(stmt).all())
 
 
-def skills_are_stale(session: BuildSession, sandbox: Sandbox | None) -> bool:
-    """Whether a live runtime predates the sandbox's managed content."""
-    return bool(
+def session_runtime_stale(session: BuildSession, sandbox: Sandbox | None) -> bool:
+    """Whether a live runtime predates the sandbox's managed content — either the
+    skill/app payload (``skills_hash``) or the craft MCP set (``mcp_config_hash``).
+    Both trigger the same reload (rewrite session config + dispose instance)."""
+    if not (
         session.status == BuildSessionStatus.ACTIVE
         and session.origin == SessionOrigin.INTERACTIVE
         and session.opencode_session_id is not None
         and sandbox is not None
-        and sandbox.skills_hash is not None
-        and session.skills_hash != sandbox.skills_hash
+    ):
+        return False
+    skills_changed = (
+        sandbox.skills_hash is not None and session.skills_hash != sandbox.skills_hash
     )
+    mcp_changed = (
+        sandbox.mcp_config_hash is not None
+        and session.mcp_config_hash != sandbox.mcp_config_hash
+    )
+    return skills_changed or mcp_changed
 
 
 async def get_webapp_access_async(

--- a/backend/onyx/server/features/build/db/sandbox.py
+++ b/backend/onyx/server/features/build/db/sandbox.py
@@ -110,6 +110,22 @@ def set_sandbox_skills_hashes__no_commit(
     db_session.flush()
 
 
+def set_sandbox_mcp_config_hashes__no_commit(
+    db_session: Session,
+    mcp_config_hashes: dict[UUID, str],
+) -> None:
+    """Record each sandbox's current craft MCP fingerprint. Tracked separately
+    from ``skills_hash`` so an MCP change doesn't ride the skill-file push."""
+    if not mcp_config_hashes:
+        return
+    sandboxes = db_session.scalars(
+        select(Sandbox).where(Sandbox.id.in_(mcp_config_hashes))
+    ).all()
+    for sandbox in sandboxes:
+        sandbox.mcp_config_hash = mcp_config_hashes[sandbox.id]
+    db_session.flush()
+
+
 def lock_sandbox_skills_hashes(
     db_session: Session,
     sandbox_ids: set[UUID],

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -196,7 +196,6 @@ class SandboxManager(_ServeMixin, ABC):
         """
         ...
 
-    @abstractmethod
     def write_session_opencode_config(
         self,
         sandbox_id: UUID,
@@ -210,7 +209,9 @@ class SandboxManager(_ServeMixin, ABC):
         hot-reloads the MCP set without a pod re-provision. Written on cold session
         setup and rewritten on skills/MCP reload.
         """
-        ...
+        self.write_sandbox_file(
+            sandbox_id, f"sessions/{session_id}/opencode.json", opencode_config_json
+        )
 
     @abstractmethod
     def cleanup_session_workspace(

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -16,7 +16,7 @@ Architecture Note (User-Shared Sandbox Model):
 
 import time
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor
 from uuid import UUID
 
@@ -31,7 +31,6 @@ from onyx.server.features.build.sandbox.event_schema import (
     ToolCallStart,
 )
 from onyx.server.features.build.sandbox.models import (
-    CraftMCPServerConfig,
     FatalWriteError,
     FileSet,
     FilesystemEntry,
@@ -121,7 +120,6 @@ class SandboxManager(_ServeMixin, ABC):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         """Provision a new sandbox for a user.
 
@@ -130,9 +128,9 @@ class SandboxManager(_ServeMixin, ABC):
         so per-prompt model overrides can cross providers without restarting
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
 
-        ``mcp_servers``: craft-enabled MCP servers to pre-register as remote
-        MCP endpoints in opencode's startup config (URL only; the proxy
-        injects credentials).
+        Craft MCP servers are NOT registered here — they live in per-session
+        ``opencode.json`` (see ``write_session_opencode_config``) so they can
+        hot-reload without a pod re-provision.
 
         Creates the sandbox container/directory with:
         - sessions/ directory for per-session workspaces
@@ -195,6 +193,22 @@ class SandboxManager(_ServeMixin, ABC):
 
         Raises:
             RuntimeError: If workspace setup fails
+        """
+        ...
+
+    @abstractmethod
+    def write_session_opencode_config(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        opencode_config_json: str,
+    ) -> None:
+        """Write the per-session project ``opencode.json`` (craft MCP servers +
+        their per-tool permission gates) into ``sessions/$session_id/``. opencode
+        merges it with the pod-global config and re-reads it whenever the session's
+        instance is disposed — so calling this then ``dispose_opencode_instance``
+        hot-reloads the MCP set without a pod re-provision. Written on cold session
+        setup and rewritten on skills/MCP reload.
         """
         ...
 

--- a/backend/onyx/server/features/build/sandbox/base.py
+++ b/backend/onyx/server/features/build/sandbox/base.py
@@ -129,7 +129,7 @@ class SandboxManager(_ServeMixin, ABC):
         the pod. Defaults to ``[llm_config]`` (single-provider, back-compat).
 
         Craft MCP servers are NOT registered here — they live in per-session
-        ``opencode.json`` (see ``write_session_opencode_config``) so they can
+        ``opencode.json`` (see ``write_session_mcp_config``) so they can
         hot-reload without a pod re-provision.
 
         Creates the sandbox container/directory with:
@@ -195,23 +195,6 @@ class SandboxManager(_ServeMixin, ABC):
             RuntimeError: If workspace setup fails
         """
         ...
-
-    def write_session_opencode_config(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-        opencode_config_json: str,
-    ) -> None:
-        """Write the per-session project ``opencode.json`` (craft MCP servers +
-        their per-tool permission gates) into ``sessions/$session_id/``. opencode
-        merges it with the pod-global config and re-reads it whenever the session's
-        instance is disposed — so calling this then ``dispose_opencode_instance``
-        hot-reloads the MCP set without a pod re-provision. Written on cold session
-        setup and rewritten on skills/MCP reload.
-        """
-        self.write_sandbox_file(
-            sandbox_id, f"sessions/{session_id}/opencode.json", opencode_config_json
-        )
 
     @abstractmethod
     def cleanup_session_workspace(

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -1151,27 +1151,6 @@ echo "Session workspace setup complete"
                 f"Failed to setup session workspace {session_id}: {e}"
             ) from e
 
-    def write_session_opencode_config(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-        opencode_config_json: str,
-    ) -> None:
-        container = self._require_container(sandbox_id)
-        session_path = f"{SESSIONS_ROOT}/{session_id}"
-        # base64 to sidestep shell-escaping the JSON's quotes/braces.
-        config_b64 = base64.b64encode(opencode_config_json.encode()).decode()
-        script = (
-            f"set -e\nmkdir -p {session_path}\n"
-            f"echo '{config_b64}' | base64 -d > {session_path}/opencode.json\n"
-        )
-        try:
-            _run_in_container_as_sandbox_user(container, ["/bin/sh", "-c", script])
-        except ExecError as e:
-            raise RuntimeError(
-                f"Failed to write session opencode config {session_id}: {e}"
-            ) from e
-
     def cleanup_session_workspace(
         self,
         sandbox_id: UUID,

--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -68,7 +68,7 @@ import shlex
 import tarfile
 import threading
 import time
-from collections.abc import Generator, Sequence
+from collections.abc import Generator
 from pathlib import Path
 from typing import TypedDict
 from uuid import UUID
@@ -120,7 +120,6 @@ from onyx.server.features.build.sandbox.labels import (
     LABEL_TENANT_ID,
 )
 from onyx.server.features.build.sandbox.models import (
-    CraftMCPServerConfig,
     FileSet,
     FilesystemEntry,
     LLMProviderConfig,
@@ -827,7 +826,6 @@ class DockerSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         if not onyx_pat:
             raise ValueError("onyx_pat is required for Docker sandbox provisioning.")
@@ -877,7 +875,6 @@ class DockerSandboxManager(SandboxManager):
                     default_model=llm_config.model_name,
                     disabled_tools=OPENCODE_DISABLED_TOOLS,
                     plugins=plugins,
-                    mcp_servers=mcp_servers,
                 )
             )
             self._ensure_sandbox_image()
@@ -1152,6 +1149,27 @@ echo "Session workspace setup complete"
         except ExecError as e:
             raise RuntimeError(
                 f"Failed to setup session workspace {session_id}: {e}"
+            ) from e
+
+    def write_session_opencode_config(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        opencode_config_json: str,
+    ) -> None:
+        container = self._require_container(sandbox_id)
+        session_path = f"{SESSIONS_ROOT}/{session_id}"
+        # base64 to sidestep shell-escaping the JSON's quotes/braces.
+        config_b64 = base64.b64encode(opencode_config_json.encode()).decode()
+        script = (
+            f"set -e\nmkdir -p {session_path}\n"
+            f"echo '{config_b64}' | base64 -d > {session_path}/opencode.json\n"
+        )
+        try:
+            _run_in_container_as_sandbox_user(container, ["/bin/sh", "-c", script])
+        except ExecError as e:
+            raise RuntimeError(
+                f"Failed to write session opencode config {session_id}: {e}"
             ) from e
 
     def cleanup_session_workspace(

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -1517,32 +1517,6 @@ echo "Session workspace setup complete"
                 f"Failed to setup session workspace {session_id}: {e}"
             ) from e
 
-    def write_session_opencode_config(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-        opencode_config_json: str,
-    ) -> None:
-        pod_name = self._get_pod_name(str(sandbox_id))
-        session_path = shlex.quote(f"/workspace/sessions/{session_id}")
-        # base64 to sidestep shell-escaping the JSON's quotes/braces.
-        config_b64 = base64.b64encode(opencode_config_json.encode()).decode()
-        script = (
-            f"set -e\nmkdir -p {session_path}\n"
-            f"echo '{config_b64}' | base64 -d > {session_path}/opencode.json\n"
-        )
-        k8s_stream(
-            self._stream_core_api.connect_get_namespaced_pod_exec,
-            name=pod_name,
-            namespace=self._namespace,
-            container=_SANDBOX_CONTAINER_NAME,
-            command=["/bin/sh", "-c", script],
-            stderr=True,
-            stdin=False,
-            stdout=True,
-            tty=False,
-        )
-
     def cleanup_session_workspace(
         self,
         sandbox_id: UUID,

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -49,7 +49,7 @@ import tarfile
 import tempfile
 import threading
 import time
-from collections.abc import Iterator, Sequence
+from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
 from typing import cast
@@ -108,7 +108,6 @@ from onyx.server.features.build.sandbox.labels import (
     LABEL_TENANT_ID,
 )
 from onyx.server.features.build.sandbox.models import (
-    CraftMCPServerConfig,
     FatalWriteError,
     FileSet,
     FilesystemEntry,
@@ -1008,7 +1007,6 @@ class KubernetesSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         """Provision a new sandbox as a Kubernetes pod (user-level).
 
@@ -1122,7 +1120,6 @@ class KubernetesSandboxManager(SandboxManager):
                             _OPENCODE_CONNECT_APP_PLUGIN_PATH,
                             _OPENCODE_SESSION_TAG_PLUGIN_PATH,
                         ],
-                        mcp_servers=mcp_servers,
                     )
                 )
                 self._provision_opencode_secret(str(sandbox_id), opencode_config_json)
@@ -1519,6 +1516,32 @@ echo "Session workspace setup complete"
             raise RuntimeError(
                 f"Failed to setup session workspace {session_id}: {e}"
             ) from e
+
+    def write_session_opencode_config(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        opencode_config_json: str,
+    ) -> None:
+        pod_name = self._get_pod_name(str(sandbox_id))
+        session_path = shlex.quote(f"/workspace/sessions/{session_id}")
+        # base64 to sidestep shell-escaping the JSON's quotes/braces.
+        config_b64 = base64.b64encode(opencode_config_json.encode()).decode()
+        script = (
+            f"set -e\nmkdir -p {session_path}\n"
+            f"echo '{config_b64}' | base64 -d > {session_path}/opencode.json\n"
+        )
+        k8s_stream(
+            self._stream_core_api.connect_get_namespaced_pod_exec,
+            name=pod_name,
+            namespace=self._namespace,
+            container=_SANDBOX_CONTAINER_NAME,
+            command=["/bin/sh", "-c", script],
+            stderr=True,
+            stdin=False,
+            stdout=True,
+            tty=False,
+        )
 
     def cleanup_session_workspace(
         self,

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -25,11 +25,17 @@ class LLMProviderConfig(BaseModel):
 
 class CraftMCPServerConfig(BaseModel):
     """A craft-enabled MCP server resolved for opencode `mcp` emission (URL only;
-    the proxy injects credentials). ``key`` is the opencode server id."""
+    the proxy injects credentials). ``key`` is the opencode server id.
+
+    ``server_id`` and ``authenticated`` are not emitted into ``opencode.json``;
+    they feed the per-session runtime hash so a hot reload fires when the server
+    set / tools change or the user (dis)connects credentials."""
 
     key: str
     url: str
     disabled_tools: tuple[str, ...] = ()
+    server_id: int
+    authenticated: bool = False
 
 
 class SandboxInfo(BaseModel):

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -7,6 +7,8 @@ import json
 import re
 from collections import defaultdict
 from collections.abc import Sequence
+from typing import TYPE_CHECKING
+from uuid import UUID
 
 from sqlalchemy.orm import Session
 
@@ -20,6 +22,9 @@ from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_session_mcp_config,
 )
+
+if TYPE_CHECKING:
+    from onyx.server.features.build.sandbox.base import SandboxManager
 
 _NON_IDENTIFIER = re.compile(r"[^a-z0-9]+")
 
@@ -70,6 +75,23 @@ def render_session_mcp_config_json(
     for ``user``, ready to write into ``session_id``'s workspace."""
     servers = resolve_craft_mcp_servers(db_session, user)
     return json.dumps(build_session_mcp_config(servers, session_id))
+
+
+def write_session_mcp_config(
+    sandbox_manager: SandboxManager,
+    db_session: Session,
+    user: User,
+    sandbox_id: UUID,
+    session_id: UUID,
+) -> None:
+    """Render ``session_id``'s craft MCP ``opencode.json`` for ``user`` and write
+    it into the sandbox — the render+write pair done together on cold session
+    setup and on every skills/MCP reload."""
+    sandbox_manager.write_session_opencode_config(
+        sandbox_id,
+        session_id,
+        render_session_mcp_config_json(db_session, user, str(session_id)),
+    )
 
 
 def craft_mcp_fingerprint(mcp_servers: Sequence[CraftMCPServerConfig]) -> str:

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -68,15 +68,6 @@ def resolve_craft_mcp_servers(
     ]
 
 
-def render_session_mcp_config_json(
-    db_session: Session, user: User, session_id: str
-) -> str:
-    """The per-session ``opencode.json`` (craft MCP servers + permission gates)
-    for ``user``, ready to write into ``session_id``'s workspace."""
-    servers = resolve_craft_mcp_servers(db_session, user)
-    return json.dumps(build_session_mcp_config(servers, session_id))
-
-
 def write_session_mcp_config(
     sandbox_manager: SandboxManager,
     db_session: Session,
@@ -84,13 +75,16 @@ def write_session_mcp_config(
     sandbox_id: UUID,
     session_id: UUID,
 ) -> None:
-    """Render ``session_id``'s craft MCP ``opencode.json`` for ``user`` and write
-    it into the sandbox — the render+write pair done together on cold session
-    setup and on every skills/MCP reload."""
-    sandbox_manager.write_session_opencode_config(
-        sandbox_id,
-        session_id,
-        render_session_mcp_config_json(db_session, user, str(session_id)),
+    """Render ``session_id``'s craft MCP config and write it to the session's
+    project ``opencode.json`` (``sessions/<id>/opencode.json``). opencode merges
+    it with the pod-global config and re-reads it when the session's instance is
+    disposed, so writing this then ``dispose_opencode_instance`` hot-reloads the
+    MCP set without a pod re-provision. Done on cold session setup and every
+    skills/MCP reload."""
+    servers = resolve_craft_mcp_servers(db_session, user)
+    config_json = json.dumps(build_session_mcp_config(servers, str(session_id)))
+    sandbox_manager.write_sandbox_file(
+        sandbox_id, f"sessions/{session_id}/opencode.json", config_json
     )
 
 

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 import re
 from collections import defaultdict
+from collections.abc import Sequence
 
 from sqlalchemy.orm import Session
 
-from onyx.db.mcp import get_craft_enabled_mcp_servers, get_mcp_tools_for_servers
+from onyx.db.mcp import (
+    get_craft_enabled_mcp_servers,
+    get_mcp_tools_for_servers,
+    get_user_authenticated_server_ids,
+)
 from onyx.db.models import MCPServer, User
 from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
+from onyx.server.features.build.sandbox.util.opencode_config import (
+    build_session_mcp_config,
+)
 
 _NON_IDENTIFIER = re.compile(r"[^a-z0-9]+")
 
@@ -35,11 +45,47 @@ def resolve_craft_mcp_servers(
     for tool in get_mcp_tools_for_servers([s.id for s in servers], db_session):
         if tool.mcp_server_id is not None and not tool.enabled:
             disabled_by_server[tool.mcp_server_id].append(tool.name)
+    # Per-user credential presence feeds the runtime hash so connecting/
+    # disconnecting credentials hot-reloads the session (opencode re-runs tool
+    # discovery, which is credential-gated).
+    authed_ids = get_user_authenticated_server_ids(
+        [s.id for s in servers], user.email, db_session
+    )
     return [
         CraftMCPServerConfig(
             key=_server_key(server),
             url=server.server_url,
-            disabled_tools=tuple(disabled_by_server.get(server.id, ())),
+            disabled_tools=tuple(sorted(disabled_by_server.get(server.id, ()))),
+            server_id=server.id,
+            authenticated=server.id in authed_ids,
         )
         for server in servers
     ]
+
+
+def render_session_mcp_config_json(
+    db_session: Session, user: User, session_id: str
+) -> str:
+    """The per-session ``opencode.json`` (craft MCP servers + permission gates)
+    for ``user``, ready to write into ``session_id``'s workspace."""
+    servers = resolve_craft_mcp_servers(db_session, user)
+    return json.dumps(build_session_mcp_config(servers, session_id))
+
+
+def craft_mcp_fingerprint(mcp_servers: Sequence[CraftMCPServerConfig]) -> str:
+    """Stable digest of everything about the craft MCP set that a running
+    session must be rebuilt to pick up: the server set (id + url), each server's
+    disabled-tool set, and whether the user is authenticated (tool discovery is
+    credential-gated). Feeds the per-session runtime hash. Order-independent."""
+    payload = sorted(
+        [
+            s.server_id,
+            s.url,
+            list(s.disabled_tools),
+            s.authenticated,
+        ]
+        for s in mcp_servers
+    )
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    ).hexdigest()

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -10,7 +10,10 @@ restart.
 from collections.abc import Sequence
 from typing import Any
 
-from onyx.server.features.build.configs import MCP_SESSION_TAG_HEADER
+from onyx.server.features.build.configs import (
+    MCP_SESSION_TAG_HEADER,
+    sign_session_tag,
+)
 from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     LLMProviderConfig,
@@ -128,16 +131,19 @@ def build_session_mcp_config(
     session_id: str,
 ) -> dict[str, Any]:
     """Per-session ``opencode.json`` fragment carrying the craft MCP servers and
-    their per-tool permission gates. opencode merges this project-level config
-    with the pod-global config (providers/base permissions), and re-reads it when
-    the session's instance is disposed — so the server set hot-reloads without a
-    pod re-provision. Kept out of the pod-global config precisely so it can change
-    per session without restarting opencode-serve.
+    their per-tool permission gates. opencode deep-merges this project-level
+    config with the pod-global config (providers/base permissions) — combining
+    keys, not replacing — and re-reads it when the session's instance is disposed,
+    so the server set hot-reloads without a pod re-provision. The MCP-gate
+    ``permission`` keys (``<serverKey>_*``) don't collide with the pod-global base
+    permissions, so both survive the merge.
 
-    Each server carries the ``MCP_SESSION_TAG_HEADER`` header stamped with
-    ``session_id``: opencode's in-process MCP client uses the untagged base proxy
-    env, so this header is how the egress proxy attributes a tool call to its
-    session for approval (the proxy strips it before the origin sees it).
+    Each server carries the ``MCP_SESSION_TAG_HEADER`` header, HMAC-signed for
+    ``session_id`` (see ``sign_session_tag``): opencode's in-process MCP client
+    uses the untagged base proxy env, so this header is how the egress proxy
+    attributes a tool call to its session for approval (the proxy strips it before
+    the origin sees it). Signing stops the sandbox forging a tag for a session it
+    doesn't own.
 
     MCP tool ids are ``<serverKey>_<toolName>``. The wildcard allow defers gating
     to the sandbox proxy and covers tools discovered at runtime.
@@ -152,13 +158,14 @@ def build_session_mcp_config(
         config["permission"] = permission
     if mcp_servers:
         # Credentials are injected by the proxy; the only header we set is the
-        # session tag the proxy consumes and strips.
+        # signed session tag the proxy verifies, consumes, and strips.
+        signed_tag = sign_session_tag(session_id)
         config["mcp"] = {
             server.key: {
                 "type": "remote",
                 "url": server.url,
                 "enabled": True,
-                "headers": {MCP_SESSION_TAG_HEADER: session_id},
+                "headers": {MCP_SESSION_TAG_HEADER: signed_tag},
             }
             for server in mcp_servers
         }

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -10,10 +10,7 @@ restart.
 from collections.abc import Sequence
 from typing import Any
 
-from onyx.server.features.build.configs import (
-    MCP_SESSION_TAG_HEADER,
-    sign_session_tag,
-)
+from onyx.server.features.build.configs import MCP_SESSION_TAG_HEADER
 from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     LLMProviderConfig,
@@ -138,12 +135,13 @@ def build_session_mcp_config(
     ``permission`` keys (``<serverKey>_*``) don't collide with the pod-global base
     permissions, so both survive the merge.
 
-    Each server carries the ``MCP_SESSION_TAG_HEADER`` header, HMAC-signed for
-    ``session_id`` (see ``sign_session_tag``): opencode's in-process MCP client
-    uses the untagged base proxy env, so this header is how the egress proxy
-    attributes a tool call to its session for approval (the proxy strips it before
-    the origin sees it). Signing stops the sandbox forging a tag for a session it
-    doesn't own.
+    Each server carries the ``MCP_SESSION_TAG_HEADER`` header stamped with
+    ``session_id``: opencode's in-process MCP client uses the untagged base proxy
+    env, so this header is how the egress proxy attributes a tool call to its
+    session for approval (the proxy strips it before the origin sees it). The tag
+    is a same-user attribution hint, not a security boundary — a sandbox is one
+    trust domain per user, so the value is not tamper-proof against a compromised
+    process in it (see the note in the gate).
 
     MCP tool ids are ``<serverKey>_<toolName>``. The wildcard allow defers gating
     to the sandbox proxy and covers tools discovered at runtime.
@@ -158,14 +156,13 @@ def build_session_mcp_config(
         config["permission"] = permission
     if mcp_servers:
         # Credentials are injected by the proxy; the only header we set is the
-        # signed session tag the proxy verifies, consumes, and strips.
-        signed_tag = sign_session_tag(session_id)
+        # session tag the proxy consumes and strips.
         config["mcp"] = {
             server.key: {
                 "type": "remote",
                 "url": server.url,
                 "enabled": True,
-                "headers": {MCP_SESSION_TAG_HEADER: signed_tag},
+                "headers": {MCP_SESSION_TAG_HEADER: session_id},
             }
             for server in mcp_servers
         }

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -10,6 +10,7 @@ restart.
 from collections.abc import Sequence
 from typing import Any
 
+from onyx.server.features.build.configs import MCP_SESSION_TAG_HEADER
 from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     LLMProviderConfig,
@@ -108,7 +109,6 @@ _TMP_EXTERNAL_DIRECTORY_RULES: dict[str, str] = {
 def _build_permissions(
     disabled_tools: list[str] | None,
     dev_mode: bool,
-    mcp_servers: Sequence[CraftMCPServerConfig],
 ) -> dict[str, Any]:
     permissions: dict[str, Any] = {
         k: (v.copy() if isinstance(v, dict) else v)
@@ -120,23 +120,49 @@ def _build_permissions(
     if disabled_tools:
         for tool in disabled_tools:
             permissions[tool] = "deny"
-    # MCP tool ids are ``<serverKey>_<toolName>``. The wildcard allow defers
-    # gating to the proxy and covers tools discovered at runtime.
-    for server in mcp_servers:
-        permissions[f"{server.key}_*"] = "allow"
-        for tool_name in server.disabled_tools:
-            permissions[f"{server.key}_{tool_name}"] = "deny"
     return permissions
 
 
-def _build_mcp_block(
+def build_session_mcp_config(
     mcp_servers: Sequence[CraftMCPServerConfig],
-) -> dict[str, dict[str, Any]]:
-    """opencode remote `mcp` entries. No auth headers — the proxy injects them."""
-    return {
-        server.key: {"type": "remote", "url": server.url, "enabled": True}
-        for server in mcp_servers
-    }
+    session_id: str,
+) -> dict[str, Any]:
+    """Per-session ``opencode.json`` fragment carrying the craft MCP servers and
+    their per-tool permission gates. opencode merges this project-level config
+    with the pod-global config (providers/base permissions), and re-reads it when
+    the session's instance is disposed — so the server set hot-reloads without a
+    pod re-provision. Kept out of the pod-global config precisely so it can change
+    per session without restarting opencode-serve.
+
+    Each server carries the ``MCP_SESSION_TAG_HEADER`` header stamped with
+    ``session_id``: opencode's in-process MCP client uses the untagged base proxy
+    env, so this header is how the egress proxy attributes a tool call to its
+    session for approval (the proxy strips it before the origin sees it).
+
+    MCP tool ids are ``<serverKey>_<toolName>``. The wildcard allow defers gating
+    to the sandbox proxy and covers tools discovered at runtime.
+    """
+    permission: dict[str, str] = {}
+    for server in mcp_servers:
+        permission[f"{server.key}_*"] = "allow"
+        for tool_name in server.disabled_tools:
+            permission[f"{server.key}_{tool_name}"] = "deny"
+    config: dict[str, Any] = {"$schema": "https://opencode.ai/config.json"}
+    if permission:
+        config["permission"] = permission
+    if mcp_servers:
+        # Credentials are injected by the proxy; the only header we set is the
+        # session tag the proxy consumes and strips.
+        config["mcp"] = {
+            server.key: {
+                "type": "remote",
+                "url": server.url,
+                "enabled": True,
+                "headers": {MCP_SESSION_TAG_HEADER: session_id},
+            }
+            for server in mcp_servers
+        }
+    return config
 
 
 def _build_provider_block(
@@ -160,16 +186,15 @@ def build_multi_provider_opencode_config(
     disabled_tools: list[str] | None = None,
     dev_mode: bool = False,
     plugins: list[str] | None = None,
-    mcp_servers: Sequence[CraftMCPServerConfig] = (),
 ) -> dict[str, Any]:
-    """opencode.json with every provider pre-registered so per-prompt
+    """Pod-global opencode.json with every provider pre-registered so per-prompt
     ``body["model"]`` overrides can target any of them.
 
     ``plugins`` is an optional list of opencode plugin specs (npm names or
     absolute file paths) loaded once per session Instance.
 
-    ``mcp_servers`` are craft-enabled servers exposed as remote MCP endpoints
-    (URL only; the proxy injects credentials).
+    Craft MCP servers are NOT emitted here — they live in per-session config
+    (``build_session_mcp_config``) so they can hot-reload without a pod restart.
 
     Raises:
         ValueError: If ``providers`` is empty or ``default_provider`` is
@@ -195,7 +220,7 @@ def build_multi_provider_opencode_config(
             f" {sorted(provider_names)}"
         )
 
-    permissions = _build_permissions(disabled_tools, dev_mode, mcp_servers)
+    permissions = _build_permissions(disabled_tools, dev_mode)
     config: dict[str, Any] = {
         "$schema": "https://opencode.ai/config.json",
         "model": f"{default_provider}/{default_model}",
@@ -205,6 +230,4 @@ def build_multi_provider_opencode_config(
     }
     if plugins:
         config["plugin"] = list(plugins)
-    if mcp_servers:
-        config["mcp"] = _build_mcp_block(mcp_servers)
     return config

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -39,6 +39,9 @@ from onyx.server.features.build.db.sandbox import (
 from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    render_session_mcp_config_json,
+)
 from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.locks import (
     SessionCreationLockAcquisitionError,
@@ -469,6 +472,13 @@ def restore_session(
                             llm_config=llm_config,
                             connectable_apps_section=connectable_apps_section,
                         )
+                        sandbox_manager.write_session_opencode_config(
+                            sandbox.id,
+                            session_id,
+                            render_session_mcp_config_json(
+                                db_session, user, str(session_id)
+                            ),
+                        )
                         session.status = BuildSessionStatus.ACTIVE
                         session.skills_hash = sandbox.skills_hash
                         db_session.commit()
@@ -486,6 +496,13 @@ def restore_session(
                         llm_config=llm_config,
                         nextjs_port=session.nextjs_port,
                         connectable_apps_section=connectable_apps_section,
+                    )
+                    sandbox_manager.write_session_opencode_config(
+                        sandbox.id,
+                        session_id,
+                        render_session_mcp_config_json(
+                            db_session, user, str(session_id)
+                        ),
                     )
                     session.status = BuildSessionStatus.ACTIVE
                     session.skills_hash = sandbox.skills_hash

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -28,8 +28,8 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.db.build_session import (
     allocate_nextjs_port,
     get_build_session,
+    session_runtime_stale,
     set_build_session_sharing_scope,
-    skills_are_stale,
 )
 from onyx.server.features.build.db.sandbox import (
     get_latest_snapshot_for_session,
@@ -400,7 +400,7 @@ def restore_session(
                 sandbox.id, session_id
             ):
                 session.status = BuildSessionStatus.ACTIVE
-                if skills_are_stale(session, sandbox):
+                if session_runtime_stale(session, sandbox):
                     SessionManager(db_session).reload_session_skills(session_id, user)
                 else:
                     update_sandbox_heartbeat(db_session, sandbox.id)
@@ -477,6 +477,7 @@ def restore_session(
                         )
                         session.status = BuildSessionStatus.ACTIVE
                         session.skills_hash = sandbox.skills_hash
+                        session.mcp_config_hash = sandbox.mcp_config_hash
                         db_session.commit()
                     except Exception as e:
                         logger.error(
@@ -498,6 +499,7 @@ def restore_session(
                     )
                     session.status = BuildSessionStatus.ACTIVE
                     session.skills_hash = sandbox.skills_hash
+                    session.mcp_config_hash = sandbox.mcp_config_hash
                     db_session.commit()
 
         else:

--- a/backend/onyx/server/features/build/session/api.py
+++ b/backend/onyx/server/features/build/session/api.py
@@ -40,7 +40,7 @@ from onyx.server.features.build.models import UploadResponse
 from onyx.server.features.build.sandbox.factory import get_sandbox_manager
 from onyx.server.features.build.sandbox.models import DirectoryListing
 from onyx.server.features.build.sandbox.util.mcp_config import (
-    render_session_mcp_config_json,
+    write_session_mcp_config,
 )
 from onyx.server.features.build.session.errors import UploadLimitExceededError
 from onyx.server.features.build.session.locks import (
@@ -472,12 +472,8 @@ def restore_session(
                             llm_config=llm_config,
                             connectable_apps_section=connectable_apps_section,
                         )
-                        sandbox_manager.write_session_opencode_config(
-                            sandbox.id,
-                            session_id,
-                            render_session_mcp_config_json(
-                                db_session, user, str(session_id)
-                            ),
+                        write_session_mcp_config(
+                            sandbox_manager, db_session, user, sandbox.id, session_id
                         )
                         session.status = BuildSessionStatus.ACTIVE
                         session.skills_hash = sandbox.skills_hash
@@ -497,12 +493,8 @@ def restore_session(
                         nextjs_port=session.nextjs_port,
                         connectable_apps_section=connectable_apps_section,
                     )
-                    sandbox_manager.write_session_opencode_config(
-                        sandbox.id,
-                        session_id,
-                        render_session_mcp_config_json(
-                            db_session, user, str(session_id)
-                        ),
+                    write_session_mcp_config(
+                        sandbox_manager, db_session, user, sandbox.id, session_id
                     )
                     session.status = BuildSessionStatus.ACTIVE
                     session.skills_hash = sandbox.skills_hash

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -44,7 +44,7 @@ from onyx.server.features.build.db.build_session import (
     get_empty_session_for_user,
     get_session_messages,
     get_user_build_sessions,
-    skills_are_stale,
+    session_runtime_stale,
     update_session_activity,
 )
 from onyx.server.features.build.db.sandbox import (
@@ -246,6 +246,7 @@ class SessionManager:
             )
             session.opencode_session_id = opencode_session_id
             session.skills_hash = sandbox.skills_hash
+            session.mcp_config_hash = sandbox.mcp_config_hash
             self._db_session.flush()
 
     def reload_session_skills(self, session_id: UUID, user: User) -> bool:
@@ -255,10 +256,11 @@ class SessionManager:
             raise OnyxError(OnyxErrorCode.SESSION_NOT_FOUND, "Session not found")
 
         sandbox = get_sandbox_by_user_id(self._db_session, user.id)
-        if sandbox is None or not skills_are_stale(session, sandbox):
+        if sandbox is None or not session_runtime_stale(session, sandbox):
             return False
 
         skills_hash = sandbox.skills_hash
+        mcp_config_hash = sandbox.mcp_config_hash
         if sandbox.status == SandboxStatus.PROVISIONING:
             raise OnyxError(
                 OnyxErrorCode.CONFLICT,
@@ -323,9 +325,10 @@ class SessionManager:
                     ) from exc
 
             session.skills_hash = skills_hash
+            session.mcp_config_hash = mcp_config_hash
             self._db_session.flush()
             self._db_session.refresh(sandbox)
-            return skills_are_stale(session, sandbox)
+            return session_runtime_stale(session, sandbox)
 
     def ensure_sandbox_running(
         self,

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -68,7 +68,7 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_connectable_apps_list,
 )
 from onyx.server.features.build.sandbox.util.mcp_config import (
-    render_session_mcp_config_json,
+    write_session_mcp_config,
 )
 from onyx.server.features.build.session import streaming as _streaming
 from onyx.server.features.build.session.errors import (
@@ -300,12 +300,12 @@ class SessionManager:
                     )
                     # Rewrite the per-session MCP config BEFORE disposing the
                     # instance so the fresh instance re-reads the current set.
-                    self._sandbox_manager.write_session_opencode_config(
+                    write_session_mcp_config(
+                        self._sandbox_manager,
+                        self._db_session,
+                        user,
                         sandbox.id,
                         session_id,
-                        render_session_mcp_config_json(
-                            self._db_session, user, str(session_id)
-                        ),
                     )
                     if session.opencode_session_id is not None:
                         self._sandbox_manager.dispose_opencode_instance(
@@ -489,12 +489,12 @@ class SessionManager:
             connectable_apps_section=connectable_apps_section,
             user_name=user_name,
         )
-        self._sandbox_manager.write_session_opencode_config(
+        write_session_mcp_config(
+            self._sandbox_manager,
+            self._db_session,
+            user,
             sandbox.id,
             build_session.id,
-            render_session_mcp_config_json(
-                self._db_session, user, str(build_session.id)
-            ),
         )
         self._prewarm_opencode_session(sandbox, build_session)
 

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -67,6 +67,9 @@ from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_connectable_apps_list,
 )
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    render_session_mcp_config_json,
+)
 from onyx.server.features.build.session import streaming as _streaming
 from onyx.server.features.build.session.errors import (
     RateLimitError,
@@ -295,6 +298,15 @@ class SessionManager:
                         ),
                         user_name=user.personal_name,
                     )
+                    # Rewrite the per-session MCP config BEFORE disposing the
+                    # instance so the fresh instance re-reads the current set.
+                    self._sandbox_manager.write_session_opencode_config(
+                        sandbox.id,
+                        session_id,
+                        render_session_mcp_config_json(
+                            self._db_session, user, str(session_id)
+                        ),
+                    )
                     if session.opencode_session_id is not None:
                         self._sandbox_manager.dispose_opencode_instance(
                             sandbox.id, session_id
@@ -476,6 +488,13 @@ class SessionManager:
             nextjs_port=nextjs_port,
             connectable_apps_section=connectable_apps_section,
             user_name=user_name,
+        )
+        self._sandbox_manager.write_session_opencode_config(
+            sandbox.id,
+            build_session.id,
+            render_session_mcp_config_json(
+                self._db_session, user, str(build_session.id)
+            ),
         )
         self._prewarm_opencode_session(sandbox, build_session)
 

--- a/backend/onyx/server/features/build/session/messages.py
+++ b/backend/onyx/server/features/build/session/messages.py
@@ -19,7 +19,7 @@ from onyx.server.features.build.db.build_session import (
     count_user_messages,
     create_message,
     get_build_session,
-    skills_are_stale,
+    session_runtime_stale,
 )
 from onyx.server.features.build.db.sandbox import (
     get_sandbox_by_user_id,
@@ -137,7 +137,7 @@ def send_message(
             )
 
         sandbox = get_sandbox_by_user_id(db_session, user.id)
-        if skills_are_stale(session, sandbox):
+        if session_runtime_stale(session, sandbox):
             SessionManager(db_session).reload_session_skills(session_id, user)
 
         check_build_rate_limits(user=user, db_session=db_session)

--- a/backend/onyx/server/features/build/session/models.py
+++ b/backend/onyx/server/features/build/session/models.py
@@ -11,7 +11,7 @@ from onyx.db.enums import (
     SessionOrigin,
     SharingScope,
 )
-from onyx.server.features.build.db.build_session import skills_are_stale
+from onyx.server.features.build.db.build_session import session_runtime_stale
 
 if TYPE_CHECKING:
     from onyx.db.models import BuildSession, Sandbox
@@ -142,7 +142,7 @@ class SessionResponse(BaseModel):
             origin=session.origin,
             agent_provider=session.agent_provider,
             agent_model=session.agent_model,
-            skills_stale=skills_are_stale(session, sandbox),
+            skills_stale=session_runtime_stale(session, sandbox),
         )
 
 

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -30,7 +30,9 @@ from onyx.server.features.build.db.sandbox import (
     ensure_sandbox_pat,
     get_running_sandbox_count,
     get_sandbox_by_user_id,
+    get_sandbox_user_map,
     get_snapshots_for_session,
+    set_sandbox_mcp_config_hashes__no_commit,
     set_sandbox_skills_hashes__no_commit,
     update_sandbox_status__no_commit,
 )
@@ -177,14 +179,27 @@ def hydrate_managed_content(
             user, db_session
         )
 
+    # The sandbox's MCP fingerprint is its baseline for session staleness and is
+    # independent of the skill-file push (MCP config is written per session), so
+    # stamp it regardless of whether that push succeeds.
+    try:
+        with db_session.begin_nested():
+            set_sandbox_mcp_config_hashes__no_commit(
+                db_session,
+                {
+                    sandbox_id: craft_mcp_fingerprint(
+                        resolve_craft_mcp_servers(db_session, user)
+                    )
+                },
+            )
+    except Exception:
+        logger.warning(
+            "Failed to stamp MCP config hash for sandbox %s", sandbox_id, exc_info=True
+        )
+
     skills_hydrated = False
     try:
-        mcp_fingerprint = craft_mcp_fingerprint(
-            resolve_craft_mcp_servers(db_session, user)
-        )
-        skills_hash = compute_skill_runtime_hash(
-            skills_files, connectable_apps_section, mcp_fingerprint
-        )
+        skills_hash = compute_skill_runtime_hash(skills_files, connectable_apps_section)
         result = hydrate_sandbox_skills(
             sandbox_id,
             user,
@@ -667,3 +682,39 @@ def rollback_failed_provisioning(db_session: DBSession, sandbox: Sandbox) -> boo
         "Rolled sandbox %s back to SLEEPING after failed provisioning", sandbox.id
     )
     return True
+
+
+def refresh_mcp_config_hashes_for_users(
+    user_ids: set[UUID], db_session: DBSession
+) -> None:
+    """Stamp each affected user's running sandbox with the current craft MCP
+    fingerprint so live sessions detect the change and reload on their next turn.
+    Unlike the skill push this touches only ``mcp_config_hash`` — no skill-file
+    push. Deliberately unlocked (the skill push locks ``skills_hash``): two
+    concurrent MCP changes for the same user could interleave and leave a
+    momentarily stale ``mcp_config_hash``, but that self-heals — the reload
+    resolves the MCP set live, and the next change re-stamps — so a brief
+    bookkeeping skew never yields a wrong runtime.
+
+    Best-effort: callers invoke this AFTER their own change has committed, so a
+    failure here must neither surface to the caller nor roll their change back —
+    it is swallowed and the session is left clean. Commits its own writes."""
+    if not user_ids:
+        return
+    try:
+        sandbox_map = get_sandbox_user_map(list(user_ids), db_session)
+        if not sandbox_map:
+            return
+        hashes = {
+            sandbox_id: craft_mcp_fingerprint(
+                resolve_craft_mcp_servers(db_session, user)
+            )
+            for sandbox_id, user in sandbox_map.items()
+        }
+        set_sandbox_mcp_config_hashes__no_commit(db_session, hashes)
+        db_session.commit()
+    except Exception:
+        logger.warning(
+            "Failed to refresh MCP config hashes for users %s", user_ids, exc_info=True
+        )
+        db_session.rollback()

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -42,7 +42,10 @@ from onyx.server.features.build.sandbox.models import (
 )
 from onyx.server.features.build.sandbox.snapshot_manager import SnapshotManager
 from onyx.server.features.build.sandbox.user_library import hydrate_user_library
-from onyx.server.features.build.sandbox.util.mcp_config import resolve_craft_mcp_servers
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    craft_mcp_fingerprint,
+    resolve_craft_mcp_servers,
+)
 from onyx.server.features.build.session.errors import SandboxProvisioningError
 from onyx.skills.push import (
     build_user_skills_payload,
@@ -176,7 +179,12 @@ def hydrate_managed_content(
 
     skills_hydrated = False
     try:
-        skills_hash = compute_skill_runtime_hash(skills_files, connectable_apps_section)
+        mcp_fingerprint = craft_mcp_fingerprint(
+            resolve_craft_mcp_servers(db_session, user)
+        )
+        skills_hash = compute_skill_runtime_hash(
+            skills_files, connectable_apps_section, mcp_fingerprint
+        )
         result = hydrate_sandbox_skills(
             sandbox_id,
             user,
@@ -249,7 +257,6 @@ def provision_sandbox(
         llm_config=all_llm_configs[0],
         onyx_pat=onyx_pat,
         all_llm_configs=all_llm_configs,
-        mcp_servers=resolve_craft_mcp_servers(db_session, user),
     )
     if sandbox_info.status == SandboxStatus.RUNNING:
         hydrate_managed_content(sandbox_manager, sandbox.id, user, db_session)

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -2461,13 +2461,20 @@ def update_mcp_server_simple(
         available_in_craft=request.available_in_craft,
     )
 
-    # Snapshot recipients under the current ACL before mutating it
-    reload_user_ids = affected_user_ids_for_mcp_server(updated_server, db_session)
-
-    if any(
+    acl_changing = any(
         value is not None
         for value in (request.is_public, request.users, request.groups)
-    ):
+    )
+    # Only an ACL change can drop a user's access; snapshot the pre-change
+    # recipients in that case so they're reloaded to lose the server (the
+    # post-update query wouldn't include them).
+    reload_user_ids: set[UUID] = (
+        affected_user_ids_for_mcp_server(updated_server, db_session)
+        if acl_changing
+        else set()
+    )
+
+    if acl_changing:
         _apply_mcp_server_access(
             mcp_server=updated_server,
             acting_user=user,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -47,6 +47,7 @@ from onyx.db.gated_app import (
     replace_action_policies__no_commit,
 )
 from onyx.db.mcp import (
+    affected_user_ids_for_mcp_server,
     create_connection_config,
     create_mcp_server__no_commit,
     delete_all_user_connection_configs_for_server_no_commit,
@@ -364,6 +365,19 @@ router = APIRouter(prefix="/mcp")
 admin_router = APIRouter(prefix="/admin/mcp")
 
 HEADER_SUBSTITUTIONS: Literal["header_substitutions"] = "header_substitutions"
+
+
+def _hot_reload_craft_sessions(user_ids: set[UUID], db_session: Session) -> None:
+    """Push the current craft MCP config to affected users' running sandboxes so
+    a live Craft session picks it up on its next turn (via the skills-reload
+    pipeline) without a pod re-provision. Best-effort — the push pipeline logs
+    and swallows per-sandbox failures. Imported lazily to avoid a build-layer
+    import cycle at module load."""
+    if not user_ids:
+        return
+    from onyx.skills.push import push_skills_for_users
+
+    push_skills_for_users(user_ids, db_session)
 
 
 def _build_headers_from_template(
@@ -870,6 +884,11 @@ async def process_oauth_callback(
         redis_client.delete(key_state(user_id))
 
         db_session.commit()
+
+        # OAuth connect unblocks tool discovery for this user's craft session;
+        # reload it (single sandbox — this user only).
+        _hot_reload_craft_sessions({user.id}, db_session)
+
         return MCPOAuthCallbackResponse(
             success=True,
             server_id=mcp_server.id,
@@ -1046,6 +1065,10 @@ def save_user_credentials(
             "User credentials saved for server %s and user %s", mcp_server.name, email
         )
         db_session.commit()
+
+        # Connecting credentials unblocks tool discovery for this user's craft
+        # session (opencode's startup tools/list is credential-gated); reload it.
+        _hot_reload_craft_sessions({user.id}, db_session)
 
         return MCPApiKeyResponse(
             success=True,
@@ -2474,6 +2497,13 @@ def update_mcp_server_simple(
         replace_action_policies__no_commit(db_session, gated_app_id, sparse_policies)
 
     db_session.commit()
+
+    # Craft availability / URL live in each session's baked opencode.json;
+    # reload affected users so the change reaches running sandboxes. (Tool
+    # policies are enforced live by the proxy and need no reload.)
+    _hot_reload_craft_sessions(
+        affected_user_ids_for_mcp_server(updated_server, db_session), db_session
+    )
 
     # Return the updated server in API format
     return _db_mcp_server_to_api_mcp_server(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -368,16 +368,18 @@ HEADER_SUBSTITUTIONS: Literal["header_substitutions"] = "header_substitutions"
 
 
 def _hot_reload_craft_sessions(user_ids: set[UUID], db_session: Session) -> None:
-    """Push the current craft MCP config to affected users' running sandboxes so
-    a live Craft session picks it up on its next turn (via the skills-reload
-    pipeline) without a pod re-provision. Best-effort — the push pipeline logs
-    and swallows per-sandbox failures. Imported lazily to avoid a build-layer
-    import cycle at module load."""
+    """Restamp affected users' running sandboxes with the current craft MCP
+    fingerprint so a live Craft session picks up the change on its next turn
+    (via the session reload) without a pod re-provision. Updates only
+    ``mcp_config_hash`` — it does not re-push skill files. Best-effort; imported
+    lazily to avoid a build-layer import cycle at module load."""
     if not user_ids:
         return
-    from onyx.skills.push import push_skills_for_users
+    from onyx.server.features.build.session.sandbox_lifecycle import (
+        refresh_mcp_config_hashes_for_users,
+    )
 
-    push_skills_for_users(user_ids, db_session)
+    refresh_mcp_config_hashes_for_users(user_ids, db_session)
 
 
 def _build_headers_from_template(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -2461,6 +2461,9 @@ def update_mcp_server_simple(
         available_in_craft=request.available_in_craft,
     )
 
+    # Snapshot recipients under the current ACL before mutating it
+    reload_user_ids = affected_user_ids_for_mcp_server(updated_server, db_session)
+
     if any(
         value is not None
         for value in (request.is_public, request.users, request.groups)
@@ -2499,11 +2502,11 @@ def update_mcp_server_simple(
     db_session.commit()
 
     # Craft availability / URL live in each session's baked opencode.json;
-    # reload affected users so the change reaches running sandboxes. (Tool
-    # policies are enforced live by the proxy and need no reload.)
-    _hot_reload_craft_sessions(
-        affected_user_ids_for_mcp_server(updated_server, db_session), db_session
-    )
+    # reload affected users so the change reaches running sandboxes. Union the
+    # pre-update recipients so newly-removed users are reloaded to drop the
+    # server. (Tool policies are enforced live by the proxy and need no reload.)
+    reload_user_ids |= affected_user_ids_for_mcp_server(updated_server, db_session)
+    _hot_reload_craft_sessions(reload_user_ids, db_session)
 
     # Return the updated server in API format
     return _db_mcp_server_to_api_mcp_server(

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -929,6 +929,11 @@ async def process_oauth_callback(
 
     db_session.commit()
 
+    # The background task committed the user's tokens before unblocking the
+    # blpop above, so the credential is persisted; reload this user's craft
+    # session (single sandbox — this user only) to retry tool discovery.
+    _hot_reload_craft_sessions({user.id}, db_session)
+
     logger.info(
         "server_id=%s server_name=%s return_path=%s",
         str(mcp_server.id),
@@ -1101,6 +1106,10 @@ def delete_user_credentials(
 
     # The helper commits internally.
     delete_user_connection_configs_for_server(server_id, user.email, db_session)
+
+    # Disconnecting revokes tool discovery for this user; reload their craft
+    # session (single sandbox — this user only) so the next turn drops it.
+    _hot_reload_craft_sessions({user.id}, db_session)
 
     return MCPApiKeyResponse(
         success=True,
@@ -2536,6 +2545,11 @@ def delete_mcp_server_admin(
 
         _ensure_mcp_server_owner_or_admin(server, user)
 
+        # Snapshot recipients before deletion: once the server (and its ACL
+        # rows) are gone, the affected-user query returns nothing, so they'd
+        # never be reloaded to drop the now-deleted server from their config.
+        reload_user_ids = affected_user_ids_for_mcp_server(server, db_session)
+
         # Log tools that will be deleted for debugging
         tools_to_delete = get_tools_by_mcp_server_id(server_id, db_session)
         logger.info(
@@ -2565,6 +2579,10 @@ def delete_mcp_server_admin(
                 )
                 delete_tool__no_commit(tool.id, db_session)
         db_session.commit()
+
+        # Restamp affected users so their running craft session drops the
+        # deleted server on its next turn.
+        _hot_reload_craft_sessions(reload_user_ids, db_session)
 
         return {"success": True}
     except ValueError:

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -35,6 +35,10 @@ from onyx.server.features.build.sandbox.models import FileSet, PushResult
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_connectable_apps_list,
 )
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    craft_mcp_fingerprint,
+    resolve_craft_mcp_servers,
+)
 from onyx.skills.built_in import (
     BUILT_IN_SKILLS,
     COMPANY_SEARCH,
@@ -58,12 +62,18 @@ _EXCLUDED_DIR_NAMES: frozenset[str] = frozenset({"__pycache__"})
 def compute_skill_runtime_hash(
     files: FileSet,
     connectable_apps_section: str,
+    mcp_fingerprint: str = "",
 ) -> str:
-    """Digest skill files and the app guidance rendered into ``AGENTS.md``."""
+    """Digest the per-session managed runtime: skill files, the app guidance
+    rendered into ``AGENTS.md``, and the craft MCP set (``mcp_fingerprint``).
+    A change in any of these makes a live session stale so it hot-reloads."""
     digest = hashlib.sha256()
     connectable_apps_bytes = connectable_apps_section.encode()
     digest.update(len(connectable_apps_bytes).to_bytes(8))
     digest.update(connectable_apps_bytes)
+    mcp_bytes = mcp_fingerprint.encode()
+    digest.update(len(mcp_bytes).to_bytes(8))
+    digest.update(mcp_bytes)
     for path in sorted(files):
         path_bytes = path.encode()
         content = files[path]
@@ -296,8 +306,16 @@ def push_skills_for_users(user_ids: set[UUID], db_session: Session) -> None:
             sandbox_id: build_user_skills_payload(user, db_session)
             for sandbox_id, user in sandbox_map.items()
         }
+        mcp_fingerprints = {
+            sandbox_id: craft_mcp_fingerprint(
+                resolve_craft_mcp_servers(db_session, user)
+            )
+            for sandbox_id, user in sandbox_map.items()
+        }
         desired_hashes = {
-            sandbox_id: compute_skill_runtime_hash(files, connectable_apps_section)
+            sandbox_id: compute_skill_runtime_hash(
+                files, connectable_apps_section, mcp_fingerprints[sandbox_id]
+            )
             for sandbox_id, (
                 connectable_apps_section,
                 files,

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -35,10 +35,6 @@ from onyx.server.features.build.sandbox.models import FileSet, PushResult
 from onyx.server.features.build.sandbox.util.agent_instructions import (
     build_connectable_apps_list,
 )
-from onyx.server.features.build.sandbox.util.mcp_config import (
-    craft_mcp_fingerprint,
-    resolve_craft_mcp_servers,
-)
 from onyx.skills.built_in import (
     BUILT_IN_SKILLS,
     COMPANY_SEARCH,
@@ -62,18 +58,14 @@ _EXCLUDED_DIR_NAMES: frozenset[str] = frozenset({"__pycache__"})
 def compute_skill_runtime_hash(
     files: FileSet,
     connectable_apps_section: str,
-    mcp_fingerprint: str = "",
 ) -> str:
-    """Digest the per-session managed runtime: skill files, the app guidance
-    rendered into ``AGENTS.md``, and the craft MCP set (``mcp_fingerprint``).
-    A change in any of these makes a live session stale so it hot-reloads."""
+    """Digest the skill files and the app guidance rendered into ``AGENTS.md``.
+    A change makes a live session stale so it hot-reloads. The craft MCP set is
+    tracked separately via ``mcp_config_hash`` (see ``session_runtime_stale``)."""
     digest = hashlib.sha256()
     connectable_apps_bytes = connectable_apps_section.encode()
     digest.update(len(connectable_apps_bytes).to_bytes(8))
     digest.update(connectable_apps_bytes)
-    mcp_bytes = mcp_fingerprint.encode()
-    digest.update(len(mcp_bytes).to_bytes(8))
-    digest.update(mcp_bytes)
     for path in sorted(files):
         path_bytes = path.encode()
         content = files[path]
@@ -306,16 +298,8 @@ def push_skills_for_users(user_ids: set[UUID], db_session: Session) -> None:
             sandbox_id: build_user_skills_payload(user, db_session)
             for sandbox_id, user in sandbox_map.items()
         }
-        mcp_fingerprints = {
-            sandbox_id: craft_mcp_fingerprint(
-                resolve_craft_mcp_servers(db_session, user)
-            )
-            for sandbox_id, user in sandbox_map.items()
-        }
         desired_hashes = {
-            sandbox_id: compute_skill_runtime_hash(
-                files, connectable_apps_section, mcp_fingerprints[sandbox_id]
-            )
+            sandbox_id: compute_skill_runtime_hash(files, connectable_apps_section)
             for sandbox_id, (
                 connectable_apps_section,
                 files,

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -125,7 +125,6 @@ class StubSandboxManager(SandboxManager):
     - ``cleanup_session_workspace_silent``
     - ``dispose_opencode_instance_silent``
     - ``regenerate_session_config_silent``
-    - ``write_session_opencode_config_silent``
     - ``restore_snapshot_silent``
     - ``write_sandbox_file_silent``
     - ``write_files_to_sandbox_silent``
@@ -176,7 +175,6 @@ class StubSandboxManager(SandboxManager):
         self.cleanup_session_workspace_silent: bool = False
         self.dispose_opencode_instance_silent: bool = False
         self.regenerate_session_config_silent: bool = False
-        self.write_session_opencode_config_silent: bool = False
         self.restore_snapshot_silent: bool = False
         self.write_sandbox_file_silent: bool = False
         self.write_files_to_sandbox_silent: bool = False
@@ -194,7 +192,6 @@ class StubSandboxManager(SandboxManager):
         self.terminate_count: int = 0
         self.terminated_sandbox_ids: list[UUID] = []
         self.setup_session_workspace_count: int = 0
-        self.write_session_opencode_config_count: int = 0
         self.cleanup_session_workspace_count: int = 0
         self.regenerate_session_config_count: int = 0
         self.create_snapshot_count: int = 0
@@ -226,7 +223,6 @@ class StubSandboxManager(SandboxManager):
         self.last_provision_payload: dict[str, Any] | None = None
         self.last_terminate_sandbox_id: UUID | None = None
         self.last_setup_session_workspace_payload: dict[str, Any] | None = None
-        self.last_write_session_opencode_config_payload: dict[str, Any] | None = None
         self.last_cleanup_session_workspace_payload: dict[str, Any] | None = None
         self.last_regenerate_session_config_payload: dict[str, Any] | None = None
         self.last_create_snapshot_payload: dict[str, Any] | None = None
@@ -301,21 +297,6 @@ class StubSandboxManager(SandboxManager):
         if self.provision_returns is None:
             raise _not_configured("provision")
         return self.provision_returns
-
-    def write_session_opencode_config(
-        self,
-        sandbox_id: UUID,
-        session_id: UUID,
-        opencode_config_json: str,
-    ) -> None:
-        self.write_session_opencode_config_count += 1
-        self.last_write_session_opencode_config_payload = {
-            "sandbox_id": sandbox_id,
-            "session_id": session_id,
-            "opencode_config_json": opencode_config_json,
-        }
-        if not self.write_session_opencode_config_silent:
-            raise _not_configured("write_session_opencode_config")
 
     def terminate(self, sandbox_id: UUID) -> None:
         self.terminate_count += 1

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -124,6 +124,8 @@ class StubSandboxManager(SandboxManager):
     - ``setup_session_workspace_silent``
     - ``cleanup_session_workspace_silent``
     - ``dispose_opencode_instance_silent``
+    - ``regenerate_session_config_silent``
+    - ``write_session_opencode_config_silent``
     - ``restore_snapshot_silent``
     - ``write_sandbox_file_silent``
     - ``write_files_to_sandbox_silent``
@@ -174,6 +176,7 @@ class StubSandboxManager(SandboxManager):
         self.cleanup_session_workspace_silent: bool = False
         self.dispose_opencode_instance_silent: bool = False
         self.regenerate_session_config_silent: bool = False
+        self.write_session_opencode_config_silent: bool = False
         self.restore_snapshot_silent: bool = False
         self.write_sandbox_file_silent: bool = False
         self.write_files_to_sandbox_silent: bool = False
@@ -311,6 +314,8 @@ class StubSandboxManager(SandboxManager):
             "session_id": session_id,
             "opencode_config_json": opencode_config_json,
         }
+        if not self.write_session_opencode_config_silent:
+            raise _not_configured("write_session_opencode_config")
 
     def terminate(self, sandbox_id: UUID) -> None:
         self.terminate_count += 1

--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -50,13 +50,12 @@ Usage
 from __future__ import annotations
 
 import contextlib
-from collections.abc import Callable, Generator, Iterable, Sequence
+from collections.abc import Callable, Generator, Iterable
 from typing import Any, cast
 from uuid import UUID
 
 from onyx.server.features.build.sandbox.base import SandboxEvent, SandboxManager
 from onyx.server.features.build.sandbox.models import (
-    CraftMCPServerConfig,
     FileSet,
     FilesystemEntry,
     LLMProviderConfig,
@@ -192,6 +191,7 @@ class StubSandboxManager(SandboxManager):
         self.terminate_count: int = 0
         self.terminated_sandbox_ids: list[UUID] = []
         self.setup_session_workspace_count: int = 0
+        self.write_session_opencode_config_count: int = 0
         self.cleanup_session_workspace_count: int = 0
         self.regenerate_session_config_count: int = 0
         self.create_snapshot_count: int = 0
@@ -223,6 +223,7 @@ class StubSandboxManager(SandboxManager):
         self.last_provision_payload: dict[str, Any] | None = None
         self.last_terminate_sandbox_id: UUID | None = None
         self.last_setup_session_workspace_payload: dict[str, Any] | None = None
+        self.last_write_session_opencode_config_payload: dict[str, Any] | None = None
         self.last_cleanup_session_workspace_payload: dict[str, Any] | None = None
         self.last_regenerate_session_config_payload: dict[str, Any] | None = None
         self.last_create_snapshot_payload: dict[str, Any] | None = None
@@ -284,7 +285,6 @@ class StubSandboxManager(SandboxManager):
         onyx_pat: str | None = None,
         *,
         all_llm_configs: list[LLMProviderConfig] | None = None,
-        mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> SandboxInfo:
         self.provision_count += 1
         self.last_provision_payload = {
@@ -294,11 +294,23 @@ class StubSandboxManager(SandboxManager):
             "llm_config": llm_config,
             "onyx_pat": onyx_pat,
             "all_llm_configs": all_llm_configs,
-            "mcp_servers": mcp_servers,
         }
         if self.provision_returns is None:
             raise _not_configured("provision")
         return self.provision_returns
+
+    def write_session_opencode_config(
+        self,
+        sandbox_id: UUID,
+        session_id: UUID,
+        opencode_config_json: str,
+    ) -> None:
+        self.write_session_opencode_config_count += 1
+        self.last_write_session_opencode_config_payload = {
+            "sandbox_id": sandbox_id,
+            "session_id": session_id,
+            "opencode_config_json": opencode_config_json,
+        }
 
     def terminate(self, sandbox_id: UUID) -> None:
         self.terminate_count += 1

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -18,9 +18,16 @@ from onyx.db.enums import (
     MCPAuthenticationType,
     MCPTransport,
 )
-from onyx.db.mcp import create_mcp_server__no_commit, update_mcp_server__no_commit
+from onyx.db.mcp import (
+    create_connection_config,
+    create_mcp_server__no_commit,
+    update_mcp_server__no_commit,
+)
 from onyx.db.models import MCPServer, Tool
-from onyx.server.features.build.sandbox.util.mcp_config import resolve_craft_mcp_servers
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    craft_mcp_fingerprint,
+    resolve_craft_mcp_servers,
+)
 from tests.external_dependency_unit.conftest import create_test_user
 
 
@@ -77,6 +84,34 @@ def test_only_craft_enabled_servers_resolved_with_tool_curation(
     assert config.key == f"linear-mcp-{craft.id}"
     # Only disabled tools are tracked; enabled ones ride the wildcard allow.
     assert config.disabled_tools == ("delete_issue",)
+
+
+def test_resolve_populates_server_id_and_user_auth(
+    db_session: Session,
+    craft_server: tuple[MCPServer, MCPServer],
+) -> None:
+    """``server_id`` and ``authenticated`` feed the runtime hash: connecting
+    credentials must flip ``authenticated`` and change the fingerprint so the
+    user's session hot-reloads (tool discovery is credential-gated)."""
+    craft, _ = craft_server
+    user = create_test_user(db_session, "mcp_auth")
+
+    before = {c.server_id: c for c in resolve_craft_mcp_servers(db_session, user)}
+    assert craft.id in before
+    assert before[craft.id].authenticated is False
+    fp_before = craft_mcp_fingerprint(list(before.values()))
+
+    create_connection_config(
+        {"headers": {"Authorization": "Bearer x"}},
+        db_session,
+        mcp_server_id=craft.id,
+        user_email=user.email,
+    )
+    db_session.commit()
+
+    after = {c.server_id: c for c in resolve_craft_mcp_servers(db_session, user)}
+    assert after[craft.id].authenticated is True
+    assert craft_mcp_fingerprint(list(after.values())) != fp_before
 
 
 def test_private_unshared_server_excluded_for_user(

--- a/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
+++ b/backend/tests/external_dependency_unit/craft/test_idle_cleanup.py
@@ -26,7 +26,7 @@ from onyx.configs.constants import OnyxRedisLocks
 from onyx.db.enums import BuildSessionStatus, SandboxStatus
 from onyx.db.models import BuildSession, Sandbox, Snapshot, User
 from onyx.redis.redis_pool import get_redis_client
-from onyx.server.features.build.db.build_session import skills_are_stale
+from onyx.server.features.build.db.build_session import session_runtime_stale
 from onyx.server.features.build.sandbox.models import SnapshotResult
 from onyx.server.features.build.session import (
     sandbox_lifecycle as sandbox_lifecycle_module,
@@ -636,8 +636,8 @@ def test_sessions_marked_idle_and_nextjs_ports_cleared(
     assert refreshed_b.status == BuildSessionStatus.IDLE
     assert refreshed_a.nextjs_port is None
     assert refreshed_b.nextjs_port is None
-    assert not skills_are_stale(refreshed_a, sandbox)
-    assert not skills_are_stale(refreshed_b, sandbox)
+    assert not session_runtime_stale(refreshed_a, sandbox)
+    assert not session_runtime_stale(refreshed_b, sandbox)
 
 
 def test_idle_reaped_before_non_idle_background_snapshot(

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -147,7 +147,7 @@ class TestIdempotentProvision:
         stub_sandbox_manager.health_check_returns = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
 
         # First call: provisions a new sandbox row.
         session_manager_with_stub.create_session__no_commit(user_id=test_user.id)
@@ -249,7 +249,7 @@ class TestHealthCheckFailureRecovery:
         stub_sandbox_manager.session_workspace_exists_returns = False
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
 
         # restore_session reads ``get_sandbox_manager`` from sessions_api.
         monkeypatch.setattr(
@@ -602,7 +602,7 @@ class TestManagedContentPushOrdering:
             stub.restore_snapshot_silent = True
         else:
             stub.setup_session_workspace_silent = True
-        stub.write_session_opencode_config_silent = True
+        stub.write_sandbox_file_silent = True
 
         monkeypatch.setattr(
             "onyx.server.features.build.session.api.get_sandbox_manager",

--- a/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_sandbox_lifecycle.py
@@ -147,6 +147,7 @@ class TestIdempotentProvision:
         stub_sandbox_manager.health_check_returns = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
 
         # First call: provisions a new sandbox row.
         session_manager_with_stub.create_session__no_commit(user_id=test_user.id)
@@ -248,6 +249,7 @@ class TestHealthCheckFailureRecovery:
         stub_sandbox_manager.session_workspace_exists_returns = False
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
 
         # restore_session reads ``get_sandbox_manager`` from sessions_api.
         monkeypatch.setattr(
@@ -600,6 +602,7 @@ class TestManagedContentPushOrdering:
             stub.restore_snapshot_silent = True
         else:
             stub.setup_session_workspace_silent = True
+        stub.write_session_opencode_config_silent = True
 
         monkeypatch.setattr(
             "onyx.server.features.build.session.api.get_sandbox_manager",

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -313,7 +313,7 @@ def test_timeout_error_event_marks_run_failed_with_timeout_class(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
-    stub_sandbox_manager.write_session_opencode_config_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         Error.model_validate(
@@ -350,7 +350,7 @@ def test_prompt_response_marks_run_succeeded(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
-    stub_sandbox_manager.write_session_opencode_config_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         PromptResponse.model_validate({"stopReason": "end_turn"}),
@@ -388,7 +388,7 @@ def test_scheduled_run_threads_budget_as_turn_timeout(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
-    stub_sandbox_manager.write_session_opencode_config_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         PromptResponse.model_validate({"stopReason": "end_turn"}),
@@ -430,7 +430,7 @@ def test_cancelled_prompt_response_marks_run_failed(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
-    stub_sandbox_manager.write_session_opencode_config_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         PromptResponse.model_validate({"stopReason": "cancelled"}),
@@ -465,7 +465,7 @@ def test_transport_error_event_marks_run_failed_with_agent_exception_class(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
-    stub_sandbox_manager.write_session_opencode_config_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         Error.model_validate(
@@ -502,7 +502,7 @@ def test_stream_without_prompt_response_marks_run_failed(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
-    stub_sandbox_manager.write_session_opencode_config_silent = True
+    stub_sandbox_manager.write_sandbox_file_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = []
 

--- a/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
+++ b/backend/tests/external_dependency_unit/craft/test_scheduled_task_executor.py
@@ -313,6 +313,7 @@ def test_timeout_error_event_marks_run_failed_with_timeout_class(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_session_opencode_config_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         Error.model_validate(
@@ -349,6 +350,7 @@ def test_prompt_response_marks_run_succeeded(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_session_opencode_config_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         PromptResponse.model_validate({"stopReason": "end_turn"}),
@@ -386,6 +388,7 @@ def test_scheduled_run_threads_budget_as_turn_timeout(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_session_opencode_config_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         PromptResponse.model_validate({"stopReason": "end_turn"}),
@@ -427,6 +430,7 @@ def test_cancelled_prompt_response_marks_run_failed(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_session_opencode_config_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         PromptResponse.model_validate({"stopReason": "cancelled"}),
@@ -461,6 +465,7 @@ def test_transport_error_event_marks_run_failed_with_agent_exception_class(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_session_opencode_config_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = [
         Error.model_validate(
@@ -497,6 +502,7 @@ def test_stream_without_prompt_response_marks_run_failed(
 
     stub_sandbox_manager.health_check_returns = True
     stub_sandbox_manager.setup_session_workspace_silent = True
+    stub_sandbox_manager.write_session_opencode_config_silent = True
     stub_sandbox_manager.write_files_to_sandbox_silent = True
     stub_sandbox_manager.send_message_events = []
 

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -128,7 +128,7 @@ class TestCreateSession:
         )
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
 
         sm = session_manager_with_stub
         build_session = sm.create_session__no_commit(user_id=test_user.id)
@@ -173,7 +173,7 @@ class TestCreateSession:
         stub_sandbox_manager.health_check_returns = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
         # provision_returns NOT configured — any provision() call would raise.
 
         sm = session_manager_with_stub
@@ -286,7 +286,7 @@ class TestEmptySessionReuse:
         stub_sandbox_manager.cleanup_session_workspace_silent = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
 
         sm = session_manager_with_stub
         new_session = sm.get_or_create_empty_session(user_id=test_user.id)
@@ -414,7 +414,7 @@ class TestReloadSessionSkills:
         )
         stub_sandbox_manager.regenerate_session_config_silent = True
         stub_sandbox_manager.dispose_opencode_instance_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
 
         response = reload_session_skills(session_row.id, test_user, db_session)
 
@@ -1026,7 +1026,7 @@ class TestRestoreSession:
         stub_sandbox_manager.session_workspace_exists_returns = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
         stub_sandbox_manager.regenerate_session_config_silent = True
         stub_sandbox_manager.dispose_opencode_instance_silent = True
 
@@ -1086,7 +1086,7 @@ class TestRestoreSession:
         stub_sandbox_manager.session_workspace_exists_returns = False
         stub_sandbox_manager.restore_snapshot_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
-        stub_sandbox_manager.write_session_opencode_config_silent = True
+        stub_sandbox_manager.write_sandbox_file_silent = True
 
         monkeypatch.setattr(
             "onyx.server.features.build.session.api.get_sandbox_manager",

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -128,6 +128,7 @@ class TestCreateSession:
         )
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
 
         sm = session_manager_with_stub
         build_session = sm.create_session__no_commit(user_id=test_user.id)
@@ -172,6 +173,7 @@ class TestCreateSession:
         stub_sandbox_manager.health_check_returns = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
         # provision_returns NOT configured — any provision() call would raise.
 
         sm = session_manager_with_stub
@@ -284,6 +286,7 @@ class TestEmptySessionReuse:
         stub_sandbox_manager.cleanup_session_workspace_silent = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
 
         sm = session_manager_with_stub
         new_session = sm.get_or_create_empty_session(user_id=test_user.id)
@@ -411,6 +414,7 @@ class TestReloadSessionSkills:
         )
         stub_sandbox_manager.regenerate_session_config_silent = True
         stub_sandbox_manager.dispose_opencode_instance_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
 
         response = reload_session_skills(session_row.id, test_user, db_session)
 
@@ -1022,6 +1026,7 @@ class TestRestoreSession:
         stub_sandbox_manager.session_workspace_exists_returns = True
         stub_sandbox_manager.setup_session_workspace_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
         stub_sandbox_manager.regenerate_session_config_silent = True
         stub_sandbox_manager.dispose_opencode_instance_silent = True
 
@@ -1081,6 +1086,7 @@ class TestRestoreSession:
         stub_sandbox_manager.session_workspace_exists_returns = False
         stub_sandbox_manager.restore_snapshot_silent = True
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.write_session_opencode_config_silent = True
 
         monkeypatch.setattr(
             "onyx.server.features.build.session.api.get_sandbox_manager",

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -26,11 +26,15 @@ from onyx.redis.redis_pool import get_redis_client
 from onyx.server.features.build.db.build_session import (
     allocate_nextjs_port,
     get_user_build_sessions,
-    skills_are_stale,
+    session_runtime_stale,
 )
 from onyx.server.features.build.db.sandbox import get_sandbox_by_user_id
 from onyx.server.features.build.sandbox.models import SandboxInfo
 from onyx.server.features.build.sandbox.user_library import USER_LIBRARY_MOUNT_PATH
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    craft_mcp_fingerprint,
+    resolve_craft_mcp_servers,
+)
 from onyx.server.features.build.session import locks as session_locks
 from onyx.server.features.build.session.api import (
     reload_session_skills,
@@ -42,7 +46,10 @@ from onyx.server.features.build.session.locks import (
     session_creation_lock,
 )
 from onyx.server.features.build.session.manager import SessionManager
-from onyx.server.features.build.session.sandbox_lifecycle import hydrate_managed_content
+from onyx.server.features.build.session.sandbox_lifecycle import (
+    hydrate_managed_content,
+    refresh_mcp_config_hashes_for_users,
+)
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 from tests.common.craft.stubs import StubSandboxManager
 
@@ -102,8 +109,65 @@ def test_warm_content_hash_change_marks_only_live_session_stale(
     )
     db_session.commit()
     db_session.refresh(sandbox_row)
-    assert skills_are_stale(existing_session, sandbox_row)
-    assert not skills_are_stale(new_session, sandbox_row)
+    assert session_runtime_stale(existing_session, sandbox_row)
+    assert not session_runtime_stale(new_session, sandbox_row)
+
+
+def test_mcp_config_hash_change_marks_session_stale_independent_of_skills(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+    stub_sandbox_manager: StubSandboxManager,
+) -> None:
+    sandbox_row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    stub_sandbox_manager.write_files_to_sandbox_silent = True
+
+    assert hydrate_managed_content(
+        stub_sandbox_manager,
+        sandbox_row.id,
+        test_user,
+        db_session,
+        connectable_apps_section="apps",
+        skills_files={"a/SKILL.md": b"x"},
+    )
+    db_session.commit()
+    db_session.refresh(sandbox_row)
+    # Provisioning stamps the MCP fingerprint alongside the skills hash.
+    assert sandbox_row.mcp_config_hash is not None
+
+    session = BuildSession(
+        user_id=test_user.id,
+        status=BuildSessionStatus.ACTIVE,
+        opencode_session_id="oc",
+        skills_hash=sandbox_row.skills_hash,
+        mcp_config_hash=sandbox_row.mcp_config_hash,
+    )
+    db_session.add(session)
+    db_session.commit()
+    assert not session_runtime_stale(session, sandbox_row)
+
+    # An MCP-config change bumps only mcp_config_hash — the session goes stale
+    # while its skill payload (skills_hash) is untouched.
+    sandbox_row.mcp_config_hash = "different-mcp-fingerprint"
+    db_session.flush()
+    assert session.skills_hash == sandbox_row.skills_hash
+    assert session_runtime_stale(session, sandbox_row)
+
+
+def test_refresh_mcp_config_hashes_stamps_current_fingerprint(
+    db_session: Session,
+    test_user: User,
+    sandbox: Callable[..., Sandbox],
+) -> None:
+    sandbox_row = sandbox(user=test_user, status=SandboxStatus.RUNNING)
+    sandbox_row.mcp_config_hash = "stale"
+    db_session.commit()
+
+    refresh_mcp_config_hashes_for_users({test_user.id}, db_session)
+
+    db_session.refresh(sandbox_row)
+    expected = craft_mcp_fingerprint(resolve_craft_mcp_servers(db_session, test_user))
+    assert sandbox_row.mcp_config_hash == expected
 
 
 class TestCreateSession:
@@ -462,7 +526,7 @@ class TestReloadSessionSkills:
 
         assert exc_info.value.error_code == OnyxErrorCode.CONFLICT
         db_session.refresh(session_row)
-        assert skills_are_stale(session_row, sandbox_row)
+        assert session_runtime_stale(session_row, sandbox_row)
         assert stub_sandbox_manager.dispose_opencode_instance_count == 0
 
 

--- a/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
@@ -13,6 +13,10 @@ from onyx.db.enums import BuildSessionStatus, SandboxStatus, SessionOrigin
 from onyx.db.models import BuildSession, Skill, User
 from onyx.server.features.build.db.build_session import skills_are_stale
 from onyx.server.features.build.sandbox.models import FatalWriteError
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    craft_mcp_fingerprint,
+    resolve_craft_mcp_servers,
+)
 from onyx.skills.push import compute_skill_runtime_hash, push_skills_for_users
 from tests.common.craft.stubs import StubSandboxManager
 from tests.external_dependency_unit.craft.db_helpers import make_sandbox, make_user
@@ -135,13 +139,20 @@ def test_connectable_app_change_pushes_and_hashes_self_heal(
         changed_user.id: "new apps",
     }
 
+    # Seed the runtime hash with the same craft MCP fingerprint push_skills_for_users
+    # computes per user, so the "unchanged" sandbox is genuinely up to date.
+    def mcp_fp(user: User) -> str:
+        return craft_mcp_fingerprint(resolve_craft_mcp_servers(db_session, user))
+
     unchanged_sandbox.skills_hash = compute_skill_runtime_hash(
         files_for(unchanged_user, db_session),
         "",
+        mcp_fp(unchanged_user),
     )
     changed_sandbox.skills_hash = compute_skill_runtime_hash(
         files_for(changed_user, db_session),
         "old apps",
+        mcp_fp(changed_user),
     )
     unchanged_session.skills_hash = unchanged_sandbox.skills_hash
     changed_session.skills_hash = changed_sandbox.skills_hash

--- a/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_push_fault.py
@@ -11,12 +11,8 @@ from sqlalchemy.orm import Session
 
 from onyx.db.enums import BuildSessionStatus, SandboxStatus, SessionOrigin
 from onyx.db.models import BuildSession, Skill, User
-from onyx.server.features.build.db.build_session import skills_are_stale
+from onyx.server.features.build.db.build_session import session_runtime_stale
 from onyx.server.features.build.sandbox.models import FatalWriteError
-from onyx.server.features.build.sandbox.util.mcp_config import (
-    craft_mcp_fingerprint,
-    resolve_craft_mcp_servers,
-)
 from onyx.skills.push import compute_skill_runtime_hash, push_skills_for_users
 from tests.common.craft.stubs import StubSandboxManager
 from tests.external_dependency_unit.craft.db_helpers import make_sandbox, make_user
@@ -80,11 +76,11 @@ def test_one_failing_sandbox_does_not_abort_push_to_others(
         push_skills_for_users({user_a.id, user_b.id, user_c.id}, db_session)
 
     assert stub.write_files_to_sandbox_count == 3
-    assert skills_are_stale(sessions[user_a.id], sandbox_a)
-    assert not skills_are_stale(sessions[user_b.id], sandbox_b)
-    assert not skills_are_stale(sessions[user_c.id], sandbox_c)
-    assert not skills_are_stale(idle_session, sandbox_a)
-    assert not skills_are_stale(scheduled_session, sandbox_a)
+    assert session_runtime_stale(sessions[user_a.id], sandbox_a)
+    assert not session_runtime_stale(sessions[user_b.id], sandbox_b)
+    assert not session_runtime_stale(sessions[user_c.id], sandbox_c)
+    assert not session_runtime_stale(idle_session, sandbox_a)
+    assert not session_runtime_stale(scheduled_session, sandbox_a)
     assert sandbox_a.skills_hash is not None
     assert sandbox_b.skills_hash is None
     assert sandbox_c.skills_hash is not None
@@ -105,7 +101,7 @@ def test_one_failing_sandbox_does_not_abort_push_to_others(
         (sessions[user_b.id], sandbox_b),
         (sessions[user_c.id], sandbox_c),
     ):
-        assert not skills_are_stale(session, sandbox)
+        assert not session_runtime_stale(session, sandbox)
 
 
 def test_connectable_app_change_pushes_and_hashes_self_heal(
@@ -139,20 +135,15 @@ def test_connectable_app_change_pushes_and_hashes_self_heal(
         changed_user.id: "new apps",
     }
 
-    # Seed the runtime hash with the same craft MCP fingerprint push_skills_for_users
-    # computes per user, so the "unchanged" sandbox is genuinely up to date.
-    def mcp_fp(user: User) -> str:
-        return craft_mcp_fingerprint(resolve_craft_mcp_servers(db_session, user))
-
+    # Seed the runtime hash exactly as push_skills_for_users computes it, so the
+    # "unchanged" sandbox is genuinely up to date.
     unchanged_sandbox.skills_hash = compute_skill_runtime_hash(
         files_for(unchanged_user, db_session),
         "",
-        mcp_fp(unchanged_user),
     )
     changed_sandbox.skills_hash = compute_skill_runtime_hash(
         files_for(changed_user, db_session),
         "old apps",
-        mcp_fp(changed_user),
     )
     unchanged_session.skills_hash = unchanged_sandbox.skills_hash
     changed_session.skills_hash = changed_sandbox.skills_hash
@@ -177,12 +168,12 @@ def test_connectable_app_change_pushes_and_hashes_self_heal(
     assert stub.write_files_to_sandbox_count == 1
     assert stub.last_write_files_to_sandbox_payload is not None
     assert stub.last_write_files_to_sandbox_payload["sandbox_id"] == changed_sandbox.id
-    assert not skills_are_stale(unchanged_session, unchanged_sandbox)
-    assert skills_are_stale(changed_session, changed_sandbox)
+    assert not session_runtime_stale(unchanged_session, unchanged_sandbox)
+    assert session_runtime_stale(changed_session, changed_sandbox)
 
     connectable_apps_sections[changed_user.id] = "old apps"
     push_skills_for_users({changed_user.id}, db_session)
 
     db_session.refresh(changed_sandbox)
     assert stub.write_files_to_sandbox_count == 2
-    assert not skills_are_stale(changed_session, changed_sandbox)
+    assert not session_runtime_stale(changed_session, changed_sandbox)

--- a/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
+++ b/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
@@ -28,6 +28,10 @@ from onyx.db.mcp import (
 )
 from onyx.db.models import MCPServer, Tool
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.build.sandbox.util.mcp_config import (
+    craft_mcp_fingerprint,
+    resolve_craft_mcp_servers,
+)
 from onyx.server.features.mcp import api as mcp_api
 from onyx.server.features.mcp.models import (
     MCPConnectionData,
@@ -211,3 +215,60 @@ def test_disconnect_removes_only_callers_credentials(
     assert resp.success is True
     assert get_user_connection_config(server.id, user_a.email, db_session) is None
     assert get_user_connection_config(server.id, user_b.email, db_session) is not None
+
+
+def test_delete_server_restamps_affected_running_sandbox(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    # Deleting a craft server must restamp affected users' running sandboxes so
+    # their live sessions detect staleness and drop the server on the next turn.
+    admin = create_test_user(db_session, "del_reload_admin", role=UserRole.ADMIN)
+    sandbox = make_sandbox(db_session, admin, status=SandboxStatus.RUNNING)
+    server = _make_craft_server(db_session, owner_email=admin.email, is_public=True)
+
+    fp_before = craft_mcp_fingerprint(resolve_craft_mcp_servers(db_session, admin))
+    sandbox.mcp_config_hash = fp_before
+    db_session.commit()
+
+    assert mcp_api.delete_mcp_server_admin(server.id, db_session, admin) == {
+        "success": True
+    }
+
+    # Restamped to the post-delete fingerprint (the server dropped out of the
+    # resolved craft set), so the live session detects staleness next turn.
+    db_session.refresh(sandbox)
+    assert sandbox.mcp_config_hash != fp_before
+    assert sandbox.mcp_config_hash == craft_mcp_fingerprint(
+        resolve_craft_mcp_servers(db_session, admin)
+    )
+
+
+def test_disconnect_restamps_callers_running_sandbox(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    # Disconnecting flips the server's authenticated flag (tool discovery is
+    # credential-gated), so the caller's running sandbox must be restamped.
+    user = create_test_user(db_session, "disc_reload")
+    sandbox = make_sandbox(db_session, user, status=SandboxStatus.RUNNING)
+    server = _make_craft_server(db_session, owner_email=user.email, is_public=True)
+    upsert_user_connection_config(
+        server_id=server.id,
+        user_email=user.email,
+        config_data=MCPConnectionData(headers={"Authorization": "Bearer user-token"}),
+        db_session=db_session,
+    )
+    db_session.commit()
+
+    fp_connected = craft_mcp_fingerprint(resolve_craft_mcp_servers(db_session, user))
+    sandbox.mcp_config_hash = fp_connected
+    db_session.commit()
+
+    mcp_api.delete_user_credentials(server.id, db_session, user)
+
+    db_session.refresh(sandbox)
+    assert sandbox.mcp_config_hash != fp_connected
+    assert sandbox.mcp_config_hash == craft_mcp_fingerprint(
+        resolve_craft_mcp_servers(db_session, user)
+    )

--- a/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
+++ b/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
@@ -15,11 +15,15 @@ from onyx.db.enums import (
     MCPAuthenticationPerformer,
     MCPAuthenticationType,
     MCPTransport,
+    SandboxStatus,
 )
 from onyx.db.gated_app import get_action_policies
 from onyx.db.mcp import (
+    add_user_to_mcp_server,
+    affected_user_ids_for_mcp_server,
     create_mcp_server__no_commit,
     get_user_connection_config,
+    update_mcp_server__no_commit,
     upsert_user_connection_config,
 )
 from onyx.db.models import MCPServer, Tool
@@ -30,6 +34,85 @@ from onyx.server.features.mcp.models import (
     MCPServerSimpleUpdateRequest,
 )
 from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.craft.db_helpers import make_sandbox
+
+
+def _make_craft_server(
+    db_session: Session, *, owner_email: str, is_public: bool
+) -> MCPServer:
+    server = create_mcp_server__no_commit(
+        owner_email=owner_email,
+        name=f"craft-{uuid4().hex[:8]}",
+        description=None,
+        server_url=f"https://api-{uuid4().hex[:8]}.example.com/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        transport=MCPTransport.STREAMABLE_HTTP,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        db_session=db_session,
+        is_public=is_public,
+    )
+    update_mcp_server__no_commit(
+        server_id=server.id, db_session=db_session, available_in_craft=True
+    )
+    db_session.commit()
+    return server
+
+
+def test_affected_user_ids_cover_direct_owner_admin_not_unrelated(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    owner = create_test_user(db_session, "aff_owner")
+    direct = create_test_user(db_session, "aff_direct")
+    unrelated = create_test_user(db_session, "aff_unrelated")
+    admin = create_test_user(db_session, "aff_admin", role=UserRole.ADMIN)
+    for u in (owner, direct, unrelated, admin):
+        make_sandbox(db_session, u, status=SandboxStatus.RUNNING)
+
+    server = _make_craft_server(db_session, owner_email=owner.email, is_public=False)
+    add_user_to_mcp_server(server.id, direct.id, db_session)
+    db_session.commit()
+
+    affected = affected_user_ids_for_mcp_server(server, db_session)
+    assert direct.id in affected
+    assert owner.id in affected
+    # Admins bypass the access filter (so they see every craft server) and must
+    # be reloaded even for a private server they aren't explicitly shared on.
+    assert admin.id in affected
+    assert unrelated.id not in affected
+
+    # A public server reaches every running-sandbox user.
+    server.is_public = True
+    db_session.flush()
+    public_affected = affected_user_ids_for_mcp_server(server, db_session)
+    assert {owner.id, direct.id, unrelated.id, admin.id} <= public_affected
+
+
+def test_public_to_private_recipient_union_covers_losing_user(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    # The recipient set differs across a public -> private transition; the union
+    # of pre- and post-change recipients that update_mcp_server_simple reloads
+    # must still cover a user who was reachable only while the server was public.
+    # (The transition itself is EE-gated at the API layer, so this exercises the
+    # db-level recipient calc the endpoint unions over.)
+    losing = create_test_user(db_session, "union_losing")
+    make_sandbox(db_session, losing, status=SandboxStatus.RUNNING)
+    server = _make_craft_server(
+        db_session, owner_email="union_owner@example.com", is_public=True
+    )
+
+    before = affected_user_ids_for_mcp_server(server, db_session)
+    assert losing.id in before  # public reaches every running-sandbox user
+
+    server.is_public = False
+    db_session.flush()
+    after = affected_user_ids_for_mcp_server(server, db_session)
+    assert losing.id not in after  # private no longer reaches them
+
+    # The reload set is the union, so the losing user is still reloaded.
+    assert losing.id in (before | after)
 
 
 def _make_server(db_session: Session, *, tool_names: list[str]) -> MCPServer:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -11,11 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from onyx.server.features.build.configs import (
-    MCP_SESSION_TAG_HEADER,
-    sign_session_tag,
-    verify_session_tag,
-)
+from onyx.server.features.build.configs import MCP_SESSION_TAG_HEADER
 from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     LLMProviderConfig,
@@ -282,27 +278,16 @@ def test_mcp_servers_emit_remote_entries_with_session_tag_header() -> None:
     config = build_session_mcp_config(
         [_mcp("linear-7", url="https://mcp.linear.app/mcp")], "sess-abc"
     )
-    entry = config["mcp"]["linear-7"]
-    assert entry["type"] == "remote"
-    assert entry["url"] == "https://mcp.linear.app/mcp"
-    assert entry["enabled"] is True
-    # The proxy reads this to attribute the tool call to a session for approval
-    # (no per-user credentials — the proxy injects those). It's HMAC-signed so
-    # the sandbox can't forge a tag for a session it doesn't own; the proxy
-    # verifies it back to the raw id.
-    assert verify_session_tag(entry["headers"][MCP_SESSION_TAG_HEADER]) == "sess-abc"
-
-
-def test_session_tag_signature_round_trips_and_rejects_forgery() -> None:
-    signed = sign_session_tag("sess-abc")
-    assert signed != "sess-abc"
-    assert verify_session_tag(signed) == "sess-abc"
-    # A raw (unsigned) id or a bogus signature is rejected.
-    assert verify_session_tag("sess-abc") is None
-    assert verify_session_tag("sess-abc.deadbeef") is None
-    # Another session's valid signature can't be reused for a different id.
-    forged = "sess-abc." + sign_session_tag("sess-other").split(".", 1)[1]
-    assert verify_session_tag(forged) is None
+    assert config["mcp"] == {
+        "linear-7": {
+            "type": "remote",
+            "url": "https://mcp.linear.app/mcp",
+            "enabled": True,
+            # The proxy reads this to attribute the tool call to a session for
+            # approval (no per-user credentials — the proxy injects those).
+            "headers": {MCP_SESSION_TAG_HEADER: "sess-abc"},
+        }
+    }
 
 
 def test_mcp_tool_curation_maps_to_wildcard_allow_and_deny_permissions() -> None:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -11,12 +11,15 @@ from __future__ import annotations
 
 import pytest
 
+from onyx.server.features.build.configs import MCP_SESSION_TAG_HEADER
 from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     LLMProviderConfig,
 )
+from onyx.server.features.build.sandbox.util.mcp_config import craft_mcp_fingerprint
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
+    build_session_mcp_config,
 )
 
 
@@ -250,10 +253,14 @@ def _mcp(
     url: str = "https://mcp.example.com/mcp",
     disabled_tools: tuple[str, ...] = (),
 ) -> CraftMCPServerConfig:
-    return CraftMCPServerConfig(key=key, url=url, disabled_tools=disabled_tools)
+    return CraftMCPServerConfig(
+        key=key, url=url, disabled_tools=disabled_tools, server_id=1
+    )
 
 
-def test_no_mcp_servers_omits_mcp_key() -> None:
+def test_pod_global_config_never_carries_mcp() -> None:
+    # Craft MCP servers live in per-session config so they can hot-reload; the
+    # pod-global config must not carry them.
     config = build_multi_provider_opencode_config(
         providers=[_cfg("anthropic", "claude-opus-4-7")],
         default_provider="anthropic",
@@ -262,28 +269,30 @@ def test_no_mcp_servers_omits_mcp_key() -> None:
     assert "mcp" not in config
 
 
-def test_mcp_servers_emit_remote_entries_without_headers() -> None:
-    config = build_multi_provider_opencode_config(
-        providers=[_cfg("anthropic", "claude-opus-4-7")],
-        default_provider="anthropic",
-        default_model="claude-opus-4-7",
-        mcp_servers=[_mcp("linear-7", url="https://mcp.linear.app/mcp")],
+def test_no_mcp_servers_emits_only_schema() -> None:
+    config = build_session_mcp_config([], "sess-1")
+    assert config == {"$schema": "https://opencode.ai/config.json"}
+
+
+def test_mcp_servers_emit_remote_entries_with_session_tag_header() -> None:
+    config = build_session_mcp_config(
+        [_mcp("linear-7", url="https://mcp.linear.app/mcp")], "sess-abc"
     )
     assert config["mcp"] == {
         "linear-7": {
             "type": "remote",
             "url": "https://mcp.linear.app/mcp",
             "enabled": True,
+            # The proxy reads this to attribute the tool call to a session for
+            # approval (no per-user credentials — the proxy injects those).
+            "headers": {MCP_SESSION_TAG_HEADER: "sess-abc"},
         }
     }
 
 
 def test_mcp_tool_curation_maps_to_wildcard_allow_and_deny_permissions() -> None:
-    config = build_multi_provider_opencode_config(
-        providers=[_cfg("anthropic", "claude-opus-4-7")],
-        default_provider="anthropic",
-        default_model="claude-opus-4-7",
-        mcp_servers=[_mcp("linear-7", disabled_tools=("delete_issue",))],
+    config = build_session_mcp_config(
+        [_mcp("linear-7", disabled_tools=("delete_issue",))], "sess-1"
     )
     permission = config["permission"]
     assert permission["linear-7_*"] == "allow"
@@ -293,10 +302,46 @@ def test_mcp_tool_curation_maps_to_wildcard_allow_and_deny_permissions() -> None
 def test_uncurated_mcp_server_still_gets_wildcard_allow() -> None:
     # Zero Tool rows: the wildcard must still allow so runtime-discovered tools
     # don't fall through to opencode's default "ask".
-    config = build_multi_provider_opencode_config(
-        providers=[_cfg("anthropic", "claude-opus-4-7")],
-        default_provider="anthropic",
-        default_model="claude-opus-4-7",
-        mcp_servers=[_mcp("linear-7")],
-    )
+    config = build_session_mcp_config([_mcp("linear-7")], "sess-1")
     assert config["permission"]["linear-7_*"] == "allow"
+
+
+def _srv(
+    server_id: int,
+    url: str = "https://mcp.example.com/mcp",
+    disabled_tools: tuple[str, ...] = (),
+    authenticated: bool = False,
+) -> CraftMCPServerConfig:
+    return CraftMCPServerConfig(
+        key=f"s-{server_id}",
+        url=url,
+        disabled_tools=disabled_tools,
+        server_id=server_id,
+        authenticated=authenticated,
+    )
+
+
+def test_craft_mcp_fingerprint_is_order_independent() -> None:
+    a, b = _srv(1, url="u1"), _srv(2, url="u2")
+    assert craft_mcp_fingerprint([a, b]) == craft_mcp_fingerprint([b, a])
+
+
+def test_craft_mcp_fingerprint_reacts_to_each_input() -> None:
+    base = [_srv(1, url="u1", disabled_tools=("x",), authenticated=False)]
+    baseline = craft_mcp_fingerprint(base)
+    # server set
+    assert craft_mcp_fingerprint(base + [_srv(2)]) != baseline
+    # url
+    assert craft_mcp_fingerprint([_srv(1, url="u2", disabled_tools=("x",))]) != baseline
+    # disabled-tool set
+    assert (
+        craft_mcp_fingerprint([_srv(1, url="u1", disabled_tools=("x", "y"))])
+        != baseline
+    )
+    # per-user auth
+    assert (
+        craft_mcp_fingerprint(
+            [_srv(1, url="u1", disabled_tools=("x",), authenticated=True)]
+        )
+        != baseline
+    )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 import pytest
 
-from onyx.server.features.build.configs import MCP_SESSION_TAG_HEADER
+from onyx.server.features.build.configs import (
+    MCP_SESSION_TAG_HEADER,
+    sign_session_tag,
+    verify_session_tag,
+)
 from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
     LLMProviderConfig,
@@ -278,16 +282,27 @@ def test_mcp_servers_emit_remote_entries_with_session_tag_header() -> None:
     config = build_session_mcp_config(
         [_mcp("linear-7", url="https://mcp.linear.app/mcp")], "sess-abc"
     )
-    assert config["mcp"] == {
-        "linear-7": {
-            "type": "remote",
-            "url": "https://mcp.linear.app/mcp",
-            "enabled": True,
-            # The proxy reads this to attribute the tool call to a session for
-            # approval (no per-user credentials — the proxy injects those).
-            "headers": {MCP_SESSION_TAG_HEADER: "sess-abc"},
-        }
-    }
+    entry = config["mcp"]["linear-7"]
+    assert entry["type"] == "remote"
+    assert entry["url"] == "https://mcp.linear.app/mcp"
+    assert entry["enabled"] is True
+    # The proxy reads this to attribute the tool call to a session for approval
+    # (no per-user credentials — the proxy injects those). It's HMAC-signed so
+    # the sandbox can't forge a tag for a session it doesn't own; the proxy
+    # verifies it back to the raw id.
+    assert verify_session_tag(entry["headers"][MCP_SESSION_TAG_HEADER]) == "sess-abc"
+
+
+def test_session_tag_signature_round_trips_and_rejects_forgery() -> None:
+    signed = sign_session_tag("sess-abc")
+    assert signed != "sess-abc"
+    assert verify_session_tag(signed) == "sess-abc"
+    # A raw (unsigned) id or a bogus signature is rejected.
+    assert verify_session_tag("sess-abc") is None
+    assert verify_session_tag("sess-abc.deadbeef") is None
+    # Another session's valid signature can't be reused for a different id.
+    forged = "sess-abc." + sign_session_tag("sess-other").split(".", 1)[1]
+    assert verify_session_tag(forged) is None
 
 
 def test_mcp_tool_curation_maps_to_wildcard_allow_and_deny_permissions() -> None:

--- a/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
+++ b/backend/tests/unit/onyx/server/features/build/session/test_messages_background_turn.py
@@ -55,7 +55,7 @@ def _patch_skill_state(
     stale: bool = False,
 ) -> None:
     monkeypatch.setattr(messages_api, "get_sandbox_by_user_id", lambda *_: object())
-    monkeypatch.setattr(messages_api, "skills_are_stale", lambda *_: stale)
+    monkeypatch.setattr(messages_api, "session_runtime_stale", lambda *_: stale)
 
 
 def test_send_message_starts_background_turn(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/onyx/skills/test_push.py
+++ b/backend/tests/unit/onyx/skills/test_push.py
@@ -61,11 +61,6 @@ def test_skill_runtime_hash_covers_files_and_connectable_apps() -> None:
     assert push.compute_skill_runtime_hash(
         files, "apps"
     ) != push.compute_skill_runtime_hash(files, "different apps")
-    # The craft MCP fingerprint is part of the runtime hash so an MCP change
-    # marks live sessions stale and hot-reloads them.
-    assert push.compute_skill_runtime_hash(
-        files, "apps", "mcp-fp-1"
-    ) != push.compute_skill_runtime_hash(files, "apps", "mcp-fp-2")
 
 
 def test_assemble_rejects_duplicate_names() -> None:

--- a/backend/tests/unit/onyx/skills/test_push.py
+++ b/backend/tests/unit/onyx/skills/test_push.py
@@ -61,6 +61,11 @@ def test_skill_runtime_hash_covers_files_and_connectable_apps() -> None:
     assert push.compute_skill_runtime_hash(
         files, "apps"
     ) != push.compute_skill_runtime_hash(files, "different apps")
+    # The craft MCP fingerprint is part of the runtime hash so an MCP change
+    # marks live sessions stale and hot-reloads them.
+    assert push.compute_skill_runtime_hash(
+        files, "apps", "mcp-fp-1"
+    ) != push.compute_skill_runtime_hash(files, "apps", "mcp-fp-2")
 
 
 def test_assemble_rejects_duplicate_names() -> None:


### PR DESCRIPTION
## What

Hot-reloads a user's craft MCP set into their **running** sandbox — enabling a server, toggling its tools, or connecting credentials now reaches a live Craft session on its next turn, with no pod re-provision.

> **Base:** this stacks on `dane/mcp-craft-approvals-fe` (the craft MCP frontend), which in turn stacks on the approvals backend (#13168). Review after those.

## Why

The craft `mcp` block was baked into the pod-global `opencode.json` (delivered once via `OPENCODE_CONFIG_CONTENT`), and opencode-serve loads that config once at process start. So a RUNNING+healthy sandbox is reused as-is and never sees an MCP config change until it's destroyed and re-provisioned.

## How

- **Per-session config.** The craft `mcp` block + its per-tool permission gates move out of the pod-global config into a per-session `opencode.json` (`build_session_mcp_config`), written by the sandbox managers (`write_session_opencode_config`) and re-read when the session's opencode instance is disposed. opencode merges it with the pod-global config, so the server set can change without restarting opencode-serve.
- **Rides the existing skills-reload pipeline.** The craft MCP set (server ids + urls, disabled-tool sets, per-user auth) is folded into the managed-runtime hash (`compute_skill_runtime_hash`), so an MCP change marks the session stale via the existing `skills_are_stale` / `reload_session_skills` path — no new staleness plumbing. `push_skills_for_users` is triggered on craft-enable (admin) and per-user credential connect (`affected_user_ids_for_mcp_server`).
- **Session attribution for MCP approvals.** opencode's in-process MCP client uses the untagged base proxy env (the shell-env proxy tag only rides shell-subprocess egress), so ASK-policy MCP tool calls previously couldn't be attributed to a session (`no_active_session`). Each per-session MCP server is now stamped with an `X-Onyx-Mcp-Session` header carrying the BuildSession id; the egress proxy reads it in `_extract_session_tag` and strips it before the origin sees it.

Approval **policy** enforcement is unchanged and still fully live (proxy `effective_mcp_tool_policy`) — only the server set / tool set / discovery state hot-reloads.

## Tests

- Unit: pod-global config never carries `mcp`; per-session builder emits the server set + permission gates + session-tag header; runtime-hash fingerprint is order-independent and reacts to server set / url / tools / per-user auth.
- External-dependency-unit: `resolve_craft_mcp_servers` populates `server_id`/`authenticated`; connecting credentials flips `authenticated` and changes the fingerprint; skills-push self-heal still holds with MCP folded into the hash.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hot-reload Craft MCP servers and tool gates into running sandboxes via per-session `opencode.json`. Sessions pick up server, tool, and credential changes on their next turn without re-provisioning; MCP staleness is tracked separately from skills.

- **New Features**
  - Per-session MCP config: write `sessions/<session>/opencode.json` on create/restore and before reload; wildcard allow with per-tool denies; pod-global `opencode.json` no longer carries `mcp`.
  - Session attribution header: each MCP server includes `X-Onyx-Mcp-Session=<session_id>`; the proxy prefers it, attributes approvals, and strips it (and `Proxy-Authorization`) before forwarding.
  - Separate MCP staleness: add `mcp_config_hash` to `sandbox` and `build_session`; sessions reload when either `skills_hash` or `mcp_config_hash` changes. `refresh_mcp_config_hashes_for_users` restamps RUNNING sandboxes after MCP edits and credential connects (incl. OAuth), includes admins, and unions pre/post ACL recipients so removed users drop servers.

- **Bug Fixes**
  - Hot-reload now also triggers on MCP server delete and user credential disconnect: snapshot recipients before delete and restamp after commit so running sessions drop the server/credentials next turn.
  - OAuth auto-discovery fix: restamp the caller’s running sandbox after the token-exchange commit so discovery state is reflected immediately.

<sup>Written for commit 72a8d63fc63b99be2667502caa3ada476d1a471d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13293?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->





