### PR TITLE
feat(craft): fail fast when SANDBOX_API_SERVER_URL lacks its API path prefix

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -134,6 +134,9 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
     ATTACHMENTS_SECTION_CONTENT,
     generate_agent_instructions,
 )
+from onyx.server.features.build.sandbox.util.api_url_check import (
+    validate_sandbox_api_url,
+)
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
 )
@@ -835,6 +838,7 @@ class DockerSandboxManager(SandboxManager):
             raise ValueError(
                 "SANDBOX_API_SERVER_URL must be set for Docker sandbox provisioning."
             )
+        validate_sandbox_api_url(SANDBOX_API_SERVER_URL)
 
         logger.info(
             "Provisioning Docker sandbox %s for user %s, tenant %s.",

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -127,6 +127,9 @@ from onyx.server.features.build.sandbox.util.agent_instructions import (
     ATTACHMENTS_SECTION_CONTENT,
     generate_agent_instructions,
 )
+from onyx.server.features.build.sandbox.util.api_url_check import (
+    validate_sandbox_api_url,
+)
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
 )
@@ -1051,6 +1054,7 @@ class KubernetesSandboxManager(SandboxManager):
             raise ValueError(
                 "SANDBOX_API_SERVER_URL must be set for Kubernetes sandbox provisioning"
             )
