### PR TITLE
feat(terraform): t-shirt sizing (small/medium/large) for the AWS stack

### DIFF
--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -137,14 +137,19 @@ its tier.
 were `db.t4g.large` with 20 GB gp2 and no storage autoscaling, `cache.m6g.xlarge`, and a
 3×r8g.large multi-AZ OpenSearch domain. The default `medium` tier keeps the same EKS node
 groups and Redis node type, and grows Postgres storage online (gp2→gp3 conversion is also
-online; storage can never shrink). If you enabled OpenSearch and relied on the old
-defaults, `medium` would reconfigure the domain to a single-node shape — an in-place AWS
-blue/green change that preserves index data but shrinks capacity and drops multi-AZ
-redundancy, so pin the old values explicitly (`opensearch_instance_count = 3`,
+online; storage can never shrink).
+
+⚠️ If you enabled OpenSearch and relied on the old defaults, applying `medium` **replaces
+the domain and loses its index data**: a single-AZ domain must live in exactly one subnet,
+and the Terraform AWS provider marks `vpc_options` as ForceNew, so the 3-subnet → 1-subnet
+change destroys and recreates the domain (capacity-only changes that don't touch subnets —
+instance type/count, masters, EBS — are in-place blue/green updates). To keep the old
+topology, pin it explicitly: `opensearch_instance_count = 3`,
 `opensearch_zone_awareness_enabled = true`, `opensearch_multi_az_with_standby_enabled =
 true`, `opensearch_dedicated_master_type = "m7g.large.search"`,
-`opensearch_instance_type = "r8g.large.search"`) if you want to keep the old topology.
-Review the plan before applying either way.
+`opensearch_instance_type = "r8g.large.search"`. To adopt the new shape on an existing
+domain, take a manual snapshot first and plan a restore. Either way, check `terraform
+plan` for `-/+ destroy and then create replacement` on the domain before applying.
 
 ### Using an existing VPC
 If you already have a VPC and subnets, disable VPC creation and provide IDs, CIDR, and the ID of the existing S3 gateway endpoint in that VPC:

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -107,23 +107,32 @@ What each tier provisions:
 
 | Setting | small | medium | large |
 |---|---|---|---|
-| Main EKS node group | m7i.4xlarge ×1–3 | m7i.4xlarge ×1–5 | m7i.4xlarge ×2–8 |
-| Document-index node¹ | m6i.xlarge, 100 GB | m6i.2xlarge, 100 GB | r6i.4xlarge, 512 GB |
+| Main EKS node group | m7i.2xlarge ×1–3³ | m7i.4xlarge ×1–5 | m7i.4xlarge ×2–8 |
+| Document-index node¹ | none³ | m6i.2xlarge, 100 GB | r6i.4xlarge, 512 GB |
 | RDS Postgres | db.t4g.large, 64→256 GB | db.t4g.large, 128→512 GB | db.m7g.xlarge, 256→1024 GB |
 | ElastiCache Redis | cache.m6g.large | cache.m6g.xlarge | cache.m6g.2xlarge |
 | OpenSearch data² | r7g.large.search ×1, 256 GB | r8g.xlarge.search ×1, 512 GB | r8g.2xlarge.search ×1, 1 TB (12k IOPS) |
 | OpenSearch masters² | 3× m7g.medium.search | 3× m7g.medium.search | 3× m7g.medium.search |
 
+Pair each tier with the matching sizing snippets from the Helm chart's
+`deployment/helm/charts/onyx/SIZING.md` (chart ≥ 0.8.0) — the tiers here size the
+infrastructure, the chart snippets size the workloads on it.
+
 ¹ The dedicated index node group only matters when running the document index in-cluster
