### PR TITLE
perf(db): add index on chat_message (chat_session_id)

### DIFF
--- a/backend/alembic/versions/f57f35403f6c_add_index_on_chat_message_chat_session_.py
+++ b/backend/alembic/versions/f57f35403f6c_add_index_on_chat_message_chat_session_.py
@@ -1,0 +1,87 @@
+"""add index on chat_message chat_session_id
+
+Revision ID: f57f35403f6c
+Revises: e0ea2ae62e51
+Create Date: 2026-07-24 21:58:22.690097
+
+Adds a btree index on chat_message (chat_session_id). Every session-scoped
+message lookup (chat history replay, the failed-session check behind
+get_chat_sessions_by_user, retention/GC deletes and the cascade delete of a
+chat_session's messages) filters on this column; without the index each of
+those is a sequential scan over chat_message (see #9802, which had to rewrite
+a correlated EXISTS into a two-step Python filter for exactly this reason).
+
+chat_message is hot (every chat turn inserts rows), so the index is built
+CONCURRENTLY. That cannot run inside a transaction, and
+op.get_context().autocommit_block() is unusable with this project's env.py:
+the async connection autobegins a transaction when env.py sets search_path, so
+alembic treats the transaction as externally managed and asserts. Instead we
+commit the migration connection's transaction (also required so CONCURRENTLY
+doesn't wait forever on our own snapshot) and run the DDL on a dedicated
+AUTOCOMMIT connection. A fresh connection does not inherit the migration
+connection's per-tenant search_path, so all statements schema-qualify using
+current_schema() read from the migration connection.
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f57f35403f6c"
+down_revision = "e0ea2ae62e51"
+branch_labels = None
+depends_on = None
+
+INDEX_NAME = "ix_chat_message_chat_session_id"
+
+
+def _index_state(conn: sa.engine.Connection, schema: str) -> bool | None:
+    """None if the index doesn't exist, otherwise pg_index.indisvalid.
+
+    A failed CREATE INDEX CONCURRENTLY leaves an INVALID index behind, which
+    IF NOT EXISTS / a plain existence check would mistake for a finished build.
+    """
+    row = conn.execute(
+        sa.text(
+            "SELECT i.indisvalid FROM pg_index i "
+            "WHERE i.indexrelid = to_regclass(:qualified_name)"
+        ),
+        {"qualified_name": f'"{schema}"."{INDEX_NAME}"'},
+    ).one_or_none()
+    return row[0] if row is not None else None
+
+
+def _release_migration_snapshot() -> tuple[sa.engine.Connection, str]:
+    """Commit the migration txn and return (bind, current tenant schema)."""
+    bind = op.get_bind()
+    schema = bind.execute(sa.text("SELECT current_schema()")).scalar_one()
+    # env.py's plain SET search_path is session-level and survives this
+    # commit; alembic's version-table update autobegins a new transaction
+    # afterwards, which env.py commits at the end of the schema's run.
+    bind.commit()
+    return bind, schema
+
+
+def upgrade() -> None:
+    bind, schema = _release_migration_snapshot()
+
+    with bind.engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        state = _index_state(conn, schema)
+        if state is True:
+            return
+        if state is False:
+            conn.exec_driver_sql(f'DROP INDEX CONCURRENTLY "{schema}"."{INDEX_NAME}"')
+        conn.exec_driver_sql(
+            f'CREATE INDEX CONCURRENTLY "{INDEX_NAME}" '
+            f'ON "{schema}".chat_message (chat_session_id)'
+        )
+
+
+def downgrade() -> None:
+    bind, schema = _release_migration_snapshot()
+
+    with bind.engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+        if _index_state(conn, schema) is None:
+            return
+        conn.exec_driver_sql(f'DROP INDEX CONCURRENTLY "{schema}"."{INDEX_NAME}"')

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -3104,6 +3104,12 @@ class ChatMessage(Base):
     """
 
     __tablename__ = "chat_message"
