### PR TITLE
fix(db): make external app downgrade resilient

### DIFF
--- a/backend/alembic/versions/ea9771dd828c_associate_external_apps_with_skills.py
+++ b/backend/alembic/versions/ea9771dd828c_associate_external_apps_with_skills.py
@@ -19,6 +19,11 @@ down_revision = "f0ff4d3e69ac"
 branch_labels = None
 depends_on = None
 
+_EMPTY_BUNDLE_SHA256 = (
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+_PLACEHOLDER_BUNDLE_PREFIX = "downgrade-placeholder-"
+
 
 def upgrade() -> None:
     op.create_table(
@@ -44,8 +49,10 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     bind = op.get_bind()
-    # The previous schema requires every app to point to a skill. Create a
-    # contentless provider-named placeholder wherever no association exists.
+    # The previous schema requires every app to point to a skill. Create an
+    # invalid custom placeholder wherever no association exists. Non-null bundle
+    # metadata lets it survive the older migration that restores those columns'
+    # NOT NULL constraints, without creating or deleting a FileStore object.
     apps_without_skills = bind.execute(
         sa.text(
             """
@@ -63,9 +70,12 @@ def downgrade() -> None:
     insert_skill = sa.text(
         """
         INSERT INTO skill (
-            id, name, description, built_in_skill_id, public_permission
+            id, name, description, bundle_file_id, bundle_sha256, is_valid,
+            public_permission
         )
-        VALUES (:skill_id, :name, '', :name, 'VIEWER')
+        VALUES (
+            :skill_id, :name, '', :bundle_file_id, :bundle_sha256, false, 'VIEWER'
+        )
         """
     ).bindparams(sa.bindparam("skill_id", type_=postgresql.UUID(as_uuid=True)))
     insert_association = sa.text(
@@ -80,7 +90,15 @@ def downgrade() -> None:
     for external_app_id, app_type in apps_without_skills:
         skill_id = uuid.uuid4()
         skill_name = app_type.lower().replace("_", "-")
-        bind.execute(insert_skill, {"skill_id": skill_id, "name": skill_name})
+        bind.execute(
+            insert_skill,
+            {
+                "skill_id": skill_id,
+                "name": skill_name,
+                "bundle_file_id": f"{_PLACEHOLDER_BUNDLE_PREFIX}{skill_id}",
+                "bundle_sha256": _EMPTY_BUNDLE_SHA256,
+            },
+        )
         bind.execute(
             insert_association,
             {"external_app_id": external_app_id, "skill_id": skill_id},

--- a/backend/alembic/versions/ea9771dd828c_associate_external_apps_with_skills.py
+++ b/backend/alembic/versions/ea9771dd828c_associate_external_apps_with_skills.py
@@ -6,6 +6,8 @@ Create Date: 2026-07-22 11:47:14.521933
 
 """
 
+import uuid
+
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
@@ -41,34 +43,55 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    has_non_representable_apps = (
-        op.get_bind()
-        .execute(
-            sa.text(
-                """
-            SELECT EXISTS (
+    bind = op.get_bind()
+    # The previous schema requires every app to point to a skill. Create a
+    # contentless provider-named placeholder wherever no association exists.
+    apps_without_skills = bind.execute(
+        sa.text(
+            """
+            SELECT external_app.id, external_app.app_type
+            FROM external_app
+            WHERE NOT EXISTS (
                 SELECT 1
-                FROM external_app
-                LEFT JOIN external_app__skill
-                    ON external_app__skill.external_app_id = external_app.id
-                GROUP BY external_app.id
-                HAVING COUNT(external_app__skill.skill_id) <> 1
+                FROM external_app__skill
+                WHERE external_app__skill.external_app_id = external_app.id
             )
             """
-            )
         )
-        .scalar_one()
+    ).all()
+
+    insert_skill = sa.text(
+        """
+        INSERT INTO skill (
+            id, name, description, built_in_skill_id, public_permission
+        )
+        VALUES (:skill_id, :name, '', :name, 'VIEWER')
+        """
+    ).bindparams(sa.bindparam("skill_id", type_=postgresql.UUID(as_uuid=True)))
+    insert_association = sa.text(
+        """
+        INSERT INTO external_app__skill (external_app_id, skill_id)
+        VALUES (:external_app_id, :skill_id)
+        """
+    ).bindparams(
+        sa.bindparam("skill_id", type_=postgresql.UUID(as_uuid=True)),
     )
-    if has_non_representable_apps:
-        raise RuntimeError(
-            "Cannot downgrade while an external app has zero or multiple "
-            "associated skills; the previous schema requires exactly one."
+
+    for external_app_id, app_type in apps_without_skills:
+        skill_id = uuid.uuid4()
+        skill_name = app_type.lower().replace("_", "-")
+        bind.execute(insert_skill, {"skill_id": skill_id, "name": skill_name})
+        bind.execute(
+            insert_association,
+            {"external_app_id": external_app_id, "skill_id": skill_id},
         )
 
     op.add_column(
         "external_app",
         sa.Column("skill_id", postgresql.UUID(as_uuid=True), nullable=True),
     )
+    # Keep every skill and its FileStore bundle reference. The legacy schema can
+    # point to only one skill, so choose one association without deleting others.
     op.execute(
         """
         UPDATE external_app
@@ -76,7 +99,7 @@ def downgrade() -> None:
         FROM (
             SELECT DISTINCT ON (external_app_id) external_app_id, skill_id
             FROM external_app__skill
-            ORDER BY external_app_id, skill_id
+            ORDER BY external_app_id, random()
         ) AS association
         WHERE external_app.id = association.external_app_id
         """

--- a/backend/alembic/versions/ea9771dd828c_associate_external_apps_with_skills.py
+++ b/backend/alembic/versions/ea9771dd828c_associate_external_apps_with_skills.py
@@ -91,7 +91,7 @@ def downgrade() -> None:
         sa.Column("skill_id", postgresql.UUID(as_uuid=True), nullable=True),
     )
     # Keep every skill and its FileStore bundle reference. The legacy schema can
-    # point to only one skill, so choose one association without deleting others.
+    # point to only one skill, so choose the first without deleting the others.
     op.execute(
         """
         UPDATE external_app
@@ -99,7 +99,7 @@ def downgrade() -> None:
         FROM (
             SELECT DISTINCT ON (external_app_id) external_app_id, skill_id
             FROM external_app__skill
-            ORDER BY external_app_id, random()
+            ORDER BY external_app_id, skill_id
         ) AS association
         WHERE external_app.id = association.external_app_id
         """


### PR DESCRIPTION
## Description

Make the latest external-app Alembic revision downgrade cleanly when an app has zero or multiple associated skills.

Apps without a skill receive an organization-viewable, provider-named custom placeholder. Its synthetic bundle metadata satisfies older schema constraints, while `is_valid = false` prevents it from representing a real FileStore bundle. This also keeps the placeholder out of the ancestor migration's built-in cleanup so multi-step rollbacks preserve the external-app row.

Apps with multiple skills retain every skill and FileStore bundle reference while the legacy schema selects the first association ordered by skill UUID. This replaces the previous hard failure and preserves existing skill permissions and bundle data.

## How Has This Been Tested?

<!--- Describe the tests you ran to verify your changes --->

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
