### PR TITLE
chore: enable claude-security plugin in shipped Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "enabledPlugins": {
-    "security-guidance@claude-plugins-official": true
+    "security-guidance@claude-plugins-official": true,
+    "claude-security@claude-plugins-official": true
   }
 }


### PR DESCRIPTION
## Description

Adds the `claude-security` plugin (from the official Claude plugin marketplace) to the `enabledPlugins` in the repo's checked-in `.claude/settings.json`, alongside the existing `security-guidance` plugin. This makes the Claude Security scan/fix tooling available out of the box to anyone running Claude Code in this repo.

## How Has This Been Tested?

Config-only change. Verified the plugin identifier matches the official marketplace name (`claude-security@claude-plugins-official`) used by an existing working installation; the plugin loads and its agents/skills are available in a session on this repo.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables `claude-security@claude-plugins-official` in `.claude/settings.json` so Claude Code sessions have built-in security scan/fix tooling by default, alongside `security-guidance@claude-plugins-official`.

<sup>Written for commit c05afb72c6929366221c7cdafc46fb4670652504. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

