### PR TITLE
fix(build): remove dev tools from the default backend image, publish a -dev variant

### DIFF
--- a/.github/actions/build-backend-image/action.yml
+++ b/.github/actions/build-backend-image/action.yml
@@ -55,6 +55,8 @@ runs:
       with:
         context: ./backend
         file: ./backend/Dockerfile
+        # The production image; the Dockerfile's default (last) stage is the dev variant.
+        target: runtime
         push: true
         build-args: |
           BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -978,6 +978,7 @@ jobs:
     environment: release
     outputs:
       digest: ${{ steps.build.outputs.digest }}
+      digest-dev: ${{ steps.build-dev.outputs.digest }}
     env:
       REGISTRY_IMAGE: onyxdotapp/onyx-backend
     steps:
@@ -1025,11 +1026,34 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
+          target: runtime
           platforms: linux/amd64
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
           cache-from: |
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+          cache-to: type=inline
+          outputs: type=image,name=${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
+
+      # Dev variant: runtime + interactive debugging tools, published with a -dev tag suffix by
+      # merge-backend. Reuses the runtime stage from the build above via the local BuildKit
+      # cache, so this only builds and pushes the extra apt layer.
+      - name: Build and push AMD64 dev
+        id: build-dev
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          target: dev
+          platforms: linux/amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ONYX_VERSION=${{ github.ref_name }}
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge-dev
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
           cache-to: type=inline
@@ -1050,6 +1074,7 @@ jobs:
     environment: release
     outputs:
       digest: ${{ steps.build.outputs.digest }}
+      digest-dev: ${{ steps.build-dev.outputs.digest }}
     env:
       REGISTRY_IMAGE: onyxdotapp/onyx-backend
     steps:
@@ -1097,11 +1122,34 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
+          target: runtime
           platforms: linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             ONYX_VERSION=${{ github.ref_name }}
           cache-from: |
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
+          cache-to: type=inline
+          outputs: type=image,name=${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          no-cache: ${{ vars.DOCKER_NO_CACHE == 'true' }}
+
+      # Dev variant: runtime + interactive debugging tools, published with a -dev tag suffix by
+      # merge-backend. Reuses the runtime stage from the build above via the local BuildKit
+      # cache, so this only builds and pushes the extra apt layer.
+      - name: Build and push ARM64 dev
+        id: build-dev
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a
+        with:
+          context: ./backend
+          file: ./backend/Dockerfile
+          target: dev
+          platforms: linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            ONYX_VERSION=${{ github.ref_name }}
+          cache-from: |
+            type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge-dev
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:edge
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:latest
           cache-to: type=inline
@@ -1166,12 +1214,43 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
             type=semver,pattern={{major}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
 
+      # Same tag set with a -dev suffix, for the dev image variant (runtime + debugging tools).
+      # The suffix is spelled out per tag rather than via flavor `suffix=` so that disabled
+      # (empty) raw tags stay empty instead of degenerating to a bare "-dev" tag.
+      - name: Docker meta (dev)
+        id: meta-dev
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        with:
+          images: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('backend-{0}-dev', needs.determine-builds.outputs.sanitized-tag) || format('{0}-dev', github.ref_name) }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta-dev' || '' }}
+            type=semver,pattern={{version}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}.{{minor}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+
       - name: Create and push manifest
         env:
           IMAGE_REPO: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           AMD64_DIGEST: ${{ needs.build-backend-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.build-backend-arm64.outputs.digest }}
           META_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          IMAGES="${IMAGE_REPO}@${AMD64_DIGEST} ${IMAGE_REPO}@${ARM64_DIGEST}"
+          docker buildx imagetools create \
+            $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
+            $IMAGES
+
+      - name: Create and push dev manifest
+        env:
+          IMAGE_REPO: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
+          AMD64_DIGEST: ${{ needs.build-backend-amd64.outputs.digest-dev }}
+          ARM64_DIGEST: ${{ needs.build-backend-arm64.outputs.digest-dev }}
+          META_TAGS: ${{ steps.meta-dev.outputs.tags }}
         run: |
           IMAGES="${IMAGE_REPO}@${AMD64_DIGEST} ${IMAGE_REPO}@${ARM64_DIGEST}"
           docker buildx imagetools create \

--- a/.github/workflows/pr-craft-compose-integration.yml
+++ b/.github/workflows/pr-craft-compose-integration.yml
@@ -152,10 +152,14 @@ jobs:
             # on (ENABLE_BROWSER defaults true) — chromium is lighter than the
             # skill bundle and keeps the CI image consistent with prod.
             extra_build_args: "ENABLE_SKILLS=false"
+            target: ""
           - image: backend
             context: ./backend
             file: ./backend/Dockerfile
             extra_build_args: ""
+            # The production image; the backend Dockerfile's default (last) stage is the
+            # dev variant.
+            target: runtime
     runs-on:
       - runs-on
       - runner=8cpu-linux-x64
@@ -187,6 +191,8 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
+          # Empty target means the Dockerfile's default (last) stage.
+          target: ${{ matrix.target }}
           platforms: linux/amd64
           build-args: |
             BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}

--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -177,10 +177,14 @@ jobs:
             # on (ENABLE_BROWSER defaults true) — chromium is lighter and the
             # browser integration test needs it.
             extra_build_args: "ENABLE_SKILLS=false"
+            target: ""
           - image: backend
             context: ./backend
             file: ./backend/Dockerfile
             extra_build_args: ""
+            # The production image; the backend Dockerfile's default (last) stage is the
+            # dev variant.
+            target: runtime
     runs-on:
       - runs-on
       - runner=8cpu-linux-x64
@@ -212,6 +216,8 @@ jobs:
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.file }}
+          # Empty target means the Dockerfile's default (last) stage.
+          target: ${{ matrix.target }}
           platforms: linux/amd64
           build-args: |
             BASE_IMAGE_REGISTRY=${{ env.BASE_IMAGE_REGISTRY }}

