### PR TITLE
feat: for edits option in ods run-ci

### DIFF
--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -418,7 +418,19 @@ ods run-ci <pr-number>
 ```shell
 # Run CI for PR #7353 from a fork
 ods run-ci 7353
+
+# Create a replacement PR for making edits and merging
+ods run-ci 7353 --for-edits
 ```
+
+`--for-edits` derives the editable branch from the contributor's branch. It
+preserves `feat/`, `fix/`, `refactor/`, and `chore/` prefixes; otherwise it adds
+`chore/`. For example, `fix/search-timeout` becomes
+`fix/search-timeout-pr-7353-edits`. It also keeps the contributor's original PR
+description and cherry-pick selection, and marks the new PR as superseding the
+original. The replacement PR should be merged and the original PR closed
+without merging. It cannot be combined with `--rerun`, which would discard
+edits made on the replacement branch.
 
 ### `cherry-pick` - Backport Commits to Release Branches
 

--- a/tools/ods/README.md
+++ b/tools/ods/README.md
@@ -430,7 +430,8 @@ preserves `feat/`, `fix/`, `refactor/`, and `chore/` prefixes; otherwise it adds
 description and cherry-pick selection, and marks the new PR as superseding the
 original. The replacement PR should be merged and the original PR closed
 without merging. It cannot be combined with `--rerun`, which would discard
-edits made on the replacement branch.
+edits made on the replacement branch. The command also refuses to overwrite an
+existing replacement PR or remote branch.
 
 ### `cherry-pick` - Backport Commits to Release Branches
 

--- a/tools/ods/cmd/run-ci.go
+++ b/tools/ods/cmd/run-ci.go
@@ -19,6 +19,25 @@ type RunCIOptions struct {
 	Yes      bool
 	Rerun    bool
 	NoVerify bool
+	ForEdits bool
+}
+
+const (
+	choreBranchPrefix    = "chore/"
+	featBranchPrefix     = "feat/"
+	fixBranchPrefix      = "fix/"
+	refactorBranchPrefix = "refactor/"
+
+	cherryPickOptionText = "Please cherry-pick this PR to the latest release version."
+	cherryPickOption     = "- [ ] [Optional] " + cherryPickOptionText
+	linearCheckOverride  = "- [x] Override Linear Check"
+)
+
+var editableBranchPrefixes = [...]string{
+	choreBranchPrefix,
+	featBranchPrefix,
+	fixBranchPrefix,
+	refactorBranchPrefix,
 }
 
 // NewRunCICommand creates a new run-ci command
@@ -40,10 +59,22 @@ This command will:
 This is useful for running CI on PRs from forks, which don't automatically
 trigger GitHub Actions for security reasons.
 
+Use --for-edits when the replacement PR will be edited and merged instead of
+only used to run CI.
+
 Example usage:
 
-	$ ods run-ci 7353`,
-		Args: cobra.ExactArgs(1),
+	$ ods run-ci 7353
+	$ ods run-ci 7353 --for-edits`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			if err := cobra.ExactArgs(1)(cmd, args); err != nil {
+				return err
+			}
+			if opts.ForEdits && opts.Rerun {
+				return fmt.Errorf("--for-edits cannot be combined with --rerun because rerunning would discard edits")
+			}
+			return nil
+		},
 		Run: func(cmd *cobra.Command, args []string) {
 			runCI(cmd, args, opts)
 		},
@@ -53,6 +84,7 @@ Example usage:
 	cmd.Flags().BoolVar(&opts.Yes, "yes", false, "Skip confirmation prompts and automatically proceed")
 	cmd.Flags().BoolVar(&opts.Rerun, "rerun", false, "Update an existing CI PR with the latest fork changes to re-trigger CI")
 	cmd.Flags().BoolVar(&opts.NoVerify, "no-verify", false, "Skip pre-push hooks when pushing the CI branch")
