### PR TITLE
fix(auth): refresh OAuth tokens with the SSO provider row's credentials

### DIFF
--- a/backend/onyx/auth/oauth_refresher.py
+++ b/backend/onyx/auth/oauth_refresher.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import time
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, cast
 
@@ -14,24 +15,25 @@ from onyx.configs.app_configs import (
     OAUTH_CLIENT_SECRET,
     OPENID_CONFIG_URL,
 )
+from onyx.db.enums import SSOProviderType
 from onyx.db.models import OAuthAccount, User
+from onyx.db.sso_provider import fetch_sso_provider_by_name_async
 from onyx.server.security.store import get_security_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
 
-# Standard OAuth refresh token endpoints, keyed by `oauth_account.oauth_name`.
+GOOGLE_TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+
+# Legacy env-credential refresh endpoints, keyed by oauth_account.oauth_name.
 REFRESH_ENDPOINTS: Dict[str, str] = {
-    "google": "https://oauth2.googleapis.com/token",
+    "google": GOOGLE_TOKEN_ENDPOINT,
 }
 
-# Token endpoint resolved from the configured OIDC discovery document.
-# Populated lazily on first successful fetch and re-used until the entry's
-# `fetched_at` exceeds OIDC_DISCOVERY_CACHE_TTL_SECONDS, at which point it is
-# re-fetched. The TTL guards against the IdP rotating its `token_endpoint`
-# without us noticing (rare for major IdPs but possible across tenant moves
-# or app-reg migrations).
-_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, str | float] = {}
+# Token endpoints from OIDC discovery, keyed by discovery URL. A None entry
+# negative-caches a failed fetch (short TTL) so a hard-down IdP is not re-tried
+# per request. Positive entries re-fetch after the long TTL (endpoint rotation).
+_OIDC_TOKEN_ENDPOINT_CACHE: Dict[str, tuple[Optional[str], float]] = {}
 
 # Default 1 hour: matches Microsoft Entra's default access-token lifetime, so
 # at worst one refresh fails after an endpoint rotation before we self-heal.
@@ -39,18 +41,31 @@ OIDC_DISCOVERY_CACHE_TTL_SECONDS: int = int(
     os.environ.get("OIDC_DISCOVERY_CACHE_TTL_SECONDS") or 3600
 )
 
-# Lazily-initialized lock guarding concurrent first-time fetches of the OIDC
-# discovery document. Created on first use so it binds to the running event
-# loop rather than at import time.
-_OIDC_TOKEN_ENDPOINT_LOCK: Optional[asyncio.Lock] = None
+# Negative entries retry quickly so a transient IdP outage self-heals fast.
+OIDC_DISCOVERY_NEGATIVE_TTL_SECONDS: int = 45
+
+# Per-discovery-URL locks so one IdP's hanging fetch never blocks another's.
+# Created on first use so they bind to the running event loop.
+_OIDC_DISCOVERY_LOCKS: Dict[str, asyncio.Lock] = {}
+_OIDC_DISCOVERY_LOCKS_GUARD: Optional[asyncio.Lock] = None
 
 
-def _get_oidc_lock() -> asyncio.Lock:
-    """Return the module-level OIDC discovery lock, creating it on first call."""
-    global _OIDC_TOKEN_ENDPOINT_LOCK
-    if _OIDC_TOKEN_ENDPOINT_LOCK is None:
-        _OIDC_TOKEN_ENDPOINT_LOCK = asyncio.Lock()
-    return _OIDC_TOKEN_ENDPOINT_LOCK
+def _get_discovery_locks_guard() -> asyncio.Lock:
+    """Lazy-init the meta-lock that protects the per-URL lock dict itself."""
+    global _OIDC_DISCOVERY_LOCKS_GUARD
+    if _OIDC_DISCOVERY_LOCKS_GUARD is None:
+        _OIDC_DISCOVERY_LOCKS_GUARD = asyncio.Lock()
+    return _OIDC_DISCOVERY_LOCKS_GUARD
+
+
+async def _get_discovery_lock(config_url: str) -> asyncio.Lock:
+    """Get-or-create the discovery lock for one discovery URL."""
+    async with _get_discovery_locks_guard():
+        lock = _OIDC_DISCOVERY_LOCKS.get(config_url)
+        if lock is None:
+            lock = asyncio.Lock()
+            _OIDC_DISCOVERY_LOCKS[config_url] = lock
+        return lock
 
 
 # Per-user locks coalescing concurrent token-refresh attempts. Without this,
