### PR TITLE
chore(deploy): drop inert AUTH_TYPE from env templates

### DIFF
--- a/deployment/docker_compose/env.prod.template
+++ b/deployment/docker_compose/env.prod.template
@@ -15,17 +15,19 @@ WEB_DOMAIN=http://localhost:3000
 # from and where data can be sent. Off by default.
 # WEB_STRICT_CSP_ENABLED=true
 
-# The following are for configuring User Authentication, supported flows are:
-# disabled
-# basic (standard username / password)
-# google_oauth (login with google/gmail account)
-# oidc
-# saml
-AUTH_TYPE=google_oauth
+# User Authentication
+# Basic (email / password) auth is always enabled. SSO -- Google, OIDC, and SAML --
+# is now configured from the admin panel, not from this file:
+#   Admin Panel > Organization > SSO Providers
+#   https://docs.onyx.app/deployment/authentication/sso_providers
+# AUTH_TYPE was removed in v4.4.0; if still set it is ignored (aside from a startup
+# warning) and Onyx runs with basic auth plus whatever providers you configure.
 
-# Set the values below to use with Google OAuth
-GOOGLE_OAUTH_CLIENT_ID=
-GOOGLE_OAUTH_CLIENT_SECRET=
+# The legacy SSO variables below are read only once, on the first v4.4.0 upgrade, to
+# migrate a pre-v4.4.0 env-based SSO config into a provider row. They do nothing on a
+# fresh install -- configure SSO from the admin panel instead.
+# GOOGLE_OAUTH_CLIENT_ID=
+# GOOGLE_OAUTH_CLIENT_SECRET=
 
 # if using basic auth and you want to require email verification, 
 # then uncomment / set the following
@@ -41,11 +43,14 @@ GOOGLE_OAUTH_CLIENT_SECRET=
 # Optional comma-separated BCC archive recipients for all emails
 #EMAIL_ARCHIVE_BCC_ADDRESSES=
 
-# OpenID Connect (OIDC)
+# OpenID Connect (OIDC) is configured from the admin panel. OPENID_CONFIG_URL below is
+# legacy (read only during migration); set the discovery URL on the provider instead.
+# See https://docs.onyx.app/deployment/authentication/oidc for env vars that still
+# apply globally (e.g. OIDC_PKCE_ENABLED, OIDC_SCOPE_OVERRIDE).
 #OPENID_CONFIG_URL=
 #OIDC_PKCE_ENABLED=
 
-# SAML config directory for OneLogin compatible setups
+# SAML config directory, read only to migrate a pre-v4.4.0 AUTH_TYPE=saml deployment.
 #SAML_CONF_DIR=
 
 

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -46,7 +46,10 @@ IMAGE_TAG=latest
 
 ## Auth Settings
 ### https://docs.onyx.app/deployment/authentication
-AUTH_TYPE=basic
+### Basic (email / password) auth is always enabled. Configure SSO (Google, OIDC,
+### SAML) from the admin panel: Admin Panel > Organization > SSO Providers.
+### https://docs.onyx.app/deployment/authentication/sso_providers
+### AUTH_TYPE was removed in v4.4.0 and is ignored if still set (startup warning only).
 # SESSION_EXPIRE_TIME_SECONDS=
 ### Signs password reset, email verification, OAuth login state, and captcha cookies.
 ### REQUIRED: the API server refuses to start with an empty value (secure by default).


### PR DESCRIPTION
## Summary

`AUTH_TYPE` was removed in v4.4.0 — SSO (Google, OIDC, SAML) is now managed from **Admin Panel → Organization → SSO Providers** — but the Docker Compose env templates still ship an active `AUTH_TYPE` assignment:

- `env.template` ships `AUTH_TYPE=basic`
- `env.prod.template` ships `AUTH_TYPE=google_oauth`, preceded by a comment block listing `disabled/basic/google_oauth/oidc/saml` as if it still selects the auth mode.

Anyone copying a template today sets an inert variable that only trips a startup warning (`verify_auth_setting()` in `backend/onyx/auth/users.py`) and configures no SSO. This was flagged in #13319, where an upgrading operator was surprised by the auth changes.

## Changes

- Remove the active `AUTH_TYPE=` lines from both templates.
- Replace the misleading "supported flows" comment block with a pointer to the admin-panel SSO flow.
- Annotate the remaining legacy SSO vars (`GOOGLE_OAUTH_CLIENT_ID/SECRET`, `OPENID_CONFIG_URL`, `SAML_CONF_DIR`) as read-only-during-migration so upgraders still have the reference without being told to set them on a fresh install.

No behavior change — comments/defaults in example env files only.

Refs #13319

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove inert `AUTH_TYPE` from Docker Compose env templates and direct users to configure SSO in the Admin Panel to avoid confusion and startup warnings. No runtime behavior changes.

- **Refactors**
  - Removed `AUTH_TYPE` from `env.template` and `env.prod.template`.
  - Replaced the old auth-mode comment block with clear SSO setup guidance (Admin Panel → Organization → SSO Providers).
  - Marked legacy SSO vars (`GOOGLE_OAUTH_CLIENT_ID/SECRET`, `OPENID_CONFIG_URL`, `SAML_CONF_DIR`) as migration-only for first upgrade to v4.4.0.

<sup>Written for commit 2cddcb1c79854ba4a92c437ba3059f99ae5671af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13390?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