+        validate_sandbox_api_url(SANDBOX_API_SERVER_URL)
         if not SANDBOX_PROXY_HOST:
             raise ValueError(
                 "SANDBOX_PROXY_HOST must be set for Kubernetes sandbox provisioning"

--- a/backend/onyx/server/features/build/sandbox/util/api_url_check.py
+++ b/backend/onyx/server/features/build/sandbox/util/api_url_check.py
@@ -11,6 +11,8 @@ import threading
 
 import httpx
 
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -87,12 +89,13 @@ def validate_sandbox_api_url(api_server_url: str) -> None:
     prefixed = f"{base}/api"
     prefixed_response = _probe_health(prefixed)
     if prefixed_response is not None and _is_health_response(prefixed_response):
-        raise RuntimeError(
+        raise OnyxError(
+            OnyxErrorCode.INTERNAL_ERROR,
             f"SANDBOX_API_SERVER_URL={api_server_url!r} is missing its API path "
             f"prefix: {base}/health does not serve the API health payload "
             f"(HTTP {response.status_code}) while {prefixed}/health does. "
             f"Set SANDBOX_API_SERVER_URL to {prefixed!r} — the full base URL a "
-            "sandbox client uses."
+            "sandbox client uses.",
         )
     logger.warning(
         "SANDBOX_API_SERVER_URL=%s: %s/health did not serve the API health "

--- a/backend/onyx/server/features/build/sandbox/util/api_url_check.py
+++ b/backend/onyx/server/features/build/sandbox/util/api_url_check.py
@@ -1,0 +1,106 @@
+"""Provision-time validation of SANDBOX_API_SERVER_URL.
+
+SANDBOX_API_SERVER_URL is the full base URL a sandbox client uses, any API
+path prefix included. The classic misconfiguration is a public URL without
+its /api prefix, which fails far from the cause: every LLM-gateway and
+onyx-cli call inside the sandbox 404s. Probe once per process at provision
+time and fail with the corrected value instead.
+"""
+
+import threading
+
+import httpx
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_PROBE_TIMEOUT_SECONDS = 5.0
+
+_validated = False
+_validated_lock = threading.Lock()
+
+
+def _probe_health(base_url: str) -> httpx.Response | None:
+    """Response of GET {base_url}/health, or None when unreachable."""
+    try:
+        return httpx.get(
+            f"{base_url}/health",
+            timeout=_PROBE_TIMEOUT_SECONDS,
+            follow_redirects=True,
+        )
+    except httpx.HTTPError:
+        return None
+
+
+def _is_health_response(response: httpx.Response) -> bool:
+    """True only for the API server's real /health payload (StatusResponse).
+
+    Status code alone is not enough: an ingress can redirect the unprefixed
+    path to a login/web page that answers 200, which would mask the missing
+    /api prefix.
+    """
+    if response.status_code != 200:
+        return False
+    try:
+        body = response.json()
+    except ValueError:
+        return False
+    return isinstance(body, dict) and body.get("success") is True
+
+
+def validate_sandbox_api_url(api_server_url: str) -> None:
+    """Fail provisioning when the URL provably lacks its API path prefix.
+
+    Evidence-based, never shape-guessing: raises only when {url}/health does
+    not serve the API health payload while {url}/api/health does. An
+    unreachable or ambiguous probe (egress quirks, hairpin NAT, WAF-guarded
+    health) logs a warning and passes — this check must never block a working
+    deployment.
+    """
+    global _validated
+    if _validated:
+        return
+
+    base = api_server_url.rstrip("/")
+    response = _probe_health(base)
+    if response is None:
+        logger.warning(
+            "Could not probe %s/health to validate SANDBOX_API_SERVER_URL; "
+            "skipping the prefix check",
+            base,
+        )
+        return
+    if _is_health_response(response):
+        with _validated_lock:
+            _validated = True
+        return
+    # 404s and 2xx responses that are not the health payload (an ingress
+    # serving a login/web page for the unprefixed path) both suggest a
+    # missing prefix. Anything else (401/403/5xx) is ambiguous — a WAF may
+    # guard /health — so pass rather than risk blocking a working deployment.
+    if response.status_code != 404 and not (200 <= response.status_code < 300):
+        with _validated_lock:
+            _validated = True
+        return
+
+    prefixed = f"{base}/api"
+    prefixed_response = _probe_health(prefixed)
+    if prefixed_response is not None and _is_health_response(prefixed_response):
+        raise RuntimeError(
+            f"SANDBOX_API_SERVER_URL={api_server_url!r} is missing its API path "
+            f"prefix: {base}/health does not serve the API health payload "
+            f"(HTTP {response.status_code}) while {prefixed}/health does. "
+            f"Set SANDBOX_API_SERVER_URL to {prefixed!r} — the full base URL a "
+            "sandbox client uses."
+        )
+    logger.warning(
+        "SANDBOX_API_SERVER_URL=%s: %s/health did not serve the API health "
+        "payload (HTTP %s) and %s/health did not either; sandbox API calls "
+        "will likely fail. Verify the URL is the full base URL including any "
+        "path prefix.",
+        api_server_url,
+        base,
+        response.status_code,
+        prefixed,
+    )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_api_url_check.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_api_url_check.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.build.sandbox.util import api_url_check
 
 
@@ -33,7 +34,7 @@ def test_missing_api_prefix_raises_with_corrected_url() -> None:
         return _health_response()
 
     with patch.object(api_url_check.httpx, "get", side_effect=fake_get):
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(OnyxError) as exc_info:
             api_url_check.validate_sandbox_api_url("https://onyx.example")
 
     assert "'https://onyx.example/api'" in str(exc_info.value)
@@ -49,7 +50,7 @@ def test_redirected_web_page_does_not_mask_missing_prefix() -> None:
         return _health_response()
 
     with patch.object(api_url_check.httpx, "get", side_effect=fake_get):
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(OnyxError) as exc_info:
             api_url_check.validate_sandbox_api_url("https://onyx.example")
 
     assert "'https://onyx.example/api'" in str(exc_info.value)

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_api_url_check.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_api_url_check.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from onyx.server.features.build.sandbox.util import api_url_check
+
+
+@pytest.fixture(autouse=True)
+def _reset_validation_cache() -> None:
+    api_url_check._validated = False
+
+
+def _response(status: int, json_body: object = None) -> MagicMock:
+    resp = MagicMock()
+    resp.status_code = status
+    if json_body is None:
+        resp.json.side_effect = ValueError("not json")
+    else:
+        resp.json.return_value = json_body
+    return resp
+
+
+def _health_response() -> MagicMock:
+    return _response(200, {"success": True, "message": "ok"})
+
+
+def test_missing_api_prefix_raises_with_corrected_url() -> None:
+    def fake_get(url: str, **_: object) -> MagicMock:
+        if url == "https://onyx.example/health":
+            return _response(404)
+        assert url == "https://onyx.example/api/health"
+        return _health_response()
+
+    with patch.object(api_url_check.httpx, "get", side_effect=fake_get):
+        with pytest.raises(RuntimeError) as exc_info:
+            api_url_check.validate_sandbox_api_url("https://onyx.example")
+
+    assert "'https://onyx.example/api'" in str(exc_info.value)
+
+
+def test_redirected_web_page_does_not_mask_missing_prefix() -> None:
+    # An ingress that redirects the unprefixed /health to a login page still
+    # answers 200 — the body, not the status, proves it isn't the API.
+    def fake_get(url: str, **_: object) -> MagicMock:
+        if url == "https://onyx.example/health":
+            return _response(200, json_body=None)  # HTML login page
+        assert url == "https://onyx.example/api/health"
+        return _health_response()
+
+    with patch.object(api_url_check.httpx, "get", side_effect=fake_get):
+        with pytest.raises(RuntimeError) as exc_info:
+            api_url_check.validate_sandbox_api_url("https://onyx.example")
+
+    assert "'https://onyx.example/api'" in str(exc_info.value)
+
+
+def test_reachable_url_passes_and_caches() -> None:
+    with patch.object(
+        api_url_check.httpx, "get", return_value=_health_response()
+    ) as probe:
+        api_url_check.validate_sandbox_api_url("http://api:8080")
+        api_url_check.validate_sandbox_api_url("http://api:8080")
+
+    probe.assert_called_once()
+
+
+def test_auth_guarded_health_counts_as_reachable() -> None:
+    with patch.object(api_url_check.httpx, "get", return_value=_response(403)):
+        api_url_check.validate_sandbox_api_url("https://onyx.example/api")
+
+
+def test_unreachable_probe_never_blocks() -> None:
+    with patch.object(
+        api_url_check.httpx,
+        "get",
+        side_effect=httpx.ConnectError("egress blocked"),
+    ):
+        api_url_check.validate_sandbox_api_url("https://onyx.example/api")
+
+
+def test_double_404_warns_without_raising() -> None:
+    with patch.object(api_url_check.httpx, "get", return_value=_response(404)):
+        api_url_check.validate_sandbox_api_url("https://onyx.example")
+
+
+def test_spa_catch_all_on_both_paths_warns_without_raising() -> None:
+    # A frontend catch-all answering 200 HTML for every path gives no
+    # evidence either way — never block.
+    with patch.object(
+        api_url_check.httpx, "get", return_value=_response(200, json_body=None)
+    ):
+        api_url_check.validate_sandbox_api_url("https://onyx.example")

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -317,6 +317,7 @@ def test_provision_generates_fresh_password_and_injects_into_container_env(
     """
     monkeypatch.setattr(dsm, "DEV_MODE", True)
     monkeypatch.setattr(dsm, "SANDBOX_API_SERVER_URL", "https://onyx.example.com")
+    monkeypatch.setattr(dsm, "validate_sandbox_api_url", lambda *_: None)
     # Skip the actual readiness HTTP probe — that needs a real container.
     monkeypatch.setattr(
         DockerSandboxManager,
@@ -475,6 +476,7 @@ def test_provision_removes_container_when_history_restore_fails(
     """
     monkeypatch.setattr(dsm, "DEV_MODE", True)
     monkeypatch.setattr(dsm, "SANDBOX_API_SERVER_URL", "https://onyx.example.com")
+    monkeypatch.setattr(dsm, "validate_sandbox_api_url", lambda *_: None)
 
     mgr = _bare_manager()
     mgr._docker = MagicMock()  # type: ignore[attr-defined]

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_k8s_push_error_mapping.py
@@ -754,6 +754,7 @@ def test_provision_cleans_up_pod_when_opencode_history_restore_fails(
     import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
 
     monkeypatch.setattr(ksm, "SANDBOX_API_SERVER_URL", "http://api-server")
+    monkeypatch.setattr(ksm, "validate_sandbox_api_url", lambda *_: None)
     monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "proxy.local")
 
     sandbox_id = _sandbox_id()
@@ -798,6 +799,7 @@ def test_provision_existing_healthy_pod_does_not_restore_opencode_history(
     import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
 
     monkeypatch.setattr(ksm, "SANDBOX_API_SERVER_URL", "http://api-server")
+    monkeypatch.setattr(ksm, "validate_sandbox_api_url", lambda *_: None)
     monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "proxy.local")
 
     sandbox_id = _sandbox_id()
@@ -835,6 +837,7 @@ def test_provision_conflicting_healthy_pod_skips_startup_restore(
     import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
 
     monkeypatch.setattr(ksm, "SANDBOX_API_SERVER_URL", "http://api-server")
+    monkeypatch.setattr(ksm, "validate_sandbox_api_url", lambda *_: None)
     monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "proxy.local")
 
     sandbox_id = _sandbox_id()
@@ -884,6 +887,7 @@ def test_provision_conflicting_not_ready_pod_runs_startup_restore(
     import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
 
     monkeypatch.setattr(ksm, "SANDBOX_API_SERVER_URL", "http://api-server")
+    monkeypatch.setattr(ksm, "validate_sandbox_api_url", lambda *_: None)
     monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "proxy.local")
 
     sandbox_id = _sandbox_id()
@@ -945,6 +949,7 @@ def test_provision_conflicting_not_ready_pod_restore_failure_does_not_cleanup(
     import onyx.server.features.build.sandbox.kubernetes.kubernetes_sandbox_manager as ksm
 
     monkeypatch.setattr(ksm, "SANDBOX_API_SERVER_URL", "http://api-server")
+    monkeypatch.setattr(ksm, "validate_sandbox_api_url", lambda *_: None)
     monkeypatch.setattr(ksm, "SANDBOX_PROXY_HOST", "proxy.local")
 
     sandbox_id = _sandbox_id()


### PR DESCRIPTION
## Description

Fail fast at sandbox provision time when `SANDBOX_API_SERVER_URL` is missing its ingress path prefix.

The classic Craft misconfiguration is a public URL without `/api` (an ingress artifact the app can't know statically — cloud NGINX strips it before proxying; docker-compose's bridge alias has none). Today it fails far from the cause: every onyx-cli and LLM-gateway call inside the sandbox 404s. This PR probes `{url}/health` once per process at provision and raises with the exact corrected value instead.

Design constraints:
- **Evidence-based, never shape-guessing** — raises only when `{url}/health` does not serve the API health JSON payload while `{url}/api/health` does. Verifying the payload (not just a 2xx) matters because an ingress can redirect the bare path to a login/web page that answers 200, masking the misconfiguration.
- **Never blocks a working deployment** — ambiguous probes (WAF-guarded `/health`, hairpin NAT, unreachable) log a warning and pass.

### Alternative considered: auto-correct instead of raise

We prototyped a `resolve_sandbox_api_url()` that returns the corrected URL (and overrides the pod's `ONYX_SERVER_URL` env on k8s, where the Helm PodTemplate stamps the raw configMap value). We backed off it for this PR because:
- the probe runs from the api-server, whose network vantage (DNS/proxy/CA) can differ from the sandbox's — the corrected value is still a guess about the sandbox's view;
- per-process caching means two api replicas can provision identical sandboxes with different URLs during a rolling deploy;
- silently rewriting infra-declared config hides drift between declared and effective state.

If the team prefers convenience over fail-fast here, the resolver variant is ready to revive — opinions welcome.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/server/features/build/sandbox/test_api_url_check.py` covering: missing prefix raises with corrected URL, redirect-to-login-200 doesn't mask it, 403-guarded health passes, unreachable passes, double-404 warns without raising, SPA catch-all warns without raising, successful probe caches.
- `test_docker_serve_plumbing.py` / `test_k8s_push_error_mapping.py` suites pass with the validator stubbed (4 pre-existing failures on the base commit are unrelated).
- Live-validated against craft-dev, where the bare URL (`https://craft-dev.onyx.app` without `/api`) is exactly this failure mode.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast during sandbox provisioning when `SANDBOX_API_SERVER_URL` is missing its `/api` prefix to prevent cascading 404s. Probes `/health` vs `/api/health` once per process and raises a structured error with the corrected URL only when clearly missing.

- **New Features**
  - Added `validate_sandbox_api_url()` that checks the real API health JSON, not just status codes; warns and passes on ambiguous or unreachable probes; 5s timeout; per-process cache.
  - Integrated validation into both Docker and Kubernetes sandbox provision flows.

- **Bug Fixes**
  - Raise a structured `OnyxError` (`INTERNAL_ERROR`) on confirmed missing prefix so the API returns `{error_code, detail}` instead of a generic 500.

<sup>Written for commit d40fcd35172f002a30471d6a2cf33d51ad9d243d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

