### PR TITLE
fix(llm): detect Claude model identity in deployment_name too

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -574,8 +574,16 @@ class LitellmLLM(LLM):
         ]
         is_claude_model = any("claude" in name.lower() for name in model_identity_names)
         is_qwen_model = "qwen" in self.config.model_name.lower()
-        is_reasoning = model_is_reasoning_model(
-            self.config.model_name, self.config.model_provider
+        # Claude >= 4.7 always reasons via the adaptive thinking API, so treat
+        # it as a reasoning model even when the litellm registry doesn't know
+        # the (possibly aliased) name — otherwise reasoning_effort is silently
+        # dropped for such models.
+        uses_adaptive_thinking = any(
+            _anthropic_uses_adaptive_thinking(name) for name in model_identity_names
+        )
+        is_reasoning = uses_adaptive_thinking or any(
+            model_is_reasoning_model(name, self.config.model_provider)
+            for name in model_identity_names
         )
         # All OpenAI models will use responses API for consistency
         # Responses API is needed to get reasoning packets from OpenAI models
@@ -700,10 +708,7 @@ class LitellmLLM(LLM):
                 # (notably Bedrock).
                 has_tool_call_history = _prompt_contains_tool_call_history(prompt)
 
-                if any(
-                    _anthropic_uses_adaptive_thinking(name)
-                    for name in model_identity_names
-                ):
+                if uses_adaptive_thinking:
                     # Newer Anthropic models (Claude Opus 4.7+) reject
                     # thinking.type.enabled — they require the adaptive
                     # thinking config with output_config.effort.

--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -564,7 +564,15 @@ class LitellmLLM(LLM):
         #########################
         # Flags that modify the final arguments
         #########################
-        is_claude_model = "claude" in self.config.model_name.lower()
+        # Custom providers (e.g. Azure AI Foundry) may carry the model identity
+        # only in the deployment alias, which is also the string actually sent
+        # to LiteLLM — so model detection must consider both names.
+        model_identity_names = [
+            name
+            for name in (self.config.model_name, self.config.deployment_name)
+            if name
+        ]
+        is_claude_model = any("claude" in name.lower() for name in model_identity_names)
         is_qwen_model = "qwen" in self.config.model_name.lower()
         is_reasoning = model_is_reasoning_model(
             self.config.model_name, self.config.model_provider
@@ -654,7 +662,9 @@ class LitellmLLM(LLM):
         # https://github.com/BerriAI/litellm/issues/26444
         # TODO(litellm): Consider removing this once the above is resolved,
         # although this assumes users have upgraded their litellm if relevant.
-        omits_sampling_params = _anthropic_omits_sampling_params(self.config.model_name)
+        omits_sampling_params = any(
+            _anthropic_omits_sampling_params(name) for name in model_identity_names
+        )
         if not omits_sampling_params:
             optional_kwargs["temperature"] = 1 if is_reasoning else self._temperature
 
@@ -690,7 +700,10 @@ class LitellmLLM(LLM):
                 # (notably Bedrock).
                 has_tool_call_history = _prompt_contains_tool_call_history(prompt)
 
-                if _anthropic_uses_adaptive_thinking(self.config.model_name):
+                if any(
+                    _anthropic_uses_adaptive_thinking(name)
+                    for name in model_identity_names
+                ):
                     # Newer Anthropic models (Claude Opus 4.7+) reject
                     # thinking.type.enabled — they require the adaptive
                     # thinking config with output_config.effort.

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -449,6 +449,9 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-sonnet-5",
     "claude-sonnet-5@20260203",
     "claude-5-sonnet",
+    "claude-opus-5",
+    "claude-opus-5@20260101",
+    "claude-5-opus",
 ]
 
 
@@ -475,6 +478,32 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         assert "temperature" not in kwargs
 
 
+def test_omits_temperature_when_claude_only_in_deployment_name() -> None:
+    # Custom providers (e.g. Azure AI Foundry) may carry the model identity only
+    # in the deployment alias — the string actually sent to LiteLLM — while
+    # model_name is an opaque label. Detection must consider both.
+    llm = LitellmLLM(
+        api_key="test_key",
+        timeout=30,
+        model_provider=LlmProviderNames.LITELLM_PROXY,
+        model_name="foundry-deploy-1",
+        deployment_name="claude-opus-5",
+        max_input_tokens=get_max_input_tokens(
+            model_provider=LlmProviderNames.LITELLM_PROXY,
+            model_name="foundry-deploy-1",
+        ),
+    )
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(llm.stream(messages))
+
+        kwargs = mock_completion.call_args.kwargs
+        assert "temperature" not in kwargs
+
+
 @pytest.mark.parametrize(
     "model_name",
     [
@@ -486,6 +515,8 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         "claude-5-mythos",
         "claude-sonnet-5",
         "claude-5-sonnet",
+        "claude-opus-5",
+        "claude-5-opus",
     ],
 )
 @pytest.mark.parametrize(
@@ -590,6 +621,8 @@ def test_keeps_temperature_for_older_sonnet_models(model_name: str) -> None:
         ("claude-5-fable", (5, 0)),
         ("claude-mythos-5", (5, 0)),
         ("claude-5-mythos", (5, 0)),
+        ("claude-opus-5", (5, 0)),
+        ("claude-5-opus", (5, 0)),
         # Date/snapshot suffixes stripped
         ("claude-opus-4-8@20260101", (4, 8)),
         ("claude-sonnet-5@20260203", (5, 0)),

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -478,10 +478,13 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         assert "temperature" not in kwargs
 
 
-def test_omits_temperature_when_claude_only_in_deployment_name() -> None:
+def test_claude_only_in_deployment_name_omits_temperature_and_reasons() -> None:
     # Custom providers (e.g. Azure AI Foundry) may carry the model identity only
     # in the deployment alias — the string actually sent to LiteLLM — while
-    # model_name is an opaque label. Detection must consider both.
+    # model_name is an opaque label. Detection must consider both, including for
+    # the reasoning path: model_is_reasoning_model is deliberately NOT patched
+    # here, since the litellm registry can't know the opaque alias — adaptive
+    # thinking must be inferred from the Claude version alone.
     llm = LitellmLLM(
         api_key="test_key",
         timeout=30,
@@ -498,10 +501,12 @@ def test_omits_temperature_when_claude_only_in_deployment_name() -> None:
         mock_completion.return_value = []
 
         messages: LanguageModelInput = [UserMessage(content="Hi")]
-        list(llm.stream(messages))
+        list(llm.stream(messages, reasoning_effort=ReasoningEffort.HIGH))
 
         kwargs = mock_completion.call_args.kwargs
         assert "temperature" not in kwargs
+        assert kwargs["thinking"] == {"type": "adaptive"}
+        assert kwargs["output_config"] == {"effort": "high"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Claude model detection (sampling-param omission for Claude >= 4.7, adaptive thinking, `is_claude_model`) only read `config.model_name`, but the model string actually sent to LiteLLM prefers `config.deployment_name`. A custom provider whose deployment alias carries the Claude identity (common with Azure AI Foundry) diverged: Onyx would still send `temperature`, which Claude 5 models reject with a 400 `invalid_request_error` ("'temperature' is deprecated for this model").

Detection now considers both names. Also adds `claude-opus-5` / `claude-5-opus` to the unit-test parametrizations — every other Claude 5 tier was covered there, Opus 5 was not (Opus 5 was also the tier missing from the pre-#12744 hardcoded lists still on release/v4.3, which is how this surfaced with a customer).

## How Has This Been Tested?

- New test: `test_omits_temperature_when_claude_only_in_deployment_name`
- Extended parametrizations with the Opus 5 names
- `uv run pytest backend/tests/unit/onyx/llm/test_multi_llm.py` — 145 passed

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects Claude identity from `deployment_name` as well as `model_name`, matching what is sent to `litellm`. Ensures Claude ≥ 4.7 triggers the reasoning path from either name (adaptive thinking + `reasoning_effort`) and stops sending `temperature` to Claude 5, fixing 400 invalid_request errors including with Azure AI Foundry aliases.

- **Bug Fixes**
  - Use both names for `is_claude_model`, sampling-params omission, and reasoning detection.
  - Add test for deployment-name-only detection (no `temperature`, `thinking={"type":"adaptive"}`, `output_config.effort`) and include `claude-opus-5` / `claude-5-opus` in parametrizations.

<sup>Written for commit e5b65db5af6053ab5b747f2ed4f47022f418eeca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Linear: https://linear.app/onyx-app/issue/CS-80
