### PR TITLE
feat(sharepoint): support OneDrive for Business and personal SharePoint site indexing [mirror of #13253 for edits]

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1258,10 +1258,10 @@ class SharepointConnector(
         # Ensure sites are sharepoint urls
         for site_url in self.sites:
             if not site_url.startswith("https://") or not (
-                "/sites/" in site_url or "/teams/" in site_url
+                "/sites/" in site_url or "/teams/" in site_url or "/personal/" in site_url
             ):
                 raise ConnectorValidationError(
-                    "Site URLs must be full Sharepoint URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site or https://your-tenant.sharepoint.com/teams/your-team)"
+                    "Site URLs must be full Sharepoint/OneDrive URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site, https://your-tenant.sharepoint.com/teams/your-team or https://your-tenant-my.sharepoint.com/personal/your-user)"
                 )
             try:
                 validate_outbound_http_url(site_url, https_only=True)
@@ -1491,14 +1491,14 @@ class SharepointConnector(
 
             lower_parts = [part.lower() for part in parts]
             site_type_index = None
-            for site_token in ("sites", "teams"):
+            for site_token in ("sites", "teams", "personal"):
                 if site_token in lower_parts:
                     site_type_index = lower_parts.index(site_token)
                     break
 
             if site_type_index is None or len(parts) <= site_type_index + 1:
                 logger.warning(
-                    "Site URL '%s' is not a valid Sharepoint URL (must contain /sites/<name> or /teams/<name>)",
+                    "Site URL '%s' is not a valid Sharepoint URL (must contain /sites/<name>, /teams/<name>, or /personal/<name>)",
                     url,
                 )
                 continue
@@ -1551,6 +1551,21 @@ class SharepointConnector(
                 and SHARED_DOCUMENTS_MAP[d.name] == drive_name
             )
         ]
+        if not matched and drives:
+            # Fallback for OneDrive for Business personal sites:
+            # Graph API returns the drive name as "OneDrive" or "documentLibrary",
+            # but the browser/SharePoint URL uses "Documents".
+            if "/personal/" in site_descriptor.url.lower():
+                matched = [drives[0]]
+            else:
+                onedrive_matches = [
+                    d
+                    for d in drives
+                    if d.name and d.name.lower() in ("onedrive", "onedrive for business", "documentlibrary")
+                ]
+                if onedrive_matches:
+                    matched = [onedrive_matches[0]]
+
         if not matched:
             logger.warning("Drive '%s' not found", drive_name)
             return None

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1570,12 +1570,18 @@ class SharepointConnector(
             # browser/SharePoint URL uses "Documents". Identify the intended
             # drive by its stable driveType (falling back to name), never by
             # position in the /drives response, whose order is not guaranteed.
-            onedrive_matches = [
+            # Prefer driveType matches so a uniquely-typed primary drive is not
+            # made ambiguous by an unrelated library sharing a fallback name;
+            # only consult names when no drive has a primary type.
+            type_matches = [
                 d
                 for d in drives
                 if (d.drive_type or "").lower() in ONEDRIVE_PRIMARY_DRIVE_TYPES
-                or (d.name and d.name.lower() in ONEDRIVE_DRIVE_NAMES)
             ]
+            name_matches = [
+                d for d in drives if d.name and d.name.lower() in ONEDRIVE_DRIVE_NAMES
+            ]
+            onedrive_matches = type_matches or name_matches
             if PERSONAL_SITE_URL_MARKER in site_descriptor.url.lower():
                 # A personal site has exactly one user OneDrive; refuse to guess
                 # when the lookup is ambiguous rather than index an arbitrary

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -94,6 +94,17 @@ SHARED_DOCUMENTS_MAP = {
 }
 SHARED_DOCUMENTS_MAP_REVERSE = {v: k for k, v in SHARED_DOCUMENTS_MAP.items()}
 
+# On OneDrive personal sites the Graph API reports the primary library's name as
+# one of these, while the browser/SharePoint URL uses "Documents".
+ONEDRIVE_DRIVE_NAMES = frozenset(
+    {"onedrive", "onedrive for business", "documentlibrary"}
+)
+# `driveType` values that identify a user's primary OneDrive (as opposed to an
+# extra "documentLibrary" added to the personal site). OneDrive personal returns
+# "personal", OneDrive for Business returns "business".
+ONEDRIVE_PRIMARY_DRIVE_TYPES = frozenset({"personal", "business"})
+PERSONAL_SITE_URL_MARKER = "/personal/"
+
 ASPX_EXTENSION = ".aspx"
 
 
@@ -1258,7 +1269,9 @@ class SharepointConnector(
         # Ensure sites are sharepoint urls
         for site_url in self.sites:
             if not site_url.startswith("https://") or not (
-                "/sites/" in site_url or "/teams/" in site_url or "/personal/" in site_url
+                "/sites/" in site_url
+                or "/teams/" in site_url
+                or "/personal/" in site_url
             ):
                 raise ConnectorValidationError(
                     "Site URLs must be full Sharepoint/OneDrive URLs (e.g. https://your-tenant.sharepoint.com/sites/your-site, https://your-tenant.sharepoint.com/teams/your-team or https://your-tenant-my.sharepoint.com/personal/your-user)"
@@ -1552,19 +1565,33 @@ class SharepointConnector(
             )
         ]
         if not matched and drives:
-            # Fallback for OneDrive for Business personal sites:
-            # Graph API returns the drive name as "OneDrive" or "documentLibrary",
-            # but the browser/SharePoint URL uses "Documents".
-            if "/personal/" in site_descriptor.url.lower():
-                matched = [drives[0]]
-            else:
-                onedrive_matches = [
-                    d
-                    for d in drives
-                    if d.name and d.name.lower() in ("onedrive", "onedrive for business", "documentlibrary")
-                ]
-                if onedrive_matches:
-                    matched = [onedrive_matches[0]]
+            # Fallback for OneDrive personal sites: Graph reports the primary
+            # library's name as "OneDrive"/"documentLibrary" while the
+            # browser/SharePoint URL uses "Documents". Identify the intended
+            # drive by its stable driveType (falling back to name), never by
+            # position in the /drives response, whose order is not guaranteed.
+            onedrive_matches = [
+                d
+                for d in drives
+                if (d.drive_type or "").lower() in ONEDRIVE_PRIMARY_DRIVE_TYPES
+                or (d.name and d.name.lower() in ONEDRIVE_DRIVE_NAMES)
+            ]
+            if PERSONAL_SITE_URL_MARKER in site_descriptor.url.lower():
+                # A personal site has exactly one user OneDrive; refuse to guess
+                # when the lookup is ambiguous rather than index an arbitrary
+                # library.
+                if len(onedrive_matches) == 1:
+                    matched = onedrive_matches
+                elif len(onedrive_matches) > 1:
+                    logger.warning(
+                        "Could not unambiguously resolve the primary OneDrive "
+                        "for personal site '%s' (%d candidate drives: %s)",
+                        site_descriptor.url,
+                        len(onedrive_matches),
+                        [d.name for d in onedrive_matches],
+                    )
+            elif onedrive_matches:
+                matched = [onedrive_matches[0]]
 
         if not matched:
             logger.warning("Drive '%s' not found", drive_name)

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -26,8 +26,9 @@ class _FakeQuery:
 
 
 class _FakeDrive:
-    def __init__(self, name: str) -> None:
+    def __init__(self, name: str, drive_type: str | None = None) -> None:
         self.name = name
+        self.drive_type = drive_type
         self.id = f"fake-drive-id-{name}"
         self.web_url = f"https://example.sharepoint.com/sites/sample/{name}"
 
@@ -277,6 +278,52 @@ def test_load_from_checkpoint_maps_drive_name(monkeypatch: pytest.MonkeyPatch) -
     assert len(documents) == 1
     assert captured_drive_names == [SHARED_DOCUMENTS_MAP["Documents"]]
     assert len(hierarchy_nodes) >= 1
+
+
+_PERSONAL_SITE_URL = "https://example-my.sharepoint.com/personal/user_example_com"
+
+
+def _resolve_personal(drives: list[_FakeDrive]) -> tuple[str, str | None] | None:
+    connector = _build_connector(drives)
+    site_descriptor = SiteDescriptor(
+        url=_PERSONAL_SITE_URL,
+        drive_name="Documents",
+        folder_path=None,
+    )
+    return connector._resolve_drive(site_descriptor, "Documents")
+
+
+def test_resolve_drive_personal_picks_by_drive_type_not_position() -> None:
+    """The user's OneDrive must be selected by driveType regardless of order."""
+    extra_library = _FakeDrive("Extra Library", drive_type="documentLibrary")
+    onedrive = _FakeDrive("OneDrive", drive_type="business")
+
+    # OneDrive is second in the (unordered) response; positional selection would
+    # have picked the wrong library.
+    result = _resolve_personal([extra_library, onedrive])
+
+    assert result is not None
+    drive_id, _ = result
+    assert drive_id == onedrive.id
+
+
+def test_resolve_drive_personal_falls_back_to_name_when_type_missing() -> None:
+    extra_library = _FakeDrive("Extra Library", drive_type="documentLibrary")
+    onedrive = _FakeDrive("OneDrive", drive_type=None)
+
+    result = _resolve_personal([extra_library, onedrive])
+
+    assert result is not None
+    drive_id, _ = result
+    assert drive_id == onedrive.id
+
+
+def test_resolve_drive_personal_ambiguous_returns_none() -> None:
+    """Refuse to guess when multiple primary-OneDrive candidates exist."""
+    first = _FakeDrive("OneDrive", drive_type="business")
+    second = _FakeDrive("Second OneDrive", drive_type="personal")
+
+    assert _resolve_personal([first, second]) is None
 
 
 def test_get_drive_items_uses_delta_when_no_folder_path(

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_drive_matching.py
@@ -318,6 +318,21 @@ def test_resolve_drive_personal_falls_back_to_name_when_type_missing() -> None:
     assert drive_id == onedrive.id
 
 
+def test_resolve_drive_personal_prefers_type_over_name_collision() -> None:
+    """A uniquely-typed primary drive wins even if another library reuses a name."""
+    # Localized primary drive name so resolution must rely on driveType.
+    primary = _FakeDrive("Mon lecteur OneDrive", drive_type="business")
+    # An extra library that happens to carry a fallback OneDrive name but is not
+    # the user's primary drive.
+    extra_library = _FakeDrive("OneDrive", drive_type="documentLibrary")
+
+    result = _resolve_personal([extra_library, primary])
+
+    assert result is not None
+    drive_id, _ = result
+    assert drive_id == primary.id
+
+
 def test_resolve_drive_personal_ambiguous_returns_none() -> None:
     """Refuse to guess when multiple primary-OneDrive candidates exist."""
     first = _FakeDrive("OneDrive", drive_type="business")


### PR DESCRIPTION
This PR runs GitHub Actions CI for #13253.

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] Override Linear Check

Will be making edit here and merging this one, then closing #13253 


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for OneDrive personal and OneDrive for Business in the SharePoint connector. Accepts `/personal/` URLs and reliably picks the primary OneDrive drive to avoid “Drive not found” and wrong-library indexing.

- **New Features**
  - Accept `/personal/` site URLs in settings and site parsing.
  - Resolve the primary OneDrive by `driveType` (`personal`/`business`) with a fallback to known names (`OneDrive`/`documentLibrary`); never use list order and refuse ambiguous matches on personal sites.

<sup>Written for commit ea5dbc3785b48648833d9169f0d15f34459d1ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13303?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