--- a/.github/workflows/pr-playwright-tests.yml
+++ b/.github/workflows/pr-playwright-tests.yml
@@ -244,6 +244,8 @@ jobs:
         with:
           context: ./backend
           file: ./backend/Dockerfile
+          # The production image; the Dockerfile's default (last) stage is the dev variant.
+          target: runtime
           platforms: linux/arm64
           tags: ${{ env.RUNS_ON_ECR_CACHE }}:playwright-test-backend-${{ github.run_id }}
           push: true

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -77,15 +77,13 @@ RUN groupadd -g 1001 onyx && \
     chown onyx:onyx /var/log/onyx
 
 # Install runtime system dependencies only (no build toolchain).
-# curl included just for users' convenience
 # zip for Vespa step further down
 # ca-certificates for HTTPS
 # libxmlsec1-openssl is the runtime counterpart to the build-time libxmlsec1-dev
-# postgresql-client for easy manual tests
-# procps so kubernetes exec sessions can use ps aux for debugging
+# Interactive debugging tools (curl, vim, nano, psql, ps) are deliberately absent to keep the
+# shipped image minimal; they live in the dev stage below, published with a -dev tag suffix.
 RUN apt-get update && \
     apt-get install -y \
-        curl \
         zip \
         ca-certificates \
         libgnutls30 \
@@ -93,9 +91,6 @@ RUN apt-get update && \
         libmount1 \
         libsmartcols1 \
         libuuid1 \
-        nano \
-        vim \
-        procps \
         libjemalloc2 \
         libxmlsec1-openssl \
         && \
@@ -123,16 +118,14 @@ COPY --from=builder \
 # removed for CVE surface reduction (requires --allow-remove-essential). It must be removed AFTER the
 # first `playwright install-deps`, because the font/X11 packages that install-deps pulls in run perl
 # scripts in their dpkg configure step. The second `playwright install-deps` then restores any
-# chromium runtime libs (libnss3, libnspr4, etc.) that autoremove swept up in the cascade.
+# chromium runtime libs (libnss3, libnspr4, etc.) that autoremove swept up in the cascade. The
+# runtime image stays perl-free from here on.
 RUN ln -s /usr/local/bin/supervisord /usr/bin/supervisord && \
     playwright install chromium && \
     playwright install-deps chromium && \
     apt-get remove -y --allow-remove-essential perl-base && \
     apt-get autoremove -y && \
     playwright install-deps chromium && \
-    # Re-install after autoremove: perl-base removal cascades through postgresql-client's
-    # perl dependency, sweeping it up. Install it here (post-autoremove) so it survives.
-    apt-get install -y postgresql-client && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -195,3 +188,28 @@ ENV LD_PRELOAD=libjemalloc.so.2
 # Default command which does nothing
 # This container is used by api server and background which specify their own CMD
 CMD ["tail", "-f", "/dev/null"]
