### PR TITLE
feat(db): add chat_session.reasoning_effort_override column

### DIFF
--- a/backend/alembic/versions/c2cc933f0a40_add_chat_session_reasoning_effort_override.py
+++ b/backend/alembic/versions/c2cc933f0a40_add_chat_session_reasoning_effort_override.py
@@ -1,0 +1,26 @@
+"""add chat session reasoning effort override
+
+Revision ID: c2cc933f0a40
+Revises: fe958f19e42b
+Create Date: 2026-07-22 14:23:57.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c2cc933f0a40"
+down_revision = "fe958f19e42b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "chat_session",
+        sa.Column("reasoning_effort_override", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("chat_session", "reasoning_effort_override")

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -117,6 +117,7 @@ from onyx.db.pydantic_type import PydanticListType, PydanticType
 from onyx.external_apps.url_glob import UrlGlob
 from onyx.file_store.models import FileDescriptor
 from onyx.kg.models import KGEntityTypeAttributes, KGStage
+from onyx.llm.models import ReasoningEffort
 from onyx.llm.override_models import LLMOverride, PromptOverride
 from onyx.server.security.models import SSRFProtectionLevel
 from onyx.tools.tool_implementations.web_search.models import WebContentProviderConfig
@@ -3051,6 +3052,15 @@ class ChatSession(Base):
 
     # The latest temperature override specified by the user
     temperature_override: Mapped[float | None] = mapped_column(Float, nullable=True)
+    # User-pinned reasoning level. NULL means no override, AUTO is never stored.
+    reasoning_effort_override: Mapped[ReasoningEffort | None] = mapped_column(
+        Enum(
+            ReasoningEffort,
+            native_enum=False,
+            values_callable=lambda x: [e.value for e in x],
+        ),
+        nullable=True,
+    )
 
     prompt_override: Mapped[PromptOverride | None] = mapped_column(
         PydanticType(PromptOverride), nullable=True


### PR DESCRIPTION
## Description

Adds a nullable `reasoning_effort_override` String column to `chat_session` (plus migration). Stores a user-selectable reasoning level pinned to the session. NULL means no override. Consumed by the backend PR stacked on this one.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check