### PR TITLE
fix(security): verify project ownership in move_chat_session (ENG-4297)

### DIFF
--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -31,6 +31,8 @@ from onyx.db.projects import (
     get_project_token_count,
     upload_files_to_user_files_with_indexing,
 )
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.projects.models import (
     CategorizedFilesSnapshot,
     ChatSessionRequest,
@@ -570,7 +572,7 @@ def move_chat_session(
         .one_or_none()
     )
     if chat_session is None:
-        raise HTTPException(status_code=404, detail="Chat session not found")
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Chat session not found")
 
     # The target project must belong to the caller; otherwise a user could
     # attach their session to another user's project and read that project's
@@ -581,7 +583,7 @@ def move_chat_session(
         .one_or_none()
     )
     if project is None:
-        raise HTTPException(status_code=404, detail="Project not found")
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Project not found")
 
     chat_session.project_id = project_id
     db_session.commit()

--- a/backend/onyx/server/features/projects/api.py
+++ b/backend/onyx/server/features/projects/api.py
@@ -571,6 +571,18 @@ def move_chat_session(
     )
     if chat_session is None:
         raise HTTPException(status_code=404, detail="Chat session not found")
+
+    # The target project must belong to the caller; otherwise a user could
+    # attach their session to another user's project and read that project's
+    # instructions back through the default agent.
+    project = (
+        db_session.query(UserProject)
+        .filter(UserProject.id == project_id, UserProject.user_id == user_id)
+        .one_or_none()
+    )
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
     chat_session.project_id = project_id
     db_session.commit()
     return Response(status_code=204)

--- a/backend/tests/external_dependency_unit/server/features/projects/test_move_chat_session_authz.py
+++ b/backend/tests/external_dependency_unit/server/features/projects/test_move_chat_session_authz.py
@@ -1,0 +1,71 @@
+"""Authorization test for ``move_chat_session`` project ownership.
+
+``POST /user/projects/{project_id}/move_chat_session`` set
+``chat_session.project_id`` from the path param without checking that the
+project belonged to the caller, so a user could attach their own session to
+another user's project and read that project's instructions back through the
+default agent. The endpoint now verifies project ownership before assigning.
+"""
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.orm import Session
+
+from onyx.db.chat import create_chat_session
+from onyx.db.models import UserProject
+from onyx.server.features.projects.api import move_chat_session
+from onyx.server.features.projects.models import ChatSessionRequest
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def test_cannot_move_session_into_another_users_project(db_session: Session) -> None:
+    attacker = create_test_user(db_session, "attacker")
+    victim = create_test_user(db_session, "victim")
+
+    attacker_session = create_chat_session(
+        db_session=db_session,
+        description="",
+        user_id=attacker.id,
+        persona_id=None,
+    )
+    victim_project = UserProject(name="victim-project", user_id=victim.id)
+    db_session.add(victim_project)
+    db_session.flush()
+
+    with pytest.raises(HTTPException) as exc:
+        move_chat_session(
+            project_id=victim_project.id,
+            body=ChatSessionRequest(chat_session_id=str(attacker_session.id)),
+            user=attacker,
+            db_session=db_session,
+        )
+    assert exc.value.status_code == 404
+
+    # The session must not have been attached to the victim's project.
+    db_session.refresh(attacker_session)
+    assert attacker_session.project_id is None
+
+
+def test_can_move_session_into_own_project(db_session: Session) -> None:
+    user = create_test_user(db_session, "owner")
+
+    session = create_chat_session(
+        db_session=db_session,
+        description="",
+        user_id=user.id,
+        persona_id=None,
+    )
+    project = UserProject(name="own-project", user_id=user.id)
+    db_session.add(project)
+    db_session.flush()
+
+    resp = move_chat_session(
+        project_id=project.id,
+        body=ChatSessionRequest(chat_session_id=str(session.id)),
+        user=user,
+        db_session=db_session,
+    )
+    assert resp.status_code == 204
+
+    db_session.refresh(session)
+    assert session.project_id == project.id

--- a/backend/tests/external_dependency_unit/server/features/projects/test_move_chat_session_authz.py
+++ b/backend/tests/external_dependency_unit/server/features/projects/test_move_chat_session_authz.py
@@ -8,11 +8,12 @@ default agent. The endpoint now verifies project ownership before assigning.
 """
 
 import pytest
-from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.db.chat import create_chat_session
 from onyx.db.models import UserProject
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.projects.api import move_chat_session
 from onyx.server.features.projects.models import ChatSessionRequest
 from tests.external_dependency_unit.conftest import create_test_user
@@ -32,14 +33,14 @@ def test_cannot_move_session_into_another_users_project(db_session: Session) -> 
     db_session.add(victim_project)
     db_session.flush()
 
-    with pytest.raises(HTTPException) as exc:
+    with pytest.raises(OnyxError) as exc:
         move_chat_session(
             project_id=victim_project.id,
             body=ChatSessionRequest(chat_session_id=str(attacker_session.id)),
             user=attacker,
             db_session=db_session,
         )
-    assert exc.value.status_code == 404
+    assert exc.value.error_code == OnyxErrorCode.NOT_FOUND
 
     # The session must not have been attached to the victim's project.
     db_session.refresh(attacker_session)


### PR DESCRIPTION
## Description

`POST /user/projects/{project_id}/move_chat_session` set `chat_session.project_id` from the path param after checking only that the **chat session** belonged to the caller — never that the **project** did. Any `BASIC_ACCESS` user could therefore attach their own session to another user's project by enumerating the integer `project_id`. Because `get_custom_agent_prompt` loads `chat_session.project.instructions` for the default agent without re-checking ownership, the victim's project instructions then get injected into the attacker's chat context and can be read back out of the model (and the attacker's session also appears inside the victim's project).

This verifies the target project belongs to the caller (`UserProject.id == project_id AND user_id == user.id`) before assigning, matching the ownership pattern used by the other project endpoints, and raises 404 otherwise.

Resolves ENG-4297.

## How Has This Been Tested?

New external_dependency_unit test `backend/tests/external_dependency_unit/server/features/projects/test_move_chat_session_authz.py` (2 cases, passing): moving a session into another user's project raises 404 and leaves the session's `project_id` unchanged, while moving into an owned project still returns 204 and sets it. `ruff` / `ruff format` / `ty` clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secures `POST /user/projects/{project_id}/move_chat_session` by verifying the target project belongs to the caller before moving a chat session. Prevents an IDOR that could expose another user's project instructions via the default agent (ENG-4297).

- **Bug Fixes**
  - Validate ownership: query `UserProject` by `id` and `user_id`; if not found, raise `OnyxError(OnyxErrorCode.NOT_FOUND)`; otherwise set `chat_session.project_id`. Also use `OnyxError(OnyxErrorCode.NOT_FOUND)` when the chat session is missing.
  - Add regression tests for unauthorized move (404, no change) and authorized move (204, set).

<sup>Written for commit 23e2832cee914d0fad92c2ca6083d6a2d1d837e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

