### PR TITLE
fix: add retriever to impersonation list when retrieving permissions

### DIFF
--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -155,9 +155,11 @@ def get_external_access_for_raw_gdrive_file(
             try:
                 drive_service = drive_service_factory()
                 return _get_permissions(drive_service) if drive_service else []
-            except RefreshError:
+            except RefreshError as error:
                 logger.warning(
-                    "Could not impersonate non-admin user for document %s", doc_id
+                    "Could not impersonate non-admin user for document %s: %s",
+                    doc_id,
+                    error,
                 )
                 return []
 

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -1,6 +1,8 @@
 from collections.abc import Callable, Generator
 from datetime import datetime, timezone
 
+from google.auth.exceptions import RefreshError
+
 from ee.onyx.external_permissions.google_drive.models import (
     GoogleDrivePermission,
     PermissionType,
@@ -147,21 +149,33 @@ def get_external_access_for_raw_gdrive_file(
                 permission_ids=permission_ids,
             )
 
+        def _get_non_admin_permissions(
+            drive_service_factory: Callable[[], GoogleDriveService | None],
+        ) -> list[GoogleDrivePermission]:
+            try:
+                drive_service = drive_service_factory()
+                return _get_permissions(drive_service) if drive_service else []
+            except RefreshError:
+                logger.warning(
+                    "Could not impersonate non-admin user for document %s", doc_id
+                )
+                return []
+
         if retriever_drive_service:
-            permissions_list = _get_permissions(retriever_drive_service)
+            permissions_list = _get_non_admin_permissions(
+                lambda: retriever_drive_service
+            )
 
         if (
             len(permissions_list) != len(permission_ids)
             and fallback_drive_service_factory
         ):
-            fallback_drive_service = fallback_drive_service_factory()
-            if fallback_drive_service:
-                permissions_list = _merge_permissions_lists(
-                    [
-                        permissions_list,
-                        _get_permissions(fallback_drive_service),
-                    ]
-                )
+            permissions_list = _merge_permissions_lists(
+                [
+                    permissions_list,
+                    _get_non_admin_permissions(fallback_drive_service_factory),
+                ]
+            )
 
         if len(permissions_list) != len(permission_ids):
             permissions_list = _merge_permissions_lists(

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -104,7 +104,9 @@ def get_external_access_for_raw_gdrive_file(
     admin_drive_service: GoogleDriveService,
     fallback_user_email: str,
     add_prefix: bool = False,
-    fallback_drive_service_factory: Callable[[], GoogleDriveService] | None = None,
+    fallback_drive_service_factory: (
+        Callable[[], GoogleDriveService | None] | None
+    ) = None,
 ) -> ExternalAccess:
     """
     Get the external access for a raw Google Drive file.
@@ -152,12 +154,14 @@ def get_external_access_for_raw_gdrive_file(
             len(permissions_list) != len(permission_ids)
             and fallback_drive_service_factory
         ):
-            permissions_list = _merge_permissions_lists(
-                [
-                    permissions_list,
-                    _get_permissions(fallback_drive_service_factory()),
-                ]
-            )
+            fallback_drive_service = fallback_drive_service_factory()
+            if fallback_drive_service:
+                permissions_list = _merge_permissions_lists(
+                    [
+                        permissions_list,
+                        _get_permissions(fallback_drive_service),
+                    ]
+                )
 
         if len(permissions_list) != len(permission_ids):
             permissions_list = _merge_permissions_lists(

--- a/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
+++ b/backend/ee/onyx/external_permissions/google_drive/doc_sync.py
@@ -1,4 +1,4 @@
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from datetime import datetime, timezone
 
 from ee.onyx.external_permissions.google_drive.models import (
@@ -104,6 +104,7 @@ def get_external_access_for_raw_gdrive_file(
     admin_drive_service: GoogleDriveService,
     fallback_user_email: str,
     add_prefix: bool = False,
+    fallback_drive_service_factory: Callable[[], GoogleDriveService] | None = None,
 ) -> ExternalAccess:
     """
     Get the external access for a raw Google Drive file.
@@ -144,17 +145,23 @@ def get_external_access_for_raw_gdrive_file(
                 permission_ids=permission_ids,
             )
 
-        permissions_list = _get_permissions(
-            retriever_drive_service or admin_drive_service
-        )
-        if len(permissions_list) != len(permission_ids) and retriever_drive_service:
-            logger.warning(
-                "Failed to get all permissions for file %s with retriever service, trying admin service",
-                doc_id,
-            )
-            backup_permissions_list = _get_permissions(admin_drive_service)
+        if retriever_drive_service:
+            permissions_list = _get_permissions(retriever_drive_service)
+
+        if (
+            len(permissions_list) != len(permission_ids)
+            and fallback_drive_service_factory
+        ):
             permissions_list = _merge_permissions_lists(
-                [permissions_list, backup_permissions_list]
+                [
+                    permissions_list,
+                    _get_permissions(fallback_drive_service_factory()),
+                ]
+            )
+
+        if len(permissions_list) != len(permission_ids):
+            permissions_list = _merge_permissions_lists(
+                [permissions_list, _get_permissions(admin_drive_service)]
             )
 
     # For externally-owned files, the Drive API may return no permissions

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -592,6 +592,7 @@ def _get_external_access_for_raw_gdrive_file(
     admin_drive_service: GoogleDriveService,
     fallback_user_email: str,
     add_prefix: bool = False,
+    fallback_drive_service_factory: Callable[[], GoogleDriveService] | None = None,
 ) -> ExternalAccess:
     """
     Get the external access for a raw Google Drive file.
@@ -611,6 +612,7 @@ def _get_external_access_for_raw_gdrive_file(
                 GoogleDriveService,
                 str,
                 bool,
+                Callable[[], GoogleDriveService] | None,
             ],
             ExternalAccess,
         ],
@@ -627,6 +629,7 @@ def _get_external_access_for_raw_gdrive_file(
         admin_drive_service,
         fallback_user_email,
         add_prefix,
+        fallback_drive_service_factory,
     )
 
 
@@ -972,6 +975,10 @@ def build_slim_document(
                 user_email=permission_sync_context.primary_admin_email,
             ),
             fallback_user_email=retriever_email,
+            fallback_drive_service_factory=lambda: get_drive_service(
+                creds,
+                user_email=retriever_email,
+            ),
         )
         if permission_sync_context
         else None

--- a/backend/onyx/connectors/google_drive/doc_conversion.py
+++ b/backend/onyx/connectors/google_drive/doc_conversion.py
@@ -592,7 +592,9 @@ def _get_external_access_for_raw_gdrive_file(
     admin_drive_service: GoogleDriveService,
     fallback_user_email: str,
     add_prefix: bool = False,
-    fallback_drive_service_factory: Callable[[], GoogleDriveService] | None = None,
+    fallback_drive_service_factory: (
+        Callable[[], GoogleDriveService | None] | None
+    ) = None,
 ) -> ExternalAccess:
     """
     Get the external access for a raw Google Drive file.
@@ -612,7 +614,7 @@ def _get_external_access_for_raw_gdrive_file(
                 GoogleDriveService,
                 str,
                 bool,
-                Callable[[], GoogleDriveService] | None,
+                Callable[[], GoogleDriveService | None] | None,
             ],
             ExternalAccess,
         ],
@@ -975,9 +977,13 @@ def build_slim_document(
                 user_email=permission_sync_context.primary_admin_email,
             ),
             fallback_user_email=retriever_email,
-            fallback_drive_service_factory=lambda: get_drive_service(
-                creds,
-                user_email=retriever_email,
+            fallback_drive_service_factory=lambda: (
+                None
+                if retriever_email == owner_email
+                else get_drive_service(
+                    creds,
+                    user_email=retriever_email,
+                )
             ),
         )
         if permission_sync_context

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
@@ -5,7 +5,7 @@ Workspace membership, not from the user's email string."""
 
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, call, patch
 
 from sqlalchemy.orm import Session
 
@@ -25,6 +25,7 @@ from onyx.db.models import User
 
 COMPANY_DOMAIN = "companya.com"
 OTHER_DOMAIN = "companyb.com"
+RETRIEVER_EMAIL = f"retriever@{COMPANY_DOMAIN}"
 
 # Never used: the file path takes inline permissions and the folder path's
 # permission fetch is patched.
@@ -98,6 +99,49 @@ def test_user_and_group_shares_unchanged() -> None:
     assert access.is_public is False
     assert access.external_user_emails == {"bob@companyb.com"}
     assert "eng@companya.com" in access.external_user_group_ids
+
+
+def test_retries_incomplete_owner_permissions_as_retriever() -> None:
+    owner_service = cast(GoogleDriveService, SimpleNamespace())
+    retriever_service = cast(GoogleDriveService, SimpleNamespace())
+    admin_service = cast(GoogleDriveService, SimpleNamespace())
+    retriever_service_factory = MagicMock(return_value=retriever_service)
+    user_permission = GoogleDrivePermission(
+        id="p1",
+        email_address=RETRIEVER_EMAIL,
+        type=PermissionType.USER,
+        domain=None,
+        permission_details=None,
+        allow_file_discovery=None,
+    )
+
+    with patch(
+        "ee.onyx.external_permissions.google_drive.doc_sync.get_permissions_by_ids",
+        side_effect=[[], [user_permission]],
+    ) as mock_get_permissions:
+        access = get_external_access_for_raw_gdrive_file(
+            file={"id": "doc-1", "permissionIds": ["p1"]},
+            company_domain=COMPANY_DOMAIN,
+            retriever_drive_service=owner_service,
+            admin_drive_service=admin_service,
+            fallback_user_email=RETRIEVER_EMAIL,
+            fallback_drive_service_factory=retriever_service_factory,
+        )
+
+    assert access.external_user_emails == {RETRIEVER_EMAIL}
+    assert mock_get_permissions.call_args_list == [
+        call(
+            drive_service=owner_service,
+            doc_id="doc-1",
+            permission_ids=["p1"],
+        ),
+        call(
+            drive_service=retriever_service,
+            doc_id="doc-1",
+            permission_ids=["p1"],
+        ),
+    ]
+    retriever_service_factory.assert_called_once_with()
 
 
 def test_indexing_path_prefixes_domain_group() -> None:

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock, call, patch
 
+from google.auth.exceptions import RefreshError
 from sqlalchemy.orm import Session
 
 from ee.onyx.external_permissions.google_drive.doc_sync import (
@@ -101,12 +102,8 @@ def test_user_and_group_shares_unchanged() -> None:
     assert "eng@companya.com" in access.external_user_group_ids
 
 
-def test_retries_incomplete_owner_permissions_as_retriever() -> None:
-    owner_service = cast(GoogleDriveService, SimpleNamespace())
-    retriever_service = cast(GoogleDriveService, SimpleNamespace())
-    admin_service = cast(GoogleDriveService, SimpleNamespace())
-    retriever_service_factory = MagicMock(return_value=retriever_service)
-    user_permission = GoogleDrivePermission(
+def _retriever_user_permission() -> GoogleDrivePermission:
+    return GoogleDrivePermission(
         id="p1",
         email_address=RETRIEVER_EMAIL,
         type=PermissionType.USER,
@@ -115,9 +112,16 @@ def test_retries_incomplete_owner_permissions_as_retriever() -> None:
         allow_file_discovery=None,
     )
 
+
+def test_retries_incomplete_owner_permissions_as_retriever() -> None:
+    owner_service = cast(GoogleDriveService, SimpleNamespace())
+    retriever_service = cast(GoogleDriveService, SimpleNamespace())
+    admin_service = cast(GoogleDriveService, SimpleNamespace())
+    retriever_service_factory = MagicMock(return_value=retriever_service)
+
     with patch(
         "ee.onyx.external_permissions.google_drive.doc_sync.get_permissions_by_ids",
-        side_effect=[[], [user_permission]],
+        side_effect=[[], [_retriever_user_permission()]],
     ) as mock_get_permissions:
         access = get_external_access_for_raw_gdrive_file(
             file={"id": "doc-1", "permissionIds": ["p1"]},
@@ -137,6 +141,46 @@ def test_retries_incomplete_owner_permissions_as_retriever() -> None:
         ),
         call(
             drive_service=retriever_service,
+            doc_id="doc-1",
+            permission_ids=["p1"],
+        ),
+    ]
+    retriever_service_factory.assert_called_once_with()
+
+
+def test_retriever_impersonation_failure_falls_back_to_admin() -> None:
+    owner_service = cast(GoogleDriveService, SimpleNamespace())
+    retriever_service = cast(GoogleDriveService, SimpleNamespace())
+    admin_service = cast(GoogleDriveService, SimpleNamespace())
+    retriever_service_factory = MagicMock(return_value=retriever_service)
+
+    with patch(
+        "ee.onyx.external_permissions.google_drive.doc_sync.get_permissions_by_ids",
+        side_effect=[[], RefreshError("unauthorized"), [_retriever_user_permission()]],
+    ) as mock_get_permissions:
+        access = get_external_access_for_raw_gdrive_file(
+            file={"id": "doc-1", "permissionIds": ["p1"]},
+            company_domain=COMPANY_DOMAIN,
+            retriever_drive_service=owner_service,
+            admin_drive_service=admin_service,
+            fallback_user_email=RETRIEVER_EMAIL,
+            fallback_drive_service_factory=retriever_service_factory,
+        )
+
+    assert access.external_user_emails == {RETRIEVER_EMAIL}
+    assert mock_get_permissions.call_args_list == [
+        call(
+            drive_service=owner_service,
+            doc_id="doc-1",
+            permission_ids=["p1"],
+        ),
+        call(
+            drive_service=retriever_service,
+            doc_id="doc-1",
+            permission_ids=["p1"],
+        ),
+        call(
+            drive_service=admin_service,
             doc_id="doc-1",
             permission_ids=["p1"],
         ),

--- a/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
+++ b/backend/tests/unit/ee/onyx/external_permissions/google_drive/test_gdrive_domain_permission_scoping.py
@@ -153,11 +153,17 @@ def test_retriever_impersonation_failure_falls_back_to_admin() -> None:
     retriever_service = cast(GoogleDriveService, SimpleNamespace())
     admin_service = cast(GoogleDriveService, SimpleNamespace())
     retriever_service_factory = MagicMock(return_value=retriever_service)
+    refresh_error = RefreshError("unauthorized")
 
-    with patch(
-        "ee.onyx.external_permissions.google_drive.doc_sync.get_permissions_by_ids",
-        side_effect=[[], RefreshError("unauthorized"), [_retriever_user_permission()]],
-    ) as mock_get_permissions:
+    with (
+        patch(
+            "ee.onyx.external_permissions.google_drive.doc_sync.get_permissions_by_ids",
+            side_effect=[[], refresh_error, [_retriever_user_permission()]],
+        ) as mock_get_permissions,
+        patch(
+            "ee.onyx.external_permissions.google_drive.doc_sync.logger.warning"
+        ) as mock_warning,
+    ):
         access = get_external_access_for_raw_gdrive_file(
             file={"id": "doc-1", "permissionIds": ["p1"]},
             company_domain=COMPANY_DOMAIN,
@@ -186,6 +192,11 @@ def test_retriever_impersonation_failure_falls_back_to_admin() -> None:
         ),
     ]
     retriever_service_factory.assert_called_once_with()
+    mock_warning.assert_called_once_with(
+        "Could not impersonate non-admin user for document %s: %s",
+        "doc-1",
+        refresh_error,
+    )
 
 
 def test_indexing_path_prefixes_domain_group() -> None:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
@@ -105,6 +105,47 @@ class TestBuildSlimDocumentPermissions:
         assert access_kwargs["admin_drive_service"] is admin_service
         assert access_kwargs["fallback_user_email"] == _RETRIEVER_EMAIL
 
+    def test_skips_retriever_fallback_when_retriever_owns_file(self) -> None:
+        creds = MagicMock()
+        owner_service = MagicMock()
+        admin_service = MagicMock()
+        file = {
+            "id": "file-id",
+            "mimeType": "text/plain",
+            "webViewLink": "https://drive.google.com/file/d/file-id/view",
+            "owners": [{"emailAddress": _RETRIEVER_EMAIL}],
+        }
+        permission_sync_context = PermissionSyncContext(
+            primary_admin_email=_ADMIN_EMAIL,
+            google_domain="example.com",
+        )
+
+        with (
+            patch(
+                f"{_DOC_CONVERSION_MODULE}.get_drive_service",
+                side_effect=[owner_service, admin_service],
+            ) as mock_get_drive_service,
+            patch(
+                f"{_DOC_CONVERSION_MODULE}._get_external_access_for_raw_gdrive_file",
+                return_value=ExternalAccess.empty(),
+            ) as mock_get_external_access,
+        ):
+            build_slim_document(
+                creds,
+                file,
+                permission_sync_context,
+                _RETRIEVER_EMAIL,
+            )
+            fallback_drive_service_factory = mock_get_external_access.call_args.kwargs[
+                "fallback_drive_service_factory"
+            ]
+            assert fallback_drive_service_factory() is None
+
+        assert mock_get_drive_service.call_args_list == [
+            call(creds, user_email=_RETRIEVER_EMAIL),
+            call(creds, user_email=_ADMIN_EMAIL),
+        ]
+
 
 class TestGoogleDriveSlimConnectorInterface:
     def test_implements_slim_connector(self) -> None:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_slim_retrieval.py
@@ -7,12 +7,17 @@ Verifies that:
 - celery_utils routing picks retrieve_all_slim_docs() for GoogleDriveConnector
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from google.auth.exceptions import RefreshError
 
+from onyx.access.models import ExternalAccess
 from onyx.background.celery.celery_utils import extract_ids_from_runnable_connector
 from onyx.connectors.google_drive.connector import GoogleDriveConnector
+from onyx.connectors.google_drive.doc_conversion import (
+    PermissionSyncContext,
+    build_slim_document,
+)
 from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
 from onyx.connectors.google_drive.models import (
     DriveRetrievalStage,
@@ -23,6 +28,11 @@ from onyx.connectors.google_utils.resources import ImpersonationError
 from onyx.connectors.interfaces import SlimConnector, SlimConnectorWithPermSync
 from onyx.connectors.models import SlimDocument
 from onyx.utils.threadpool_concurrency import ThreadSafeDict, ThreadSafeSet
+
+_ADMIN_EMAIL = "admin@example.com"
+_EXTERNAL_OWNER_EMAIL = "owner@external.example"
+_RETRIEVER_EMAIL = "retriever@example.com"
+_DOC_CONVERSION_MODULE = "onyx.connectors.google_drive.doc_conversion"
 
 
 def _make_done_checkpoint() -> GoogleDriveCheckpoint:
@@ -38,8 +48,62 @@ def _make_done_checkpoint() -> GoogleDriveCheckpoint:
 def _make_connector() -> GoogleDriveConnector:
     connector = GoogleDriveConnector(include_my_drives=True)
     connector._creds = MagicMock()
-    connector._primary_admin_email = "admin@example.com"
+    connector._primary_admin_email = _ADMIN_EMAIL
     return connector
+
+
+class TestBuildSlimDocumentPermissions:
+    def test_routes_owner_then_retriever_fallback(self) -> None:
+        creds = MagicMock()
+        owner_service = MagicMock()
+        retriever_service = MagicMock()
+        admin_service = MagicMock()
+        external_access = ExternalAccess.empty()
+        file = {
+            "id": "file-id",
+            "mimeType": "text/plain",
+            "webViewLink": "https://drive.google.com/file/d/file-id/view",
+            "owners": [{"emailAddress": _EXTERNAL_OWNER_EMAIL}],
+        }
+        permission_sync_context = PermissionSyncContext(
+            primary_admin_email=_ADMIN_EMAIL,
+            google_domain="example.com",
+        )
+
+        with (
+            patch(
+                f"{_DOC_CONVERSION_MODULE}.get_drive_service",
+                side_effect=[owner_service, admin_service, retriever_service],
+            ) as mock_get_drive_service,
+            patch(
+                f"{_DOC_CONVERSION_MODULE}._get_external_access_for_raw_gdrive_file",
+                return_value=external_access,
+            ) as mock_get_external_access,
+        ):
+            slim_document = build_slim_document(
+                creds,
+                file,
+                permission_sync_context,
+                _RETRIEVER_EMAIL,
+            )
+            fallback_drive_service_factory = mock_get_external_access.call_args.kwargs[
+                "fallback_drive_service_factory"
+            ]
+            assert fallback_drive_service_factory() is retriever_service
+
+        assert slim_document is not None
+        assert slim_document.external_access == external_access
+        assert mock_get_drive_service.call_args_list == [
+            call(creds, user_email=_EXTERNAL_OWNER_EMAIL),
+            call(creds, user_email=_ADMIN_EMAIL),
+            call(creds, user_email=_RETRIEVER_EMAIL),
+        ]
+        access_kwargs = mock_get_external_access.call_args.kwargs
+        assert access_kwargs["file"] == file
+        assert access_kwargs["company_domain"] == "example.com"
+        assert access_kwargs["retriever_drive_service"] is owner_service
+        assert access_kwargs["admin_drive_service"] is admin_service
+        assert access_kwargs["fallback_user_email"] == _RETRIEVER_EMAIL
 
 
 class TestGoogleDriveSlimConnectorInterface:


### PR DESCRIPTION
## Description

Previously we used only the file owner and drive admin to get permission info for a given drive item. This adds a fallback to using the original user we impersonated to retrieve the file when fetching perms. Handles edge cases where a) the owner of the file can't fetch the permissions (potentially outside the org so we can't impersonate them) and b) neither can the drive admin. The idea is that if the retriever was able to fetch the original file, they may be able to see who has access as well.

## How Has This Been Tested?

added tests

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add retriever impersonation as a fallback when resolving Google Drive permissions to avoid missing shares when the owner can’t fetch them. If impersonation fails, we log and fall back to admin; we also skip retriever fallback when the retriever owns the file.

- **Bug Fixes**
  - Added `fallback_drive_service_factory` and wired it through `_get_external_access_for_raw_gdrive_file` and `build_slim_document`; returns `None` when the retriever owns the file.
  - Merge permissions in order: owner → retriever fallback → admin; handles `RefreshError` and continues.
  - Expanded tests for retry order, impersonation failure logging and admin fallback, and `build_slim_document` wiring.

<sup>Written for commit 17582ca70406868453d3d087ab73471666bd7d43. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