@@ -81,69 +96,135 @@ async def _get_user_refresh_lock(user_id: uuid.UUID) -> asyncio.Lock:
         return lock
 
 
-def _cached_token_endpoint() -> Optional[str]:
-    """Return the cached endpoint if still within its TTL, else None."""
-    cached_url = _OIDC_TOKEN_ENDPOINT_CACHE.get("url")
-    fetched_at = _OIDC_TOKEN_ENDPOINT_CACHE.get("fetched_at")
-    if not isinstance(cached_url, str) or not isinstance(fetched_at, float):
+def _cached_token_endpoint(config_url: str) -> tuple[bool, Optional[str]]:
+    """(hit, endpoint) for a URL. A hit with None is a live negative entry."""
+    entry = _OIDC_TOKEN_ENDPOINT_CACHE.get(config_url)
+    if entry is None:
+        return False, None
+    endpoint, fetched_at = entry
+    ttl = (
+        OIDC_DISCOVERY_CACHE_TTL_SECONDS
+        if endpoint
+        else OIDC_DISCOVERY_NEGATIVE_TTL_SECONDS
+    )
+    if (time.monotonic() - fetched_at) >= ttl:
+        return False, None
+    return True, endpoint
+
+
+async def _get_oidc_token_endpoint(config_url: str) -> Optional[str]:
+    """Resolve token_endpoint from an OIDC discovery document. The per-URL
+    lock + double check coalesce concurrent fetches into one request."""
+    if not config_url:
         return None
-    if (time.monotonic() - fetched_at) >= OIDC_DISCOVERY_CACHE_TTL_SECONDS:
-        return None
-    return cached_url
-
-
-async def _get_oidc_token_endpoint() -> Optional[str]:
-    """Resolve the OAuth2 token endpoint for the configured OIDC provider.
-
-    Reads `token_endpoint` from the OPENID_CONFIG_URL discovery document so
-    refresh works for any OIDC provider (Microsoft Entra, Okta, Keycloak,
-    Auth0, ...) without hardcoding provider-specific URLs. The lock + double
-    check ensures concurrent callers (e.g. multiple tokens expiring at once
-    after a server restart) coalesce into a single discovery request, and the
-    TTL ensures we re-fetch periodically in case the IdP rotates the endpoint.
-    """
-    cached = _cached_token_endpoint()
-    if cached:
+    hit, cached = _cached_token_endpoint(config_url)
+    if hit:
         return cached
-    if not OPENID_CONFIG_URL:
-        return None
-    async with _get_oidc_lock():
+    async with await _get_discovery_lock(config_url):
         # Re-check inside the lock — another coroutine may have populated
         # the cache while we were waiting to acquire it.
-        cached = _cached_token_endpoint()
-        if cached:
+        hit, cached = _cached_token_endpoint(config_url)
+        if hit:
             return cached
+        token_endpoint: Optional[str] = None
         try:
             async with httpx.AsyncClient() as client:
-                response = await client.get(OPENID_CONFIG_URL, timeout=10.0)
+                response = await client.get(config_url, timeout=10.0)
                 response.raise_for_status()
                 config: Dict[str, Any] = response.json()
+            raw_endpoint = config.get("token_endpoint")
+            if isinstance(raw_endpoint, str) and raw_endpoint:
+                token_endpoint = raw_endpoint
         except (httpx.HTTPError, ValueError) as e:
             # ValueError covers json.JSONDecodeError when the IdP returns a
             # non-JSON body (e.g. an HTML error page from a misconfigured URL).
             logger.warning("Failed to fetch OIDC discovery document: %s", e)
-            return None
-        token_endpoint = config.get("token_endpoint")
-        if isinstance(token_endpoint, str) and token_endpoint:
-            _OIDC_TOKEN_ENDPOINT_CACHE["url"] = token_endpoint
-            _OIDC_TOKEN_ENDPOINT_CACHE["fetched_at"] = time.monotonic()
-            return token_endpoint
-        return None
+        _OIDC_TOKEN_ENDPOINT_CACHE[config_url] = (token_endpoint, time.monotonic())
+        return token_endpoint
 
 
 async def _resolve_token_endpoint(provider: str) -> Optional[str]:
