### PR TITLE
feat(auth): per-provider PKCE and scope overrides on SSO provider rows

### DIFF
--- a/backend/onyx/auth/sso_web_error.py
+++ b/backend/onyx/auth/sso_web_error.py
@@ -18,7 +18,7 @@ from fastapi.responses import RedirectResponse
 from starlette.responses import Response
 
 from onyx.configs.app_configs import WEB_DOMAIN
-from onyx.error_handling.exceptions import OnyxError
+from onyx.error_handling.exceptions import OnyxError, clear_marked_cookie
 
 
 def redirect_sso_errors_to_web(
@@ -41,9 +41,12 @@ def redirect_sso_errors_to_web(
                 raise
             detail = error.detail
             detail_str = detail.value if isinstance(detail, enum.Enum) else str(detail)
-            return RedirectResponse(
+            response = RedirectResponse(
                 f"{WEB_DOMAIN}/auth/error?error={quote(detail_str)}",
                 status_code=302,
             )
+            if isinstance(request, Request):
+                clear_marked_cookie(request, response)
+            return response
 
     return wrapper

--- a/backend/onyx/auth/sso_web_error.py
+++ b/backend/onyx/auth/sso_web_error.py
@@ -1,52 +1,82 @@
-"""Render SSO callback failures as a readable page for browsers.
+"""Render SSO callback failures for browsers and drop the flow's PKCE cookie.
 
 Non-legacy OIDC provider rows and all SAML callbacks terminate directly in
 FastAPI (no Next.js wrapper), so an ``OnyxError`` from those handlers would
 reach the browser as raw JSON. This decorator converts it into a redirect to
 the ``/auth/error`` page for browser navigations, while non-browser callers
-(mobile, API, tests) still get the JSON error via content negotiation.
+(mobile, API, tests) get the standard JSON error. Either way the flow's
+single-use PKCE cookie is deleted with the error response.
 """
 
 import enum
 import functools
-from collections.abc import Awaitable, Callable
-from typing import Any
+from collections.abc import Awaitable, Callable, Coroutine
+from typing import Any, ParamSpec
 from urllib.parse import quote
 
 from fastapi import Request
 from fastapi.responses import RedirectResponse
 from starlette.responses import Response
 
+from onyx.auth.users import get_pkce_cookie_name
 from onyx.configs.app_configs import WEB_DOMAIN
-from onyx.error_handling.exceptions import OnyxError, clear_marked_cookie
+from onyx.error_handling.exceptions import (
+    OnyxError,
+    log_onyx_error,
+    onyx_error_to_json_response,
+)
+
+_COOKIE_SECURE = WEB_DOMAIN.startswith("https")
+
+
+def delete_pkce_cookie(response: Response, state: str) -> None:
+    """Path must match the set-cookie or browsers treat the delete as a
+    different cookie and keep the original."""
+    response.delete_cookie(
+        key=get_pkce_cookie_name(state),
+        path="/",
+        secure=_COOKIE_SECURE,
+        httponly=True,
+        samesite="lax",
+    )
+
+
+def _delete_flow_pkce_cookie(request: Request, response: Response) -> None:
+    state = request.query_params.get("state")
+    if state and request.cookies.get(get_pkce_cookie_name(state)) is not None:
+        delete_pkce_cookie(response, state)
+
+
+_P = ParamSpec("_P")
 
 
 def redirect_sso_errors_to_web(
-    handler: Callable[..., Awaitable[Response]],
-) -> Callable[..., Awaitable[Response]]:
+    handler: Callable[_P, Awaitable[Response]],
+) -> Callable[_P, Coroutine[Any, Any, Response]]:
     @functools.wraps(handler)
-    async def wrapper(*args: Any, **kwargs: Any) -> Response:
+    async def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> Response:
         try:
             return await handler(*args, **kwargs)
         except OnyxError as error:
             request = kwargs.get("request")
-            accept = (
-                request.headers.get("accept", "")
-                if isinstance(request, Request)
-                else ""
-            )
+            if not isinstance(request, Request):
+                raise
+            log_onyx_error(error)
+            accept = request.headers.get("accept", "")
             # Only browser navigations get the page. Mobile and API clients keep
             # the JSON error they can parse.
-            if "text/html" not in accept.lower():
-                raise
-            detail = error.detail
-            detail_str = detail.value if isinstance(detail, enum.Enum) else str(detail)
-            response = RedirectResponse(
-                f"{WEB_DOMAIN}/auth/error?error={quote(detail_str)}",
-                status_code=302,
-            )
-            if isinstance(request, Request):
-                clear_marked_cookie(request, response)
+            if "text/html" in accept.lower():
+                detail = error.detail
+                detail_str = (
+                    detail.value if isinstance(detail, enum.Enum) else str(detail)
+                )
+                response: Response = RedirectResponse(
+                    f"{WEB_DOMAIN}/auth/error?error={quote(detail_str)}",
+                    status_code=302,
+                )
+            else:
+                response = onyx_error_to_json_response(error)
+            _delete_flow_pkce_cookie(request, response)
             return response
 
     return wrapper

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -2309,7 +2309,7 @@ class OAuth2AuthorizeResponse(BaseModel):
 
 
 def generate_state_token(
-    data: Dict[str, str],
+    data: Dict[str, Any],
     secret: SecretType,
     lifetime_seconds: int = STATE_TOKEN_LIFETIME_SECONDS,
 ) -> str:
@@ -2344,7 +2344,7 @@ def decode_and_validate_oauth_state(
     state_secret: SecretType,
     csrf_token_cookie_name: str = CSRF_TOKEN_COOKIE_NAME,
     expected_provider_name: str | None = None,
-) -> Dict[str, str]:
+) -> Dict[str, Any]:
     """Decode the signed OAuth state and enforce the CSRF double-submit.
     Optionally bind the flow to a provider so a state minted for one provider
     cannot be replayed on another provider's callback."""

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -29,19 +29,26 @@ class _ProviderConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
-class GoogleProviderConfig(_ProviderConfig):
+class _OAuth2ProviderConfig(_ProviderConfig):
     client_id: str
     client_secret: str
     # Rows migrated from single-provider env config keep the redirect URI the
     # customer's IdP client already allowlists.
     legacy_callback: bool = False
+    # PKCE for this provider's login flow. The deployment-wide env flag can
+    # still force it on while that flag exists.
+    pkce_enabled: bool = False
+    # OAuth scopes requested at login. Empty falls back to the env override,
+    # then the built-in defaults.
+    scopes: list[str] = []
 
 
-class OIDCProviderConfig(_ProviderConfig):
-    client_id: str
-    client_secret: str
+class GoogleProviderConfig(_OAuth2ProviderConfig):
+    pass
+
+
+class OIDCProviderConfig(_OAuth2ProviderConfig):
     openid_config_url: str
-    legacy_callback: bool = False
     # Strict opt-in: reject sign-ins when userinfo omits the optional
     # email_verified claim (some IdPs, e.g. Microsoft Entra ID, omit it).
     # Any present value other than true is rejected regardless.

--- a/backend/onyx/db/sso_provider.py
+++ b/backend/onyx/db/sso_provider.py
@@ -4,7 +4,7 @@ import re
 from pathlib import Path
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +13,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import SAML_CONF_DIR, VALID_EMAIL_DOMAINS
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
+from onyx.utils.encryption import mask_string
 from onyx.utils.logger import setup_logger
 from shared_configs.configs import MULTI_TENANT
 
@@ -31,7 +32,7 @@ class _ProviderConfig(BaseModel):
 
 class _OAuth2ProviderConfig(_ProviderConfig):
     client_id: str
-    client_secret: str
+    client_secret: str = Field(json_schema_extra={"secret": True})
     # Rows migrated from single-provider env config keep the redirect URI the
     # customer's IdP client already allowlists.
     legacy_callback: bool = False
@@ -66,7 +67,7 @@ class SAMLProviderConfig(_ProviderConfig):
     # SP signing material, only needed when the deployment signs AuthnRequests
     # or decrypts assertions. Held in the encrypted config blob.
     sp_x509_cert: str | None = None
-    sp_private_key: str | None = None
+    sp_private_key: str | None = Field(default=None, json_schema_extra={"secret": True})
     # IdP attribute the email is read from. None falls back to the common keys
     # (email, mail, the Entra/ADFS claim URIs) the SAML callback already tries.
     email_attribute: str | None = None
@@ -78,6 +79,34 @@ _CONFIG_MODEL_BY_TYPE: dict[SSOProviderType, type[_ProviderConfig]] = {
     SSOProviderType.OIDC: OIDCProviderConfig,
     SSOProviderType.SAML: SAMLProviderConfig,
 }
+
+
+def secret_config_keys(provider_type: SSOProviderType) -> frozenset[str]:
+    """Config fields marked secret on the provider type's config model."""
+    model = _CONFIG_MODEL_BY_TYPE[provider_type]
+    return frozenset(
+        name
+        for name, field in model.model_fields.items()
+        if isinstance(field.json_schema_extra, dict)
+        and field.json_schema_extra.get("secret")
+    )
+
+
+def mask_secret_config_values(
+    provider_type: SSOProviderType, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Admin-response view of a config: secret fields masked, everything else
+    readable. Non-secret values (client IDs, IdP URLs) are public identifiers
+    an admin must be able to read back to verify a provider's setup."""
+    secret_keys = secret_config_keys(provider_type)
+    return {
+        key: (
+            mask_string(value)
+            if key in secret_keys and isinstance(value, str) and value
+            else value
+        )
+        for key, value in config.items()
+    }
 
 
 def validate_sso_config(

--- a/backend/onyx/error_handling/exceptions.py
+++ b/backend/onyx/error_handling/exceptions.py
@@ -23,12 +23,37 @@ use ``status_code_override``::
 """
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, PlainTextResponse, Response
 
+from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+# Routes that set a single-use cookie (e.g. the OIDC PKCE verifier) mark the
+# request with the cookie's name so any error response, whichever handler
+# builds it, deletes the cookie instead of leaving it until expiry. The marker
+# carries the computed name, keeping auth knowledge out of this module.
+CLEANUP_COOKIE_STATE_ATTR = "onyx_cleanup_cookie_name"
+
+_COOKIE_SECURE = WEB_DOMAIN.startswith("https")
+
+
+def clear_marked_cookie(request: Request, response: Response) -> None:
+    """Delete the request's marked single-use cookie on an error response.
+    Path must match the set-cookie or browsers treat it as a different
+    cookie and keep the original."""
+    cookie_name = getattr(request.state, CLEANUP_COOKIE_STATE_ATTR, None)
+    if not cookie_name or request.cookies.get(cookie_name) is None:
+        return
+    response.delete_cookie(
+        key=cookie_name,
+        path="/",
+        secure=_COOKIE_SECURE,
+        httponly=True,
+        samesite="lax",
+    )
 
 
 class OnyxError(Exception):
@@ -94,8 +119,22 @@ def register_onyx_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(OnyxError)
     async def _handle_onyx_error(
-        request: Request,  # noqa: ARG001
+        request: Request,
         exc: OnyxError,
     ) -> JSONResponse:
         log_onyx_error(exc)
-        return onyx_error_to_json_response(exc)
+        response = onyx_error_to_json_response(exc)
+        clear_marked_cookie(request, response)
+        return response
+
+    # Starlette re-raises the exception after this response is sent, so
+    # logging and error tracking still see unhandled errors. The plain 500
+    # matches the default ServerErrorMiddleware body.
+    @app.exception_handler(Exception)
+    async def _handle_unhandled_error(
+        request: Request,
+        exc: Exception,  # noqa: ARG001
+    ) -> Response:
+        response = PlainTextResponse("Internal Server Error", status_code=500)
+        clear_marked_cookie(request, response)
+        return response

--- a/backend/onyx/error_handling/exceptions.py
+++ b/backend/onyx/error_handling/exceptions.py
@@ -23,37 +23,12 @@ use ``status_code_override``::
 """
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, PlainTextResponse, Response
+from fastapi.responses import JSONResponse
 
-from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-# Routes that set a single-use cookie (e.g. the OIDC PKCE verifier) mark the
-# request with the cookie's name so any error response, whichever handler
-# builds it, deletes the cookie instead of leaving it until expiry. The marker
-# carries the computed name, keeping auth knowledge out of this module.
-CLEANUP_COOKIE_STATE_ATTR = "onyx_cleanup_cookie_name"
-
-_COOKIE_SECURE = WEB_DOMAIN.startswith("https")
-
-
-def clear_marked_cookie(request: Request, response: Response) -> None:
-    """Delete the request's marked single-use cookie on an error response.
-    Path must match the set-cookie or browsers treat it as a different
-    cookie and keep the original."""
-    cookie_name = getattr(request.state, CLEANUP_COOKIE_STATE_ATTR, None)
-    if not cookie_name or request.cookies.get(cookie_name) is None:
-        return
-    response.delete_cookie(
-        key=cookie_name,
-        path="/",
-        secure=_COOKIE_SECURE,
-        httponly=True,
-        samesite="lax",
-    )
 
 
 class OnyxError(Exception):
@@ -119,22 +94,8 @@ def register_onyx_exception_handlers(app: FastAPI) -> None:
 
     @app.exception_handler(OnyxError)
     async def _handle_onyx_error(
-        request: Request,
+        request: Request,  # noqa: ARG001
         exc: OnyxError,
     ) -> JSONResponse:
         log_onyx_error(exc)
-        response = onyx_error_to_json_response(exc)
-        clear_marked_cookie(request, response)
-        return response
-
-    # Starlette re-raises the exception after this response is sent, so
-    # logging and error tracking still see unhandled errors. The plain 500
-    # matches the default ServerErrorMiddleware body.
-    @app.exception_handler(Exception)
-    async def _handle_unhandled_error(
-        request: Request,
-        exc: Exception,  # noqa: ARG001
-    ) -> Response:
-        response = PlainTextResponse("Internal Server Error", status_code=500)
-        clear_marked_cookie(request, response)
-        return response
+        return onyx_error_to_json_response(exc)

--- a/backend/onyx/server/manage/sso/models.py
+++ b/backend/onyx/server/manage/sso/models.py
@@ -39,8 +39,8 @@ class SSOProviderResponse(BaseModel):
 
     @classmethod
     def from_model(cls, provider: SSOProvider, web_domain: str) -> SSOProviderResponse:
-        # Only secret fields are masked, so client IDs and IdP URLs read back
-        # real and the displayed URI always matches what the flow sends.
+        # Only secrets are masked, so the URI computed below matches what the
+        # flow sends.
         config = (
             mask_secret_config_values(
                 provider.provider_type, provider.config.get_value(apply_mask=False)

--- a/backend/onyx/server/manage/sso/models.py
+++ b/backend/onyx/server/manage/sso/models.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 
 from onyx.db.enums import SSOProviderType
 from onyx.db.models import SSOProvider
-from onyx.db.sso_provider import sso_login_callback_uri
+from onyx.db.sso_provider import mask_secret_config_values, sso_login_callback_uri
 
 
 class SSOProviderCreateRequest(BaseModel):
@@ -39,9 +39,15 @@ class SSOProviderResponse(BaseModel):
 
     @classmethod
     def from_model(cls, provider: SSOProvider, web_domain: str) -> SSOProviderResponse:
-        config = provider.config.get_value(apply_mask=True) if provider.config else {}
-        # Masking leaves booleans untouched, so legacy_callback is readable and
-        # the displayed URI always matches what the flow sends.
+        # Only secret fields are masked, so client IDs and IdP URLs read back
+        # real and the displayed URI always matches what the flow sends.
+        config = (
+            mask_secret_config_values(
+                provider.provider_type, provider.config.get_value(apply_mask=False)
+            )
+            if provider.config
+            else {}
+        )
         redirect_uri = sso_login_callback_uri(provider, config, web_domain)
 
         return cls(

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -54,7 +54,7 @@ from onyx.db.sso_provider import (
     validate_sso_config,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import OnyxError
+from onyx.error_handling.exceptions import CLEANUP_COOKIE_STATE_ATTR, OnyxError
 from onyx.utils.url import sanitize_next_url
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -97,11 +97,18 @@ def _resolve_oidc_provider(
     return provider, config
 
 
+def _pkce_enabled(config: dict[str, Any]) -> bool:
+    """PKCE is on when the provider row enables it. The deployment-wide env
+    flag can still force it on while that flag exists."""
+    return bool(config.get("pkce_enabled")) or OIDC_PKCE_ENABLED
+
+
 def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
     if provider.provider_type is SSOProviderType.OIDC:
-        # Env override lets deployments request extra API scopes (e.g. MS Graph
-        # User.Read for claims capture). offline_access secures refresh tokens.
-        scopes = list(OIDC_SCOPE_OVERRIDE or BASE_SCOPES)
+        # Scope overrides let providers request extra API scopes (e.g. MS Graph
+        # User.Read for claims capture): the row's scopes win, then the env
+        # override while it exists. offline_access secures refresh tokens.
+        scopes = list(config.get("scopes") or OIDC_SCOPE_OVERRIDE or BASE_SCOPES)
         if "offline_access" not in scopes:
             scopes.append("offline_access")
         return VerifiedEmailOpenID(
@@ -116,7 +123,11 @@ def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[A
         return GoogleOAuth2(
             config["client_id"],
             config["client_secret"],
-            scopes=list(GOOGLE_OAUTH_SCOPE_OVERRIDE or GOOGLE_LOGIN_BASE_SCOPES),
+            scopes=list(
+                config.get("scopes")
+                or GOOGLE_OAUTH_SCOPE_OVERRIDE
+                or GOOGLE_LOGIN_BASE_SCOPES
+            ),
             name=provider.name,
         )
 
@@ -195,10 +206,14 @@ async def oidc_login_for_provider(
     redirect_uri = _callback_uri(provider, config)
     next_url = sanitize_next_url(request.query_params.get("next"))
     csrf_token = generate_csrf_token()
+    use_pkce = _pkce_enabled(config)
     state = generate_state_token(
         {
             "next_url": next_url,
             "provider_name": provider_name,
+            # Pins this flow's PKCE mode, so a provider edit mid-login cannot
+            # make the callback disagree with the authorization request.
+            "pkce": use_pkce,
             CSRF_TOKEN_KEY: csrf_token,
         },
         USER_AUTH_SECRET,
@@ -209,7 +224,7 @@ async def oidc_login_for_provider(
         extras = {"access_type": "offline", "prompt": "consent"}
 
     code_verifier: str | None = None
-    if OIDC_PKCE_ENABLED:
+    if use_pkce:
         code_verifier, code_challenge = generate_pkce_pair()
         authorization_url = await client.get_authorization_url(
             redirect_uri,
@@ -263,6 +278,9 @@ async def oidc_login_callback(
             OnyxErrorCode.VALIDATION_ERROR,
             "Missing state parameter in OAuth callback",
         )
+    # Marked before decode so even a state-validation failure deletes the
+    # flow's single-use PKCE verifier cookie.
+    setattr(request.state, CLEANUP_COOKIE_STATE_ATTR, get_pkce_cookie_name(state))
     state_data = decode_and_validate_oauth_state(
         request=request,
         state_value=state,
@@ -298,6 +316,11 @@ async def oidc_login_callback_for_provider(
     strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
     user_manager: UserManager = Depends(get_user_manager),
 ) -> Response:
+    # Marked first so any failure below deletes the flow's single-use PKCE
+    # verifier cookie, whichever error handler builds the response.
+    if state is not None:
+        setattr(request.state, CLEANUP_COOKIE_STATE_ATTR, get_pkce_cookie_name(state))
+
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
     redirect_uri = _callback_uri(provider, config)
@@ -325,8 +348,13 @@ async def oidc_login_callback_for_provider(
         expected_provider_name=provider_name,
     )
 
+    # The state pins the flow's PKCE mode. States without the claim fall back
+    # to the row's current setting so logins in flight across a deploy complete.
+    use_pkce = (
+        bool(state_data["pkce"]) if "pkce" in state_data else _pkce_enabled(config)
+    )
     code_verifier: str | None = None
-    if OIDC_PKCE_ENABLED:
+    if use_pkce:
         code_verifier = request.cookies.get(get_pkce_cookie_name(state))
         if not code_verifier:
             raise OnyxError(
@@ -355,7 +383,7 @@ async def oidc_login_callback_for_provider(
         allowed_email_domains_override=provider.allowed_email_domains,
     )
 
-    if OIDC_PKCE_ENABLED:
+    if use_pkce:
         _delete_pkce_cookie(redirect_response, state)
 
     return redirect_response

--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -21,7 +21,7 @@ from httpx_oauth.oauth2 import BaseOAuth2, GetAccessTokenError
 from sqlalchemy.orm import Session
 
 from onyx.auth.oidc_client import VerifiedEmailOpenID
-from onyx.auth.sso_web_error import redirect_sso_errors_to_web
+from onyx.auth.sso_web_error import delete_pkce_cookie, redirect_sso_errors_to_web
 from onyx.auth.users import (
     CSRF_TOKEN_COOKIE_NAME,
     CSRF_TOKEN_KEY,
@@ -54,7 +54,7 @@ from onyx.db.sso_provider import (
     validate_sso_config,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
-from onyx.error_handling.exceptions import CLEANUP_COOKIE_STATE_ATTR, OnyxError
+from onyx.error_handling.exceptions import OnyxError
 from onyx.utils.url import sanitize_next_url
 from shared_configs.contextvars import get_current_tenant_id
 
@@ -178,16 +178,6 @@ def _set_oauth_cookie(
     )
 
 
-def _delete_pkce_cookie(response: Response, state: str) -> None:
-    response.delete_cookie(
-        key=get_pkce_cookie_name(state),
-        path="/",
-        secure=_COOKIE_SECURE,
-        httponly=True,
-        samesite="lax",
-    )
-
-
 def _callback_uri(provider: SSOProvider, config: dict[str, Any]) -> str:
     # Legacy-callback rows land on the web wrappers at the legacy paths, which
     # forward to this router. The fixed /callback below resolves the row from
@@ -261,6 +251,7 @@ async def oidc_login_for_provider(
 
 
 @router.get("/callback")
+@redirect_sso_errors_to_web
 async def oidc_login_callback(
     request: Request,
     code: str | None = None,
@@ -278,9 +269,6 @@ async def oidc_login_callback(
             OnyxErrorCode.VALIDATION_ERROR,
             "Missing state parameter in OAuth callback",
         )
-    # Marked before decode so even a state-validation failure deletes the
-    # flow's single-use PKCE verifier cookie.
-    setattr(request.state, CLEANUP_COOKIE_STATE_ATTR, get_pkce_cookie_name(state))
     state_data = decode_and_validate_oauth_state(
         request=request,
         state_value=state,
@@ -316,11 +304,6 @@ async def oidc_login_callback_for_provider(
     strategy: Strategy[User, uuid.UUID] = Depends(auth_backend.get_strategy),
     user_manager: UserManager = Depends(get_user_manager),
 ) -> Response:
-    # Marked first so any failure below deletes the flow's single-use PKCE
-    # verifier cookie, whichever error handler builds the response.
-    if state is not None:
-        setattr(request.state, CLEANUP_COOKIE_STATE_ATTR, get_pkce_cookie_name(state))
-
     provider, config = _resolve_oidc_provider(db_session, provider_name)
     client = await _get_oauth_client(provider, config)
     redirect_uri = _callback_uri(provider, config)
@@ -384,6 +367,6 @@ async def oidc_login_callback_for_provider(
     )
 
     if use_pkce:
-        _delete_pkce_cookie(redirect_response, state)
+        delete_pkce_cookie(redirect_response, state)
 
     return redirect_response

--- a/backend/onyx/utils/encryption.py
+++ b/backend/onyx/utils/encryption.py
@@ -151,19 +151,21 @@ MASK_CREDENTIALS_WHITELIST = {
     "wiki_base",
     "cloud_name",
     "cloud_id",
+    # OAuth scope lists are public identifiers, not secrets, and masked list
+    # items cannot round-trip through a chip editor.
+    "scopes",
 }
 
 
 def mask_credential_dict(credential_dict: dict[str, Any]) -> dict[str, Any]:
     masked_creds: dict[str, Any] = {}
     for key, val in credential_dict.items():
-        if isinstance(val, str):
-            # we want to pass the authentication_method field through so the frontend
-            # can disambiguate credentials created by different methods
-            if key in MASK_CREDENTIALS_WHITELIST:
-                masked_creds[key] = val
-            else:
-                masked_creds[key] = mask_string(val)
+        # Whitelisted keys pass through whole (e.g. authentication_method so
+        # the frontend can disambiguate credential kinds) whatever their type.
+        if key in MASK_CREDENTIALS_WHITELIST:
+            masked_creds[key] = val
+        elif isinstance(val, str):
+            masked_creds[key] = mask_string(val)
         elif isinstance(val, dict):
             masked_creds[key] = mask_credential_dict(val)
         elif isinstance(val, list):

--- a/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
+++ b/backend/tests/external_dependency_unit/auth/test_sso_admin_api.py
@@ -150,6 +150,13 @@ def test_sso_provider_crud_masks_and_restores_secrets(
     assert masked_secret != original_secret
     assert is_masked_credential(masked_secret) is True
 
+    # Non-secret fields read back real so an admin can verify the setup.
+    assert created_provider["config"]["client_id"] == "client-id"
+    assert (
+        created_provider["config"]["openid_config_url"]
+        == "https://idp.example.com/.well-known/openid-configuration"
+    )
+
     provider_id = created_provider["id"]
     provider_names.append(name)
 
@@ -286,6 +293,8 @@ def test_create_saml_provider(
     # AuthnRequest advertises this exact URL).
     assert body["redirect_uri"] == f"{WEB_DOMAIN}/auth/saml/callback"
     assert is_masked_credential(body["config"]["sp_private_key"]) is True
+    assert body["config"]["idp_sso_url"] == "https://idp.example.com/sso"
+    assert body["config"]["idp_x509_cert"] == "MIIDsamplecertvalue"
 
     raw = _stored_config(db_session, body["id"])
     assert raw["idp_entity_id"] == "https://idp.example.com/entity"

--- a/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
+++ b/backend/tests/external_dependency_unit/db/test_sso_provider_store.py
@@ -68,6 +68,8 @@ def test_create_and_fetch_roundtrip(db_session: Session, provider_name: str) -> 
     assert fetched.config.get_value(apply_mask=False) == {
         **_GOOGLE_CONFIG,
         "legacy_callback": False,
+        "pkce_enabled": False,
+        "scopes": [],
     }
     assert fetched.config.get_value(apply_mask=True)["client_secret"] != "super-secret"
 
@@ -179,6 +181,8 @@ def test_partial_update_preserves_config(
     assert updated.config.get_value(apply_mask=False) == {
         **_GOOGLE_CONFIG,
         "legacy_callback": False,
+        "pkce_enabled": False,
+        "scopes": [],
     }
 
 

--- a/backend/tests/unit/onyx/auth/test_sso_web_error.py
+++ b/backend/tests/unit/onyx/auth/test_sso_web_error.py
@@ -3,6 +3,7 @@ redirect for browser navigations, while non-browser callers still receive the
 JSON error they can parse."""
 
 import enum
+from typing import Any, cast
 
 import pytest
 from fastapi import Request
@@ -14,10 +15,12 @@ from onyx.error_handling.exceptions import OnyxError
 
 
 def _request_with_accept(accept: str) -> Request:
+    # query_string is always present on real ASGI scopes.
     return Request(
         {
             "type": "http",
             "headers": [(b"accept", accept.encode())],
+            "query_string": b"",
         }
     )
 
@@ -71,3 +74,75 @@ async def test_enum_detail_uses_value_in_url() -> None:
     resp = await _enum_handler(request=_request_with_accept("text/html"))
     assert isinstance(resp, RedirectResponse)
     assert "error=SAMPLE_CODE" in resp.headers["location"]
+
+
+def _browser_request_with_marked_cookie(cookie_name: str) -> Request:
+    from onyx.error_handling.exceptions import CLEANUP_COOKIE_STATE_ATTR
+
+    request = Request(
+        {
+            "type": "http",
+            "headers": [
+                (b"accept", b"text/html"),
+                (b"cookie", f"{cookie_name}=verifier".encode()),
+            ],
+            "query_string": b"",
+        }
+    )
+    setattr(request.state, CLEANUP_COOKIE_STATE_ATTR, cookie_name)
+    return request
+
+
+@pytest.mark.asyncio
+async def test_error_redirect_clears_marked_cookie() -> None:
+    resp = await _handler(
+        request=_browser_request_with_marked_cookie("onyx_pkce_abc123"),
+        raise_error=True,
+    )
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "onyx_pkce_abc123" in set_cookie
+    assert "Max-Age=0" in set_cookie or "expires" in set_cookie.lower()
+
+
+@pytest.mark.asyncio
+async def test_error_redirect_without_pkce_cookie_sets_nothing() -> None:
+    resp = await _handler(
+        request=_request_with_accept("text/html"),
+        raise_error=True,
+    )
+    assert "set-cookie" not in resp.headers
+
+
+@pytest.mark.asyncio
+async def test_onyx_error_json_handler_clears_marked_cookie() -> None:
+    # JSON clients get the cleanup from the global handler, not the decorator.
+    from fastapi import FastAPI
+
+    from onyx.error_handling.error_codes import OnyxErrorCode
+    from onyx.error_handling.exceptions import register_onyx_exception_handlers
+
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    handler = cast(Any, app.exception_handlers[OnyxError])
+
+    request = _browser_request_with_marked_cookie("onyx_pkce_json")
+    resp = await handler(request, OnyxError(OnyxErrorCode.UNAUTHORIZED, "nope"))
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "onyx_pkce_json" in set_cookie
+
+
+@pytest.mark.asyncio
+async def test_unhandled_error_handler_clears_marked_cookie() -> None:
+    from fastapi import FastAPI
+
+    from onyx.error_handling.exceptions import register_onyx_exception_handlers
+
+    app = FastAPI()
+    register_onyx_exception_handlers(app)
+    handler = cast(Any, app.exception_handlers[Exception])
+
+    request = _browser_request_with_marked_cookie("onyx_pkce_boom")
+    resp = await handler(request, RuntimeError("boom"))
+    assert resp.status_code == 500
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert "onyx_pkce_boom" in set_cookie

--- a/backend/tests/unit/onyx/auth/test_sso_web_error.py
+++ b/backend/tests/unit/onyx/auth/test_sso_web_error.py
@@ -1,26 +1,40 @@
 """The SSO web-error decorator turns OnyxError into a readable /auth/error
-redirect for browser navigations, while non-browser callers still receive the
-JSON error they can parse."""
+redirect for browser navigations, serves the standard JSON error to other
+callers, and deletes the flow's single-use PKCE cookie either way."""
 
 import enum
-from typing import Any, cast
+import json
+from typing import Any
 
 import pytest
 from fastapi import Request
 from fastapi.responses import RedirectResponse
 
 from onyx.auth.sso_web_error import redirect_sso_errors_to_web
+from onyx.auth.users import get_pkce_cookie_name
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 
 
-def _request_with_accept(accept: str) -> Request:
+def _request(
+    accept: str, query_string: bytes = b"", cookie: str | None = None
+) -> Request:
+    headers = [(b"accept", accept.encode())]
+    if cookie:
+        headers.append((b"cookie", cookie.encode()))
     # query_string is always present on real ASGI scopes.
+    return Request({"type": "http", "headers": headers, "query_string": query_string})
+
+
+def _request_with_pkce_cookie(accept: str, state: str) -> Request:
     return Request(
         {
             "type": "http",
-            "headers": [(b"accept", accept.encode())],
-            "query_string": b"",
+            "headers": [
+                (b"accept", accept.encode()),
+                (b"cookie", f"{get_pkce_cookie_name(state)}=verifier".encode()),
+            ],
+            "query_string": f"state={state}".encode(),
         }
     )
 
@@ -35,7 +49,7 @@ async def _handler(*, request: Request, raise_error: bool) -> RedirectResponse: 
 @pytest.mark.asyncio
 async def test_browser_gets_redirect_to_auth_error() -> None:
     resp = await _handler(
-        request=_request_with_accept("text/html,application/xhtml+xml"),
+        request=_request("text/html,application/xhtml+xml"),
         raise_error=True,
     )
     assert isinstance(resp, RedirectResponse)
@@ -45,20 +59,27 @@ async def test_browser_gets_redirect_to_auth_error() -> None:
 
 
 @pytest.mark.asyncio
-async def test_non_browser_still_raises_for_json() -> None:
+async def test_non_browser_gets_standard_json_error() -> None:
+    resp = await _handler(request=_request("application/json"), raise_error=True)
+    assert resp.status_code == OnyxErrorCode.UNAUTHORIZED.status_code
+    body = json.loads(bytes(resp.body))
+    assert body["error_code"] == OnyxErrorCode.UNAUTHORIZED.code
+    assert body["detail"] == "invite only"
+
+
+@pytest.mark.asyncio
+async def test_no_request_kwarg_reraises() -> None:
+    @redirect_sso_errors_to_web
+    async def _no_request_handler(**_: Any) -> RedirectResponse:
+        raise OnyxError(OnyxErrorCode.UNAUTHORIZED, "nope")
+
     with pytest.raises(OnyxError):
-        await _handler(
-            request=_request_with_accept("application/json"),
-            raise_error=True,
-        )
+        await _no_request_handler()
 
 
 @pytest.mark.asyncio
 async def test_success_passes_through_untouched() -> None:
-    resp = await _handler(
-        request=_request_with_accept("text/html"),
-        raise_error=False,
-    )
+    resp = await _handler(request=_request("text/html"), raise_error=False)
     assert resp.headers["location"] == "/ok"
 
 
@@ -71,78 +92,42 @@ async def test_enum_detail_uses_value_in_url() -> None:
     async def _enum_handler(*, request: Request) -> RedirectResponse:  # noqa: ARG001
         raise OnyxError(OnyxErrorCode.VALIDATION_ERROR, _Code.SAMPLE)
 
-    resp = await _enum_handler(request=_request_with_accept("text/html"))
+    resp = await _enum_handler(request=_request("text/html"))
     assert isinstance(resp, RedirectResponse)
     assert "error=SAMPLE_CODE" in resp.headers["location"]
 
 
-def _browser_request_with_marked_cookie(cookie_name: str) -> Request:
-    from onyx.error_handling.exceptions import CLEANUP_COOKIE_STATE_ATTR
-
-    request = Request(
-        {
-            "type": "http",
-            "headers": [
-                (b"accept", b"text/html"),
-                (b"cookie", f"{cookie_name}=verifier".encode()),
-            ],
-            "query_string": b"",
-        }
-    )
-    setattr(request.state, CLEANUP_COOKIE_STATE_ATTR, cookie_name)
-    return request
-
-
 @pytest.mark.asyncio
-async def test_error_redirect_clears_marked_cookie() -> None:
+async def test_error_redirect_deletes_flow_pkce_cookie() -> None:
     resp = await _handler(
-        request=_browser_request_with_marked_cookie("onyx_pkce_abc123"),
+        request=_request_with_pkce_cookie("text/html", "abc123"),
         raise_error=True,
     )
     set_cookie = resp.headers.get("set-cookie", "")
-    assert "onyx_pkce_abc123" in set_cookie
+    assert get_pkce_cookie_name("abc123") in set_cookie
     assert "Max-Age=0" in set_cookie or "expires" in set_cookie.lower()
 
 
 @pytest.mark.asyncio
-async def test_error_redirect_without_pkce_cookie_sets_nothing() -> None:
+async def test_json_error_deletes_flow_pkce_cookie() -> None:
     resp = await _handler(
-        request=_request_with_accept("text/html"),
+        request=_request_with_pkce_cookie("application/json", "xyz789"),
         raise_error=True,
     )
+    set_cookie = resp.headers.get("set-cookie", "")
+    assert get_pkce_cookie_name("xyz789") in set_cookie
+
+
+@pytest.mark.asyncio
+async def test_error_without_state_sets_no_cookie() -> None:
+    resp = await _handler(request=_request("text/html"), raise_error=True)
     assert "set-cookie" not in resp.headers
 
 
 @pytest.mark.asyncio
-async def test_onyx_error_json_handler_clears_marked_cookie() -> None:
-    # JSON clients get the cleanup from the global handler, not the decorator.
-    from fastapi import FastAPI
-
-    from onyx.error_handling.error_codes import OnyxErrorCode
-    from onyx.error_handling.exceptions import register_onyx_exception_handlers
-
-    app = FastAPI()
-    register_onyx_exception_handlers(app)
-    handler = cast(Any, app.exception_handlers[OnyxError])
-
-    request = _browser_request_with_marked_cookie("onyx_pkce_json")
-    resp = await handler(request, OnyxError(OnyxErrorCode.UNAUTHORIZED, "nope"))
-    set_cookie = resp.headers.get("set-cookie", "")
-    assert "onyx_pkce_json" in set_cookie
-
-
-@pytest.mark.asyncio
-async def test_unhandled_error_handler_clears_marked_cookie() -> None:
-    from fastapi import FastAPI
-
-    from onyx.error_handling.exceptions import register_onyx_exception_handlers
-
-    app = FastAPI()
-    register_onyx_exception_handlers(app)
-    handler = cast(Any, app.exception_handlers[Exception])
-
-    request = _browser_request_with_marked_cookie("onyx_pkce_boom")
-    resp = await handler(request, RuntimeError("boom"))
-    assert resp.status_code == 500
-    set_cookie = resp.headers.get("set-cookie", "")
-    assert "onyx_pkce_boom" in set_cookie
+async def test_error_with_state_but_no_cookie_sets_nothing() -> None:
+    resp = await _handler(
+        request=_request("text/html", query_string=b"state=lonely"),
+        raise_error=True,
+    )
+    assert "set-cookie" not in resp.headers

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -54,6 +54,8 @@ def test_resolve_oidc_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
         **_OIDC_CONFIG,
         "legacy_callback": False,
         "require_verified_email": False,
+        "pkce_enabled": False,
+        "scopes": [],
     }
 
 
@@ -67,7 +69,12 @@ def test_resolve_google_returns_config(monkeypatch: pytest.MonkeyPatch) -> None:
         oidc_multi, "fetch_sso_provider_by_name", lambda **_kw: provider
     )
     _resolved, config = oidc_multi._resolve_oidc_provider(_DB, "google")
-    assert config == {**_GOOGLE_CONFIG, "legacy_callback": False}
+    assert config == {
+        **_GOOGLE_CONFIG,
+        "legacy_callback": False,
+        "pkce_enabled": False,
+        "scopes": [],
+    }
 
 
 def test_resolve_fail_closed_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -162,7 +169,12 @@ def test_decode_state_accepts_valid() -> None:
     state = generate_state_token(
         {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
     )
-    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
+    request = cast(
+        Any,
+        SimpleNamespace(
+            cookies={CSRF_TOKEN_COOKIE_NAME: csrf}, state=SimpleNamespace()
+        ),
+    )
     data = decode_and_validate_oauth_state(
         request=request,
         state_value=state,
@@ -193,7 +205,12 @@ def test_decode_state_rejects_wrong_provider() -> None:
     state = generate_state_token(
         {"next_url": "/", "provider_name": "okta", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET
     )
-    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
+    request = cast(
+        Any,
+        SimpleNamespace(
+            cookies={CSRF_TOKEN_COOKIE_NAME: csrf}, state=SimpleNamespace()
+        ),
+    )
     with pytest.raises(OnyxError):
         decode_and_validate_oauth_state(
             request=request,
@@ -358,7 +375,12 @@ def test_fixed_callback_rejects_state_without_provider(
     monkeypatch.setattr(oidc_multi, "USER_AUTH_SECRET", _TEST_SECRET)
     csrf = generate_csrf_token()
     state = generate_state_token({"next_url": "/", CSRF_TOKEN_KEY: csrf}, _TEST_SECRET)
-    request = cast(Any, SimpleNamespace(cookies={CSRF_TOKEN_COOKIE_NAME: csrf}))
+    request = cast(
+        Any,
+        SimpleNamespace(
+            cookies={CSRF_TOKEN_COOKIE_NAME: csrf}, state=SimpleNamespace()
+        ),
+    )
     with pytest.raises(OnyxError):
         asyncio.run(
             oidc_multi.oidc_login_callback(
@@ -371,3 +393,114 @@ def test_fixed_callback_rejects_state_without_provider(
                 user_manager=cast(Any, None),
             )
         )
+
+
+def test_validate_config_pkce_and_scopes_on_oauth_types() -> None:
+    from onyx.db.sso_provider import validate_sso_config
+
+    oidc = validate_sso_config(
+        SSOProviderType.OIDC,
+        {**_OIDC_CONFIG, "pkce_enabled": True, "scopes": ["openid", "email"]},
+    )
+    assert oidc["pkce_enabled"] is True
+    assert oidc["scopes"] == ["openid", "email"]
+    google = validate_sso_config(
+        SSOProviderType.GOOGLE_OAUTH,
+        {**_GOOGLE_CONFIG, "pkce_enabled": True, "scopes": ["openid"]},
+    )
+    assert google["pkce_enabled"] is True
+    # SAML has no OAuth flow, so the fields are invalid there.
+    with pytest.raises(ValueError):
+        validate_sso_config(
+            SSOProviderType.SAML,
+            {
+                "idp_entity_id": "e",
+                "idp_sso_url": "https://idp/sso",
+                "idp_x509_cert": "cert",
+                "sp_entity_id": "sp",
+                "pkce_enabled": True,
+            },
+        )
+
+
+def test_pkce_row_true_sufficient_env_can_force_on(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(oidc_multi, "OIDC_PKCE_ENABLED", False)
+    assert oidc_multi._pkce_enabled({"pkce_enabled": True}) is True
+    assert oidc_multi._pkce_enabled({"pkce_enabled": False}) is False
+    assert oidc_multi._pkce_enabled({}) is False
+    # The deployment-wide env flag still forces PKCE on while it exists.
+    monkeypatch.setattr(oidc_multi, "OIDC_PKCE_ENABLED", True)
+    assert oidc_multi._pkce_enabled({"pkce_enabled": False}) is True
+
+
+def test_build_client_scopes_row_over_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def _fake_openid(
+        _client_id: str,
+        _client_secret: str,
+        _config_url: str,
+        *,
+        base_scopes: list[str],
+        **_kwargs: Any,
+    ) -> Any:
+        captured["scopes"] = base_scopes
+        return SimpleNamespace(base_scopes=base_scopes)
+
+    monkeypatch.setattr(oidc_multi, "VerifiedEmailOpenID", _fake_openid)
+    monkeypatch.setattr(oidc_multi, "OIDC_SCOPE_OVERRIDE", ["env-scope"])
+
+    # Row scopes win over the env override.
+    oidc_multi._build_client(
+        _provider(), {**_OIDC_CONFIG, "scopes": ["openid", "profile"]}
+    )
+    assert captured["scopes"] == ["openid", "profile", "offline_access"]
+
+    # Empty row scopes fall back to the env override.
+    oidc_multi._build_client(_provider(), {**_OIDC_CONFIG, "scopes": []})
+    assert captured["scopes"] == ["env-scope", "offline_access"]
+
+
+def test_build_client_google_scopes_row_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(oidc_multi, "GOOGLE_OAUTH_SCOPE_OVERRIDE", ["env-scope"])
+    provider = _provider(name="google", provider_type=SSOProviderType.GOOGLE_OAUTH)
+
+    client = oidc_multi._build_client(
+        provider, {**_GOOGLE_CONFIG, "scopes": ["openid", "email"]}
+    )
+    assert client.base_scopes == ["openid", "email"]
+
+    client = oidc_multi._build_client(provider, {**_GOOGLE_CONFIG, "scopes": []})
+    assert client.base_scopes == ["env-scope"]
+
+
+def test_state_pins_pkce_mode() -> None:
+    # The callback must honor the mode the authorize leg minted, not the
+    # row's current setting, so mid-flow provider edits cannot break logins.
+    csrf = generate_csrf_token()
+    state = generate_state_token(
+        {
+            "next_url": "/",
+            "provider_name": "okta",
+            "pkce": True,
+            CSRF_TOKEN_KEY: csrf,
+        },
+        _TEST_SECRET,
+    )
+    request = cast(
+        Any,
+        SimpleNamespace(
+            cookies={CSRF_TOKEN_COOKIE_NAME: csrf}, state=SimpleNamespace()
+        ),
+    )
+    data = decode_and_validate_oauth_state(
+        request=request,
+        state_value=state,
+        state_secret=_TEST_SECRET,
+        expected_provider_name="okta",
+    )
+    assert data["pkce"] is True

--- a/backend/tests/unit/onyx/utils/test_mask_credential_whitelist.py
+++ b/backend/tests/unit/onyx/utils/test_mask_credential_whitelist.py
@@ -1,0 +1,23 @@
+"""mask_credential_dict must pass whitelisted keys through whole (any value
+type) while non-whitelisted strings and lists stay masked, so non-secret
+lists like OAuth scopes survive an admin-UI round trip."""
+
+from onyx.utils.encryption import mask_credential_dict
+
+
+def test_whitelisted_list_passes_through_unmasked() -> None:
+    masked = mask_credential_dict(
+        {"scopes": ["openid", "email"], "client_secret": "supersecretvalue"}
+    )
+    assert masked["scopes"] == ["openid", "email"]
+    assert masked["client_secret"] != "supersecretvalue"
+
+
+def test_non_whitelisted_list_items_still_mask() -> None:
+    masked = mask_credential_dict({"recovery_codes": ["alpha", "beta"]})
+    assert masked["recovery_codes"] != ["alpha", "beta"]
+
+
+def test_whitelisted_string_passes_through() -> None:
+    masked = mask_credential_dict({"wiki_base": "https://wiki.example.com"})
+    assert masked["wiki_base"] == "https://wiki.example.com"

--- a/web/src/app/auth/oauth/callback/route.ts
+++ b/web/src/app/auth/oauth/callback/route.ts
@@ -34,15 +34,25 @@ export const GET = async (request: NextRequest) => {
     redirect: "manual",
     headers: cookieHeader ? { cookie: cookieHeader } : undefined,
   });
-  const setCookieHeader = response.headers.get("set-cookie");
-
   if (response.status === 401) {
     return NextResponse.redirect(
       new URL("/auth/create-account", getDomain(request))
     );
   }
 
-  if (!setCookieHeader) {
+  // Error responses can carry a Set-Cookie too (PKCE cleanup), so status is
+  // the success signal, not cookie presence. Forward those cookies so the
+  // cleanup still reaches the browser.
+  if (!response.ok) {
+    const errorRedirect = await authErrorRedirect(request, response);
+    for (const cookie of response.headers.getSetCookie()) {
+      errorRedirect.headers.append("set-cookie", cookie);
+    }
+    return errorRedirect;
+  }
+
+  const setCookieHeaders = response.headers.getSetCookie();
+  if (setCookieHeaders.length === 0) {
     return authErrorRedirect(request, response);
   }
 
@@ -53,6 +63,10 @@ export const GET = async (request: NextRequest) => {
     new URL(redirectUrl, getDomain(request))
   );
 
-  redirectResponse.headers.set("set-cookie", setCookieHeader);
+  // Re-emit each Set-Cookie separately. Comma-joining would let one cookie's
+  // attributes (e.g. the PKCE deletion's Max-Age=0) bleed into the session's.
+  for (const cookie of setCookieHeaders) {
+    redirectResponse.headers.append("set-cookie", cookie);
+  }
   return redirectResponse;
 };

--- a/web/src/app/auth/oidc/callback/route.ts
+++ b/web/src/app/auth/oidc/callback/route.ts
@@ -15,15 +15,25 @@ export const GET = async (request: NextRequest) => {
     redirect: "manual",
     headers: cookieHeader ? { cookie: cookieHeader } : undefined,
   });
-  const setCookieHeader = response.headers.get("set-cookie");
-
   if (response.status === 401) {
     return NextResponse.redirect(
       new URL("/auth/create-account", getDomain(request))
     );
   }
 
-  if (!setCookieHeader) {
+  // Error responses can carry a Set-Cookie too (PKCE cleanup), so status is
+  // the success signal, not cookie presence. Forward those cookies so the
+  // cleanup still reaches the browser.
+  if (!response.ok) {
+    const errorRedirect = await authErrorRedirect(request, response);
+    for (const cookie of response.headers.getSetCookie()) {
+      errorRedirect.headers.append("set-cookie", cookie);
+    }
+    return errorRedirect;
+  }
+
+  const setCookieHeaders = response.headers.getSetCookie();
+  if (setCookieHeaders.length === 0) {
     return authErrorRedirect(request, response);
   }
 
@@ -34,6 +44,10 @@ export const GET = async (request: NextRequest) => {
     new URL(redirectUrl, getDomain(request))
   );
 
-  redirectResponse.headers.set("set-cookie", setCookieHeader);
+  // Re-emit each Set-Cookie separately. Comma-joining would let one cookie's
+  // attributes (e.g. the PKCE deletion's Max-Age=0) bleed into the session's.
+  for (const cookie of setCookieHeaders) {
+    redirectResponse.headers.append("set-cookie", cookie);
+  }
   return redirectResponse;
 };

--- a/web/src/app/auth/saml/callback/route.ts
+++ b/web/src/app/auth/saml/callback/route.ts
@@ -50,9 +50,15 @@ async function handleSamlCallback(
   }
 
   const response = await fetch(url.toString(), fetchOptions);
-  const setCookieHeader = response.headers.get("set-cookie");
 
-  if (!setCookieHeader) {
+  // Error responses can carry a Set-Cookie too, so status is the success
+  // signal, not cookie presence.
+  if (!response.ok) {
+    return authErrorRedirect(request, response, SEE_OTHER_REDIRECT_STATUS);
+  }
+
+  const setCookieHeaders = response.headers.getSetCookie();
+  if (setCookieHeaders.length === 0) {
     return authErrorRedirect(request, response, SEE_OTHER_REDIRECT_STATUS);
   }
 
@@ -63,7 +69,11 @@ async function handleSamlCallback(
     new URL(redirectDestination, getDomain(request)),
     SEE_OTHER_REDIRECT_STATUS
   );
-  redirectResponse.headers.set("set-cookie", setCookieHeader);
+  // Re-emit each Set-Cookie separately. Comma-joining would let one cookie's
+  // attributes bleed into another's.
+  for (const cookie of setCookieHeaders) {
+    redirectResponse.headers.append("set-cookie", cookie);
+  }
   return redirectResponse;
 }
 

--- a/web/src/lib/sso/interfaces.ts
+++ b/web/src/lib/sso/interfaces.ts
@@ -1,7 +1,8 @@
 // Admin-side shapes for the SSO provider list, mirroring the backend response
 // model. String `config` values come back masked (bullets, or a truncated
 // first4...last4 form for longer values) and are accepted back verbatim to
-// keep the stored value. Booleans round-trip as real values.
+// keep the stored value. Booleans and non-secret lists (scopes) round-trip
+// as real values.
 
 export type SSOProviderType = "GOOGLE_OAUTH" | "OIDC" | "SAML";
 
@@ -12,7 +13,7 @@ export interface SSOProviderResponse {
   provider_type: SSOProviderType;
   enabled: boolean;
   allowed_email_domains: string[];
-  config: Record<string, string | boolean>;
+  config: Record<string, string | boolean | string[]>;
   redirect_uri: string;
 }
 
@@ -20,12 +21,12 @@ export interface SSOProviderCreateRequest {
   name: string;
   display_name: string;
   provider_type: SSOProviderType;
-  config: Record<string, string | boolean>;
+  config: Record<string, string | boolean | string[]>;
   allowed_email_domains: string[];
 }
 
 export interface SSOProviderUpdateRequest {
   display_name?: string;
   allowed_email_domains?: string[];
-  config?: Record<string, string | boolean>;
+  config?: Record<string, string | boolean | string[]>;
 }

--- a/web/src/lib/sso/interfaces.ts
+++ b/web/src/lib/sso/interfaces.ts
@@ -1,8 +1,8 @@
 // Admin-side shapes for the SSO provider list, mirroring the backend response
-// model. String `config` values come back masked (bullets, or a truncated
-// first4...last4 form for longer values) and are accepted back verbatim to
-// keep the stored value. Booleans and non-secret lists (scopes) round-trip
-// as real values.
+// model. Secret `config` fields (client secret, SP private key) come back
+// masked (bullets, or a truncated first4...last4 form) and are accepted back
+// verbatim to keep the stored value. All other fields round-trip as real
+// values.
 
 export type SSOProviderType = "GOOGLE_OAUTH" | "OIDC" | "SAML";
 

--- a/web/src/lib/sso/utils.ts
+++ b/web/src/lib/sso/utils.ts
@@ -36,7 +36,12 @@ export const CREATABLE_SSO_PROVIDER_TYPES: SSOProviderType[] = [
   "SAML",
 ];
 
-export type SSOConfigFieldKind = "text" | "textarea" | "password" | "switch";
+export type SSOConfigFieldKind =
+  | "text"
+  | "textarea"
+  | "password"
+  | "switch"
+  | "chips";
 
 // One entry per admin-editable key in a provider type's backend config model.
 // `name` must match the backend config field exactly, since values are sent
@@ -64,10 +69,33 @@ const CLIENT_SECRET_FIELD: SSOConfigField = {
   description: "The OAuth client secret. Stored encrypted.",
   placeholder: "Client secret",
 };
+const PKCE_FIELD: SSOConfigField = {
+  name: "pkce_enabled",
+  label: "Enable PKCE",
+  kind: "switch",
+  description:
+    "Send a PKCE code challenge with this provider's login flow. " +
+    "A deployment-wide setting may force this on.",
+};
+const SCOPES_FIELD: SSOConfigField = {
+  name: "scopes",
+  label: "Scopes",
+  kind: "chips",
+  optional: true,
+  description:
+    "Override the OAuth scopes requested at login. " +
+    "Empty uses the deployment defaults.",
+  placeholder: "Add a scope (e.g. openid)",
+};
 
 export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
   {
-    GOOGLE_OAUTH: [CLIENT_ID_FIELD, CLIENT_SECRET_FIELD],
+    GOOGLE_OAUTH: [
+      CLIENT_ID_FIELD,
+      CLIENT_SECRET_FIELD,
+      PKCE_FIELD,
+      SCOPES_FIELD,
+    ],
     OIDC: [
       CLIENT_ID_FIELD,
       CLIENT_SECRET_FIELD,
@@ -87,6 +115,8 @@ export const CONFIG_FIELDS_BY_TYPE: Record<SSOProviderType, SSOConfigField[]> =
           "claim. Leave off for IdPs that do not send it, such as " +
           "Microsoft Entra ID.",
       },
+      PKCE_FIELD,
+      SCOPES_FIELD,
     ],
     SAML: [
       {

--- a/web/src/sections/modals/sso/SSOProviderModal.tsx
+++ b/web/src/sections/modals/sso/SSOProviderModal.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useState } from "react";
-import { Form, Formik } from "formik";
+import { Form, Formik, useField } from "formik";
 import * as Yup from "yup";
-import { Button, Text } from "@opal/components";
+import { Button, InputTags, type TagItem, Text } from "@opal/components";
 import { SvgCopy, SvgSimpleLoader } from "@opal/icons";
 import { InputVertical, toast } from "@opal/layouts";
 import { cn } from "@opal/utils";
@@ -25,9 +25,6 @@ import PasswordInputTypeInField from "@/refresh-components/form/PasswordInputTyp
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
 import SwitchField from "@/refresh-components/form/SwitchField";
-import InputChipField, {
-  type ChipItem,
-} from "@/refresh-components/inputs/InputChipField";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
 import { Modal } from "@opal/components";
 import { useModalClose } from "@opal/components";
@@ -43,7 +40,7 @@ interface SSOProviderFormValues {
   provider_type: SSOProviderType;
   name: string;
   display_name: string;
-  config: Record<string, string | boolean>;
+  config: Record<string, string | boolean | string[]>;
   allowed_email_domains: string[];
 }
 
@@ -59,10 +56,14 @@ const ALL_CONFIG_FIELDS: SSOConfigField[] = Array.from(
 );
 
 function configSchemaForType(fields: SSOConfigField[]) {
-  const shape: Record<string, Yup.StringSchema | Yup.BooleanSchema> = {};
+  const shape: Record<string, Yup.AnySchema> = {};
   for (const field of fields) {
     if (field.kind === "switch") {
       shape[field.name] = Yup.boolean();
+      continue;
+    }
+    if (field.kind === "chips") {
+      shape[field.name] = Yup.array().of(Yup.string().required());
       continue;
     }
     shape[field.name] = field.optional
@@ -109,11 +110,16 @@ const SSO_VALIDATION_SCHEMA = Yup.object({
 function buildConfig(
   providerType: SSOProviderType,
   values: SSOProviderFormValues
-): Record<string, string | boolean> {
-  const config: Record<string, string | boolean> = {};
+): Record<string, string | boolean | string[]> {
+  const config: Record<string, string | boolean | string[]> = {};
   for (const field of CONFIG_FIELDS_BY_TYPE[providerType]) {
     if (field.kind === "switch") {
       config[field.name] = Boolean(values.config[field.name]);
+      continue;
+    }
+    if (field.kind === "chips") {
+      const raw = values.config[field.name];
+      config[field.name] = Array.isArray(raw) ? raw : [];
       continue;
     }
     const raw = values.config[field.name];
@@ -128,16 +134,56 @@ function buildConfig(
 }
 
 function initialConfig(
-  config: Record<string, string | boolean>
-): Record<string, string | boolean> {
-  const initial: Record<string, string | boolean> = {};
+  config: Record<string, string | boolean | string[]>
+): Record<string, string | boolean | string[]> {
+  const initial: Record<string, string | boolean | string[]> = {};
   for (const field of ALL_CONFIG_FIELDS) {
-    initial[field.name] =
-      field.kind === "switch"
-        ? config[field.name] === true
-        : (config[field.name] ?? "");
+    if (field.kind === "switch") {
+      initial[field.name] = config[field.name] === true;
+      continue;
+    }
+    if (field.kind === "chips") {
+      const raw = config[field.name];
+      initial[field.name] = Array.isArray(raw) ? raw : [];
+      continue;
+    }
+    initial[field.name] = config[field.name] ?? "";
   }
   return initial;
+}
+
+interface TagListFieldProps {
+  name: string;
+  placeholder?: string;
+  // Applied to each entry before dedupe/store (trim always runs first).
+  transform?: (value: string) => string;
+}
+
+// Formik-bound Opal InputTags for string[] values. Always writes an array, so
+// clearing every tag stores [] rather than leaving the previous value.
+function TagListField({ name, placeholder, transform }: TagListFieldProps) {
+  const [field, , helpers] = useField<string[]>(name);
+  const [input, setInput] = useState("");
+  const values = field.value ?? [];
+  const tags: TagItem[] = values.map((value) => ({ id: value, label: value }));
+  return (
+    <InputTags
+      tags={tags}
+      onRemoveTag={(id) => {
+        void helpers.setValue(values.filter((value) => value !== id));
+      }}
+      onAdd={(value) => {
+        const entry = transform ? transform(value.trim()) : value.trim();
+        if (entry && !values.includes(entry)) {
+          void helpers.setValue([...values, entry]);
+        }
+        setInput("");
+      }}
+      value={input}
+      onChange={setInput}
+      placeholder={placeholder}
+    />
+  );
 }
 
 function ConfigInput({
@@ -150,6 +196,9 @@ function ConfigInput({
   const name = `config.${field.name}`;
   if (field.kind === "switch") {
     return <SwitchField name={name} />;
+  }
+  if (field.kind === "chips") {
+    return <TagListField name={name} placeholder={field.placeholder} />;
   }
   if (field.kind === "textarea") {
     return <InputTextAreaField name={name} placeholder={field.placeholder} />;
@@ -169,7 +218,6 @@ function ConfigInput({
 export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
   const onClose = useModalClose();
   const isEditing = provider !== null;
-  const [domainInput, setDomainInput] = useState("");
 
   const initialValues: SSOProviderFormValues = {
     provider_type: provider?.provider_type ?? "GOOGLE_OAUTH",
@@ -239,9 +287,6 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
           }) => {
             const providerType = values.provider_type;
             const providerTypeIcon = SSO_PROVIDER_DETAILS[providerType].icon;
-            const domainChips: ChipItem[] = values.allowed_email_domains.map(
-              (domain) => ({ id: domain, label: domain })
-            );
 
             return (
               // flex-col fills the fixed-height Content so Modal.Body scrolls
@@ -341,32 +386,10 @@ export function SSOProviderModal({ provider, onSaved }: SSOProviderModalProps) {
                     description="Only emails in these domains may sign in through this provider. Empty allows any."
                     withLabel
                   >
-                    <InputChipField
-                      chips={domainChips}
-                      onRemoveChip={(id) => {
-                        void setFieldValue(
-                          "allowed_email_domains",
-                          values.allowed_email_domains.filter(
-                            (domain) => domain !== id
-                          )
-                        );
-                      }}
-                      onAdd={(value) => {
-                        const trimmed = value.trim().toLowerCase();
-                        if (
-                          trimmed &&
-                          !values.allowed_email_domains.includes(trimmed)
-                        ) {
-                          void setFieldValue("allowed_email_domains", [
-                            ...values.allowed_email_domains,
-                            trimmed,
-                          ]);
-                        }
-                        setDomainInput("");
-                      }}
-                      value={domainInput}
-                      onChange={setDomainInput}
+                    <TagListField
+                      name="allowed_email_domains"
                       placeholder="Add a domain (e.g. onyx.app)"
+                      transform={(value) => value.toLowerCase()}
                     />
                   </InputVertical>
 


### PR DESCRIPTION
## Description

Second PR of the SSO env-var retirement stack (after #13346). `OIDC_PKCE_ENABLED`, `OIDC_SCOPE_OVERRIDE`, and `GOOGLE_OAUTH_SCOPE_OVERRIDE` become per-provider settings on the SSO provider row, so one IdP's needs stop being deployment-wide. Env values remain as fallbacks until the purge PR removes them.

- `_OAuth2ProviderConfig` base gains `pkce_enabled: bool = False` and `scopes: list[str] = []` (no migration, config is a validated JSON blob).
- `_pkce_enabled(config)` replaces the three env gates in `oidc_multi` (row OR env: the env flag can still force PKCE on fleet-wide until it dies). Scope precedence: row, then env override, then built-ins; OIDC keeps the forced `offline_access`.
- Admin modal: "Enable PKCE" switch and a "Scopes" chip list on Google and OIDC providers, via the Opal `InputTags` component with a modal-local Formik binding (Allowed Email Domains now uses it too).
- Masking fix that fell out of review: `mask_credential_dict` masked list *items*, so stored scopes came back as identical bullets and chip edits corrupted the override. Whitelisted keys now pass through whole, with `scopes` whitelisted (public identifiers, not secrets).
- Admin responses now mask only secret config fields (client secret, SP private key, marked on the config models). Client IDs and IdP URLs read back real so an admin can verify a provider's setup.
- PKCE cookie cleanup on callback errors lives in the SSO error decorator (both callbacks), which derives the cookie name from the `state` query param and also serves the standard JSON error to non-browser clients. No `request.state` marker, no error-handler coupling.
- The Next.js legacy-callback wrappers now treat response status as the success signal instead of Set-Cookie presence (error responses carry the PKCE cleanup cookie), and re-emit multiple Set-Cookie headers separately instead of comma-joining them.

`IDP_PROFILE_*` is deliberately not here and keeps working unchanged. It is a single deployment-wide claim map applied at prompt-placeholder resolution, where claim snapshots from every provider a user has logged in with are merged into one pool. Making the map per-provider requires reworking that resolution (keep provider identity per source, define which provider's map wins for a merged profile), so it moves in its own PR.

## How Has This Been Tested?

<img width="631" height="611" alt="Screenshot 2026-07-23 at 4 45 24 PM" src="https://github.com/user-attachments/assets/1a0ac605-bae6-4450-b111-149374bdc06d" />


Live-tested on a dev stack against Keycloak 26 with two OIDC provider rows:

- The edit modal renders the new Enable PKCE switch and the Scopes tag input for OIDC and Google providers.
- Set scopes `openid`, `email`, `profile`, enabled PKCE, saved, and reopened. Both round-trip as real values, since scopes are whitelisted from masking.
- `GET /api/auth/oidc/keycloak/authorize` then returned `scope=openid email profile offline_access` with `code_challenge` and `code_challenge_method=S256`.
- Cleared the scopes and disabled PKCE, saved. The authorize URL returned to the deployment defaults (`openid email offline_access`, no code challenge).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check



