### PR TITLE
chore: exclude sharepoint site from tests

### DIFF
--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.secrets(
 )
 
 # NOTE: Sharepoint site for tests is "sharepoint-tests"
+SCALE_TEST_SITE_URL = "https://danswerai.sharepoint.com/sites/OnyxTesting2"
 
 
 @dataclass
@@ -171,9 +172,10 @@ def test_sharepoint_connector_all_sites__docs_only(
         "onyx.connectors.sharepoint.connector.store_image_and_create_section",
         mock_store_image,
     ):
-        # Initialize connector with no sites
         connector = SharepointConnector(
-            include_site_pages=False, include_site_documents=True
+            excluded_sites=[SCALE_TEST_SITE_URL],
+            include_site_pages=False,
+            include_site_documents=True,
         )
 
         # Load credentials
@@ -198,9 +200,10 @@ def test_sharepoint_connector_all_sites__pages_only(
         "onyx.connectors.sharepoint.connector.store_image_and_create_section",
         mock_store_image,
     ):
-        # Initialize connector with no docs
         connector = SharepointConnector(
-            include_site_pages=True, include_site_documents=False
+            excluded_sites=[SCALE_TEST_SITE_URL],
+            include_site_pages=True,
+            include_site_documents=False,
         )
 
         # Load credentials


### PR DESCRIPTION
## Description

Going to be adding a bunch of data to help use perform tests at scale, and don't want it to interact with daily and per-PR connector tests

## How Has This Been Tested?

N/A this is harmless

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the scale-test SharePoint site `https://danswerai.sharepoint.com/sites/OnyxTesting2` from daily and per-PR SharePoint connector tests to prevent interference from large test data. The docs-only and pages-only tests now initialize `SharepointConnector` with `excluded_sites=[SCALE_TEST_SITE_URL]`.

<sup>Written for commit a72670cbf35a2ac77826cd9975e475d4a38e4e1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

