### PR TITLE
feat(llm): per-session reasoning effort control and provider-rejection fallback

### DIFF
--- a/backend/onyx/chat/chat_state.py
+++ b/backend/onyx/chat/chat_state.py
@@ -18,6 +18,7 @@ from onyx.context.search.models import SearchDoc
 from onyx.db.memory import UserMemoryContext
 from onyx.db.models import ChatMessage, ChatSession, Persona
 from onyx.llm.interfaces import LLM, LLMUserIdentity
+from onyx.llm.models import ReasoningEffort
 from onyx.onyxbot.slack.models import SlackContext
 from onyx.server.query_and_chat.models import SendMessageRequest
 from onyx.tools.models import ChatFile, ToolCallInfo
@@ -203,6 +204,7 @@ class ChatTurnSetup:
     # Processing-fence value and stream-buffer key — single source for the run id
     processing_run_id: int
     reserved_token_count: int
+    reasoning_effort: ReasoningEffort
     search_params: SearchParams
     all_injected_file_metadata: dict[str, FileToolMetadata]
     available_files: AvailableFiles

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -45,6 +45,7 @@ from onyx.db.models import Persona
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.interfaces import LLM, LLMUserIdentity, ToolChoiceOptions
 from onyx.llm.model_capabilities import is_true_openai_model
+from onyx.llm.models import ReasoningEffort
 from onyx.prompts.chat_prompts import IMAGE_GEN_REMINDER, OPEN_URL_REMINDER
 from onyx.prompts.prompt_utils import substitute_user_placeholders
 from onyx.server.query_and_chat.placement import Placement
