### PR TITLE
feat(craft): git-over-HTTPS (clone/fetch/push) for GitHub external app (ENG-4291)

### DIFF
--- a/backend/onyx/external_apps/providers/github.py
+++ b/backend/onyx/external_apps/providers/github.py
@@ -44,6 +44,8 @@ class GitHubAction(ExternalAppAction):
     CONTENTS_WRITE = "github.contents.write"
     REFS_WRITE = "github.refs.write"
     PULLS_CREATE = "github.pulls.create"
+    GIT_HTTP_READ = "github.git_http.read"
+    GIT_HTTP_WRITE = "github.git_http.write"
 
 
 # GitHub's REST API is a path-addressed JSON API rooted at
@@ -221,6 +223,38 @@ _ENDPOINTS: list[EndpointSpec] = [
             GraphQLOp(operation_type="mutation", field="createPullRequest"),
         ),
     ),
+    # Git smart-HTTP over github.com (not api.github.com): the endpoints
+    # `git clone` / `git fetch` / `git push` hit directly. The proxy drops the
+    # `?service=` query before matching, so the shared `info/refs` handshake is
+    # treated as a read; the distinct upload-pack (fetch) vs receive-pack (push)
+    # POST paths separate read from write. `{repo}` matches the `<name>.git`
+    # segment (the `.git` suffix is optional).
+    EndpointSpec(
+        id=GitHubAction.GIT_HTTP_READ,
+        normalised_name="Clone and fetch over HTTPS",
+        description=(
+            "Read a repository over git smart-HTTP on github.com — the ref "
+            "advertisement and upload-pack negotiation behind `git clone` and "
+            "`git fetch`."
+        ),
+        matches=(
+            RestRoute(method="GET", path="/{owner}/{repo}/info/refs"),
+            RestRoute(method="POST", path="/{owner}/{repo}/git-upload-pack"),
+        ),
+        default_policy=EndpointPolicy.ALWAYS,
+    ),
+    EndpointSpec(
+        id=GitHubAction.GIT_HTTP_WRITE,
+        normalised_name="Push over HTTPS",
+        description=(
+            "Write to a repository over git smart-HTTP on github.com — the "
+            "receive-pack upload behind `git push` (new commits, branch "
+            "updates, and force-pushes)."
+        ),
+        matches=(
+            RestRoute(method="POST", path="/{owner}/{repo}/git-receive-pack"),
+        ),
+    ),
 ]
 
 
