### PR TITLE
perf(db): add composite index on chat_session (user_id, onyxbot_flow, time_updated DESC)

### DIFF
--- a/backend/alembic/versions/e0ea2ae62e51_add_index_on_chat_session_user_id_and_.py
+++ b/backend/alembic/versions/e0ea2ae62e51_add_index_on_chat_session_user_id_and_.py
@@ -27,7 +27,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = "e0ea2ae62e51"
-down_revision = "fe958f19e42b"
+down_revision = "c2cc933f0a40"
 branch_labels = None
 depends_on = None
 

--- a/backend/alembic/versions/e0ea2ae62e51_add_index_on_chat_session_user_id_and_.py
+++ b/backend/alembic/versions/e0ea2ae62e51_add_index_on_chat_session_user_id_and_.py
@@ -1,0 +1,85 @@
+"""add index on chat_session user_id and time_updated
+
+Revision ID: e0ea2ae62e51
+Revises: fe958f19e42b
+Create Date: 2026-07-23 23:13:21.795575
+
+Adds a composite btree index on (user_id, onyxbot_flow, time_updated DESC) to
+back the chat-history sidebar query (get_chat_sessions_by_user), which filters
+on user_id + onyxbot_flow and orders by time_updated DESC. Without it Postgres
+plans a Seq Scan + Sort that degrades linearly as chat_session grows.
+
+chat_session is hot (time_updated is bumped on every message), so the index is
+built CONCURRENTLY. That cannot run inside a transaction, and
+op.get_context().autocommit_block() is unusable with this project's env.py:
+the async connection autobegins a transaction when env.py sets search_path, so
+alembic treats the transaction as externally managed and asserts. Instead we
+commit the migration connection's transaction (also required so CONCURRENTLY
+doesn't wait forever on our own snapshot) and run the DDL on a dedicated
+AUTOCOMMIT connection. A fresh connection does not inherit the migration
+connection's per-tenant search_path, so all statements schema-qualify using
+current_schema() read from the migration connection.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "e0ea2ae62e51"
+down_revision = "fe958f19e42b"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_chat_session_user_id_onyxbot_flow_time_updated"
+
+
+def _index_state(conn: sa.engine.Connection, schema: str) -> bool | None:
+    """None if the index doesn't exist, otherwise pg_index.indisvalid.
+
+    A failed CREATE INDEX CONCURRENTLY leaves an INVALID index behind, which
+    IF NOT EXISTS / a plain existence check would mistake for a finished build.
+    """
+    row = conn.execute(
+        sa.text(
+            "SELECT i.indisvalid FROM pg_index i "
+            "WHERE i.indexrelid = to_regclass(:qualified_name)"
+        ),
+        {"qualified_name": f'"{schema}"."{INDEX_NAME}"'},
+    ).one_or_none()
+    return row[0] if row is not None else None
+
+
+def _release_migration_snapshot() -> tuple[sa.engine.Connection, str]:
+    """Commit the migration txn and return (bind, current tenant schema)."""
+    bind = op.get_bind()
+    schema = bind.execute(sa.text("SELECT current_schema()")).scalar_one()
+    # env.py's plain SET search_path is session-level and survives this
+    # commit; alembic's version-table update autobegins a new transaction
+    # afterwards, which env.py commits at the end of the schema's run.
+    bind.commit()
+    return bind, schema
+
+
+def upgrade() -> None:
+    bind, schema = _release_migration_snapshot()
+
+    with bind.engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        state = _index_state(conn, schema)
+        if state is True:
+            return
+        if state is False:
+            conn.exec_driver_sql(f'DROP INDEX CONCURRENTLY "{schema}"."{INDEX_NAME}"')
+        conn.exec_driver_sql(
+            f'CREATE INDEX CONCURRENTLY "{INDEX_NAME}" '
+            f'ON "{schema}".chat_session (user_id, onyxbot_flow, time_updated DESC)'
+        )
+
+
+def downgrade() -> None:
+    bind, schema = _release_migration_snapshot()
+
+    with bind.engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        if _index_state(conn, schema) is None:
+            return
+        conn.exec_driver_sql(f'DROP INDEX CONCURRENTLY "{schema}"."{INDEX_NAME}"')

--- a/backend/alembic/versions/e0ea2ae62e51_add_index_on_chat_session_user_id_and_.py
+++ b/backend/alembic/versions/e0ea2ae62e51_add_index_on_chat_session_user_id_and_.py
@@ -1,7 +1,7 @@
 """add index on chat_session user_id and time_updated
 
 Revision ID: e0ea2ae62e51
-Revises: fe958f19e42b
+Revises: c2cc933f0a40
 Create Date: 2026-07-23 23:13:21.795575
 
 Adds a composite btree index on (user_id, onyxbot_flow, time_updated DESC) to

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3004,6 +3004,16 @@ Messages Tables
 
 class ChatSession(Base):
     __tablename__ = "chat_session"
