### PR TITLE
fix: confluence dc link

### DIFF
--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -664,13 +664,19 @@ class ConfluenceConnector(
                     attachment["title"],
                     page["title"],
                 )
-                # Build the download URL ourselves for a stable, filename-bearing link:
-                # `_links.download` is a token-only REST endpoint on Cloud and
-                # `_links.webui` points at the attachments viewer, not the file.
+                # Cloud's download link may be a filename-free REST URL.
                 try:
+                    attachment_url = (
+                        f"/download/attachments/{_get_page_id(page)}/{quote(attachment['title'])}"
+                        if self.is_cloud
+                        else attachment["_links"]["download"]
+                    )
+                    attachment_id = build_confluence_document_id(
+                        self.wiki_base, attachment["_links"]["webui"], self.is_cloud
+                    )
                     object_url = build_confluence_document_id(
                         self.wiki_base,
-                        f"/download/attachments/{_get_page_id(page)}/{quote(attachment['title'])}",
+                        attachment_url,
                         self.is_cloud,
                     )
                 except Exception as e:
@@ -720,9 +726,6 @@ class ConfluenceConnector(
                         self.wiki_base, page["_links"]["webui"], self.is_cloud
                     )
                     attachment_metadata["parent_page_id"] = page_url
-                    attachment_id = build_confluence_document_id(
-                        self.wiki_base, attachment["_links"]["webui"], self.is_cloud
-                    )
 
                     primary_owners: list[BasicExpertInfo] | None = None
                     if "version" in attachment and "by" in attachment["version"]:
@@ -779,7 +782,7 @@ class ConfluenceConnector(
                     attachment_failures.append(
                         ConnectorFailure(
                             failed_document=DocumentFailure(
-                                document_id=object_url,
+                                document_id=attachment_id,
                                 document_link=object_url,
                             ),
                             failure_message=f"Failed to extract/summarize attachment {attachment['title']} for doc {object_url}",

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_attachment_links.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_attachment_links.py
@@ -89,3 +89,38 @@ def test_attachment_section_link_uses_platform_specific_url(
     attachment_document = documents[0]
     assert isinstance(attachment_document, Document)
     assert attachment_document.sections[0].link == expected_link
+
+
+def test_attachment_failure_uses_attachment_document_id() -> None:
+    connector = ConfluenceConnector(
+        wiki_base="https://wiki.example.com", is_cloud=False
+    )
+    confluence_client = mock.Mock(spec=OnyxConfluence)
+    confluence_client.paginated_cql_retrieval.return_value = iter([_ATTACHMENT])
+
+    with (
+        mock.patch.object(
+            ConfluenceConnector,
+            "confluence_client",
+            new_callable=mock.PropertyMock,
+            return_value=confluence_client,
+        ),
+        mock.patch(
+            "onyx.connectors.confluence.connector.convert_attachment_to_content",
+            side_effect=RuntimeError("conversion failed"),
+        ),
+    ):
+        documents, failures = connector._fetch_page_attachments(_PAGE)
+
+    assert documents == []
+    assert len(failures) == 1
+    failed_document = failures[0].failed_document
+    assert failed_document is not None
+    assert failed_document.document_id == (
+        "https://wiki.example.com/pages/viewpageattachments.action"
+        f"?pageId={_ATTACHMENT_PAGE_ID}&preview=att123"
+    )
+    assert failed_document.document_link == (
+        f"https://wiki.example.com/download/attachments/{_ATTACHMENT_PAGE_ID}/"
+        f"{_ENCODED_ATTACHMENT_TITLE}"
+    )

--- a/backend/tests/unit/onyx/connectors/confluence/test_confluence_attachment_links.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_confluence_attachment_links.py
@@ -1,0 +1,91 @@
+"""Confluence attachment links retain their platform-specific canonical form."""
+
+from unittest import mock
+
+import pytest
+
+from onyx.connectors.confluence.connector import ConfluenceConnector
+from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
+from onyx.connectors.models import Document
+
+_PAGE_ID = "111"
+_ATTACHMENT_PAGE_ID = "222"
+_ATTACHMENT_TITLE = "project overview.pptx"
+_ENCODED_ATTACHMENT_TITLE = "project%20overview.pptx"
+
+_PAGE = {
+    "id": _PAGE_ID,
+    "title": "Parent page",
+    "_links": {"webui": f"/pages/viewpage.action?pageId={_PAGE_ID}"},
+}
+_ATTACHMENT = {
+    "id": "att123",
+    "title": _ATTACHMENT_TITLE,
+    "metadata": {
+        "mediaType": "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+    },
+    "_links": {
+        "download": (
+            f"/download/attachments/{_ATTACHMENT_PAGE_ID}/{_ENCODED_ATTACHMENT_TITLE}"
+        ),
+        "webui": (
+            "/pages/viewpageattachments.action"
+            f"?pageId={_ATTACHMENT_PAGE_ID}&preview=att123"
+        ),
+    },
+    "history": {"createdDate": "2018-01-01T00:00:00.000+0000"},
+}
+
+
+@pytest.mark.parametrize(
+    ("is_cloud", "wiki_base", "expected_link"),
+    [
+        (
+            False,
+            "https://wiki.example.com",
+            (
+                f"https://wiki.example.com/download/attachments/{_ATTACHMENT_PAGE_ID}/"
+                f"{_ENCODED_ATTACHMENT_TITLE}"
+            ),
+        ),
+        (
+            True,
+            "https://example.atlassian.net/wiki",
+            (
+                f"https://example.atlassian.net/wiki/download/attachments/{_PAGE_ID}/"
+                f"{_ENCODED_ATTACHMENT_TITLE}"
+            ),
+        ),
+    ],
+)
+def test_attachment_section_link_uses_platform_specific_url(
+    is_cloud: bool,
+    wiki_base: str,
+    expected_link: str,
+) -> None:
+    connector = ConfluenceConnector(wiki_base=wiki_base, is_cloud=is_cloud)
+    confluence_client = mock.Mock(spec=OnyxConfluence)
+    confluence_client.paginated_cql_retrieval.return_value = iter([_ATTACHMENT])
+
+    with (
+        mock.patch.object(
+            ConfluenceConnector,
+            "confluence_client",
+            new_callable=mock.PropertyMock,
+            return_value=confluence_client,
+        ),
+        mock.patch(
+            "onyx.connectors.confluence.connector.convert_attachment_to_content",
+            return_value=("attachment content", None),
+        ),
+        mock.patch.object(
+            connector, "_maybe_yield_page_hierarchy_node", return_value=None
+        ),
+    ):
+        documents, failures = connector._fetch_page_attachments(_PAGE)
+
+    assert failures == []
+    assert len(documents) == 1
+    attachment_document = documents[0]
+    assert isinstance(attachment_document, Document)
+    assert attachment_document.sections[0].link == expected_link


### PR DESCRIPTION
## Description

revert to old behavior for attachment link generation (prior to #12124 ) on non-cloud confluence instances. Also fixes an incorrect doc id in ConnectorFailure bug.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores correct Confluence attachment links on Data Center/Server while keeping stable, filename-bearing links on Cloud. Also fixes the `document_id` used in attachment failure reporting.

- **Bug Fixes**
  - Non-cloud: use `_links.download` so links match DC/Server canonical paths.
  - Cloud: keep building `/download/attachments/{pageId}/{filename}` to avoid token-only URLs.
  - Set `ConnectorFailure.document_id` to the attachment’s web UI id, not the file URL.
  - Added unit tests for platform-specific section links and failure document IDs/links.

<sup>Written for commit ae31189c178865d0f1506a7b34a61b4ed126cf83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13341?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

