### PR TITLE
fix(web): anchor the Add Model tooltip to the add button

### DIFF
--- a/web/src/sections/model-selector/MultiModelSelector.tsx
+++ b/web/src/sections/model-selector/MultiModelSelector.tsx
@@ -62,14 +62,11 @@ export default function MultiModelSelector({
   const isMultiModel = selectedModels.length > 1;
   const atMax = selectedModels.length >= MAX_MODELS || !multiModelAllowed;
 
-  // Single tooltip for the whole selector. The disabled reason takes
-  // precedence; otherwise it labels the add affordance. When at max there is
-  // no add action, so the tooltip is omitted.
+  // Container-level tooltip carries only the disabled reason. The add button
+  // labels itself, so an enabled row shows no tooltip outside the button.
   const selectorTooltip = noModelsToSelect
     ? "No models currently configured"
-    : atMax
-      ? undefined
-      : "Add Model";
+    : undefined;
 
   const selectedKeys = useMemo(
     () => new Set(selectedModels.map(llmOptionKey)),
@@ -149,11 +146,8 @@ export default function MultiModelSelector({
 
   return (
     <Popover open={open} onOpenChange={handleOpenChange}>
-      {/*
-        When disabled, pointer events are blocked on the children (so the add
-        button / pills are inert) while the container itself stays hoverable, so
-        the Tooltip can still surface its message even in the disabled state.
-      */}
+      {/* Disabled state blocks pointer events on children only, so the
+          container stays hoverable and this Tooltip can surface the reason. */}
       <Tooltip tooltip={selectorTooltip} side="top">
         <div
           data-testid="model-selector"
@@ -169,6 +163,7 @@ export default function MultiModelSelector({
               prominence="tertiary"
               icon={SvgPlusCircle}
               size="sm"
+              tooltip="Add Model"
               onClick={(e: React.MouseEvent) => {
                 if (noModelsToSelect) return;
                 anchorRef.current = e.currentTarget as HTMLElement;


### PR DESCRIPTION
## Description

**Bug**
- The "Add Model" tooltip wrapped the entire selector row above the chat input, so hovering anywhere on that strip popped the tooltip centered over the container instead of above the + button.

**Fix**
- The container tooltip now carries only the disabled reason ("No models currently configured", which needs container-level hover because the children are pointer-events-none in that state).
- The + button labels itself via Opal Button's native `tooltip` prop, so "Add Model" anchors above the icon.
- The `atMax` branch is gone because the button does not render at max.

## How Has This Been Tested?

<img width="1560" height="544" alt="2026-07-24 10 54 54" src="https://github.com/user-attachments/assets/a705376d-acb7-41bf-b281-9538aef1a4ca" />


## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check