### PR TITLE
Bound search preprocessing LLM calls

### DIFF
--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -48,6 +48,35 @@ DR_REPORT_LLM_TIMEOUT_S = int(os.environ.get("DR_REPORT_LLM_TIMEOUT_S") or "60")
 SECONDARY_LLM_FLOW_TIMEOUT_S = int(
     os.environ.get("SECONDARY_LLM_FLOW_TIMEOUT_S") or "60"
 )
+# Emergency escape hatch for the post-retrieval LLM section-selection and
+# context-expansion phase. Retrieval still runs, but results are passed through
+# without secondary LLM filtering/expansion.
+DISABLE_LLM_SEARCH_SECTION_PROCESSING = (
+    os.environ.get("DISABLE_LLM_SEARCH_SECTION_PROCESSING", "").lower() == "true"
+)
+# Section expansion issues one LLM call per selected section. Keep the default
+# serialized to avoid stressing shared sync provider connection pools.
+SEARCH_SECTION_EXPANSION_MAX_WORKERS = max(
+    1, int(os.environ.get("SEARCH_SECTION_EXPANSION_MAX_WORKERS") or "1")
+)
+# Wall-clock cap for the post-retrieval section-selection LLM call. This is
+# separate from the provider timeout because lock acquisition may not observe it.
+SEARCH_SECTION_SELECTION_TIMEOUT_S = max(
+    1,
+    int(
+        os.environ.get("SEARCH_SECTION_SELECTION_TIMEOUT_S")
+        or str(SECONDARY_LLM_FLOW_TIMEOUT_S)
+    ),
+)
+# Wall-clock cap for the whole section-expansion phase. Timed-out work falls
+# back to the original selected section while the stuck worker is abandoned.
+SEARCH_SECTION_EXPANSION_TIMEOUT_S = max(
+    1,
+    int(
+        os.environ.get("SEARCH_SECTION_EXPANSION_TIMEOUT_S")
+        or str(SECONDARY_LLM_FLOW_TIMEOUT_S)
+    ),
+)
 # Live buffer TTL. Refreshed per write.
 CHAT_STREAM_BUFFER_TTL_S = int(os.environ.get("CHAT_STREAM_BUFFER_TTL_S") or 3600)
 # Retention after the run is done.

