### PR TITLE
fix(llm): don't send reasoning_effort to o1-mini / o1-preview (#13334) to release v4.4

### DIFF
--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -410,6 +410,25 @@ def model_is_reasoning_model(model_name: str, model_provider: str) -> bool:
         return False
 
 
+# OpenAI models that reject the reasoning-effort parameter on every API surface
+# (chat completions and responses alike) — only their default effort works.
+# Explicit list rather than a registry lookup: LiteLLM's Azure config wrongly
+# claims support for these, and its OpenAI answer is an accident of the models
+# missing from the registry.
+_OPENAI_MODELS_REJECTING_REASONING_EFFORT = ("o1-mini", "o1-preview")
+
+
+def openai_model_rejects_reasoning_effort(model_name: str) -> bool:
+    """Deliberately name-only — no provider guard. These names are OpenAI
+    models wherever they're hosted (Azure, LiteLLM proxy, OpenAI-compatible
+    gateways), and a provider guard would reintroduce the 400 behind
+    gateways. The asymmetry favors matching broadly: a false positive only
+    omits an optional parameter, a false negative is a hard request failure.
+    """
+    base_model_name = model_name.lower().split("/")[-1]
+    return base_model_name.startswith(_OPENAI_MODELS_REJECTING_REASONING_EFFORT)
+
+
 def is_true_openai_model(model_provider: str, model_name: str) -> bool:
     """
     Determines if a model is a true OpenAI model or just using OpenAI-compatible API.

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -28,7 +28,11 @@ from onyx.llm.interfaces import (
     ReasoningEffort,
     ToolChoiceOptions,
 )
-from onyx.llm.model_capabilities import is_true_openai_model, model_is_reasoning_model
+from onyx.llm.model_capabilities import (
+    is_true_openai_model,
+    model_is_reasoning_model,
+    openai_model_rejects_reasoning_effort,
+)
 from onyx.llm.model_response import ModelResponse, ModelResponseStream, Usage
 from onyx.llm.models import (
     ANTHROPIC_ADAPTIVE_REASONING_EFFORT,
@@ -649,6 +653,7 @@ class LitellmLLM(LLM):
             # The default of this parameter not set is surprisingly not the equivalent of an Auto but is actually Off
             and reasoning_effort != ReasoningEffort.OFF
             and not is_vertex_model_rejecting_output_config
+            and not openai_model_rejects_reasoning_effort(self.config.model_name)
         ):
             if is_openai_model:
                 # OpenAI API does not accept reasoning params for GPT 5 chat models

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -822,6 +822,52 @@ def test_non_azure_responses_bridge_keeps_api_version() -> None:
     assert kwargs["api_version"] == "2025-03-01-preview"
 
 
+@pytest.mark.parametrize("model_name", ["o1-mini", "o1-preview", "o1-mini-2024-09-12"])
+@pytest.mark.parametrize("routed_via_responses", [True, False])
+def test_reasoning_effort_omitted_for_models_rejecting_it(
+    model_name: str, routed_via_responses: bool
+) -> None:
+    """o1-mini / o1-preview reject the reasoning-effort parameter on every API
+    surface; neither the nested responses param nor the root-level one may be
+    sent, regardless of routing."""
+    llm = _azure_llm(model_name, api_version="2025-03-01-preview")
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
+        patch(
+            "onyx.llm.multi_llm.is_true_openai_model",
+            return_value=routed_via_responses,
+        ),
+    ):
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.AUTO))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "reasoning" not in kwargs
+        assert "reasoning_effort" not in kwargs
+
+
+def test_reasoning_effort_sent_for_o1() -> None:
+    """The o1-mini/o1-preview deny-list must not catch the bare o1 model."""
+    llm = _azure_llm("o1", api_version="2025-03-01-preview")
+
+    with (
+        patch("litellm.completion") as mock_completion,
+        patch("onyx.llm.multi_llm.model_is_reasoning_model", return_value=True),
+        patch("onyx.llm.multi_llm.is_true_openai_model", return_value=True),
+    ):
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.AUTO))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert kwargs["reasoning"]["effort"] == "medium"
+
+
 def test_user_identity_metadata_enabled(default_multi_llm: LitellmLLM) -> None:
     with (
         patch("litellm.completion") as mock_completion,


### PR DESCRIPTION
Cherry-pick of commit cd241ae3040d124da150409734a82a7970c90a8a to release/v4.4 branch.

Original PR: #13334

- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop sending the reasoning_effort parameter to o1-mini and o1-preview to prevent 400s across OpenAI, Azure, and proxy routes. Use the models’ default effort; `o1` is unaffected; tests added including Azure responses v1 routing.

- **Bug Fixes**
  - Omit reasoning params for o1-mini/o1-preview on all API surfaces (responses and chat completions).
  - Add provider-agnostic, name-only check `openai_model_rejects_reasoning_effort` that matches versioned names (e.g., o1-mini-2024-09-12) without catching `o1`.
  - Tests: cover omit logic for responses/chat and versioned names; ensure `o1` still sends effort; verify Azure responses bridge drops dated `api_version` to v1 and preserves v1/None; non-Azure keeps configured versions.

<sup>Written for commit de099077806195a710c4de67865ca055e9a55ebf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13361?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

