### PR TITLE
fix(test): configure regenerate/dispose stubs in empty-session reuse test

### DIFF
--- a/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
+++ b/backend/tests/external_dependency_unit/craft/test_session_lifecycle.py
@@ -295,6 +295,10 @@ class TestEmptySessionReuse:
             "refreshed-opencode-session"
         )
         stub_sandbox_manager.write_files_to_sandbox_silent = True
+        # Session reuse regenerates the sandbox config and disposes the stale
+        # opencode instance (gateway routing, #13249).
+        stub_sandbox_manager.regenerate_session_config_silent = True
+        stub_sandbox_manager.dispose_opencode_instance_silent = True
 
         sm = session_manager_with_stub
         result = sm.get_or_create_empty_session(user_id=test_user.id)


### PR DESCRIPTION
## Description

`external-dependency-unit-tests (craft)` is red on main (last 3 runs) and failing every open PR:

```
NotImplementedError: StubSandboxManager.regenerate_session_config not configured for this test
```

Since #13249 (Craft gateway routing), the empty-session **reuse** path in `SessionManager.get_or_create_empty_session` regenerates the sandbox session config and then disposes the stale opencode instance. `test_empty_session_reused_when_sandbox_healthy_and_workspace_exists` seeds a session with a stale opencode id, so both calls fire — and the stub was configured for neither. Sets `regenerate_session_config_silent` and `dispose_opencode_instance_silent`, matching the stub's intended usage.

## How Has This Been Tested?

Local external-dependency runs are blocked by an unrelated local-DB migration issue, so verification is by code-path reading (`session/manager.py` reuse block calls regenerate → dispose) plus this shard's CI on this PR.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix failing craft external-dependency test by enabling regenerate/dispose stubs in the empty-session reuse path. Aligns the test with current session reuse behavior and unblocks CI.

- **Bug Fixes**
  - Set `stub_sandbox_manager.regenerate_session_config_silent = True` and `stub_sandbox_manager.dispose_opencode_instance_silent = True` in `test_empty_session_reused_when_sandbox_healthy_and_workspace_exists`.
  - Matches the flow where session reuse regenerates the sandbox config and disposes the stale opencode instance.

<sup>Written for commit b2cc764d7d1a6b970e0877f9c9ea2b01226bd8fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13452?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

