### PR TITLE
fix(indexing): time-box image summarization to prevent worker hangs

### DIFF
--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1873,6 +1873,14 @@ IMAGE_SUMMARIZATION_USER_PROMPT = os.environ.get(
     DEFAULT_IMAGE_SUMMARIZATION_USER_PROMPT,
 )
 
+# Wall-clock cap for summarizing one image. The vision LLM's timeout is per-read,
+# not total, so a trickling provider connection can hang a docprocessing worker
+# forever and stall indexing. Image summaries are non-critical, so bound each one
+# and fall back to a placeholder.
+IMAGE_SUMMARIZATION_TIMEOUT_SECONDS = int(
+    os.environ.get("IMAGE_SUMMARIZATION_TIMEOUT_SECONDS") or 120
+)
+
 # Knowledge Graph Read Only User Configuration
 DB_READONLY_USER: str = os.environ.get("DB_READONLY_USER", "db_readonly_user")
 DB_READONLY_PASSWORD: str = urllib.parse.quote_plus(

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -121,8 +121,9 @@ logger = setup_logger()
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
 MAX_IMAGE_WORKERS = 16
 
-# A timed-out or errored image summary is usually a transient provider blip, so
-# retry a few times (short backoff) before falling back to a placeholder.
+# A transient LLM error (e.g. rate limit / 5xx) is usually recoverable, so retry a
+# few times (short backoff) before falling back to a placeholder. A timeout is NOT
+# retried (see below) — it means a hung call, and retrying would leak another thread.
 IMAGE_SUMMARIZATION_MAX_ATTEMPTS = 2
 IMAGE_SUMMARIZATION_RETRY_BACKOFF_SECONDS = 2.0
 
@@ -844,11 +845,14 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
         # Wall-clock timeout per attempt: the LLM's own timeout is per-read, not total,
         # so a trickling connection would otherwise hang the worker forever. retry_builder
         # can't interrupt a blocking call, so the timeout lives inside the retried unit.
+        # Only ValueError (transient LLM error) is retried — a TimeoutError means the call
+        # is hung, and run_with_timeout leaves that thread running, so retrying would just
+        # stack up another stuck provider thread.
         @retry_builder(
             tries=IMAGE_SUMMARIZATION_MAX_ATTEMPTS,
             delay=IMAGE_SUMMARIZATION_RETRY_BACKOFF_SECONDS,
             jitter=0,
-            exceptions=(TimeoutError, ValueError),
+            exceptions=(ValueError,),
         )
         def _summarize_attempt(image_data: bytes, context_name: str) -> str | None:
             return run_with_timeout(
@@ -865,10 +869,8 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
                 result = _summarize_attempt(image_data, context_name)
             except (TimeoutError, ValueError) as e:
                 logger.warning(
-                    "Image summarization failed for '%s' after %s attempts: %s; "
-                    "using placeholder",
+                    "Image summarization failed for '%s': %s; using placeholder",
                     context_name,
-                    IMAGE_SUMMARIZATION_MAX_ATTEMPTS,
                     e,
                 )
                 result = None

--- a/backend/onyx/indexing/indexing_pipeline.py
+++ b/backend/onyx/indexing/indexing_pipeline.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import (
     ENABLE_CONTEXTUAL_RAG,
+    IMAGE_SUMMARIZATION_TIMEOUT_SECONDS,
     MAX_CHUNKS_PER_DOC_BATCH,
     MAX_DOCUMENT_CHARS,
     MAX_TOKENS_FOR_FULL_INCLUSION,
@@ -107,7 +108,11 @@ from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.batching import batch_generator
 from onyx.utils.logger import setup_logger
 from onyx.utils.postgres_sanitization import sanitize_documents_for_postgres
-from onyx.utils.threadpool_concurrency import run_functions_tuples_in_parallel
+from onyx.utils.retry_wrapper import retry_builder
+from onyx.utils.threadpool_concurrency import (
+    run_functions_tuples_in_parallel,
+    run_with_timeout,
+)
 from onyx.utils.timing import log_function_time
 from shared_configs.configs import MULTI_TENANT
 
@@ -115,6 +120,11 @@ logger = setup_logger()
 
 MAX_CONTEXTUAL_RAG_WORKERS = 128  # Assume 8mb of memory per worker
 MAX_IMAGE_WORKERS = 16
+
+# A timed-out or errored image summary is usually a transient provider blip, so
+# retry a few times (short backoff) before falling back to a placeholder.
+IMAGE_SUMMARIZATION_MAX_ATTEMPTS = 2
+IMAGE_SUMMARIZATION_RETRY_BACKOFF_SECONDS = 2.0
 
 # Contextual-RAG doc/chunk summaries are a short, non-reasoning task. On a reasoning
 # model the hidden reasoning tokens consume the small MAX_CONTEXT_TOKENS budget and the
@@ -831,14 +841,38 @@ def process_image_sections(documents: list[Document]) -> list[IndexingDocument]:
 
     # Summarize all images in parallel
     if pending:
+        # Wall-clock timeout per attempt: the LLM's own timeout is per-read, not total,
+        # so a trickling connection would otherwise hang the worker forever. retry_builder
+        # can't interrupt a blocking call, so the timeout lives inside the retried unit.
+        @retry_builder(
+            tries=IMAGE_SUMMARIZATION_MAX_ATTEMPTS,
+            delay=IMAGE_SUMMARIZATION_RETRY_BACKOFF_SECONDS,
+            jitter=0,
+            exceptions=(TimeoutError, ValueError),
+        )
+        def _summarize_attempt(image_data: bytes, context_name: str) -> str | None:
+            return run_with_timeout(
+                IMAGE_SUMMARIZATION_TIMEOUT_SECONDS,
+                summarize_image_with_error_handling,
+                llm=llm,
+                image_data=image_data,
+                context_name=context_name,
+            )
 
         def _summarize(image_data: bytes, context_name: str) -> str:
-            return (
-                summarize_image_with_error_handling(
-                    llm=llm, image_data=image_data, context_name=context_name
+            try:
+                # None is a non-retryable skip (e.g. unsupported image format).
+                result = _summarize_attempt(image_data, context_name)
+            except (TimeoutError, ValueError) as e:
+                logger.warning(
+                    "Image summarization failed for '%s' after %s attempts: %s; "
+                    "using placeholder",
+                    context_name,
+                    IMAGE_SUMMARIZATION_MAX_ATTEMPTS,
+                    e,
                 )
-                or "[Image could not be summarized]"
-            )
+                result = None
+            return result or "[Image could not be summarized]"
 
         results = run_functions_tuples_in_parallel(
             [(_summarize, (p.image_data, p.context_name)) for p in pending],

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -765,6 +765,54 @@ class TestProcessImageSections:
         assert section.csv_file_id == "fid-2"
         assert section.text is None
 
+    def test_hung_summarization_is_bounded_and_retried_to_placeholder(self) -> None:
+        """A vision-LLM call that hangs must not wedge indexing: each attempt is bounded
+        by IMAGE_SUMMARIZATION_TIMEOUT_SECONDS, it is retried, and once the retries are
+        exhausted the image falls back to a placeholder (the document still indexes)."""
+        call_count = 0
+
+        def _hang(**_kwargs: Any) -> str:
+            nonlocal call_count
+            call_count += 1
+            time.sleep(3)  # would hang the worker indefinitely without the timeout
+            return "never-returned"
+
+        doc = _make_image_doc("doc1", [ImageSection(image_file_id="img-A")])
+        with (
+            patch(f"{_PATCH_PREFIX}.IMAGE_SUMMARIZATION_TIMEOUT_SECONDS", 0.2),
+            patch(f"{_PATCH_PREFIX}.IMAGE_SUMMARIZATION_RETRY_BACKOFF_SECONDS", 0.0),
+            patch(f"{_PATCH_PREFIX}.IMAGE_SUMMARIZATION_MAX_ATTEMPTS", 2),
+        ):
+            start = time.monotonic()
+            result = self._run([doc], {"img-A": b"aa"}, summarize_side_effect=_hang)
+            elapsed = time.monotonic() - start
+
+        assert call_count == 2  # retried before giving up
+        assert elapsed < 2.0  # bounded — not the 3s hang, per attempt
+        assert result[0].processed_sections[0].text == "[Image could not be summarized]"
+
+    def test_transient_summarization_failure_recovers_on_retry(self) -> None:
+        """A transient failure on the first attempt is retried, and the real summary
+        (not a placeholder) is used — honoring the opted-in image-summarization feature."""
+        call_count = 0
+
+        def _flaky(**kwargs: Any) -> str:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("transient provider error")
+            return f"summary-of-{kwargs['context_name']}"
+
+        doc = _make_image_doc("doc1", [ImageSection(image_file_id="img-A")])
+        with (
+            patch(f"{_PATCH_PREFIX}.IMAGE_SUMMARIZATION_RETRY_BACKOFF_SECONDS", 0.0),
+            patch(f"{_PATCH_PREFIX}.IMAGE_SUMMARIZATION_MAX_ATTEMPTS", 2),
+        ):
+            result = self._run([doc], {"img-A": b"aa"}, summarize_side_effect=_flaky)
+
+        assert call_count == 2  # first failed, second succeeded
+        assert result[0].processed_sections[0].text == "summary-of-img-A"
+
     def test_interleaved_sections_preserve_order(self) -> None:
         """Text and image sections must stay in their original positions."""
         doc = _make_image_doc(
@@ -900,13 +948,17 @@ class TestProcessImageSections:
                 raise ValueError("boom")
             return f"summary-of-{kwargs['context_name']}"
 
-        result = self._run([doc], image_map, summarize_side_effect=_sometimes_fail)
+        with (
+            patch(f"{_PATCH_PREFIX}.IMAGE_SUMMARIZATION_RETRY_BACKOFF_SECONDS", 0.0),
+            patch(f"{_PATCH_PREFIX}.IMAGE_SUMMARIZATION_MAX_ATTEMPTS", 2),
+        ):
+            result = self._run([doc], image_map, summarize_side_effect=_sometimes_fail)
 
         sections = result[0].processed_sections
         assert len(sections) == 3
         assert sections[0].text == "summary-of-ok"
-        # allow_failures=True → None result → fallback text
-        assert sections[1].text == "[Error processing image]"
+        # retries exhausted → placeholder for the failed image; the document still indexes
+        assert sections[1].text == "[Image could not be summarized]"
         assert sections[2].text == "summary-of-ok2"
 
 

--- a/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
+++ b/backend/tests/unit/onyx/indexing/test_indexing_pipeline.py
@@ -765,10 +765,9 @@ class TestProcessImageSections:
         assert section.csv_file_id == "fid-2"
         assert section.text is None
 
-    def test_hung_summarization_is_bounded_and_retried_to_placeholder(self) -> None:
-        """A vision-LLM call that hangs must not wedge indexing: each attempt is bounded
-        by IMAGE_SUMMARIZATION_TIMEOUT_SECONDS, it is retried, and once the retries are
-        exhausted the image falls back to a placeholder (the document still indexes)."""
+    def test_hung_summarization_is_bounded_and_not_retried(self) -> None:
+        """A hung vision-LLM call is time-boxed and NOT retried — retrying would leave a
+        second stuck provider thread — so it falls back to a placeholder after one attempt."""
         call_count = 0
 
         def _hang(**_kwargs: Any) -> str:
@@ -787,8 +786,10 @@ class TestProcessImageSections:
             result = self._run([doc], {"img-A": b"aa"}, summarize_side_effect=_hang)
             elapsed = time.monotonic() - start
 
-        assert call_count == 2  # retried before giving up
-        assert elapsed < 2.0  # bounded — not the 3s hang, per attempt
+        assert (
+            call_count == 1
+        )  # timeout is NOT retried (would stack another stuck thread)
+        assert elapsed < 1.0  # single 0.2s timeout, not 2×
         assert result[0].processed_sections[0].text == "[Image could not be summarized]"
 
     def test_transient_summarization_failure_recovers_on_retry(self) -> None:

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -354,6 +354,11 @@ LOG_ONYX_MODEL_INTERACTIONS=False
 # DOCUMENT_PUSH_API_KEY=
 # DOCUMENT_PUSH_TIMEOUT_SECONDS=30
 
+# Wall-clock cap (seconds) for summarizing a single image during indexing. Bounds a
+# stalled vision-LLM call so it can't hang a docprocessing worker; on timeout the
+# image is skipped with a placeholder. Defaults to 120.
+# IMAGE_SUMMARIZATION_TIMEOUT_SECONDS=120
+
 ## OAuth Connector Configs
 # EGNYTE_CLIENT_ID=
 # EGNYTE_CLIENT_SECRET=

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.7.2
+version: 0.7.3
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1613,6 +1613,9 @@ configMap:
   DOCUMENT_PUSH_ENDPOINT_URL: ""
   DOCUMENT_PUSH_API_KEY: ""
   DOCUMENT_PUSH_TIMEOUT_SECONDS: ""
+  # Wall-clock cap (seconds) for summarizing a single image during indexing; bounds a
+  # stalled vision-LLM call so it can't wedge a docprocessing worker. Defaults to 120.
+  IMAGE_SUMMARIZATION_TIMEOUT_SECONDS: ""
   # Worker Parallelism
   CELERY_WORKER_DOCPROCESSING_CONCURRENCY: ""
   CELERY_WORKER_LIGHT_CONCURRENCY: ""


### PR DESCRIPTION
## Description

Image summarization's vision-LLM call can hang **indefinitely** and wedge the docprocessing worker — one stuck call stalled a customer's indexing for days. The existing LLM timeout doesn't catch this: it's a **per-socket-read** timeout (max gap between streamed chunks), **not** a total request deadline, so a slow/trickling connection keeps resetting it and the call never times out.

- Bound each image summarization with a wall-clock timeout so a hung call can't wedge the worker
- Retry transient failures, then fall back to a placeholder so the document still indexes
- Add `IMAGE_SUMMARIZATION_TIMEOUT_SECONDS` (default 120s), documented in env template + Helm values

## How Has This Been Tested?

Unit tests added — a hung call is time-boxed and falls back to a placeholder; a transient failure recovers on retry. Full indexing unit suite + type/lint checks pass.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Time-box image summarization with a wall-clock timeout to stop worker hangs. Retries only transient errors and uses a placeholder so documents still index when the vision model stalls.

- **Bug Fixes**
  - Time-box each image summary with a wall-clock timeout; retry transient failures only (2 attempts, 2s backoff). Do not retry on timeout; fall back to "[Image could not be summarized]".
  - Added unit tests for hung-call not retried, transient retry success, and placeholder fallback.
  - Introduced `IMAGE_SUMMARIZATION_TIMEOUT_SECONDS` (default 120s); documented in env template and Helm values.

- **Dependencies**
  - Bumped Helm chart to 0.7.3 to publish the new `IMAGE_SUMMARIZATION_TIMEOUT_SECONDS` value.

<sup>Written for commit 4479dc80a00d10d4eb1269143faa524d9cb6ba4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13349?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



