### PR TITLE
backport(v4.3): gate Anthropic thinking/sampling on parsed model version (#12744)

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -1,5 +1,6 @@
 import copy
 import os
+import re
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -80,41 +81,22 @@ _VERTEX_ANTHROPIC_MODELS_REJECTING_OUTPUT_CONFIG = (
     "claude-opus-4-8",
 )
 
-# Anthropic models that require the adaptive thinking API (thinking.type.adaptive
-# + output_config.effort) instead of the legacy thinking.type.enabled + budget_tokens.
-_ANTHROPIC_ADAPTIVE_THINKING_MODELS = (
-    "claude-opus-4-7",
-    "claude-opus-4-8",
-    "claude-fable-5",
-    "claude-5-fable",
-    "claude-mythos-5",
-    "claude-5-mythos",
-    "claude-sonnet-5",
-    "claude-5-sonnet",
-)
+# Starting with Claude Opus 4.7, Anthropic requires the adaptive thinking API
+# (thinking.type.adaptive + output_config.effort) in place of the legacy
+# thinking.type.enabled + budget_tokens, and rejects any non-default sampling
+# parameter (temperature/top_p/top_k) with a 400 invalid_request_error. Every
+# later model — Opus 4.8, the Claude 5 line (fable/mythos/sonnet), and beyond —
+# inherits both behaviors, so we gate on the parsed model version rather than an
+# explicit list. This lets new releases be handled without a code change, and
+# avoids relying on LiteLLM's drop_params (unreliable here, since AnthropicConfig
+# still advertises temperature as supported).
+_ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION = (4, 7)
 
-# Anthropic models that reject any non-default sampling parameter (temperature,
-# top_p, top_k). For these models we must omit these params entirely from the
-# request payload — passing them returns a 400 invalid_request_error. LiteLLM's
-# drop_params is unreliable here because AnthropicConfig still lists temperature
-# as supported. Match on substring to cover proxy/Vertex naming variants (e.g.
-# "claude-4.7-opus" via litellm_proxy).
-_ANTHROPIC_NO_SAMPLING_PARAMS_MODELS = (
-    "claude-opus-4-7",
-    "claude-opus-4.7",
-    "claude-4-7-opus",
-    "claude-4.7-opus",
-    "claude-opus-4-8",
-    "claude-opus-4.8",
-    "claude-4-8-opus",
-    "claude-4.8-opus",
-    "claude-fable-5",
-    "claude-5-fable",
-    "claude-mythos-5",
-    "claude-5-mythos",
-    "claude-sonnet-5",
-    "claude-5-sonnet",
-)
+# Named tiers spanning Claude's naming schemes, including the Claude 5 line whose
+# version digit can precede or follow the tier ("claude-sonnet-5" vs
+# "claude-5-sonnet").
+_ANTHROPIC_MODEL_TIERS = ("opus", "sonnet", "haiku", "fable", "mythos")
+_ANTHROPIC_VERSION_PATTERN = r"\d+(?:[.-]\d+)?"
 
 
 class LLMTimeoutError(Exception):
@@ -277,20 +259,53 @@ def _is_vertex_model_rejecting_output_config(model_name: str) -> bool:
     )
 
 
+def _parse_anthropic_model_version(model_name: str) -> tuple[int, int] | None:
+    """Extract the (major, minor) version from a Claude model name.
+
+    Handles the naming variants that reach LiteLLM: tier-first
+    ("claude-opus-4-8"), version-first ("claude-4-8-opus"), dot-separated
+    ("claude-opus-4.8"), the named Claude 5 tiers ("claude-fable-5",
+    "claude-5-sonnet"), legacy names ("claude-3-5-sonnet-20241022"), and
+    provider-prefixed / date-snapshot forms. Returns None when the name is not a
+    Claude model or carries no parseable version.
+    """
+    name = model_name.lower()
+    if "claude" not in name:
+        return None
+    # Drop any provider prefix (e.g. "anthropic/", "bedrock/anthropic.").
+    name = name[name.index("claude") :]
+    # Drop date/snapshot suffixes ("@20260101", "-20241022") so their digits
+    # can't be mistaken for a version.
+    name = name.split("@")[0]
+    name = re.sub(r"\d{6,}", "", name)
+
+    tier = next((t for t in _ANTHROPIC_MODEL_TIERS if t in name), None)
+    if tier is not None:
+        # The version can sit on either side of the tier depending on scheme.
+        match = re.search(
+            rf"{tier}[.-]?({_ANTHROPIC_VERSION_PATTERN})", name
+        ) or re.search(rf"({_ANTHROPIC_VERSION_PATTERN})[.-]?{tier}", name)
+        version_str = match.group(1) if match else None
+    else:
+        match = re.search(_ANTHROPIC_VERSION_PATTERN, name)
+        version_str = match.group(0) if match else None
+
+    if not version_str:
+        return None
+    parts = re.split(r"[.-]", version_str)
+    major = int(parts[0])
+    minor = int(parts[1]) if len(parts) > 1 else 0
+    return (major, minor)
+
+
 def _anthropic_uses_adaptive_thinking(model_name: str) -> bool:
-    normalized_model_name = model_name.lower()
-    return any(
-        adaptive_model in normalized_model_name
-        for adaptive_model in _ANTHROPIC_ADAPTIVE_THINKING_MODELS
-    )
+    version = _parse_anthropic_model_version(model_name)
+    return version is not None and version >= _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
 
 
 def _anthropic_omits_sampling_params(model_name: str) -> bool:
