### PR TITLE
backport(v4.3): Confluence include_attachments setting (#13283)

### DIFF
--- a/backend/onyx/connectors/README.md
+++ b/backend/onyx/connectors/README.md
@@ -76,6 +76,29 @@ if __name__ == "__main__":
 
 > Note: Be sure to set PYTHONPATH to onyx/backend before running the above main.
 
+#### Supporting "Include Attachments"
+
+If the source has attachments (files attached to pages, tickets, etc.), let admins opt out of
+indexing them by following the shared convention:
+
+- Accept an `include_attachments: bool` kwarg in the connector's `__init__`. The value flows in
+  automatically from `connector_specific_config`; no factory or API changes are needed.
+  - New connectors should default it to `False`.
+  - When retrofitting a connector that already indexes attachments unconditionally, default it to
+    `True` — existing connector rows have no `include_attachments` key stored, so the constructor
+    default is what they get and their behavior must not change.
+- Gate **every** attachment enumeration path on the flag: the main indexing pass **and** the
+  slim-doc pass (pruning / permission sync) if the connector has one. The slim pass must admit
+  exactly the same documents as the main pass — emitting attachment slim docs the main pass
+  skipped leaves permanent `chunk_count IS NULL` rows, while correctly omitting them lets pruning
+  clean up previously indexed attachments after an admin turns the setting off.
+- In the frontend form, add `buildIncludeAttachmentsOption(<default>)` from
+  `web/src/lib/connectors/connectors.tsx` to the connector's `connectorConfigs` entry (use the
+  same default as the backend), and add `include_attachments?: boolean` to the connector's config
+  interface in that file.
+
+`ConfluenceConnector` and `DrupalWikiConnector` are reference implementations.
+
 ### Additional Required Changes:
 
 #### Backend Changes

--- a/backend/onyx/connectors/confluence/connector.py
+++ b/backend/onyx/connectors/confluence/connector.py
@@ -1,6 +1,6 @@
 import copy
 import re
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from urllib.parse import quote
@@ -168,6 +168,9 @@ class ConfluenceConnector(
         labels_to_skip: list[str] = CONFLUENCE_CONNECTOR_LABELS_TO_SKIP,
         timezone_offset: float = CONFLUENCE_TIMEZONE_OFFSET,
         scoped_token: bool = False,
+        # default True: configs stored before this option existed must keep
+        # indexing attachments
+        include_attachments: bool = True,
     ) -> None:
         self.wiki_base = wiki_base
         self.is_cloud = is_cloud