+
+
+####################################################################################################
+# Dev stage
+#
+# Superset of the runtime image, published with a -dev tag suffix (e.g. v1.2.3-dev, latest-dev).
+# Adds interactive debugging conveniences that are deliberately excluded from the shipped image:
+# curl for poking APIs, postgresql-client for manual DB inspection (pulls perl-base back in,
+# acceptable here), procps so `ps aux` works in exec sessions, and the nano/vim editors.
+#
+# NOTE: as the last stage this is the default build target; builds of the shipped image must pin
+# --target runtime (release and CI workflows and the docker-compose build blocks all do).
+####################################################################################################
+FROM runtime AS dev
+
+RUN apt-get update && \
+    apt-get install -y \
+        curl \
+        nano \
+        postgresql-client \
+        procps \
+        vim \
+        && \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get clean

--- a/deployment/docker_compose/README.md
+++ b/deployment/docker_compose/README.md
@@ -45,5 +45,7 @@ downloaded during the initial setup. Feel free to edit the .env file to customiz
 located near the top of the file.
 
 IMAGE_TAG is the version of Onyx to run. It is recommended to leave it as latest to get all updates with each redeployment.
-Every backend release tag also has a `-dev` twin (e.g. `latest-dev`, `v1.2.3-dev`) that adds interactive debugging tools
-(vim, nano, curl, ps, psql) to the backend image; the default images ship without them to stay minimal.
+The backend image also publishes a `-dev` twin for every tag (e.g. `latest-dev`, `v1.2.3-dev`) that adds interactive
+debugging tools (vim, nano, curl, ps, psql); the default images ship without them to stay minimal. Only the backend has
+`-dev` tags, so select it with `ONYX_BACKEND_IMAGE=onyxdotapp/onyx-backend:latest-dev` rather than `IMAGE_TAG`, which
+the web-server and model-server images share.

--- a/deployment/docker_compose/README.md
+++ b/deployment/docker_compose/README.md
@@ -45,3 +45,5 @@ downloaded during the initial setup. Feel free to edit the .env file to customiz
 located near the top of the file.
 
 IMAGE_TAG is the version of Onyx to run. It is recommended to leave it as latest to get all updates with each redeployment.
+Every backend release tag also has a `-dev` twin (e.g. `latest-dev`, `v1.2.3-dev`) that adds interactive debugging tools
+(vim, nano, curl, ps, psql) to the backend image; the default images ship without them to stay minimal.

--- a/deployment/docker_compose/docker-compose.dev.yml
+++ b/deployment/docker_compose/docker-compose.dev.yml
@@ -10,6 +10,12 @@
 
 services:
   api_server:
+    # Building through this overlay produces the dev image variant (runtime + debugging
+    # tools such as vim/psql/curl), matching the published -dev tag suffix. CI is
+    # unaffected: it injects prebuilt images via ONYX_BACKEND_IMAGE and never builds
+    # through compose.
+    build:
+      target: dev
     ports:
       - "8080:8080"
     deploy:
@@ -17,6 +23,10 @@ services:
         limits:
           cpus: "${API_SERVER_CPU_LIMIT:-0}"
           memory: "${API_SERVER_MEM_LIMIT:-0}"
+
+  background:
+    build:
+      target: dev
 
   # Uncomment the block below to enable the MCP server for Onyx.
   # mcp_server:

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "
@@ -143,8 +143,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "

--- a/deployment/docker_compose/docker-compose.multitenant-dev.yml
+++ b/deployment/docker_compose/docker-compose.multitenant-dev.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "
       alembic -n schema_private upgrade head &&
@@ -140,6 +143,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "
       if [ -f /etc/ssl/certs/custom-ca.crt ]; then
@@ -310,6 +316,7 @@ services:
   #   build:
   #     context: ../../backend
   #     dockerfile: Dockerfile
+  #     target: runtime
   #   command: >
   #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
   #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "alembic upgrade head &&
       echo \"Starting Onyx Api Server\" &&
@@ -57,6 +60,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: /app/scripts/supervisord_entrypoint.sh
     depends_on:
       - relational_db
@@ -127,6 +133,7 @@ services:
   #   build:
   #     context: ../../backend
   #     dockerfile: Dockerfile
+  #     target: runtime
   #   command: >
   #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
   #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';

--- a/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
+++ b/deployment/docker_compose/docker-compose.prod-no-letsencrypt.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "alembic upgrade head &&
@@ -60,8 +60,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: /app/scripts/supervisord_entrypoint.sh
     depends_on:

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "
       alembic upgrade head &&
@@ -57,6 +60,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "
       if [ -f /etc/ssl/certs/custom-ca.crt ]; then
@@ -146,6 +152,7 @@ services:
   #   build:
   #     context: ../../backend
   #     dockerfile: Dockerfile
+  #     target: runtime
   #   command: >
   #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
   #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';