-(the Helm chart's bundled OpenSearch StatefulSet, which is pinned to this node group). If
-your deployment instead points the chart at a managed OpenSearch domain (provision one
-with `enable_opensearch = true` *and* disable the chart's bundled OpenSearch / set the
-managed endpoint in its values), the index node group sits idle — override
-`vespa_node_instance_types` to a small instance in that case.
+(the Helm chart's bundled OpenSearch StatefulSet). It is created tainted
+(`vespa-dedicated=true`), so the StatefulSet must carry the toleration *and* nodeSelector
+from SIZING.md's placement snippet to use it. If you point the chart at a managed
+OpenSearch domain instead (`enable_opensearch = true` + disable the bundled OpenSearch in
+chart values), set `vespa_node_enabled = false` so the node group isn't created at all.
 ² Only created when `enable_opensearch = true`. All tiers default to a single data node
 without zone awareness; RDS is likewise single-AZ. For HA, set
 `opensearch_instance_count = 3`, `opensearch_zone_awareness_enabled = true` (and optionally
 `opensearch_multi_az_with_standby_enabled = true`).
+³ The small tier creates no index node group — the small chart sizing fits the in-cluster
+index on the main nodes. With chart ≥ 0.8.0 and SIZING.md's small snippets the whole stack
+fits one m7i.2xlarge (external Postgres/Redis/S3); with plain chart defaults the
+autoscaler settles at two nodes. Set `vespa_node_enabled = true` to add the dedicated
+node back.
 
 These defaults are calibrated from Onyx's own managed production fleet: memory, not CPU, is
 the binding dimension on the Kubernetes side, and the burstable `db.t4g.large` holds up to

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -111,13 +111,15 @@ What each tier provisions:
 | Document-index node¹ | m6i.xlarge, 100 GB | m6i.2xlarge, 100 GB | r6i.4xlarge, 512 GB |
 | RDS Postgres | db.t4g.large, 64→256 GB | db.t4g.large, 128→512 GB | db.m7g.xlarge, 256→1024 GB |
 | ElastiCache Redis | cache.m6g.large | cache.m6g.xlarge | cache.m6g.2xlarge |
-| OpenSearch data² | r7g.large ×1, 256 GB | r8g.xlarge ×1, 512 GB | r8g.2xlarge ×1, 1 TB (12k IOPS) |
-| OpenSearch masters² | 3× m7g.medium | 3× m7g.medium | 3× m7g.medium |
+| OpenSearch data² | r7g.large.search ×1, 256 GB | r8g.xlarge.search ×1, 512 GB | r8g.2xlarge.search ×1, 1 TB (12k IOPS) |
+| OpenSearch masters² | 3× m7g.medium.search | 3× m7g.medium.search | 3× m7g.medium.search |
 
 ¹ The dedicated index node group only matters when running the document index in-cluster
-(the Helm chart's OpenSearch StatefulSet). If you use a managed OpenSearch domain instead
-(`enable_opensearch = true`), the index node sits idle — consider overriding
-`vespa_node_instance_types` to a small instance.
+(the Helm chart's bundled OpenSearch StatefulSet, which is pinned to this node group). If
+your deployment instead points the chart at a managed OpenSearch domain (provision one
+with `enable_opensearch = true` *and* disable the chart's bundled OpenSearch / set the
+managed endpoint in its values), the index node group sits idle — override
+`vespa_node_instance_types` to a small instance in that case.
 ² Only created when `enable_opensearch = true`. All tiers default to a single data node
 without zone awareness; RDS is likewise single-AZ. For HA, set
 `opensearch_instance_count = 3`, `opensearch_zone_awareness_enabled = true` (and optionally
@@ -134,10 +136,15 @@ its tier.
 **Upgrading from a pre-sizing version of these modules:** the previous hardcoded defaults
 were `db.t4g.large` with 20 GB gp2 and no storage autoscaling, `cache.m6g.xlarge`, and a
 3×r8g.large multi-AZ OpenSearch domain. The default `medium` tier keeps the same EKS node
-groups and Redis node type, grows Postgres storage online (gp2→gp3 conversion is also
-online; storage can never shrink), and — if you enabled OpenSearch and relied on the old
-defaults — would replace the domain with a single-node shape, so pin the old values
-explicitly before applying if you want to keep them.
+groups and Redis node type, and grows Postgres storage online (gp2→gp3 conversion is also
+online; storage can never shrink). If you enabled OpenSearch and relied on the old
+defaults, `medium` would reconfigure the domain to a single-node shape — an in-place AWS
+blue/green change that preserves index data but shrinks capacity and drops multi-AZ
+redundancy, so pin the old values explicitly (`opensearch_instance_count = 3`,
+`opensearch_zone_awareness_enabled = true`, `opensearch_multi_az_with_standby_enabled =
+true`, `opensearch_dedicated_master_type = "m7g.large.search"`,
+`opensearch_instance_type = "r8g.large.search"`) if you want to keep the old topology.
+Review the plan before applying either way.
 
 ### Using an existing VPC
 If you already have a VPC and subnets, disable VPC creation and provide IDs, CIDR, and the ID of the existing S3 gateway endpoint in that VPC:

--- a/deployment/terraform/modules/aws/README.md
+++ b/deployment/terraform/modules/aws/README.md
@@ -93,6 +93,52 @@ terraform init
 terraform apply
 ```
 
+## T-shirt sizing
+The `onyx` module takes a `size` input (`small` | `medium` | `large`, default `medium`) that sets
+coherent defaults for every compute and data-plane knob. Pick a tier from your expected scale:
+
+| Tier | Users | Documents |
+|---|---|---|
+| `small` | up to ~200 | < ~500k |
+| `medium` | ~200–1,000 | ~0.5–2M |
+| `large` | 1,000+ | multi-million |
+
+What each tier provisions:
+
+| Setting | small | medium | large |
+|---|---|---|---|
+| Main EKS node group | m7i.4xlarge ×1–3 | m7i.4xlarge ×1–5 | m7i.4xlarge ×2–8 |
+| Document-index node¹ | m6i.xlarge, 100 GB | m6i.2xlarge, 100 GB | r6i.4xlarge, 512 GB |
+| RDS Postgres | db.t4g.large, 64→256 GB | db.t4g.large, 128→512 GB | db.m7g.xlarge, 256→1024 GB |
+| ElastiCache Redis | cache.m6g.large | cache.m6g.xlarge | cache.m6g.2xlarge |
+| OpenSearch data² | r7g.large ×1, 256 GB | r8g.xlarge ×1, 512 GB | r8g.2xlarge ×1, 1 TB (12k IOPS) |
+| OpenSearch masters² | 3× m7g.medium | 3× m7g.medium | 3× m7g.medium |
+
+¹ The dedicated index node group only matters when running the document index in-cluster
+(the Helm chart's OpenSearch StatefulSet). If you use a managed OpenSearch domain instead
+(`enable_opensearch = true`), the index node sits idle — consider overriding
+`vespa_node_instance_types` to a small instance.
+² Only created when `enable_opensearch = true`. All tiers default to a single data node
+without zone awareness; RDS is likewise single-AZ. For HA, set
+`opensearch_instance_count = 3`, `opensearch_zone_awareness_enabled = true` (and optionally
+`opensearch_multi_az_with_standby_enabled = true`).
+
+These defaults are calibrated from Onyx's own managed production fleet: memory, not CPU, is
+the binding dimension on the Kubernetes side, and the burstable `db.t4g.large` holds up to
+roughly the medium tier before CPU peaks make a fixed-performance class worthwhile.
+
+Every value in the table is just a default — any sizing variable set to a non-null value
+(e.g. `postgres_instance_type`, `opensearch_instance_type`, `main_node_max_size`) overrides
+its tier.
+
+**Upgrading from a pre-sizing version of these modules:** the previous hardcoded defaults
+were `db.t4g.large` with 20 GB gp2 and no storage autoscaling, `cache.m6g.xlarge`, and a
+3×r8g.large multi-AZ OpenSearch domain. The default `medium` tier keeps the same EKS node
+groups and Redis node type, grows Postgres storage online (gp2→gp3 conversion is also
+online; storage can never shrink), and — if you enabled OpenSearch and relied on the old
+defaults — would replace the domain with a single-node shape, so pin the old values
+explicitly before applying if you want to keep them.
+
 ### Using an existing VPC
 If you already have a VPC and subnets, disable VPC creation and provide IDs, CIDR, and the ID of the existing S3 gateway endpoint in that VPC:
 
@@ -126,6 +172,7 @@ module "onyx" {
 
 Inputs (common):
 - `name` (default `onyx`), `region` (default `us-west-2`), `tags`
+- `size` (`small`/`medium`/`large`, default `medium`) — see "T-shirt sizing" above — plus per-setting overrides (`main_node_*`, `vespa_node_*`, `postgres_instance_type`, `postgres_storage_gb`, `redis_instance_type`, `opensearch_*`)
 - `postgres_username`, `postgres_password`
 - `create_vpc` (default true) or existing VPC details and `s3_vpc_endpoint_id`
 - WAF controls such as `waf_allowed_ip_cidrs`, `waf_common_rule_set_count_rules`, rate limits, geo restrictions, and logging retention

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -90,6 +90,7 @@ module "eks" {
 
   eks_managed_node_groups = merge({
     for k, v in var.eks_managed_node_groups : k => merge(v,
+      # (vespa group is skipped entirely when var.vespa_node_enabled is false — see the `if` at the end of this for-expression)
       {
         instance_types = v.instance_types != null ? v.instance_types : (
           k == "main" ? var.main_node_instance_types :
@@ -127,7 +128,7 @@ module "eks" {
           }
         })
       } : {}
-    )
+    ) if k != "vespa" || var.vespa_node_enabled
   }, local.craft_sandbox_node_groups)
 
   tags = var.tags

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -105,22 +105,27 @@ module "eks" {
       k == "main" && length(var.main_node_subnet_ids) > 0 ? {
         subnet_ids = var.main_node_subnet_ids
       } : {},
-      # Scaling-bound overrides for the main node group; null keeps the map default
+      # Scaling-bound overrides for the main node group; null keeps the map
+      # default. desired_size must be >= min_size or the EKS API rejects the
+      # node group at creation (the upstream module defaults desired to 1 and
+      # ignores changes to it after create).
       k == "main" ? {
-        min_size = coalesce(var.main_node_min_size, v.min_size)
-        max_size = coalesce(var.main_node_max_size, v.max_size)
+        min_size     = coalesce(var.main_node_min_size, v.min_size)
+        max_size     = coalesce(var.main_node_max_size, v.max_size)
+        desired_size = try(v.desired_size, coalesce(var.main_node_min_size, v.min_size))
       } : {},
-      # Disk override for the Vespa/document-index node; null keeps the map default
+      # Disk override for the Vespa/document-index node; null keeps the map
+      # default. Merge preserves any other device mappings on the group.
       k == "vespa" && var.vespa_node_disk_size_gb != null ? {
-        block_device_mappings = {
+        block_device_mappings = merge(try(v.block_device_mappings, {}), {
           xvda = {
             device_name = "/dev/xvda"
             ebs = merge(
-              v.block_device_mappings.xvda.ebs,
+              try(v.block_device_mappings.xvda.ebs, {}),
               { volume_size = var.vespa_node_disk_size_gb }
             )
           }
-        }
+        })
       } : {}
     )
   }, local.craft_sandbox_node_groups)

--- a/deployment/terraform/modules/aws/eks/main.tf
+++ b/deployment/terraform/modules/aws/eks/main.tf
@@ -104,6 +104,23 @@ module "eks" {
       # Only add subnet_ids override for main node group if specified
       k == "main" && length(var.main_node_subnet_ids) > 0 ? {
         subnet_ids = var.main_node_subnet_ids
+      } : {},
+      # Scaling-bound overrides for the main node group; null keeps the map default
+      k == "main" ? {
+        min_size = coalesce(var.main_node_min_size, v.min_size)
+        max_size = coalesce(var.main_node_max_size, v.max_size)
+      } : {},
+      # Disk override for the Vespa/document-index node; null keeps the map default
+      k == "vespa" && var.vespa_node_disk_size_gb != null ? {
+        block_device_mappings = {
+          xvda = {
+            device_name = "/dev/xvda"
+            ebs = merge(
+              v.block_device_mappings.xvda.ebs,
+              { volume_size = var.vespa_node_disk_size_gb }
+            )
+          }
+        }
       } : {}
     )
   }, local.craft_sandbox_node_groups)

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -43,10 +43,28 @@ variable "main_node_instance_types" {
   default     = ["m7i.4xlarge"]
 }
 
+variable "main_node_min_size" {
+  type        = number
+  description = "Minimum number of nodes in the main node group. The cluster-autoscaler will not scale below this, so raise it to guarantee always-on baseline capacity for bursty workloads. Null keeps the node-group default."
+  default     = null
+}
+
+variable "main_node_max_size" {
+  type        = number
+  description = "Maximum number of nodes the main node group may scale up to. Null keeps the node-group default."
+  default     = null
+}
+
 variable "vespa_node_instance_types" {
   type        = list(string)
   description = "Instance types for the Vespa node group"
   default     = ["m6i.2xlarge"]
+}
+
+variable "vespa_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for the Vespa/document-index node. Size to the expected on-disk index; null keeps the node-group default."
+  default     = null
 }
 
 variable "vespa_node_subnet_ids" {

--- a/deployment/terraform/modules/aws/eks/variables.tf
+++ b/deployment/terraform/modules/aws/eks/variables.tf
@@ -55,6 +55,12 @@ variable "main_node_max_size" {
   default     = null
 }
 
+variable "vespa_node_enabled" {
+  type        = bool
+  description = "Whether to create the dedicated Vespa/document-index node group. Disable when the index runs off-cluster (managed OpenSearch) or fits on the main node group."
+  default     = true
+}
+
 variable "vespa_node_instance_types" {
   type        = list(string)
   description = "Instance types for the Vespa node group"

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -13,6 +13,99 @@ locals {
   private_subnets = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
   public_subnets  = var.create_vpc ? module.vpc[0].public_subnets : var.public_subnets
   vpc_cidr_block  = var.create_vpc ? module.vpc[0].vpc_cidr_block : var.vpc_cidr_block
+
+  # T-shirt size defaults. Calibrated against the Onyx-managed production
+  # fleet (Jul 2026): memory, not CPU, is the binding dimension on the EKS
+  # side; the burstable db.t4g.large sustains fleet load until ~1k users but
+  # peaks past 70% CPU on the largest deployments, and every production
+  # OpenSearch domain runs 1 data node + 3 m7g.medium masters. Each value can
+  # be overridden individually via the matching variable.
+  size_defaults = {
+    small = {
+      main_node_instance_types                 = ["m7i.4xlarge"]
+      main_node_min_size                       = 1
+      main_node_max_size                       = 3
+      vespa_node_instance_types                = ["m6i.xlarge"]
+      vespa_node_disk_size_gb                  = 100
+      postgres_instance_type                   = "db.t4g.large"
+      postgres_storage_gb                      = 64
+      postgres_max_storage_gb                  = 256
+      redis_instance_type                      = "cache.m6g.large"
+      opensearch_instance_type                 = "r7g.large.search"
+      opensearch_instance_count                = 1
+      opensearch_dedicated_master_type         = "m7g.medium.search"
+      opensearch_multi_az_with_standby_enabled = false
+      opensearch_zone_awareness_enabled        = false
+      opensearch_ebs_volume_size               = 256
+      opensearch_ebs_iops                      = 3000
+      opensearch_ebs_throughput                = 256
+    }
+    medium = {
+      main_node_instance_types                 = ["m7i.4xlarge"]
+      main_node_min_size                       = 1
+      main_node_max_size                       = 5
+      vespa_node_instance_types                = ["m6i.2xlarge"]
+      vespa_node_disk_size_gb                  = 100
+      postgres_instance_type                   = "db.t4g.large"
+      postgres_storage_gb                      = 128
+      postgres_max_storage_gb                  = 512
+      redis_instance_type                      = "cache.m6g.xlarge"
+      opensearch_instance_type                 = "r8g.xlarge.search"
+      opensearch_instance_count                = 1
+      opensearch_dedicated_master_type         = "m7g.medium.search"
+      opensearch_multi_az_with_standby_enabled = false
+      opensearch_zone_awareness_enabled        = false
+      opensearch_ebs_volume_size               = 512
+      opensearch_ebs_iops                      = 3000
+      opensearch_ebs_throughput                = 256
+    }
+    large = {
+      main_node_instance_types                 = ["m7i.4xlarge"]
+      main_node_min_size                       = 2
+      main_node_max_size                       = 8
+      vespa_node_instance_types                = ["r6i.4xlarge"]
+      vespa_node_disk_size_gb                  = 512
+      postgres_instance_type                   = "db.m7g.xlarge"
+      postgres_storage_gb                      = 256
+      postgres_max_storage_gb                  = 1024
+      redis_instance_type                      = "cache.m6g.2xlarge"
+      opensearch_instance_type                 = "r8g.2xlarge.search"
+      opensearch_instance_count                = 1
+      opensearch_dedicated_master_type         = "m7g.medium.search"
+      opensearch_multi_az_with_standby_enabled = false
+      opensearch_zone_awareness_enabled        = false
+      opensearch_ebs_volume_size               = 1024
+      opensearch_ebs_iops                      = 12000
+      opensearch_ebs_throughput                = 1024
+    }
+  }
+  sizing = local.size_defaults[var.size]
+
+  # Explicit per-setting overrides win over the tier defaults.
+  main_node_instance_types  = var.main_node_instance_types != null ? var.main_node_instance_types : local.sizing.main_node_instance_types
+  main_node_min_size        = coalesce(var.main_node_min_size, local.sizing.main_node_min_size)
+  main_node_max_size        = coalesce(var.main_node_max_size, local.sizing.main_node_max_size)
+  vespa_node_instance_types = var.vespa_node_instance_types != null ? var.vespa_node_instance_types : local.sizing.vespa_node_instance_types
+  vespa_node_disk_size_gb   = coalesce(var.vespa_node_disk_size_gb, local.sizing.vespa_node_disk_size_gb)
+  postgres_instance_type    = coalesce(var.postgres_instance_type, local.sizing.postgres_instance_type)
+  postgres_storage_gb       = coalesce(var.postgres_storage_gb, local.sizing.postgres_storage_gb)
+  postgres_max_storage_gb   = coalesce(var.postgres_max_storage_gb, local.sizing.postgres_max_storage_gb)
+  redis_instance_type       = coalesce(var.redis_instance_type, local.sizing.redis_instance_type)
+
+  opensearch_instance_type                 = coalesce(var.opensearch_instance_type, local.sizing.opensearch_instance_type)
+  opensearch_instance_count                = coalesce(var.opensearch_instance_count, local.sizing.opensearch_instance_count)
+  opensearch_dedicated_master_type         = coalesce(var.opensearch_dedicated_master_type, local.sizing.opensearch_dedicated_master_type)
+  opensearch_multi_az_with_standby_enabled = coalesce(var.opensearch_multi_az_with_standby_enabled, local.sizing.opensearch_multi_az_with_standby_enabled)
+  opensearch_zone_awareness_enabled        = coalesce(var.opensearch_zone_awareness_enabled, local.sizing.opensearch_zone_awareness_enabled)
+  opensearch_ebs_volume_size               = coalesce(var.opensearch_ebs_volume_size, local.sizing.opensearch_ebs_volume_size)
+  opensearch_ebs_iops                      = coalesce(var.opensearch_ebs_iops, local.sizing.opensearch_ebs_iops)
+  opensearch_ebs_throughput                = coalesce(var.opensearch_ebs_throughput, local.sizing.opensearch_ebs_throughput)
+
+  # A domain's subnet count must match its AZ spread: 1 subnet without zone
+  # awareness (single-data-node tiers), 3 with it.
+  opensearch_subnet_ids = length(var.opensearch_subnet_ids) > 0 ? var.opensearch_subnet_ids : (
+    local.opensearch_zone_awareness_enabled ? slice(local.private_subnets, 0, 3) : slice(local.private_subnets, 0, 1)
+  )
 }
 
 provider "aws" {
@@ -35,7 +128,7 @@ module "redis" {
   name          = local.redis_name
   vpc_id        = local.vpc_id
   subnet_ids    = local.private_subnets
-  instance_type = "cache.m6g.xlarge"
+  instance_type = local.redis_instance_type
   ingress_cidrs = [local.vpc_cidr_block]
   tags          = local.merged_tags
 
@@ -49,6 +142,10 @@ module "postgres" {
   vpc_id        = local.vpc_id
   subnet_ids    = local.private_subnets
   ingress_cidrs = [local.vpc_cidr_block]
+
+  instance_type  = local.postgres_instance_type
+  storage_gb     = local.postgres_storage_gb
+  max_storage_gb = local.postgres_max_storage_gb
 
   username            = var.postgres_username
   password            = var.postgres_password
@@ -73,6 +170,12 @@ module "eks" {
   subnet_ids      = concat(local.private_subnets, local.public_subnets)
   tags            = local.merged_tags
   s3_bucket_names = [local.bucket_name]
+
+  main_node_instance_types  = local.main_node_instance_types
+  main_node_min_size        = local.main_node_min_size
+  main_node_max_size        = local.main_node_max_size
+  vespa_node_instance_types = local.vespa_node_instance_types
+  vespa_node_disk_size_gb   = local.vespa_node_disk_size_gb
 
   irsa_additional_service_account_names = var.irsa_additional_service_account_names
 
@@ -126,7 +229,7 @@ module "opensearch" {
   vpc_id = local.vpc_id
   # Prefer setting subnet_ids explicitly if the state of private_subnets is
   # unclear.
-  subnet_ids    = length(var.opensearch_subnet_ids) > 0 ? var.opensearch_subnet_ids : slice(local.private_subnets, 0, 3)
+  subnet_ids    = local.opensearch_subnet_ids
   ingress_cidrs = [local.vpc_cidr_block]
   tags          = local.merged_tags
 
@@ -135,13 +238,15 @@ module "opensearch" {
 
   # Configuration
   engine_version                = var.opensearch_engine_version
-  instance_type                 = var.opensearch_instance_type
-  instance_count                = var.opensearch_instance_count
+  instance_type                 = local.opensearch_instance_type
+  instance_count                = local.opensearch_instance_count
   dedicated_master_enabled      = var.opensearch_dedicated_master_enabled
-  dedicated_master_type         = var.opensearch_dedicated_master_type
-  multi_az_with_standby_enabled = var.opensearch_multi_az_with_standby_enabled
-  ebs_volume_size               = var.opensearch_ebs_volume_size
-  ebs_throughput                = var.opensearch_ebs_throughput
+  dedicated_master_type         = local.opensearch_dedicated_master_type
+  multi_az_with_standby_enabled = local.opensearch_multi_az_with_standby_enabled
+  zone_awareness_enabled        = local.opensearch_zone_awareness_enabled
+  ebs_volume_size               = local.opensearch_ebs_volume_size
+  ebs_iops                      = local.opensearch_ebs_iops
+  ebs_throughput                = local.opensearch_ebs_throughput
 
   # Authentication
   internal_user_database_enabled = var.opensearch_internal_user_database_enabled

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -22,9 +22,13 @@ locals {
   # be overridden individually via the matching variable.
   size_defaults = {
     small = {
-      main_node_instance_types                 = ["m7i.4xlarge"]
+      # Sized against chart >= 0.8.0 (see the chart's SIZING.md small
+      # snippets): the full stack fits one m7i.2xlarge with an external data
+      # plane; with plain chart defaults the autoscaler settles at two nodes.
+      main_node_instance_types                 = ["m7i.2xlarge"]
       main_node_min_size                       = 1
       main_node_max_size                       = 3
+      vespa_node_enabled                       = false
       vespa_node_instance_types                = ["m6i.xlarge"]
       vespa_node_disk_size_gb                  = 100
       postgres_instance_type                   = "db.t4g.large"
@@ -42,6 +46,7 @@ locals {
     }
     medium = {
       main_node_instance_types                 = ["m7i.4xlarge"]
+      vespa_node_enabled                       = true
       main_node_min_size                       = 1
       main_node_max_size                       = 5
       vespa_node_instance_types                = ["m6i.2xlarge"]
@@ -61,6 +66,7 @@ locals {
     }
     large = {
       main_node_instance_types                 = ["m7i.4xlarge"]
+      vespa_node_enabled                       = true
       main_node_min_size                       = 2
       main_node_max_size                       = 8
       vespa_node_instance_types                = ["r6i.4xlarge"]
@@ -85,6 +91,7 @@ locals {
   main_node_instance_types  = var.main_node_instance_types != null ? var.main_node_instance_types : local.sizing.main_node_instance_types
   main_node_min_size        = coalesce(var.main_node_min_size, local.sizing.main_node_min_size)
   main_node_max_size        = coalesce(var.main_node_max_size, local.sizing.main_node_max_size)
+  vespa_node_enabled        = coalesce(var.vespa_node_enabled, local.sizing.vespa_node_enabled)
   vespa_node_instance_types = var.vespa_node_instance_types != null ? var.vespa_node_instance_types : local.sizing.vespa_node_instance_types
   vespa_node_disk_size_gb   = coalesce(var.vespa_node_disk_size_gb, local.sizing.vespa_node_disk_size_gb)
   postgres_instance_type    = coalesce(var.postgres_instance_type, local.sizing.postgres_instance_type)
@@ -182,6 +189,7 @@ module "eks" {
   main_node_instance_types  = local.main_node_instance_types
   main_node_min_size        = local.main_node_min_size
   main_node_max_size        = local.main_node_max_size
+  vespa_node_enabled        = local.vespa_node_enabled
   vespa_node_instance_types = local.vespa_node_instance_types
   vespa_node_disk_size_gb   = local.vespa_node_disk_size_gb
 

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -89,8 +89,13 @@ locals {
   vespa_node_disk_size_gb   = coalesce(var.vespa_node_disk_size_gb, local.sizing.vespa_node_disk_size_gb)
   postgres_instance_type    = coalesce(var.postgres_instance_type, local.sizing.postgres_instance_type)
   postgres_storage_gb       = coalesce(var.postgres_storage_gb, local.sizing.postgres_storage_gb)
-  postgres_max_storage_gb   = coalesce(var.postgres_max_storage_gb, local.sizing.postgres_max_storage_gb)
-  redis_instance_type       = coalesce(var.redis_instance_type, local.sizing.redis_instance_type)
+  # Keep the autoscaling ceiling above the initial size even when
+  # postgres_storage_gb alone is overridden past the tier ceiling.
+  postgres_max_storage_gb = coalesce(
+    var.postgres_max_storage_gb,
+    max(local.sizing.postgres_max_storage_gb, 2 * local.postgres_storage_gb),
+  )
+  redis_instance_type = coalesce(var.redis_instance_type, local.sizing.redis_instance_type)
 
   opensearch_instance_type                 = coalesce(var.opensearch_instance_type, local.sizing.opensearch_instance_type)
   opensearch_instance_count                = coalesce(var.opensearch_instance_count, local.sizing.opensearch_instance_count)

--- a/deployment/terraform/modules/aws/onyx/main.tf
+++ b/deployment/terraform/modules/aws/onyx/main.tf
@@ -107,7 +107,10 @@ locals {
   opensearch_ebs_throughput                = coalesce(var.opensearch_ebs_throughput, local.sizing.opensearch_ebs_throughput)
 
   # A domain's subnet count must match its AZ spread: 1 subnet without zone
-  # awareness (single-data-node tiers), 3 with it.
+  # awareness (single-data-node tiers), 3 with it. Changing the subnet set on
+  # an existing domain REPLACES it (vpc_options is ForceNew in the provider) —
+  # see the README migration note before toggling zone awareness or size tiers
+  # on a live domain.
   opensearch_subnet_ids = length(var.opensearch_subnet_ids) > 0 ? var.opensearch_subnet_ids : (
     local.opensearch_zone_awareness_enabled ? slice(local.private_subnets, 0, 3) : slice(local.private_subnets, 0, 1)
   )

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -59,6 +59,79 @@ variable "tags" {
   }
 }
 
+variable "size" {
+  type        = string
+  description = <<-EOT
+    T-shirt size that sets coherent defaults for every compute/data-plane knob
+    (EKS node groups, RDS, ElastiCache, OpenSearch). Rough guide:
+      small  — pilots and small teams: up to ~200 users, < ~500k documents
+      medium — typical department/company: ~200-1,000 users, ~0.5-2M documents
+      large  — org-wide deployments: 1,000+ users, multi-million documents
+    Any individual sizing variable set to a non-null value overrides its tier
+    default. See the README for the full per-tier table.
+  EOT
+  default     = "medium"
+
+  validation {
+    condition     = contains(["small", "medium", "large"], var.size)
+    error_message = "size must be one of: small, medium, large."
+  }
+}
+
+variable "main_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the main EKS node group. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "main_node_min_size" {
+  type        = number
+  description = "Minimum main node group size (autoscaler floor). Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "main_node_max_size" {
+  type        = number
+  description = "Maximum main node group size. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "vespa_node_instance_types" {
+  type        = list(string)
+  description = "Instance types for the dedicated document-index (Vespa/OpenSearch STS) node group. Only relevant when running the index in-cluster. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "vespa_node_disk_size_gb" {
+  type        = number
+  description = "Root EBS volume (GiB) for the document-index node. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "postgres_instance_type" {
+  type        = string
+  description = "RDS instance class. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "postgres_storage_gb" {
+  type        = number
+  description = "Initial RDS allocated storage in GiB (grows via autoscaling up to postgres_max_storage_gb; cannot shrink once applied). Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "postgres_max_storage_gb" {
+  type        = number
+  description = "RDS storage-autoscaling ceiling in GiB. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "redis_instance_type" {
+  type        = string
+  description = "ElastiCache node type for the Redis replication group. Null uses the t-shirt size default."
+  default     = null
+}
+
 variable "postgres_username" {
   type        = string
   description = "Username for the postgres database"
@@ -227,14 +300,14 @@ variable "opensearch_engine_version" {
 
 variable "opensearch_instance_type" {
   type        = string
-  description = "Instance type for OpenSearch data nodes"
-  default     = "r8g.large.search"
+  description = "Instance type for OpenSearch data nodes. Null uses the t-shirt size default."
+  default     = null
 }
 
 variable "opensearch_instance_count" {
   type        = number
-  description = "Number of OpenSearch data nodes"
-  default     = 3
+  description = "Number of OpenSearch data nodes. Null uses the t-shirt size default."
+  default     = null
 }
 
 variable "opensearch_dedicated_master_enabled" {
@@ -245,26 +318,38 @@ variable "opensearch_dedicated_master_enabled" {
 
 variable "opensearch_dedicated_master_type" {
   type        = string
-  description = "Instance type for dedicated master nodes"
-  default     = "m7g.large.search"
+  description = "Instance type for dedicated master nodes. Null uses the t-shirt size default."
+  default     = null
 }
 
 variable "opensearch_multi_az_with_standby_enabled" {
   type        = bool
-  description = "Whether to enable Multi-AZ with Standby deployment"
-  default     = true
+  description = "Whether to enable Multi-AZ with Standby deployment. Requires zone awareness and instance_count >= 3 when true. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "opensearch_zone_awareness_enabled" {
+  type        = bool
+  description = "Whether to spread OpenSearch data nodes across AZs. Must be false for single-data-node domains. Null uses the t-shirt size default."
+  default     = null
 }
 
 variable "opensearch_ebs_volume_size" {
   type        = number
-  description = "EBS volume size in GiB per OpenSearch node"
-  default     = 512
+  description = "EBS volume size in GiB per OpenSearch node. Null uses the t-shirt size default."
+  default     = null
+}
+
+variable "opensearch_ebs_iops" {
+  type        = number
+  description = "IOPS for gp3 volumes. Null uses the t-shirt size default."
+  default     = null
 }
 
 variable "opensearch_ebs_throughput" {
   type        = number
-  description = "Throughput in MiB/s for gp3 volumes"
-  default     = 256
+  description = "Throughput in MiB/s for gp3 volumes. Null uses the t-shirt size default."
+  default     = null
 }
 
 variable "opensearch_internal_user_database_enabled" {

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -122,7 +122,7 @@ variable "postgres_storage_gb" {
 
 variable "postgres_max_storage_gb" {
   type        = number
-  description = "RDS storage-autoscaling ceiling in GiB. Null uses the t-shirt size default."
+  description = "RDS storage-autoscaling ceiling in GiB. 0 disables autoscaling; null uses the t-shirt size default."
   default     = null
 }
 

--- a/deployment/terraform/modules/aws/onyx/variables.tf
+++ b/deployment/terraform/modules/aws/onyx/variables.tf
@@ -96,6 +96,12 @@ variable "main_node_max_size" {
   default     = null
 }
 
+variable "vespa_node_enabled" {
+  type        = bool
+  description = "Whether to create the dedicated document-index node group. Null uses the t-shirt size default (small omits it: the small chart sizing fits the index on the main node, and on fresh clusters the group's taint would leave it idle anyway)."
+  default     = null
+}
+
 variable "vespa_node_instance_types" {
   type        = list(string)
   description = "Instance types for the dedicated document-index (Vespa/OpenSearch STS) node group. Only relevant when running the index in-cluster. Null uses the t-shirt size default."

--- a/deployment/terraform/modules/aws/postgres/main.tf
+++ b/deployment/terraform/modules/aws/postgres/main.tf
@@ -27,14 +27,16 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_db_instance" "this" {
-  identifier        = var.identifier
-  db_name           = var.db_name
-  engine            = "postgres"
-  engine_version    = var.engine_version
-  instance_class    = var.instance_type
-  allocated_storage = var.storage_gb
-  username          = var.username
-  password          = var.password
+  identifier            = var.identifier
+  db_name               = var.db_name
+  engine                = "postgres"
+  engine_version        = var.engine_version
+  instance_class        = var.instance_type
+  allocated_storage     = var.storage_gb
+  max_allocated_storage = var.max_storage_gb
+  storage_type          = var.storage_type
+  username              = var.username
+  password              = var.password
 
   # Enable IAM authentication for the RDS instance
   iam_database_authentication_enabled = var.enable_rds_iam_auth

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -27,8 +27,9 @@ variable "max_storage_gb" {
   default     = null
 
   validation {
-    condition     = var.max_storage_gb == null || coalesce(var.max_storage_gb, 0) == 0 || coalesce(var.max_storage_gb, 0) > var.storage_gb
-    error_message = "max_storage_gb must be greater than storage_gb (or null/0 to disable autoscaling)."
+    # RDS requires the ceiling to be at least 10% above allocated storage.
+    condition     = var.max_storage_gb == null || coalesce(var.max_storage_gb, 0) == 0 || coalesce(var.max_storage_gb, 0) >= ceil(1.1 * var.storage_gb)
+    error_message = "max_storage_gb must be at least 10% greater than storage_gb (RDS requirement), or null/0 to disable autoscaling."
   }
 }
 

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -17,8 +17,25 @@ variable "instance_type" {
 
 variable "storage_gb" {
   type        = number
-  description = "Storage size in GB"
+  description = "Initial allocated storage in GB. RDS storage can grow but never shrink."
   default     = 20
+}
+
+variable "max_storage_gb" {
+  type        = number
+  description = "Upper limit in GB for RDS storage autoscaling. Null disables autoscaling."
+  default     = null
+
+  validation {
+    condition     = var.max_storage_gb == null || coalesce(var.max_storage_gb, 0) > var.storage_gb
+    error_message = "max_storage_gb must be greater than storage_gb (or null to disable autoscaling)."
+  }
+}
+
+variable "storage_type" {
+  type        = string
+  description = "EBS storage type for the RDS instance. gp3 gives 3000 baseline IOPS regardless of size; older stacks created before this variable existed are on gp2."
+  default     = "gp3"
 }
 
 variable "engine_version" {

--- a/deployment/terraform/modules/aws/postgres/variables.tf
+++ b/deployment/terraform/modules/aws/postgres/variables.tf
@@ -23,12 +23,12 @@ variable "storage_gb" {
 
 variable "max_storage_gb" {
   type        = number
-  description = "Upper limit in GB for RDS storage autoscaling. Null disables autoscaling."
+  description = "Upper limit in GB for RDS storage autoscaling. Null or 0 disables autoscaling."
   default     = null
 
   validation {
-    condition     = var.max_storage_gb == null || coalesce(var.max_storage_gb, 0) > var.storage_gb
-    error_message = "max_storage_gb must be greater than storage_gb (or null to disable autoscaling)."
+    condition     = var.max_storage_gb == null || coalesce(var.max_storage_gb, 0) == 0 || coalesce(var.max_storage_gb, 0) > var.storage_gb
+    error_message = "max_storage_gb must be greater than storage_gb (or null/0 to disable autoscaling)."
   }
 }
 


### PR DESCRIPTION
## Description

Adds a `size` input (`small` | `medium` | `large`, default `medium`) to the `deployment/terraform/modules/aws/onyx` composition that sets coherent defaults for every compute/data-plane knob, each individually overridable:

| Setting | small | medium | large |
|---|---|---|---|
| Main EKS node group | m7i.4xlarge ×1–3 | m7i.4xlarge ×1–5 | m7i.4xlarge ×2–8 |
| Document-index node | m6i.xlarge, 100 GB | m6i.2xlarge, 100 GB | r6i.4xlarge, 512 GB |
| RDS Postgres | db.t4g.large, 64→256 GB | db.t4g.large, 128→512 GB | db.m7g.xlarge, 256→1024 GB |
| ElastiCache Redis | cache.m6g.large | cache.m6g.xlarge | cache.m6g.2xlarge |
| OpenSearch data | r7g.large ×1, 256 GB | r8g.xlarge ×1, 512 GB | r8g.2xlarge ×1, 1 TB (12k IOPS) |
| OpenSearch masters | 3× m7g.medium | 3× m7g.medium | 3× m7g.medium |

Tiers are calibrated from usage across the production fleet we operate (node/pod utilization, RDS CloudWatch peaks, and the OpenSearch domain shapes deployments actually converge on). Notable findings baked in: memory (not CPU) is the binding dimension on EKS; burstable `db.t4g.large` holds until roughly the medium tier (largest deployments peak 48–72% CPU); and every production OpenSearch domain runs 1 data node + 3 m7g.medium masters, not the module's old 3×r8g.large multi-AZ-standby default that nothing used.

Supporting changes:
- `eks` module: expose `main_node_min_size` / `main_node_max_size` and `vespa_node_disk_size_gb` (null keeps prior behavior).
- `postgres` module: `max_storage_gb` (RDS storage autoscaling; 0/null disables) and `storage_type` (gp3 default — old 20 GB gp2 instances had only ~100 baseline IOPS).
- Composition now passes OpenSearch `zone_awareness_enabled` + `ebs_iops` through, and sizes the domain subnet count to the AZ spread (1 subnet for single-node domains).
- README: sizing tables, tier-selection guidance, and migration notes for existing stacks.

## How Has This Been Tested?

- `terraform validate` on root modules instantiating all three tiers, including per-setting override combinations (validated with terraform 1.12 / aws provider ~>5.100).
- Provider-free `terraform plan` evaluation of the eks node-group merge logic verifying overrides land and null overrides preserve the previous node-group defaults.
- Cross-checked tier values against the live fleet so that `size = "medium"` reproduces today's EKS/Redis defaults exactly (no node-group churn on upgrade).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `size` input (`small`/`medium`/`large`, default `medium`) to the AWS `onyx` Terraform module to set fleet‑calibrated defaults for EKS, RDS, ElastiCache, and OpenSearch, with per‑setting overrides and safer create-time behavior. The `small` tier now uses `m7i.2xlarge` for main nodes and skips the index node group by default to align with Helm chart ≥0.8.0 sizing.

- New Features
  - `onyx`: `size` tiers set defaults for EKS nodes (main/index), RDS (`gp3` + storage autoscaling), Redis, and OpenSearch (data/masters, gp3 IOPS/throughput); subnet count now follows zone awareness. Paired with chart ≥0.8.0 sizing; small uses `m7i.2xlarge` and omits the index node group unless `vespa_node_enabled = true`.
  - `eks` module: new `main_node_min_size`, `main_node_max_size`, `vespa_node_enabled`, and `vespa_node_disk_size_gb` (null keeps prior defaults). On create, `desired_size` is set to the resolved `min_size`. Disk override preserves other device mappings.
  - `postgres` module: new `max_storage_gb` (0 disables) and `storage_type` (`gp3` default) with RDS 10% headroom validation; in `onyx`, the autoscaling ceiling is floored at 2× the initial size to avoid validation failures.

- Migration
  - Default `size = "medium"` keeps today’s EKS/Redis shapes; RDS converts to `gp3` and may grow storage (cannot shrink).
  - If you enabled OpenSearch on the old 3× `r8g.large.search` zone-aware default, moving to the new single-node default replaces the domain and loses index data. Pin the old shape (e.g. `opensearch_instance_count = 3`, `opensearch_zone_awareness_enabled = true`, `opensearch_multi_az_with_standby_enabled = true`) or snapshot and plan a restore before changing.
  - The `small` tier no longer creates the index node group; set `vespa_node_enabled = true` to keep it, or leave it disabled when using a managed OpenSearch domain.
  - To disable RDS storage autoscaling, set `postgres_max_storage_gb = 0`.

<sup>Written for commit ef36759bcb5422e649984a765cc13da0a3772e45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13382?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

