### PR TITLE
feat(web): reasoning level and temperature controls in the model selector

### DIFF
--- a/web/lib/opal/src/icons/index.ts
+++ b/web/lib/opal/src/icons/index.ts
@@ -188,6 +188,7 @@ export { default as SvgTerminal } from "@opal/icons/terminal";
 export { default as SvgTerminalSmall } from "@opal/icons/terminal-small";
 export { default as SvgTextLines } from "@opal/icons/text-lines";
 export { default as SvgTextLinesSmall } from "@opal/icons/text-lines-small";
+export { default as SvgThermometer } from "@opal/icons/thermometer";
 export { default as SvgThumbsDown } from "@opal/icons/thumbs-down";
 export { default as SvgThumbsUp } from "@opal/icons/thumbs-up";
 export { default as SvgTrash } from "@opal/icons/trash";

--- a/web/lib/opal/src/icons/thermometer.tsx
+++ b/web/lib/opal/src/icons/thermometer.tsx
@@ -1,0 +1,21 @@
+import type { IconProps } from "@opal/types";
+
+const SvgThermometer = ({ size, ...props }: IconProps) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 16 16"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="currentColor"
+    {...props}
+  >
+    <path
+      d="M8 1C8.9078 1 9.6667 1.7589 9.6667 2.6667L9.6667 8.4215C10.7586 9.0139 11.5 10.1704 11.5 11.5C11.5 13.433 9.933 15 8 15C6.067 15 4.5 13.433 4.5 11.5C4.5 10.1704 5.2414 9.0139 6.3333 8.4215L6.3333 2.6667C6.3333 1.7589 7.0922 1 8 1Z"
+      strokeWidth={1.5}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+export default SvgThermometer;

--- a/web/src/app/app/interfaces.ts
+++ b/web/src/app/app/interfaces.ts
@@ -5,6 +5,7 @@ import {
   StreamStopReason,
 } from "@/lib/search/interfaces";
 import { Packet } from "./services/streamingModels";
+import { ReasoningEffortOverride } from "@/lib/languageModels/types";
 
 export type FeedbackType = "like" | "dislike";
 
@@ -59,6 +60,7 @@ export interface ChatSessionSummary {
   shared_status: ChatSessionSharedStatus;
   current_alternate_model: string | null;
   current_temperature_override: number | null;
+  current_reasoning_effort_override: ReasoningEffortOverride | null;
   highlights?: string[];
 }
 
@@ -142,6 +144,7 @@ export interface ChatSession {
   project_id: number | null;
   current_alternate_model: string;
   current_temperature_override: number | null;
+  current_reasoning_effort_override: ReasoningEffortOverride | null;
 }
 
 export interface SearchSession {
@@ -203,6 +206,7 @@ export interface BackendChatSession {
   time_updated: string;
   shared_status: ChatSessionSharedStatus;
   current_temperature_override: number | null;
+  current_reasoning_effort_override: ReasoningEffortOverride | null;
   current_alternate_model?: string;
 
   owner_name: string | null;
@@ -222,6 +226,8 @@ export function toChatSession(backend: BackendChatSession): ChatSession {
     project_id: null,
     current_alternate_model: backend.current_alternate_model ?? "",
     current_temperature_override: backend.current_temperature_override,
+    current_reasoning_effort_override:
+      backend.current_reasoning_effort_override,
   };
 }
 

--- a/web/src/app/app/message/messageComponents/MessageToolbar.tsx
+++ b/web/src/app/app/message/messageComponents/MessageToolbar.tsx
@@ -347,6 +347,7 @@ export default function MessageToolbar({
                       });
                     }}
                     temperatureManager={llmManager}
+                    reasoningManager={llmManager}
                   />
                 </div>
               )}

--- a/web/src/app/app/services/lib.tsx
+++ b/web/src/app/app/services/lib.tsx
@@ -4,6 +4,7 @@ import {
   StreamStopInfo,
 } from "@/lib/search/interfaces";
 import { handleSSEStream } from "@/lib/search/streamingUtils";
+import { ReasoningEffortOverride } from "@/lib/languageModels/types";
 import { FeedbackType } from "@/app/app/interfaces";
 import {
   BackendMessage,
@@ -55,6 +56,23 @@ export async function updateTemperatureOverrideForChatSession(
     body: JSON.stringify({
       chat_session_id: chatSessionId,
       temperature_override: newTemperature,
+    }),
+  });
+  return response;
+}
+
+export async function updateReasoningEffortForChatSession(
+  chatSessionId: string,
+  newReasoningEffort: ReasoningEffortOverride | null
+) {
+  const response = await fetch("/api/chat/update-chat-session-reasoning", {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      chat_session_id: chatSessionId,
+      reasoning_effort_override: newReasoningEffort,
     }),
   });
   return response;

--- a/web/src/app/nrf/NRFPage.tsx
+++ b/web/src/app/nrf/NRFPage.tsx
@@ -516,6 +516,8 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
                       onAdd={multiModel.addModel}
                       onRemove={multiModel.removeModel}
                       onReplace={multiModel.replaceModel}
+                      temperatureManager={llmManager}
+                      reasoningManager={llmManager}
                     />
                   )}
                 </Section>
