### PR TITLE
fix(telemetry): version heartbeat tests fail in CI where DISABLE_TELEMETRY is set

### DIFF
--- a/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
+++ b/backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py
@@ -17,6 +17,17 @@ from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 _TENANT_ID = POSTGRES_DEFAULT_SCHEMA_STANDARD_VALUE
 
 
+@pytest.fixture(autouse=True)
+def enable_telemetry() -> Generator[None, None, None]:
+    # CI runs with DISABLE_TELEMETRY=true; force the task's gate open so the
+    # heartbeat logic under test actually executes
+    with patch(
+        "onyx.background.celery.tasks.monitoring.tasks.DISABLE_TELEMETRY",
+        False,
+    ):
+        yield
+
+
 @pytest.fixture
 def clear_version_telemetry_marker() -> Generator[None, None, None]:
     redis_client = get_redis_client(tenant_id=_TENANT_ID)


### PR DESCRIPTION
## Description

The external-dependency-unit `celery` shard has been failing since #13317 merged (including merge-queue runs, so it's blocking other PRs). Root cause: the CI workflow sets `DISABLE_TELEMETRY=true`, and `emit_version_telemetry` early-returns on that flag — so the mocked `optional_telemetry` is never called and the Redis marker is never set. 3 of the 5 new tests fail:

- `test_emits_version_once_per_day` — `Expected 'optional_telemetry' to be called once. Called 0 times.`
- `test_failed_delivery_releases_marker` — `assert 0 == 2`
- `test_marker_has_expiration` — `assert 0 < -2` (marker never created, TTL is -2)

Fix: an autouse fixture patches `DISABLE_TELEMETRY` to `False` in the task module for these tests, mirroring how `test_noop_on_multi_tenant` already patches `MULTI_TENANT`. No production code change.

## How Has This Been Tested?

Ran `pytest backend/tests/external_dependency_unit/celery/test_version_telemetry_heartbeat.py` both with `DISABLE_TELEMETRY=true` (reproduces the CI failure before the fix) and without — 5/5 pass in both environments after the fix.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI failures in the version telemetry heartbeat tests when `DISABLE_TELEMETRY=true`. Adds an autouse pytest fixture to set the task’s `DISABLE_TELEMETRY=false` so the heartbeat runs and the Redis marker is set.

<sup>Written for commit fc67b8c2a369a10c5d28f7da1433bb96c53a9f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13337?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