-    """Return the OAuth2 token endpoint URL for a given provider.
-
-    Falls back to the OIDC discovery document when the provider is "openid"
-    (the default name used by httpx_oauth's generic OIDC client) so any
-    OIDC-compliant identity provider supports token refresh, not just Google.
-    """
+    """Legacy env-credential resolution for accounts with no provider row:
+    "openid" resolves via the env discovery URL, other names are static."""
     static = REFRESH_ENDPOINTS.get(provider)
     if static:
         return static
     if provider == "openid":
-        return await _get_oidc_token_endpoint()
+        return await _get_oidc_token_endpoint(OPENID_CONFIG_URL)
     return None
+
+
+@dataclass(frozen=True)
+class _RefreshContext:
+    token_endpoint: str
+    client_id: str
+    # repr=False keeps the secret out of any future log/repr of the context.
+    client_secret: str = field(repr=False)
+
+
+async def _resolve_refresh_context(
+    db_session: AsyncSession, oauth_name: str
+) -> Optional[_RefreshContext]:
+    """Endpoint + client credentials for an account: the provider row matching
+    oauth_name wins, rowless accounts fall back to the legacy env config."""
+    try:
+        provider = await fetch_sso_provider_by_name_async(db_session, oauth_name)
+    except Exception:
+        # A failed lookup may have aborted the shared transaction that later
+        # persists the token: roll back and skip, or a rotating IdP's fresh
+        # refresh token would be minted and then lost.
+        logger.exception(
+            "SSO provider lookup failed for %s; skipping token refresh", oauth_name
+        )
+        try:
+            await db_session.rollback()
+        except Exception:
+            logger.exception("Session rollback failed after provider lookup error")
+        return None
+
+    if provider is not None and provider.provider_type is not SSOProviderType.SAML:
+        try:
+            raw_config = (
+                provider.config.get_value(apply_mask=False) if provider.config else None
+            )
+            config: Dict[str, Any] = raw_config or {}
+        except Exception:
+            # Never fall back to env creds (a different app registration).
+            logger.exception(
+                "Could not read SSO provider %s config (re-encryption needed after "
+                "a key rotation?); token refresh disabled for its accounts",
+                oauth_name,
+            )
+            return None
+        client_id = config.get("client_id") or ""
+        client_secret = config.get("client_secret") or ""
+        endpoint = (
+            GOOGLE_TOKEN_ENDPOINT
+            if provider.provider_type is SSOProviderType.GOOGLE_OAUTH
+            else await _get_oidc_token_endpoint(config.get("openid_config_url") or "")
+        )
+        if endpoint and client_id and client_secret:
+            return _RefreshContext(endpoint, client_id, client_secret)
+        logger.error(
+            "SSO provider %s cannot refresh tokens: has_endpoint=%s "
+            "has_client_id=%s has_client_secret=%s",
+            oauth_name,
+            bool(endpoint),
+            bool(client_id),
+            bool(client_secret),
+        )
+        return None
+
+    endpoint = await _resolve_token_endpoint(oauth_name)
+    if not endpoint:
+        logger.warning("Refresh endpoint not configured for provider: %s", oauth_name)
+        return None
+    if not OAUTH_CLIENT_ID or not OAUTH_CLIENT_SECRET:
+        logger.error(
+            "No OAuth credentials configured to refresh provider: %s", oauth_name
+        )
+        return None
+    return _RefreshContext(endpoint, OAUTH_CLIENT_ID, OAUTH_CLIENT_SECRET)
 
 
 # NOTE: Keeping this as a utility function for potential future debugging,