@@ -655,6 +656,7 @@ def run_llm_loop(
     user_identity: LLMUserIdentity | None = None,
     chat_session_id: str | None = None,
     chat_files: list[ChatFile] | None = None,
+    reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
     include_citations: bool = True,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
     inject_memories_in_prompt: bool = True,
@@ -946,6 +948,7 @@ def run_llm_loop(
                 final_documents=gathered_documents,
                 user_identity=user_identity,
                 pre_answer_processing_time=pre_answer_processing_time,
+                reasoning_effort=reasoning_effort,
             )
             if has_reasoned:
                 reasoning_cycles += 1

--- a/backend/onyx/chat/process_message.py
+++ b/backend/onyx/chat/process_message.py
@@ -100,7 +100,7 @@ from onyx.hooks.points.query_processing import (
 )
 from onyx.llm.factory import get_llm_for_persona, get_llm_token_counter
 from onyx.llm.interfaces import LLM, LLMUserIdentity
-from onyx.llm.models import LLMErrorInfo
+from onyx.llm.models import LLMErrorInfo, ReasoningEffort
 from onyx.llm.override_models import LLMOverride
 from onyx.llm.request_context import reset_llm_mock_response, set_llm_mock_response
 from onyx.llm.utils import (
@@ -1018,6 +1018,7 @@ def build_chat_turn(
         reserved_messages=reserved_messages,
         processing_run_id=processing_run_id,
         reserved_token_count=reserved_token_count,
+        reasoning_effort=chat_session.reasoning_effort_override or ReasoningEffort.AUTO,
         search_params=search_params,
         all_injected_file_metadata=all_injected_file_metadata,
         available_files=available_files,
@@ -1274,6 +1275,7 @@ def _run_models(
                     custom_agent_prompt=setup.custom_agent_prompt,
                     llm=model_llm,
                     token_counter=get_llm_token_counter(model_llm),
+                    reasoning_effort=setup.reasoning_effort,
                     skip_clarification=setup.skip_clarification,
                     user_identity=setup.user_identity,
                     chat_session_id=str(setup.chat_session.id),
@@ -1295,6 +1297,7 @@ def _run_models(
                     user_identity=setup.user_identity,
                     chat_session_id=str(setup.chat_session.id),
                     chat_files=setup.chat_files_for_tools,
+                    reasoning_effort=setup.reasoning_effort,
                     include_citations=setup.new_msg_req.include_citations,
                     all_injected_file_metadata=setup.all_injected_file_metadata,
                     inject_memories_in_prompt=user.use_memories,

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -38,7 +38,7 @@ from onyx.deep_research.utils import (
 )
 from onyx.llm.interfaces import LLM, LLMUserIdentity
 from onyx.llm.model_capabilities import model_is_reasoning_model
-from onyx.llm.models import ToolChoiceOptions
+from onyx.llm.models import ReasoningEffort, ToolChoiceOptions
 from onyx.prompts.deep_research.orchestration_layer import (
     CLARIFICATION_PROMPT,
     FINAL_REPORT_PROMPT,
@@ -111,6 +111,7 @@ def generate_final_report(
     turn_index: int,
     citation_mapping: CitationMapping,
     user_identity: LLMUserIdentity | None,
+    reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
     saved_reasoning: str | None = None,
     pre_answer_processing_time: float | None = None,
     all_injected_file_metadata: dict[str, FileToolMetadata] | None = None,
@@ -159,6 +160,7 @@ def generate_final_report(
             tool_definitions=[],
             tool_choice=ToolChoiceOptions.NONE,
             llm=llm,
+            reasoning_effort=reasoning_effort,
             placement=Placement(turn_index=turn_index),
             citation_processor=citation_processor,
             state_container=state_container,
@@ -204,6 +206,7 @@ def run_deep_research_llm_loop(
     custom_agent_prompt: str | None,  # noqa: ARG001
     llm: LLM,
     token_counter: Callable[[str], int],
+    reasoning_effort: ReasoningEffort = ReasoningEffort.AUTO,
     skip_clarification: bool = False,
     user_identity: LLMUserIdentity | None = None,
     chat_session_id: str | None = None,
@@ -283,6 +286,7 @@ def run_deep_research_llm_loop(
                     tool_definitions=get_clarification_tool_definitions(),
                     tool_choice=ToolChoiceOptions.AUTO,
                     llm=llm,
+                    reasoning_effort=reasoning_effort,
                     placement=Placement(turn_index=0),
                     # No citations in this step, it should just pass through all
                     # tokens directly so initialized as an empty citation processor
@@ -343,6 +347,7 @@ def run_deep_research_llm_loop(
                 tool_definitions=[],
                 tool_choice=ToolChoiceOptions.NONE,
                 llm=llm,
+                reasoning_effort=reasoning_effort,
                 placement=Placement(turn_index=0),
                 citation_processor=None,
                 state_container=state_container,
@@ -459,6 +464,7 @@ def run_deep_research_llm_loop(
                         turn_index=report_turn_index,
                         citation_mapping=citation_mapping,
                         user_identity=user_identity,
+                        reasoning_effort=reasoning_effort,
                         pre_answer_processing_time=elapsed_seconds,
                         all_injected_file_metadata=all_injected_file_metadata,
                     )
@@ -517,6 +523,7 @@ def run_deep_research_llm_loop(
                     ),
                     tool_choice=ToolChoiceOptions.REQUIRED,
                     llm=llm,
+                    reasoning_effort=reasoning_effort,
                     placement=Placement(
                         turn_index=orchestrator_start_turn_index
                         + cycle
@@ -562,6 +569,7 @@ def run_deep_research_llm_loop(
                         turn_index=report_turn_index,
                         citation_mapping=citation_mapping,
                         user_identity=user_identity,
+                        reasoning_effort=reasoning_effort,
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
                         all_injected_file_metadata=all_injected_file_metadata,
@@ -583,6 +591,7 @@ def run_deep_research_llm_loop(
                         turn_index=report_turn_index,
                         citation_mapping=citation_mapping,
                         user_identity=user_identity,
+                        reasoning_effort=reasoning_effort,
                         saved_reasoning=most_recent_reasoning,
                         pre_answer_processing_time=time.monotonic()
                         - processing_start_time,
@@ -657,6 +666,7 @@ def run_deep_research_llm_loop(
                             turn_index=report_turn_index,
                             citation_mapping=citation_mapping,
                             user_identity=user_identity,
+                            reasoning_effort=reasoning_effort,
                             pre_answer_processing_time=time.monotonic()
                             - processing_start_time,
                             all_injected_file_metadata=all_injected_file_metadata,
@@ -694,6 +704,12 @@ def run_deep_research_llm_loop(
                         token_counter=token_counter,
                         citation_mapping=citation_mapping,
                         user_identity=user_identity,
+                        # Session override wins in sub-agents. AUTO keeps the tuned LOW default.
+                        reasoning_effort=(
+                            reasoning_effort
+                            if reasoning_effort is not ReasoningEffort.AUTO
+                            else ReasoningEffort.LOW
+                        ),
                     )
 
                     citation_mapping = research_results.citation_mapping

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -31,6 +31,37 @@ class ReasoningEffort(str, Enum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
+    # Supported by OpenAI and by Anthropic adaptive-thinking models
+    # (Claude >= 4.7). Other provider mappings clamp it to their highest
+    # supported effort.
+    XHIGH = "xhigh"
+
+
+# Reasoning-effort values a user may pin per chat session. AUTO is excluded
+# because a cleared override (NULL) already resolves to AUTO.
+USER_SELECTABLE_REASONING_EFFORTS: frozenset[ReasoningEffort] = frozenset(
+    {
+        ReasoningEffort.OFF,
+        ReasoningEffort.LOW,
+        ReasoningEffort.MEDIUM,
+        ReasoningEffort.HIGH,
+        ReasoningEffort.XHIGH,
+    }
+)
+
+
+def parse_reasoning_effort_override(value: str | None) -> ReasoningEffort:
+    """Resolve a stored per-session override string to a ReasoningEffort.
+
+    NULL means no override, which resolves to AUTO. Raises ValueError for an
+    unknown value or an explicit "auto", neither of which is user-selectable.
+    """
+    if value is None:
+        return ReasoningEffort.AUTO
+    effort = ReasoningEffort(value)
+    if effort not in USER_SELECTABLE_REASONING_EFFORTS:
+        raise ValueError(f"{value!r} is not a selectable reasoning effort")
+    return effort
 
 
 # OpenAI reasoning effort mapping
@@ -41,6 +72,7 @@ OPENAI_REASONING_EFFORT: dict[ReasoningEffort, str] = {
     ReasoningEffort.LOW: "low",
     ReasoningEffort.MEDIUM: "medium",
     ReasoningEffort.HIGH: "high",
+    ReasoningEffort.XHIGH: "xhigh",
 }
 
 # Anthropic reasoning effort to budget tokens mapping
@@ -50,6 +82,7 @@ ANTHROPIC_REASONING_EFFORT_BUDGET: dict[ReasoningEffort, int] = {
     ReasoningEffort.LOW: 1024,
     ReasoningEffort.MEDIUM: 2048,
     ReasoningEffort.HIGH: 4096,
+    ReasoningEffort.XHIGH: 4096,
 }
 
 # Newer Anthropic models (Claude Opus 4.7+) use adaptive thinking with
@@ -59,6 +92,7 @@ ANTHROPIC_ADAPTIVE_REASONING_EFFORT: dict[ReasoningEffort, str] = {
     ReasoningEffort.LOW: "low",
     ReasoningEffort.MEDIUM: "medium",
     ReasoningEffort.HIGH: "high",
+    ReasoningEffort.XHIGH: "xhigh",
 }
 
 

--- a/backend/onyx/llm/models.py
+++ b/backend/onyx/llm/models.py
@@ -31,9 +31,8 @@ class ReasoningEffort(str, Enum):
     LOW = "low"
     MEDIUM = "medium"
     HIGH = "high"
-    # Supported by OpenAI and by Anthropic adaptive-thinking models
-    # (Claude >= 4.7). Other provider mappings clamp it to their highest
-    # supported effort.
+    # Supported by OpenAI and Anthropic adaptive-thinking models (Claude >= 4.7).
+    # Other provider mappings clamp it to their highest supported effort.
     XHIGH = "xhigh"
 
 
@@ -50,14 +49,9 @@ USER_SELECTABLE_REASONING_EFFORTS: frozenset[ReasoningEffort] = frozenset(
 )
 
 
-def parse_reasoning_effort_override(value: str | None) -> ReasoningEffort:
-    """Resolve a stored per-session override string to a ReasoningEffort.
-
-    NULL means no override, which resolves to AUTO. Raises ValueError for an
-    unknown value or an explicit "auto", neither of which is user-selectable.
-    """
-    if value is None:
-        return ReasoningEffort.AUTO
+def parse_user_selectable_reasoning_effort(value: str) -> ReasoningEffort:
+    """Parse a user-supplied override value. Raises ValueError for an unknown
+    value or an explicit "auto", neither of which is user-selectable."""
     effort = ReasoningEffort(value)
     if effort not in USER_SELECTABLE_REASONING_EFFORTS:
         raise ValueError(f"{value!r} is not a selectable reasoning effort")

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -93,9 +93,7 @@ _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
 _REASONING_KWARG_KEYS = frozenset(
     {"thinking", "output_config", "reasoning", "reasoning_effort"}
 )
-_BEST_EFFORT_KWARG_KEYS = _REASONING_KWARG_KEYS | frozenset(
-    {"temperature", "stream_options"}
-)
+_BEST_EFFORT_KWARG_KEYS = _REASONING_KWARG_KEYS | frozenset({"temperature"})
 
 # Substrings provider 400s use to name each strippable kwarg (legacy thinking
 # errors cite the inner budget_tokens field, effort errors may cite only the
@@ -106,7 +104,6 @@ _KWARG_ERROR_ALIASES: dict[str, tuple[str, ...]] = {
     "reasoning": ("reasoning", "effort"),
     "reasoning_effort": ("reasoning_effort", "effort"),
     "temperature": ("temperature",),
-    "stream_options": ("stream_options",),
 }
 
 

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -87,6 +87,16 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
 # still advertises temperature as supported).
 _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
 
+# Best-effort tuning kwargs, never worth failing a chat over. _completion
+# retries provider rejections without them: reasoning keys first, then all.
+# Semantics-changing keys (tools, tool_choice, messages) are never stripped.
+_REASONING_KWARG_KEYS = frozenset(
+    {"thinking", "output_config", "reasoning", "reasoning_effort"}
+)
+_BEST_EFFORT_KWARG_KEYS = _REASONING_KWARG_KEYS | frozenset(
+    {"temperature", "stream_options"}
+)
+
 # Named tiers spanning Claude's naming schemes, including the Claude 5 line whose
 # version digit can precede or follow the tier ("claude-sonnet-5" vs
 # "claude-5-sonnet").
@@ -527,7 +537,7 @@ class LitellmLLM(LLM):
         client: "HTTPHandler | None" = None,
     ) -> Union["ModelResponse", "CustomStreamWrapper"]:
         # Lazy loading to avoid memory bloat for non-inference flows
-        from litellm.exceptions import RateLimitError, Timeout
+        from litellm.exceptions import BadRequestError, RateLimitError, Timeout
 
         from onyx.llm.litellm_singleton import litellm
 
@@ -699,6 +709,9 @@ class LitellmLLM(LLM):
                     ReasoningEffort.HIGH,
                 ]:
                     optional_kwargs["reasoning_effort"] = reasoning_effort.value
+                elif reasoning_effort is ReasoningEffort.XHIGH:
+                    # litellm's generic reasoning_effort path has no xhigh, clamp to high.
+                    optional_kwargs["reasoning_effort"] = ReasoningEffort.HIGH.value
                 else:
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.MEDIUM.value
 
@@ -808,36 +821,63 @@ class LitellmLLM(LLM):
             if tools and tool_choice is not None:
                 optional_kwargs["tool_choice"] = tool_choice
 
-            # Injection disabled means no env writer exists anywhere in the
-            # process, so skip the rwlock entirely.
-            env_ctx: AbstractContextManager[None]
-            if _env_injection_enabled():
-                env_ctx = temporary_env_and_lock(self._env_only_custom_config)
-            else:
-                if self._env_only_custom_config:
-                    _warn_dropped_env_only_keys(
-                        self._model_provider,
-                        tuple(sorted(self._env_only_custom_config)),
-                    )
-                env_ctx = nullcontext()
-
-            with env_ctx:
-                response = litellm.completion(
-                    mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
-                    model=model,
-                    base_url=self._api_base or None,
-                    api_version=api_version,
-                    custom_llm_provider=self._custom_llm_provider or None,
-                    messages=messages,
-                    tools=tools,
-                    stream=stream,
-                    timeout=timeout_override or self._timeout,
-                    max_tokens=max_tokens,
-                    client=client,
-                    **optional_kwargs,
-                    **passthrough_kwargs,
+            if not _env_injection_enabled() and self._env_only_custom_config:
+                _warn_dropped_env_only_keys(
+                    self._model_provider,
+                    tuple(sorted(self._env_only_custom_config)),
                 )
-            return response
+
+            def _call_litellm(opts: dict[str, Any]) -> Any:
+                # Injection disabled means no env writer exists anywhere in
+                # the process, so skip the rwlock entirely. Built per attempt
+                # because the context manager is single-use.
+                env_ctx: AbstractContextManager[None] = (
+                    temporary_env_and_lock(self._env_only_custom_config)
+                    if _env_injection_enabled()
+                    else nullcontext()
+                )
+                with env_ctx:
+                    return litellm.completion(
+                        mock_response=get_llm_mock_response() or MOCK_LLM_RESPONSE,
+                        model=model,
+                        base_url=self._api_base or None,
+                        api_version=api_version,
+                        custom_llm_provider=self._custom_llm_provider or None,
+                        messages=messages,
+                        tools=tools,
+                        stream=stream,
+                        timeout=timeout_override or self._timeout,
+                        max_tokens=max_tokens,
+                        client=client,
+                        **opts,
+                        **passthrough_kwargs,
+                    )
+
+            # Retry ladder for provider 400s: drop reasoning kwargs, then every
+            # best-effort kwarg. Unknown models or capability drift degrade to
+            # provider defaults with a warning instead of failing the message.
+            attempts = [optional_kwargs]
+            for strip_keys in (_REASONING_KWARG_KEYS, _BEST_EFFORT_KWARG_KEYS):
+                stripped = {
+                    k: v for k, v in optional_kwargs.items() if k not in strip_keys
+                }
+                if len(stripped) < len(attempts[-1]):
+                    attempts.append(stripped)
+
+            for i, opts in enumerate(attempts):
+                try:
+                    return _call_litellm(opts)
+                except BadRequestError as e:
+                    if i == len(attempts) - 1:
+                        raise
+                    logger.warning(
+                        "Provider rejected request for model %s. Retrying "
+                        "without %s: %s",
+                        model,
+                        sorted(set(opts) - set(attempts[i + 1])),
+                        e,
+                    )
+            raise RuntimeError("unreachable: retry ladder always returns or raises")
         except Exception as e:
             # for break pointing
             if isinstance(e, Timeout):

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -95,9 +95,8 @@ _REASONING_KWARG_KEYS = frozenset(
 )
 _BEST_EFFORT_KWARG_KEYS = _REASONING_KWARG_KEYS | frozenset({"temperature"})
 
-# Substrings provider 400s use to name each strippable kwarg (legacy thinking
-# errors cite the inner budget_tokens field, effort errors may cite only the
-# inner effort field of reasoning or output_config).
+# Substrings provider 400s use to name each strippable kwarg (errors may
+# cite only inner fields like budget_tokens or effort).
 _KWARG_ERROR_ALIASES: dict[str, tuple[str, ...]] = {
     "thinking": ("thinking", "budget_tokens"),
     "output_config": ("output_config", "effort"),
@@ -731,7 +730,8 @@ class LitellmLLM(LLM):
                 ]:
                     optional_kwargs["reasoning_effort"] = reasoning_effort.value
                 elif reasoning_effort is ReasoningEffort.XHIGH:
-                    # litellm's generic reasoning_effort path has no xhigh, clamp to high.
+                    # Provider mappings behind litellm's reasoning_effort are
+                    # uneven (Gemini raises on xhigh), clamp to high.
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.HIGH.value
                 else:
                     optional_kwargs["reasoning_effort"] = ReasoningEffort.MEDIUM.value

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -97,6 +97,30 @@ _BEST_EFFORT_KWARG_KEYS = _REASONING_KWARG_KEYS | frozenset(
     {"temperature", "stream_options"}
 )
 
+# Substrings provider 400s use to name each strippable kwarg (legacy thinking
+# errors cite the inner budget_tokens field, effort errors may cite only the
+# inner effort field of reasoning or output_config).
+_KWARG_ERROR_ALIASES: dict[str, tuple[str, ...]] = {
+    "thinking": ("thinking", "budget_tokens"),
+    "output_config": ("output_config", "effort"),
+    "reasoning": ("reasoning", "effort"),
+    "reasoning_effort": ("reasoning_effort", "effort"),
+    "temperature": ("temperature",),
+    "stream_options": ("stream_options",),
+}
+
+
+def _rejection_names_strippable_kwargs(error: Exception, strippable: set[str]) -> bool:
+    """True when the 400's message names a kwarg a later attempt would drop.
+    Unrelated 400s (context length, malformed input) must not be retried."""
+    message = str(error).lower()
+    return any(
+        alias in message
+        for key in strippable
+        for alias in _KWARG_ERROR_ALIASES.get(key, (key,))
+    )
+
+
 # Named tiers spanning Claude's naming schemes, including the Claude 5 line whose
 # version digit can precede or follow the tier ("claude-sonnet-5" vs
 # "claude-5-sonnet").
@@ -869,6 +893,10 @@ class LitellmLLM(LLM):
                     return _call_litellm(opts)
                 except BadRequestError as e:
                     if i == len(attempts) - 1:
+                        raise
+                    # Only retry rejections a later attempt can strip away.
+                    remaining_strippable = set(opts) - set(attempts[-1])
+                    if not _rejection_names_strippable_kwargs(e, remaining_strippable):
                         raise
                     logger.warning(
                         "Provider rejected request for model %s. Retrying "

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -74,7 +74,7 @@ from onyx.llm.factory import get_default_llm, get_llm_for_persona, get_llm_token
 from onyx.llm.models import (
     USER_SELECTABLE_REASONING_EFFORTS,
     ReasoningEffort,
-    parse_reasoning_effort_override,
+    parse_user_selectable_reasoning_effort,
 )
 from onyx.secondary_llm_flows.chat_session_naming import generate_chat_session_name
 from onyx.server.api_key_usage import check_api_key_usage
@@ -278,7 +278,7 @@ def update_chat_session_reasoning(
     reasoning_effort: ReasoningEffort | None = None
     if update_thread_req.reasoning_effort_override is not None:
         try:
-            reasoning_effort = parse_reasoning_effort_override(
+            reasoning_effort = parse_user_selectable_reasoning_effort(
                 update_thread_req.reasoning_effort_override
             )
         except ValueError:

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -71,6 +71,11 @@ from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
 from onyx.llm.factory import get_default_llm, get_llm_for_persona, get_llm_token_counter
+from onyx.llm.models import (
+    USER_SELECTABLE_REASONING_EFFORTS,
+    ReasoningEffort,
+    parse_reasoning_effort_override,
+)
 from onyx.secondary_llm_flows.chat_session_naming import generate_chat_session_name
 from onyx.server.api_key_usage import check_api_key_usage
 from onyx.server.middleware.rate_limiting import get_feedback_rate_limiters
@@ -95,6 +100,7 @@ from onyx.server.query_and_chat.models import (
     RenameChatSessionResponse,
     SendMessageRequest,
     SetPreferredResponseRequest,
+    UpdateChatSessionReasoningRequest,
     UpdateChatSessionTemperatureRequest,
     UpdateChatSessionThreadRequest,
 )
@@ -208,6 +214,7 @@ def get_user_chat_sessions(
                 shared_status=chat.shared_status,
                 current_alternate_model=chat.current_alternate_model,
                 current_temperature_override=chat.temperature_override,
+                current_reasoning_effort_override=chat.reasoning_effort_override,
             )
             for chat in chat_sessions
         ],
@@ -251,6 +258,41 @@ def update_chat_session_temperature(
 
     chat_session.temperature_override = update_thread_req.temperature_override
 
+    db_session.add(chat_session)
+    db_session.commit()
+
+
+@router.put("/update-chat-session-reasoning")
+def update_chat_session_reasoning(
+    update_thread_req: UpdateChatSessionReasoningRequest,
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    chat_session = get_chat_session_by_id(
+        chat_session_id=update_thread_req.chat_session_id,
+        user_id=user.id,
+        db_session=db_session,
+    )
+
+    # NULL clears the override. Any set value must be a user-selectable effort.
+    reasoning_effort: ReasoningEffort | None = None
+    if update_thread_req.reasoning_effort_override is not None:
+        try:
+            reasoning_effort = parse_reasoning_effort_override(
+                update_thread_req.reasoning_effort_override
+            )
+        except ValueError:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "reasoning_effort_override must be one of: "
+                + ", ".join(
+                    effort.value
+                    for effort in ReasoningEffort
+                    if effort in USER_SELECTABLE_REASONING_EFFORTS
+                ),
+            )
+
+    chat_session.reasoning_effort_override = reasoning_effort
     db_session.add(chat_session)
     db_session.commit()
 
@@ -379,6 +421,7 @@ def get_chat_session(
         time_created=chat_session.time_created,
         shared_status=chat_session.shared_status,
         current_temperature_override=chat_session.temperature_override,
+        current_reasoning_effort_override=chat_session.reasoning_effort_override,
         deleted=chat_session.deleted,
         owner_name=chat_session.user.personal_name if chat_session.user else None,
         # Packets are now directly serialized as Packet Pydantic models
@@ -994,6 +1037,7 @@ def search_chats(
             shared_status=session.shared_status,
             current_alternate_model=session.current_alternate_model,
             current_temperature_override=session.temperature_override,
+            current_reasoning_effort_override=session.reasoning_effort_override,
         )
 
         if session_date == today:

--- a/backend/onyx/server/query_and_chat/models.py
+++ b/backend/onyx/server/query_and_chat/models.py
@@ -69,6 +69,11 @@ class UpdateChatSessionTemperatureRequest(BaseModel):
     temperature_override: float
 
 
+class UpdateChatSessionReasoningRequest(BaseModel):
+    chat_session_id: UUID
+    reasoning_effort_override: str | None = None
+
+
 class ChatSessionCreationRequest(BaseModel):
     # If not specified, use Onyx default persona
     persona_id: int = 0
@@ -187,6 +192,7 @@ class ChatSessionDetails(BaseModel):
     shared_status: ChatSessionSharedStatus
     current_alternate_model: str | None = None
     current_temperature_override: float | None = None
+    current_reasoning_effort_override: str | None = None
 
     @classmethod
     def from_model(cls, model: ChatSession) -> "ChatSessionDetails":
@@ -199,6 +205,7 @@ class ChatSessionDetails(BaseModel):
             shared_status=model.shared_status,
             current_alternate_model=model.current_alternate_model,
             current_temperature_override=model.temperature_override,
+            current_reasoning_effort_override=model.reasoning_effort_override,
         )
 
 
@@ -260,6 +267,7 @@ class ChatSessionDetailResponse(BaseModel):
     shared_status: ChatSessionSharedStatus
     current_alternate_model: str | None
     current_temperature_override: float | None
+    current_reasoning_effort_override: str | None
     deleted: bool = False
     owner_name: str | None = None
     packets: list[list[Packet]]
@@ -285,6 +293,7 @@ class ChatSessionSummary(BaseModel):
     shared_status: ChatSessionSharedStatus
     current_alternate_model: str | None = None
     current_temperature_override: float | None = None
+    current_reasoning_effort_override: str | None = None
 
 
 class ChatSessionGroup(BaseModel):

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -63,7 +63,7 @@ class Settings(BaseModel):
     # Resolved per-tenant tier for ENTERPRISE-only feature gating in the FE.
     tier: Tier = Tier.COMMUNITY
 
-    temperature_override_enabled: bool | None = False
+    temperature_override_enabled: bool | None = True
     auto_scroll: bool | None = False
     query_history_type: QueryHistoryType | None = None
 

--- a/backend/onyx/tools/fake_tools/research_agent.py
+++ b/backend/onyx/tools/fake_tools/research_agent.py
@@ -102,6 +102,7 @@ def generate_intermediate_report(
     user_identity: LLMUserIdentity | None,
     emitter: Emitter,
     placement: Placement,
+    reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> str:
     # NOTE: This step outputs a lot of tokens and has been observed to run for more than 10 minutes in a nontrivial percentage of
     # research tasks. This is also model / inference provider dependent.
@@ -142,7 +143,7 @@ def generate_intermediate_report(
             placement=placement,
             citation_processor=citation_processor,
             state_container=state_container,
-            reasoning_effort=ReasoningEffort.LOW,
+            reasoning_effort=reasoning_effort,
             final_documents=None,
             user_identity=user_identity,
             max_tokens=MAX_INTERMEDIATE_REPORT_LENGTH_TOKENS,
@@ -222,6 +223,7 @@ def run_research_agent_call(
     is_reasoning_model: bool,
     token_counter: Callable[[str], int],
     user_identity: LLMUserIdentity | None,
+    reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> ResearchAgentCallResult | None:
     turn_index = research_agent_call.placement.turn_index
     tab_index = research_agent_call.placement.tab_index
@@ -371,7 +373,7 @@ def run_research_agent_call(
                     ),
                     citation_processor=None,
                     state_container=None,
-                    reasoning_effort=ReasoningEffort.LOW,
+                    reasoning_effort=reasoning_effort,
                     final_documents=None,
                     user_identity=user_identity,
                     custom_token_processor=custom_processor,
@@ -412,6 +414,7 @@ def run_research_agent_call(
                         citation_processor=citation_processor,
                         user_identity=user_identity,
                         emitter=emitter,
+                        reasoning_effort=reasoning_effort,
                         placement=Placement(
                             turn_index=turn_index,
                             tab_index=tab_index,
@@ -612,6 +615,7 @@ def run_research_agent_call(
                 citation_processor=citation_processor,
                 user_identity=user_identity,
                 emitter=emitter,
+                reasoning_effort=reasoning_effort,
                 placement=Placement(
                     turn_index=turn_index,
                     tab_index=tab_index,
@@ -670,6 +674,7 @@ def run_research_agent_calls(
     token_counter: Callable[[str], int],
     citation_mapping: CitationMapping,
     user_identity: LLMUserIdentity | None = None,
+    reasoning_effort: ReasoningEffort = ReasoningEffort.LOW,
 ) -> CombinedResearchAgentCallResult:
     # Run all research agent calls in parallel with timeout
     functions_with_args = [
@@ -685,6 +690,7 @@ def run_research_agent_calls(
                 is_reasoning_model,
                 token_counter,
                 user_identity,
+                reasoning_effort,
             ),
         )
         for research_agent_call, parent_tool_call_id in zip(

--- a/backend/tests/unit/onyx/llm/test_reasoning_effort_mapping.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_effort_mapping.py
@@ -35,6 +35,7 @@ def test_openai_reasoning_effort_mapping_covers_all_effort_levels() -> None:
         ReasoningEffort.LOW,
         ReasoningEffort.MEDIUM,
         ReasoningEffort.HIGH,
+        ReasoningEffort.XHIGH,
     }
 
     mapped_effort_levels = set(OPENAI_REASONING_EFFORT.keys())

--- a/backend/tests/unit/onyx/llm/test_reasoning_effort_override.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_effort_override.py
@@ -1,0 +1,39 @@
+"""Guards parsing of stored chat-session reasoning-effort overrides."""
+
+import pytest
+
+from onyx.llm.models import ReasoningEffort, parse_reasoning_effort_override
+
+
+def test_parse_reasoning_effort_override_none_defaults_to_auto() -> None:
+    assert parse_reasoning_effort_override(None) is ReasoningEffort.AUTO
+
+
+@pytest.mark.parametrize(
+    ("stored_value", "expected_effort"),
+    [
+        ("off", ReasoningEffort.OFF),
+        ("low", ReasoningEffort.LOW),
+        ("medium", ReasoningEffort.MEDIUM),
+        ("high", ReasoningEffort.HIGH),
+        ("xhigh", ReasoningEffort.XHIGH),
+    ],
+)
+def test_parse_reasoning_effort_override_accepts_user_selectable_values(
+    stored_value: str,
+    expected_effort: ReasoningEffort,
+) -> None:
+    assert parse_reasoning_effort_override(stored_value) is expected_effort
+
+
+def test_parse_reasoning_effort_override_rejects_auto() -> None:
+    with pytest.raises(ValueError):
+        parse_reasoning_effort_override("auto")
+
+
+@pytest.mark.parametrize("stored_value", ["ultra", ""])
+def test_parse_reasoning_effort_override_rejects_unknown_values(
+    stored_value: str,
+) -> None:
+    with pytest.raises(ValueError):
+        parse_reasoning_effort_override(stored_value)

--- a/backend/tests/unit/onyx/llm/test_reasoning_effort_override.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_effort_override.py
@@ -1,16 +1,12 @@
-"""Guards parsing of stored chat-session reasoning-effort overrides."""
+"""Guards parsing of user-selectable reasoning-effort override values."""
 
 import pytest
 
-from onyx.llm.models import ReasoningEffort, parse_reasoning_effort_override
-
-
-def test_parse_reasoning_effort_override_none_defaults_to_auto() -> None:
-    assert parse_reasoning_effort_override(None) is ReasoningEffort.AUTO
+from onyx.llm.models import ReasoningEffort, parse_user_selectable_reasoning_effort
 
 
 @pytest.mark.parametrize(
-    ("stored_value", "expected_effort"),
+    ("value", "expected_effort"),
     [
         ("off", ReasoningEffort.OFF),
         ("low", ReasoningEffort.LOW),
@@ -19,21 +15,21 @@ def test_parse_reasoning_effort_override_none_defaults_to_auto() -> None:
         ("xhigh", ReasoningEffort.XHIGH),
     ],
 )
-def test_parse_reasoning_effort_override_accepts_user_selectable_values(
-    stored_value: str,
+def test_parse_user_selectable_reasoning_effort_accepts_user_selectable_values(
+    value: str,
     expected_effort: ReasoningEffort,
 ) -> None:
-    assert parse_reasoning_effort_override(stored_value) is expected_effort
+    assert parse_user_selectable_reasoning_effort(value) is expected_effort
 
 
-def test_parse_reasoning_effort_override_rejects_auto() -> None:
+def test_parse_user_selectable_reasoning_effort_rejects_auto() -> None:
     with pytest.raises(ValueError):
-        parse_reasoning_effort_override("auto")
+        parse_user_selectable_reasoning_effort("auto")
 
 
-@pytest.mark.parametrize("stored_value", ["ultra", ""])
-def test_parse_reasoning_effort_override_rejects_unknown_values(
-    stored_value: str,
+@pytest.mark.parametrize("value", ["ultra", ""])
+def test_parse_user_selectable_reasoning_effort_rejects_unknown_values(
+    value: str,
 ) -> None:
     with pytest.raises(ValueError):
-        parse_reasoning_effort_override(stored_value)
+        parse_user_selectable_reasoning_effort(value)

--- a/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
@@ -66,7 +66,8 @@ def test_bad_request_without_reasoning_params_raises() -> None:
         calls.append(kwargs)
         raise _bad_request("bad prompt")
 
-    # OFF sends no reasoning kwargs, so there is nothing to strip.
+    # OFF sends no reasoning kwargs and claude-sonnet-5 omits temperature,
+    # so nothing is strippable.
     with pytest.raises(BadRequestError):
         _run(_make_llm(), completion, ReasoningEffort.OFF)
     assert len(calls) == 1

--- a/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
@@ -75,11 +75,24 @@ def test_bad_request_after_strip_propagates() -> None:
 
     def completion(**kwargs: Any) -> Any:
         calls.append(kwargs)
-        raise _bad_request("still broken")
+        raise _bad_request("thinking is not supported on this endpoint")
 
     with pytest.raises(BadRequestError):
         _run(_make_llm(), completion, ReasoningEffort.HIGH)
     assert len(calls) == 2
+
+
+def test_unrelated_bad_request_is_not_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("prompt is too long: 250000 tokens > 200000 maximum")
+
+    # The 400 names no strippable kwarg, so the ladder must not burn retries.
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.HIGH)
+    assert len(calls) == 1
 
 
 def test_ladder_strips_reasoning_then_all_best_effort_kwargs() -> None:
@@ -87,8 +100,10 @@ def test_ladder_strips_reasoning_then_all_best_effort_kwargs() -> None:
 
     def completion(**kwargs: Any) -> Any:
         calls.append(kwargs)
-        if "reasoning" in kwargs or "temperature" in kwargs:
-            raise _bad_request()
+        if "reasoning" in kwargs:
+            raise _bad_request("reasoning is not supported with this model")
+        if "temperature" in kwargs:
+            raise _bad_request("temperature is not supported with this model")
         return _SENTINEL
 
     # gpt-5.4 sets both a reasoning kwarg and temperature, exercising the

--- a/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
@@ -27,13 +27,15 @@ def _bad_request(message: str = "effort not supported") -> BadRequestError:
     return BadRequestError(message=message, model="m", llm_provider="anthropic")
 
 
-def _run(llm: LitellmLLM, completion: Any, effort: ReasoningEffort) -> Any:
+def _run(
+    llm: LitellmLLM, completion: Any, effort: ReasoningEffort, stream: bool = False
+) -> Any:
     with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
         return llm._completion(
             prompt=[UserMessage(content="hello")],
             tools=None,
             tool_choice=None,
-            stream=False,
+            stream=stream,
             parallel_tool_calls=False,
             reasoning_effort=effort,
         )
@@ -142,6 +144,21 @@ def test_rejected_sampling_params_retry_without_reasoning_tier() -> None:
     assert len(calls) == 2
     assert "temperature" in calls[0]
     assert "temperature" not in calls[1]
+
+
+def test_stream_options_rejection_is_not_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("stream_options is not supported with this model")
+
+    # Only reasoning kwargs and temperature are strippable, so a 400 naming
+    # stream_options surfaces immediately.
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.OFF, stream=True)
+    assert len(calls) == 1
+    assert "stream_options" in calls[0]
 
 
 def test_rate_limit_is_not_retried() -> None:

--- a/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
+++ b/backend/tests/unit/onyx/llm/test_reasoning_param_fallback.py
@@ -1,0 +1,141 @@
+"""Guards the degrade-and-retry behavior for provider-rejected reasoning params."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from litellm.exceptions import BadRequestError, RateLimitError
+
+from onyx.llm.models import ReasoningEffort, UserMessage
+from onyx.llm.multi_llm import LitellmLLM, LLMRateLimitError
+
+_SENTINEL = object()
+
+
+def _make_llm(
+    model_name: str = "claude-sonnet-5", model_provider: str = "anthropic"
+) -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider=model_provider,
+        model_name=model_name,
+        max_input_tokens=100000,
+    )
+
+
+def _bad_request(message: str = "effort not supported") -> BadRequestError:
+    return BadRequestError(message=message, model="m", llm_provider="anthropic")
+
+
+def _run(llm: LitellmLLM, completion: Any, effort: ReasoningEffort) -> Any:
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        return llm._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=None,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=effort,
+        )
+
+
+def test_rejected_reasoning_params_are_stripped_and_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "thinking" in kwargs or "output_config" in kwargs:
+            raise _bad_request()
+        return _SENTINEL
+
+    result = _run(_make_llm(), completion, ReasoningEffort.XHIGH)
+
+    assert result is _SENTINEL
+    assert len(calls) == 2
+    assert "thinking" in calls[0] or "output_config" in calls[0]
+    for key in ("thinking", "output_config", "reasoning", "reasoning_effort"):
+        assert key not in calls[1]
+
+
+def test_bad_request_without_reasoning_params_raises() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("bad prompt")
+
+    # OFF sends no reasoning kwargs, so there is nothing to strip.
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.OFF)
+    assert len(calls) == 1
+
+
+def test_bad_request_after_strip_propagates() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise _bad_request("still broken")
+
+    with pytest.raises(BadRequestError):
+        _run(_make_llm(), completion, ReasoningEffort.HIGH)
+    assert len(calls) == 2
+
+
+def test_ladder_strips_reasoning_then_all_best_effort_kwargs() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "reasoning" in kwargs or "temperature" in kwargs:
+            raise _bad_request()
+        return _SENTINEL
+
+    # gpt-5.4 sets both a reasoning kwarg and temperature, exercising the
+    # full three-attempt ladder.
+    result = _run(
+        _make_llm(model_name="gpt-5.4", model_provider="openai"),
+        completion,
+        ReasoningEffort.HIGH,
+    )
+
+    assert result is _SENTINEL
+    assert len(calls) == 3
+    assert "reasoning" in calls[0] and "temperature" in calls[0]
+    assert "reasoning" not in calls[1] and "temperature" in calls[1]
+    assert "reasoning" not in calls[2] and "temperature" not in calls[2]
+
+
+def test_rejected_sampling_params_retry_without_reasoning_tier() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        if "temperature" in kwargs:
+            raise _bad_request("temperature not supported")
+        return _SENTINEL
+
+    # A non-reasoning model sends temperature but no reasoning kwargs, so the
+    # ladder has exactly one fallback step.
+    result = _run(
+        _make_llm(model_name="gpt-4.1", model_provider="openai"),
+        completion,
+        ReasoningEffort.AUTO,
+    )
+
+    assert result is _SENTINEL
+    assert len(calls) == 2
+    assert "temperature" in calls[0]
+    assert "temperature" not in calls[1]
+
+
+def test_rate_limit_is_not_retried() -> None:
+    calls: list[dict[str, Any]] = []
+
+    def completion(**kwargs: Any) -> Any:
+        calls.append(kwargs)
+        raise RateLimitError(message="slow down", model="m", llm_provider="anthropic")
+
+    with pytest.raises(LLMRateLimitError):
+        _run(_make_llm(), completion, ReasoningEffort.HIGH)
+    assert len(calls) == 1

--- a/backend/tests/unit/onyx/server/query_and_chat/test_update_chat_session_reasoning.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_update_chat_session_reasoning.py
@@ -1,0 +1,116 @@
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+
+from onyx.db.models import User
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.query_and_chat.chat_backend import update_chat_session_reasoning
+from onyx.server.query_and_chat.models import UpdateChatSessionReasoningRequest
+
+
+def test_update_chat_session_reasoning_rejects_auto(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chat_session = SimpleNamespace(reasoning_effort_override="medium")
+    db_session = MagicMock()
+    user = cast(User, SimpleNamespace(id=uuid4()))
+
+    monkeypatch.setattr(
+        "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
+        lambda **_: chat_session,
+    )
+
+    with pytest.raises(OnyxError) as exc:
+        update_chat_session_reasoning(
+            UpdateChatSessionReasoningRequest(
+                chat_session_id=uuid4(), reasoning_effort_override="auto"
+            ),
+            user=user,
+            db_session=db_session,
+        )
+
+    assert exc.value.error_code is OnyxErrorCode.INVALID_INPUT
+    assert chat_session.reasoning_effort_override == "medium"
+    db_session.add.assert_not_called()
+    db_session.commit.assert_not_called()
+
+
+def test_update_chat_session_reasoning_rejects_unknown_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chat_session = SimpleNamespace(reasoning_effort_override="low")
+    db_session = MagicMock()
+    user = cast(User, SimpleNamespace(id=uuid4()))
+
+    monkeypatch.setattr(
+        "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
+        lambda **_: chat_session,
+    )
+
+    with pytest.raises(OnyxError) as exc:
+        update_chat_session_reasoning(
+            UpdateChatSessionReasoningRequest(
+                chat_session_id=uuid4(), reasoning_effort_override="bogus"
+            ),
+            user=user,
+            db_session=db_session,
+        )
+
+    assert exc.value.error_code is OnyxErrorCode.INVALID_INPUT
+    assert chat_session.reasoning_effort_override == "low"
+    db_session.add.assert_not_called()
+    db_session.commit.assert_not_called()
+
+
+def test_update_chat_session_reasoning_writes_valid_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chat_session = SimpleNamespace(reasoning_effort_override=None)
+    db_session = MagicMock()
+    user = cast(User, SimpleNamespace(id=uuid4()))
+
+    monkeypatch.setattr(
+        "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
+        lambda **_: chat_session,
+    )
+
+    update_chat_session_reasoning(
+        UpdateChatSessionReasoningRequest(
+            chat_session_id=uuid4(), reasoning_effort_override="high"
+        ),
+        user=user,
+        db_session=db_session,
+    )
+
+    assert chat_session.reasoning_effort_override == "high"
+    db_session.add.assert_called_once_with(chat_session)
+    db_session.commit.assert_called_once()
+
+
+def test_update_chat_session_reasoning_clears_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    chat_session = SimpleNamespace(reasoning_effort_override="off")
+    db_session = MagicMock()
+    user = cast(User, SimpleNamespace(id=uuid4()))
+
+    monkeypatch.setattr(
+        "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
+        lambda **_: chat_session,
+    )
+
+    update_chat_session_reasoning(
+        UpdateChatSessionReasoningRequest(
+            chat_session_id=uuid4(), reasoning_effort_override=None
+        ),
+        user=user,
+        db_session=db_session,
+    )
+
+    assert chat_session.reasoning_effort_override is None
+    db_session.add.assert_called_once_with(chat_session)
+    db_session.commit.assert_called_once()

--- a/backend/tests/unit/onyx/server/query_and_chat/test_update_chat_session_reasoning.py
+++ b/backend/tests/unit/onyx/server/query_and_chat/test_update_chat_session_reasoning.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import MagicMock
@@ -12,56 +13,41 @@ from onyx.server.query_and_chat.chat_backend import update_chat_session_reasonin
 from onyx.server.query_and_chat.models import UpdateChatSessionReasoningRequest
 
 
-def test_update_chat_session_reasoning_rejects_auto(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    chat_session = SimpleNamespace(reasoning_effort_override="medium")
+def _setup(
+    monkeypatch: pytest.MonkeyPatch, chat_session: SimpleNamespace
+) -> tuple[MagicMock, Callable[[str | None], None]]:
+    """Patch the session lookup and return (mock db session, endpoint invoker)."""
     db_session = MagicMock()
-    user = cast(User, SimpleNamespace(id=uuid4()))
-
     monkeypatch.setattr(
         "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
         lambda **_: chat_session,
     )
 
-    with pytest.raises(OnyxError) as exc:
+    def call(override: str | None) -> None:
         update_chat_session_reasoning(
             UpdateChatSessionReasoningRequest(
-                chat_session_id=uuid4(), reasoning_effort_override="auto"
+                chat_session_id=uuid4(), reasoning_effort_override=override
             ),
-            user=user,
+            user=cast(User, SimpleNamespace(id=uuid4())),
             db_session=db_session,
         )
+
+    return db_session, call
+
+
+@pytest.mark.parametrize("invalid_override", ["auto", "bogus"])
+def test_update_chat_session_reasoning_rejects_invalid_values(
+    monkeypatch: pytest.MonkeyPatch,
+    invalid_override: str,
+) -> None:
+    chat_session = SimpleNamespace(reasoning_effort_override="medium")
+    db_session, call = _setup(monkeypatch, chat_session)
+
+    with pytest.raises(OnyxError) as exc:
+        call(invalid_override)
 
     assert exc.value.error_code is OnyxErrorCode.INVALID_INPUT
     assert chat_session.reasoning_effort_override == "medium"
-    db_session.add.assert_not_called()
-    db_session.commit.assert_not_called()
-
-
-def test_update_chat_session_reasoning_rejects_unknown_value(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    chat_session = SimpleNamespace(reasoning_effort_override="low")
-    db_session = MagicMock()
-    user = cast(User, SimpleNamespace(id=uuid4()))
-
-    monkeypatch.setattr(
-        "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
-        lambda **_: chat_session,
-    )
-
-    with pytest.raises(OnyxError) as exc:
-        update_chat_session_reasoning(
-            UpdateChatSessionReasoningRequest(
-                chat_session_id=uuid4(), reasoning_effort_override="bogus"
-            ),
-            user=user,
-            db_session=db_session,
-        )
-
-    assert exc.value.error_code is OnyxErrorCode.INVALID_INPUT
-    assert chat_session.reasoning_effort_override == "low"
     db_session.add.assert_not_called()
     db_session.commit.assert_not_called()
 
@@ -70,21 +56,9 @@ def test_update_chat_session_reasoning_writes_valid_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     chat_session = SimpleNamespace(reasoning_effort_override=None)
-    db_session = MagicMock()
-    user = cast(User, SimpleNamespace(id=uuid4()))
+    db_session, call = _setup(monkeypatch, chat_session)
 
-    monkeypatch.setattr(
-        "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
-        lambda **_: chat_session,
-    )
-
-    update_chat_session_reasoning(
-        UpdateChatSessionReasoningRequest(
-            chat_session_id=uuid4(), reasoning_effort_override="high"
-        ),
-        user=user,
-        db_session=db_session,
-    )
+    call("high")
 
     assert chat_session.reasoning_effort_override == "high"
     db_session.add.assert_called_once_with(chat_session)
@@ -95,21 +69,9 @@ def test_update_chat_session_reasoning_clears_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     chat_session = SimpleNamespace(reasoning_effort_override="off")
-    db_session = MagicMock()
-    user = cast(User, SimpleNamespace(id=uuid4()))
+    db_session, call = _setup(monkeypatch, chat_session)
 
-    monkeypatch.setattr(
-        "onyx.server.query_and_chat.chat_backend.get_chat_session_by_id",
-        lambda **_: chat_session,
-    )
-
-    update_chat_session_reasoning(
-        UpdateChatSessionReasoningRequest(
-            chat_session_id=uuid4(), reasoning_effort_override=None
-        ),
-        user=user,
-        db_session=db_session,
-    )
+    call(None)
 
     assert chat_session.reasoning_effort_override is None
     db_session.add.assert_called_once_with(chat_session)


### PR DESCRIPTION
## Description

Backend for user-controlled reasoning levels, stacked on #13377.

- `ReasoningEffort` gains user-selectable levels (off, low, medium, high, xhigh) with provider maps: OpenAI `reasoning_effort` (incl. xhigh), Anthropic adaptive `output_config.effort` for Claude >= 4.7 or legacy `budget_tokens`, generic litellm clamped to high.
- PUT `/api/chat/update-chat-session-reasoning` validates and stores the override. NULL clears it. Turn setup threads it through the llm loop and deep research.
- Temperature control defaults on (`temperature_override_enabled`).
- Unit tests: parse validation, endpoint contract, retry ladder behavior, effort-map parity.

### Retry ladder

`_completion` retries a provider rejection at most twice, re-sending the identical request with fewer tuning kwargs each time:

1. Attempt 1 sends the full request.
2. Attempt 2 drops the reasoning kwargs. `thinking`, `output_config`, `reasoning`, and `reasoning_effort` are the per-provider spellings of the one reasoning setting, and a request only carries its provider's spelling.
3. Attempt 3 drops `temperature` as well.

A retry only happens when both gates pass:

- Error type. Only litellm `BadRequestError` (provider 400s) enters the ladder. Timeouts, rate limits, connection errors, and 5xx propagate immediately with zero retries.
- Error content. The 400's message must name a kwarg a later rung would drop (`_KWARG_ERROR_ALIASES` covers provider spellings like `budget_tokens` and `effort`). Unrelated 400s such as context length fail on attempt 1.

Rungs only exist when they remove something, so a request with no reasoning kwargs has at most one fallback, and a request with no tuning kwargs is a single attempt. Semantics-changing kwargs (`messages`, `tools`, `tool_choice`, `response_format`, `parallel_tool_calls`) are never stripped, and neither is `stream_options`.

### Why not litellm's support registry

litellm publishes `get_supported_openai_params` and `get_model_info`, but the registry is wrong exactly where this matters. It still advertises `temperature` as supported for adaptive-thinking Claude models (for example claude-opus-4-8), which Anthropic rejects when thinking is on (BerriAI/litellm#26444). `drop_params` relies on the same data, so it would silently drop nothing and let the 400 through. The known Anthropic case is instead handled up front by a version gate that omits `temperature` for Claude >= 4.7, and the ladder exists as a safety net for registry drift and unknown models.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
