### PR TITLE
fix(mcp): stop emitting unauthenticated MCP servers into craft sessions

### DIFF
--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -1,10 +1,11 @@
 import datetime
+from collections.abc import Mapping
 from typing import cast
 from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict
 from sqlalchemy import Select, and_, delete, select
-from sqlalchemy.orm import Session, aliased
+from sqlalchemy.orm import Session, aliased, selectinload
 from sqlalchemy.orm.attributes import flag_modified
 
 from onyx.db.constants import UNSET, UnsetType
@@ -65,8 +66,15 @@ def get_craft_enabled_mcp_servers(
 ) -> list[MCPServer]:
     """MCP servers an admin has made available to the Craft agent, filtered to
     those ``user`` may use (public / shared / owned). ``None`` skips the access
-    filter — only for host matching before a user is known (proxy claim path)."""
-    stmt = select(MCPServer).where(MCPServer.available_in_craft.is_(True))
+    filter — only for host matching before a user is known (proxy claim path).
+
+    Eager-loads ``admin_connection_config`` so credential resolution across the
+    returned set doesn't lazy-load one row per admin-managed server."""
+    stmt = (
+        select(MCPServer)
+        .where(MCPServer.available_in_craft.is_(True))
+        .options(selectinload(MCPServer.admin_connection_config))
+    )
     if user is not None:
         stmt = _add_mcp_server_access_filter(stmt, user)
     return list(db_session.scalars(stmt).all())
@@ -452,6 +460,8 @@ def resolve_mcp_credentials(
     mcp_server: MCPServer,
     user: User,
     db_session: Session,
+    *,
+    user_configs: Mapping[int, MCPConnectionConfig] | None = None,
 ) -> ResolvedMCPCredentials:
     """Resolve which stored credentials authenticate `user` against `mcp_server`.
 
@@ -461,6 +471,11 @@ def resolve_mcp_credentials(
     - API_TOKEN / OAUTH: the user's own `mcp_connection_config` row for
       PER_USER servers, the admin config row otherwise.
     - NONE: no credentials.
+
+    `user_configs` lets a caller resolving many servers pre-load the per-user
+    rows in one query (see `get_user_connection_configs`) instead of one per
+    server. It must cover every server the caller resolves — a miss reads as no
+    stored credential, not as unknown.
 
     Raises MCPCredentialsError for PT_OAUTH with the anonymous user, who has no
     login OAuth token.
@@ -482,8 +497,10 @@ def resolve_mcp_credentials(
         MCPAuthenticationType.OAUTH,
     ):
         if mcp_server.auth_performer == MCPAuthenticationPerformer.PER_USER:
-            connection_config = get_user_connection_config(
-                mcp_server.id, user.email, db_session
+            connection_config = (
+                user_configs.get(mcp_server.id)
+                if user_configs is not None
+                else get_user_connection_config(mcp_server.id, user.email, db_session)
             )
         else:
             connection_config = mcp_server.admin_connection_config
@@ -498,21 +515,44 @@ def can_resolve_mcp_credentials(
     mcp_server: MCPServer,
     user: User,
     db_session: Session,
+    *,
+    user_configs: Mapping[int, MCPConnectionConfig] | None = None,
 ) -> bool:
     """Whether the sandbox proxy will be able to authenticate `user` against
     `mcp_server`, mirroring `MCPServerResolver._resolve_for_server`'s block
     condition so callers can't drift from what injection does.
 
     Not the same as the user having their own connection config: admin-managed,
-    `PT_OAUTH`, and no-auth servers all authenticate without one.
+    `PT_OAUTH`, and no-auth servers all authenticate without one. See
+    `resolve_mcp_credentials` for `user_configs`.
     """
     if mcp_server.auth_type in (None, MCPAuthenticationType.NONE):
         return True
     try:
-        credentials = resolve_mcp_credentials(mcp_server, user, db_session)
+        credentials = resolve_mcp_credentials(
+            mcp_server, user, db_session, user_configs=user_configs
+        )
     except MCPCredentialsError:
         return False
     return bool(credentials.build_headers())
+
+
+def get_user_connection_configs(
+    server_ids: list[int], user_email: str, db_session: Session
+) -> dict[int, MCPConnectionConfig]:
+    """`user_email`'s own connection configs for `server_ids`, keyed by server id.
+    One query, for callers resolving credentials across many servers."""
+    if not server_ids:
+        return {}
+    rows = db_session.scalars(
+        select(MCPConnectionConfig).where(
+            and_(
+                MCPConnectionConfig.mcp_server_id.in_(server_ids),
+                MCPConnectionConfig.user_email == user_email,
+            )
+        )
+    )
+    return {row.mcp_server_id: row for row in rows if row.mcp_server_id is not None}
 
 
 def get_user_connection_configs_for_server(

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -500,13 +500,11 @@ def can_resolve_mcp_credentials(
     db_session: Session,
 ) -> bool:
     """Whether the sandbox proxy will be able to authenticate `user` against