--- a/deployment/docker_compose/docker-compose.prod.yml
+++ b/deployment/docker_compose/docker-compose.prod.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "
@@ -60,8 +60,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -6,6 +6,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "alembic upgrade head &&
       echo \"Starting Onyx Api Server\" &&
@@ -50,6 +53,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: /app/scripts/supervisord_entrypoint.sh
     depends_on:
       - relational_db

--- a/deployment/docker_compose/docker-compose.search-testing.yml
+++ b/deployment/docker_compose/docker-compose.search-testing.yml
@@ -6,8 +6,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "alembic upgrade head &&
@@ -53,8 +53,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: /app/scripts/supervisord_entrypoint.sh
     depends_on:

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -43,6 +43,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "alembic upgrade head &&
       echo \"Starting Onyx Api Server\" &&
@@ -122,6 +125,9 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
+      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      target: runtime
     command: >
       /bin/sh -c "
       if [ -f /etc/ssl/certs/custom-ca.crt ]; then
@@ -226,6 +232,7 @@ services:
   #   build:
   #     context: ../../backend
   #     dockerfile: Dockerfile
+  #     target: runtime
   #   command: >
   #     /bin/sh -c "if [ \"${MCP_SERVER_ENABLED:-}\" != \"True\" ] && [ \"${MCP_SERVER_ENABLED:-}\" != \"true\" ]; then
   #       echo 'MCP server is disabled (MCP_SERVER_ENABLED=false), skipping...';

--- a/deployment/docker_compose/docker-compose.yml
+++ b/deployment/docker_compose/docker-compose.yml
@@ -43,8 +43,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "alembic upgrade head &&
@@ -125,8 +125,8 @@ services:
     build:
       context: ../../backend
       dockerfile: Dockerfile
-      # The shipped image; the Dockerfile's default (last) stage is the dev variant with
-      # debugging tools (published as the -dev tag suffix, e.g. IMAGE_TAG=latest-dev).
+      # The shipped image; the Dockerfile's default (last) stage is the dev variant
+      # with debugging tools (published with a -dev tag suffix).
       target: runtime
     command: >
       /bin/sh -c "

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -9,6 +9,8 @@
 ## Version of Onyx to deploy, default is latest (main built nightly).
 ## Craft uses this same tag for the sandbox image; do not set a separate
 ## sandbox image for normal deployments.
+## Every backend release tag also has a -dev twin (e.g. latest-dev, v1.2.3-dev)
+## that adds debugging tools (vim, nano, curl, ps, psql) to the backend image.
 IMAGE_TAG=latest
 
 ## Onyx Craft Configuration (off by default).

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -9,9 +9,12 @@
 ## Version of Onyx to deploy, default is latest (main built nightly).
 ## Craft uses this same tag for the sandbox image; do not set a separate
 ## sandbox image for normal deployments.
-## Every backend release tag also has a -dev twin (e.g. latest-dev, v1.2.3-dev)
-## that adds debugging tools (vim, nano, curl, ps, psql) to the backend image.
+## The backend image also publishes a -dev twin for every tag (e.g. latest-dev,
+## v1.2.3-dev) with debugging tools (vim, nano, curl, ps, psql). Only the backend
+## has -dev tags, so select it via ONYX_BACKEND_IMAGE below — NOT via IMAGE_TAG,
+## which the web-server and model-server images share.
 IMAGE_TAG=latest
+# ONYX_BACKEND_IMAGE=onyxdotapp/onyx-backend:latest-dev
 
 ## Onyx Craft Configuration (off by default).
 ## When enabling Craft through install.sh --include-craft or by manually adding

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.1
+version: 0.8.2
 appVersion: latest
 annotations:
   category: Productivity
@@ -16,15 +16,11 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: added
-      description: celery_beat.schedulePath (default /tmp/celerybeat-schedule) — beat's
-        schedule file now defaults to /tmp, and the beat pod mounts an emptyDir at
-        /tmp (skipped when celery_beat.volumeMounts already provides /tmp), so beat
-        runs under hardened securityContexts (non-root or readOnlyRootFilesystem),
-        where the previous working-directory default (/app) is not writable.
-    - kind: added
-      description: celery_beat.extraArgs — extra CLI arguments appended to the celery
-        beat command.
+    - kind: changed
+      description: Documented that the default backend images no longer ship psql (it
+        moved to the -dev suffixed image variants); the opt-in tooling.pgInto helper
+        now needs a -dev backend image tag or a custom image providing the client
+        binary.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -308,6 +308,8 @@ config:
 tooling:
   pgInto:
     # -- Mounts a small helper script into app pods that opens psql using the pod's POSTGRES_* env vars.
