### PR TITLE
fix(craft): preseed OpenCode plugin SDK

### DIFF
--- a/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/docker/docker_sandbox_manager.py
@@ -138,6 +138,7 @@ from onyx.server.features.build.sandbox.util.api_url_check import (
 )
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
+    build_opencode_dependencies_setup_script,
 )
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
@@ -1106,10 +1107,13 @@ class DockerSandboxManager(SandboxManager):
             if nextjs_port is not None
             else ""
         )
+        opencode_dependencies_setup = build_opencode_dependencies_setup_script(
+            session_path
+        )
         setup_script = f"""
 set -e
 echo "Creating session directory: {session_path}"
-mkdir -p {session_path}/outputs {session_path}/attachments {session_path}/.opencode
+mkdir -p {session_path}/outputs {session_path}/attachments
 if [ -d {TEMPLATES_OUTPUTS_PATH} ]; then
     cp -r {TEMPLATES_OUTPUTS_PATH}/* {session_path}/outputs/
     # flock+sentinel: serialize concurrent session setups; .ready guards
@@ -1131,6 +1135,7 @@ else
     echo "Warning: outputs template not found at {TEMPLATES_OUTPUTS_PATH}"
     mkdir -p {session_path}/outputs/web
 fi
+{opencode_dependencies_setup}
 ln -sf {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 ln -sf {MANAGED_USER_LIBRARY_PATH} {session_path}/user_library
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md
@@ -1542,9 +1547,12 @@ fi
         attachments_content_b64 = base64.b64encode(
             ATTACHMENTS_SECTION_CONTENT.encode()
         ).decode()
+        opencode_dependencies_setup = build_opencode_dependencies_setup_script(
+            session_path
+        )
         script = f"""
 set -e
-mkdir -p {session_path}/.opencode
+{opencode_dependencies_setup}
 ln -sfn {MANAGED_SKILLS_PATH} {session_path}/.opencode/skills
 ln -sfn {MANAGED_USER_LIBRARY_PATH} {session_path}/user_library
 printf '%s' '{agents_md}' > {session_path}/AGENTS.md

--- a/backend/onyx/server/features/build/sandbox/image/Dockerfile
+++ b/backend/onyx/server/features/build/sandbox/image/Dockerfile
@@ -174,6 +174,14 @@ USER sandbox
 RUN curl -fsSL -o /tmp/opencode-install.sh https://opencode.ai/install && \
     bash /tmp/opencode-install.sh --version "${OPENCODE_VERSION}" --no-modify-path && \
     rm /tmp/opencode-install.sh
+# OpenCode ensures @opencode-ai/plugin is installed in every project config
+# directory before loading local plugins. Seed one shared installation so
+# session startup never depends on live npm access.
+RUN mkdir -p /workspace/templates/opencode && \
+    cd /workspace/templates/opencode && \
+    npm install --ignore-scripts --save-exact "@opencode-ai/plugin@${OPENCODE_VERSION}" && \
+    npm cache clean --force && \
+    rm -rf /home/sandbox/.npm
 # Pre-warm Bun's tarball cache so per-session installs hit a local store.
 RUN cd /workspace/templates/outputs/web && \
     bun install --frozen-lockfile && \

--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -131,6 +131,7 @@ from onyx.server.features.build.sandbox.util.api_url_check import (
 )
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_multi_provider_opencode_config,
+    build_opencode_dependencies_setup_script,
 )
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
@@ -1454,6 +1455,9 @@ fi
             if nextjs_port is not None
             else ""
         )
+        opencode_dependencies_setup = build_opencode_dependencies_setup_script(
+            session_path
+        )
 
         setup_script = f"""
 set -e
@@ -1470,7 +1474,7 @@ mkdir -p {session_path}/attachments
 # here — the push daemon swaps these paths via os.rename(symlink, mount),
 # which fails if the mount is a real directory. Dangling until the first
 # push lands is fine; nothing reads these during the rest of setup.
-mkdir -p {session_path}/.opencode
+{opencode_dependencies_setup}
 ln -sf /workspace/managed/skills {session_path}/.opencode/skills
 echo "Linked skills to /workspace/managed/skills"
 ln -sf /workspace/managed/user_library {session_path}/user_library
@@ -1937,9 +1941,12 @@ echo "Session cleanup complete"
         attachments_content_b64 = base64.b64encode(
             ATTACHMENTS_SECTION_CONTENT.encode()
         ).decode()
+        opencode_dependencies_setup = build_opencode_dependencies_setup_script(
+            session_path
+        )
         config_script = f"""
 set -e
