### PR TITLE
fix(ttl): register EE TTL tasks on the light worker app

### DIFF
--- a/backend/ee/onyx/background/celery/apps/light.py
+++ b/backend/ee/onyx/background/celery/apps/light.py
@@ -6,6 +6,10 @@ celery_app.autodiscover_tasks(
         [
             "ee.onyx.background.celery.tasks.doc_permission_syncing",
             "ee.onyx.background.celery.tasks.external_group_syncing",
+            # perform_ttl_management_task routes to the chat_ttl_deletion queue,
+            # which the light worker consumes — it must be registered here, not
+            # just on the primary app, or the worker rejects it as unregistered.
+            "ee.onyx.background.celery.tasks.ttl_management",
         ]
     )
 )

--- a/backend/ee/onyx/background/celery/apps/light.py
+++ b/backend/ee/onyx/background/celery/apps/light.py
@@ -6,9 +6,6 @@ celery_app.autodiscover_tasks(
         [
             "ee.onyx.background.celery.tasks.doc_permission_syncing",
             "ee.onyx.background.celery.tasks.external_group_syncing",
-            # perform_ttl_management_task routes to the chat_ttl_deletion queue,
-            # which the light worker consumes — it must be registered here, not
-            # just on the primary app, or the worker rejects it as unregistered.
             "ee.onyx.background.celery.tasks.ttl_management",
         ]
     )


### PR DESCRIPTION
## Description

Since #12928 moved chat-retention deletion off the primary queue, `perform_ttl_management_task` is sent to the `chat_ttl_deletion` queue, which only the **light** worker consumes (`supervisord.conf`, `celery-worker-light.yaml`). But the `ttl_management` module is only autodiscovered by the EE **primary** app — the light worker has no such task registered, so it rejects every delete task as unregistered ("Received unregistered task of type ..."), and EE chat-retention cleanup never actually deletes anything.

The failure is quiet in practice: `check_ttl_management_task` (running on primary, where it *is* registered) claims the Redis chain marker and enqueues the perform task, which the light worker then discards. The marker expires after an hour and the cycle repeats — retention appears scheduled but no sessions are ever reclaimed.

Fix: add `ee.onyx.background.celery.tasks.ttl_management` to the EE light app's autodiscover list.

## How Has This Been Tested?

Finalized the versioned light app with `ENABLE_PAID_ENTERPRISE_EDITION_FEATURES=true` and inspected `app.tasks`:

- before: no `ttl` tasks in the registry (18 tasks, none TTL-related)
- after: `perform_ttl_management_task` and `check_ttl_management_task` both registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Registers EE TTL management tasks on the light Celery app so chat-retention deletions run on the `chat_ttl_deletion` queue. Fixes unregistered task rejections that were silently preventing session cleanup.

- **Bug Fixes**
  - Added `ee.onyx.background.celery.tasks.ttl_management` to the EE light app autodiscover list, ensuring `perform_ttl_management_task` and `check_ttl_management_task` are registered on the light worker.

<sup>Written for commit 3c6130603f774cf260cf9777373752382be2f539. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