+    # NOTE: the default backend images do not ship psql; use a -dev suffixed image tag
+    # (e.g. v1.2.3-dev) or an image that provides the client binary.
     enabled: false
     # -- Where to place the helper inside the container.
     mountPath: /usr/local/bin/pginto


### PR DESCRIPTION
## Description

The shipped `onyxdotapp/onyx-backend` image carries interactive debugging tools that nothing at runtime needs: `vim`, `nano`, `curl`, `procps`, and `postgresql-client`. Worse, the `postgresql-client` re-install at the end of the Playwright RUN drags `perl-base` back in after the CVE-motivated perl removal — so the image ships perl today despite the removal dance.

This PR:

- **Slims the runtime image**: drops all five packages and the postgresql-client re-install, making the default image genuinely perl-free. (Supersedes the standalone-psql approach in #12201.)
- **Adds a `dev` stage** (`FROM runtime AS dev`) that installs the removed tools — a thin superset, one apt layer on top of runtime.
- **Publishes the dev variant** from the deployment workflow with a `-dev` tag twin for every backend tag: `v1.2.3-dev`, `latest-dev`, `edge-dev`, `beta-dev`, semver variants, and `backend-<tag>-dev` on test runs. The suffix is spelled out per tag rather than via metadata-action `flavor: suffix=` so disabled (empty) conditional tags can't degenerate into a bare `-dev` tag. `image-audit` keeps gating only the shipped runtime digest; the dev variant is intentionally unscanned (its extra packages would add CVE noise for an image that isn't a production artifact).
- **Pins `target: runtime` everywhere the shipped image is built**, since the new `dev` stage is last and therefore the Dockerfile's default target: the release workflow, the shared `build-backend-image` action, `pr-playwright-tests`, the `pr-craft-*` build matrices, and all backend `build:` blocks in the docker-compose files. `pr-python-connector-tests` (which runs pytest *inside* the production image) keeps testing the artifact we actually ship.
- **`docker-compose.dev.yml`** opts `api_server`/`background` local builds into `target: dev`, so developers building through the dev overlay keep the tools (CI injects prebuilt images via `ONYX_BACKEND_IMAGE` and never builds through compose).
- Docs: compose README + `env.template` note the `-dev` twins; the Helm `pgInto` comment notes psql now requires a `-dev` image.

Verified that nothing consumes the removed tools at runtime: compose healthchecks use `python -c urllib`, supervisord/entrypoints and backend code never shell out to curl/ps/psql, Helm probes don't exec curl, and `pgInto` is opt-in (disabled by default).

## How Has This Been Tested?

- `pre-commit run` on all 15 changed files passes (zizmor, actionlint, YAML checks).
- Repo-wide sweep confirms no remaining builder of `backend/Dockerfile` is missing a `target` pin.
- Recommended before release: `workflow_dispatch` the deployment workflow on this branch — the test-run path should push both `backend-<sanitized-tag>` and `backend-<sanitized-tag>-dev` to the ECR cache, with `image-audit` scanning only the runtime digest.
- Local spot-check: `docker build --target runtime backend/` then confirm `vim`/`curl`/`ps`/`psql`/`perl` are absent and `playwright` present; `docker build --target dev backend/` restores the tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Slimmed the production `onyxdotapp/onyx-backend` image by removing debugging tools and introduced a `-dev` image variant that includes them. This reduces the runtime attack surface (perl-free) while keeping a convenient image for debugging.

- **New Features**
  - Added a `dev` stage in `backend/Dockerfile` that installs `curl`, `vim`, `nano`, `procps`, and `postgresql-client`.
  - CI publishes `-dev` tags for all backend tags (`latest-dev`, `edge-dev`, `beta-dev`, `vX.Y.Z-dev`) as multi-arch manifests.
  - `docker-compose.dev.yml` builds with `target: dev`; docs mention `-dev` tags; Helm notes that `pgInto` requires a `-dev` image for `psql`.

- **Refactors**
  - The runtime image drops the above tools and the `postgresql-client` reinstall, and stays perl-free after Playwright deps removal (`perl-base` no longer returns).
  - All production builds explicitly set `target: runtime` (release and PR workflows, shared `build-backend-image` action, and compose files).
  - `image-audit` scans only the runtime digest; the `-dev` image is intentionally unscanned.
  - Bumped Helm chart to `0.8.2`; docs and `env.template` clarify selecting `-dev` via `ONYX_BACKEND_IMAGE` (only backend publishes `-dev` tags).

<sup>Written for commit 642abbe73bfe26cd760ead08bc86cdd762ec768f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13441?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

