### PR TITLE
perf: stop search_chats from blocking the event loop with sync DB I/O

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -948,7 +948,7 @@ def fetch_chat_file(
 
 
 @router.get("/search", tags=PUBLIC_API_TAGS)
-async def search_chats(
+def search_chats(
     query: str | None = Query(None),
     page: int = Query(1),
     page_size: int = Query(10),


### PR DESCRIPTION
## Problem

`GET /chat/search` (`search_chats` in `backend/onyx/server/query_and_chat/chat_backend.py`) was the only `async def` handler in the file, yet it calls `search_chat_sessions(...)` with a synchronous SQLAlchemy `Session` — a blocking psycopg2 round trip running a tsvector full-text query joined against `ChatMessage`. Because the handler was `async def` with no `await`, the blocking query ran directly on the asyncio event-loop thread instead of FastAPI's threadpool.

This endpoint backs the chat-history search box (invoked per keystroke/debounce). While the query runs, the event loop cannot service anything else on that worker — including writing already-generated bytes for other users' in-flight `/send-chat-message` SSE streams. A slow search stalls first-token latency for every concurrent chat on the worker, not just the searcher.

## Fix

One word: `async def search_chats(` → `def search_chats(`. The body contains no `await` (verified via AST), so FastAPI now dispatches it to the threadpool like every other handler in the file.

## Validation

- `pre-commit` (ruff, ruff-format, ty, lazy-imports) passes on the file.
- No existing backend test covers this endpoint, so smoke-tested live: authenticated `GET /chat/search?query=test` returns 200 with a well-formed `ChatSearchResponse` (~76ms). Threadpool dispatch for `def` handlers is framework-guaranteed.

## Other offenders (out of scope, noted for follow-up)

An AST scan of `backend/onyx/server/` and `backend/ee/onyx/server/` found 29 more `async def` handlers taking a sync `Session = Depends(get_session)`. Six have **no `await` at all** and would take the same one-word fix:

- `onyx/server/manage/users.py:762` `delete_user`
- `ee/onyx/server/license/api.py:64` `get_license_status`
- `ee/onyx/server/license/api.py:89` `get_seat_usage`
- `ee/onyx/server/license/api.py:111` `claim_license`
- `ee/onyx/server/license/api.py:270` `refresh_license_cache_endpoint`
- `ee/onyx/server/license/api.py:300` `delete_license`

The remaining 23 (e.g. `onyx/server/features/mcp/api.py`, `ee/onyx/server/billing/api.py`, `oidc_multi.py`, `saml_multi.py`) genuinely `await` something but still perform blocking DB I/O on the event loop — a broader follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Changed `search_chats` (`GET /chat/search`) from async to sync so its blocking SQLAlchemy query runs in `FastAPI`'s threadpool instead of the event loop. This prevents stalls of concurrent SSE streams and improves first-token latency during chat-history searches.

<sup>Written for commit 865dd48a73b4571645148fe0161fed70c7f1b768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13379?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



## Measured impact

Local A/B on the dev server (single uvicorn worker), seeded with 15,010 chat sessions / 75,066 messages for one user, making `GET /chat/search?query=pytest` cost ~390ms standalone. Load: 4 concurrent clients hammering the search for 30s while a probe hit `/health` (a trivial `async def` served purely by the event loop) every 20ms. Only the one-word handler change differs between runs:

| Metric | Before (`async def`) | After (`def`) |
|---|---|---|
| `/health` p50 | 354 ms | 54 ms |
| `/health` p90 | 462 ms | 70 ms |
| `/health` p99 | 591 ms | 120 ms |
| Probe samples achieved in 30s | 82 | 386 |
| Searches completed in 30s | 219 | 410 |
| Search mean latency | 550 ms | 293 ms |

Before the fix, every in-flight search froze the event loop, so unrelated requests waited behind it (~354ms median stall) and the prober couldn't even hold its 20ms cadence. The searches themselves also serialized on the loop, halving search throughput. After the fix, searches run in parallel on the threadpool; residual probe latency (~54ms median) is GIL contention from 4 concurrent ORM result-processing threads, not loop blocking.