@@ -179,6 +182,7 @@ class ConfluenceConnector(
         self.labels_to_skip = labels_to_skip
         self.timezone_offset = timezone_offset
         self.scoped_token = scoped_token
+        self.include_attachments = include_attachments
         self._confluence_client: OnyxConfluence | None = None
         self._low_timeout_confluence_client: OnyxConfluence | None = None
         self._fetched_titles: set[str] = set()
@@ -606,6 +610,9 @@ class ConfluenceConnector(
         If there are valid attachments, the page itself is yielded as a hierarchy node
         (since attachments are children of the page in the hierarchy).
         """
+        if not self.include_attachments:
+            return [], []
+
         attachment_query = self._construct_attachment_query(
             _get_page_id(page), start, end
         )
@@ -1167,18 +1174,21 @@ class ConfluenceConnector(
             # Attachments resolve from inline `restrictions` only; no
             # ancestor walk, so per-page mode is a no-op for them.
             page_hierarchy_node_yielded = False
-            attachment_query = self._construct_attachment_query(
-                _get_page_id(page), start, end
-            )
-            for attachment in self.confluence_client.cql_paginate_all_expansions(
-                cql=attachment_query,
-                expand=restrictions_expand,
-                limit=_SLIM_DOC_BATCH_SIZE,
-            ):
-                # If you skip images in the main indexing pass (allow_images
-                # is False), skip them here too. Otherwise the slim path emits
-                # a SlimDocument for an attachment the main path never produces
-                # a Document for, leaving a permanent chunk_count IS NULL row.
+            attachment_results: Iterable[dict[str, Any]] = ()
+            if self.include_attachments:
+                attachment_query = self._construct_attachment_query(
+                    _get_page_id(page), start, end
+                )
+                attachment_results = self.confluence_client.cql_paginate_all_expansions(
+                    cql=attachment_query,
+                    expand=restrictions_expand,
+                    limit=_SLIM_DOC_BATCH_SIZE,
+                )
+            for attachment in attachment_results:
+                # admission must mirror the main indexing pass
+                # (include_attachments + allow_images): extra slim docs become
+                # permanent chunk_count IS NULL rows, missing ones let pruning
+                # clean up docs the main pass no longer indexes
                 media_type = attachment.get("metadata", {}).get("mediaType", "")
                 if not self.allow_images and media_type.startswith("image/"):
                     continue

--- a/backend/tests/unit/onyx/connectors/confluence/test_include_attachments_skip.py
+++ b/backend/tests/unit/onyx/connectors/confluence/test_include_attachments_skip.py
@@ -1,0 +1,137 @@
+"""Tests that `include_attachments=False` suppresses attachments in both the
+main indexing pass and the slim-doc pass, which must stay in lockstep (see
+the admission comment in `_retrieve_all_slim_docs`)."""
+
+from typing import Any
+from unittest import mock
+
+from onyx.connectors.confluence.connector import ConfluenceConnector
+from onyx.connectors.confluence.onyx_confluence import OnyxConfluence
+from onyx.connectors.models import SlimDocument
+
+_PAGE_CQL = "PAGE_CQL"
+_ATTACHMENT_CQL = "ATTACHMENT_CQL"
+
+_CREATED = {"createdDate": "2023-01-01T12:00:00.000+0000"}
+_PAGE = {
+    "id": "111",
+    "_links": {"webui": "/spaces/X/pages/111/Page"},
+    "restrictions": {},
+    "space": {"key": "X"},
+    "ancestors": [],
+    "history": _CREATED,
+}
+_PDF_ATTACHMENT = {
+    "title": "spec.pdf",
+    "metadata": {"mediaType": "application/pdf"},
+    "_links": {"webui": "/download/attachments/111/spec.pdf"},
+    "restrictions": {},
+    "space": {"key": "X"},
+    "history": _CREATED,
+}
+
+
+def _build_connector(include_attachments: bool) -> ConfluenceConnector:
+    return ConfluenceConnector(
+        wiki_base="https://fake-cloud.atlassian.net/wiki",
+        is_cloud=True,
+        include_attachments=include_attachments,
+    )
+
+
+def _collect_slim_doc_ids(
+    connector: ConfluenceConnector, fake_client: mock.Mock
+) -> list[str]:
+    """Drive the pruning slim-doc path (include_permissions=False) with a
+    fake client and return every emitted SlimDocument id."""
+
+    def fake_paginate(**kwargs: Any) -> Any:
+        cql = kwargs.get("cql")
+        if cql == _PAGE_CQL:
+            return iter([_PAGE])
+        if cql == _ATTACHMENT_CQL:
+            return iter([_PDF_ATTACHMENT])
+        return iter([])
+
+    fake_client.cql_paginate_all_expansions.side_effect = fake_paginate
+
+    with (
+        mock.patch.object(
+            ConfluenceConnector,
+            "confluence_client",
+            new_callable=mock.PropertyMock,
+            return_value=fake_client,
+        ),
+        mock.patch.object(
+            connector, "_yield_space_hierarchy_nodes", return_value=iter([])
+        ),
+        mock.patch.object(
+            connector, "_yield_ancestor_hierarchy_nodes", return_value=iter([])
+        ),
+        mock.patch.object(
+            connector, "_maybe_yield_page_hierarchy_node", return_value=None
+        ),
+        mock.patch.object(connector, "_get_parent_hierarchy_raw_id", return_value=None),
+        mock.patch.object(
+            connector, "_construct_page_cql_query", return_value=_PAGE_CQL
+        ),
+        mock.patch.object(
+            connector, "_construct_attachment_query", return_value=_ATTACHMENT_CQL
+        ),
+    ):
+        ids: list[str] = []
+        for batch in connector.retrieve_all_slim_docs():
+            for item in batch:
+                if isinstance(item, SlimDocument):
+                    ids.append(item.id)
+    return ids
+
+
+def test_slim_docs_skip_attachments_when_disabled() -> None:
+    connector = _build_connector(include_attachments=False)
+    fake_client = mock.Mock(spec=OnyxConfluence)
+
+    ids = _collect_slim_doc_ids(connector, fake_client)
+
+    # the page itself is still emitted, but no attachment slim docs
+    assert any("/pages/111" in doc_id for doc_id in ids)
+    assert not any("spec.pdf" in doc_id for doc_id in ids)
+    # the attachment CQL endpoint is never even queried
+    queried_cqls = [
+        call.kwargs.get("cql")
+        for call in fake_client.cql_paginate_all_expansions.call_args_list
+    ]
+    assert _ATTACHMENT_CQL not in queried_cqls
+
+
+def test_slim_docs_include_attachments_by_default() -> None:
+    """The constructor default (True) preserves the historical behavior of
+    existing Confluence connectors, whose stored configs lack the key."""
+    connector = ConfluenceConnector(
+        wiki_base="https://fake-cloud.atlassian.net/wiki",
+        is_cloud=True,
+    )
+    connector.allow_images = True
+    fake_client = mock.Mock(spec=OnyxConfluence)
+
+    ids = _collect_slim_doc_ids(connector, fake_client)
+
+    assert any("/pages/111" in doc_id for doc_id in ids)
+    assert any("spec.pdf" in doc_id for doc_id in ids)
+
+
+def test_main_pass_skips_attachment_fetch_when_disabled() -> None:
+    connector = _build_connector(include_attachments=False)
+    fake_client = mock.Mock(spec=OnyxConfluence)
+
+    with mock.patch.object(
+        ConfluenceConnector,
+        "confluence_client",
+        new_callable=mock.PropertyMock,
+        return_value=fake_client,
+    ):
+        docs, failures = connector._fetch_page_attachments(_PAGE)
+
+    assert docs == []
+    assert failures == []
+    fake_client.paginated_cql_retrieval.assert_not_called()

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -142,6 +142,23 @@ export interface ConnectionConfiguration {
   ) => boolean;
 }
 
+// Shared "Include Attachments" checkbox. Pair with an `include_attachments`
+// kwarg on the backend connector; see backend/onyx/connectors/README.md for
+// the convention, including how to pick the default.
+export function buildIncludeAttachmentsOption(
+  defaultValue: boolean
+): BooleanOption {
+  return {
+    type: "checkbox",
+    query: "Include attachments?",
+    label: "Include Attachments",
+    name: "include_attachments",
+    description:
+      "Enable processing of page attachments including images and documents",
+    default: defaultValue,
+  };
+}
+
 export const connectorConfigs: Record<
   ConfigurableSources,
   ConnectionConfiguration
@@ -666,6 +683,7 @@ export const connectorConfigs: Record<
         ],
         defaultTab: "space",
       },
+      buildIncludeAttachmentsOption(true),
     ],
     advanced_values: [],
   },
@@ -1040,15 +1058,7 @@ export const connectorConfigs: Record<
           },
         ],
       },
-      {
-        type: "checkbox",
-        query: "Include attachments?",
-        label: "Include Attachments",
-        name: "include_attachments",
-        description:
-          "Enable processing of page attachments including images and documents",
-        default: false,
-      },
+      buildIncludeAttachmentsOption(false),
     ],
     advanced_values: [],
   },
@@ -2023,6 +2033,7 @@ export interface ConfluenceConfig {
   is_cloud?: boolean;
   index_recursively?: boolean;
   cql_query?: string;
+  include_attachments?: boolean;
 }
 
 export interface JiraConfig {


### PR DESCRIPTION
## Description

Clean cherry-pick of #13283 (squash commit `20b6d4b8d44e`) onto `release/v4.3` — customer-requested **Include Attachments** setting for the Confluence connector. No conflicts.

## How Has This Been Tested?

- Backported unit tests pass on this branch: `backend/tests/unit/onyx/connectors/confluence/test_include_attachments_skip.py` (3 passed).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backport to v4.3: add the Include Attachments setting to the Confluence connector so admins can opt out of indexing attachments. Behavior for existing Confluence connections is preserved by default.

- New Features
  - Added `include_attachments` flag to `ConfluenceConnector`. When false, we skip fetching attachments in the main pass and omit attachment slim docs.
  - Added shared UI helper `buildIncludeAttachmentsOption(<default>)` and wired it for Confluence with `true`. Standardized the option in the UI.
  - Documented the convention for connectors that support attachments, including default selection and slim-doc parity.
  - Added unit tests to verify attachments are suppressed when disabled.

- Migration
  - No action needed. Existing Confluence configs default to including attachments (true) to preserve behavior.

<sup>Written for commit ed65dda72250a69a628603e1417a9c23a382cc8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