--- a/backend/onyx/secondary_llm_flows/query_expansion.py
+++ b/backend/onyx/secondary_llm_flows/query_expansion.py
@@ -1,3 +1,4 @@
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
 from onyx.configs.constants import MessageType
 from onyx.llm.interfaces import LLM
 from onyx.llm.models import (
@@ -138,7 +139,11 @@ def semantic_query_rephrase(
     with llm_generation_span(
         llm=llm, flow=LLMFlow.SEMANTIC_QUERY_REPHRASE, input_messages=messages
     ) as span_generation:
-        response = llm.invoke(prompt=messages, reasoning_effort=ReasoningEffort.OFF)
+        response = llm.invoke(
+            prompt=messages,
+            reasoning_effort=ReasoningEffort.OFF,
+            timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S,
+        )
         record_llm_response(span_generation, response)
         final_query = response.choice.message.content
 
@@ -218,7 +223,11 @@ def keyword_query_expansion(
     with llm_generation_span(
         llm=llm, flow=LLMFlow.KEYWORD_QUERY_EXPANSION, input_messages=messages
     ) as span_generation:
-        response = llm.invoke(prompt=messages, reasoning_effort=ReasoningEffort.OFF)
+        response = llm.invoke(
+            prompt=messages,
+            reasoning_effort=ReasoningEffort.OFF,
+            timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S,
+        )
         record_llm_response(span_generation, response)
         content = response.choice.message.content
 

--- a/backend/onyx/secondary_llm_flows/source_filter.py
+++ b/backend/onyx/secondary_llm_flows/source_filter.py
@@ -2,6 +2,7 @@ import json
 
 from pydantic import BaseModel
 
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
 from onyx.configs.constants import DocumentSource, MessageType
 from onyx.llm.interfaces import LLM
 from onyx.llm.models import ChatCompletionMessage, ReasoningEffort, UserMessage
@@ -114,7 +115,11 @@ def decide_search_scope(
             flow=LLMFlow.SOURCE_FILTER_EXTRACTION,
             input_messages=messages,
         ) as span_generation:
-            response = llm.invoke(prompt=messages, reasoning_effort=ReasoningEffort.OFF)
+            response = llm.invoke(
+                prompt=messages,
+                reasoning_effort=ReasoningEffort.OFF,
+                timeout_override=SECONDARY_LLM_FLOW_TIMEOUT_S,
+            )
             record_llm_response(span_generation, response)
             content = response.choice.message.content
     except Exception:

--- a/backend/onyx/tools/tool_implementations/search/search_tool.py
+++ b/backend/onyx/tools/tool_implementations/search/search_tool.py
@@ -42,7 +42,13 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.chat.emitter import Emitter
-from onyx.configs.chat_configs import MAX_CHUNKS_FED_TO_CHAT
+from onyx.configs.chat_configs import (
+    DISABLE_LLM_SEARCH_SECTION_PROCESSING,
+    MAX_CHUNKS_FED_TO_CHAT,
+    SEARCH_SECTION_EXPANSION_MAX_WORKERS,
+    SEARCH_SECTION_EXPANSION_TIMEOUT_S,
+    SEARCH_SECTION_SELECTION_TIMEOUT_S,
+)
 from onyx.configs.constants import DocumentSource, FederatedConnectorSource
 from onyx.context.search.federated.slack_search import slack_retrieval
 from onyx.context.search.models import (
@@ -1097,24 +1103,49 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
             max_chunks_per_section=MAX_CHUNKS_FOR_RELEVANCE,
         )
 
-        # Start timing for LLM document selection
-        document_selection_start_time = time.time()
+        if DISABLE_LLM_SEARCH_SECTION_PROCESSING:
+            selected_sections = top_sections
+            best_doc_ids = None
+            logger.warning(
+                "Search tool - LLM section processing disabled; using retrieved sections directly"
+            )
+        else:
+            # Start timing for LLM document selection
+            document_selection_start_time = time.time()
 
-        # Use LLM to select the most relevant sections for expansion
-        selected_sections, best_doc_ids = select_sections_for_expansion(
-            sections=sections_for_selection,
-            user_query=secondary_flows_user_query,
-            llm=self.llm,
-            max_chunks_per_section=MAX_CHUNKS_FOR_RELEVANCE,
-        )
+            def selection_timeout_callback(
+                _index: int, _func: Callable, _args: tuple[Any, ...]
+            ) -> tuple[list[InferenceSection], list[str] | None]:
+                logger.warning(
+                    "Search tool - LLM section selection timed out; using top retrieved sections."
+                )
+                return sections_for_selection[:10], None
 
-        # End timing for LLM document selection
-        document_selection_elapsed = time.time() - document_selection_start_time
-        logger.debug(
-            "Search tool - LLM picking documents took %s seconds (selected %s sections)",
-            format(document_selection_elapsed, ".3f"),
-            len(selected_sections),
-        )
+            selection_results = run_functions_tuples_in_parallel(
+                [
+                    (
+                        select_sections_for_expansion,
+                        (
+                            sections_for_selection,
+                            secondary_flows_user_query,
+                            self.llm,
+                            10,
+                            MAX_CHUNKS_FOR_RELEVANCE,
+                        ),
+                    )
+                ],
+                timeout=SEARCH_SECTION_SELECTION_TIMEOUT_S,
+                timeout_callback=selection_timeout_callback,
+            )
+            selected_sections, best_doc_ids = selection_results[0]
+
+            # End timing for LLM document selection
+            document_selection_elapsed = time.time() - document_selection_start_time
+            logger.debug(
+                "Search tool - LLM picking documents took %s seconds (selected %s sections)",
+                format(document_selection_elapsed, ".3f"),
+                len(selected_sections),
+            )
 
         # Create a set of best document IDs for quick lookup
         best_doc_ids_set = set(best_doc_ids) if best_doc_ids else set()
@@ -1159,34 +1190,53 @@ class SearchTool(Tool[SearchToolOverrideKwargs]):
                 )
                 return section
 
-        # Build parallel function calls for all sections
-        expansion_functions: list[tuple[Callable, tuple]] = [
-            (
-                expand_section_safe,
+        if DISABLE_LLM_SEARCH_SECTION_PROCESSING:
+            expanded_sections = selected_sections
+        else:
+            # Build parallel function calls for all sections
+            expansion_functions: list[tuple[Callable, tuple]] = [
                 (
-                    section,
-                    secondary_flows_user_query,
-                    self.llm,
-                    self.document_index,
-                    section.center_chunk.document_id in best_doc_ids_set,
-                ),
+                    expand_section_safe,
+                    (
+                        section,
+                        secondary_flows_user_query,
+                        self.llm,
+                        self.document_index,
+                        section.center_chunk.document_id in best_doc_ids_set,
+                    ),
+                )
+                for section in selected_sections
+            ]
+
+            def expansion_timeout_callback(
+                index: int, _func: Callable, _args: tuple[Any, ...]
+            ) -> InferenceSection:
+                section = selected_sections[index]
+                logger.warning(
+                    "Search tool - section context expansion timed out for document %s; using original section.",
+                    section.center_chunk.document_id,
+                )
+                return section
+
+            # Start timing for document expansion
+            document_expansion_start_time = time.time()
+
+            # Run expansions with bounded concurrency so a stuck provider pool
+            # cannot hold the entire request open indefinitely.
+            expanded_sections = run_functions_tuples_in_parallel(
+                expansion_functions,
+                max_workers=SEARCH_SECTION_EXPANSION_MAX_WORKERS,
+                timeout=SEARCH_SECTION_EXPANSION_TIMEOUT_S,
+                timeout_callback=expansion_timeout_callback,
             )
-            for section in selected_sections
-        ]
 
-        # Start timing for document expansion
-        document_expansion_start_time = time.time()
-
-        # Run all expansions in parallel
-        expanded_sections = run_functions_tuples_in_parallel(expansion_functions)
-
-        # End timing for document expansion
-        document_expansion_elapsed = time.time() - document_expansion_start_time
-        logger.debug(
-            "Search tool - Expansion of selected documents took %s seconds (expanded %s sections)",
-            format(document_expansion_elapsed, ".3f"),
-            len(expanded_sections),
-        )
+            # End timing for document expansion
+            document_expansion_elapsed = time.time() - document_expansion_start_time
+            logger.debug(
+                "Search tool - Expansion of selected documents took %s seconds (expanded %s sections)",
+                format(document_expansion_elapsed, ".3f"),
+                len(expanded_sections),
+            )
 
         if not expanded_sections:
             expanded_sections = selected_sections

--- a/backend/tests/unit/onyx/secondary_llm_flows/conftest.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/conftest.py
@@ -1,0 +1,16 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+from onyx.llm.interfaces import LLM
+
+
+@contextmanager
+def noop_span() -> Iterator[MagicMock]:
+    yield MagicMock()
+
+
+def make_llm(invoke: MagicMock) -> LLM:
+    llm = MagicMock(spec=LLM)
+    llm.invoke = invoke
+    return llm

--- a/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py
@@ -1,5 +1,3 @@
-from collections.abc import Iterator
-from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
@@ -9,17 +7,12 @@ from onyx.context.search.models import (
     InferenceChunk,
     InferenceSection,
 )
-from onyx.llm.interfaces import LLM
 from onyx.llm.multi_llm import LLMTimeoutError
 from onyx.secondary_llm_flows.document_filter import (
     classify_section_relevance,
     select_sections_for_expansion,
 )
-
-
-@contextmanager
-def _noop_span() -> Iterator[MagicMock]:
-    yield MagicMock()
+from tests.unit.onyx.secondary_llm_flows.conftest import make_llm, noop_span
 
 
 def _make_section() -> InferenceSection:
@@ -49,16 +42,10 @@ def _make_section() -> InferenceSection:
     )
 
 
-def _make_llm(invoke: MagicMock) -> LLM:
-    llm = MagicMock(spec=LLM)
-    llm.invoke = invoke
-    return llm
-
-
 @patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
 @patch(
     "onyx.secondary_llm_flows.document_filter.llm_generation_span",
-    return_value=_noop_span(),
+    return_value=noop_span(),
 )
 def test_classify_section_relevance_timeout_falls_back(
     _span: MagicMock, _record: MagicMock
@@ -66,7 +53,7 @@ def test_classify_section_relevance_timeout_falls_back(
     """A timed-out classification call must degrade to the safe default instead
     of propagating, so a stalled provider can't hang the worker."""
     invoke = MagicMock(side_effect=LLMTimeoutError("timed out"))
-    llm = _make_llm(invoke)
+    llm = make_llm(invoke)
 
     result = classify_section_relevance(
         document_title="Doc",
@@ -86,7 +73,7 @@ def test_classify_section_relevance_timeout_falls_back(
 @patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
 @patch(
     "onyx.secondary_llm_flows.document_filter.llm_generation_span",
-    return_value=_noop_span(),
+    return_value=noop_span(),
 )
 def test_classify_section_relevance_passes_timeout_on_success(
     _span: MagicMock, _record: MagicMock
@@ -94,7 +81,7 @@ def test_classify_section_relevance_passes_timeout_on_success(
     response = MagicMock()
     response.choice.message.content = "3"  # FULL_DOCUMENT
     invoke = MagicMock(return_value=response)
-    llm = _make_llm(invoke)
+    llm = make_llm(invoke)
 
     result = classify_section_relevance(
         document_title="Doc",
@@ -112,7 +99,7 @@ def test_classify_section_relevance_passes_timeout_on_success(
 @patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
 @patch(
     "onyx.secondary_llm_flows.document_filter.llm_generation_span",
-    return_value=_noop_span(),
+    return_value=noop_span(),
 )
 def test_select_sections_for_expansion_timeout_falls_back(
     _span: MagicMock, _record: MagicMock
@@ -121,7 +108,7 @@ def test_select_sections_for_expansion_timeout_falls_back(
     (capped) instead of propagating and hanging the worker."""
     sections = [_make_section()]
     invoke = MagicMock(side_effect=LLMTimeoutError("timed out"))
-    llm = _make_llm(invoke)
+    llm = make_llm(invoke)
 
     selected, doc_ids = select_sections_for_expansion(
         sections=sections, user_query="q", llm=llm, max_sections=10
@@ -135,7 +122,7 @@ def test_select_sections_for_expansion_timeout_falls_back(
 @patch("onyx.secondary_llm_flows.document_filter.record_llm_response")
 @patch(
     "onyx.secondary_llm_flows.document_filter.llm_generation_span",
-    return_value=_noop_span(),
+    return_value=noop_span(),
 )
 def test_select_sections_for_expansion_passes_timeout_on_success(
     _span: MagicMock, _record: MagicMock
@@ -144,7 +131,7 @@ def test_select_sections_for_expansion_passes_timeout_on_success(
     response = MagicMock()
     response.choice.message.content = "[0]"
     invoke = MagicMock(return_value=response)
-    llm = _make_llm(invoke)
+    llm = make_llm(invoke)
 
     selected, _doc_ids = select_sections_for_expansion(
         sections=sections, user_query="q", llm=llm, max_sections=10

--- a/backend/tests/unit/onyx/secondary_llm_flows/test_query_expansion.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/test_query_expansion.py
@@ -1,20 +1,13 @@
-from collections.abc import Iterator
-from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
 from onyx.configs.constants import MessageType
-from onyx.llm.interfaces import LLM
 from onyx.secondary_llm_flows.query_expansion import (
     keyword_query_expansion,
     semantic_query_rephrase,
 )
 from onyx.tools.models import ChatMinimalTextMessage
-
-
-@contextmanager
-def _noop_span() -> Iterator[MagicMock]:
-    yield MagicMock()
+from tests.unit.onyx.secondary_llm_flows.conftest import make_llm, noop_span
 
 
 def _make_history() -> list[ChatMinimalTextMessage]:
@@ -32,22 +25,16 @@ def _make_response(content: str) -> MagicMock:
     return response
 
 
-def _make_llm(invoke: MagicMock) -> LLM:
-    llm = MagicMock(spec=LLM)
-    llm.invoke = invoke
-    return llm
-
-
 @patch("onyx.secondary_llm_flows.query_expansion.record_llm_response")
 @patch(
     "onyx.secondary_llm_flows.query_expansion.llm_generation_span",
-    return_value=_noop_span(),
+    return_value=noop_span(),
 )
 def test_semantic_query_rephrase_passes_timeout(
     _span: MagicMock, _record: MagicMock
 ) -> None:
     invoke = MagicMock(return_value=_make_response("onboarding documentation"))
-    llm = _make_llm(invoke)
+    llm = make_llm(invoke)
 
     result = semantic_query_rephrase(_make_history(), llm)
 
@@ -58,13 +45,13 @@ def test_semantic_query_rephrase_passes_timeout(
 @patch("onyx.secondary_llm_flows.query_expansion.record_llm_response")
 @patch(
     "onyx.secondary_llm_flows.query_expansion.llm_generation_span",
-    return_value=_noop_span(),
+    return_value=noop_span(),
 )
 def test_keyword_query_expansion_passes_timeout(
     _span: MagicMock, _record: MagicMock
 ) -> None:
     invoke = MagicMock(return_value=_make_response("onboarding docs\nnew hire guide"))
-    llm = _make_llm(invoke)
+    llm = make_llm(invoke)
 
     result = keyword_query_expansion(_make_history(), llm)
 

--- a/backend/tests/unit/onyx/secondary_llm_flows/test_query_expansion.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/test_query_expansion.py
@@ -1,0 +1,72 @@
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
+from onyx.configs.constants import MessageType
+from onyx.llm.interfaces import LLM
+from onyx.secondary_llm_flows.query_expansion import (
+    keyword_query_expansion,
+    semantic_query_rephrase,
+)
+from onyx.tools.models import ChatMinimalTextMessage
+
+
+@contextmanager
+def _noop_span() -> Iterator[MagicMock]:
+    yield MagicMock()
+
+
+def _make_history() -> list[ChatMinimalTextMessage]:
+    return [
+        ChatMinimalTextMessage(
+            message="Find recent onboarding docs.",
+            message_type=MessageType.USER,
+        )
+    ]
+
+
+def _make_response(content: str) -> MagicMock:
+    response = MagicMock()
+    response.choice.message.content = content
+    return response
+
+
+def _make_llm(invoke: MagicMock) -> LLM:
+    llm = MagicMock(spec=LLM)
+    llm.invoke = invoke
+    return llm
+
+
+@patch("onyx.secondary_llm_flows.query_expansion.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.query_expansion.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_semantic_query_rephrase_passes_timeout(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    invoke = MagicMock(return_value=_make_response("onboarding documentation"))
+    llm = _make_llm(invoke)
+
+    result = semantic_query_rephrase(_make_history(), llm)
+
+    assert result == "onboarding documentation"
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
+
+
+@patch("onyx.secondary_llm_flows.query_expansion.record_llm_response")
+@patch(
+    "onyx.secondary_llm_flows.query_expansion.llm_generation_span",
+    return_value=_noop_span(),
+)
+def test_keyword_query_expansion_passes_timeout(
+    _span: MagicMock, _record: MagicMock
+) -> None:
+    invoke = MagicMock(return_value=_make_response("onboarding docs\nnew hire guide"))
+    llm = _make_llm(invoke)
+
+    result = keyword_query_expansion(_make_history(), llm)
+
+    assert result == ["onboarding docs", "new hire guide"]
+    assert invoke.call_args.kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S

--- a/backend/tests/unit/onyx/secondary_llm_flows/test_source_filter.py
+++ b/backend/tests/unit/onyx/secondary_llm_flows/test_source_filter.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from contextlib import nullcontext
 from unittest.mock import MagicMock, patch
 
+from onyx.configs.chat_configs import SECONDARY_LLM_FLOW_TIMEOUT_S
 from onyx.configs.constants import DocumentSource, MessageType
 from onyx.llm.models import UserMessage
 from onyx.secondary_llm_flows.source_filter import SearchCycle, decide_search_scope
@@ -17,13 +18,13 @@ def _run_decision(
     connected: list[DocumentSource],
     previous_cycles: list[SearchCycle],
     llm_returns: str,
-) -> tuple[list[DocumentSource] | None, list]:
-    """Run decide_search_scope with the LLM stubbed to return `llm_returns`.
-    Returns (scope, prompt_messages)."""
+) -> tuple[list[DocumentSource] | None, list, dict[str, object]]:
+    """Run decide_search_scope with the LLM stubbed to return `llm_returns`."""
     captured: dict = {}
 
     def fake_invoke(prompt: list, **_kwargs: object) -> MagicMock:
         captured["prompt"] = prompt
+        captured["kwargs"] = _kwargs
         resp = MagicMock()
         resp.choice.message.content = llm_returns
         return resp
@@ -38,7 +39,7 @@ def _run_decision(
         patch("onyx.secondary_llm_flows.source_filter.record_llm_response"),
     ):
         scope = decide_search_scope(history, llm, connected, previous_cycles, ["q"])
-    return scope, captured["prompt"]
+    return scope, captured["prompt"], captured["kwargs"]
 
 
 def test_prompt_excludes_assistant_turns_and_ends_with_user() -> None:
@@ -60,7 +61,7 @@ def test_prompt_excludes_assistant_turns_and_ends_with_user() -> None:
             message_type=MessageType.TOOL_CALL_RESPONSE,
         ),
     ]
-    scope, prompt = _run_decision(history, [A, B], [], "[confluence]")
+    scope, prompt, _kwargs = _run_decision(history, [A, B], [], "[confluence]")
 
     assert all(isinstance(m, UserMessage) for m in prompt)
     assert isinstance(prompt[-1], UserMessage)
@@ -76,7 +77,7 @@ def test_first_search_renders_na_for_previous_cycles() -> None:
             message="Search Confluence.", message_type=MessageType.USER
         )
     ]
-    _scope, prompt = _run_decision(history, [A, B], [], "[]")
+    _scope, prompt, _kwargs = _run_decision(history, [A, B], [], "[]")
     assert "N/A This is the first search" in prompt[-1].content
 
 
@@ -96,7 +97,7 @@ def test_previous_cycles_are_rendered_in_the_prompt() -> None:
             searched_sources=["zendesk"],
         )
     ]
-    scope, prompt = _run_decision(history, [A, B], cycles, "[confluence]")
+    scope, prompt, _kwargs = _run_decision(history, [A, B], cycles, "[confluence]")
     text = prompt[-1].content
     assert "zendesk" in text and "login bug" in text
     assert scope == [B]
@@ -119,7 +120,7 @@ def test_empty_bracket_is_unscoped() -> None:
             message="What's our PTO policy?", message_type=MessageType.USER
         )
     ]
-    scope, _prompt = _run_decision(history, [A, B], [], "[]")
+    scope, _prompt, _kwargs = _run_decision(history, [A, B], [], "[]")
     assert scope is None
 
 
@@ -127,8 +128,18 @@ def test_stray_text_around_list_still_parses() -> None:
     history = [
         ChatMinimalTextMessage(message="Check Zendesk.", message_type=MessageType.USER)
     ]
-    scope, _prompt = _run_decision(history, [A, B], [], "Sure: [zendesk]")
+    scope, _prompt, _kwargs = _run_decision(history, [A, B], [], "Sure: [zendesk]")
     assert scope == [A]
+
+
+def test_scope_decision_passes_timeout() -> None:
+    history = [
+        ChatMinimalTextMessage(message="Check Zendesk.", message_type=MessageType.USER)
+    ]
+    scope, _prompt, kwargs = _run_decision(history, [A, B], [], "[zendesk]")
+
+    assert scope == [A]
+    assert kwargs["timeout_override"] == SECONDARY_LLM_FLOW_TIMEOUT_S
 
 
 def test_only_the_last_five_user_turns_reach_the_prompt() -> None:
@@ -137,7 +148,7 @@ def test_only_the_last_five_user_turns_reach_the_prompt() -> None:
         ChatMinimalTextMessage(message=f"msg {i}", message_type=MessageType.USER)
         for i in range(8)
     ]
-    _scope, prompt = _run_decision(history, [A, B], [], "[]")
+    _scope, prompt, _kwargs = _run_decision(history, [A, B], [], "[]")
 
     text = prompt[-1].content
     # msg 7 is the current query (query reminder); msgs 3-6 are recent history;

--- a/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
+++ b/backend/tests/unit/onyx/tools/tool_implementations/search/test_search_tool_run.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+from contextlib import ExitStack
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 from onyx.configs.constants import DocumentSource, MessageType
-from onyx.context.search.models import BaseFilters
+from onyx.context.search.models import BaseFilters, InferenceChunk, InferenceSection
 from onyx.server.query_and_chat.placement import Placement
 from onyx.server.query_and_chat.streaming_models import SearchToolFilterDelta
 from onyx.tools.models import ChatMinimalTextMessage, SearchToolOverrideKwargs
@@ -32,6 +33,33 @@ def _make_tool(
         project_id_filter=None,
         enable_slack_search=False,
         auto_detect_filters=auto_detect_filters,
+    )
+
+
+def _make_section(document_id: str = "doc-1") -> InferenceSection:
+    chunk = InferenceChunk(
+        document_id=document_id,
+        chunk_id=0,
+        content="section content",
+        source_type=DocumentSource.MOCK_CONNECTOR,
+        semantic_identifier=f"sem-{document_id}",
+        title=document_id,
+        boost=1,
+        score=0.5,
+        hidden=False,
+        metadata={},
+        match_highlights=[],
+        doc_summary="",
+        chunk_context="",
+        updated_at=None,
+        image_file_id=None,
+        source_links={},
+        section_continuation=False,
+        blurb="blurb",
+        file_id=None,
+    )
+    return InferenceSection(
+        center_chunk=chunk, chunks=[chunk], combined_content=chunk.content
     )
 
 
@@ -109,6 +137,50 @@ def _emitted_filter_sources(tool: SearchTool) -> list[list[str]]:
     emit_mock = cast(MagicMock, tool.emitter.emit)
     emitted = [call.args[0].obj for call in emit_mock.call_args_list]
     return [obj.sources for obj in emitted if isinstance(obj, SearchToolFilterDelta)]
+
+
+def _patch_non_empty_search(stack: ExitStack, section: InferenceSection) -> None:
+    mock_session_ctx = stack.enter_context(
+        patch(f"{MODULE}.get_session_with_current_tenant")
+    )
+    mock_session_ctx.return_value.__enter__ = MagicMock(return_value=MagicMock())
+    mock_session_ctx.return_value.__exit__ = MagicMock(return_value=False)
+    stack.enter_context(
+        patch(f"{MODULE}.build_access_filters_for_user", return_value=[])
+    )
+    stack.enter_context(
+        patch(f"{MODULE}.get_current_search_settings", return_value=MagicMock())
+    )
+    stack.enter_context(patch(f"{MODULE}.EmbeddingModel"))
+    stack.enter_context(
+        patch(f"{MODULE}.get_federated_retrieval_functions", return_value=[])
+    )
+    stack.enter_context(
+        patch(f"{MODULE}.fetch_unique_document_sources", return_value=[])
+    )
+    stack.enter_context(
+        patch(f"{MODULE}.semantic_query_rephrase", return_value="rephrased query")
+    )
+    stack.enter_context(patch(f"{MODULE}.keyword_query_expansion", return_value=[]))
+    stack.enter_context(patch(f"{MODULE}.decide_search_scope", return_value=None))
+    stack.enter_context(patch(f"{MODULE}.decide_time_filter", return_value=None))
+    stack.enter_context(patch(f"{MODULE}.search_pipeline", return_value=[]))
+    stack.enter_context(
+        patch(f"{MODULE}.weighted_reciprocal_rank_fusion", return_value=[section])
+    )
+    stack.enter_context(
+        patch(f"{MODULE}.merge_individual_chunks", return_value=[section])
+    )
+    stack.enter_context(patch(f"{MODULE}.populate_file_ids_on_sections"))
+    stack.enter_context(
+        patch(f"{MODULE}.get_llm_token_counter", return_value=lambda text: len(text))
+    )
+    stack.enter_context(
+        patch(
+            f"{MODULE}.convert_inference_sections_to_llm_string",
+            return_value=("docs", {}),
+        )
+    )
 
 
 def test_decided_scope_is_passed_to_search() -> None:
@@ -344,3 +416,197 @@ def test_auto_detect_disabled_keeps_user_selected_filters() -> None:
     for applied in filters:
         assert applied is not None
         assert applied.source_type == restriction
+
+
+def test_section_expansion_uses_bounded_runner() -> None:
+    section = _make_section()
+    tool = _make_tool()
+    runner_calls: list[dict[str, object]] = []
+
+    def fake_runner(functions: list[tuple[Any, tuple]], **kwargs: object) -> list[Any]:
+        runner_calls.append(kwargs)
+        return [func(*args) for func, args in functions]
+
+    with ExitStack() as stack:
+        _patch_non_empty_search(stack, section)
+        stack.enter_context(
+            patch(f"{MODULE}.DISABLE_LLM_SEARCH_SECTION_PROCESSING", False)
+        )
+        stack.enter_context(patch(f"{MODULE}.SEARCH_SECTION_EXPANSION_MAX_WORKERS", 1))
+        stack.enter_context(patch(f"{MODULE}.SEARCH_SECTION_EXPANSION_TIMEOUT_S", 7))
+        stack.enter_context(patch(f"{MODULE}.SEARCH_SECTION_SELECTION_TIMEOUT_S", 5))
+        stack.enter_context(
+            patch(
+                f"{MODULE}.select_sections_for_expansion",
+                return_value=([section], None),
+            )
+        )
+        stack.enter_context(
+            patch(f"{MODULE}.expand_section_with_context", return_value=section)
+        )
+        stack.enter_context(
+            patch(
+                f"{MODULE}.run_functions_tuples_in_parallel",
+                side_effect=fake_runner,
+            )
+        )
+        tool.run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=SearchToolOverrideKwargs(
+                starting_citation_num=1,
+                original_query="resolve the ticket",
+                message_history=[
+                    ChatMinimalTextMessage(
+                        message="resolve the ticket",
+                        message_type=MessageType.USER,
+                    )
+                ],
+            ),
+            queries=["ticket"],
+        )
+
+    selection_call = runner_calls[-2]
+    assert selection_call["timeout"] == 5
+    assert callable(selection_call["timeout_callback"])
+
+    expansion_call = runner_calls[-1]
+    assert expansion_call["max_workers"] == 1
+    assert expansion_call["timeout"] == 7
+    assert callable(expansion_call["timeout_callback"])
+
+
+def test_disable_llm_section_processing_skips_selection_and_expansion() -> None:
+    section = _make_section()
+    tool = _make_tool()
+
+    with ExitStack() as stack:
+        _patch_non_empty_search(stack, section)
+        stack.enter_context(
+            patch(f"{MODULE}.DISABLE_LLM_SEARCH_SECTION_PROCESSING", True)
+        )
+        select_mock = stack.enter_context(
+            patch(f"{MODULE}.select_sections_for_expansion")
+        )
+        expand_mock = stack.enter_context(
+            patch(f"{MODULE}.expand_section_with_context")
+        )
+        merge_mock = stack.enter_context(
+            patch(f"{MODULE}.merge_overlapping_sections", return_value=[section])
+        )
+        tool.run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=SearchToolOverrideKwargs(
+                starting_citation_num=1,
+                original_query="resolve the ticket",
+                message_history=[
+                    ChatMinimalTextMessage(
+                        message="resolve the ticket",
+                        message_type=MessageType.USER,
+                    )
+                ],
+            ),
+            queries=["ticket"],
+        )
+
+    select_mock.assert_not_called()
+    expand_mock.assert_not_called()
+    assert merge_mock.call_args.args[0] == [section]
+
+
+def test_section_selection_timeout_falls_back_to_retrieved_sections() -> None:
+    section = _make_section()
+    tool = _make_tool()
+
+    def fake_runner(functions: list[tuple[Any, tuple]], **kwargs: object) -> list[Any]:
+        timeout_callback = kwargs.get("timeout_callback")
+        if callable(timeout_callback) and "max_workers" not in kwargs:
+            func, args = functions[0]
+            return [timeout_callback(0, func, args)]
+        return [func(*args) for func, args in functions]
+
+    with ExitStack() as stack:
+        _patch_non_empty_search(stack, section)
+        stack.enter_context(
+            patch(f"{MODULE}.DISABLE_LLM_SEARCH_SECTION_PROCESSING", False)
+        )
+        stack.enter_context(
+            patch(f"{MODULE}.run_functions_tuples_in_parallel", side_effect=fake_runner)
+        )
+        select_mock = stack.enter_context(
+            patch(f"{MODULE}.select_sections_for_expansion")
+        )
+        stack.enter_context(
+            patch(f"{MODULE}.expand_section_with_context", return_value=section)
+        )
+        merge_mock = stack.enter_context(
+            patch(f"{MODULE}.merge_overlapping_sections", return_value=[section])
+        )
+
+        tool.run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=SearchToolOverrideKwargs(
+                starting_citation_num=1,
+                original_query="resolve the ticket",
+                message_history=[
+                    ChatMinimalTextMessage(
+                        message="resolve the ticket",
+                        message_type=MessageType.USER,
+                    )
+                ],
+            ),
+            queries=["ticket"],
+        )
+
+    select_mock.assert_not_called()
+    assert merge_mock.call_args.args[0] == [section]
+
+
+def test_section_expansion_timeout_falls_back_to_original_section() -> None:
+    section = _make_section()
+    tool = _make_tool()
+
+    def fake_runner(functions: list[tuple[Any, tuple]], **kwargs: object) -> list[Any]:
+        timeout_callback = kwargs.get("timeout_callback")
+        if callable(timeout_callback) and "max_workers" in kwargs:
+            func, args = functions[0]
+            return [timeout_callback(0, func, args)]
+        return [func(*args) for func, args in functions]
+
+    with ExitStack() as stack:
+        _patch_non_empty_search(stack, section)
+        stack.enter_context(
+            patch(f"{MODULE}.DISABLE_LLM_SEARCH_SECTION_PROCESSING", False)
+        )
+        stack.enter_context(
+            patch(
+                f"{MODULE}.select_sections_for_expansion",
+                return_value=([section], None),
+            )
+        )
+        stack.enter_context(
+            patch(f"{MODULE}.run_functions_tuples_in_parallel", side_effect=fake_runner)
+        )
+        expand_mock = stack.enter_context(
+            patch(f"{MODULE}.expand_section_with_context")
+        )
+        merge_mock = stack.enter_context(
+            patch(f"{MODULE}.merge_overlapping_sections", return_value=[section])
+        )
+
+        tool.run(
+            placement=Placement(turn_index=0, tab_index=0),
+            override_kwargs=SearchToolOverrideKwargs(
+                starting_citation_num=1,
+                original_query="resolve the ticket",
+                message_history=[
+                    ChatMinimalTextMessage(
+                        message="resolve the ticket",
+                        message_type=MessageType.USER,
+                    )
+                ],
+            ),
+            queries=["ticket"],
+        )
+
+    expand_mock.assert_not_called()
+    assert merge_mock.call_args.args[0] == [section]


### PR DESCRIPTION
## Summary

Fixes #13178.

The synchronous `/api/search` path runs secondary LLM preprocessing before retrieval. Three of those calls were invoking the configured LLM without a timeout:

- semantic query rephrase
- keyword query expansion
- source-scope detection

If the provider connection stalled, the worker could wait indefinitely before retrieval. This mirrors the failure mode previously addressed for document filtering.

## Changes

- Reuse `SECONDARY_LLM_FLOW_TIMEOUT_S` for the three reported preprocessing calls.
- Pass `timeout_override` into `semantic_query_rephrase`, `keyword_query_expansion`, and `decide_search_scope`.
- Add focused unit coverage asserting the timeout is forwarded to `LLM.invoke`.

## Validation

- `.venv\Scripts\python.exe -m pytest -q backend/tests/unit/onyx/secondary_llm_flows/test_query_expansion.py backend/tests/unit/onyx/secondary_llm_flows/test_source_filter.py backend/tests/unit/onyx/secondary_llm_flows/test_document_filter.py`
- `.venv\Scripts\python.exe -m ruff check backend/onyx/secondary_llm_flows/query_expansion.py backend/onyx/secondary_llm_flows/source_filter.py backend/tests/unit/onyx/secondary_llm_flows/test_query_expansion.py backend/tests/unit/onyx/secondary_llm_flows/test_source_filter.py`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents hangs in synchronous `/api/search` by bounding all secondary LLM work before and after retrieval, with timeouts and safe fallbacks if a provider stalls.

- **Bug Fixes**
  - Pre-retrieval: enforce `SECONDARY_LLM_FLOW_TIMEOUT_S` on semantic query rephrase, keyword expansion, and source-scope; tests assert `timeout_override` is forwarded.
  - Post-retrieval: add wall-clock caps for section selection and expansion (select up to 10, limit workers), with timeouts falling back to top retrieved sections or the original section; add `DISABLE_LLM_SEARCH_SECTION_PROCESSING`, `SEARCH_SECTION_SELECTION_TIMEOUT_S`, `SEARCH_SECTION_EXPANSION_TIMEOUT_S`, `SEARCH_SECTION_EXPANSION_MAX_WORKERS`; tests cover fallbacks and bounded runner; share `noop_span`/`make_llm` helpers.

<sup>Written for commit 21e344ea777d226e52e931c3ebcba5347db16e89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13294?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