+    __table_args__ = (
+        # Backs the chat-history sidebar query: filter on (user_id,
+        # onyxbot_flow), order by time_updated DESC.
+        Index(
+            "ix_chat_session_user_id_onyxbot_flow_time_updated",
+            "user_id",
+            "onyxbot_flow",
+            desc("time_updated"),
+        ),
+    )
 
     id: Mapped[UUID] = mapped_column(
         PGUUID(as_uuid=True), primary_key=True, default=uuid4


### PR DESCRIPTION
## Problem

`get_chat_sessions_by_user` (`backend/onyx/db/chat.py`) backs the chat-history sidebar (`GET /chat/get-user-chat-sessions`), fetched on essentially every chat page load. It filters `user_id = ? AND onyxbot_flow = false` and orders by `time_updated DESC`, but `chat_session` has no index on `user_id` — Postgres plans a Seq Scan + Sort that degrades linearly with table size.

## Fix

- New migration `e0ea2ae62e51`: composite btree index `ix_chat_session_user_id_onyxbot_flow_time_updated` on `(user_id, onyxbot_flow, time_updated DESC)`, matching the filter + sort exactly so the LIMIT'd query terminates after reading exactly the rows it returns.
- Matching `Index(...)` added to `ChatSession.__table_args__` so the ORM stays in sync for autogenerate.

`chat_session` is hot (`time_updated` bumps on every message), so the index builds `CONCURRENTLY`. Notes on the mechanics, all empirically verified against the dev DB:

- `op.get_context().autocommit_block()` **cannot** be used with this repo's `env.py`: the async connection autobegins a transaction when `env.py` sets `search_path`, alembic classifies it as externally managed, and `autocommit_block()` fails on `assert self._transaction is not None`. The migration instead commits the migration transaction (also required so `CONCURRENTLY` doesn't wait on its own snapshot) and runs DDL on a dedicated AUTOCOMMIT connection.
- A fresh connection does not inherit the per-tenant `search_path`, so all DDL is schema-qualified via `current_schema()` read from the migration connection — keeps multi-tenant (`schema_private`) runs correct.
- A failed `CREATE INDEX CONCURRENTLY` leaves an INVALID index that `IF NOT EXISTS`/existence checks mistake for a finished build; the migration checks `pg_index.indisvalid` and drops + rebuilds in that case.

## Validation (live dev DB, seeded to 115k rows across ~100 users, then cleaned up)

| Query | Before | After |
|---|---|---|
| Sidebar shape, `LIMIT 51`, user with 15k sessions | Seq Scan + top-N heapsort, **24.8 ms** | Index Scan, no Sort, **0.26 ms** |
| Sidebar shape, `LIMIT 51`, user with 1k sessions | Seq Scan + top-N heapsort, **17.6 ms** | Index Scan, no Sort, **0.11 ms** |
| Endpoint default path (no SQL limit), 15k rows | Seq Scan + quicksort, **32.1 ms** | Bitmap Index Scan + sort, **17.6 ms** |

- Migration tested: upgrade, downgrade, re-upgrade, and idempotent re-run with the index already present.
- Regression: `GET /api/chat/get-user-chat-sessions` JSON (page 1 and page 2 via the `before` cursor) byte-identical before/after.

## ⚠️ Overlaps with #13385

A sibling kanban session opened #13385 for the same finding (index on `(user_id, time_updated DESC)`). Only one of the two should merge — both migrations branch from `fe958f19e42b`, so merging both leaves alembic with two heads. This PR additionally: includes `onyxbot_flow` in the key (the sidebar filter becomes an index condition, so the LIMIT'd scan stops after exactly 51 matching rows even for users with many OnyxBot sessions), schema-qualifies the DDL for multi-tenant runs (#13385 builds on a fresh connection whose `search_path` defaults to `public`, so tenant schemas would silently not get the index), and handles INVALID leftover indexes from failed concurrent builds.

## Related follow-ups (not in this PR)

- `get_chat_sessions_by_user` only applies `LIMIT` in SQL when `include_failed_chats=True`; the default sidebar path fetches all matching rows and truncates in Python. Bounding that overfetch is a separate small win (it dominates end-to-end latency for users with very many sessions).
- Observed while validating: `chat_message.chat_session_id` and `tool_call.chat_session_id` have no index, so cascade-deleting chat sessions seq-scans `chat_message` per deleted row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a composite index on `chat_session` (`user_id`, `onyxbot_flow`, `time_updated DESC`) to speed up the chat-history sidebar query. Sidebar fetch drops from ~25 ms to ~0.3 ms on a 115k-row dev DB (LIMIT 51).

- **Migration**
  - Creates `ix_chat_session_user_id_onyxbot_flow_time_updated` CONCURRENTLY on a dedicated AUTOCOMMIT connection after committing the migration transaction.
  - Schema-qualified DDL per tenant via `current_schema()`; detects INVALID leftovers and drops/rebuilds; safe to re-run.
  - Adds matching `Index(...)` in `ChatSession` with `desc("time_updated")` to keep the ORM in sync.

<sup>Written for commit 344726a9ffc8ff18124bc9f7d6497977aea557ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13391?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

