### PR TITLE
feat(tracing): record effective LLM request params on generation spans

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -46,6 +46,7 @@ from onyx.llm.models import (
 from onyx.llm.request_context import get_llm_mock_response
 from onyx.llm.utils import build_litellm_passthrough_kwargs
 from onyx.llm.well_known_providers.constants import VERTEX_LOCATION_KWARG
+from onyx.tracing.llm_utils import record_llm_request_params
 from onyx.utils.encryption import mask_env_value_for_logging, mask_string
 from onyx.utils.logger import setup_logger
 
@@ -886,6 +887,19 @@ class LitellmLLM(LLM):
                     attempts.append(stripped)
 
             for i, opts in enumerate(attempts):
+                # Last write wins: sent_kwargs holds what the returning (or
+                # final failing) attempt sent, reasoning_effort the requested
+                # intent.
+                record_llm_request_params(
+                    {
+                        "reasoning_effort": reasoning_effort.value,
+                        "max_tokens": max_tokens,
+                        "sent_kwargs": {
+                            k: opts[k]
+                            for k in sorted(_BEST_EFFORT_KWARG_KEYS & opts.keys())
+                        },
+                    }
+                )
                 try:
                     return _call_litellm(opts)
                 except BadRequestError as e:

--- a/backend/onyx/tracing/braintrust_tracing_processor.py
+++ b/backend/onyx/tracing/braintrust_tracing_processor.py
@@ -199,6 +199,11 @@ class BraintrustTracingProcessor(TracingProcessor):
         if span.span_data.reasoning:
             metadata["reasoning"] = span.span_data.reasoning
 
+        # Request-shaping params from record_llm_request_params: requested
+        # reasoning effort plus the kwargs actually sent to the provider.
+        if span.span_data.request_params:
+            metadata["request_params"] = span.span_data.request_params
+
         # Include the full tool catalog (name, description, parameters) offered
         # to the model on this call, if any.
         if span.span_data.tools:

--- a/backend/onyx/tracing/framework/span_data.py
+++ b/backend/onyx/tracing/framework/span_data.py
@@ -102,6 +102,7 @@ class GenerationSpanData(SpanData):
         "usage",
         "time_to_first_action_seconds",
         "tools",
+        "request_params",
     )
 
     def __init__(
@@ -115,6 +116,7 @@ class GenerationSpanData(SpanData):
         usage: dict[str, Any] | None = None,
         time_to_first_action_seconds: float | None = None,
         tools: Sequence[Mapping[str, Any]] | None = None,
+        request_params: Mapping[str, Any] | None = None,
     ):
         if image_count is not None and image_count < 1:
             raise ValueError("image_count must be positive")
@@ -127,6 +129,7 @@ class GenerationSpanData(SpanData):
         self.usage = usage
         self.time_to_first_action_seconds = time_to_first_action_seconds
         self.tools = tools
+        self.request_params = request_params
 
     @property
     def type(self) -> str:
@@ -144,4 +147,5 @@ class GenerationSpanData(SpanData):
             "usage": self.usage,
             "time_to_first_action_seconds": self.time_to_first_action_seconds,
             "tools": self.tools,
+            "request_params": self.request_params,
         }

--- a/backend/onyx/tracing/llm_utils.py
+++ b/backend/onyx/tracing/llm_utils.py
@@ -8,7 +8,7 @@ from onyx.llm.interfaces import LLM
 from onyx.llm.model_response import ModelResponse
 from onyx.llm.models import ToolCall
 from onyx.tracing.flows import LLMFlow
-from onyx.tracing.framework.create import generation_span
+from onyx.tracing.framework.create import generation_span, get_current_span
 from onyx.tracing.framework.span_data import GenerationSpanData
 from onyx.tracing.framework.spans import Span
 
@@ -92,6 +92,16 @@ def traced_llm_call(
                 Sequence[Mapping[str, Any]], normalized_messages
             )
         yield span
