### PR TITLE
feat(craft): manage external app skill associations

### DIFF
--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -154,9 +154,7 @@ def get_external_app_by_skill_id(
     db_session: Session,
     skill_id: UUID,
 ) -> ExternalApp | None:
-    """The external-app gateway backing ``skill_id``, or None if the skill isn't
-    an external app. Returns just the row — callers that need its policies fetch
-    them via ``get_action_policies``."""
+    """Return the app that ``skill_id`` depends on, if one is associated."""
     stmt = (
         select(ExternalApp)
         .join(
@@ -389,6 +387,153 @@ def associate_built_in_skill__no_commit(
     app.associated_skills.append(skill)
     db_session.flush()
     return skill
+
+
+def associate_custom_skill_with_external_app__no_commit(
+    db_session: Session,
+    *,
+    external_app_id: int,
+    skill_id: UUID,
+) -> Skill:
+    """Associate a custom skill with an app and require org-wide visibility.
+
+    The skill row is locked so concurrent association attempts serialize.
+    Existing user preferences and explicit editor grants are preserved.
+    """
+    app = db_session.scalar(
+        select(ExternalApp).where(ExternalApp.id == external_app_id).with_for_update()
+    )
+    if app is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"External app with id {external_app_id} not found.",
+        )
+
+    skill = db_session.scalar(
+        select(Skill).where(Skill.id == skill_id).with_for_update()
+    )
+    if skill is None:
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "Skill not found.")
+    if not skill.is_custom:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Built-in skills cannot be associated through the admin workflow.",
+        )
+
+    existing_app = get_external_app_by_skill_id(db_session, skill.id)
+    if existing_app is not None:
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            (
+                f"Skill '{skill.name}' is already associated with "
+                f"app '{existing_app.name}'."
+            ),
+        )
+
+    skill.public_permission = SkillSharePermission.VIEWER
+    db_session.add(ExternalApp__Skill(external_app_id=app.id, skill_id=skill.id))
+    db_session.flush()
+    return skill
+
+
+def replace_custom_skill_associations__no_commit(
+    db_session: Session,
+    *,
+    external_app_id: int,
+    skill_ids: Iterable[UUID],
+) -> list[Skill]:
+    """Replace an app's custom-skill associations and return affected skills.
+
+    Built-in provider associations are preserved. New associations promote the
+    skill to organization-wide viewer access; removed skills keep their current
+    visibility and content.
+    """
+    requested_ids = list(skill_ids)
+    target_ids = set(requested_ids)
+    if len(target_ids) != len(requested_ids):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "associated_skill_ids must not contain duplicates.",
+        )
+
+    app = db_session.scalar(
+        select(ExternalApp).where(ExternalApp.id == external_app_id).with_for_update()
+    )
+    if app is None:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND,
+            f"External app with id {external_app_id} not found.",
+        )
+
+    target_skills = list(
+        db_session.scalars(
+            select(Skill)
+            .where(Skill.id.in_(target_ids))
+            .order_by(Skill.id)
+            .with_for_update()
+        )
+    )
+    if len(target_skills) != len(target_ids):
+        raise OnyxError(OnyxErrorCode.NOT_FOUND, "One or more skills were not found.")
+    if any(not skill.is_custom for skill in target_skills):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Built-in skills cannot be associated through the admin workflow.",
+        )
+
+    conflicting_app = db_session.execute(
+        select(Skill.name, ExternalApp.name)
+        .select_from(ExternalApp__Skill)
+        .join(Skill, Skill.id == ExternalApp__Skill.skill_id)
+        .join(ExternalApp, ExternalApp.id == ExternalApp__Skill.external_app_id)
+        .where(
+            ExternalApp__Skill.skill_id.in_(target_ids),
+            ExternalApp__Skill.external_app_id != app.id,
+        )
+        .limit(1)
+    ).one_or_none()
+    if conflicting_app is not None:
+        skill_name, app_name = conflicting_app
+        raise OnyxError(
+            OnyxErrorCode.DUPLICATE_RESOURCE,
+            f"Skill '{skill_name}' is already associated with app '{app_name}'.",
+        )
+
+    current_skills = list(
+        db_session.scalars(
+            select(Skill)
+            .join(
+                ExternalApp__Skill,
+                ExternalApp__Skill.skill_id == Skill.id,
+            )
+            .where(
+                ExternalApp__Skill.external_app_id == app.id,
+                Skill.built_in_skill_id.is_(None),
+            )
+        )
+    )
+    current_ids = {skill.id for skill in current_skills}
+
+    removed_ids = current_ids - target_ids
+    if removed_ids:
+        db_session.execute(
+            delete(ExternalApp__Skill).where(
+                ExternalApp__Skill.external_app_id == app.id,
+                ExternalApp__Skill.skill_id.in_(removed_ids),
+            )
+        )
+
+    for skill in target_skills:
+        skill.public_permission = SkillSharePermission.VIEWER
+        if skill.id not in current_ids:
+            db_session.add(
+                ExternalApp__Skill(external_app_id=app.id, skill_id=skill.id)
+            )
+
+    db_session.flush()
+    return current_skills + [
+        skill for skill in target_skills if skill.id not in current_ids
+    ]
 
 
 def update_external_app(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -419,6 +419,11 @@ def associate_custom_skill_with_external_app__no_commit(
             OnyxErrorCode.INVALID_INPUT,
             "Built-in skills cannot be associated through the admin workflow.",
         )
+    if skill.is_valid is False:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Invalid skill '{skill.name}' cannot be associated with an app.",
+        )
 
     existing_app = get_external_app_by_skill_id(db_session, skill.id)
     if existing_app is not None:
