### PR TITLE
perf(db): bound the SQL fetch in get_chat_sessions_by_user

### DIFF
--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -93,6 +93,40 @@ def get_chat_sessions_by_slack_thread_id(
     return db_session.scalars(stmt).all()
 
 
+# Number of extra rows fetched beyond the requested limit when filtering out
+# failed chats, so that a page containing a few failed sessions can still be
+# served by a single query.
+_FAILED_CHAT_FETCH_SLACK = 10
+
+
+def _filter_out_failed_chat_sessions(
+    chat_sessions: list[ChatSession],
+    leeway: datetime,
+    db_session: Session,
+) -> list[ChatSession]:
+    """Drop "failed" sessions: those created before `leeway` with only SYSTEM
+    messages. Uses a separate query on chat_message instead of a correlated
+    EXISTS subquery, which causes full sequential scans of chat_message.
+    """
+    session_ids = [cs.id for cs in chat_sessions if cs.time_created < leeway]
+    if not session_ids:
+        return chat_sessions
+
+    valid_session_ids_stmt = (
+        select(ChatMessage.chat_session_id)
+        .where(ChatMessage.chat_session_id.in_(session_ids))
+        .where(ChatMessage.message_type != MessageType.SYSTEM)
+        .distinct()
+    )
+    valid_session_ids = set(db_session.execute(valid_session_ids_stmt).scalars().all())
+
+    return [
+        cs
+        for cs in chat_sessions
+        if cs.time_created >= leeway or cs.id in valid_session_ids
+    ]
+
+
 # Retrieves chat sessions by user
 # Chat sessions do not include onyxbot flows
 def get_chat_sessions_by_user(
@@ -115,50 +149,45 @@ def get_chat_sessions_by_user(
     if deleted is not None:
         stmt = stmt.where(ChatSession.deleted == deleted)
 
-    if before is not None:
-        stmt = stmt.where(ChatSession.time_updated < before)
-
     if project_id is not None:
         stmt = stmt.where(ChatSession.project_id == project_id)
     elif only_non_project_chats:
         stmt = stmt.where(ChatSession.project_id.is_(None))
 
-    # When filtering out failed chats, we apply the limit in Python after
-    # filtering rather than in SQL, since the post-filter may remove rows.
-    if limit and include_failed_chats:
-        stmt = stmt.limit(limit)
-
-    result = db_session.execute(stmt)
-    chat_sessions = list(result.scalars().all())
-
-    if not include_failed_chats and chat_sessions:
-        # Filter out "failed" sessions (those with only SYSTEM messages)
-        # using a separate efficient query instead of a correlated EXISTS
-        # subquery, which causes full sequential scans of chat_message.
-        leeway = datetime.now(timezone.utc) - timedelta(minutes=5)
-        session_ids = [cs.id for cs in chat_sessions if cs.time_created < leeway]
-
-        if session_ids:
-            valid_session_ids_stmt = (
-                select(ChatMessage.chat_session_id)
-                .where(ChatMessage.chat_session_id.in_(session_ids))
-                .where(ChatMessage.message_type != MessageType.SYSTEM)
-                .distinct()
-            )
-            valid_session_ids = set(
-                db_session.execute(valid_session_ids_stmt).scalars().all()
-            )
-
-            chat_sessions = [
-                cs
-                for cs in chat_sessions
-                if cs.time_created >= leeway or cs.id in valid_session_ids
-            ]
-
+    if include_failed_chats or not limit:
+        # Single fetch: the SQL LIMIT is exact when failed chats are included,
+        # and limit=0 callers want the full history either way.
+        if before is not None:
+            stmt = stmt.where(ChatSession.time_updated < before)
         if limit:
-            chat_sessions = chat_sessions[:limit]
+            stmt = stmt.limit(limit)
+        chat_sessions = list(db_session.execute(stmt).scalars().all())
+        if include_failed_chats:
+            return chat_sessions
+        leeway = datetime.now(timezone.utc) - timedelta(minutes=5)
+        return _filter_out_failed_chat_sessions(chat_sessions, leeway, db_session)
 
-    return chat_sessions
+    # The failed-chat filter runs in Python, so a plain SQL LIMIT could
+    # undershoot after filtering. Instead of fetching the user's entire
+    # history, fetch limit + slack rows at a time and keyset-paginate
+    # (time_updated < last row, the same semantics as `before` — including
+    # its caveat that rows tied on time_updated at a boundary are skipped)
+    # only if filtering leaves fewer than `limit` survivors.
+    leeway = datetime.now(timezone.utc) - timedelta(minutes=5)
+    batch_size = limit + _FAILED_CHAT_FETCH_SLACK
+    cursor = before
+    chat_sessions: list[ChatSession] = []
+    while True:
+        batch_stmt = stmt
+        if cursor is not None:
+            batch_stmt = batch_stmt.where(ChatSession.time_updated < cursor)
+        batch = list(db_session.execute(batch_stmt.limit(batch_size)).scalars().all())
+        chat_sessions.extend(
+            _filter_out_failed_chat_sessions(batch, leeway, db_session)
+        )
+        if len(chat_sessions) >= limit or len(batch) < batch_size:
+            return chat_sessions[:limit]
+        cursor = batch[-1].time_updated
 
 
 def delete_orphaned_search_docs(db_session: Session) -> None:

--- a/backend/tests/unit/onyx/db/test_chat_sessions.py
+++ b/backend/tests/unit/onyx/db/test_chat_sessions.py
@@ -202,6 +202,71 @@ class TestGetChatSessionsByUser:
         assert recent_no_msgs.id in result_ids
         assert old_failed.id not in result_ids
 
+    def test_fetches_next_batch_when_filtering_undershoots(
+        self, user_id: UUID, old_time: datetime
+    ) -> None:
+        """When failed sessions shrink a batch below the limit, the next batch
+        is fetched with a keyset cursor instead of fetching the full history."""
+        # limit=2 fetches batches of 2 + slack (10) = 12 rows.
+        first_batch = [
+            _make_session(
+                user_id,
+                time_created=old_time,
+                time_updated=old_time - timedelta(minutes=i),
+            )
+            for i in range(12)
+        ]
+        second_batch = [
+            _make_session(
+                user_id,
+                time_created=old_time,
+                time_updated=old_time - timedelta(minutes=20 + i),
+            )
+            for i in range(2)
+        ]
+
+        db_session = MagicMock(spec=Session)
+
+        # Batch 1: only one of the 12 sessions is valid -> undershoots limit.
+        mock_batch_1 = MagicMock()
+        mock_batch_1.scalars.return_value.all.return_value = first_batch
+        mock_filter_1 = MagicMock()
+        mock_filter_1.scalars.return_value.all.return_value = [first_batch[0].id]
+
+        # Batch 2: both sessions are valid.
+        mock_batch_2 = MagicMock()
+        mock_batch_2.scalars.return_value.all.return_value = second_batch
+        mock_filter_2 = MagicMock()
+        mock_filter_2.scalars.return_value.all.return_value = [
+            s.id for s in second_batch
+        ]
+
+        db_session.execute.side_effect = [
+            mock_batch_1,
+            mock_filter_1,
+            mock_batch_2,
+            mock_filter_2,
+        ]
+
+        result = get_chat_sessions_by_user(
+            user_id=user_id,
+            deleted=False,
+            db_session=db_session,
+            include_failed_chats=False,
+            limit=2,
+        )
+
+        assert [cs.id for cs in result] == [first_batch[0].id, second_batch[0].id]
+        assert db_session.execute.call_count == 4
+
+        # Both session fetches are SQL-limited, and the second one is
+        # keyset-cursored on the last row of the first batch.
+        first_stmt = db_session.execute.call_args_list[0].args[0]
+        second_stmt = db_session.execute.call_args_list[2].args[0]
+        assert "LIMIT" in str(first_stmt)
+        assert "LIMIT" in str(second_stmt)
+        assert first_batch[-1].time_updated in second_stmt.compile().params.values()
+
     def test_empty_result(self, user_id: UUID) -> None:
         """No sessions should return empty list without errors."""
         db_session = MagicMock(spec=Session)


### PR DESCRIPTION
Follow-up to #13391, which was merged index-only. As the review there pointed out, the index alone cannot bound the sidebar query's fetch: `GET /chat/get-user-chat-sessions` defaults `include_failed_chats=False` (the web frontend never overrides it), and on that path `get_chat_sessions_by_user` applied **no SQL LIMIT** — it fetched the user's entire chat history, filtered "failed" sessions (older than 5 min with only SYSTEM messages) in Python, then truncated to `page_size + 1`. Cost grew linearly with account age on the most-hit chat endpoint: for a 15k-session dev user, every sidebar load transferred and ORM-hydrated all 15k rows to return 50, and the companion `chat_message` IN-list query received all 15k session ids.

## Fix

Batched keyset pagination:

- Fetch `limit + slack` (slack = 10) rows with a SQL `LIMIT`.
- Apply the existing Python failed-chat filter per batch (extracted into `_filter_out_failed_chat_sessions`, unchanged logic).
- Only fetch another batch — cursored on `time_updated < last row`, the same semantics as the endpoint's existing `before` param — if filtering leaves fewer than `limit` survivors.

Pages without failed sessions cost a single round trip of ~61 rows. The `include_failed_chats=True` and `limit=0` (EE admin query-history endpoint) paths keep their previous single-fetch behavior.

## Validation

- **Unit**: new test for the multi-batch path (asserts both fetches are SQL-limited, the second is keyset-cursored on the last row of the first batch, and results truncate to `limit` in order); 7/7 passing in `backend/tests/unit/onyx/db/test_chat_sessions.py`.
- **Live regression** (15k-session dev user, captures toggled via stash on a hot-reloading server against the same data): responses byte-identical before/after for page 1, page 2 via `before` cursor, `page_size=100`, and `include_failed_chats=true`.
- **Live multi-batch**: seeded 15 failed sessions at the very top of the sidebar ordering (inside the first 61-row batch); page 1 stayed byte-identical to the unseeded reference — 50 rows, none leaked, `has_more` intact. Since the first batch could only yield 46 survivors, this confirms the second keyset batch fires and fills the page correctly.
- **Timing** (15k-session dev user, page 1, 30 steady-state samples per side, hot-reload toggle so both run against the same data):
  - Endpoint latency:

    | | old | new | change |
    |---|---|---|---|
    | median | 1731 ms | 90 ms | **~19x faster** |
    | p90 | 1780 ms | 95 ms | ~19x |
    | max | 1850 ms | 109 ms | ~17x |
    | `page_size=100` (1 sample) | 1792 ms | 89 ms | ~20x |
  - `chat_session` fetch (`EXPLAIN ANALYZE`): 24.0ms / 15001 rows / seq scan + sort → **0.31ms / 61 rows** via `ix_chat_session_user_id_onyxbot_flow_time_updated` — the #13391 index only gets picked once the LIMIT exists.
  - Companion `chat_message` IN-list query: 15001 ids (585KB of SQL, 8.4ms plan + 36.7ms exec) → 61 ids (2.4KB, 0.7ms + 19.2ms).
  - The remaining ~1.6s of the old endpoint time was Python-side — transferring + ORM-hydrating 15001 rows and compiling a 15001-parameter IN clause — which the fix removes by construction: per-request work is now O(page), not O(total history).
- pre-commit (ty, ruff, ruff format) clean.

## Notes

- Rejected for now: moving the failed-chat filter into SQL as a correlated `EXISTS` + `LIMIT` — `chat_message.chat_session_id` is unindexed, so `EXISTS` seq-scans `chat_message` (the code comments already warn about this). Worth revisiting if an index on `chat_message(chat_session_id)` lands (independently justified: cascade deletes of chat sessions currently seq-scan `chat_message` per row).
- Known caveat (accepted): if `time_updated` ties straddle a batch boundary, the strict `<` cursor skips the tied row — identical to the existing behavior of the endpoint's `before` pagination; microsecond timestamps make this essentially theoretical.
- Rebased on top of #13411 (removal of the dead `include_onyxbot_flows` param), which merged first — no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bound the SQL fetch in `get_chat_sessions_by_user` with batched keyset pagination to stop loading a user’s entire history when `include_failed_chats=false`. This removes linear growth on the sidebar endpoint and cuts latency significantly on large accounts.

- **Performance**
  - Fetches `limit + 10` per batch with SQL `LIMIT`, filters failed sessions per batch, and only fetches the next batch with `time_updated < last`.
  - Keeps single-fetch behavior when `include_failed_chats=true` or the limit is unset/0.

- **Validation**
  - Added a unit test covering the multi-batch path, SQL limits, and keyset cursoring.
  - Local runs on a 15k-session user return identical results; page 1 latency drops from 0.7–4.5s to ~0.06–0.14s.

<sup>Written for commit 5814e594c6fc3fa34c8b3e8904aa0a6fece0e6fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13416?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

