### PR TITLE
fix(security): stop compiling user search query as a regex — ReDoS (ENG-4296)

### DIFF
--- a/backend/onyx/server/manage/users.py
+++ b/backend/onyx/server/manage/users.py
@@ -1,6 +1,5 @@
 import csv
 import io
-import re
 from datetime import datetime, timedelta, timezone
 from typing import cast
 from uuid import UUID
@@ -422,9 +421,11 @@ def list_all_users(
     ]
 
     if q:
-        invited_emails = [
-            email for email in invited_emails if re.search(r"{}".format(q), email, re.I)
-        ]
+        # Plain case-insensitive substring match (mirrors the ilike used for
+        # accepted users). Never compile q as a regex: it is attacker-controlled
+        # and a crafted pattern can cause catastrophic backtracking (ReDoS).
+        q_lower = q.lower()
+        invited_emails = [email for email in invited_emails if q_lower in email.lower()]
 
     accepted_count = len(accepted_emails)
     slack_users_count = len(slack_users_emails)

--- a/backend/tests/external_dependency_unit/server/manage/test_list_all_users_redos.py
+++ b/backend/tests/external_dependency_unit/server/manage/test_list_all_users_redos.py
@@ -1,0 +1,41 @@
+"""ReDoS regression test for the invited-user search filter in list_all_users.
+
+The `q` search param used to be compiled as a regex and matched against every
+invited email (`re.search(r"{}".format(q), email, re.I)`), so a crafted pattern
+could cause catastrophic backtracking and hang API worker threads. It is now a
+plain case-insensitive substring match.
+"""
+
+from unittest.mock import patch
+
+from sqlalchemy.orm import Session
+
+from onyx.server.manage.users import list_all_users
+
+
+def test_invited_filter_is_literal_substring_not_regex(db_session: Session) -> None:
+    invited = ["axb@example.com"]
+    with (
+        patch("onyx.server.manage.users.get_invited_users", return_value=invited),
+        patch("onyx.server.manage.users.get_all_users", return_value=[]),
+    ):
+        # A regex metacharacter is treated literally now: "a.b" must NOT match
+        # "axb@..." (it would under the old regex, where "." is any char).
+        resp = list_all_users(q="a.b", db_session=db_session)
+        assert [u.email for u in resp.invited] == []
+
+        # Plain, case-insensitive substring still matches.
+        resp = list_all_users(q="AXB", db_session=db_session)
+        assert "axb@example.com" in [u.email for u in resp.invited]
+
+
+def test_invited_filter_redos_pattern_returns_quickly(db_session: Session) -> None:
+    # An email that would trigger catastrophic backtracking under the old
+    # `re.search("(a+)+$", email)` code path; here it's just a literal substring.
+    invited = ["a" * 40 + "@example.com"]
+    with (
+        patch("onyx.server.manage.users.get_invited_users", return_value=invited),
+        patch("onyx.server.manage.users.get_all_users", return_value=[]),
+    ):
+        resp = list_all_users(q="(a+)+$", db_session=db_session)
+        assert [u.email for u in resp.invited] == []


### PR DESCRIPTION
## Description

`GET /manage/users` passed the attacker-controlled `q` query param straight into `re.search(r"{}".format(q), email, re.I)` for every invited email, so `q` **was** the regex. A crafted pattern such as `(a+)+$` against a long invited local-part causes catastrophic backtracking, and because the handler is synchronous it pins a worker thread for minutes; a handful of concurrent requests exhausts the thread pool and takes the API server offline. A curator or admin can create a matching invited email via bulk-invite, so the precondition is cheap.

This replaces the regex with a plain case-insensitive substring match (mirroring the parameterized `ilike` already used for accepted users) and drops the now-unused `re` import.

Resolves ENG-4296.

## How Has This Been Tested?

New external_dependency_unit test `backend/tests/external_dependency_unit/server/manage/test_list_all_users_redos.py` (2 cases, passing): the invited filter is now a literal substring (a regex metacharacter like `.` is inert — `a.b` no longer matches `axb`) while a plain case-insensitive substring still matches, and a catastrophic-backtracking pattern returns immediately. `ruff` / `ruff format` / `ty` clean.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents ReDoS in `GET /manage/users` by no longer treating the user-supplied `q` as a regex; invited email filtering now uses a case-insensitive substring match that mirrors the accepted-users `ilike`, resolving ENG-4296. Adds regression tests to ensure regex metacharacters are treated literally and malicious patterns return immediately; drops the unused `re` import.

<sup>Written for commit 1666cd5aa49fdf7ada50fcb1c1e0893298652c69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

