### PR TITLE
refactor: remove dead include_onyxbot_flows option

### DIFF
--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -99,19 +99,18 @@ def get_chat_sessions_by_user(
     user_id: UUID | None,
     deleted: bool | None,
     db_session: Session,
-    include_onyxbot_flows: bool = False,
     limit: int = 50,
     before: datetime | None = None,
     project_id: int | None = None,
     only_non_project_chats: bool = False,
     include_failed_chats: bool = False,
 ) -> list[ChatSession]:
-    stmt = select(ChatSession).where(ChatSession.user_id == user_id)
-
-    if not include_onyxbot_flows:
-        stmt = stmt.where(ChatSession.onyxbot_flow.is_(False))
-
-    stmt = stmt.order_by(desc(ChatSession.time_updated))
+    stmt = (
+        select(ChatSession)
+        .where(ChatSession.user_id == user_id)
+        .where(ChatSession.onyxbot_flow.is_(False))
+        .order_by(desc(ChatSession.time_updated))
+    )
 
     if deleted is not None:
         stmt = stmt.where(ChatSession.deleted == deleted)

--- a/backend/onyx/db/chat_search.py
+++ b/backend/onyx/db/chat_search.py
@@ -1,7 +1,7 @@
 from typing import List, Optional, Tuple
 from uuid import UUID
 
-from sqlalchemy import column, desc, func, select
+from sqlalchemy import ColumnElement, column, desc, func, select
 from sqlalchemy.orm import Session, joinedload
 from sqlalchemy.sql.expression import ColumnClause
 
@@ -15,7 +15,6 @@ def search_chat_sessions(
     page: int = 1,
     page_size: int = 10,
     include_deleted: bool = False,
-    include_onyxbot_flows: bool = False,
 ) -> Tuple[List[ChatSession], bool]:
     """
     Fast full-text search on ChatSession + ChatMessage using tsvectors.
@@ -32,14 +31,13 @@ def search_chat_sessions(
     if not query or not query.strip():
         stmt = (
             select(ChatSession)
+            .where(ChatSession.onyxbot_flow.is_(False))
             .order_by(desc(ChatSession.time_created))
             .offset(offset_val)
             .limit(page_size + 1)
         )
         if user_id is not None:
             stmt = stmt.where(ChatSession.user_id == user_id)
-        if not include_onyxbot_flows:
-            stmt = stmt.where(ChatSession.onyxbot_flow.is_(False))
         if not include_deleted:
             stmt = stmt.where(ChatSession.deleted.is_(False))
 
@@ -55,11 +53,9 @@ def search_chat_sessions(
     # Otherwise, proceed with full-text search
     query = query.strip()
 
-    base_conditions = []
+    base_conditions: list[ColumnElement[bool]] = [ChatSession.onyxbot_flow.is_(False)]
     if user_id is not None:
         base_conditions.append(ChatSession.user_id == user_id)
-    if not include_onyxbot_flows:
-        base_conditions.append(ChatSession.onyxbot_flow.is_(False))
     if not include_deleted:
         base_conditions.append(ChatSession.deleted.is_(False))
 

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -968,7 +968,6 @@ def search_chats(
         page=page,
         page_size=page_size,
         include_deleted=False,
-        include_onyxbot_flows=False,
     )
 
     # Group chat sessions by time period


### PR DESCRIPTION
## Summary

`include_onyxbot_flows` was a dead parameter on `get_chat_sessions_by_user` (`onyx/db/chat.py`) and `search_chat_sessions` (`onyx/db/chat_search.py`). This removes it.

Confirmed dead / not publicly exposed:
- **No caller ever passes `True`** — the two `chat_backend.py` endpoints and the EE `query_history` endpoint all leave it at the `False` default (one explicitly passed `include_onyxbot_flows=False`).
- **Not an API query parameter** — none of the endpoints (`/get-user-chat-sessions`, `/search`, EE query-history) surface it.
- **No frontend reference** — zero hits across `.ts`/`.tsx`.
- **Never `True` in git history** — `git log -S "include_onyxbot_flows=True"` is empty.

Because the flag was always `False`, the `ChatSession.onyxbot_flow.is_(False)` filter was always applied. This change drops the parameter and applies that filter unconditionally, so **behavior is unchanged**.

## Testing
- `pre-commit` (ruff, ruff format, `ty` type check) passes on the changed files.
- `backend/tests/unit/onyx/db/test_chat_sessions.py` — 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the unused `include_onyxbot_flows` flag from chat queries and always filter out OnyxBot flows. Behavior is unchanged.

- **Refactors**
  - Dropped `include_onyxbot_flows` from `get_chat_sessions_by_user` and `search_chat_sessions`; apply `ChatSession.onyxbot_flow.is_(False)` unconditionally.
  - Removed the unused argument from the `chat_backend.py` call site.

<sup>Written for commit 50ee658b4b5301c60f8555d852e70366582616b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13411?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

