### PR TITLE
fix(chat): explain empty attachments to the model instead of silent emptiness

### DIFF
--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -38,6 +38,7 @@ from onyx.db.models import ChatMessage, ChatSession, Persona, User, UserFile
 from onyx.db.models import SearchDoc as DbSearchDoc
 from onyx.db.persona import user_can_access_persona
 from onyx.db.projects import check_project_ownership
+from onyx.db.user_file import get_user_file_by_id
 from onyx.file_processing.extract_file_text import extract_file_text
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType, FileDescriptor
@@ -466,10 +467,7 @@ def load_chat_file(
     user_file: UserFile | None = None
     if user_file_id_str:
         try:
-            user_file_id = UUID(user_file_id_str)
-            user_file = (
-                db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
-            )
+            user_file = get_user_file_by_id(UUID(user_file_id_str), db_session)
         except (ValueError, TypeError) as e:
             logger.warning("Failed to look up user file for %s: %s", file_id, e)
     token_count = user_file.token_count if user_file and user_file.token_count else 0

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -463,7 +463,7 @@ def load_chat_file(
 
     # Look up the UserFile row first (when one exists) — it supplies the token
     # count and tells us whether the user-file worker is still processing.
-    user_file_id_str = file_descriptor.get("user_file_id")
+    user_file_id_str = file_descriptor.get("user_file_id", "")
     user_file: UserFile | None = None
     if user_file_id_str:
         try:

--- a/backend/onyx/chat/chat_utils.py
+++ b/backend/onyx/chat/chat_utils.py
@@ -28,6 +28,7 @@ from onyx.db.chat import (
     get_chat_messages_by_session,
     get_or_create_root_message,
 )
+from onyx.db.enums import UserFileStatus
 from onyx.db.file_record import FileRecordNotFoundError
 from onyx.db.kg_config import (
     get_kg_config_settings,
@@ -68,6 +69,20 @@ class FileContextResult(BaseModel):
     tool_metadata: FileToolMetadata
 
 
+CONTENT_PENDING_NOTICE = (
+    "[This file is still being processed and its contents are not yet "
+    "available. Do not guess what it contains — tell the user the file is "
+    "still processing and to ask again in a moment.]"
+)
+
+CONTENT_UNAVAILABLE_NOTICE = (
+    "[No machine-readable text could be extracted from this file. It is "
+    "likely image-only (e.g. a scanned document) or in an unsupported "
+    "format. Its contents are not available to you — do not guess them. If "
+    "needed, ask the user for a text-based copy.]"
+)
+
+
 def build_file_context(
     tool_file_id: str,
     filename: str,
@@ -75,6 +90,7 @@ def build_file_context(
     content_text: str | None = None,
     token_count: int = 0,
     approx_char_count: int | None = None,
+    content_pending: bool = False,
 ) -> FileContextResult:
     """Build the LLM context representation for a single file.
 
@@ -87,6 +103,20 @@ def build_file_context(
             "Use the file_reader or python tools to access "
             "this file's contents."
         )
+        message = ChatMessageSimple(
+            message=message_text,
+            token_count=max(1, len(message_text) // 4),
+            message_type=MessageType.USER,
+            file_id=tool_file_id,
+        )
+    elif not (content_text or "").strip():
+        # An empty file block gives the model nothing to go on, and it tends
+        # to invent workarounds (search the web for the document, guess its
+        # contents). Say explicitly why there is no content.
+        notice = (
+            CONTENT_PENDING_NOTICE if content_pending else CONTENT_UNAVAILABLE_NOTICE
+        )
+        message_text = f"File: {filename}\n{notice}\nEnd of File"
         message = ChatMessageSimple(
             message=message_text,
             token_count=max(1, len(message_text) // 4),
@@ -373,6 +403,7 @@ def process_kg_commands(
 def _get_or_extract_plaintext(
     file_id: str,
     extract_fn: Callable[[], str],
+    store_on_miss: bool = True,
 ) -> str:
     """Load cached plaintext for a file, or extract and store it.
 
@@ -396,9 +427,12 @@ def _get_or_extract_plaintext(
     # don't get re-fetched from object storage and re-attempted on every
     # subsequent chat turn.  Transient extraction errors surface as raised
     # exceptions, not empty returns, so they propagate without poisoning the
-    # cache.
+    # cache.  Callers pass store_on_miss=False when another writer owns the
+    # canonical plaintext for this key (e.g. the user-file worker, whose
+    # result may include image captions this inline extraction can't produce).
     content_text = extract_fn()
-    store_plaintext(file_id, content_text)
+    if store_on_miss:
+        store_plaintext(file_id, content_text)
     return content_text
 
 
@@ -426,6 +460,24 @@ def load_chat_file(
     file_type = ChatFileType(file_descriptor["type"])
     filename = file_descriptor.get("name")
 
+    # Look up the UserFile row first (when one exists) — it supplies the token
+    # count and tells us whether the user-file worker is still processing.
+    user_file_id_str = file_descriptor.get("user_file_id")
+    user_file: UserFile | None = None
+    if user_file_id_str:
+        try:
+            user_file_id = UUID(user_file_id_str)
+            user_file = (
+                db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
+            )
+        except (ValueError, TypeError) as e:
+            logger.warning("Failed to look up user file for %s: %s", file_id, e)
+    token_count = user_file.token_count if user_file and user_file.token_count else 0
+    content_pending = user_file is not None and user_file.status in (
+        UserFileStatus.PROCESSING,
+        UserFileStatus.INDEXING,
+    )
+
     # Extract text content if it's a text file type (not an image). The
     # cached-plaintext path avoids reading the original bytes on the steady
     # state; only the cache miss branch opens the binary stream.
@@ -444,31 +496,21 @@ def load_chat_file(
         # Use the user_file_id as cache key when available (matches what
         # the celery indexing worker stores), otherwise fall back to the
         # file store id (covers code-interpreter-generated files, etc.).
-        user_file_id_str = file_descriptor.get("user_file_id")
         cache_key = user_file_id_str or file_id
 
         try:
-            content_text = _get_or_extract_plaintext(cache_key, _extract)
+            # While the worker is still processing, don't store the inline
+            # extraction under its key: the worker's canonical plaintext (which
+            # may include image captions) should be what later turns read.
+            content_text = _get_or_extract_plaintext(
+                cache_key, _extract, store_on_miss=not content_pending
+            )
         except Exception as e:
             logger.warning(
                 "Failed to retrieve content for file %s: %s",
                 file_id,
                 str(e),
             )
-
-    # Get token count from UserFile if available
-    token_count = 0
-    user_file_id_str = file_descriptor.get("user_file_id")
-    if user_file_id_str:
-        try:
-            user_file_id = UUID(user_file_id_str)
-            user_file = (
-                db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
-            )
-            if user_file and user_file.token_count:
-                token_count = user_file.token_count
-        except (ValueError, TypeError) as e:
-            logger.warning("Failed to get token count for file %s: %s", file_id, e)
 
     def _load_content() -> bytes:
         # Chat messages keep file references in their JSONB `files` column, but
@@ -504,6 +546,7 @@ def load_chat_file(
         content_text=content_text,
         token_count=token_count,
         loader=_load_content,
+        content_pending=content_pending,
     )
 
 
@@ -700,6 +743,7 @@ def convert_chat_history(
                     file_type=text_file.file_type,
                     content_text=text_file.content_text,
                     token_count=text_file.token_count,
+                    content_pending=text_file.content_pending,
                 )
                 simple_messages.append(ctx.message)
                 all_injected_file_metadata[tool_id] = ctx.tool_metadata

--- a/backend/onyx/chat/models.py
+++ b/backend/onyx/chat/models.py
@@ -99,6 +99,9 @@ class ChatFullResponse(BaseModel):
 class ChatLoadedFile(InMemoryChatFile):
     content_text: str | None
     token_count: int
+    # True while the user-file worker is still processing the file — its
+    # canonical plaintext (e.g. including image captions) doesn't exist yet.
+    content_pending: bool = False
 
     # Named distinctly from the base ``lazy_from_descriptor`` so the subclass
     # can require ``content_text`` / ``token_count`` without violating LSP on
@@ -113,6 +116,7 @@ class ChatLoadedFile(InMemoryChatFile):
         content_text: str | None,
         token_count: int,
         loader: Callable[[], bytes],
+        content_pending: bool = False,
     ) -> "ChatLoadedFile":
         """Construct a ``ChatLoadedFile`` whose ``content`` bytes are loaded
         only on first access. ``content_text`` and ``token_count`` are passed
@@ -127,6 +131,7 @@ class ChatLoadedFile(InMemoryChatFile):
             filename=filename,
             content_text=content_text,
             token_count=token_count,
+            content_pending=content_pending,
         )
         install_lazy_content_loader(inst, loader)
         return inst

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -104,6 +104,10 @@ def update_last_accessed_at_for_user_files(
     db_session.commit()
 
 
+def get_user_file_by_id(user_file_id: UUID, db_session: Session) -> UserFile | None:
+    return db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
+
+
 def get_file_id_by_user_file_id(user_file_id: str, db_session: Session) -> str | None:
     """Resolve a `UserFile.id` to its underlying `FileRecord.file_id`.
 

--- a/backend/onyx/db/user_file.py
+++ b/backend/onyx/db/user_file.py
@@ -104,7 +104,11 @@ def update_last_accessed_at_for_user_files(
     db_session.commit()
 
 
-def get_user_file_by_id(user_file_id: UUID, db_session: Session) -> UserFile | None:
+def get_user_file_by_id(
+    user_file_id: UUID | str, db_session: Session
+) -> UserFile | None:
+    """Fetch a UserFile row by id. Accepts str for callers whose input may not
+    even be a UserFile id (e.g. a storage file_id) — those resolve to None."""
     return db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
 
 
@@ -115,7 +119,7 @@ def get_file_id_by_user_file_id(user_file_id: str, db_session: Session) -> str |
     caller is already passing a storage `file_id`), so the caller can fall
     through to a direct file-store lookup.
     """
-    user_file = db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
+    user_file = get_user_file_by_id(user_file_id, db_session)
     if user_file:
         return user_file.file_id
     return None

--- a/backend/onyx/file_store/utils.py
+++ b/backend/onyx/file_store/utils.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import FileOrigin
 from onyx.db.models import UserFile
+from onyx.db.user_file import get_user_file_by_id
 from onyx.file_store.file_store import get_default_file_store
 from onyx.file_store.models import ChatFileType, FileDescriptor, InMemoryChatFile
 from onyx.server.query_and_chat.chat_utils import mime_type_to_chat_file_type
@@ -90,7 +91,7 @@ def load_chat_file_by_id(file_id: str) -> InMemoryChatFile:
 def load_user_file(file_id: UUID, db_session: Session) -> InMemoryChatFile:
     status = "not_loaded"
 
-    user_file = db_session.query(UserFile).filter(UserFile.id == file_id).first()
+    user_file = get_user_file_by_id(file_id, db_session)
     if not user_file:
         raise ValueError(f"User file with id {file_id} not found")
 
@@ -207,10 +208,7 @@ def get_user_files(
 
     # 1. Fetch UserFile records for specific file IDs
     for user_file_id in user_file_ids:
-        # Query the database for a UserFile with the matching ID
-        user_file = (
-            db_session.query(UserFile).filter(UserFile.id == user_file_id).first()
-        )
+        user_file = get_user_file_by_id(user_file_id, db_session)
         # If found, add it to the list
         if user_file is not None:
             user_files.append(user_file)

--- a/backend/tests/unit/onyx/chat/test_build_file_context.py
+++ b/backend/tests/unit/onyx/chat/test_build_file_context.py
@@ -1,0 +1,74 @@
+"""build_file_context must explain empty files to the model.
+
+An image-only PDF (or a file whose worker-side processing hasn't finished)
+used to be injected as a bare "File: x\n\nEnd of File" block, which led models
+to invent workarounds (web-searching for the document, guessing contents).
+"""
+
+from onyx.chat.chat_utils import (
+    CONTENT_PENDING_NOTICE,
+    CONTENT_UNAVAILABLE_NOTICE,
+    build_file_context,
+)
+from onyx.file_store.models import ChatFileType
+
+
+def test_content_is_injected_verbatim() -> None:
+    result = build_file_context(
+        tool_file_id="abc",
+        filename="doc.pdf",
+        file_type=ChatFileType.DOC,
+        content_text="hello world",
+        token_count=3,
+    )
+    assert "hello world" in result.message.message
+    assert CONTENT_UNAVAILABLE_NOTICE not in result.message.message
+    assert result.message.token_count == 3
+
+
+def test_empty_content_gets_unavailable_notice() -> None:
+    result = build_file_context(
+        tool_file_id="abc",
+        filename="scan.pdf",
+        file_type=ChatFileType.DOC,
+        content_text="",
+        token_count=0,
+    )
+    assert CONTENT_UNAVAILABLE_NOTICE in result.message.message
+    assert result.message.token_count > 0
+
+
+def test_whitespace_only_content_gets_unavailable_notice() -> None:
+    result = build_file_context(
+        tool_file_id="abc",
+        filename="scan.pdf",
+        file_type=ChatFileType.DOC,
+        content_text="  \n\n  ",
+        token_count=0,
+    )
+    assert CONTENT_UNAVAILABLE_NOTICE in result.message.message
+
+
+def test_empty_pending_content_gets_pending_notice() -> None:
+    result = build_file_context(
+        tool_file_id="abc",
+        filename="scan.pdf",
+        file_type=ChatFileType.DOC,
+        content_text=None,
+        token_count=0,
+        content_pending=True,
+    )
+    assert CONTENT_PENDING_NOTICE in result.message.message
+    assert CONTENT_UNAVAILABLE_NOTICE not in result.message.message
+
+
+def test_metadata_only_files_keep_tool_instructions() -> None:
+    result = build_file_context(
+        tool_file_id="abc",
+        filename="sheet.xlsx",
+        file_type=ChatFileType.TABULAR,
+        content_text=None,
+        token_count=0,
+    )
+    assert "file_reader" in result.message.message
+    assert CONTENT_UNAVAILABLE_NOTICE not in result.message.message


### PR DESCRIPTION
## Description

When a user attaches an image-only PDF (e.g. a scanned document) in chat, text extraction yields nothing and the vision captions produced by the user-file worker either don't exist yet (indexing still running) or never will (no vision-capable LLM configured). The model was handed a literally empty file block:

```
File: scan.pdf

End of File
```

with no explanation — and predictably invented workarounds: trying the code interpreter, web-searching for the document by its metadata, or guessing contents. Reported by a customer testing an image-based patent PDF (both Sonnet 4.6 and GPT 5.4 behaved this way).

Two changes:

1. **`build_file_context` explains empty files.** Empty/whitespace-only text files now inject an explicit notice: "still being processed — tell the user to ask again in a moment" while the user-file worker is running (`UserFile.status` PROCESSING/INDEXING), otherwise "no machine-readable text could be extracted... do not guess".
2. **The chat path no longer pre-empts the worker's plaintext cache.** `load_chat_file` extracted inline on cache miss and stored the result under the same key the user-file worker writes its canonical plaintext to (which can include image captions inline extraction can't produce). While the file is still processing, we now extract for the current turn without storing.

Not in scope: actually passing PDF page images to vision-capable chat models (feature gap — the chat LLM only ever sees text for `DOC` files).

## How Has This Been Tested?

- New unit tests: `backend/tests/unit/onyx/chat/test_build_file_context.py`
- `uv run pytest backend/tests/unit/onyx/chat` — 464 passed

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explain empty file attachments in chat so the model stops guessing; instead, it tells users when files are still processing and only reads canonical plaintext once ready. Also prevents caching inline extractions under the worker’s key until processing finishes.

- **Bug Fixes**
  - `build_file_context`: Adds notices for empty/whitespace-only text files — “still processing, ask again soon” while processing; otherwise “no machine-readable text, do not guess.”
  - `load_chat_file`: Checks `UserFile` status, avoids storing inline-extracted plaintext under the worker’s cache key while processing, and threads `content_pending` into the model context.

- **Refactors**
  - Add `get_user_file_by_id` and reuse it across duplicate query sites (`get_file_id_by_user_file_id`, `load_user_file`, `get_user_files`); default `user_file_id` lookup to `""` in chat.

<sup>Written for commit a006efd43a1b97acdcbcbd39ac3bae2f977ccb00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Linear: https://linear.app/onyx-app/issue/CS-32
