### PR TITLE
fix(logging): clarify that LICENSE_ENFORCEMENT_ENABLED does not mean the deployment is Enterprise

### DIFF
--- a/backend/onyx/utils/variable_functionality.py
+++ b/backend/onyx/utils/variable_functionality.py
@@ -63,7 +63,12 @@ def set_is_ee_based_on_env_variable() -> None:
         )
         global_version.set_ee()
     elif _LICENSE_ENFORCEMENT_ENABLED:
-        logger.notice("Enterprise Edition enabled via LICENSE_ENFORCEMENT_ENABLED")
+        logger.notice(
+            "License enforcement is enabled (LICENSE_ENFORCEMENT_ENABLED). "
+            "Enterprise Edition code is loaded, but paid features stay locked "
+            "until a valid license is applied. Without a license this "
+            "deployment behaves as Community Edition."
+        )
         global_version.set_ee()
 
 


### PR DESCRIPTION
## Description

Self-hosted deployments log `Enterprise Edition enabled via LICENSE_ENFORCEMENT_ENABLED` on every boot because the flag defaults to true. Users keep reading it as "this deployment is now running Enterprise Edition". A customer hit this again during an upgrade this week.

String-only change. The notice now states what actually happens: EE code is loaded, paid features stay locked until a valid license is applied, and without a license the deployment behaves as Community Edition.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check