### PR TITLE
fix: expand $PATH at hook time in Claude Code SessionStart env hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=%q:\"$PATH\"\\n' \"$CLAUDE_PROJECT_DIR/.venv/bin\" >> \"$CLAUDE_ENV_FILE\" || true"
+            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=%q\\n' \"$CLAUDE_PROJECT_DIR/.venv/bin:$PATH\" >> \"$CLAUDE_ENV_FILE\" || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

#13380 added a SessionStart hook that appends a PATH override to `$CLAUDE_ENV_FILE` so Claude Code shells pick up the repo venv. The line it wrote was:

```
export PATH=/workspace/.venv/bin:"$PATH"
```

leaving `$PATH` as an unexpanded reference to be resolved when the env file is applied. Per the Claude Code docs, that file is run as a shell-script preamble before each Bash tool command — but the preamble does not run in the environment the hook saw, so the `$PATH` self-reference doesn't resolve to the real profile PATH. Observed result: every Bash tool call in a Claude Code session started with a completely empty `PATH` (not even `git`/`which` resolved).

## Fix

Expand `$PATH` in the hook's own shell (where it holds the real value) so the env file receives a fully-literal line with nothing left to resolve at source time:

```
export PATH=/workspace/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin
```

`%q` now quotes the entire value (previously only the venv dir), so paths containing spaces or shell metacharacters round-trip correctly through the sourced preamble.

## Testing

- Extracted the command verbatim from the edited `.claude/settings.json` and ran it against a test env file: writes the fully-expanded line above.
- Repeated with `CLAUDE_PROJECT_DIR='/tmp/my weird $proj'`: the `%q`-escaped line sources back to the exact original PATH in a clean shell (`env -i bash`).
- Exits 0 when `CLAUDE_ENV_FILE` is unset (non-Claude contexts).
- `pre-commit run --files .claude/settings.json` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)