### PR TITLE
chore(log export): Symlink followup

### DIFF
--- a/backend/ee/onyx/server/log_export/collection.py
+++ b/backend/ee/onyx/server/log_export/collection.py
@@ -45,10 +45,16 @@ def _find_log_files(log_directories: Sequence[Path]) -> list[Path]:
     for directory in log_directories:
         if not directory.is_dir():
             continue
+        root = directory.resolve()
         for path in sorted(directory.rglob(LOG_FILE_GLOB)):
             if not path.is_file():
                 continue
             resolved = path.resolve()
+            if not resolved.is_relative_to(root):
+                # A planted ``*.log*`` symlink pointing outside the log
+                # directory would otherwise pull arbitrary server-readable
+                # files into the archive.
+                continue
             if resolved in seen:
                 continue
             seen.add(resolved)

--- a/backend/tests/unit/ee/onyx/server/log_export/test_log_collection.py
+++ b/backend/tests/unit/ee/onyx/server/log_export/test_log_collection.py
@@ -72,6 +72,35 @@ def test_overlapping_directories_deduplicate(tmp_path: Path) -> None:
             _entry_ending_with(zip_file, "worker.log")
 
 
+def test_symlink_escaping_log_directory_is_skipped(tmp_path: Path) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    (log_dir / "real.log").write_text("real line\n")
+    secret = tmp_path / "secret.txt"
+    secret.write_text("not a log\n")
+    (log_dir / "evil.log").symlink_to(secret)
+
+    with build_log_zip([log_dir], SCOPE_NOTE) as zip_buffer:
+        with zipfile.ZipFile(zip_buffer) as zip_file:
+            names = _zip_names(zip_file)
+            # README plus ``real.log``; the escaping symlink is dropped.
+            assert len(names) == 2
+            _entry_ending_with(zip_file, "real.log")
+            assert not any("evil" in name or "secret" in name for name in names)
+
+
+def test_symlink_within_log_directory_is_included(tmp_path: Path) -> None:
+    target = tmp_path / "target.txt"
+    target.write_text("aliased content\n")
+    (tmp_path / "alias.log").symlink_to(target)
+
+    with build_log_zip([tmp_path], SCOPE_NOTE) as zip_buffer:
+        with zipfile.ZipFile(zip_buffer) as zip_file:
+            # The entry is stored under its resolved path, hence ``target.txt``.
+            entry = _entry_ending_with(zip_file, "target.txt")
+            assert zip_file.read(entry) == b"aliased content\n"
+
+
 @pytest.mark.skipif(os.geteuid() == 0, reason="Root can read mode-000 files")
 def test_unreadable_file_is_skipped_and_noted(tmp_path: Path) -> None:
     readable = tmp_path / "readable.log"


### PR DESCRIPTION
## Description

Followup for https://github.com/onyx-dot-app/onyx/pull/13398#discussion_r3642241035. If some log file is a symlink to some unknown thing outside the logs directory, let's just skip it.

## How Has This Been Tested?

Unit tests.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip symlinked log files that resolve outside the log directory to prevent unintended files from being included in exports. This hardens the log export against path traversal.

- **Bug Fixes**
  - Ignore `*.log*` symlinks that resolve outside the given log root.
  - Include symlinks within the log directory and store them under their resolved path.
  - Added unit tests for both cases.

<sup>Written for commit e54efdd5b6f8fe2bc896f138649d4463e42876ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13432?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

