### PR TITLE
feat(hooks): drive endpoint SSRF validation from ssrf_protection_level

### DIFF
--- a/backend/ee/onyx/server/features/hooks/api.py
+++ b/backend/ee/onyx/server/features/hooks/api.py
@@ -52,10 +52,9 @@ def _check_ssrf_safety(endpoint_url: str) -> None:
     ``https_only`` is unconditional at every level.
 
     Validation runs at configuration time only; delivery trusts the stored URL
-    (see ``post_json_to_endpoint``). A hostname that later drifts to a private
-    IP is kept harmless by HTTPS certificate verification at delivery time —
-    revisit with a send-time re-check if cert verification ever becomes
-    optional for hooks.
+    (see ``post_json_to_endpoint``). HTTPS certificate verification does not
+    prevent a validated hostname from later resolving to a private address;
+    preventing DNS rebinding requires validating again at delivery time.
 
     Uses BAD_GATEWAY so the frontend maps the error to the Endpoint URL field.
     """

--- a/backend/ee/onyx/server/features/hooks/api.py
+++ b/backend/ee/onyx/server/features/hooks/api.py
@@ -29,6 +29,8 @@ from onyx.hooks.models import (
     HookValidateStatus,
 )
 from onyx.hooks.registry import get_all_specs, get_hook_point_spec
+from onyx.server.security.models import outbound_ssrf_params
+from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 from onyx.utils.url import SSRFException, validate_outbound_http_url
 
@@ -42,11 +44,30 @@ logger = setup_logger()
 def _check_ssrf_safety(endpoint_url: str) -> None:
     """Raise OnyxError if endpoint_url could be used for SSRF.
 
-    Delegates to validate_outbound_http_url with https_only=True.
+    Strictness follows the admin ``SSRF Protection`` setting, matching how MCP
+    and OAuth endpoints treat it: at the VALIDATE_* levels private/internal
+    targets are blocked; ``allow_private_network`` opens RFC1918 LAN hosts
+    (self-hosted deployments calling a cluster-internal hook service) while
+    loopback and cloud-metadata stay blocked; ``disabled`` also opens loopback.
+    ``https_only`` is unconditional at every level.
+
+    Validation runs at configuration time only; delivery trusts the stored URL
+    (see ``post_json_to_endpoint``). A hostname that later drifts to a private
+    IP is kept harmless by HTTPS certificate verification at delivery time —
+    revisit with a send-time re-check if cert verification ever becomes
+    optional for hooks.
+
     Uses BAD_GATEWAY so the frontend maps the error to the Endpoint URL field.
     """
+    params = outbound_ssrf_params(get_security_settings().ssrf_protection_level)
     try:
-        validate_outbound_http_url(endpoint_url, https_only=True)
+        validate_outbound_http_url(
+            endpoint_url,
+            https_only=True,
+            allow_private_network=params.allow_private_network,
+            block_loopback_and_link_local=params.block_loopback_and_link_local,
+            block_link_local_only=params.block_link_local_only,
+        )
     except (SSRFException, ValueError) as e:
         raise OnyxError(OnyxErrorCode.BAD_GATEWAY, str(e))
 

--- a/backend/tests/unit/ee/onyx/server/features/hooks/test_api.py
+++ b/backend/tests/unit/ee/onyx/server/features/hooks/test_api.py
@@ -1,7 +1,9 @@
 """Unit tests for ee.onyx.server.features.hooks.api helpers.
 
 Covers:
-- _check_ssrf_safety: scheme enforcement and private-IP blocklist
+- _check_ssrf_safety: scheme enforcement and private-IP blocklist, driven by
+  the admin SSRF Protection level (allow_private_network opens RFC1918 hosts
+  while loopback/metadata stay blocked; https_only holds at every level)
 - _validate_endpoint: httpx exception → HookValidateStatus mapping
   ConnectTimeout     → timeout         (any timeout directs user to increase timeout_seconds)
   ConnectError       → cannot_connect  (DNS / TLS failure)
