### PR TITLE
Fix form-encoded MCP OAuth refresh responses

### DIFF
--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -9,8 +9,10 @@ Routes and route-only flow helpers stay in `api.py`.
 import asyncio
 import json
 import time
-from typing import Any
-from urllib.parse import urlparse
+from collections.abc import Awaitable, Callable
+from typing import Any, TypedDict
+from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
 
 import httpx
 from mcp.client.auth import OAuthClientProvider, TokenStorage
@@ -21,7 +23,7 @@ from mcp.shared.auth import (
     OAuthMetadata,
     OAuthToken,
 )
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl, BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
 from onyx.cache.interface import CacheLockAcquisitionError
@@ -43,7 +45,7 @@ from onyx.server.features.mcp.models import MCPConnectionData, MCPOAuthKeys
 from onyx.server.features.mcp.ssrf import mcp_ssrf_httpx_client_factory
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
-from shared_configs.contextvars import get_current_tenant_id
+from shared_configs.contextvars import ONYX_REQUEST_ID_CONTEXTVAR, get_current_tenant_id
 
 logger = setup_logger()
 
@@ -100,6 +102,77 @@ class MCPOauthState(BaseModel):
     is_admin: bool
     state: str
     code_verifier: str | None = None
+
+
+class MCPRefreshLogContext(TypedDict):
+    mcp_server_id: int | None
+    mcp_server_name: str
+    connection_config_id: int
+    transport: str
+    oauth_provider_mode: str
+
+
+def _refresh_log_context(
+    mcp_server: DbMCPServer, connection_config_id: int
+) -> MCPRefreshLogContext:
+    transport = getattr(mcp_server, "transport", None)
+    provider_mode = getattr(mcp_server, "oauth_provider_mode", None)
+    return {
+        "mcp_server_id": getattr(mcp_server, "id", None),
+        "mcp_server_name": mcp_server.name,
+        "connection_config_id": connection_config_id,
+        "transport": getattr(transport, "value", transport) or "UNKNOWN",
+        "oauth_provider_mode": getattr(provider_mode, "value", provider_mode)
+        or "UNKNOWN",
+    }
+
+
+def _oauth_error_from_response(
+    body: bytes, content_type: str | None
+) -> tuple[str | None, str]:
+    """Extract only the safe OAuth error code and body format from a response."""
+    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
+    body_format = (
+        "form"
+        if normalized_content_type == "application/x-www-form-urlencoded"
+        else "json"
+    )
+
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        if body_format != "form":
+            body_format = "unknown"
+        form_payload = parse_qs(body.decode("utf-8", errors="replace"))
+        return (form_payload.get("error", [None])[0], body_format)
+
+    if isinstance(payload, dict):
+        return (payload.get("error"), body_format)
+    return None, body_format
+
+
+def _response_request_hostname(response: httpx.Response) -> str | None:
+    """Return the response hostname when httpx attached the originating request."""
+    try:
+        return response.request.url.host
+    except RuntimeError:
+        return None
+
+
+def _oauth_token_from_response(
+    body: bytes, content_type: str | None
+) -> OAuthToken:
+    """Parse JSON or form-encoded OAuth token responses."""
+    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
+    if normalized_content_type == "application/x-www-form-urlencoded":
+        form_payload = parse_qs(body.decode("utf-8", errors="replace"))
+        payload = {
+            key: values[0]
+            for key, values in form_payload.items()
+            if values
+        }
+        return OAuthToken.model_validate(payload)
+    return OAuthToken.model_validate_json(body)
 
 
 def _token_dict_with_preserved_refresh(
@@ -267,9 +340,16 @@ class OnyxTokenStorage(TokenStorage):
     store auth info in a particular user's connection config in postgres
     """
 
-    def __init__(self, connection_config_id: int, alt_config_id: int | None = None):
+    def __init__(
+        self,
+        connection_config_id: int,
+        alt_config_id: int | None = None,
+        refresh_log_context: MCPRefreshLogContext | None = None,
+    ):
         self.alt_config_id = alt_config_id
         self.connection_config_id = connection_config_id
+        self.refresh_log_context = refresh_log_context
+        self.refresh_attempt_id: str | None = None
         # When bound, `get_tokens` hydrates its `token_expiry_time` from the
         # config read it already does — no separate query for the expiry.
         self._oauth_context: OAuthContext | None = None
@@ -313,8 +393,12 @@ class OnyxTokenStorage(TokenStorage):
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)
             existing_tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
-            config_data[MCPOAuthKeys.TOKENS.value] = _token_dict_with_preserved_refresh(
+            persisted_token_dict = _token_dict_with_preserved_refresh(
                 tokens, existing_tokens_raw
+            )
+            config_data[MCPOAuthKeys.TOKENS.value] = persisted_token_dict
+            token_expires_at_before_refresh = config_data.get(
+                MCPOAuthKeys.TOKEN_EXPIRES_AT.value
             )
             expires_at = _absolute_token_expiry(tokens)
             if expires_at is not None:
@@ -336,6 +420,30 @@ class OnyxTokenStorage(TokenStorage):
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
             update_connection_config(config.id, db_session, config_data)
+
+        if self.refresh_attempt_id and self.refresh_log_context:
+            logger.info(
+                "mcp_oauth.refresh.persisted",
+                extra={
+                    **self.refresh_log_context,
+                    "request_id": ONYX_REQUEST_ID_CONTEXTVAR.get(),
+                    "refresh_attempt_id": self.refresh_attempt_id,
+                    "access_token_persisted": bool(
+                        persisted_token_dict.get("access_token")
+                    ),
+                    "refresh_token_persisted": bool(
+                        persisted_token_dict.get("refresh_token")
+                    ),
+                    "refresh_token_replaced": bool(
+                        tokens.refresh_token
+                        and tokens.refresh_token
+                        != (existing_tokens_raw or {}).get("refresh_token")
+                    ),
+                    "token_expires_at_before_refresh": token_expires_at_before_refresh,
+                    "token_expires_at_after_refresh": expires_at,
+                    "token_expiry_persisted": expires_at is not None,
+                },
+            )
 
         # The shared admin row is intentionally NOT written here: it
         # serves as the OAuth `client_info` registry shared across all
@@ -397,6 +505,110 @@ class OnyxTokenStorage(TokenStorage):
                 update_connection_config(
                     self.alt_config_id, db_session, alt_config_data
                 )
+
+
+class OnyxOAuthClientProvider(OAuthClientProvider):
+    """MCP SDK OAuth provider with safe refresh telemetry and error parsing."""
+
+    def __init__(
+        self,
+        server_url: str,
+        client_metadata: OAuthClientMetadata,
+        storage: TokenStorage,
+        redirect_handler: Callable[[str], Awaitable[None]] | None = None,
+        callback_handler: Callable[[], Awaitable[tuple[str, str | None]]] | None = None,
+        timeout: float = 300.0,
+        client_metadata_url: str | None = None,
+        *,
+        refresh_log_context: MCPRefreshLogContext,
+    ) -> None:
+        super().__init__(
+            server_url=server_url,
+            client_metadata=client_metadata,
+            storage=storage,
+            redirect_handler=redirect_handler,
+            callback_handler=callback_handler,
+            timeout=timeout,
+            client_metadata_url=client_metadata_url,
+        )
+        self.refresh_log_context = refresh_log_context
+        self.refresh_attempt_id: str | None = None
+        self.token_expiry_before_refresh: float | None = None
+
+    def _refresh_log_fields(self, **fields: Any) -> dict[str, Any]:
+        log_fields: dict[str, Any] = {
+            **self.refresh_log_context,
+            "request_id": ONYX_REQUEST_ID_CONTEXTVAR.get(),
+            "refresh_attempt_id": self.refresh_attempt_id,
+        }
+        log_fields.update(fields)
+        return log_fields
+
+    async def _refresh_token(self) -> httpx.Request:
+        self.refresh_attempt_id = uuid4().hex
+        self.token_expiry_before_refresh = self.context.token_expiry_time
+        storage = self.context.storage
+        if isinstance(storage, OnyxTokenStorage):
+            storage.refresh_attempt_id = self.refresh_attempt_id
+
+        request = await super()._refresh_token()
+        logger.info(
+            "mcp_oauth.refresh.started",
+            extra=self._refresh_log_fields(
+                token_expires_at_before_refresh=self.token_expiry_before_refresh,
+                token_endpoint_hostname=request.url.host,
+                access_token_present=bool(
+                    self.context.current_tokens
+                    and self.context.current_tokens.access_token
+                ),
+                refresh_token_present=bool(
+                    self.context.current_tokens
+                    and self.context.current_tokens.refresh_token
+                ),
+            ),
+        )
+        return request
+
+    async def _handle_refresh_response(self, response: httpx.Response) -> bool:
+        """Handle JSON and form-encoded refresh responses without logging secrets."""
+        body = await response.aread()
+        content_type = response.headers.get("content-type")
+        oauth_error, body_format = _oauth_error_from_response(body, content_type)
+        token_endpoint_hostname = _response_request_hostname(response)
+
+        response_fields = self._refresh_log_fields(
+            http_status=response.status_code,
+            response_content_type=content_type,
+            response_body_format=body_format,
+            oauth_error=oauth_error,
+            token_endpoint_hostname=token_endpoint_hostname,
+        )
+
+        if response.status_code != 200:
+            logger.warning("mcp_oauth.refresh.failed", extra=response_fields)
+            self.context.clear_tokens()
+            return False
+
+        try:
+            token_response = _oauth_token_from_response(body, content_type)
+        except ValidationError:
+            logger.warning("mcp_oauth.refresh.invalid_response", extra=response_fields)
+            self.context.clear_tokens()
+            return False
+
+        self.context.current_tokens = token_response
+        self.context.update_token_expiry(token_response)
+        await self.context.storage.set_tokens(token_response)
+        logger.info(
+            "mcp_oauth.refresh.succeeded",
+            extra=self._refresh_log_fields(
+                http_status=response.status_code,
+                response_content_type=content_type,
+                response_body_format=body_format,
+                token_endpoint_hostname=token_endpoint_hostname,
+            ),
+        )
+        return True
 
 
 def make_oauth_provider(
@@ -463,8 +675,14 @@ def make_oauth_provider(
         r.delete(key_auth_url(user_id), key_state(user_id))
         return code, state_obj.state
 
-    storage = OnyxTokenStorage(connection_config_id, admin_config_id)
-    provider = OAuthClientProvider(
+    refresh_log_context = _refresh_log_context(mcp_server, connection_config_id)
+    storage = OnyxTokenStorage(
+        connection_config_id,
+        admin_config_id,
+        refresh_log_context,
+    )
+    provider = OnyxOAuthClientProvider(
+        refresh_log_context=refresh_log_context,
         server_url=mcp_server.server_url,
         client_metadata=OAuthClientMetadata(
             client_name=f"Onyx - {mcp_server.name}",

--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -159,20 +159,21 @@ def _response_request_hostname(response: httpx.Response) -> str | None:
         return None
 
 
-def _oauth_token_from_response(
-    body: bytes, content_type: str | None
-) -> OAuthToken:
+def _oauth_token_from_response(body: bytes) -> OAuthToken:
     """Parse JSON or form-encoded OAuth token responses."""
-    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
-    if normalized_content_type == "application/x-www-form-urlencoded":
+    try:
+        return OAuthToken.model_validate_json(body)
+    except ValidationError as json_error:
         form_payload = parse_qs(body.decode("utf-8", errors="replace"))
         payload = {
             key: values[0]
             for key, values in form_payload.items()
             if values
         }
-        return OAuthToken.model_validate(payload)
-    return OAuthToken.model_validate_json(body)
+        try:
+            return OAuthToken.model_validate(payload)
+        except ValidationError:
+            raise json_error from None
 
 
 def _token_dict_with_preserved_refresh(
@@ -590,7 +591,7 @@ class OnyxOAuthClientProvider(OAuthClientProvider):
             return False
 
         try:
-            token_response = _oauth_token_from_response(body, content_type)
+            token_response = _oauth_token_from_response(body)
         except ValidationError:
             logger.warning("mcp_oauth.refresh.invalid_response", extra=response_fields)
             self.context.clear_tokens()

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -12,7 +12,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import Any, cast
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlencode
 
 import httpx
 import pytest
@@ -132,6 +132,21 @@ def _token_response(**overrides: Any) -> httpx.Response:
     return httpx.Response(200, json=payload)
 
 
+def _form_token_response(**overrides: Any) -> httpx.Response:
+    payload: dict[str, Any] = {
+        "access_token": "NEW",
+        "token_type": "bearer",
+        "expires_in": 7200,
+        "refresh_token": "REFRESH_2",
+    }
+    payload.update(overrides)
+    return httpx.Response(
+        200,
+        content=urlencode(payload).encode(),
+        headers={"content-type": "application/x-www-form-urlencoded; charset=utf-8"},
+    )
+
+
 def test_refreshes_expired_token_with_client_secret_post(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -177,6 +192,53 @@ def test_refreshes_expired_token_with_client_secret_post(
     assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
     assert persisted["headers"]["Authorization"] == "Bearer NEW"
     assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+
+
+def test_refreshes_form_encoded_token_response_with_rotated_refresh_token(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "redirect_uris": [_REDIRECT_URI],
+            "token_endpoint_auth_method": "client_secret_post",
+        },
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://gitlab.example.com",
+            "authorization_endpoint": "https://gitlab.example.com/oauth/authorize",
+            "token_endpoint": _TOKEN_ENDPOINT,
+        },
+    }
+    captured = _install_mocks(
+        monkeypatch, config_data, response=_form_token_response()
+    )
+
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    assert header == "Bearer NEW"
+    persisted = captured["updated_config_data"]
+    assert persisted[MCPOAuthKeys.TOKENS.value]["access_token"] == "NEW"
+    assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
+    assert persisted["headers"]["Authorization"] == "Bearer NEW"
+    assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+    assert any(
+        record.getMessage() == "mcp_oauth.refresh.succeeded"
+        for record in caplog.records
+    )
+    assert any(
+        record.getMessage() == "mcp_oauth.refresh.persisted"
+        for record in caplog.records
+    )
 
 
 def test_refresh_uses_basic_auth_for_client_secret_basic(
@@ -367,6 +429,65 @@ def test_refresh_failure_is_non_fatal_to_caller(
 
     with pytest.raises(RuntimeError):
         refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+
+def test_form_encoded_refresh_error_is_logged_without_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD_ACCESS_TOKEN",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "ROTATING_REFRESH_TOKEN",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "redirect_uris": [_REDIRECT_URI],
+            "token_endpoint_auth_method": "client_secret_post",
+        },
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://github.example.com",
+            "authorization_endpoint": "https://github.example.com/oauth/authorize",
+            "token_endpoint": "https://github.example.com/oauth/token",
+        },
+    }
+    response = httpx.Response(
+        400,
+        content=b"error=bad_refresh_token&error_description=refresh+token+expired",
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+    _install_mocks(monkeypatch, config_data, response=response)
+
+    with pytest.raises(RuntimeError):
+        refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    failed_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "mcp_oauth.refresh.failed"
+    )
+    started_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "mcp_oauth.refresh.started"
+    )
+    assert getattr(failed_record, "oauth_error") == "bad_refresh_token"
+    assert (
+        getattr(failed_record, "response_content_type")
+        == "application/x-www-form-urlencoded"
+    )
+    assert getattr(failed_record, "response_body_format") == "form"
+    assert getattr(failed_record, "refresh_attempt_id") == getattr(
+        started_record, "refresh_attempt_id"
+    )
+    assert "OLD_ACCESS_TOKEN" not in caplog.text
+    assert "ROTATING_REFRESH_TOKEN" not in caplog.text
+    assert "csecret" not in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -132,7 +132,10 @@ def _token_response(**overrides: Any) -> httpx.Response:
     return httpx.Response(200, json=payload)
 
 
-def _form_token_response(**overrides: Any) -> httpx.Response:
+def _form_token_response(
+    *, content_type: str | None = "application/x-www-form-urlencoded; charset=utf-8",
+    **overrides: Any,
+) -> httpx.Response:
     payload: dict[str, Any] = {
         "access_token": "NEW",
         "token_type": "bearer",
@@ -140,11 +143,8 @@ def _form_token_response(**overrides: Any) -> httpx.Response:
         "refresh_token": "REFRESH_2",
     }
     payload.update(overrides)
-    return httpx.Response(
-        200,
-        content=urlencode(payload).encode(),
-        headers={"content-type": "application/x-www-form-urlencoded; charset=utf-8"},
-    )
+    headers = {} if content_type is None else {"content-type": content_type}
+    return httpx.Response(200, content=urlencode(payload).encode(), headers=headers)
 
 
 def test_refreshes_expired_token_with_client_secret_post(
@@ -194,9 +194,14 @@ def test_refreshes_expired_token_with_client_secret_post(
     assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
 
 
+@pytest.mark.parametrize(
+    "content_type",
+    ["application/x-www-form-urlencoded; charset=utf-8", None, "application/json"],
+)
 def test_refreshes_form_encoded_token_response_with_rotated_refresh_token(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    content_type: str | None,
 ) -> None:
     config_data: dict[str, Any] = {
         "headers": {"Authorization": "Bearer OLD"},
@@ -220,7 +225,9 @@ def test_refreshes_form_encoded_token_response_with_rotated_refresh_token(
         },
     }
     captured = _install_mocks(
-        monkeypatch, config_data, response=_form_token_response()
+        monkeypatch,
+        config_data,
+        response=_form_token_response(content_type=content_type),
     )
 
     header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")


### PR DESCRIPTION
## What

Fix MCP OAuth refresh handling for providers that return form-encoded token responses.

Key changes:

- Parse `application/x-www-form-urlencoded` OAuth token responses in addition to JSON.
- Persist rotated refresh tokens through the existing `OnyxTokenStorage` path.
- Add regression coverage for GitHub-style refresh responses.
- Preserve existing refresh locking, error handling, and secret-free logging.

## Why

GitHub returned a successful form-encoded refresh response, but Onyx rejected it because the refresh handler only supported JSON. The rotated refresh token was not persisted, causing later requests to reuse an invalid refresh token and fail with `bad_refresh_token`.

## How to Review

Review the response parsing and persistence flow in:

- `backend/onyx/server/features/mcp/oauth.py`

Review the regression coverage in:

- `backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py`

Pay particular attention to:

- JSON and form-encoded response compatibility.
- Persistence of replacement refresh tokens.
- Expiry and authorization-header updates.
- Existing single-flight refresh behavior.
- Secret-free logging.

## Testing

Passed:

- 36 focused and related MCP OAuth tests.
- Ruff checks for the changed files.
- Ty type checks for the changed files.
- `git diff --check`.

The behavior was also manually verified against a local GitHub MCP connection by forcing the stored token expiry and confirming a successful refresh with a rotated refresh token.

## Risks / Impact

- No API, schema, migration, or dependency changes.
- JSON-based OAuth providers are unaffected.
- Providers returning form-encoded token responses now refresh correctly.
- Users whose refresh tokens were already invalidated by the previous behavior may need to reauthenticate once.
- Existing refresh locking and failure behavior remain unchanged.

## Related
- [GitHub MCP OAuth refresh fails with rotating refresh tokens](https://github.com/onyx-dot-app/onyx/issues/13330)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP OAuth refresh for providers that return form-encoded token responses, including cases where the `Content-Type` is missing or mislabeled. Rotated refresh tokens are now persisted, and refresh works reliably with GitHub-style flows.

- **Bug Fixes**
  - Parse token responses as JSON or form-encoded based on body, not headers; handle mislabeled or absent `Content-Type`.
  - Persist rotated `refresh_token` via `OnyxTokenStorage`, update `Authorization` header and token expiry, and log a safe “persisted” event.
  - Use `OnyxOAuthClientProvider` to handle refresh responses and emit safe telemetry (attempt IDs, token endpoint hostname, body format, error code).
  - Add tests for form-encoded success across header variants and for error logging without secrets; existing refresh locking and failure behavior unchanged.

<sup>Written for commit 507bb881f252c46668a98e4befb148a3650370f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