@@ -182,7 +263,7 @@ async def _test_expire_oauth_token(
 async def refresh_oauth_token(
     user: User,
     oauth_account: OAuthAccount,
-    db_session: AsyncSession,  # noqa: ARG001
+    db_session: AsyncSession,
     user_manager: BaseUserManager[User, Any],
 ) -> bool:
     """
@@ -198,9 +279,8 @@ async def refresh_oauth_token(
         return False
 
     provider = oauth_account.oauth_name
-    token_endpoint = await _resolve_token_endpoint(provider)
-    if not token_endpoint:
-        logger.warning("Refresh endpoint not configured for provider: %s", provider)
+    context = await _resolve_refresh_context(db_session, provider)
+    if context is None:
         return False
 
     try:
@@ -208,10 +288,10 @@ async def refresh_oauth_token(
 
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                token_endpoint,
+                context.token_endpoint,
                 data={
-                    "client_id": OAUTH_CLIENT_ID,
-                    "client_secret": OAUTH_CLIENT_SECRET,
+                    "client_id": context.client_id,
+                    "client_secret": context.client_secret,
                     "refresh_token": oauth_account.refresh_token,
                     "grant_type": "refresh_token",
                 },

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -7,6 +7,7 @@ from typing import Any
 from pydantic import BaseModel, ConfigDict, ValidationError
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import SAML_CONF_DIR, VALID_EMAIL_DOMAINS
@@ -134,6 +135,15 @@ def fetch_sso_provider_by_name(
     if enabled_only:
         stmt = stmt.where(SSOProvider.enabled.is_(True))
     return db_session.scalars(stmt).first()
+
+
+async def fetch_sso_provider_by_name_async(
+    db_session: AsyncSession, name: str
+) -> SSOProvider | None:
+    """Async twin of fetch_sso_provider_by_name. Reads disabled rows too:
+    disabling a provider stops new logins, not existing sessions."""
+    stmt = select(SSOProvider).where(SSOProvider.name == name)
+    return (await db_session.scalars(stmt)).first()
 
 
 def create_sso_provider(

--- a/backend/tests/unit/onyx/auth/test_oauth_refresher.py
+++ b/backend/tests/unit/onyx/auth/test_oauth_refresher.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from onyx.auth import oauth_refresher
 from onyx.auth.oauth_refresher import (
+    _resolve_refresh_context,
     _resolve_token_endpoint,
     _test_expire_oauth_token,
     check_and_refresh_oauth_tokens,
@@ -13,10 +14,34 @@ from onyx.auth.oauth_refresher import (
     get_oauth_accounts_requiring_refresh_token,
     refresh_oauth_token,
 )
+from onyx.db.enums import SSOProviderType
 from onyx.db.models import OAuthAccount
+from onyx.utils.sensitive import make_mock_sensitive_value
+
+_ENV_DISCOVERY_URL = "https://idp.example.com/.well-known/openid-configuration"
+
+
+@pytest.fixture
+def legacy_env_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No provider row resolves and the legacy env credentials are set."""
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_ID", "env-cid")
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_SECRET", "env-secret")
+
+
+def _provider_row(provider_type: SSOProviderType, config: dict[str, str]) -> MagicMock:
+    provider = MagicMock()
+    provider.provider_type = provider_type
+    provider.config = make_mock_sensitive_value(config)
+    return provider
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("legacy_env_mode")
 async def test_refresh_oauth_token_success(
     mock_user: MagicMock,
     mock_oauth_account: MagicMock,
@@ -67,6 +92,7 @@ async def test_refresh_oauth_token_success(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("legacy_env_mode")
 async def test_refresh_oauth_token_failure(
     mock_user: MagicMock,
     mock_oauth_account: MagicMock,
@@ -321,9 +347,10 @@ async def test_resolve_token_endpoint_openid_via_discovery(
 ) -> None:
     """For OIDC ("openid"), the token endpoint is read from the discovery doc."""
     monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
-    # Reset the lock so it gets created in the current test's event loop;
+    # Reset the locks so they get created in the current test's event loop;
     # without this, a prior test's lock could be bound to a different loop.
-    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS", {})
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS_GUARD", None)
     monkeypatch.setattr(
         oauth_refresher,
         "OPENID_CONFIG_URL",
@@ -345,11 +372,12 @@ async def test_resolve_token_endpoint_openid_via_discovery(
         endpoint = await _resolve_token_endpoint("openid")
 
     assert endpoint == "https://idp.example.com/oauth2/v2.0/token"
-    # Cached after first successful fetch.
-    assert (
-        oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE.get("url")
-        == "https://idp.example.com/oauth2/v2.0/token"
+    # Cached after first successful fetch, keyed by discovery URL.
+    cached_entry = oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE.get(
+        "https://idp.example.com/.well-known/openid-configuration"
     )
+    assert cached_entry is not None
+    assert cached_entry[0] == "https://idp.example.com/oauth2/v2.0/token"
 
     # Subsequent calls do not re-fetch the discovery document.
     mock_client.get.reset_mock()
@@ -365,7 +393,8 @@ async def test_resolve_token_endpoint_openid_cache_ttl_expiry(
     """An expired cache entry triggers a fresh discovery fetch."""
     import time as _time
 
-    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS", {})
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS_GUARD", None)
     monkeypatch.setattr(
         oauth_refresher,
         "OPENID_CONFIG_URL",
@@ -378,8 +407,10 @@ async def test_resolve_token_endpoint_openid_cache_ttl_expiry(
         oauth_refresher,
         "_OIDC_TOKEN_ENDPOINT_CACHE",
         {
-            "url": "https://idp.example.com/old-token-endpoint",
-            "fetched_at": expired_fetched_at,
+            "https://idp.example.com/.well-known/openid-configuration": (
+                "https://idp.example.com/old-token-endpoint",
+                expired_fetched_at,
+            ),
         },
     )
 
@@ -429,7 +460,8 @@ async def test_resolve_token_endpoint_openid_invalid_json(
 ) -> None:
     """A non-JSON discovery body degrades to None instead of crashing."""
     monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
-    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS", {})
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS_GUARD", None)
     monkeypatch.setattr(
         oauth_refresher,
         "OPENID_CONFIG_URL",
@@ -450,8 +482,16 @@ async def test_resolve_token_endpoint_openid_invalid_json(
         endpoint = await _resolve_token_endpoint("openid")
 
     assert endpoint is None
-    # Cache stays empty so a subsequent call retries cleanly.
-    assert oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE == {}
+    # The failure is negative-cached so a hard-down IdP is not re-fetched on
+    # every request within the (short) negative TTL.
+    entry = oauth_refresher._OIDC_TOKEN_ENDPOINT_CACHE.get(
+        "https://idp.example.com/.well-known/openid-configuration"
+    )
+    assert entry is not None and entry[0] is None
+    mock_client.get.reset_mock()
+    endpoint_again = await _resolve_token_endpoint("openid")
+    assert endpoint_again is None
+    mock_client.get.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -462,7 +502,8 @@ async def test_resolve_token_endpoint_openid_concurrent_fetches_coalesce(
     import asyncio as _asyncio
 
     monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_CACHE", {})
-    monkeypatch.setattr(oauth_refresher, "_OIDC_TOKEN_ENDPOINT_LOCK", None)
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS", {})
+    monkeypatch.setattr(oauth_refresher, "_OIDC_DISCOVERY_LOCKS_GUARD", None)
     monkeypatch.setattr(
         oauth_refresher,
         "OPENID_CONFIG_URL",
@@ -507,6 +548,7 @@ async def test_resolve_token_endpoint_openid_concurrent_fetches_coalesce(
 
 
 @pytest.mark.asyncio
+@pytest.mark.usefixtures("legacy_env_mode")
 async def test_refresh_oauth_token_openid_provider(
     mock_user: MagicMock,
     mock_oauth_account: MagicMock,
@@ -524,10 +566,13 @@ async def test_refresh_oauth_token_openid_provider(
         oauth_refresher,
         "_OIDC_TOKEN_ENDPOINT_CACHE",
         {
-            "url": "https://idp.example.com/oauth2/v2.0/token",
-            "fetched_at": _time.monotonic(),
+            _ENV_DISCOVERY_URL: (
+                "https://idp.example.com/oauth2/v2.0/token",
+                _time.monotonic(),
+            ),
         },
     )
+    monkeypatch.setattr(oauth_refresher, "OPENID_CONFIG_URL", _ENV_DISCOVERY_URL)
 
     mock_oauth_account.oauth_name = "openid"
     mock_oauth_account.refresh_token = "old_refresh_token"
@@ -590,3 +635,164 @@ async def test_expire_oauth_token(
     now = datetime.now(timezone.utc).timestamp()
     assert update_data["expires_at"] - now >= 8.8  # Allow ~1 second for test execution
     assert update_data["expires_at"] - now <= 11.2  # Allow ~1 second for test execution
+
+
+@pytest.mark.asyncio
+async def test_resolve_context_from_oidc_provider_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An account named after an OIDC provider row refreshes with that row's
+    credentials and its discovery-resolved endpoint, whatever the row's name."""
+    import time as _time
+
+    row = _provider_row(
+        SSOProviderType.OIDC,
+        {
+            "client_id": "row-cid",
+            "client_secret": "row-secret",
+            "openid_config_url": "https://keycloak.example.com/.well-known/openid-configuration",
+        },
+    )
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(return_value=row),
+    )
+    monkeypatch.setattr(
+        oauth_refresher,
+        "_OIDC_TOKEN_ENDPOINT_CACHE",
+        {
+            "https://keycloak.example.com/.well-known/openid-configuration": (
+                "https://keycloak.example.com/token",
+                _time.monotonic(),
+            ),
+        },
+    )
+    # Env creds absent: the row must be sufficient on its own.
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_ID", "")
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_SECRET", "")
+
+    context = await _resolve_refresh_context(MagicMock(), "keycloak")
+    assert context is not None
+    assert context.token_endpoint == "https://keycloak.example.com/token"
+    assert context.client_id == "row-cid"
+    assert context.client_secret == "row-secret"
+
+
+@pytest.mark.asyncio
+async def test_resolve_context_from_google_provider_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Google rows use the static Google token endpoint with row credentials."""
+    row = _provider_row(
+        SSOProviderType.GOOGLE_OAUTH,
+        {"client_id": "g-cid", "client_secret": "g-secret"},
+    )
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(return_value=row),
+    )
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_ID", "")
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_SECRET", "")
+
+    context = await _resolve_refresh_context(MagicMock(), "google")
+    assert context is not None
+    assert context.token_endpoint == "https://oauth2.googleapis.com/token"
+    assert context.client_id == "g-cid"
+    assert context.client_secret == "g-secret"
+
+
+@pytest.mark.asyncio
+async def test_resolve_context_row_lookup_failure_rolls_back_and_skips(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed lookup may have aborted the shared transaction, so the session
+    is rolled back and this refresh is skipped rather than POSTing a refresh
+    whose result could not be persisted."""
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(side_effect=RuntimeError("db down")),
+    )
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_ID", "env-cid")
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_SECRET", "env-secret")
+
+    session = MagicMock()
+    session.rollback = AsyncMock()
+    context = await _resolve_refresh_context(session, "google")
+    assert context is None
+    session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_resolve_context_no_row_unknown_name_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without a row, names outside the legacy set have no refresh path."""
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(return_value=None),
+    )
+    context = await _resolve_refresh_context(MagicMock(), "keycloak")
+    assert context is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_context_env_without_credentials_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The legacy path refuses to POST empty credentials to the IdP."""
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_ID", "")
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_SECRET", "")
+
+    context = await _resolve_refresh_context(MagicMock(), "google")
+    assert context is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_context_unreadable_row_config_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row whose config cannot be decrypted disables refresh for its
+    accounts instead of falling back to env credentials or raising."""
+    row = MagicMock()
+    row.provider_type = SSOProviderType.OIDC
+    row.config = MagicMock()
+    row.config.get_value.side_effect = ValueError("bad key")
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(return_value=row),
+    )
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_ID", "env-cid")
+    monkeypatch.setattr(oauth_refresher, "OAUTH_CLIENT_SECRET", "env-secret")
+
+    context = await _resolve_refresh_context(MagicMock(), "keycloak")
+    assert context is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_context_null_row_config_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A row whose config decrypts to None resolves like an empty config
+    (missing credentials) instead of raising AttributeError."""
+    row = MagicMock()
+    row.provider_type = SSOProviderType.OIDC
+    row.config = MagicMock()
+    row.config.get_value.return_value = None
+    monkeypatch.setattr(
+        oauth_refresher,
+        "fetch_sso_provider_by_name_async",
+        AsyncMock(return_value=row),
+    )
+
+    context = await _resolve_refresh_context(MagicMock(), "keycloak")
+    assert context is None


### PR DESCRIPTION
## Description

First PR of the SSO env-var retirement stack (target: all SSO configuration lives on provider rows by `v4.5`).

**Bug:** token refresh only knew the account names `google`/`openid` and always POSTed the env `OAUTH_CLIENT_ID`/`OAUTH_CLIENT_SECRET` (endpoint for `openid` from env `OPENID_CONFIG_URL`). Accounts created through new multi-IdP provider rows (any other name, e.g. `okta`) had no refresh path at all, and the env vars were unremovable.

**Fix:** `_resolve_refresh_context` resolves the SSO provider row matching the account's `oauth_name`. Google rows use the static Google token endpoint, OIDC rows resolve discovery from the row's `openid_config_url`, credentials come from the row's encrypted config. No matching row falls back to the exact legacy env behavior.

Hardening that came out of review:

- A failed row lookup rolls back the shared request session and skips the refresh (POST-then-fail-persist would lose the rotated refresh token on IdPs like Entra).
- Config decryption failure disables refresh for that row with an actionable error, never falls back to env credentials.
- Discovery failures are negative-cached (45s) and locks are per discovery URL, so a hard-down IdP costs one 10s attempt per window instead of one per request and cannot head-of-line block other IdPs.
- Misconfiguration logs at error with `has_endpoint`/`has_client_id`/`has_client_secret` booleans, never values.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
