### PR TITLE
fix: extract cached calculated values from xlsx, not formula strings

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -678,7 +678,7 @@ def _load_readonly_workbook(file: IO[Any], file_name: str) -> openpyxl.Workbook 
     / known-openpyxl-bug cases the xlsx indexers treat as skip-and-continue rather
     than a hard failure."""
     try:
-        return openpyxl.load_workbook(file, read_only=True)
+        return openpyxl.load_workbook(file, read_only=True, data_only=True)
     except BadZipFile as e:
         error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
         if file_name.startswith("~"):


### PR DESCRIPTION
Fixes #13353.

openpyxl defaults to `data_only=False`, so every formula cell extracts as its formula string (`=SUM(C57:E57)`) instead of the calculated number. Spreadsheet figures — totals, margins, KPIs — therefore never reach the index and are unanswerable in search/chat. In our production index, 63% of sampled xlsx chunks contained formula strings.

`data_only=True` returns the value cached by the application that last saved the file, which is what every mainstream ingestion path emits (pandas hardcodes it; docling and RAGFlow fixed this same bug: docling-project/docling#2520, infiniflow/ragflow#6613). Onyx itself extracted values during the MarkItDown period (#5115) and silently regressed when #5444 reverted to raw openpyxl for memory reasons.

Trade-off (ecosystem-standard): workbooks written programmatically without a calc engine store no cached values, so their formula cells extract as empty instead of the formula string. If any test fixture xlsx is generated by openpyxl and contains formulas, its expected output will need regenerating (docling hit exactly this in their fix). A per-cell fallback (cached value if present, else formula string, via a second `load_workbook` pass) avoids that loss entirely — we run that variant in production and can follow up with it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Read cached calculated values from .xlsx files instead of formula strings by loading workbooks with data_only=True. This makes totals and other formula-derived numbers indexable and answerable in search/chat.

- **Bug Fixes**
  - Use `openpyxl.load_workbook(file, read_only=True, data_only=True)` so formula cells return cached numbers rather than "=SUM(...)" strings.

<sup>Written for commit 6bd7f0949d80a673e8a368652caafb79288a6546. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13354?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

