### PR TITLE
feat(craft): add external app skill association UI

### DIFF
--- a/web/lib/opal/src/components/modal/components.tsx
+++ b/web/lib/opal/src/components/modal/components.tsx
@@ -355,7 +355,13 @@ function ModalHeader({
       className="opal-modal-close-focus"
     >
       <DialogPrimitive.Close asChild>
-        <Button icon={SvgX} prominence="tertiary" size="sm" onClick={onClose} />
+        <Button
+          aria-label="Close"
+          icon={SvgX}
+          prominence="tertiary"
+          size="sm"
+          onClick={onClose}
+        />
       </DialogPrimitive.Close>
     </div>
   );

--- a/web/src/app/craft/services/externalAppsService.test.ts
+++ b/web/src/app/craft/services/externalAppsService.test.ts
@@ -27,9 +27,6 @@ describe("createCustomExternalApp", () => {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(input),
     });
-    const request = jest.mocked(global.fetch).mock.calls[0]![1]!;
-    expect(request.body).not.toBeInstanceOf(FormData);
-    expect(String(request.body)).not.toContain("bundle");
   });
 
   it("disconnects through the credential deletion endpoint", async () => {

--- a/web/src/app/craft/services/externalAppsService.test.ts
+++ b/web/src/app/craft/services/externalAppsService.test.ts
@@ -1,6 +1,7 @@
 import {
   createCustomExternalApp,
   disconnectUserFromApp,
+  updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
 
 describe("createCustomExternalApp", () => {
@@ -38,5 +39,21 @@ describe("createCustomExternalApp", () => {
       "/api/build/apps/17/credentials",
       { method: "DELETE" }
     );
+  });
+
+  it("sends one complete custom-skill association replacement", async () => {
+    await updateExternalApp(17, {
+      name: "Acme CRM",
+      associated_skill_ids: ["skill-a", "skill-b"],
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/build/admin/apps/17", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Acme CRM",
+        associated_skill_ids: ["skill-a", "skill-b"],
+      }),
+    });
   });
 });

--- a/web/src/app/craft/services/externalAppsService.ts
+++ b/web/src/app/craft/services/externalAppsService.ts
@@ -82,6 +82,9 @@ interface UpdateExternalAppBody {
   organization_credentials?: Record<string, string>;
   // Full replace when present; omit to leave stored policies untouched.
   action_policies?: Record<string, EndpointPolicy>;
+  // Full replacement of the app's custom-skill associations. Provider-owned
+  // built-in skills are preserved by the backend.
+  associated_skill_ids?: string[];
 }
 
 /**

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -13,7 +13,7 @@ import InputSelect from "@/refresh-components/inputs/InputSelect";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import PolicyToggle from "@/sections/actions/PolicyToggle";
 import type { EndpointPolicy } from "@/app/craft/v1/apps/registry";
-import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
+import { UnsavedChangesModalContent } from "@/sections/modals/UnsavedChangesModal";
 import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
 
 // One agent-callable capability whose approval policy an admin can set —
@@ -36,8 +36,13 @@ export interface EditorField {
 }
 
 interface ActionPolicyEditorModalProps {
-  /** Alternate view rendered inside the same modal surface. */
-  alternateContent?: React.ReactNode;
+  /** Alternate view rendered inside the same modal surface. It remains
+   * mounted while the discard confirmation is visible so local draft state
+   * survives cancellation. */
+  alternateContent?: (context: {
+    requestLeave: (navigate: () => void) => void;
+    hidden: boolean;
+  }) => React.ReactNode;
   isAdditionalContentDirty?: boolean;
   onClose: () => void;
   title: string;
@@ -60,6 +65,7 @@ interface ActionPolicyEditorModalProps {
   bodyAfterPolicies?: (
     requestLeave: (navigate: () => void) => void
   ) => React.ReactNode;
+  autoFocusFirstField?: boolean;
   /** Keep the modal mounted when save advances its caller to another step. */
   closeAfterSave?: boolean;
 }
