### PR TITLE
feat(chat): garbage-collect failed chat sessions in the background

### DIFF
--- a/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
+++ b/backend/ee/onyx/background/celery/tasks/ttl_management/tasks.py
@@ -14,41 +14,16 @@ from onyx.configs.constants import (
 )
 from onyx.db.chat import delete_chat_session, get_chat_sessions_older_than
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.redis.chain_fence import (
+    claim_chain,
+    refresh_chain_if_owned,
+    release_chain_if_owned,
+)
 from onyx.redis.redis_pool import get_redis_client
-from onyx.redis.tenant_redis_client import TenantRedisClient
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
-
-# Extend the chain lease only if we still own it (marker value == our token).
-# Returns 1 when owned+extended, 0 otherwise. Prevents a task whose lease lapsed
-# (and whose chain a later beat has replaced) from extending someone else's lease.
-_REFRESH_IF_OWNED = """
-if redis.call('get', KEYS[1]) == ARGV[1] then
-    return redis.call('expire', KEYS[1], ARGV[2])
-else
-    return 0
-end
-"""
-
-# Release the chain marker only if we still own it.
-_RELEASE_IF_OWNED = """
-if redis.call('get', KEYS[1]) == ARGV[1] then
-    return redis.call('del', KEYS[1])
-else
-    return 0
-end
-"""
-
-
-def _release_chain_if_owned(redis_client: TenantRedisClient, chain_token: str) -> None:
-    """Delete the chain marker only if ``chain_token`` still owns it."""
-    redis_client.eval(
-        _RELEASE_IF_OWNED,
-        [OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE],
-        [chain_token],
-    )
 
 
 @shared_task(
@@ -92,12 +67,12 @@ def perform_ttl_management_task(
     redis_client = get_redis_client(tenant_id=tenant_id)
     # Extend our lease only if we still own the chain; if a replacement chain has
     # taken over, stop — we're a superseded task and must not touch its marker.
-    owns_chain = redis_client.eval(
-        _REFRESH_IF_OWNED,
-        [OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE],
-        [chain_token, str(CELERY_CHAT_TTL_DELETE_TASK_EXPIRES)],
-    )
-    if not owns_chain:
+    if not refresh_chain_if_owned(
+        redis_client,
+        OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
+        chain_token,
+        CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+    ):
         return
 
     with get_session_with_current_tenant() as db_session:
@@ -138,10 +113,14 @@ def perform_ttl_management_task(
                 expires=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
             )
         except Exception:
-            _release_chain_if_owned(redis_client, chain_token)
+            release_chain_if_owned(
+                redis_client, OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE, chain_token
+            )
             raise
     else:
-        _release_chain_if_owned(redis_client, chain_token)
+        release_chain_if_owned(
+            redis_client, OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE, chain_token
+        )
 
 
 @shared_task(
@@ -171,11 +150,11 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
     chain_token = uuid.uuid4().hex
     # Claim the chain. If the marker is already set, a chain is in flight (its
     # active task may not be sitting in the queue), so don't start another.
-    if not redis_client.set(
+    if not claim_chain(
+        redis_client,
         OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE,
         chain_token,
-        nx=True,
-        ex=CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
+        CELERY_CHAT_TTL_DELETE_TASK_EXPIRES,
     ):
         return
 
@@ -193,5 +172,7 @@ def check_ttl_management_task(self: Task, *, tenant_id: str) -> None:
         )
     except Exception:
         # Roll back the claim so the next beat can start the chain.
-        _release_chain_if_owned(redis_client, chain_token)
+        release_chain_if_owned(
+            redis_client, OnyxRedisLocks.CHAT_TTL_CHAIN_ACTIVE, chain_token
+        )
         raise

--- a/backend/onyx/background/celery/apps/light.py
+++ b/backend/onyx/background/celery/apps/light.py
@@ -159,6 +159,8 @@ celery_app.autodiscover_tasks(
             "onyx.background.celery.tasks.doc_permission_syncing",
             "onyx.background.celery.tasks.docprocessing",
             "onyx.background.celery.tasks.opensearch_migration",
+            # Failed-chat (husk) GC; runs on the chat_ttl_deletion queue
+            "onyx.background.celery.tasks.chat_cleanup",
             # Sandbox cleanup tasks (build feature)
             "onyx.background.celery.tasks.build",
         ]

--- a/backend/onyx/background/celery/tasks/beat_schedule.py
+++ b/backend/onyx/background/celery/tasks/beat_schedule.py
@@ -90,6 +90,21 @@ beat_task_templates: list[dict] = [
         },
     },
     {
+        "name": "check-failed-chat-cleanup",
+        "task": OnyxCeleryTask.CHECK_FAILED_CHAT_CLEANUP_TASK,
+        "schedule": timedelta(hours=6),
+        "options": {
+            "priority": OnyxCeleryPriority.LOW,
+            "expires": BEAT_EXPIRES_DEFAULT,
+            # Both the dispatcher and the batch tasks it chains run on the
+            # light worker's chat-deletion queue.
+            "queue": OnyxCeleryQueues.CHAT_TTL_DELETION,
+            # Run on gated tenants too — they may still accumulate husks.
+            "skip_gated": False,
+            "work_gated": True,
+        },
+    },
+    {
         "name": "check-for-checkpoint-cleanup",
         "task": OnyxCeleryTask.CHECK_FOR_CHECKPOINT_CLEANUP,
         "schedule": timedelta(hours=1),

--- a/backend/onyx/background/celery/tasks/chat_cleanup/tasks.py
+++ b/backend/onyx/background/celery/tasks/chat_cleanup/tasks.py
@@ -1,0 +1,198 @@
+"""Garbage collection for "failed" chat sessions (husks).
+
+The web client creates a chat session lazily at first send, and the send flow
+writes an empty SYSTEM root message before committing the user message. A send
+that never lands or fails during setup therefore leaves a session that has
+never contained a non-SYSTEM message — no user-visible content. These husks
+used to be hidden at read time by get_chat_sessions_by_user; now they are
+returned as-is and reclaimed here in the background instead.
+
+The sweep walks chat_session in primary-key order, one bounded batch per task,
+chaining batches on the light queue with the same token-fenced Redis marker
+the chat-TTL cleanup uses, so at most one sweep runs per tenant at a time.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+from celery import Task, shared_task
+
+from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.configs.chat_configs import FAILED_CHAT_CLEANUP_AFTER_DAYS
+from onyx.configs.constants import (
+    CELERY_FAILED_CHAT_CLEANUP_TASK_EXPIRES,
+    FAILED_CHAT_CLEANUP_BATCH_SIZE,
+    OnyxCeleryPriority,
+    OnyxCeleryQueues,
+    OnyxCeleryTask,
+    OnyxRedisLocks,
+)
+from onyx.db.chat import delete_chat_session, get_failed_chat_session_batch
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.redis.chain_fence import (
+    claim_chain,
+    refresh_chain_if_owned,
+    release_chain_if_owned,
+)
+from onyx.redis.redis_pool import get_redis_client
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+
+@shared_task(
+    name=OnyxCeleryTask.PERFORM_FAILED_CHAT_CLEANUP_TASK,
+    ignore_result=True,
+    soft_time_limit=JOB_TIMEOUT,
+    bind=True,
+    trail=False,
+)
+def perform_failed_chat_cleanup_task(
+    self: Task,
+    cleanup_after_days: float,
+    chain_token: str,
+    after_id: str | None,
+    deleted_so_far: int,
+    *,
+    tenant_id: str,
+) -> None:
+    """Delete one batch of failed chat sessions, then chain the next batch.
+
+    Each run scans at most ``FAILED_CHAT_CLEANUP_BATCH_SIZE`` GC-candidate
+    sessions starting after the ``after_id`` keyset cursor, hard-deletes the
+    husks among them, and exits, so it occupies a single light-worker thread
+    for only one short batch. While the scan returns full batches the sweep
+    continues by enqueuing the next task with the advanced cursor; once the
+    table is exhausted it logs the sweep total and releases the in-flight
+    marker so ``check_failed_chat_cleanup_task`` can start a fresh sweep.
+
+    ``chain_token`` fences the chain exactly like the chat-TTL cleanup: a run
+    that no longer owns the marker exits without touching anything.
+    """
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    if not refresh_chain_if_owned(
+        redis_client,
+        OnyxRedisLocks.FAILED_CHAT_CLEANUP_CHAIN_ACTIVE,
+        chain_token,
+        CELERY_FAILED_CHAT_CLEANUP_TASK_EXPIRES,
+    ):
+        return
+
+    cutoff = datetime.now(tz=timezone.utc) - timedelta(days=cleanup_after_days)
+    with get_session_with_current_tenant() as db_session:
+        failed_sessions, next_after_id = get_failed_chat_session_batch(
+            db_session=db_session,
+            cutoff=cutoff,
+            after_id=UUID(after_id) if after_id else None,
+            batch_size=FAILED_CHAT_CLEANUP_BATCH_SIZE,
+        )
+
+    num_deleted = 0
+    for user_id, session_id in failed_sessions:
+        try:
+            with get_session_with_current_tenant() as db_session:
+                delete_chat_session(
+                    user_id,
+                    session_id,
+                    db_session,
+                    include_deleted=True,
+                    hard_delete=True,
+                )
+            num_deleted += 1
+        except Exception:
+            logger.exception(
+                "Failed to delete failed chat session user_id=%s session_id=%s, "
+                "continuing with remaining sessions",
+                user_id,
+                session_id,
+            )
+
+    total_deleted = deleted_so_far + num_deleted
+    if next_after_id is not None:
+        try:
+            self.app.send_task(
+                OnyxCeleryTask.PERFORM_FAILED_CHAT_CLEANUP_TASK,
+                kwargs={
+                    "cleanup_after_days": cleanup_after_days,
+                    "chain_token": chain_token,
+                    "after_id": str(next_after_id),
+                    "deleted_so_far": total_deleted,
+                    "tenant_id": tenant_id,
+                },
+                queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+                priority=OnyxCeleryPriority.LOW,
+                expires=CELERY_FAILED_CHAT_CLEANUP_TASK_EXPIRES,
+            )
+        except Exception:
+            release_chain_if_owned(
+                redis_client,
+                OnyxRedisLocks.FAILED_CHAT_CLEANUP_CHAIN_ACTIVE,
+                chain_token,
+            )
+            raise
+    else:
+        logger.info(
+            "Failed-chat cleanup sweep complete: deleted %d session(s) with no "
+            "user-visible content older than %s day(s)",
+            total_deleted,
+            cleanup_after_days,
+        )
+        release_chain_if_owned(
+            redis_client,
+            OnyxRedisLocks.FAILED_CHAT_CLEANUP_CHAIN_ACTIVE,
+            chain_token,
+        )
+
+
+@shared_task(
+    name=OnyxCeleryTask.CHECK_FAILED_CHAT_CLEANUP_TASK,
+    ignore_result=True,
+    soft_time_limit=JOB_TIMEOUT,
+    bind=True,
+    trail=False,
+)
+def check_failed_chat_cleanup_task(self: Task, *, tenant_id: str) -> None:
+    """Start a failed-chat cleanup sweep if one isn't already running.
+
+    Deletion happens in ``perform_failed_chat_cleanup_task``, which chains
+    itself batch-by-batch and holds a token-fenced in-flight marker for the
+    whole sweep. This dispatcher claims that marker with a fresh token; if
+    it's already held a sweep is active, so we skip and don't stack a second
+    one.
+    """
+    if FAILED_CHAT_CLEANUP_AFTER_DAYS <= 0:
+        return
+
+    redis_client = get_redis_client(tenant_id=tenant_id)
+    chain_token = uuid.uuid4().hex
+    if not claim_chain(
+        redis_client,
+        OnyxRedisLocks.FAILED_CHAT_CLEANUP_CHAIN_ACTIVE,
+        chain_token,
+        CELERY_FAILED_CHAT_CLEANUP_TASK_EXPIRES,
+    ):
+        return
+
+    try:
+        self.app.send_task(
+            OnyxCeleryTask.PERFORM_FAILED_CHAT_CLEANUP_TASK,
+            kwargs={
+                "cleanup_after_days": FAILED_CHAT_CLEANUP_AFTER_DAYS,
+                "chain_token": chain_token,
+                "after_id": None,
+                "deleted_so_far": 0,
+                "tenant_id": tenant_id,
+            },
+            queue=OnyxCeleryQueues.CHAT_TTL_DELETION,
+            priority=OnyxCeleryPriority.LOW,
+            expires=CELERY_FAILED_CHAT_CLEANUP_TASK_EXPIRES,
+        )
+    except Exception:
+        # Roll back the claim so the next beat can start the sweep.
+        release_chain_if_owned(
+            redis_client,
+            OnyxRedisLocks.FAILED_CHAT_CLEANUP_CHAIN_ACTIVE,
+            chain_token,
+        )
+        raise

--- a/backend/onyx/configs/chat_configs.py
+++ b/backend/onyx/configs/chat_configs.py
@@ -83,6 +83,15 @@ STOP_STREAM_PAT = os.environ.get("STOP_STREAM_PAT") or None
 # As opposed to soft deleting them, which just hides them from non-admin users
 HARD_DELETE_CHATS = os.environ.get("HARD_DELETE_CHATS", "").lower() == "true"
 
+# Days after which a "failed" chat session — one that has never contained a
+# non-SYSTEM message, i.e. no user-visible content — is garbage-collected by
+# the background cleanup task. Generous by default because create-chat-session
+# is a public API: an external consumer may pre-create a session and send its
+# first message much later. Set to 0 to disable the cleanup entirely.
+FAILED_CHAT_CLEANUP_AFTER_DAYS = float(
+    os.environ.get("FAILED_CHAT_CLEANUP_AFTER_DAYS") or 7
+)
+
 # Internet Search
 NUM_INTERNET_SEARCH_RESULTS = int(os.environ.get("NUM_INTERNET_SEARCH_RESULTS") or 10)
 NUM_INTERNET_SEARCH_CHUNKS = int(os.environ.get("NUM_INTERNET_SEARCH_CHUNKS") or 50)

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -214,6 +214,14 @@ CHAT_TTL_DELETE_BATCH_SIZE = 100
 # growth; if a task expires the beat starts a fresh chain on its next run.
 CELERY_CHAT_TTL_DELETE_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
 
+# Failed-chat (husk) GC tuning. Each sweep task scans one primary-key-ordered
+# batch of chat_session rows for sessions older than
+# FAILED_CHAT_CLEANUP_AFTER_DAYS that have never contained a non-SYSTEM
+# message, hard-deletes them, and chains the next batch on the light queue.
+FAILED_CHAT_CLEANUP_BATCH_SIZE = 500
+# See CELERY_CHAT_TTL_DELETE_TASK_EXPIRES; same role for the failed-chat chain.
+CELERY_FAILED_CHAT_CLEANUP_TASK_EXPIRES = 60 * 60  # 1 hour (in seconds)
+
 DANSWER_REDIS_FUNCTION_LOCK_PREFIX = "da_function_lock:"
 
 TMP_DRALPHA_PERSONA_NAME = "KG Beta"
@@ -442,8 +450,9 @@ class OnyxCeleryQueues:
     CONNECTOR_HIERARCHY_FETCHING = "connector_hierarchy_fetching"
     CSV_GENERATION = "csv_generation"
 
-    # Chat retention (TTL) hard-deletion queue, consumed by the light worker.
-    # Kept off the primary "celery" queue so cleanup never starves check_for_indexing.
+    # Chat hard-deletion queue (retention TTL + failed-chat GC), consumed by the
+    # light worker. Kept off the primary "celery" queue so cleanup never starves
+    # check_for_indexing.
     CHAT_TTL_DELETION = "chat_ttl_deletion"
 
     # User file processing queue
@@ -498,6 +507,8 @@ class OnyxRedisLocks:
     # In-flight marker: set while a chat-TTL cleanup chain is active (spanning
     # its chained tasks) so the beat won't start a second chain per tenant.
     CHAT_TTL_CHAIN_ACTIVE = "da_lock:chat_ttl_chain_active"
+    # Same, for the failed-chat (husk) GC sweep chain.
+    FAILED_CHAT_CLEANUP_CHAIN_ACTIVE = "da_lock:failed_chat_cleanup_chain_active"
     CHECK_AVAILABLE_TENANTS_LOCK = "da_lock:check_available_tenants"
     CLOUD_PRE_PROVISION_TENANT_LOCK = "da_lock:pre_provision_tenant"
 
@@ -653,6 +664,10 @@ class OnyxCeleryTask:
     # chat retention
     CHECK_TTL_MANAGEMENT_TASK = "check_ttl_management_task"
     PERFORM_TTL_MANAGEMENT_TASK = "perform_ttl_management_task"
+
+    # failed-chat (husk) garbage collection
+    CHECK_FAILED_CHAT_CLEANUP_TASK = "check_failed_chat_cleanup_task"
+    PERFORM_FAILED_CHAT_CLEANUP_TASK = "perform_failed_chat_cleanup_task"
 
     GENERATE_USAGE_REPORT_TASK = "generate_usage_report_task"
 

--- a/backend/onyx/db/chat.py
+++ b/backend/onyx/db/chat.py
@@ -402,6 +402,79 @@ def get_chat_sessions_older_than(
     return returned_sessions
 
 
+def get_failed_chat_session_batch(
+    db_session: Session,
+    cutoff: datetime,
+    after_id: UUID | None,
+    batch_size: int,
+) -> tuple[list[tuple[UUID | None, UUID]], UUID | None]:
+    """Find "failed" chat sessions (husks) in one primary-key-ordered batch.
+
+    A failed session is one that has never contained a non-SYSTEM message —
+    the web client creates sessions lazily at first send and the SYSTEM root
+    message is written before the user message, so a SYSTEM-only session holds
+    no user-visible content. Only sessions whose time_created, time_updated
+    and every message time_sent all predate ``cutoff`` qualify; the message
+    recency guard keeps a sweep from racing a first send into an old
+    pre-created session (the root SYSTEM message lands moments before the user
+    message commits).
+
+    The scan is keyset-paginated over ChatSession.id so a sweep can walk the
+    whole table in bounded batches: pass ``after_id=None`` for the first batch
+    and the returned cursor for each subsequent one. The message check is a
+    single IN-list aggregate per batch rather than a correlated subquery,
+    which would seq-scan chat_message on deployments without the
+    chat_message(chat_session_id) index (see #9802).
+
+    Returns ``(failed_sessions, next_after_id)`` where failed_sessions are
+    (user_id, chat_session_id) tuples and next_after_id is None once the table
+    is exhausted.
+    """
+    stmt = (
+        select(ChatSession.id, ChatSession.user_id)
+        .where(ChatSession.time_created < cutoff)
+        .where(ChatSession.time_updated < cutoff)
+        .order_by(ChatSession.id)
+        .limit(batch_size)
+    )
+    if after_id is not None:
+        stmt = stmt.where(ChatSession.id > after_id)
+
+    candidates = db_session.execute(stmt).all()
+    if not candidates:
+        return [], None
+    next_after_id = candidates[-1][0] if len(candidates) == batch_size else None
+
+    message_stats: dict[UUID, tuple[bool, datetime]] = {
+        session_id: (has_non_system, last_time_sent)
+        for session_id, has_non_system, last_time_sent in db_session.execute(
+            select(
+                ChatMessage.chat_session_id,
+                func.bool_or(ChatMessage.message_type != MessageType.SYSTEM),
+                func.max(ChatMessage.time_sent),
+            )
+            .where(
+                ChatMessage.chat_session_id.in_(
+                    [session_id for session_id, _ in candidates]
+                )
+            )
+            .group_by(ChatMessage.chat_session_id)
+        ).all()
+    }
+
+    failed_sessions: list[tuple[UUID | None, UUID]] = []
+    for session_id, user_id in candidates:
+        stats = message_stats.get(session_id)
+        if stats is None:
+            failed_sessions.append((user_id, session_id))
+            continue
+        has_non_system, last_time_sent = stats
+        if not has_non_system and last_time_sent < cutoff:
+            failed_sessions.append((user_id, session_id))
+
+    return failed_sessions, next_after_id
+
+
 def get_chat_message(
     chat_message_id: int,
     user_id: UUID | None,

--- a/backend/onyx/redis/chain_fence.py
+++ b/backend/onyx/redis/chain_fence.py
@@ -1,0 +1,54 @@
+"""Token-fenced Redis markers for self-chaining Celery cleanup sweeps.
+
+A "chain" is a sequence of tasks that each process one batch and enqueue the
+next. A dispatcher claims the marker with a fresh token before sending the
+first task (SET NX EX); each chained task then extends the lease only while it
+still owns the marker. If a slow batch outlives the lease and a later beat
+starts a replacement chain, the superseded task can neither extend nor delete
+the new chain's marker — it just exits. This guarantees at most one chain per
+tenant per marker key.
+"""
+
+from onyx.redis.tenant_redis_client import TenantRedisClient
+
+# Extend the chain lease only if we still own it (marker value == our token).
+# Returns 1 when owned+extended, 0 otherwise. Prevents a task whose lease lapsed
+# (and whose chain a later beat has replaced) from extending someone else's lease.
+_REFRESH_IF_OWNED = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('expire', KEYS[1], ARGV[2])
+else
+    return 0
+end
+"""
+
+# Release the chain marker only if we still own it.
+_RELEASE_IF_OWNED = """
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+else
+    return 0
+end
+"""
+
+
+def claim_chain(
+    redis_client: TenantRedisClient, key: str, token: str, expires: int
+) -> bool:
+    """Claim the chain marker with ``token``. False means a chain is in flight
+    (its active task may not be sitting in the queue), so don't start another."""
+    return bool(redis_client.set(key, token, nx=True, ex=expires))
+
+
+def refresh_chain_if_owned(
+    redis_client: TenantRedisClient, key: str, token: str, expires: int
+) -> bool:
+    """Extend the chain lease iff ``token`` still owns the marker."""
+    return bool(redis_client.eval(_REFRESH_IF_OWNED, [key], [token, str(expires)]))
+
+
+def release_chain_if_owned(
+    redis_client: TenantRedisClient, key: str, token: str
+) -> None:
+    """Delete the chain marker only if ``token`` still owns it."""
+    redis_client.eval(_RELEASE_IF_OWNED, [key], [token])

--- a/backend/tests/external_dependency_unit/db/test_failed_chat_cleanup.py
+++ b/backend/tests/external_dependency_unit/db/test_failed_chat_cleanup.py
@@ -1,0 +1,255 @@
+"""Tests for the failed-chat (husk) GC criterion and deletion path.
+
+A "failed" chat session is one that has never contained a non-SYSTEM message:
+the web client creates sessions lazily at first send and the SYSTEM root
+message is written before the user message, so a SYSTEM-only session holds no
+user-visible content. These tests exercise get_failed_chat_session_batch — the
+criterion used by the perform_failed_chat_cleanup_task sweep — and the hard
+delete it performs, against a real Postgres.
+"""
+
+from collections.abc import Generator
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+import pytest
+from sqlalchemy import func, select, update
+from sqlalchemy.orm import Session
+
+from onyx.configs.constants import MessageType
+from onyx.db.chat import (
+    create_chat_session,
+    create_new_chat_message,
+    delete_chat_session,
+    get_chat_session_by_id,
+    get_failed_chat_session_batch,
+    get_or_create_root_message,
+)
+from onyx.db.models import ChatMessage, ChatSession, User
+from tests.external_dependency_unit.conftest import create_test_user
+
+_WINDOW = timedelta(days=7)
+
+
+@pytest.fixture
+def test_user(db_session: Session) -> User:
+    return create_test_user(db_session, email_prefix="failed_chat_gc")
+
+
+@pytest.fixture
+def session_tracker(
+    db_session: Session,
+) -> Generator[list[UUID], None, None]:
+    """Collects created session ids and hard-deletes any that survive the test."""
+    created: list[UUID] = []
+    yield created
+    for session_id in created:
+        if db_session.get(ChatSession, session_id) is not None:
+            delete_chat_session(
+                user_id=None,
+                chat_session_id=session_id,
+                db_session=db_session,
+                include_deleted=True,
+                hard_delete=True,
+            )
+
+
+def _create_session(
+    db_session: Session,
+    user_id: UUID,
+    tracker: list[UUID],
+    age: timedelta,
+    with_root_message: bool = True,
+    deleted: bool = False,
+) -> ChatSession:
+    chat_session = create_chat_session(
+        db_session=db_session,
+        description=None,
+        user_id=user_id,
+        persona_id=None,
+    )
+    tracker.append(chat_session.id)
+    if with_root_message:
+        get_or_create_root_message(
+            chat_session_id=chat_session.id, db_session=db_session
+        )
+    _backdate(db_session, chat_session.id, age, deleted=deleted)
+    return chat_session
+
+
+def _backdate(
+    db_session: Session,
+    chat_session_id: UUID,
+    age: timedelta,
+    deleted: bool = False,
+    include_messages: bool = True,
+) -> None:
+    """Set the session (and optionally its messages) timestamps ``age`` in the
+    past. time_updated must be assigned explicitly or onupdate would bump it."""
+    ts = datetime.now(timezone.utc) - age
+    db_session.execute(
+        update(ChatSession)
+        .where(ChatSession.id == chat_session_id)
+        .values(time_created=ts, time_updated=ts, deleted=deleted)
+    )
+    if include_messages:
+        db_session.execute(
+            update(ChatMessage)
+            .where(ChatMessage.chat_session_id == chat_session_id)
+            .values(time_sent=ts)
+        )
+    db_session.commit()
+
+
+def _add_user_message(db_session: Session, chat_session_id: UUID) -> None:
+    root = get_or_create_root_message(
+        chat_session_id=chat_session_id, db_session=db_session
+    )
+    create_new_chat_message(
+        chat_session_id=chat_session_id,
+        parent_message=root,
+        message="hello",
+        token_count=1,
+        message_type=MessageType.USER,
+        db_session=db_session,
+        commit=True,
+    )
+
+
+def _sweep_failed_ids(db_session: Session, cutoff: datetime) -> set[UUID]:
+    """Run a full keyset sweep, exactly like the chained cleanup task does."""
+    failed: set[UUID] = set()
+    after_id: UUID | None = None
+    while True:
+        batch, after_id = get_failed_chat_session_batch(
+            db_session=db_session,
+            cutoff=cutoff,
+            after_id=after_id,
+            batch_size=100,
+        )
+        failed.update(session_id for _, session_id in batch)
+        if after_id is None:
+            return failed
+
+
+def test_old_husks_are_flagged_and_hard_deleted(
+    db_session: Session, test_user: User, session_tracker: list[UUID]
+) -> None:
+    husk = _create_session(
+        db_session, test_user.id, session_tracker, age=_WINDOW + timedelta(days=1)
+    )
+    soft_deleted_husk = _create_session(
+        db_session,
+        test_user.id,
+        session_tracker,
+        age=_WINDOW + timedelta(days=30),
+        deleted=True,
+    )
+    messageless_husk = _create_session(
+        db_session,
+        test_user.id,
+        session_tracker,
+        age=_WINDOW + timedelta(days=1),
+        with_root_message=False,
+    )
+
+    cutoff = datetime.now(timezone.utc) - _WINDOW
+    failed_ids = _sweep_failed_ids(db_session, cutoff)
+    assert husk.id in failed_ids
+    assert soft_deleted_husk.id in failed_ids
+    assert messageless_husk.id in failed_ids
+
+    for session_id in (husk.id, soft_deleted_husk.id, messageless_husk.id):
+        delete_chat_session(
+            user_id=test_user.id,
+            chat_session_id=session_id,
+            db_session=db_session,
+            include_deleted=True,
+            hard_delete=True,
+        )
+        assert db_session.get(ChatSession, session_id) is None
+        orphaned_messages = db_session.execute(
+            select(func.count())
+            .select_from(ChatMessage)
+            .where(ChatMessage.chat_session_id == session_id)
+        ).scalar_one()
+        assert orphaned_messages == 0
+
+
+def test_recent_husk_is_kept(
+    db_session: Session, test_user: User, session_tracker: list[UUID]
+) -> None:
+    recent_husk = _create_session(
+        db_session, test_user.id, session_tracker, age=timedelta(days=1)
+    )
+
+    cutoff = datetime.now(timezone.utc) - _WINDOW
+    assert recent_husk.id not in _sweep_failed_ids(db_session, cutoff)
+
+
+def test_old_session_with_user_messages_is_kept(
+    db_session: Session, test_user: User, session_tracker: list[UUID]
+) -> None:
+    real_session = _create_session(
+        db_session, test_user.id, session_tracker, age=_WINDOW + timedelta(days=30)
+    )
+    _add_user_message(db_session, real_session.id)
+    # Messages predate the cutoff too — age alone must not doom the session.
+    _backdate(db_session, real_session.id, age=_WINDOW + timedelta(days=30))
+
+    cutoff = datetime.now(timezone.utc) - _WINDOW
+    assert real_session.id not in _sweep_failed_ids(db_session, cutoff)
+
+
+def test_precreated_session_that_later_receives_messages_stays_usable(
+    db_session: Session, test_user: User, session_tracker: list[UUID]
+) -> None:
+    # An API consumer pre-created an empty session inside the window ...
+    precreated = _create_session(
+        db_session,
+        test_user.id,
+        session_tracker,
+        age=timedelta(days=3),
+        with_root_message=False,
+    )
+
+    cutoff = datetime.now(timezone.utc) - _WINDOW
+    assert precreated.id not in _sweep_failed_ids(db_session, cutoff)
+
+    # ... and sends its first message days later: still present, still usable.
+    _add_user_message(db_session, precreated.id)
+    assert precreated.id not in _sweep_failed_ids(db_session, cutoff)
+    assert (
+        get_chat_session_by_id(
+            chat_session_id=precreated.id,
+            user_id=test_user.id,
+            db_session=db_session,
+        ).id
+        == precreated.id
+    )
+
+
+def test_recent_system_message_guards_old_session(
+    db_session: Session, test_user: User, session_tracker: list[UUID]
+) -> None:
+    """An in-flight first send writes the SYSTEM root moments before the user
+    message commits; a session with a fresh SYSTEM message must not be swept
+    even when the session row itself is old enough."""
+    racing_session = _create_session(
+        db_session,
+        test_user.id,
+        session_tracker,
+        age=_WINDOW + timedelta(days=1),
+        with_root_message=False,
+    )
+    # Root created "now", session rows backdated — the mid-send state.
+    get_or_create_root_message(chat_session_id=racing_session.id, db_session=db_session)
+    _backdate(
+        db_session,
+        racing_session.id,
+        age=_WINDOW + timedelta(days=1),
+        include_messages=False,
+    )
+
+    cutoff = datetime.now(timezone.utc) - _WINDOW
+    assert racing_session.id not in _sweep_failed_ids(db_session, cutoff)

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -77,6 +77,10 @@ USER_AUTH_SECRET=""
 
 ## Chat Configuration
 # HARD_DELETE_CHATS=
+# Days after which chat sessions that never got a user-visible message
+# (e.g. created but never used, or whose first send failed) are deleted
+# by the background cleanup. 0 disables the cleanup.
+# FAILED_CHAT_CLEANUP_AFTER_DAYS=7
 # MAX_ALLOWED_UPLOAD_SIZE_MB=250
 # Default per-user upload size limit (MB) when no admin value is set.
 # Automatically clamped to MAX_ALLOWED_UPLOAD_SIZE_MB at runtime.

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1592,6 +1592,7 @@ configMap:
   DOMAIN: "localhost"
   # Chat Configs
   HARD_DELETE_CHATS: ""
+  FAILED_CHAT_CLEANUP_AFTER_DAYS: ""
   MAX_ALLOWED_UPLOAD_SIZE_MB: ""
   DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB: ""
   # Sandbox config — always "kubernetes" for Helm deployments


### PR DESCRIPTION
## Description

Phase 2 of the "show failed chat sessions and GC them instead of filtering at read time" plan (see #13424 for phase 1). Independently shippable; changes no user-visible behavior on its own.

**What a "failed" session (husk) is:** the web client creates the session lazily at first send, and the send flow writes an empty SYSTEM root message before committing the user message. A send that never lands (network drop, client crash, backend down) or an API-created session that's never used leaves a session that has never contained a non-SYSTEM message — no user-visible content. Today `get_chat_sessions_by_user` hides these at read time and nothing ever reclaims them; CE keeps them forever.

**This PR adds the reclaim side:**

- `check_failed_chat_cleanup_task` (beat, every 6h) starts a sweep unless one is already running; `perform_failed_chat_cleanup_task` walks `chat_session` in primary-key keyset batches (500/batch), flags sessions older than the window with no non-SYSTEM messages, hard-deletes them via `delete_chat_session`, and chains the next batch. Runs on the light worker's existing `chat_ttl_deletion` queue with `expires=` set.
- **Config:** `FAILED_CHAT_CLEANUP_AFTER_DAYS` (default 7, `0` disables), documented in `env.template` and helm values (chart 0.8.0 → 0.8.1). The window is deliberately generous: `create-chat-session` is a public API and a consumer may pre-create a session and send its first message much later.
- **Race guard:** a session only qualifies if `time_created`, `time_updated` *and* every message `time_sent` predate the cutoff — an in-flight first send into an old pre-created session writes its SYSTEM root moments before the user message commits, and that fresh `time_sent` protects it.
- **Shared chain fencing:** the token-fenced Redis marker pattern (claim / refresh-if-owned / release-if-owned) is extracted from the EE TTL task into CE `onyx/redis/chain_fence.py`; the EE TTL task now uses it too (behavior unchanged).
- The husk check is a batched IN-list aggregate, not a correlated subquery — safe on deployments that don't yet have `chat_message(chat_session_id)` (#13424), though the sweep and cascade deletes get much cheaper with it.

Related: #13426 (registers the EE TTL tasks on the light worker; independent but same queue).

## How Has This Been Tested?

`backend/tests/external_dependency_unit/db/test_failed_chat_cleanup.py` (real Postgres, full keyset sweep exactly like the chained task):
- old husk, old soft-deleted husk, and old messageless session are flagged; hard delete leaves no orphaned `chat_message` rows
- recent husk kept; old session with USER messages kept (even with old messages)
- pre-created empty session inside the window kept, receives messages later, still usable
- old session with a *fresh* SYSTEM root (mid-send race) kept

Also verified the beat entry appears in both self-hosted and cloud schedules, and that both tasks register on the light worker app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a background sweep that deletes “failed” chat sessions (husks) that never received a non-SYSTEM message, after `FAILED_CHAT_CLEANUP_AFTER_DAYS` (default 7). This reduces storage and prevents old, unused sessions from piling up.

- **New Features**
  - Added `check_failed_chat_cleanup_task` (every 6h) and `perform_failed_chat_cleanup_task` to scan in keyset batches (500) on the `CHAT_TTL_DELETION` queue and hard-delete qualifying sessions.
  - Race guard: only delete if `time_created`, `time_updated`, and all message `time_sent` are older than the cutoff; fresh SYSTEM roots are protected.
  - Config: `FAILED_CHAT_CLEANUP_AFTER_DAYS` (0 disables). Documented in `deployment/docker_compose/env.template` and Helm `values.yaml` (chart `0.8.1`).

- **Refactors**
  - Extracted token-fenced Redis chain helpers to `onyx/redis/chain_fence.py` and reused by the EE TTL task (behavior unchanged).

<sup>Written for commit 652872e078573923df3e0c4a7be0f378c79780e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13428?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

