### PR TITLE
fix(model selection): emit display-cased vendor from the backend

### DIFF
--- a/backend/onyx/llm/model_name_parser.py
+++ b/backend/onyx/llm/model_name_parser.py
@@ -35,7 +35,7 @@ class ParsedModelName(BaseModel):
 
     raw_name: str  # Original: "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0"
     provider: str  # "bedrock", "azure", "openai", etc. (the API route)
-    vendor: str | None = None  # From enrichment: "anthropic", "openai", "meta", etc.
+    vendor: str | None = None  # Display-cased: "Anthropic", "OpenAI", "Meta", etc.
     version: str | None = None  # From enrichment: "20241022-v2:0", "v1:0", etc.
     region: str | None = None  # Extracted: "us", "eu", or None
     display_name: str  # From enrichment: "Claude 3.5 Sonnet"
@@ -264,7 +264,8 @@ def parse_litellm_model_name(raw_name: str) -> ParsedModelName:
     return ParsedModelName(
         raw_name=raw_name,
         provider=provider,
-        vendor=vendor,
+        # Display-cased for UI grouping, matching extract_vendor_from_model_name
+        vendor=_format_name(vendor) if vendor else None,
         version=version,
         region=region,
         display_name=display_name,

--- a/backend/tests/unit/onyx/llm/test_model_name_parser.py
+++ b/backend/tests/unit/onyx/llm/test_model_name_parser.py
@@ -16,7 +16,7 @@ def test_bedrock_model_with_enrichment() -> None:
 
     assert result.raw_name == "bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0"
     assert result.provider == LlmProviderNames.BEDROCK
-    assert result.vendor == LlmProviderNames.ANTHROPIC
+    assert result.vendor == "Anthropic"
     assert result.display_name == "Claude Sonnet 3.5"
     assert result.provider_display_name == "Claude (Bedrock - Anthropic)"
 
@@ -45,7 +45,7 @@ def test_gpt_model_fallback_keeps_gpt_prefix() -> None:
     result = parse_litellm_model_name("azure/gpt-4o-mini-custom")
 
     assert result.display_name == "GPT-4o Mini Custom"
-    assert result.vendor == "openai"
+    assert result.vendor == "OpenAI"
 
 
 def test_unknown_model_fallback() -> None:

--- a/web/src/lib/languageModels/options.ts
+++ b/web/src/lib/languageModels/options.ts
@@ -164,9 +164,8 @@ export function groupLlmOptions(
     if (!groups.has(groupKey)) {
       let displayName: string;
       if (isAggregator && option.vendor) {
-        const vendorDisplayName =
-          option.vendor.charAt(0).toUpperCase() + option.vendor.slice(1);
-        displayName = `${option.providerDisplayName}/${vendorDisplayName}`;
+        // vendor arrives display-cased from the backend (e.g. "OpenAI", "xAI")
+        displayName = `${option.providerDisplayName}/${option.vendor}`;
       } else {
         displayName = option.providerDisplayName;
       }

--- a/web/src/refresh-components/popovers/LLMPopover.test.tsx
+++ b/web/src/refresh-components/popovers/LLMPopover.test.tsx
@@ -95,7 +95,7 @@ describe("LLMPopover helpers", () => {
         providerDisplayName: "Amazon Bedrock",
         modelName: "claude-3-5-sonnet",
         displayName: "Claude 3.5 Sonnet",
-        vendor: "anthropic",
+        vendor: "Anthropic",
       },
       {
         name: "OpenAI Provider",


### PR DESCRIPTION
## Problem

Models served through an aggregator provider (e.g. a LiteLLM proxy gateway) are grouped in the model picker by `vendor`, producing headings like `LiteLLM Proxy/Openai` — the vendor arrives lowercase and the frontend hand-rolls capitalization.

#13407 fixes this on the frontend by duplicating the backend's `PROVIDER_DISPLAY_NAMES` map into a new `VENDOR_DISPLAY_NAMES` map in `options.ts`. But the root cause is a backend inconsistency: `ModelConfigurationView.vendor` is display-cased on the dynamic-provider path (`extract_vendor_from_model_name` already returns `"Anthropic"`, `"OpenAI"`) but lowercase on the litellm-parser path (`parse_litellm_model_name` passes the raw enrichment slug through) — which is the path `litellm_proxy` takes. The parser even already applies the right formatting helper (`_format_name`, backed by `PROVIDER_DISPLAY_NAMES`) when building `provider_display_name`; it just never applied it to the `vendor` field itself.

## Fix

- **Backend (one line):** apply `_format_name()` to `vendor` in `parse_litellm_model_name`, so both backend paths emit display-cased vendors (`openai → OpenAI`, `xai → xAI`) from the single existing `PROVIDER_DISPLAY_NAMES` source of truth — which also covers more vendors (Groq, Fireworks AI, DeepInfra, …) than the frontend copy would.
- **Frontend:** render `option.vendor` as-is in `groupLlmOptions()`, dropping the naive `charAt(0).toUpperCase()` capitalization (which would also mangle a correctly-cased `xAI` into `XAI`).

Safe because every other consumer of `vendor` already lowercases before use: the group key in `options.ts` and the search filter in `ModelSelectorContent.tsx`.

Closes #13407 — supersedes the frontend-only fix by implementing the backend follow-up its description suggests, without the duplicated map.

## Tests

- Updated `test_model_name_parser.py` expectations to the display-cased vendor; suite passes.
- Updated the `LLMPopover.test.tsx` fixture to feed a display-cased vendor, matching what the backend actually emits; suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)