@@ -428,6 +433,24 @@ def associate_custom_skill_with_external_app__no_commit(
                 f"Skill '{skill.name}' is already associated with "
                 f"app '{existing_app.name}'."
             ),
+        )
+
+    if db_session.scalar(
+        select(Skill.id)
+        .join(
+            ExternalApp__Skill,
+            ExternalApp__Skill.skill_id == Skill.id,
+        )
+        .where(
+            ExternalApp__Skill.external_app_id == app.id,
+            Skill.name == skill.name,
+            Skill.id != skill.id,
+        )
+        .limit(1)
+    ):
+        raise OnyxError(
+            OnyxErrorCode.SKILL_NAME_CONFLICT,
+            (f"App '{app.name}' already has an associated skill named '{skill.name}'."),
         )
 
     skill.public_permission = SkillSharePermission.VIEWER
@@ -479,6 +502,44 @@ def replace_custom_skill_associations__no_commit(
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT,
             "Built-in skills cannot be associated through the admin workflow.",
+        )
+    invalid_skill = next(
+        (skill for skill in target_skills if skill.is_valid is False),
+        None,
+    )
+    if invalid_skill is not None:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            f"Invalid skill '{invalid_skill.name}' cannot be associated with an app.",
+        )
+
+    preserved_provider_skills = list(
+        db_session.scalars(
+            select(Skill)
+            .join(
+                ExternalApp__Skill,
+                ExternalApp__Skill.skill_id == Skill.id,
+            )
+            .where(
+                ExternalApp__Skill.external_app_id == app.id,
+                Skill.built_in_skill_id.is_not(None),
+            )
+        )
+    )
+    seen_names: set[str] = set()
+    conflicting_name: str | None = None
+    for skill in [*preserved_provider_skills, *target_skills]:
+        if skill.name in seen_names:
+            conflicting_name = skill.name
+            break
+        seen_names.add(skill.name)
+    if conflicting_name is not None:
+        raise OnyxError(
+            OnyxErrorCode.SKILL_NAME_CONFLICT,
+            (
+                f"App '{app.name}' cannot have more than one associated skill "
+                f"named '{conflicting_name}'."
+            ),
         )
 
     conflicting_app = db_session.execute(

--- a/backend/onyx/db/external_app.py
+++ b/backend/onyx/db/external_app.py
@@ -435,7 +435,7 @@ def associate_custom_skill_with_external_app__no_commit(
             ),
         )
 