@@ -235,7 +269,15 @@ class GitHubProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
             scope_param="scope",
         ),
         descriptor=AdminDescriptorSpec(
-            upstream_url_patterns=["https://api\\.github\\.com/.*"],
+            upstream_url_patterns=[
+                "https://api\\.github\\.com/.*",
+                # Git smart-HTTP on github.com so the proxy credentials
+                # `git clone` / `fetch` / `push` (ENG-4291), scoped to the git
+                # endpoints so ordinary github.com web traffic isn't claimed.
+                "https://github\\.com/[^/]+/[^/]+/info/refs\\?service=git-(?:upload|receive)-pack",
+                "https://github\\.com/[^/]+/[^/]+/git-upload-pack",
+                "https://github\\.com/[^/]+/[^/]+/git-receive-pack",
+            ],
             auth_template={"Authorization": "Bearer {access_token}"},
             required_org_credential_fields=[
                 OrgCredentialField(
@@ -262,7 +304,8 @@ class GitHubProvider(OAuthExternalAppProvider, OnyxManagedExtApp):
                 "instance's callback URL (/craft/v1/apps/oauth/callback). Save, "
                 "then generate a client secret. Paste the Client ID and Client "
                 "Secret below. The agent is granted the repo, read:org, and "
-                "read:user scopes."
+                "read:user scopes. Git clone, fetch, and push over HTTPS are "
+                "also supported."
             ),
         ),
         endpoint_catalog=_ENDPOINTS,

--- a/backend/onyx/skills/builtin/github/SKILL.md.template
+++ b/backend/onyx/skills/builtin/github/SKILL.md.template
@@ -86,9 +86,12 @@ the command failed — surface the error rather than retrying blindly.
 
 ## Notes
 
-- **HTTPS only.** SSH and `github.com` git remotes are unreachable from here, so
-  `git clone`/`push` against GitHub and `gh repo clone` over SSH will fail. Stay
-  on the API commands above (and `gh api`).
+- **Git over HTTPS works; SSH does not.** `git clone`, `git fetch`, and
+  `git push` (incl. `--force-with-lease`) over HTTPS against `github.com` are
+  credentialed by the proxy and work. Use HTTPS remotes
+  (`https://github.com/OWNER/REPO.git`) — SSH remotes are unreachable.
+  `git push` is an approval-gated action, so it may pause for the user's
+  approval.
 - **Scopes are fixed** by the admin (repo, read:org, read:user). An operation
   needing a scope you don't have returns `403 / Resource not accessible` — tell
   the user rather than retrying.

--- a/backend/tests/unit/external_apps/test_github_catalog.py
+++ b/backend/tests/unit/external_apps/test_github_catalog.py
@@ -9,13 +9,14 @@ pure rule layer (including GraphQL body parsing) directly."""
 from __future__ import annotations
 
 import json
+import re
 
 import pytest
 
 from onyx.db.enums import EndpointPolicy, ExternalAppType
 from onyx.external_apps.matching.request import MatchContext, ProxiedRequest
 from onyx.external_apps.matching.rules import rule_matches
-from onyx.external_apps.providers.github import GitHubAction
+from onyx.external_apps.providers.github import GitHubAction, GitHubProvider
 from onyx.external_apps.providers.registry import get_endpoint_catalog
 
 _CATALOG = get_endpoint_catalog(ExternalAppType.GITHUB)
@@ -81,6 +82,12 @@ def _graphql(query: str) -> bytes:
         ),
         ("POST", "/repos/onyx/onyx/git/refs", {GitHubAction.REFS_WRITE}),
         ("POST", "/repos/onyx/onyx/pulls", {GitHubAction.PULLS_CREATE}),
+        # Git smart-HTTP over github.com (clone / fetch / push).
+        ("GET", "/onyx-dot-app/onyx.git/info/refs", {GitHubAction.GIT_HTTP_READ}),
+        ("POST", "/onyx-dot-app/onyx.git/git-upload-pack", {GitHubAction.GIT_HTTP_READ}),
+        ("POST", "/onyx-dot-app/onyx.git/git-receive-pack", {GitHubAction.GIT_HTTP_WRITE}),
+        # The `.git` suffix is optional.
+        ("GET", "/onyx-dot-app/onyx/info/refs", {GitHubAction.GIT_HTTP_READ}),
     ],
 )
 def test_rest_route_resolves_to_exactly_one_action(
@@ -170,6 +177,8 @@ def test_rest_request_does_not_trigger_graphql_match() -> None:
         (GitHubAction.CONTENTS_WRITE, EndpointPolicy.ASK),
         (GitHubAction.REFS_WRITE, EndpointPolicy.ASK),
         (GitHubAction.PULLS_CREATE, EndpointPolicy.ASK),
+        (GitHubAction.GIT_HTTP_READ, EndpointPolicy.ALWAYS),
+        (GitHubAction.GIT_HTTP_WRITE, EndpointPolicy.ASK),
     ],
 )
 def test_default_policies(
@@ -177,3 +186,20 @@ def test_default_policies(
 ) -> None:
     by_id = {endpoint.id: endpoint for endpoint in _CATALOG}
     assert by_id[action].default_policy == expected_policy
+
+
+@pytest.mark.parametrize(
+    "url, should_match",
+    [
+        ("https://github.com/onyx-dot-app/onyx.git/info/refs?service=git-receive-pack", True),
+        ("https://github.com/onyx-dot-app/onyx.git/git-receive-pack", True),
+        ("https://github.com/onyx-dot-app/onyx.git/git-upload-pack", True),
+        ("https://api.github.com/repos/onyx-dot-app/onyx", True),
+        # A plain github.com web page must NOT be claimed by the git patterns.
+        ("https://github.com/onyx-dot-app/onyx", False),
+    ],
+)
+def test_upstream_url_patterns_match_git_endpoints(url: str, should_match: bool) -> None:
+    patterns = GitHubProvider.spec.descriptor.upstream_url_patterns
+    matched = any(re.fullmatch(p, url) for p in patterns)
+    assert matched is should_match


### PR DESCRIPTION
## Summary

Extends the GitHub external-app provider so Onyx's sandbox egress proxy attributes and credentials git-over-HTTPS to `github.com` (not just `api.github.com`).

- Adds the github.com git smart-HTTP endpoints to the provider's `upstream_url_patterns` (`info/refs?service=git-(upload|receive)-pack`, `git-upload-pack`, `git-receive-pack`), scoped so ordinary github.com web traffic isn't claimed.
- Adds two catalog actions — `GIT_HTTP_READ` (clone/fetch: `info/refs` handshake + `git-upload-pack`, default `ALWAYS`) and `GIT_HTTP_WRITE` (push: `git-receive-pack`, default `ASK`). The proxy drops the `?service=` query before path-matching, so the shared `info/refs` handshake resolves as a read while the distinct upload-pack vs receive-pack POST paths split read from write. `{repo}` matches the `<name>.git` segment (the `.git` suffix is optional).
- Git-over-HTTPS auth reuses the app-wide `Authorization: Bearer {access_token}` template unchanged.
- Updates the built-in GitHub SKILL.md note to state git clone/fetch/push over HTTPS work (SSH does not), and updates `setup_instructions`.
- Adds unit tests: route→action resolution for the git endpoints (incl. optional `.git`), default policies, and an `upstream_url_patterns` regex test asserting the git endpoints match while a plain github.com web page does not.

Fixes ENG-4291
https://linear.app/onyx-app/issue/ENG-4291-craft-sandbox-git-push-fails

## Testing

`cd backend && python -m pytest tests/unit/external_apps/test_github_catalog.py -q` → **58 passed**.

## Notes / caveats

- Git-over-HTTPS auth reuses the app-wide `Authorization: Bearer` template — GitHub accepts Bearer for git smart-HTTP (verified the scheme is parsed; a dummy bearer returns "invalid credentials"). Full end-to-end `git push` can only be verified against a deployed proxy.
- Already-connected GitHub external-app installs may need to be re-provisioned/re-synced to pick up the new `upstream_url_patterns`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables git-over-HTTPS (clone, fetch, push) for the GitHub external app by credentialing `github.com` smart-HTTP endpoints via the sandbox egress proxy. Fixes ENG-4291 so `git push` from Craft sandboxes works with approval.

- **New Features**
  - Proxy now matches and credentials `/{owner}/{repo}/info/refs`, `/git-upload-pack`, and `/git-receive-pack` on `github.com` (web pages excluded; `api.github.com` remains supported).
  - Adds `GIT_HTTP_READ` (clone/fetch, default `ALWAYS`) and `GIT_HTTP_WRITE` (push, default `ASK`) catalog actions; auth reuses `Authorization: Bearer {access_token}`.
  - Updates docs to state HTTPS git works (SSH does not); adds unit tests for routing, defaults, and regex patterns.

- **Migration**
  - Existing GitHub external-app installs may need re-provisioning/re-sync to pick up the new `upstream_url_patterns`.

<sup>Written for commit 9c1ede07170b39cfe260bdedc814eaf4811fac9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

