### PR TITLE
fix(craft): support Claude 5 adaptive thinking

### DIFF
--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -7,6 +7,7 @@ key otherwise — letting per-prompt model overrides cross providers without a
 restart.
 """
 
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -16,19 +17,28 @@ from onyx.server.features.build.sandbox.models import (
     LLMProviderConfig,
 )
 
-# 4.6+ supports adaptive thinking; older needs enabled+budgetTokens.
 _ADAPTIVE_THINKING_MODELS = frozenset(
     {"claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6"}
 )
+_CLAUDE_MAJOR_VERSION = re.compile(r"claude[.-](?:[a-z]+[.-])?(\d+)")
+
+
+def _uses_adaptive_thinking(model_name: str) -> bool:
+    normalized_name = model_name.lower()
+    if normalized_name in _ADAPTIVE_THINKING_MODELS or normalized_name.startswith(
+        tuple(f"{model}-" for model in _ADAPTIVE_THINKING_MODELS)
+    ):
+        return True
+
+    match = _CLAUDE_MAJOR_VERSION.search(normalized_name)
+    return match is not None and int(match.group(1)) >= 5
 
 
 def _model_options(provider: str, model_name: str) -> dict[str, Any]:
     if provider == "openai":
         return {"reasoningEffort": "high"}
     if provider in ("anthropic", "bedrock"):
-        if model_name in _ADAPTIVE_THINKING_MODELS or model_name.startswith(
-            tuple(f"{m}-" for m in _ADAPTIVE_THINKING_MODELS)
-        ):
+        if _uses_adaptive_thinking(model_name):
             return {"thinking": {"type": "adaptive", "display": "summarized"}}
         return {"thinking": {"type": "enabled", "budgetTokens": 16000}}
     if provider == "google":

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -63,6 +63,29 @@ def test_adaptive_anthropic_models_request_readable_thinking_summaries() -> None
     ] == {"type": "adaptive", "display": "summarized"}
 
 
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "claude-opus-5",
+        "claude-fable-5",
+        "claude-5-sonnet",
+        "anthropic.claude-mythos-6@20270101",
+    ],
+)
+def test_current_and_future_claude_models_use_adaptive_thinking(
+    model_name: str,
+) -> None:
+    config = build_multi_provider_opencode_config(
+        providers=[_cfg("anthropic", model_name)],
+        default_provider="anthropic",
+        default_model=model_name,
+    )
+
+    assert config["provider"]["anthropic"]["models"][model_name]["options"][
+        "thinking"
+    ] == {"type": "adaptive", "display": "summarized"}
+
+
 def test_multi_provider_each_gets_its_own_block() -> None:
     """
     All three providers should be pre-loaded with their own api_key so


### PR DESCRIPTION
## Description

Craft's OpenCode configuration used a fixed allowlist to decide which Claude models receive adaptive thinking options. Newly available Claude 5 models—including Fable and the recommended Claude model—fell through to the legacy `thinking.type=enabled` configuration, which Anthropic rejects.

This change keeps the existing Claude 4 exceptions and treats Claude major version 5 or newer as adaptive-thinking models. It supports tier-first and version-first names as well as provider-prefixed model identifiers.

## How Has This Been Tested?

- `pytest -q backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py`
- `pre-commit run --files backend/onyx/server/features/build/sandbox/util/opencode_config.py backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py`
- Local Kubernetes Craft E2E through `localhost:3000` as `wenxi@onyx.app`:
  - `claude-opus-5`
  - `claude-fable-5`
  - `claude-opus-4-8`

All three models completed real first turns without Anthropic thinking-configuration errors.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenCode config to enable adaptive thinking for all Claude 5+ models, preventing Anthropic “thinking.type=enabled” rejections. Keeps Claude 4 exceptions and supports varied model ID formats.

- **Bug Fixes**
  - Detect Claude major version >= 5 and set thinking to {"type":"adaptive","display":"summarized"}.
  - Keep allowlist for `claude-opus-4-7`, `claude-opus-4-8`, `claude-sonnet-4-6`.
  - Support tier-first, version-first, and provider-prefixed IDs (e.g., `anthropic.claude-…`).
  - Added tests covering new and future Claude model names.

<sup>Written for commit d4f6b4d77315d5a590c9d0d3a1f0032d56c25a9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13415?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