-    if db_session.scalar(
+    conflicting_skill_id = db_session.scalar(
         select(Skill.id)
         .join(
             ExternalApp__Skill,
@@ -447,7 +447,8 @@ def associate_custom_skill_with_external_app__no_commit(
             Skill.id != skill.id,
         )
         .limit(1)
-    ):
+    )
+    if conflicting_skill_id is not None:
         raise OnyxError(
             OnyxErrorCode.SKILL_NAME_CONFLICT,
             (f"App '{app.name}' already has an associated skill named '{skill.name}'."),
@@ -488,13 +489,17 @@ def replace_custom_skill_associations__no_commit(
             f"External app with id {external_app_id} not found.",
         )
 
-    target_skills = list(
-        db_session.scalars(
-            select(Skill)
-            .where(Skill.id.in_(target_ids))
-            .order_by(Skill.id)
-            .with_for_update()
+    target_skills = (
+        list(
+            db_session.scalars(
+                select(Skill)
+                .where(Skill.id.in_(target_ids))
+                .order_by(Skill.id)
+                .with_for_update()
+            )
         )
+        if target_ids
+        else []
     )
     if len(target_skills) != len(target_ids):
         raise OnyxError(OnyxErrorCode.NOT_FOUND, "One or more skills were not found.")
@@ -513,22 +518,12 @@ def replace_custom_skill_associations__no_commit(
             f"Invalid skill '{invalid_skill.name}' cannot be associated with an app.",
         )
 
-    preserved_provider_skills = list(
-        db_session.scalars(
-            select(Skill)
-            .join(
-                ExternalApp__Skill,
-                ExternalApp__Skill.skill_id == Skill.id,
-            )
-            .where(
-                ExternalApp__Skill.external_app_id == app.id,
-                Skill.built_in_skill_id.is_not(None),
-            )
-        )
-    )
+    associated_skills = get_skills_for_external_app(db_session, app.id)
+    provider_skills = [skill for skill in associated_skills if not skill.is_custom]
+    current_custom_skills = [skill for skill in associated_skills if skill.is_custom]
     seen_names: set[str] = set()
     conflicting_name: str | None = None
-    for skill in [*preserved_provider_skills, *target_skills]:
+    for skill in [*provider_skills, *target_skills]:
         if skill.name in seen_names:
             conflicting_name = skill.name
             break
@@ -560,20 +555,7 @@ def replace_custom_skill_associations__no_commit(
             f"Skill '{skill_name}' is already associated with app '{app_name}'.",
         )
 
-    current_skills = list(
-        db_session.scalars(
-            select(Skill)
-            .join(
-                ExternalApp__Skill,
-                ExternalApp__Skill.skill_id == Skill.id,
-            )
-            .where(
-                ExternalApp__Skill.external_app_id == app.id,
-                Skill.built_in_skill_id.is_(None),
-            )
-        )
-    )
-    current_ids = {skill.id for skill in current_skills}
+    current_ids = {skill.id for skill in current_custom_skills}
 
     removed_ids = current_ids - target_ids
     if removed_ids:
@@ -592,7 +574,7 @@ def replace_custom_skill_associations__no_commit(
             )
 
     db_session.flush()
-    return current_skills + [
+    return current_custom_skills + [
         skill for skill in target_skills if skill.id not in current_ids
     ]
 

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -258,6 +258,10 @@ def update_external_app_admin(
     affected: set[UUID] = set()
     for skill in affected_skills_by_id.values():
         affected.update(affected_user_ids_for_skill(skill, db_session))
+
+    # The database is the source of truth; sandbox files are a derived,
+    # best-effort projection of the committed app and association state.
+    db_session.commit()
     push_skills_for_users(affected, db_session)
     db_session.commit()
     if request.associated_skill_ids is not None:

--- a/backend/onyx/server/features/build/external_apps/api.py
+++ b/backend/onyx/server/features/build/external_apps/api.py
@@ -22,6 +22,7 @@ from onyx.db.external_app import (
     get_external_apps,
     get_skills_for_external_app,
     get_user_credentials_by_app_id,
+    replace_custom_skill_associations__no_commit,
     required_user_credential_keys,
     update_external_app,
     upsert_external_app_user_credential,
@@ -98,9 +99,13 @@ def _to_admin_response(
         enabled=app.enabled,
         actions=action_policy_views(app.app_type, stored),
         associated_skills=[
-            ExternalAppAssociatedSkill(id=skill.id, name=skill.name)
+            ExternalAppAssociatedSkill(
+                id=skill.id,
+                name=skill.name,
+                is_valid=skill.is_valid,
+            )
             for skill in sorted(
-                app.associated_skills,
+                (skill for skill in app.associated_skills if skill.is_custom),
                 key=lambda skill: (skill.name, str(skill.id)),
             )
         ],
@@ -220,6 +225,9 @@ def update_external_app_admin(
         request.action_policies,
         get_action_policies(db_session, GatedAppKind.EXTERNAL_APP, external_app_id),
     )
+    affected_skills_by_id = {
+        skill.id: skill for skill in get_skills_for_external_app(db_session, app.id)
+    }
     app = update_external_app(
         db_session=db_session,
         external_app_id=external_app_id,
@@ -236,11 +244,24 @@ def update_external_app_admin(
         ),
         action_policies=action_policies,
     )
+    if request.associated_skill_ids is not None:
+        affected_skills_by_id.update(
+            {
+                skill.id: skill
+                for skill in replace_custom_skill_associations__no_commit(
+                    db_session,
+                    external_app_id=external_app_id,
+                    skill_ids=request.associated_skill_ids,
+                )
+            }
+        )
     affected: set[UUID] = set()
-    for skill in app.associated_skills:
+    for skill in affected_skills_by_id.values():
         affected.update(affected_user_ids_for_skill(skill, db_session))
     push_skills_for_users(affected, db_session)
     db_session.commit()
+    if request.associated_skill_ids is not None:
+        db_session.expire(app, ["associated_skills"])
     # ``action_policies`` is exactly what was persisted — no need to re-read.
     return _to_admin_response(app, stored=action_policies)
 

--- a/backend/onyx/server/features/build/external_apps/models.py
+++ b/backend/onyx/server/features/build/external_apps/models.py
@@ -57,6 +57,9 @@ class UpdateExternalAppRequest(BaseModel):
     upstream_url_patterns: list[str] | None = None
     auth_template: dict[str, Any] | None = None
     organization_credentials: dict[str, str] | None = None
+    # When present, atomically replaces only the app's custom-skill
+    # associations. System-managed built-in associations are preserved.
+    associated_skill_ids: list[UUID] | None = None
     # Full-replace stored overrides when present (empty clears); None leaves them.
     action_policies: dict[str, EndpointPolicy] | None = None
 
@@ -64,6 +67,7 @@ class UpdateExternalAppRequest(BaseModel):
 class ExternalAppAssociatedSkill(BaseModel):
     id: UUID
     name: str
+    is_valid: bool | None
 
 
 class ExternalAppAdminResponse(BaseModel):

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -304,6 +304,7 @@ def create_custom_skill_from_editor(
         instructions_markdown=create_request.instructions_markdown,
     )
     file_store = get_default_file_store()
+    should_auto_enable = auto_enable and external_app_id is None
     with ingested_skill_bundle(
         bundle_bytes,
         f"{canonical_name}.zip",
@@ -318,9 +319,6 @@ def create_custom_skill_from_editor(
                 bundle_sha256=ingested.bundle_sha256,
                 is_valid=True,
                 author_user_id=user.id,
-                public_permission=(
-                    SkillSharePermission.VIEWER if external_app_id is not None else None
-                ),
             ),
             db_session,
         )
@@ -330,9 +328,6 @@ def create_custom_skill_from_editor(
                 external_app_id=external_app_id,
                 skill_id=skill.id,
             )
-        # App-originated skills become org content first; each user selects them
-        # after the app is available to that user.
-        should_auto_enable = auto_enable and external_app_id is None
         if should_auto_enable and not enable_new_skill_if_name_available__no_commit(
             skill, user.id, db_session
         ):

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -7,10 +7,14 @@ from fastapi import APIRouter, Depends, File, Form, UploadFile
 from pydantic import ValidationError
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import require_permission
+from onyx.auth.permissions import get_effective_permissions, require_permission
 from onyx.auth.schemas import UserRole
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import AccountType, Permission, SkillSharePermission
+from onyx.db.external_app import (
+    associate_custom_skill_with_external_app__no_commit,
+    get_external_app_by_id,
+)
 from onyx.db.models import Skill, User
 from onyx.db.skill import (
     SkillManagementPolicy,
@@ -250,9 +254,23 @@ def create_custom_skill_from_editor(
     instructions_markdown: Annotated[str, Form(min_length=1)],
     upload: Annotated[UploadFile | None, File()] = None,
     auto_enable: Annotated[bool, Form()] = True,
+    external_app_id: Annotated[int | None, Form(gt=0)] = None,
     user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> SkillEditableDetailResponse:
+    if external_app_id is not None:
+        if (
+            user.role != UserRole.ADMIN
+            and Permission.FULL_ADMIN_PANEL_ACCESS
+            not in get_effective_permissions(user)
+        ):
+            raise OnyxError(
+                OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                "Only administrators can create a skill for an external app.",
+            )
+        if get_external_app_by_id(db_session, external_app_id) is None:
+            raise OnyxError(OnyxErrorCode.NOT_FOUND, "External app not found.")
+
     try:
         create_request = SkillCreateRequest(
             name=name,
@@ -300,10 +318,22 @@ def create_custom_skill_from_editor(
                 bundle_sha256=ingested.bundle_sha256,
                 is_valid=True,
                 author_user_id=user.id,
+                public_permission=(
+                    SkillSharePermission.VIEWER if external_app_id is not None else None
+                ),
             ),
             db_session,
         )
-        if auto_enable and not enable_new_skill_if_name_available__no_commit(
+        if external_app_id is not None:
+            associate_custom_skill_with_external_app__no_commit(
+                db_session,
+                external_app_id=external_app_id,
+                skill_id=skill.id,
+            )
+        # App-originated skills become org content first; each user selects them
+        # after the app is available to that user.
+        should_auto_enable = auto_enable and external_app_id is None
+        if should_auto_enable and not enable_new_skill_if_name_available__no_commit(
             skill, user.id, db_session
         ):
             raise OnyxError(
@@ -312,7 +342,7 @@ def create_custom_skill_from_editor(
             )
         db_session.commit()
 
-    if auto_enable:
+    if should_auto_enable:
         push_skill_to_affected_sandboxes(skill, db_session)
         db_session.commit()
 

--- a/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_admin_update.py
@@ -1,6 +1,7 @@
 """The unified ``PATCH /admin/apps/{id}`` update path, single-tenant (non-managed,
-so config fields are editable): full update, partial update, and push-failure
-rollback. The managed (cloud) variant lives in ``test_managed_external_apps.py``.
+so config fields are editable): full update, partial update, and sandbox
+reconciliation ordering. The managed (cloud) variant lives in
+``test_managed_external_apps.py``.
 """
 
 from __future__ import annotations
@@ -99,30 +100,32 @@ def test_patch_updates_config_on_non_managed_built_in(
     }
 
 
-def test_patch_rolls_back_when_push_fails(
+def test_patch_commits_before_sandbox_reconciliation(
     db_session: Session,
     test_user: User,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Push failure leaves the app update uncommitted."""
     app = _slack_app(db_session)
     app_id = app.id
-    original_name = app.name
+    observed_names: list[str] = []
 
-    def _boom(*_args: object, **_kwargs: object) -> None:
-        raise RuntimeError("push failed")
+    def _observe_committed_state(*_args: object, **_kwargs: object) -> None:
+        with Session(db_session.get_bind()) as observer:
+            stored = get_external_app_by_id(observer, app_id)
+            assert stored is not None
+            observed_names.append(stored.name)
 
-    monkeypatch.setattr(api, "push_skills_for_users", _boom)
+    monkeypatch.setattr(
+        api,
+        "push_skills_for_users",
+        _observe_committed_state,
+    )
 
-    with pytest.raises(RuntimeError):
-        api.update_external_app_admin(
-            external_app_id=app_id,
-            request=UpdateExternalAppRequest(name="changed"),
-            _=test_user,
-            db_session=db_session,
-        )
+    api.update_external_app_admin(
+        external_app_id=app_id,
+        request=UpdateExternalAppRequest(name="changed"),
+        _=test_user,
+        db_session=db_session,
+    )
 
-    db_session.rollback()
-    stored = get_external_app_by_id(db_session, app_id)
-    assert stored is not None
-    assert stored.name == original_name
+    assert observed_names == ["changed"]

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
@@ -14,7 +14,7 @@ from onyx.db.external_app import (
     get_skills_for_external_app,
     replace_custom_skill_associations__no_commit,
 )
-from onyx.db.models import ExternalApp, Skill, User, UserRole, UserSkillPreference
+from onyx.db.models import Skill, User, UserRole, UserSkillPreference
 from onyx.db.skill import set_skill_public_permission
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -60,10 +60,6 @@ def test_associate_promotes_visibility_and_preserves_preferences(
     )
     db_session.flush()
     app_id = _make_app(db_session)
-    app = db_session.get(ExternalApp, app_id)
-    assert app is not None
-    app.enabled = False
-    db_session.flush()
 
     associated = associate_custom_skill_with_external_app__no_commit(
         db_session,

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
@@ -121,6 +121,107 @@ def test_associate_rejects_built_in_and_already_associated_skills(
     assert dependency.id == first_app_id
 
 
+def test_associate_rejects_a_second_skill_with_the_same_name(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    app_id = _make_app(db_session)
+    associated = make_skill(db_session, name="shared-app-skill", is_public=True)
+    conflicting = make_skill(db_session, name=associated.name, is_public=False)
+    associate_custom_skill_with_external_app__no_commit(
+        db_session,
+        external_app_id=app_id,
+        skill_id=associated.id,
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        associate_custom_skill_with_external_app__no_commit(
+            db_session,
+            external_app_id=app_id,
+            skill_id=conflicting.id,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.SKILL_NAME_CONFLICT
+    assert get_external_app_by_skill_id(db_session, conflicting.id) is None
+    assert conflicting.public_permission is None
+    assert get_skills_for_external_app(db_session, app_id) == [associated]
+
+
+def test_associate_rejects_an_invalid_skill_without_promoting_it(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    app_id = _make_app(db_session)
+    invalid = make_skill(db_session, name="invalid-app-skill", is_public=False)
+    invalid.is_valid = False
+    db_session.flush()
+
+    with pytest.raises(OnyxError) as exc_info:
+        associate_custom_skill_with_external_app__no_commit(
+            db_session,
+            external_app_id=app_id,
+            skill_id=invalid.id,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert get_external_app_by_skill_id(db_session, invalid.id) is None
+    assert invalid.public_permission is None
+
+
+def test_replace_rejects_same_named_skills_without_mutating_associations(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    app_id = _make_app(db_session)
+    original = make_skill(db_session, name="original-skill", is_public=True)
+    first = make_skill(db_session, name="duplicate-name", is_public=False)
+    second = make_skill(db_session, name=first.name, is_public=False)
+    associate_custom_skill_with_external_app__no_commit(
+        db_session,
+        external_app_id=app_id,
+        skill_id=original.id,
+    )
+
+    with pytest.raises(OnyxError) as exc_info:
+        replace_custom_skill_associations__no_commit(
+            db_session,
+            external_app_id=app_id,
+            skill_ids=[first.id, second.id],
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.SKILL_NAME_CONFLICT
+    assert get_skills_for_external_app(db_session, app_id) == [original]
+    assert first.public_permission is None
+    assert second.public_permission is None
+
+
+def test_replace_rejects_an_invalid_skill_without_mutating_associations(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    app_id = _make_app(db_session)
+    original = make_skill(db_session, name="original-skill", is_public=True)
+    invalid = make_skill(db_session, name="invalid-app-skill", is_public=False)
+    invalid.is_valid = False
+    associate_custom_skill_with_external_app__no_commit(
+        db_session,
+        external_app_id=app_id,
+        skill_id=original.id,
+    )
+    db_session.flush()
+
+    with pytest.raises(OnyxError) as exc_info:
+        replace_custom_skill_associations__no_commit(
+            db_session,
+            external_app_id=app_id,
+            skill_ids=[invalid.id],
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
+    assert get_skills_for_external_app(db_session, app_id) == [original]
+    assert invalid.public_permission is None
+
+
 def test_unlink_retains_skill_visibility_content_and_preferences(
     db_session: Session,
     test_user: User,  # noqa: ARG001
@@ -210,7 +311,6 @@ def test_app_update_batches_associations_into_one_sandbox_refresh(
         is_public=False,
         author_user_id=owner.id,
     )
-    skill.is_valid = False
     second_skill = make_skill(
         db_session,
         is_public=False,
@@ -238,12 +338,6 @@ def test_app_update_batches_associations_into_one_sandbox_refresh(
         second_skill.id,
     }
     assert linked.name == "Renamed CRM"
-    assert (
-        next(
-            summary for summary in linked.associated_skills if summary.id == skill.id
-        ).is_valid
-        is False
-    )
     assert {owner.id, other_user.id} <= pushed_user_sets[0]
     assert len(pushed_user_sets) == 1
 

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from onyx.db.enums import ExternalAppType, SkillSharePermission
+from onyx.db.external_app import (
+    associate_custom_skill_with_external_app__no_commit,
+    create_external_app,
+    get_external_app_by_skill_id,
+    get_skills_for_external_app,
+    replace_custom_skill_associations__no_commit,
+)
+from onyx.db.models import ExternalApp, Skill, User, UserRole, UserSkillPreference
+from onyx.db.skill import set_skill_public_permission
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.file_store.file_store import get_default_file_store
+from onyx.server.features.build.external_apps.api import (
+    update_external_app_admin,
+)
+from onyx.server.features.build.external_apps.models import UpdateExternalAppRequest
+from onyx.server.features.skill.api import create_custom_skill_from_editor
+from onyx.skills.ingest import delete_bundle_blob
+from tests.external_dependency_unit.craft.db_helpers import (
+    make_built_in_skill_row,
+    make_external_app,
+    make_sandbox,
+    make_skill,
+    make_user,
+)
+
+
+def _make_app(db_session: Session, name: str = "Acme CRM") -> int:
+    return create_external_app(
+        db_session=db_session,
+        name=name,
+        app_type=ExternalAppType.CUSTOM,
+        upstream_url_patterns=[],
+        auth_template={},
+        organization_credentials={},
+    ).id
+
+
+def test_associate_promotes_visibility_and_preserves_preferences(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    skill = make_skill(
+        db_session,
+        is_public=False,
+        author_user_id=owner.id,
+    )
+    db_session.add(
+        UserSkillPreference(user_id=owner.id, skill_id=skill.id, name=skill.name)
+    )
+    db_session.flush()
+    app_id = _make_app(db_session)
+    app = db_session.get(ExternalApp, app_id)
+    assert app is not None
+    app.enabled = False
+    db_session.flush()
+
+    associated = associate_custom_skill_with_external_app__no_commit(
+        db_session,
+        external_app_id=app_id,
+        skill_id=skill.id,
+    )
+
+    assert associated.public_permission == SkillSharePermission.VIEWER
+    dependency = get_external_app_by_skill_id(db_session, skill.id)
+    assert dependency is not None
+    assert dependency.id == app_id
+    assert (
+        db_session.get(
+            UserSkillPreference,
+            {"user_id": owner.id, "skill_id": skill.id},
+        )
+        is not None
+    )
+
+
+def test_associate_rejects_built_in_and_already_associated_skills(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    first_app_id = _make_app(db_session, "First app")
+    second_app_id = _make_app(db_session, "Second app")
+    built_in = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id=f"association-test-{uuid4().hex[:8]}",
+    )
+    custom = make_skill(db_session, is_public=True)
+    associate_custom_skill_with_external_app__no_commit(
+        db_session,
+        external_app_id=first_app_id,
+        skill_id=custom.id,
+    )
+
+    with pytest.raises(OnyxError) as built_in_error:
+        associate_custom_skill_with_external_app__no_commit(
+            db_session,
+            external_app_id=first_app_id,
+            skill_id=built_in.id,
+        )
+    assert built_in_error.value.error_code == OnyxErrorCode.INVALID_INPUT
+
+    with pytest.raises(OnyxError) as duplicate_error:
+        associate_custom_skill_with_external_app__no_commit(
+            db_session,
+            external_app_id=second_app_id,
+            skill_id=custom.id,
+        )
+    assert duplicate_error.value.error_code == OnyxErrorCode.DUPLICATE_RESOURCE
+    dependency = get_external_app_by_skill_id(db_session, custom.id)
+    assert dependency is not None
+    assert dependency.id == first_app_id
+
+
+def test_unlink_retains_skill_visibility_content_and_preferences(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    skill = make_skill(db_session, is_public=True, author_user_id=owner.id)
+    original_bundle_file_id = skill.bundle_file_id
+    db_session.add(
+        UserSkillPreference(user_id=owner.id, skill_id=skill.id, name=skill.name)
+    )
+    app_id = _make_app(db_session)
+    associate_custom_skill_with_external_app__no_commit(
+        db_session,
+        external_app_id=app_id,
+        skill_id=skill.id,
+    )
+
+    affected = replace_custom_skill_associations__no_commit(
+        db_session,
+        external_app_id=app_id,
+        skill_ids=[],
+    )
+    unlinked = affected[0]
+
+    assert unlinked.public_permission == SkillSharePermission.VIEWER
+    assert unlinked.bundle_file_id == original_bundle_file_id
+    assert get_external_app_by_skill_id(db_session, skill.id) is None
+    assert (
+        db_session.get(
+            UserSkillPreference,
+            {"user_id": owner.id, "skill_id": skill.id},
+        )
+        is not None
+    )
+    set_skill_public_permission(
+        skill=unlinked,
+        public_permission=None,
+        db_session=db_session,
+    )
+    assert unlinked.public_permission is None
+
+
+def test_replacing_custom_associations_preserves_provider_skill(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    provider_skill = make_built_in_skill_row(
+        db_session,
+        built_in_skill_id=f"provider-association-{uuid4().hex[:8]}",
+    )
+    app = make_external_app(
+        db_session,
+        skill=provider_skill,
+        auth_template={},
+    )
+    custom_skill = make_skill(db_session, is_public=False)
+
+    replace_custom_skill_associations__no_commit(
+        db_session,
+        external_app_id=app.id,
+        skill_ids=[custom_skill.id],
+    )
+    assert {skill.id for skill in get_skills_for_external_app(db_session, app.id)} == {
+        provider_skill.id,
+        custom_skill.id,
+    }
+
+    replace_custom_skill_associations__no_commit(
+        db_session,
+        external_app_id=app.id,
+        skill_ids=[],
+    )
+    assert get_skills_for_external_app(db_session, app.id) == [provider_skill]
+
+
+def test_app_update_batches_associations_into_one_sandbox_refresh(
+    db_session: Session,
+    test_user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    owner = make_user(db_session, role=UserRole.BASIC)
+    other_user = make_user(db_session, role=UserRole.BASIC)
+    make_sandbox(db_session, owner)
+    make_sandbox(db_session, other_user)
+    skill = make_skill(
+        db_session,
+        is_public=False,
+        author_user_id=owner.id,
+    )
+    skill.is_valid = False
+    second_skill = make_skill(
+        db_session,
+        is_public=False,
+        author_user_id=owner.id,
+    )
+    app_id = _make_app(db_session)
+    pushed_user_sets: list[set[UUID]] = []
+    monkeypatch.setattr(
+        "onyx.server.features.build.external_apps.api.push_skills_for_users",
+        lambda user_ids, _db: pushed_user_sets.append(user_ids),
+    )
+
+    linked = update_external_app_admin(
+        external_app_id=app_id,
+        request=UpdateExternalAppRequest(
+            name="Renamed CRM",
+            associated_skill_ids=[skill.id, second_skill.id],
+        ),
+        _=test_user,
+        db_session=db_session,
+    )
+
+    assert {summary.id for summary in linked.associated_skills} == {
+        skill.id,
+        second_skill.id,
+    }
+    assert linked.name == "Renamed CRM"
+    assert (
+        next(
+            summary for summary in linked.associated_skills if summary.id == skill.id
+        ).is_valid
+        is False
+    )
+    assert {owner.id, other_user.id} <= pushed_user_sets[0]
+    assert len(pushed_user_sets) == 1
+
+    unlinked = update_external_app_admin(
+        external_app_id=app_id,
+        request=UpdateExternalAppRequest(associated_skill_ids=[]),
+        _=test_user,
+        db_session=db_session,
+    )
+
+    assert unlinked.associated_skills == []
+    assert len(pushed_user_sets) == 2
+
+
+def test_editor_creation_with_app_context_is_atomic_and_not_auto_enabled(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    admin = make_user(db_session, role=UserRole.ADMIN)
+    app_id = _make_app(db_session)
+    response = create_custom_skill_from_editor(
+        name=f"associated-{uuid4().hex[:8]}",
+        description="Looks up CRM records.",
+        instructions_markdown="Use the CRM app to look up the requested record.",
+        auto_enable=True,
+        external_app_id=app_id,
+        user=admin,
+        db_session=db_session,
+    )
+    skill = db_session.scalar(select(Skill).where(Skill.id == response.id))
+    assert skill is not None
+    bundle_file_id = skill.bundle_file_id
+
+    try:
+        assert response.public_permission == SkillSharePermission.VIEWER
+        assert response.external_app is not None
+        assert response.external_app.external_app_id == app_id
+        assert response.enabled is False
+        assert (
+            db_session.scalar(
+                select(UserSkillPreference).where(
+                    UserSkillPreference.user_id == admin.id,
+                    UserSkillPreference.skill_id == skill.id,
+                )
+            )
+            is None
+        )
+    finally:
+        db_session.delete(skill)
+        db_session.commit()
+        if bundle_file_id is not None:
+            delete_bundle_blob(get_default_file_store(), bundle_file_id)
+
+
+def test_editor_app_context_requires_an_admin_before_writing_skill_content(
+    db_session: Session,
+    test_user: User,  # noqa: ARG001
+) -> None:
+    user = make_user(db_session, role=UserRole.BASIC)
+    app_id = _make_app(db_session)
+    skill_ids_before = set(db_session.scalars(select(Skill.id)))
+
+    with pytest.raises(OnyxError) as exc_info:
+        create_custom_skill_from_editor(
+            name=f"unauthorized-{uuid4().hex[:8]}",
+            description="Should not be created.",
+            instructions_markdown="Do not persist this bundle.",
+            external_app_id=app_id,
+            user=user,
+            db_session=db_session,
+        )
+
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    assert set(db_session.scalars(select(Skill.id))) == skill_ids_before

--- a/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
+++ b/backend/tests/external_dependency_unit/craft/test_external_app_skill_associations.py
@@ -261,6 +261,7 @@ def test_app_update_batches_associations_into_one_sandbox_refresh(
 def test_editor_creation_with_app_context_is_atomic_and_not_auto_enabled(
     db_session: Session,
     test_user: User,  # noqa: ARG001
+    initialize_file_store: None,  # noqa: ARG001
 ) -> None:
     admin = make_user(db_session, role=UserRole.ADMIN)
     app_id = _make_app(db_session)

--- a/web/src/app/craft/v1/apps/registry.ts
+++ b/web/src/app/craft/v1/apps/registry.ts
@@ -92,7 +92,11 @@ export interface ExternalAppAdminResponse {
   organization_credentials: Record<string, string>;
   enabled: boolean;
   actions: ActionPolicyView[];
-  associated_skills: { id: string; name: string }[];
+  associated_skills: {
+    id: string;
+    name: string;
+    is_valid: boolean | null;
+  }[];
   // Onyx-managed built-in (cloud): creds/config Onyx-owned and blanked here; the
   // admin may only set availability and policies (the UI hides the rest).
   is_onyx_managed: boolean;


### PR DESCRIPTION
## Description

https://github.com/user-attachments/assets/3d46804e-ef5e-4214-9526-1ba5676d2f2a


Decouple custom-skill association management from individual external-app mutations.

- Add an optional replacement set of custom skill IDs to the external-app update contract so app configuration and all association changes save atomically.
- Preserve system-managed provider skills while promoting newly associated custom skills to organization-wide viewer access.
- Support privileged editor-based skill creation with fixed external-app context.
- Reconcile affected sandboxes once per app save and clarify dependency-oriented database lookups.
- Return associated-skill validity for the upcoming app-owned association UI.

## How Has This Been Tested?

- Tested end to end through `http://localhost:3000` with admin and basic-user sessions.
- Provisioned real Kubernetes sandboxes for both users and verified associated skill bundles were hydrated.
- Verified disabling the app removed associated bundles while preserving preferences.
- Verified batched unlinking restored the selected skills as standalone bundles.
- Verified duplicate association returned `409 DUPLICATE_RESOURCE` and atomically rolled back the accompanying app rename.
- Verified app deletion retained custom skills, cleared preferences, and removed sandbox files.
- Ran Ruff, `ty`, frontend formatting/lint/type checks, and focused backend unit tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add atomic management of custom-skill associations for external apps with stronger validation, and expose skill validity in the admin API. Commit app and association changes before sandbox refresh so the database is the source of truth.

- **New Features**
  - Add `associated_skill_ids` to `UpdateExternalAppRequest` to atomically replace an app’s custom-skill associations; preserve built-in provider skills.
  - Validate requests: reject built-ins, invalid skills, duplicate IDs, cross-app conflicts (`DUPLICATE_RESOURCE`), and same-name conflicts per app (`SKILL_NAME_CONFLICT`).
  - Return only custom associated skills in `ExternalAppAdminResponse` and include `is_valid` for each.
  - Add `associate_custom_skill_with_external_app__no_commit` for single-skill association.
  - Editor flow (admin-only): support `external_app_id`. New skills become `VIEWER`, are associated to the app, and are not auto-enabled.
  - Batch all affected sandbox refreshes into one push per app update.

- **Bug Fixes**
  - Commit app and association updates before sandbox reconciliation so responses reflect committed state and we don’t roll back on push errors.

<sup>Written for commit 9639a2fe1ad08ff38da7db214349dbaf7c522f82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

