### PR TITLE
feat(model selection): accurate model group vendor capitalization

### DIFF
--- a/web/src/lib/languageModels/options.ts
+++ b/web/src/lib/languageModels/options.ts
@@ -141,6 +141,48 @@ export function buildModelProviderLookup(
 // ---------------------------------------------------------------------------
 
 /**
+ * Proper display names for known model vendors. Vendors arrive lowercase from
+ * the backend (e.g. "openai"), so naive capitalization would produce "Openai".
+ * Unknown vendors fall back to per-word title casing (see `vendorDisplayName`).
+ */
+const VENDOR_DISPLAY_NAMES: Record<string, string> = {
+  openai: "OpenAI",
+  anthropic: "Anthropic",
+  google: "Google",
+  gemini: "Gemini",
+  amazon: "Amazon",
+  meta: "Meta",
+  "meta-llama": "Meta",
+  mistral: "Mistral",
+  mistralai: "Mistral",
+  cohere: "Cohere",
+  deepseek: "DeepSeek",
+  xai: "xAI",
+  perplexity: "Perplexity",
+  ai21: "AI21",
+  nvidia: "NVIDIA",
+  qwen: "Qwen",
+  alibaba: "Alibaba",
+  writer: "Writer",
+  microsoft: "Microsoft",
+  databricks: "Databricks",
+  stability: "Stability",
+};
+
+/**
+ * Resolves a lowercase vendor slug to its display name, using the known-vendor
+ * map and falling back to per-word title casing for unrecognized vendors.
+ */
+function vendorDisplayName(vendor: string): string {
+  const known = VENDOR_DISPLAY_NAMES[vendor.toLowerCase()];
+  if (known) return known;
+  return vendor
+    .split(/[\s_-]+/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
+}
+
+/**
  * Groups a flat list of model options by provider, treating aggregator
  * providers (e.g. Bedrock) as sub-grouped by vendor. Groups are sorted
  * alphabetically by display name.
@@ -164,9 +206,9 @@ export function groupLlmOptions(
     if (!groups.has(groupKey)) {
       let displayName: string;
       if (isAggregator && option.vendor) {
-        const vendorDisplayName =
-          option.vendor.charAt(0).toUpperCase() + option.vendor.slice(1);
-        displayName = `${option.providerDisplayName}/${vendorDisplayName}`;
+        displayName = `${option.providerDisplayName}/${vendorDisplayName(
+          option.vendor
+        )}`;
       } else {
         displayName = option.providerDisplayName;
       }


### PR DESCRIPTION
## Problem

Models served through an aggregator provider (e.g. a LiteLLM proxy gateway) are grouped in the model picker by their `vendor`, producing headings like `LiteLLM Proxy/<vendor>`. The vendor arrives lowercase from the backend (`openai`, `anthropic`, `google`), and `groupLlmOptions()` hand-rolled the display casing with `vendor.charAt(0).toUpperCase() + vendor.slice(1)`.

That yields **`Openai`** instead of `OpenAI`. Single-word brands like Anthropic/Google happened to look right only because they're naturally title-case.

## Fix

Replace the naive capitalization in `web/src/lib/languageModels/options.ts` with a `vendorDisplayName()` helper backed by a `VENDOR_DISPLAY_NAMES` map (mirroring the backend's `PROVIDER_DISPLAY_NAMES`): `openai → OpenAI`, `xai → xAI`, `deepseek → DeepSeek`, etc. Unknown vendors fall back to per-word title casing.

## Notes

The map is duplicated on the frontend to keep the fix local and low-risk. A follow-up could instead have the backend emit an already-display-cased vendor for the `litellm_proxy` path (it already has `PROVIDER_DISPLAY_NAMES`), removing the duplication.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes vendor capitalization in aggregator group headings in the model picker so brands display correctly (e.g., OpenAI, xAI). Replaces naive casing with a `vendorDisplayName()` helper backed by a `VENDOR_DISPLAY_NAMES` map and a safe fallback.

- **Bug Fixes**
  - Use `vendorDisplayName()` in `groupLlmOptions()` for aggregator headings (e.g., `LiteLLM Proxy/OpenAI` instead of `LiteLLM Proxy/Openai`).
  - Map covers common vendors (OpenAI, xAI, DeepSeek, NVIDIA, etc.); unknown vendors fall back to per-word title case.

<sup>Written for commit 37a507a7e56a4c67354a8596d4a6e74a7e2f04a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

