### PR TITLE
fix: run Claude Code venv PATH hook portably under /bin/sh

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=%q\\n' \"$CLAUDE_PROJECT_DIR/.venv/bin:$PATH\" >> \"$CLAUDE_ENV_FILE\" || true"
+            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=\"%s\"\\n' \"$CLAUDE_PROJECT_DIR/.venv/bin${PATH:+:$PATH}\" >> \"$CLAUDE_ENV_FILE\" || true"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "d=\"$CLAUDE_PROJECT_DIR/.venv/bin\"; case \"$PATH\" in \"$d:\"*|\"$d\") ;; *) [ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=\"%s\"\\n' \"$d${PATH:+:$PATH}\" >> \"$CLAUDE_ENV_FILE\" || true ;; esac"
+            "command": "d=\"$CLAUDE_PROJECT_DIR/.venv/bin\"; case \"$PATH\" in \"$d:\"*|\"$d\") ;; *) [ -n \"$CLAUDE_ENV_FILE\" ] && printf 'IFS= read -r PATH <<%s__ONYX_PATH_EOF__\\n%s\\n__ONYX_PATH_EOF__\\nexport PATH\\n' '\\' \"$d${PATH:+:$PATH}\" >> \"$CLAUDE_ENV_FILE\" || true ;; esac"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=\"%s\"\\n' \"$CLAUDE_PROJECT_DIR/.venv/bin${PATH:+:$PATH}\" >> \"$CLAUDE_ENV_FILE\" || true"
+            "command": "d=\"$CLAUDE_PROJECT_DIR/.venv/bin\"; case \"$PATH\" in \"$d:\"*|\"$d\") ;; *) [ -n \"$CLAUDE_ENV_FILE\" ] && printf 'export PATH=\"%s\"\\n' \"$d${PATH:+:$PATH}\" >> \"$CLAUDE_ENV_FILE\" || true ;; esac"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Follow-up to #13380 / #13386, root-causing why the SessionStart PATH hook still broke shells. Supersedes #13393 (folds in its idempotency guard).

**Root cause:** hook commands are spawned with Node's `shell: true`, i.e. **`/bin/sh`** — which is **dash** on Debian-based devcontainers. dash's builtin `printf` does not support the bash/coreutils `%q` extension:

```
$ dash -c 'printf "export PATH=%q\n" "/x:/usr/bin"'
dash: 1: printf: %q: invalid directive
export PATH=
```

It prints the format prefix, then aborts — before the value or newline are ever emitted. The env file ends up containing exactly `export PATH=` (verified byte-for-byte: a 12-byte `sessionstart-hook-0.sh` under `~/.claude/session-env/<session-id>/`). Claude Code inlines that file's content into every Bash tool invocation *after* sourcing the shell snapshot, so every shell ran with a **completely empty PATH** — worse than having no hook at all. Both #13380 and #13386 die on the same directive, which is why #13386 didn't resolve the reports.

**Fix:**

- POSIX-only serialization: the value is emitted between a backslash-quoted heredoc consumed by the `read` builtin (`IFS= read -r PATH <<\__ONYX_PATH_EOF__ … export PATH`). The env file **is** shell-evaluated by bash (inlined into the Bash tool's command chain), and a quoted heredoc keeps every metacharacter inert — command/backtick substitution, embedded quotes, backslashes, spaces — the value is never parsed as shell code. Only builtins are used (`printf`/`read`/`export`), so the hook also works if its own PATH is broken/empty — an escaping pipeline through `sed` would silently fail there and write `export PATH=''`, recreating the original clobber.
- Idempotency guard from #13393: skip writing when `.venv/bin` is already the first PATH entry (claude launched from an activated venv, repeat SessionStart firings), so duplicates don't stack.
- `${PATH:+:$PATH}` avoids a trailing colon (an implicit cwd PATH entry) if PATH is empty at hook time.

## Testing

Extracted the command back out of `settings.json` with `json.load` and ran it under `dash -c` (matching how hooks actually execute on Linux — `spawn(..., {shell: true})` → `/bin/sh`), with a scratch `CLAUDE_ENV_FILE`:

- clean PATH → heredoc block with `<repo>/.venv/bin:<expanded PATH>`, exit 0, no stderr; evaluating it in bash (as the Bash tool does) yields venv-first PATH and `command -v python` → `<repo>/.venv/bin/python`
- hostile PATH containing `$(touch …)`, backticks, `"`, `\`, `'`, and spaces → exact round-trip after bash evaluation, no command execution
- venv already first / venv is the entire PATH → writes nothing, exit 0
- venv present but not first → still prepends (venv must win)
- empty PATH at hook time → block writes just `<repo>/.venv/bin`, no trailing colon, no external-command dependency
- `CLAUDE_ENV_FILE` unset → writes nothing, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)