### PR TITLE
fix(mcp): require stored tokens for per-user OAuth "connected" status

### DIFF
--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -410,7 +410,7 @@ def _oauth_user_config_has_tokens(
     """
     if user_config is None:
         return False
-    config_data = extract_connection_data(user_config, apply_mask=True)
+    config_data = extract_connection_data(user_config, apply_mask=False)
     return bool(config_data.get(MCPOAuthKeys.TOKENS.value))
 
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -403,13 +403,10 @@ def _build_oauth_admin_config_data(
 def _oauth_user_config_has_tokens(
     user_config: MCPConnectionConfig | None,
 ) -> bool:
-    """Whether a per-user OAuth connection config holds a completed token set.
+    """Whether a per-user OAuth config holds tokens from a completed handshake.
 
-    The row is created when the user *initiates* the OAuth connect flow, before
-    the provider redirect and token exchange, so its mere existence does not
-    mean the user finished authenticating. Only stored tokens (written by
-    `OnyxTokenStorage.set_tokens` / the known-provider callback) indicate a
-    completed handshake.
+    The row is created when the connect flow starts, before token exchange, so
+    existence alone doesn't prove the user finished authenticating.
     """
     if user_config is None:
         return False
@@ -1328,10 +1325,8 @@ def _db_mcp_server_to_api_mcp_server(
                     )
     else:  # currently: per user auth using api key OR oauth
         user_config = get_user_connection_config(db_server.id, email, db)
-        # OAuth rows are created at the start of the connect flow, so existence
-        # alone doesn't prove the handshake completed — require stored tokens.
-        # API-token rows are only written once the user submits credentials, so
-        # existence is sufficient there.
+        # API-token rows exist only once credentials are submitted; OAuth rows
+        # are created before token exchange, so require tokens there.
         if db_server.auth_type == MCPAuthenticationType.OAUTH:
             user_authenticated = _oauth_user_config_has_tokens(user_config)
         else:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -400,6 +400,23 @@ def _build_oauth_admin_config_data(
     return config_data
 
 
+def _oauth_user_config_has_tokens(
+    user_config: MCPConnectionConfig | None,
+) -> bool:
+    """Whether a per-user OAuth connection config holds a completed token set.
+
+    The row is created when the user *initiates* the OAuth connect flow, before
+    the provider redirect and token exchange, so its mere existence does not
+    mean the user finished authenticating. Only stored tokens (written by
+    `OnyxTokenStorage.set_tokens` / the known-provider callback) indicate a
+    completed handshake.
+    """
+    if user_config is None:
+        return False
+    config_data = extract_connection_data(user_config, apply_mask=True)
+    return bool(config_data.get(MCPOAuthKeys.TOKENS.value))
+
+
 def _build_oauth_admin_config_data_for_update(
     *,
     client_id: str | None,
@@ -1311,7 +1328,14 @@ def _db_mcp_server_to_api_mcp_server(
                     )
     else:  # currently: per user auth using api key OR oauth
         user_config = get_user_connection_config(db_server.id, email, db)
-        user_authenticated = user_config is not None
+        # OAuth rows are created at the start of the connect flow, so existence
+        # alone doesn't prove the handshake completed — require stored tokens.
+        # API-token rows are only written once the user submits credentials, so
+        # existence is sufficient there.
+        if db_server.auth_type == MCPAuthenticationType.OAUTH:
+            user_authenticated = _oauth_user_config_has_tokens(user_config)
+        else:
+            user_authenticated = user_config is not None
 
         if user_authenticated and user_config:
             # Avoid hitting the MCP server when assembling response data.

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
@@ -3,6 +3,8 @@ handshake (stored tokens), not mere connection-config row existence, since the
 row is created before token exchange. API-token servers stay authenticated on
 row existence alone."""
 
+from uuid import uuid4
+
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import (
@@ -29,7 +31,7 @@ def _make_per_user_server(
     db_session.flush()
     server = MCPServer(
         owner="admin@example.com",
-        name="oauth_status_server",
+        name=f"oauth_status_server_{uuid4().hex[:8]}",
         server_url="https://example.com/mcp",
         transport=MCPTransport.STREAMABLE_HTTP,
         auth_type=auth_type,

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
@@ -1,0 +1,106 @@
+"""The per-user OAuth connection-config row is created when a user *initiates*
+the connect flow, before the provider redirect and token exchange. These verify
+that `is_authenticated` reflects whether the handshake actually completed
+(stored tokens) rather than mere row existence, while API-token servers stay
+authenticated on row existence alone."""
+
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.db.mcp import create_connection_config
+from onyx.db.models import MCPServer
+from onyx.server.features.mcp.api import _db_mcp_server_to_api_mcp_server
+from onyx.server.features.mcp.models import MCPConnectionData
+from tests.external_dependency_unit.conftest import create_test_user
+
+
+def _make_per_user_server(
+    db_session: Session,
+    auth_type: MCPAuthenticationType,
+) -> MCPServer:
+    admin_config = create_connection_config(
+        config_data=MCPConnectionData(headers={}),
+        db_session=db_session,
+        user_email="",
+    )
+    db_session.flush()
+    server = MCPServer(
+        owner="admin@example.com",
+        name="oauth_status_server",
+        server_url="https://example.com/mcp",
+        transport=MCPTransport.STREAMABLE_HTTP,
+        auth_type=auth_type,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        admin_connection_config_id=admin_config.id,
+        is_public=True,
+    )
+    db_session.add(server)
+    db_session.commit()
+    db_session.refresh(server)
+    return server
+
+
+def test_oauth_tokenless_row_is_not_authenticated(db_session: Session) -> None:
+    """A row seeded at connect-initiation (client_info only, no tokens) must not
+    read as authenticated."""
+    user = create_test_user(db_session, "mcp_oauth_pending")
+    server = _make_per_user_server(db_session, MCPAuthenticationType.OAUTH)
+    create_connection_config(
+        config_data=MCPConnectionData(headers={}, client_info={"client_id": "abc"}),
+        db_session=db_session,
+        mcp_server_id=server.id,
+        user_email=user.email,
+    )
+    db_session.commit()
+
+    api_server = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=user)
+    assert api_server.user_authenticated is False
+    assert api_server.is_authenticated is False
+
+
+def test_oauth_row_with_tokens_is_authenticated(db_session: Session) -> None:
+    """Once tokens are stored (handshake completed) the server reads as
+    authenticated."""
+    user = create_test_user(db_session, "mcp_oauth_done")
+    server = _make_per_user_server(db_session, MCPAuthenticationType.OAUTH)
+    create_connection_config(
+        config_data=MCPConnectionData(
+            headers={"Authorization": "Bearer tok"},
+            tokens={"access_token": "tok", "token_type": "Bearer"},
+        ),
+        db_session=db_session,
+        mcp_server_id=server.id,
+        user_email=user.email,
+    )
+    db_session.commit()
+
+    api_server = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=user)
+    assert api_server.user_authenticated is True
+    assert api_server.is_authenticated is True
+
+
+def test_api_token_row_is_authenticated_without_tokens_key(
+    db_session: Session,
+) -> None:
+    """API-token rows are only written once the user submits credentials, so
+    existence alone (no OAuth `tokens` key) still counts as authenticated."""
+    user = create_test_user(db_session, "mcp_api_token")
+    server = _make_per_user_server(db_session, MCPAuthenticationType.API_TOKEN)
+    create_connection_config(
+        config_data=MCPConnectionData(
+            headers={"Authorization": "Bearer key"},
+            header_substitutions={"api_key": "key"},
+        ),
+        db_session=db_session,
+        mcp_server_id=server.id,
+        user_email=user.email,
+    )
+    db_session.commit()
+
+    api_server = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=user)
+    assert api_server.user_authenticated is True
+    assert api_server.is_authenticated is True

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_mcp_oauth_authenticated_status.py
@@ -1,8 +1,7 @@
-"""The per-user OAuth connection-config row is created when a user *initiates*
-the connect flow, before the provider redirect and token exchange. These verify
-that `is_authenticated` reflects whether the handshake actually completed
-(stored tokens) rather than mere row existence, while API-token servers stay
-authenticated on row existence alone."""
+"""`is_authenticated` for per-user OAuth servers must reflect a completed
+handshake (stored tokens), not mere connection-config row existence, since the
+row is created before token exchange. API-token servers stay authenticated on
+row existence alone."""
 
 from sqlalchemy.orm import Session
 
@@ -45,8 +44,6 @@ def _make_per_user_server(
 
 
 def test_oauth_tokenless_row_is_not_authenticated(db_session: Session) -> None:
-    """A row seeded at connect-initiation (client_info only, no tokens) must not
-    read as authenticated."""
     user = create_test_user(db_session, "mcp_oauth_pending")
     server = _make_per_user_server(db_session, MCPAuthenticationType.OAUTH)
     create_connection_config(
@@ -63,8 +60,6 @@ def test_oauth_tokenless_row_is_not_authenticated(db_session: Session) -> None:
 
 
 def test_oauth_row_with_tokens_is_authenticated(db_session: Session) -> None:
-    """Once tokens are stored (handshake completed) the server reads as
-    authenticated."""
     user = create_test_user(db_session, "mcp_oauth_done")
     server = _make_per_user_server(db_session, MCPAuthenticationType.OAUTH)
     create_connection_config(
@@ -86,8 +81,6 @@ def test_oauth_row_with_tokens_is_authenticated(db_session: Session) -> None:
 def test_api_token_row_is_authenticated_without_tokens_key(
     db_session: Session,
 ) -> None:
-    """API-token rows are only written once the user submits credentials, so
-    existence alone (no OAuth `tokens` key) still counts as authenticated."""
     user = create_test_user(db_session, "mcp_api_token")
     server = _make_per_user_server(db_session, MCPAuthenticationType.API_TOKEN)
     create_connection_config(


### PR DESCRIPTION
## Problem

Per-user OAuth MCP servers (e.g. **Asana**, **Linear** in st-dev) show as **connected** for users who never completed — or even never started — the OAuth flow.

### Root cause

For `OAUTH` + `PER_USER` servers, the green "connected" indicator maps to `is_authenticated` in `_db_mcp_server_to_api_mcp_server`, which was driven purely by `user_authenticated = get_user_connection_config(...) is not None` — i.e. **whether a `mcp_connection_config` row exists**, not whether it contains tokens.

But that row is created (and committed) at the *start* of `_connect_oauth`, before the provider redirect and token exchange, because it doubles as the OAuth provider's storage backend during the handshake (`OnyxTokenStorage` is keyed by `connection_config_id`; `set_client_info`/`set_tokens` write to it). So the moment a user clicks "connect", a tokenless row is created and they show as connected — even if they abandon the provider consent screen.

Observed in st-dev: users had rows with `created_at == updated_at` (created at connect-initiation, never updated with tokens by `set_tokens`) yet displayed as connected.

## Fix

Gate per-user OAuth `user_authenticated` on the presence of stored `tokens` (the `MCPOAuthKeys.TOKENS` key, written only by `OnyxTokenStorage.set_tokens` and the known-provider callback). API-token rows are unaffected — they're written only when the user submits credentials, so row existence remains a valid signal there.

This is display-only logic; the runtime tool-call path (`resolve_mcp_credentials`) already fails correctly without an `Authorization` header. Existing tokenless "zombie" rows now display as disconnected with no migration required.

## Testing

New external-dependency-unit test `test_mcp_oauth_authenticated_status.py`:
- OAuth row with only `client_info`/empty headers (connect initiated, not completed) → `is_authenticated is False`
- OAuth row with stored `tokens` → `is_authenticated is True`
- API-token row without a `tokens` key → still `is_authenticated is True` (regression guard)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes per-user OAuth MCP servers showing as connected before users finish OAuth. We now mark them connected only when stored tokens exist.

- **Bug Fixes**
  - Require stored `tokens` for `OAUTH` + `PER_USER` servers to report `is_authenticated` (uses unmasked config for the check).
  - Keep `API_TOKEN` per-user servers unchanged (row existence still counts).
  - Tests cover tokenless OAuth, OAuth with tokens, and API-token; use unique server names for isolation.

<sup>Written for commit 6ac14205bb38a9c916cdd6f4ea8d5d9a4b3375ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13381?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



