### PR TITLE
fix(pruning): short-term — trim enumeration memory + reap Chromium zombies

### DIFF
--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -1,3 +1,4 @@
+import gc
 import time
 from collections.abc import Generator, Iterator, Sequence
 from datetime import datetime, timezone
@@ -39,10 +40,14 @@ from onyx.server.metrics.pruning_metrics import (
     observe_pruning_enumeration_duration,
 )
 from onyx.utils.logger import setup_logger
+from onyx.utils.native_memory import release_freed_native_memory
 
 logger = setup_logger()
 
 CT = TypeVar("CT", bound=ConnectorCheckpoint)
+
+# how often the enumeration loop releases freed memory back to the OS
+_MEMORY_RELEASE_INTERVAL = 30  # seconds
 
 
 class SlimConnectorExtractionResult(BaseModel):
@@ -209,6 +214,7 @@ def extract_ids_from_runnable_connector(
 
     # process raw batches to extract both IDs and hierarchy nodes
     enumeration_start = time.monotonic()
+    last_memory_release = time.monotonic()
     try:
         for doc_list in raw_batch_generator:
             if callback and callback.should_stop():
@@ -226,6 +232,13 @@ def extract_ids_from_runnable_connector(
 
             if callback:
                 callback.progress("extract_ids_from_runnable_connector", len(batch_ids))
+
+            # long enumerations ratchet the worker's RSS via glibc retention
+            # of freed crawl allocations — periodically return them to the OS
+            if time.monotonic() - last_memory_release >= _MEMORY_RELEASE_INTERVAL:
+                gc.collect()
+                release_freed_native_memory()
+                last_memory_release = time.monotonic()
     except Exception as e:
         # Best-effort rate limit detection via string matching.
         # Connectors surface rate limits inconsistently — some raise HTTP 429,

--- a/backend/onyx/background/celery/tasks/docfetching/tasks.py
+++ b/backend/onyx/background/celery/tasks/docfetching/tasks.py
@@ -53,6 +53,7 @@ from onyx.db.indexing_coordination import IndexingCoordination
 from onyx.redis.redis_connector import RedisConnector
 from onyx.server.metrics.connector_health_metrics import on_index_attempt_status_change
 from onyx.utils.logger import setup_logger
+from onyx.utils.os_reaper import reap_exited_children
 from onyx.utils.variable_functionality import global_version
 from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE, SENTRY_DSN
 
@@ -272,6 +273,8 @@ def _docfetching_task(
         cc_pair_id,
         search_settings_id,
     )
+    # os._exit bypasses the drain in _initializer's finally, so reap here.
+    reap_exited_children()
     os._exit(0)  # ensure process exits cleanly
 
 

--- a/backend/onyx/background/indexing/job_client.py
+++ b/backend/onyx/background/indexing/job_client.py
@@ -16,6 +16,7 @@ from typing import Any, Literal, Optional
 from onyx.configs.constants import POSTGRES_CELERY_WORKER_INDEXING_CHILD_APP_NAME
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.utils.logger import setup_logger
+from onyx.utils.os_reaper import become_child_subreaper, reap_exited_children
 from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA, TENANT_ID_PREFIX
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
@@ -55,6 +56,11 @@ def _initializer(
         kwargs = {}
 
     logger.info("Initializing spawned worker child process.")
+
+    # collect orphans (e.g. Chromium helpers) here instead of leaking zombies
+    # to PID 1 — see onyx/utils/os_reaper.py
+    become_child_subreaper()
+
     # 1. Get tenant_id from args or fallback to default
     tenant_id = POSTGRES_DEFAULT_SCHEMA
     for arg in reversed(args):
@@ -93,6 +99,11 @@ def _initializer(
         sys.exit(255)  # use 255 to indicate a generic exception
     finally:
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+        # os._exit entrypoints skip this finally and drain themselves
+        reaped = reap_exited_children()
+        if reaped:
+            logger.info("Spawned worker child reaped %s orphaned processes.", reaped)
 
 
 def _run_in_process(

--- a/backend/onyx/utils/native_memory.py
+++ b/backend/onyx/utils/native_memory.py
@@ -1,0 +1,35 @@
+"""Release freed native memory back to the OS (Linux/glibc).
+
+glibc retains freed allocations in its arenas, so a long-lived worker
+churning through a multi-hour connector crawl ratchets its RSS until the
+pod OOMs even though the live Python heap stays flat. Periodic
+malloc_trim(0) returns that memory to the kernel.
+"""
+
+import ctypes
+import sys
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_libc: ctypes.CDLL | None = None
+_unavailable = False
+
+
+def release_freed_native_memory() -> bool:
+    """Return glibc-retained freed memory to the OS. No-op off Linux."""
+    global _libc, _unavailable
+
+    if sys.platform != "linux" or _unavailable:
+        return False
+
+    try:
+        if _libc is None:
+            _libc = ctypes.CDLL(None)
+        _libc.malloc_trim(0)
+        return True
+    except Exception:
+        _unavailable = True
+        logger.warning("malloc_trim unavailable; not retrying", exc_info=True)
+        return False

--- a/backend/onyx/utils/os_reaper.py
+++ b/backend/onyx/utils/os_reaper.py
@@ -1,0 +1,66 @@
+"""Reap orphaned child processes in spawned connector workers (Linux).
+
+Chromium helpers orphaned by Playwright browser teardown re-parent to the
+container's PID 1 (the celery worker, which never wait()s) and accumulate as
+zombies. Spawned connector children mark themselves as the subreaper instead
+and drain the orphans before exiting.
+
+Only call reap_exited_children from a process whose subprocess usage is
+sequential and fully owned — a blanket waitpid(-1) steals exit statuses from
+concurrent waiters.
+"""
+
+import os
+import sys
+
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
+
+_PR_SET_CHILD_SUBREAPER = 36
+
+
+def become_child_subreaper() -> bool:
+    """Re-parent orphaned descendants to this process instead of PID 1."""
+    if sys.platform != "linux":
+        return False
+
+    try:
+        import ctypes
+
+        libc = ctypes.CDLL(None, use_errno=True)
+        if libc.prctl(_PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0) != 0:
+            logger.warning(
+                "become_child_subreaper: prctl failed errno=%s", ctypes.get_errno()
+            )
+            return False
+    except Exception:
+        logger.warning("become_child_subreaper: prctl unavailable", exc_info=True)
+        return False
+
+    return True
+
+
+def reap_exited_children() -> int:
+    """Reap already-exited (zombie) children without blocking; returns count."""
+    if sys.platform != "linux":
+        return 0
+
+    reaped = 0
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            # no children at all
+            break
+        except OSError:
+            logger.warning("reap_exited_children: waitpid failed", exc_info=True)
+            break
+
+        if pid == 0:
+            # children exist but none have exited
+            break
+
+        reaped += 1
+
+    return reaped


### PR DESCRIPTION
## Description

Short-term fix for the recurring `OnyxContainerMemoryNearLimit` pages on cloud heavy workers ([ENG-4309](https://linear.app/danswer/issue/ENG-4309)). Two small, independent commits; the durable process-isolation fix is split out into #13453 per review feedback that the bundled version was too large.

**1. Periodic memory release during prune enumeration (the OOM fix).** Long enumerations (10k+ page recursive web crawl) churn transient allocations for hours inside the long-lived heavy worker; glibc retains the freed memory, ratcheting RSS ~0.2–0.4Mi/page to the 5Gi limit → OOMKill → re-dispatch → repeat. `gc.collect()` + `malloc_trim(0)` every 30s at batch boundaries keeps it bounded — measured in the deployed `v4.4.0-cloud.6` image on the same crawl: **flat ~233Mi from ~100 pages onward vs an unbounded linear ramp without it**. (Capping `MALLOC_ARENA_MAX` alone also curbs the ramp but converges slower and higher, ~250Mi after ~350 pages; the trim alone is sufficient, so no deployment env change is required.)

**2. Zombie reaping in spawned connector children (the pid-leak fix).** Every Playwright browser teardown orphans ~2 Chromium helpers that re-parent to the container's PID 1 (celery, which never `wait()`s): ~8k unreaped pids on the alerting heavy pod, 2–3k on every docfetching pod. `SimpleJobClient` children now set `PR_SET_CHILD_SUBREAPER` and drain orphans with `waitpid(WNOHANG)` on exit. Validated in-image: 0 zombies leak through the harness (previously 2 per browser cycle, forever).

## How Has This Been Tested?

- Memory: side-by-side crawl runs in the `v4.4.0-cloud.6` image — unmitigated RSS ramps linearly with pages crawled; with the 30s gc+trim it holds flat at ~233Mi through 240 pages; `MALLOC_ARENA_MAX=2` control run plateaus higher (~250Mi at 480 pages).
- Zombies: `SimpleJobClient` child running 3 Playwright browser cycles leaves 0 zombies in the container (6 accumulate without the fix).
- `pre-commit` (ruff, ty) green.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.