+    __table_args__ = (
+        # Backs every session-scoped message lookup (history replay, the
+        # failed-session check, retention/GC deletes and the cascade delete of
+        # a session's messages), which otherwise seq-scan chat_message.
+        Index("ix_chat_message_chat_session_id", "chat_session_id"),
+    )
 
     id: Mapped[int] = mapped_column(primary_key=True)
 


### PR DESCRIPTION
## Description

Adds a btree index on `chat_message (chat_session_id)` — the follow-up that #9802 called for but never landed.

Every session-scoped message lookup filters on this column: chat history replay, the "failed" session check behind `get_chat_sessions_by_user`, retention/TTL hard-deletes, and the cascade delete of a session's messages. Without an index each of those is a sequential scan over `chat_message` (#9802 had to rewrite a correlated `EXISTS` into a two-step Python filter for exactly this reason after it took down a production cluster).

The migration mirrors e0ea2ae62e51 (#13391): `CREATE INDEX CONCURRENTLY` on a dedicated AUTOCOMMIT connection, schema-qualified via `current_schema()` so it works in multi-tenant runs, with INVALID-index cleanup so a failed/interrupted build retries cleanly. The model gains the matching `Index` in `ChatMessage.__table_args__`.

This is phase 1 of the "show failed chat sessions and garbage-collect them" plan — it gates the read-path-filter removal and the GC task, and is independently shippable.

## Measured impact (in isolation)

Benchmarked on a dev DB (75K-row / 16MB `chat_message`, 15k-session user) by dropping/recreating the index around each measurement — no other change in play:

| Consumer | Without index | With index |
|---|---|---|
| Chat open: load one session's messages (`WHERE chat_session_id = X`, 13 of 75K rows) | 15.6 ms (seq scan) | 0.23 ms |
| `GET /chat/get-chat-session/{id}` end-to-end (median of 11) | 240 ms | 207 ms |
| Failed-session check as shipped in #13416 (IN-list of 61 ids) | 19.2 ms | 1.0 ms |
| Failed-session check on pre-#13416 releases (IN-list of 15k ids) | 36.7 ms | 35.7 ms |
| Correlated `EXISTS` + `ORDER BY time_updated DESC` + `LIMIT 51` (the #9802 query shape) | 10.5 s on the #9802 cluster | 1.5 ms |

Notes:

- The per-chat-open seq scan scales linearly with total `chat_message` size — the #9802 cluster's table was 1.1GB (~70x this dev table), so the hidden per-request cost there is proportionally larger. This is the biggest beneficiary of the index, ahead of any sidebar concern.
- The unbounded pre-#13416 IN-list is intentionally unchanged: with 15k ids covering essentially the whole table, the planner correctly prefers a hash join. This index and #13416 compose; neither substitutes for the other.
- The `EXISTS` row shows the #9802 workaround is no longer load-bearing: with this index plus `ix_chat_session_user_id_onyxbot_flow_time_updated` (#13391), Postgres walks the session index and probes `chat_message` per row (51 probes at ~0.02 ms).

## How Has This Been Tested?

- `alembic upgrade head` against a local Postgres: index created and valid.
- `alembic downgrade -1` → index dropped; `upgrade head` again → recreated.
- Re-running upgrade with the index already present is a no-op (indisvalid check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a btree index on `chat_message(chat_session_id)` to eliminate full-table scans in session-scoped queries and speed up history reads, failed-session checks, and deletes. Also declares the index in the `ChatMessage` model and builds it CONCURRENTLY with retry-safe cleanup.

- **Migration**
  - Run `alembic upgrade head`.
  - Index build is concurrent and schema-aware (`current_schema()`); safe to re-run. `alembic downgrade -1` drops it.

<sup>Written for commit ca51a3b40b02069053a6ed4eb7cb4625e5294d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13424?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


