### PR TITLE
chore: put repo venv on PATH for Claude Code shells via SessionStart hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,5 +2,17 @@
   "enabledPlugins": {
     "security-guidance@claude-plugins-official": true,
     "claude-security@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && echo \"export PATH=\\\"$CLAUDE_PROJECT_DIR/.venv/bin:\\$PATH\\\"\" >> \"$CLAUDE_ENV_FILE\" || true"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && echo \"export PATH=\\\"$CLAUDE_PROJECT_DIR/.venv/bin:\\$PATH\\\"\" >> \"$CLAUDE_ENV_FILE\" || true"
+            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=%q:\"$PATH\"\\n' \"$CLAUDE_PROJECT_DIR/.venv/bin\" >> \"$CLAUDE_ENV_FILE\" || true"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Claude Code's Bash tool runs non-interactive shells with the stock system PATH. The devcontainer only auto-activates the repo venv in interactive **zsh** (`.devcontainer/zshrc`), so in agent shells venv-installed tools — most notably `ods` — fail with `command not found`, even though the devcontainer docs tell agents to use `ods backend api` / `ods web dev`.

## Why not `env` in settings?

The settings `env` map sets values **literally** — `"PATH": "…:${PATH}"` is not interpolated, so the only `env`-based option would be hardcoding a full machine-specific PATH into a committed file, clobbering PATH for everyone on host checkouts.

## Fix

The documented mechanism for extending PATH per-project: a `SessionStart` hook that appends an `export` line to `$CLAUDE_ENV_FILE`, which Claude Code sources before every Bash command:

```
export PATH="<repo>/.venv/bin:$PATH"
```

- `$CLAUDE_PROJECT_DIR` expands at session start → works on any checkout location, not just `/workspace`.
- `$PATH` is escaped so it stays lazy in the env file → prepends to whatever the real PATH is, per command.
- If `.venv` doesn't exist yet, a nonexistent dir is prepended — harmless no-op.
- No-ops silently (`|| true`) when `$CLAUDE_ENV_FILE` isn't set (older CLI versions).

This also puts venv `python`/`pytest`/etc. on PATH for agent shells, matching the repo docs' assumption that the venv is activated.

## Validation

Extracted the command verbatim from the settings file with `jq` and executed it against a scratch `CLAUDE_ENV_FILE`: it writes exactly `export PATH="/workspace/.venv/bin:$PATH"`, and sourcing that resolves `ods` to `/workspace/.venv/bin/ods`. JSON structure validated with `jq -e` against the hook schema path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Claude Code Bash shells use the repo virtualenv by prepending `.venv/bin` to PATH at session start, with safe quoting for any checkout path. Fixes `command not found` for `ods`, `python`, and `pytest` in non-interactive shells.

- **Bug Fixes**
  - Added `SessionStart` hook that appends `export PATH="<repo>/.venv/bin":"$PATH"` to `$CLAUDE_ENV_FILE`.
  - Uses `printf %q` to shell-quote the expanded `$CLAUDE_PROJECT_DIR/.venv/bin` (handles spaces/quotes/$); harmless if `.venv` is missing and a no-op if `CLAUDE_ENV_FILE` is unset.

- **Migration**
  - Start a new Claude Code session so the hook applies.

<sup>Written for commit e58a757d570ab8f7c9bef0184d147564667722da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13380?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

