### PR TITLE
perf(db): add composite index on chat_session (user_id, time_updated DESC)

### DIFF
--- a/backend/alembic/versions/13ee089a188f_add_index_on_chat_session_user_id_and_.py
+++ b/backend/alembic/versions/13ee089a188f_add_index_on_chat_session_user_id_and_.py
@@ -1,0 +1,75 @@
+"""add index on chat_session user_id and time_updated
+
+Revision ID: 13ee089a188f
+Revises: fe958f19e42b
+Create Date: 2026-07-23 22:54:43.874508
+
+Adds a composite btree index on (user_id, time_updated DESC) to back the
+chat-history sidebar query (get_chat_sessions_by_user), which filters by
+user_id and orders by time_updated DESC. Without it Postgres plans a Seq Scan
++ Sort that degrades linearly as chat_session grows.
+
+chat_session is hot and frequently written (time_updated is bumped on every
+message), so the index is built CONCURRENTLY to avoid blocking writes. This
+project's alembic env.py sets search_path before configuring the migration
+context, so the migration runs inside an externally-managed transaction and
+op.get_context().autocommit_block() is unavailable. We instead commit the
+pending migration transaction and build the index on a dedicated AUTOCOMMIT
+connection (CREATE INDEX CONCURRENTLY cannot run inside a transaction block).
+"""
+
+from alembic import op
+import sqlalchemy as sa
+import logging
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+# revision identifiers, used by Alembic.
+revision = "13ee089a188f"
+down_revision = "fe958f19e42b"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_chat_session_user_id_time_updated"
+
+
+def _existing_indexes(bind: sa.engine.Connection) -> list[str | None]:
+    try:
+        return [ix.get("name") for ix in sa.inspect(bind).get_indexes("chat_session")]
+    except Exception:
+        return []
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    if INDEX_NAME in _existing_indexes(bind):
+        return
+
+    logger.info("Creating index %s on chat_session (CONCURRENTLY)...", INDEX_NAME)
+    # End alembic's transaction so CONCURRENTLY can run; otherwise the build
+    # would wait forever on this still-open transaction's snapshot.
+    bind.commit()
+    with bind.engine.connect().execution_options(
+        isolation_level="AUTOCOMMIT"
+    ) as autocommit_conn:
+        autocommit_conn.exec_driver_sql(
+            f'CREATE INDEX CONCURRENTLY IF NOT EXISTS "{INDEX_NAME}" '
+            "ON chat_session (user_id, time_updated DESC)"
+        )
+    logger.info("Created index %s", INDEX_NAME)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    if INDEX_NAME not in _existing_indexes(bind):
+        return
+
+    logger.info("Dropping index %s on chat_session (CONCURRENTLY)...", INDEX_NAME)
+    bind.commit()
+    with bind.engine.connect().execution_options(
+        isolation_level="AUTOCOMMIT"
+    ) as autocommit_conn:
+        autocommit_conn.exec_driver_sql(
+            f'DROP INDEX CONCURRENTLY IF EXISTS "{INDEX_NAME}"'
+        )
+    logger.info("Dropped index %s", INDEX_NAME)

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3073,6 +3073,16 @@ class ChatSession(Base):
     )
     persona: Mapped["Persona"] = relationship("Persona")
 
+    __table_args__ = (
+        # Backs the chat-history sidebar query (get_chat_sessions_by_user):
+        # filter by user_id, order by time_updated DESC.
+        Index(
+            "ix_chat_session_user_id_time_updated",
+            "user_id",
+            desc("time_updated"),
+        ),
+    )
+
 
 class ChatMessage(Base):
     """Note, the first message in a chain has no contents, it's a workaround to allow edits


### PR DESCRIPTION
## Problem

`get_chat_sessions_by_user` (`backend/onyx/db/chat.py`) filters `ChatSession.user_id == user_id` and orders by `time_updated DESC`. It backs `GET /chat/get-user-chat-sessions`, the chat-history sidebar fetched on essentially every chat page load for every user.

`chat_session.user_id` has **no index** — the initial migration and all later ALTERs only added `chat_session_pkey`, `idx_chat_session_desc_tsv`, and `ix_chat_session_project_id`. So Postgres plans a **Seq Scan + Sort**, which degrades linearly as the table grows.

## Fix

Add a composite btree index `ix_chat_session_user_id_time_updated` on `(user_id, time_updated DESC)`, matching the filter + sort so Postgres skips the in-memory sort. The mirroring `Index(...)` is added to `ChatSession.__table_args__` so autogenerate stays in sync.

**Column choice:** went with the 2-column `(user_id, time_updated DESC)` rather than adding `onyxbot_flow` — for any real user virtually all rows are `onyxbot_flow=false`, so that column adds negligible selectivity, and the 2-column form also cleanly serves the `include_onyxbot_flows=True` ordering path (chat_search / ee query history).

**Built CONCURRENTLY** since `chat_session` is hot and `time_updated` is bumped on every message. Note: this repo's `alembic/env.py` sets `search_path` before configuring the migration context, so migrations run inside an externally-managed transaction and `op.get_context().autocommit_block()` asserts (which is why no existing migration uses CONCURRENTLY). The migration instead commits alembic's pending transaction and builds the index on a dedicated `AUTOCOMMIT` connection. It's idempotent (inspector guard + `IF NOT EXISTS`), and `downgrade()` drops the index concurrently under an existence guard.

## Validation (live dev DB, user with 15,002 sessions)

| Query | Before (no index) | After (index) |
|---|---|---|
| Sidebar **LIMIT 51** (top-N) | Seq Scan + top-N Sort, 368 buffers, **14.99 ms** | Index Scan, 53 buffers, **0.37 ms** (~40×) |
| Default path (no SQL LIMIT) | Seq Scan + Sort, **20.1 ms** | Index Scan, **no Sort node**, 11.7 ms |

- Index is **valid** (`indisvalid=t`); `alembic check` shows zero drift for it (ORM matches DB).
- **Correctness:** top-51 result rows + order are byte-identical with vs. without the index (0 duplicate `time_updated` values → deterministic ordering).
- Downgrade → re-upgrade cycle verified (both directions run CONCURRENTLY cleanly).

## Follow-up (not in this PR)

The default sidebar path (`chat.py`) only applies the SQL `LIMIT` when `include_failed_chats=True`; otherwise it fetches **all** matching rows via the index (14,825 buffer hits for the 15k-session user) and truncates in Python — vs. 53 buffers when bounded. The index makes the top-N case fast; bounding that overfetch is the complementary win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a composite index on chat_session (user_id, time_updated DESC) to speed up the chat-history sidebar query (`GET /chat/get-user-chat-sessions`). Cuts top-N fetch from ~15 ms to ~0.37 ms (~40x) and removes the Sort on the default path.

- **Migration**
  - Creates `ix_chat_session_user_id_time_updated` concurrently; mirrored in `ChatSession.__table_args__`.
  - Uses an AUTOCOMMIT connection due to env-managed transactions; idempotent with inspector guard and IF NOT EXISTS.
  - Downgrade drops the index concurrently.

<sup>Written for commit c46afe72b140422fb9e569eb0409d06d3a1a0eb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

