### PR TITLE
feat: add stdio MCP transport

### DIFF
--- a/.vscode/env_template.txt
+++ b/.vscode/env_template.txt
@@ -62,6 +62,11 @@ S3_AWS_SECRET_ACCESS_KEY=minioadmin
 # Show extra/uncommon connectors.
 SHOW_EXTRA_CONNECTORS=True
 
+# Allow admins to launch locally installed MCP servers over stdio. This is
+# single-tenant only and disabled by default because it executes a process on
+# the API host.
+MCP_STDIO_ENABLED=False
+
 
 # Local langsmith tracing
 LANGSMITH_TRACING="true"

--- a/backend/alembic/versions/4c8e1a7d2b6f_add_stdio_config_to_mcp_server.py
+++ b/backend/alembic/versions/4c8e1a7d2b6f_add_stdio_config_to_mcp_server.py
@@ -1,0 +1,29 @@
+"""add stdio config to mcp server
+
+Revision ID: 4c8e1a7d2b6f
+Revises: f57f35403f6c
+Create Date: 2026-07-24 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "4c8e1a7d2b6f"
+down_revision = "f57f35403f6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("mcp_server", sa.Column("stdio_command", sa.Text(), nullable=True))
+    op.add_column(
+        "mcp_server",
+        sa.Column("stdio_args", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("mcp_server", "stdio_args")
+    op.drop_column("mcp_server", "stdio_command")

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -1121,6 +1121,13 @@ MCP_SERVER_ALLOW_LOOPBACK = (
     os.environ.get("MCP_SERVER_ALLOW_LOOPBACK", "false").lower() == "true"
 )
 
+# Stdio MCP servers execute an operator-supplied binary on the API host. Keep
+# this disabled unless a single-tenant operator explicitly opts in; tenant
+# admins in Onyx Cloud must never gain a process-execution primitive.
+MCP_STDIO_ENABLED = (
+    not MULTI_TENANT and os.environ.get("MCP_STDIO_ENABLED", "false").lower() == "true"
+)
+
 HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY = os.environ.get(
     "HTML_BASED_CONNECTOR_TRANSFORM_LINKS_STRATEGY",
     HtmlBasedConnectorTransformLinksStrategy.STRIP,

--- a/backend/onyx/db/mcp.py
+++ b/backend/onyx/db/mcp.py
@@ -29,7 +29,11 @@ from onyx.db.models import (
     User__UserGroup,
     UserRole,
 )
-from onyx.server.features.mcp.models import DENYLISTED_MCP_HEADERS, MCPConnectionData
+from onyx.server.features.mcp.models import (
+    DENYLISTED_MCP_HEADERS,
+    MCPConnectionData,
+    MCPStdioServerConfig,
+)
 from onyx.utils.logger import setup_logger
 from onyx.utils.sensitive import SensitiveValue
 
@@ -221,6 +225,8 @@ def create_mcp_server__no_commit(
     transport: MCPTransport | None,
     auth_performer: MCPAuthenticationPerformer | None,
     db_session: Session,
+    stdio_command: str | None = None,
+    stdio_args: list[str] | None = None,
     oauth_provider_mode: MCPOAuthProviderMode = MCPOAuthProviderMode.AUTO_DISCOVERY,
     oauth_authorization_endpoint: str | None = None,
     oauth_token_endpoint: str | None = None,
@@ -235,6 +241,8 @@ def create_mcp_server__no_commit(
         name=name,
         description=description,
         server_url=server_url,
+        stdio_command=stdio_command,
+        stdio_args=stdio_args,
         transport=transport,
         auth_type=auth_type,
         auth_performer=auth_performer,
@@ -257,6 +265,8 @@ def update_mcp_server__no_commit(
     name: str | None = None,
     description: str | None = None,
     server_url: str | None = None,
+    stdio_command: str | None | UnsetType = UNSET,
+    stdio_args: list[str] | None | UnsetType = UNSET,
     auth_type: MCPAuthenticationType | None = None,
     admin_connection_config_id: int | None = None,
     auth_performer: MCPAuthenticationPerformer | None = None,
@@ -282,6 +292,10 @@ def update_mcp_server__no_commit(
         server.description = description
     if server_url is not None:
         server.server_url = server_url
+    if not isinstance(stdio_command, UnsetType):
+        server.stdio_command = stdio_command
+    if not isinstance(stdio_args, UnsetType):
+        server.stdio_args = stdio_args
     if auth_type is not None:
         server.auth_type = auth_type
     if admin_connection_config_id is not None:
@@ -387,6 +401,41 @@ def extract_connection_data(
     if isinstance(config.config, SensitiveValue):
         return cast(MCPConnectionData, config.config.get_value(apply_mask=apply_mask))
     return cast(MCPConnectionData, config.config)
+
+
+def get_mcp_stdio_config(mcp_server: MCPServer) -> MCPStdioServerConfig:
+    """Return validated stdio process parameters without exposing secrets to
+    API callers. Environment values are read from the encrypted admin config."""
+    if mcp_server.transport != MCPTransport.STDIO:
+        raise ValueError("MCP server does not use stdio transport")
+    config_data = extract_connection_data(
+        mcp_server.admin_connection_config, apply_mask=False
+    )
+    return MCPStdioServerConfig(
+        command=mcp_server.stdio_command or "",
+        args=mcp_server.stdio_args or [],
+        env=config_data.get("stdio_env", {}),
+    )
+
+
+def set_mcp_stdio_config__no_commit(
+    mcp_server: MCPServer,
+    stdio_env: dict[str, str],
+    db_session: Session,
+) -> MCPConnectionConfig:
+    """Create or replace the encrypted environment for a stdio server."""
+    config_data = MCPConnectionData(headers={}, stdio_env=stdio_env)
+    config = mcp_server.admin_connection_config
+    if config is None:
+        config = create_connection_config(
+            config_data=config_data, db_session=db_session
+        )
+        mcp_server.admin_connection_config_id = config.id
+    else:
+        config.config = config_data  # ty: ignore[invalid-assignment]
+        flag_modified(config, "config")
+    db_session.flush()
+    return config
 
 
 def get_connection_config_by_id(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5414,6 +5414,13 @@ class MCPServer(Base):
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str | None] = mapped_column(String, nullable=True)
     server_url: Mapped[str] = mapped_column(String, nullable=False)
+    # Stdio uses direct executable + argv fields; no shell command string is
+    # ever evaluated. Environment values live in the encrypted connection
+    # config rather than this table.
+    stdio_command: Mapped[str | None] = mapped_column(Text, nullable=True)
+    stdio_args: Mapped[list[str] | None] = mapped_column(
+        postgresql.JSONB(), nullable=True
+    )
     # Transport type for connecting to the MCP server
     transport: Mapped[MCPTransport | None] = mapped_column(
         Enum(MCPTransport, native_enum=False), nullable=True

--- a/backend/onyx/mcp_server/README.md
+++ b/backend/onyx/mcp_server/README.md
@@ -14,7 +14,36 @@ All access controls are managed within the main Onyx application.
 Provide an Onyx Personal Access Token or API Key in the `Authorization` header as a Bearer token.
 The MCP server quickly validates and passes through the token on every request.
 
-Depending on usage, the MCP Server may support OAuth and stdio in the future.
+The MCP server exposed by Onyx currently uses HTTP transport. The outbound
+stdio connector support below is a separate MCP client capability.
+
+## Admin-managed stdio connectors
+
+This package documents the MCP server exposed *by* Onyx. Separately, Onyx can
+act as an MCP client and launch a locally installed MCP server over stdio for
+agent actions.
+
+Stdio connectors are disabled by default because the configured executable
+runs on the API host. A single-tenant operator can enable the admin-only
+configuration surface with:
+
+```bash
+MCP_STDIO_ENABLED=true
+```
+
+After restarting the API and web services, an Onyx admin can choose **Local
+process (stdio)** when adding an MCP server. The command and each argument are
+passed directly to the MCP SDK without a shell. Environment values are stored
+in the encrypted MCP connection config and are masked when read back.
+
+The executable and all required packages must already exist in the API
+server's runtime environment. Container deployments should install the MCP
+server in a custom API image; Onyx does not download or install commands from
+the admin form.
+
+Stdio tools use the same public/user/group access rules and agent assignment
+flow as HTTP MCP tools. They are not exposed to Craft sandboxes because the
+API host's executable is not present inside those sandboxes.
 
 ### Default Configuration
 - **Transport**: HTTP POST (MCP over HTTP)

--- a/backend/onyx/server/features/build/sandbox/util/mcp_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/mcp_config.py
@@ -10,6 +10,7 @@ from collections.abc import Sequence
 
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import MCPTransport
 from onyx.db.mcp import (
     can_resolve_mcp_credentials,
     get_craft_enabled_mcp_servers,
@@ -50,6 +51,13 @@ def resolve_craft_mcp_servers(
     )
     servers: list[MCPServer] = []
     for server in accessible:
+        if server.transport == MCPTransport.STDIO:
+            logger.info(
+                "craft_mcp_skip_stdio server_id=%s name=%r",
+                server.id,
+                server.name,
+            )
+            continue
         if can_resolve_mcp_credentials(
             server, user, db_session, user_configs=user_configs
         ):

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -29,7 +29,8 @@ from onyx.auth.oauth_token_manager import (
 from onyx.auth.permissions import require_permission
 from onyx.auth.schemas import UserRole
 from onyx.auth.users import current_curator_or_admin_user
-from onyx.configs.app_configs import WEB_DOMAIN
+from onyx.configs.app_configs import MCP_STDIO_ENABLED, WEB_DOMAIN
+from onyx.db.constants import UNSET
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import (
     EndpointPolicy,
@@ -61,8 +62,10 @@ from onyx.db.mcp import (
     get_mcp_server_by_id,
     get_mcp_servers_accessible_to_user,
     get_mcp_servers_for_persona,
+    get_mcp_stdio_config,
     get_server_auth_template,
     get_user_connection_config,
+    set_mcp_stdio_config__no_commit,
     update_connection_config,
     update_mcp_server__no_commit,
     upsert_user_connection_config,
@@ -95,6 +98,7 @@ from onyx.server.features.mcp.models import (
     MCPServerSimpleUpdateRequest,
     MCPServersResponse,
     MCPServerUpdateResponse,
+    MCPStdioServerConfig,
     MCPToolCreateRequest,
     MCPToolListResponse,
     MCPToolUpdateRequest,
@@ -152,6 +156,39 @@ _SSRF_HINT_SET_DISABLED = (
     " To reach a loopback MCP server, set SSRF Protection to Disabled in the admin "
     "Security settings (cloud-metadata stays blocked)."
 )
+
+
+def _ensure_stdio_admin(user: User) -> None:
+    if not MCP_STDIO_ENABLED:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Stdio MCP servers are disabled for this deployment. A single-tenant "
+            "operator must set MCP_STDIO_ENABLED=true.",
+        )
+    if user.role != UserRole.ADMIN:
+        raise OnyxError(
+            OnyxErrorCode.UNAUTHORIZED,
+            "Only Onyx admins may configure stdio MCP servers.",
+        )
+
+
+def _resolve_stdio_env(
+    requested: dict[str, str],
+    existing: dict[str, str],
+) -> dict[str, str]:
+    """Replace masked edit-form values with the encrypted originals."""
+    resolved: dict[str, str] = {}
+    for key, value in requested.items():
+        if is_masked_credential(value):
+            if key not in existing:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    f"Masked stdio environment value has no stored value for {key}.",
+                )
+            resolved[key] = existing[key]
+        else:
+            resolved[key] = value
+    return resolved
 
 
 def _ssrf_error_hint(url: str, error: Exception) -> str:
@@ -1274,6 +1311,7 @@ def _db_mcp_server_to_api_mcp_server(
     user_authenticated: bool | None = None
     user_credentials = None
     admin_credentials = None
+    stdio_env = None
     is_owner_or_admin = request_user is not None and (
         request_user.role == UserRole.ADMIN
         or (request_user.email and request_user.email == db_server.owner)
@@ -1285,6 +1323,18 @@ def _db_mcp_server_to_api_mcp_server(
     can_view_server_details = is_owner_or_admin
     if db_server.auth_type == MCPAuthenticationType.NONE:
         user_authenticated = True  # No auth required
+        if (
+            db_server.transport == MCPTransport.STDIO
+            and can_view_admin_credentials
+            and db_server.admin_connection_config is not None
+        ):
+            stdio_config_data = extract_connection_data(
+                db_server.admin_connection_config, apply_mask=False
+            )
+            stdio_env = {
+                key: mask_string(value)
+                for key, value in stdio_config_data.get("stdio_env", {}).items()
+            }
     elif auth_performer == MCPAuthenticationPerformer.ADMIN:
         user_authenticated = db_server.admin_connection_config is not None
         if (
@@ -1379,9 +1429,13 @@ def _db_mcp_server_to_api_mcp_server(
     # supply shared credentials, and the template can legitimately carry
     # literal header values that must not leak.
     auth_template = None
-    if db_server.auth_type != MCPAuthenticationType.OAUTH and (
-        auth_performer == MCPAuthenticationPerformer.PER_USER
-        or can_view_admin_credentials
+    if (
+        db_server.transport != MCPTransport.STDIO
+        and db_server.auth_type != MCPAuthenticationType.OAUTH
+        and (
+            auth_performer == MCPAuthenticationPerformer.PER_USER
+            or can_view_admin_credentials
+        )
     ):
         try:
             template_config = db_server.admin_connection_config
@@ -1433,6 +1487,17 @@ def _db_mcp_server_to_api_mcp_server(
         name=db_server.name,
         description=db_server.description,
         server_url=db_server.server_url if can_view_server_details else "",
+        stdio_command=(
+            db_server.stdio_command
+            if can_view_server_details and db_server.transport == MCPTransport.STDIO
+            else None
+        ),
+        stdio_args=(
+            (db_server.stdio_args or [])
+            if can_view_server_details and db_server.transport == MCPTransport.STDIO
+            else []
+        ),
+        stdio_env=stdio_env,
         owner=db_server.owner if can_view_server_details else "",
         transport=db_server.transport,
         auth_type=db_server.auth_type,
@@ -1775,12 +1840,30 @@ def _list_mcp_tools_by_id(
             detail="MCP server transport is not configured",
         )
 
-    discovered_tools = discover_mcp_tools(
-        server_url,
-        headers,
-        transport=mcp_server.transport,
-        auth=auth,
-    )
+    stdio_config = None
+    if mcp_server.transport == MCPTransport.STDIO:
+        if not MCP_STDIO_ENABLED:
+            raise OnyxError(
+                OnyxErrorCode.INVALID_INPUT,
+                "Stdio MCP servers are disabled for this deployment.",
+            )
+        stdio_config = get_mcp_stdio_config(mcp_server)
+
+    if stdio_config is not None:
+        discovered_tools = discover_mcp_tools(
+            server_url,
+            headers,
+            transport=mcp_server.transport,
+            auth=auth,
+            stdio_config=stdio_config,
+        )
+    else:
+        discovered_tools = discover_mcp_tools(
+            server_url,
+            headers,
+            transport=mcp_server.transport,
+            auth=auth,
+        )
     logger.info(
         "Discovered %s tools for MCP server: %s: %s",
         len(discovered_tools),
@@ -2435,6 +2518,12 @@ def upsert_mcp_server(
 ) -> MCPServerCreateResponse:
     """Create or update an MCP server (no tools yet)"""
 
+    if request.transport == MCPTransport.STDIO:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Configure stdio MCP servers from the basic server form.",
+        )
+
     # Validate auth_performer for non-none auth types
     if request.auth_type != MCPAuthenticationType.NONE and not request.auth_performer:
         raise HTTPException(
@@ -2558,16 +2647,36 @@ def create_mcp_server_simple(
 ) -> MCPServer:
     """Create MCP server with minimal information - auth to be configured later"""
 
-    _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
+    admin_config_id = None
+    if request.transport == MCPTransport.STDIO:
+        _ensure_stdio_admin(user)
+        stdio_config = MCPStdioServerConfig(
+            command=request.stdio_command or "",
+            args=request.stdio_args,
+            env=request.stdio_env,
+        )
+        admin_config = create_connection_config(
+            MCPConnectionData(headers={}, stdio_env=stdio_config.env),
+            db_session,
+        )
+        admin_config_id = admin_config.id
+    else:
+        _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
+        stdio_config = None
 
     mcp_server = create_mcp_server__no_commit(
         owner_email=user.email,
         name=request.name,
         description=request.description,
-        server_url=request.server_url,
-        auth_type=None,  # To be configured later
-        transport=None,  # To be configured later
-        auth_performer=None,  # To be configured later
+        server_url=request.server_url if stdio_config is None else "",
+        stdio_command=stdio_config.command if stdio_config else None,
+        stdio_args=stdio_config.args if stdio_config else None,
+        auth_type=(
+            MCPAuthenticationType.NONE if stdio_config else None
+        ),  # HTTP auth is configured later
+        transport=request.transport if stdio_config else None,
+        auth_performer=(MCPAuthenticationPerformer.ADMIN if stdio_config else None),
+        admin_connection_config_id=admin_config_id,
         db_session=db_session,
     )
 
@@ -2583,30 +2692,11 @@ def create_mcp_server_simple(
 
     db_session.commit()
 
-    return MCPServer(
-        id=mcp_server.id,
-        name=mcp_server.name,
-        description=mcp_server.description,
-        server_url=mcp_server.server_url,
-        owner=mcp_server.owner,
-        transport=mcp_server.transport,
-        auth_type=mcp_server.auth_type,
-        auth_performer=mcp_server.auth_performer,
-        oauth_provider_mode=mcp_server.oauth_provider_mode,
-        oauth_authorization_endpoint=mcp_server.oauth_authorization_endpoint,
-        oauth_token_endpoint=mcp_server.oauth_token_endpoint,
-        oauth_scopes_override=mcp_server.oauth_scopes_override,
-        oauth_additional_auth_params=mcp_server.oauth_additional_auth_params,
-        is_authenticated=False,  # Not authenticated yet
-        status=mcp_server.status,
-        is_public=mcp_server.is_public,
-        groups=[group.id for group in mcp_server.user_groups],
-        users=[user.id for user in mcp_server.users],
-        available_in_craft=mcp_server.available_in_craft,
-        tool_count=0,  # New server, no tools yet
-        auth_template=None,
-        user_credentials=None,
-        admin_credentials=None,
+    return _db_mcp_server_to_api_mcp_server(
+        mcp_server,
+        db_session,
+        request_user=user,
+        include_auth_config=True,
     )
 
 
@@ -2625,7 +2715,42 @@ def update_mcp_server_simple(
 
     _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
-    _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
+    if (
+        request.transport is not None
+        and mcp_server.transport is not None
+        and request.transport != mcp_server.transport
+    ):
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "MCP transport cannot be changed after the server is created.",
+        )
+
+    if mcp_server.transport == MCPTransport.STDIO:
+        _ensure_stdio_admin(user)
+        existing_stdio = get_mcp_stdio_config(mcp_server)
+        resolved_env = _resolve_stdio_env(
+            request.stdio_env if request.stdio_env is not None else existing_stdio.env,
+            existing_stdio.env,
+        )
+        stdio_config = MCPStdioServerConfig(
+            command=request.stdio_command or existing_stdio.command,
+            args=(
+                request.stdio_args
+                if request.stdio_args is not None
+                else existing_stdio.args
+            ),
+            env=resolved_env,
+        )
+        set_mcp_stdio_config__no_commit(mcp_server, stdio_config.env, db_session)
+    else:
+        _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
+        stdio_config = None
+
+    if request.available_in_craft and mcp_server.transport == MCPTransport.STDIO:
+        raise OnyxError(
+            OnyxErrorCode.INVALID_INPUT,
+            "Stdio MCP servers run on the API host and are not available inside Craft sandboxes.",
+        )
 
     # Update only provided fields
     updated_server = update_mcp_server__no_commit(
@@ -2634,6 +2759,8 @@ def update_mcp_server_simple(
         name=request.name,
         description=request.description,
         server_url=request.server_url,
+        stdio_command=stdio_config.command if stdio_config else UNSET,
+        stdio_args=stdio_config.args if stdio_config else UNSET,
         available_in_craft=request.available_in_craft,
     )
 

--- a/backend/onyx/server/features/mcp/client.py
+++ b/backend/onyx/server/features/mcp/client.py
@@ -9,10 +9,11 @@ from collections.abc import Callable, Coroutine
 from enum import Enum
 from typing import Any, Dict, TypeVar
 
-from mcp import ClientSession
+from mcp import ClientSession, StdioServerParameters
 from mcp.client.auth import OAuthClientProvider
 from mcp.client.sse import sse_client
-from mcp.client.streamable_http import streamablehttp_client  # or use stdio_client
+from mcp.client.stdio import stdio_client
+from mcp.client.streamable_http import streamablehttp_client
 from mcp.types import (
     CallToolResult,
     InitializeResult,
@@ -24,6 +25,7 @@ from pydantic import BaseModel
 
 from onyx.configs.app_configs import MCP_TOOL_CALL_TIMEOUT_SECONDS
 from onyx.db.enums import MCPTransport
+from onyx.server.features.mcp.models import MCPStdioServerConfig
 from onyx.server.features.mcp.ssrf import mcp_ssrf_httpx_client_factory
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
@@ -126,6 +128,7 @@ def _create_mcp_client_function_runner(
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,  # TODO: maybe used this for all auth types
+    stdio_config: MCPStdioServerConfig | None = None,
     **kwargs: Any,
 ) -> Callable[[], Coroutine[Any, Any, T]]:
     auth_headers = connection_headers or {}
@@ -134,25 +137,13 @@ def _create_mcp_client_function_runner(
     # with SSE (infinite stream). Avoid passing auth for SSE; rely on headers.
     auth_for_request = auth if transport == MCPTransport.STREAMABLE_HTTP else None
 
-    # doing this here for type-checking
-    client_func = (
-        streamablehttp_client
-        if transport == MCPTransport.STREAMABLE_HTTP
-        else sse_client
-    )
-
     async def run_client_function() -> T:
-        async with client_func(
-            server_url,
-            headers=auth_headers,
-            auth=auth_for_request,
-            httpx_client_factory=mcp_ssrf_httpx_client_factory,
-        ) as client_tuple:
+        async def run_session(client_tuple: tuple[Any, ...]) -> T:
             if len(client_tuple) == 3:
                 read, write, _ = client_tuple
             elif len(client_tuple) == 2:
                 assert isinstance(client_tuple, tuple)  # for type-checking
-                read, write = client_tuple  # ty: ignore[invalid-assignment]
+                read, write = client_tuple
             else:
                 raise ValueError(
                     f"Unexpected number of client tuple elements: {len(client_tuple)}"
@@ -165,6 +156,32 @@ def _create_mcp_client_function_runner(
                 read_timeout_seconds=timedelta(seconds=MCP_TOOL_CALL_TIMEOUT_SECONDS),
             ) as session:
                 return await function(session, **kwargs)
+
+        if transport == MCPTransport.STDIO:
+            if stdio_config is None:
+                raise ValueError("stdio transport requires process configuration")
+            server_params = StdioServerParameters(
+                command=stdio_config.command,
+                args=stdio_config.args,
+                # Do not merge the API server's environment: that would leak
+                # unrelated deployment secrets into a third-party process.
+                env=stdio_config.env or None,
+            )
+            async with stdio_client(server_params) as client_tuple:
+                return await run_session(client_tuple)
+
+        client_func = (
+            streamablehttp_client
+            if transport == MCPTransport.STREAMABLE_HTTP
+            else sse_client
+        )
+        async with client_func(
+            server_url,
+            headers=auth_headers,
+            auth=auth_for_request,
+            httpx_client_factory=mcp_ssrf_httpx_client_factory,
+        ) as client_tuple:
+            return await run_session(client_tuple)
 
     return run_client_function
 
@@ -188,10 +205,17 @@ def _call_mcp_client_function_sync(
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,
+    stdio_config: MCPStdioServerConfig | None = None,
     **kwargs: Any,
 ) -> T:
     run_client_function = _create_mcp_client_function_runner(
-        function, server_url, connection_headers, transport, auth, **kwargs
+        function,
+        server_url,
+        connection_headers,
+        transport,
+        auth,
+        stdio_config,
+        **kwargs,
     )
     try:
         return run_async_sync_no_cancel(run_client_function())
@@ -212,10 +236,17 @@ async def _call_mcp_client_function_async(
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,
+    stdio_config: MCPStdioServerConfig | None = None,
     **kwargs: Any,
 ) -> T:
     run_client_function = _create_mcp_client_function_runner(
-        function, server_url, connection_headers, transport, auth, **kwargs
+        function,
+        server_url,
+        connection_headers,
+        transport,
+        auth,
+        stdio_config,
+        **kwargs,
     )
     return await run_client_function()
 
@@ -262,6 +293,7 @@ def call_mcp_tool(
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,
+    stdio_config: MCPStdioServerConfig | None = None,
 ) -> str:
     """Call a specific tool on the MCP server"""
     return _call_mcp_client_function_sync(
@@ -270,6 +302,7 @@ def call_mcp_tool(
         connection_headers,
         transport,
         auth,
+        stdio_config,
     )
 
 
@@ -278,6 +311,7 @@ async def initialize_mcp_client(
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,
+    stdio_config: MCPStdioServerConfig | None = None,
 ) -> InitializeResult:
     return await _call_mcp_client_function_async(
         lambda session: session.initialize(),
@@ -285,6 +319,7 @@ async def initialize_mcp_client(
         connection_headers,
         transport,
         auth,
+        stdio_config,
     )
 
 
@@ -308,6 +343,7 @@ def discover_mcp_tools(
     connection_headers: dict[str, str] | None = None,
     transport: MCPTransport = MCPTransport.STREAMABLE_HTTP,
     auth: OAuthClientProvider | None = None,
+    stdio_config: MCPStdioServerConfig | None = None,
 ) -> list[MCPLibTool]:
     """
     Synchronous wrapper for discovering MCP tools.
