### PR TITLE
fix: make Claude Code venv PATH hook idempotent and quoting-safe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=%q\\n' \"$CLAUDE_PROJECT_DIR/.venv/bin:$PATH\" >> \"$CLAUDE_ENV_FILE\" || true"
+            "command": "d=\"$CLAUDE_PROJECT_DIR/.venv/bin\"; case \"$PATH\" in \"$d:\"*|\"$d\") ;; *) [ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=%s\\n' \"$d:$PATH\" >> \"$CLAUDE_ENV_FILE\" || true ;; esac"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Follow-up to #13380 / #13386. Two remaining issues with the SessionStart PATH hook:

- **Not idempotent**: the hook unconditionally prepends `.venv/bin` and bakes the full expanded PATH into `$CLAUDE_ENV_FILE`, so every firing (startup, resume, `/clear`, or launching from a shell that already has the venv active) grows PATH with another duplicate venv entry. Now it skips writing entirely when the venv is already the first PATH entry.
- **Wrong quoting**: `%q` produces shell-style escaping, but the env file is applied literally rather than shell-evaluated (the reason #13386 was needed in the first place), so e.g. a PATH entry containing a space would get a literal backslash baked into the value. Switched to `%s`.

## Testing

Extracted the command back out of `settings.json` with `json.load` and ran it via `bash -c` (matching how hooks execute):

- clean PATH → writes `export PATH=<repo>/.venv/bin:<expanded PATH>`, exit 0
- venv already first (resume/`/clear` case) → writes nothing, exit 0
- `CLAUDE_ENV_FILE` unset → writes nothing, exit 0
- PATH entry containing a space → value written raw, no backslashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the SessionStart PATH hook idempotent and fix quoting in `.claude/settings.json`. This prevents duplicate `.venv/bin` entries and writes PATH values with spaces correctly.

- **Bug Fixes**
  - Only prepends `.venv/bin` when it isn’t already the first PATH entry.
  - Uses `printf '%s'` instead of `'%q'` so the env file stores the raw PATH without shell-escape backslashes.

<sup>Written for commit ec61295a46b2c2827ec58e3d34b1358a1e5ca7f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13393?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