@@ -15,6 +17,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from ee.onyx.server.features.hooks import api as hooks_api
 from ee.onyx.server.features.hooks.api import (
     _check_ssrf_safety,
     _raise_for_validation_failure,
@@ -23,6 +26,8 @@ from ee.onyx.server.features.hooks.api import (
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.hooks.models import HookValidateResponse, HookValidateStatus
+from onyx.server.security.models import SecuritySettings, SSRFProtectionLevel
+from onyx.server.security.store import _build_env_defaults
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -37,6 +42,23 @@ def _mock_response(status_code: int) -> MagicMock:
     response = MagicMock()
     response.status_code = status_code
     return response
+
+
+def _settings_with(level: SSRFProtectionLevel) -> SecuritySettings:
+    return _build_env_defaults().model_copy(update={"ssrf_protection_level": level})
+
+
+def _set_level(monkeypatch: pytest.MonkeyPatch, level: SSRFProtectionLevel) -> None:
+    """Pin the effective SSRF level for _check_ssrf_safety, bypassing the
+    tenant-aware store (no DB in unit tests)."""
+    settings = _settings_with(level)
+    monkeypatch.setattr(hooks_api, "get_security_settings", lambda: settings)
+
+
+@pytest.fixture(autouse=True)
+def _default_ssrf_level(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default every test to the shipped default level unless it overrides."""
+    _set_level(monkeypatch, SSRFProtectionLevel.VALIDATE_ALL)
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +129,54 @@ class TestCheckSsrfSafety:
         ):
             self._call("https://no-such-host.example.com/hook")
         assert exc_info.value.error_code == OnyxErrorCode.BAD_GATEWAY
+
+    # --- SSRF protection level ---
+
+    def test_allow_private_network_allows_private_ip(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_level(monkeypatch, SSRFProtectionLevel.ALLOW_PRIVATE_NETWORK)
+        self._call("https://10.0.0.5/hook")  # must not raise
+
+    def test_allow_private_network_allows_private_hostname(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_level(monkeypatch, SSRFProtectionLevel.ALLOW_PRIVATE_NETWORK)
+        with patch("onyx.utils.url.socket.getaddrinfo") as mock_dns:
+            mock_dns.return_value = [(None, None, None, None, ("10.0.0.5", 0))]
+            self._call("https://hook-svc.internal.cluster.local/hook")  # must not raise
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            pytest.param("https://127.0.0.1/hook", id="loopback"),
+            pytest.param("https://169.254.169.254/hook", id="link-local-IMDS"),
+            pytest.param("https://localhost/hook", id="blocked-hostname"),
+        ],
+    )
+    def test_allow_private_network_keeps_loopback_and_metadata_blocked(
+        self, url: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_level(monkeypatch, SSRFProtectionLevel.ALLOW_PRIVATE_NETWORK)
+        with pytest.raises(OnyxError) as exc_info:
+            self._call(url)
+        assert exc_info.value.error_code == OnyxErrorCode.BAD_GATEWAY
+
+    def test_disabled_allows_loopback_but_not_metadata(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_level(monkeypatch, SSRFProtectionLevel.DISABLED)
+        self._call("https://127.0.0.1/hook")  # must not raise
+        with pytest.raises(OnyxError):
+            self._call("https://169.254.169.254/hook")
+
+    def test_https_required_even_when_disabled(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _set_level(monkeypatch, SSRFProtectionLevel.DISABLED)
+        with pytest.raises(OnyxError) as exc_info:
+            self._call("http://10.0.0.5/hook")
+        assert "https" in (exc_info.value.detail or "").lower()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

Hook endpoint SSRF validation was hardcoded to the strict private-IP guard, so self-hosted deployments couldn't configure a hook pointing at a cluster-internal (RFC1918) service. `_check_ssrf_safety` now derives its strictness from the existing admin `SSRF Protection` setting via `outbound_ssrf_params()`, matching how MCP and OAuth endpoints already interpret it — at `allow_private_network`, private LAN hosts pass while loopback, cloud-metadata, and blocked hostnames stay rejected, and `https_only` remains unconditional at every level.

Behavior at the default `validate_all`/`validate_llm` levels is byte-for-byte unchanged; validation still runs at configuration time only (create/update/activate/validate).

## How Has This Been Tested?

Unit tests in `backend/tests/unit/ee/onyx/server/features/hooks/test_api.py`: new level-matrix cases (private IP + private-resolving hostname pass at `allow_private_network`; loopback/IMDS/`localhost` still blocked; loopback opens only at `disabled`; `http://` rejected at every level), with the pre-existing strict-path tests pinned to the default level via an autouse fixture. All 44 tests pass; pre-commit clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hook endpoint SSRF checks now follow the admin SSRF Protection level, allowing self-hosted installs to use internal RFC1918 services while keeping HTTPS-only and other critical blocks in place. Default behavior is unchanged and this aligns hooks with MCP and OAuth endpoints.

- **New Features**
  - `_check_ssrf_safety` now derives strictness from `ssrf_protection_level` via `outbound_ssrf_params(...)` and `get_security_settings()`.
  - At `allow_private_network`, private LAN hosts pass; loopback, link-local/IMDS, and `localhost` stay blocked. `https_only` is enforced at every level.
  - Validation still runs only at config time (create/update/activate/validate).

- **Bug Fixes**
  - Corrected DNS rebinding note in `_check_ssrf_safety` docstring: TLS hostname checks don’t stop a validated name from later resolving to a private IP.

<sup>Written for commit abb1a16c6268118c9e278d9b0be3e782c4acb681. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

