### PR TITLE
feat(auth): add OIDC_TRUST_UNVERIFIED_EMAIL option to bypass strict verification

### DIFF
--- a/backend/onyx/auth/oidc_client.py
+++ b/backend/onyx/auth/oidc_client.py
@@ -9,6 +9,8 @@ from urllib.parse import unquote, urlsplit
 from httpx_oauth.clients.openid import BASE_SCOPES, OpenID
 from httpx_oauth.exceptions import GetIdEmailError
 
+from onyx.configs.app_configs import OIDC_TRUST_UNVERIFIED_EMAIL
+
 
 class OpenIDConfigurationIssuerMismatch(ValueError):
     """The discovery document's issuer does not own the configured URL."""
@@ -134,7 +136,7 @@ class VerifiedEmailOpenID(OpenID):
                 raise GetIdEmailError(
                     "Userinfo 'email' was not a string", response=response
                 )
-            if email is not None and data.get("email_verified") is not True:
+            if email is not None and not OIDC_TRUST_UNVERIFIED_EMAIL and data.get("email_verified") is not True:
                 raise GetIdEmailError(
                     "Identity provider did not mark the email as verified",
                     response=response,

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -261,6 +261,13 @@ if _OIDC_SCOPE_OVERRIDE:
 # backwards compatibility for existing OIDC deployments.
 OIDC_PKCE_ENABLED = os.environ.get("OIDC_PKCE_ENABLED", "").lower() == "true"
 
+# OIDC Trust Unverified Email - if true, will allow OIDC sign-ins and bypass the
+# "email_verified" check when it is missing or false. Necessary for OIDC
+# providers that do not provide or support the "email_verified" claim, such as Microsoft Entra ID.
+OIDC_TRUST_UNVERIFIED_EMAIL = (
+    os.environ.get("OIDC_TRUST_UNVERIFIED_EMAIL", "").lower() == "true"
+)
+
 # Opt-in: capture IdP claims at OAuth login and enrich the chat experience
 # with the user's directory profile (country, department, job title, ...) —
 # an "Organization Profile" block in the system prompt plus `{{user.<key>}}`


### PR DESCRIPTION
### Summary
This PR introduces a new environment variable `OIDC_TRUST_UNVERIFIED_EMAIL` to allow OIDC sign-ins and bypass the strict `"email_verified"` check when it is missing or false.
### Why is this needed?
In Onyx `v4.4.0`, a strict check was introduced requiring identity providers to explicitly return `"email_verified": true` in the OpenID user information payload.
However, **Microsoft Entra ID (Azure AD)** — the single most common enterprise identity provider in the world — **does not emit the standard OIDC `email_verified` claim** by default for workforce or managed tenant accounts. This causes all stock `v4.4.0` Onyx OIDC deployments with Entra ID to fail out-of-the-box with:
`OnyxError VALIDATION_ERROR: Could not retrieve a verified identity from the SSO provider`
Setting `OIDC_TRUST_UNVERIFIED_EMAIL=true` provides a standard way to bypass this strict check and trust the email, resolving this blocker for all Azure AD/Entra ID enterprise users.
### Proposed Changes
- **`backend/onyx/configs/app_configs.py`**: Added the `OIDC_TRUST_UNVERIFIED_EMAIL` environment variable configuration (defaults to `False`).
- **`backend/onyx/auth/oidc_client.py`**: Updated `VerifiedEmailOpenID.get_id_email()` to bypass the strict `"email_verified"` claim check if `OIDC_TRUST_UNVERIFIED_EMAIL` is set to `True`.
### Verification Plan
1. Deploy Onyx behind Microsoft Entra ID.
2. Set `OIDC_TRUST_UNVERIFIED_EMAIL=true` in the environment.
3. Attempt OIDC SSO login. It should succeed without any validation errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `OIDC_TRUST_UNVERIFIED_EMAIL` to allow OIDC sign-ins when `email_verified` is missing or false. This keeps the strict default while enabling Microsoft Entra ID setups to work.

- New Features
  - Introduced `OIDC_TRUST_UNVERIFIED_EMAIL` env var (default: false).
  - When true, `VerifiedEmailOpenID.get_id_email()` skips the `email_verified` check and trusts the `email` claim.

- Migration
  - For Microsoft Entra ID, set `OIDC_TRUST_UNVERIFIED_EMAIL=true` to allow sign-in.

<sup>Written for commit ba470d8a08f37e8aaf10de910a7595494c527f4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13297?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

