### PR TITLE
fix(llm): route Azure responses-bridge calls to the v1 responses surface

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -248,7 +248,7 @@ def _log_azure_responses_api_version_override(
 ) -> None:
     """Log once per provider config per process (LLM instances and calls are
     per-request, so unconditional logging here would fire on every LLM call)."""
-    logger.info(
+    logger.warning(
         "Azure responses API calls for %s ignore the configured api_version %s: "
         "dated api-versions target the legacy /openai/responses surface, which "
         "some clouds (e.g. Azure Government) do not serve. These calls use "

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -4,6 +4,7 @@ import re
 import time
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager, nullcontext
+from functools import lru_cache
 from typing import TYPE_CHECKING, Any, Union, cast
 
 from readerwriterlock import rwlock
@@ -59,6 +60,11 @@ if TYPE_CHECKING:
 _LLM_PROMPT_LONG_TERM_LOG_CATEGORY = "llm_prompt"
 LEGACY_MAX_TOKENS_KWARG = "max_tokens"
 STANDARD_MAX_TOKENS_KWARG = "max_completion_tokens"
+
+# Azure api-versions that route to the modern /openai/v1/* surface. Mirrors
+# LiteLLM's BaseAzureLLM._is_azure_v1_api_version.
+_AZURE_V1_API_VERSIONS = frozenset({"preview", "latest", "v1"})
+
 _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
     "claude-opus-4-5",
     "claude-opus-4-6",
@@ -234,6 +240,24 @@ def _prompt_contains_tool_call_history(prompt: LanguageModelInput) -> bool:
 
     msgs = prompt if isinstance(prompt, list) else [prompt]
     return any(isinstance(msg, AssistantMessage) and msg.tool_calls for msg in msgs)
+
+
+@lru_cache(maxsize=None)
+def _log_azure_responses_api_version_override(
+    api_base: str | None, configured_api_version: str
+) -> None:
+    """Log once per provider config per process (LLM instances and calls are
+    per-request, so unconditional logging here would fire on every LLM call)."""
+    logger.info(
+        "Azure responses API calls for %s ignore the configured api_version %s: "
+        "dated api-versions target the legacy /openai/responses surface, which "
+        "some clouds (e.g. Azure Government) do not serve. These calls use "
+        "LiteLLM's responses default instead (AZURE_DEFAULT_RESPONSES_API_VERSION, "
+        "default 'preview'); the configured version still applies to "
+        "chat-completions calls.",
+        api_base,
+        configured_api_version,
+    )
 
 
 def _is_vertex_model_rejecting_output_config(model_name: str) -> bool:
@@ -543,6 +567,25 @@ class LitellmLLM(LLM):
             if is_openai_model  # Uses litellm's completions -> responses bridge
             else self.config.model_provider
         )
+
+        # Azure responses-bridge calls must target the v1 responses surface:
+        # with a dated api-version, LiteLLM builds the legacy /openai/responses
+        # URL, which sovereign clouds (e.g. Azure Government) do not serve
+        # (#11420). Dropping the dated version lets LiteLLM apply its responses
+        # default (AZURE_DEFAULT_RESPONSES_API_VERSION env var, default
+        # "preview"), which routes to /openai/v1/responses — working on all
+        # clouds with reasoning summaries intact. Admin-configured v1 versions
+        # ("preview"/"latest"/"v1") pass through, and the dated version still
+        # applies to every non-bridge call (e.g. Azure chat completions).
+        api_version = self._api_version or None
+        if (
+            is_openai_model
+            and self._model_provider == LlmProviderNames.AZURE
+            and api_version is not None
+            and api_version not in _AZURE_V1_API_VERSIONS
+        ):
+            _log_azure_responses_api_version_override(self._api_base, api_version)
+            api_version = None
         if is_openai_compatible_proxy:
             # OpenAI-compatible proxies (Bifrost, generic OpenAI-compatible
             # servers) expect model names sent directly to their endpoint.
@@ -778,7 +821,7 @@ class LitellmLLM(LLM):
                     mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
                     model=model,
                     base_url=self._api_base or None,
-                    api_version=self._api_version or None,
+                    api_version=api_version,
                     custom_llm_provider=self._custom_llm_provider or None,
                     messages=messages,
                     tools=tools,

--- a/backend/tests/external_dependency_unit/llm/test_azure_responses_api.py
+++ b/backend/tests/external_dependency_unit/llm/test_azure_responses_api.py
@@ -1,0 +1,106 @@
+"""Live guard for the Azure Responses API surface routing (#11420).
+
+`LitellmLLM` routes true OpenAI models on Azure through LiteLLM's responses
+bridge. The bridge must target the modern `/openai/v1/responses` surface even
+when the provider is configured with a dated api-version: dated versions make
+LiteLLM build the legacy `/openai/responses?api-version=<dated>` URL, which
+sovereign clouds (e.g. Azure Government) do not serve.
+
+Commercial Azure serves BOTH surfaces successfully, so a plain success
+assertion cannot catch a regression to the legacy surface — these tests
+intercept the actual request URL. The URL construction happens inside
+LiteLLM, so this is also the guard that a LiteLLM version bump doesn't
+silently change the surface.
+"""
+
+from urllib.parse import urlparse
+
+import pytest
+from litellm.llms.custom_httpx.http_handler import HTTPHandler
+
+from onyx.llm.constants import LlmProviderNames
+from onyx.llm.models import LanguageModelInput, UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from tests.utils.secret_names import TestSecret
+
+pytestmark = pytest.mark.nightly
+
+# Deployment that exists on the shared Azure test resource (the same resource
+# AZURE_API_URL points at; see tests/daily/embedding for its embedding use).
+_CHAT_DEPLOYMENT = "gpt-4o"
+
+# A dated api-version, as admins configure for Azure chat completions. Before
+# the v1-surface fix this routed responses-bridge calls to the legacy surface.
+_DATED_API_VERSION = "2025-03-01-preview"
+
+
+def _resource_base(azure_api_url: str) -> str:
+    """AZURE_API_URL is a full deployment target URI; extract the resource base."""
+    parsed = urlparse(azure_api_url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _build_azure_llm(test_secrets: dict[TestSecret, str]) -> LitellmLLM:
+    return LitellmLLM(
+        api_key=test_secrets[TestSecret.AZURE_API_KEY],
+        model_provider=LlmProviderNames.AZURE,
+        model_name=_CHAT_DEPLOYMENT,
+        deployment_name=_CHAT_DEPLOYMENT,
+        api_base=_resource_base(test_secrets[TestSecret.AZURE_API_URL]),
+        api_version=_DATED_API_VERSION,
+        max_input_tokens=128_000,
+        timeout=60,
+    )
+
+
+def _record_posted_urls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    urls: list[str] = []
+    original_post = HTTPHandler.post
+
+    def recording_post(self: HTTPHandler, url: str, *args: object, **kwargs: object):
+        urls.append(str(url))
+        return original_post(self, url, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(HTTPHandler, "post", recording_post)
+    return urls
+
+
+def _assert_v1_surface(urls: list[str], api_base: str) -> None:
+    azure_urls = [url for url in urls if api_base in url]
+    assert azure_urls, f"no request reached the Azure resource; saw: {urls}"
+    for url in azure_urls:
+        assert "/openai/v1/responses" in url, f"legacy responses surface used: {url}"
+        assert "api-version=preview" in url, f"unexpected api-version: {url}"
+
+
+@pytest.mark.secrets(TestSecret.AZURE_API_KEY, TestSecret.AZURE_API_URL)
+def test_azure_responses_bridge_targets_v1_surface(
+    test_secrets: dict[TestSecret, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    urls = _record_posted_urls(monkeypatch)
+    llm = _build_azure_llm(test_secrets)
+
+    messages: LanguageModelInput = [UserMessage(content="Say hello in three words")]
+    response = llm.invoke(messages, max_tokens=32)
+
+    assert response.choice.message.content
+    _assert_v1_surface(urls, _resource_base(test_secrets[TestSecret.AZURE_API_URL]))
+
+
+@pytest.mark.secrets(TestSecret.AZURE_API_KEY, TestSecret.AZURE_API_URL)
+def test_azure_responses_bridge_streams_on_v1_surface(
+    test_secrets: dict[TestSecret, str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    urls = _record_posted_urls(monkeypatch)
+    llm = _build_azure_llm(test_secrets)
+
+    messages: LanguageModelInput = [UserMessage(content="Say hello in three words")]
+    content = "".join(
+        chunk.choice.delta.content or ""
+        for chunk in llm.stream(messages, max_tokens=32)
+    )
+
+    assert content
+    _assert_v1_surface(urls, _resource_base(test_secrets[TestSecret.AZURE_API_URL]))

--- a/backend/tests/external_dependency_unit/llm/test_azure_responses_api.py
+++ b/backend/tests/external_dependency_unit/llm/test_azure_responses_api.py
@@ -13,6 +13,7 @@ LiteLLM, so this is also the guard that a LiteLLM version bump doesn't
 silently change the surface.
 """
 
+from typing import Any
 from urllib.parse import urlparse
 
 import pytest
@@ -57,9 +58,9 @@ def _record_posted_urls(monkeypatch: pytest.MonkeyPatch) -> list[str]:
     urls: list[str] = []
     original_post = HTTPHandler.post
 
-    def recording_post(self: HTTPHandler, url: str, *args: object, **kwargs: object):
+    def recording_post(self: HTTPHandler, url: str, *args: Any, **kwargs: Any) -> Any:
         urls.append(str(url))
-        return original_post(self, url, *args, **kwargs)  # type: ignore[arg-type]
+        return original_post(self, url, *args, **kwargs)
 
     monkeypatch.setattr(HTTPHandler, "post", recording_post)
     return urls

--- a/backend/tests/external_dependency_unit/llm/test_azure_responses_api.py
+++ b/backend/tests/external_dependency_unit/llm/test_azure_responses_api.py
@@ -14,14 +14,14 @@ silently change the surface.
 """
 
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 from litellm.llms.custom_httpx.http_handler import HTTPHandler
 
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.models import LanguageModelInput, UserMessage
-from onyx.llm.multi_llm import LitellmLLM
+from onyx.llm.multi_llm import _AZURE_V1_API_VERSIONS, LitellmLLM
 from tests.utils.secret_names import TestSecret
 
 pytestmark = pytest.mark.nightly
@@ -71,7 +71,10 @@ def _assert_v1_surface(urls: list[str], api_base: str) -> None:
     assert azure_urls, f"no request reached the Azure resource; saw: {urls}"
     for url in azure_urls:
         assert "/openai/v1/responses" in url, f"legacy responses surface used: {url}"
-        assert "api-version=preview" in url, f"unexpected api-version: {url}"
+        # Any v1 value is fine (AZURE_DEFAULT_RESPONSES_API_VERSION can pick
+        # among them); a dated value here would mean the legacy surface.
+        api_version = parse_qs(urlparse(url).query).get("api-version", [""])[0]
+        assert api_version in _AZURE_V1_API_VERSIONS, f"non-v1 api-version: {url}"
 
 
 @pytest.mark.secrets(TestSecret.AZURE_API_KEY, TestSecret.AZURE_API_URL)

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -748,7 +748,9 @@ def _azure_llm(model_name: str, api_version: str | None) -> LitellmLLM:
     )
 
 
-def _stream_and_get_completion_kwargs(llm: LitellmLLM, is_openai: bool) -> dict:
+def _stream_and_get_completion_kwargs(
+    llm: LitellmLLM, is_openai: bool
+) -> dict[str, Any]:
     with (
         patch("litellm.completion") as mock_completion,
         patch("onyx.llm.multi_llm.is_true_openai_model", return_value=is_openai),
@@ -756,7 +758,7 @@ def _stream_and_get_completion_kwargs(llm: LitellmLLM, is_openai: bool) -> dict:
         mock_completion.return_value = []
         messages: LanguageModelInput = [UserMessage(content="Hi")]
         list(llm.stream(messages))
-        return mock_completion.call_args.kwargs
+        return dict(mock_completion.call_args.kwargs)
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -733,6 +733,93 @@ def test_openai_chat_omits_reasoning_params() -> None:
         assert mock_is_openai.called
 
 
+def _azure_llm(model_name: str, api_version: str | None) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.AZURE,
+        model_name=model_name,
+        api_base="https://my-resource.openai.azure.us",
+        api_version=api_version,
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.AZURE,
+            model_name=model_name,
+        ),
+    )
+
+
+def _stream_and_get_completion_kwargs(llm: LitellmLLM, is_openai: bool) -> dict:
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.is_true_openai_model", return_value=is_openai),
+    ):
+        mock_completion.return_value = []
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+        return mock_completion.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "configured_api_version", ["2025-03-01-preview", "2024-08-01-preview"]
+)
+def test_azure_responses_bridge_drops_dated_api_version(
+    configured_api_version: str,
+) -> None:
+    """Responses-bridge calls must target the v1 surface: a dated api-version
+    makes LiteLLM build the legacy /openai/responses URL, which sovereign
+    clouds (e.g. Azure Government) do not serve (#11420). Dropping it defers
+    to LiteLLM's responses default (AZURE_DEFAULT_RESPONSES_API_VERSION)."""
+    llm = _azure_llm("gpt-5.1", api_version=configured_api_version)
+    kwargs = _stream_and_get_completion_kwargs(llm, is_openai=True)
+    assert kwargs["model"] == "azure/responses/gpt-5.1"
+    assert kwargs["api_version"] is None
+
+
+@pytest.mark.parametrize("configured_api_version", ["preview", "latest", "v1"])
+def test_azure_responses_bridge_keeps_v1_api_version(
+    configured_api_version: str,
+) -> None:
+    llm = _azure_llm("gpt-5.1", api_version=configured_api_version)
+    kwargs = _stream_and_get_completion_kwargs(llm, is_openai=True)
+    assert kwargs["api_version"] == configured_api_version
+
+
+def test_azure_responses_bridge_leaves_none_api_version() -> None:
+    """None must stay None so LiteLLM's AZURE_DEFAULT_RESPONSES_API_VERSION
+    env override keeps working."""
+    llm = _azure_llm("gpt-5.1", api_version=None)
+    kwargs = _stream_and_get_completion_kwargs(llm, is_openai=True)
+    assert kwargs["api_version"] is None
+
+
+def test_azure_chat_completions_keeps_dated_api_version() -> None:
+    """Non-bridge Azure calls keep the admin-configured dated api-version."""
+    llm = _azure_llm("mistral-large", api_version="2025-03-01-preview")
+    kwargs = _stream_and_get_completion_kwargs(llm, is_openai=False)
+    assert kwargs["model"] == "azure/mistral-large"
+    assert kwargs["api_version"] == "2025-03-01-preview"
+
+
+def test_non_azure_responses_bridge_keeps_api_version() -> None:
+    """The upgrade is Azure-only: a LiteLLM proxy fronting Azure manages its
+    own upstream routing, so its configured api-version passes through."""
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name="gpt-5.1",
+        api_base="https://my-proxy.internal",
+        api_version="2025-03-01-preview",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name="gpt-5.1",
+        ),
+    )
+    kwargs = _stream_and_get_completion_kwargs(llm, is_openai=True)
+    assert kwargs["model"] == "litellm_proxy/responses/gpt-5.1"
+    assert kwargs["api_version"] == "2025-03-01-preview"
+
+
 def test_user_identity_metadata_enabled(default_multi_llm: LitellmLLM) -> None:
     with (
         patch("litellm.completion") as mock_completion,


### PR DESCRIPTION
## Description

Fixes #11420.

Azure providers are configured with a dated `api-version` (required for chat completions), and Onyx forwarded it to LiteLLM's completions → responses bridge. That makes LiteLLM build the **legacy** responses URL:

```
/openai/responses?api-version=2025-03-01-preview
```

Sovereign clouds — Azure Government in the report — do not serve that surface, so every true-OpenAI model (gpt-5.x, o-series) on such deployments failed with `400`/`404`. The modern surface, `/openai/v1/responses`, is served on all clouds.

## Changes

- **Azure responses-bridge calls drop the dated `api_version`** (`multi_llm.py`), deferring to LiteLLM's responses default (`AZURE_DEFAULT_RESPONSES_API_VERSION` env var, default `preview`), which routes to `/openai/v1/responses`. Reasoning summaries and native streaming are preserved — this is strictly better than downgrading reasoning models to chat completions.
- Admin-configured **v1 versions (`preview`/`latest`/`v1`) pass through untouched**; the dated version still applies to all non-bridge calls (Azure chat completions, non-Azure providers).
- An **info log, once per provider config per process**, records the override so a configured-vs-wire api-version mismatch is diagnosable from logs.

### Deliberate trade-off

After this change an admin cannot route the responses bridge to the *legacy dated* surface via provider config — that combination is exactly the bug, and LiteLLM's default for a blank api-version already targets v1/`preview` today. Operators who prefer the GA surface can set `AZURE_DEFAULT_RESPONSES_API_VERSION=latest` (validated working) or configure `latest`/`v1` on the provider directly.

## Validation

- **Azure Government** (the reporter, [issue comment](https://github.com/onyx-dot-app/onyx/issues/11420#issuecomment-5052452373)): `/openai/v1/responses?api-version=preview` with `gpt-5.1` — 200 non-streaming with reasoning item, clean SSE streaming.
- **Commercial Azure** (live, this change): before/after runs through `LitellmLLM.invoke` show the wire URL moving from `/openai/responses?api-version=2025-03-01-preview` to `/openai/v1/responses?api-version=preview`, both succeeding (commercial serves both surfaces — which is why this bug never showed there). GA variants (`latest`, `v1`) also verified serving responses.

## Testing

- 8 unit tests on the version-selection logic (dated → dropped, v1 values pass through, `None` untouched, chat-completions and LiteLLM-proxy unaffected).
- 2 new **nightly external-dependency tests** (`test_azure_responses_api.py`) that run live against the shared Azure test resource (existing `AZURE_API_KEY`/`AZURE_API_URL` test secrets) and intercept the actual request URLs. URL interception is required: commercial Azure serves both surfaces, so success alone can never catch a regression to the legacy surface. Verified they fail with the fix reverted. These also guard LiteLLM version bumps, where this URL construction actually lives.
- `pytest backend/tests/unit/onyx/llm` — 351 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes Azure responses-bridge calls to the v1 responses API by dropping dated Azure api-versions, fixing 400/404s on sovereign clouds while keeping reasoning and streaming working.

- **Bug Fixes**
  - For Azure responses-bridge (true OpenAI models), drop dated `api_version` so `litellm` defaults to `AZURE_DEFAULT_RESPONSES_API_VERSION` and hits /openai/v1/responses; v1 values (`preview`/`latest`/`v1`) pass through.
  - Dated versions still apply to non-bridge calls (Azure chat completions, non-Azure providers).
  - Log the override at warning, once per provider config per process, to surface config-vs-wire mismatches.
  - Tests: typed helpers (incl. completion-kwargs) and updated live assertions to accept any v1 value; kept `Any` in the `HTTPHandler.post` wrapper to avoid typing issues.

<sup>Written for commit d910498a92559de5e8b3a08df11ce59b8a1707a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13340?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