+
+
+def record_llm_request_params(params: Mapping[str, Any]) -> None:
+    """Attach request-shaping params (reasoning effort, provider kwargs) to the
+    active generation span. Call once per send attempt with the provider-mapped
+    kwargs: last write wins. No-op when the current span is not a generation span."""
+    span = get_current_span()
+    if span is None or not isinstance(span.span_data, GenerationSpanData):
+        return
+    span.span_data.request_params = dict(params)
 
 
 def record_llm_response(

--- a/backend/tests/unit/onyx/llm/test_trace_request_params.py
+++ b/backend/tests/unit/onyx/llm/test_trace_request_params.py
@@ -1,0 +1,74 @@
+"""Guards that generation spans record the requested effort and the kwargs actually sent."""
+
+from typing import Any
+from unittest.mock import patch
+
+from litellm.exceptions import BadRequestError
+
+from onyx.llm.models import ReasoningEffort, UserMessage
+from onyx.llm.multi_llm import LitellmLLM
+from onyx.tracing.framework.create import generation_span, trace
+
+_SENTINEL = object()
+
+
+def _make_llm() -> LitellmLLM:
+    return LitellmLLM(
+        api_key="test-key",
+        model_provider="anthropic",
+        model_name="claude-sonnet-5",
+        max_input_tokens=100000,
+    )
+
+
+def _run(completion: Any, effort: ReasoningEffort) -> Any:
+    with patch("onyx.llm.litellm_singleton.litellm.completion", side_effect=completion):
+        return _make_llm()._completion(
+            prompt=[UserMessage(content="hello")],
+            tools=None,
+            tool_choice=None,
+            stream=False,
+            parallel_tool_calls=False,
+            reasoning_effort=effort,
+        )
+
+
+def test_request_params_recorded_on_generation_span() -> None:
+    def completion(**_kwargs: Any) -> Any:
+        return _SENTINEL
+
+    with trace("test"), generation_span(model="claude-sonnet-5") as span:
+        result = _run(completion, ReasoningEffort.XHIGH)
+
+    assert result is _SENTINEL
+    params = span.span_data.request_params
+    assert params is not None
+    assert params["reasoning_effort"] == "xhigh"
+    assert params["sent_kwargs"]["thinking"] == {"type": "adaptive"}
+    assert params["sent_kwargs"]["output_config"] == {"effort": "xhigh"}
+
+
+def test_request_params_reflect_stripped_retry() -> None:
+    def completion(**kwargs: Any) -> Any:
+        if "thinking" in kwargs or "output_config" in kwargs:
+            raise BadRequestError(
+                message="effort not supported", model="m", llm_provider="anthropic"
+            )
+        return _SENTINEL
+
+    with trace("test"), generation_span(model="claude-sonnet-5") as span:
+        result = _run(completion, ReasoningEffort.XHIGH)
+
+    assert result is _SENTINEL
+    params = span.span_data.request_params
+    assert params is not None
+    assert params["reasoning_effort"] == "xhigh"
+    assert "thinking" not in params["sent_kwargs"]
+    assert "output_config" not in params["sent_kwargs"]
+
+
+def test_request_params_noop_without_span() -> None:
+    def completion(**_kwargs: Any) -> Any:
+        return _SENTINEL
+
+    assert _run(completion, ReasoningEffort.LOW) is _SENTINEL


### PR DESCRIPTION
## Description

Braintrust generation spans do not record any of the request-shaping params, so a trace cannot answer questions like whether a message was sent with xhigh reasoning. This adds a `request_params` field to `GenerationSpanData` and exports it as `metadata.request_params` in the Braintrust processor. The value is recorded inside `LitellmLLM`'s retry ladder, so it reflects what was actually sent after provider mapping and rejection-strip retries: the requested reasoning effort, `max_tokens`, and the `thinking` / `output_config` / `reasoning` / `temperature` kwargs.

## How Has This Been Tested?

- New unit tests in `backend/tests/unit/onyx/llm/test_trace_request_params.py`: params recorded on the active generation span, post-strip retry recorded truthfully, and no-op without a span. Ran with the adjacent reasoning-param suites, 14 passed.
- `ty check` project-wide, clean.
- `ruff format --check` and pre-commit hooks on the changed files.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
