### PR TITLE
fix(security): scope Slack chat-seed to caller's own/Slack sessions (ENG-4294)

### DIFF
--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -246,12 +246,17 @@ def duplicate_chat_session_for_user_from_slack(
         (if it is available to the user clicking the button)
     - Sets the user to the given user (if provided)
     """
+    # Copying is limited to Slack-seed sessions the caller is allowed to see:
+    # their own, or the unowned bot-created ones. Passing the caller's user_id
+    # (rather than None) stops one user copying another user's private session by
+    # its id; the onyxbot/slack_thread guard stops copying arbitrary non-Slack
+    # sessions.
     chat_session = get_chat_session_by_id(
         chat_session_id=chat_session_id,
-        user_id=None,  # Ignore user permissions for this
+        user_id=user.id,
         db_session=db_session,
     )
-    if not chat_session:
+    if not chat_session.onyxbot_flow and chat_session.slack_thread_id is None:
         raise HTTPException(status_code=400, detail="Invalid Chat Session ID provided")
 
     # This enforces permissions and sets a default

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -3,7 +3,6 @@ from datetime import datetime, timedelta, timezone
 from typing import Tuple
 from uuid import UUID
 
-from fastapi import HTTPException
 from sqlalchemy import Row, delete, desc, func, nullsfirst, or_, select, update
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Session, joinedload, selectinload
@@ -257,7 +256,9 @@ def duplicate_chat_session_for_user_from_slack(
         db_session=db_session,
     )
     if not chat_session.onyxbot_flow and chat_session.slack_thread_id is None:
-        raise HTTPException(status_code=400, detail="Invalid Chat Session ID provided")
+        # Same error as an unauthorized/invalid id above, so the two rejection
+        # paths are indistinguishable and no HTTPException leaks into the DB layer.
+        raise ValueError("Invalid Chat Session ID provided")
 
     # This enforces permissions and sets a default
     new_persona_id = get_best_persona_id_for_user(

--- a/backend/tests/external_dependency_unit/chat/test_seed_chat_from_slack_authz.py
+++ b/backend/tests/external_dependency_unit/chat/test_seed_chat_from_slack_authz.py
@@ -12,7 +12,6 @@ be a Slack-originated session.
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.db.chat import create_chat_session, duplicate_chat_session_for_user_from_slack
@@ -56,7 +55,7 @@ def test_cannot_seed_from_non_slack_unowned_session(db_session: Session) -> None
         onyxbot_flow=False,
     )
 
-    with pytest.raises(HTTPException):
+    with pytest.raises(ValueError):
         duplicate_chat_session_for_user_from_slack(
             db_session=db_session,
             user=attacker,

--- a/backend/tests/external_dependency_unit/chat/test_seed_chat_from_slack_authz.py
+++ b/backend/tests/external_dependency_unit/chat/test_seed_chat_from_slack_authz.py
@@ -1,0 +1,95 @@
+"""Authorization tests for the Slack chat-seed copy path.
+
+Regression coverage for the IDOR fix in
+``duplicate_chat_session_for_user_from_slack``: the endpoint that backs
+``POST /chat/seed-chat-session-from-slack`` used to read the source session
+with ``user_id=None`` (ignoring permissions), so any authenticated user could
+copy an arbitrary other user's chat session into a session they own and read it
+back. The fix scopes the source lookup to the caller and requires the source to
+be a Slack-originated session.
+"""
+
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from onyx.db.chat import create_chat_session, duplicate_chat_session_for_user_from_slack
+from onyx.db.models import Persona
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def test_cannot_seed_from_another_users_session(db_session: Session) -> None:
+    """An attacker cannot copy a session owned by another user."""
+    attacker = create_test_user(db_session, "attacker")
+    victim = create_test_user(db_session, "victim")
+
+    victim_session = create_chat_session(
+        db_session=db_session,
+        description="victim private chat",
+        user_id=victim.id,
+        persona_id=None,
+        onyxbot_flow=False,
+    )
+
+    # The source lookup is now scoped to the caller, so the victim's session is
+    # invisible and no copy is made.
+    with pytest.raises(ValueError):
+        duplicate_chat_session_for_user_from_slack(
+            db_session=db_session,
+            user=attacker,
+            chat_session_id=victim_session.id,
+        )
+
+
+def test_cannot_seed_from_non_slack_unowned_session(db_session: Session) -> None:
+    """Even an unowned (user_id is None) session can't be copied unless it is
+    Slack-originated, so arbitrary bot/eval sessions aren't exfiltrated."""
+    attacker = create_test_user(db_session, "attacker")
+
+    unowned_web_session = create_chat_session(
+        db_session=db_session,
+        description="",
+        user_id=None,
+        persona_id=None,
+        onyxbot_flow=False,
+    )
+
+    with pytest.raises(HTTPException):
+        duplicate_chat_session_for_user_from_slack(
+            db_session=db_session,
+            user=attacker,
+            chat_session_id=unowned_web_session.id,
+        )
+
+
+def test_can_seed_from_slack_session(db_session: Session) -> None:
+    """The legitimate flow still works: a Slack-originated (unowned) session is
+    copied into a new session owned by the requesting user."""
+    user = create_test_user(db_session, "slack-user")
+    persona = Persona(
+        name=f"seed-test-{uuid4().hex[:6]}",
+        description="t",
+        user_id=user.id,
+    )
+    db_session.add(persona)
+    db_session.flush()
+
+    slack_session = create_chat_session(
+        db_session=db_session,
+        description="",
+        user_id=None,
+        persona_id=persona.id,
+        onyxbot_flow=True,
+        slack_thread_id=f"T-{uuid4().hex[:8]}",
+    )
+
+    new_session = duplicate_chat_session_for_user_from_slack(
+        db_session=db_session,
+        user=user,
+        chat_session_id=slack_session.id,
+    )
+
+    assert new_session.id != slack_session.id
+    assert new_session.user_id == user.id


### PR DESCRIPTION
## Description

`POST /chat/seed-chat-session-from-slack` (the "continue in web" button behind a Slack thread) copied a source session by id **without any ownership check**. `duplicate_chat_session_for_user_from_slack` and the follow-on message copy read the source with `user_id=None` / `skip_permission_check=True`, so any authenticated `BASIC_ACCESS` user could POST another user's `chat_session_id` (session IDs appear in chat URLs / shared links) and copy that user's entire conversation — message text, reasoning tokens, errors, and **file references** — into a session they own, then read it back via `GET /chat/get-chat-session/{id}`. Because the copied file descriptors then belong to the attacker's session, the chat-file check (`ChatSession.user_id == user.id`) also authorized downloading the victim's attachments via `GET /chat/file/{id}`. (Finding severity: HIGH.)

The fix scopes the source lookup in `duplicate_chat_session_for_user_from_slack` to the caller — passing `user.id` instead of `None`, which still allows the genuinely unowned bot-created Slack sessions (`user_id IS NULL`) but excludes sessions owned by other users — and additionally requires the source to be Slack-originated (`onyxbot_flow=True` or `slack_thread_id` set), so arbitrary non-Slack unowned sessions can't be exfiltrated either. The endpoint calls this function first, so the guard also gates the subsequent `add_chats_to_session_from_slack_thread` message copy.

A blocked request raises `ValueError` for an unauthorized-but-existing session (mapped to HTTP 400 by the global handler) — the same response an invalid id already produces — so nothing is disclosed.

Resolves ENG-4294.

## How Has This Been Tested?

New external_dependency_unit regression test `backend/tests/external_dependency_unit/chat/test_seed_chat_from_slack_authz.py` (3 cases, all passing):
- seeding from another user's session is rejected,
- seeding from a non-Slack unowned session is rejected,
- the legitimate flow (an unowned Slack-originated session) still succeeds and yields a new session owned by the caller.

`ruff`, `ruff format`, and `ty` clean on `backend/onyx/db/chat.py`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a HIGH-severity IDOR in the Slack “continue in web” seed path by scoping the source session lookup to the caller and only Slack-originated sessions. Prevents cross-user chat and file disclosure while keeping the valid Slack flow working. Addresses ENG-4294.

- **Bug Fixes**
  - Restrict `duplicate_chat_session_for_user_from_slack` to caller-owned sessions or unowned Slack sessions by passing `user.id` to `get_chat_session_by_id` and requiring `onyxbot_flow` or `slack_thread_id`.
  - Raise `ValueError` in the DB layer so invalid or unauthorized IDs map to HTTP 400 without details; add regression tests covering: reject seeding another user’s session, reject non-Slack unowned sessions, and allow Slack-originated sessions.

<sup>Written for commit ef137ca174b54b42a6650825dbc3f56220e6b626. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

