### PR TITLE
fix(e2e): deflake share-modal-link-created visual screenshot

### DIFF
--- a/web/tests/e2e/chat/share_chat.spec.ts
+++ b/web/tests/e2e/chat/share_chat.spec.ts
@@ -165,9 +165,8 @@ test.describe("Share Chat Session Modal", () => {
       dialog.locator('[aria-label="share-modal-cancel"]')
     ).toBeHidden();
 
-    // The button stays disabled (isLoading) until refreshChatSessions +
-    // clipboard copy finish; wait for the settled state so the screenshot
-    // doesn't race it
+    // The button stays disabled (isLoading) until refreshChatSessions
+    // completes; wait for the settled state so the screenshot doesn't race it
     await expect(submitButton).toBeEnabled();
 
     await expectElementScreenshot(dialog, {

--- a/web/tests/e2e/chat/share_chat.spec.ts
+++ b/web/tests/e2e/chat/share_chat.spec.ts
@@ -165,6 +165,11 @@ test.describe("Share Chat Session Modal", () => {
       dialog.locator('[aria-label="share-modal-cancel"]')
     ).toBeHidden();
 
+    // The button stays disabled (isLoading) until refreshChatSessions +
+    // clipboard copy finish; wait for the settled state so the screenshot
+    // doesn't race it
+    await expect(submitButton).toBeEnabled();
+
     await expectElementScreenshot(dialog, {
       name: "share-modal-link-created",
       mask: ['[aria-label="share-modal-link-input"]'],


### PR DESCRIPTION
## Description

The `share-modal-link-created.png` visual regression screenshot flakes between a gray (disabled) and black (enabled) "Copy Link" button — e.g. [this report](https://onyx-playwright-artifacts.s3.us-east-2.amazonaws.com/reports/pr-13370/30044298054/admin/index.html), where it was the only diff out of 181 screenshots.

**Root cause:** in `ShareChatSessionModal.handleSubmit`, the submit button is disabled via `isLoading` for the whole submit flow. When the PATCH resolves, `setShareLink()` immediately puts the modal in its final visual state (title "Chat shared", link input populated, button relabeled "Copy Link", Cancel hidden) — but `isLoading` stays true through `await refreshChatSessions()` (an SWR revalidation round-trip) and the clipboard copy, only flipping false in the `finally` block.

Every assertion the test makes before the screenshot is already true during that window, so the captured button state raced the SWR revalidation: baseline was captured mid-refresh (disabled/gray), other runs after (enabled/black).

**Fix:** wait for `submitButton` to be enabled before taking the screenshot — that's exactly the state flip that was racing. The settled (enabled) state becomes the canonical baseline.

## How Has This Been Tested?

Existing `share_chat.spec.ts` suite; the added `toBeEnabled()` expectation pins the settled state before the screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky “share-modal-link-created” visual test by waiting until the submit/“Copy Link” button is enabled before taking the screenshot, avoiding the race with the SWR refresh that keeps `isLoading` true. Also updates the comment to clarify that only the refresh gates `isLoading` (clipboard copy is unawaited).

<sup>Written for commit b0a4628f97910ee79d5e9c5db244e49e16a66931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