-    `mcp_server`.
+    `mcp_server`, mirroring `MCPServerResolver._resolve_for_server`'s block
+    condition so callers can't drift from what injection does.
 
-    Mirrors `MCPServerResolver._resolve_for_server`'s terminal condition
-    (`requires_auth and not headers` blocks the request), so callers deciding
-    whether a server is usable cannot drift from what injection actually does.
-    Note this is NOT the same as the user having their own connection config:
-    admin-managed, `PT_OAUTH`, and no-auth servers all authenticate without one.
+    Not the same as the user having their own connection config: admin-managed,
+    `PT_OAUTH`, and no-auth servers all authenticate without one.
     """
     if mcp_server.auth_type in (None, MCPAuthenticationType.NONE):
         return True

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -407,24 +407,6 @@ def get_user_connection_config(
     )
 
 
-def get_user_authenticated_server_ids(
-    server_ids: list[int], user_email: str, db_session: Session
-) -> set[int]:
-    """Subset of ``server_ids`` for which ``user_email`` has a stored connection
-    config (per-user credentials / OAuth tokens)."""
-    if not server_ids:
-        return set()
-    rows = db_session.scalars(
-        select(MCPConnectionConfig.mcp_server_id).where(
-            and_(
-                MCPConnectionConfig.mcp_server_id.in_(server_ids),
-                MCPConnectionConfig.user_email == user_email,
-            )
-        )
-    )
-    return {sid for sid in rows if sid is not None}
-
-
 class MCPCredentialsError(Exception):
     """Credentials for an MCP server cannot be resolved for this user."""
 
@@ -510,6 +492,29 @@ def resolve_mcp_credentials(
         )
 
     return ResolvedMCPCredentials(connection_config=None, user_oauth_token=None)
+
+
+def can_resolve_mcp_credentials(
+    mcp_server: MCPServer,
+    user: User,
+    db_session: Session,
+) -> bool:
+    """Whether the sandbox proxy will be able to authenticate `user` against
+    `mcp_server`.
+
+    Mirrors `MCPServerResolver._resolve_for_server`'s terminal condition
+    (`requires_auth and not headers` blocks the request), so callers deciding
+    whether a server is usable cannot drift from what injection actually does.
+    Note this is NOT the same as the user having their own connection config:
+    admin-managed, `PT_OAUTH`, and no-auth servers all authenticate without one.
+    """
+    if mcp_server.auth_type in (None, MCPAuthenticationType.NONE):
+        return True
+    try:
+        credentials = resolve_mcp_credentials(mcp_server, user, db_session)
+    except MCPCredentialsError:
+        return False
+    return bool(credentials.build_headers())
 
 
 def get_user_connection_configs_for_server(

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -27,15 +27,14 @@ class CraftMCPServerConfig(BaseModel):
     """A craft-enabled MCP server resolved for opencode `mcp` emission (URL only;
     the proxy injects credentials). ``key`` is the opencode server id.
 
-    ``server_id`` and ``authenticated`` are not emitted into ``opencode.json``;
-    they feed the per-session runtime hash so a hot reload fires when the server
-    set / tools change or the user (dis)connects credentials."""
+    ``server_id`` is not emitted into ``opencode.json``; it feeds the per-session
+    runtime hash so a hot reload fires when the server set / tools change or the
+    user (dis)connects credentials (which adds/removes the server)."""
 
     key: str
     url: str
     disabled_tools: tuple[str, ...] = ()
     server_id: int
-    authenticated: bool = False
 
 
 class SandboxInfo(BaseModel):

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -28,8 +28,7 @@ class CraftMCPServerConfig(BaseModel):
     the proxy injects credentials). ``key`` is the opencode server id.
 
     ``server_id`` is not emitted into ``opencode.json``; it feeds the per-session
-    runtime hash so a hot reload fires when the server set / tools change or the
-    user (dis)connects credentials (which adds/removes the server)."""
+    runtime hash so a hot reload fires when the server set or tools change."""
 
     key: str
     url: str

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -13,18 +13,21 @@ from uuid import UUID
 from sqlalchemy.orm import Session
 
 from onyx.db.mcp import (
+    can_resolve_mcp_credentials,
     get_craft_enabled_mcp_servers,
     get_mcp_tools_for_servers,
-    get_user_authenticated_server_ids,
 )
 from onyx.db.models import MCPServer, User
 from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_session_mcp_config,
 )
+from onyx.utils.logger import setup_logger
 
 if TYPE_CHECKING:
     from onyx.server.features.build.sandbox.base import SandboxManager
+
+logger = setup_logger()
 
 _NON_IDENTIFIER = re.compile(r"[^a-z0-9]+")
 
