### PR TITLE
fix(tools): disabling web search puts open_url in indexed-only mode

### DIFF
--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -119,14 +119,16 @@ def _get_image_generation_config(llm: LLM, db_session: Session) -> LLMConfig:
     )
 
 
-def should_exclude_open_url_tool(
+def should_disable_open_url_web_fetch(
     persona_tools: Sequence[ToolDBModel],
     allowed_tool_ids: list[int] | None,
 ) -> bool:
     """OpenURLTool is hidden from the chat tool toggles (chat_selectable=False)
-    but reaches the internet on its own via the crawler fallback. Treat an
-    explicit exclusion of WebSearchTool as excluding OpenURLTool too, so that
-    disabling web search for a message actually cuts off web access."""
+    but reaches the live internet on its own via the crawler fallback. Treat an
+    explicit exclusion of WebSearchTool as disabling OpenURLTool's web
+    fetching, so that turning off web search for a message actually cuts off
+    web access — while pasted links can still be served from indexed
+    documents."""
     if allowed_tool_ids is None:
         return False
     return any(
@@ -227,7 +229,9 @@ def _construct_tools_impl(
             auto_detect_filters=config.auto_detect_filters,
         )
 
-    exclude_open_url = should_exclude_open_url_tool(persona.tools, allowed_tool_ids)
+    open_url_web_fetch_disabled = should_disable_open_url_web_fetch(
+        persona.tools, allowed_tool_ids
+    )
 
     added_search_tool = False
     for db_tool_model in persona.tools:
@@ -305,10 +309,12 @@ def _construct_tools_impl(
 
             # Handle Open URL Tool
             elif tool_cls.__name__ == OpenURLTool.__name__:
-                if exclude_open_url:
+                if open_url_web_fetch_disabled and DISABLE_VECTOR_DB:
+                    # Without an index, open_url can serve nothing once web
+                    # fetching is off (crawl-only deployments).
                     logger.debug(
-                        "Skipping OpenURLTool because WebSearchTool is excluded "
-                        "for this message"
+                        "Skipping OpenURLTool: WebSearchTool is excluded for "
+                        "this message and no document index is available"
                     )
                     continue
                 try:
@@ -318,6 +324,7 @@ def _construct_tools_impl(
                             emitter=emitter,
                             document_index=document_index,
                             user=user,
+                            web_fetch_disabled=open_url_web_fetch_disabled,
                         )
                     ]
                 except RuntimeError as e:

--- a/backend/onyx/tools/tool_constructor.py
+++ b/backend/onyx/tools/tool_constructor.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from collections.abc import Sequence
 from typing import cast
 from uuid import UUID
 
@@ -18,6 +19,7 @@ from onyx.db.mcp import (
     resolve_mcp_credentials,
 )
 from onyx.db.models import Persona, User
+from onyx.db.models import Tool as ToolDBModel
 from onyx.db.oauth_config import get_oauth_config
 from onyx.db.search_settings import get_current_search_settings
 from onyx.db.tools import get_builtin_tool
@@ -117,6 +119,23 @@ def _get_image_generation_config(llm: LLM, db_session: Session) -> LLMConfig:
     )
 
 
+def should_exclude_open_url_tool(
+    persona_tools: Sequence[ToolDBModel],
+    allowed_tool_ids: list[int] | None,
+) -> bool:
+    """OpenURLTool is hidden from the chat tool toggles (chat_selectable=False)
+    but reaches the internet on its own via the crawler fallback. Treat an
+    explicit exclusion of WebSearchTool as excluding OpenURLTool too, so that
+    disabling web search for a message actually cuts off web access."""
+    if allowed_tool_ids is None:
+        return False
+    return any(
+        tool.in_code_tool_id == WebSearchTool.__name__
+        and tool.id not in allowed_tool_ids
+        for tool in persona_tools
+    )
+
+
 def construct_tools(
     persona: Persona,
     emitter: Emitter,
@@ -208,6 +227,8 @@ def _construct_tools_impl(
             auto_detect_filters=config.auto_detect_filters,
         )
 
+    exclude_open_url = should_exclude_open_url_tool(persona.tools, allowed_tool_ids)
+
     added_search_tool = False
     for db_tool_model in persona.tools:
         # If allowed_tool_ids is specified, skip tools not in the allowed list
@@ -284,6 +305,12 @@ def _construct_tools_impl(
 
             # Handle Open URL Tool
             elif tool_cls.__name__ == OpenURLTool.__name__:
+                if exclude_open_url:
+                    logger.debug(
+                        "Skipping OpenURLTool because WebSearchTool is excluded "
+                        "for this message"
+                    )
+                    continue
                 try:
                     tool_dict[db_tool_model.id] = [
                         OpenURLTool(

--- a/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
+++ b/backend/onyx/tools/tool_implementations/open_url/open_url_tool.py
@@ -74,6 +74,13 @@ MAX_CHARS_ACROSS_URLS = 10 * MAX_CHARS_PER_URL
 # it still gets included normally.
 MIN_CONTENT_CHARS = 200
 
+# LLM-facing reason used when the chat disabled web access (Web Search off) and
+# a URL couldn't be served from indexed documents.
+WEB_FETCH_DISABLED_REASON = (
+    "not fetched: web access is disabled for this conversation and this URL's "
+    "content is not in the connected knowledge sources"
+)
+
 
 class IndexedDocumentRequest(BaseModel):
     document_id: str
@@ -405,6 +412,12 @@ def _convert_sections_to_llm_string_with_citations(
 class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
     NAME = "open_url"
     DESCRIPTION = "Open and read the content of one or more URLs."
+    DESCRIPTION_NO_WEB_FETCH = (
+        "Open and read the content of one or more URLs. Web access is "
+        "disabled for this conversation, so only URLs whose content already "
+        "exists in the connected knowledge sources can be read — nothing is "
+        "fetched from the live internet."
+    )
     DISPLAY_NAME = "Open URL"
 
     def __init__(
@@ -414,6 +427,7 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
         document_index: DocumentIndex,
         user: User,
         content_provider: WebContentProvider | None = None,
+        web_fetch_disabled: bool = False,
     ) -> None:
         """Initialize the OpenURLTool.
 
@@ -425,14 +439,22 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
             content_provider: Optional content provider. If not provided,
                 will use the default provider from the database or fall back
                 to the built-in Onyx web crawler.
+            web_fetch_disabled: When True (e.g. the user turned Web Search off
+                for the chat), URLs are only served from indexed documents —
+                the live-crawl path is never used.
         """
         super().__init__(emitter=emitter)
         self._id = tool_id
         self._document_index = document_index
         self._user = user
+        self._web_fetch_disabled = web_fetch_disabled
 
+        self._provider: WebContentProvider | None
         if content_provider is not None:
             self._provider = content_provider
+        elif web_fetch_disabled:
+            # Indexed-only mode never crawls, so no provider is needed.
+            self._provider = None
         else:
             provider = get_default_content_provider()
             if provider is None:
@@ -453,6 +475,8 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
 
     @property
     def description(self) -> str:
+        if self._web_fetch_disabled:
+            return self.DESCRIPTION_NO_WEB_FETCH
         return self.DESCRIPTION
 
     @property
@@ -558,6 +582,14 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                 return None
 
             if DISABLE_VECTOR_DB:
+                if self._web_fetch_disabled:
+                    # No index to serve from and crawling is off — nothing to do.
+                    # (construct_tools normally drops the tool in this config;
+                    # this is a defensive fallback.)
+                    return ToolResponse(
+                        rich_response=None,
+                        llm_facing_response=WEB_FETCH_DISABLED_REASON,
+                    )
                 # Crawl-only: no indexed retrieval / link-based fallback without a vector DB.
                 crawled_result = run_functions_tuples_in_parallel(
                     [
@@ -605,19 +637,41 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
                         requests, filters
                     )
 
-                # Indexed + crawl in parallel; allow_failures keeps partial results.
-                indexed_result, crawled_result = run_functions_tuples_in_parallel(
-                    [
-                        (_retrieve_indexed_with_filters, (all_requests,)),
-                        (
-                            self._fetch_web_content,
-                            (urls, override_kwargs.url_snippet_map),
-                        ),
-                    ],
-                    allow_failures=True,
-                    timeout=OPEN_URL_TIMEOUT_SECONDS,
-                    timeout_callback=_timeout_handler,
-                )
+                if self._web_fetch_disabled:
+                    # Indexed-only: never crawl. Unresolved URLs are seeded as
+                    # failed (with the disabled reason) so the link-based
+                    # fallback below still gets a chance to serve them from the
+                    # index; whatever it can't rescue is reported as
+                    # unavailable rather than silently fetched from the web.
+                    indexed_result = run_functions_tuples_in_parallel(
+                        [(_retrieve_indexed_with_filters, (all_requests,))],
+                        allow_failures=True,
+                        timeout=OPEN_URL_TIMEOUT_SECONDS,
+                        timeout_callback=_timeout_handler,
+                    )[0]
+                    crawled_result = (
+                        [],
+                        [
+                            FailedFetch(
+                                url=url, failure_reason=WEB_FETCH_DISABLED_REASON
+                            )
+                            for url in unresolved_urls
+                        ],
+                    )
+                else:
+                    # Indexed + crawl in parallel; allow_failures keeps partial results.
+                    indexed_result, crawled_result = run_functions_tuples_in_parallel(
+                        [
+                            (_retrieve_indexed_with_filters, (all_requests,)),
+                            (
+                                self._fetch_web_content,
+                                (urls, override_kwargs.url_snippet_map),
+                            ),
+                        ],
+                        allow_failures=True,
+                        timeout=OPEN_URL_TIMEOUT_SECONDS,
+                        timeout_callback=_timeout_handler,
+                    )
 
                 indexed_result = indexed_result or IndexedRetrievalResult(
                     sections=[], missing_document_ids=[]
@@ -882,6 +936,13 @@ class OpenURLTool(Tool[OpenURLToolOverrideKwargs]):
     ) -> tuple[list[InferenceSection], list[FailedFetch]]:
         if not urls:
             return [], []
+
+        if self._provider is None:
+            # Only possible in web-fetch-disabled mode, which never routes here.
+            return [], [
+                FailedFetch(url=url, failure_reason=WEB_FETCH_DISABLED_REASON)
+                for url in urls
+            ]
 
         raw_web_contents = self._provider.contents(urls)
         # Track per-URL failure reasons (preferred) but de-dupe by URL since the

--- a/backend/tests/unit/onyx/tools/test_open_url_web_search_coupling.py
+++ b/backend/tests/unit/onyx/tools/test_open_url_web_search_coupling.py
@@ -1,15 +1,19 @@
-"""OpenURLTool must not survive a message that explicitly excludes WebSearchTool.
+"""Disabling Web Search in chat must cut off open_url's live web access.
 
-OpenURLTool is hidden from the chat tool toggles (chat_selectable=False), so the
-frontend always includes it in allowed_tool_ids. Without the coupling in
-should_exclude_open_url_tool, disabling "Web Search" in chat still leaves the
-model with internet access via open_url.
+OpenURLTool is hidden from the chat tool toggles (chat_selectable=False), so
+the frontend always includes it in allowed_tool_ids. When WebSearchTool is
+explicitly excluded, the tool stays available but in indexed-only mode: pasted
+links are still served from indexed documents, nothing is fetched from the
+live internet.
 """
 
 from unittest.mock import MagicMock
 
-from onyx.tools.tool_constructor import should_exclude_open_url_tool
-from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
+from onyx.tools.tool_constructor import should_disable_open_url_web_fetch
+from onyx.tools.tool_implementations.open_url.open_url_tool import (
+    WEB_FETCH_DISABLED_REASON,
+    OpenURLTool,
+)
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 
 
@@ -25,35 +29,73 @@ OPEN_URL = _tool(2, OpenURLTool.__name__)
 SEARCH = _tool(3, "SearchTool")
 
 
-def test_excluded_when_web_search_not_in_allowed_list() -> None:
+def test_disabled_when_web_search_not_in_allowed_list() -> None:
     assert (
-        should_exclude_open_url_tool(
+        should_disable_open_url_web_fetch(
             [WEB_SEARCH, OPEN_URL, SEARCH], allowed_tool_ids=[OPEN_URL.id, SEARCH.id]
         )
         is True
     )
 
 
-def test_not_excluded_when_web_search_allowed() -> None:
+def test_not_disabled_when_web_search_allowed() -> None:
     assert (
-        should_exclude_open_url_tool(
+        should_disable_open_url_web_fetch(
             [WEB_SEARCH, OPEN_URL], allowed_tool_ids=[WEB_SEARCH.id, OPEN_URL.id]
         )
         is False
     )
 
 
-def test_not_excluded_without_allowlist() -> None:
+def test_not_disabled_without_allowlist() -> None:
     assert (
-        should_exclude_open_url_tool([WEB_SEARCH, OPEN_URL], allowed_tool_ids=None)
+        should_disable_open_url_web_fetch([WEB_SEARCH, OPEN_URL], allowed_tool_ids=None)
         is False
     )
 
 
-def test_not_excluded_when_persona_has_no_web_search() -> None:
-    # An agent configured with open_url but no web_search keeps open_url; there
-    # is no web-search toggle whose state could express "no internet" intent.
+def test_not_disabled_when_persona_has_no_web_search() -> None:
+    # An agent configured with open_url but no web_search tool keeps full
+    # open_url behavior; there is no web-search toggle whose state could
+    # express "no internet" intent.
     assert (
-        should_exclude_open_url_tool([OPEN_URL, SEARCH], allowed_tool_ids=[OPEN_URL.id])
+        should_disable_open_url_web_fetch(
+            [OPEN_URL, SEARCH], allowed_tool_ids=[OPEN_URL.id]
+        )
         is False
     )
+
+
+def _build_tool(web_fetch_disabled: bool) -> OpenURLTool:
+    # No content_provider passed in disabled mode: the constructor must not
+    # try to resolve one (and must not raise when none is configured).
+    return OpenURLTool(
+        tool_id=2,
+        emitter=MagicMock(),
+        document_index=MagicMock(),
+        user=MagicMock(),
+        content_provider=None if web_fetch_disabled else MagicMock(),
+        web_fetch_disabled=web_fetch_disabled,
+    )
+
+
+def test_disabled_tool_needs_no_content_provider_and_says_so() -> None:
+    tool = _build_tool(web_fetch_disabled=True)
+    assert tool._provider is None
+    assert "disabled" in tool.description
+    assert tool.tool_definition()["function"]["description"] == tool.description
+
+
+def test_enabled_tool_keeps_default_description() -> None:
+    tool = _build_tool(web_fetch_disabled=False)
+    assert tool.description == OpenURLTool.DESCRIPTION
+
+
+def test_fetch_web_content_guard_when_provider_missing() -> None:
+    tool = _build_tool(web_fetch_disabled=True)
+    sections, failures = tool._fetch_web_content(
+        ["https://example.com"], url_snippet_map={}
+    )
+    assert sections == []
+    assert [f.url for f in failures] == ["https://example.com"]
+    assert failures[0].failure_reason == WEB_FETCH_DISABLED_REASON

--- a/backend/tests/unit/onyx/tools/test_open_url_web_search_coupling.py
+++ b/backend/tests/unit/onyx/tools/test_open_url_web_search_coupling.py
@@ -1,0 +1,59 @@
+"""OpenURLTool must not survive a message that explicitly excludes WebSearchTool.
+
+OpenURLTool is hidden from the chat tool toggles (chat_selectable=False), so the
+frontend always includes it in allowed_tool_ids. Without the coupling in
+should_exclude_open_url_tool, disabling "Web Search" in chat still leaves the
+model with internet access via open_url.
+"""
+
+from unittest.mock import MagicMock
+
+from onyx.tools.tool_constructor import should_exclude_open_url_tool
+from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
+from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
+
+
+def _tool(tool_id: int, in_code_tool_id: str | None) -> MagicMock:
+    tool = MagicMock()
+    tool.id = tool_id
+    tool.in_code_tool_id = in_code_tool_id
+    return tool
+
+
+WEB_SEARCH = _tool(1, WebSearchTool.__name__)
+OPEN_URL = _tool(2, OpenURLTool.__name__)
+SEARCH = _tool(3, "SearchTool")
+
+
+def test_excluded_when_web_search_not_in_allowed_list() -> None:
+    assert (
+        should_exclude_open_url_tool(
+            [WEB_SEARCH, OPEN_URL, SEARCH], allowed_tool_ids=[OPEN_URL.id, SEARCH.id]
+        )
+        is True
+    )
+
+
+def test_not_excluded_when_web_search_allowed() -> None:
+    assert (
+        should_exclude_open_url_tool(
+            [WEB_SEARCH, OPEN_URL], allowed_tool_ids=[WEB_SEARCH.id, OPEN_URL.id]
+        )
+        is False
+    )
+
+
+def test_not_excluded_without_allowlist() -> None:
+    assert (
+        should_exclude_open_url_tool([WEB_SEARCH, OPEN_URL], allowed_tool_ids=None)
+        is False
+    )
+
+
+def test_not_excluded_when_persona_has_no_web_search() -> None:
+    # An agent configured with open_url but no web_search keeps open_url; there
+    # is no web-search toggle whose state could express "no internet" intent.
+    assert (
+        should_exclude_open_url_tool([OPEN_URL, SEARCH], allowed_tool_ids=[OPEN_URL.id])
+        is False
+    )


### PR DESCRIPTION
## Description

Disabling the **Web Search** toggle in chat only removed the `web_search` tool from the message's `allowed_tool_ids`. `OpenURLTool` is hidden from the chat tool toggles (`chat_selectable=False`), so the frontend always includes its id in the allowlist — the model kept full internet access through `open_url`, which works even without a configured web-search provider via the crawler fallback. Reported by a customer who disabled both web search and code interpreter in a session and watched the model fetch a public URL anyway.

**Design:** rather than removing the tool (first revision of this PR), `open_url` stays available in **indexed-only mode** when the message excludes `WebSearchTool` — pasting a link whose content is already in the connected knowledge sources still works (doc-id resolution + link-based fallback against the document index), but nothing is ever fetched from the live internet. Specifically:

- `OpenURLTool(web_fetch_disabled=True)`: skips the crawl path entirely, needs no content provider, and its tool description tells the model only indexed content is readable.
- URLs that can't be served from the index are reported with an explicit `"web access is disabled for this conversation"` reason instead of silently failing (or being fetched).
- Enforced server-side in `tool_constructor.py` so web, mobile, and raw API clients all behave the same. Crawl-only deployments (`DISABLE_VECTOR_DB`) drop the tool when web search is off, since there is no index to serve from.
- Agents configured with `open_url` but no `web_search` tool are unaffected — there is no toggle whose state could express the user's intent in that case.

Not covered here (possible follow-up): the Code Interpreter toggle similarly leaves the separate `coding_agent`/`bash` tools enabled.

## How Has This Been Tested?

- Unit tests: coupling helper, restricted-mode constructor/description, and the no-provider fetch guard (`backend/tests/unit/onyx/tools/test_open_url_web_search_coupling.py`)
- `uv run pytest backend/tests/unit/onyx/tools` — 466 passed

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Linear: https://linear.app/onyx-app/issue/CS-79