+	cmd.Flags().BoolVar(&opts.ForEdits, "for-edits", false, "Create a replacement PR intended for editing and merging")
 
 	return cmd
 }
@@ -61,6 +93,7 @@ Example usage:
 type PRInfo struct {
 	Number         int    `json:"number"`
 	Title          string `json:"title"`
+	Body           string `json:"body"`
 	HeadRefName    string `json:"headRefName"`
 	HeadRepository struct {
 		Name string `json:"name"`
@@ -78,6 +111,62 @@ func (p *PRInfo) ForkRepo() string {
 		return ""
 	}
 	return fmt.Sprintf("%s/%s", p.HeadRepositoryOwner.Login, p.HeadRepository.Name)
+}
+
+type runCIPRMetadata struct {
+	Branch string
+	Title  string
+	Body   string
+}
+
+func buildEditableBranchName(prInfo *PRInfo) string {
+	branchName := prInfo.HeadRefName
+	hasExpectedPrefix := false
+	for _, prefix := range editableBranchPrefixes {
+		if strings.HasPrefix(branchName, prefix) {
+			hasExpectedPrefix = true
+			break
+		}
+	}
+	if !hasExpectedPrefix {
+		branchName = choreBranchPrefix + branchName
+	}
+	return fmt.Sprintf("%s-pr-%d-edits", branchName, prInfo.Number)
+}
+
+func buildRunCIPRMetadata(prInfo *PRInfo, forEdits bool) runCIPRMetadata {
+	if !forEdits {
+		return runCIPRMetadata{
+			Branch: fmt.Sprintf("run-ci/%d", prInfo.Number),
+			Title:  fmt.Sprintf("chore: [Running GitHub actions for #%d]", prInfo.Number),
+			Body: fmt.Sprintf(
+				"This PR runs GitHub Actions CI for #%d.\n\n%s\n\n**This PR should be closed (not merged) after CI completes.**",
+				prInfo.Number,
+				linearCheckOverride,
+			),
+		}
+	}
+
+	body := fmt.Sprintf(
+		"> [!IMPORTANT]\n> This PR supersedes #%d. Merge this PR and close #%d without merging.",
+		prInfo.Number,
+		prInfo.Number,
+	)
+	if originalBody := strings.TrimSpace(prInfo.Body); originalBody != "" {
+		body += "\n\n## Original PR description\n\n" + originalBody
+	}
+	additionalOptions := []string{}
+	if !strings.Contains(prInfo.Body, cherryPickOptionText) {
+		additionalOptions = append(additionalOptions, cherryPickOption)
+	}
+	additionalOptions = append(additionalOptions, linearCheckOverride)
+	body += "\n\n" + strings.Join(additionalOptions, "\n")
+
+	return runCIPRMetadata{
+		Branch: buildEditableBranchName(prInfo),
+		Title:  fmt.Sprintf("%s [edit of #%d]", prInfo.Title, prInfo.Number),
+		Body:   body,
+	}
 }
 
 func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
@@ -111,10 +200,8 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 		log.Fatalf("PR #%s is not from a fork - CI should already run automatically", prNumber)
 	}
 
-	// Create the CI branch
-	ciBranch := fmt.Sprintf("run-ci/%s", prNumber)
-	prTitle := fmt.Sprintf("chore: [Running GitHub actions for #%s]", prNumber)
-	prBody := fmt.Sprintf("This PR runs GitHub Actions CI for #%s.\n\n- [x] Override Linear Check\n\n**This PR should be closed (not merged) after CI completes.**", prNumber)
+	prMetadata := buildRunCIPRMetadata(prInfo, opts.ForEdits)
+	ciBranch := prMetadata.Branch
 
 	// Check if a CI PR already exists for this branch
 	existingPRURL, err := findExistingCIPR(ciBranch)
