### PR TITLE
fix(web): hide zero-tool MCP servers in agent editor Actions

### DIFF
--- a/web/src/views/AgentEditorPage.tsx
+++ b/web/src/views/AgentEditorPage.tsx
@@ -677,6 +677,12 @@ export default function AgentEditorPage({
     return { server, tools: serverTools, isLoading: false };
   });
 
+  // Render-only filter. Form state registers every server through
+  // mcpServersWithTools.
+  const mcpServersWithVisibleTools = mcpServersWithTools.filter(
+    ({ tools }) => tools.length > 0
+  );
+
   const initialValues = {
     // General
     icon_name: existingAgent?.icon_name ?? null,
@@ -1674,8 +1680,8 @@ export default function AgentEditorPage({
 
                             {/* Tools */}
                             <>
-                              {/* render the divider if there is at least one mcp-server or open-api-tool */}
-                              {(mcpServers.length > 0 ||
+                              {/* render the divider if there is at least one mcp-server with tools or open-api-tool */}
+                              {(mcpServersWithVisibleTools.length > 0 ||
                                 openApiTools.length > 0) && (
                                 <Divider
                                   paddingPerpendicular="xs"
@@ -1684,9 +1690,12 @@ export default function AgentEditorPage({
                               )}
 
                               {/* MCP tools */}
-                              {mcpServersWithTools.length > 0 && (
-                                <GeneralLayouts.Section gap={0.5}>
-                                  {mcpServersWithTools.map(
+                              {mcpServersWithVisibleTools.length > 0 && (
+                                <GeneralLayouts.Section
+                                  gap={0.5}
+                                  alignItems="stretch"
+                                >
+                                  {mcpServersWithVisibleTools.map(
                                     ({ server, tools, isLoading }) => (
                                       <MCPServerCard
                                         key={server.id}


### PR DESCRIPTION
## Description

**Bug**
- MCP servers with zero discovered tools rendered as empty "0 of 0" cards in the agent editor Actions section, shrink-wrapped to content width.

**Fix**
- Derive `mcpServersWithVisibleTools` (`tools.length > 0`) and render Actions MCP cards from it. The divider gate uses the same list, so no orphan divider when every server is empty.
- Form state (`initialValues`, validation, submit) keeps the unfiltered list, so attached-but-inaccessible servers with tools on the agent are preserved and still render (their tools join from `existingAgent.tools`).
- `alignItems="stretch"` on the MCP Section so any edge-case card keeps full width.

## How Has This Been Tested?

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check