### PR TITLE
test(craft): cover config reconciliation on session reuse

### DIFF
--- a/backend/tests/common/craft/stubs.py
+++ b/backend/tests/common/craft/stubs.py
@@ -35,6 +35,8 @@ payload snapshots so tests assert observable manager outcomes:
   ``last_cleanup_session_workspace_payload``,
   ``last_restore_snapshot_payload``, ``last_send_message_payload``,
   ``last_write_sandbox_file_payload``, ``last_write_files_to_sandbox_payload``.
+- ``session_runtime_call_order`` records config regeneration, instance disposal,
+  and session prewarming in invocation order.
 
 Usage
 -----
@@ -206,6 +208,7 @@ class StubSandboxManager(SandboxManager):
         self.health_check_count: int = 0
         self.ensure_opencode_session_count: int = 0
         self.last_ensure_opencode_session_payload: dict[str, Any] | None = None
+        self.session_runtime_call_order: list[str] = []
         self.send_message_count: int = 0
         self.subscribe_to_opencode_session_count: int = 0
         self.list_directory_count: int = 0
@@ -350,6 +353,7 @@ class StubSandboxManager(SandboxManager):
         llm_config: CraftLLMProviderConfig | None = None,
         mcp_servers: Sequence[CraftMCPServerConfig] = (),
     ) -> None:
+        self.session_runtime_call_order.append("regenerate_session_config")
         self.regenerate_session_config_count += 1
         self.last_regenerate_session_config_payload = {
             "sandbox_id": sandbox_id,
@@ -488,6 +492,7 @@ class StubSandboxManager(SandboxManager):
         sandbox_id: UUID,
         session_id: UUID,
     ) -> None:
+        self.session_runtime_call_order.append("dispose_opencode_instance")
         self.dispose_opencode_instance_count += 1
         self.last_dispose_opencode_instance_payload = {
             "sandbox_id": sandbox_id,
@@ -506,6 +511,7 @@ class StubSandboxManager(SandboxManager):
     ) -> str | None:
         # Override the real _ServeMixin preflight (which POSTs /session over
         # HTTP to a pod) so send_message tests run fully in-memory.
+        self.session_runtime_call_order.append("ensure_opencode_session")
         self.ensure_opencode_session_count += 1
         self.last_ensure_opencode_session_payload = {
             "sandbox_id": sandbox_id,

--- a/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
+++ b/backend/tests/external_dependency_unit/craft/test_mcp_config_resolution.py
@@ -1,4 +1,4 @@
-"""External-dependency-unit tests for `resolve_craft_mcp_servers`.
+"""External-dependency-unit tests for ``resolve_craft_mcp_servers``.
 
 Verifies the DB → opencode-config-input step: only craft-enabled servers the
 user may access *and the proxy can authenticate them against* are emitted, tools

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -295,6 +295,8 @@ class TestEmptySessionReuse:
             "refreshed-opencode-session"
         )
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        stub_sandbox_manager.regenerate_session_config_silent = True
+        stub_sandbox_manager.dispose_opencode_instance_silent = True
 
         sm = session_manager_with_stub
         result = sm.get_or_create_empty_session(user_id=test_user.id)
@@ -303,6 +305,11 @@ class TestEmptySessionReuse:
 
         assert result.id == existing_empty.id
         assert result.opencode_session_id == "refreshed-opencode-session"
+        assert stub_sandbox_manager.regenerate_session_config_count == 1
+        assert stub_sandbox_manager.last_dispose_opencode_instance_payload == {
+            "sandbox_id": sandbox_row.id,
+            "session_id": existing_empty.id,
+        }
         assert stub_sandbox_manager.last_ensure_opencode_session_payload == {
             "sandbox_id": sandbox_row.id,
             "session_id": existing_empty.id,

--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -294,6 +294,7 @@ class TestEmptySessionReuse:
         stub_sandbox_manager.ensure_opencode_session_returns = (
             "refreshed-opencode-session"
         )
+        stub_sandbox_manager.read_file_returns = b"{}"
         stub_sandbox_manager.write_files_to_sandbox_silent = True
         stub_sandbox_manager.regenerate_session_config_silent = True
         stub_sandbox_manager.dispose_opencode_instance_silent = True
@@ -315,6 +316,11 @@ class TestEmptySessionReuse:
             "session_id": existing_empty.id,
             "opencode_session_id": "stale-opencode-session",
         }
+        assert stub_sandbox_manager.session_runtime_call_order == [
+            "regenerate_session_config",
+            "dispose_opencode_instance",
+            "ensure_opencode_session",
+        ]
         # No new sandbox was provisioned, and only one BuildSession row exists
         # for this user.
         rows = (


### PR DESCRIPTION
## Description

Updates the empty-session reuse lifecycle test for the gateway configuration reconciliation added to the production reuse path. The strict sandbox stub now explicitly permits session config regeneration and OpenCode instance disposal, and the test asserts that both operations occur before the existing session is prewarmed.

This fixes the external dependency unit failure caused by the test's stale stub contract while preserving strict behavior for unconfigured sandbox operations.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand the empty-session reuse test to cover gateway config reconciliation and assert the exact order: regenerate, dispose, then ensure. Add `session_runtime_call_order` to the strict stub, assert one regeneration and the expected dispose/ensure payloads, and move MCP config resolution tests off the legacy path to fix the stale-stub external-dependency failure.

<sup>Written for commit 13249652a01c49122c67aa71ffd8b6041ce9eaf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

