### PR TITLE
chore(craft): bump sandbox onyx-cli pin to 1.2.3

### DIFF
--- a/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
+++ b/backend/onyx/server/features/build/sandbox/image/initial-requirements.txt
@@ -24,7 +24,7 @@ lxml==6.1.1               # via python-docx, python-pptx, -r initial-requirement
 matplotlib==3.11.0        # via -r initial-requirements.in
 matplotlib-inline==0.2.2  # via -r initial-requirements.in
 numpy==2.4.6              # via contourpy, matplotlib, pandas, -r initial-requirements.in
-onyx-cli==1.2.2           # via -r initial-requirements.in
+onyx-cli==1.2.3           # via -r initial-requirements.in
 openpyxl==3.1.5           # via -r initial-requirements.in
 packaging==26.2           # via matplotlib
 pandas==3.0.3             # via -r initial-requirements.in


### PR DESCRIPTION
## Description

Post-merge follow-up to #13282. That PR added client-side handling in `onyx-cli` for the image-generation endpoint's streamed keepalives and in-band error envelopes. `cli/v1.2.3` is now tagged and published to PyPI, so this bumps the pinned `onyx-cli` in the sandbox image from `1.2.2` → `1.2.3` so newly built/deployed sandboxes get the improved error reporting on slow image generations. (Successes already worked with the old CLI; this is about proper error mapping.)

Recompiled `initial-requirements.txt` with the documented `uv pip compile --upgrade-package onyx-cli` flow; `onyx-cli` has no Python deps so the diff is a single line.

## How Has This Been Tested?

- Confirmed `onyx-cli==1.2.3` is published on PyPI (release-cli workflow: pypi + docker jobs green).
- Validated the wheel-only install resolves on both target platforms with the documented command:
  `uv pip install --dry-run --refresh --only-binary=:all: --python-version 3.13 --python-platform {x86_64,aarch64}-manylinux_2_28 -r initial-requirements.txt` → `onyx-cli==1.2.3`, resolves clean on both.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump sandbox image pin for `onyx-cli` to 1.2.3 to pick up client handling for streamed keepalives and in-band error envelopes on image-generation requests. New sandboxes get clearer error reporting during slow image generations.

<sup>Written for commit 63bcf55b70df652177c33d4d017f5d9127ef75c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