@@ -83,6 +89,7 @@ export default function ActionPolicyEditorModal({
   saveLabel,
   onSave,
   bodyAfterPolicies,
+  autoFocusFirstField = true,
   closeAfterSave = true,
 }: ActionPolicyEditorModalProps) {
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({
@@ -116,107 +123,133 @@ export default function ActionPolicyEditorModal({
     }
   }
 
+  function handleDismiss(event: Event) {
+    const preventedByModal = event.defaultPrevented;
+    event.preventDefault();
+    if (preventedByModal || isSaving) return;
+    if (unsavedChanges.confirmationOpen) {
+      unsavedChanges.cancelLeave();
+      return;
+    }
+    if (alternateContent) {
+      onClose();
+    } else {
+      unsavedChanges.requestLeave(onClose);
+    }
+  }
+
+  const confirmationContent = unsavedChanges.confirmationOpen ? (
+    <UnsavedChangesModalContent
+      onCancel={unsavedChanges.cancelLeave}
+      onDiscard={unsavedChanges.discardAndLeave}
+    />
+  ) : null;
+
   return (
-    <>
-      <Modal
-        open
-        onOpenChange={(open) => {
-          if (open) return;
-          if (alternateContent) {
-            onClose();
-          } else {
-            unsavedChanges.requestLeave(onClose);
-          }
+    <Modal open>
+      <Modal.Content
+        width={
+          unsavedChanges.confirmationOpen || alternateContent ? "sm" : "lg"
+        }
+        height={
+          unsavedChanges.confirmationOpen || alternateContent ? "fit" : "lg"
+        }
+        onOpenAutoFocus={(event) => {
+          if (!autoFocusFirstField) event.preventDefault();
         }}
+        preventAccidentalClose={!unsavedChanges.confirmationOpen}
+        onInteractOutside={handleDismiss}
+        onEscapeKeyDown={handleDismiss}
       >
-        <Modal.Content
-          width={alternateContent ? "sm" : "lg"}
-          height={alternateContent ? "fit" : "lg"}
-        >
-          {alternateContent ?? (
-            <>
-              <Modal.Header title={title} description={description} />
-              <Modal.Body>
-                <div className="flex flex-col gap-3">
-                  {note && (
-                    <Text font="secondary-body" color="text-03">
-                      {note}
-                    </Text>
-                  )}
+        {alternateContent ? (
+          <>
+            {alternateContent({
+              requestLeave: unsavedChanges.requestLeave,
+              hidden: unsavedChanges.confirmationOpen,
+            })}
+            {confirmationContent}
+          </>
+        ) : confirmationContent ? (
+          confirmationContent
+        ) : (
+          <>
+            <Modal.Header title={title} description={description} />
+            <Modal.Body>
+              <div className="flex flex-col gap-3">
+                {note && (
+                  <Text font="secondary-body" color="text-03">
+                    {note}
+                  </Text>
+                )}
 
-                  {fields.map((field) => {
-                    const Input = field.secret
-                      ? PasswordInputTypeIn
-                      : InputTypeIn;
-                    return (
-                      <div key={field.key} className="flex flex-col gap-1">
-                        <Text font="main-ui-action">{field.label}</Text>
-                        <Input
-                          value={fieldValues[field.key] ?? ""}
-                          onChange={(e) =>
-                            setFieldValues((prev) => ({
-                              ...prev,
-                              [field.key]: e.target.value,
-                            }))
-                          }
-                          placeholder={field.placeholder}
-                        />
-                        <Text font="secondary-body" color="text-03">
-                          {field.description}
-                        </Text>
-                      </div>
-                    );
-                  })}
+                {fields.map((field) => {
+                  const Input = field.secret
+                    ? PasswordInputTypeIn
+                    : InputTypeIn;
+                  return (
+                    <div key={field.key} className="flex flex-col gap-1">
+                      <Text font="main-ui-action">{field.label}</Text>
+                      <Input
+                        autoFocus={autoFocusFirstField && field === fields[0]}
+                        value={fieldValues[field.key] ?? ""}
+                        onChange={(e) =>
+                          setFieldValues((prev) => ({
+                            ...prev,
+                            [field.key]: e.target.value,
+                          }))
+                        }
+                        placeholder={field.placeholder}
+                      />
+                      <Text font="secondary-body" color="text-03">
+                        {field.description}
+                      </Text>
+                    </div>
+                  );
+                })}
 
-                  {policyItems === undefined ? (
-                    <Text font="main-content-body" color="text-03">
-                      Loading…
-                    </Text>
-                  ) : policyItems.length === 0 ? (
-                    <Text font="secondary-body" color="text-03">
-                      {emptyPoliciesMessage}
-                    </Text>
-                  ) : (
-                    <PolicyEditor
-                      items={policyItems}
-                      policies={policies}
-                      onChange={setPolicies}
-                    />
-                  )}
+                {policyItems === undefined ? (
+                  <Text font="main-content-body" color="text-03">
+                    Loading…
+                  </Text>
+                ) : policyItems.length === 0 ? (
+                  <Text font="secondary-body" color="text-03">
+                    {emptyPoliciesMessage}
+                  </Text>
+                ) : (
+                  <PolicyEditor
+                    items={policyItems}
+                    policies={policies}
+                    onChange={setPolicies}
+                  />
+                )}
 
-                  {bodyAfterPolicies?.(unsavedChanges.requestLeave)}
+                {bodyAfterPolicies?.(unsavedChanges.requestLeave)}
 
-                  {error && (
-                    <Text font="secondary-body" color="text-03">
-                      {error}
-                    </Text>
-                  )}
-                </div>
-              </Modal.Body>
-              <Modal.Footer>
-                <div className="flex justify-end gap-2 w-full">
-                  <Button
-                    prominence="secondary"
-                    onClick={() => unsavedChanges.requestLeave(onClose)}
-                    disabled={isSaving}
-                  >
-                    Cancel
-                  </Button>
-                  <Button onClick={save} disabled={!canSave}>
-                    {isSaving ? "Saving…" : saveLabel}
-                  </Button>
-                </div>
-              </Modal.Footer>
-            </>
-          )}
-        </Modal.Content>
-      </Modal>
-      <UnsavedChangesModal
-        open={unsavedChanges.confirmationOpen}
-        onCancel={unsavedChanges.cancelLeave}
-        onDiscard={unsavedChanges.discardAndLeave}
-      />
-    </>
+                {error && (
+                  <Text font="secondary-body" color="text-03">
+                    {error}
+                  </Text>
+                )}
+              </div>
+            </Modal.Body>
+            <Modal.Footer>
+              <div className="flex justify-end gap-2 w-full">
+                <Button
+                  prominence="secondary"
+                  onClick={() => unsavedChanges.requestLeave(onClose)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                <Button onClick={save} disabled={!canSave}>
+                  {isSaving ? "Saving…" : saveLabel}
+                </Button>
+              </div>
+            </Modal.Footer>
+          </>
+        )}
+      </Modal.Content>
+    </Modal>
   );
 }
 

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import isEqual from "lodash/isEqual";
 import {
   Button,
   InputTypeIn,
@@ -12,6 +13,8 @@ import InputSelect from "@/refresh-components/inputs/InputSelect";
 import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import PolicyToggle from "@/sections/actions/PolicyToggle";
 import type { EndpointPolicy } from "@/app/craft/v1/apps/registry";
+import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
 
 // One agent-callable capability whose approval policy an admin can set —
 // an external-app action or an MCP tool.
@@ -33,6 +36,9 @@ export interface EditorField {
 }
 
 interface ActionPolicyEditorModalProps {
+  /** Alternate view rendered inside the same modal surface. */
+  alternateContent?: React.ReactNode;
+  isAdditionalContentDirty?: boolean;
   onClose: () => void;
   title: string;
   description: string;
@@ -52,7 +58,7 @@ interface ActionPolicyEditorModalProps {
     policies: Record<string, EndpointPolicy>
   ) => Promise<void>;
   bodyAfterPolicies?: (
-    saveWithoutClosing: () => Promise<boolean>
+    requestLeave: (navigate: () => void) => void
   ) => React.ReactNode;
   /** Keep the modal mounted when save advances its caller to another step. */
   closeAfterSave?: boolean;
@@ -63,6 +69,8 @@ interface ActionPolicyEditorModalProps {
  * policy items and supply the save call; the UI is identical for both.
  * Mount it only while open — initial values are read once. */
 export default function ActionPolicyEditorModal({
+  alternateContent,
+  isAdditionalContentDirty = false,
   onClose,
   title,
   description,
@@ -88,101 +96,127 @@ export default function ActionPolicyEditorModal({
   const fieldsFilled = fields.every(
     (field) => (fieldValues[field.key] ?? "").trim().length > 0
   );
-  const canSave = fieldsFilled && policyItems !== undefined && !isSaving;
+  const fieldsDirty = !isEqual(fieldValues, initialFieldValues);
+  const policiesDirty = !isEqual(policies, initialPolicies);
+  const isDirty = fieldsDirty || policiesDirty || isAdditionalContentDirty;
+  const unsavedChanges = useUnsavedChangesGuard({ isDirty });
+  const canSave =
+    fieldsFilled && policyItems !== undefined && !isSaving && isDirty;
 
-  async function persist(): Promise<boolean> {
+  async function save() {
     setIsSaving(true);
     setError(null);
     try {
       await onSave(fieldValues, policies);
-      return true;
+      if (closeAfterSave) onClose();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
-      return false;
     } finally {
       setIsSaving(false);
     }
   }
 
-  async function save() {
-    if ((await persist()) && closeAfterSave) onClose();
-  }
-
   return (
-    <Modal open onOpenChange={(o) => !o && onClose()}>
-      <Modal.Content width="lg" height="lg">
-        <Modal.Header title={title} description={description} />
-        <Modal.Body>
-          <div className="flex flex-col gap-3">
-            {note && (
-              <Text font="secondary-body" color="text-03">
-                {note}
-              </Text>
-            )}
+    <>
+      <Modal
+        open
+        onOpenChange={(open) => {
+          if (open) return;
+          if (alternateContent) {
+            onClose();
+          } else {
+            unsavedChanges.requestLeave(onClose);
+          }
+        }}
+      >
+        <Modal.Content
+          width={alternateContent ? "sm" : "lg"}
+          height={alternateContent ? "fit" : "lg"}
+        >
+          {alternateContent ?? (
+            <>
+              <Modal.Header title={title} description={description} />
+              <Modal.Body>
+                <div className="flex flex-col gap-3">
+                  {note && (
+                    <Text font="secondary-body" color="text-03">
+                      {note}
+                    </Text>
+                  )}
 
-            {fields.map((field) => {
-              const Input = field.secret ? PasswordInputTypeIn : InputTypeIn;
-              return (
-                <div key={field.key} className="flex flex-col gap-1">
-                  <Text font="main-ui-action">{field.label}</Text>
-                  <Input
-                    value={fieldValues[field.key] ?? ""}
-                    onChange={(e) =>
-                      setFieldValues((prev) => ({
-                        ...prev,
-                        [field.key]: e.target.value,
-                      }))
-                    }
-                    placeholder={field.placeholder}
-                  />
-                  <Text font="secondary-body" color="text-03">
-                    {field.description}
-                  </Text>
+                  {fields.map((field) => {
+                    const Input = field.secret
+                      ? PasswordInputTypeIn
+                      : InputTypeIn;
+                    return (
+                      <div key={field.key} className="flex flex-col gap-1">
+                        <Text font="main-ui-action">{field.label}</Text>
+                        <Input
+                          value={fieldValues[field.key] ?? ""}
+                          onChange={(e) =>
+                            setFieldValues((prev) => ({
+                              ...prev,
+                              [field.key]: e.target.value,
+                            }))
+                          }
+                          placeholder={field.placeholder}
+                        />
+                        <Text font="secondary-body" color="text-03">
+                          {field.description}
+                        </Text>
+                      </div>
+                    );
+                  })}
+
+                  {policyItems === undefined ? (
+                    <Text font="main-content-body" color="text-03">
+                      Loading…
+                    </Text>
+                  ) : policyItems.length === 0 ? (
+                    <Text font="secondary-body" color="text-03">
+                      {emptyPoliciesMessage}
+                    </Text>
+                  ) : (
+                    <PolicyEditor
+                      items={policyItems}
+                      policies={policies}
+                      onChange={setPolicies}
+                    />
+                  )}
+
+                  {bodyAfterPolicies?.(unsavedChanges.requestLeave)}
+
+                  {error && (
+                    <Text font="secondary-body" color="text-03">
+                      {error}
+                    </Text>
+                  )}
                 </div>
-              );
-            })}
-
-            {policyItems === undefined ? (
-              <Text font="main-content-body" color="text-03">
-                Loading…
-              </Text>
-            ) : policyItems.length === 0 ? (
-              <Text font="secondary-body" color="text-03">
-                {emptyPoliciesMessage}
-              </Text>
-            ) : (
-              <PolicyEditor
-                items={policyItems}
-                policies={policies}
-                onChange={setPolicies}
-              />
-            )}
-
-            {bodyAfterPolicies?.(persist)}
-
-            {error && (
-              <Text font="secondary-body" color="text-03">
-                {error}
-              </Text>
-            )}
-          </div>
-        </Modal.Body>
-        <Modal.Footer>
-          <div className="flex justify-end gap-2 w-full">
-            <Button
-              prominence="secondary"
-              onClick={onClose}
-              disabled={isSaving}
-            >
-              Cancel
-            </Button>
-            <Button onClick={save} disabled={!canSave}>
-              {isSaving ? "Saving…" : saveLabel}
-            </Button>
-          </div>
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal>
+              </Modal.Body>
+              <Modal.Footer>
+                <div className="flex justify-end gap-2 w-full">
+                  <Button
+                    prominence="secondary"
+                    onClick={() => unsavedChanges.requestLeave(onClose)}
+                    disabled={isSaving}
+                  >
+                    Cancel
+                  </Button>
+                  <Button onClick={save} disabled={!canSave}>
+                    {isSaving ? "Saving…" : saveLabel}
+                  </Button>
+                </div>
+              </Modal.Footer>
+            </>
+          )}
+        </Modal.Content>
+      </Modal>
+      <UnsavedChangesModal
+        open={unsavedChanges.confirmationOpen}
+        onCancel={unsavedChanges.cancelLeave}
+        onDiscard={unsavedChanges.discardAndLeave}
+      />
+    </>
   );
 }
 

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -51,6 +51,11 @@ interface ActionPolicyEditorModalProps {
     fieldValues: Record<string, string>,
     policies: Record<string, EndpointPolicy>
   ) => Promise<void>;
+  bodyAfterPolicies?: (
+    saveWithoutClosing: () => Promise<boolean>
+  ) => React.ReactNode;
+  /** Keep the modal mounted when save advances its caller to another step. */
+  closeAfterSave?: boolean;
 }
 
 /** The one edit dialog for everything the Craft agent can be granted.
@@ -69,6 +74,8 @@ export default function ActionPolicyEditorModal({
   emptyPoliciesMessage,
   saveLabel,
   onSave,
+  bodyAfterPolicies,
+  closeAfterSave = true,
 }: ActionPolicyEditorModalProps) {
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({
     ...initialFieldValues,
@@ -78,23 +85,27 @@ export default function ActionPolicyEditorModal({
   });
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
   const fieldsFilled = fields.every(
     (field) => (fieldValues[field.key] ?? "").trim().length > 0
   );
   const canSave = fieldsFilled && policyItems !== undefined && !isSaving;
 
-  async function save() {
+  async function persist(): Promise<boolean> {
     setIsSaving(true);
     setError(null);
     try {
       await onSave(fieldValues, policies);
-      onClose();
+      return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
+      return false;
     } finally {
       setIsSaving(false);
     }
+  }
+
+  async function save() {
+    if ((await persist()) && closeAfterSave) onClose();
   }
 
   return (
@@ -146,6 +157,8 @@ export default function ActionPolicyEditorModal({
                 onChange={setPolicies}
               />
             )}
+
+            {bodyAfterPolicies?.(persist)}
 
             {error && (
               <Text font="secondary-body" color="text-03">

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -67,6 +67,8 @@ interface ActionPolicyEditorModalProps {
     requestLeave: (navigate: () => void) => void
   ) => React.ReactNode;
   autoFocusFirstField?: boolean;
+  /** Allow create flows to persist valid defaults without an artificial edit. */
+  allowPristineSave?: boolean;
   /** Keep the modal mounted when save advances its caller to another step. */
   closeAfterSave?: boolean;
 }
@@ -92,6 +94,7 @@ export default function ActionPolicyEditorModal({
   onSave,
   bodyAfterPolicies,
   autoFocusFirstField = true,
+  allowPristineSave = false,
   closeAfterSave = true,
 }: ActionPolicyEditorModalProps) {
   const [fieldValues, setFieldValues] = useState<Record<string, string>>({
@@ -112,7 +115,10 @@ export default function ActionPolicyEditorModal({
   const confirmationOpen =
     alternateContentConfirmationOpen || unsavedChanges.confirmationOpen;
   const canSave =
-    fieldsFilled && policyItems !== undefined && !isSaving && isDirty;
+    fieldsFilled &&
+    policyItems !== undefined &&
+    !isSaving &&
+    (allowPristineSave || isDirty);
 
   async function save() {
     setIsSaving(true);

--- a/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ActionPolicyEditorModal.tsx
@@ -43,6 +43,7 @@ interface ActionPolicyEditorModalProps {
     requestLeave: (navigate: () => void) => void;
     hidden: boolean;
   }) => React.ReactNode;
+  alternateContentConfirmationOpen?: boolean;
   isAdditionalContentDirty?: boolean;
   onClose: () => void;
   title: string;
@@ -76,6 +77,7 @@ interface ActionPolicyEditorModalProps {
  * Mount it only while open — initial values are read once. */
 export default function ActionPolicyEditorModal({
   alternateContent,
+  alternateContentConfirmationOpen = false,
   isAdditionalContentDirty = false,
   onClose,
   title,
@@ -107,6 +109,8 @@ export default function ActionPolicyEditorModal({
   const policiesDirty = !isEqual(policies, initialPolicies);
   const isDirty = fieldsDirty || policiesDirty || isAdditionalContentDirty;
   const unsavedChanges = useUnsavedChangesGuard({ isDirty });
+  const confirmationOpen =
+    alternateContentConfirmationOpen || unsavedChanges.confirmationOpen;
   const canSave =
     fieldsFilled && policyItems !== undefined && !isSaving && isDirty;
 
@@ -148,16 +152,12 @@ export default function ActionPolicyEditorModal({
   return (
     <Modal open>
       <Modal.Content
-        width={
-          unsavedChanges.confirmationOpen || alternateContent ? "sm" : "lg"
-        }
-        height={
-          unsavedChanges.confirmationOpen || alternateContent ? "fit" : "lg"
-        }
+        width={confirmationOpen || alternateContent ? "sm" : "lg"}
+        height={confirmationOpen || alternateContent ? "fit" : "lg"}
         onOpenAutoFocus={(event) => {
           if (!autoFocusFirstField) event.preventDefault();
         }}
-        preventAccidentalClose={!unsavedChanges.confirmationOpen}
+        preventAccidentalClose={!confirmationOpen}
         onInteractOutside={handleDismiss}
         onEscapeKeyDown={handleDismiss}
       >
@@ -165,7 +165,7 @@ export default function ActionPolicyEditorModal({
           <>
             {alternateContent({
               requestLeave: unsavedChanges.requestLeave,
-              hidden: unsavedChanges.confirmationOpen,
+              hidden: confirmationOpen,
             })}
             {confirmationContent}
           </>

--- a/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
+++ b/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Button,
+  Card,
+  InputTypeIn,
+  Popover,
+  Tag,
+  Text,
+} from "@opal/components";
+import { SvgCheck, SvgPlus, SvgX } from "@opal/icons";
+import useUserSkills from "@/hooks/useUserSkills";
+import type { Skill } from "@/lib/skills/types";
+import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
+import LineItem from "@/refresh-components/buttons/LineItem";
+
+interface AssociatedSkillsEditorProps {
+  app: ExternalAppAdminResponse;
+  selectedSkillIds: string[];
+  onChange: (skillIds: string[]) => void;
+  onOpenSkill: (skillId: string) => void;
+  onCreateSkill: () => void;
+  onUploadSkill: () => void;
+}
+
+interface PendingUnlink {
+  id: string;
+  name: string;
+}
+
+function canAssociate(skill: Skill, appId: number): boolean {
+  const canEdit =
+    skill.user_permission === "OWNER" || skill.user_permission === "EDITOR";
+  return (
+    canEdit &&
+    (skill.external_app === null ||
+      skill.external_app.external_app_id === appId)
+  );
+}
+
+export default function AssociatedSkillsEditor({
+  app,
+  selectedSkillIds,
+  onChange,
+  onOpenSkill,
+  onCreateSkill,
+  onUploadSkill,
+}: AssociatedSkillsEditorProps) {
+  const { data, isLoading } = useUserSkills();
+  const [query, setQuery] = useState("");
+  const [associateOpen, setAssociateOpen] = useState(false);
+  const [pendingPromotion, setPendingPromotion] = useState<Skill | null>(null);
+  const [pendingUnlink, setPendingUnlink] = useState<PendingUnlink | null>(
+    null
+  );
+  const customSkills = data?.customs ?? [];
+  const customSkillById = useMemo(
+    () => new Map(customSkills.map((skill) => [skill.id, skill])),
+    [customSkills]
+  );
+  const selectedIds = useMemo(
+    () => new Set(selectedSkillIds),
+    [selectedSkillIds]
+  );
+  const selectedNames = useMemo(
+    () =>
+      new Set(
+        selectedSkillIds.flatMap((skillId) => {
+          const name =
+            customSkillById.get(skillId)?.name ??
+            app.associated_skills.find((skill) => skill.id === skillId)?.name;
+          return name ? [name] : [];
+        })
+      ),
+    [app.associated_skills, customSkillById, selectedSkillIds]
+  );
+  const selectableSkills = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return customSkills
+      .filter((skill) => canAssociate(skill, app.id))
+      .filter(
+        (skill) =>
+          normalizedQuery.length === 0 ||
+          skill.name.toLowerCase().includes(normalizedQuery) ||
+          skill.description.toLowerCase().includes(normalizedQuery)
+      );
+  }, [app.id, customSkills, query]);
+  function unavailableReason(skill: Skill): string | null {
+    if (skill.is_valid === false) {
+      return "Invalid skill — fix it before associating.";
+    }
+    if (!selectedIds.has(skill.id) && selectedNames.has(skill.name)) {
+      return `A skill named “${skill.name}” is already associated.`;
+    }
+    return null;
+  }
+  function select(skill: Skill) {
+    if (unavailableReason(skill)) return;
+    if (selectedIds.has(skill.id)) {
+      setPendingUnlink(skill);
+      setAssociateOpen(false);
+      return;
+    }
+    if (skill.public_permission === null) {
+      setPendingPromotion(skill);
+      return;
+    }
+    onChange([...selectedSkillIds, skill.id]);
+    setAssociateOpen(false);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex flex-col gap-0.5">
+          <Text font="main-ui-action">Associated skills</Text>
+          <Text font="secondary-body" color="text-03">
+            Skills give Craft instructions for using this app. They are
+            organization-wide; users may need to enable all of them for the app
+            to work correctly.
+          </Text>
+        </div>
+        <div className="flex shrink-0 gap-2">
+          <Popover
+            modal
+            open={associateOpen}
+            onOpenChange={(open) => {
+              setAssociateOpen(open);
+              if (!open) setPendingPromotion(null);
+            }}
+          >
+            <Popover.Trigger asChild>
+              <Button prominence="secondary">Associate existing</Button>
+            </Popover.Trigger>
+            <Popover.Content align="end" sideOffset={4} width="xl">
+              <div className="flex max-h-[min(20rem,calc(var(--radix-popover-content-available-height)-0.5rem))] flex-col gap-2 overflow-hidden p-2">
+                <InputTypeIn
+                  searchIcon
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search editable skills..."
+                  variant="internal"
+                />
+                <div className="flex min-h-0 flex-col gap-1 overflow-y-auto overscroll-contain">
+                  {isLoading ? (
+                    <Text font="secondary-body" color="text-03">
+                      Loading skills…
+                    </Text>
+                  ) : selectableSkills.length === 0 ? (
+                    <Text font="secondary-body" color="text-03">
+                      No editable skills found.
+                    </Text>
+                  ) : (
+                    selectableSkills.map((skill) => {
+                      const disabledReason = unavailableReason(skill);
+                      return (
+                        <LineItem
+                          key={skill.id}
+                          onClick={() => select(skill)}
+                          description={disabledReason ?? skill.description}
+                          disabled={disabledReason !== null}
+                          selected={selectedIds.has(skill.id)}
+                          rightChildren={
+                            selectedIds.has(skill.id) ? (
+                              <SvgCheck className="size-4 stroke-action-link-05" />
+                            ) : undefined
+                          }
+                          aria-label={`Associate ${skill.name}`}
+                        >
+                          {skill.name}
+                        </LineItem>
+                      );
+                    })
+                  )}
+                </div>
+                {pendingPromotion && (
+                  <div className="flex flex-col gap-2 border-t border-border-01 pt-2">
+                    <Text font="main-ui-action">
+                      {`Make “${pendingPromotion.name}” organization-wide?`}
+                    </Text>
+                    <Text font="secondary-body" color="text-03">
+                      App-associated skills must be available to everyone. This
+                      change is applied when you save the app.
+                    </Text>
+                    <div className="flex justify-end gap-2">
+                      <Button
+                        prominence="secondary"
+                        onClick={() => setPendingPromotion(null)}
+                      >
+                        Cancel
+                      </Button>
+                      <Button
+                        onClick={() => {
+                          onChange([...selectedSkillIds, pendingPromotion.id]);
+                          setPendingPromotion(null);
+                          setAssociateOpen(false);
+                        }}
+                      >
+                        Make organization-wide
+                      </Button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            </Popover.Content>
+          </Popover>
+          <Popover>
+            <Popover.Trigger asChild>
+              <Button icon={SvgPlus}>Create skill</Button>
+            </Popover.Trigger>
+            <Popover.Content align="end" sideOffset={4} width="md">
+              <Popover.Menu>
+                <LineItem
+                  onClick={onCreateSkill}
+                  description="Write instructions and add supporting files."
+                  wrapDescription
+                >
+                  Start from scratch
+                </LineItem>
+                <LineItem
+                  onClick={onUploadSkill}
+                  description="Import a SKILL.md file, ZIP file, or skill folder."
+                  wrapDescription
+                >
+                  Upload a skill
+                </LineItem>
+              </Popover.Menu>
+            </Popover.Content>
+          </Popover>
+        </div>
+      </div>
+
+      {selectedSkillIds.length === 0 ? (
+        <Card border="solid" rounding="lg" padding="sm">
+          <Text font="secondary-body" color="text-03">
+            No skills are associated yet. This app can still be saved and used
+            without one.
+          </Text>
+        </Card>
+      ) : (
+        <Card border="solid" rounding="sm" padding="fit">
+          <div className="flex max-h-48 flex-col divide-y divide-border-01 overflow-y-auto overscroll-contain">
+            {selectedSkillIds.map((skillId) => {
+              const skill = customSkillById.get(skillId);
+              const canEdit =
+                skill?.user_permission === "OWNER" ||
+                skill?.user_permission === "EDITOR";
+              const summary = app.associated_skills.find(
+                (candidate) => candidate.id === skillId
+              );
+              const name = skill?.name ?? summary?.name;
+              if (!name) return null;
+              if (pendingUnlink?.id === skillId) {
+                return (
+                  <div
+                    key={skillId}
+                    className="flex min-h-9 items-center gap-2 px-2 py-1"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <Text font="secondary-body">
+                        {`Unlink “${pendingUnlink.name}” from this app?`}
+                      </Text>
+                    </div>
+                    <Button
+                      size="md"
+                      prominence="secondary"
+                      onClick={() => setPendingUnlink(null)}
+                    >
+                      Cancel
+                    </Button>
+                    <Button
+                      size="md"
+                      onClick={() => {
+                        onChange(
+                          selectedSkillIds.filter(
+                            (selectedSkillId) =>
+                              selectedSkillId !== pendingUnlink.id
+                          )
+                        );
+                        setPendingUnlink(null);
+                      }}
+                    >
+                      Unlink
+                    </Button>
+                  </div>
+                );
+              }
+              return (
+                <div
+                  key={skillId}
+                  className="flex min-h-9 items-center gap-1 px-2 py-1"
+                >
+                  <div className="min-w-0 flex-1">
+                    <Text font="main-ui-action">{name}</Text>
+                  </div>
+                  {(skill?.is_valid ?? summary?.is_valid) === false && (
+                    <Tag title="Invalid" color="amber" />
+                  )}
+                  <Button
+                    size="md"
+                    prominence="tertiary"
+                    onClick={() => onOpenSkill(skillId)}
+                  >
+                    {canEdit ? "Edit" : "View"}
+                  </Button>
+                  <Button
+                    size="md"
+                    prominence="tertiary"
+                    icon={SvgX}
+                    aria-label={`Unlink ${name}`}
+                    onClick={() => {
+                      setPendingUnlink({ id: skillId, name });
+                    }}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
+++ b/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
@@ -71,10 +71,8 @@ export default function AssociatedSkillsEditor({
     return customSkills
       .filter(
         (skill) =>
-          (skill.user_permission === "OWNER" ||
-            skill.user_permission === "EDITOR") &&
-          (skill.external_app === null ||
-            skill.external_app.external_app_id === app.id)
+          skill.user_permission === "OWNER" ||
+          skill.user_permission === "EDITOR"
       )
       .filter(
         (skill) =>
@@ -86,6 +84,12 @@ export default function AssociatedSkillsEditor({
   function unavailableReason(skill: Skill): string | null {
     if (skill.is_valid === false) {
       return "Invalid skill — fix it before associating.";
+    }
+    if (
+      skill.external_app !== null &&
+      skill.external_app.external_app_id !== app.id
+    ) {
+      return `Already associated with app “${skill.external_app.name}”.`;
     }
     if (!selectedIds.has(skill.id) && selectedNames.has(skill.name)) {
       return `A skill named “${skill.name}” is already associated.`;

--- a/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
+++ b/web/src/app/craft/v1/apps/admin/AssociatedSkillsEditor.tsx
@@ -29,16 +29,6 @@ interface PendingUnlink {
   name: string;
 }
 
-function canAssociate(skill: Skill, appId: number): boolean {
-  const canEdit =
-    skill.user_permission === "OWNER" || skill.user_permission === "EDITOR";
-  return (
-    canEdit &&
-    (skill.external_app === null ||
-      skill.external_app.external_app_id === appId)
-  );
-}
-
 export default function AssociatedSkillsEditor({
   app,
   selectedSkillIds,
@@ -50,6 +40,7 @@ export default function AssociatedSkillsEditor({
   const { data, isLoading } = useUserSkills();
   const [query, setQuery] = useState("");
   const [associateOpen, setAssociateOpen] = useState(false);
+  const [createOpen, setCreateOpen] = useState(false);
   const [pendingPromotion, setPendingPromotion] = useState<Skill | null>(null);
   const [pendingUnlink, setPendingUnlink] = useState<PendingUnlink | null>(
     null
@@ -78,7 +69,13 @@ export default function AssociatedSkillsEditor({
   const selectableSkills = useMemo(() => {
     const normalizedQuery = query.trim().toLowerCase();
     return customSkills
-      .filter((skill) => canAssociate(skill, app.id))
+      .filter(
+        (skill) =>
+          (skill.user_permission === "OWNER" ||
+            skill.user_permission === "EDITOR") &&
+          (skill.external_app === null ||
+            skill.external_app.external_app_id === app.id)
+      )
       .filter(
         (skill) =>
           normalizedQuery.length === 0 ||
@@ -205,21 +202,27 @@ export default function AssociatedSkillsEditor({
               </div>
             </Popover.Content>
           </Popover>
-          <Popover>
+          <Popover modal open={createOpen} onOpenChange={setCreateOpen}>
             <Popover.Trigger asChild>
               <Button icon={SvgPlus}>Create skill</Button>
             </Popover.Trigger>
             <Popover.Content align="end" sideOffset={4} width="md">
               <Popover.Menu>
                 <LineItem
-                  onClick={onCreateSkill}
+                  onClick={() => {
+                    setCreateOpen(false);
+                    onCreateSkill();
+                  }}
                   description="Write instructions and add supporting files."
                   wrapDescription
                 >
                   Start from scratch
                 </LineItem>
                 <LineItem
-                  onClick={onUploadSkill}
+                  onClick={() => {
+                    setCreateOpen(false);
+                    onUploadSkill();
+                  }}
                   description="Import a SKILL.md file, ZIP file, or skill folder."
                   wrapDescription
                 >

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
@@ -2,7 +2,13 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@tests/setup/test-utils";
 import ConfigureProviderModal from "@/app/craft/v1/apps/admin/ConfigureProviderModal";
 import type {
   BuiltInExternalAppDescriptor,
@@ -26,12 +32,12 @@ jest.mock("@/lib/skills/creationDraft", () => ({
 jest.mock("@/sections/modals/skills/CreateSkillModal", () => ({
   CreateSkillModalContent: ({
     hidden = false,
-    onClose,
+    onRequestClose,
     onContinue,
     onDirtyChange,
   }: {
     hidden?: boolean;
-    onClose: () => void;
+    onRequestClose: () => void;
     onContinue: (draft: SkillCreationDraft) => void;
     onDirtyChange?: (dirty: boolean) => void;
   }) =>
@@ -41,7 +47,7 @@ jest.mock("@/sections/modals/skills/CreateSkillModal", () => ({
         <button type="button" onClick={() => onDirtyChange?.(true)}>
           Select bundle
         </button>
-        <button type="button" onClick={onClose}>
+        <button type="button" onClick={onRequestClose}>
           Cancel
         </button>
         <button
@@ -221,9 +227,16 @@ describe("ConfigureProviderModal", () => {
     ).toBeVisible();
     expect(onClose).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(
+      within(
+        screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+      ).getByRole("button", { name: "Cancel" })
+    );
     expect(screen.getByText("Upload skill")).toBeInTheDocument();
-    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
     fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
 
     expect(screen.getByRole("dialog", { name: /Edit Slack/ })).toBeVisible();
@@ -276,6 +289,41 @@ describe("ConfigureProviderModal", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("guards a selected upload in the post-create skills step", async () => {
+    jest
+      .mocked(externalAppsService.createBuiltInExternalApp)
+      .mockResolvedValue({ ...APP, associated_skills: [] });
+
+    render(
+      <ConfigureProviderModal
+        onClose={jest.fn()}
+        onSaved={jest.fn()}
+        descriptor={DESCRIPTOR}
+        existingApp={null}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText("Token"), {
+      target: { value: "org-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(await screen.findByText("Add skills to Slack")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Select bundle" }));
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    const confirmation = screen.getByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    fireEvent.click(
+      within(confirmation).getByRole("button", { name: "Cancel" })
+    );
+
+    expect(screen.getByText("Upload skill")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled();
   });
 
   it("guards pending post-create associations before reviewing an upload", async () => {

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
@@ -10,6 +10,8 @@ import type {
 } from "@/app/craft/v1/apps/registry";
 import * as externalAppsService from "@/app/craft/services/externalAppsService";
 
+const mockRouterPush = jest.fn();
+
 jest.mock("@/app/craft/services/externalAppsService");
 jest.mock("@/hooks/useUserSkills", () => ({
   __esModule: true,
@@ -19,7 +21,7 @@ jest.mock("@/hooks/useUserSkills", () => ({
   }),
 }));
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockRouterPush }),
   usePathname: () => "/admin/craft/apps",
 }));
 
@@ -55,6 +57,18 @@ const APP: ExternalAppAdminResponse = {
   is_onyx_managed: false,
 };
 
+function renderExistingProvider(onClose = jest.fn()) {
+  render(
+    <ConfigureProviderModal
+      onClose={onClose}
+      onSaved={jest.fn()}
+      descriptor={DESCRIPTOR}
+      existingApp={APP}
+    />
+  );
+  return { onClose };
+}
+
 describe("ConfigureProviderModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -62,16 +76,12 @@ describe("ConfigureProviderModal", () => {
 
   it("saves built-in app settings and custom associations together", async () => {
     jest.mocked(externalAppsService.updateExternalApp).mockResolvedValue(APP);
-    const onClose = jest.fn();
-
-    render(
-      <ConfigureProviderModal
-        onClose={onClose}
-        onSaved={jest.fn()}
-        descriptor={DESCRIPTOR}
-        existingApp={APP}
-      />
-    );
+    const { onClose } = renderExistingProvider();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    fireEvent.change(screen.getByPlaceholderText("Token"), {
+      target: { value: "updated-token" },
+    });
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() =>
@@ -80,11 +90,50 @@ describe("ConfigureProviderModal", () => {
         upstream_url_patterns: ["https://slack.com/api/.*"],
         auth_template: { Authorization: "Bearer {token}" },
         action_policies: {},
-        organization_credentials: { token: "masked-token" },
+        organization_credentials: { token: "updated-token" },
         associated_skill_ids: ["custom-skill"],
       })
     );
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("guards unsaved provider edits before skill creation", () => {
+    const { onClose } = renderExistingProvider();
+    fireEvent.change(screen.getByPlaceholderText("Token"), {
+      target: { value: "unsaved-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Start from scratch/ })
+    );
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/craft/v1/skills/new?externalAppId=7&externalAppName=Slack"
+    );
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("restores unsaved provider settings after upload is canceled", () => {
+    const { onClose } = renderExistingProvider();
+    fireEvent.change(screen.getByPlaceholderText("Token"), {
+      target: { value: "updated-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+
+    expect(screen.getByText("Upload skill")).toBeInTheDocument();
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getByRole("dialog", { name: /Edit Slack/ })).toBeVisible();
+    expect(screen.getByPlaceholderText("Token")).toHaveValue("updated-token");
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("keeps a newly created provider durable while skills are skipped", async () => {
@@ -109,8 +158,9 @@ describe("ConfigureProviderModal", () => {
     expect(await screen.findByText("Add skills to Slack")).toBeInTheDocument();
     expect(onClose).not.toHaveBeenCalled();
     expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Save skills" })).toBeDisabled();
 
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
   });
 });

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
@@ -134,6 +134,43 @@ describe("ConfigureProviderModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it("creates a provider whose valid defaults need no manual edits", async () => {
+    const noInputDescriptor: BuiltInExternalAppDescriptor = {
+      ...DESCRIPTOR,
+      required_org_credential_fields: [],
+    };
+    jest
+      .mocked(externalAppsService.createBuiltInExternalApp)
+      .mockResolvedValue({ ...APP, associated_skills: [] });
+
+    render(
+      <ConfigureProviderModal
+        onClose={jest.fn()}
+        onSaved={jest.fn()}
+        descriptor={noInputDescriptor}
+        existingApp={null}
+      />
+    );
+
+    const addButton = screen.getByRole("button", { name: "Add" });
+    expect(addButton).toBeEnabled();
+    fireEvent.click(addButton);
+
+    await waitFor(() =>
+      expect(externalAppsService.createBuiltInExternalApp).toHaveBeenCalledWith(
+        {
+          name: "Slack",
+          app_type: "SLACK",
+          upstream_url_patterns: DESCRIPTOR.upstream_url_patterns,
+          auth_template: DESCRIPTOR.auth_template,
+          organization_credentials: {},
+          action_policies: {},
+        }
+      )
+    );
+    expect(await screen.findByText("Add skills to Slack")).toBeInTheDocument();
+  });
+
   it("guards unsaved provider edits before skill creation", () => {
     const { onClose } = renderExistingProvider();
     fireEvent.change(screen.getByPlaceholderText("Token"), {

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
@@ -111,7 +111,7 @@ describe("ConfigureProviderModal", () => {
     });
   });
 
-  it("saves built-in app settings and custom associations together", async () => {
+  it("omits unchanged associations from a provider settings update", async () => {
     jest.mocked(externalAppsService.updateExternalApp).mockResolvedValue(APP);
     const { onClose } = renderExistingProvider();
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
@@ -128,7 +128,6 @@ describe("ConfigureProviderModal", () => {
         auth_template: { Authorization: "Bearer {token}" },
         action_policies: {},
         organization_credentials: { token: "updated-token" },
-        associated_skill_ids: ["custom-skill"],
       })
     );
     expect(onClose).toHaveBeenCalledTimes(1);

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
+import ConfigureProviderModal from "@/app/craft/v1/apps/admin/ConfigureProviderModal";
+import type {
+  BuiltInExternalAppDescriptor,
+  ExternalAppAdminResponse,
+} from "@/app/craft/v1/apps/registry";
+import * as externalAppsService from "@/app/craft/services/externalAppsService";
+
+jest.mock("@/app/craft/services/externalAppsService");
+jest.mock("@/hooks/useUserSkills", () => ({
+  __esModule: true,
+  default: () => ({
+    data: { builtins: [], customs: [] },
+    isLoading: false,
+  }),
+}));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/admin/craft/apps",
+}));
+
+const DESCRIPTOR: BuiltInExternalAppDescriptor = {
+  app_type: "SLACK",
+  name: "Slack",
+  upstream_url_patterns: ["https://slack.com/api/.*"],
+  auth_template: { Authorization: "Bearer {token}" },
+  required_org_credential_fields: [
+    {
+      key: "token",
+      label: "Token",
+      description: "Slack organization token",
+      secret: true,
+    },
+  ],
+  setup_instructions: "Configure Slack.",
+  actions: [],
+};
+
+const APP: ExternalAppAdminResponse = {
+  id: 7,
+  name: "Slack",
+  app_type: "SLACK",
+  upstream_url_patterns: DESCRIPTOR.upstream_url_patterns,
+  auth_template: DESCRIPTOR.auth_template,
+  organization_credentials: { token: "masked-token" },
+  enabled: true,
+  actions: [],
+  associated_skills: [
+    { id: "custom-skill", name: "slack-workflow", is_valid: true },
+  ],
+  is_onyx_managed: false,
+};
+
+describe("ConfigureProviderModal", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("saves built-in app settings and custom associations together", async () => {
+    jest.mocked(externalAppsService.updateExternalApp).mockResolvedValue(APP);
+    const onClose = jest.fn();
+
+    render(
+      <ConfigureProviderModal
+        onClose={onClose}
+        onSaved={jest.fn()}
+        descriptor={DESCRIPTOR}
+        existingApp={APP}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(externalAppsService.updateExternalApp).toHaveBeenCalledWith(7, {
+        name: "Slack",
+        upstream_url_patterns: ["https://slack.com/api/.*"],
+        auth_template: { Authorization: "Bearer {token}" },
+        action_policies: {},
+        organization_credentials: { token: "masked-token" },
+        associated_skill_ids: ["custom-skill"],
+      })
+    );
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a newly created provider durable while skills are skipped", async () => {
+    jest
+      .mocked(externalAppsService.createBuiltInExternalApp)
+      .mockResolvedValue({ ...APP, associated_skills: [] });
+    const onClose = jest.fn();
+
+    render(
+      <ConfigureProviderModal
+        onClose={onClose}
+        onSaved={jest.fn()}
+        descriptor={DESCRIPTOR}
+        existingApp={null}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText("Token"), {
+      target: { value: "org-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    expect(await screen.findByText("Add skills to Slack")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
@@ -9,16 +9,44 @@ import type {
   ExternalAppAdminResponse,
 } from "@/app/craft/v1/apps/registry";
 import * as externalAppsService from "@/app/craft/services/externalAppsService";
+import type { SkillCreationDraft } from "@/lib/skills/creationDraft";
+import { customFixture } from "@/lib/skills/__fixtures__/picker";
 
 const mockRouterPush = jest.fn();
+const mockUseUserSkills = jest.fn();
 
 jest.mock("@/app/craft/services/externalAppsService");
 jest.mock("@/hooks/useUserSkills", () => ({
   __esModule: true,
-  default: () => ({
-    data: { builtins: [], customs: [] },
-    isLoading: false,
-  }),
+  default: () => mockUseUserSkills(),
+}));
+jest.mock("@/lib/skills/creationDraft", () => ({
+  stageSkillCreationDraft: () => "draft-id",
+}));
+jest.mock("@/sections/modals/skills/CreateSkillModal", () => ({
+  CreateSkillModalContent: ({
+    hidden = false,
+    onClose,
+    onContinue,
+  }: {
+    hidden?: boolean;
+    onClose: () => void;
+    onContinue: (draft: SkillCreationDraft) => void;
+  }) =>
+    hidden ? null : (
+      <>
+        <div>Upload skill</div>
+        <button type="button" onClick={onClose}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={() => onContinue({} as SkillCreationDraft)}
+        >
+          Review skill
+        </button>
+      </>
+    ),
 }));
 jest.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockRouterPush }),
@@ -72,6 +100,10 @@ function renderExistingProvider(onClose = jest.fn()) {
 describe("ConfigureProviderModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseUserSkills.mockReturnValue({
+      data: { builtins: [], customs: [] },
+      isLoading: false,
+    });
   });
 
   it("saves built-in app settings and custom associations together", async () => {
@@ -136,6 +168,26 @@ describe("ConfigureProviderModal", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("guards unsaved provider settings before reviewing an upload", () => {
+    renderExistingProvider();
+    fireEvent.change(screen.getByPlaceholderText("Token"), {
+      target: { value: "unsaved-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Review skill" }));
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/craft/v1/skills/new?externalAppId=7&externalAppName=Slack&draft=draft-id"
+    );
+  });
+
   it("keeps a newly created provider durable while skills are skipped", async () => {
     jest
       .mocked(externalAppsService.createBuiltInExternalApp)
@@ -162,5 +214,63 @@ describe("ConfigureProviderModal", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+  });
+
+  it("guards pending post-create associations before reviewing an upload", async () => {
+    mockUseUserSkills.mockReturnValue({
+      data: {
+        builtins: [],
+        customs: [
+          customFixture({
+            id: "pending-skill",
+            name: "slack-helper",
+            description: "Uses Slack",
+            enabled: false,
+            author_user_id: "admin-id",
+            author_email: "admin@example.com",
+            owner: { id: "admin-id", email: "admin@example.com" },
+            ownership_vacant: false,
+            user_permission: "OWNER",
+          }),
+        ],
+      },
+      isLoading: false,
+    });
+    jest
+      .mocked(externalAppsService.createBuiltInExternalApp)
+      .mockResolvedValue({ ...APP, associated_skills: [] });
+
+    render(
+      <ConfigureProviderModal
+        onClose={jest.fn()}
+        onSaved={jest.fn()}
+        descriptor={DESCRIPTOR}
+        existingApp={null}
+      />
+    );
+    fireEvent.change(screen.getByPlaceholderText("Token"), {
+      target: { value: "org-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    expect(await screen.findByText("Add skills to Slack")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Associate existing" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Associate slack-helper" })
+    );
+    expect(screen.getByRole("button", { name: "Save skills" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Review skill" }));
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/craft/v1/skills/new?externalAppId=7&externalAppName=Slack&draft=draft-id"
+    );
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.test.tsx
@@ -28,14 +28,19 @@ jest.mock("@/sections/modals/skills/CreateSkillModal", () => ({
     hidden = false,
     onClose,
     onContinue,
+    onDirtyChange,
   }: {
     hidden?: boolean;
     onClose: () => void;
     onContinue: (draft: SkillCreationDraft) => void;
+    onDirtyChange?: (dirty: boolean) => void;
   }) =>
     hidden ? null : (
       <>
         <div>Upload skill</div>
+        <button type="button" onClick={() => onDirtyChange?.(true)}>
+          Select bundle
+        </button>
         <button type="button" onClick={onClose}>
           Cancel
         </button>
@@ -165,6 +170,27 @@ describe("ConfigureProviderModal", () => {
 
     expect(screen.getByRole("dialog", { name: /Edit Slack/ })).toBeVisible();
     expect(screen.getByPlaceholderText("Token")).toHaveValue("updated-token");
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("confirms before accidentally closing a selected upload", () => {
+    const { onClose } = renderExistingProvider();
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Select bundle" }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByText("Upload skill")).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
+
+    expect(screen.getByRole("dialog", { name: /Edit Slack/ })).toBeVisible();
     expect(onClose).not.toHaveBeenCalled();
   });
 

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -3,7 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import isEqual from "lodash/isEqual";
-import { Button, Divider, MessageCard, Modal } from "@opal/components";
+import { Divider } from "@opal/components";
 import ActionPolicyEditorModal, {
   EditorField,
 } from "@/app/craft/v1/apps/admin/ActionPolicyEditorModal";
@@ -17,14 +17,17 @@ import {
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
 import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
+import ExternalAppSkillsStepModal from "@/app/craft/v1/apps/admin/ExternalAppSkillsStepModal";
 import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
-import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
-import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
-import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
+import {
+  stageSkillCreationDraft,
+  type SkillCreationDraft,
+} from "@/lib/skills/creationDraft";
 import {
   skillEditorUrlForApp,
   skillEditUrlForApp,
 } from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
+import { useSyncedAssociatedSkillIds } from "@/lib/externalApps/hooks";
 
 // Field key for the instance name; prefixed so it can never collide with a
 // descriptor-declared credential key.
@@ -47,31 +50,19 @@ export default function ConfigureProviderModal({
   existingApp,
 }: ConfigureProviderModalProps) {
   const router = useRouter();
-  const [selectedSkillIds, setSelectedSkillIds] = useState(
-    existingApp?.associated_skills.map((skill) => skill.id) ?? []
-  );
   const [uploadOpen, setUploadOpen] = useState(false);
   const [uploadBusy, setUploadBusy] = useState(false);
   const [createdApp, setCreatedApp] = useState<ExternalAppAdminResponse | null>(
     null
   );
-  const [isSavingSkills, setIsSavingSkills] = useState(false);
-  const [skillsError, setSkillsError] = useState<string | null>(null);
+  const [selectedSkillIds, setSelectedSkillIds] =
+    useSyncedAssociatedSkillIds(existingApp);
   const existingAssociationDirty =
     existingApp !== null &&
     !isEqual(
       new Set(selectedSkillIds),
       new Set(existingApp.associated_skills.map((skill) => skill.id))
     );
-  const createdAssociationDirty =
-    createdApp !== null &&
-    !isEqual(
-      new Set(selectedSkillIds),
-      new Set(createdApp.associated_skills.map((skill) => skill.id))
-    );
-  const createdAppUnsavedChanges = useUnsavedChangesGuard({
-    isDirty: createdAssociationDirty,
-  });
   // Managed built-ins (cloud): Onyx owns creds/config, so the modal only edits
   // policies — cred fields are hidden and the backend ignores them anyway.
   const managed = existingApp?.is_onyx_managed ?? false;
@@ -157,206 +148,115 @@ export default function ConfigureProviderModal({
           organization_credentials: credentialValues,
         });
         setCreatedApp(created);
-        setSelectedSkillIds([]);
       }
     }
     onSaved();
   }
 
   function navigateToSkillEditor(draftId?: string) {
-    const app = existingApp ?? createdApp;
-    if (!app) return;
-    router.push(skillEditorUrlForApp(app, draftId));
+    if (!existingApp) return;
+    router.push(skillEditorUrlForApp(existingApp, draftId));
   }
 
   function navigateToExistingSkill(skillId: string) {
-    const app = existingApp ?? createdApp;
-    if (!app) return;
-    router.push(skillEditUrlForApp(skillId, app));
+    if (!existingApp) return;
+    router.push(skillEditUrlForApp(skillId, existingApp));
   }
 
-  async function saveCreatedAppSkills(): Promise<boolean> {
-    if (!createdApp) return false;
-    setIsSavingSkills(true);
-    setSkillsError(null);
-    try {
-      const updated = await updateExternalApp(createdApp.id, {
-        associated_skill_ids: selectedSkillIds,
-      });
-      setCreatedApp(updated);
-      onSaved();
-      return true;
-    } catch (error) {
-      setSkillsError(error instanceof Error ? error.message : String(error));
-      return false;
-    } finally {
-      setIsSavingSkills(false);
-    }
+  function validateUploadedSkill(draft: SkillCreationDraft): string | null {
+    return existingApp?.associated_skills.some(
+      (skill) => skill.name === draft.contents.name
+    )
+      ? `App “${existingApp.name}” already has an associated skill named “${draft.contents.name}”. Upload a skill with a different name.`
+      : null;
   }
 
   if (createdApp) {
     return (
-      <>
-        <Modal
-          open
-          onOpenChange={(open) => {
-            if (open) return;
-            if (uploadOpen) {
-              if (!uploadBusy) setUploadOpen(false);
-            } else {
-              createdAppUnsavedChanges.requestLeave(onClose);
-            }
-          }}
-        >
-          <Modal.Content
-            width={uploadOpen ? "sm" : "lg"}
-            height={uploadOpen ? "fit" : "lg"}
-          >
-            {uploadOpen ? (
-              <CreateSkillModalContent
-                onClose={() => setUploadOpen(false)}
-                onBusyChange={setUploadBusy}
-                onContinue={(draft) => {
-                  navigateToSkillEditor(stageSkillCreationDraft(draft));
-                }}
-              />
-            ) : (
-              <>
-                <Modal.Header
-                  title={`Add skills to ${createdApp.name}`}
-                  description="Optional — associate existing skills or create one for this app."
-                />
-                <Modal.Body>
-                  <div className="flex flex-col gap-3">
-                    <AssociatedSkillsEditor
-                      app={createdApp}
-                      selectedSkillIds={selectedSkillIds}
-                      onChange={setSelectedSkillIds}
-                      onOpenSkill={(skillId) =>
-                        createdAppUnsavedChanges.requestLeave(() =>
-                          navigateToExistingSkill(skillId)
-                        )
-                      }
-                      onCreateSkill={() =>
-                        createdAppUnsavedChanges.requestLeave(() =>
-                          navigateToSkillEditor()
-                        )
-                      }
-                      onUploadSkill={() => setUploadOpen(true)}
-                    />
-                    {skillsError && (
-                      <MessageCard
-                        variant="error"
-                        title="Couldn't save"
-                        description={skillsError}
-                      />
-                    )}
-                  </div>
-                </Modal.Body>
-                <Modal.Footer>
-                  <div className="flex w-full justify-end gap-2">
-                    <Button
-                      prominence="secondary"
-                      onClick={() =>
-                        createdAppUnsavedChanges.requestLeave(onClose)
-                      }
-                      disabled={isSavingSkills}
-                    >
-                      Skip for now
-                    </Button>
-                    <Button
-                      disabled={isSavingSkills || !createdAssociationDirty}
-                      onClick={async () => {
-                        if (await saveCreatedAppSkills()) onClose();
-                      }}
-                    >
-                      {isSavingSkills ? "Saving…" : "Save skills"}
-                    </Button>
-                  </div>
-                </Modal.Footer>
-              </>
-            )}
-          </Modal.Content>
-        </Modal>
-        <UnsavedChangesModal
-          open={createdAppUnsavedChanges.confirmationOpen}
-          onCancel={createdAppUnsavedChanges.cancelLeave}
-          onDiscard={createdAppUnsavedChanges.discardAndLeave}
-        />
-      </>
+      <ExternalAppSkillsStepModal
+        app={createdApp}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
     );
   }
 
   return (
-    <>
-      <ActionPolicyEditorModal
-        alternateContent={
-          uploadOpen && existingApp ? (
-            <CreateSkillModalContent
-              onClose={() => setUploadOpen(false)}
-              onBusyChange={setUploadBusy}
-              onContinue={(draft) => {
-                navigateToSkillEditor(stageSkillCreationDraft(draft));
-              }}
-            />
-          ) : undefined
-        }
-        isAdditionalContentDirty={existingAssociationDirty}
-        onClose={
-          uploadOpen
-            ? () => {
-                if (!uploadBusy) setUploadOpen(false);
-              }
-            : onClose
-        }
-        title={
-          existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
-        }
-        description={
-          managed
-            ? "Provided by Onyx — configure what the agent may do."
-            : descriptor.setup_instructions
-        }
-        note={
-          managed
-            ? "This app is provided by Onyx — credentials are managed for you. Choose what the agent may do below. Users connect it from the Apps page."
-            : undefined
-        }
-        fields={fields}
-        initialFieldValues={initialFieldValues}
-        policyItems={descriptor.actions.map((action) => ({
-          id: action.action_id,
-          name: action.normalised_name,
-          description: action.description,
-          defaultPolicy: action.default_policy,
-        }))}
-        initialPolicies={initialPolicies}
-        emptyPoliciesMessage="This provider has no actions to configure."
-        saveLabel={existingApp ? "Save" : "Add"}
-        onSave={save}
-        closeAfterSave={existingApp !== null}
-        bodyAfterPolicies={
-          existingApp
-            ? (requestLeave) => (
-                <>
-                  <Divider />
-                  <AssociatedSkillsEditor
-                    app={existingApp}
-                    selectedSkillIds={selectedSkillIds}
-                    onChange={setSelectedSkillIds}
-                    onOpenSkill={(skillId) =>
-                      requestLeave(() => navigateToExistingSkill(skillId))
-                    }
-                    onCreateSkill={() =>
-                      requestLeave(() => navigateToSkillEditor())
-                    }
-                    onUploadSkill={() => setUploadOpen(true)}
-                  />
-                </>
-              )
-            : undefined
-        }
-      />
-    </>
+    <ActionPolicyEditorModal
+      alternateContent={
+        uploadOpen && existingApp
+          ? ({ requestLeave, hidden }) => (
+              <CreateSkillModalContent
+                hidden={hidden}
+                onClose={() => setUploadOpen(false)}
+                onBusyChange={setUploadBusy}
+                preserveDraftOnContinue
+                validateDraft={validateUploadedSkill}
+                onContinue={(draft) => {
+                  requestLeave(() =>
+                    navigateToSkillEditor(stageSkillCreationDraft(draft))
+                  );
+                }}
+              />
+            )
+          : undefined
+      }
+      isAdditionalContentDirty={existingAssociationDirty}
+      onClose={
+        uploadOpen
+          ? () => {
+              if (!uploadBusy) setUploadOpen(false);
+            }
+          : onClose
+      }
+      title={
+        existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
+      }
+      description={
+        managed
+          ? "Provided by Onyx — configure what the agent may do."
+          : descriptor.setup_instructions
+      }
+      note={
+        managed
+          ? "This app is provided by Onyx — credentials are managed for you. Choose what the agent may do below. Users connect it from the Apps page."
+          : undefined
+      }
+      fields={fields}
+      initialFieldValues={initialFieldValues}
+      policyItems={descriptor.actions.map((action) => ({
+        id: action.action_id,
+        name: action.normalised_name,
+        description: action.description,
+        defaultPolicy: action.default_policy,
+      }))}
+      initialPolicies={initialPolicies}
+      emptyPoliciesMessage="This provider has no actions to configure."
+      saveLabel={existingApp ? "Save" : "Add"}
+      autoFocusFirstField={existingApp === null}
+      onSave={save}
+      closeAfterSave={existingApp !== null}
+      bodyAfterPolicies={
+        existingApp
+          ? (requestLeave) => (
+              <>
+                <Divider />
+                <AssociatedSkillsEditor
+                  app={existingApp}
+                  selectedSkillIds={selectedSkillIds}
+                  onChange={setSelectedSkillIds}
+                  onOpenSkill={(skillId) =>
+                    requestLeave(() => navigateToExistingSkill(skillId))
+                  }
+                  onCreateSkill={() =>
+                    requestLeave(() => navigateToSkillEditor())
+                  }
+                  onUploadSkill={() => setUploadOpen(true)}
+                />
+              </>
+            )
+          : undefined
+      }
+    />
   );
 }

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -193,7 +193,7 @@ export default function ConfigureProviderModal({
               <>
                 <CreateSkillModalContent
                   hidden={hidden || upload.confirmationOpen}
-                  onClose={upload.close}
+                  onRequestClose={upload.requestDismiss}
                   onBusyChange={upload.setBusy}
                   onDirtyChange={upload.setDirty}
                   preserveDraftOnContinue
@@ -207,7 +207,7 @@ export default function ConfigureProviderModal({
                 {upload.confirmationOpen && (
                   <UnsavedChangesModalContent
                     onCancel={upload.cancelDiscard}
-                    onDiscard={upload.confirmDiscard}
+                    onDiscard={upload.discardAndClose}
                   />
                 )}
               </>
@@ -216,7 +216,7 @@ export default function ConfigureProviderModal({
       }
       alternateContentConfirmationOpen={upload.confirmationOpen}
       isAdditionalContentDirty={existingAssociationDirty}
-      onClose={upload.isOpen ? upload.dismiss : onClose}
+      onClose={upload.isOpen ? upload.requestDismiss : onClose}
       title={
         existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
       }

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -239,6 +239,7 @@ export default function ConfigureProviderModal({
       emptyPoliciesMessage="This provider has no actions to configure."
       saveLabel={existingApp ? "Save" : "Add"}
       autoFocusFirstField={existingApp === null}
+      allowPristineSave={existingApp === null}
       onSave={save}
       closeAfterSave={existingApp !== null}
       bodyAfterPolicies={

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
+import isEqual from "lodash/isEqual";
 import { Button, Divider, MessageCard, Modal } from "@opal/components";
 import ActionPolicyEditorModal, {
   EditorField,
@@ -16,7 +17,9 @@ import {
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
 import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
-import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
+import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
+import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
 import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
 import {
   skillEditorUrlForApp,
@@ -48,11 +51,27 @@ export default function ConfigureProviderModal({
     existingApp?.associated_skills.map((skill) => skill.id) ?? []
   );
   const [uploadOpen, setUploadOpen] = useState(false);
+  const [uploadBusy, setUploadBusy] = useState(false);
   const [createdApp, setCreatedApp] = useState<ExternalAppAdminResponse | null>(
     null
   );
   const [isSavingSkills, setIsSavingSkills] = useState(false);
   const [skillsError, setSkillsError] = useState<string | null>(null);
+  const existingAssociationDirty =
+    existingApp !== null &&
+    !isEqual(
+      new Set(selectedSkillIds),
+      new Set(existingApp.associated_skills.map((skill) => skill.id))
+    );
+  const createdAssociationDirty =
+    createdApp !== null &&
+    !isEqual(
+      new Set(selectedSkillIds),
+      new Set(createdApp.associated_skills.map((skill) => skill.id))
+    );
+  const createdAppUnsavedChanges = useUnsavedChangesGuard({
+    isDirty: createdAssociationDirty,
+  });
   // Managed built-ins (cloud): Onyx owns creds/config, so the modal only edits
   // policies — cred fields are hidden and the backend ignores them anyway.
   const managed = existingApp?.is_onyx_managed ?? false;
@@ -147,14 +166,12 @@ export default function ConfigureProviderModal({
   function navigateToSkillEditor(draftId?: string) {
     const app = existingApp ?? createdApp;
     if (!app) return;
-    onClose();
     router.push(skillEditorUrlForApp(app, draftId));
   }
 
   function navigateToExistingSkill(skillId: string) {
     const app = existingApp ?? createdApp;
     if (!app) return;
-    onClose();
     router.push(skillEditUrlForApp(skillId, app));
   }
 
@@ -167,7 +184,7 @@ export default function ConfigureProviderModal({
         associated_skill_ids: selectedSkillIds,
       });
       setCreatedApp(updated);
-      await onSaved();
+      onSaved();
       return true;
     } catch (error) {
       setSkillsError(error instanceof Error ? error.message : String(error));
@@ -180,70 +197,92 @@ export default function ConfigureProviderModal({
   if (createdApp) {
     return (
       <>
-        <Modal open onOpenChange={(open) => !open && onClose()}>
-          <Modal.Content width="lg" height="lg">
-            <Modal.Header
-              title={`Add skills to ${createdApp.name}`}
-              description="Optional — associate existing skills or create one for this app."
-            />
-            <Modal.Body>
-              <div className="flex flex-col gap-3">
-                <AssociatedSkillsEditor
-                  app={createdApp}
-                  selectedSkillIds={selectedSkillIds}
-                  onChange={setSelectedSkillIds}
-                  onOpenSkill={async (skillId) => {
-                    if (await saveCreatedAppSkills()) {
-                      navigateToExistingSkill(skillId);
-                    }
-                  }}
-                  onCreateSkill={async () => {
-                    if (await saveCreatedAppSkills()) navigateToSkillEditor();
-                  }}
-                  onUploadSkill={async () => {
-                    if (await saveCreatedAppSkills()) setUploadOpen(true);
-                  }}
+        <Modal
+          open
+          onOpenChange={(open) => {
+            if (open) return;
+            if (uploadOpen) {
+              if (!uploadBusy) setUploadOpen(false);
+            } else {
+              createdAppUnsavedChanges.requestLeave(onClose);
+            }
+          }}
+        >
+          <Modal.Content
+            width={uploadOpen ? "sm" : "lg"}
+            height={uploadOpen ? "fit" : "lg"}
+          >
+            {uploadOpen ? (
+              <CreateSkillModalContent
+                onClose={() => setUploadOpen(false)}
+                onBusyChange={setUploadBusy}
+                onContinue={(draft) => {
+                  navigateToSkillEditor(stageSkillCreationDraft(draft));
+                }}
+              />
+            ) : (
+              <>
+                <Modal.Header
+                  title={`Add skills to ${createdApp.name}`}
+                  description="Optional — associate existing skills or create one for this app."
                 />
-                {skillsError && (
-                  <MessageCard
-                    variant="error"
-                    title="Couldn't save"
-                    description={skillsError}
-                  />
-                )}
-              </div>
-            </Modal.Body>
-            <Modal.Footer>
-              <div className="flex w-full justify-end gap-2">
-                <Button
-                  prominence="secondary"
-                  onClick={onClose}
-                  disabled={isSavingSkills}
-                >
-                  Skip for now
-                </Button>
-                <Button
-                  disabled={isSavingSkills}
-                  onClick={async () => {
-                    if (await saveCreatedAppSkills()) onClose();
-                  }}
-                >
-                  {isSavingSkills ? "Saving…" : "Save skills"}
-                </Button>
-              </div>
-            </Modal.Footer>
+                <Modal.Body>
+                  <div className="flex flex-col gap-3">
+                    <AssociatedSkillsEditor
+                      app={createdApp}
+                      selectedSkillIds={selectedSkillIds}
+                      onChange={setSelectedSkillIds}
+                      onOpenSkill={(skillId) =>
+                        createdAppUnsavedChanges.requestLeave(() =>
+                          navigateToExistingSkill(skillId)
+                        )
+                      }
+                      onCreateSkill={() =>
+                        createdAppUnsavedChanges.requestLeave(() =>
+                          navigateToSkillEditor()
+                        )
+                      }
+                      onUploadSkill={() => setUploadOpen(true)}
+                    />
+                    {skillsError && (
+                      <MessageCard
+                        variant="error"
+                        title="Couldn't save"
+                        description={skillsError}
+                      />
+                    )}
+                  </div>
+                </Modal.Body>
+                <Modal.Footer>
+                  <div className="flex w-full justify-end gap-2">
+                    <Button
+                      prominence="secondary"
+                      onClick={() =>
+                        createdAppUnsavedChanges.requestLeave(onClose)
+                      }
+                      disabled={isSavingSkills}
+                    >
+                      Skip for now
+                    </Button>
+                    <Button
+                      disabled={isSavingSkills || !createdAssociationDirty}
+                      onClick={async () => {
+                        if (await saveCreatedAppSkills()) onClose();
+                      }}
+                    >
+                      {isSavingSkills ? "Saving…" : "Save skills"}
+                    </Button>
+                  </div>
+                </Modal.Footer>
+              </>
+            )}
           </Modal.Content>
         </Modal>
-        {uploadOpen && (
-          <CreateSkillModal
-            open
-            skipOverlay
-            onClose={() => setUploadOpen(false)}
-            onContinue={(draft) => {
-              navigateToSkillEditor(stageSkillCreationDraft(draft));
-            }}
-          />
-        )}
+        <UnsavedChangesModal
+          open={createdAppUnsavedChanges.confirmationOpen}
+          onCancel={createdAppUnsavedChanges.cancelLeave}
+          onDiscard={createdAppUnsavedChanges.discardAndLeave}
+        />
       </>
     );
   }
@@ -251,7 +290,25 @@ export default function ConfigureProviderModal({
   return (
     <>
       <ActionPolicyEditorModal
-        onClose={onClose}
+        alternateContent={
+          uploadOpen && existingApp ? (
+            <CreateSkillModalContent
+              onClose={() => setUploadOpen(false)}
+              onBusyChange={setUploadBusy}
+              onContinue={(draft) => {
+                navigateToSkillEditor(stageSkillCreationDraft(draft));
+              }}
+            />
+          ) : undefined
+        }
+        isAdditionalContentDirty={existingAssociationDirty}
+        onClose={
+          uploadOpen
+            ? () => {
+                if (!uploadBusy) setUploadOpen(false);
+              }
+            : onClose
+        }
         title={
           existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
         }
@@ -280,40 +337,26 @@ export default function ConfigureProviderModal({
         closeAfterSave={existingApp !== null}
         bodyAfterPolicies={
           existingApp
-            ? (saveWithoutClosing) => (
+            ? (requestLeave) => (
                 <>
                   <Divider />
                   <AssociatedSkillsEditor
                     app={existingApp}
                     selectedSkillIds={selectedSkillIds}
                     onChange={setSelectedSkillIds}
-                    onOpenSkill={async (skillId) => {
-                      if (await saveWithoutClosing()) {
-                        navigateToExistingSkill(skillId);
-                      }
-                    }}
-                    onCreateSkill={async () => {
-                      if (await saveWithoutClosing()) navigateToSkillEditor();
-                    }}
-                    onUploadSkill={async () => {
-                      if (await saveWithoutClosing()) setUploadOpen(true);
-                    }}
+                    onOpenSkill={(skillId) =>
+                      requestLeave(() => navigateToExistingSkill(skillId))
+                    }
+                    onCreateSkill={() =>
+                      requestLeave(() => navigateToSkillEditor())
+                    }
+                    onUploadSkill={() => setUploadOpen(true)}
                   />
                 </>
               )
             : undefined
         }
       />
-      {uploadOpen && existingApp && (
-        <CreateSkillModal
-          open
-          skipOverlay
-          onClose={() => setUploadOpen(false)}
-          onContinue={(draft) => {
-            navigateToSkillEditor(stageSkillCreationDraft(draft));
-          }}
-        />
-      )}
     </>
   );
 }

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button, Divider, MessageCard, Modal } from "@opal/components";
 import ActionPolicyEditorModal, {
   EditorField,
 } from "@/app/craft/v1/apps/admin/ActionPolicyEditorModal";
@@ -12,6 +15,13 @@ import {
   createBuiltInExternalApp,
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
+import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
+import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
+import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
+import {
+  skillEditorUrlForApp,
+  skillEditUrlForApp,
+} from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
 
 // Field key for the instance name; prefixed so it can never collide with a
 // descriptor-declared credential key.
@@ -33,6 +43,16 @@ export default function ConfigureProviderModal({
   descriptor,
   existingApp,
 }: ConfigureProviderModalProps) {
+  const router = useRouter();
+  const [selectedSkillIds, setSelectedSkillIds] = useState(
+    existingApp?.associated_skills.map((skill) => skill.id) ?? []
+  );
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [createdApp, setCreatedApp] = useState<ExternalAppAdminResponse | null>(
+    null
+  );
+  const [isSavingSkills, setIsSavingSkills] = useState(false);
+  const [skillsError, setSkillsError] = useState<string | null>(null);
   // Managed built-ins (cloud): Onyx owns creds/config, so the modal only edits
   // policies — cred fields are hidden and the backend ignores them anyway.
   const managed = existingApp?.is_onyx_managed ?? false;
@@ -84,7 +104,10 @@ export default function ConfigureProviderModal({
   ) {
     if (managed && existingApp) {
       // Managed: only policies are persisted; a partial PATCH leaves the rest.
-      await updateExternalApp(existingApp.id, { action_policies: policies });
+      await updateExternalApp(existingApp.id, {
+        action_policies: policies,
+        associated_skill_ids: selectedSkillIds,
+      });
     } else {
       const credentialValues = Object.fromEntries(
         descriptor.required_org_credential_fields.map((field) => [
@@ -106,46 +129,191 @@ export default function ConfigureProviderModal({
             ...existingApp.organization_credentials,
             ...credentialValues,
           },
+          associated_skill_ids: selectedSkillIds,
         });
       } else {
-        await createBuiltInExternalApp({
+        const created = await createBuiltInExternalApp({
           ...shared,
           app_type: descriptor.app_type,
           organization_credentials: credentialValues,
         });
+        setCreatedApp(created);
+        setSelectedSkillIds([]);
       }
     }
     onSaved();
   }
 
+  function navigateToSkillEditor(draftId?: string) {
+    const app = existingApp ?? createdApp;
+    if (!app) return;
+    onClose();
+    router.push(skillEditorUrlForApp(app, draftId));
+  }
+
+  function navigateToExistingSkill(skillId: string) {
+    const app = existingApp ?? createdApp;
+    if (!app) return;
+    onClose();
+    router.push(skillEditUrlForApp(skillId, app));
+  }
+
+  async function saveCreatedAppSkills(): Promise<boolean> {
+    if (!createdApp) return false;
+    setIsSavingSkills(true);
+    setSkillsError(null);
+    try {
+      const updated = await updateExternalApp(createdApp.id, {
+        associated_skill_ids: selectedSkillIds,
+      });
+      setCreatedApp(updated);
+      await onSaved();
+      return true;
+    } catch (error) {
+      setSkillsError(error instanceof Error ? error.message : String(error));
+      return false;
+    } finally {
+      setIsSavingSkills(false);
+    }
+  }
+
+  if (createdApp) {
+    return (
+      <>
+        <Modal open onOpenChange={(open) => !open && onClose()}>
+          <Modal.Content width="lg" height="lg">
+            <Modal.Header
+              title={`Add skills to ${createdApp.name}`}
+              description="Optional — associate existing skills or create one for this app."
+            />
+            <Modal.Body>
+              <div className="flex flex-col gap-3">
+                <AssociatedSkillsEditor
+                  app={createdApp}
+                  selectedSkillIds={selectedSkillIds}
+                  onChange={setSelectedSkillIds}
+                  onOpenSkill={async (skillId) => {
+                    if (await saveCreatedAppSkills()) {
+                      navigateToExistingSkill(skillId);
+                    }
+                  }}
+                  onCreateSkill={async () => {
+                    if (await saveCreatedAppSkills()) navigateToSkillEditor();
+                  }}
+                  onUploadSkill={async () => {
+                    if (await saveCreatedAppSkills()) setUploadOpen(true);
+                  }}
+                />
+                {skillsError && (
+                  <MessageCard
+                    variant="error"
+                    title="Couldn't save"
+                    description={skillsError}
+                  />
+                )}
+              </div>
+            </Modal.Body>
+            <Modal.Footer>
+              <div className="flex w-full justify-end gap-2">
+                <Button
+                  prominence="secondary"
+                  onClick={onClose}
+                  disabled={isSavingSkills}
+                >
+                  Skip for now
+                </Button>
+                <Button
+                  disabled={isSavingSkills}
+                  onClick={async () => {
+                    if (await saveCreatedAppSkills()) onClose();
+                  }}
+                >
+                  {isSavingSkills ? "Saving…" : "Save skills"}
+                </Button>
+              </div>
+            </Modal.Footer>
+          </Modal.Content>
+        </Modal>
+        {uploadOpen && (
+          <CreateSkillModal
+            open
+            skipOverlay
+            onClose={() => setUploadOpen(false)}
+            onContinue={(draft) => {
+              navigateToSkillEditor(stageSkillCreationDraft(draft));
+            }}
+          />
+        )}
+      </>
+    );
+  }
+
   return (
-    <ActionPolicyEditorModal
-      onClose={onClose}
-      title={
-        existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
-      }
-      description={
-        managed
-          ? "Provided by Onyx — configure what the agent may do."
-          : descriptor.setup_instructions
-      }
-      note={
-        managed
-          ? "This app is provided by Onyx — credentials are managed for you. Choose what the agent may do below. Users connect this app on the Apps page to make its skill available."
-          : undefined
-      }
-      fields={fields}
-      initialFieldValues={initialFieldValues}
-      policyItems={descriptor.actions.map((action) => ({
-        id: action.action_id,
-        name: action.normalised_name,
-        description: action.description,
-        defaultPolicy: action.default_policy,
-      }))}
-      initialPolicies={initialPolicies}
-      emptyPoliciesMessage="This provider has no actions to configure."
-      saveLabel={existingApp ? "Save" : "Add"}
-      onSave={save}
-    />
+    <>
+      <ActionPolicyEditorModal
+        onClose={onClose}
+        title={
+          existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
+        }
+        description={
+          managed
+            ? "Provided by Onyx — configure what the agent may do."
+            : descriptor.setup_instructions
+        }
+        note={
+          managed
+            ? "This app is provided by Onyx — credentials are managed for you. Choose what the agent may do below. Users connect it from the Apps page."
+            : undefined
+        }
+        fields={fields}
+        initialFieldValues={initialFieldValues}
+        policyItems={descriptor.actions.map((action) => ({
+          id: action.action_id,
+          name: action.normalised_name,
+          description: action.description,
+          defaultPolicy: action.default_policy,
+        }))}
+        initialPolicies={initialPolicies}
+        emptyPoliciesMessage="This provider has no actions to configure."
+        saveLabel={existingApp ? "Save" : "Add"}
+        onSave={save}
+        closeAfterSave={existingApp !== null}
+        bodyAfterPolicies={
+          existingApp
+            ? (saveWithoutClosing) => (
+                <>
+                  <Divider />
+                  <AssociatedSkillsEditor
+                    app={existingApp}
+                    selectedSkillIds={selectedSkillIds}
+                    onChange={setSelectedSkillIds}
+                    onOpenSkill={async (skillId) => {
+                      if (await saveWithoutClosing()) {
+                        navigateToExistingSkill(skillId);
+                      }
+                    }}
+                    onCreateSkill={async () => {
+                      if (await saveWithoutClosing()) navigateToSkillEditor();
+                    }}
+                    onUploadSkill={async () => {
+                      if (await saveWithoutClosing()) setUploadOpen(true);
+                    }}
+                  />
+                </>
+              )
+            : undefined
+        }
+      />
+      {uploadOpen && existingApp && (
+        <CreateSkillModal
+          open
+          skipOverlay
+          onClose={() => setUploadOpen(false)}
+          onContinue={(draft) => {
+            navigateToSkillEditor(stageSkillCreationDraft(draft));
+          }}
+        />
+      )}
+    </>
   );
 }

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -19,6 +19,8 @@ import {
 import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
 import ExternalAppSkillsStepModal from "@/app/craft/v1/apps/admin/ExternalAppSkillsStepModal";
 import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
+import useSkillUploadModal from "@/sections/modals/skills/useSkillUploadModal";
+import { UnsavedChangesModalContent } from "@/sections/modals/UnsavedChangesModal";
 import {
   stageSkillCreationDraft,
   type SkillCreationDraft,
@@ -50,8 +52,7 @@ export default function ConfigureProviderModal({
   existingApp,
 }: ConfigureProviderModalProps) {
   const router = useRouter();
-  const [uploadOpen, setUploadOpen] = useState(false);
-  const [uploadBusy, setUploadBusy] = useState(false);
+  const upload = useSkillUploadModal();
   const [createdApp, setCreatedApp] = useState<ExternalAppAdminResponse | null>(
     null
   );
@@ -184,31 +185,35 @@ export default function ConfigureProviderModal({
   return (
     <ActionPolicyEditorModal
       alternateContent={
-        uploadOpen && existingApp
+        upload.isOpen && existingApp
           ? ({ requestLeave, hidden }) => (
-              <CreateSkillModalContent
-                hidden={hidden}
-                onClose={() => setUploadOpen(false)}
-                onBusyChange={setUploadBusy}
-                preserveDraftOnContinue
-                validateDraft={validateUploadedSkill}
-                onContinue={(draft) => {
-                  requestLeave(() =>
-                    navigateToSkillEditor(stageSkillCreationDraft(draft))
-                  );
-                }}
-              />
+              <>
+                <CreateSkillModalContent
+                  hidden={hidden || upload.confirmationOpen}
+                  onClose={upload.close}
+                  onBusyChange={upload.setBusy}
+                  onDirtyChange={upload.setDirty}
+                  preserveDraftOnContinue
+                  validateDraft={validateUploadedSkill}
+                  onContinue={(draft) => {
+                    requestLeave(() =>
+                      navigateToSkillEditor(stageSkillCreationDraft(draft))
+                    );
+                  }}
+                />
+                {upload.confirmationOpen && (
+                  <UnsavedChangesModalContent
+                    onCancel={upload.cancelDiscard}
+                    onDiscard={upload.confirmDiscard}
+                  />
+                )}
+              </>
             )
           : undefined
       }
+      alternateContentConfirmationOpen={upload.confirmationOpen}
       isAdditionalContentDirty={existingAssociationDirty}
-      onClose={
-        uploadOpen
-          ? () => {
-              if (!uploadBusy) setUploadOpen(false);
-            }
-          : onClose
-      }
+      onClose={upload.isOpen ? upload.dismiss : onClose}
       title={
         existingApp ? `Edit ${existingApp.name}` : `Add ${descriptor.name}`
       }
@@ -251,7 +256,7 @@ export default function ConfigureProviderModal({
                   onCreateSkill={() =>
                     requestLeave(() => navigateToSkillEditor())
                   }
-                  onUploadSkill={() => setUploadOpen(true)}
+                  onUploadSkill={upload.open}
                 />
               </>
             )

--- a/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ConfigureProviderModal.tsx
@@ -64,6 +64,9 @@ export default function ConfigureProviderModal({
       new Set(selectedSkillIds),
       new Set(existingApp.associated_skills.map((skill) => skill.id))
     );
+  const associationPatch = existingAssociationDirty
+    ? { associated_skill_ids: selectedSkillIds }
+    : {};
   // Managed built-ins (cloud): Onyx owns creds/config, so the modal only edits
   // policies — cred fields are hidden and the backend ignores them anyway.
   const managed = existingApp?.is_onyx_managed ?? false;
@@ -117,7 +120,7 @@ export default function ConfigureProviderModal({
       // Managed: only policies are persisted; a partial PATCH leaves the rest.
       await updateExternalApp(existingApp.id, {
         action_policies: policies,
-        associated_skill_ids: selectedSkillIds,
+        ...associationPatch,
       });
     } else {
       const credentialValues = Object.fromEntries(
@@ -140,7 +143,7 @@ export default function ConfigureProviderModal({
             ...existingApp.organization_credentials,
             ...credentialValues,
           },
-          associated_skill_ids: selectedSkillIds,
+          ...associationPatch,
         });
       } else {
         const created = await createBuiltInExternalApp({

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
@@ -2,15 +2,46 @@
  * @jest-environment jsdom
  */
 
-import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
+import {
+  act,
+  deferred,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "@tests/setup/test-utils";
 import CreateCustomAppModal from "@/app/craft/v1/apps/admin/CreateCustomAppModal";
 import * as externalAppsService from "@/app/craft/services/externalAppsService";
 import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
+import { customFixture } from "@/lib/skills/__fixtures__/picker";
 
 const mockUseUserSkills = jest.fn();
 const mockRouterPush = jest.fn();
+const mockInspectSkillBundle = jest.fn();
 
 jest.mock("@/app/craft/services/externalAppsService");
+jest.mock("@/lib/skills/api", () => ({
+  ...jest.requireActual("@/lib/skills/api"),
+  inspectSkillBundle: (...args: unknown[]) => mockInspectSkillBundle(...args),
+}));
+jest.mock("@/sections/skills/SkillBundlePicker", () => ({
+  __esModule: true,
+  default: ({ onChange }: { onChange: (bundle: object) => void }) => (
+    <button
+      type="button"
+      onClick={() =>
+        onChange({
+          file: new File(["bundle"], "skill.zip"),
+          displayName: "skill.zip",
+          source: "zip",
+        })
+      }
+    >
+      Select bundle
+    </button>
+  ),
+}));
 jest.mock("@/hooks/useUserSkills", () => ({
   __esModule: true,
   default: () => mockUseUserSkills(),
@@ -40,23 +71,39 @@ function renderExistingApp({
   onClose?: jest.Mock;
   onSaved?: jest.Mock;
 } = {}) {
-  render(
+  const { unmount } = render(
     <CreateCustomAppModal
       onClose={onClose}
       onSaved={onSaved}
       existingApp={CUSTOM_APP}
     />
   );
-  return { onClose, onSaved };
+  return { onClose, onSaved, unmount };
 }
 
 describe("CreateCustomAppModal", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockInspectSkillBundle.mockReset();
     mockUseUserSkills.mockReturnValue({
       data: { builtins: [], customs: [] },
       isLoading: false,
     });
+  });
+
+  it("focuses the name only when creating an app", () => {
+    const { unmount } = renderExistingApp();
+    expect(screen.getByPlaceholderText("My Custom App")).not.toHaveFocus();
+    unmount();
+
+    render(
+      <CreateCustomAppModal
+        onClose={jest.fn()}
+        onSaved={jest.fn()}
+        existingApp={null}
+      />
+    );
+    expect(screen.getByPlaceholderText("My Custom App")).toHaveFocus();
   });
 
   it("persists the app before offering the optional skills step", async () => {
@@ -115,29 +162,31 @@ describe("CreateCustomAppModal", () => {
   });
 
   it("confirms visibility promotion and batches association with app edits", async () => {
-    const editableSkill = {
-      source: "custom" as const,
+    const editableSkill = customFixture({
       id: "skill-a",
       name: "acme-lookup",
       description: "Looks up Acme records",
-      is_available: true,
-      unavailable_reason: null,
-      is_valid: true,
-      is_personal: true,
       enabled: false,
-      can_toggle: true,
       author_user_id: "admin-id",
       author_email: "admin@example.com",
       owner: { id: "admin-id", email: "admin@example.com" },
       ownership_vacant: false,
-      created_at: null,
-      updated_at: null,
-      user_shares: [],
-      group_shares: [],
       public_permission: null,
-      user_permission: "OWNER" as const,
-      external_app: null,
-    };
+      is_personal: true,
+      user_permission: "OWNER",
+    });
+    const otherAppSkill = customFixture({
+      id: "other-app-skill",
+      name: "other-app-skill",
+      description: "Already used by another app",
+      user_permission: "OWNER",
+      external_app: {
+        external_app_id: 99,
+        name: "Other CRM",
+        enabled: true,
+        ready: true,
+      },
+    });
     mockUseUserSkills.mockReturnValue({
       data: {
         builtins: [],
@@ -150,6 +199,7 @@ describe("CreateCustomAppModal", () => {
             name: "broken-skill",
             is_valid: false,
           },
+          otherAppSkill,
         ],
       },
       isLoading: false,
@@ -196,6 +246,13 @@ describe("CreateCustomAppModal", () => {
     expect(invalidSkill).toHaveAttribute("aria-disabled", "true");
     expect(invalidSkill).toHaveTextContent(
       "Invalid skill — fix it before associating."
+    );
+    const otherAppAssociation = screen.getByRole("button", {
+      name: "Associate other-app-skill",
+    });
+    expect(otherAppAssociation).toHaveAttribute("aria-disabled", "true");
+    expect(otherAppAssociation).toHaveTextContent(
+      "Already associated with app “Other CRM”."
     );
     fireEvent.keyDown(document, { key: "Escape" });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
@@ -247,12 +304,67 @@ describe("CreateCustomAppModal", () => {
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(onClose).not.toHaveBeenCalled();
+    let confirmation = screen.getByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    fireEvent.click(
+      within(confirmation).getByRole("button", { name: "Cancel" })
+    );
     expect(
-      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
-    ).toBeVisible();
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("Unsaved Acme CRM")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("Unsaved Acme CRM")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    confirmation = screen.getByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    fireEvent.click(
+      within(confirmation).getByRole("button", { name: "Close" })
+    );
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" })
+    ).not.toBeInTheDocument();
+    expect(screen.getByDisplayValue("Unsaved Acme CRM")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+  });
+
+  it("cannot discard an app edit while its save is in flight", async () => {
+    const save = deferred<ExternalAppAdminResponse>();
+    jest
+      .mocked(externalAppsService.updateExternalApp)
+      .mockReturnValue(save.promise);
+    const { onClose } = renderExistingApp();
+    fireEvent.change(screen.getByDisplayValue("Acme CRM"), {
+      target: { value: "Updated Acme CRM" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    await waitFor(() =>
+      expect(externalAppsService.updateExternalApp).toHaveBeenCalledTimes(1)
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(
+      screen.queryByRole("dialog", { name: "Discard unsaved changes?" })
+    ).not.toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+
+    await act(async () => {
+      save.resolve({ ...CUSTOM_APP, name: "Updated Acme CRM" });
+      await save.promise;
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it("restores unsaved app settings after upload is canceled", () => {
@@ -272,7 +384,69 @@ describe("CreateCustomAppModal", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  it("preserves the draft when refreshed app data arrives", () => {
+  it("returns to the uploaded draft when navigation is canceled", async () => {
+    mockInspectSkillBundle.mockResolvedValue({
+      name: "new-skill",
+      description: "Uses Acme",
+      instructions_markdown: "Use the Acme API.",
+      files: [{ path: "SKILL.md", size: 64 }],
+    });
+    renderExistingApp();
+    fireEvent.change(screen.getByDisplayValue("Acme CRM"), {
+      target: { value: "Unsaved Acme CRM" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Select bundle" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review skill" }));
+
+    const confirmation = await screen.findByRole("dialog", {
+      name: "Discard unsaved changes?",
+    });
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    fireEvent.click(
+      within(confirmation).getByRole("button", { name: "Cancel" })
+    );
+
+    expect(screen.getByText("Upload skill")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled()
+    );
+    expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it("rejects an uploaded skill whose name is already associated", async () => {
+    mockInspectSkillBundle.mockResolvedValue({
+      name: "hubspot-crm",
+      description: "Uses HubSpot",
+      instructions_markdown: "Use the HubSpot API.",
+      files: [{ path: "SKILL.md", size: 64 }],
+    });
+    render(
+      <CreateCustomAppModal
+        onClose={jest.fn()}
+        onSaved={jest.fn()}
+        existingApp={{
+          ...CUSTOM_APP,
+          associated_skills: [
+            { id: "existing-skill", name: "hubspot-crm", is_valid: true },
+          ],
+        }}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Select bundle" }));
+    fireEvent.click(screen.getByRole("button", { name: "Review skill" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "App “Acme CRM” already has an associated skill named “hubspot-crm”. Upload a skill with a different name."
+    );
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled();
+  });
+
+  it("preserves the draft and displays a newly persisted association", async () => {
     const props = {
       onClose: jest.fn(),
       onSaved: jest.fn(),
@@ -286,11 +460,66 @@ describe("CreateCustomAppModal", () => {
     rerender(
       <CreateCustomAppModal
         {...props}
-        existingApp={{ ...CUSTOM_APP, associated_skills: [] }}
+        existingApp={{
+          ...CUSTOM_APP,
+          associated_skills: [
+            { id: "new-skill", name: "newly-created", is_valid: true },
+          ],
+        }}
       />
     );
 
     expect(screen.getByDisplayValue("Unsaved Acme CRM")).toBeInTheDocument();
+    expect(await screen.findByText("newly-created")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+  });
+
+  it("does not overwrite a pending association when app data refreshes", async () => {
+    const pendingSkill = customFixture({
+      id: "pending-skill",
+      name: "pending-skill",
+      description: "Selected locally",
+      public_permission: "VIEWER",
+      is_personal: false,
+      user_permission: "OWNER",
+    });
+    mockUseUserSkills.mockReturnValue({
+      data: { builtins: [], customs: [pendingSkill] },
+      isLoading: false,
+    });
+    const props = {
+      onClose: jest.fn(),
+      onSaved: jest.fn(),
+      existingApp: CUSTOM_APP,
+    };
+    const { rerender } = render(<CreateCustomAppModal {...props} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Associate existing" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Associate pending-skill" })
+    );
+    expect(screen.getByText("pending-skill")).toBeInTheDocument();
+
+    rerender(
+      <CreateCustomAppModal
+        {...props}
+        existingApp={{
+          ...CUSTOM_APP,
+          associated_skills: [
+            { id: "server-skill", name: "server-skill", is_valid: true },
+          ],
+        }}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(externalAppsService.updateExternalApp).toHaveBeenCalledWith(
+        CUSTOM_APP.id,
+        expect.objectContaining({
+          associated_skill_ids: ["pending-skill"],
+        })
+      )
+    );
   });
 });

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
@@ -156,6 +156,10 @@ describe("CreateCustomAppModal", () => {
       screen.getByRole("button", { name: "Associate existing" })
     ).toBeInTheDocument();
 
+    const beforeUnload = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(beforeUnload);
+    expect(beforeUnload.defaultPrevented).toBe(false);
+
     fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     expect(onClose).toHaveBeenCalledTimes(1);
     expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
@@ -5,8 +5,10 @@
 import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
 import CreateCustomAppModal from "@/app/craft/v1/apps/admin/CreateCustomAppModal";
 import * as externalAppsService from "@/app/craft/services/externalAppsService";
+import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
 
 const mockUseUserSkills = jest.fn();
+const mockRouterPush = jest.fn();
 
 jest.mock("@/app/craft/services/externalAppsService");
 jest.mock("@/hooks/useUserSkills", () => ({
@@ -14,9 +16,39 @@ jest.mock("@/hooks/useUserSkills", () => ({
   default: () => mockUseUserSkills(),
 }));
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: mockRouterPush }),
   usePathname: () => "/admin/craft/apps",
 }));
+
+const CUSTOM_APP: ExternalAppAdminResponse = {
+  id: 17,
+  name: "Acme CRM",
+  app_type: "CUSTOM",
+  upstream_url_patterns: ["https://api.acme.test/*"],
+  auth_template: {},
+  organization_credentials: {},
+  enabled: true,
+  actions: [],
+  associated_skills: [],
+  is_onyx_managed: false,
+};
+
+function renderExistingApp({
+  onClose = jest.fn(),
+  onSaved = jest.fn(),
+}: {
+  onClose?: jest.Mock;
+  onSaved?: jest.Mock;
+} = {}) {
+  render(
+    <CreateCustomAppModal
+      onClose={onClose}
+      onSaved={onSaved}
+      existingApp={CUSTOM_APP}
+    />
+  );
+  return { onClose, onSaved };
+}
 
 describe("CreateCustomAppModal", () => {
   beforeEach(() => {
@@ -30,22 +62,12 @@ describe("CreateCustomAppModal", () => {
   it("persists the app before offering the optional skills step", async () => {
     const onClose = jest.fn();
     const onSaved = jest.fn();
-    jest.mocked(externalAppsService.createCustomExternalApp).mockResolvedValue({
-      id: 17,
-      name: "Acme CRM",
-      app_type: "CUSTOM",
-      upstream_url_patterns: ["https://api.acme.test/*"],
-      auth_template: {},
-      organization_credentials: {},
-      enabled: true,
-      actions: [],
-      associated_skills: [],
-      is_onyx_managed: false,
-    });
+    jest
+      .mocked(externalAppsService.createCustomExternalApp)
+      .mockResolvedValue(CUSTOM_APP);
 
     render(
       <CreateCustomAppModal
-        open
         onClose={onClose}
         onSaved={onSaved}
         existingApp={null}
@@ -93,20 +115,6 @@ describe("CreateCustomAppModal", () => {
   });
 
   it("confirms visibility promotion and batches association with app edits", async () => {
-    const onClose = jest.fn();
-    const onSaved = jest.fn();
-    const existingApp = {
-      id: 17,
-      name: "Acme CRM",
-      app_type: "CUSTOM" as const,
-      upstream_url_patterns: ["https://api.acme.test/*"],
-      auth_template: {},
-      organization_credentials: {},
-      enabled: true,
-      actions: [],
-      associated_skills: [],
-      is_onyx_managed: false,
-    };
     const editableSkill = {
       source: "custom" as const,
       id: "skill-a",
@@ -147,20 +155,13 @@ describe("CreateCustomAppModal", () => {
       isLoading: false,
     });
     jest.mocked(externalAppsService.updateExternalApp).mockResolvedValue({
-      ...existingApp,
+      ...CUSTOM_APP,
       associated_skills: [
         { id: "skill-a", name: "acme-lookup", is_valid: true },
       ],
     });
 
-    render(
-      <CreateCustomAppModal
-        open
-        onClose={onClose}
-        onSaved={onSaved}
-        existingApp={existingApp}
-      />
-    );
+    const { onClose, onSaved } = renderExistingApp();
 
     const appModal = screen.getByRole("dialog", { name: /Edit Acme CRM/ });
     fireEvent.click(screen.getByRole("button", { name: "Associate existing" }));
@@ -183,21 +184,19 @@ describe("CreateCustomAppModal", () => {
       name: "Associate acme-lookup",
     });
     expect(sameNamedSkills).toHaveLength(2);
-    expect(
-      sameNamedSkills.filter(
-        (item) => item.getAttribute("aria-disabled") === "true"
-      )
-    ).toHaveLength(1);
-    expect(
-      screen.getByRole("button", { name: "Associate broken-skill" })
-    ).toHaveAttribute("aria-disabled", "true");
-    expect(
-      screen.getAllByText("Invalid skill — fix it before associating.").length
-    ).toBeGreaterThan(0);
-    expect(
-      screen.getAllByText("A skill named “acme-lookup” is already associated.")
-        .length
-    ).toBeGreaterThan(0);
+    const disabledSameNamedSkill = sameNamedSkills.find(
+      (item) => item.getAttribute("aria-disabled") === "true"
+    );
+    expect(disabledSameNamedSkill).toHaveTextContent(
+      "A skill named “acme-lookup” is already associated."
+    );
+    const invalidSkill = screen.getByRole("button", {
+      name: "Associate broken-skill",
+    });
+    expect(invalidSkill).toHaveAttribute("aria-disabled", "true");
+    expect(invalidSkill).toHaveTextContent(
+      "Invalid skill — fix it before associating."
+    );
     fireEvent.keyDown(document, { key: "Escape" });
     fireEvent.click(screen.getByRole("button", { name: "Save" }));
 
@@ -214,38 +213,84 @@ describe("CreateCustomAppModal", () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps app settings mounted beneath the upload chooser", () => {
-    const existingApp = {
-      id: 17,
-      name: "Acme CRM",
-      app_type: "CUSTOM" as const,
-      upstream_url_patterns: ["https://api.acme.test/*"],
-      auth_template: {},
-      organization_credentials: {},
-      enabled: true,
-      actions: [],
-      associated_skills: [],
-      is_onyx_managed: false,
-    };
+  it("guards unsaved edits before skill creation without persisting them", () => {
+    const { onClose, onSaved } = renderExistingApp();
 
-    render(
-      <CreateCustomAppModal
-        open
-        onClose={jest.fn()}
-        onSaved={jest.fn()}
-        existingApp={existingApp}
-      />
+    fireEvent.change(screen.getByDisplayValue("Acme CRM"), {
+      target: { value: "Unsaved Acme CRM" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /^Start from scratch/ })
     );
+
+    expect(mockRouterPush).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/craft/v1/skills/new?externalAppId=17&externalAppName=Acme+CRM"
+    );
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("warns before discarding dirty app settings", () => {
+    const { onClose } = renderExistingApp();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    fireEvent.change(screen.getByDisplayValue("Acme CRM"), {
+      target: { value: "Unsaved Acme CRM" },
+    });
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(onClose).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Discard changes" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+  });
+
+  it("restores unsaved app settings after upload is canceled", () => {
+    const { onClose } = renderExistingApp();
+    fireEvent.change(screen.getByDisplayValue("Acme CRM"), {
+      target: { value: "Edited Acme CRM" },
+    });
     fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
     fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
 
-    expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
-    expect(screen.getByText("Edit Acme CRM")).toBeInTheDocument();
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
     expect(screen.getByText("Upload skill")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
 
-    expect(screen.getAllByRole("dialog")).toHaveLength(1);
-    expect(screen.getByDisplayValue("Acme CRM")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Edited Acme CRM")).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("preserves the draft when refreshed app data arrives", () => {
+    const props = {
+      onClose: jest.fn(),
+      onSaved: jest.fn(),
+      existingApp: CUSTOM_APP,
+    };
+    const { rerender } = render(<CreateCustomAppModal {...props} />);
+    fireEvent.change(screen.getByDisplayValue("Acme CRM"), {
+      target: { value: "Unsaved Acme CRM" },
+    });
+
+    rerender(
+      <CreateCustomAppModal
+        {...props}
+        existingApp={{ ...CUSTOM_APP, associated_skills: [] }}
+      />
+    );
+
+    expect(screen.getByDisplayValue("Unsaved Acme CRM")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeEnabled();
   });
 });

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
@@ -427,12 +427,16 @@ describe("CreateCustomAppModal", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
     fireEvent.click(screen.getByRole("button", { name: "Select bundle" }));
 
-    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(
       screen.getByRole("dialog", { name: "Discard unsaved changes?" })
     ).toBeVisible();
 
-    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    fireEvent.click(
+      within(
+        screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+      ).getByRole("button", { name: "Cancel" })
+    );
     expect(screen.getByText("Upload skill")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled();
   });

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
@@ -384,6 +384,22 @@ describe("CreateCustomAppModal", () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  it("preserves a selected upload when accidental close is canceled", () => {
+    renderExistingApp();
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+    fireEvent.click(screen.getByRole("button", { name: "Select bundle" }));
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(
+      screen.getByRole("dialog", { name: "Discard unsaved changes?" })
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.getByText("Upload skill")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled();
+  });
+
   it("returns to the uploaded draft when navigation is canceled", async () => {
     mockInspectSkillBundle.mockResolvedValue({
       name: "new-skill",

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
@@ -6,10 +6,28 @@ import { fireEvent, render, screen, waitFor } from "@tests/setup/test-utils";
 import CreateCustomAppModal from "@/app/craft/v1/apps/admin/CreateCustomAppModal";
 import * as externalAppsService from "@/app/craft/services/externalAppsService";
 
+const mockUseUserSkills = jest.fn();
+
 jest.mock("@/app/craft/services/externalAppsService");
+jest.mock("@/hooks/useUserSkills", () => ({
+  __esModule: true,
+  default: () => mockUseUserSkills(),
+}));
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ push: jest.fn() }),
+  usePathname: () => "/admin/craft/apps",
+}));
 
 describe("CreateCustomAppModal", () => {
-  it("creates a custom app without asking for a skill bundle", async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseUserSkills.mockReturnValue({
+      data: { builtins: [], customs: [] },
+      isLoading: false,
+    });
+  });
+
+  it("persists the app before offering the optional skills step", async () => {
     const onClose = jest.fn();
     const onSaved = jest.fn();
     jest.mocked(externalAppsService.createCustomExternalApp).mockResolvedValue({
@@ -63,6 +81,171 @@ describe("CreateCustomAppModal", () => {
       });
     });
     expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByText("Add skills to Acme CRM")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Associate existing" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Skip for now" }));
     expect(onClose).toHaveBeenCalledTimes(1);
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+  });
+
+  it("confirms visibility promotion and batches association with app edits", async () => {
+    const onClose = jest.fn();
+    const onSaved = jest.fn();
+    const existingApp = {
+      id: 17,
+      name: "Acme CRM",
+      app_type: "CUSTOM" as const,
+      upstream_url_patterns: ["https://api.acme.test/*"],
+      auth_template: {},
+      organization_credentials: {},
+      enabled: true,
+      actions: [],
+      associated_skills: [],
+      is_onyx_managed: false,
+    };
+    const editableSkill = {
+      source: "custom" as const,
+      id: "skill-a",
+      name: "acme-lookup",
+      description: "Looks up Acme records",
+      is_available: true,
+      unavailable_reason: null,
+      is_valid: true,
+      is_personal: true,
+      enabled: false,
+      can_toggle: true,
+      author_user_id: "admin-id",
+      author_email: "admin@example.com",
+      owner: { id: "admin-id", email: "admin@example.com" },
+      ownership_vacant: false,
+      created_at: null,
+      updated_at: null,
+      user_shares: [],
+      group_shares: [],
+      public_permission: null,
+      user_permission: "OWNER" as const,
+      external_app: null,
+    };
+    mockUseUserSkills.mockReturnValue({
+      data: {
+        builtins: [],
+        customs: [
+          editableSkill,
+          { ...editableSkill, id: "skill-b" },
+          {
+            ...editableSkill,
+            id: "invalid-skill",
+            name: "broken-skill",
+            is_valid: false,
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    jest.mocked(externalAppsService.updateExternalApp).mockResolvedValue({
+      ...existingApp,
+      associated_skills: [
+        { id: "skill-a", name: "acme-lookup", is_valid: true },
+      ],
+    });
+
+    render(
+      <CreateCustomAppModal
+        open
+        onClose={onClose}
+        onSaved={onSaved}
+        existingApp={existingApp}
+      />
+    );
+
+    const appModal = screen.getByRole("dialog", { name: /Edit Acme CRM/ });
+    fireEvent.click(screen.getByRole("button", { name: "Associate existing" }));
+    expect(appModal).not.toContainElement(
+      screen.getByPlaceholderText("Search editable skills...")
+    );
+    fireEvent.click(screen.getAllByRole("button", { name: /acme-lookup/ })[0]!);
+    expect(
+      screen.getByText(
+        "App-associated skills must be available to everyone. This change is applied when you save the app."
+      )
+    ).toBeInTheDocument();
+    expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Make organization-wide" })
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Associate existing" }));
+    const sameNamedSkills = screen.getAllByRole("button", {
+      name: "Associate acme-lookup",
+    });
+    expect(sameNamedSkills).toHaveLength(2);
+    expect(
+      sameNamedSkills.filter(
+        (item) => item.getAttribute("aria-disabled") === "true"
+      )
+    ).toHaveLength(1);
+    expect(
+      screen.getByRole("button", { name: "Associate broken-skill" })
+    ).toHaveAttribute("aria-disabled", "true");
+    expect(
+      screen.getAllByText("Invalid skill — fix it before associating.").length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("A skill named “acme-lookup” is already associated.")
+        .length
+    ).toBeGreaterThan(0);
+    fireEvent.keyDown(document, { key: "Escape" });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(externalAppsService.updateExternalApp).toHaveBeenCalledWith(17, {
+        name: "Acme CRM",
+        upstream_url_patterns: ["https://api.acme.test/*"],
+        auth_template: {},
+        organization_credentials: {},
+        associated_skill_ids: ["skill-a"],
+      })
+    );
+    expect(onSaved).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps app settings mounted beneath the upload chooser", () => {
+    const existingApp = {
+      id: 17,
+      name: "Acme CRM",
+      app_type: "CUSTOM" as const,
+      upstream_url_patterns: ["https://api.acme.test/*"],
+      auth_template: {},
+      organization_credentials: {},
+      enabled: true,
+      actions: [],
+      associated_skills: [],
+      is_onyx_managed: false,
+    };
+
+    render(
+      <CreateCustomAppModal
+        open
+        onClose={jest.fn()}
+        onSaved={jest.fn()}
+        existingApp={existingApp}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Create skill" }));
+    fireEvent.click(screen.getByRole("button", { name: /^Upload a skill/ }));
+
+    expect(document.querySelectorAll('[role="dialog"]')).toHaveLength(2);
+    expect(screen.getByText("Edit Acme CRM")).toBeInTheDocument();
+    expect(screen.getByText("Upload skill")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(screen.getAllByRole("dialog")).toHaveLength(1);
+    expect(screen.getByDisplayValue("Acme CRM")).toBeInTheDocument();
   });
 });

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.test.tsx
@@ -165,6 +165,39 @@ describe("CreateCustomAppModal", () => {
     expect(externalAppsService.updateExternalApp).not.toHaveBeenCalled();
   });
 
+  it("omits unchanged associations from a custom app settings update", async () => {
+    jest.mocked(externalAppsService.updateExternalApp).mockResolvedValue({
+      ...CUSTOM_APP,
+      name: "Updated CRM",
+    });
+    render(
+      <CreateCustomAppModal
+        onClose={jest.fn()}
+        onSaved={jest.fn()}
+        existingApp={{
+          ...CUSTOM_APP,
+          associated_skills: [
+            { id: "invalid-skill", name: "broken-skill", is_valid: false },
+          ],
+        }}
+      />
+    );
+
+    fireEvent.change(screen.getByDisplayValue("Acme CRM"), {
+      target: { value: "Updated CRM" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(externalAppsService.updateExternalApp).toHaveBeenCalledWith(17, {
+        name: "Updated CRM",
+        upstream_url_patterns: ["https://api.acme.test/*"],
+        auth_template: {},
+        organization_credentials: {},
+      })
+    );
+  });
+
   it("confirms visibility promotion and batches association with app edits", async () => {
     const editableSkill = customFixture({
       id: "skill-a",

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -110,7 +110,9 @@ export default function CreateCustomAppModal({
         Object.keys(toRecord(headers)).length ||
         Object.keys(toRecord(orgCredentials)).length
       );
-  const unsavedChanges = useUnsavedChangesGuard({ isDirty: configDirty });
+  const unsavedChanges = useUnsavedChangesGuard({
+    isDirty: createdApp === null && configDirty,
+  });
 
   // Headers and org credentials are optional; name + at least one upstream
   // pattern are required.

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -24,6 +24,7 @@ import {
 import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
 import ExternalAppSkillsStepModal from "@/app/craft/v1/apps/admin/ExternalAppSkillsStepModal";
 import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
+import useSkillUploadModal from "@/sections/modals/skills/useSkillUploadModal";
 import { UnsavedChangesModalContent } from "@/sections/modals/UnsavedChangesModal";
 import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
 import {
@@ -92,8 +93,7 @@ export default function CreateCustomAppModal({
   const [error, setError] = useState<string | null>(null);
   const [selectedSkillIds, setSelectedSkillIds] =
     useSyncedAssociatedSkillIds(existingApp);
-  const [uploadOpen, setUploadOpen] = useState(false);
-  const [uploadBusy, setUploadBusy] = useState(false);
+  const upload = useSkillUploadModal();
 
   const configDirty = existingApp
     ? name !== existingApp.name ||
@@ -196,14 +196,21 @@ export default function CreateCustomAppModal({
       unsavedChanges.cancelLeave();
       return;
     }
-    if (uploadOpen) {
-      if (!uploadBusy) setUploadOpen(false);
+    if (upload.isOpen) {
+      upload.dismiss();
     } else {
       unsavedChanges.requestLeave(onClose);
     }
   }
 
-  const confirmationContent = unsavedChanges.confirmationOpen ? (
+  const confirmationOpen =
+    upload.confirmationOpen || unsavedChanges.confirmationOpen;
+  const confirmationContent = upload.confirmationOpen ? (
+    <UnsavedChangesModalContent
+      onCancel={upload.cancelDiscard}
+      onDiscard={upload.confirmDiscard}
+    />
+  ) : unsavedChanges.confirmationOpen ? (
     <UnsavedChangesModalContent
       onCancel={unsavedChanges.cancelLeave}
       onDiscard={unsavedChanges.discardAndLeave}
@@ -223,21 +230,22 @@ export default function CreateCustomAppModal({
   return (
     <Modal open>
       <Modal.Content
-        width={unsavedChanges.confirmationOpen || uploadOpen ? "sm" : "lg"}
-        height={unsavedChanges.confirmationOpen || uploadOpen ? "fit" : "lg"}
+        width={confirmationOpen || upload.isOpen ? "sm" : "lg"}
+        height={confirmationOpen || upload.isOpen ? "fit" : "lg"}
         onOpenAutoFocus={(event) => {
           if (isEdit) event.preventDefault();
         }}
-        preventAccidentalClose={!unsavedChanges.confirmationOpen}
+        preventAccidentalClose={!confirmationOpen}
         onInteractOutside={handleDismiss}
         onEscapeKeyDown={handleDismiss}
       >
-        {uploadOpen && existingApp ? (
+        {upload.isOpen && existingApp ? (
           <>
             <CreateSkillModalContent
-              hidden={unsavedChanges.confirmationOpen}
-              onClose={() => setUploadOpen(false)}
-              onBusyChange={setUploadBusy}
+              hidden={confirmationOpen}
+              onClose={upload.close}
+              onBusyChange={upload.setBusy}
+              onDirtyChange={upload.setDirty}
               preserveDraftOnContinue
               validateDraft={(draft) =>
                 existingApp.associated_skills.some(
@@ -335,7 +343,7 @@ export default function CreateCustomAppModal({
                       onChange={setSelectedSkillIds}
                       onOpenSkill={openExistingSkill}
                       onCreateSkill={openSkillEditor}
-                      onUploadSkill={() => setUploadOpen(true)}
+                      onUploadSkill={upload.open}
                     />
                   </>
                 )}

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -1,16 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useRouter } from "next/navigation";
-import type { Route } from "next";
-import { Modal } from "@opal/components";
+import isEqual from "lodash/isEqual";
 import {
   Button,
+  Divider,
   InputTypeIn,
   MessageCard,
+  Modal,
   Text,
   Tooltip,
-  Divider,
 } from "@opal/components";
 import { ListFieldInput } from "@/refresh-components/inputs/ListFieldInput";
 import InputKeyValue, {
@@ -22,7 +22,9 @@ import {
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
 import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
-import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
+import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
+import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
 import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
 import {
   skillEditorUrlForApp,
@@ -30,7 +32,6 @@ import {
 } from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
 
 interface CreateCustomAppModalProps {
-  open: boolean;
   onClose: () => void;
   /** Invoked after a successful create/edit so callers can refresh their list. */
   onSaved: () => void;
@@ -58,7 +59,6 @@ function toKeyValues(record: Record<string, string>): KeyValue[] {
 }
 
 export default function CreateCustomAppModal({
-  open,
   onClose,
   onSaved,
   existingApp,
@@ -70,45 +70,58 @@ export default function CreateCustomAppModal({
     existingApp
   );
   const [step, setStep] = useState<"config" | "skills">("config");
-  const [name, setName] = useState("");
-  const [upstreamPatterns, setUpstreamPatterns] = useState<string[]>([]);
-  const [headers, setHeaders] = useState<KeyValue[]>([{ key: "", value: "" }]);
-  const [orgCredentials, setOrgCredentials] = useState<KeyValue[]>([
-    { key: "", value: "" },
-  ]);
+  const [name, setName] = useState(existingApp?.name ?? "");
+  const [upstreamPatterns, setUpstreamPatterns] = useState<string[]>(
+    existingApp?.upstream_url_patterns ?? []
+  );
+  const [headers, setHeaders] = useState<KeyValue[]>(
+    existingApp
+      ? toKeyValues(existingApp.auth_template)
+      : [{ key: "", value: "" }]
+  );
+  const [orgCredentials, setOrgCredentials] = useState<KeyValue[]>(
+    existingApp
+      ? toKeyValues(existingApp.organization_credentials)
+      : [{ key: "", value: "" }]
+  );
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>(
+    existingApp?.associated_skills.map((skill) => skill.id) ?? []
+  );
   const [uploadOpen, setUploadOpen] = useState(false);
-  // Re-seed every time the modal opens: from the existing app when editing,
-  // blank when creating. Prevents a prior attempt from leaking in.
-  useEffect(() => {
-    if (!open) return;
-    setActiveApp(existingApp);
-    setStep("config");
-    setName(existingApp?.name ?? "");
-    setUpstreamPatterns(existingApp?.upstream_url_patterns ?? []);
-    setHeaders(
-      existingApp
-        ? toKeyValues(existingApp.auth_template)
-        : [{ key: "", value: "" }]
+  const [uploadBusy, setUploadBusy] = useState(false);
+
+  const configDirty = existingApp
+    ? name !== existingApp.name ||
+      !isEqual(
+        new Set(selectedSkillIds),
+        new Set(existingApp.associated_skills.map((skill) => skill.id))
+      ) ||
+      !isEqual(upstreamPatterns, existingApp.upstream_url_patterns) ||
+      !isEqual(toRecord(headers), existingApp.auth_template) ||
+      !isEqual(toRecord(orgCredentials), existingApp.organization_credentials)
+    : Boolean(
+        name ||
+        upstreamPatterns.length ||
+        Object.keys(toRecord(headers)).length ||
+        Object.keys(toRecord(orgCredentials)).length
+      );
+  const skillsDirty =
+    activeApp !== null &&
+    !isEqual(
+      new Set(selectedSkillIds),
+      new Set(activeApp.associated_skills.map((skill) => skill.id))
     );
-    setOrgCredentials(
-      existingApp
-        ? toKeyValues(existingApp.organization_credentials)
-        : [{ key: "", value: "" }]
-    );
-    setError(null);
-    setSelectedSkillIds(
-      existingApp?.associated_skills.map((skill) => skill.id) ?? []
-    );
-    setUploadOpen(false);
-  }, [open, existingApp]);
+  const unsavedChanges = useUnsavedChangesGuard({
+    isDirty: step === "config" ? configDirty : skillsDirty,
+  });
 
   // Headers and org credentials are optional; name + at least one upstream
   // pattern are required.
   const disabledCreateReason = (() => {
     if (isSaving) return "Save is already in progress.";
+    if (isEdit && !configDirty) return "Make a change before saving.";
     if (name.trim().length === 0) {
       return "Enter a name before creating this custom app.";
     }
@@ -134,7 +147,13 @@ export default function CreateCustomAppModal({
     setError(null);
     try {
       if (existingApp) {
-        await saveExistingApp();
+        await updateExternalApp(existingApp.id, {
+          name: name.trim(),
+          upstream_url_patterns: upstreamPatterns,
+          auth_template: toRecord(headers),
+          organization_credentials: toRecord(orgCredentials),
+          associated_skill_ids: selectedSkillIds,
+        });
         onSaved();
         onClose();
       } else {
@@ -157,33 +176,17 @@ export default function CreateCustomAppModal({
     }
   }
 
-  async function saveExistingApp() {
-    if (!existingApp) return null;
-    return updateExternalApp(existingApp.id, {
-      name: name.trim(),
-      upstream_url_patterns: upstreamPatterns,
-      auth_template: toRecord(headers),
-      organization_credentials: toRecord(orgCredentials),
-      associated_skill_ids: selectedSkillIds,
-    });
-  }
-
-  async function persistActiveApp() {
-    if (!activeApp) return false;
-    if (existingApp) return saveExistingApp();
-    const updated = await updateExternalApp(activeApp.id, {
-      associated_skill_ids: selectedSkillIds,
-    });
-    setActiveApp(updated);
-    setSelectedSkillIds(updated.associated_skills.map((skill) => skill.id));
-    return updated;
-  }
-
   async function saveSkills(): Promise<boolean> {
+    if (!activeApp) return false;
     setIsSaving(true);
     setError(null);
     try {
-      return (await persistActiveApp()) !== false;
+      const updated = await updateExternalApp(activeApp.id, {
+        associated_skill_ids: selectedSkillIds,
+      });
+      setActiveApp(updated);
+      setSelectedSkillIds(updated.associated_skills.map((skill) => skill.id));
+      return true;
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       return false;
@@ -192,196 +195,207 @@ export default function CreateCustomAppModal({
     }
   }
 
-  async function navigateAfterSave(
-    destination: (app: ExternalAppAdminResponse) => Route
-  ) {
-    setIsSaving(true);
-    setError(null);
-    try {
-      const saved = await persistActiveApp();
-      if (!saved) return;
-      await onSaved();
-      onClose();
-      router.push(destination(saved));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setIsSaving(false);
-    }
-  }
-
   function openSkillEditor(draftId?: string) {
-    return navigateAfterSave((app) => skillEditorUrlForApp(app, draftId));
+    if (!activeApp) return;
+    unsavedChanges.requestLeave(() =>
+      router.push(skillEditorUrlForApp(activeApp, draftId))
+    );
   }
 
   function openExistingSkill(skillId: string) {
-    return navigateAfterSave((app) => skillEditUrlForApp(skillId, app));
+    if (!activeApp) return;
+    unsavedChanges.requestLeave(() =>
+      router.push(skillEditUrlForApp(skillId, activeApp))
+    );
   }
 
   return (
     <>
-      <Modal open={open} onOpenChange={(o) => !o && onClose()}>
-        <Modal.Content width="lg" height="lg">
-          <Modal.Header
-            title={
-              step === "skills" && activeApp
-                ? `Add skills to ${activeApp.name}`
-                : existingApp
-                  ? `Edit ${existingApp.name}`
-                  : "Create custom app"
-            }
-            description={
-              step === "skills"
-                ? "Optional — associate existing skills or create one for this app."
-                : isEdit
-                  ? "Update gateway settings and manage associated skills."
-                  : "Configure how the egress proxy reaches and authenticates this app. A skill is not required."
-            }
-          />
-          <Modal.Body>
-            <div className="flex flex-col gap-4">
-              {step === "config" && (
-                <>
-                  <div className="flex flex-col gap-1">
-                    <Text font="main-ui-action">Name</Text>
-                    <InputTypeIn
-                      value={name}
-                      onChange={(e) => setName(e.target.value)}
-                      placeholder="My Custom App"
-                    />
-                  </div>
-
-                  <div className="flex flex-col gap-1">
-                    <Text font="main-ui-action">Upstream URL patterns</Text>
-                    <Text font="secondary-body" color="text-03">
-                      {
-                        "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
-                      }
-                    </Text>
-                    <ListFieldInput
-                      values={upstreamPatterns}
-                      onChange={setUpstreamPatterns}
-                      placeholder="https://api.example.com/*"
-                    />
-                  </div>
-
-                  <div className="flex flex-col gap-1">
-                    <Text font="main-ui-action">Header credential pattern</Text>
-                    <Text font="secondary-body" color="text-03">
-                      {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
-                    </Text>
-                    <InputKeyValue
-                      keyTitle="Header"
-                      valueTitle="Value"
-                      keyPlaceholder="Authorization"
-                      valuePlaceholder="Bearer {api_key}"
-                      items={headers}
-                      onChange={setHeaders}
-                      mode="line"
-                      addButtonLabel="Add header"
-                    />
-                  </div>
-
-                  <div className="flex flex-col gap-1">
-                    <Text font="main-ui-action">Organization credentials</Text>
-                    <Text font="secondary-body" color="text-03">
-                      Optional — values your org pre-fills for every user. Leave
-                      empty for apps where each user supplies their own
-                      credentials.
-                    </Text>
-                    <InputKeyValue
-                      keyTitle="Credential key"
-                      valueTitle="Value"
-                      keyPlaceholder="api_key"
-                      valuePlaceholder="sk-…"
-                      items={orgCredentials}
-                      onChange={setOrgCredentials}
-                      mode="line"
-                      addButtonLabel="Add credential"
-                    />
-                  </div>
-
-                  {existingApp && (
+      <Modal
+        open
+        onOpenChange={(o) => {
+          if (o) return;
+          if (uploadOpen) {
+            if (!uploadBusy) setUploadOpen(false);
+          } else {
+            unsavedChanges.requestLeave(onClose);
+          }
+        }}
+      >
+        <Modal.Content
+          width={uploadOpen ? "sm" : "lg"}
+          height={uploadOpen ? "fit" : "lg"}
+        >
+          {uploadOpen && activeApp ? (
+            <CreateSkillModalContent
+              onClose={() => setUploadOpen(false)}
+              onBusyChange={setUploadBusy}
+              onContinue={(draft) => {
+                const draftId = stageSkillCreationDraft(draft);
+                setUploadOpen(false);
+                openSkillEditor(draftId);
+              }}
+            />
+          ) : (
+            <>
+              <Modal.Header
+                title={
+                  step === "skills" && activeApp
+                    ? `Add skills to ${activeApp.name}`
+                    : existingApp
+                      ? `Edit ${existingApp.name}`
+                      : "Create custom app"
+                }
+                description={
+                  step === "skills"
+                    ? "Optional — associate existing skills or create one for this app."
+                    : isEdit
+                      ? "Update gateway settings and manage associated skills."
+                      : "Configure how the egress proxy reaches and authenticates this app. A skill is not required."
+                }
+              />
+              <Modal.Body>
+                <div className="flex flex-col gap-4">
+                  {step === "config" && (
                     <>
-                      <Divider />
-                      <AssociatedSkillsEditor
-                        app={existingApp}
-                        selectedSkillIds={selectedSkillIds}
-                        onChange={setSelectedSkillIds}
-                        onOpenSkill={(skillId) =>
-                          void openExistingSkill(skillId)
-                        }
-                        onCreateSkill={() => void openSkillEditor()}
-                        onUploadSkill={() => setUploadOpen(true)}
-                      />
+                      <div className="flex flex-col gap-1">
+                        <Text font="main-ui-action">Name</Text>
+                        <InputTypeIn
+                          value={name}
+                          onChange={(e) => setName(e.target.value)}
+                          placeholder="My Custom App"
+                        />
+                      </div>
+
+                      <div className="flex flex-col gap-1">
+                        <Text font="main-ui-action">Upstream URL patterns</Text>
+                        <Text font="secondary-body" color="text-03">
+                          {
+                            "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
+                          }
+                        </Text>
+                        <ListFieldInput
+                          values={upstreamPatterns}
+                          onChange={setUpstreamPatterns}
+                          placeholder="https://api.example.com/*"
+                        />
+                      </div>
+
+                      <div className="flex flex-col gap-1">
+                        <Text font="main-ui-action">
+                          Header credential pattern
+                        </Text>
+                        <Text font="secondary-body" color="text-03">
+                          {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
+                        </Text>
+                        <InputKeyValue
+                          keyTitle="Header"
+                          valueTitle="Value"
+                          keyPlaceholder="Authorization"
+                          valuePlaceholder="Bearer {api_key}"
+                          items={headers}
+                          onChange={setHeaders}
+                          mode="line"
+                          addButtonLabel="Add header"
+                        />
+                      </div>
+
+                      <div className="flex flex-col gap-1">
+                        <Text font="main-ui-action">
+                          Organization credentials
+                        </Text>
+                        <Text font="secondary-body" color="text-03">
+                          Optional — values your org pre-fills for every user.
+                          Leave empty for apps where each user supplies their
+                          own credentials.
+                        </Text>
+                        <InputKeyValue
+                          keyTitle="Credential key"
+                          valueTitle="Value"
+                          keyPlaceholder="api_key"
+                          valuePlaceholder="sk-…"
+                          items={orgCredentials}
+                          onChange={setOrgCredentials}
+                          mode="line"
+                          addButtonLabel="Add credential"
+                        />
+                      </div>
+
+                      {existingApp && (
+                        <>
+                          <Divider />
+                          <AssociatedSkillsEditor
+                            app={existingApp}
+                            selectedSkillIds={selectedSkillIds}
+                            onChange={setSelectedSkillIds}
+                            onOpenSkill={openExistingSkill}
+                            onCreateSkill={openSkillEditor}
+                            onUploadSkill={() => setUploadOpen(true)}
+                          />
+                        </>
+                      )}
                     </>
                   )}
-                </>
-              )}
 
-              {step === "skills" && activeApp && (
-                <AssociatedSkillsEditor
-                  app={activeApp}
-                  selectedSkillIds={selectedSkillIds}
-                  onChange={setSelectedSkillIds}
-                  onOpenSkill={(skillId) => void openExistingSkill(skillId)}
-                  onCreateSkill={() => void openSkillEditor()}
-                  onUploadSkill={() => setUploadOpen(true)}
-                />
-              )}
+                  {step === "skills" && activeApp && (
+                    <AssociatedSkillsEditor
+                      app={activeApp}
+                      selectedSkillIds={selectedSkillIds}
+                      onChange={setSelectedSkillIds}
+                      onOpenSkill={openExistingSkill}
+                      onCreateSkill={openSkillEditor}
+                      onUploadSkill={() => setUploadOpen(true)}
+                    />
+                  )}
 
-              {error && (
-                <MessageCard
-                  variant="error"
-                  title="Couldn't save"
-                  description={error}
-                />
-              )}
-            </div>
-          </Modal.Body>
-          <Modal.Footer>
-            <div className="flex justify-end gap-2 w-full">
-              <Button
-                prominence="secondary"
-                onClick={onClose}
-                disabled={isSaving}
-              >
-                {step === "skills" ? "Skip for now" : "Cancel"}
-              </Button>
-              {step === "skills" ? (
-                <Button
-                  onClick={async () => {
-                    if (await saveSkills()) {
-                      await onSaved();
-                      onClose();
-                    }
-                  }}
-                  disabled={isSaving}
-                >
-                  {isSaving ? "Saving…" : "Save skills"}
-                </Button>
-              ) : disabledCreateReason ? (
-                <Tooltip tooltip={disabledCreateReason}>
-                  <span className="inline-flex">{saveButton}</span>
-                </Tooltip>
-              ) : (
-                saveButton
-              )}
-            </div>
-          </Modal.Footer>
+                  {error && (
+                    <MessageCard
+                      variant="error"
+                      title="Couldn't save"
+                      description={error}
+                    />
+                  )}
+                </div>
+              </Modal.Body>
+              <Modal.Footer>
+                <div className="flex justify-end gap-2 w-full">
+                  <Button
+                    prominence="secondary"
+                    onClick={() => unsavedChanges.requestLeave(onClose)}
+                    disabled={isSaving}
+                  >
+                    {step === "skills" ? "Skip for now" : "Cancel"}
+                  </Button>
+                  {step === "skills" ? (
+                    <Button
+                      onClick={async () => {
+                        if (await saveSkills()) {
+                          onSaved();
+                          onClose();
+                        }
+                      }}
+                      disabled={isSaving || !skillsDirty}
+                    >
+                      {isSaving ? "Saving…" : "Save skills"}
+                    </Button>
+                  ) : disabledCreateReason ? (
+                    <Tooltip tooltip={disabledCreateReason}>
+                      <span className="inline-flex">{saveButton}</span>
+                    </Tooltip>
+                  ) : (
+                    saveButton
+                  )}
+                </div>
+              </Modal.Footer>
+            </>
+          )}
         </Modal.Content>
       </Modal>
-      {uploadOpen && activeApp && (
-        <CreateSkillModal
-          open
-          skipOverlay
-          onClose={() => setUploadOpen(false)}
-          onContinue={(draft) => {
-            const draftId = stageSkillCreationDraft(draft);
-            void openSkillEditor(draftId).finally(() => setUploadOpen(false));
-          }}
-        />
-      )}
+      <UnsavedChangesModal
+        open={unsavedChanges.confirmationOpen}
+        onCancel={unsavedChanges.cancelLeave}
+        onDiscard={unsavedChanges.discardAndLeave}
+      />
     </>
   );
 }

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -22,14 +22,19 @@ import {
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
 import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
+import ExternalAppSkillsStepModal from "@/app/craft/v1/apps/admin/ExternalAppSkillsStepModal";
 import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
-import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
+import { UnsavedChangesModalContent } from "@/sections/modals/UnsavedChangesModal";
 import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
-import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
+import {
+  stageSkillCreationDraft,
+  type SkillCreationDraft,
+} from "@/lib/skills/creationDraft";
 import {
   skillEditorUrlForApp,
   skillEditUrlForApp,
 } from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
+import { useSyncedAssociatedSkillIds } from "@/lib/externalApps/hooks";
 
 interface CreateCustomAppModalProps {
   onClose: () => void;
@@ -66,10 +71,9 @@ export default function CreateCustomAppModal({
   const isEdit = existingApp !== null;
   const router = useRouter();
 
-  const [activeApp, setActiveApp] = useState<ExternalAppAdminResponse | null>(
-    existingApp
+  const [createdApp, setCreatedApp] = useState<ExternalAppAdminResponse | null>(
+    null
   );
-  const [step, setStep] = useState<"config" | "skills">("config");
   const [name, setName] = useState(existingApp?.name ?? "");
   const [upstreamPatterns, setUpstreamPatterns] = useState<string[]>(
     existingApp?.upstream_url_patterns ?? []
@@ -86,9 +90,8 @@ export default function CreateCustomAppModal({
   );
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>(
-    existingApp?.associated_skills.map((skill) => skill.id) ?? []
-  );
+  const [selectedSkillIds, setSelectedSkillIds] =
+    useSyncedAssociatedSkillIds(existingApp);
   const [uploadOpen, setUploadOpen] = useState(false);
   const [uploadBusy, setUploadBusy] = useState(false);
 
@@ -107,15 +110,7 @@ export default function CreateCustomAppModal({
         Object.keys(toRecord(headers)).length ||
         Object.keys(toRecord(orgCredentials)).length
       );
-  const skillsDirty =
-    activeApp !== null &&
-    !isEqual(
-      new Set(selectedSkillIds),
-      new Set(activeApp.associated_skills.map((skill) => skill.id))
-    );
-  const unsavedChanges = useUnsavedChangesGuard({
-    isDirty: step === "config" ? configDirty : skillsDirty,
-  });
+  const unsavedChanges = useUnsavedChangesGuard({ isDirty: configDirty });
 
   // Headers and org credentials are optional; name + at least one upstream
   // pattern are required.
@@ -163,9 +158,7 @@ export default function CreateCustomAppModal({
           auth_template: toRecord(headers),
           organization_credentials: toRecord(orgCredentials),
         });
-        setActiveApp(created);
-        setSelectedSkillIds([]);
-        setStep("skills");
+        setCreatedApp(created);
         onSaved();
       }
     } catch (e) {
@@ -176,226 +169,207 @@ export default function CreateCustomAppModal({
     }
   }
 
-  async function saveSkills(): Promise<boolean> {
-    if (!activeApp) return false;
-    setIsSaving(true);
-    setError(null);
-    try {
-      const updated = await updateExternalApp(activeApp.id, {
-        associated_skill_ids: selectedSkillIds,
-      });
-      setActiveApp(updated);
-      setSelectedSkillIds(updated.associated_skills.map((skill) => skill.id));
-      return true;
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      return false;
-    } finally {
-      setIsSaving(false);
-    }
-  }
-
-  function openSkillEditor(draftId?: string) {
-    if (!activeApp) return;
+  function openSkillEditor(draft?: SkillCreationDraft) {
+    if (!existingApp) return;
     unsavedChanges.requestLeave(() =>
-      router.push(skillEditorUrlForApp(activeApp, draftId))
+      router.push(
+        skillEditorUrlForApp(
+          existingApp,
+          draft ? stageSkillCreationDraft(draft) : undefined
+        )
+      )
     );
   }
 
   function openExistingSkill(skillId: string) {
-    if (!activeApp) return;
+    if (!existingApp) return;
     unsavedChanges.requestLeave(() =>
-      router.push(skillEditUrlForApp(skillId, activeApp))
+      router.push(skillEditUrlForApp(skillId, existingApp))
+    );
+  }
+
+  function handleDismiss(event: Event) {
+    const preventedByModal = event.defaultPrevented;
+    event.preventDefault();
+    if (preventedByModal || isSaving) return;
+    if (unsavedChanges.confirmationOpen) {
+      unsavedChanges.cancelLeave();
+      return;
+    }
+    if (uploadOpen) {
+      if (!uploadBusy) setUploadOpen(false);
+    } else {
+      unsavedChanges.requestLeave(onClose);
+    }
+  }
+
+  const confirmationContent = unsavedChanges.confirmationOpen ? (
+    <UnsavedChangesModalContent
+      onCancel={unsavedChanges.cancelLeave}
+      onDiscard={unsavedChanges.discardAndLeave}
+    />
+  ) : null;
+
+  if (createdApp) {
+    return (
+      <ExternalAppSkillsStepModal
+        app={createdApp}
+        onClose={onClose}
+        onSaved={onSaved}
+      />
     );
   }
 
   return (
-    <>
-      <Modal
-        open
-        onOpenChange={(o) => {
-          if (o) return;
-          if (uploadOpen) {
-            if (!uploadBusy) setUploadOpen(false);
-          } else {
-            unsavedChanges.requestLeave(onClose);
-          }
+    <Modal open>
+      <Modal.Content
+        width={unsavedChanges.confirmationOpen || uploadOpen ? "sm" : "lg"}
+        height={unsavedChanges.confirmationOpen || uploadOpen ? "fit" : "lg"}
+        onOpenAutoFocus={(event) => {
+          if (isEdit) event.preventDefault();
         }}
+        preventAccidentalClose={!unsavedChanges.confirmationOpen}
+        onInteractOutside={handleDismiss}
+        onEscapeKeyDown={handleDismiss}
       >
-        <Modal.Content
-          width={uploadOpen ? "sm" : "lg"}
-          height={uploadOpen ? "fit" : "lg"}
-        >
-          {uploadOpen && activeApp ? (
+        {uploadOpen && existingApp ? (
+          <>
             <CreateSkillModalContent
+              hidden={unsavedChanges.confirmationOpen}
               onClose={() => setUploadOpen(false)}
               onBusyChange={setUploadBusy}
-              onContinue={(draft) => {
-                const draftId = stageSkillCreationDraft(draft);
-                setUploadOpen(false);
-                openSkillEditor(draftId);
-              }}
+              preserveDraftOnContinue
+              validateDraft={(draft) =>
+                existingApp.associated_skills.some(
+                  (skill) => skill.name === draft.contents.name
+                )
+                  ? `App “${existingApp.name}” already has an associated skill named “${draft.contents.name}”. Upload a skill with a different name.`
+                  : null
+              }
+              onContinue={openSkillEditor}
             />
-          ) : (
-            <>
-              <Modal.Header
-                title={
-                  step === "skills" && activeApp
-                    ? `Add skills to ${activeApp.name}`
-                    : existingApp
-                      ? `Edit ${existingApp.name}`
-                      : "Create custom app"
-                }
-                description={
-                  step === "skills"
-                    ? "Optional — associate existing skills or create one for this app."
-                    : isEdit
-                      ? "Update gateway settings and manage associated skills."
-                      : "Configure how the egress proxy reaches and authenticates this app. A skill is not required."
-                }
-              />
-              <Modal.Body>
-                <div className="flex flex-col gap-4">
-                  {step === "config" && (
-                    <>
-                      <div className="flex flex-col gap-1">
-                        <Text font="main-ui-action">Name</Text>
-                        <InputTypeIn
-                          value={name}
-                          onChange={(e) => setName(e.target.value)}
-                          placeholder="My Custom App"
-                        />
-                      </div>
+            {confirmationContent}
+          </>
+        ) : confirmationContent ? (
+          confirmationContent
+        ) : (
+          <>
+            <Modal.Header
+              title={
+                existingApp ? `Edit ${existingApp.name}` : "Create custom app"
+              }
+              description={
+                isEdit
+                  ? "Update gateway settings and manage associated skills."
+                  : "Configure how the egress proxy reaches and authenticates this app. A skill is not required."
+              }
+            />
+            <Modal.Body>
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-1">
+                  <Text font="main-ui-action">Name</Text>
+                  <InputTypeIn
+                    autoFocus={!isEdit}
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="My Custom App"
+                  />
+                </div>
 
-                      <div className="flex flex-col gap-1">
-                        <Text font="main-ui-action">Upstream URL patterns</Text>
-                        <Text font="secondary-body" color="text-03">
-                          {
-                            "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
-                          }
-                        </Text>
-                        <ListFieldInput
-                          values={upstreamPatterns}
-                          onChange={setUpstreamPatterns}
-                          placeholder="https://api.example.com/*"
-                        />
-                      </div>
+                <div className="flex flex-col gap-1">
+                  <Text font="main-ui-action">Upstream URL patterns</Text>
+                  <Text font="secondary-body" color="text-03">
+                    {
+                      "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
+                    }
+                  </Text>
+                  <ListFieldInput
+                    values={upstreamPatterns}
+                    onChange={setUpstreamPatterns}
+                    placeholder="https://api.example.com/*"
+                  />
+                </div>
 
-                      <div className="flex flex-col gap-1">
-                        <Text font="main-ui-action">
-                          Header credential pattern
-                        </Text>
-                        <Text font="secondary-body" color="text-03">
-                          {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
-                        </Text>
-                        <InputKeyValue
-                          keyTitle="Header"
-                          valueTitle="Value"
-                          keyPlaceholder="Authorization"
-                          valuePlaceholder="Bearer {api_key}"
-                          items={headers}
-                          onChange={setHeaders}
-                          mode="line"
-                          addButtonLabel="Add header"
-                        />
-                      </div>
+                <div className="flex flex-col gap-1">
+                  <Text font="main-ui-action">Header credential pattern</Text>
+                  <Text font="secondary-body" color="text-03">
+                    {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
+                  </Text>
+                  <InputKeyValue
+                    keyTitle="Header"
+                    valueTitle="Value"
+                    keyPlaceholder="Authorization"
+                    valuePlaceholder="Bearer {api_key}"
+                    items={headers}
+                    onChange={setHeaders}
+                    mode="line"
+                    addButtonLabel="Add header"
+                  />
+                </div>
 
-                      <div className="flex flex-col gap-1">
-                        <Text font="main-ui-action">
-                          Organization credentials
-                        </Text>
-                        <Text font="secondary-body" color="text-03">
-                          Optional — values your org pre-fills for every user.
-                          Leave empty for apps where each user supplies their
-                          own credentials.
-                        </Text>
-                        <InputKeyValue
-                          keyTitle="Credential key"
-                          valueTitle="Value"
-                          keyPlaceholder="api_key"
-                          valuePlaceholder="sk-…"
-                          items={orgCredentials}
-                          onChange={setOrgCredentials}
-                          mode="line"
-                          addButtonLabel="Add credential"
-                        />
-                      </div>
+                <div className="flex flex-col gap-1">
+                  <Text font="main-ui-action">Organization credentials</Text>
+                  <Text font="secondary-body" color="text-03">
+                    Optional — values your org pre-fills for every user. Leave
+                    empty for apps where each user supplies their own
+                    credentials.
+                  </Text>
+                  <InputKeyValue
+                    keyTitle="Credential key"
+                    valueTitle="Value"
+                    keyPlaceholder="api_key"
+                    valuePlaceholder="sk-…"
+                    items={orgCredentials}
+                    onChange={setOrgCredentials}
+                    mode="line"
+                    addButtonLabel="Add credential"
+                  />
+                </div>
 
-                      {existingApp && (
-                        <>
-                          <Divider />
-                          <AssociatedSkillsEditor
-                            app={existingApp}
-                            selectedSkillIds={selectedSkillIds}
-                            onChange={setSelectedSkillIds}
-                            onOpenSkill={openExistingSkill}
-                            onCreateSkill={openSkillEditor}
-                            onUploadSkill={() => setUploadOpen(true)}
-                          />
-                        </>
-                      )}
-                    </>
-                  )}
-
-                  {step === "skills" && activeApp && (
+                {existingApp && (
+                  <>
+                    <Divider />
                     <AssociatedSkillsEditor
-                      app={activeApp}
+                      app={existingApp}
                       selectedSkillIds={selectedSkillIds}
                       onChange={setSelectedSkillIds}
                       onOpenSkill={openExistingSkill}
                       onCreateSkill={openSkillEditor}
                       onUploadSkill={() => setUploadOpen(true)}
                     />
-                  )}
+                  </>
+                )}
 
-                  {error && (
-                    <MessageCard
-                      variant="error"
-                      title="Couldn't save"
-                      description={error}
-                    />
-                  )}
-                </div>
-              </Modal.Body>
-              <Modal.Footer>
-                <div className="flex justify-end gap-2 w-full">
-                  <Button
-                    prominence="secondary"
-                    onClick={() => unsavedChanges.requestLeave(onClose)}
-                    disabled={isSaving}
-                  >
-                    {step === "skills" ? "Skip for now" : "Cancel"}
-                  </Button>
-                  {step === "skills" ? (
-                    <Button
-                      onClick={async () => {
-                        if (await saveSkills()) {
-                          onSaved();
-                          onClose();
-                        }
-                      }}
-                      disabled={isSaving || !skillsDirty}
-                    >
-                      {isSaving ? "Saving…" : "Save skills"}
-                    </Button>
-                  ) : disabledCreateReason ? (
-                    <Tooltip tooltip={disabledCreateReason}>
-                      <span className="inline-flex">{saveButton}</span>
-                    </Tooltip>
-                  ) : (
-                    saveButton
-                  )}
-                </div>
-              </Modal.Footer>
-            </>
-          )}
-        </Modal.Content>
-      </Modal>
-      <UnsavedChangesModal
-        open={unsavedChanges.confirmationOpen}
-        onCancel={unsavedChanges.cancelLeave}
-        onDiscard={unsavedChanges.discardAndLeave}
-      />
-    </>
+                {error && (
+                  <MessageCard
+                    variant="error"
+                    title="Couldn't save"
+                    description={error}
+                  />
+                )}
+              </div>
+            </Modal.Body>
+            <Modal.Footer>
+              <div className="flex justify-end gap-2 w-full">
+                <Button
+                  prominence="secondary"
+                  onClick={() => unsavedChanges.requestLeave(onClose)}
+                  disabled={isSaving}
+                >
+                  Cancel
+                </Button>
+                {disabledCreateReason ? (
+                  <Tooltip tooltip={disabledCreateReason}>
+                    <span className="inline-flex">{saveButton}</span>
+                  </Tooltip>
+                ) : (
+                  saveButton
+                )}
+              </div>
+            </Modal.Footer>
+          </>
+        )}
+      </Modal.Content>
+    </Modal>
   );
 }

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import type { Route } from "next";
 import { Modal } from "@opal/components";
 import {
   Button,
@@ -8,6 +10,7 @@ import {
   MessageCard,
   Text,
   Tooltip,
+  Divider,
 } from "@opal/components";
 import { ListFieldInput } from "@/refresh-components/inputs/ListFieldInput";
 import InputKeyValue, {
@@ -18,6 +21,13 @@ import {
   createCustomExternalApp,
   updateExternalApp,
 } from "@/app/craft/services/externalAppsService";
+import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
+import CreateSkillModal from "@/sections/modals/skills/CreateSkillModal";
+import { stageSkillCreationDraft } from "@/lib/skills/creationDraft";
+import {
+  skillEditorUrlForApp,
+  skillEditUrlForApp,
+} from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
 
 interface CreateCustomAppModalProps {
   open: boolean;
@@ -54,7 +64,12 @@ export default function CreateCustomAppModal({
   existingApp,
 }: CreateCustomAppModalProps) {
   const isEdit = existingApp !== null;
+  const router = useRouter();
 
+  const [activeApp, setActiveApp] = useState<ExternalAppAdminResponse | null>(
+    existingApp
+  );
+  const [step, setStep] = useState<"config" | "skills">("config");
   const [name, setName] = useState("");
   const [upstreamPatterns, setUpstreamPatterns] = useState<string[]>([]);
   const [headers, setHeaders] = useState<KeyValue[]>([{ key: "", value: "" }]);
@@ -63,11 +78,14 @@ export default function CreateCustomAppModal({
   ]);
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
-
+  const [selectedSkillIds, setSelectedSkillIds] = useState<string[]>([]);
+  const [uploadOpen, setUploadOpen] = useState(false);
   // Re-seed every time the modal opens: from the existing app when editing,
   // blank when creating. Prevents a prior attempt from leaking in.
   useEffect(() => {
     if (!open) return;
+    setActiveApp(existingApp);
+    setStep("config");
     setName(existingApp?.name ?? "");
     setUpstreamPatterns(existingApp?.upstream_url_patterns ?? []);
     setHeaders(
@@ -81,6 +99,10 @@ export default function CreateCustomAppModal({
         : [{ key: "", value: "" }]
     );
     setError(null);
+    setSelectedSkillIds(
+      existingApp?.associated_skills.map((skill) => skill.id) ?? []
+    );
+    setUploadOpen(false);
   }, [open, existingApp]);
 
   // Headers and org credentials are optional; name + at least one upstream
@@ -95,8 +117,8 @@ export default function CreateCustomAppModal({
     }
     return null;
   })();
-  const createButton = (
-    <Button onClick={save} disabled={disabledCreateReason !== null}>
+  const saveButton = (
+    <Button onClick={saveConfig} disabled={disabledCreateReason !== null}>
       {isSaving
         ? isEdit
           ? "Saving…"
@@ -107,27 +129,26 @@ export default function CreateCustomAppModal({
     </Button>
   );
 
-  async function save() {
+  async function saveConfig() {
     setIsSaving(true);
     setError(null);
     try {
       if (existingApp) {
-        await updateExternalApp(existingApp.id, {
-          name: name.trim(),
-          upstream_url_patterns: upstreamPatterns,
-          auth_template: toRecord(headers),
-          organization_credentials: toRecord(orgCredentials),
-        });
+        await saveExistingApp();
+        onSaved();
+        onClose();
       } else {
-        await createCustomExternalApp({
+        const created = await createCustomExternalApp({
           name: name.trim(),
           upstream_url_patterns: upstreamPatterns,
           auth_template: toRecord(headers),
           organization_credentials: toRecord(orgCredentials),
         });
+        setActiveApp(created);
+        setSelectedSkillIds([]);
+        setStep("skills");
+        onSaved();
       }
-      onSaved();
-      onClose();
     } catch (e) {
       const detail = e instanceof Error ? e.message : String(e);
       setError(detail);
@@ -136,105 +157,231 @@ export default function CreateCustomAppModal({
     }
   }
 
+  async function saveExistingApp() {
+    if (!existingApp) return null;
+    return updateExternalApp(existingApp.id, {
+      name: name.trim(),
+      upstream_url_patterns: upstreamPatterns,
+      auth_template: toRecord(headers),
+      organization_credentials: toRecord(orgCredentials),
+      associated_skill_ids: selectedSkillIds,
+    });
+  }
+
+  async function persistActiveApp() {
+    if (!activeApp) return false;
+    if (existingApp) return saveExistingApp();
+    const updated = await updateExternalApp(activeApp.id, {
+      associated_skill_ids: selectedSkillIds,
+    });
+    setActiveApp(updated);
+    setSelectedSkillIds(updated.associated_skills.map((skill) => skill.id));
+    return updated;
+  }
+
+  async function saveSkills(): Promise<boolean> {
+    setIsSaving(true);
+    setError(null);
+    try {
+      return (await persistActiveApp()) !== false;
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      return false;
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function navigateAfterSave(
+    destination: (app: ExternalAppAdminResponse) => Route
+  ) {
+    setIsSaving(true);
+    setError(null);
+    try {
+      const saved = await persistActiveApp();
+      if (!saved) return;
+      await onSaved();
+      onClose();
+      router.push(destination(saved));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  function openSkillEditor(draftId?: string) {
+    return navigateAfterSave((app) => skillEditorUrlForApp(app, draftId));
+  }
+
+  function openExistingSkill(skillId: string) {
+    return navigateAfterSave((app) => skillEditUrlForApp(skillId, app));
+  }
+
   return (
-    <Modal open={open} onOpenChange={(o) => !o && onClose()}>
-      <Modal.Content width="lg" height="lg">
-        <Modal.Header
-          title={existingApp ? `Edit ${existingApp.name}` : "Create custom app"}
-          description={
-            isEdit
-              ? "Update how the egress proxy reaches and authenticates this app."
-              : "Configure how the egress proxy reaches and authenticates this app. A skill is not required."
-          }
+    <>
+      <Modal open={open} onOpenChange={(o) => !o && onClose()}>
+        <Modal.Content width="lg" height="lg">
+          <Modal.Header
+            title={
+              step === "skills" && activeApp
+                ? `Add skills to ${activeApp.name}`
+                : existingApp
+                  ? `Edit ${existingApp.name}`
+                  : "Create custom app"
+            }
+            description={
+              step === "skills"
+                ? "Optional — associate existing skills or create one for this app."
+                : isEdit
+                  ? "Update gateway settings and manage associated skills."
+                  : "Configure how the egress proxy reaches and authenticates this app. A skill is not required."
+            }
+          />
+          <Modal.Body>
+            <div className="flex flex-col gap-4">
+              {step === "config" && (
+                <>
+                  <div className="flex flex-col gap-1">
+                    <Text font="main-ui-action">Name</Text>
+                    <InputTypeIn
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      placeholder="My Custom App"
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <Text font="main-ui-action">Upstream URL patterns</Text>
+                    <Text font="secondary-body" color="text-03">
+                      {
+                        "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
+                      }
+                    </Text>
+                    <ListFieldInput
+                      values={upstreamPatterns}
+                      onChange={setUpstreamPatterns}
+                      placeholder="https://api.example.com/*"
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <Text font="main-ui-action">Header credential pattern</Text>
+                    <Text font="secondary-body" color="text-03">
+                      {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
+                    </Text>
+                    <InputKeyValue
+                      keyTitle="Header"
+                      valueTitle="Value"
+                      keyPlaceholder="Authorization"
+                      valuePlaceholder="Bearer {api_key}"
+                      items={headers}
+                      onChange={setHeaders}
+                      mode="line"
+                      addButtonLabel="Add header"
+                    />
+                  </div>
+
+                  <div className="flex flex-col gap-1">
+                    <Text font="main-ui-action">Organization credentials</Text>
+                    <Text font="secondary-body" color="text-03">
+                      Optional — values your org pre-fills for every user. Leave
+                      empty for apps where each user supplies their own
+                      credentials.
+                    </Text>
+                    <InputKeyValue
+                      keyTitle="Credential key"
+                      valueTitle="Value"
+                      keyPlaceholder="api_key"
+                      valuePlaceholder="sk-…"
+                      items={orgCredentials}
+                      onChange={setOrgCredentials}
+                      mode="line"
+                      addButtonLabel="Add credential"
+                    />
+                  </div>
+
+                  {existingApp && (
+                    <>
+                      <Divider />
+                      <AssociatedSkillsEditor
+                        app={existingApp}
+                        selectedSkillIds={selectedSkillIds}
+                        onChange={setSelectedSkillIds}
+                        onOpenSkill={(skillId) =>
+                          void openExistingSkill(skillId)
+                        }
+                        onCreateSkill={() => void openSkillEditor()}
+                        onUploadSkill={() => setUploadOpen(true)}
+                      />
+                    </>
+                  )}
+                </>
+              )}
+
+              {step === "skills" && activeApp && (
+                <AssociatedSkillsEditor
+                  app={activeApp}
+                  selectedSkillIds={selectedSkillIds}
+                  onChange={setSelectedSkillIds}
+                  onOpenSkill={(skillId) => void openExistingSkill(skillId)}
+                  onCreateSkill={() => void openSkillEditor()}
+                  onUploadSkill={() => setUploadOpen(true)}
+                />
+              )}
+
+              {error && (
+                <MessageCard
+                  variant="error"
+                  title="Couldn't save"
+                  description={error}
+                />
+              )}
+            </div>
+          </Modal.Body>
+          <Modal.Footer>
+            <div className="flex justify-end gap-2 w-full">
+              <Button
+                prominence="secondary"
+                onClick={onClose}
+                disabled={isSaving}
+              >
+                {step === "skills" ? "Skip for now" : "Cancel"}
+              </Button>
+              {step === "skills" ? (
+                <Button
+                  onClick={async () => {
+                    if (await saveSkills()) {
+                      await onSaved();
+                      onClose();
+                    }
+                  }}
+                  disabled={isSaving}
+                >
+                  {isSaving ? "Saving…" : "Save skills"}
+                </Button>
+              ) : disabledCreateReason ? (
+                <Tooltip tooltip={disabledCreateReason}>
+                  <span className="inline-flex">{saveButton}</span>
+                </Tooltip>
+              ) : (
+                saveButton
+              )}
+            </div>
+          </Modal.Footer>
+        </Modal.Content>
+      </Modal>
+      {uploadOpen && activeApp && (
+        <CreateSkillModal
+          open
+          skipOverlay
+          onClose={() => setUploadOpen(false)}
+          onContinue={(draft) => {
+            const draftId = stageSkillCreationDraft(draft);
+            void openSkillEditor(draftId).finally(() => setUploadOpen(false));
+          }}
         />
-        <Modal.Body>
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-1">
-              <Text font="main-ui-action">Name</Text>
-              <InputTypeIn
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                placeholder="My Custom App"
-              />
-            </div>
-
-            <div className="flex flex-col gap-1">
-              <Text font="main-ui-action">Upstream URL patterns</Text>
-              <Text font="secondary-body" color="text-03">
-                {
-                  "Outbound URLs the proxy may inject credentials into. Use * to match any characters (e.g. https://api.example.com/* covers every path on that host). The host must be literal — no wildcards before the first slash. Type a pattern and press Enter."
-                }
-              </Text>
-              <ListFieldInput
-                values={upstreamPatterns}
-                onChange={setUpstreamPatterns}
-                placeholder="https://api.example.com/*"
-              />
-            </div>
-
-            <div className="flex flex-col gap-1">
-              <Text font="main-ui-action">Header credential pattern</Text>
-              <Text font="secondary-body" color="text-03">
-                {`Optional — headers injected into outbound requests. Use {placeholder} for values the user (or org below) supplies, e.g. "Bearer {api_key}". Leave empty to allowlist the upstream patterns without injecting credentials.`}
-              </Text>
-              <InputKeyValue
-                keyTitle="Header"
-                valueTitle="Value"
-                keyPlaceholder="Authorization"
-                valuePlaceholder="Bearer {api_key}"
-                items={headers}
-                onChange={setHeaders}
-                mode="line"
-                addButtonLabel="Add header"
-              />
-            </div>
-
-            <div className="flex flex-col gap-1">
-              <Text font="main-ui-action">Organization credentials</Text>
-              <Text font="secondary-body" color="text-03">
-                Optional — values your org pre-fills for every user. Leave empty
-                for apps where each user supplies their own credentials.
-              </Text>
-              <InputKeyValue
-                keyTitle="Credential key"
-                valueTitle="Value"
-                keyPlaceholder="api_key"
-                valuePlaceholder="sk-…"
-                items={orgCredentials}
-                onChange={setOrgCredentials}
-                mode="line"
-                addButtonLabel="Add credential"
-              />
-            </div>
-
-            {error && (
-              <MessageCard
-                variant="error"
-                title="Couldn't save"
-                description={error}
-              />
-            )}
-          </div>
-        </Modal.Body>
-        <Modal.Footer>
-          <div className="flex justify-end gap-2 w-full">
-            <Button
-              prominence="secondary"
-              onClick={onClose}
-              disabled={isSaving}
-            >
-              Cancel
-            </Button>
-            {disabledCreateReason ? (
-              <Tooltip tooltip={disabledCreateReason}>
-                <span className="inline-flex">{createButton}</span>
-              </Tooltip>
-            ) : (
-              createButton
-            )}
-          </div>
-        </Modal.Footer>
-      </Modal.Content>
-    </Modal>
+      )}
+    </>
   );
 }

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -95,12 +95,15 @@ export default function CreateCustomAppModal({
     useSyncedAssociatedSkillIds(existingApp);
   const upload = useSkillUploadModal();
 
+  const associationDirty =
+    existingApp !== null &&
+    !isEqual(
+      new Set(selectedSkillIds),
+      new Set(existingApp.associated_skills.map((skill) => skill.id))
+    );
   const configDirty = existingApp
     ? name !== existingApp.name ||
-      !isEqual(
-        new Set(selectedSkillIds),
-        new Set(existingApp.associated_skills.map((skill) => skill.id))
-      ) ||
+      associationDirty ||
       !isEqual(upstreamPatterns, existingApp.upstream_url_patterns) ||
       !isEqual(toRecord(headers), existingApp.auth_template) ||
       !isEqual(toRecord(orgCredentials), existingApp.organization_credentials)
@@ -149,7 +152,9 @@ export default function CreateCustomAppModal({
           upstream_url_patterns: upstreamPatterns,
           auth_template: toRecord(headers),
           organization_credentials: toRecord(orgCredentials),
-          associated_skill_ids: selectedSkillIds,
+          ...(associationDirty
+            ? { associated_skill_ids: selectedSkillIds }
+            : {}),
         });
         onSaved();
         onClose();

--- a/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/CreateCustomAppModal.tsx
@@ -204,7 +204,7 @@ export default function CreateCustomAppModal({
       return;
     }
     if (upload.isOpen) {
-      upload.dismiss();
+      upload.requestDismiss();
     } else {
       unsavedChanges.requestLeave(onClose);
     }
@@ -215,7 +215,7 @@ export default function CreateCustomAppModal({
   const confirmationContent = upload.confirmationOpen ? (
     <UnsavedChangesModalContent
       onCancel={upload.cancelDiscard}
-      onDiscard={upload.confirmDiscard}
+      onDiscard={upload.discardAndClose}
     />
   ) : unsavedChanges.confirmationOpen ? (
     <UnsavedChangesModalContent
@@ -250,7 +250,7 @@ export default function CreateCustomAppModal({
           <>
             <CreateSkillModalContent
               hidden={confirmationOpen}
-              onClose={upload.close}
+              onRequestClose={upload.requestDismiss}
               onBusyChange={upload.setBusy}
               onDirtyChange={upload.setDirty}
               preserveDraftOnContinue

--- a/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/lib/skills/creationDraft";
 import { UnsavedChangesModalContent } from "@/sections/modals/UnsavedChangesModal";
 import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
+import useSkillUploadModal from "@/sections/modals/skills/useSkillUploadModal";
 
 interface ExternalAppSkillsStepModalProps {
   app: ExternalAppAdminResponse;
@@ -35,8 +36,7 @@ export default function ExternalAppSkillsStepModal({
   const router = useRouter();
   const [selectedSkillIds, setSelectedSkillIds] =
     useSyncedAssociatedSkillIds(app);
-  const [uploadOpen, setUploadOpen] = useState(false);
-  const [uploadBusy, setUploadBusy] = useState(false);
+  const upload = useSkillUploadModal();
   const [isSaving, setIsSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isDirty = !isEqual(
@@ -60,8 +60,8 @@ export default function ExternalAppSkillsStepModal({
     if (preventedByModal || isSaving) return;
     if (unsavedChanges.confirmationOpen) {
       unsavedChanges.cancelLeave();
-    } else if (uploadOpen) {
-      if (!uploadBusy) setUploadOpen(false);
+    } else if (upload.isOpen) {
+      upload.dismiss();
     } else {
       unsavedChanges.requestLeave(onClose);
     }
@@ -85,7 +85,14 @@ export default function ExternalAppSkillsStepModal({
     }
   }
 
-  const confirmationContent = unsavedChanges.confirmationOpen ? (
+  const confirmationOpen =
+    upload.confirmationOpen || unsavedChanges.confirmationOpen;
+  const confirmationContent = upload.confirmationOpen ? (
+    <UnsavedChangesModalContent
+      onCancel={upload.cancelDiscard}
+      onDiscard={upload.confirmDiscard}
+    />
+  ) : unsavedChanges.confirmationOpen ? (
     <UnsavedChangesModalContent
       onCancel={unsavedChanges.cancelLeave}
       onDiscard={unsavedChanges.discardAndLeave}
@@ -95,18 +102,19 @@ export default function ExternalAppSkillsStepModal({
   return (
     <Modal open>
       <Modal.Content
-        width={unsavedChanges.confirmationOpen || uploadOpen ? "sm" : "lg"}
-        height={unsavedChanges.confirmationOpen || uploadOpen ? "fit" : "lg"}
-        preventAccidentalClose={!unsavedChanges.confirmationOpen}
+        width={confirmationOpen || upload.isOpen ? "sm" : "lg"}
+        height={confirmationOpen || upload.isOpen ? "fit" : "lg"}
+        preventAccidentalClose={!confirmationOpen}
         onInteractOutside={handleDismiss}
         onEscapeKeyDown={handleDismiss}
       >
-        {uploadOpen ? (
+        {upload.isOpen ? (
           <>
             <CreateSkillModalContent
-              hidden={unsavedChanges.confirmationOpen}
-              onClose={() => setUploadOpen(false)}
-              onBusyChange={setUploadBusy}
+              hidden={confirmationOpen}
+              onClose={upload.close}
+              onBusyChange={upload.setBusy}
+              onDirtyChange={upload.setDirty}
               preserveDraftOnContinue
               validateDraft={(draft) =>
                 app.associated_skills.some(
@@ -143,7 +151,7 @@ export default function ExternalAppSkillsStepModal({
                   onCreateSkill={() =>
                     unsavedChanges.requestLeave(() => navigateToSkillEditor())
                   }
-                  onUploadSkill={() => setUploadOpen(true)}
+                  onUploadSkill={upload.open}
                 />
                 {error && (
                   <MessageCard

--- a/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
@@ -61,7 +61,7 @@ export default function ExternalAppSkillsStepModal({
     if (unsavedChanges.confirmationOpen) {
       unsavedChanges.cancelLeave();
     } else if (upload.isOpen) {
-      upload.dismiss();
+      upload.requestDismiss();
     } else {
       unsavedChanges.requestLeave(onClose);
     }
@@ -90,7 +90,7 @@ export default function ExternalAppSkillsStepModal({
   const confirmationContent = upload.confirmationOpen ? (
     <UnsavedChangesModalContent
       onCancel={upload.cancelDiscard}
-      onDiscard={upload.confirmDiscard}
+      onDiscard={upload.discardAndClose}
     />
   ) : unsavedChanges.confirmationOpen ? (
     <UnsavedChangesModalContent
@@ -112,7 +112,7 @@ export default function ExternalAppSkillsStepModal({
           <>
             <CreateSkillModalContent
               hidden={confirmationOpen}
-              onClose={upload.close}
+              onRequestClose={upload.requestDismiss}
               onBusyChange={upload.setBusy}
               onDirtyChange={upload.setDirty}
               preserveDraftOnContinue

--- a/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
+++ b/web/src/app/craft/v1/apps/admin/ExternalAppSkillsStepModal.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import isEqual from "lodash/isEqual";
+import { Button, MessageCard, Modal } from "@opal/components";
+import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
+import { updateExternalApp } from "@/app/craft/services/externalAppsService";
+import AssociatedSkillsEditor from "@/app/craft/v1/apps/admin/AssociatedSkillsEditor";
+import {
+  skillEditorUrlForApp,
+  skillEditUrlForApp,
+} from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
+import useUnsavedChangesGuard from "@/hooks/useUnsavedChangesGuard";
+import { useSyncedAssociatedSkillIds } from "@/lib/externalApps/hooks";
+import {
+  stageSkillCreationDraft,
+  type SkillCreationDraft,
+} from "@/lib/skills/creationDraft";
+import { UnsavedChangesModalContent } from "@/sections/modals/UnsavedChangesModal";
+import { CreateSkillModalContent } from "@/sections/modals/skills/CreateSkillModal";
+
+interface ExternalAppSkillsStepModalProps {
+  app: ExternalAppAdminResponse;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+/** Optional association step shown after an external app becomes durable. */
+export default function ExternalAppSkillsStepModal({
+  app,
+  onClose,
+  onSaved,
+}: ExternalAppSkillsStepModalProps) {
+  const router = useRouter();
+  const [selectedSkillIds, setSelectedSkillIds] =
+    useSyncedAssociatedSkillIds(app);
+  const [uploadOpen, setUploadOpen] = useState(false);
+  const [uploadBusy, setUploadBusy] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const isDirty = !isEqual(
+    new Set(selectedSkillIds),
+    new Set(app.associated_skills.map((skill) => skill.id))
+  );
+  const unsavedChanges = useUnsavedChangesGuard({ isDirty });
+
+  function navigateToSkillEditor(draft?: SkillCreationDraft) {
+    router.push(
+      skillEditorUrlForApp(
+        app,
+        draft ? stageSkillCreationDraft(draft) : undefined
+      )
+    );
+  }
+
+  function handleDismiss(event: Event) {
+    const preventedByModal = event.defaultPrevented;
+    event.preventDefault();
+    if (preventedByModal || isSaving) return;
+    if (unsavedChanges.confirmationOpen) {
+      unsavedChanges.cancelLeave();
+    } else if (uploadOpen) {
+      if (!uploadBusy) setUploadOpen(false);
+    } else {
+      unsavedChanges.requestLeave(onClose);
+    }
+  }
+
+  async function save() {
+    setIsSaving(true);
+    setError(null);
+    try {
+      await updateExternalApp(app.id, {
+        associated_skill_ids: selectedSkillIds,
+      });
+      onSaved();
+      onClose();
+    } catch (saveError) {
+      setError(
+        saveError instanceof Error ? saveError.message : String(saveError)
+      );
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  const confirmationContent = unsavedChanges.confirmationOpen ? (
+    <UnsavedChangesModalContent
+      onCancel={unsavedChanges.cancelLeave}
+      onDiscard={unsavedChanges.discardAndLeave}
+    />
+  ) : null;
+
+  return (
+    <Modal open>
+      <Modal.Content
+        width={unsavedChanges.confirmationOpen || uploadOpen ? "sm" : "lg"}
+        height={unsavedChanges.confirmationOpen || uploadOpen ? "fit" : "lg"}
+        preventAccidentalClose={!unsavedChanges.confirmationOpen}
+        onInteractOutside={handleDismiss}
+        onEscapeKeyDown={handleDismiss}
+      >
+        {uploadOpen ? (
+          <>
+            <CreateSkillModalContent
+              hidden={unsavedChanges.confirmationOpen}
+              onClose={() => setUploadOpen(false)}
+              onBusyChange={setUploadBusy}
+              preserveDraftOnContinue
+              validateDraft={(draft) =>
+                app.associated_skills.some(
+                  (skill) => skill.name === draft.contents.name
+                )
+                  ? `App “${app.name}” already has an associated skill named “${draft.contents.name}”. Upload a skill with a different name.`
+                  : null
+              }
+              onContinue={(draft) =>
+                unsavedChanges.requestLeave(() => navigateToSkillEditor(draft))
+              }
+            />
+            {confirmationContent}
+          </>
+        ) : confirmationContent ? (
+          confirmationContent
+        ) : (
+          <>
+            <Modal.Header
+              title={`Add skills to ${app.name}`}
+              description="Optional — associate existing skills or create one for this app."
+            />
+            <Modal.Body>
+              <div className="flex flex-col gap-3">
+                <AssociatedSkillsEditor
+                  app={app}
+                  selectedSkillIds={selectedSkillIds}
+                  onChange={setSelectedSkillIds}
+                  onOpenSkill={(skillId) =>
+                    unsavedChanges.requestLeave(() =>
+                      router.push(skillEditUrlForApp(skillId, app))
+                    )
+                  }
+                  onCreateSkill={() =>
+                    unsavedChanges.requestLeave(() => navigateToSkillEditor())
+                  }
+                  onUploadSkill={() => setUploadOpen(true)}
+                />
+                {error && (
+                  <MessageCard
+                    variant="error"
+                    title="Couldn't save"
+                    description={error}
+                  />
+                )}
+              </div>
+            </Modal.Body>
+            <Modal.Footer>
+              <div className="flex w-full justify-end gap-2">
+                <Button
+                  prominence="secondary"
+                  onClick={() => unsavedChanges.requestLeave(onClose)}
+                  disabled={isSaving}
+                >
+                  Skip for now
+                </Button>
+                <Button
+                  disabled={isSaving || !isDirty}
+                  onClick={() => void save()}
+                >
+                  {isSaving ? "Saving…" : "Save skills"}
+                </Button>
+              </div>
+            </Modal.Footer>
+          </>
+        )}
+      </Modal.Content>
+    </Modal>
+  );
+}

--- a/web/src/app/craft/v1/apps/admin/skillAssociationNavigation.ts
+++ b/web/src/app/craft/v1/apps/admin/skillAssociationNavigation.ts
@@ -1,14 +1,48 @@
 import type { Route } from "next";
 import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
 
+interface ExternalAppContext {
+  externalAppId?: number;
+  externalAppName?: string;
+}
+
+interface ExternalAppSearchParams {
+  externalAppId?: string | string[];
+  externalAppName?: string | string[];
+}
+
+function externalAppParams(app: ExternalAppAdminResponse): URLSearchParams {
+  return new URLSearchParams({
+    externalAppId: String(app.id),
+    externalAppName: app.name,
+  });
+}
+
+export function externalAppContextFromSearchParams({
+  externalAppId,
+  externalAppName,
+}: ExternalAppSearchParams): ExternalAppContext {
+  const parsedAppId =
+    typeof externalAppId === "string" ? Number(externalAppId) : undefined;
+  return {
+    ...(Number.isInteger(parsedAppId) &&
+    parsedAppId !== undefined &&
+    parsedAppId > 0
+      ? { externalAppId: parsedAppId }
+      : {}),
+    ...(typeof externalAppName === "string" ? { externalAppName } : {}),
+  };
+}
+
+export function externalAppAdminUrl(externalAppId: number): Route {
+  return `/admin/craft/apps?editAppId=${externalAppId}` as Route;
+}
+
 export function skillEditorUrlForApp(
   app: ExternalAppAdminResponse,
   draftId?: string
 ): Route {
-  const params = new URLSearchParams({
-    externalAppId: String(app.id),
-    externalAppName: app.name,
-  });
+  const params = externalAppParams(app);
   if (draftId) params.set("draft", draftId);
   return `/craft/v1/skills/new?${params.toString()}` as Route;
 }
@@ -17,9 +51,5 @@ export function skillEditUrlForApp(
   skillId: string,
   app: ExternalAppAdminResponse
 ): Route {
-  const params = new URLSearchParams({
-    externalAppId: String(app.id),
-    externalAppName: app.name,
-  });
-  return `/craft/v1/skills/edit/${skillId}?${params.toString()}` as Route;
+  return `/craft/v1/skills/edit/${skillId}?${externalAppParams(app).toString()}` as Route;
 }

--- a/web/src/app/craft/v1/apps/admin/skillAssociationNavigation.ts
+++ b/web/src/app/craft/v1/apps/admin/skillAssociationNavigation.ts
@@ -1,0 +1,25 @@
+import type { Route } from "next";
+import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
+
+export function skillEditorUrlForApp(
+  app: ExternalAppAdminResponse,
+  draftId?: string
+): Route {
+  const params = new URLSearchParams({
+    externalAppId: String(app.id),
+    externalAppName: app.name,
+  });
+  if (draftId) params.set("draft", draftId);
+  return `/craft/v1/skills/new?${params.toString()}` as Route;
+}
+
+export function skillEditUrlForApp(
+  skillId: string,
+  app: ExternalAppAdminResponse
+): Route {
+  const params = new URLSearchParams({
+    externalAppId: String(app.id),
+    externalAppName: app.name,
+  });
+  return `/craft/v1/skills/edit/${skillId}?${params.toString()}` as Route;
+}

--- a/web/src/app/craft/v1/skills/edit/[id]/page.tsx
+++ b/web/src/app/craft/v1/skills/edit/[id]/page.tsx
@@ -2,9 +2,30 @@ import SkillEditorPage from "@/views/SkillEditorPage";
 
 export interface PageProps {
   params: Promise<{ id: string }>;
+  searchParams: Promise<{
+    externalAppId?: string | string[];
+    externalAppName?: string | string[];
+  }>;
 }
 
-export default async function Page({ params }: PageProps) {
+export default async function Page({ params, searchParams }: PageProps) {
   const { id } = await params;
-  return <SkillEditorPage skillId={id} />;
+  const { externalAppId, externalAppName } = await searchParams;
+  const parsedExternalAppId =
+    typeof externalAppId === "string" ? Number(externalAppId) : undefined;
+  return (
+    <SkillEditorPage
+      skillId={id}
+      externalAppId={
+        Number.isInteger(parsedExternalAppId) &&
+        parsedExternalAppId !== undefined &&
+        parsedExternalAppId > 0
+          ? parsedExternalAppId
+          : undefined
+      }
+      externalAppName={
+        typeof externalAppName === "string" ? externalAppName : undefined
+      }
+    />
+  );
 }

--- a/web/src/app/craft/v1/skills/edit/[id]/page.tsx
+++ b/web/src/app/craft/v1/skills/edit/[id]/page.tsx
@@ -1,4 +1,5 @@
 import SkillEditorPage from "@/views/SkillEditorPage";
+import { externalAppContextFromSearchParams } from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
 
 export interface PageProps {
   params: Promise<{ id: string }>;
@@ -10,22 +11,6 @@ export interface PageProps {
 
 export default async function Page({ params, searchParams }: PageProps) {
   const { id } = await params;
-  const { externalAppId, externalAppName } = await searchParams;
-  const parsedExternalAppId =
-    typeof externalAppId === "string" ? Number(externalAppId) : undefined;
-  return (
-    <SkillEditorPage
-      skillId={id}
-      externalAppId={
-        Number.isInteger(parsedExternalAppId) &&
-        parsedExternalAppId !== undefined &&
-        parsedExternalAppId > 0
-          ? parsedExternalAppId
-          : undefined
-      }
-      externalAppName={
-        typeof externalAppName === "string" ? externalAppName : undefined
-      }
-    />
-  );
+  const appContext = externalAppContextFromSearchParams(await searchParams);
+  return <SkillEditorPage skillId={id} {...appContext} />;
 }

--- a/web/src/app/craft/v1/skills/new/page.tsx
+++ b/web/src/app/craft/v1/skills/new/page.tsx
@@ -1,4 +1,5 @@
 import SkillEditorPage from "@/views/SkillEditorPage";
+import { externalAppContextFromSearchParams } from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
 
 interface CreateSkillPageProps {
   searchParams: Promise<{
@@ -11,22 +12,11 @@ interface CreateSkillPageProps {
 export default async function CreateSkillPage({
   searchParams,
 }: CreateSkillPageProps) {
-  const { draft, externalAppId, externalAppName } = await searchParams;
-  const parsedExternalAppId =
-    typeof externalAppId === "string" ? Number(externalAppId) : undefined;
+  const params = await searchParams;
   return (
     <SkillEditorPage
-      draftId={typeof draft === "string" ? draft : undefined}
-      externalAppId={
-        Number.isInteger(parsedExternalAppId) &&
-        parsedExternalAppId !== undefined &&
-        parsedExternalAppId > 0
-          ? parsedExternalAppId
-          : undefined
-      }
-      externalAppName={
-        typeof externalAppName === "string" ? externalAppName : undefined
-      }
+      draftId={typeof params.draft === "string" ? params.draft : undefined}
+      {...externalAppContextFromSearchParams(params)}
     />
   );
 }

--- a/web/src/app/craft/v1/skills/new/page.tsx
+++ b/web/src/app/craft/v1/skills/new/page.tsx
@@ -1,14 +1,32 @@
 import SkillEditorPage from "@/views/SkillEditorPage";
 
 interface CreateSkillPageProps {
-  searchParams: Promise<{ draft?: string | string[] }>;
+  searchParams: Promise<{
+    draft?: string | string[];
+    externalAppId?: string | string[];
+    externalAppName?: string | string[];
+  }>;
 }
 
 export default async function CreateSkillPage({
   searchParams,
 }: CreateSkillPageProps) {
-  const { draft } = await searchParams;
+  const { draft, externalAppId, externalAppName } = await searchParams;
+  const parsedExternalAppId =
+    typeof externalAppId === "string" ? Number(externalAppId) : undefined;
   return (
-    <SkillEditorPage draftId={typeof draft === "string" ? draft : undefined} />
+    <SkillEditorPage
+      draftId={typeof draft === "string" ? draft : undefined}
+      externalAppId={
+        Number.isInteger(parsedExternalAppId) &&
+        parsedExternalAppId !== undefined &&
+        parsedExternalAppId > 0
+          ? parsedExternalAppId
+          : undefined
+      }
+      externalAppName={
+        typeof externalAppName === "string" ? externalAppName : undefined
+      }
+    />
   );
 }

--- a/web/src/lib/externalApps/hooks.ts
+++ b/web/src/lib/externalApps/hooks.ts
@@ -1,0 +1,26 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import isEqual from "lodash/isEqual";
+import type { ExternalAppAdminResponse } from "@/app/craft/v1/apps/registry";
+
+export function useSyncedAssociatedSkillIds(
+  app: ExternalAppAdminResponse | null
+) {
+  const persistedSkillIds = useMemo(
+    () => app?.associated_skills.map((skill) => skill.id) ?? [],
+    [app?.associated_skills]
+  );
+  const previousPersistedSkillIds = useRef(persistedSkillIds);
+  const [selectedSkillIds, setSelectedSkillIds] = useState(persistedSkillIds);
+
+  useEffect(() => {
+    const previous = previousPersistedSkillIds.current;
+    previousPersistedSkillIds.current = persistedSkillIds;
+    setSelectedSkillIds((current) =>
+      isEqual(new Set(current), new Set(previous)) ? persistedSkillIds : current
+    );
+  }, [persistedSkillIds]);
+
+  return [selectedSkillIds, setSelectedSkillIds] as const;
+}

--- a/web/src/lib/skills/api.test.ts
+++ b/web/src/lib/skills/api.test.ts
@@ -29,9 +29,12 @@ describe("skills API", () => {
     expect(
       (fetchMock.mock.calls[0]![1]!.body as FormData).get("auto_enable")
     ).toBe("false");
+    expect(
+      (fetchMock.mock.calls[0]![1]!.body as FormData).get("external_app_id")
+    ).toBeNull();
   });
 
-  it("sends app context only for app-launched skill creation", async () => {
+  it("sends app context for app-launched skill creation", async () => {
     await createCustomSkillFromEditor({
       name: "acme-lookup",
       description: "Looks up Acme records",

--- a/web/src/lib/skills/api.test.ts
+++ b/web/src/lib/skills/api.test.ts
@@ -40,6 +40,7 @@ describe("skills API", () => {
       external_app_id: 17,
     });
 
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     const body = fetchMock.mock.calls[0]![1]!.body as FormData;
     expect(body.get("external_app_id")).toBe("17");
     expect(body.get("auto_enable")).toBe("false");

--- a/web/src/lib/skills/api.test.ts
+++ b/web/src/lib/skills/api.test.ts
@@ -31,6 +31,20 @@ describe("skills API", () => {
     ).toBe("false");
   });
 
+  it("sends app context only for app-launched skill creation", async () => {
+    await createCustomSkillFromEditor({
+      name: "acme-lookup",
+      description: "Looks up Acme records",
+      instructions_markdown: "Use the Acme API.",
+      auto_enable: false,
+      external_app_id: 17,
+    });
+
+    const body = fetchMock.mock.calls[0]![1]!.body as FormData;
+    expect(body.get("external_app_id")).toBe("17");
+    expect(body.get("auto_enable")).toBe("false");
+  });
+
   it("recognizes only the dedicated skill-name conflict", () => {
     expect(
       isSkillNameConflict(

--- a/web/src/lib/skills/api.ts
+++ b/web/src/lib/skills/api.ts
@@ -49,6 +49,7 @@ export interface CreateCustomSkillInput {
   description: string;
   instructions_markdown: string;
   auto_enable?: boolean;
+  external_app_id?: number;
 }
 
 export async function createCustomSkillFromEditor(
@@ -60,6 +61,9 @@ export async function createCustomSkillFromEditor(
   form.append("description", input.description);
   form.append("instructions_markdown", input.instructions_markdown);
   form.append("auto_enable", String(input.auto_enable ?? true));
+  if (input.external_app_id !== undefined) {
+    form.append("external_app_id", String(input.external_app_id));
+  }
   if (upload) form.append("upload", upload);
 
   const res = await fetch("/api/skills/custom/editor", {

--- a/web/src/sections/modals/UnsavedChangesModal.test.tsx
+++ b/web/src/sections/modals/UnsavedChangesModal.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen, setupUser } from "@tests/setup/test-utils";
+import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
+
+describe("UnsavedChangesModal", () => {
+  it("reports a single cancellation when the close button is clicked", async () => {
+    const user = setupUser();
+    const onCancel = jest.fn();
+
+    render(
+      <UnsavedChangesModal open onCancel={onCancel} onDiscard={jest.fn()} />
+    );
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/sections/modals/UnsavedChangesModal.tsx
+++ b/web/src/sections/modals/UnsavedChangesModal.tsx
@@ -1,6 +1,5 @@
-import { Button } from "@opal/components";
+import { Button, Modal, Text } from "@opal/components";
 import { SvgAlertTriangle } from "@opal/icons";
-import { ConfirmationModalLayout } from "@opal/layouts";
 
 interface UnsavedChangesModalProps {
   open: boolean;
@@ -16,17 +15,43 @@ export default function UnsavedChangesModal({
   if (!open) return null;
 
   return (
-    <ConfirmationModalLayout
-      icon={SvgAlertTriangle}
-      title="Discard unsaved changes?"
-      onClose={onCancel}
-      submit={
+    <Modal open>
+      <Modal.Content
+        width="sm"
+        preventAccidentalClose={false}
+        onInteractOutside={onCancel}
+        onEscapeKeyDown={onCancel}
+      >
+        <UnsavedChangesModalContent onCancel={onCancel} onDiscard={onDiscard} />
+      </Modal.Content>
+    </Modal>
+  );
+}
+
+export function UnsavedChangesModalContent({
+  onCancel,
+  onDiscard,
+}: Omit<UnsavedChangesModalProps, "open">) {
+  return (
+    <>
+      <Modal.Header
+        icon={SvgAlertTriangle}
+        title="Discard unsaved changes?"
+        onClose={onCancel}
+      />
+      <Modal.Body twoTone>
+        <Text as="p" color="text-03">
+          Your changes have not been saved. If you leave now, they will be lost.
+        </Text>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button type="button" prominence="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
         <Button type="button" variant="danger" onClick={onDiscard}>
           Discard changes
         </Button>
-      }
-    >
-      Your changes have not been saved. If you leave now, they will be lost.
-    </ConfirmationModalLayout>
+      </Modal.Footer>
+    </>
   );
 }

--- a/web/src/sections/modals/skills/CreateSkillModal.test.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.test.tsx
@@ -101,23 +101,26 @@ describe("CreateSkillModal", () => {
     );
   });
 
-  it("prevents duplicate review submissions while inspection is pending", async () => {
+  it("cannot submit again or close while inspection is pending", async () => {
     const user = setupUser();
     const inspection = deferred<SkillBundleContents>();
+    const onClose = jest.fn();
     mockInspectSkillBundle.mockReturnValue(inspection.promise);
 
-    render(
-      <CreateSkillModal open onClose={jest.fn()} onContinue={jest.fn()} />
-    );
+    render(<CreateSkillModal open onClose={onClose} onContinue={jest.fn()} />);
     await user.click(screen.getByRole("button", { name: "Select bundle" }));
     await user.click(screen.getByRole("button", { name: "Review skill" }));
 
     expect(screen.getByRole("button", { name: "Opening…" })).toBeDisabled();
     expect(mockInspectSkillBundle).toHaveBeenCalledTimes(1);
+    await user.keyboard("{Escape}");
+    expect(onClose).not.toHaveBeenCalled();
 
     await act(async () => {
       inspection.resolve(inspectedContents);
       await inspection.promise;
     });
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/sections/modals/skills/CreateSkillModal.test.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.test.tsx
@@ -74,6 +74,7 @@ describe("CreateSkillModal", () => {
     );
     expect(draft.upload.file).toBeInstanceOf(File);
     expect(mockInspectSkillBundle).toHaveBeenCalledWith(draft.upload.file);
+    expect(screen.getByRole("button", { name: "Review skill" })).toBeDisabled();
   });
 
   it("keeps the modal open and reports inspection failures", async () => {
@@ -99,6 +100,31 @@ describe("CreateSkillModal", () => {
       "Failed to inspect skill bundle",
       expect.any(Error)
     );
+  });
+
+  it("keeps a rejected inspected draft in the upload modal", async () => {
+    const user = setupUser();
+    const onContinue = jest.fn();
+    const validationMessage =
+      "App “Acme CRM” already has an associated skill named “report-writer”. Upload a skill with a different name.";
+    mockInspectSkillBundle.mockResolvedValue(inspectedContents);
+
+    render(
+      <CreateSkillModal
+        open
+        onClose={jest.fn()}
+        onContinue={onContinue}
+        validateDraft={() => validationMessage}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: "Select bundle" }));
+    await user.click(screen.getByRole("button", { name: "Review skill" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      validationMessage
+    );
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Review skill" })).toBeEnabled();
   });
 
   it("cannot submit again or close while inspection is pending", async () => {

--- a/web/src/sections/modals/skills/CreateSkillModal.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.tsx
@@ -17,9 +17,10 @@ interface CreateSkillModalProps {
 
 interface CreateSkillModalContentProps extends Omit<
   CreateSkillModalProps,
-  "open"
+  "open" | "onClose"
 > {
   hidden?: boolean;
+  onRequestClose: () => void;
   onBusyChange?: (busy: boolean) => void;
   onDirtyChange?: (dirty: boolean) => void;
   preserveDraftOnContinue?: boolean;
@@ -27,7 +28,7 @@ interface CreateSkillModalContentProps extends Omit<
 
 export function CreateSkillModalContent({
   hidden = false,
-  onClose,
+  onRequestClose,
   onContinue,
   onBusyChange,
   onDirtyChange,
@@ -52,8 +53,7 @@ export function CreateSkillModalContent({
 
   function handleClose() {
     if (busy) return;
-    reset();
-    onClose();
+    onRequestClose();
   }
 
   async function handleContinue() {
@@ -167,7 +167,7 @@ export default function CreateSkillModal({
     <Modal open={open} onOpenChange={(isOpen) => !isOpen && !busy && onClose()}>
       <Modal.Content width="sm">
         <CreateSkillModalContent
-          onClose={onClose}
+          onRequestClose={onClose}
           onContinue={onContinue}
           onBusyChange={setBusy}
           validateDraft={validateDraft}

--- a/web/src/sections/modals/skills/CreateSkillModal.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.tsx
@@ -12,12 +12,15 @@ interface CreateSkillModalProps {
   open: boolean;
   onClose: () => void;
   onContinue: (draft: SkillCreationDraft) => void;
+  /** Omit the second scrim when this dialog is layered over another modal. */
+  skipOverlay?: boolean;
 }
 
 export default function CreateSkillModal({
   open,
   onClose,
   onContinue,
+  skipOverlay = false,
 }: CreateSkillModalProps) {
   const [bundle, setBundle] = useState<PreparedSkillBundle | null>(null);
   const [preparing, setPreparing] = useState(false);
@@ -64,7 +67,7 @@ export default function CreateSkillModal({
 
   return (
     <Modal open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
-      <Modal.Content width="sm">
+      <Modal.Content width="sm" skipOverlay={skipOverlay}>
         <Modal.Header
           icon={SvgUploadCloud}
           title="Upload skill"

--- a/web/src/sections/modals/skills/CreateSkillModal.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.tsx
@@ -12,19 +12,25 @@ interface CreateSkillModalProps {
   open: boolean;
   onClose: () => void;
   onContinue: (draft: SkillCreationDraft) => void;
+  validateDraft?: (draft: SkillCreationDraft) => string | null;
 }
 
 interface CreateSkillModalContentProps extends Omit<
   CreateSkillModalProps,
   "open"
 > {
+  hidden?: boolean;
   onBusyChange?: (busy: boolean) => void;
+  preserveDraftOnContinue?: boolean;
 }
 
 export function CreateSkillModalContent({
+  hidden = false,
   onClose,
   onContinue,
   onBusyChange,
+  preserveDraftOnContinue = false,
+  validateDraft,
 }: CreateSkillModalContentProps) {
   const [bundle, setBundle] = useState<PreparedSkillBundle | null>(null);
   const [preparing, setPreparing] = useState(false);
@@ -62,7 +68,12 @@ export function CreateSkillModalContent({
           containsSkillMd: true,
         },
       };
-      reset();
+      const validationError = validateDraft?.(draft);
+      if (validationError) {
+        setErrorMessage(validationError);
+        return;
+      }
+      if (!preserveDraftOnContinue) reset();
       onContinue(draft);
     } catch (error) {
       console.error("Failed to inspect skill bundle", error);
@@ -73,6 +84,8 @@ export function CreateSkillModalContent({
       setInspecting(false);
     }
   }
+
+  if (hidden) return null;
 
   return (
     <>
@@ -141,6 +154,7 @@ export default function CreateSkillModal({
   open,
   onClose,
   onContinue,
+  validateDraft,
 }: CreateSkillModalProps) {
   const [busy, setBusy] = useState(false);
 
@@ -151,6 +165,7 @@ export default function CreateSkillModal({
           onClose={onClose}
           onContinue={onContinue}
           onBusyChange={setBusy}
+          validateDraft={validateDraft}
         />
       </Modal.Content>
     </Modal>

--- a/web/src/sections/modals/skills/CreateSkillModal.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.tsx
@@ -21,6 +21,7 @@ interface CreateSkillModalContentProps extends Omit<
 > {
   hidden?: boolean;
   onBusyChange?: (busy: boolean) => void;
+  onDirtyChange?: (dirty: boolean) => void;
   preserveDraftOnContinue?: boolean;
 }
 
@@ -29,6 +30,7 @@ export function CreateSkillModalContent({
   onClose,
   onContinue,
   onBusyChange,
+  onDirtyChange,
   preserveDraftOnContinue = false,
   validateDraft,
 }: CreateSkillModalContentProps) {
@@ -45,6 +47,7 @@ export function CreateSkillModalContent({
   function reset() {
     setBundle(null);
     setErrorMessage(null);
+    onDirtyChange?.(false);
   }
 
   function handleClose() {
@@ -103,10 +106,12 @@ export function CreateSkillModalContent({
           onChange={(nextBundle) => {
             setBundle(nextBundle);
             setErrorMessage(null);
+            onDirtyChange?.(nextBundle !== null);
           }}
           onError={(message) => {
             setBundle(null);
             setErrorMessage(message);
+            onDirtyChange?.(false);
           }}
         />
         <div className="mt-3">

--- a/web/src/sections/modals/skills/CreateSkillModal.tsx
+++ b/web/src/sections/modals/skills/CreateSkillModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Button, Modal, Text } from "@opal/components";
 import { SvgUploadCloud } from "@opal/icons";
 import { inspectSkillBundle } from "@/lib/skills/api";
@@ -12,20 +12,29 @@ interface CreateSkillModalProps {
   open: boolean;
   onClose: () => void;
   onContinue: (draft: SkillCreationDraft) => void;
-  /** Omit the second scrim when this dialog is layered over another modal. */
-  skipOverlay?: boolean;
 }
 
-export default function CreateSkillModal({
-  open,
+interface CreateSkillModalContentProps extends Omit<
+  CreateSkillModalProps,
+  "open"
+> {
+  onBusyChange?: (busy: boolean) => void;
+}
+
+export function CreateSkillModalContent({
   onClose,
   onContinue,
-  skipOverlay = false,
-}: CreateSkillModalProps) {
+  onBusyChange,
+}: CreateSkillModalContentProps) {
   const [bundle, setBundle] = useState<PreparedSkillBundle | null>(null);
   const [preparing, setPreparing] = useState(false);
   const [inspecting, setInspecting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const busy = preparing || inspecting;
+
+  useEffect(() => {
+    onBusyChange?.(busy);
+  }, [busy, onBusyChange]);
 
   function reset() {
     setBundle(null);
@@ -33,7 +42,7 @@ export default function CreateSkillModal({
   }
 
   function handleClose() {
-    if (preparing || inspecting) return;
+    if (busy) return;
     reset();
     onClose();
   }
@@ -66,69 +75,83 @@ export default function CreateSkillModal({
   }
 
   return (
-    <Modal open={open} onOpenChange={(isOpen) => !isOpen && handleClose()}>
-      <Modal.Content width="sm" skipOverlay={skipOverlay}>
-        <Modal.Header
-          icon={SvgUploadCloud}
-          title="Upload skill"
-          description="Upload a SKILL.md file, ZIP file, or skill folder. You can review and edit its details before saving."
-          onClose={handleClose}
+    <>
+      <Modal.Header
+        icon={SvgUploadCloud}
+        title="Upload skill"
+        description="Upload a SKILL.md file, ZIP file, or skill folder. You can review and edit its details before saving."
+        onClose={handleClose}
+      />
+      <Modal.Body>
+        <SkillBundlePicker
+          value={bundle}
+          disabled={inspecting}
+          onPreparingChange={setPreparing}
+          onChange={(nextBundle) => {
+            setBundle(nextBundle);
+            setErrorMessage(null);
+          }}
+          onError={(message) => {
+            setBundle(null);
+            setErrorMessage(message);
+          }}
         />
-        <Modal.Body>
-          <SkillBundlePicker
-            value={bundle}
-            disabled={inspecting}
-            onPreparingChange={setPreparing}
-            onChange={(nextBundle) => {
-              setBundle(nextBundle);
-              setErrorMessage(null);
-            }}
-            onError={(message) => {
-              setBundle(null);
-              setErrorMessage(message);
-            }}
-          />
-          <div className="mt-3">
-            <Text as="p" font="main-ui-body" color="text-02">
-              File requirements
+        <div className="mt-3">
+          <Text as="p" font="main-ui-body" color="text-02">
+            File requirements
+          </Text>
+          <ul className="mt-1 list-disc space-y-1 pl-5">
+            <Text as="li" font="secondary-body" color="text-03">
+              SKILL.md must include valid frontmatter with a name and
+              description.
             </Text>
-            <ul className="mt-1 list-disc space-y-1 pl-5">
-              <Text as="li" font="secondary-body" color="text-03">
-                SKILL.md must include valid frontmatter with a name and
-                description.
-              </Text>
-              <Text as="li" font="secondary-body" color="text-03">
-                ZIP files must contain a SKILL.md file.
-              </Text>
-              <Text as="li" font="secondary-body" color="text-03">
-                Upload one skill at a time.
-              </Text>
-            </ul>
+            <Text as="li" font="secondary-body" color="text-03">
+              ZIP files must contain a SKILL.md file.
+            </Text>
+            <Text as="li" font="secondary-body" color="text-03">
+              Upload one skill at a time.
+            </Text>
+          </ul>
+        </div>
+        {errorMessage && (
+          <div role="alert" className="mt-2">
+            <Text as="p" font="secondary-body" color="status-error-05">
+              {errorMessage}
+            </Text>
           </div>
-          {errorMessage && (
-            <div role="alert" className="mt-2">
-              <Text as="p" font="secondary-body" color="status-error-05">
-                {errorMessage}
-              </Text>
-            </div>
-          )}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button
-            prominence="secondary"
-            disabled={preparing || inspecting}
-            onClick={handleClose}
-          >
-            Cancel
-          </Button>
-          <Button
-            disabled={preparing || inspecting || !bundle}
-            onClick={() => void handleContinue()}
-            icon={SvgUploadCloud}
-          >
-            {inspecting ? "Opening…" : "Review skill"}
-          </Button>
-        </Modal.Footer>
+        )}
+      </Modal.Body>
+      <Modal.Footer>
+        <Button prominence="secondary" disabled={busy} onClick={handleClose}>
+          Cancel
+        </Button>
+        <Button
+          disabled={busy || !bundle}
+          onClick={() => void handleContinue()}
+          icon={SvgUploadCloud}
+        >
+          {inspecting ? "Opening…" : "Review skill"}
+        </Button>
+      </Modal.Footer>
+    </>
+  );
+}
+
+export default function CreateSkillModal({
+  open,
+  onClose,
+  onContinue,
+}: CreateSkillModalProps) {
+  const [busy, setBusy] = useState(false);
+
+  return (
+    <Modal open={open} onOpenChange={(isOpen) => !isOpen && !busy && onClose()}>
+      <Modal.Content width="sm">
+        <CreateSkillModalContent
+          onClose={onClose}
+          onContinue={onContinue}
+          onBusyChange={setBusy}
+        />
       </Modal.Content>
     </Modal>
   );

--- a/web/src/sections/modals/skills/useSkillUploadModal.ts
+++ b/web/src/sections/modals/skills/useSkillUploadModal.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useState } from "react";
+
+export default function useSkillUploadModal() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const [isDirty, setIsDirty] = useState(false);
+  const [confirmationOpen, setConfirmationOpen] = useState(false);
+
+  function open() {
+    setIsOpen(true);
+  }
+
+  function close() {
+    if (isBusy) return;
+    setIsOpen(false);
+    setIsDirty(false);
+    setConfirmationOpen(false);
+  }
+
+  function dismiss() {
+    if (isBusy) {
+      return;
+    }
+    if (confirmationOpen) {
+      setConfirmationOpen(false);
+    } else if (isDirty) {
+      setConfirmationOpen(true);
+    } else {
+      close();
+    }
+  }
+
+  return {
+    isOpen,
+    confirmationOpen,
+    open,
+    close,
+    dismiss,
+    confirmDiscard: close,
+    cancelDiscard: () => setConfirmationOpen(false),
+    setBusy: setIsBusy,
+    setDirty: setIsDirty,
+  };
+}

--- a/web/src/sections/modals/skills/useSkillUploadModal.ts
+++ b/web/src/sections/modals/skills/useSkillUploadModal.ts
@@ -12,14 +12,14 @@ export default function useSkillUploadModal() {
     setIsOpen(true);
   }
 
-  function close() {
+  function discardAndClose() {
     if (isBusy) return;
     setIsOpen(false);
     setIsDirty(false);
     setConfirmationOpen(false);
   }
 
-  function dismiss() {
+  function requestDismiss() {
     if (isBusy) {
       return;
     }
@@ -28,7 +28,7 @@ export default function useSkillUploadModal() {
     } else if (isDirty) {
       setConfirmationOpen(true);
     } else {
-      close();
+      discardAndClose();
     }
   }
 
@@ -36,9 +36,8 @@ export default function useSkillUploadModal() {
     isOpen,
     confirmationOpen,
     open,
-    close,
-    dismiss,
-    confirmDiscard: close,
+    requestDismiss,
+    discardAndClose,
     cancelDiscard: () => setConfirmationOpen(false),
     setBusy: setIsBusy,
     setDirty: setIsDirty,

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -11,6 +11,7 @@ import type { SkillEditableDetail } from "@/lib/skills/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
 
 const mockCreateCustomSkillFromEditor = jest.fn();
+const mockDeleteUserSkill = jest.fn();
 const mockRouterReplace = jest.fn();
 const mockRouterPush = jest.fn();
 const mockGetSkillCreationDraft = jest.fn();
@@ -96,6 +97,7 @@ jest.mock("@/lib/skills/api", () => ({
   ...jest.requireActual("@/lib/skills/api"),
   createCustomSkillFromEditor: (...args: unknown[]) =>
     mockCreateCustomSkillFromEditor(...args),
+  deleteUserSkill: (...args: unknown[]) => mockDeleteUserSkill(...args),
 }));
 
 jest.mock("@/sections/skills/SkillFilesPicker", () => ({
@@ -106,6 +108,8 @@ jest.mock("@/sections/skills/SkillFilesPicker", () => ({
 describe("SkillEditorPage", () => {
   beforeEach(() => {
     mockCreateCustomSkillFromEditor.mockReset();
+    mockDeleteUserSkill.mockReset();
+    mockDeleteUserSkill.mockResolvedValue(undefined);
     mockRouterReplace.mockReset();
     mockRouterPush.mockReset();
     mockGetSkillCreationDraft.mockReset();
@@ -362,6 +366,58 @@ describe("SkillEditorPage", () => {
     expect(mockRouterPush).toHaveBeenCalledWith(
       "/admin/craft/apps?editAppId=42"
     );
+  });
+
+  it("refreshes app associations before returning after skill deletion", async () => {
+    const user = setupUser();
+    const appRefresh = deferred<void>();
+    const skill = existingSkill({
+      external_app: {
+        external_app_id: 42,
+        name: "Acme CRM",
+        enabled: true,
+        ready: true,
+      },
+    });
+    mockUseSWR.mockReturnValue({
+      data: skill,
+      error: undefined,
+      isLoading: false,
+      mutate: mockRefreshSkill,
+    });
+    mockMutate.mockImplementation((key: string) =>
+      key === SWR_KEYS.buildExternalAppsAdmin
+        ? appRefresh.promise
+        : Promise.resolve()
+    );
+
+    render(
+      <SkillEditorPage
+        skillId={skill.id}
+        externalAppId={42}
+        externalAppName="Acme CRM"
+      />
+    );
+    await user.click(screen.getByRole("button", { name: "Delete skill" }));
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() =>
+      expect(mockDeleteUserSkill).toHaveBeenCalledWith(skill.id)
+    );
+    expect(mockRouterPush).not.toHaveBeenCalled();
+
+    await act(async () => {
+      appRefresh.resolve();
+      await appRefresh.promise;
+    });
+
+    await waitFor(() =>
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        "/admin/craft/apps?editAppId=42"
+      )
+    );
+    expect(mockMutate).toHaveBeenCalledWith(SWR_KEYS.buildExternalAppsAdmin);
+    expect(mockMutate).toHaveBeenCalledWith(SWR_KEYS.userSkills);
   });
 
   it("returns app-launched skill creation to that app on Cancel", async () => {

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -8,6 +8,7 @@ import {
 } from "@tests/setup/test-utils";
 import SkillEditorPage from "@/views/SkillEditorPage";
 import type { SkillEditableDetail } from "@/lib/skills/types";
+import { SWR_KEYS } from "@/lib/swr-keys";
 
 const mockCreateCustomSkillFromEditor = jest.fn();
 const mockRouterReplace = jest.fn();
@@ -205,11 +206,17 @@ describe("SkillEditorPage", () => {
 
   it("creates an app-associated skill disabled and returns to that app", async () => {
     const user = setupUser();
+    const appRefresh = deferred<void>();
     mockCreateCustomSkillFromEditor.mockResolvedValue({
       id: "created-id",
       name: "report-writer",
       enabled: false,
     } as SkillEditableDetail);
+    mockMutate.mockImplementation((key: string) =>
+      key === SWR_KEYS.buildExternalAppsAdmin
+        ? appRefresh.promise
+        : Promise.resolve()
+    );
 
     render(<SkillEditorPage externalAppId={42} externalAppName="Acme CRM" />);
     expect(
@@ -230,14 +237,21 @@ describe("SkillEditorPage", () => {
         undefined
       )
     );
-    expect(mockRouterReplace).toHaveBeenCalledWith(
-      "/admin/craft/apps?editAppId=42"
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+
+    await act(async () => {
+      appRefresh.resolve();
+      await appRefresh.promise;
+    });
+    await waitFor(() =>
+      expect(mockRouterReplace).toHaveBeenCalledWith(
+        "/admin/craft/apps?editAppId=42"
+      )
     );
   });
 
-  it("does not offer a disabled retry for an app association conflict", async () => {
+  it("keeps an app-associated creation open with a clear name conflict", async () => {
     const user = setupUser();
-    const consoleError = jest.spyOn(console, "error").mockImplementation();
     mockCreateCustomSkillFromEditor.mockRejectedValue(
       Object.assign(new Error("This app already has a skill with that name"), {
         errorCode: "SKILL_NAME_CONFLICT",
@@ -248,17 +262,34 @@ describe("SkillEditorPage", () => {
     await fillRequiredFields(user);
     await user.click(screen.getByRole("button", { name: "Save" }));
 
-    await waitFor(() =>
-      expect(consoleError).toHaveBeenCalledWith(
-        "Failed to save skill",
-        expect.any(Error)
+    expect(
+      await screen.findByText("Choose a different skill name")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "App “Acme CRM” already has an associated skill named “report-writer”."
       )
+    ).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Name your skill")).toHaveValue(
+      "report-writer"
     );
     expect(
-      screen.queryByText("Create another “report-writer” skill?")
-    ).not.toBeInTheDocument();
-    expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(1);
+      screen.getByPlaceholderText("What does this skill help with?")
+    ).toHaveValue("Writes reports");
+    expect(
+      screen.getByPlaceholderText("Write the skill instructions.")
+    ).toHaveValue("Write the requested report.");
     expect(mockRouterReplace).not.toHaveBeenCalled();
+    expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(1);
+
+    await user.clear(screen.getByPlaceholderText("Name your skill"));
+    await user.type(
+      screen.getByPlaceholderText("Name your skill"),
+      "report-writer-v2"
+    );
+    expect(
+      screen.queryByText("Choose a different skill name")
+    ).not.toBeInTheDocument();
   });
 
   it("confirms before canceling a create page with unsaved changes", async () => {

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -142,7 +142,7 @@ describe("SkillEditorPage", () => {
     );
     await waitFor(() =>
       expect(consoleError).toHaveBeenCalledWith(
-        "Failed to refresh skill list after creation",
+        "Failed to refresh skill data after creation",
         expect.any(Error)
       )
     );
@@ -203,6 +203,38 @@ describe("SkillEditorPage", () => {
     expect(mockRouterReplace).toHaveBeenCalledWith("/craft/v1/skills");
   });
 
+  it("creates an app-associated skill disabled and returns to that app", async () => {
+    const user = setupUser();
+    mockCreateCustomSkillFromEditor.mockResolvedValue({
+      id: "created-id",
+      name: "report-writer",
+      enabled: false,
+    } as SkillEditableDetail);
+
+    render(<SkillEditorPage externalAppId={42} externalAppName="Acme CRM" />);
+    expect(
+      screen.getByText("Add an organization skill to app “Acme CRM”")
+    ).toBeInTheDocument();
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledWith(
+        {
+          name: "report-writer",
+          description: "Writes reports",
+          instructions_markdown: "Write the requested report.",
+          auto_enable: false,
+          external_app_id: 42,
+        },
+        undefined
+      )
+    );
+    expect(mockRouterReplace).toHaveBeenCalledWith(
+      "/admin/craft/apps?editAppId=42"
+    );
+  });
+
   it("confirms before canceling a create page with unsaved changes", async () => {
     const user = setupUser();
     render(<SkillEditorPage />);
@@ -249,6 +281,30 @@ describe("SkillEditorPage", () => {
     await user.click(screen.getByRole("button", { name: "Discard changes" }));
     expect(mockRouterPush).toHaveBeenCalledWith("/craft/v1/skills");
     expect(mockDiscardSkillCreationDraft).not.toHaveBeenCalled();
+  });
+
+  it("returns an app-launched edit to that app on Cancel", async () => {
+    const user = setupUser();
+    const skill = existingSkill();
+    mockUseSWR.mockReturnValue({
+      data: skill,
+      error: undefined,
+      isLoading: false,
+      mutate: mockRefreshSkill,
+    });
+
+    render(
+      <SkillEditorPage
+        skillId={skill.id}
+        externalAppId={42}
+        externalAppName="Acme CRM"
+      />
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/admin/craft/apps?editAppId=42"
+    );
   });
 
   it("shows the app dependency and required organization visibility", () => {

--- a/web/src/views/SkillEditorPage.test.tsx
+++ b/web/src/views/SkillEditorPage.test.tsx
@@ -235,6 +235,32 @@ describe("SkillEditorPage", () => {
     );
   });
 
+  it("does not offer a disabled retry for an app association conflict", async () => {
+    const user = setupUser();
+    const consoleError = jest.spyOn(console, "error").mockImplementation();
+    mockCreateCustomSkillFromEditor.mockRejectedValue(
+      Object.assign(new Error("This app already has a skill with that name"), {
+        errorCode: "SKILL_NAME_CONFLICT",
+      })
+    );
+
+    render(<SkillEditorPage externalAppId={42} externalAppName="Acme CRM" />);
+    await fillRequiredFields(user);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        "Failed to save skill",
+        expect.any(Error)
+      )
+    );
+    expect(
+      screen.queryByText("Create another “report-writer” skill?")
+    ).not.toBeInTheDocument();
+    expect(mockCreateCustomSkillFromEditor).toHaveBeenCalledTimes(1);
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+  });
+
   it("confirms before canceling a create page with unsaved changes", async () => {
     const user = setupUser();
     render(<SkillEditorPage />);
@@ -300,6 +326,17 @@ describe("SkillEditorPage", () => {
         externalAppName="Acme CRM"
       />
     );
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      "/admin/craft/apps?editAppId=42"
+    );
+  });
+
+  it("returns app-launched skill creation to that app on Cancel", async () => {
+    const user = setupUser();
+
+    render(<SkillEditorPage externalAppId={42} externalAppName="Acme CRM" />);
     await user.click(screen.getByRole("button", { name: "Cancel" }));
 
     expect(mockRouterPush).toHaveBeenCalledWith(

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -423,6 +423,16 @@ export default function SkillEditorPage({
     setIsDeleting(true);
     try {
       await deleteUserSkill(skill.id);
+      if (hasAppContext) {
+        try {
+          await mutate(SWR_KEYS.buildExternalAppsAdmin);
+        } catch (error) {
+          console.error(
+            "Failed to refresh external app after skill deletion",
+            error
+          );
+        }
+      }
       // The skill is gone — a transient list-refresh failure must not mask
       // the successful delete or block navigation off the dead editor page.
       void refreshSkillList();

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -64,10 +64,13 @@ import UnsavedChangesModal from "@/sections/modals/UnsavedChangesModal";
 import SkillFileTree from "@/sections/skills/SkillFileTree";
 import SkillFilesPicker from "@/sections/skills/SkillFilesPicker";
 import { ConfirmationModalLayout } from "@opal/layouts";
+import { useUser } from "@/providers/UserProvider";
 
 interface SkillEditorPageProps {
   skillId?: string;
   draftId?: string;
+  externalAppId?: number;
+  externalAppName?: string;
 }
 
 function getSharingStatus(skill: SkillEditableDetail): {
@@ -114,9 +117,14 @@ function getSharingStatus(skill: SkillEditableDetail): {
 export default function SkillEditorPage({
   skillId,
   draftId,
+  externalAppId,
+  externalAppName,
 }: SkillEditorPageProps) {
   const isCreating = skillId === undefined;
+  const hasAppContext = externalAppId !== undefined;
+  const isCreatingForApp = isCreating && hasAppContext;
   const router = useRouter();
+  const { isAdmin } = useUser();
   const creationDraft = useMemo(
     () => (isCreating && draftId ? getSkillCreationDraft(draftId) : undefined),
     [draftId, isCreating]
@@ -217,7 +225,11 @@ export default function SkillEditorPage({
     !isSaving;
 
   function leaveEditor() {
-    router.push("/craft/v1/skills" as Route);
+    router.push(
+      hasAppContext
+        ? (`/admin/craft/apps?editAppId=${externalAppId}` as Route)
+        : ("/craft/v1/skills" as Route)
+    );
   }
 
   function handleCancel() {
@@ -243,17 +255,28 @@ export default function SkillEditorPage({
             name,
             description,
             instructions_markdown: instructionsMarkdown,
-            auto_enable: !createDisabled,
+            auto_enable: isCreatingForApp ? false : !createDisabled,
+            ...(externalAppId !== undefined
+              ? { external_app_id: externalAppId }
+              : {}),
           },
           pendingFilesUpload?.file
         );
         setConflictingSkillName(null);
         if (draftId) discardSkillCreationDraft(draftId);
-        void refreshSkillList().catch((error: unknown) => {
-          console.error("Failed to refresh skill list after creation", error);
+        const refreshes = [mutate(SWR_KEYS.userSkills)];
+        if (isCreatingForApp) {
+          refreshes.push(mutate(SWR_KEYS.buildExternalAppsAdmin));
+        }
+        void Promise.all(refreshes).catch((error: unknown) => {
+          console.error("Failed to refresh skill data after creation", error);
         });
         toast.success(`Created "${created.name}"`);
-        router.replace("/craft/v1/skills" as Route);
+        router.replace(
+          isCreatingForApp
+            ? (`/admin/craft/apps?editAppId=${externalAppId}` as Route)
+            : ("/craft/v1/skills" as Route)
+        );
         return;
       }
 
@@ -382,7 +405,7 @@ export default function SkillEditorPage({
       // the successful delete or block navigation off the dead editor page.
       void refreshSkillList();
       toast.success(`Deleted "${skill.name}"`);
-      router.push("/craft/v1/skills" as Route);
+      leaveEditor();
     } catch (err) {
       console.error("Failed to delete skill", err);
       toast.error(
@@ -442,7 +465,9 @@ export default function SkillEditorPage({
           title={isCreating ? "Create skill" : "Edit skill"}
           description={
             isCreating
-              ? "Build a personal skill"
+              ? isCreatingForApp
+                ? `Add an organization skill to app “${externalAppName ?? "External app"}”`
+                : "Build a personal skill"
               : "Update skill details and files"
           }
           rightChildren={
@@ -682,12 +707,23 @@ export default function SkillEditorPage({
                             }
                             center
                           >
-                            <Tag
-                              title={skill.external_app.name}
-                              color={
-                                skill.external_app.ready ? "blue" : "amber"
-                              }
-                            />
+                            <div className="flex items-center gap-2">
+                              <Tag
+                                title={skill.external_app.name}
+                                color={
+                                  skill.external_app.ready ? "blue" : "amber"
+                                }
+                              />
+                              {isAdmin && (
+                                <Button
+                                  type="button"
+                                  prominence="secondary"
+                                  href={`/admin/craft/apps?editAppId=${skill.external_app.external_app_id}`}
+                                >
+                                  Manage in app settings
+                                </Button>
+                              )}
+                            </div>
                           </InputHorizontal>
                         )}
                         {sharingStatus && (

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -165,6 +165,9 @@ export default function SkillEditorPage({
   const [conflictingSkillName, setConflictingSkillName] = useState<
     string | null
   >(null);
+  const [appConflictingSkillName, setAppConflictingSkillName] = useState<
+    string | null
+  >(null);
 
   const syncEditableFields = useCallback((nextSkill: SkillEditableDetail) => {
     setName(nextSkill.name);
@@ -249,6 +252,7 @@ export default function SkillEditorPage({
     event?.preventDefault();
     if (!canSave) return;
     setIsSaving(true);
+    setAppConflictingSkillName(null);
     try {
       if (isCreating) {
         const created = await createCustomSkillFromEditor(
@@ -265,11 +269,19 @@ export default function SkillEditorPage({
         );
         setConflictingSkillName(null);
         if (draftId) discardSkillCreationDraft(draftId);
-        const refreshes = [mutate(SWR_KEYS.userSkills)];
         if (isCreatingForApp) {
-          refreshes.push(mutate(SWR_KEYS.buildExternalAppsAdmin));
+          // The app editor reads this cache as soon as we return. Wait for its
+          // association to refresh so the newly created skill is visible.
+          try {
+            await mutate(SWR_KEYS.buildExternalAppsAdmin);
+          } catch (error) {
+            console.error(
+              "Failed to refresh external app after skill creation",
+              error
+            );
+          }
         }
-        void Promise.all(refreshes).catch((error: unknown) => {
+        void mutate(SWR_KEYS.userSkills).catch((error: unknown) => {
           console.error("Failed to refresh skill data after creation", error);
         });
         toast.success(`Created "${created.name}"`);
@@ -296,6 +308,10 @@ export default function SkillEditorPage({
       await refreshSkillList();
       toast.success(`Saved "${updated.name}"`);
     } catch (err) {
+      if (isCreatingForApp && isSkillNameConflict(err)) {
+        setAppConflictingSkillName(name.trim());
+        return;
+      }
       if (
         isCreating &&
         !isCreatingForApp &&
@@ -514,6 +530,14 @@ export default function SkillEditorPage({
 
           {(isCreating || skill) && !isLoading && !error && (
             <>
+              {appConflictingSkillName && (
+                <MessageCard
+                  variant="error"
+                  title="Choose a different skill name"
+                  description={`App “${externalAppName ?? "External app"}” already has an associated skill named “${appConflictingSkillName}”.`}
+                />
+              )}
+
               {isCreating && !creationDraft && (
                 <>
                   <Section gap={0.5} alignItems="stretch" height="auto">
@@ -575,7 +599,10 @@ export default function SkillEditorPage({
                         id="name"
                         name="name"
                         value={name}
-                        onChange={(event) => setName(event.target.value)}
+                        onChange={(event) => {
+                          setName(event.target.value);
+                          setAppConflictingSkillName(null);
+                        }}
                         placeholder="Name your skill"
                         variant={
                           fieldsLocked || !isCreating ? "disabled" : "primary"

--- a/web/src/views/SkillEditorPage.tsx
+++ b/web/src/views/SkillEditorPage.tsx
@@ -65,6 +65,7 @@ import SkillFileTree from "@/sections/skills/SkillFileTree";
 import SkillFilesPicker from "@/sections/skills/SkillFilesPicker";
 import { ConfirmationModalLayout } from "@opal/layouts";
 import { useUser } from "@/providers/UserProvider";
+import { externalAppAdminUrl } from "@/app/craft/v1/apps/admin/skillAssociationNavigation";
 
 interface SkillEditorPageProps {
   skillId?: string;
@@ -227,7 +228,7 @@ export default function SkillEditorPage({
   function leaveEditor() {
     router.push(
       hasAppContext
-        ? (`/admin/craft/apps?editAppId=${externalAppId}` as Route)
+        ? externalAppAdminUrl(externalAppId)
         : ("/craft/v1/skills" as Route)
     );
   }
@@ -274,7 +275,7 @@ export default function SkillEditorPage({
         toast.success(`Created "${created.name}"`);
         router.replace(
           isCreatingForApp
-            ? (`/admin/craft/apps?editAppId=${externalAppId}` as Route)
+            ? externalAppAdminUrl(externalAppId)
             : ("/craft/v1/skills" as Route)
         );
         return;
@@ -295,7 +296,12 @@ export default function SkillEditorPage({
       await refreshSkillList();
       toast.success(`Saved "${updated.name}"`);
     } catch (err) {
-      if (isCreating && !createDisabled && isSkillNameConflict(err)) {
+      if (
+        isCreating &&
+        !isCreatingForApp &&
+        !createDisabled &&
+        isSkillNameConflict(err)
+      ) {
         setConflictingSkillName(name.trim());
         return;
       }
@@ -718,7 +724,9 @@ export default function SkillEditorPage({
                                 <Button
                                   type="button"
                                   prominence="secondary"
-                                  href={`/admin/craft/apps?editAppId=${skill.external_app.external_app_id}`}
+                                  href={externalAppAdminUrl(
+                                    skill.external_app.external_app_id
+                                  )}
                                 >
                                   Manage in app settings
                                 </Button>

--- a/web/src/views/admin/ExternalAppsPage.test.tsx
+++ b/web/src/views/admin/ExternalAppsPage.test.tsx
@@ -24,11 +24,15 @@ jest.mock("swr", () => ({
 jest.mock("@/app/craft/services/externalAppsService");
 
 jest.mock("next/navigation", () => ({
-  useRouter: () => ({ push: jest.fn() }),
+  useRouter: () => ({ push: jest.fn(), replace: mockRouterReplace }),
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => "/admin/craft/apps",
 }));
 
 const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
 const mockMutateApps = jest.fn();
+const mockRouterReplace = jest.fn();
+let mockSearchParams = new URLSearchParams();
 
 const APP: ExternalAppAdminResponse = {
   id: 1,
@@ -46,6 +50,7 @@ const APP: ExternalAppAdminResponse = {
 describe("ExternalAppsPage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
     mockUseSWR.mockImplementation((key) => {
       if (key === SWR_KEYS.buildExternalAppsAdmin) {
         return {
@@ -94,5 +99,62 @@ describe("ExternalAppsPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("button", { name: "Disable" })).toBeEnabled();
     });
+  });
+
+  it("confirms retained skill behavior before deleting an app", async () => {
+    mockUseSWR.mockImplementation((key) => {
+      if (key === SWR_KEYS.buildExternalAppsAdmin) {
+        return {
+          data: [
+            {
+              ...APP,
+              associated_skills: [
+                { id: "skill-a", name: "acme-lookup", is_valid: true },
+                { id: "skill-b", name: "acme-write", is_valid: true },
+              ],
+            },
+          ],
+          mutate: mockMutateApps,
+          error: undefined,
+          isLoading: false,
+          isValidating: false,
+        } as ReturnType<typeof useSWR>;
+      }
+      return {
+        data: [],
+        mutate: jest.fn(),
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+      } as ReturnType<typeof useSWR>;
+    });
+    jest.mocked(externalAppsService.deleteExternalApp).mockResolvedValue();
+    mockMutateApps.mockResolvedValue(undefined);
+
+    render(<ExternalAppsPage />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete Custom app" }));
+
+    expect(
+      screen.getByText(
+        "2 associated skills will be kept, unlinked from this app, and disabled for everyone."
+      )
+    ).toBeInTheDocument();
+    expect(externalAppsService.deleteExternalApp).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete app" }));
+    await waitFor(() =>
+      expect(externalAppsService.deleteExternalApp).toHaveBeenCalledWith(1)
+    );
+  });
+
+  it("reopens fresh app settings after returning from skill creation", async () => {
+    mockSearchParams = new URLSearchParams({ editAppId: "1" });
+
+    render(<ExternalAppsPage />);
+
+    expect(await screen.findByText("Edit Custom app")).toBeInTheDocument();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(mockRouterReplace).toHaveBeenCalledWith("/admin/craft/apps");
   });
 });

--- a/web/src/views/admin/ExternalAppsPage.test.tsx
+++ b/web/src/views/admin/ExternalAppsPage.test.tsx
@@ -108,6 +108,8 @@ describe("ExternalAppsPage", () => {
           data: [
             {
               ...APP,
+              name: "Slack",
+              app_type: "SLACK",
               associated_skills: [
                 { id: "skill-a", name: "acme-lookup", is_valid: true },
                 { id: "skill-b", name: "acme-write", is_valid: true },
@@ -132,11 +134,14 @@ describe("ExternalAppsPage", () => {
     mockMutateApps.mockResolvedValue(undefined);
 
     render(<ExternalAppsPage />);
-    fireEvent.click(screen.getByRole("button", { name: "Delete Custom app" }));
+    fireEvent.click(screen.getByRole("button", { name: "Delete Slack" }));
 
+    expect(screen.getByRole("dialog")).toHaveTextContent(
+      "This deletes the app configuration, connection data, and any provider-managed skills."
+    );
     expect(
       screen.getByText(
-        "2 associated skills will be kept, unlinked from this app, and disabled for everyone."
+        "2 associated custom skills will be kept, unlinked from this app, and disabled for everyone."
       )
     ).toBeInTheDocument();
     expect(externalAppsService.deleteExternalApp).not.toHaveBeenCalled();
@@ -147,13 +152,37 @@ describe("ExternalAppsPage", () => {
     );
   });
 
-  it("reopens fresh app settings after returning from skill creation", async () => {
+  it("keeps deep-linked app settings open during revalidation", async () => {
     mockSearchParams = new URLSearchParams({ editAppId: "1" });
+    let isValidating = false;
+    mockUseSWR.mockImplementation((key) => {
+      if (key === SWR_KEYS.buildExternalAppsAdmin) {
+        return {
+          data: [APP],
+          error: undefined,
+          isLoading: false,
+          isValidating,
+          mutate: mockMutateApps,
+        } as ReturnType<typeof useSWR>;
+      }
+      return {
+        data: [],
+        error: undefined,
+        isLoading: false,
+        isValidating: false,
+        mutate: jest.fn(),
+      } as ReturnType<typeof useSWR>;
+    });
 
-    render(<ExternalAppsPage />);
+    const { rerender } = render(<ExternalAppsPage />);
 
     expect(await screen.findByText("Edit Custom app")).toBeInTheDocument();
     expect(mockRouterReplace).not.toHaveBeenCalled();
+
+    isValidating = true;
+    rerender(<ExternalAppsPage />);
+    expect(screen.getByText("Edit Custom app")).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(mockRouterReplace).toHaveBeenCalledWith("/admin/craft/apps");
   });

--- a/web/src/views/admin/ExternalAppsPage.tsx
+++ b/web/src/views/admin/ExternalAppsPage.tsx
@@ -73,11 +73,7 @@ function AppsAdminContent() {
     errorHandlingFetcher,
     { keepPreviousData: true }
   );
-  const {
-    data: apps,
-    mutate: mutateApps,
-    isValidating: appsValidating,
-  } = useSWR<ExternalAppAdminResponse[]>(
+  const { data: apps, mutate: mutateApps } = useSWR<ExternalAppAdminResponse[]>(
     SWR_KEYS.buildExternalAppsAdmin,
     errorHandlingFetcher,
     { keepPreviousData: true }
@@ -116,9 +112,7 @@ function AppsAdminContent() {
 
   const deepLinkedAppId = searchParams.get("editAppId");
   const deepLinkedApp =
-    !appsValidating &&
-    deepLinkedAppId !== null &&
-    deepLinkedAppId !== dismissedDeepLink
+    deepLinkedAppId !== null && deepLinkedAppId !== dismissedDeepLink
       ? apps?.find((app) => app.id === Number(deepLinkedAppId))
       : undefined;
   const deepLinkedDescriptor = deepLinkedApp
@@ -311,7 +305,7 @@ interface ConfiguredIntegration {
   /** Null → not deletable (MCP servers, Onyx-managed apps). */
   remove: {
     run: () => Promise<void>;
-    retainedSkillCount: number;
+    retainedCustomSkillCount: number;
   } | null;
 }
 
@@ -352,7 +346,7 @@ function externalAppToIntegration(
     remove: app.is_onyx_managed
       ? null
       : {
-          retainedSkillCount: app.associated_skills.length,
+          retainedCustomSkillCount: app.associated_skills.length,
           run: async () => {
             await deleteExternalApp(app.id);
             await onChange();
@@ -466,7 +460,7 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
         <ConfirmationModalLayout
           icon={SvgTrash}
           title={`Delete “${name}”?`}
-          description="This deletes the app configuration and connection data."
+          description="This deletes the app configuration, connection data, and any provider-managed skills."
           onClose={isMutating ? undefined : () => setConfirmingRemoval(false)}
           submit={
             <Button
@@ -482,10 +476,10 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
             </Button>
           }
         >
-          {remove.retainedSkillCount === 0
-            ? "No skills will be deleted."
-            : `${remove.retainedSkillCount} associated ${
-                remove.retainedSkillCount === 1 ? "skill" : "skills"
+          {remove.retainedCustomSkillCount === 0
+            ? "No associated custom skills will be deleted."
+            : `${remove.retainedCustomSkillCount} associated custom ${
+                remove.retainedCustomSkillCount === 1 ? "skill" : "skills"
               } will be kept, unlinked from this app, and disabled for everyone.`}
         </ConfirmationModalLayout>
       )}

--- a/web/src/views/admin/ExternalAppsPage.tsx
+++ b/web/src/views/admin/ExternalAppsPage.tsx
@@ -224,7 +224,7 @@ function AppsAdminContent() {
 
       {activeCustomModal && (
         <CreateCustomAppModal
-          open
+          key={activeCustomModal.existingApp?.id ?? "new"}
           onClose={closeAppModal}
           onSaved={() => mutateApps()}
           existingApp={activeCustomModal.existingApp}
@@ -472,13 +472,11 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
             <Button
               variant="danger"
               disabled={isMutating}
-              onClick={() =>
-                void run(remove.run, `Failed to delete "${name}"`).then(
-                  (removed) => {
-                    if (removed) setConfirmingRemoval(false);
-                  }
-                )
-              }
+              onClick={async () => {
+                if (await run(remove.run, `Failed to delete "${name}"`)) {
+                  setConfirmingRemoval(false);
+                }
+              }}
             >
               {isMutating ? "Deleting…" : "Delete app"}
             </Button>

--- a/web/src/views/admin/ExternalAppsPage.tsx
+++ b/web/src/views/admin/ExternalAppsPage.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import type { Route } from "next";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type { IconFunctionComponent } from "@opal/types";
 import { Button, Divider, Text } from "@opal/components";
-import { SettingsLayouts, toast } from "@opal/layouts";
+import { ConfirmationModalLayout, SettingsLayouts, toast } from "@opal/layouts";
 import Card from "@/refresh-components/cards/Card";
 import {
   SvgArrowLeft,
@@ -64,12 +66,18 @@ export default function ExternalAppsPage() {
 }
 
 function AppsAdminContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const { data: descriptors } = useSWR<BuiltInExternalAppDescriptor[]>(
     SWR_KEYS.buildExternalAppsBuiltInOptions,
     errorHandlingFetcher,
     { keepPreviousData: true }
   );
-  const { data: apps, mutate: mutateApps } = useSWR<ExternalAppAdminResponse[]>(
+  const {
+    data: apps,
+    mutate: mutateApps,
+    isValidating: appsValidating,
+  } = useSWR<ExternalAppAdminResponse[]>(
     SWR_KEYS.buildExternalAppsAdmin,
     errorHandlingFetcher,
     { keepPreviousData: true }
@@ -80,14 +88,24 @@ function AppsAdminContent() {
   const [customModal, setCustomModal] = useState<{
     existingApp: ExternalAppAdminResponse | null;
   } | null>(null);
+  const [dismissedDeepLink, setDismissedDeepLink] = useState<string | null>(
+    null
+  );
 
   const isReady = descriptors !== undefined && apps !== undefined;
   const hasConfigured = isReady && apps.length > 0;
 
   // Edit only works for apps whose app_type still has a descriptor. Apps with
   // an orphan app_type still render but can only be disabled/deleted.
-  const descriptorByAppType = new Map<string, BuiltInExternalAppDescriptor>(
-    (descriptors ?? []).map((d) => [d.app_type, d])
+  const descriptorByAppType = useMemo(
+    () =>
+      new Map<string, BuiltInExternalAppDescriptor>(
+        (descriptors ?? []).map((descriptor) => [
+          descriptor.app_type,
+          descriptor,
+        ])
+      ),
+    [descriptors]
   );
 
   // Already-configured providers drop off the available list (one per provider).
@@ -95,6 +113,36 @@ function AppsAdminContent() {
     descriptors ?? [],
     apps ?? []
   );
+
+  const deepLinkedAppId = searchParams.get("editAppId");
+  const deepLinkedApp =
+    !appsValidating &&
+    deepLinkedAppId !== null &&
+    deepLinkedAppId !== dismissedDeepLink
+      ? apps?.find((app) => app.id === Number(deepLinkedAppId))
+      : undefined;
+  const deepLinkedDescriptor = deepLinkedApp
+    ? descriptorByAppType.get(deepLinkedApp.app_type)
+    : undefined;
+  const activeCustomModal =
+    customModal ??
+    (deepLinkedApp?.app_type === "CUSTOM"
+      ? { existingApp: deepLinkedApp }
+      : null);
+  const activeProviderModal =
+    modalState ??
+    (deepLinkedApp && deepLinkedDescriptor
+      ? { descriptor: deepLinkedDescriptor, existingApp: deepLinkedApp }
+      : null);
+
+  function closeAppModal() {
+    setCustomModal(null);
+    setModalState(null);
+    if (deepLinkedAppId) {
+      setDismissedDeepLink(deepLinkedAppId);
+      router.replace("/admin/craft/apps" as Route);
+    }
+  }
 
   if (!isReady) {
     return (
@@ -161,22 +209,25 @@ function AppsAdminContent() {
         </div>
       </section>
 
-      {modalState && (
+      {activeProviderModal && (
         <ConfigureProviderModal
-          key={modalState.existingApp?.id ?? modalState.descriptor.app_type}
-          onClose={() => setModalState(null)}
+          key={
+            activeProviderModal.existingApp?.id ??
+            activeProviderModal.descriptor.app_type
+          }
+          onClose={closeAppModal}
           onSaved={() => mutateApps()}
-          descriptor={modalState.descriptor}
-          existingApp={modalState.existingApp}
+          descriptor={activeProviderModal.descriptor}
+          existingApp={activeProviderModal.existingApp}
         />
       )}
 
-      {customModal && (
+      {activeCustomModal && (
         <CreateCustomAppModal
-          open={customModal !== null}
-          onClose={() => setCustomModal(null)}
+          open
+          onClose={closeAppModal}
           onSaved={() => mutateApps()}
-          existingApp={customModal.existingApp}
+          existingApp={activeCustomModal.existingApp}
         />
       )}
     </div>
@@ -258,7 +309,10 @@ interface ConfiguredIntegration {
   /** Null → no Edit button (e.g. orphaned app types). */
   edit: (() => void) | null;
   /** Null → not deletable (MCP servers, Onyx-managed apps). */
-  remove: (() => Promise<void>) | null;
+  remove: {
+    run: () => Promise<void>;
+    retainedSkillCount: number;
+  } | null;
 }
 
 interface ExternalAppHandlers {
@@ -279,7 +333,7 @@ function externalAppToIntegration(
     logo: getAppTypeLogo(app.app_type),
     name: app.name,
     statusText: app.enabled
-      ? "Users connect this app on the Apps page to make its skill available"
+      ? "Users connect this app from the Apps page"
       : "Disabled — unavailable to users",
     enabled: app.enabled,
     toggleEnabled: async () => {
@@ -297,9 +351,12 @@ function externalAppToIntegration(
     // Onyx-managed built-ins are provisioned by Onyx.
     remove: app.is_onyx_managed
       ? null
-      : async () => {
-          await deleteExternalApp(app.id);
-          await onChange();
+      : {
+          retainedSkillCount: app.associated_skills.length,
+          run: async () => {
+            await deleteExternalApp(app.id);
+            await onChange();
+          },
         },
   };
 }
@@ -347,13 +404,19 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
     remove,
   } = integration;
   const [isMutating, setIsMutating] = useState(false);
+  const [confirmingRemoval, setConfirmingRemoval] = useState(false);
 
-  async function run(action: () => Promise<void>, failureMessage: string) {
+  async function run(
+    action: () => Promise<void>,
+    failureMessage: string
+  ): Promise<boolean> {
     setIsMutating(true);
     try {
       await action();
+      return true;
     } catch (e) {
       toast.error(e instanceof Error ? e.message : failureMessage);
+      return false;
     } finally {
       setIsMutating(false);
     }
@@ -392,13 +455,42 @@ function IntegrationCard({ integration }: IntegrationCardProps) {
               prominence="tertiary"
               variant="danger"
               icon={SvgTrash}
-              onClick={() => run(remove, `Failed to delete "${name}"`)}
+              onClick={() => setConfirmingRemoval(true)}
               disabled={isMutating}
               aria-label={`Delete ${name}`}
             />
           )}
         </div>
       </div>
+      {confirmingRemoval && remove && (
+        <ConfirmationModalLayout
+          icon={SvgTrash}
+          title={`Delete “${name}”?`}
+          description="This deletes the app configuration and connection data."
+          onClose={isMutating ? undefined : () => setConfirmingRemoval(false)}
+          submit={
+            <Button
+              variant="danger"
+              disabled={isMutating}
+              onClick={() =>
+                void run(remove.run, `Failed to delete "${name}"`).then(
+                  (removed) => {
+                    if (removed) setConfirmingRemoval(false);
+                  }
+                )
+              }
+            >
+              {isMutating ? "Deleting…" : "Delete app"}
+            </Button>
+          }
+        >
+          {remove.retainedSkillCount === 0
+            ? "No skills will be deleted."
+            : `${remove.retainedSkillCount} associated ${
+                remove.retainedSkillCount === 1 ? "skill" : "skills"
+              } will be kept, unlinked from this app, and disabled for everyone.`}
+        </ConfirmationModalLayout>
+      )}
     </Card>
   );
 }


### PR DESCRIPTION
## Description

Adds external-app skill association management to the app create/edit flow. Users can associate existing valid skills or create a skill in app context, with dirty-state protection, conflict and availability handling, and compact associated-skill presentation.

This PR is stacked on #13394 and is intended to ship with it.

## How Has This Been Tested?

- Ran frontend formatting, lint, TypeScript checks, and focused component/service tests.
- Tested the full association lifecycle locally through `http://localhost:3000`: custom app creation, app-context skill creation, existing-skill association, non-admin visibility and enablement, authorization failures, unlinking, app deletion, and preference cleanup.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a UI to link organization skills to external apps in the create/edit flow. Users can pick existing skills or create/upload in app context, with URL-driven deep links, strong unsaved-change guards, and atomic full-replace saves.

- **New Features**
  - Associated-skills editor and a dedicated skills step in app create/configure; link/unlink skills and open, upload, or create skills in-place.
  - App-launched skill creation passes `external_app_id`, creates disabled, and returns to the app; the skill editor reads app context and offers a one-click return.
  - Save is a full replacement via `associated_skill_ids`; only custom skills are listed, built-ins are preserved by the server, and selection auto-syncs with server changes without losing in-progress edits.

- **Bug Fixes**
  - Commit app updates before sandbox reconciliation to avoid losing changes on push errors.
  - Stronger unsaved-change guards across the policy editor, app config, skills step, skill editor, and the upload modal; discard confirmation keeps local drafts; close buttons are labeled and trigger a single cancel; unified upload draft dismissal across all entry points.
  - Harden bundle inspection and selected skill uploads: disable Review while inspecting, block duplicate submissions, validate against current selection/app conflicts, keep rejected uploads visible with clear errors, and refresh post-create to avoid stale associations.

<sup>Written for commit 65adc4ab8b2847d4de0eba7bd4af6624591f34cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13410?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

