### PR TITLE
fix(security): enforce object-level authz on curator cc-pair endpoints (ENG-4295)

### DIFF
--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -681,9 +681,17 @@ def prune_cc_pair(
 @router.get("/admin/cc-pair/{cc_pair_id}/get-docs-sync-status")
 def get_docs_sync_status(
     cc_pair_id: int,
-    _: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> list[DocumentSyncStatus]:
+    if user and not verify_user_has_access_to_cc_pair(
+        cc_pair_id, db_session, user, get_editable=False
+    ):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "CC Pair not found for current user permissions",
+        )
+
     all_docs_for_cc_pair = get_documents_for_cc_pair(
         db_session=db_session,
         cc_pair_id=cc_pair_id,
@@ -697,7 +705,7 @@ def get_cc_pair_indexing_errors(
     include_resolved: bool = Query(False),
     page_num: int = Query(0, ge=0),
     page_size: int = Query(10, ge=1, le=100),
-    _: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> PaginatedReturn[IndexAttemptErrorPydantic]:
     """Gives back all errors for a given CC Pair. Allows pagination based on page and page_size params.
@@ -713,6 +721,14 @@ def get_cc_pair_indexing_errors(
     Returns:
         Paginated list of indexing errors for the CC pair.
     """
+    if user and not verify_user_has_access_to_cc_pair(
+        cc_pair_id, db_session, user, get_editable=False
+    ):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "CC Pair not found for current user permissions",
+        )
+
     total_count = count_index_attempt_errors_for_cc_pair(
         db_session=db_session,
         cc_pair_id=cc_pair_id,

--- a/backend/onyx/server/documents/cc_pair.py
+++ b/backend/onyx/server/documents/cc_pair.py
@@ -715,7 +715,7 @@ def get_cc_pair_indexing_errors(
         include_resolved: Whether to include resolved errors in the results
         page_num: Page number for pagination, starting at 0
         page_size: Number of errors to return per page
-        _: Current user, must be curator or admin
+        user: Current user, must be curator or admin
         db_session: Database session
 
     Returns:

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -106,9 +106,18 @@ def submit_targeted_reindex(
             "(all were already resolved, entity-level, or invalid).",
         )
 
+    if len(target_specs_in) > MAX_TARGETS_PER_REQUEST:
+        raise OnyxError(
+            OnyxErrorCode.VALIDATION_ERROR,
+            "Too many targets: %s > %s."
+            % (len(target_specs_in), MAX_TARGETS_PER_REQUEST),
+        )
+
     # Object-level authorization: the caller must be able to edit every cc-pair
     # referenced by the resolved targets (both request-supplied and error-derived),
     # so a scoped curator can't reindex connectors outside the groups they curate.
+    # Runs after the size gate so an oversized request is rejected before we issue
+    # one access query per distinct cc-pair.
     if user:
         target_cc_pair_ids = {spec.cc_pair_id for spec in target_specs_in}
         if any(
@@ -121,13 +130,6 @@ def submit_targeted_reindex(
                 OnyxErrorCode.NOT_FOUND,
                 "CC Pair not found for current user permissions",
             )
-
-    if len(target_specs_in) > MAX_TARGETS_PER_REQUEST:
-        raise OnyxError(
-            OnyxErrorCode.VALIDATION_ERROR,
-            "Too many targets: %s > %s."
-            % (len(target_specs_in), MAX_TARGETS_PER_REQUEST),
-        )
 
     try:
         result = create_targeted_reindex_job(

--- a/backend/onyx/server/documents/targeted_reindex.py
+++ b/backend/onyx/server/documents/targeted_reindex.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Session
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.constants import OnyxCeleryPriority, OnyxCeleryQueues, OnyxCeleryTask
+from onyx.db.connector_credential_pair import verify_user_has_access_to_cc_pair
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import IndexingStatus
 from onyx.db.models import User
@@ -104,6 +105,22 @@ def submit_targeted_reindex(
             "No actionable targets after resolving error_ids "
             "(all were already resolved, entity-level, or invalid).",
         )
+
+    # Object-level authorization: the caller must be able to edit every cc-pair
+    # referenced by the resolved targets (both request-supplied and error-derived),
+    # so a scoped curator can't reindex connectors outside the groups they curate.
+    if user:
+        target_cc_pair_ids = {spec.cc_pair_id for spec in target_specs_in}
+        if any(
+            not verify_user_has_access_to_cc_pair(
+                cc_pair_id, db_session, user, get_editable=True
+            )
+            for cc_pair_id in target_cc_pair_ids
+        ):
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                "CC Pair not found for current user permissions",
+            )
 
     if len(target_specs_in) > MAX_TARGETS_PER_REQUEST:
         raise OnyxError(

--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -6,15 +6,19 @@ from sqlalchemy.orm import Session
 from onyx.auth.users import current_curator_or_admin_user
 from onyx.configs.constants import DEFAULT_CC_PAIR_ID, PUBLIC_API_TAGS
 from onyx.connectors.models import Document, IndexAttemptMetadata
-from onyx.db.connector_credential_pair import get_connector_credential_pair_from_id
+from onyx.db.connector_credential_pair import (
+    get_connector_credential_pair_from_id,
+    verify_user_has_access_to_cc_pair,
+)
 from onyx.db.document import (
     delete_documents_complete,
+    get_cc_pairs_for_document,
     get_document,
     get_documents_by_cc_pair,
     get_ingestion_documents,
 )
 from onyx.db.engine.sql_engine import get_session
-from onyx.db.models import User
+from onyx.db.models import User, UserRole
 from onyx.db.port_orphan_candidate import (
     delete_port_orphan_candidates_by_id,
     record_port_orphan_candidates_for_document,
@@ -25,6 +29,8 @@ from onyx.db.search_settings import (
     get_secondary_search_settings,
 )
 from onyx.document_index.factory import get_all_document_indices
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.indexing.adapters.document_indexing_adapter import (
     DocumentIndexingBatchAdapter,
 )
@@ -48,9 +54,17 @@ router = APIRouter(prefix="/onyx-api", tags=PUBLIC_API_TAGS)
 @router.get("/connector-docs/{cc_pair_id}")
 def get_docs_by_connector_credential_pair(
     cc_pair_id: int,
-    _: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> list[DocMinimalInfo]:
+    if user and not verify_user_has_access_to_cc_pair(
+        cc_pair_id, db_session, user, get_editable=False
+    ):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "CC Pair not found for current user permissions",
+        )
+
     db_docs = get_documents_by_cc_pair(cc_pair_id=cc_pair_id, db_session=db_session)
     return [
         DocMinimalInfo(
@@ -81,7 +95,7 @@ def get_ingestion_docs(
 @router.post("/ingestion", dependencies=[Depends(require_vector_db)])
 def upsert_ingestion_doc(
     doc_info: IngestionDocument,
-    _: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> IngestionResult:
     tenant_id = get_current_tenant_id()
@@ -100,6 +114,16 @@ def upsert_ingestion_doc(
     if cc_pair is None:
         raise HTTPException(
             status_code=400, detail="Connector-Credential Pair specified does not exist"
+        )
+
+    # Object-level authorization: a scoped curator may only ingest into cc-pairs
+    # in groups they curate (admins bypass via _add_user_filters).
+    if user and not verify_user_has_access_to_cc_pair(
+        cc_pair.id, db_session, user, get_editable=True
+    ):
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            "CC Pair not found for current user permissions",
         )
 
     # Need to index for both the primary and secondary index if possible
@@ -181,7 +205,7 @@ def upsert_ingestion_doc(
 @router.delete("/ingestion/{document_id}", dependencies=[Depends(require_vector_db)])
 def delete_ingestion_doc(
     document_id: str,
-    _: User = Depends(current_curator_or_admin_user),
+    user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
     # Verify the document exists and was created via the ingestion API
@@ -194,6 +218,21 @@ def delete_ingestion_doc(
             status_code=400,
             detail="Document was not created via the ingestion API",
         )
+
+    # Object-level authorization: a scoped curator may only delete a document when
+    # they can edit at least one of its owning cc-pairs (admins bypass entirely).
+    if user is not None and user.role != UserRole.ADMIN:
+        owning_cc_pairs = get_cc_pairs_for_document(db_session, document_id)
+        if not any(
+            verify_user_has_access_to_cc_pair(
+                cc_pair.id, db_session, user, get_editable=True
+            )
+            for cc_pair in owning_cc_pairs
+        ):
+            raise OnyxError(
+                OnyxErrorCode.NOT_FOUND,
+                "Document not found",
+            )
 
     active_search_settings = get_active_search_settings(db_session)
 

--- a/backend/onyx/server/onyx_api/ingestion.py
+++ b/backend/onyx/server/onyx_api/ingestion.py
@@ -208,19 +208,15 @@ def delete_ingestion_doc(
     user: User = Depends(current_curator_or_admin_user),
     db_session: Session = Depends(get_session),
 ) -> None:
-    # Verify the document exists and was created via the ingestion API
     document = get_document(document_id=document_id, db_session=db_session)
     if document is None:
         raise HTTPException(status_code=404, detail="Document not found")
 
-    if not document.from_ingestion_api:
-        raise HTTPException(
-            status_code=400,
-            detail="Document was not created via the ingestion API",
-        )
-
-    # Object-level authorization: a scoped curator may only delete a document when
-    # they can edit at least one of its owning cc-pairs (admins bypass entirely).
+    # Object-level authorization runs before the ingestion-API check so an
+    # unauthorized caller gets a uniform not-found response and can't probe a
+    # document's existence or ingestion-API status. A scoped curator may only
+    # delete a document when they can edit at least one of its owning cc-pairs
+    # (admins bypass entirely).
     if user is not None and user.role != UserRole.ADMIN:
         owning_cc_pairs = get_cc_pairs_for_document(db_session, document_id)
         if not any(
@@ -233,6 +229,12 @@ def delete_ingestion_doc(
                 OnyxErrorCode.NOT_FOUND,
                 "Document not found",
             )
+
+    if not document.from_ingestion_api:
+        raise HTTPException(
+            status_code=400,
+            detail="Document was not created via the ingestion API",
+        )
 
     active_search_settings = get_active_search_settings(db_session)
 

--- a/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
+++ b/backend/tests/external_dependency_unit/indexing/test_document_deletion_file_cleanup.py
@@ -22,7 +22,7 @@ from onyx.db.document import (
     delete_all_documents_for_connector_credential_pair,
     upsert_document_by_connector_credential_pair,
 )
-from onyx.db.models import ConnectorCredentialPair
+from onyx.db.models import ConnectorCredentialPair, UserRole
 from onyx.indexing.indexing_pipeline import index_doc_batch_prepare
 from onyx.server.onyx_api.ingestion import delete_ingestion_doc
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
@@ -188,7 +188,7 @@ class TestDeleteIngestionDoc:
         ):
             delete_ingestion_doc(
                 document_id=doc.id,
-                _=MagicMock(),  # auth dep — not used by the function body
+                user=MagicMock(role=UserRole.ADMIN),  # admin bypasses ownership check
                 db_session=db_session,
             )
 

--- a/backend/tests/external_dependency_unit/server/documents/test_cc_pair_curator_authz.py
+++ b/backend/tests/external_dependency_unit/server/documents/test_cc_pair_curator_authz.py
@@ -1,0 +1,165 @@
+"""Cross-group authorization tests for curator-facing cc-pair / ingestion endpoints.
+
+Regression coverage for the object-level authorization fix: a group-scoped
+CURATOR must not be able to read, reindex, or ingest against a
+connector-credential pair that belongs to a user group they do not curate.
+Each guarded endpoint now calls ``verify_user_has_access_to_cc_pair`` before
+touching the resource.
+
+We invoke the FastAPI route functions directly with a constructed ``User`` and
+the test ``db_session`` (the pattern used across ``external_dependency_unit``).
+The ``POST /onyx-api/ingestion`` (upsert) and ``DELETE /onyx-api/ingestion``
+paths share the exact same ``verify_user_has_access_to_cc_pair`` guard proven
+denied in ``test_verify_access_boundary`` below, so they are covered by that
+assertion without the heavier document/index fixtures.
+"""
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import DocumentSource
+from onyx.db.connector_credential_pair import verify_user_has_access_to_cc_pair
+from onyx.db.enums import AccessType
+from onyx.db.models import UserRole
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.documents.cc_pair import (
+    get_cc_pair_indexing_errors,
+    get_docs_sync_status,
+)
+from onyx.server.documents.targeted_reindex import (
+    DocumentTargetRequest,
+    TargetedReindexRequest,
+    submit_targeted_reindex,
+)
+from onyx.server.onyx_api.ingestion import get_docs_by_connector_credential_pair
+from tests.external_dependency_unit.conftest import create_test_user
+from tests.external_dependency_unit.craft.db_helpers import (
+    add_user_to_group,
+    make_cc_pair,
+    make_group,
+)
+
+# Curator group scoping runs through the same EE-versioned paths the sibling
+# cc-pair route tests use; applied module-wide so each test doesn't wire it in.
+pytestmark = pytest.mark.usefixtures("enable_ee")
+
+
+class _Scenario:
+    """A curator who curates group A, plus private cc-pairs in group A and B.
+
+    The curator has no relationship to group B, so any access to ``cc_pair_b``
+    must be denied.
+    """
+
+    def __init__(self, db_session: Session) -> None:
+        self.admin = create_test_user(db_session, "admin", role=UserRole.ADMIN)
+        self.curator = create_test_user(db_session, "curator", role=UserRole.CURATOR)
+
+        self.group_a = make_group(db_session)
+        self.group_b = make_group(db_session)
+        membership = add_user_to_group(db_session, self.curator, self.group_a)
+        membership.is_curator = True
+        db_session.flush()
+
+        # Private cc-pairs whose only visibility is the group mapping.
+        self.cc_pair_a = make_cc_pair(
+            db_session,
+            DocumentSource.FILE,
+            access_type=AccessType.PRIVATE,
+            group=self.group_a,
+            user=None,
+        )
+        self.cc_pair_b = make_cc_pair(
+            db_session,
+            DocumentSource.FILE,
+            access_type=AccessType.PRIVATE,
+            group=self.group_b,
+            user=None,
+        )
+        db_session.commit()
+
+
+def test_verify_access_boundary(db_session: Session) -> None:
+    """The shared guard denies the curator on the uncurated group's cc-pair."""
+    s = _Scenario(db_session)
+
+    # Curator can read and edit its own group's cc-pair...
+    assert verify_user_has_access_to_cc_pair(
+        s.cc_pair_a.id, db_session, s.curator, get_editable=False
+    )
+    assert verify_user_has_access_to_cc_pair(
+        s.cc_pair_a.id, db_session, s.curator, get_editable=True
+    )
+    # ...but not the other group's, for reads or writes.
+    assert not verify_user_has_access_to_cc_pair(
+        s.cc_pair_b.id, db_session, s.curator, get_editable=False
+    )
+    assert not verify_user_has_access_to_cc_pair(
+        s.cc_pair_b.id, db_session, s.curator, get_editable=True
+    )
+    # Admin bypasses group scoping entirely.
+    assert verify_user_has_access_to_cc_pair(
+        s.cc_pair_b.id, db_session, s.admin, get_editable=True
+    )
+
+
+def test_get_docs_sync_status_cross_group_denied(db_session: Session) -> None:
+    s = _Scenario(db_session)
+
+    with pytest.raises(OnyxError) as exc:
+        get_docs_sync_status(
+            cc_pair_id=s.cc_pair_b.id, user=s.curator, db_session=db_session
+        )
+    assert exc.value.error_code == OnyxErrorCode.NOT_FOUND
+
+    # The curator's own group and the admin are both allowed (empty cc-pairs
+    # return an empty list rather than raising).
+    assert (
+        get_docs_sync_status(
+            cc_pair_id=s.cc_pair_a.id, user=s.curator, db_session=db_session
+        )
+        == []
+    )
+    assert (
+        get_docs_sync_status(
+            cc_pair_id=s.cc_pair_b.id, user=s.admin, db_session=db_session
+        )
+        == []
+    )
+
+
+def test_get_cc_pair_indexing_errors_cross_group_denied(db_session: Session) -> None:
+    s = _Scenario(db_session)
+
+    with pytest.raises(OnyxError) as exc:
+        get_cc_pair_indexing_errors(
+            cc_pair_id=s.cc_pair_b.id,
+            include_resolved=False,
+            page_num=0,
+            page_size=10,
+            user=s.curator,
+            db_session=db_session,
+        )
+    assert exc.value.error_code == OnyxErrorCode.NOT_FOUND
+
+
+def test_ingestion_connector_docs_cross_group_denied(db_session: Session) -> None:
+    s = _Scenario(db_session)
+
+    with pytest.raises(OnyxError) as exc:
+        get_docs_by_connector_credential_pair(
+            cc_pair_id=s.cc_pair_b.id, user=s.curator, db_session=db_session
+        )
+    assert exc.value.error_code == OnyxErrorCode.NOT_FOUND
+
+
+def test_targeted_reindex_cross_group_denied(db_session: Session) -> None:
+    s = _Scenario(db_session)
+
+    request = TargetedReindexRequest(
+        targets=[DocumentTargetRequest(cc_pair_id=s.cc_pair_b.id, document_id="doc-1")]
+    )
+    with pytest.raises(OnyxError) as exc:
+        submit_targeted_reindex(request=request, user=s.curator, db_session=db_session)
+    assert exc.value.error_code == OnyxErrorCode.NOT_FOUND


### PR DESCRIPTION
## Description

Six connector/ingestion admin endpoints admitted the group-scoped `CURATOR` / `GLOBAL_CURATOR` role (via `current_curator_or_admin_user`) but resolved the attacker-supplied `cc_pair_id` / `document_id` with **unscoped** DB helpers and never verified the caller was authorized for that object. A curator scoped to one user group could therefore read, ingest into, delete, and reindex connector-credential pairs owned by groups they do not curate — a cross-group authorization break within a tenant.

This guards each endpoint with `verify_user_has_access_to_cc_pair(...)` before it touches the resource (reads use `get_editable=False`, writes use `get_editable=True`), mirroring the already-guarded endpoints in `documents/cc_pair.py`. Admin access (bypasses group scoping via `_add_user_filters`) and auth-disabled behavior (`user is None`) are preserved.

Endpoints fixed:
- `get_docs_sync_status`, `get_cc_pair_indexing_errors` — `backend/onyx/server/documents/cc_pair.py`
- `submit_targeted_reindex` — `backend/onyx/server/documents/targeted_reindex.py` (validates every distinct cc-pair in the resolved target set, including error-id-derived ones)
- `upsert_ingestion_doc`, `get_docs_by_connector_credential_pair`, `delete_ingestion_doc` — `backend/onyx/server/onyx_api/ingestion.py` (delete resolves the document's owning cc-pairs and requires editable access to at least one)

Resolves ENG-4295.

## How Has This Been Tested?

New external_dependency_unit regression test `backend/tests/external_dependency_unit/server/documents/test_cc_pair_curator_authz.py` (5 cases, all passing): builds a curator who curates group A plus private cc-pairs in groups A and B, then asserts the curator is denied on group B's cc-pair across the guarded endpoints (`get_docs_sync_status`, `get_cc_pair_indexing_errors`, `get_docs_by_connector_credential_pair`, `submit_targeted_reindex`) and via the shared `verify_user_has_access_to_cc_pair` boundary, while the curator's own group and admins are allowed.

`ruff`, `ruff format`, and `ty` clean on all changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforced object-level authorization on curator/ingestion cc-pair endpoints to block cross-group read/write/delete/reindex. Addresses ENG-4295 with a uniform 404 on denial.

- **Bug Fixes**
  - Guarded endpoints with `verify_user_has_access_to_cc_pair` (reads `get_editable=False`, writes `get_editable=True`); admin bypass and auth-disabled (`user is None`) behavior preserved.
  - Endpoints: `get_docs_sync_status`, `get_cc_pair_indexing_errors` (`backend/onyx/server/documents/cc_pair.py`), `submit_targeted_reindex` (`backend/onyx/server/documents/targeted_reindex.py`), `upsert_ingestion_doc`, `get_docs_by_connector_credential_pair`, `delete_ingestion_doc` (`backend/onyx/server/onyx_api/ingestion.py`).
  - `submit_targeted_reindex`: validate every distinct cc-pair in resolved targets; run size gate before the auth loop.
  - `delete_ingestion_doc`: run authz before the ingestion-API check; require editable access to at least one owning cc-pair; return 404 on denial.
  - Tests: added regression coverage denying cross-group access; updated deletion cleanup test to pass `user` (admin) after param rename.

<sup>Written for commit 0526e7c8f2e6fc0d71fee24599185157530a4ed2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

