### PR TITLE
fix(web): separate slider captions from tick labels in model selector

### DIFF
--- a/web/src/sections/model-selector/ModelSelectorContent.tsx
+++ b/web/src/sections/model-selector/ModelSelectorContent.tsx
@@ -235,13 +235,25 @@ function SettingRow({
 }: SettingRowProps) {
   return (
     <Disabled disabled={disabled} tooltip={disabledTooltip} tooltipSide="top">
-      <div className="flex flex-col rounded-08 p-1.5">
-        <div className="flex flex-row items-center gap-2">
-          <div className="flex size-5 items-center justify-center text-text-04">
-            <Icon size={16} />
-          </div>
-          <Text font="main-ui-action">{title}</Text>
-          <div className="flex-1" />
+      <Section
+        alignItems="stretch"
+        height="auto"
+        gap={0}
+        padding={0.375}
+        className="rounded-08"
+      >
+        <Section
+          flexDirection="row"
+          justifyContent="between"
+          height="auto"
+          gap={0.5}
+        >
+          <Section flexDirection="row" width="fit" height="auto" gap={0.5}>
+            <Section width={1.25} height={1.25} className="text-text-04">
+              <Icon size={16} />
+            </Section>
+            <Text font="main-ui-action">{title}</Text>
+          </Section>
           {value !== undefined && (
             <Tooltip tooltip={valueTooltip} side="top">
               <Text font="secondary-mono" color="text-04">
@@ -249,12 +261,14 @@ function SettingRow({
               </Text>
             </Tooltip>
           )}
-        </div>
+        </Section>
         {children}
-        <Text font="secondary-body" color="text-03">
-          {caption}
-        </Text>
-      </div>
+        <Section alignItems="stretch" height="auto" className="mt-2">
+          <Text font="secondary-body" color="text-03">
+            {caption}
+          </Text>
+        </Section>
+      </Section>
     </Disabled>
   );
 }


### PR DESCRIPTION
## Description

In the model selector detail pane, the caption under each slider ("How much thinking the model should perform before answering") sits flush against the slider's tick labels, so the two read as one block of text. Same defect on the Temperature row.

Fix in `SettingRow`: the caption gets 0.5rem of top separation, so tick labels stay attached to their slider and the caption reads as a footnote. The row's raw layout divs are converted to Opal `Section` (which also drops the flex spacer div). Spacing was tuned against the live rendered pane. A uniform container gap overflows the fixed-height pane, so the single seam under the row content is deliberate.

## How Has This Been Tested?

- Previewed the exact spacing on the live rendered pane via injected styles and compared before/after:

| Before | After |
|---|---|
| ![before](https://github.com/user-attachments/assets/298e803e-4630-447e-a28f-3451e6c2d8bb) | ![after](https://github.com/user-attachments/assets/5f873a56-6f4e-41db-bfee-a27cd3ebe8a1) |

- `bun run types:check` exit 0, `oxlint` clean, pre-commit (oxfmt, oxlint, tsc) passed on the changed file.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
