### PR TITLE
feat(telemetry): daily version heartbeat for self-hosted instances

### DIFF
--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -422,6 +422,20 @@ if not MULTI_TENANT:
                     "queue": OnyxCeleryQueues.PRIMARY,
                 },
             },
+            # Hourly tick, but the task self-limits to one telemetry report per
+            # day via a Redis marker. Kept at an hourly cadence because beat
+            # schedule state does not reliably survive restarts, so a daily
+            # interval could fail to ever fire on frequently-restarted instances.
+            {
+                "name": "emit-version-telemetry",
+                "task": OnyxCeleryTask.EMIT_VERSION_TELEMETRY,
+                "schedule": timedelta(hours=1),
+                "options": {
+                    "priority": OnyxCeleryPriority.LOW,
+                    "expires": BEAT_EXPIRES_DEFAULT,
+                    "queue": OnyxCeleryQueues.MONITORING,
+                },
+            },
         ]
     )
 

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -422,10 +422,7 @@ if not MULTI_TENANT:
                     "queue": OnyxCeleryQueues.PRIMARY,
                 },
             },
-            # Hourly tick, but the task self-limits to one telemetry report per
-            # day via a Redis marker. Kept at an hourly cadence because beat
-            # schedule state does not reliably survive restarts, so a daily
-            # interval could fail to ever fire on frequently-restarted instances.
+            # hourly tick; the task itself enforces a once-per-day cadence
             {
                 "name": "emit-version-telemetry",
                 "task": OnyxCeleryTask.EMIT_VERSION_TELEMETRY,

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -21,6 +21,7 @@ from onyx.background.celery.celery_redis import (
     celery_get_unacked_task_ids,
 )
 from onyx.background.celery.memory_monitoring import emit_process_memory
+from onyx.configs.app_configs import DISABLE_TELEMETRY
 from onyx.configs.constants import (
     CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
     ONYX_CLOUD_TENANT_ID,
@@ -1155,6 +1156,7 @@ def cloud_monitor_celery_pidbox(
 """Version telemetry heartbeat"""
 
 _VERSION_TELEMETRY_EMITTED_KEY = "monitoring_version_telemetry_emitted"
+_VERSION_TELEMETRY_TTL_SECONDS = 24 * 60 * 60
 
 
 @shared_task(
@@ -1169,16 +1171,25 @@ def emit_version_telemetry(*, tenant_id: str) -> None:
     interval could never fire); the 1-day-TTL Redis marker enforces the daily
     cadence.
     """
-    if MULTI_TENANT:
+    if MULTI_TENANT or DISABLE_TELEMETRY:
         return
 
     redis_std = get_redis_client(tenant_id=tenant_id)
-    if _has_metric_been_emitted(redis_std, _VERSION_TELEMETRY_EMITTED_KEY):
+    # atomically claim the daily slot so overlapping runs can't double-report
+    if not redis_std.set(
+        _VERSION_TELEMETRY_EMITTED_KEY,
+        "1",
+        nx=True,
+        ex=_VERSION_TELEMETRY_TTL_SECONDS,
+    ):
         return
 
-    optional_telemetry(
+    delivered = optional_telemetry(
         record_type=RecordType.VERSION,
         data={"version": __version__},
         tenant_id=tenant_id,
+        blocking=True,
     )
-    _mark_metric_as_emitted(redis_std, _VERSION_TELEMETRY_EMITTED_KEY)
+    if not delivered:
+        # release the slot so the next hourly tick retries
+        redis_std.delete(_VERSION_TELEMETRY_EMITTED_KEY)

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -1154,11 +1154,6 @@ def cloud_monitor_celery_pidbox(
 
 """Version telemetry heartbeat"""
 
-# The api_server emits a VERSION record at startup, but instances that run for a
-# long time without restarting would otherwise go silent. This heartbeat keeps
-# active self-hosted instances reporting the build they are running. The beat
-# entry ticks hourly; the Redis marker (1 day TTL) enforces the daily cadence and
-# is robust to beat schedule state being lost on restarts.
 _VERSION_TELEMETRY_EMITTED_KEY = "monitoring_version_telemetry_emitted"
 
 
@@ -1168,9 +1163,12 @@ _VERSION_TELEMETRY_EMITTED_KEY = "monitoring_version_telemetry_emitted"
     queue=OnyxCeleryQueues.MONITORING,
 )
 def emit_version_telemetry(*, tenant_id: str) -> None:
-    """Daily heartbeat reporting the running build of self-hosted instances."""
-    # Cloud deployment versions are tracked at deploy time; VERSION telemetry
-    # records are only meaningful for self-hosted instances.
+    """Daily heartbeat reporting the running build of self-hosted instances.
+
+    Scheduled hourly (beat schedule state doesn't survive restarts, so a daily
+    interval could never fire); the 1-day-TTL Redis marker enforces the daily
+    cadence.
+    """
     if MULTI_TENANT:
         return
 

--- a/backend/onyx/background/celery/tasks/monitoring/tasks.py
+++ b/backend/onyx/background/celery/tasks/monitoring/tasks.py
@@ -13,6 +13,7 @@ from redis.lock import Lock as RedisLock
 from sqlalchemy import select, text
 from sqlalchemy.orm import Session
 
+from onyx import __version__
 from onyx.background.celery.apps.app_base import task_logger
 from onyx.background.celery.celery_redis import (
     celery_get_broker_client,
@@ -1149,3 +1150,37 @@ def cloud_monitor_celery_pidbox(
 
     # Enable later in case we want some aggregate metrics
     # task_logger.info(f"Deleted idle pidbox: pidbox={key_str}")
+
+
+"""Version telemetry heartbeat"""
+
+# The api_server emits a VERSION record at startup, but instances that run for a
+# long time without restarting would otherwise go silent. This heartbeat keeps
+# active self-hosted instances reporting the build they are running. The beat
+# entry ticks hourly; the Redis marker (1 day TTL) enforces the daily cadence and
+# is robust to beat schedule state being lost on restarts.
+_VERSION_TELEMETRY_EMITTED_KEY = "monitoring_version_telemetry_emitted"
+
+
+@shared_task(
+    name=OnyxCeleryTask.EMIT_VERSION_TELEMETRY,
+    ignore_result=True,
+    queue=OnyxCeleryQueues.MONITORING,
+)
+def emit_version_telemetry(*, tenant_id: str) -> None:
+    """Daily heartbeat reporting the running build of self-hosted instances."""
+    # Cloud deployment versions are tracked at deploy time; VERSION telemetry
+    # records are only meaningful for self-hosted instances.
+    if MULTI_TENANT:
+        return
+
+    redis_std = get_redis_client(tenant_id=tenant_id)
+    if _has_metric_been_emitted(redis_std, _VERSION_TELEMETRY_EMITTED_KEY):
+        return
+
+    optional_telemetry(
+        record_type=RecordType.VERSION,
+        data={"version": __version__},
+        tenant_id=tenant_id,
+    )
+    _mark_metric_as_emitted(redis_std, _VERSION_TELEMETRY_EMITTED_KEY)

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -629,6 +629,7 @@ class OnyxCeleryTask:
     MONITOR_CELERY_QUEUES = "monitor_celery_queues"
     MONITOR_PROCESS_MEMORY = "monitor_process_memory"
     CELERY_BEAT_HEARTBEAT = "celery_beat_heartbeat"
+    EMIT_VERSION_TELEMETRY = "emit_version_telemetry"
 
     CONNECTOR_PERMISSION_SYNC_GENERATOR_TASK = (
         "connector_permission_sync_generator_task"

--- a/backend/onyx/utils/telemetry.py
+++ b/backend/onyx/utils/telemetry.py
@@ -99,15 +99,18 @@ def optional_telemetry(
     data: dict,
     user_id: str | None = None,
     tenant_id: str | None = None,  # Allows for override of tenant_id
-) -> None:
+    blocking: bool = False,
+) -> bool | None:
+    """Fire-and-forget by default. With blocking=True, sends in the current
+    thread and returns whether the POST succeeded."""
     if DISABLE_TELEMETRY:
-        return
+        return False if blocking else None
 
     tenant_id = tenant_id or get_current_tenant_id()
 
     try:
 
-        def telemetry_logic() -> None:
+        def telemetry_logic() -> bool:
             try:
                 customer_uuid = (
                     _get_or_generate_customer_id_mt(tenant_id)
@@ -125,16 +128,20 @@ def optional_telemetry(
                 }
                 if ENTERPRISE_EDITION_ENABLED:
                     payload["instance_domain"] = _get_or_generate_instance_domain()
-                requests.post(
+                response = requests.post(
                     _DANSWER_TELEMETRY_ENDPOINT,
                     headers={"Content-Type": "application/json"},
                     json=payload,
                     timeout=_TELEMETRY_POST_TIMEOUT_SECONDS,
                 )
+                return response.ok
 
             except Exception:
                 # This way it silences all thread level logging as well
-                pass
+                return False
+
+        if blocking:
+            return telemetry_logic()
 
         # Run in separate thread with the same context as the current thread
         # This is to ensure that the thread gets the current tenant ID
@@ -146,6 +153,8 @@ def optional_telemetry(
     except Exception:
         # Should never interfere with normal functions of Onyx
         pass
+
+    return None
 
 
 def mt_cloud_telemetry(

--- a/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
+++ b/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
@@ -1,0 +1,98 @@
+"""Tests for the self-hosted version telemetry heartbeat task.
+
+Verifies the daily dedupe behavior (Redis marker) and the multi-tenant no-op,
+using a real Redis instance and a mocked telemetry sender.
+"""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+
+from onyx import __version__
+from onyx.background.celery.tasks.monitoring.tasks import (
+    _VERSION_TELEMETRY_EMITTED_KEY,
+    emit_version_telemetry,
+)
+from onyx.redis.redis_pool import get_redis_client
+from onyx.utils.telemetry import RecordType
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+
+_TENANT_ID = POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
+
+
+@pytest.fixture
+def clear_version_telemetry_marker() -> Generator[None, None, None]:
+    redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    redis_client.delete(_VERSION_TELEMETRY_EMITTED_KEY)
+    try:
+        yield
+    finally:
+        redis_client.delete(_VERSION_TELEMETRY_EMITTED_KEY)
+
+
+@pytest.mark.usefixtures("clear_version_telemetry_marker")
+def test_emits_version_once_per_day() -> None:
+    with patch(
+        "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+    ) as mock_telemetry:
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+
+        mock_telemetry.assert_called_once_with(
+            record_type=RecordType.VERSION,
+            data={"version": __version__},
+            tenant_id=_TENANT_ID,
+        )
+
+        # Marker is set, so subsequent runs within the TTL window are no-ops
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+        assert mock_telemetry.call_count == 1
+
+    # Once the marker expires (simulated by deleting it), the task emits again
+    redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    redis_client.delete(_VERSION_TELEMETRY_EMITTED_KEY)
+
+    with patch(
+        "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+    ) as mock_telemetry:
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+        assert mock_telemetry.call_count == 1
+
+
+@pytest.mark.usefixtures("clear_version_telemetry_marker")
+def test_marker_has_expiration() -> None:
+    with patch("onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"):
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+
+    redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    ttl = redis_client.ttl(_VERSION_TELEMETRY_EMITTED_KEY)
+    # A marker without a TTL (-1) would permanently silence the heartbeat
+    assert 0 < ttl <= 24 * 60 * 60
+
+
+@pytest.mark.usefixtures("clear_version_telemetry_marker")
+def test_noop_on_multi_tenant() -> None:
+    with (
+        patch(
+            "onyx.background.celery.tasks.monitoring.tasks.MULTI_TENANT",
+            True,
+        ),
+        patch(
+            "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+        ) as mock_telemetry,
+    ):
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+
+    mock_telemetry.assert_not_called()
+    redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    assert not redis_client.exists(_VERSION_TELEMETRY_EMITTED_KEY)
+
+
+def test_task_is_scheduled_self_hosted() -> None:
+    """The heartbeat must be present in the self-hosted beat schedule."""
+    from onyx.background.celery.tasks.beat_schedule import get_tasks_to_schedule
+    from onyx.configs.constants import OnyxCeleryTask
+
+    scheduled_task_names = {entry["task"] for entry in get_tasks_to_schedule()}
+    assert OnyxCeleryTask.EMIT_VERSION_TELEMETRY in scheduled_task_names

--- a/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
+++ b/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
@@ -1,8 +1,4 @@
-"""Tests for the self-hosted version telemetry heartbeat task.
-
-Verifies the daily dedupe behavior (Redis marker) and the multi-tenant no-op,
-using a real Redis instance and a mocked telemetry sender.
-"""
+"""Tests for the self-hosted version telemetry heartbeat task."""
 
 from collections.abc import Generator
 from unittest.mock import patch
@@ -44,12 +40,11 @@ def test_emits_version_once_per_day() -> None:
             tenant_id=_TENANT_ID,
         )
 
-        # Marker is set, so subsequent runs within the TTL window are no-ops
         emit_version_telemetry(tenant_id=_TENANT_ID)
         emit_version_telemetry(tenant_id=_TENANT_ID)
         assert mock_telemetry.call_count == 1
 
-    # Once the marker expires (simulated by deleting it), the task emits again
+    # marker expiry (simulated by deleting it) allows the next report
     redis_client = get_redis_client(tenant_id=_TENANT_ID)
     redis_client.delete(_VERSION_TELEMETRY_EMITTED_KEY)
 
@@ -66,8 +61,8 @@ def test_marker_has_expiration() -> None:
         emit_version_telemetry(tenant_id=_TENANT_ID)
 
     redis_client = get_redis_client(tenant_id=_TENANT_ID)
+    # a marker without a TTL would permanently silence the heartbeat
     ttl = redis_client.ttl(_VERSION_TELEMETRY_EMITTED_KEY)
-    # A marker without a TTL (-1) would permanently silence the heartbeat
     assert 0 < ttl <= 24 * 60 * 60
 
 
@@ -90,7 +85,6 @@ def test_noop_on_multi_tenant() -> None:
 
 
 def test_task_is_scheduled_self_hosted() -> None:
-    """The heartbeat must be present in the self-hosted beat schedule."""
     from onyx.background.celery.tasks.beat_schedule import get_tasks_to_schedule
     from onyx.configs.constants import OnyxCeleryTask
 

--- a/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
+++ b/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
@@ -38,6 +38,7 @@ def test_emits_version_once_per_day() -> None:
             record_type=RecordType.VERSION,
             data={"version": __version__},
             tenant_id=_TENANT_ID,
+            blocking=True,
         )
 
         emit_version_telemetry(tenant_id=_TENANT_ID)
@@ -53,6 +54,24 @@ def test_emits_version_once_per_day() -> None:
     ) as mock_telemetry:
         emit_version_telemetry(tenant_id=_TENANT_ID)
         assert mock_telemetry.call_count == 1
+
+
+@pytest.mark.usefixtures("clear_version_telemetry_marker")
+def test_failed_delivery_releases_marker() -> None:
+    with patch(
+        "onyx.background.celery.tasks.monitoring.tasks.optional_telemetry"
+    ) as mock_telemetry:
+        mock_telemetry.return_value = False
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+
+        redis_client = get_redis_client(tenant_id=_TENANT_ID)
+        assert not redis_client.exists(_VERSION_TELEMETRY_EMITTED_KEY)
+
+        # next tick retries; a successful send keeps the marker
+        mock_telemetry.return_value = True
+        emit_version_telemetry(tenant_id=_TENANT_ID)
+        assert mock_telemetry.call_count == 2
+        assert redis_client.exists(_VERSION_TELEMETRY_EMITTED_KEY)
 
 
 @pytest.mark.usefixtures("clear_version_telemetry_marker")


### PR DESCRIPTION
## Description

Self-hosted instances currently emit a `VERSION` telemetry record only on api_server startup, so an instance that runs for a long time without restarting goes silent — from the telemetry data alone we can't distinguish "active on version X" from "churned". This makes it impossible to answer "how many self-hosted deployments are on which version" with any confidence.

This adds a lightweight version heartbeat:

- New `emit_version_telemetry` task on the monitoring worker that re-emits the existing `RecordType.VERSION` record (`{"version": __version__}`) through `optional_telemetry`.
- Scheduled hourly in the self-hosted-only beat block, but self-limited to **one report per day** via the same Redis marker pattern (24h TTL) the other monitoring metrics use. The hourly tick + Redis marker makes the cadence robust to beat schedule state being lost on restarts, which a raw 24h beat interval is not.
- No-ops on multi-tenant (cloud versions are tracked at deploy time; the beat entry isn't even scheduled there, and the task itself also guards).
- Respects the existing `DISABLE_TELEMETRY` opt-out (enforced inside `optional_telemetry`).

No telemetry-server changes are needed — it already appends every VERSION report to the `version` table keyed by the instance's stable customer UUID, so "active instances by version over the last N days" becomes a simple query on existing tables.

## How Has This Been Tested?

New external dependency unit tests (`backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py`, real Redis + mocked telemetry sender):
- emits exactly once while the Redis marker is live, emits again after the marker expires
- marker always carries a TTL (a persistent marker would permanently silence the heartbeat)
- no-op + no marker written when `MULTI_TENANT` is set
- task is present in the self-hosted beat schedule

All 4 pass locally; pre-commit (ruff, ruff format, ty, lazy-imports) clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a daily version heartbeat for self-hosted instances so we can see which versions are actively running over time. Sends one `VERSION` telemetry report per day and avoids relying on server restarts.

- **New Features**
  - Added `emit_version_telemetry` task to send `RecordType.VERSION` via `optional_telemetry` with `{"version": __version__}` (uses blocking mode).
  - Scheduled hourly on the monitoring worker; enforces once per day using an atomic Redis `SET NX` with a 24h TTL, and releases the marker to retry if delivery fails.
  - Self-hosted only: scheduled in self-hosted beat, guarded by `MULTI_TENANT`, and respects `DISABLE_TELEMETRY`.
  - No telemetry-server changes needed; data continues to append to the existing `version` table.

<sup>Written for commit 9d667a5c24e9e34b96e8ea30ebbdf552fcbb28ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13317?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

