### PR TITLE
fix(chat): ensure agent persists correctly after page refresh

### DIFF
--- a/web/src/lib/agents/hooks.ts
+++ b/web/src/lib/agents/hooks.ts
@@ -266,19 +266,29 @@ export function useAgentController(
     return pinnedAgents[0] || availableAgents[0];
   }, [selectedAgent, pinnedAgents, availableAgents, disableDefaultAssistant]);
 
+  const availableAgentsRef = useRef<MinimalAgent[]>(availableAgents);
+  const defaultAgentIdRef = useRef<number | undefined>(defaultAgentId);
+  availableAgentsRef.current = availableAgents;
+  defaultAgentIdRef.current = defaultAgentId;
   const setSelectedAgentFromId = useCallback(
     (agentId: number | null | undefined) => {
+      const latestAvailableAgents = availableAgentsRef.current;
+      const latestDefaultAgentId = defaultAgentIdRef.current;
+
       let newAssistant =
         agentId !== null
-          ? availableAgents.find((a) => a.id === agentId)
+          ? latestAvailableAgents.find((a) => a.id === agentId)
           : undefined;
-      if (!newAssistant && defaultAgentId !== undefined) {
-        newAssistant = availableAgents.find((a) => a.id === defaultAgentId);
+
+      if (!newAssistant && latestDefaultAgentId !== undefined) {
+        newAssistant = latestAvailableAgents.find(
+          (a) => a.id === latestDefaultAgentId
+        );
       }
       setSelectedAssistant(newAssistant);
       onAgentSelect?.();
     },
-    [availableAgents, defaultAgentId, onAgentSelect]
+    [onAgentSelect]
   );
 
   return { selectedAgent, setSelectedAgentFromId, liveAgent };


### PR DESCRIPTION
## Description

Mirror of #13127 by @juliennonin, opened from a branch inside this repo so CI (which requires org-repo config vars unavailable to fork-triggered workflows) can run. All credit and commit authorship belong to @juliennonin — this PR exists purely to unblock CI; no changes were made to the original commit.

Fixes #8087.

**Description of the bug**
On page refresh in an existing chat session, `selectedAgent` could become undefined, causing the UI to display the wrong agent.

**Root cause**
`useChatSessionController` calls `setSelectedAgentFromId` asynchronously with the correct agent ID, but `setSelectedAgentFromId` could resolve against a stale captured snapshot of `availableAgents` instead of the latest list.

**Fix**
`setSelectedAgentFromId` now always resolves using the latest available agent list at call time, preventing refresh-time resets to undefined and keeping the selected agent consistent.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes loss of the selected agent after a page refresh in chat. Selection now resolves against the latest agent list, preventing resets to undefined.

- **Bug Fixes**
  - Root cause: `setSelectedAgentFromId` captured a stale `availableAgents`, so refresh could clear the selection.
  - Change: read `availableAgents` and `defaultAgentId` via refs inside the callback; dependency narrowed to `onAgentSelect`.
  - Result: the chosen agent persists across reloads and the UI shows the correct agent.

<sup>Written for commit 95507d8046b1fdf6d45f14e2a622de20b1910ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13355?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->