### PR TITLE
fix(auth): tolerate OIDC IdPs that omit email_verified, strict as per-provider opt-in

### DIFF
--- a/backend/onyx/auth/oidc_client.py
+++ b/backend/onyx/auth/oidc_client.py
@@ -69,11 +69,13 @@ def validate_issuer_owns_config_url(
 
 
 class VerifiedEmailOpenID(OpenID):
-    """OpenID client that refuses to hand back an email the IdP has not
-    verified. An absent email_verified claim counts as unverified, since a
-    mutable, unverified email claim is exactly the nOAuth account-takeover
-    vector. A response with no email at all is passed through unchanged and
-    rejected by the login flow's existing no-email handling."""
+    """OpenID client that guards the email claim. Any present email_verified
+    value other than true is rejected, since a mutable, unverified email
+    claim is exactly the nOAuth account-takeover vector. An absent claim
+    (optional per OIDC and omitted by some IdPs such as Microsoft Entra ID)
+    is tolerated unless require_verified_email opts this provider into
+    requiring it. A response with no email at all is passed through
+    unchanged and rejected by the login flow's existing no-email handling."""
 
     def __init__(
         self,
@@ -82,6 +84,7 @@ class VerifiedEmailOpenID(OpenID):
         openid_configuration_endpoint: str,
         name: str = "openid",
         base_scopes: list[str] | None = BASE_SCOPES,
+        require_verified_email: bool = False,
     ):
         super().__init__(
             client_id,
@@ -90,6 +93,7 @@ class VerifiedEmailOpenID(OpenID):
             name=name,
             base_scopes=base_scopes,
         )
+        self.require_verified_email = require_verified_email
         validate_issuer_owns_config_url(
             self.openid_configuration.get("issuer"), openid_configuration_endpoint
         )
@@ -134,10 +138,19 @@ class VerifiedEmailOpenID(OpenID):
                 raise GetIdEmailError(
                     "Userinfo 'email' was not a string", response=response
                 )
-            if email is not None and data.get("email_verified") is not True:
-                raise GetIdEmailError(
-                    "Identity provider did not mark the email as verified",
-                    response=response,
-                )
+            email_verified = data.get("email_verified")
+            if email is not None and email_verified is not True:
+                if email_verified is False:
+                    raise GetIdEmailError(
+                        "Identity provider marked the email as unverified",
+                        response=response,
+                    )
+                # Only a genuinely absent claim is tolerable. Any present
+                # value, including null or a stringly-typed one, rejects.
+                if "email_verified" in data or self.require_verified_email:
+                    raise GetIdEmailError(
+                        "Identity provider did not mark the email as verified",
+                        response=response,
+                    )
 
             return sub, email

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -41,6 +41,10 @@ class OIDCProviderConfig(_ProviderConfig):
     client_secret: str
     openid_config_url: str
     legacy_callback: bool = False
+    # Strict opt-in: reject sign-ins when userinfo omits the optional
+    # email_verified claim (some IdPs, e.g. Microsoft Entra ID, omit it).
+    # Any present value other than true is rejected regardless.
+    require_verified_email: bool = False
 
 
 class SAMLProviderConfig(_ProviderConfig):

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -110,6 +110,7 @@ def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[A
             config["openid_config_url"],
             name=provider.name,
             base_scopes=scopes,
+            require_verified_email=config.get("require_verified_email", False),
         )
     if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
         return GoogleOAuth2(

--- a/backend/tests/unit/onyx/auth/test_verified_email_openid_client.py
+++ b/backend/tests/unit/onyx/auth/test_verified_email_openid_client.py
@@ -1,6 +1,7 @@
-"""The hardened OpenID client must reject unverified email claims (absent
-email_verified counts as unverified) and refuse discovery documents whose
-issuer does not own the configured endpoint."""
+"""The hardened OpenID client must reject any present email_verified value
+other than true, tolerate an absent claim unless the provider opts into
+require_verified_email, and refuse discovery documents whose issuer does
+not own the configured endpoint."""
 
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -30,7 +31,9 @@ def _discovery(issuer: str = _ISSUER) -> dict[str, Any]:
 
 
 def _build_client(
-    discovery: dict[str, Any], config_url: str = _CONFIG_URL
+    discovery: dict[str, Any],
+    config_url: str = _CONFIG_URL,
+    require_verified_email: bool = False,
 ) -> VerifiedEmailOpenID:
     discovery_response = MagicMock()
     discovery_response.json.return_value = discovery
@@ -39,7 +42,12 @@ def _build_client(
     http_client.__exit__ = MagicMock(return_value=None)
     http_client.get.return_value = discovery_response
     with patch("httpx_oauth.clients.openid.httpx.Client", return_value=http_client):
-        return VerifiedEmailOpenID("cid", "csecret", config_url)
+        return VerifiedEmailOpenID(
+            "cid",
+            "csecret",
+            config_url,
+            require_verified_email=require_verified_email,
+        )
 
 
 class _FakeResponse:
@@ -102,9 +110,32 @@ async def test_explicitly_unverified_email_rejected() -> None:
 
 
 @pytest.mark.asyncio
-async def test_absent_verified_claim_rejected() -> None:
+async def test_absent_verified_claim_accepted_by_default() -> None:
     client = _build_client(_discovery())
     _with_userinfo(client, {"sub": "s1", "email": "bob@companyb.com"})
+    assert await client.get_id_email("tok") == ("s1", "bob@companyb.com")
+
+
+@pytest.mark.asyncio
+async def test_absent_verified_claim_rejected_when_required() -> None:
+    client = _build_client(_discovery(), require_verified_email=True)
+    _with_userinfo(client, {"sub": "s1", "email": "bob@companyb.com"})
+    with pytest.raises(GetIdEmailError):
+        await client.get_id_email("tok")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("required", [False, True])
+@pytest.mark.parametrize("claim", [False, "true", "false", 1, None])
+async def test_present_non_true_claim_rejected_in_both_modes(
+    required: bool, claim: Any
+) -> None:
+    # Only a genuinely absent claim is tolerable. A present malformed value
+    # (explicit null included) rejects regardless of the strict flag.
+    client = _build_client(_discovery(), require_verified_email=required)
+    _with_userinfo(
+        client, {"sub": "s1", "email": "bob@companyb.com", "email_verified": claim}
+    )
     with pytest.raises(GetIdEmailError):
         await client.get_id_email("tok")
 

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -50,7 +50,11 @@ def test_resolve_oidc_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
     )
     resolved, config = oidc_multi._resolve_oidc_provider(_DB, "okta")
     assert resolved is provider
-    assert config == {**_OIDC_CONFIG, "legacy_callback": False}
+    assert config == {
+        **_OIDC_CONFIG,
+        "legacy_callback": False,
+        "require_verified_email": False,
+    }
 
 
 def test_resolve_google_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -255,6 +259,53 @@ def test_validate_config_accepts_legacy_callback_for_oauth_types() -> None:
         validate_sso_config(SSOProviderType.OIDC, dict(_OIDC_CONFIG))["legacy_callback"]
         is False
     )
+
+
+def test_validate_config_require_verified_email_is_oidc_only() -> None:
+    from onyx.db.sso_provider import validate_sso_config
+
+    oidc = validate_sso_config(
+        SSOProviderType.OIDC, {**_OIDC_CONFIG, "require_verified_email": True}
+    )
+    assert oidc["require_verified_email"] is True
+    # Omitting the flag stays valid and defaults off.
+    assert (
+        validate_sso_config(SSOProviderType.OIDC, dict(_OIDC_CONFIG))[
+            "require_verified_email"
+        ]
+        is False
+    )
+    # The flag only parameterizes the OIDC client, and the Google config
+    # model forbids unknown keys.
+    with pytest.raises(ValueError):
+        validate_sso_config(
+            SSOProviderType.GOOGLE_OAUTH,
+            {**_GOOGLE_CONFIG, "require_verified_email": True},
+        )
+
+
+def test_build_client_passes_require_verified_email(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fake_openid(
+        _client_id: str,
+        _client_secret: str,
+        _config_url: str,
+        *,
+        require_verified_email: bool = False,
+        **_kwargs: Any,
+    ) -> Any:
+        return SimpleNamespace(require_verified_email=require_verified_email)
+
+    monkeypatch.setattr(oidc_multi, "VerifiedEmailOpenID", _fake_openid)
+    client = cast(
+        Any,
+        oidc_multi._build_client(
+            _provider(name="entra"),
+            {**_OIDC_CONFIG, "require_verified_email": True},
+        ),
+    )
+    assert client.require_verified_email is True
 
 
 def test_validate_config_rejects_legacy_callback_for_saml() -> None:

--- a/web/src/lib/sso/interfaces.ts
+++ b/web/src/lib/sso/interfaces.ts
@@ -1,7 +1,7 @@
 // Admin-side shapes for the SSO provider list, mirroring the backend response
-// model. `config` values come back masked (bullets, or a truncated
-// first4...last4 form for longer values) and are accepted back verbatim to keep
-// the stored value.
+// model. String `config` values come back masked (bullets, or a truncated
+// first4...last4 form for longer values) and are accepted back verbatim to
+// keep the stored value. Booleans round-trip as real values.
 
 export type SSOProviderType = "GOOGLE_OAUTH" | "OIDC" | "SAML";
 
@@ -12,7 +12,7 @@ export interface SSOProviderResponse {
   provider_type: SSOProviderType;
   enabled: boolean;
   allowed_email_domains: string[];
-  config: Record<string, string>;
+  config: Record<string, string | boolean>;
   redirect_uri: string;
 }
 
@@ -20,12 +20,12 @@ export interface SSOProviderCreateRequest {
   name: string;
   display_name: string;
   provider_type: SSOProviderType;
-  config: Record<string, string>;
+  config: Record<string, string | boolean>;
   allowed_email_domains: string[];
 }
 
 export interface SSOProviderUpdateRequest {
   display_name?: string;
   allowed_email_domains?: string[];
-  config?: Record<string, string>;
+  config?: Record<string, string | boolean>;
 }

--- a/web/src/lib/sso/utils.ts
+++ b/web/src/lib/sso/utils.ts
@@ -36,11 +36,11 @@ export const CREATABLE_SSO_PROVIDER_TYPES: SSOProviderType[] = [
   "SAML",
 ];
 
-export type SSOConfigFieldKind = "text" | "textarea" | "password";
+export type SSOConfigFieldKind = "text" | "textarea" | "password" | "switch";
 
-// One entry per key in a provider type's backend config model. `name` must
-// match the backend config field exactly, since values are sent as
-// config.<name>.
+// One entry per admin-editable key in a provider type's backend config model.
+// `name` must match the backend config field exactly, since values are sent
+// as config.<name>.
 export interface SSOConfigField {
   name: string;
   label: string;
@@ -77,6 +77,15 @@ export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
         kind: "text",
         description: "The IdP's OpenID Connect discovery document URL.",
         placeholder: "https://example.com/.well-known/openid-configuration",
+      },
+      {
+        name: "require_verified_email",
+        label: "Require Verified Email Claim",
+        kind: "switch",
+        description:
+          "Reject sign-ins when the IdP omits the optional email_verified " +
+          "claim. Leave off for IdPs that do not send it, such as " +
+          "Microsoft Entra ID.",
       },
     ],
     SAML: [

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -24,6 +24,7 @@ import {
 import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTypeInField";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
+import SwitchField from "@/refresh-components/form/SwitchField";
 import InputChipField, {
   type ChipItem,
 } from "@/refresh-components/inputs/InputChipField";
@@ -42,7 +43,7 @@ interface SSOProviderFormValues {
   provider_type: SSOProviderType;
   name: string;
   display_name: string;
-  config: Record<string, string>;
+  config: Record<string, string | boolean>;
   allowed_email_domains: string[];
 }
 
@@ -58,8 +59,12 @@ const ALL_CONFIG_FIELDS: SSOConfigField[] = Array.from(
 );
 
 function configSchemaForType(fields: SSOConfigField[]) {
-  const shape: Record<string, Yup.StringSchema> = {};
+  const shape: Record<string, Yup.StringSchema | Yup.BooleanSchema> = {};
   for (const field of fields) {
+    if (field.kind === "switch") {
+      shape[field.name] = Yup.boolean();
+      continue;
+    }
     shape[field.name] = field.optional
       ? Yup.string().optional()
       : Yup.string().required(`${field.label} is required`);
@@ -98,15 +103,22 @@ const SSO_VALIDATION_SCHEMA = Yup.object({
 
 // The backend masks every config string on read and restores any value sent
 // back unchanged, so the form sends its current values as-is. Blank optional
-// keys are omitted rather than sent as empty strings.
+// keys are omitted rather than sent as empty strings. Switch values are always
+// sent: the update endpoint overlays only the keys present, so turning a flag
+// off must send an explicit false.
 function buildConfig(
   providerType: SSOProviderType,
   values: SSOProviderFormValues
-): Record<string, string> {
-  const config: Record<string, string> = {};
+): Record<string, string | boolean> {
+  const config: Record<string, string | boolean> = {};
   for (const field of CONFIG_FIELDS_BY_TYPE[providerType]) {
-    const raw = values.config[field.name] ?? "";
-    const value = field.kind === "password" ? raw : raw.trim();
+    if (field.kind === "switch") {
+      config[field.name] = Boolean(values.config[field.name]);
+      continue;
+    }
+    const raw = values.config[field.name];
+    const str = typeof raw === "string" ? raw : "";
+    const value = field.kind === "password" ? str : str.trim();
     if (field.optional && !value) {
       continue;
     }
@@ -115,10 +127,15 @@ function buildConfig(
   return config;
 }
 
-function initialConfig(config: Record<string, string>): Record<string, string> {
-  const initial: Record<string, string> = {};
+function initialConfig(
+  config: Record<string, string | boolean>
+): Record<string, string | boolean> {
+  const initial: Record<string, string | boolean> = {};
   for (const field of ALL_CONFIG_FIELDS) {
-    initial[field.name] = config[field.name] ?? "";
+    initial[field.name] =
+      field.kind === "switch"
+        ? config[field.name] === true
+        : (config[field.name] ?? "");
   }
   return initial;
 }
@@ -131,6 +148,9 @@ function ConfigInput({
   isEditing: boolean;
 }) {
   const name = `config.${field.name}`;
+  if (field.kind === "switch") {
+    return <SwitchField name={name} />;
+  }
   if (field.kind === "textarea") {
     return <InputTextAreaField name={name} placeholder={field.placeholder} />;
   }


### PR DESCRIPTION
## Description

**Bug:** Microsoft Entra ID does not emit the optional OIDC `email_verified` claim, so every v4.4.0 OIDC + Entra login fails with "Could not retrieve a verified identity from the SSO provider". Reported in #13297 (thanks @Oht8wooWi8yait9n).

**Fix:** an absent `email_verified` claim is now tolerated by default, so Entra works out of the box. A new per-provider `require_verified_email` switch on the OIDC provider row opts back into requiring the claim, instead of #13297's global env var. Per-provider matches the v4.4 model (one strict setting must not be forced by another IdP on a multi-IdP instance) and follows Dex/oauth2-proxy per-connector precedent.

**Semantics:** any *present* `email_verified` value other than `true` (explicit `false`, JSON `null`, stringly-typed values) is rejected in both modes, so the guard against the nOAuth takeover vector stays intact. IdPs that send the claim (Google, Okta, Auth0, Keycloak, Cognito) keep full strictness automatically. The default only changes behavior for deployments that are currently hard-broken.

- `OIDCProviderConfig.require_verified_email: bool = False` (no migration, config is a validated JSON blob; `extra="forbid"` keeps it OIDC-only)
- `VerifiedEmailOpenID` constructor kwarg consulted in `get_id_email`
- Admin modal: "Require Verified Email Claim" switch via a new `switch` field kind rendered by the existing Formik `SwitchField`
- Unit tests pin the full semantics matrix (54 pass)

Closes #13297.

## How Has This Been Tested?
<img width="706" height="684" alt="Screenshot 2026-07-22 at 10 24 33 AM" src="https://github.com/user-attachments/assets/c953955d-7949-438a-b164-6a09f976d535" />

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check