### PR TITLE
chore(log export): Enforce enterprise tier

### DIFF
--- a/backend/ee/onyx/configs/license_enforcement_config.py
+++ b/backend/ee/onyx/configs/license_enforcement_config.py
@@ -77,6 +77,7 @@ PATH_PREFIX_MIN_TIER: dict[str, Tier] = {
     "/manage/admin/standard-answer": Tier.ENTERPRISE,
     "/admin/token-rate-limits": Tier.ENTERPRISE,
     "/admin/hooks": Tier.ENTERPRISE,  # outbound webhooks
+    "/admin/log-export": Tier.ENTERPRISE,  # container-local log download
     "/analytics": Tier.ENTERPRISE,  # non-admin analytics (e.g. assistant stats)
     "/evals": Tier.ENTERPRISE,
     "/scim": Tier.ENTERPRISE,  # SCIM protocol

--- a/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
+++ b/backend/tests/unit/ee/onyx/server/middleware/test_tier_gate.py
@@ -94,6 +94,32 @@ async def test_enterprise_passes_enterprise_path(
 
 
 @pytest.mark.asyncio
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_business_blocked_from_log_export(
+    mock_get_tier: MagicMock, middleware_harness: MiddlewareHarness
+) -> None:
+    mock_get_tier.return_value = Tier.BUSINESS
+    middleware, call_next = middleware_harness
+    response = await middleware(
+        _make_request("/api/admin/log-export/download"), call_next
+    )
+    assert response.status_code == 402
+
+
+@pytest.mark.asyncio
+@patch("ee.onyx.server.middleware.tier_gate.get_tier")
+async def test_enterprise_passes_log_export(
+    mock_get_tier: MagicMock, middleware_harness: MiddlewareHarness
+) -> None:
+    mock_get_tier.return_value = Tier.ENTERPRISE
+    middleware, call_next = middleware_harness
+    response = await middleware(
+        _make_request("/api/admin/log-export/download"), call_next
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
 async def test_unmapped_path_passes_through(
     middleware_harness: MiddlewareHarness,
 ) -> None:


### PR DESCRIPTION
## Description

Disallow tiers below enterprise from using this feature. Resolves https://github.com/onyx-dot-app/onyx/pull/13399#discussion_r3642266281.

## How Has This Been Tested?

Added to an existing test module for this guard.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce Enterprise-only access for the admin log export feature. Business and lower tiers now get 402; Enterprise access remains 200.

<sup>Written for commit b4ebe392b68bac3bcb04bb6cb3cf733079c1e1b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13433?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