-mkdir -p {session_path}/.opencode
+{opencode_dependencies_setup}
 ln -sfn /workspace/managed/skills {session_path}/.opencode/skills
 ln -sfn /workspace/managed/user_library {session_path}/user_library
 printf '%s' '{agent_instructions_escaped}' > {session_path}/AGENTS.md

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -16,6 +16,24 @@ from onyx.server.features.build.sandbox.models import (
     LLMProviderConfig,
 )
 
+OPENCODE_DEPENDENCIES_TEMPLATE_PATH = "/workspace/templates/opencode"
+
+
+def build_opencode_dependencies_setup_script(session_path: str) -> str:
+    """Seed OpenCode's per-project dependency metadata from the sandbox image."""
+    config_path = f"{session_path}/.opencode"
+    template_path = OPENCODE_DEPENDENCIES_TEMPLATE_PATH
+    return f"""
+mkdir -p {config_path}
+if [ -d {template_path}/node_modules ]; then
+    cp {template_path}/package.json {template_path}/package-lock.json {config_path}/
+    if [ ! -e {config_path}/node_modules ]; then
+        ln -s {template_path}/node_modules {config_path}/node_modules
+    fi
+fi
+"""
+
+
 # 4.6+ supports adaptive thinking; older needs enabled+budgetTokens.
 _ADAPTIVE_THINKING_MODELS = frozenset(
     {"claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6"}

--- a/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
+++ b/backend/tests/integration/tests/craft/docker_e2e/test_workspace_setup_docker.py
@@ -92,12 +92,20 @@ def test_session_setup_creates_user_writable_workspace(
                 f'test -f "{session_path}/AGENTS.md" && '
                 f'test -L "{session_path}/.opencode/skills" && '
                 f'test "$(readlink "{session_path}/.opencode/skills")" = '
-                '"/workspace/managed/skills"'
+                '"/workspace/managed/skills" && '
+                f'test -f "{session_path}/.opencode/package.json" && '
+                f'test -f "{session_path}/.opencode/package-lock.json" && '
+                f'test -L "{session_path}/.opencode/node_modules" && '
+                f'test "$(readlink "{session_path}/.opencode/node_modules")" = '
+                '"/workspace/templates/opencode/node_modules" && '
+                f'cd "{session_path}" && '
+                "timeout 20 opencode debug config >/dev/null"
             ),
         ],
+        user=SANDBOX_EXEC_USER,
     )
     assert symlink_result.returncode == 0, (
-        "Expected AGENTS.md plus .opencode/skills symlink after provision. "
+        "Expected provisioned OpenCode config and preinstalled dependencies. "
         f"stdout={symlink_result.stdout!r} stderr={symlink_result.stderr!r}"
     )
 


### PR DESCRIPTION
## Description

Preinstall the version-matched `@opencode-ai/plugin` SDK in the sandbox image and link that shared dependency tree into each session's `.opencode` directory. This keeps OpenCode's project dependency check local and prevents session startup from stalling on live npm access.

Apply the same setup during initial provisioning and config regeneration for both Docker and Kubernetes sandboxes. Extend the Docker workspace integration coverage to start OpenCode against the provisioned dependency tree.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preseed the version-matched `@opencode-ai/plugin` SDK in the sandbox image and link it into each session’s `.opencode` directory to remove live npm from startup and prevent stalls. Applied to Docker and Kubernetes during both initial setup and config regeneration.

- **Bug Fixes**
  - Image seeds a shared install in /workspace/templates/opencode; session setup copies package files and symlinks node_modules into `.opencode`.
  - Added a setup script used by Docker and Kubernetes managers for provisioning and regeneration.
  - Updated Docker E2E to verify provisioned OpenCode config, dependency symlink, and `opencode debug config` runs.

<sup>Written for commit 92faad231b6e94f5fe3af74e833ba41b23ad021e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

