### PR TITLE
feat(helm): configurable celery beat schedule path + extraArgs (chart 0.8.1)

### DIFF
--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -18,9 +18,10 @@ annotations:
   artifacthub.io/changes: |
     - kind: added
       description: celery_beat.schedulePath (default /tmp/celerybeat-schedule) — beat's
-        schedule file now defaults to /tmp so the pod runs under hardened
-        securityContexts (non-root or readOnlyRootFilesystem), where the previous
-        working-directory default (/app) is not writable.
+        schedule file now defaults to /tmp, and the beat pod mounts an emptyDir at
+        /tmp (skipped when celery_beat.volumeMounts already provides /tmp), so beat
+        runs under hardened securityContexts (non-root or readOnlyRootFilesystem),
+        where the previous working-directory default (/app) is not writable.
     - kind: added
       description: celery_beat.extraArgs — extra CLI arguments appended to the celery
         beat command.

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.0
+version: 0.8.1
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,15 +17,13 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: added
-      description: SIZING.md — per-scale tuning guidance (small/medium/large snippets)
-        calibrated from production fleet usage, covering both in-cluster and managed
-        document-index topologies.
-    - kind: changed
-      description: Default resources retuned from production evidence — api-server CPU raised
-        (request 1, limit 3; a 1-core limit stalls /health under load and causes liveness
-        kills), model-server CPU requests lowered to 1 (limits unchanged), heavy-worker and
-        code-interpreter memory limits raised to stop production OOMKills, and the OpenSearch
-        PVC default grown to 64Gi. Existing OpenSearch PVCs are not resized by upgrades.
+      description: celery_beat.schedulePath (default /tmp/celerybeat-schedule) — beat's
+        schedule file now defaults to /tmp so the pod runs under hardened
+        securityContexts (non-root or readOnlyRootFilesystem), where the previous
+        working-directory default (/app) is not writable.
+    - kind: added
+      description: celery_beat.extraArgs — extra CLI arguments appended to the celery
+        beat command.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -1,4 +1,17 @@
 {{- if and .Values.vectorDB.enabled (gt (int .Values.celery_beat.replicaCount) 0) }}
