### PR TITLE
refactor(craft): make external app skills first-class

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -497,7 +497,7 @@ def delete_external_app(
         )
 
     skills = get_skills_for_external_app(db_session, app.id)
-    custom_skill_ids = [skill.id for skill in skills if skill.built_in_skill_id is None]
+    custom_skill_ids = [skill.id for skill in skills if skill.is_custom]
     if custom_skill_ids:
         db_session.execute(
             delete(UserSkillPreference).where(
@@ -507,7 +507,7 @@ def delete_external_app(
 
     db_session.delete(app)
     for skill in skills:
-        if skill.built_in_skill_id is not None:
+        if not skill.is_custom:
             db_session.delete(skill)
     db_session.flush()
 

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -1,4 +1,6 @@
 import re
+from collections.abc import Iterable
+from dataclasses import dataclass
 from typing import Any, cast
 from uuid import UUID
 
@@ -22,6 +24,7 @@ from onyx.db.models import (
     ExternalAppUserCredential,
     Skill,
     User,
+    UserSkillPreference,
 )
 from onyx.db.utils import UNSET, UnsetType, is_set
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -34,6 +37,14 @@ from onyx.utils.sensitive import SensitiveValue
 logger = setup_logger()
 
 _PLACEHOLDER_RE = re.compile(r"\{([a-zA-Z_][a-zA-Z0-9_]*)\}")
+
+
+@dataclass(frozen=True)
+class SkillExternalAppDependencyState:
+    external_app_id: int
+    name: str
+    enabled: bool
+    ready: bool
 
 
 def _placeholders_in_template(auth_template: dict[str, Any]) -> set[str]:
@@ -175,20 +186,6 @@ def get_skills_for_external_app(
     )
 
 
-def get_first_skill_for_external_app(
-    db_session: Session,
-    external_app_id: int,
-) -> Skill:
-    """Return the first associated skill for transitional bundle operations."""
-    skills = get_skills_for_external_app(db_session, external_app_id)
-    if not skills:
-        raise OnyxError(
-            OnyxErrorCode.NOT_FOUND,
-            f"External app {external_app_id} has no associated skills.",
-        )
-    return skills[0]
-
-
 def get_connectable_apps_for_user(
     db_session: Session,
     user: User,
@@ -206,12 +203,13 @@ def get_connectable_apps_for_user(
     ]
 
 
-def available_external_app_skill_ids_for_user(
+def get_skill_external_app_dependencies(
     db_session: Session,
     user: User,
-) -> list[UUID]:
-    """Return app-backed skill IDs whose credentials are ready for this user."""
-    rows = db_session.execute(
+    skill_ids: Iterable[UUID] | None = None,
+) -> dict[UUID, SkillExternalAppDependencyState]:
+    """Return dependency state for all or selected associated skills."""
+    stmt = (
         select(ExternalApp__Skill.skill_id, ExternalApp, ExternalAppUserCredential)
         .join(
             ExternalApp,
@@ -225,13 +223,23 @@ def available_external_app_skill_ids_for_user(
             ),
             isouter=True,
         )
-        .where(ExternalApp.enabled.is_(True))
-    ).all()
-    return [
-        skill_id
+    )
+    if skill_ids is not None:
+        requested_ids = set(skill_ids)
+        if not requested_ids:
+            return {}
+        stmt = stmt.where(ExternalApp__Skill.skill_id.in_(requested_ids))
+
+    rows = db_session.execute(stmt).all()
+    return {
+        skill_id: SkillExternalAppDependencyState(
+            external_app_id=app.id,
+            name=app.name,
+            enabled=app.enabled,
+            ready=app.enabled and is_user_authenticated_for_app(app, credential),
+        )
         for skill_id, app, credential in rows
-        if is_user_authenticated_for_app(app, credential)
-    ]
+    }
 
 
 def get_external_apps(
@@ -370,7 +378,6 @@ def associate_built_in_skill__no_commit(
                 public_permission=SkillSharePermission.VIEWER,
             ),
             db_session,
-            is_external_app_backing=True,
         )
     elif get_external_app_by_skill_id(db_session, skill.id) is not None:
         raise OnyxError(
@@ -476,12 +483,11 @@ def _write_policies__no_commit(
 def delete_external_app(
     db_session: Session,
     external_app_id: int,
-) -> list[str]:
-    """Delete the app and its currently associated skills.
+) -> None:
+    """Delete an app, detach custom skills, and remove provider-owned skills.
 
-    Flush only — the caller commits after pushing, so a push failure rolls back.
-    Returns bundle file IDs for post-commit cleanup. Raises
-    ``OnyxError(NOT_FOUND)`` if absent.
+    Detached custom skills remain organization-visible but become ordinary
+    disabled skills. Flush only; the caller owns the transaction.
     """
     app = get_external_app_by_id(db_session, external_app_id)
     if app is None:
@@ -491,12 +497,19 @@ def delete_external_app(
         )
 
     skills = get_skills_for_external_app(db_session, app.id)
-    bundle_file_ids = [skill.bundle_file_id for skill in skills if skill.bundle_file_id]
+    custom_skill_ids = [skill.id for skill in skills if skill.built_in_skill_id is None]
+    if custom_skill_ids:
+        db_session.execute(
+            delete(UserSkillPreference).where(
+                UserSkillPreference.skill_id.in_(custom_skill_ids)
+            )
+        )
+
     db_session.delete(app)
     for skill in skills:
-        db_session.delete(skill)
+        if skill.built_in_skill_id is not None:
+            db_session.delete(skill)
     db_session.flush()
-    return bundle_file_ids
 
 
 def upsert_external_app_user_credential(
@@ -565,18 +578,29 @@ def upsert_external_app_user_credential(
     return cred
 
 
-def delete_external_app_user_credential(
+def disconnect_external_app_for_user(
     db_session: Session,
     *,
     external_app_id: int,
     user_id: UUID,
 ) -> None:
-    """Delete the user's stored credentials for one app, and commit (no-op if
-    absent). Used when a refresh terminally fails so the user reconnects."""
+    """Remove a user's app credentials and associated skill preferences.
+
+    Flush only; the caller refreshes the user's sandbox and commits.
+    """
     db_session.execute(
         delete(ExternalAppUserCredential).where(
             ExternalAppUserCredential.external_app_id == external_app_id,
             ExternalAppUserCredential.user_id == user_id,
         )
     )
-    db_session.commit()
+    associated_skill_ids = select(ExternalApp__Skill.skill_id).where(
+        ExternalApp__Skill.external_app_id == external_app_id
+    )
+    db_session.execute(
+        delete(UserSkillPreference).where(
+            UserSkillPreference.user_id == user_id,
+            UserSkillPreference.skill_id.in_(associated_skill_ids),
+        )
+    )
+    db_session.flush()

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -4583,7 +4583,7 @@ class FileContent(Base):
 
 
 class Skill(Base):
-    """A custom (admin-uploaded) skill.
+    """A built-in or custom skill.
 
     Skill metadata is shared schema state. Group-based grants use user_group,
     which is available in the base migration chain even though its ORM model
@@ -4668,6 +4668,10 @@ class Skill(Base):
             name="ck_skill_definition_source",
         ),
     )
+
+    @property
+    def is_custom(self) -> bool:
+        return self.built_in_skill_id is None
 
 
 """

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -1,13 +1,15 @@
 """DB operations for skill rows.
 
-Access model:
-- `VIEW` excludes external-app-backed rows, applies normal ownership and
-  sharing visibility, and lets admins view all remaining skills.
-- `EDIT` is the skill mutation policy. It excludes external-app-backed
-  and built-in rows, and only returns rows the user can modify.
-- `USE` is the runtime/sandbox policy. It applies user visibility without an
-  admin bypass, resolves per-user enablement for ordinary skills, includes
-  authenticated external-app-backed rows, and hides unavailable built-ins.
+Management authorization:
+- `VIEW` includes associated custom rows but excludes associated built-in
+  provider rows, applies normal ownership and sharing visibility, and lets
+  admins view all remaining skills.
+- `EDIT` is the skill mutation policy. It excludes built-in rows and only
+  returns custom rows the user can modify.
+
+Runtime selection is deliberately separate from authorization. It applies
+visibility without an admin bypass, user enablement for custom skills, app
+readiness for associated skills, validity, and built-in availability.
 
 Delete is a hard delete — `delete_skill` removes the row and returns its
 `bundle_file_id` so the caller can drop the blob from the file store
@@ -43,9 +45,11 @@ from sqlalchemy.orm import Session, selectinload
 from onyx.auth.schemas import UserRole
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import SandboxStatus, SkillSharePermission
-from onyx.db.external_app import available_external_app_skill_ids_for_user
+from onyx.db.external_app import (
+    SkillExternalAppDependencyState,
+    get_skill_external_app_dependencies,
+)
 from onyx.db.models import (
-    ExternalApp,
     ExternalApp__Skill,
     Sandbox,
     Skill,
@@ -61,10 +65,9 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.skills.built_in import BUILT_IN_SKILLS
 
 
-class SkillAccessPolicy(str, Enum):
+class SkillManagementPolicy(str, Enum):
     VIEW = "view"
     EDIT = "edit"
-    USE = "use"
 
 
 @dataclass(frozen=True)
@@ -78,6 +81,7 @@ class SkillValidityUpdate:
 class SkillUserState:
     enabled: bool
     can_toggle: bool
+    external_app_dependency: SkillExternalAppDependencyState | None
 
 
 def _is_shared_with_user(
@@ -214,66 +218,39 @@ def _skill_select_with_eager_load(*, order_by_name: bool) -> Select[tuple[Skill]
     return stmt
 
 
-def _skill_select_for_access_policy(
+def _has_external_app_dependency() -> ColumnElement[bool]:
+    return exists().where(ExternalApp__Skill.skill_id == Skill.id)
+
+
+def _skill_select_for_management_policy(
     *,
-    policy: SkillAccessPolicy,
+    policy: SkillManagementPolicy,
     db_session: Session,
     user: User,
     order_by_name: bool,
 ) -> Select[tuple[Skill]]:
-    stmt = (
-        _skill_select_with_eager_load(order_by_name=order_by_name)
-        .outerjoin(
-            ExternalApp__Skill,
-            ExternalApp__Skill.skill_id == Skill.id,
+    stmt = _skill_select_with_eager_load(order_by_name=order_by_name)
+    if policy == SkillManagementPolicy.VIEW:
+        # Associated custom skills are first-class; provider-owned built-ins
+        # remain represented only through the Apps surfaces.
+        stmt = stmt.where(
+            or_(
+                Skill.built_in_skill_id.is_(None),
+                ~_has_external_app_dependency(),
+            )
         )
-        .outerjoin(
-            ExternalApp,
-            ExternalApp.id == ExternalApp__Skill.external_app_id,
-        )
-    )
-    if policy == SkillAccessPolicy.VIEW:
-        stmt = stmt.where(ExternalApp.id.is_(None))
         if user.role == UserRole.ADMIN:
             return stmt
         stmt = stmt.where(skill_visible_to_user(user))
         return _exclude_unavailable_built_in_skills(stmt, db_session)
 
-    if policy == SkillAccessPolicy.EDIT:
-        stmt = stmt.where(
-            ExternalApp.id.is_(None),
-            Skill.built_in_skill_id.is_(None),
-        )
+    if policy == SkillManagementPolicy.EDIT:
+        stmt = stmt.where(Skill.built_in_skill_id.is_(None))
         if user.role == UserRole.ADMIN:
             return stmt
         return stmt.where(_is_editable_by_user(user))
 
-    if policy == SkillAccessPolicy.USE:
-        available_external_app_skill_ids = available_external_app_skill_ids_for_user(
-            db_session, user
-        )
-        enabled_in_sandbox = or_(
-            and_(
-                ExternalApp.id.isnot(None),
-                Skill.id.in_(available_external_app_skill_ids),
-            ),
-            and_(
-                ExternalApp.id.is_(None),
-                _is_enabled_for_user(user),
-            ),
-        )
-        stmt = stmt.where(
-            enabled_in_sandbox,
-            skill_visible_to_user(user),
-            or_(
-                Skill.built_in_skill_id.isnot(None),
-                Skill.is_valid.is_(None),
-                Skill.is_valid.is_(True),
-            ),
-        )
-        return _exclude_unavailable_built_in_skills(stmt, db_session)
-
-    raise ValueError(f"Unknown skill access policy: {policy}")
+    raise ValueError(f"Unknown skill management policy: {policy}")
 
 
 def affected_user_ids_for_skill(skill: Skill, db_session: Session) -> set[UUID]:
@@ -325,11 +302,11 @@ def affected_user_ids_for_skill(skill: Skill, db_session: Session) -> set[UUID]:
 
 def list_skills(
     *,
-    policy: SkillAccessPolicy,
+    policy: SkillManagementPolicy,
     db_session: Session,
     user: User,
 ) -> list[Skill]:
-    stmt = _skill_select_for_access_policy(
+    stmt = _skill_select_for_management_policy(
         policy=policy,
         db_session=db_session,
         user=user,
@@ -338,15 +315,50 @@ def list_skills(
     return list(db_session.scalars(stmt))
 
 
+def list_runtime_skills_for_user(
+    *,
+    db_session: Session,
+    user: User,
+) -> list[Skill]:
+    """Return the user's effective sandbox skills.
+
+    Management visibility, user selection, bundle validity, built-in
+    availability, and external-app readiness remain independent inputs.
+    """
+    external_app_dependencies = get_skill_external_app_dependencies(db_session, user)
+    ready_external_app_skill_ids = [
+        skill_id
+        for skill_id, dependency in external_app_dependencies.items()
+        if dependency.ready
+    ]
+    has_external_app_dependency = _has_external_app_dependency()
+    stmt = _skill_select_with_eager_load(order_by_name=True).where(
+        skill_visible_to_user(user),
+        _is_enabled_for_user(user),
+        or_(
+            ~has_external_app_dependency,
+            Skill.id.in_(ready_external_app_skill_ids),
+        ),
+        or_(
+            Skill.built_in_skill_id.isnot(None),
+            Skill.is_valid.is_(None),
+            Skill.is_valid.is_(True),
+        ),
+    )
+    return list(
+        db_session.scalars(_exclude_unavailable_built_in_skills(stmt, db_session))
+    )
+
+
 def fetch_skill(
     skill_id: UUID,
     *,
-    policy: SkillAccessPolicy,
+    policy: SkillManagementPolicy,
     db_session: Session,
     user: User,
     lock_for_update: bool = False,
 ) -> Skill | None:
-    stmt = _skill_select_for_access_policy(
+    stmt = _skill_select_for_management_policy(
         policy=policy,
         db_session=db_session,
         user=user,
@@ -360,29 +372,7 @@ def fetch_skill(
 def add_new_skill__no_commit(
     skill: Skill,
     db_session: Session,
-    *,
-    is_external_app_backing: bool = False,
 ) -> Skill:
-    # App-backed skills share the sandbox directory namespace until their
-    # lifecycle is decoupled, so they cannot share a name with another skill.
-    existing_name = select(Skill.id).where(Skill.name == skill.name)
-    if not is_external_app_backing:
-        existing_name = existing_name.join(
-            ExternalApp__Skill,
-            ExternalApp__Skill.skill_id == Skill.id,
-        ).join(
-            ExternalApp,
-            ExternalApp.id == ExternalApp__Skill.external_app_id,
-        )
-    if db_session.scalar(existing_name.limit(1)) is not None:
-        conflicting_resource = (
-            "another skill" if is_external_app_backing else "an external app"
-        )
-        raise OnyxError(
-            OnyxErrorCode.DUPLICATE_RESOURCE,
-            f"The skill name '{skill.name}' is already used by {conflicting_resource}.",
-        )
-
     db_session.add(skill)
     db_session.flush()
     return skill
@@ -451,6 +441,19 @@ def set_skill_public_permission(
     public_permission: SkillSharePermission | None,
     db_session: Session,
 ) -> None:
+    is_associated = db_session.scalar(
+        select(
+            exists().where(
+                ExternalApp__Skill.skill_id == skill.id,
+            )
+        )
+    )
+    if is_associated and public_permission != SkillSharePermission.VIEWER:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Skills associated with an external app must remain visible to the "
+            "organization with viewer access.",
+        )
     skill.public_permission = public_permission
     db_session.flush()
 
@@ -464,6 +467,11 @@ def skill_user_states(
     if not requested_ids:
         return {}
 
+    external_app_dependencies = get_skill_external_app_dependencies(
+        db_session,
+        user,
+        requested_ids,
+    )
     rows = db_session.execute(
         select(
             Skill.id,
@@ -478,7 +486,14 @@ def skill_user_states(
     return {
         skill_id: SkillUserState(
             enabled=enabled,
-            can_toggle=visible and supports_preference,
+            can_toggle=visible
+            and supports_preference
+            and (
+                enabled
+                or skill_id not in external_app_dependencies
+                or external_app_dependencies[skill_id].ready
+            ),
+            external_app_dependency=external_app_dependencies.get(skill_id),
         )
         for skill_id, enabled, visible, supports_preference in rows
     }
@@ -494,7 +509,7 @@ def set_skill_enabled_for_user(
 ) -> Skill:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.VIEW,
+        policy=SkillManagementPolicy.VIEW,
         user=user,
         db_session=db_session,
         lock_for_update=True,

--- a/backend/onyx/db/skill.py
+++ b/backend/onyx/db/skill.py
@@ -218,10 +218,6 @@ def _skill_select_with_eager_load(*, order_by_name: bool) -> Select[tuple[Skill]
     return stmt
 
 
-def _has_external_app_dependency() -> ColumnElement[bool]:
-    return exists().where(ExternalApp__Skill.skill_id == Skill.id)
-
-
 def _skill_select_for_management_policy(
     *,
     policy: SkillManagementPolicy,
@@ -236,7 +232,7 @@ def _skill_select_for_management_policy(
         stmt = stmt.where(
             or_(
                 Skill.built_in_skill_id.is_(None),
-                ~_has_external_app_dependency(),
+                ~exists().where(ExternalApp__Skill.skill_id == Skill.id),
             )
         )
         if user.role == UserRole.ADMIN:
@@ -331,12 +327,11 @@ def list_runtime_skills_for_user(
         for skill_id, dependency in external_app_dependencies.items()
         if dependency.ready
     ]
-    has_external_app_dependency = _has_external_app_dependency()
     stmt = _skill_select_with_eager_load(order_by_name=True).where(
         skill_visible_to_user(user),
         _is_enabled_for_user(user),
         or_(
-            ~has_external_app_dependency,
+            ~exists().where(ExternalApp__Skill.skill_id == Skill.id),
             Skill.id.in_(ready_external_app_skill_ids),
         ),
         or_(
@@ -412,7 +407,7 @@ def replace_skill_bundle(
 
     Rejects built-in rows — they have no bundle.
     """
-    if skill.built_in_skill_id is not None:
+    if not skill.is_custom:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             f"Skill '{skill.name}' is a built-in and has no bundle.",
@@ -608,7 +603,7 @@ def transfer_skill_ownership(
     new_owner_user_id: UUID,
     db_session: Session,
 ) -> None:
-    if skill.built_in_skill_id is not None:
+    if not skill.is_custom:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             f"Skill '{skill.name}' is a built-in and cannot have its ownership transferred.",

--- a/backend/onyx/external_apps/token_refresh.py
+++ b/backend/onyx/external_apps/token_refresh.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 
 from onyx.db.engine.sql_engine import get_session_with_tenant
 from onyx.db.external_app import (
-    delete_external_app_user_credential,
+    disconnect_external_app_for_user,
     get_external_app_by_id,
     get_external_app_user_credential,
     upsert_external_app_user_credential,
@@ -30,6 +30,7 @@ from onyx.external_apps.providers.base import (
 from onyx.external_apps.providers.registry import get_provider_for_app
 from onyx.external_apps.token_utils import needs_refresh, stamp_expires_at
 from onyx.redis.lock_context import RedisSharedLockAcquisitionError, redis_shared_lock
+from onyx.skills.push import push_skills_for_users
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -116,9 +117,11 @@ def _refresh_under_lock(
     except TokenRefreshTerminalError as exc:
         # Dead grant: drop the credential so the app reads as disconnected.
         with get_session_with_tenant(tenant_id=tenant_id) as db:
-            delete_external_app_user_credential(
+            disconnect_external_app_for_user(
                 db, external_app_id=external_app_id, user_id=user_id
             )
+            push_skills_for_users({user_id}, db)
+            db.commit()
         logger.warning(
             "ea_token_refresh.terminal_cleared external_app_id=%s user_id=%s error=%s",
             external_app_id,

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -17,6 +17,7 @@ from onyx.db.external_app import (
     associate_built_in_skill__no_commit,
     create_external_app,
     delete_external_app,
+    disconnect_external_app_for_user,
     get_external_app_by_id,
     get_external_apps,
     get_skills_for_external_app,
@@ -235,9 +236,10 @@ def update_external_app_admin(
         ),
         action_policies=action_policies,
     )
-    # Push before commit so a push failure rolls back the change.
+    affected: set[UUID] = set()
     for skill in app.associated_skills:
-        push_skill_to_affected_sandboxes(skill, db_session)
+        affected.update(affected_user_ids_for_skill(skill, db_session))
+    push_skills_for_users(affected, db_session)
     db_session.commit()
     # ``action_policies`` is exactly what was persisted — no need to re-read.
     return _to_admin_response(app, stored=action_policies)
@@ -311,10 +313,10 @@ def delete_external_app_admin(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    """Delete an external app, cascading to its user-credential rows. 404 if
-    absent.
+    """Delete an app and its provider-owned skills. Associated custom skills
+    are detached and left disabled. Returns 404 if the app is absent.
     """
-    # Resolve affected users before the delete cascades the skill row away.
+    # Resolve affected users before deleting the associations.
     app = _get_app_or_404(db_session, external_app_id)
     if MULTI_TENANT and get_onyx_managed_provider(app.app_type) is not None:
         raise OnyxError(
@@ -364,6 +366,23 @@ def upsert_user_credentials(
     )
 
     # Authenticating opens this user's per-user gate; refresh their sandboxes now.
+    push_skills_for_users({user.id}, db_session)
+    db_session.commit()
+
+
+@router.delete("/apps/{external_app_id}/credentials")
+def disconnect_user_from_external_app(
+    external_app_id: int,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    """Disconnect the calling user and disable the app's associated skills."""
+    _get_app_or_404(db_session, external_app_id)
+    disconnect_external_app_for_user(
+        db_session,
+        external_app_id=external_app_id,
+        user_id=user.id,
+    )
     push_skills_for_users({user.id}, db_session)
     db_session.commit()
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -660,7 +660,7 @@ def transfer_current_user_skill_ownership(
     )
     if skill is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    if skill.built_in_skill_id is not None:
+    if not skill.is_custom:
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             f"Skill '{skill.name}' is a built-in and cannot change ownership.",

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -13,7 +13,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccountType, Permission, SkillSharePermission
 from onyx.db.models import Skill, User
 from onyx.db.skill import (
-    SkillAccessPolicy,
+    SkillManagementPolicy,
     add_new_skill__no_commit,
     affected_user_ids_for_skill,
     delete_skill,
@@ -137,7 +137,7 @@ def list_skills_for_current_user(
     db_session: Session = Depends(get_session),
 ) -> SkillsList:
     rows = list_skills(
-        policy=SkillAccessPolicy.VIEW,
+        policy=SkillManagementPolicy.VIEW,
         user=user,
         db_session=db_session,
     )
@@ -172,7 +172,7 @@ def fetch_skill_for_current_user(
 ) -> SkillResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.VIEW,
+        policy=SkillManagementPolicy.VIEW,
         user=user,
         db_session=db_session,
     )
@@ -189,13 +189,13 @@ def preview_skill_for_current_user(
 ) -> SkillPreviewResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.VIEW,
+        policy=SkillManagementPolicy.VIEW,
         user=user,
         db_session=db_session,
     )
     if skill is None:
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found")
-    return skill_preview_response(skill)
+    return skill_preview_response(skill, user, db_session)
 
 
 @user_router.post("/custom")
@@ -327,7 +327,7 @@ def fetch_custom_skill_for_edit(
 ) -> SkillEditableDetailResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.EDIT,
+        policy=SkillManagementPolicy.EDIT,
         user=user,
         db_session=db_session,
     )
@@ -378,7 +378,7 @@ def replace_current_user_skill_bundle(
 ) -> SkillResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.EDIT,
+        policy=SkillManagementPolicy.EDIT,
         user=user,
         db_session=db_session,
         lock_for_update=True,
@@ -423,7 +423,7 @@ def upload_current_user_skill_files(
 ) -> SkillEditableDetailResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.EDIT,
+        policy=SkillManagementPolicy.EDIT,
         user=user,
         db_session=db_session,
         lock_for_update=True,
@@ -451,7 +451,7 @@ def remove_current_user_skill_file(
 ) -> SkillEditableDetailResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.EDIT,
+        policy=SkillManagementPolicy.EDIT,
         user=user,
         db_session=db_session,
         lock_for_update=True,
@@ -479,7 +479,7 @@ def patch_current_user_skill(
 ) -> SkillResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.EDIT,
+        policy=SkillManagementPolicy.EDIT,
         user=user,
         db_session=db_session,
         lock_for_update=True,
@@ -578,7 +578,7 @@ def share_current_user_skill(
 ) -> SkillResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.EDIT,
+        policy=SkillManagementPolicy.EDIT,
         user=user,
         db_session=db_session,
         lock_for_update=True,
@@ -653,7 +653,7 @@ def transfer_current_user_skill_ownership(
 ) -> SkillResponse:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.VIEW,
+        policy=SkillManagementPolicy.VIEW,
         user=user,
         db_session=db_session,
         lock_for_update=True,
@@ -731,7 +731,7 @@ def delete_current_user_skill(
 ) -> None:
     skill = fetch_skill(
         skill_id,
-        policy=SkillAccessPolicy.EDIT,
+        policy=SkillManagementPolicy.EDIT,
         user=user,
         db_session=db_session,
         lock_for_update=True,

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -25,6 +25,13 @@ class SkillGroupShare(BaseModel):
     permission: SkillSharePermission
 
 
+class SkillExternalAppDependencyResponse(BaseModel):
+    external_app_id: int
+    name: str
+    enabled: bool
+    ready: bool
+
+
 class SkillResponse(BaseModel):
     source: Literal["builtin", "custom"]
     id: UUID
@@ -48,6 +55,7 @@ class SkillResponse(BaseModel):
     public_permission: SkillSharePermission | None = None
     is_personal: bool = False
     user_permission: SkillAccessLevel | None = None
+    external_app: SkillExternalAppDependencyResponse | None = None
 
     @classmethod
     def from_builtin(
@@ -79,6 +87,7 @@ class SkillResponse(BaseModel):
         can_toggle: bool = True,
         user_permission: SkillAccessLevel | None = None,
         include_share_details: bool = False,
+        external_app: SkillExternalAppDependencyResponse | None = None,
     ) -> "SkillResponse":
         user_shares = [
             SkillUserShare(
@@ -126,6 +135,7 @@ class SkillResponse(BaseModel):
             and not user_shares
             and not group_shares,
             user_permission=user_permission,
+            external_app=external_app,
         )
 
 
@@ -141,6 +151,7 @@ class SkillPreviewResponse(BaseModel):
     description: str
     author_email: str | None = None
     instructions_markdown: str
+    external_app: SkillExternalAppDependencyResponse | None = None
 
     @classmethod
     def from_builtin(
@@ -164,6 +175,7 @@ class SkillPreviewResponse(BaseModel):
         skill: Skill,
         *,
         instructions_markdown: str,
+        external_app: SkillExternalAppDependencyResponse | None = None,
     ) -> "SkillPreviewResponse":
         return cls(
             source="custom",
@@ -172,6 +184,7 @@ class SkillPreviewResponse(BaseModel):
             description=skill.description,
             author_email=skill.author.email if skill.author is not None else None,
             instructions_markdown=instructions_markdown,
+            external_app=external_app,
         )
 
 

--- a/backend/onyx/server/features/skill/response_helpers.py
+++ b/backend/onyx/server/features/skill/response_helpers.py
@@ -2,6 +2,10 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
 from onyx.db.enums import SkillAccessLevel, SkillSharePermission
+from onyx.db.external_app import (
+    SkillExternalAppDependencyState,
+    get_skill_external_app_dependencies,
+)
 from onyx.db.models import Skill, User
 from onyx.db.persona_sharing import (
     get_curated_user_group_ids_for_user,
@@ -11,6 +15,7 @@ from onyx.db.skill import SkillUserState, skill_user_states
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.skill.models import (
+    SkillExternalAppDependencyResponse,
     SkillPreviewResponse,
     SkillResponse,
     SkillsList,
@@ -23,6 +28,19 @@ from onyx.skills.content import (
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
+
+
+def _dependency_response(
+    dependency: SkillExternalAppDependencyState | None,
+) -> SkillExternalAppDependencyResponse | None:
+    if dependency is None:
+        return None
+    return SkillExternalAppDependencyResponse(
+        external_app_id=dependency.external_app_id,
+        name=dependency.name,
+        enabled=dependency.enabled,
+        ready=dependency.ready,
+    )
 
 
 def user_permission_for_skill(
@@ -117,6 +135,7 @@ def skill_response_for_user(
             curated_user_group_ids,
         ),
         include_share_details=include_share_details,
+        external_app=_dependency_response(state.external_app_dependency),
     )
 
 
@@ -134,7 +153,6 @@ def skills_list_response_for_user(
         else set()
     )
     states = skill_user_states(user, (skill.id for skill in rows), db_session)
-
     for skill in rows:
         if (
             skill.built_in_skill_id is not None
@@ -160,7 +178,11 @@ def skills_list_response_for_user(
     return SkillsList(builtins=builtins, customs=customs)
 
 
-def skill_preview_response(skill: Skill) -> SkillPreviewResponse:
+def skill_preview_response(
+    skill: Skill,
+    user: User,
+    db_session: Session,
+) -> SkillPreviewResponse:
     if skill.built_in_skill_id is not None:
         definition = BUILT_IN_SKILLS.get(skill.built_in_skill_id)
         if definition is None:
@@ -173,4 +195,11 @@ def skill_preview_response(skill: Skill) -> SkillPreviewResponse:
     return SkillPreviewResponse.from_custom(
         skill,
         instructions_markdown=read_custom_skill_bundle_instructions(skill),
+        external_app=_dependency_response(
+            get_skill_external_app_dependencies(
+                db_session,
+                user,
+                [skill.id],
+            ).get(skill.id)
+        ),
     )

--- a/backend/onyx/server/features/skill/response_helpers.py
+++ b/backend/onyx/server/features/skill/response_helpers.py
@@ -49,7 +49,7 @@ def user_permission_for_skill(
     user_group_ids: set[int],
     curated_user_group_ids: set[int] | None = None,
 ) -> SkillAccessLevel | None:
-    if skill.built_in_skill_id is not None:
+    if not skill.is_custom:
         return SkillAccessLevel.VIEWER
 
     if skill.author_user_id == user.id:
@@ -173,7 +173,7 @@ def skills_list_response_for_user(
             user_group_ids=user_group_ids,
             curated_user_group_ids=curated_user_group_ids,
         )
-        (builtins if skill.built_in_skill_id is not None else customs).append(response)
+        (customs if skill.is_custom else builtins).append(response)
 
     return SkillsList(builtins=builtins, customs=customs)
 

--- a/backend/onyx/skills/push.py
+++ b/backend/onyx/skills/push.py
@@ -15,10 +15,9 @@ from onyx.db.external_app import (
 )
 from onyx.db.models import Skill, User
 from onyx.db.skill import (
-    SkillAccessPolicy,
     SkillValidityUpdate,
     affected_user_ids_for_skill,
-    list_skills,
+    list_runtime_skills_for_user,
     persist_skill_validity,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -237,11 +236,7 @@ def _assemble_fileset(
 
 def build_skills_fileset_for_user(user: User, db_session: Session) -> FileSet:
     """Return a flat ``{path: bytes}`` map of every skill the user can see."""
-    skills = list_skills(
-        policy=SkillAccessPolicy.USE,
-        user=user,
-        db_session=db_session,
-    )
+    skills = list_runtime_skills_for_user(user=user, db_session=db_session)
     return _assemble_fileset(skills, user, db_session)
 
 
@@ -251,11 +246,7 @@ def build_user_skills_payload(user: User, db_session: Session) -> tuple[str, Fil
     The connectable-apps section lists org apps the user has not connected yet,
     so the agent can offer to set one up through the connect tool.
     """
-    skills = list_skills(
-        policy=SkillAccessPolicy.USE,
-        user=user,
-        db_session=db_session,
-    )
+    skills = list_runtime_skills_for_user(user=user, db_session=db_session)
     files = _assemble_fileset(skills, user, db_session)
     connectable_apps_section = build_connectable_apps_list(
         get_connectable_apps_for_user(db_session, user)

--- a/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
+++ b/backend/tests/external_dependency_unit/craft/test_built_in_skill_seeding.py
@@ -21,7 +21,12 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from onyx.db.models import Skill, User
-from onyx.db.skill import SkillAccessPolicy, fetch_skill, list_skills
+from onyx.db.skill import (
+    SkillManagementPolicy,
+    fetch_skill,
+    list_runtime_skills_for_user,
+    list_skills,
+)
 from onyx.skills.built_in import BUILT_IN_SKILLS, BuiltInSkillDefinition
 from tests.external_dependency_unit.craft.db_helpers import (
     make_built_in_skill_row,
@@ -81,7 +86,7 @@ class TestAvailabilityGate:
         visible = {
             s.built_in_skill_id
             for s in list_skills(
-                policy=SkillAccessPolicy.VIEW,
+                policy=SkillManagementPolicy.VIEW,
                 user=test_user,
                 db_session=db_session,
             )
@@ -98,7 +103,7 @@ class TestAvailabilityGate:
         visible_built_ins = {
             s.built_in_skill_id
             for s in list_skills(
-                policy=SkillAccessPolicy.VIEW,
+                policy=SkillManagementPolicy.VIEW,
                 user=test_user,
                 db_session=db_session,
             )
@@ -124,8 +129,7 @@ class TestAvailabilityGate:
         monkeypatch.setattr("onyx.skills.built_in.ENABLE_BROWSER", False)
         off = {
             s.built_in_skill_id
-            for s in list_skills(
-                policy=SkillAccessPolicy.USE,
+            for s in list_runtime_skills_for_user(
                 user=test_user,
                 db_session=db_session,
             )
@@ -135,8 +139,7 @@ class TestAvailabilityGate:
         monkeypatch.setattr("onyx.skills.built_in.ENABLE_BROWSER", True)
         on = {
             s.built_in_skill_id
-            for s in list_skills(
-                policy=SkillAccessPolicy.USE,
+            for s in list_runtime_skills_for_user(
                 user=test_user,
                 db_session=db_session,
             )
@@ -166,7 +169,7 @@ class TestAvailabilityGate:
         assert (
             fetch_skill(
                 row.id,
-                policy=SkillAccessPolicy.VIEW,
+                policy=SkillManagementPolicy.VIEW,
                 user=test_user,
                 db_session=db_session,
             )
@@ -188,7 +191,7 @@ class TestBuiltInIsImmutable:
         assert (
             fetch_skill(
                 row.id,
-                policy=SkillAccessPolicy.EDIT,
+                policy=SkillManagementPolicy.EDIT,
                 user=test_user,
                 db_session=db_session,
             )
@@ -206,7 +209,7 @@ class TestBuiltInIsImmutable:
 
         skill = fetch_skill(
             custom.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=test_user,
             db_session=db_session,
         )

--- a/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
@@ -15,7 +15,7 @@ import onyx.server.features.build.external_apps.api as api
 from onyx.db.enums import ExternalAppType
 from onyx.db.external_app import (
     get_external_app_by_id,
-    get_first_skill_for_external_app,
+    get_skills_for_external_app,
 )
 from onyx.db.models import ExternalApp, Skill, User
 from onyx.server.features.build.external_apps.models import UpdateExternalAppRequest
@@ -61,12 +61,11 @@ def test_patch_updates_config_on_non_managed_built_in(
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _noop)
+    monkeypatch.setattr(api, "push_skills_for_users", _noop)
     app = _slack_app(db_session)
     app_id = app.id
-    original_skill_description = get_first_skill_for_external_app(
-        db_session, app_id
-    ).description
+    [original_skill] = get_skills_for_external_app(db_session, app_id)
+    original_skill_description = original_skill.description
 
     new_patterns = ["https://slack.com/api/chat.postMessage"]
     new_auth = {"Authorization": "Bearer {access_token}"}
@@ -89,7 +88,7 @@ def test_patch_updates_config_on_non_managed_built_in(
     db_session.expire_all()
     stored = get_external_app_by_id(db_session, app_id)
     assert stored is not None
-    skill = get_first_skill_for_external_app(db_session, app_id)
+    [skill] = get_skills_for_external_app(db_session, app_id)
     assert stored.name == "Slack — Eng"
     assert skill.name == "slack"
     assert skill.description == original_skill_description
@@ -108,14 +107,12 @@ def test_patch_rolls_back_when_push_fails(
     """Push failure leaves the app update uncommitted."""
     app = _slack_app(db_session)
     app_id = app.id
-    original_description = get_first_skill_for_external_app(
-        db_session, app_id
-    ).description
+    original_name = app.name
 
     def _boom(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("push failed")
 
-    monkeypatch.setattr(api, "push_skill_to_affected_sandboxes", _boom)
+    monkeypatch.setattr(api, "push_skills_for_users", _boom)
 
     with pytest.raises(RuntimeError):
         api.update_external_app_admin(
@@ -128,7 +125,4 @@ def test_patch_rolls_back_when_push_fails(
     db_session.rollback()
     stored = get_external_app_by_id(db_session, app_id)
     assert stored is not None
-    assert (
-        get_first_skill_for_external_app(db_session, app_id).description
-        == original_description
-    )
+    assert stored.name == original_name

--- a/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
@@ -7,7 +7,12 @@ from sqlalchemy.orm import Session
 
 import onyx.server.features.build.external_apps.api as api
 from onyx.db.enums import ExternalAppType
-from onyx.db.models import ExternalApp, Skill, User
+from onyx.db.external_app import (
+    get_external_app_by_skill_id,
+    get_external_app_user_credential,
+)
+from onyx.db.models import ExternalApp, Skill, User, UserSkillPreference
+from onyx.db.skill import list_runtime_skills_for_user, set_skill_enabled_for_user
 from onyx.server.features.build.external_apps.models import (
     CreateBuiltInExternalAppRequest,
     UpdateExternalAppRequest,
@@ -17,7 +22,9 @@ from tests.external_dependency_unit.craft.db_helpers import (
     make_built_in_skill_row,
     make_external_app,
     make_sandbox,
+    make_skill,
     make_user,
+    make_user_credential,
 )
 
 
@@ -53,6 +60,80 @@ def test_credential_upsert_refreshes_only_the_calling_user(
     )
 
     assert calls == [{user.id}]
+
+
+def test_disconnect_clears_associated_skill_preferences_only(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user = make_user(db_session)
+    associated_skill = make_skill(
+        db_session,
+        is_public=True,
+        name=f"disconnect-associated-{uuid4().hex[:8]}",
+    )
+    unrelated_skill = make_skill(
+        db_session,
+        is_public=True,
+        name=f"disconnect-unrelated-{uuid4().hex[:8]}",
+    )
+    app = make_external_app(
+        db_session,
+        skill=associated_skill,
+        auth_template={"Authorization": "Bearer {token}"},
+    )
+    make_user_credential(
+        db_session,
+        app=app,
+        user=user,
+        user_credentials={"token": "t"},
+    )
+    for skill in (associated_skill, unrelated_skill):
+        set_skill_enabled_for_user(
+            skill_id=skill.id,
+            user=user,
+            enabled=True,
+            db_session=db_session,
+        )
+    db_session.commit()
+
+    calls: list[set[UUID]] = []
+    monkeypatch.setattr(
+        api,
+        "push_skills_for_users",
+        lambda user_ids, _db: calls.append(set(user_ids)),
+    )
+
+    api.disconnect_user_from_external_app(
+        external_app_id=app.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert calls == [{user.id}]
+    assert (
+        get_external_app_user_credential(
+            db_session,
+            external_app_id=app.id,
+            user_id=user.id,
+        )
+        is None
+    )
+    assert (
+        db_session.get(
+            UserSkillPreference,
+            {"user_id": user.id, "skill_id": associated_skill.id},
+        )
+        is None
+    )
+    assert (
+        db_session.get(
+            UserSkillPreference,
+            {"user_id": user.id, "skill_id": unrelated_skill.id},
+        )
+        is not None
+    )
 
 
 def test_create_refreshes_the_created_skill(
@@ -112,6 +193,7 @@ def test_admin_toggle_updates_app_and_refreshes_affected_sandboxes(
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    make_sandbox(db_session, test_user)
     skill = make_built_in_skill_row(
         db_session,
         built_in_skill_id=f"toggle-push-{uuid4().hex[:8]}",
@@ -123,14 +205,20 @@ def test_admin_toggle_updates_app_and_refreshes_affected_sandboxes(
         app_type=ExternalAppType.SLACK,
         auth_template={"Authorization": "Bearer {token}"},
     )
+    second_skill = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id=f"toggle-push-second-{uuid4().hex[:8]}",
+        is_public=True,
+    )
+    app.associated_skills.append(second_skill)
     db_session.commit()
 
-    pushed_skill_ids: list[UUID] = []
+    calls: list[set[UUID]] = []
     monkeypatch.setattr(api, "MULTI_TENANT", False)
     monkeypatch.setattr(
         api,
-        "push_skill_to_affected_sandboxes",
-        lambda pushed_skill, _db: pushed_skill_ids.append(pushed_skill.id),
+        "push_skills_for_users",
+        lambda user_ids, _db: calls.append(set(user_ids)),
     )
 
     response = api.update_external_app_admin(
@@ -142,10 +230,10 @@ def test_admin_toggle_updates_app_and_refreshes_affected_sandboxes(
 
     assert response.enabled is False
     assert app.enabled is False
-    assert pushed_skill_ids == [skill.id]
+    assert calls == [{test_user.id}]
 
 
-def test_delete_resolves_affected_users_before_cascade(
+def test_delete_removes_provider_skill_and_refreshes_affected_users(
     db_session: Session,
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
@@ -163,6 +251,8 @@ def test_delete_resolves_affected_users_before_cascade(
         app_type=ExternalAppType.SLACK,
         auth_template={"Authorization": "Bearer {token}"},
     )
+    app_id = app.id
+    skill_id = skill.id
     db_session.commit()
 
     calls: list[set[UUID]] = []
@@ -172,11 +262,76 @@ def test_delete_resolves_affected_users_before_cascade(
     )
 
     api.delete_external_app_admin(
-        external_app_id=app.id,
+        external_app_id=app_id,
         _=test_user,
         db_session=db_session,
     )
 
     assert len(calls) == 1
     assert user.id in calls[0]
-    assert api.get_external_app_by_id(db_session, app.id) is None
+    assert api.get_external_app_by_id(db_session, app_id) is None
+    assert db_session.get(Skill, skill_id) is None
+
+
+def test_delete_detaches_custom_skill_and_clears_enablement(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    make_sandbox(db_session, test_user)
+    skill = make_skill(db_session, is_public=True, name="retained-custom-skill")
+    set_skill_enabled_for_user(
+        skill_id=skill.id,
+        user=test_user,
+        enabled=True,
+        db_session=db_session,
+    )
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        app_type=ExternalAppType.CUSTOM,
+        auth_template={},
+    )
+    app_id = app.id
+    skill_id = skill.id
+    db_session.commit()
+
+    assert skill_id in {
+        runtime_skill.id
+        for runtime_skill in list_runtime_skills_for_user(
+            user=test_user,
+            db_session=db_session,
+        )
+    }
+
+    calls: list[set[UUID]] = []
+    monkeypatch.setattr(api, "MULTI_TENANT", False)
+    monkeypatch.setattr(
+        api, "push_skills_for_users", lambda user_ids, _db: calls.append(set(user_ids))
+    )
+
+    api.delete_external_app_admin(
+        external_app_id=app_id,
+        _=test_user,
+        db_session=db_session,
+    )
+
+    db_session.expire_all()
+    assert calls == [{test_user.id}]
+    assert api.get_external_app_by_id(db_session, app_id) is None
+    assert db_session.get(Skill, skill_id) is not None
+    assert get_external_app_by_skill_id(db_session, skill_id) is None
+    assert (
+        db_session.get(
+            UserSkillPreference,
+            {"user_id": test_user.id, "skill_id": skill_id},
+        )
+        is None
+    )
+    assert skill_id not in {
+        runtime_skill.id
+        for runtime_skill in list_runtime_skills_for_user(
+            user=test_user,
+            db_session=db_session,
+        )
+    }

--- a/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_sandbox_push.py
@@ -317,7 +317,8 @@ def test_delete_detaches_custom_skill_and_clears_enablement(
     )
 
     db_session.expire_all()
-    assert calls == [{test_user.id}]
+    assert len(calls) == 1
+    assert test_user.id in calls[0]
     assert api.get_external_app_by_id(db_session, app_id) is None
     assert db_session.get(Skill, skill_id) is not None
     assert get_external_app_by_skill_id(db_session, skill_id) is None

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_visibility.py
@@ -1,4 +1,4 @@
-"""External-app skills are hidden from skill management and gated by auth."""
+"""External-app skill management and runtime dependency behavior."""
 
 from __future__ import annotations
 
@@ -8,20 +8,24 @@ import pytest
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import SkillSharePermission
 from onyx.db.external_app import (
     get_external_app_by_skill_id,
-    get_first_skill_for_external_app,
+    get_skills_for_external_app,
 )
-from onyx.db.models import ExternalApp__Skill, User, UserRole
+from onyx.db.models import ExternalApp__Skill, User, UserRole, UserSkillPreference
 from onyx.db.skill import (
-    SkillAccessPolicy,
+    SkillManagementPolicy,
     fetch_skill,
+    list_runtime_skills_for_user,
     list_skills,
     set_skill_enabled_for_user,
+    set_skill_public_permission,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from tests.external_dependency_unit.craft.db_helpers import (
+    make_built_in_skill_row,
     make_external_app,
     make_skill,
     make_user,
@@ -32,10 +36,10 @@ _AUTH_TEMPLATE = {"token": "{token}", "account": "{account}"}
 _FULL_CREDS = {"token": "t", "account": "a"}
 
 
-def _skill_ids(
+def _management_skill_ids(
     user: User,
     db_session: Session,
-    policy: SkillAccessPolicy,
+    policy: SkillManagementPolicy,
 ) -> set[UUID]:
     return {
         skill.id
@@ -47,7 +51,17 @@ def _skill_ids(
     }
 
 
-def test_view_hides_external_app_regardless_of_authentication(
+def _runtime_skill_ids(user: User, db_session: Session) -> set[UUID]:
+    return {
+        skill.id
+        for skill in list_runtime_skills_for_user(
+            user=user,
+            db_session=db_session,
+        )
+    }
+
+
+def test_view_exposes_associated_custom_skill_regardless_of_authentication(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -63,33 +77,47 @@ def test_view_hides_external_app_regardless_of_authentication(
     )
 
     for user in (unauthenticated_user, authenticated_user):
-        assert skill.id not in _skill_ids(user, db_session, SkillAccessPolicy.VIEW)
+        assert skill.id in _management_skill_ids(
+            user, db_session, SkillManagementPolicy.VIEW
+        )
         assert (
             fetch_skill(
                 skill.id,
-                policy=SkillAccessPolicy.VIEW,
+                policy=SkillManagementPolicy.VIEW,
                 user=user,
                 db_session=db_session,
             )
-            is None
+            == skill
         )
 
 
-def test_admin_view_hides_external_apps(
+def test_admin_view_includes_associated_custom_but_hides_associated_builtin(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
     admin = make_user(db_session, role=UserRole.ADMIN)
     regular = make_skill(db_session, is_public=True, name="plain-admin-skill")
-    external = make_skill(db_session, is_public=True, name="ext-admin-hidden")
-    make_external_app(db_session, skill=external, auth_template={})
+    custom = make_skill(db_session, is_public=True, name="ext-admin-custom")
+    built_in = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id="ext-admin-builtin",
+    )
+    make_external_app(db_session, skill=custom, auth_template={})
+    make_external_app(db_session, skill=built_in, auth_template={})
 
-    visible = _skill_ids(admin, db_session, SkillAccessPolicy.VIEW)
+    visible = _management_skill_ids(admin, db_session, SkillManagementPolicy.VIEW)
     assert regular.id in visible
-    assert external.id not in visible
+    assert custom.id in visible
+    assert built_in.id not in visible
+    assert custom.id in _management_skill_ids(
+        admin, db_session, SkillManagementPolicy.EDIT
+    )
+    assert built_in.id not in _management_skill_ids(
+        admin, db_session, SkillManagementPolicy.EDIT
+    )
 
 
-def test_external_app_preference_cannot_be_set(
+def test_associated_custom_skill_requires_normal_user_selection(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -97,26 +125,45 @@ def test_external_app_preference_cannot_be_set(
     skill = make_skill(db_session, is_public=True)
     make_external_app(db_session, skill=skill, auth_template={})
 
-    with pytest.raises(OnyxError) as exc_info:
-        set_skill_enabled_for_user(
-            skill_id=skill.id,
-            enabled=False,
-            user=user,
-            db_session=db_session,
-        )
-    assert exc_info.value.error_code == OnyxErrorCode.NOT_FOUND
+    assert skill.id not in _runtime_skill_ids(user, db_session)
+
+    set_skill_enabled_for_user(
+        skill_id=skill.id,
+        enabled=True,
+        user=user,
+        db_session=db_session,
+    )
+    assert skill.id in _runtime_skill_ids(user, db_session)
 
 
-def test_use_includes_authenticated_external_app_without_preference(
+def test_runtime_requires_selection_and_authenticated_external_app(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
     user = make_user(db_session)
     skill = make_skill(db_session, is_public=True)
     app = make_external_app(db_session, skill=skill, auth_template=_AUTH_TEMPLATE)
+
+    assert skill.id not in _runtime_skill_ids(user, db_session)
+    with pytest.raises(OnyxError) as exc_info:
+        set_skill_enabled_for_user(
+            skill_id=skill.id,
+            enabled=True,
+            user=user,
+            db_session=db_session,
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+
     make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
 
-    assert skill.id in _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    assert skill.id not in _runtime_skill_ids(user, db_session)
+    set_skill_enabled_for_user(
+        skill_id=skill.id,
+        enabled=True,
+        user=user,
+        db_session=db_session,
+    )
+    assert skill.id in _runtime_skill_ids(user, db_session)
 
 
 def test_one_external_app_can_gate_multiple_skills(
@@ -133,18 +180,21 @@ def test_one_external_app_can_gate_multiple_skills(
     )
     db_session.add(ExternalApp__Skill(external_app_id=app.id, skill_id=second_skill.id))
     db_session.flush()
-
-    assert get_first_skill_for_external_app(db_session, app.id) == first_skill
-    assert not {
-        first_skill.id,
-        second_skill.id,
-    } & _skill_ids(user, db_session, SkillAccessPolicy.USE)
-
     make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
-    db_session.flush()
+    for skill in (first_skill, second_skill):
+        set_skill_enabled_for_user(
+            skill_id=skill.id,
+            enabled=True,
+            user=user,
+            db_session=db_session,
+        )
 
+    assert get_skills_for_external_app(db_session, app.id) == [
+        first_skill,
+        second_skill,
+    ]
     assert get_external_app_by_skill_id(db_session, second_skill.id) == app
-    usable = _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    usable = _runtime_skill_ids(user, db_session)
     assert {first_skill.id, second_skill.id} <= usable
 
     app.enabled = False
@@ -152,7 +202,7 @@ def test_one_external_app_can_gate_multiple_skills(
     assert not {
         first_skill.id,
         second_skill.id,
-    } & _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    } & _runtime_skill_ids(user, db_session)
 
 
 def test_one_skill_cannot_be_associated_with_two_external_apps(
@@ -184,7 +234,7 @@ def test_one_skill_cannot_be_associated_with_two_external_apps(
     assert get_external_app_by_skill_id(db_session, shared_skill.id) == first_app
 
 
-def test_use_excludes_disabled_external_app(
+def test_runtime_excludes_disabled_external_app(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -194,19 +244,26 @@ def test_use_excludes_disabled_external_app(
         db_session,
         skill=skill,
         auth_template=_AUTH_TEMPLATE,
-        enabled=False,
     )
     make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
+    set_skill_enabled_for_user(
+        skill_id=skill.id,
+        enabled=True,
+        user=user,
+        db_session=db_session,
+    )
 
-    assert skill.id not in _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    app.enabled = False
+    db_session.flush()
+    assert skill.id not in _runtime_skill_ids(user, db_session)
 
     app.enabled = True
     db_session.flush()
 
-    assert skill.id in _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    assert skill.id in _runtime_skill_ids(user, db_session)
 
 
-def test_use_excludes_unauthenticated_or_partially_authenticated_external_app(
+def test_runtime_excludes_unauthenticated_or_partially_authenticated_external_app(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -220,14 +277,21 @@ def test_use_excludes_unauthenticated_or_partially_authenticated_external_app(
         user=partial_user,
         user_credentials={"token": "t"},
     )
+    for user in (unauthenticated_user, partial_user):
+        db_session.add(
+            UserSkillPreference(
+                user_id=user.id,
+                skill_id=skill.id,
+                name=skill.name,
+            )
+        )
+    db_session.flush()
 
-    assert skill.id not in _skill_ids(
-        unauthenticated_user, db_session, SkillAccessPolicy.USE
-    )
-    assert skill.id not in _skill_ids(partial_user, db_session, SkillAccessPolicy.USE)
+    assert skill.id not in _runtime_skill_ids(unauthenticated_user, db_session)
+    assert skill.id not in _runtime_skill_ids(partial_user, db_session)
 
 
-def test_use_includes_external_app_with_no_user_credentials_required(
+def test_runtime_includes_external_app_with_no_user_credentials_required(
     db_session: Session,
     test_user: User,  # noqa: ARG001
 ) -> None:
@@ -249,10 +313,109 @@ def test_use_includes_external_app_with_no_user_credentials_required(
         auth_template={"token": "static"},
         organization_credentials={"token": "from-org"},
     )
+    for skill in (empty_template_skill, org_filled_skill):
+        set_skill_enabled_for_user(
+            skill_id=skill.id,
+            enabled=True,
+            user=user,
+            db_session=db_session,
+        )
 
-    usable = _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    usable = _runtime_skill_ids(user, db_session)
     assert empty_template_skill.id in usable
     assert org_filled_skill.id in usable
+
+
+def test_associated_same_name_switch_changes_only_the_acting_user(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    first_user = make_user(db_session)
+    second_user = make_user(db_session)
+    standalone = make_skill(db_session, is_public=True, name="shared-runtime-name")
+    associated = make_skill(db_session, is_public=True, name="shared-runtime-name")
+    make_external_app(db_session, skill=associated, auth_template={})
+
+    for user in (first_user, second_user):
+        set_skill_enabled_for_user(
+            skill_id=standalone.id,
+            enabled=True,
+            user=user,
+            db_session=db_session,
+        )
+
+    with pytest.raises(OnyxError) as exc_info:
+        set_skill_enabled_for_user(
+            skill_id=associated.id,
+            enabled=True,
+            user=first_user,
+            db_session=db_session,
+        )
+    assert exc_info.value.error_code == OnyxErrorCode.SKILL_NAME_CONFLICT
+
+    set_skill_enabled_for_user(
+        skill_id=associated.id,
+        enabled=True,
+        replace_conflict=True,
+        user=first_user,
+        db_session=db_session,
+    )
+
+    assert associated.id in _runtime_skill_ids(first_user, db_session)
+    assert standalone.id not in _runtime_skill_ids(first_user, db_session)
+    assert standalone.id in _runtime_skill_ids(second_user, db_session)
+    assert associated.id not in _runtime_skill_ids(second_user, db_session)
+
+
+def test_associated_builtin_stays_hidden_and_uses_app_readiness_without_preference(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session)
+    skill = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id="external-provider-system-skill",
+    )
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        auth_template=_AUTH_TEMPLATE,
+    )
+
+    assert skill.id not in _management_skill_ids(
+        user, db_session, SkillManagementPolicy.VIEW
+    )
+    assert skill.id not in _management_skill_ids(
+        user, db_session, SkillManagementPolicy.EDIT
+    )
+    assert skill.id not in _runtime_skill_ids(user, db_session)
+
+    make_user_credential(db_session, app=app, user=user, user_credentials=_FULL_CREDS)
+
+    assert skill.id in _runtime_skill_ids(user, db_session)
+
+
+@pytest.mark.parametrize(
+    "public_permission",
+    [None, SkillSharePermission.EDITOR],
+)
+def test_associated_skill_cannot_change_required_org_viewer_visibility(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+    public_permission: SkillSharePermission | None,
+) -> None:
+    skill = make_skill(db_session, is_public=True)
+    make_external_app(db_session, skill=skill, auth_template={})
+
+    with pytest.raises(OnyxError) as exc_info:
+        set_skill_public_permission(
+            skill=skill,
+            public_permission=public_permission,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert skill.public_permission == SkillSharePermission.VIEWER
 
 
 def test_regular_shared_skill_still_requires_enabled_preference(
@@ -262,8 +425,10 @@ def test_regular_shared_skill_still_requires_enabled_preference(
     user = make_user(db_session)
     skill = make_skill(db_session, is_public=True, name="plain-skill")
 
-    assert skill.id in _skill_ids(user, db_session, SkillAccessPolicy.VIEW)
-    assert skill.id not in _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    assert skill.id in _management_skill_ids(
+        user, db_session, SkillManagementPolicy.VIEW
+    )
+    assert skill.id not in _runtime_skill_ids(user, db_session)
 
     set_skill_enabled_for_user(
         skill_id=skill.id,
@@ -272,4 +437,4 @@ def test_regular_shared_skill_still_requires_enabled_preference(
         db_session=db_session,
     )
 
-    assert skill.id in _skill_ids(user, db_session, SkillAccessPolicy.USE)
+    assert skill.id in _runtime_skill_ids(user, db_session)

--- a/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_api_access.py
@@ -29,9 +29,11 @@ from onyx.server.features.skill.models import SkillEnableRequest, SkillPatchRequ
 from onyx.skills.bundle import SKILL_MD_NAME, build_single_file_bundle, build_skill_md
 from tests.external_dependency_unit.craft.db_helpers import (
     add_user_to_group,
+    make_external_app,
     make_group,
     make_skill,
     make_user,
+    make_user_credential,
     share_skill_with_group,
     share_skill_with_user,
 )
@@ -82,6 +84,74 @@ def test_fetch_direct_shared_skill_is_not_personal(
     assert response.source == "custom"
     assert response.is_personal is False
     assert response.user_permission == SkillAccessLevel.VIEWER
+
+
+def test_fetch_associated_skill_reports_current_user_dependency_readiness(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session, role=UserRole.BASIC)
+    skill = make_skill(db_session, is_public=True)
+    app = make_external_app(
+        db_session,
+        skill=skill,
+        auth_template={"Authorization": "Bearer {token}"},
+    )
+    app.name = "Acme CRM"
+    db_session.flush()
+
+    disconnected = fetch_skill_for_current_user(
+        skill.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert disconnected.external_app is not None
+    assert disconnected.external_app.external_app_id == app.id
+    assert disconnected.external_app.name == "Acme CRM"
+    assert disconnected.external_app.enabled is True
+    assert disconnected.external_app.ready is False
+    assert disconnected.enabled is False
+    assert disconnected.can_toggle is False
+
+    make_user_credential(
+        db_session,
+        app=app,
+        user=user,
+        user_credentials={"token": "connected"},
+    )
+    connected = fetch_skill_for_current_user(
+        skill.id,
+        user=user,
+        db_session=db_session,
+    )
+
+    assert connected.external_app is not None
+    assert connected.external_app.ready is True
+    assert connected.enabled is False
+    assert connected.can_toggle is True
+
+    selected = set_skill_enabled_for_current_user(
+        skill.id,
+        SkillEnableRequest(enabled=True),
+        user=user,
+        db_session=db_session,
+    )
+    assert selected.enabled is True
+    assert selected.external_app is not None
+    assert selected.external_app.ready is True
+
+    app.enabled = False
+    db_session.flush()
+    unavailable = fetch_skill_for_current_user(
+        skill.id,
+        user=user,
+        db_session=db_session,
+    )
+    assert unavailable.enabled is True
+    assert unavailable.can_toggle is True
+    assert unavailable.external_app is not None
+    assert unavailable.external_app.ready is False
 
 
 def test_viewer_share_cannot_patch_skill(

--- a/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_db_mutations.py
@@ -9,11 +9,11 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.schemas import UserRole
 from onyx.db.enums import SkillSharePermission
-from onyx.db.models import Skill__User, Skill__UserGroup, UserSkillPreference
+from onyx.db.models import Skill, Skill__User, Skill__UserGroup, UserSkillPreference
 from onyx.db.skill import (
-    SkillAccessPolicy,
+    add_new_skill__no_commit,
     enable_new_skill_if_name_available__no_commit,
-    list_skills,
+    list_runtime_skills_for_user,
     replace_skill_shares,
     set_skill_enabled_for_user,
     skill_user_states,
@@ -24,6 +24,7 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.skill.response_helpers import skill_response_for_user
 from tests.external_dependency_unit.craft.db_helpers import (
     make_built_in_skill_row,
+    make_external_app,
     make_group,
     make_skill,
     make_user,
@@ -103,6 +104,29 @@ def test_new_skill_is_enabled_only_when_name_is_available(
             )
         )
     ) == {first_skill.id}
+
+
+def test_new_skill_name_is_not_reserved_by_external_app_association(
+    db_session: Session,
+) -> None:
+    name = f"shared-skill-name-{uuid4().hex[:8]}"
+    associated_skill = make_skill(db_session, name=name, is_public=True)
+    make_external_app(db_session, skill=associated_skill, auth_template={})
+    standalone_skill = Skill(
+        id=uuid4(),
+        name=name,
+        description="Independent skill with the same runtime name",
+        bundle_file_id=f"bundle-{uuid4().hex[:8]}",
+        bundle_sha256="0" * 64,
+        is_valid=True,
+    )
+
+    add_new_skill__no_commit(standalone_skill, db_session)
+
+    assert set(db_session.scalars(select(Skill.id).where(Skill.name == name))) == {
+        associated_skill.id,
+        standalone_skill.id,
+    }
 
 
 def test_orphaned_private_skill_has_boolean_admin_state(
@@ -332,8 +356,7 @@ def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> Non
 
     assert {
         skill.id
-        for skill in list_skills(
-            policy=SkillAccessPolicy.USE,
+        for skill in list_runtime_skills_for_user(
             user=first_user,
             db_session=db_session,
         )
@@ -341,8 +364,7 @@ def test_same_name_skills_switch_atomically_per_user(db_session: Session) -> Non
     } == {first_skill.id}
     assert {
         skill.id
-        for skill in list_skills(
-            policy=SkillAccessPolicy.USE,
+        for skill in list_runtime_skills_for_user(
             user=second_user,
             db_session=db_session,
         )

--- a/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
+++ b/backend/tests/external_dependency_unit/craft/test_skill_visibility.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from onyx.db.enums import SkillSharePermission
 from onyx.db.models import User, UserRole
 from onyx.db.skill import (
-    SkillAccessPolicy,
+    SkillManagementPolicy,
     fetch_skill,
     list_skills,
     set_skill_public_permission,
@@ -24,7 +24,7 @@ from tests.external_dependency_unit.craft.db_helpers import (
 
 def _user_skills(user: User, db_session: Session):
     return list_skills(
-        policy=SkillAccessPolicy.VIEW,
+        policy=SkillManagementPolicy.VIEW,
         user=user,
         db_session=db_session,
     )
@@ -41,7 +41,7 @@ class TestSkillVisibility:
 
         result = fetch_skill(
             skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=admin,
             db_session=db_session,
         )
@@ -71,7 +71,7 @@ class TestSkillVisibility:
 
         result = fetch_skill(
             skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=user,
             db_session=db_session,
         )
@@ -88,7 +88,7 @@ class TestSkillVisibility:
         assert (
             fetch_skill(
                 skill.id,
-                policy=SkillAccessPolicy.VIEW,
+                policy=SkillManagementPolicy.VIEW,
                 user=user,
                 db_session=db_session,
             )
@@ -102,7 +102,7 @@ class TestSkillVisibility:
         )
         editor_result = fetch_skill(
             skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=user,
             db_session=db_session,
         )
@@ -117,7 +117,7 @@ class TestSkillVisibility:
         assert (
             fetch_skill(
                 skill.id,
-                policy=SkillAccessPolicy.VIEW,
+                policy=SkillManagementPolicy.VIEW,
                 user=user,
                 db_session=db_session,
             )
@@ -190,7 +190,7 @@ class TestSkillVisibility:
 
         result = fetch_skill(
             private_skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=curator,
             db_session=db_session,
         )
@@ -211,7 +211,7 @@ class TestSkillVisibility:
 
         result = fetch_skill(
             private_skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=curator,
             db_session=db_session,
         )
@@ -235,7 +235,7 @@ class TestSkillVisibility:
 
         result = fetch_skill(
             private_skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=curator,
             db_session=db_session,
         )
@@ -255,7 +255,7 @@ class TestSkillVisibility:
 
         result = fetch_skill(
             private_skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=curator,
             db_session=db_session,
         )
@@ -273,7 +273,7 @@ class TestSkillVisibility:
 
         result = fetch_skill(
             public_skill.id,
-            policy=SkillAccessPolicy.EDIT,
+            policy=SkillManagementPolicy.EDIT,
             user=curator,
             db_session=db_session,
         )

--- a/backend/tests/integration/tests/craft/k8s/test_skill_push.py
+++ b/backend/tests/integration/tests/craft/k8s/test_skill_push.py
@@ -333,7 +333,7 @@ def _rendered_company_search_lines(db_session: Session, user: User) -> list[str]
 
 
 class TestSkillPush:
-    def test_external_app_skill_lands_after_user_authenticates(
+    def test_external_app_skill_requires_authentication_and_selection(
         self,
         k8s_admin_user: DATestUser,
         running_sandbox: Callable[..., SandboxHandle],
@@ -377,6 +377,8 @@ class TestSkillPush:
                 credentials={"access_token": "integration-test-token"},
             )
 
+            skill_file.wait_for_absent()
+            SkillManager.set_enabled(skill_response, user, True)
             skill_file.wait_for_bytes(b"credential gated skill body\n")
         finally:
             ExternalAppManager.delete(k8s_admin_user, app.id)

--- a/backend/tests/unit/external_apps/test_token_refresh.py
+++ b/backend/tests/unit/external_apps/test_token_refresh.py
@@ -1,8 +1,8 @@
 import json
 from contextlib import contextmanager
 from typing import Any
-from unittest.mock import MagicMock
-from uuid import uuid4
+from unittest.mock import ANY, MagicMock
+from uuid import UUID, uuid4
 
 import pytest
 import requests
@@ -285,16 +285,27 @@ def _setup(
     )
     monkeypatch.setattr(tr, "_client_credentials", lambda _app: ("cid", "secret"))
     upsert = MagicMock()
-    delete = MagicMock()
+    disconnect = MagicMock()
+    push = MagicMock()
     refresh = MagicMock()
     monkeypatch.setattr(tr, "upsert_external_app_user_credential", upsert)
-    monkeypatch.setattr(tr, "delete_external_app_user_credential", delete)
+    monkeypatch.setattr(tr, "disconnect_external_app_for_user", disconnect)
+    monkeypatch.setattr(tr, "push_skills_for_users", push)
     monkeypatch.setattr(provider, "refresh_credentials", refresh)
-    return {"upsert": upsert, "delete": delete, "refresh": refresh}
+    return {
+        "upsert": upsert,
+        "disconnect": disconnect,
+        "push": push,
+        "refresh": refresh,
+    }
 
 
-def _run() -> None:
-    tr.ensure_fresh_credentials("public", 1, uuid4())
+def _run(*, external_app_id: int = 1, user_id: UUID | None = None) -> None:
+    tr.ensure_fresh_credentials(
+        "public",
+        external_app_id,
+        user_id or uuid4(),
+    )
 
 
 def test_ensure_fresh_noop_when_token_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -336,8 +347,14 @@ def test_ensure_fresh_terminal_clears_credential_without_raising(
 ) -> None:
     spies = _setup(monkeypatch, creds_sequence=[_stale_creds(), _stale_creds()])
     spies["refresh"].side_effect = TokenRefreshTerminalError("invalid_grant")
-    _run()  # does not raise — the app simply reads as disconnected afterwards
-    spies["delete"].assert_called_once()
+    user_id = uuid4()
+    _run(external_app_id=42, user_id=user_id)
+    spies["disconnect"].assert_called_once_with(
+        ANY,
+        external_app_id=42,
+        user_id=user_id,
+    )
+    spies["push"].assert_called_once_with({user_id}, ANY)
     spies["upsert"].assert_not_called()
 
 
@@ -348,7 +365,7 @@ def test_ensure_fresh_transient_keeps_existing_token(
     spies["refresh"].side_effect = TokenRefreshTransientError("503")
     _run()  # does not raise
     spies["upsert"].assert_not_called()
-    spies["delete"].assert_not_called()
+    spies["disconnect"].assert_not_called()
 
 
 def test_ensure_fresh_redis_unavailable_keeps_existing_token(
@@ -367,7 +384,7 @@ def test_ensure_fresh_redis_unavailable_keeps_existing_token(
     _run()  # must not raise
     spies["refresh"].assert_not_called()
     spies["upsert"].assert_not_called()
-    spies["delete"].assert_not_called()
+    spies["disconnect"].assert_not_called()
 
 
 def test_ensure_fresh_db_error_keeps_existing_token(
@@ -386,7 +403,7 @@ def test_ensure_fresh_db_error_keeps_existing_token(
     _run()  # must not raise
     spies["refresh"].assert_not_called()
     spies["upsert"].assert_not_called()
-    spies["delete"].assert_not_called()
+    spies["disconnect"].assert_not_called()
 
 
 def test_ensure_fresh_noop_for_non_oauth_app(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/backend/tests/unit/onyx/skills/test_push.py
+++ b/backend/tests/unit/onyx/skills/test_push.py
@@ -217,15 +217,17 @@ def test_user_payload_returns_hydrated_files_and_connectable_apps(
     invalid_skill = _skill(name="invalid-skill", is_valid=False)
     user = cast(User, SimpleNamespace())
     db_session = MagicMock(spec=Session)
+    list_runtime_skills = MagicMock(return_value=[valid_skill, invalid_skill])
+    assemble_fileset = MagicMock(return_value={"canonical-name/SKILL.md": b"content"})
     monkeypatch.setattr(
         push,
-        "list_skills",
-        lambda **_kwargs: [valid_skill, invalid_skill],
+        "list_runtime_skills_for_user",
+        list_runtime_skills,
     )
     monkeypatch.setattr(
         push,
         "_assemble_fileset",
-        lambda *_args: {"canonical-name/SKILL.md": b"content"},
+        assemble_fileset,
     )
     monkeypatch.setattr(push, "get_connectable_apps_for_user", lambda *_args: [])
     monkeypatch.setattr(push, "build_connectable_apps_list", lambda _apps: "apps")
@@ -234,3 +236,12 @@ def test_user_payload_returns_hydrated_files_and_connectable_apps(
 
     assert apps_section == "apps"
     assert files == {"canonical-name/SKILL.md": b"content"}
+    list_runtime_skills.assert_called_once_with(
+        user=user,
+        db_session=db_session,
+    )
+    assemble_fileset.assert_called_once_with(
+        [valid_skill, invalid_skill],
+        user,
+        db_session,
+    )


### PR DESCRIPTION
## Description

Final result video:

https://github.com/user-attachments/assets/86c59079-d4ab-4ceb-a79e-194c714930ee




Make external-app-associated custom skills first-class skill records while keeping built-in provider skills hidden and automatic.

This separates skill management authorization from runtime selection, requires custom skills to be selected and their associated app to be ready before sandbox hydration, preserves normal same-name conflict handling, and removes stale preferences when users disconnect or admins delete an app. It also exposes per-user app dependency state through the skill APIs for the stacked frontend PR.

This is the backend half of a two-PR stack split only for reviewability. It is intended to ship together with the frontend PR.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make external‑app–associated custom skills first‑class while keeping provider‑owned built‑ins hidden and automatic. Separates management from runtime, surfaces per‑user app readiness in skill APIs, and refreshes affected users on app update, disconnect, or deletion.

- **New Features**
  - Associated custom skills are visible and manageable; provider‑owned built‑ins stay hidden and auto‑managed.
  - Runtime requires user selection and app readiness; provider built‑ins follow readiness without a preference.
  - Skill list/fetch/preview include external app state (external_app_id, name, enabled, ready).
  - New endpoint: DELETE `/apps/{external_app_id}/credentials` disconnects a user, clears related preferences, and refreshes their sandbox.
  - Deleting an app detaches associated custom skills (left disabled), removes provider‑owned skills, clears related preferences, and refreshes affected users.

- **Refactors**
  - Replace `SkillAccessPolicy` with `SkillManagementPolicy`; add `list_runtime_skills_for_user` for sandbox hydration.
  - Add `get_skill_external_app_dependencies`; include dependency state in responses and gate `can_toggle` on readiness.
  - Token refresh terminal failure uses `disconnect_external_app_for_user`, triggers `push_skills_for_users`, and commits.
  - Enforce associated skills must keep org visibility at `VIEWER`.
  - External‑app associations no longer reserve names; per‑user enablement can replace a same‑name skill when selecting an associated custom skill.
  - Use `Skill.is_custom` for clearer built‑in/custom checks.

<sup>Written for commit bd34e6f8ed45fe21cb9f9cddff49ac58b5603e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13373?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



