### PR TITLE
fix(llm): isolate Anthropic sync calls from litellm's shared HTTP pool

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -862,6 +862,14 @@ class LitellmLLM(LLM):
             max_input_tokens=self._max_input_tokens,
         )
 
+    def _uses_isolated_client(self) -> bool:
+        """Providers whose sync calls need a fresh per-call HTTPHandler instead of
+        litellm's shared module_level_client (see threading notes in invoke())."""
+        return (
+            is_true_openai_model(self.config.model_provider, self.config.model_name)
+            or self.config.model_provider == LlmProviderNames.ANTHROPIC
+        )
+
     def invoke(
         self,
         prompt: LanguageModelInput,
@@ -897,11 +905,12 @@ class LitellmLLM(LLM):
         #      corrupt the pool state for other threads
         #    - Each request gets its own fresh httpx.Client via HTTPHandler
         #
-        # 3. WHY OTHER PROVIDERS DON'T NEED THIS:
-        #    - Other providers (Anthropic, Bedrock, etc.) use litellm.module_level_client
-        #      which handles concurrency appropriately
-        #    - httpx.Client itself IS thread-safe for concurrent requests
-        #    - The issue is specific to OpenAI's responses API path and connection reuse
+        # 3. WHY ANTHROPIC ALSO GETS AN ISOLATED CLIENT:
+        #    - An abandoned sync stream is finalized by GC, which can fire on a thread
+        #      already inside the shared pool's non-reentrant lock and deadlock it,
+        #      wedging all later LLM calls (encode/httpcore#996; seen in prod).
+        #    - A per-call client keeps abandoned streams off the shared pool. litellm's
+        #      anthropic handler uses module_level_client only when client is None.
         #
         # 4. PITFALL - is_true_openai_model() CHECK:
         #    - Must use is_true_openai_model() NOT just check model_provider == "openai"
@@ -913,7 +922,7 @@ class LitellmLLM(LLM):
         # and not every model path was traced thoroughly. It is also possible that in future versions of LiteLLM
         # they will realize that their OpenAI handling is not threadsafe. Hope they will just fix it.
         client = None
-        if is_true_openai_model(self.config.model_provider, self.config.model_name):
+        if self._uses_isolated_client():
             client = HTTPHandler(timeout=timeout_override or self._timeout)
 
         try:
@@ -995,7 +1004,7 @@ class LitellmLLM(LLM):
         # See invoke() method for full explanation. Key points for streaming:
         #
         # 1. SAME RESTRICTIONS APPLY:
-        #    - HTTPHandler ONLY for true OpenAI models (use is_true_openai_model())
+        #    - HTTPHandler only for providers in _uses_isolated_client()
         #    - OpenAI-compatible providers will fail with AttributeError on api_key
         #
         # 2. STREAMING-SPECIFIC CONCERNS:
@@ -1021,7 +1030,7 @@ class LitellmLLM(LLM):
         #    - Per-request HTTPHandler eliminates cross-thread interference
         for attempt in range(max_attempts):
             client = None
-            if is_true_openai_model(self.config.model_provider, self.config.model_name):
+            if self._uses_isolated_client():
                 client = HTTPHandler(timeout=timeout_override or self._timeout)
 
             try:

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -1058,8 +1058,11 @@ def test_openai_model_stream_uses_httphandler_client(
         assert isinstance(kwargs["client"], HTTPHandler)
 
 
-def test_anthropic_model_passes_no_client() -> None:
-    """Test that non-OpenAI models (Anthropic) don't get a client passed."""
+def test_anthropic_model_passes_isolated_client() -> None:
+    """Anthropic gets a per-call HTTPHandler so abandoned streams can't deadlock
+    litellm's shared module_level_client pool (see _uses_isolated_client)."""
+    from litellm import HTTPHandler
+
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,
@@ -1089,7 +1092,7 @@ def test_anthropic_model_passes_no_client() -> None:
 
         mock_completion.assert_called_once()
         kwargs = mock_completion.call_args.kwargs
-        assert kwargs["client"] is None
+        assert isinstance(kwargs["client"], HTTPHandler)
 
 
 def test_bedrock_model_passes_no_client() -> None:


### PR DESCRIPTION
## Description

Fixes a production deadlock that wedged all multi-tenant cloud API pods (v4.4.0-cloud.3) and presented as unbounded api-server memory growth.

**Mechanism (proven via py-spy on the wedged pods):** an Anthropic sync stream abandoned without close (mid-stream error, first-chunk retry, consumer disconnect) is only finalized by the periodic GC, which can run on a thread already inside the shared `litellm.module_level_client` pool's non-reentrant lock. The finalizer re-enters that lock on the same thread and permanently deadlocks the pool; every later LLM call parks forever at the lock acquire, each pinning an anyio worker thread plus its request context — the observed "memory leak" — until the sync threadpool is exhausted and the pod stops answering while its async `/health` probe keeps passing. Upstream: encode/httpcore#996 (closed unfixed; httpcore 1.0.9 is latest).

**Fix:** reuse the per-call `HTTPHandler` pattern already applied to true OpenAI models (which is why only the Anthropic path deadlocked) and extend it to Anthropic via a `_uses_isolated_client()` helper. Each call gets a private connection pool, so a GC-time close touches an idle private pool instead of the shared one another thread may be holding — the self-deadlock requires re-entering the *same* lock, which is no longer possible. litellm's anthropic handler honors `client=` for sync streaming (`make_sync_call` falls back to `module_level_client` only when `client is None`), and `stream()`'s retry loop already creates and closes the client per attempt, so a failed attempt's abandoned stream is cleaned up deterministically before the next attempt.

**Cost note:** one extra TCP+TLS handshake per Anthropic call — the same trade already accepted in production for true OpenAI models, and negligible against multi-second LLM latencies.

**Scope note:** this covers the observed incident vector (direct Anthropic API, the only provider that wedged). Providers still on the shared pool (Bedrock, Vertex, etc.) retain the theoretical hazard; if that ever materializes, the httpcore RLock fix can be picked up from upstream once encode/httpcore#1003 ships.

*History: an earlier revision of this PR took a two-layer approach (deterministic close of the innermost httpx stream generator + an httpcore ThreadLock→RLock monkey patch, old head 8b81e43). Replaced with this minimal approach — no monkey patches, no litellm/httpcore internals.*

## How Has This Been Tested?

- Updated `test_multi_llm.py::test_anthropic_model_passes_isolated_client` (was `test_anthropic_model_passes_no_client`) to assert Anthropic now receives an isolated `HTTPHandler`; existing tests cover the OpenAI-gets-client and Bedrock-gets-None cases.
- Full `backend/tests/unit/onyx/llm` suite: 358 passed.
- Root cause verified in production via py-spy stack dumps on the deadlocked pods; fleet recovered after rollout restart.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