-    normalized_model_name = model_name.lower()
-    return any(
-        no_sampling_model in normalized_model_name
-        for no_sampling_model in _ANTHROPIC_NO_SAMPLING_PARAMS_MODELS
-    )
+    version = _parse_anthropic_model_version(model_name)
+    return version is not None and version >= _ANTHROPIC_ADAPTIVE_THINKING_MIN_VERSION
 
 
 class LitellmLLM(LLM):

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -22,7 +22,11 @@ from onyx.llm.models import (
     ToolCall,
     UserMessage,
 )
-from onyx.llm.multi_llm import LitellmLLM, temporary_env_and_lock
+from onyx.llm.multi_llm import (
+    LitellmLLM,
+    _parse_anthropic_model_version,
+    temporary_env_and_lock,
+)
 from onyx.llm.utils import get_max_input_tokens
 
 VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG = [
@@ -560,6 +564,50 @@ def test_keeps_temperature_for_older_sonnet_models(model_name: str) -> None:
 
         kwargs = mock_completion.call_args.kwargs
         assert "temperature" in kwargs
+
+
+@pytest.mark.parametrize(
+    "model_name, expected",
+    [
+        # Tier-first, hyphenated
+        ("claude-opus-4-8", (4, 8)),
+        ("claude-opus-4-7", (4, 7)),
+        ("claude-sonnet-4-6", (4, 6)),
+        ("claude-sonnet-4-5", (4, 5)),
+        # Tier-first, dot-separated
+        ("claude-opus-4.8", (4, 8)),
+        ("claude-opus-4.7", (4, 7)),
+        # Version-first (litellm_proxy / reversed schemes)
+        ("claude-4-8-opus", (4, 8)),
+        ("claude-4.8-opus", (4, 8)),
+        ("claude-4-7-opus", (4, 7)),
+        ("claude-4.7-opus", (4, 7)),
+        # Claude 5 named tiers, version digit on either side
+        ("claude-sonnet-5", (5, 0)),
+        ("claude-5-sonnet", (5, 0)),
+        ("claude-fable-5", (5, 0)),
+        ("claude-5-fable", (5, 0)),
+        ("claude-mythos-5", (5, 0)),
+        ("claude-5-mythos", (5, 0)),
+        # Date/snapshot suffixes stripped
+        ("claude-opus-4-8@20260101", (4, 8)),
+        ("claude-sonnet-5@20260203", (5, 0)),
+        ("claude-opus-4-5@20251101", (4, 5)),
+        ("claude-3-5-sonnet-20241022", (3, 5)),
+        # Legacy naming
+        ("claude-3-7-sonnet", (3, 7)),
+        # Provider-prefixed
+        ("anthropic/claude-opus-4-8", (4, 8)),
+        ("bedrock/anthropic.claude-opus-4-7", (4, 7)),
+        # Non-Claude models parse to None
+        ("gpt-5.2", None),
+        ("gemini-2.5-pro", None),
+    ],
+)
+def test_parse_anthropic_model_version(
+    model_name: str, expected: tuple[int, int] | None
+) -> None:
+    assert _parse_anthropic_model_version(model_name) == expected
 
 
 @pytest.mark.parametrize("model_name", VERTEX_OPUS_MODELS_REJECTING_OUTPUT_CONFIG)

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -448,6 +448,9 @@ ANTHROPIC_MODELS_OMITTING_SAMPLING_PARAMS = [
     "claude-sonnet-5",
     "claude-sonnet-5@20260203",
     "claude-5-sonnet",
+    "claude-opus-5",
+    "claude-opus-5@20260101",
+    "claude-5-opus",
 ]
 
 
@@ -485,6 +488,8 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         "claude-5-mythos",
         "claude-sonnet-5",
         "claude-5-sonnet",
+        "claude-opus-5",
+        "claude-5-opus",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Cherry-pick of #12744 (`a99826825d`) to `release/v4.3`, plus a small test commit adding `claude-opus-5` coverage.

The v4.3 line still gates the Claude "omit sampling params" / adaptive-thinking behavior on hardcoded model-name lists. Those lists were extended ad hoc for Sonnet 5 / Fable 5 / Mythos 5 but **Claude Opus 5 was never added**, so deployments on v4.3.x send `temperature` for `claude-opus-5`, and the request fails with a 400 `invalid_request_error` ("'temperature' is deprecated for this model"). Hit by a customer deploying Opus 5 through a custom (Azure AI Foundry) provider — but the bug applies on every provider on this line. #12744 replaces the lists with a parsed `>= (4, 7)` version gate, so Opus 5 and future releases are handled without code changes.

Conflicts resolved: import-style only (both files); no functional divergence.

## How Has This Been Tested?

- `uv run pytest backend/tests/unit/onyx/llm/test_multi_llm.py` on the branch — 119 passed, including the new `claude-opus-5` / `claude-5-opus` parametrizations

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports version-based gating for Anthropic models to v4.3. Claude >= 4.7 (including `claude-opus-5`) now omit sampling params and use adaptive thinking, preventing 400 invalid_request_error across providers.

- **Bug Fixes**
  - Fix requests to `claude-opus-5` and newer by dropping `temperature`/`top_p`/`top_k` and enabling adaptive thinking across naming variants and provider prefixes.

- **Refactors**
  - Replace hardcoded lists with `_parse_anthropic_model_version` and a `(4, 7)` minimum; add unit tests and `claude-opus-5` coverage.

<sup>Written for commit c76f5070181e33716d42879d3ba7de85cc22484d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13445?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




Linear: https://linear.app/onyx-app/issue/CS-80