@@ -188,7 +275,7 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 	if opts.DryRun {
 		log.Warnf("[DRY RUN] Would push CI branch: %s", ciBranch)
 		if existingPRURL == "" {
-			log.Warnf("[DRY RUN] Would create PR: %s", prTitle)
+			log.Warnf("[DRY RUN] Would create PR: %s", prMetadata.Title)
 		} else {
 			log.Warnf("[DRY RUN] Would update existing PR: %s", existingPRURL)
 		}
@@ -227,7 +314,7 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 
 	// Create PR using GitHub CLI
 	log.Info("Creating PR...")
-	prURL, err := createCIPR(ciBranch, prInfo.BaseRefName, prTitle, prBody)
+	prURL, err := createCIPR(ciBranch, prInfo.BaseRefName, prMetadata.Title, prMetadata.Body)
 	if err != nil {
 		// Switch back to original branch before exiting
 		if switchErr := git.RunCommand("switch", "--quiet", originalBranch); switchErr != nil {
@@ -243,13 +330,17 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 	}
 
 	log.Infof("PR created successfully: %s", prURL)
+	if opts.ForEdits {
+		log.Infof("Make edits on %s, merge this PR, and close #%s without merging.", ciBranch, prNumber)
+		return
+	}
 	log.Info("Remember to close (not merge) this PR after CI completes!")
 }
 
 // getPRInfo fetches PR information using the GitHub CLI
 func getPRInfo(prNumber string) (*PRInfo, error) {
 	cmd := exec.Command("gh", "pr", "view", prNumber,
-		"--json", "number,title,headRefName,headRepository,headRepositoryOwner,baseRefName,isCrossRepository")
+		"--json", "number,title,body,headRefName,headRepository,headRepositoryOwner,baseRefName,isCrossRepository")
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/tools/ods/cmd/run-ci.go
+++ b/tools/ods/cmd/run-ci.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
+	"unicode/utf8"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -31,6 +33,11 @@ const (
 	cherryPickOptionText = "Please cherry-pick this PR to the latest release version."
 	cherryPickOption     = "- [ ] [Optional] " + cherryPickOptionText
 	linearCheckOverride  = "- [x] Override Linear Check"
+
+	gitRefComponentMaxBytes = 255
+	githubPRTitleMaxRunes   = 256
+	prStateAll              = "all"
+	prStateOpen             = "open"
 )
 
 var editableBranchPrefixes = [...]string{
@@ -39,6 +46,11 @@ var editableBranchPrefixes = [...]string{
 	fixBranchPrefix,
 	refactorBranchPrefix,
 }
+
+var cherryPickOptionPattern = regexp.MustCompile(
+	`(?im)^[ \t]*-[ \t]*\[[ x]\][ \t]*(?:\[[^\r\n]*\][ \t]*)?` +
+		regexp.QuoteMeta(cherryPickOptionText) + `[ \t]*$`,
+)
 
 // NewRunCICommand creates a new run-ci command
 func NewRunCICommand() *cobra.Command {
@@ -119,19 +131,44 @@ type runCIPRMetadata struct {
 	Body   string
 }
 
+func truncateUTF8Bytes(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	for !utf8.ValidString(value[:maxBytes]) {
+		maxBytes--
+	}
+	return value[:maxBytes]
+}
+
 func buildEditableBranchName(prInfo *PRInfo) string {
 	branchName := prInfo.HeadRefName
-	hasExpectedPrefix := false
 	for _, prefix := range editableBranchPrefixes {
 		if strings.HasPrefix(branchName, prefix) {
-			hasExpectedPrefix = true
-			break
+			return appendEditableBranchSuffix(branchName, prInfo.Number)
 		}
 	}
-	if !hasExpectedPrefix {
-		branchName = choreBranchPrefix + branchName
+	return appendEditableBranchSuffix(choreBranchPrefix+branchName, prInfo.Number)
+}
+
+func appendEditableBranchSuffix(branchName string, prNumber int) string {
+	suffix := fmt.Sprintf("-pr-%d-edits", prNumber)
+	componentStart := strings.LastIndex(branchName, "/") + 1
+	component := truncateUTF8Bytes(
+		branchName[componentStart:],
+		gitRefComponentMaxBytes-len(suffix),
+	)
+	return branchName[:componentStart] + component + suffix
+}
+
+func buildEditablePRTitle(prInfo *PRInfo) string {
+	suffix := fmt.Sprintf(" [edit of #%d]", prInfo.Number)
+	maxTitleRunes := githubPRTitleMaxRunes - utf8.RuneCountInString(suffix)
+	titleRunes := []rune(strings.TrimSpace(prInfo.Title))
+	if len(titleRunes) > maxTitleRunes {
+		titleRunes = titleRunes[:maxTitleRunes]
 	}
-	return fmt.Sprintf("%s-pr-%d-edits", branchName, prInfo.Number)
+	return strings.TrimSpace(string(titleRunes)) + suffix
 }
 
 func buildRunCIPRMetadata(prInfo *PRInfo, forEdits bool) runCIPRMetadata {
@@ -156,7 +193,7 @@ func buildRunCIPRMetadata(prInfo *PRInfo, forEdits bool) runCIPRMetadata {
 		body += "\n\n## Original PR description\n\n" + originalBody
 	}
 	additionalOptions := []string{}
-	if !strings.Contains(prInfo.Body, cherryPickOptionText) {
+	if !cherryPickOptionPattern.MatchString(prInfo.Body) {
 		additionalOptions = append(additionalOptions, cherryPickOption)
 	}
 	additionalOptions = append(additionalOptions, linearCheckOverride)
@@ -164,9 +201,28 @@ func buildRunCIPRMetadata(prInfo *PRInfo, forEdits bool) runCIPRMetadata {
 
 	return runCIPRMetadata{
 		Branch: buildEditableBranchName(prInfo),
-		Title:  fmt.Sprintf("%s [edit of #%d]", prInfo.Title, prInfo.Number),
+		Title:  buildEditablePRTitle(prInfo),
 		Body:   body,
 	}
+}
+
+func ensureEditableBranchAvailable(branchName string) error {
+	existingPRURL, err := findExistingEditablePR(branchName)
+	if err != nil {
+		return fmt.Errorf("failed to check for an existing editable PR: %w", err)
+	}
+	if existingPRURL != "" {
+		return fmt.Errorf("editable PR already exists for branch %s: %s", branchName, existingPRURL)
+	}
+
+	exists, err := remoteBranchExists(branchName)
+	if err != nil {
+		return fmt.Errorf("failed to check for an existing remote branch: %w", err)
+	}
+	if exists {
+		return fmt.Errorf("refusing to overwrite existing remote branch %s; delete it manually if it is safe to replace", branchName)
+	}
+	return nil
 }
 
 func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
@@ -203,10 +259,16 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 	prMetadata := buildRunCIPRMetadata(prInfo, opts.ForEdits)
 	ciBranch := prMetadata.Branch
 
-	// Check if a CI PR already exists for this branch
-	existingPRURL, err := findExistingCIPR(ciBranch)
-	if err != nil {
-		log.Fatalf("Failed to check for existing CI PR: %v", err)
+	existingPRURL := ""
+	if opts.ForEdits {
+		if err := ensureEditableBranchAvailable(ciBranch); err != nil {
+			log.Fatalf("Cannot create editable PR: %v", err)
+		}
+	} else {
+		existingPRURL, err = findExistingCIPR(ciBranch)
+		if err != nil {
+			log.Fatalf("Failed to check for existing CI PR: %v", err)
+		}
 	}
 
 	if existingPRURL != "" && !opts.Rerun {
@@ -286,13 +348,18 @@ func runCI(cmd *cobra.Command, args []string, opts *RunCIOptions) {
 		return
 	}
 
-	// Push the CI branch (force push in case it already exists)
+	// Editable branches must still be absent when pushed.
 	log.Infof("Pushing CI branch: %s", ciBranch)
 	pushArgs := []string{"push"}
 	if opts.NoVerify {
 		pushArgs = append(pushArgs, "--no-verify")
 	}
-	pushArgs = append(pushArgs, "--quiet", "-f", "-u", "origin", ciBranch)
+	if opts.ForEdits {
+		pushArgs = append(pushArgs, fmt.Sprintf("--force-with-lease=refs/heads/%s:", ciBranch))
+	} else {
+		pushArgs = append(pushArgs, "-f")
+	}
+	pushArgs = append(pushArgs, "--quiet", "-u", "origin", ciBranch)
 	if err := git.RunCommand(pushArgs...); err != nil {
 		// Switch back to original branch before exiting
 		if switchErr := git.RunCommand("switch", "--quiet", originalBranch); switchErr != nil {
@@ -360,9 +427,18 @@ func getPRInfo(prNumber string) (*PRInfo, error) {
 // findExistingCIPR checks if an open PR already exists for the given CI branch.
 // Returns the PR URL if found, or empty string if not.
 func findExistingCIPR(headBranch string) (string, error) {
+	return findExistingPR(headBranch, prStateOpen)
+}
+
+func findExistingEditablePR(headBranch string) (string, error) {
+	return findExistingPR(headBranch, prStateAll)
+}
+
+func findExistingPR(headBranch string, state string) (string, error) {
 	cmd := exec.Command("gh", "pr", "list",
 		"--head", headBranch,
-		"--state", "open",
+		"--state", state,
+		"--limit", "1",
 		"--json", "url",
 	)
 	output, err := cmd.Output()
@@ -382,12 +458,25 @@ func findExistingCIPR(headBranch string) (string, error) {
 	}
 
 	if len(prs) == 0 {
-		log.Debugf("No existing open PRs found for branch %s", headBranch)
+		log.Debugf("No existing %s PRs found for branch %s", state, headBranch)
 		return "", nil
 	}
 
 	log.Debugf("Found existing PR for branch %s: %s", headBranch, prs[0].URL)
 	return prs[0].URL, nil
+}
+
+func remoteBranchExists(branchName string) (bool, error) {
+	ref := "refs/heads/" + branchName
+	cmd := exec.Command("git", "ls-remote", "--heads", "origin", ref)
+	output, err := cmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return false, fmt.Errorf("%w: %s", err, string(exitErr.Stderr))
+		}
+		return false, err
+	}
+	return strings.TrimSpace(string(output)) != "", nil
 }
 
 // createCIPR creates a pull request for CI using the GitHub CLI

--- a/tools/ods/cmd/run_ci_metadata_test.go
+++ b/tools/ods/cmd/run_ci_metadata_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildRunCIPRMetadataForEdits(t *testing.T) {
+	prInfo := &PRInfo{
+		Number:      1234,
+		Title:       "feat: add useful feature",
+		Body:        "Contributor-provided context.",
+		HeadRefName: "feat/useful-feature",
+	}
+
+	metadata := buildRunCIPRMetadata(prInfo, true)
+
+	if metadata.Branch != "feat/useful-feature-pr-1234-edits" {
+		t.Errorf("unexpected branch: %s", metadata.Branch)
+	}
+	if metadata.Title != "feat: add useful feature [edit of #1234]" {
+		t.Errorf("unexpected title: %s", metadata.Title)
+	}
+	expectedBodyParts := []string{
+		"This PR supersedes #1234.",
+		"Merge this PR and close #1234 without merging.",
+		"## Original PR description",
+		prInfo.Body,
+		cherryPickOption,
+		linearCheckOverride,
+	}
+	for _, expected := range expectedBodyParts {
+		if !strings.Contains(metadata.Body, expected) {
+			t.Errorf("expected body to contain %q, got:\n%s", expected, metadata.Body)
+		}
+	}
+}
+
+func TestBuildEditableBranchName(t *testing.T) {
+	tests := []struct {
+		name           string
+		originalBranch string
+		expectedBranch string
+	}{
+		{
+			name:           "preserves expected prefix",
+			originalBranch: "refactor/simplify-indexing",
+			expectedBranch: "refactor/simplify-indexing-pr-1234-edits",
+		},
+		{
+			name:           "defaults to chore prefix",
+			originalBranch: "simplify-indexing",
+			expectedBranch: "chore/simplify-indexing-pr-1234-edits",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			prInfo := &PRInfo{Number: 1234, HeadRefName: test.originalBranch}
+			if branch := buildEditableBranchName(prInfo); branch != test.expectedBranch {
+				t.Errorf("expected branch %q, got %q", test.expectedBranch, branch)
+			}
+		})
+	}
+}
+
+func TestBuildRunCIPRMetadataForEditsPreservesCherryPickSelection(t *testing.T) {
+	originalOption := "- [x] [Optional] " + cherryPickOptionText
+	prInfo := &PRInfo{
+		Number:      1234,
+		Title:       "fix: example",
+		Body:        originalOption,
+		HeadRefName: "fix/example",
+	}
+
+	metadata := buildRunCIPRMetadata(prInfo, true)
+
+	if strings.Count(metadata.Body, cherryPickOptionText) != 1 {
+		t.Errorf("expected original cherry-pick option exactly once, got:\n%s", metadata.Body)
+	}
+	if !strings.Contains(metadata.Body, originalOption) {
+		t.Errorf("expected checked cherry-pick option to be preserved, got:\n%s", metadata.Body)
+	}
+}
+
+func TestBuildRunCIPRMetadataForEditsOmitsEmptyOriginalBody(t *testing.T) {
+	metadata := buildRunCIPRMetadata(
+		&PRInfo{Number: 1234, Title: "fix: example", HeadRefName: "fix/example"},
+		true,
+	)
+
+	if strings.Contains(metadata.Body, "Original PR description") {
+		t.Errorf("empty original description should be omitted, got:\n%s", metadata.Body)
+	}
+}
+
+func TestBuildRunCIPRMetadataForCI(t *testing.T) {
+	metadata := buildRunCIPRMetadata(&PRInfo{Number: 1234}, false)
+
+	if metadata.Branch != "run-ci/1234" {
+		t.Errorf("unexpected branch: %s", metadata.Branch)
+	}
+	if metadata.Title != "chore: [Running GitHub actions for #1234]" {
+		t.Errorf("unexpected title: %s", metadata.Title)
+	}
+	if !strings.Contains(metadata.Body, "closed (not merged)") {
+		t.Errorf("CI-only PR body should say not to merge it, got:\n%s", metadata.Body)
+	}
+}
+
+func TestRunCIRejectsForEditsWithRerun(t *testing.T) {
+	command := NewRunCICommand()
+	if err := command.ParseFlags([]string{"--for-edits", "--rerun"}); err != nil {
+		t.Fatalf("failed to parse flags: %v", err)
+	}
+
+	err := command.Args(command, []string{"1234"})
+	if err == nil || !strings.Contains(err.Error(), "would discard edits") {
+		t.Fatalf("expected incompatible flags error, got: %v", err)
+	}
+}

--- a/tools/ods/cmd/run_ci_metadata_test.go
+++ b/tools/ods/cmd/run_ci_metadata_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestBuildRunCIPRMetadataForEdits(t *testing.T) {
@@ -64,6 +65,47 @@ func TestBuildEditableBranchName(t *testing.T) {
 	}
 }
 
+func TestBuildEditableBranchNameBoundsLastComponent(t *testing.T) {
+	longComponent := strings.Repeat("界", 85)
+	prInfo := &PRInfo{
+		Number:      1234,
+		HeadRefName: fixBranchPrefix + longComponent,
+	}
+
+	branch := buildEditableBranchName(prInfo)
+	component := strings.TrimPrefix(branch, fixBranchPrefix)
+
+	if len(component) > gitRefComponentMaxBytes {
+		t.Errorf("component exceeds %d bytes: %d", gitRefComponentMaxBytes, len(component))
+	}
+	if !utf8.ValidString(component) {
+		t.Errorf("branch component is not valid UTF-8: %q", component)
+	}
+	if !strings.HasSuffix(component, "-pr-1234-edits") {
+		t.Errorf("branch component is missing edit suffix: %q", component)
+	}
+}
+
+func TestBuildEditablePRTitleBoundsLength(t *testing.T) {
+	prInfo := &PRInfo{
+		Number: 1234,
+		Title:  strings.Repeat("界", githubPRTitleMaxRunes),
+	}
+
+	title := buildEditablePRTitle(prInfo)
+
+	if utf8.RuneCountInString(title) != githubPRTitleMaxRunes {
+		t.Errorf(
+			"expected %d-rune title, got %d",
+			githubPRTitleMaxRunes,
+			utf8.RuneCountInString(title),
+		)
+	}
+	if !strings.HasSuffix(title, " [edit of #1234]") {
+		t.Errorf("title is missing edit suffix: %q", title)
+	}
+}
+
 func TestBuildRunCIPRMetadataForEditsPreservesCherryPickSelection(t *testing.T) {
 	originalOption := "- [x] [Optional] " + cherryPickOptionText
 	prInfo := &PRInfo{
@@ -80,6 +122,21 @@ func TestBuildRunCIPRMetadataForEditsPreservesCherryPickSelection(t *testing.T) 
 	}
 	if !strings.Contains(metadata.Body, originalOption) {
 		t.Errorf("expected checked cherry-pick option to be preserved, got:\n%s", metadata.Body)
+	}
+}
+
+func TestBuildRunCIPRMetadataForEditsIgnoresCherryPickTextInProse(t *testing.T) {
+	prInfo := &PRInfo{
+		Number:      1234,
+		Title:       "fix: example",
+		Body:        "Use the checkbox if you want us to Please cherry-pick this PR to the latest release version.",
+		HeadRefName: "fix/example",
+	}
+
+	metadata := buildRunCIPRMetadata(prInfo, true)
+
+	if !strings.Contains(metadata.Body, cherryPickOption) {
+		t.Errorf("expected cherry-pick checkbox to be added, got:\n%s", metadata.Body)
 	}
 }
 


### PR DESCRIPTION
## Description

Adds --for-edits as an option to `ods run-ci`, which just makes some cosmetic edits to the PR produced that make it better for contributor PRs where the Onyx Eng wants to make edits. I was doing these steps manually so this will save me some time going forwards.

## How Has This Been Tested?

tested on a PR: TBD

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--for-edits` option to `ods run-ci` that creates a replacement PR meant for editing and merging, removing the manual setup steps.

**New Features**
- `--for-edits` derives the replacement branch from the contributor's branch, preserves `feat/`, `fix/`, `refactor/`, and `chore/` prefixes (adding `chore/` otherwise), and appends `-pr-<num>-edits`; long final path components are truncated within git ref and UTF-8 limits.
- The title appends `[edit of #<num>]` and stays within GitHub's 256-rune limit.
- The body says to merge the replacement PR and close the original without merging, includes the original description when present, and preserves an existing cherry-pick checkbox or adds the default checkbox plus `- [x] Override Linear Check`.
- `--for-edits` cannot be combined with `--rerun`, and creation is refused if the replacement PR or remote branch already exists.
- README and CLI help are updated; tests cover the editable workflow end to end, metadata, naming bounds, cherry-pick handling, empty bodies, and flag validation.

<sup>Written for commit 6bf7a94bea830cc55ef336388905bbc1a1e99946. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13363?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