@@ -40,32 +43,44 @@ def resolve_craft_mcp_servers(
     db_session: Session, user: User
 ) -> list[CraftMCPServerConfig]:
     """Craft-enabled MCP servers ``user`` may use, as opencode config input.
-    Two queries: the servers, then a bulk fetch of their tools.
 
-    Access is filtered here; authentication is not — auth state changes
-    mid-session while this config is baked at provision, so the proxy enforces
-    credentials per request."""
-    servers = get_craft_enabled_mcp_servers(db_session, user)
+    Filtered by access and by whether the proxy can authenticate ``user``
+    against the server: an unauthenticated server's tool discovery is blocked at
+    injection, so emitting it only buys a permanently failed MCP client. Set
+    membership is what the runtime fingerprint sees, so connecting or
+    disconnecting credentials still hot-reloads the session."""
+    servers = [
+        server
+        for server in get_craft_enabled_mcp_servers(db_session, user)
+        if _emit_or_log_skip(server, user, db_session)
+    ]
     disabled_by_server: dict[int, list[str]] = defaultdict(list)
     for tool in get_mcp_tools_for_servers([s.id for s in servers], db_session):
         if tool.mcp_server_id is not None and not tool.enabled:
             disabled_by_server[tool.mcp_server_id].append(tool.name)
-    # Per-user credential presence feeds the runtime hash so connecting/
-    # disconnecting credentials hot-reloads the session (opencode re-runs tool
-    # discovery, which is credential-gated).
-    authed_ids = get_user_authenticated_server_ids(
-        [s.id for s in servers], user.email, db_session
-    )
     return [
         CraftMCPServerConfig(
             key=_server_key(server),
             url=server.server_url,
             disabled_tools=tuple(sorted(disabled_by_server.get(server.id, ()))),
             server_id=server.id,
-            authenticated=server.id in authed_ids,
         )
         for server in servers
     ]
+
+
+def _emit_or_log_skip(server: MCPServer, user: User, db_session: Session) -> bool:
+    """``can_resolve_mcp_credentials``, logging the skips. Craft reads no MCP
+    status back from opencode, so this is the only trace of why a server is
+    missing from a session's config."""
+    if can_resolve_mcp_credentials(server, user, db_session):
+        return True
+    logger.info(
+        "craft_mcp_skip_unauthenticated server_id=%s name=%r",
+        server.id,
+        server.name,
+    )
+    return False
 
 
 def write_session_mcp_config(
@@ -90,15 +105,15 @@ def write_session_mcp_config(
 
 def craft_mcp_fingerprint(mcp_servers: Sequence[CraftMCPServerConfig]) -> str:
     """Stable digest of everything about the craft MCP set that a running
-    session must be rebuilt to pick up: the server set (id + url), each server's
-    disabled-tool set, and whether the user is authenticated (tool discovery is
-    credential-gated). Feeds the per-session runtime hash. Order-independent."""
+    session must be rebuilt to pick up: the server set (id + url) and each
+    server's disabled-tool set. Credential state rides in set membership —
+    ``resolve_craft_mcp_servers`` omits servers the proxy can't authenticate, so
+    (dis)connecting credentials changes this digest. Order-independent."""
     payload = sorted(
         [
             s.server_id,
             s.url,
             list(s.disabled_tools),
-            s.authenticated,
         ]
         for s in mcp_servers
     )

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -44,16 +44,21 @@ def resolve_craft_mcp_servers(
 ) -> list[CraftMCPServerConfig]:
     """Craft-enabled MCP servers ``user`` may use, as opencode config input.
 
-    Filtered by access and by whether the proxy can authenticate ``user``
-    against the server: an unauthenticated server's tool discovery is blocked at
-    injection, so emitting it only buys a permanently failed MCP client. Set
-    membership is what the runtime fingerprint sees, so connecting or
-    disconnecting credentials still hot-reloads the session."""
-    servers = [
-        server
-        for server in get_craft_enabled_mcp_servers(db_session, user)
-        if _emit_or_log_skip(server, user, db_session)
-    ]
+    Filtered by access and by resolvable credentials — injection blocks an
+    unauthenticated server's tool discovery, so emitting it only buys a
+    permanently failed MCP client."""
+    servers: list[MCPServer] = []
+    for server in get_craft_enabled_mcp_servers(db_session, user):
+        if can_resolve_mcp_credentials(server, user, db_session):
+            servers.append(server)
+        else:
+            # Craft reads no MCP status back from opencode; this is the only
+            # trace of why a server is missing from a session's config.
+            logger.info(
+                "craft_mcp_skip_unauthenticated server_id=%s name=%r",
+                server.id,
+                server.name,
+            )
     disabled_by_server: dict[int, list[str]] = defaultdict(list)
     for tool in get_mcp_tools_for_servers([s.id for s in servers], db_session):
         if tool.mcp_server_id is not None and not tool.enabled:
@@ -67,20 +72,6 @@ def resolve_craft_mcp_servers(
         )
         for server in servers
     ]
-
-
-def _emit_or_log_skip(server: MCPServer, user: User, db_session: Session) -> bool:
-    """``can_resolve_mcp_credentials``, logging the skips. Craft reads no MCP
-    status back from opencode, so this is the only trace of why a server is
-    missing from a session's config."""
-    if can_resolve_mcp_credentials(server, user, db_session):
-        return True
-    logger.info(
-        "craft_mcp_skip_unauthenticated server_id=%s name=%r",
-        server.id,
-        server.name,
-    )
-    return False
 
 
 def write_session_mcp_config(
@@ -106,9 +97,9 @@ def write_session_mcp_config(
 def craft_mcp_fingerprint(mcp_servers: Sequence[CraftMCPServerConfig]) -> str:
     """Stable digest of everything about the craft MCP set that a running
     session must be rebuilt to pick up: the server set (id + url) and each
-    server's disabled-tool set. Credential state rides in set membership —
-    ``resolve_craft_mcp_servers`` omits servers the proxy can't authenticate, so
-    (dis)connecting credentials changes this digest. Order-independent."""
+    server's disabled-tool set. Credential state rides in set membership, since
+    ``resolve_craft_mcp_servers`` omits what it can't authenticate.
+    Order-independent."""
     payload = sorted(
         [
             s.server_id,

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -16,6 +16,7 @@ from onyx.db.mcp import (
     can_resolve_mcp_credentials,
     get_craft_enabled_mcp_servers,
     get_mcp_tools_for_servers,
+    get_user_connection_configs,
 )
 from onyx.db.models import MCPServer, User
 from onyx.server.features.build.sandbox.models import CraftMCPServerConfig
@@ -46,10 +47,20 @@ def resolve_craft_mcp_servers(
 
     Filtered by access and by resolvable credentials — injection blocks an
     unauthenticated server's tool discovery, so emitting it only buys a
-    permanently failed MCP client."""
+    permanently failed MCP client.
+
+    Query count is flat in the number of servers: this runs per user in the
+    admin restamp fan-out (``refresh_mcp_config_hashes_for_users``), which for a
+    public server covers every user with a running sandbox."""
+    accessible = get_craft_enabled_mcp_servers(db_session, user)
+    user_configs = get_user_connection_configs(
+        [s.id for s in accessible], user.email, db_session
+    )
     servers: list[MCPServer] = []
-    for server in get_craft_enabled_mcp_servers(db_session, user):
-        if can_resolve_mcp_credentials(server, user, db_session):
+    for server in accessible:
+        if can_resolve_mcp_credentials(
+            server, user, db_session, user_configs=user_configs
+        ):
             servers.append(server)
         else:
             # Craft reads no MCP status back from opencode; this is the only

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -156,10 +156,9 @@ def build_session_mcp_config(
         config["permission"] = permission
     if mcp_servers:
         # Credentials are injected by the proxy; the only header we set is the
-        # session tag the proxy consumes and strips. ``oauth: false`` turns off
-        # opencode's own OAuth auto-detection — it would run discovery and
-        # dynamic client registration against paths the proxy blocks, and report
-        # `needs_auth` for servers the proxy authenticates fine.
+        # session tag the proxy consumes and strips. ``oauth: false`` keeps
+        # opencode from running its own discovery against paths the proxy
+        # blocks, which reports `needs_auth` for servers that work.
         config["mcp"] = {
             server.key: {
                 "type": "remote",

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -156,12 +156,16 @@ def build_session_mcp_config(
         config["permission"] = permission
     if mcp_servers:
         # Credentials are injected by the proxy; the only header we set is the
-        # session tag the proxy consumes and strips.
+        # session tag the proxy consumes and strips. ``oauth: false`` turns off
+        # opencode's own OAuth auto-detection — it would run discovery and
+        # dynamic client registration against paths the proxy blocks, and report
+        # `needs_auth` for servers the proxy authenticates fine.
         config["mcp"] = {
             server.key: {
                 "type": "remote",
                 "url": server.url,
                 "enabled": True,
+                "oauth": False,
                 "headers": {MCP_SESSION_TAG_HEADER: session_id},
             }
             for server in mcp_servers

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -12,6 +12,7 @@ from collections.abc import Generator
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.orm import Session
 
 from onyx.db.enums import (
@@ -159,6 +160,78 @@ def test_no_auth_server_emitted_with_no_credentials_stored(
     assert craft.id in {
         c.server_id for c in resolve_craft_mcp_servers(db_session, user)
     }
+
+
+def test_query_count_flat_in_number_of_servers(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> None:
+    """Resolution runs per user in the admin restamp fan-out, which for a public
+    server covers every user with a running sandbox — so credential state must be
+    batch-loaded rather than queried per server."""
+    user = create_test_user(db_session, "mcp_queries")
+    created: list[MCPServer] = []
+
+    def _add_per_user_server(*, connected: bool) -> None:
+        server = create_mcp_server__no_commit(
+            owner_email="admin@example.com",
+            name=f"perf-{uuid4().hex[:8]}",
+            description=None,
+            server_url=f"https://api-{uuid4().hex[:8]}.example.com/mcp",
+            auth_type=MCPAuthenticationType.API_TOKEN,
+            transport=MCPTransport.STREAMABLE_HTTP,
+            auth_performer=MCPAuthenticationPerformer.PER_USER,
+            db_session=db_session,
+        )
+        update_mcp_server__no_commit(
+            server_id=server.id, db_session=db_session, available_in_craft=True
+        )
+        if connected:
+            create_connection_config(
+                {"headers": {"Authorization": "Bearer x"}},
+                db_session,
+                mcp_server_id=server.id,
+                user_email=user.email,
+            )
+        created.append(server)
+
+    def _executed_statements() -> list[str]:
+        statements: list[str] = []
+
+        def _record(
+            _conn: object, _cursor: object, statement: str, *_rest: object
+        ) -> None:
+            statements.append(statement)
+
+        db_session.expire_all()
+        event.listen(db_session.bind, "before_cursor_execute", _record)
+        try:
+            resolve_craft_mcp_servers(db_session, user)
+        finally:
+            event.remove(db_session.bind, "before_cursor_execute", _record)
+        return statements
+
+    try:
+        for _ in range(2):
+            _add_per_user_server(connected=True)
+            _add_per_user_server(connected=False)
+        db_session.commit()
+        baseline = _executed_statements()
+
+        for _ in range(6):
+            _add_per_user_server(connected=True)
+            _add_per_user_server(connected=False)
+        db_session.commit()
+        grown = _executed_statements()
+        assert len(grown) == len(baseline), (
+            f"4 servers -> {len(baseline)} queries, 16 -> {len(grown)}: "
+            f"{grown[len(baseline) :]}"
+        )
+    finally:
+        db_session.rollback()
+        for server in created:
+            db_session.delete(server)
+        db_session.commit()
 
 
 def test_private_unshared_server_excluded_for_user(

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -1,8 +1,9 @@
 """External-dependency-unit tests for `resolve_craft_mcp_servers`.
 
 Verifies the DB → opencode-config-input step: only craft-enabled servers the
-user may access are emitted, tools split into enabled/disabled by the admin's
-chat-side curation, and the opencode server key is stable + identifier-safe.
+user may access *and the proxy can authenticate them against* are emitted, tools
+split into enabled/disabled by the admin's chat-side curation, and the opencode
+server key is stable + identifier-safe.
 """
 
 from __future__ import annotations
@@ -39,12 +40,14 @@ def craft_server(
     created: list[MCPServer] = []
 
     def _server(name: str, *, available_in_craft: bool) -> MCPServer:
+        # NONE auth keeps these fixtures about access + tool curation: they need
+        # no stored credentials to pass the emission filter.
         server = create_mcp_server__no_commit(
             owner_email="admin@example.com",
             name=name,
             description=None,
             server_url=f"https://api-{uuid4().hex[:8]}.example.com/mcp",
-            auth_type=MCPAuthenticationType.API_TOKEN,
+            auth_type=MCPAuthenticationType.NONE,
             transport=MCPTransport.STREAMABLE_HTTP,
             auth_performer=MCPAuthenticationPerformer.ADMIN,
             db_session=db_session,
@@ -86,22 +89,24 @@ def test_only_craft_enabled_servers_resolved_with_tool_curation(
     assert config.disabled_tools == ("delete_issue",)
 
 
-def test_resolve_populates_server_id_and_user_auth(
+def test_per_user_server_emitted_only_once_credentials_connected(
     db_session: Session,
     craft_server: tuple[MCPServer, MCPServer],
 ) -> None:
-    """``server_id`` and ``authenticated`` feed the runtime hash: connecting
-    credentials must flip ``authenticated`` and change the fingerprint so the
-    user's session hot-reloads (tool discovery is credential-gated)."""
+    """A PER_USER server the proxy can't authenticate is not emitted at all —
+    its tool discovery would be blocked at injection. Connecting credentials adds
+    it to the set, which changes the fingerprint so the session hot-reloads."""
     craft, _ = craft_server
+    craft.auth_type = MCPAuthenticationType.API_TOKEN
+    craft.auth_performer = MCPAuthenticationPerformer.PER_USER
+    db_session.commit()
     user = create_test_user(db_session, "mcp_auth")
 
-    before = {c.server_id: c for c in resolve_craft_mcp_servers(db_session, user)}
-    assert craft.id in before
-    assert before[craft.id].authenticated is False
-    fp_before = craft_mcp_fingerprint(list(before.values()))
+    before = resolve_craft_mcp_servers(db_session, user)
+    assert craft.id not in {c.server_id for c in before}
+    fp_before = craft_mcp_fingerprint(before)
 
-    create_connection_config(
+    config = create_connection_config(
         {"headers": {"Authorization": "Bearer x"}},
         db_session,
         mcp_server_id=craft.id,
@@ -109,9 +114,53 @@ def test_resolve_populates_server_id_and_user_auth(
     )
     db_session.commit()
 
-    after = {c.server_id: c for c in resolve_craft_mcp_servers(db_session, user)}
-    assert after[craft.id].authenticated is True
-    assert craft_mcp_fingerprint(list(after.values())) != fp_before
+    after = resolve_craft_mcp_servers(db_session, user)
+    assert craft.id in {c.server_id for c in after}
+    assert craft_mcp_fingerprint(after) != fp_before
+
+    # Disconnecting drops it back out, restoring the original fingerprint.
+    db_session.delete(config)
+    db_session.commit()
+    assert (
+        craft_mcp_fingerprint(resolve_craft_mcp_servers(db_session, user)) == fp_before
+    )
+
+
+def test_admin_managed_server_emitted_without_per_user_credentials(
+    db_session: Session,
+    craft_server: tuple[MCPServer, MCPServer],
+) -> None:
+    """An ADMIN-performer server authenticates every user off the admin's stored
+    credential (`user_email=""`), so it must be emitted for a user who has no
+    per-user row of their own."""
+    craft, _ = craft_server
+    craft.auth_type = MCPAuthenticationType.API_TOKEN
+    craft.auth_performer = MCPAuthenticationPerformer.ADMIN
+    craft.admin_connection_config = create_connection_config(
+        {"headers": {"Authorization": "Bearer admin-token"}},
+        db_session,
+        mcp_server_id=craft.id,
+        user_email="",
+    )
+    db_session.commit()
+
+    user = create_test_user(db_session, "mcp_admin_managed")
+    assert craft.id in {
+        c.server_id for c in resolve_craft_mcp_servers(db_session, user)
+    }
+
+
+def test_no_auth_server_emitted_with_no_credentials_stored(
+    db_session: Session,
+    craft_server: tuple[MCPServer, MCPServer],
+) -> None:
+    """`auth_type=NONE` needs no credentials, so it is emitted as-is."""
+    craft, _ = craft_server
+    assert craft.auth_type == MCPAuthenticationType.NONE
+    user = create_test_user(db_session, "mcp_no_auth")
+    assert craft.id in {
+        c.server_id for c in resolve_craft_mcp_servers(db_session, user)
+    }
 
 
 def test_private_unshared_server_excluded_for_user(

--- a/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py
@@ -40,8 +40,8 @@ def craft_server(
     created: list[MCPServer] = []
 
     def _server(name: str, *, available_in_craft: bool) -> MCPServer:
-        # NONE auth keeps these fixtures about access + tool curation: they need
-        # no stored credentials to pass the emission filter.
+        # NONE auth keeps these fixtures about access + tool curation, not
+        # credentials.
         server = create_mcp_server__no_commit(
             owner_email="admin@example.com",
             name=name,
@@ -93,9 +93,8 @@ def test_per_user_server_emitted_only_once_credentials_connected(
     db_session: Session,
     craft_server: tuple[MCPServer, MCPServer],
 ) -> None:
-    """A PER_USER server the proxy can't authenticate is not emitted at all —
-    its tool discovery would be blocked at injection. Connecting credentials adds
-    it to the set, which changes the fingerprint so the session hot-reloads."""
+    """An unauthenticated PER_USER server is not emitted at all; connecting
+    credentials adds it, changing the fingerprint so the session hot-reloads."""
     craft, _ = craft_server
     craft.auth_type = MCPAuthenticationType.API_TOKEN
     craft.auth_performer = MCPAuthenticationPerformer.PER_USER
@@ -118,7 +117,7 @@ def test_per_user_server_emitted_only_once_credentials_connected(
     assert craft.id in {c.server_id for c in after}
     assert craft_mcp_fingerprint(after) != fp_before
 
-    # Disconnecting drops it back out, restoring the original fingerprint.
+    # Disconnecting drops it back out.
     db_session.delete(config)
     db_session.commit()
     assert (
@@ -131,8 +130,7 @@ def test_admin_managed_server_emitted_without_per_user_credentials(
     craft_server: tuple[MCPServer, MCPServer],
 ) -> None:
     """An ADMIN-performer server authenticates every user off the admin's stored
-    credential (`user_email=""`), so it must be emitted for a user who has no
-    per-user row of their own."""
+    credential (`user_email=""`), so a user with no per-user row still gets it."""
     craft, _ = craft_server
     craft.auth_type = MCPAuthenticationType.API_TOKEN
     craft.auth_performer = MCPAuthenticationPerformer.ADMIN

--- a/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
+++ b/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
@@ -226,7 +226,7 @@ def test_delete_server_restamps_affected_running_sandbox(
     admin = create_test_user(db_session, "del_reload_admin", role=UserRole.ADMIN)
     sandbox = make_sandbox(db_session, admin, status=SandboxStatus.RUNNING)
     server = _make_craft_server(db_session, owner_email=admin.email, is_public=True)
-    # Credentials are what put the server in the resolved craft set at all.
+    # Credentials are what put the server in the resolved craft set.
     upsert_user_connection_config(
         server_id=server.id,
         user_email=admin.email,

--- a/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
+++ b/backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py
@@ -226,6 +226,14 @@ def test_delete_server_restamps_affected_running_sandbox(
     admin = create_test_user(db_session, "del_reload_admin", role=UserRole.ADMIN)
     sandbox = make_sandbox(db_session, admin, status=SandboxStatus.RUNNING)
     server = _make_craft_server(db_session, owner_email=admin.email, is_public=True)
+    # Credentials are what put the server in the resolved craft set at all.
+    upsert_user_connection_config(
+        server_id=server.id,
+        user_email=admin.email,
+        config_data=MCPConnectionData(headers={"Authorization": "Bearer admin-token"}),
+        db_session=db_session,
+    )
+    db_session.commit()
 
     fp_before = craft_mcp_fingerprint(resolve_craft_mcp_servers(db_session, admin))
     sandbox.mcp_config_hash = fp_before

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -283,6 +283,9 @@ def test_mcp_servers_emit_remote_entries_with_session_tag_header() -> None:
             "type": "remote",
             "url": "https://mcp.linear.app/mcp",
             "enabled": True,
+            # The proxy owns credentials, so opencode must not run its own OAuth
+            # discovery against these servers.
+            "oauth": False,
             # The proxy reads this to attribute the tool call to a session for
             # approval (no per-user credentials — the proxy injects those).
             "headers": {MCP_SESSION_TAG_HEADER: "sess-abc"},
@@ -310,14 +313,12 @@ def _srv(
     server_id: int,
     url: str = "https://mcp.example.com/mcp",
     disabled_tools: tuple[str, ...] = (),
-    authenticated: bool = False,
 ) -> CraftMCPServerConfig:
     return CraftMCPServerConfig(
         key=f"s-{server_id}",
         url=url,
         disabled_tools=disabled_tools,
         server_id=server_id,
-        authenticated=authenticated,
     )
 
 
@@ -327,21 +328,16 @@ def test_craft_mcp_fingerprint_is_order_independent() -> None:
 
 
 def test_craft_mcp_fingerprint_reacts_to_each_input() -> None:
-    base = [_srv(1, url="u1", disabled_tools=("x",), authenticated=False)]
+    base = [_srv(1, url="u1", disabled_tools=("x",))]
     baseline = craft_mcp_fingerprint(base)
-    # server set
+    # server set — also how credential state reaches the digest, since an
+    # unauthenticated server is never resolved into the set.
     assert craft_mcp_fingerprint(base + [_srv(2)]) != baseline
+    assert craft_mcp_fingerprint([]) != baseline
     # url
     assert craft_mcp_fingerprint([_srv(1, url="u2", disabled_tools=("x",))]) != baseline
     # disabled-tool set
     assert (
         craft_mcp_fingerprint([_srv(1, url="u1", disabled_tools=("x", "y"))])
-        != baseline
-    )
-    # per-user auth
-    assert (
-        craft_mcp_fingerprint(
-            [_srv(1, url="u1", disabled_tools=("x",), authenticated=True)]
-        )
         != baseline
     )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -283,8 +283,8 @@ def test_mcp_servers_emit_remote_entries_with_session_tag_header() -> None:
             "type": "remote",
             "url": "https://mcp.linear.app/mcp",
             "enabled": True,
-            # The proxy owns credentials, so opencode must not run its own OAuth
-            # discovery against these servers.
+            # The proxy owns credentials; opencode must not run its own OAuth
+            # discovery.
             "oauth": False,
             # The proxy reads this to attribute the tool call to a session for
             # approval (no per-user credentials — the proxy injects those).
@@ -330,8 +330,7 @@ def test_craft_mcp_fingerprint_is_order_independent() -> None:
 def test_craft_mcp_fingerprint_reacts_to_each_input() -> None:
     base = [_srv(1, url="u1", disabled_tools=("x",))]
     baseline = craft_mcp_fingerprint(base)
-    # server set — also how credential state reaches the digest, since an
-    # unauthenticated server is never resolved into the set.
+    # server set — also how credential state reaches the digest
     assert craft_mcp_fingerprint(base + [_srv(2)]) != baseline
     assert craft_mcp_fingerprint([]) != baseline
     # url


### PR DESCRIPTION
## Description

`resolve_craft_mcp_servers` filtered craft-enabled MCP servers by **access** only, so every server a user could see was written into their session's `opencode.json` with `enabled: true` — including servers the sandbox proxy cannot authenticate them against. opencode dials each one, credential injection answers `403 credential_error` on both transport legs (streamable-HTTP `POST`, then the SSE fallback `GET`), and the server lands in opencode as `status: "failed"` with zero tools.

Three things this fixes:

1. **Dead MCP clients.** Unusable servers are no longer emitted. Nothing is lost by dropping them: they surface no tools either way, and `connect_app` is keyed by `external_app_id` against the external-apps catalog, so the agent can neither see such a server nor prompt the user to connect it.
2. **The `authenticated` flag was unusable as a predicate.** It came from `get_user_authenticated_server_ids`, which matches only `MCPConnectionConfig` rows keyed to the user's own email — but admin-managed credentials are stored with `user_email=""`. It therefore read `False` for every ADMIN-performer, `PT_OAUTH`, and `auth_type=NONE` server, all of which the proxy authenticates fine. Filtering on it would have broken working integrations. The new `can_resolve_mcp_credentials` mirrors `MCPServerResolver._resolve_for_server`'s terminal condition (`requires_auth and not headers → block`) by delegating to `resolve_mcp_credentials`, so emission and injection cannot drift.
3. **Admin-managed servers never hot-reloaded.** That flag fed the per-session runtime fingerprint, and since it could never flip for ADMIN-performer servers, an admin connecting one did not restamp any user's running sandbox — the hot-reload from #13293 only ever worked for PER_USER servers. Credential state now rides in **set membership**, which the fingerprint already covers, so connecting/disconnecting reloads the session for every auth performer.

Also emits `oauth: false` per server. Credentials come from the proxy, so opencode's OAuth auto-detection only generates discovery / dynamic-client-registration requests against paths the proxy blocks, plus `needs_auth` reports for servers that work.

`get_user_authenticated_server_ids` is deleted — it had no remaining callers.

### Scope note: this is not the 60s MCP-init fix

This was investigated as the cause of a 60s MCP initialization stall. It is **not** that, and the ticket should not be closed on this PR. Measured against opencode's client:

| Origin behavior | Cost |
| --- | --- |
| Proxy 403 on both legs, reachable host | 0.17s |
| Origin holds the SSE `GET` open | 30s |
| Origin never responds | 60s (2 × 30s `withTimeout`, StreamableHTTP then SSE) |

Servers connect with unbounded concurrency, so the stall is set by the slowest single server, not the sum. A dead server on a *reachable* host costs ~0.17s.

Two related findings, both deliberately out of scope here:

- **`mcp.timeout` is a trap.** opencode passes it into `client.callTool`, not just connect, and craft's approval gate holds a gated `tools/call` for up to `SANDBOX_APPROVAL_WAIT_TIMEOUT_SECONDS` (180). A value short enough to cap a hanging connect would kill approval-gated tool calls. Separately: with it unset, tool calls inherit the MCP SDK's 60s default, so an MCP call the user takes >60s to approve already fails client-side while the gate still waits.
- **`connection_strategy` is `eager`.** `_build_mitm_options()` doesn't override mitmproxy's default, so the proxy establishes the upstream TCP+TLS connection *before* the request hook can block. A blocked request to an unreachable host therefore still burns the full connect timeout and never returns its 403. Verified locally with a 403-everything addon: eager → reachable 0.14s, blackholed hangs >25s; `lazy` → reachable 0.11s, blackholed **0.01s**. `lazy` looks like the real fix for that class of stall, but it changes upstream cert / ALPN mirroring for all sandbox egress, so it belongs in its own PR with a pass over the gate's TLS assumptions.

## How Has This Been Tested?

- `backend/tests/external_dependency_unit/build/test_mcp_config_resolution.py` — 5 passed. Rewrote the credential test as absence → presence → absence with fingerprint assertions across each transition, and added the two cases the old flag would have regressed: an ADMIN-performer server with an admin credential is emitted for a user with no per-user row, and an `auth_type=NONE` server is emitted with nothing stored. Its fixture now uses `NONE` auth so the access/tool-curation tests stay about access and curation.
- `backend/tests/external_dependency_unit/mcp/test_craft_admin_api.py` — 6 passed, after giving the restamp fixture a credential; without one its server is now absent both before and after the delete, which would have made the assertion vacuous.
- `backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py` — 20 passed, updated for the `oauth` key and the dropped model field.
- `pre-commit` clean on all touched files (`ty`, `ruff`, `ruff format`).

`test_session_lifecycle.py` fails locally on a missing `external_app__skill` table, which reproduces identically with these changes stashed — a local schema lag, not this diff.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop emitting unauthenticated MCP servers into craft sessions to prevent permanently failed clients. Also batch-load credential state so session resolution avoids N+1 queries.

- **Bug Fixes**
  - Filter craft MCP servers with an auth check that mirrors injection; skip servers the proxy cannot authenticate.
  - Remove the unusable `authenticated` flag; fingerprint now tracks server set + disabled tools only.
  - Ensure admin-managed, `PT_OAUTH`, and no-auth servers are emitted correctly.
  - Emit `oauth: false` per server to disable opencode’s OAuth auto-detection.
  - Delete the old per-user auth lookup and add logging for skipped servers.
  - Update tests and fixtures, including fingerprinting and a query-count check.

- **Refactors**
  - Inline the emission filter into an explicit loop for clarity and skip-logging.
  - Batch-load per-user connection configs and eager-load admin configs to eliminate N+1; resolution now uses a constant number of DB queries across server counts.
  - Extend `resolve_mcp_credentials` with `user_configs` and add `get_user_connection_configs` for bulk loads.

<sup>Written for commit 328b67db334e54798d5f833d1c6bf090ee3fffdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