+{{- /* beat must be able to write /tmp (schedule file + probe files) even under
+readOnlyRootFilesystem, so default an emptyDir there unless the user mounts
+their own /tmp volume. */}}
+{{- $beatMounts := .Values.celery_beat.volumeMounts | default list }}
+{{- $beatVolumes := .Values.celery_beat.volumes | default list }}
+{{- $hasTmpMount := false }}
+{{- range $beatMounts }}
+{{- if eq .mountPath "/tmp" }}{{- $hasTmpMount = true }}{{- end }}
+{{- end }}
+{{- if not $hasTmpMount }}
+{{- $beatMounts = append $beatMounts (dict "name" "beat-tmp" "mountPath" "/tmp") }}
+{{- $beatVolumes = append $beatVolumes (dict "name" "beat-tmp" "emptyDir" dict) }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -93,7 +106,7 @@ spec:
             {{- with .Values.celery_beat.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-          {{- with include "onyx.volumeMountsWithCA" (dict "ctx" . "volumeMounts" .Values.celery_beat.volumeMounts) }}
+          {{- with include "onyx.volumeMountsWithCA" (dict "ctx" . "volumeMounts" $beatMounts) }}
           {{- . | nindent 10 }}
           {{- end }}
           startupProbe:
@@ -118,7 +131,7 @@ spec:
                     python onyx/background/celery/celery_k8s_probe.py
                     --probe liveness
                     --filename /tmp/onyx_k8s_beat_liveness.txt
-      {{- with include "onyx.volumesWithCA" (dict "ctx" . "volumes" .Values.celery_beat.volumes) }}
+      {{- with include "onyx.volumesWithCA" (dict "ctx" . "volumes" $beatVolumes) }}
       {{- . | nindent 6 }}
       {{- end }}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/celery-beat.yaml
+++ b/deployment/helm/charts/onyx/templates/celery-beat.yaml
@@ -69,6 +69,12 @@ spec:
               {{- with .Values.celery_beat.logLevel }}
               {{ printf "--loglevel=%s" . | quote }},
               {{- end }}
+              {{- with .Values.celery_beat.schedulePath }}
+              {{ printf "--schedule=%s" . | quote }},
+              {{- end }}
+              {{- range .Values.celery_beat.extraArgs }}
+              {{ . | quote }},
+              {{- end }}
             ]
           resources:
             {{- toYaml .Values.celery_beat.resources | nindent 12 }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -658,10 +658,11 @@ celery_beat:
   # this worker only — this becomes `--loglevel=<value>` on the celery worker
   # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
-  # Path of beat's schedule file. /tmp stays writable under hardened
-  # securityContexts (non-root, or readOnlyRootFilesystem with an emptyDir on
-  # /tmp), unlike celery's default of the working directory (/app). Set to ""
-  # to restore celery's default.
+  # Path of beat's schedule file. Kept under /tmp — where the chart mounts an
+  # emptyDir (unless volumeMounts below already provide /tmp) — so beat runs
+  # under hardened securityContexts (non-root or readOnlyRootFilesystem),
+  # which can't write celery's default location, the working directory /app.
+  # Set to "" to restore celery's default.
   schedulePath: "/tmp/celerybeat-schedule"
   # Extra CLI args appended to the celery beat command, after the flags above.
   extraArgs: []

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -658,6 +658,13 @@ celery_beat:
   # this worker only — this becomes `--loglevel=<value>` on the celery worker
   # command and takes precedence over LOG_LEVEL inside the worker process.
   logLevel: ""
+  # Path of beat's schedule file. /tmp stays writable under hardened
+  # securityContexts (non-root, or readOnlyRootFilesystem with an emptyDir on
+  # /tmp), unlike celery's default of the working directory (/app). Set to ""
+  # to restore celery's default.
+  schedulePath: "/tmp/celerybeat-schedule"
+  # Extra CLI args appended to the celery beat command, after the flags above.
+  extraArgs: []
   podAnnotations: {}
   podLabels:
     scope: onyx-backend-celery


### PR DESCRIPTION
## Description

A self-hosted customer needs to pass `--schedule=/tmp/celerybeat-schedule` to the celery beat container, but the beat command is hardcoded in `templates/celery-beat.yaml` (only `celery_beat.logLevel` is templated).

The underlying problem is real, not just a convenience ask: beat's `DynamicTenantScheduler` subclasses celery's `PersistentScheduler`, which writes its schedule file to the CWD — `/app`, root-owned in the backend image (subdirs are chowned to 1001, `/app` itself is not). Under a hardened securityContext (non-root or `readOnlyRootFilesystem`) beat crash-loops with `OSError: [Errno 30] Read-only file system: 'celerybeat-schedule'`. Our values.yaml explicitly invites non-root overrides, so the chart should survive them.

Changes (chart 0.8.0 → 0.8.1):
- **`celery_beat.schedulePath`** — new, defaults to `/tmp/celerybeat-schedule`, so hardened deployments work with no extra values. The schedule file is ephemeral container-layer state either way (lost on every restart today), so defaulting it to /tmp changes no persistence semantics. `""` restores celery's CWD default.
- **`celery_beat.extraArgs`** — new, extra CLI args appended after the templated flags (later flags win in celery's click-based CLI, so `extraArgs` can override `schedulePath`/`logLevel` if ever needed).
- **Default emptyDir at `/tmp` on the beat pod** (review catch) — under `readOnlyRootFilesystem` there is otherwise no writable `/tmp` at all; beat also touches its k8s probe files there every tick, so this closes that pre-existing gap too. Skipped when `celery_beat.volumeMounts` already provides `/tmp`.

Scoped to beat only — the schedule file is beat-specific; the other celery workers don't write one.

Linear: https://linear.app/onyx-app/issue/CS-78

## How Has This Been Tested?

- `helm template` matrix, each output strictly YAML-parsed and the rendered `command` array + volumes verified: defaults (`--schedule=/tmp/celerybeat-schedule` present, `beat-tmp` emptyDir mounted at /tmp), `schedulePath=""` (flag absent), `logLevel` + 2 `extraArgs` (all flags, correct order), user-supplied `/tmp` volumeMount (default emptyDir correctly suppressed, no duplicate mountPath), `customCACerts` enabled (shell prefix + both mounts compose correctly).
- `helm lint` passes with `ci/ct-values.yaml`.
- Functional repro with the repo venv (celery 5.5.1 + `DynamicTenantScheduler`): beat launched from an unwritable CWD **without** the flag dies with `OSError: [Errno 30] Read-only file system: 'celerybeat-schedule'`; **with** `--schedule=/tmp/...` it creates the schedule store at the target path and starts cleanly.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check