@@ -318,6 +354,7 @@ def discover_mcp_tools(
         connection_headers,
         transport,
         auth,
+        stdio_config,
     )
 
 

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -5,7 +5,7 @@ from typing import Any, List, NotRequired, Optional, TypedDict
 from uuid import UUID
 
 from mcp.types import Tool as MCPLibTool
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from onyx.db.enums import (
     EndpointPolicy,
@@ -89,6 +89,9 @@ class MCPConnectionData(TypedDict):
     # serves as the template); empty/absent on regular per-user configs and on
     # admin-credential configs.
     required_fields: NotRequired[list[str]]
+    # Stdio environment values are shared by every allowed user and encrypted
+    # at rest with the rest of the MCP connection config.
+    stdio_env: NotRequired[dict[str, str]]
 
     # For OAuth only
     # Note: Update MCPOAuthKeys if necessary when modifying these
@@ -101,6 +104,52 @@ class MCPConnectionData(TypedDict):
 
     # the actual models are defined in mcp.shared.auth
     # from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+
+
+_ENVIRONMENT_VARIABLE_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+
+
+class MCPStdioServerConfig(BaseModel):
+    """Validated process parameters for one stdio MCP server.
+
+    Command and arguments remain separate all the way to ``create_subprocess``;
+    Onyx never evaluates a shell command.
+    """
+
+    command: str = Field(min_length=1, max_length=4096)
+    args: list[str] = Field(default_factory=list, max_length=100)
+    env: dict[str, str] = Field(default_factory=dict, max_length=100)
+
+    @field_validator("command")
+    @classmethod
+    def validate_command(cls, value: str) -> str:
+        command = value.strip()
+        if not command:
+            raise ValueError("stdio command cannot be empty")
+        if "\x00" in command:
+            raise ValueError("stdio command cannot contain a null byte")
+        return command
+
+    @field_validator("args")
+    @classmethod
+    def validate_args(cls, value: list[str]) -> list[str]:
+        if any(len(arg) > 4096 or "\x00" in arg for arg in value):
+            raise ValueError(
+                "stdio arguments must be at most 4096 characters and cannot contain null bytes"
+            )
+        return value
+
+    @field_validator("env")
+    @classmethod
+    def validate_env(cls, value: dict[str, str]) -> dict[str, str]:
+        for key, env_value in value.items():
+            if _ENVIRONMENT_VARIABLE_RE.fullmatch(key) is None:
+                raise ValueError(f"invalid environment variable name: {key}")
+            if len(env_value) > 16384 or "\x00" in env_value:
+                raise ValueError(
+                    f"environment variable {key} is too long or contains a null byte"
+                )
+        return value
 
 
 class MCPAuthTemplate(BaseModel):
@@ -357,7 +406,16 @@ class MCPServerSimpleCreateRequest(BaseModel):
     description: Optional[str] = Field(
         None, description="Description of the MCP server"
     )
-    server_url: str = Field(..., description="URL of the MCP server")
+    server_url: str = Field(default="", description="URL of an HTTP MCP server")
+    transport: MCPTransport = Field(default=MCPTransport.STREAMABLE_HTTP)
+    stdio_command: Optional[str] = Field(
+        default=None, description="Executable for a stdio MCP server"
+    )
+    stdio_args: list[str] = Field(default_factory=list)
+    stdio_env: dict[str, str] = Field(
+        default_factory=dict,
+        description="Encrypted environment variables for a stdio MCP process",
+    )
     is_public: bool = Field(
         default=True,
         description=(
@@ -374,6 +432,18 @@ class MCPServerSimpleCreateRequest(BaseModel):
         description="User IDs allowed to use this server when not public",
     )
 
+    @model_validator(mode="after")
+    def validate_transport_configuration(self) -> "MCPServerSimpleCreateRequest":
+        if self.transport == MCPTransport.STDIO:
+            MCPStdioServerConfig(
+                command=self.stdio_command or "",
+                args=self.stdio_args,
+                env=self.stdio_env,
+            )
+        elif not self.server_url:
+            raise ValueError("server_url is required for HTTP MCP transports")
+        return self
+
 
 class MCPServerSimpleUpdateRequest(BaseModel):
     name: Optional[str] = Field(None, description="Name of the MCP server")
@@ -381,6 +451,10 @@ class MCPServerSimpleUpdateRequest(BaseModel):
         None, description="Description of the MCP server"
     )
     server_url: Optional[str] = Field(None, description="URL of the MCP server")
+    transport: Optional[MCPTransport] = None
+    stdio_command: Optional[str] = None
+    stdio_args: Optional[list[str]] = None
+    stdio_env: Optional[dict[str, str]] = None
     tool_policies: Optional[dict[str, EndpointPolicy]] = Field(
         default=None,
         description=(
@@ -557,6 +631,9 @@ class MCPServer(BaseModel):
     name: str
     description: Optional[str] = None
     server_url: str
+    stdio_command: Optional[str] = None
+    stdio_args: list[str] = Field(default_factory=list)
+    stdio_env: Optional[dict[str, str]] = None
     owner: str
     transport: Optional[MCPTransport] = None
     auth_type: Optional[MCPAuthenticationType] = None

--- a/backend/onyx/server/settings/api.py
+++ b/backend/onyx/server/settings/api.py
@@ -11,6 +11,7 @@ from onyx.configs.app_configs import (
     DEFAULT_USER_FILE_MAX_UPLOAD_SIZE_MB,
     DISABLE_VECTOR_DB,
     MAX_ALLOWED_UPLOAD_SIZE_MB,
+    MCP_STDIO_ENABLED,
     POSTHOG_API_KEY,
     POSTHOG_HOST,
 )
@@ -189,6 +190,7 @@ def fetch_settings(
         opencode_debugging_enabled=ENABLE_OPENCODE_DEBUGGING,
         vector_db_enabled=not DISABLE_VECTOR_DB,
         hooks_enabled=not MULTI_TENANT,
+        mcp_stdio_enabled=MCP_STDIO_ENABLED,
         version=onyx_version,
         max_allowed_upload_size_mb=MAX_ALLOWED_UPLOAD_SIZE_MB,
         default_user_file_max_upload_size_mb=min(

--- a/backend/onyx/server/settings/models.py
+++ b/backend/onyx/server/settings/models.py
@@ -127,6 +127,8 @@ class UserSettings(Settings):
     vector_db_enabled: bool = True
     # True when hooks are available: single-tenant EE deployments only.
     hooks_enabled: bool = False
+    # Deployment-level gate for admin-managed stdio MCP processes.
+    mcp_stdio_enabled: bool = False
     # Application version, read from the ONYX_VERSION env var at startup.
     version: str | None = None
     # Hard ceiling for user_file_max_upload_size_mb, derived from env var.

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -11,10 +11,12 @@ from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.model_configs import GEN_AI_TEMPERATURE
 from onyx.context.search.models import BaseFilters, PersonaSearchInfo
 from onyx.db.engine.sql_engine import get_session_with_current_tenant_if_none
+from onyx.db.enums import MCPTransport
 from onyx.db.mcp import (
     MCPCredentialsError,
     get_all_mcp_tools_for_server,
     get_mcp_server_by_id,
+    get_mcp_stdio_config,
     resolve_mcp_credentials,
 )
 from onyx.db.models import Persona, User
@@ -415,6 +417,11 @@ def _construct_tools_impl(
                 continue
 
             mcp_server = get_mcp_server_by_id(db_tool_model.mcp_server_id, db_session)
+            stdio_config = (
+                get_mcp_stdio_config(mcp_server)
+                if mcp_server.transport == MCPTransport.STDIO
+                else None
+            )
 
             try:
                 mcp_credentials = resolve_mcp_credentials(mcp_server, user, db_session)
@@ -449,6 +456,7 @@ def _construct_tools_impl(
                     user_id=str(user.id),
                     user_oauth_token=mcp_credentials.user_oauth_token,
                     additional_headers=additional_mcp_headers,
+                    stdio_config=stdio_config,
                 )
                 mcp_tool_cache[db_tool_model.mcp_server_id][saved_tool.id] = mcp_tool
 

--- a/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
+++ b/backend/onyx/tools/tool_implementations/mcp/mcp_tool.py
@@ -5,11 +5,15 @@ from typing import Any
 from mcp.client.auth import OAuthClientProvider
 
 from onyx.chat.emitter import Emitter
+from onyx.configs.app_configs import MCP_STDIO_ENABLED
 from onyx.db.enums import MCPAuthenticationType, MCPTransport
 from onyx.db.mcp import ResolvedMCPCredentials
 from onyx.db.models import MCPConnectionConfig, MCPServer
 from onyx.server.features.mcp.client import call_mcp_tool
-from onyx.server.features.mcp.models import DENYLISTED_MCP_HEADERS
+from onyx.server.features.mcp.models import (
+    DENYLISTED_MCP_HEADERS,
+    MCPStdioServerConfig,
+)
 from onyx.server.features.mcp.oauth import (
     UNUSED_RETURN_PATH,
     make_oauth_provider,
@@ -79,6 +83,7 @@ class MCPTool(Tool[None]):
         user_id: str = "",
         user_oauth_token: str | None = None,
         additional_headers: dict[str, str] | None = None,
+        stdio_config: MCPStdioServerConfig | None = None,
     ) -> None:
         super().__init__(emitter=emitter)
 
@@ -89,6 +94,7 @@ class MCPTool(Tool[None]):
         self._user_id = user_id
         self._user_oauth_token = user_oauth_token
         self._additional_headers = additional_headers or {}
+        self._stdio_config = stdio_config
 
         self._mcp_tool_name = tool_name
         self._name = tool_name  # NOTE: this may change in _disambiguate_mcp_tool_names
@@ -272,14 +278,31 @@ class MCPTool(Tool[None]):
                         None,
                     )
 
-            tool_result = call_mcp_tool(
-                self.mcp_server.server_url,
-                self._mcp_tool_name,
-                llm_kwargs,
-                connection_headers=headers,
-                transport=self.mcp_server.transport or MCPTransport.STREAMABLE_HTTP,
-                auth=auth,
-            )
+            if (
+                self.mcp_server.transport == MCPTransport.STDIO
+                and not MCP_STDIO_ENABLED
+            ):
+                raise RuntimeError("Stdio MCP servers are disabled for this deployment")
+
+            if self._stdio_config is not None:
+                tool_result = call_mcp_tool(
+                    self.mcp_server.server_url,
+                    self._mcp_tool_name,
+                    llm_kwargs,
+                    connection_headers=headers,
+                    transport=self.mcp_server.transport or MCPTransport.STREAMABLE_HTTP,
+                    auth=auth,
+                    stdio_config=self._stdio_config,
+                )
+            else:
+                tool_result = call_mcp_tool(
+                    self.mcp_server.server_url,
+                    self._mcp_tool_name,
+                    llm_kwargs,
+                    connection_headers=headers,
+                    transport=self.mcp_server.transport or MCPTransport.STREAMABLE_HTTP,
+                    auth=auth,
+                )
 
             logger.info("MCP tool '%s' executed successfully", self._name)
 

--- a/backend/tests/unit/onyx/server/features/mcp/stdio_test_server.py
+++ b/backend/tests/unit/onyx/server/features/mcp/stdio_test_server.py
@@ -1,0 +1,21 @@
+import os
+
+from fastmcp import FastMCP
+
+mcp = FastMCP("Onyx stdio test server")
+
+
+@mcp.tool
+def read_configured_value() -> str:
+    """Return a value supplied through the stdio process environment."""
+    return os.environ["ONYX_STDIO_TEST_VALUE"]
+
+
+@mcp.tool
+def read_unrelated_secret() -> str:
+    """Verify that arbitrary API-host environment values are not inherited."""
+    return os.environ.get("ONYX_UNRELATED_SECRET", "not-inherited")
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/backend/tests/unit/onyx/server/features/mcp/test_stdio_client.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_stdio_client.py
@@ -1,0 +1,131 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+import pytest
+from pydantic import ValidationError
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import MCPTransport
+from onyx.db.models import User
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.mcp import api as mcp_api
+from onyx.server.features.mcp.api import _ensure_stdio_admin, _resolve_stdio_env
+from onyx.server.features.mcp.client import call_mcp_tool, discover_mcp_tools
+from onyx.server.features.mcp.models import MCPStdioServerConfig
+from onyx.utils.encryption import mask_string
+
+_TEST_SERVER = Path(__file__).with_name("stdio_test_server.py")
+
+
+def test_stdio_transport_discovers_and_calls_tool(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ONYX_UNRELATED_SECRET", "must-not-leak")
+    config = MCPStdioServerConfig(
+        command=sys.executable,
+        args=[str(_TEST_SERVER)],
+        env={"ONYX_STDIO_TEST_VALUE": "configured-secret"},
+    )
+
+    tools = discover_mcp_tools(
+        "",
+        transport=MCPTransport.STDIO,
+        stdio_config=config,
+    )
+    assert {tool.name for tool in tools} == {
+        "read_configured_value",
+        "read_unrelated_secret",
+    }
+
+    result = call_mcp_tool(
+        "",
+        "read_configured_value",
+        {},
+        transport=MCPTransport.STDIO,
+        stdio_config=config,
+    )
+    assert result == "configured-secret"
+
+    unrelated = call_mcp_tool(
+        "",
+        "read_unrelated_secret",
+        {},
+        transport=MCPTransport.STDIO,
+        stdio_config=config,
+    )
+    assert unrelated == "not-inherited"
+
+
+def test_stdio_transport_requires_process_configuration() -> None:
+    with pytest.raises(
+        ValueError, match="stdio transport requires process configuration"
+    ):
+        discover_mcp_tools("", transport=MCPTransport.STDIO)
+
+
+def test_stdio_configuration_requires_deployment_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_api, "MCP_STDIO_ENABLED", False)
+    admin = cast(User, SimpleNamespace(role=UserRole.ADMIN))
+
+    with pytest.raises(OnyxError, match="disabled for this deployment"):
+        _ensure_stdio_admin(admin)
+
+
+def test_stdio_configuration_requires_admin(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(mcp_api, "MCP_STDIO_ENABLED", True)
+    basic_user = cast(User, SimpleNamespace(role=UserRole.BASIC))
+
+    with pytest.raises(OnyxError, match="Only Onyx admins"):
+        _ensure_stdio_admin(basic_user)
+
+
+def test_stdio_env_edit_preserves_masked_values_and_removes_omitted_keys() -> None:
+    existing = {
+        "WORDPRESS_TOKEN": "a-long-existing-wordpress-token",
+        "REMOVED_VALUE": "remove-me",
+    }
+
+    assert _resolve_stdio_env(
+        {
+            "WORDPRESS_TOKEN": mask_string(existing["WORDPRESS_TOKEN"]),
+            "SITE_URL": "https://example.com",
+        },
+        existing,
+    ) == {
+        "WORDPRESS_TOKEN": existing["WORDPRESS_TOKEN"],
+        "SITE_URL": "https://example.com",
+    }
+
+
+def test_stdio_env_edit_rejects_unknown_masked_value() -> None:
+    with pytest.raises(OnyxError, match="has no stored value"):
+        _resolve_stdio_env({"UNKNOWN": "••••••••••••"}, {})
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("command", "\x00bad"),
+        ("args", ["safe", "bad\x00"]),
+        ("env", {"INVALID-NAME": "value"}),
+        ("env", {"VALID_NAME": "bad\x00"}),
+    ],
+)
+def test_stdio_config_rejects_unsafe_process_values(
+    field: str, value: str | list[str] | dict[str, str]
+) -> None:
+    kwargs: dict[str, object] = {
+        "command": sys.executable,
+        "args": [],
+        "env": {},
+    }
+    kwargs[field] = value
+
+    with pytest.raises(ValidationError):
+        MCPStdioServerConfig.model_validate(kwargs)

--- a/web/src/lib/settings/types.ts
+++ b/web/src/lib/settings/types.ts
@@ -97,6 +97,10 @@ export interface Settings {
   // True when hooks are available: single-tenant deployment with HOOK_ENABLED=true.
   hooks_enabled?: boolean;
 
+  // Whether this single-tenant deployment allows admins to launch stdio MCP
+  // server processes on the API host.
+  mcp_stdio_enabled?: boolean;
+
   // Application version from the ONYX_VERSION env var on the server.
   version?: string | null;
   // Hard ceiling for user_file_max_upload_size_mb, derived from env var.

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -23,6 +23,10 @@ export interface MCPServer {
   name: string;
   description?: string;
   server_url: string;
+  stdio_command?: string | null;
+  stdio_args?: string[];
+  // Only returned, masked, from the owner/admin detail endpoint.
+  stdio_env?: Record<string, string> | null;
   owner: string;
   transport?: MCPTransportType;
   auth_type?: MCPAuthenticationType;
@@ -67,6 +71,10 @@ export interface MCPServerCreateRequest {
   name: string;
   description?: string;
   server_url: string;
+  transport: MCPTransportType;
+  stdio_command?: string;
+  stdio_args: string[];
+  stdio_env: Record<string, string>;
   is_public: boolean;
   groups: number[];
   users: string[];
@@ -76,6 +84,10 @@ export interface MCPServerUpdateRequest {
   name?: string;
   description?: string;
   server_url?: string;
+  transport?: MCPTransportType;
+  stdio_command?: string;
+  stdio_args?: string[];
+  stdio_env?: Record<string, string>;
   // Omit to leave the server's existing access unchanged.
   is_public?: boolean;
   groups?: number[];

--- a/web/src/sections/actions/MCPPageContent.tsx
+++ b/web/src/sections/actions/MCPPageContent.tsx
@@ -10,6 +10,7 @@ import {
   ActionStatus,
   MCPServerStatus,
   MCPServer,
+  MCPTransportType,
   ToolSnapshot,
 } from "@/lib/tools/interfaces";
 import { toast } from "@opal/layouts";
@@ -257,10 +258,14 @@ export default function MCPPageContent() {
       const server = mcpServers.find((s) => s.id === serverId);
       if (server) {
         setActiveServer(server);
-        authModal.toggle(true);
+        if (server.transport === MCPTransportType.STDIO) {
+          manageServerModal.toggle(true);
+        } else {
+          authModal.toggle(true);
+        }
       }
     },
-    [mcpServers, authModal]
+    [mcpServers, authModal, manageServerModal]
   );
 
   const triggerFetchToolsInPlace = useCallback(
@@ -435,9 +440,13 @@ export default function MCPPageContent() {
   const onServerCreated = useCallback(
     (server: MCPServer) => {
       setActiveServer(server);
-      authModal.toggle(true);
+      if (server.transport === MCPTransportType.STDIO) {
+        void triggerFetchToolsInPlace(server.id);
+      } else {
+        authModal.toggle(true);
+      }
     },
-    [authModal]
+    [authModal, triggerFetchToolsInPlace]
   );
 
   const handleAddServer = useCallback(() => {
@@ -471,7 +480,8 @@ export default function MCPPageContent() {
       (server) =>
         server.name.toLowerCase().includes(query) ||
         server.description?.toLowerCase().includes(query) ||
-        server.server_url.toLowerCase().includes(query)
+        server.server_url.toLowerCase().includes(query) ||
+        server.stdio_command?.toLowerCase().includes(query)
     );
   }, [mcpServers, searchQuery]);
 
@@ -514,7 +524,12 @@ export default function MCPPageContent() {
                   serverId={server.id}
                   server={server}
                   title={server.name}
-                  description={server.description || server.server_url}
+                  description={
+                    server.description ||
+                    server.server_url ||
+                    server.stdio_command ||
+                    "Local stdio process"
+                  }
                   logo={getActionIcon(server.server_url, server.name)}
                   status={status}
                   toolCount={server.tool_count}

--- a/web/src/sections/actions/modals/AddMCPServerModal.tsx
+++ b/web/src/sections/actions/modals/AddMCPServerModal.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 import { Formik, Form } from "formik";
+import useSWR from "swr";
 import * as Yup from "yup";
-import { Modal } from "@opal/components";
+import { InputSelect, MessageCard, Modal } from "@opal/components";
 import { InputVertical, toast } from "@opal/layouts";
 import InputTypeInField from "@/refresh-components/form/InputTypeInField";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
@@ -12,6 +13,7 @@ import {
   MCPServerCreateRequest,
   MCPServerStatus,
   MCPServer,
+  MCPTransportType,
 } from "@/lib/tools/interfaces";
 import { useModal } from "@opal/components";
 import { Button, Divider } from "@opal/components";
@@ -20,6 +22,12 @@ import { SvgCheckCircle, SvgServer, SvgUnplug } from "@opal/icons";
 import { Section } from "@/layouts/general-layouts";
 import Text from "@/refresh-components/texts/Text";
 import { IsPublicGroupSelector } from "@/components/IsPublicGroupSelector";
+import { FormField } from "@/refresh-components/form/FormField";
+import { SWR_KEYS } from "@/lib/swr-keys";
+import { errorHandlingFetcher } from "@/lib/fetcher";
+import { useSettings } from "@/lib/settings/hooks";
+import { useCurrentUser } from "@/lib/users/hooks";
+import { UserRole } from "@/lib/types";
 
 interface AddMCPServerModalProps {
   skipOverlay?: boolean;
@@ -32,12 +40,56 @@ interface AddMCPServerModalProps {
   mutateMcpServers?: () => Promise<void>;
 }
 
+interface MCPServerFormValues {
+  name: string;
+  description?: string;
+  server_url: string;
+  transport: MCPTransportType;
+  stdio_command: string;
+  stdio_args: string;
+  stdio_env: string;
+  is_public: boolean;
+  groups: number[];
+  users: string[];
+}
+
 const validationSchema = Yup.object().shape({
   name: Yup.string().required("Server name is required"),
   description: Yup.string(),
-  server_url: Yup.string()
-    .url("Must be a valid URL")
-    .required("Server URL is required"),
+  server_url: Yup.string().when("transport", {
+    is: (transport: MCPTransportType) => transport !== MCPTransportType.STDIO,
+    then: (schema) =>
+      schema.url("Must be a valid URL").required("Server URL is required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+  stdio_command: Yup.string().when("transport", {
+    is: MCPTransportType.STDIO,
+    then: (schema) => schema.required("Command is required"),
+    otherwise: (schema) => schema.notRequired(),
+  }),
+  stdio_env: Yup.string().test(
+    "stdio-env-json",
+    "Environment must be a JSON object containing string values",
+    (value, context) => {
+      if (
+        context.parent.transport !== MCPTransportType.STDIO ||
+        !value?.trim()
+      ) {
+        return true;
+      }
+      try {
+        const parsed = JSON.parse(value);
+        return (
+          parsed !== null &&
+          typeof parsed === "object" &&
+          !Array.isArray(parsed) &&
+          Object.values(parsed).every((entry) => typeof entry === "string")
+        );
+      } catch {
+        return false;
+      }
+    }
+  ),
 });
 
 export default function AddMCPServerModal({
@@ -51,9 +103,18 @@ export default function AddMCPServerModal({
 }: AddMCPServerModalProps) {
   const { isOpen, toggle } = useModal();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const settings = useSettings();
+  const { user } = useCurrentUser();
 
   // Use activeServer from props
   const server = activeServer;
+  const { data: detailedServer } = useSWR<MCPServer>(
+    server ? SWR_KEYS.adminMcpServer(server.id) : null,
+    errorHandlingFetcher
+  );
+  const editableServer = detailedServer ?? server;
+  const stdioEnabled =
+    settings.mcp_stdio_enabled === true && user?.role === UserRole.ADMIN;
 
   // Handler for disconnect button
   const handleDisconnectClick = () => {
@@ -67,21 +128,39 @@ export default function AddMCPServerModal({
   // Determine if we're in edit mode
   const isEditMode = !!server;
 
-  const initialValues: MCPServerCreateRequest = {
-    name: server?.name || "",
-    description: server?.description || "",
-    server_url: server?.server_url || "",
-    is_public: server?.is_public ?? true,
-    groups: server?.groups ?? [],
-    users: server?.users ?? [],
+  const initialValues: MCPServerFormValues = {
+    name: editableServer?.name || "",
+    description: editableServer?.description || "",
+    server_url: editableServer?.server_url || "",
+    transport: editableServer?.transport || MCPTransportType.STREAMABLE_HTTP,
+    stdio_command: editableServer?.stdio_command || "",
+    stdio_args: (editableServer?.stdio_args || []).join("\n"),
+    stdio_env: JSON.stringify(editableServer?.stdio_env || {}, null, 2),
+    is_public: editableServer?.is_public ?? true,
+    groups: editableServer?.groups ?? [],
+    users: editableServer?.users ?? [],
   };
 
-  const handleSubmit = async (values: MCPServerCreateRequest) => {
+  const handleSubmit = async (values: MCPServerFormValues) => {
     setIsSubmitting(true);
 
+    const isStdio = values.transport === MCPTransportType.STDIO;
     // A public server has no group restriction.
     const payload: MCPServerCreateRequest = {
-      ...values,
+      name: values.name,
+      description: values.description,
+      server_url: isStdio ? "" : values.server_url,
+      transport: values.transport,
+      stdio_command: isStdio ? values.stdio_command.trim() : undefined,
+      stdio_args: isStdio
+        ? values.stdio_args
+            .split("\n")
+            .map((arg) => arg.trim())
+            .filter(Boolean)
+        : [],
+      stdio_env:
+        isStdio && values.stdio_env.trim() ? JSON.parse(values.stdio_env) : {},
+      is_public: values.is_public,
       groups: values.is_public ? [] : values.groups,
       users: values.is_public ? [] : values.users,
     };
@@ -140,6 +219,7 @@ export default function AddMCPServerModal({
           initialValues={initialValues}
           validationSchema={validationSchema}
           onSubmit={handleSubmit}
+          enableReinitialize
         >
           {(formikProps) => (
             <Form>
@@ -177,16 +257,93 @@ export default function AddMCPServerModal({
 
                 <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
-                <InputVertical
-                  withLabel="server_url"
-                  title="MCP Server URL"
-                  subDescription="Only connect to servers you trust. You are responsible for actions taken with this connection and keeping your tools updated."
-                >
-                  <InputTypeInField
-                    name="server_url"
-                    placeholder="https://your-mcp-server.com/mcp"
-                  />
-                </InputVertical>
+                {(stdioEnabled ||
+                  editableServer?.transport === MCPTransportType.STDIO) && (
+                  <FormField name="transport">
+                    <FormField.Label>Transport</FormField.Label>
+                    <FormField.Control asChild>
+                      <InputSelect
+                        value={formikProps.values.transport}
+                        disabled={isEditMode}
+                        onValueChange={(value) =>
+                          formikProps.setFieldValue("transport", value)
+                        }
+                      >
+                        <InputSelect.Trigger />
+                        <InputSelect.Content>
+                          <InputSelect.Item
+                            value={MCPTransportType.STREAMABLE_HTTP}
+                          >
+                            Streamable HTTP
+                          </InputSelect.Item>
+                          {editableServer?.transport ===
+                            MCPTransportType.SSE && (
+                            <InputSelect.Item value={MCPTransportType.SSE}>
+                              Server-sent events
+                            </InputSelect.Item>
+                          )}
+                          <InputSelect.Item value={MCPTransportType.STDIO}>
+                            Local process (stdio)
+                          </InputSelect.Item>
+                        </InputSelect.Content>
+                      </InputSelect>
+                    </FormField.Control>
+                    {isEditMode && (
+                      <FormField.Description>
+                        Transport cannot be changed after creation.
+                      </FormField.Description>
+                    )}
+                  </FormField>
+                )}
+
+                {formikProps.values.transport === MCPTransportType.STDIO ? (
+                  <>
+                    <MessageCard
+                      title="Runs a process on the Onyx API host"
+                      description="Only configure software you trust. Onyx executes the command directly without a shell, and shares these tools with the users or groups selected below."
+                    />
+                    <InputVertical withLabel="stdio_command" title="Command">
+                      <InputTypeInField
+                        name="stdio_command"
+                        placeholder="/usr/local/bin/wordpress-mcp"
+                      />
+                    </InputVertical>
+                    <InputVertical
+                      withLabel="stdio_args"
+                      title="Arguments"
+                      suffix="optional, one per line"
+                    >
+                      <InputTextAreaField
+                        name="stdio_args"
+                        placeholder={"--site\nhttps://example.com"}
+                        rows={3}
+                      />
+                    </InputVertical>
+                    <InputVertical
+                      withLabel="stdio_env"
+                      title="Environment Variables"
+                      suffix="optional JSON"
+                      subDescription="Values are encrypted at rest. Existing values remain masked while editing."
+                    >
+                      <InputTextAreaField
+                        name="stdio_env"
+                        placeholder={'{\n  "WORDPRESS_TOKEN": "secret"\n}'}
+                        rows={5}
+                      />
+                    </InputVertical>
+                  </>
+                ) : (
+                  <InputVertical
+                    withLabel="server_url"
+                    title="MCP Server URL"
+                    subDescription="Only connect to servers you trust. You are responsible for actions taken with this connection and keeping your tools updated."
+                  >
+                    <InputTypeInField
+                      name="server_url"
+                      placeholder="https://your-mcp-server.com/mcp"
+                    />
+                  </InputVertical>
+                )}
 
                 <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 
@@ -239,17 +396,19 @@ export default function AddMCPServerModal({
                           tooltip="Disconnect Server"
                           onClick={handleDisconnectClick}
                         />
-                        <Button
-                          prominence="secondary"
-                          type="button"
-                          onClick={() => {
-                            // Close this modal and open the auth modal for this server
-                            toggle(false);
-                            handleAuthenticate(server.id);
-                          }}
-                        >
-                          Edit Configs
-                        </Button>
+                        {server.transport !== MCPTransportType.STDIO && (
+                          <Button
+                            prominence="secondary"
+                            type="button"
+                            onClick={() => {
+                              // Close this modal and open the auth modal for this server
+                              toggle(false);
+                              handleAuthenticate(server.id);
+                            }}
+                          >
+                            Edit Configs
+                          </Button>
+                        )}
                       </Section>
                     </Section>
                   )}


### PR DESCRIPTION
## Description

Adds **stdio** as a transport option for MCP servers, alongside the existing HTTP-based transports, so an operator can connect locally installed MCP servers that only speak stdio.

Because a stdio server means executing a process on the API host, the feature is gated deliberately:

- New `MCP_STDIO_ENABLED` config flag, **disabled by default**. It is additionally force-disabled whenever `MULTI_TENANT` is set, so tenant admins in a multi-tenant deployment can never gain a process-execution primitive — only a single-tenant operator can opt in.
- Configuration is **admin-only**, and availability is exposed through the settings endpoint so the frontend hides the option entirely when the flag is off.
- The child process is launched from a **direct argv list, never through a shell**.
- Per-server environment variables are stored **encrypted and masked on read**, and the child does not inherit unrelated parent-process secrets.
- Existing user/group ACLs and per-agent tool assignments are reused unchanged — stdio servers are not a separate permission path.

**Schema change:** one Alembic migration (`4c8e1a7d2b6f_add_stdio_config_to_mcp_server`) adding stdio configuration to the MCP server model.

**Surface area:** MCP client/transport layer, MCP admin API and models, tool constructor and `mcp_tool`, sandbox MCP config, settings model, and the Actions admin UI (`AddMCPServerModal`, `MCPPageContent`).

## How Has This Been Tested?

- New unit coverage in `backend/tests/unit/onyx/server/features/mcp/test_stdio_client.py`, driven by a minimal stdio server fixture (`stdio_test_server.py`) — covering connection lifecycle, tool discovery and invocation, environment handling, and the disabled-by-default path.
- Focused backend test selection passing locally, plus Ruff, `ty`, oxlint, oxfmt, and an Alembic single-head check.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stdio transport for MCP so admins can connect locally installed servers by launching a process on the API host. It’s off by default and single-tenant only via `MCP_STDIO_ENABLED`, with encrypted env handling and no shell execution.

- **New Features**
  - Added `STDIO` transport: launches a child process with argv only; no shell; parent env is not inherited.
  - Admin-only and gated by `MCP_STDIO_ENABLED`; forced off in `MULTI_TENANT`; setting exposed as `mcp_stdio_enabled` for UI gating.
  - Model/API: new `stdio_command`/`stdio_args`; stdio env lives in encrypted connection config and is masked on read; transport is immutable; stdio servers are excluded from Craft sandboxes.
  - Client/Tools: discovery and tool calls work over stdio using `stdio_client`; tool constructor passes stdio config; calls are blocked if the flag is off.
  - UI: “Local process (stdio)” option in Add Server modal with command/args/env fields; masked env editing; auth modal is skipped for stdio; search and cards show command when applicable; env template adds `MCP_STDIO_ENABLED`.

- **Migration**
  - Apply Alembic migration `4c8e1a7d2b6f_add_stdio_config_to_mcp_server`.
  - To enable, set `MCP_STDIO_ENABLED=true` on a single-tenant deployment and restart API and web.
  - Ensure the MCP executable and dependencies are installed in the API host/container; Onyx does not install them.

<sup>Written for commit 4d056103d7a1d43c7a8febfed182040f9c37a1eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