@@ -538,6 +540,8 @@ export default function NRFPage({ isSidePanel = false }: NRFPageProps) {
                     onAdd={multiModel.addModel}
                     onRemove={multiModel.removeModel}
                     onReplace={multiModel.replaceModel}
+                    temperatureManager={llmManager}
+                    reasoningManager={llmManager}
                   />
                 </div>
               )}

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -877,9 +877,9 @@ export default function useChatController({
       let streamSucceeded = false;
 
       try {
-        // When the manager has no bound session row, this submit is the only
-        // write path for the overrides. Awaited so the send cannot race the
-        // session-row read. A failure renders as a chat error.
+        // Overrides picked before the session row existed are not yet
+        // persisted. Await the writes so the backend's session-row read
+        // during the send sees them. A failed write surfaces as a chat error.
         if (!llmManager.hasBoundSession) {
           const overrideWrites: Promise<Response>[] = [];
           if (llmManager.reasoningEffort) {

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -877,35 +877,37 @@ export default function useChatController({
       let streamSucceeded = false;
 
       try {
-        // Awaited so the send cannot race these writes (turn setup reads
-        // reasoning effort from the session row). Inside the try so a failure
-        // renders as a chat error in the already-adopted session.
-        const overrideWrites: Promise<Response>[] = [];
-        if (llmManager.reasoningEffort) {
-          overrideWrites.push(
-            updateReasoningEffortForChatSession(
-              currChatSessionId,
-              llmManager.reasoningEffort
-            )
-          );
-        }
-        if (llmManager.temperatureExplicitlySet) {
-          overrideWrites.push(
-            updateTemperatureOverrideForChatSession(
-              currChatSessionId,
-              llmManager.temperature
-            )
-          );
-        }
-        if (overrideWrites.length > 0) {
-          const overrideResponses = await Promise.all(overrideWrites);
-          const failedWrite = overrideResponses.find(
-            (response) => !response.ok
-          );
-          if (failedWrite) {
-            throw new Error(
-              `Failed to persist chat session overrides: ${failedWrite.status}`
+        // When the manager has no bound session row, this submit is the only
+        // write path for the overrides. Awaited so the send cannot race the
+        // session-row read. A failure renders as a chat error.
+        if (!llmManager.hasBoundSession) {
+          const overrideWrites: Promise<Response>[] = [];
+          if (llmManager.reasoningEffort) {
+            overrideWrites.push(
+              updateReasoningEffortForChatSession(
+                currChatSessionId,
+                llmManager.reasoningEffort
+              )
             );
+          }
+          if (llmManager.temperatureExplicitlySet) {
+            overrideWrites.push(
+              updateTemperatureOverrideForChatSession(
+                currChatSessionId,
+                llmManager.temperature
+              )
+            );
+          }
+          if (overrideWrites.length > 0) {
+            const overrideResponses = await Promise.all(overrideWrites);
+            const failedWrite = overrideResponses.find(
+              (response) => !response.ok
+            );
+            if (failedWrite) {
+              throw new Error(
+                `Failed to persist chat session overrides: ${failedWrite.status}`
+              );
+            }
           }
         }
 

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -204,10 +204,6 @@ export default function useChatController({
   const currentChatState = useCurrentChatState();
 
   const navigatingAway = useRef(false);
-  // Session whose pre-send override writes failed. The manager binds the
-  // session row on the render after adoption, so without this marker a
-  // retry would skip the writes and send with the override unpersisted.
-  const overrideWritesFailedForSession = useRef<string | null>(null);
 
   // Sync store state changes
   useEffect(() => {
@@ -881,12 +877,13 @@ export default function useChatController({
       let streamSucceeded = false;
 
       try {
-        // Overrides picked before the session row existed are not yet
-        // persisted. Await the writes so the backend's session-row read
-        // during the send sees them. A failed write surfaces as a chat error.
+        // Override selections are only best-effort persisted until a send
+        // confirms them. Await the writes so the backend's session-row read
+        // during the send sees them. A failed write surfaces as a chat error
+        // and leaves the overrides marked unpersisted for the retry.
         if (
           !llmManager.hasBoundSession ||
-          overrideWritesFailedForSession.current === currChatSessionId
+          llmManager.hasUnpersistedOverrides()
         ) {
           const overrideWrites: Promise<Response>[] = [];
           if (llmManager.reasoningEffort) {
@@ -906,9 +903,6 @@ export default function useChatController({
             );
           }
           if (overrideWrites.length > 0) {
-            // Marked failed until every write lands, covering both rejected
-            // promises and non-ok responses.
-            overrideWritesFailedForSession.current = currChatSessionId;
             const overrideResponses = await Promise.all(overrideWrites);
             const failedWrite = overrideResponses.find(
               (response) => !response.ok
@@ -918,7 +912,7 @@ export default function useChatController({
                 `Failed to persist chat session overrides: ${failedWrite.status}`
               );
             }
-            overrideWritesFailedForSession.current = null;
+            llmManager.markOverridesPersisted();
           }
         }
 

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -5,8 +5,6 @@ import {
   getAvailableContextTokens,
   nameChatSession,
   updateLlmOverrideForChatSession,
-  updateReasoningEffortForChatSession,
-  updateTemperatureOverrideForChatSession,
 } from "@/app/app/services/lib";
 import { getMaxSelectedDocumentTokens } from "@/lib/projects/svc";
 import { DEFAULT_CONTEXT_TOKENS } from "@/lib/constants";
@@ -877,44 +875,11 @@ export default function useChatController({
       let streamSucceeded = false;
 
       try {
-        // Override selections are only best-effort persisted until a send
-        // confirms them. Await the writes so the backend's session-row read
-        // during the send sees them. A failed write surfaces as a chat error
-        // and leaves the overrides marked unpersisted for the retry.
-        if (
-          !llmManager.hasBoundSession ||
-          llmManager.hasUnpersistedOverrides()
-        ) {
-          const overrideWrites: Promise<Response>[] = [];
-          if (llmManager.reasoningEffort) {
-            overrideWrites.push(
-              updateReasoningEffortForChatSession(
-                currChatSessionId,
-                llmManager.reasoningEffort
-              )
-            );
-          }
-          if (llmManager.temperatureExplicitlySet) {
-            overrideWrites.push(
-              updateTemperatureOverrideForChatSession(
-                currChatSessionId,
-                llmManager.temperature
-              )
-            );
-          }
-          if (overrideWrites.length > 0) {
-            const overrideResponses = await Promise.all(overrideWrites);
-            const failedWrite = overrideResponses.find(
-              (response) => !response.ok
-            );
-            if (failedWrite) {
-              throw new Error(
-                `Failed to persist chat session overrides: ${failedWrite.status}`
-              );
-            }
-            llmManager.markOverridesPersisted();
-          }
-        }
+        // Selection-time override writes are best-effort. Await confirmation
+        // so the backend's session-row read during the send sees the current
+        // selections. A failed write surfaces as a chat error and the next
+        // send re-persists.
+        await llmManager.persistOverrides(currChatSessionId);
 
         const lastSuccessfulMessageId = getLastSuccessfulMessageId(
           currentMessageTreeLocal

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -204,6 +204,10 @@ export default function useChatController({
   const currentChatState = useCurrentChatState();
 
   const navigatingAway = useRef(false);
+  // Session whose pre-send override writes failed. The manager binds the
+  // session row on the render after adoption, so without this marker a
+  // retry would skip the writes and send with the override unpersisted.
+  const overrideWritesFailedForSession = useRef<string | null>(null);
 
   // Sync store state changes
   useEffect(() => {
@@ -880,7 +884,10 @@ export default function useChatController({
         // Overrides picked before the session row existed are not yet
         // persisted. Await the writes so the backend's session-row read
         // during the send sees them. A failed write surfaces as a chat error.
-        if (!llmManager.hasBoundSession) {
+        if (
+          !llmManager.hasBoundSession ||
+          overrideWritesFailedForSession.current === currChatSessionId
+        ) {
           const overrideWrites: Promise<Response>[] = [];
           if (llmManager.reasoningEffort) {
             overrideWrites.push(
@@ -899,6 +906,9 @@ export default function useChatController({
             );
           }
           if (overrideWrites.length > 0) {
+            // Marked failed until every write lands, covering both rejected
+            // promises and non-ok responses.
+            overrideWritesFailedForSession.current = currChatSessionId;
             const overrideResponses = await Promise.all(overrideWrites);
             const failedWrite = overrideResponses.find(
               (response) => !response.ok
@@ -908,6 +918,7 @@ export default function useChatController({
                 `Failed to persist chat session overrides: ${failedWrite.status}`
               );
             }
+            overrideWritesFailedForSession.current = null;
           }
         }
 

--- a/web/src/hooks/useChatController.ts
+++ b/web/src/hooks/useChatController.ts
@@ -5,6 +5,8 @@ import {
   getAvailableContextTokens,
   nameChatSession,
   updateLlmOverrideForChatSession,
+  updateReasoningEffortForChatSession,
+  updateTemperatureOverrideForChatSession,
 } from "@/app/app/services/lib";
 import { getMaxSelectedDocumentTokens } from "@/lib/projects/svc";
 import { DEFAULT_CONTEXT_TOKENS } from "@/lib/constants";
@@ -875,6 +877,38 @@ export default function useChatController({
       let streamSucceeded = false;
 
       try {
+        // Awaited so the send cannot race these writes (turn setup reads
+        // reasoning effort from the session row). Inside the try so a failure
+        // renders as a chat error in the already-adopted session.
+        const overrideWrites: Promise<Response>[] = [];
+        if (llmManager.reasoningEffort) {
+          overrideWrites.push(
+            updateReasoningEffortForChatSession(
+              currChatSessionId,
+              llmManager.reasoningEffort
+            )
+          );
+        }
+        if (llmManager.temperatureExplicitlySet) {
+          overrideWrites.push(
+            updateTemperatureOverrideForChatSession(
+              currChatSessionId,
+              llmManager.temperature
+            )
+          );
+        }
+        if (overrideWrites.length > 0) {
+          const overrideResponses = await Promise.all(overrideWrites);
+          const failedWrite = overrideResponses.find(
+            (response) => !response.ok
+          );
+          if (failedWrite) {
+            throw new Error(
+              `Failed to persist chat session overrides: ${failedWrite.status}`
+            );
+          }
+        }
+
         const lastSuccessfulMessageId = getLastSuccessfulMessageId(
           currentMessageTreeLocal
         );

--- a/web/src/hooks/useChatSessions.ts
+++ b/web/src/hooks/useChatSessions.ts
@@ -270,6 +270,7 @@ export default function useChatSessions(): UseChatSessionsOutput {
         project_id: projectId ?? null,
         current_alternate_model: "",
         current_temperature_override: null,
+        current_reasoning_effort_override: null,
       });
     },
     []

--- a/web/src/lib/chat/exportChatSession.test.ts
+++ b/web/src/lib/chat/exportChatSession.test.ts
@@ -59,6 +59,7 @@ function makeSession(messages: BackendMessage[]): BackendChatSession {
     time_updated: "2026-01-01T00:00:00Z",
     shared_status: ChatSessionSharedStatus.Private,
     current_temperature_override: null,
+    current_reasoning_effort_override: null,
     owner_name: null,
     packets: [],
   };

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -787,9 +787,12 @@ export function useLlmManager(
   const [temperatureExplicitlySet, setTemperatureExplicitlySet] =
     useState(false);
 
-  // Set on every override selection, cleared when a send confirms the values
-  // persisted or when a session's stored values are adopted.
-  const unpersistedOverridesRef = useRef(false);
+  // A selection bumps selectionGen alongside its value, and a confirmed
+  // persist records the generation whose values it wrote. Overrides are
+  // unconfirmed while persistedGen trails, so a selection made mid-persist
+  // can never be marked clean by an older persist completing.
+  const [selectionGen, setSelectionGen] = useState(0);
+  const persistedGenRef = useRef(0);
 
   // Serializes every override PUT so an older selection can never land on
   // the server after a newer one. persistOverrides joins the same chain.
@@ -813,7 +816,7 @@ export function useLlmManager(
     if (prevSessionIdRef.current === sessionId) return;
     prevSessionIdRef.current = sessionId;
     setTemperatureExplicitlySet(false);
-    unpersistedOverridesRef.current = false;
+    persistedGenRef.current = selectionGen;
     setReasoningEffort(
       currentChatSession?.current_reasoning_effort_override ?? null
     );
@@ -886,7 +889,7 @@ export function useLlmManager(
       : temperature;
     setTemperature(clampedTemp);
     setTemperatureExplicitlySet(true);
-    unpersistedOverridesRef.current = true;
+    setSelectionGen((generation) => generation + 1);
     const sessionId = chatSession?.id;
     if (sessionId) {
       void enqueueOverrideWrite(() =>
@@ -897,7 +900,7 @@ export function useLlmManager(
 
   const updateReasoningEffort = (effort: ReasoningEffortOverride | null) => {
     setReasoningEffort(effort);
-    unpersistedOverridesRef.current = true;
+    setSelectionGen((generation) => generation + 1);
     const sessionId = chatSession?.id;
     if (sessionId) {
       void enqueueOverrideWrite(() =>
@@ -907,7 +910,11 @@ export function useLlmManager(
   };
 
   const persistOverrides = async (sessionId: string): Promise<void> => {
-    if (chatSession != null && !unpersistedOverridesRef.current) return;
+    // selectionGen is render-captured with the values below, so this persist
+    // confirms exactly the generation whose values it writes.
+    if (chatSession != null && persistedGenRef.current >= selectionGen) {
+      return;
+    }
     const writes: Promise<Response>[] = [];
     if (reasoningEffort) {
       writes.push(
@@ -931,7 +938,7 @@ export function useLlmManager(
         `Failed to persist chat session overrides: ${failed.status}`
       );
     }
-    unpersistedOverridesRef.current = false;
+    persistedGenRef.current = Math.max(persistedGenRef.current, selectionGen);
   };
 
   // Track if any provider exists for the current persona context.

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -411,6 +411,8 @@ export interface LlmManager {
   temperatureExplicitlySet: boolean;
   reasoningEffort: ReasoningEffortOverride | null;
   updateReasoningEffort: (effort: ReasoningEffortOverride | null) => void;
+  /** True when updates persist to a session row at selection time. */
+  hasBoundSession: boolean;
   updateModelOverrideBasedOnChatSession: (chatSession?: ChatSession) => void;
   imageFilesPresent: boolean;
   updateImageFilesPresent: (present: boolean) => void;
@@ -888,6 +890,7 @@ export function useLlmManager(
     temperatureExplicitlySet,
     reasoningEffort,
     updateReasoningEffort,
+    hasBoundSession: chatSession != null,
     imageFilesPresent,
     updateImageFilesPresent,
     liveAgent: liveAgent ?? null,

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -413,10 +413,10 @@ export interface LlmManager {
   updateReasoningEffort: (effort: ReasoningEffortOverride | null) => void;
   /** True when updates persist to a session row at selection time. */
   hasBoundSession: boolean;
-  /** True while an override selection is not yet confirmed persisted.
-   * Selection-time PUTs are best-effort and never clear this. */
-  hasUnpersistedOverrides: () => boolean;
-  markOverridesPersisted: () => void;
+  /** Ensure the session row reflects the local override selections. No-op
+   * when the session is bound and every selection is confirmed persisted.
+   * Throws when a write fails, leaving the overrides unconfirmed for retry. */
+  persistOverrides: (sessionId: string) => Promise<void>;
   updateModelOverrideBasedOnChatSession: (chatSession?: ChatSession) => void;
   imageFilesPresent: boolean;
   updateImageFilesPresent: (present: boolean) => void;
@@ -791,6 +791,17 @@ export function useLlmManager(
   // persisted or when a session's stored values are adopted.
   const unpersistedOverridesRef = useRef(false);
 
+  // Serializes every override PUT so an older selection can never land on
+  // the server after a newer one. persistOverrides joins the same chain.
+  const overrideWriteChainRef = useRef<Promise<unknown>>(Promise.resolve());
+  const enqueueOverrideWrite = (
+    write: () => Promise<Response>
+  ): Promise<Response> => {
+    const next = overrideWriteChainRef.current.then(write, write);
+    overrideWriteChainRef.current = next.catch(() => undefined);
+    return next;
+  };
+
   // Adopt the stored reasoning override (and reset the explicit-temperature
   // flag) only when session identity changes. Keying on identity, not the
   // object, keeps new-chat dep churn from wiping a pre-first-message choice.
@@ -828,24 +839,26 @@ export function useLlmManager(
     if (isAnthropic(currentLlm.provider, currentLlm.modelName)) {
       const newTemperature = Math.min(temperature, 1.0);
       setTemperature(newTemperature);
-      if (chatSession?.id) {
-        updateTemperatureOverrideForChatSession(chatSession.id, newTemperature);
+      const sessionId = chatSession?.id;
+      if (sessionId) {
+        void enqueueOverrideWrite(() =>
+          updateTemperatureOverrideForChatSession(sessionId, newTemperature)
+        );
       }
     }
   }, [currentLlm]);
 
   useEffect(() => {
     if (!chatSession && currentChatSession) {
+      const sessionId = currentChatSession.id;
       if (temperature) {
-        updateTemperatureOverrideForChatSession(
-          currentChatSession.id,
-          temperature
+        void enqueueOverrideWrite(() =>
+          updateTemperatureOverrideForChatSession(sessionId, temperature)
         );
       }
       if (reasoningEffort) {
-        updateReasoningEffortForChatSession(
-          currentChatSession.id,
-          reasoningEffort
+        void enqueueOverrideWrite(() =>
+          updateReasoningEffortForChatSession(sessionId, reasoningEffort)
         );
       }
       return;
@@ -874,17 +887,51 @@ export function useLlmManager(
     setTemperature(clampedTemp);
     setTemperatureExplicitlySet(true);
     unpersistedOverridesRef.current = true;
-    if (chatSession) {
-      void updateTemperatureOverrideForChatSession(chatSession.id, clampedTemp);
+    const sessionId = chatSession?.id;
+    if (sessionId) {
+      void enqueueOverrideWrite(() =>
+        updateTemperatureOverrideForChatSession(sessionId, clampedTemp)
+      );
     }
   };
 
   const updateReasoningEffort = (effort: ReasoningEffortOverride | null) => {
     setReasoningEffort(effort);
     unpersistedOverridesRef.current = true;
-    if (chatSession) {
-      void updateReasoningEffortForChatSession(chatSession.id, effort);
+    const sessionId = chatSession?.id;
+    if (sessionId) {
+      void enqueueOverrideWrite(() =>
+        updateReasoningEffortForChatSession(sessionId, effort)
+      );
     }
+  };
+
+  const persistOverrides = async (sessionId: string): Promise<void> => {
+    if (chatSession != null && !unpersistedOverridesRef.current) return;
+    const writes: Promise<Response>[] = [];
+    if (reasoningEffort) {
+      writes.push(
+        enqueueOverrideWrite(() =>
+          updateReasoningEffortForChatSession(sessionId, reasoningEffort)
+        )
+      );
+    }
+    if (temperatureExplicitlySet) {
+      writes.push(
+        enqueueOverrideWrite(() =>
+          updateTemperatureOverrideForChatSession(sessionId, temperature)
+        )
+      );
+    }
+    if (writes.length === 0) return;
+    const responses = await Promise.all(writes);
+    const failed = responses.find((response) => !response.ok);
+    if (failed) {
+      throw new Error(
+        `Failed to persist chat session overrides: ${failed.status}`
+      );
+    }
+    unpersistedOverridesRef.current = false;
   };
 
   // Track if any provider exists for the current persona context.
@@ -902,10 +949,7 @@ export function useLlmManager(
     reasoningEffort,
     updateReasoningEffort,
     hasBoundSession: chatSession != null,
-    hasUnpersistedOverrides: () => unpersistedOverridesRef.current,
-    markOverridesPersisted: () => {
-      unpersistedOverridesRef.current = false;
-    },
+    persistOverrides,
     imageFilesPresent,
     updateImageFilesPresent,
     liveAgent: liveAgent ?? null,

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -27,13 +27,17 @@ import { MinimalAgent } from "@/lib/agents/types";
 import {
   DefaultModel,
   LLMProviderDescriptor,
+  ReasoningEffortOverride,
 } from "@/lib/languageModels/types";
 import { isAnthropic } from "@/lib/languageModels/svc";
 import { getSourceMetadataForSources } from "./sources";
 import { DEFAULT_AGENT_ID, NEXT_PUBLIC_CLOUD_ENABLED } from "./constants";
 import { useUser } from "@/providers/UserProvider";
 import { SEARCH_TOOL_ID } from "@/app/app/components/tools/constants";
-import { updateTemperatureOverrideForChatSession } from "@/app/app/services/lib";
+import {
+  updateReasoningEffortForChatSession,
+  updateTemperatureOverrideForChatSession,
+} from "@/app/app/services/lib";
 import { useLLMProviders } from "@/lib/languageModels/hooks";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
@@ -402,6 +406,11 @@ export interface LlmManager {
   updateCurrentLlm: (newOverride: LlmDescriptor) => void;
   temperature: number;
   updateTemperature: (temperature: number) => void;
+  /** True once updateTemperature was called for the current session, marking
+   * an explicit choice vs the 0/0.5 heuristic default. */
+  temperatureExplicitlySet: boolean;
+  reasoningEffort: ReasoningEffortOverride | null;
+  updateReasoningEffort: (effort: ReasoningEffortOverride | null) => void;
   updateModelOverrideBasedOnChatSession: (chatSession?: ChatSession) => void;
   imageFilesPresent: boolean;
   updateImageFilesPresent: (present: boolean) => void;
@@ -765,6 +774,29 @@ export function useLlmManager(
     return 0.5;
   });
 
+  const [reasoningEffort, setReasoningEffort] =
+    useState<ReasoningEffortOverride | null>(
+      currentChatSession?.current_reasoning_effort_override ?? null
+    );
+  const [temperatureExplicitlySet, setTemperatureExplicitlySet] =
+    useState(false);
+
+  // Adopt the stored reasoning override (and reset the explicit-temperature
+  // flag) only when session identity changes. Keying on identity, not the
+  // object, keeps new-chat dep churn from wiping a pre-first-message choice.
+  const prevSessionIdRef = useRef<string | null>(
+    currentChatSession?.id ?? null
+  );
+  useEffect(() => {
+    const sessionId = currentChatSession?.id ?? null;
+    if (prevSessionIdRef.current === sessionId) return;
+    prevSessionIdRef.current = sessionId;
+    setTemperatureExplicitlySet(false);
+    setReasoningEffort(
+      currentChatSession?.current_reasoning_effort_override ?? null
+    );
+  }, [currentChatSession]);
+
   const maxTemperature = useMemo(() => {
     // Check currentLlm first, fall back to chat session model if currentLlm isn't populated
     if (currentLlm.provider) {
@@ -799,6 +831,12 @@ export function useLlmManager(
           temperature
         );
       }
+      if (reasoningEffort) {
+        updateReasoningEffortForChatSession(
+          currentChatSession.id,
+          reasoningEffort
+        );
+      }
       return;
     }
 
@@ -823,8 +861,16 @@ export function useLlmManager(
       ? Math.min(temperature, 1.0)
       : temperature;
     setTemperature(clampedTemp);
+    setTemperatureExplicitlySet(true);
     if (chatSession) {
       updateTemperatureOverrideForChatSession(chatSession.id, clampedTemp);
+    }
+  };
+
+  const updateReasoningEffort = (effort: ReasoningEffortOverride | null) => {
+    setReasoningEffort(effort);
+    if (chatSession) {
+      updateReasoningEffortForChatSession(chatSession.id, effort);
     }
   };
 
@@ -839,6 +885,9 @@ export function useLlmManager(
     updateCurrentLlm,
     temperature,
     updateTemperature,
+    temperatureExplicitlySet,
+    reasoningEffort,
+    updateReasoningEffort,
     imageFilesPresent,
     updateImageFilesPresent,
     liveAgent: liveAgent ?? null,

--- a/web/src/lib/hooks.ts
+++ b/web/src/lib/hooks.ts
@@ -413,6 +413,10 @@ export interface LlmManager {
   updateReasoningEffort: (effort: ReasoningEffortOverride | null) => void;
   /** True when updates persist to a session row at selection time. */
   hasBoundSession: boolean;
+  /** True while an override selection is not yet confirmed persisted.
+   * Selection-time PUTs are best-effort and never clear this. */
+  hasUnpersistedOverrides: () => boolean;
+  markOverridesPersisted: () => void;
   updateModelOverrideBasedOnChatSession: (chatSession?: ChatSession) => void;
   imageFilesPresent: boolean;
   updateImageFilesPresent: (present: boolean) => void;
@@ -783,6 +787,10 @@ export function useLlmManager(
   const [temperatureExplicitlySet, setTemperatureExplicitlySet] =
     useState(false);
 
+  // Set on every override selection, cleared when a send confirms the values
+  // persisted or when a session's stored values are adopted.
+  const unpersistedOverridesRef = useRef(false);
+
   // Adopt the stored reasoning override (and reset the explicit-temperature
   // flag) only when session identity changes. Keying on identity, not the
   // object, keeps new-chat dep churn from wiping a pre-first-message choice.
@@ -794,6 +802,7 @@ export function useLlmManager(
     if (prevSessionIdRef.current === sessionId) return;
     prevSessionIdRef.current = sessionId;
     setTemperatureExplicitlySet(false);
+    unpersistedOverridesRef.current = false;
     setReasoningEffort(
       currentChatSession?.current_reasoning_effort_override ?? null
     );
@@ -864,15 +873,17 @@ export function useLlmManager(
       : temperature;
     setTemperature(clampedTemp);
     setTemperatureExplicitlySet(true);
+    unpersistedOverridesRef.current = true;
     if (chatSession) {
-      updateTemperatureOverrideForChatSession(chatSession.id, clampedTemp);
+      void updateTemperatureOverrideForChatSession(chatSession.id, clampedTemp);
     }
   };
 
   const updateReasoningEffort = (effort: ReasoningEffortOverride | null) => {
     setReasoningEffort(effort);
+    unpersistedOverridesRef.current = true;
     if (chatSession) {
-      updateReasoningEffortForChatSession(chatSession.id, effort);
+      void updateReasoningEffortForChatSession(chatSession.id, effort);
     }
   };
 
@@ -891,6 +902,10 @@ export function useLlmManager(
     reasoningEffort,
     updateReasoningEffort,
     hasBoundSession: chatSession != null,
+    hasUnpersistedOverrides: () => unpersistedOverridesRef.current,
+    markOverridesPersisted: () => {
+      unpersistedOverridesRef.current = false;
+    },
     imageFilesPresent,
     updateImageFilesPresent,
     liveAgent: liveAgent ?? null,

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -1,6 +1,17 @@
 import type { OnboardingActions } from "@/interfaces/onboarding";
 import type { LLMProviderConfiguredSource } from "@/lib/analytics/utils";
 
+/**
+ * Per-session reasoning-effort override. Mirrors the backend ReasoningEffort
+ * enum minus "auto", since no override (null) already means auto.
+ */
+export type ReasoningEffortOverride =
+  | "off"
+  | "low"
+  | "medium"
+  | "high"
+  | "xhigh";
+
 export interface ModelConfiguration {
   id?: number;
   name: string;

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -86,7 +86,7 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
           temperature_override_enabled:
             currentUser.preferences?.temperature_override_enabled ??
             wsTemperatureOverride ??
-            false,
+            true,
         },
       };
     },

--- a/web/src/sections/model-selector/ModelSelector.tsx
+++ b/web/src/sections/model-selector/ModelSelector.tsx
@@ -1,28 +1,18 @@
 "use client";
 
-import React, {
-  useState,
-  useEffect,
-  useCallback,
-  useMemo,
-  useRef,
-} from "react";
-import { Popover, OpenButton, Text } from "@opal/components";
-import { Slider } from "@/components/ui/slider";
+import React, { useState, useCallback, useMemo, useRef } from "react";
+import { Popover, OpenButton } from "@opal/components";
 import { getModelIcon } from "@/lib/languageModels";
 import {
   GLOBAL_DEFAULT_LLM_OPTION,
   LLMOption,
 } from "@/lib/languageModels/options";
-import { useUser } from "@/providers/UserProvider";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
-import ModelSelectorContent from "@/sections/model-selector/ModelSelectorContent";
-
-interface TemperatureManager {
-  temperature: number;
-  updateTemperature: (value: number) => void;
-  maxTemperature: number;
-}
+import ModelSelectorContent, {
+  ReasoningManager,
+  TemperatureManager,
+  useModelDetailManagers,
+} from "@/sections/model-selector/ModelSelectorContent";
 
 export interface ModelSelectorProps {
   /** The currently selected model, identified by model_configuration_id. */
@@ -37,10 +27,16 @@ export interface ModelSelectorProps {
   renderTrigger?: () => React.ReactNode;
 
   /**
-   * When provided, a temperature slider is shown at the bottom of the
-   * popover (gated on user.preferences.temperature_override_enabled).
+   * When provided, a temperature slider is shown in the per-model detail
+   * pane (gated on user.preferences.temperature_override_enabled).
    */
   temperatureManager?: TemperatureManager;
+
+  /**
+   * When provided, the reasoning-level slider in the per-model detail pane is
+   * enabled for models that report supports_reasoning, disabled otherwise.
+   */
+  reasoningManager?: ReasoningManager;
 
   disabled?: boolean;
   /**
@@ -59,13 +55,13 @@ export default function ModelSelector({
   requiresImageInput,
   renderTrigger,
   temperatureManager,
+  reasoningManager,
   disabled = false,
   includeGlobalDefault = false,
   side = "top",
 }: ModelSelectorProps) {
   const { llmProviders, defaultText } = useCurrentAgentLLMProviders();
   const [open, setOpen] = useState(false);
-  const { user } = useUser();
   const scrollContainerRef = useRef<HTMLDivElement>(null);
 
   // Resolve the currently selected option from the ID
@@ -121,53 +117,10 @@ export default function ModelSelector({
     [onChange]
   );
 
-  // Temperature state — only used when temperatureManager is provided
-  const [localTemperature, setLocalTemperature] = useState(
-    temperatureManager?.temperature ?? 0.5
+  const modelDetail = useModelDetailManagers(
+    temperatureManager,
+    reasoningManager
   );
-
-  useEffect(() => {
-    if (temperatureManager) {
-      setLocalTemperature(temperatureManager.temperature ?? 0.5);
-    }
-  }, [temperatureManager?.temperature]);
-
-  const handleTemperatureChange = useCallback((vals: number[]) => {
-    if (vals[0] !== undefined) setLocalTemperature(vals[0]);
-  }, []);
-
-  const handleTemperatureCommit = useCallback(
-    (vals: number[]) => {
-      if (vals[0] !== undefined) temperatureManager?.updateTemperature(vals[0]);
-    },
-    [temperatureManager]
-  );
-
-  const temperatureFooter =
-    temperatureManager && user?.preferences?.temperature_override_enabled ? (
-      <>
-        <div className="border-t border-border-02 mx-2" />
-        <div className="flex flex-col w-full py-2 gap-2">
-          <Slider
-            value={[localTemperature]}
-            max={temperatureManager.maxTemperature}
-            min={0}
-            step={0.01}
-            onValueChange={handleTemperatureChange}
-            onValueCommit={handleTemperatureCommit}
-            className="w-full"
-          />
-          <div className="flex flex-row items-center justify-between">
-            <Text font="secondary-body" color="text-03">
-              Temperature (creativity)
-            </Text>
-            <Text font="secondary-body" color="text-03">
-              {localTemperature.toFixed(1)}
-            </Text>
-          </div>
-        </div>
-      </>
-    ) : undefined;
 
   const triggerIcon = effectiveOption
     ? getModelIcon(effectiveOption.provider, effectiveOption.modelName)
@@ -195,7 +148,7 @@ export default function ModelSelector({
           isSelected={isSelected}
           includeGlobalDefault={includeGlobalDefault}
           scrollContainerRef={scrollContainerRef}
-          footer={temperatureFooter}
+          modelDetail={modelDetail}
         />
       </Popover.Content>
     </Popover>

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   InputTypeIn,
   PopoverMenu,
+  Tooltip,
 } from "@opal/components";
 import {
   SvgBarChart,
@@ -206,6 +207,8 @@ interface SettingRowProps {
   icon: IconFunctionComponent;
   title: string;
   value?: string;
+  /** Shown when hovering the value readout. */
+  valueTooltip?: string;
   caption: string;
   children?: React.ReactNode;
 }
@@ -214,6 +217,7 @@ function SettingRow({
   icon: Icon,
   title,
   value,
+  valueTooltip,
   caption,
   children,
 }: SettingRowProps) {
@@ -226,9 +230,11 @@ function SettingRow({
         <Text font="main-ui-action">{title}</Text>
         <div className="flex-1" />
         {value !== undefined && (
-          <Text font="secondary-mono" color="text-04">
-            {value}
-          </Text>
+          <Tooltip tooltip={valueTooltip} side="top">
+            <Text font="secondary-mono" color="text-04">
+              {value}
+            </Text>
+          </Tooltip>
         )}
       </div>
       {children}
@@ -247,6 +253,9 @@ interface ModelDetailPaneProps {
 
 const UNSUPPORTED_SETTING_TOOLTIP =
   "Modifying this setting is not supported for this model.";
+
+const UNKNOWN_CONTEXT_TOOLTIP =
+  "Context size is not available for this model. Chats still apply a token limit automatically.";
 
 function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   // Backend pins temperature to 1 (or omits it) for reasoning models, so the
@@ -294,7 +303,7 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   const contextLabel =
     option.maxInputTokens != null && option.maxInputTokens > 0
       ? formatContextWindow(option.maxInputTokens)
-      : "—";
+      : null;
 
   return (
     <div
@@ -325,7 +334,8 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
       <SettingRow
         icon={SvgCode}
         title="Context Window"
-        value={contextLabel}
+        value={contextLabel ?? "—"}
+        valueTooltip={contextLabel ? undefined : UNKNOWN_CONTEXT_TOOLTIP}
         caption="Tokens limit for each session"
       />
 

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -142,14 +142,6 @@ function formatContextWindow(tokens: number): string {
   return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : `${tokens}`;
 }
 
-const CONTEXT_AXIS_STOPS = [
-  200_000, 500_000, 1_000_000, 2_000_000, 5_000_000, 10_000_000,
-];
-
-function contextAxisMax(tokens: number): number {
-  return CONTEXT_AXIS_STOPS.find((stop) => stop >= tokens) ?? tokens;
-}
-
 /** Both views render at this height so the popover never resizes. */
 const PANE_HEIGHT_CLASS = "h-[352px]";
 
@@ -191,7 +183,7 @@ function PaneSlider({
 }: PaneSliderProps) {
   return (
     <SliderPrimitive.Root
-      className="relative flex h-7 w-full touch-none select-none items-center"
+      className="relative flex h-7 w-full cursor-pointer touch-none select-none items-center"
       value={[value]}
       min={min}
       max={max}
@@ -207,22 +199,6 @@ function PaneSlider({
       </SliderPrimitive.Track>
       <SliderPrimitive.Thumb className={SLIDER_THUMB_CLASS} />
     </SliderPrimitive.Root>
-  );
-}
-
-/** Read-only gauge matching the PaneSlider look, for informational rows. */
-function ContextGauge({ fraction }: { fraction: number }) {
-  const pct = Math.min(100, Math.max(0, fraction * 100));
-  return (
-    <div className="relative flex h-7 w-full items-center">
-      <div className={SLIDER_TRACK_CLASS}>
-        <div className={SLIDER_FILL_CLASS} style={{ width: `${pct}%` }} />
-      </div>
-      <div
-        className={cn(SLIDER_THUMB_CLASS, "absolute -translate-x-1/2")}
-        style={{ left: `${pct}%` }}
-      />
-    </div>
   );
 }
 
@@ -315,14 +291,10 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
   if (temperatureFraction < 1 / 3) temperatureAnchor = 0;
   else if (temperatureFraction > 2 / 3) temperatureAnchor = 2;
 
-  const hasContextWindow =
-    option.maxInputTokens != null && option.maxInputTokens > 0;
-  const contextLabel = hasContextWindow
-    ? formatContextWindow(option.maxInputTokens!)
-    : "—";
-  const contextAxis = hasContextWindow
-    ? contextAxisMax(option.maxInputTokens!)
-    : 1;
+  const contextLabel =
+    option.maxInputTokens != null && option.maxInputTokens > 0
+      ? formatContextWindow(option.maxInputTokens)
+      : "—";
 
   return (
     <div
@@ -355,24 +327,7 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
         title="Context Window"
         value={contextLabel}
         caption="Tokens limit for each session"
-      >
-        {hasContextWindow && (
-          <>
-            <ContextGauge fraction={option.maxInputTokens! / contextAxis} />
-            <div className="flex flex-row items-center justify-between">
-              <Text font="figure-small-value" color="text-02">
-                0
-              </Text>
-              <Text font="figure-small-value" color="text-04">
-                {contextLabel}
-              </Text>
-              <Text font="figure-small-value" color="text-02">
-                {formatContextWindow(contextAxis)}
-              </Text>
-            </div>
-          </>
-        )}
-      </SettingRow>
+      />
 
       <Disabled
         disabled={!temperatureEnabled}

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -21,7 +21,7 @@ import {
 } from "@opal/icons";
 import { ContentAction, Section } from "@opal/layouts";
 import { cn } from "@opal/utils";
-import type { IconFunctionComponent } from "@opal/types";
+import type { IconFunctionComponent, IconProps } from "@opal/types";
 import { Disabled, Hoverable, Interactive } from "@opal/core";
 import {
   GLOBAL_DEFAULT_LLM_OPTION,
@@ -152,15 +152,22 @@ const SLIDER_TRACK_CLASS =
   "h-1.5 w-full overflow-hidden rounded bg-background-tint-02";
 const SLIDER_FILL_CLASS = "h-full bg-theme-primary-05";
 
-/** Left icon slot for selectable rows: a blue check, or reserved space. */
-function selectionIcon(selected: boolean): IconFunctionComponent {
-  if (!selected) return (props) => <div {...(props as any)} />;
-  return (props) => (
+function EmptyIconSlot(props: IconProps) {
+  return <div {...(props as any)} />;
+}
+
+function SelectedCheckIcon(props: IconProps) {
+  return (
     <SvgCheck
-      {...(props as any)}
-      className={cn((props as any).className, "text-action-link-05")}
+      {...props}
+      className={cn(props.className, "text-action-link-05")}
     />
   );
+}
+
+/** Left icon slot for selectable rows: a blue check, or reserved space. */
+function selectionIcon(selected: boolean): IconFunctionComponent {
+  return selected ? SelectedCheckIcon : EmptyIconSlot;
 }
 
 interface PaneSliderProps {
@@ -210,6 +217,9 @@ interface SettingRowProps {
   /** Shown when hovering the value readout. */
   valueTooltip?: string;
   caption: string;
+  disabled?: boolean;
+  /** Shown when hovering the row while disabled. */
+  disabledTooltip?: string;
   children?: React.ReactNode;
 }
 
@@ -219,29 +229,33 @@ function SettingRow({
   value,
   valueTooltip,
   caption,
+  disabled = false,
+  disabledTooltip,
   children,
 }: SettingRowProps) {
   return (
-    <div className="flex flex-col rounded-08 p-1.5">
-      <div className="flex flex-row items-center gap-2">
-        <div className="flex size-5 items-center justify-center text-text-04">
-          <Icon size={16} />
+    <Disabled disabled={disabled} tooltip={disabledTooltip} tooltipSide="top">
+      <div className="flex flex-col rounded-08 p-1.5">
+        <div className="flex flex-row items-center gap-2">
+          <div className="flex size-5 items-center justify-center text-text-04">
+            <Icon size={16} />
+          </div>
+          <Text font="main-ui-action">{title}</Text>
+          <div className="flex-1" />
+          {value !== undefined && (
+            <Tooltip tooltip={valueTooltip} side="top">
+              <Text font="secondary-mono" color="text-04">
+                {value}
+              </Text>
+            </Tooltip>
+          )}
         </div>
-        <Text font="main-ui-action">{title}</Text>
-        <div className="flex-1" />
-        {value !== undefined && (
-          <Tooltip tooltip={valueTooltip} side="top">
-            <Text font="secondary-mono" color="text-04">
-              {value}
-            </Text>
-          </Tooltip>
-        )}
+        {children}
+        <Text font="secondary-body" color="text-03">
+          {caption}
+        </Text>
       </div>
-      {children}
-      <Text font="secondary-body" color="text-03">
-        {caption}
-      </Text>
-    </div>
+    </Disabled>
   );
 }
 
@@ -258,9 +272,8 @@ const UNKNOWN_CONTEXT_TOOLTIP =
   "Context size is not available for this model. Chats still apply a token limit automatically.";
 
 function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
-  // Backend pins temperature to 1 (or omits it) for reasoning models, so the
-  // slider is locked at 1. Reasoning is only adjustable when the model
-  // supports it.
+  // Backend pins temperature to 1 (or omits it) for reasoning models, so
+  // the slider is locked at 1.
   const temperatureManager = managers.temperature;
   const reasoningManager = managers.reasoning;
   const temperatureEnabled = !option.supportsReasoning && !!temperatureManager;
@@ -273,6 +286,7 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
     (modelSupportsXhigh(option)
       ? ALL_REASONING_STOPS.length
       : BASE_REASONING_STOPS.length) - 1;
+  const clampStop = (stop: number) => Math.min(stop, maxSupportedStop);
 
   const [localTemperature, setLocalTemperature] = useState(
     temperatureManager?.temperature ?? 0.5
@@ -283,9 +297,8 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
     reasoningManager?.reasoningEffort ?? "medium"
   );
   const [localEffortStop, setLocalEffortStop] = useState(
-    Math.min(
-      storedStop === -1 ? ALL_REASONING_STOPS.indexOf("medium") : storedStop,
-      maxSupportedStop
+    clampStop(
+      storedStop === -1 ? ALL_REASONING_STOPS.indexOf("medium") : storedStop
     )
   );
 
@@ -339,108 +352,97 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
         caption="Tokens limit for each session"
       />
 
-      <Disabled
+      <SettingRow
+        icon={SvgThermometer}
+        title="Temperature"
+        value={displayTemperature.toFixed(1)}
+        caption="How predictable or creative the model should respond"
         disabled={!temperatureEnabled}
-        tooltip={UNSUPPORTED_SETTING_TOOLTIP}
-        tooltipSide="top"
+        disabledTooltip={UNSUPPORTED_SETTING_TOOLTIP}
       >
-        <SettingRow
-          icon={SvgThermometer}
-          title="Temperature"
-          value={displayTemperature.toFixed(1)}
-          caption="How predictable or creative the model should respond"
-        >
-          <PaneSlider
-            value={displayTemperature}
-            min={0}
-            max={maxTemperature}
-            step={0.01}
-            disabled={!temperatureEnabled}
-            onValueChange={setLocalTemperature}
-            onValueCommit={(value) =>
-              temperatureManager?.updateTemperature(value)
-            }
-          />
-          <div className="flex flex-row items-center justify-between">
-            {["Deterministic", "Balanced", "Creative"].map((label, index) => (
-              <Text
-                key={label}
-                font="figure-small-value"
-                color={index === temperatureAnchor ? "text-04" : "text-02"}
-              >
-                {label}
-              </Text>
-            ))}
-          </div>
-        </SettingRow>
-      </Disabled>
+        <PaneSlider
+          value={displayTemperature}
+          min={0}
+          max={maxTemperature}
+          step={0.01}
+          disabled={!temperatureEnabled}
+          onValueChange={setLocalTemperature}
+          onValueCommit={(value) =>
+            temperatureManager?.updateTemperature(value)
+          }
+        />
+        <div className="flex flex-row items-center justify-between">
+          {["Deterministic", "Balanced", "Creative"].map((label, index) => (
+            <Text
+              key={label}
+              font="figure-small-value"
+              color={index === temperatureAnchor ? "text-04" : "text-02"}
+            >
+              {label}
+            </Text>
+          ))}
+        </div>
+      </SettingRow>
 
-      <Disabled
+      <SettingRow
+        icon={SvgBarChart}
+        title="Reasoning Level"
+        value={effortLabel}
+        caption="How much thinking the model should perform before answering"
         disabled={!reasoningEnabled}
-        tooltip={UNSUPPORTED_SETTING_TOOLTIP}
-        tooltipSide="top"
+        disabledTooltip={UNSUPPORTED_SETTING_TOOLTIP}
       >
-        <SettingRow
-          icon={SvgBarChart}
-          title="Reasoning Level"
-          value={effortLabel}
-          caption="How much thinking the model should perform before answering"
-        >
-          <PaneSlider
-            value={localEffortStop}
-            min={0}
-            max={ALL_REASONING_STOPS.length - 1}
-            step={1}
-            disabled={!reasoningEnabled}
-            onValueChange={(value) =>
-              setLocalEffortStop(Math.min(value, maxSupportedStop))
-            }
-            onValueCommit={(value) => {
-              const effort =
-                ALL_REASONING_STOPS[Math.min(value, maxSupportedStop)];
-              if (effort) reasoningManager?.updateReasoningEffort(effort);
-            }}
-          />
-          {/* Labels anchor at the slider's index/lastStop fractions so they
+        <PaneSlider
+          value={localEffortStop}
+          min={0}
+          max={ALL_REASONING_STOPS.length - 1}
+          step={1}
+          disabled={!reasoningEnabled}
+          onValueChange={(value) => setLocalEffortStop(clampStop(value))}
+          onValueCommit={(value) => {
+            const effort = ALL_REASONING_STOPS[clampStop(value)];
+            if (effort) reasoningManager?.updateReasoningEffort(effort);
+          }}
+        />
+        {/* Labels anchor at the slider's index/lastStop fractions so they
               line up with the stops. End labels align to the row edges to
               avoid overflow. */}
-          <div className="relative h-4 w-full">
-            {ALL_REASONING_STOPS.map((stop, index) => {
-              const lastStop = ALL_REASONING_STOPS.length - 1;
-              return (
-                <div
-                  key={stop}
-                  className={cn(
-                    "absolute top-0",
-                    index === lastStop
-                      ? "-translate-x-full"
-                      : index > 0 && "-translate-x-1/2"
-                  )}
-                  style={{ left: `${(index / lastStop) * 100}%` }}
+        <div className="relative h-4 w-full">
+          {ALL_REASONING_STOPS.map((stop, index) => {
+            const lastStop = ALL_REASONING_STOPS.length - 1;
+            return (
+              <div
+                key={stop}
+                className={cn(
+                  "absolute top-0",
+                  index === lastStop
+                    ? "-translate-x-full"
+                    : index > 0 && "-translate-x-1/2"
+                )}
+                style={{ left: `${(index / lastStop) * 100}%` }}
+              >
+                <Disabled
+                  disabled={reasoningEnabled && index > maxSupportedStop}
+                  tooltip={UNSUPPORTED_SETTING_TOOLTIP}
+                  tooltipSide="top"
                 >
-                  <Disabled
-                    disabled={reasoningEnabled && index > maxSupportedStop}
-                    tooltip={UNSUPPORTED_SETTING_TOOLTIP}
-                    tooltipSide="top"
+                  <Text
+                    font="figure-small-value"
+                    color={
+                      reasoningEnabled && index === localEffortStop
+                        ? "text-04"
+                        : "text-02"
+                    }
+                    nowrap
                   >
-                    <Text
-                      font="figure-small-value"
-                      color={
-                        reasoningEnabled && index === localEffortStop
-                          ? "text-04"
-                          : "text-02"
-                      }
-                      nowrap
-                    >
-                      {REASONING_STOP_LABELS[stop]}
-                    </Text>
-                  </Disabled>
-                </div>
-              );
-            })}
-          </div>
-        </SettingRow>
-      </Disabled>
+                    {REASONING_STOP_LABELS[stop]}
+                  </Text>
+                </Disabled>
+              </div>
+            );
+          })}
+        </div>
+      </SettingRow>
     </div>
   );
 }

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -391,26 +391,43 @@ function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
               if (effort) reasoningManager?.updateReasoningEffort(effort);
             }}
           />
-          <div className="flex flex-row items-center justify-between">
-            {ALL_REASONING_STOPS.map((stop, index) => (
-              <Disabled
-                key={stop}
-                disabled={reasoningEnabled && index > maxSupportedStop}
-                tooltip={UNSUPPORTED_SETTING_TOOLTIP}
-                tooltipSide="top"
-              >
-                <Text
-                  font="figure-small-value"
-                  color={
-                    reasoningEnabled && index === localEffortStop
-                      ? "text-04"
-                      : "text-02"
-                  }
+          {/* Labels anchor at the slider's index/lastStop fractions so they
+              line up with the stops. End labels align to the row edges to
+              avoid overflow. */}
+          <div className="relative h-4 w-full">
+            {ALL_REASONING_STOPS.map((stop, index) => {
+              const lastStop = ALL_REASONING_STOPS.length - 1;
+              return (
+                <div
+                  key={stop}
+                  className={cn(
+                    "absolute top-0",
+                    index === lastStop
+                      ? "-translate-x-full"
+                      : index > 0 && "-translate-x-1/2"
+                  )}
+                  style={{ left: `${(index / lastStop) * 100}%` }}
                 >
-                  {REASONING_STOP_LABELS[stop]}
-                </Text>
-              </Disabled>
-            ))}
+                  <Disabled
+                    disabled={reasoningEnabled && index > maxSupportedStop}
+                    tooltip={UNSUPPORTED_SETTING_TOOLTIP}
+                    tooltipSide="top"
+                  >
+                    <Text
+                      font="figure-small-value"
+                      color={
+                        reasoningEnabled && index === localEffortStop
+                          ? "text-04"
+                          : "text-02"
+                      }
+                      nowrap
+                    >
+                      {REASONING_STOP_LABELS[stop]}
+                    </Text>
+                  </Disabled>
+                </div>
+              );
+            })}
           </div>
         </SettingRow>
       </Disabled>

--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect } from "react";
+import * as SliderPrimitive from "@radix-ui/react-slider";
 import {
   Button,
   LineItemButton,
@@ -8,10 +9,19 @@ import {
   InputTypeIn,
   PopoverMenu,
 } from "@opal/components";
-import { SvgCheck, SvgChevronRight } from "@opal/icons";
+import {
+  SvgBarChart,
+  SvgCheck,
+  SvgChevronLeft,
+  SvgChevronRight,
+  SvgCode,
+  SvgSliders,
+  SvgThermometer,
+} from "@opal/icons";
 import { ContentAction, Section } from "@opal/layouts";
 import { cn } from "@opal/utils";
-import { Disabled, Interactive } from "@opal/core";
+import type { IconFunctionComponent } from "@opal/types";
+import { Disabled, Hoverable, Interactive } from "@opal/core";
 import {
   GLOBAL_DEFAULT_LLM_OPTION,
   LLMOption,
@@ -19,12 +29,439 @@ import {
   groupLlmOptions,
   llmOptionKey,
 } from "@/lib/languageModels/options";
+import { ReasoningEffortOverride } from "@/lib/languageModels/types";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
+import { useUser } from "@/providers/UserProvider";
 import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/refresh-components/Collapsible";
+
+export interface TemperatureManager {
+  temperature: number;
+  updateTemperature: (value: number) => void;
+  maxTemperature: number;
+}
+
+export interface ReasoningManager {
+  reasoningEffort: ReasoningEffortOverride | null;
+  updateReasoningEffort: (effort: ReasoningEffortOverride | null) => void;
+}
+
+/** Managers powering the per-model detail pane. Rows always render, and an absent manager leaves its row disabled. */
+export interface ModelDetailManagers {
+  temperature?: TemperatureManager;
+  reasoning?: ReasoningManager;
+}
+
+/**
+ * Builds the detail-pane managers for a selector host. Temperature is gated
+ * on user.preferences.temperature_override_enabled. The result is undefined
+ * when no block would render.
+ */
+export function useModelDetailManagers(
+  temperatureManager?: TemperatureManager,
+  reasoningManager?: ReasoningManager
+): ModelDetailManagers | undefined {
+  const { user } = useUser();
+  const temperatureOverrideEnabled =
+    user?.preferences?.temperature_override_enabled;
+  return useMemo(() => {
+    const temperature =
+      temperatureManager && temperatureOverrideEnabled
+        ? temperatureManager
+        : undefined;
+    return temperature || reasoningManager
+      ? { temperature, reasoning: reasoningManager }
+      : undefined;
+  }, [temperatureManager, reasoningManager, temperatureOverrideEnabled]);
+}
+
+const BASE_REASONING_STOPS: ReasoningEffortOverride[] = [
+  "off",
+  "low",
+  "medium",
+  "high",
+];
+
+/** Every stop the slider renders. Unsupported stops are greyed, never hidden. */
+const ALL_REASONING_STOPS: ReasoningEffortOverride[] = [
+  ...BASE_REASONING_STOPS,
+  "xhigh",
+];
+
+const REASONING_STOP_LABELS: Record<ReasoningEffortOverride, string> = {
+  off: "Off",
+  low: "Low",
+  medium: "Medium",
+  high: "High",
+  xhigh: "XHigh",
+};
+
+/** Providers whose models can be true OpenAI models (responses API). */
+const TRUE_OPENAI_PROVIDERS = new Set(["openai", "azure", "litellm_proxy"]);
+
+/**
+ * Approximates the backend's _parse_anthropic_model_version. Segments longer
+ * than two digits are date snapshots, not minor versions, and parse as 0.
+ */
+function anthropicModelVersion(modelName: string): [number, number] | null {
+  const name = modelName.toLowerCase();
+  const claudeIndex = name.indexOf("claude");
+  if (claudeIndex === -1) return null;
+  const match = name.slice(claudeIndex).match(/\d+(?:[.-]\d+)?/);
+  if (!match) return null;
+  const parts = match[0].split(/[.-]/);
+  if (!parts[0]) return null;
+  const minor = parts[1] && parts[1].length <= 2 ? parseInt(parts[1], 10) : 0;
+  return [parseInt(parts[0], 10), minor];
+}
+
+/**
+ * Display-side mirror of the backend capability checks: xhigh is supported by
+ * true OpenAI models and by Anthropic adaptive-thinking models (Claude >= 4.7,
+ * matching _anthropic_uses_adaptive_thinking). The backend clamps unsupported
+ * levels or strips rejected reasoning params and retries, so an imperfect
+ * match here degrades gracefully.
+ */
+function modelSupportsXhigh(option: LLMOption): boolean {
+  const openAiXhigh =
+    TRUE_OPENAI_PROVIDERS.has(option.provider) &&
+    /^(gpt-|o\d)/i.test(option.modelName);
+  const claudeVersion = anthropicModelVersion(option.modelName);
+  const anthropicXhigh =
+    claudeVersion !== null &&
+    (claudeVersion[0] > 4 || (claudeVersion[0] === 4 && claudeVersion[1] >= 7));
+  return openAiXhigh || anthropicXhigh;
+}
+
+function formatContextWindow(tokens: number): string {
+  if (tokens >= 1_000_000)
+    return `${(tokens / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+  return tokens >= 1000 ? `${Math.round(tokens / 1000)}K` : `${tokens}`;
+}
+
+const CONTEXT_AXIS_STOPS = [
+  200_000, 500_000, 1_000_000, 2_000_000, 5_000_000, 10_000_000,
+];
+
+function contextAxisMax(tokens: number): number {
+  return CONTEXT_AXIS_STOPS.find((stop) => stop >= tokens) ?? tokens;
+}
+
+/** Both views render at this height so the popover never resizes. */
+const PANE_HEIGHT_CLASS = "h-[352px]";
+
+const SLIDER_THUMB_CLASS =
+  "block size-3 rounded-full bg-background-neutral-00 shadow-[0_0_2px_1px_rgba(0,0,0,0.15)] focus:outline-none";
+const SLIDER_TRACK_CLASS =
+  "h-1.5 w-full overflow-hidden rounded bg-background-tint-02";
+const SLIDER_FILL_CLASS = "h-full bg-theme-primary-05";
+
+/** Left icon slot for selectable rows: a blue check, or reserved space. */
+function selectionIcon(selected: boolean): IconFunctionComponent {
+  if (!selected) return (props) => <div {...(props as any)} />;
+  return (props) => (
+    <SvgCheck
+      {...(props as any)}
+      className={cn((props as any).className, "text-action-link-05")}
+    />
+  );
+}
+
+interface PaneSliderProps {
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  disabled?: boolean;
+  onValueChange: (value: number) => void;
+  onValueCommit: (value: number) => void;
+}
+
+function PaneSlider({
+  value,
+  min,
+  max,
+  step,
+  disabled,
+  onValueChange,
+  onValueCommit,
+}: PaneSliderProps) {
+  return (
+    <SliderPrimitive.Root
+      className="relative flex h-7 w-full touch-none select-none items-center"
+      value={[value]}
+      min={min}
+      max={max}
+      step={step}
+      disabled={disabled}
+      onValueChange={(vals) => vals[0] !== undefined && onValueChange(vals[0])}
+      onValueCommit={(vals) => vals[0] !== undefined && onValueCommit(vals[0])}
+    >
+      <SliderPrimitive.Track
+        className={cn(SLIDER_TRACK_CLASS, "relative grow")}
+      >
+        <SliderPrimitive.Range className={cn(SLIDER_FILL_CLASS, "absolute")} />
+      </SliderPrimitive.Track>
+      <SliderPrimitive.Thumb className={SLIDER_THUMB_CLASS} />
+    </SliderPrimitive.Root>
+  );
+}
+
+/** Read-only gauge matching the PaneSlider look, for informational rows. */
+function ContextGauge({ fraction }: { fraction: number }) {
+  const pct = Math.min(100, Math.max(0, fraction * 100));
+  return (
+    <div className="relative flex h-7 w-full items-center">
+      <div className={SLIDER_TRACK_CLASS}>
+        <div className={SLIDER_FILL_CLASS} style={{ width: `${pct}%` }} />
+      </div>
+      <div
+        className={cn(SLIDER_THUMB_CLASS, "absolute -translate-x-1/2")}
+        style={{ left: `${pct}%` }}
+      />
+    </div>
+  );
+}
+
+interface SettingRowProps {
+  icon: IconFunctionComponent;
+  title: string;
+  value?: string;
+  caption: string;
+  children?: React.ReactNode;
+}
+
+function SettingRow({
+  icon: Icon,
+  title,
+  value,
+  caption,
+  children,
+}: SettingRowProps) {
+  return (
+    <div className="flex flex-col rounded-08 p-1.5">
+      <div className="flex flex-row items-center gap-2">
+        <div className="flex size-5 items-center justify-center text-text-04">
+          <Icon size={16} />
+        </div>
+        <Text font="main-ui-action">{title}</Text>
+        <div className="flex-1" />
+        {value !== undefined && (
+          <Text font="secondary-mono" color="text-04">
+            {value}
+          </Text>
+        )}
+      </div>
+      {children}
+      <Text font="secondary-body" color="text-03">
+        {caption}
+      </Text>
+    </div>
+  );
+}
+
+interface ModelDetailPaneProps {
+  option: LLMOption;
+  managers: ModelDetailManagers;
+  onBack: () => void;
+}
+
+const UNSUPPORTED_SETTING_TOOLTIP =
+  "Modifying this setting is not supported for this model.";
+
+function ModelDetailPane({ option, managers, onBack }: ModelDetailPaneProps) {
+  // Backend pins temperature to 1 (or omits it) for reasoning models, so the
+  // slider is locked at 1. Reasoning is only adjustable when the model
+  // supports it.
+  const temperatureManager = managers.temperature;
+  const reasoningManager = managers.reasoning;
+  const temperatureEnabled = !option.supportsReasoning && !!temperatureManager;
+  const reasoningEnabled = option.supportsReasoning && !!reasoningManager;
+
+  // Supported stops are always a prefix of ALL_REASONING_STOPS. The slider
+  // spans all stops for uniform geometry and clamps input to the max
+  // supported index.
+  const maxSupportedStop =
+    (modelSupportsXhigh(option)
+      ? ALL_REASONING_STOPS.length
+      : BASE_REASONING_STOPS.length) - 1;
+
+  const [localTemperature, setLocalTemperature] = useState(
+    temperatureManager?.temperature ?? 0.5
+  );
+  // A stored level the model doesn't support (e.g. xhigh after switching
+  // models) displays clamped to the highest supported stop.
+  const storedStop = ALL_REASONING_STOPS.indexOf(
+    reasoningManager?.reasoningEffort ?? "medium"
+  );
+  const [localEffortStop, setLocalEffortStop] = useState(
+    Math.min(
+      storedStop === -1 ? ALL_REASONING_STOPS.indexOf("medium") : storedStop,
+      maxSupportedStop
+    )
+  );
+
+  const displayTemperature = temperatureEnabled ? localTemperature : 1;
+  const effortLabel =
+    REASONING_STOP_LABELS[ALL_REASONING_STOPS[localEffortStop] ?? "medium"];
+
+  const maxTemperature = temperatureManager?.maxTemperature ?? 2;
+  const temperatureFraction =
+    maxTemperature > 0 ? displayTemperature / maxTemperature : 0;
+  let temperatureAnchor = 1;
+  if (temperatureFraction < 1 / 3) temperatureAnchor = 0;
+  else if (temperatureFraction > 2 / 3) temperatureAnchor = 2;
+
+  const hasContextWindow =
+    option.maxInputTokens != null && option.maxInputTokens > 0;
+  const contextLabel = hasContextWindow
+    ? formatContextWindow(option.maxInputTokens!)
+    : "—";
+  const contextAxis = hasContextWindow
+    ? contextAxisMax(option.maxInputTokens!)
+    : 1;
+
+  return (
+    <div
+      className={cn(
+        PANE_HEIGHT_CLASS,
+        "flex w-full flex-col gap-1 overflow-y-auto"
+      )}
+    >
+      <div className="flex flex-row items-center gap-1 p-1">
+        <Button
+          icon={SvgChevronLeft}
+          prominence="tertiary"
+          size="sm"
+          onClick={onBack}
+        />
+        <div className="flex min-w-0 flex-1 flex-row items-baseline justify-between gap-2">
+          <Text font="main-ui-body" color="text-02" nowrap>
+            {option.displayName}
+          </Text>
+          <div className="min-w-0 truncate">
+            <Text font="secondary-body" color="text-02">
+              {option.modelName}
+            </Text>
+          </div>
+        </div>
+      </div>
+
+      <SettingRow
+        icon={SvgCode}
+        title="Context Window"
+        value={contextLabel}
+        caption="Tokens limit for each session"
+      >
+        {hasContextWindow && (
+          <>
+            <ContextGauge fraction={option.maxInputTokens! / contextAxis} />
+            <div className="flex flex-row items-center justify-between">
+              <Text font="figure-small-value" color="text-02">
+                0
+              </Text>
+              <Text font="figure-small-value" color="text-04">
+                {contextLabel}
+              </Text>
+              <Text font="figure-small-value" color="text-02">
+                {formatContextWindow(contextAxis)}
+              </Text>
+            </div>
+          </>
+        )}
+      </SettingRow>
+
+      <Disabled
+        disabled={!temperatureEnabled}
+        tooltip={UNSUPPORTED_SETTING_TOOLTIP}
+        tooltipSide="top"
+      >
+        <SettingRow
+          icon={SvgThermometer}
+          title="Temperature"
+          value={displayTemperature.toFixed(1)}
+          caption="How predictable or creative the model should respond"
+        >
+          <PaneSlider
+            value={displayTemperature}
+            min={0}
+            max={maxTemperature}
+            step={0.01}
+            disabled={!temperatureEnabled}
+            onValueChange={setLocalTemperature}
+            onValueCommit={(value) =>
+              temperatureManager?.updateTemperature(value)
+            }
+          />
+          <div className="flex flex-row items-center justify-between">
+            {["Deterministic", "Balanced", "Creative"].map((label, index) => (
+              <Text
+                key={label}
+                font="figure-small-value"
+                color={index === temperatureAnchor ? "text-04" : "text-02"}
+              >
+                {label}
+              </Text>
+            ))}
+          </div>
+        </SettingRow>
+      </Disabled>
+
+      <Disabled
+        disabled={!reasoningEnabled}
+        tooltip={UNSUPPORTED_SETTING_TOOLTIP}
+        tooltipSide="top"
+      >
+        <SettingRow
+          icon={SvgBarChart}
+          title="Reasoning Level"
+          value={effortLabel}
+          caption="How much thinking the model should perform before answering"
+        >
+          <PaneSlider
+            value={localEffortStop}
+            min={0}
+            max={ALL_REASONING_STOPS.length - 1}
+            step={1}
+            disabled={!reasoningEnabled}
+            onValueChange={(value) =>
+              setLocalEffortStop(Math.min(value, maxSupportedStop))
+            }
+            onValueCommit={(value) => {
+              const effort =
+                ALL_REASONING_STOPS[Math.min(value, maxSupportedStop)];
+              if (effort) reasoningManager?.updateReasoningEffort(effort);
+            }}
+          />
+          <div className="flex flex-row items-center justify-between">
+            {ALL_REASONING_STOPS.map((stop, index) => (
+              <Disabled
+                key={stop}
+                disabled={reasoningEnabled && index > maxSupportedStop}
+                tooltip={UNSUPPORTED_SETTING_TOOLTIP}
+                tooltipSide="top"
+              >
+                <Text
+                  font="figure-small-value"
+                  color={
+                    reasoningEnabled && index === localEffortStop
+                      ? "text-04"
+                      : "text-02"
+                  }
+                >
+                  {REASONING_STOP_LABELS[stop]}
+                </Text>
+              </Disabled>
+            ))}
+          </div>
+        </SettingRow>
+      </Disabled>
+    </div>
+  );
+}
 
 export interface ModelSelectorContentProps {
   currentModelName?: string;
@@ -35,7 +472,8 @@ export interface ModelSelectorContentProps {
   scrollContainerRef?: React.RefObject<HTMLDivElement | null>;
   /** When true, a "Global Default Model" entry is prepended to the list. */
   includeGlobalDefault?: boolean;
-  footer?: React.ReactNode;
+  /** When provided, model rows gain a drill-in settings pane. */
+  modelDetail?: ModelDetailManagers;
 }
 
 export default function ModelSelectorContent({
@@ -46,8 +484,9 @@ export default function ModelSelectorContent({
   isDisabled,
   scrollContainerRef: externalScrollRef,
   includeGlobalDefault = false,
-  footer,
+  modelDetail,
 }: ModelSelectorContentProps) {
+  const [detailOption, setDetailOption] = useState<LLMOption | null>(null);
   const { llmProviders, isLoading, defaultText } =
     useCurrentAgentLLMProviders();
 
@@ -125,37 +564,56 @@ export default function ModelSelectorContent({
     const selected = isSelected(option);
     const disabled = isDisabled?.(option) ?? false;
 
-    const capabilities: string[] = [];
-    if (option.supportsReasoning) capabilities.push("Reasoning");
-    if (option.supportsImageInput) capabilities.push("Vision");
+    // Skip the model-id description when it would just repeat the display name.
     const description =
-      capabilities.length > 0 ? capabilities.join(", ") : undefined;
+      option.modelName !== option.displayName ? option.modelName : undefined;
 
     return (
       <Disabled key={llmOptionKey(option)} disabled={disabled}>
-        <LineItemButton
-          selectVariant="select-heavy"
-          state={selected ? "selected" : "empty"}
-          icon={(props) => <div {...(props as any)} />}
-          title={option.displayName}
-          description={description}
-          onClick={() => onSelect(option)}
-          rightChildren={
-            selected ? (
-              <div className="flex h-5 items-center">
-                <SvgCheck className="text-action-link-05" size={16} />
-              </div>
-            ) : null
-          }
-          sizePreset="main-ui"
-          rounding="sm"
-        />
+        <Hoverable.Root group="model-row">
+          <LineItemButton
+            selectVariant="select-heavy"
+            state={selected ? "selected" : "empty"}
+            icon={selectionIcon(selected)}
+            title={option.displayName}
+            description={description}
+            onClick={() => onSelect(option)}
+            rightChildren={
+              modelDetail ? (
+                <Hoverable.Item group="model-row" variant="appear-on-hover">
+                  <Button
+                    icon={SvgSliders}
+                    prominence="tertiary"
+                    size="sm"
+                    aria-label={`${option.displayName} settings`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDetailOption(option);
+                    }}
+                  />
+                </Hoverable.Item>
+              ) : null
+            }
+            sizePreset="main-ui"
+            rounding="sm"
+          />
+        </Hoverable.Root>
       </Disabled>
     );
   };
 
+  if (detailOption && modelDetail) {
+    return (
+      <ModelDetailPane
+        option={detailOption}
+        managers={modelDetail}
+        onBack={() => setDetailOption(null)}
+      />
+    );
+  }
+
   return (
-    <Section gap={0.5}>
+    <div className={cn(PANE_HEIGHT_CLASS, "flex w-full flex-col gap-1")}>
       <InputTypeIn
         searchIcon
         variant="internal"
@@ -174,17 +632,10 @@ export default function ModelSelectorContent({
                   state={
                     isSelected(GLOBAL_DEFAULT_LLM_OPTION) ? "selected" : "empty"
                   }
-                  icon={(props) => <div {...(props as any)} />}
+                  icon={selectionIcon(isSelected(GLOBAL_DEFAULT_LLM_OPTION))}
                   title={GLOBAL_DEFAULT_LLM_OPTION.displayName}
                   description={globalDefaultDisplayName ?? undefined}
                   onClick={() => onSelect(GLOBAL_DEFAULT_LLM_OPTION)}
-                  rightChildren={
-                    isSelected(GLOBAL_DEFAULT_LLM_OPTION) ? (
-                      <div className="flex h-5 items-center">
-                        <SvgCheck className="text-action-link-05" size={16} />
-                      </div>
-                    ) : null
-                  }
                   sizePreset="main-ui"
                   rounding="sm"
                 />,
@@ -213,9 +664,9 @@ export default function ModelSelectorContent({
                       {groupedOptions[0]!.options.map(renderModelItem)}
                     </Section>,
                   ]
-                : groupedOptions.map((group) => {
+                : groupedOptions.flatMap((group, groupIndex) => {
                     const open = isGroupOpen(group.key);
-                    return (
+                    const collapsible = (
                       <Collapsible
                         key={group.key}
                         open={open}
@@ -229,7 +680,7 @@ export default function ModelSelectorContent({
                               rounding="sm"
                               width="full"
                             >
-                              <div className="pl-2 pr-1 py-1 w-full">
+                              <div className="pl-2 pr-1 py-1 w-full rounded-08 bg-background-tint-01">
                                 <ContentAction
                                   sizePreset="secondary"
                                   variant="body"
@@ -269,11 +720,11 @@ export default function ModelSelectorContent({
                         </CollapsibleContent>
                       </Collapsible>
                     );
+                    // null children render as PopoverMenu divider lines.
+                    return groupIndex > 0 ? [null, collapsible] : [collapsible];
                   })),
         ]}
       </PopoverMenu>
-
-      {footer}
-    </Section>
+    </div>
   );
 }

--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -18,7 +18,11 @@ import {
   llmOptionKey,
 } from "@/lib/languageModels/options";
 import { useCurrentAgentLLMProviders } from "@/lib/languageModels/hooks";
-import ModelSelectorContent from "@/sections/model-selector/ModelSelectorContent";
+import ModelSelectorContent, {
+  ReasoningManager,
+  TemperatureManager,
+  useModelDetailManagers,
+} from "@/sections/model-selector/ModelSelectorContent";
 
 export const MAX_MODELS = 3;
 
@@ -36,6 +40,9 @@ export interface MultiModelSelectorProps {
   onAdd: (model: SelectedModel) => void;
   onRemove: (index: number) => void;
   onReplace: (index: number, model: SelectedModel) => void;
+  /** See ModelSelectorProps. Powers the per-model detail pane. */
+  temperatureManager?: TemperatureManager;
+  reasoningManager?: ReasoningManager;
 }
 
 export default function MultiModelSelector({
@@ -43,6 +50,8 @@ export default function MultiModelSelector({
   onAdd,
   onRemove,
   onReplace,
+  temperatureManager,
+  reasoningManager,
 }: MultiModelSelectorProps) {
   const [open, setOpen] = useState(false);
   const [replacingIndex, setReplacingIndex] = useState<number | null>(null);
@@ -50,6 +59,11 @@ export default function MultiModelSelector({
 
   const settings = useSettings();
   const multiModelAllowed = settings.multi_model_chat_enabled ?? true;
+
+  const modelDetail = useModelDetailManagers(
+    temperatureManager,
+    reasoningManager
+  );
 
   // Mirror the data source used by `ModelSelectorContent` so the selector is
   // disabled precisely when the popover would render "No models found".
@@ -248,6 +262,7 @@ export default function MultiModelSelector({
             onSelect={handleSelect}
             isSelected={isSelected}
             isDisabled={isDisabled}
+            modelDetail={modelDetail}
           />
         </Popover.Content>
       )}

--- a/web/src/views/AppPage.tsx
+++ b/web/src/views/AppPage.tsx
@@ -919,6 +919,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                             onAdd={multiModel.addModel}
                             onRemove={multiModel.removeModel}
                             onReplace={multiModel.replaceModel}
+                            temperatureManager={llmManager}
+                            reasoningManager={llmManager}
                           />
                         )}
                     </Section>
@@ -999,6 +1001,8 @@ export default function AppPage({ firstMessage }: ChatPageProps) {
                             onAdd={multiModel.addModel}
                             onRemove={multiModel.removeModel}
                             onReplace={multiModel.replaceModel}
+                            temperatureManager={llmManager}
+                            reasoningManager={llmManager}
                           />
                         </div>
                       )}

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -926,7 +926,7 @@ export default function ChatPreferencesPage() {
                 withLabel
               >
                 <Switch
-                  checked={s.temperature_override_enabled ?? false}
+                  checked={s.temperature_override_enabled ?? true}
                   onCheckedChange={(checked) => {
                     void saveSettings({
                       temperature_override_enabled: checked,


### PR DESCRIPTION
## Description

Frontend for user-controlled reasoning levels, stacked on #13378 (backend) and #13377 (db).

- Model selector rows gain a hover-revealed settings pane per the Figma design: context window gauge, temperature slider, reasoning slider (off to xhigh) at a fixed popover height.
- Every model shows the same three rows. Unsupported settings render disabled with an explanatory tooltip. Unsupported reasoning stops are greyed and clamped (xhigh only for true OpenAI models and Claude >= 4.7).
- Overrides persist per chat session, adopt on session switch, and pre-first-message choices are awaited before the send (a rejected write fails the send rather than silently degrading).
- Adds the Opal thermometer icon from the design's icon set.

### Why Context Window can be blank

The pane reads `model_configuration.max_input_tokens`, which is persisted once at model-registration time from whatever source knew it then (dynamic providers like OpenRouter report `context_length`, others come from the litellm registry current at that moment). Models newer than that snapshot get NULL, and Bedrock never reports a value. Nothing backfills rows after a litellm upgrade. Only the display is affected: at runtime the backend resolves a real limit through `get_max_input_tokens_from_llm_provider` (DB row, then litellm's registry, then a 32k default). For these models the row shows a dash with a tooltip so users are not left guessing. Follow-up: serve the resolved limit to the UI instead of the raw column.

## How Has This Been Tested?

On dev1 against live providers. Each model's pane shows its own capability gating with the session-wide overrides.

GPT-4.1 (no reasoning support): temperature active and set to 0.7, reasoning row disabled.

<img width="400" alt="GPT-4.1 pane with temperature 0.7 and reasoning disabled" src="https://github.com/user-attachments/assets/76cb058c-2534-4638-87d0-cb3a79fecdff" />

GPT-5.4: reasoning set to XHigh, temperature locked at 1.0 while reasoning is on.

<img width="400" alt="GPT-5.4 pane with reasoning XHigh and temperature locked" src="https://github.com/user-attachments/assets/7f6f60c8-7fa0-4ef5-bf88-a7509952d5a6" />

Claude Haiku 4.5: reasoning set to High, the XHigh stop is greyed out as unsupported, temperature locked.

<img width="400" alt="Claude Haiku 4.5 pane with reasoning High and XHigh disabled" src="https://github.com/user-attachments/assets/9bff6122-2122-4cf9-b2df-7c204b434ad8" />

Claude Fable 5 (no registered context size on this environment): the Context Window row shows a dash and hovering it explains why.

<img width="400" alt="Tooltip explaining an unavailable context size" src="https://github.com/user-attachments/assets/940a9f75-b138-4508-a5cb-9a190f744446" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
