### PR TITLE
fix(pruning): run connector enumeration in a spawned child process

### DIFF
--- a/backend/onyx/background/celery/celery_utils.py
+++ b/backend/onyx/background/celery/celery_utils.py
@@ -35,10 +35,6 @@ from onyx.file_store.staging import (
 )
 from onyx.httpx.httpx_pool import HttpxPool
 from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
-from onyx.server.metrics.pruning_metrics import (
-    inc_pruning_rate_limit_error,
-    observe_pruning_enumeration_duration,
-)
 from onyx.utils.logger import setup_logger
 from onyx.utils.native_memory import release_freed_native_memory
 
@@ -212,8 +208,10 @@ def extract_ids_from_runnable_connector(
         else lambda x: x
     )
 
-    # process raw batches to extract both IDs and hierarchy nodes
-    enumeration_start = time.monotonic()
+    # process raw batches to extract both IDs and hierarchy nodes.
+    # NOTE: Prometheus metrics (enumeration duration, rate limit errors) are
+    # emitted by the pruning parent task — this function runs in a spawned
+    # child whose metric registry is never scraped.
     last_memory_release = time.monotonic()
     try:
         for doc_list in raw_batch_generator:
@@ -239,24 +237,10 @@ def extract_ids_from_runnable_connector(
                 gc.collect()
                 release_freed_native_memory()
                 last_memory_release = time.monotonic()
-    except Exception as e:
-        # Best-effort rate limit detection via string matching.
-        # Connectors surface rate limits inconsistently — some raise HTTP 429,
-        # some use SDK-specific exceptions (e.g. google.api_core.exceptions.ResourceExhausted)
-        # that may or may not include "rate limit" or "429" in the message.
-        # TODO(Bo): replace with a standard ConnectorRateLimitError exception that all
-        # connectors raise when rate limited, making this check precise.
-        error_str = str(e)
-        if "rate limit" in error_str.lower() or "429" in error_str:
-            inc_pruning_rate_limit_error(connector_type)
-        raise
     finally:
         delete_files_best_effort(
             staged_csv_ids,
             context=f"pruning-id-enumeration cleanup ({connector_type})",
-        )
-        observe_pruning_enumeration_duration(
-            time.monotonic() - enumeration_start, connector_type
         )
 
     return SlimConnectorExtractionResult(

--- a/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
+++ b/backend/onyx/background/celery/tasks/pruning/enumeration_spawn.py
@@ -1,0 +1,226 @@
+"""Run pruning's connector enumeration in a spawned child process.
+
+Multi-hour enumerations ratchet the long-lived heavy worker's RSS until the
+pod OOMs; running them in an ephemeral child (mirroring docfetching's
+`SimpleJobClient` pattern) lets the OS reclaim everything at child exit.
+The celery task acts as the watchdog (owns the redis lock/fence, kills the
+child on stop or timeout); the child returns its result through a JSON file,
+schema-validated on read (an mp queue can deadlock on multi-MB payloads).
+Prometheus metrics are emitted by the parent — the child's registry is never
+scraped.
+"""
+
+import os
+import tempfile
+import time
+from collections.abc import Callable
+from pathlib import Path
+
+from onyx.background.celery.celery_utils import (
+    SlimConnectorExtractionResult,
+    extract_ids_from_runnable_connector,
+)
+from onyx.background.indexing.job_client import SimpleJob, SimpleJobClient
+from onyx.configs.app_configs import JOB_TIMEOUT
+from onyx.connectors.factory import instantiate_connector
+from onyx.connectors.models import InputType
+from onyx.db.connector_credential_pair import get_connector_credential_pair
+from onyx.db.engine.sql_engine import get_session_with_current_tenant
+from onyx.indexing.indexing_heartbeat import IndexingHeartbeatInterface
+from onyx.redis.redis_connector import RedisConnector
+from onyx.utils.logger import pruning_ctx, setup_logger
+from onyx.utils.os_reaper import reap_exited_children
+from shared_configs.configs import SENTRY_CELERY_TRACES_SAMPLE_RATE, SENTRY_DSN
+
+logger = setup_logger()
+
+# how long the watchdog waits on the child between liveness checks
+_WATCHDOG_POLL_SECONDS = 5
+
+# how often the watchdog reacquires the pruning redis lock
+_LOCK_REACQUIRE_INTERVAL_SECONDS = 60
+
+# grace period for the child to exit after SIGTERM before SIGKILL
+_TERMINATE_GRACE_SECONDS = 10
+
+
+class PruneEnumerationError(RuntimeError):
+    """Raised when the spawned enumeration child fails, is stopped, or times out."""
+
+
+class SpawnedPruneCallback(IndexingHeartbeatInterface):
+    """Child-side heartbeat: liveness, stop fence, and orphan reaping.
+
+    The parent watchdog owns the redis lock and enforces the timeout by
+    killing this process. A raise out of the enumeration (stop fence, crawl
+    error) means no result file is written — a partial enumeration can never
+    be mistaken for a complete one.
+    """
+
+    def __init__(self, redis_connector: RedisConnector):
+        super().__init__()
+        self.redis_connector = redis_connector
+
+    def should_stop(self) -> bool:
+        return bool(self.redis_connector.stop.fenced)
+
+    def progress(self, tag: str, amount: int) -> None:  # noqa: ARG002
+        self.redis_connector.prune.set_active()
+        reap_exited_children()
+
+
+def pruning_enumeration_task(
+    result_path: str,
+    cc_pair_id: int,
+    connector_id: int,
+    credential_id: int,
+    tenant_id: str,
+) -> None:
+    """Entrypoint of the spawned enumeration child process.
+
+    Instantiates the connector from the DB, enumerates all document IDs and
+    hierarchy nodes, and writes the pickled `SlimConnectorExtractionResult`
+    to `result_path` (atomically, via rename). Exits 0 on success.
+    """
+    # Spawned via SimpleJobClient, so init Sentry ourselves (mirrors
+    # _docfetching_task).
+    if SENTRY_DSN:
+        from onyx.configs.sentry import init_sentry
+
+        init_sentry(traces_sample_rate=SENTRY_CELERY_TRACES_SAMPLE_RATE)
+
+    pruning_ctx_dict = pruning_ctx.get()
+    pruning_ctx_dict["cc_pair_id"] = cc_pair_id
+    pruning_ctx.set(pruning_ctx_dict)
+
+    logger.info(
+        "Pruning enumeration child starting: tenant=%s cc_pair=%s",
+        tenant_id,
+        cc_pair_id,
+    )
+
+    redis_connector = RedisConnector(tenant_id, cc_pair_id)
+
+    with get_session_with_current_tenant() as db_session:
+        cc_pair = get_connector_credential_pair(
+            db_session=db_session,
+            connector_id=connector_id,
+            credential_id=credential_id,
+        )
+        if not cc_pair:
+            raise RuntimeError(f"cc_pair not found for {connector_id} {credential_id}")
+
+        connector_type = cc_pair.connector.source.value
+        runnable_connector = instantiate_connector(
+            db_session,
+            cc_pair.connector.source,
+            InputType.SLIM_RETRIEVAL,
+            cc_pair.connector.connector_specific_config,
+            cc_pair.credential,
+        )
+    # session closed here — no DB connection held during the crawl
+
+    callback = SpawnedPruneCallback(redis_connector)
+
+    extraction_result = extract_ids_from_runnable_connector(
+        runnable_connector, callback, connector_type=connector_type
+    )
+
+    tmp_path = f"{result_path}.tmp"
+    with open(tmp_path, "w", encoding="utf-8") as f:
+        f.write(extraction_result.model_dump_json())
+    os.replace(tmp_path, result_path)
+
+    logger.info(
+        "Pruning enumeration child finished: cc_pair=%s num_docs=%s num_hierarchy_nodes=%s",
+        cc_pair_id,
+        len(extraction_result.raw_id_to_parent),
+        len(extraction_result.hierarchy_nodes),
+    )
+
+    # reap Playwright orphans, then exit hard — os._exit skips
+    # _initializer's finally (mirrors _docfetching_task)
+    reap_exited_children()
+    os._exit(0)
+
+
+def run_enumeration_in_subprocess(
+    cc_pair_id: int,
+    connector_id: int,
+    credential_id: int,
+    tenant_id: str,
+    redis_connector: RedisConnector,
+    reacquire_lock: Callable[[], object],
+) -> SlimConnectorExtractionResult:
+    """Spawn the enumeration child and babysit it until it produces a result.
+
+    `reacquire_lock` is invoked periodically so the parent task's redis lock
+    does not expire during multi-hour enumerations.
+    Raises PruneEnumerationError on child failure, stop signal, or timeout.
+    """
+    result_path = Path(tempfile.gettempdir()) / (
+        f"onyx_prune_enum_{os.getpid()}_{cc_pair_id}_{time.monotonic_ns()}.json"
+    )
+
+    client = SimpleJobClient(n_workers=1)
+    job: SimpleJob | None = client.submit(
+        pruning_enumeration_task,
+        str(result_path),
+        cc_pair_id,
+        connector_id,
+        credential_id,
+        tenant_id,
+    )
+    if job is None or job.process is None:
+        raise PruneEnumerationError(
+            f"Failed to spawn pruning enumeration child: cc_pair={cc_pair_id}"
+        )
+
+    logger.info(
+        "Pruning enumeration child spawned: cc_pair=%s pid=%s",
+        cc_pair_id,
+        job.process.pid,
+    )
+
+    start = time.monotonic()
+    last_lock_reacquire = start
+    try:
+        while True:
+            job.process.join(timeout=_WATCHDOG_POLL_SECONDS)
+            if not job.process.is_alive():
+                break
+
+            now = time.monotonic()
+
+            if now - last_lock_reacquire >= _LOCK_REACQUIRE_INTERVAL_SECONDS:
+                reacquire_lock()
+                last_lock_reacquire = now
+
+            if redis_connector.stop.fenced:
+                raise PruneEnumerationError(
+                    f"Pruning enumeration stopped by signal: cc_pair={cc_pair_id}"
+                )
+
+            # NOTE: celery's time limits don't work with thread pools, so the
+            # watchdog is the timeout enforcement for the enumeration
+            if now - start > JOB_TIMEOUT:
+                raise PruneEnumerationError(
+                    f"Pruning enumeration timed out: cc_pair={cc_pair_id} "
+                    f"timeout={JOB_TIMEOUT}s"
+                )
+
+        if job.process.exitcode == 0 and result_path.exists():
+            return SlimConnectorExtractionResult.model_validate_json(
+                result_path.read_text(encoding="utf-8")
+            )
+
+        raise PruneEnumerationError(
+            f"Pruning enumeration child failed: cc_pair={cc_pair_id} "
+            f"exit_code={job.process.exitcode} exception={job.exception()}"
+        )
+    finally:
+        # never leave a live child behind — this also covers exits caused by
+        # the watchdog itself failing (e.g. a lock reacquisition error)
+        job.terminate_and_wait(_TERMINATE_GRACE_SECONDS)
+        result_path.unlink(missing_ok=True)
+        Path(f"{result_path}.tmp").unlink(missing_ok=True)

--- a/backend/onyx/background/celery/tasks/pruning/tasks.py
+++ b/backend/onyx/background/celery/tasks/pruning/tasks.py
@@ -18,9 +18,11 @@ from onyx.background.celery.celery_redis import (
     celery_get_queued_task_ids,
     celery_get_unacked_task_ids,
 )
-from onyx.background.celery.celery_utils import extract_ids_from_runnable_connector
 from onyx.background.celery.tasks.beat_schedule import CLOUD_BEAT_MULTIPLIER_DEFAULT
-from onyx.background.celery.tasks.docprocessing.utils import IndexingCallbackBase
+from onyx.background.celery.tasks.pruning.enumeration_spawn import (
+    PruneEnumerationError,
+    run_enumeration_in_subprocess,
+)
 from onyx.configs.app_configs import ALLOW_SIMULTANEOUS_PRUNING, JOB_TIMEOUT
 from onyx.configs.constants import (
     CELERY_GENERIC_BEAT_LOCK_TIMEOUT,
@@ -35,9 +37,6 @@ from onyx.configs.constants import (
     OnyxRedisLocks,
     OnyxRedisSignals,
 )
-from onyx.connectors.factory import instantiate_connector
-from onyx.connectors.interfaces import BaseConnector
-from onyx.connectors.models import InputType
 from onyx.db.connector import mark_ccpair_as_pruned
 from onyx.db.connector_credential_pair import (
     get_connector_credential_pair,
@@ -83,7 +82,11 @@ from onyx.redis.redis_hierarchy import (
 from onyx.redis.redis_pool import get_redis_client, get_redis_replica_client
 from onyx.redis.redis_tenant_work_gating import maybe_mark_tenant_active
 from onyx.redis.tenant_redis_client import TenantRedisClient
-from onyx.server.metrics.pruning_metrics import observe_pruning_diff_duration
+from onyx.server.metrics.pruning_metrics import (
+    inc_pruning_rate_limit_error,
+    observe_pruning_diff_duration,
+    observe_pruning_enumeration_duration,
+)
 from onyx.server.runtime.onyx_runtime import OnyxRuntime
 from onyx.server.utils import make_short_id
 from onyx.utils.logger import (
@@ -131,12 +134,6 @@ def _get_fence_validation_block_expiration() -> int:
         beat_multiplier = CLOUD_BEAT_MULTIPLIER_DEFAULT
 
     return int(base_expiration * beat_multiplier)
-
-
-class PruneCallback(IndexingCallbackBase):
-    def progress(self, tag: str, amount: int) -> None:
-        self.redis_connector.prune.set_active()
-        super().progress(tag, amount)
 
 
 def _resolve_and_update_document_parents(
@@ -562,13 +559,12 @@ def connector_pruning_generator_task(
         return None
 
     try:
-        # Session 1: pre-enumeration — load cc_pair and instantiate the connector.
+        # Session 1: pre-enumeration — load cc_pair metadata and update the fence.
         # The session is closed before enumeration so the DB connection is not held
-        # open during the 10–30+ minute connector crawl.
+        # open during the multi-hour connector crawl.
         connector_source: DocumentSource | None = None
         connector_type: str = ""
         is_connector_public: bool = False
-        runnable_connector: BaseConnector | None = None
 
         with get_session_with_current_tenant() as db_session:
             cc_pair = get_connector_credential_pair(
@@ -602,28 +598,35 @@ def connector_pruning_generator_task(
             task_logger.info(
                 f"Pruning generator running connector: cc_pair={cc_pair_id} connector_source={connector_source}"
             )
-
-            runnable_connector = instantiate_connector(
-                db_session,
-                connector_source,
-                InputType.SLIM_RETRIEVAL,
-                cc_pair.connector.connector_specific_config,
-                cc_pair.credential,
-            )
         # Session 1 closed here — connection released before enumeration.
 
-        callback = PruneCallback(
-            0,
-            redis_connector,
-            lock,
-            r,
-            timeout_seconds=JOB_TIMEOUT,
-        )
-
-        # Extract docs and hierarchy nodes from the source (no DB session held).
-        extraction_result = extract_ids_from_runnable_connector(
-            runnable_connector, callback, connector_type=connector_type
-        )
+        # Enumerate source doc IDs in a spawned child process so the crawl's
+        # memory churn is reclaimed by the OS instead of ratcheting up this
+        # long-lived worker's RSS (see enumeration_spawn.py). This task
+        # babysits the child: it keeps the redis lock alive and kills the
+        # child on stop signals or timeout.
+        enumeration_start = time.monotonic()
+        try:
+            extraction_result = run_enumeration_in_subprocess(
+                cc_pair_id=cc_pair_id,
+                connector_id=connector_id,
+                credential_id=credential_id,
+                tenant_id=tenant_id,
+                redis_connector=redis_connector,
+                reacquire_lock=lock.reacquire,
+            )
+        except PruneEnumerationError as e:
+            # Best-effort rate limit detection via string matching on the
+            # child's exception text (the child's own Prometheus registry
+            # dies with it, so the metric must be emitted here).
+            error_str = str(e)
+            if "rate limit" in error_str.lower() or "429" in error_str:
+                inc_pruning_rate_limit_error(connector_type)
+            raise
+        finally:
+            observe_pruning_enumeration_duration(
+                time.monotonic() - enumeration_start, connector_type
+            )
         all_connector_doc_ids = extraction_result.raw_id_to_parent
 
         # Session 2: post-enumeration — hierarchy upserts, diff computation, task dispatch.

--- a/backend/tests/external_dependency_unit/celery/test_pruning_enumeration_spawn.py
+++ b/backend/tests/external_dependency_unit/celery/test_pruning_enumeration_spawn.py
@@ -1,0 +1,141 @@
+"""External dependency unit tests for the spawned pruning enumeration.
+
+Verifies the child-process enumeration harness end to end:
+1. A real connector (WEB, single URL) is instantiated inside the spawned
+   child from DB state, enumerated, and the result round-trips back to the
+   parent through the JSON handoff file.
+2. A child that fails (unreachable URL) surfaces a PruneEnumerationError in
+   the parent with the child's exception text attached.
+
+Requires Postgres + Redis (child sets prune-active liveness) + internet.
+"""
+
+from collections.abc import Generator
+
+import pytest
+from sqlalchemy.orm import Session
+
+from onyx.background.celery.tasks.pruning.enumeration_spawn import (
+    PruneEnumerationError,
+    run_enumeration_in_subprocess,
+)
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.models import InputType
+from onyx.db.enums import AccessType, ConnectorCredentialPairStatus
+from onyx.db.models import Connector, ConnectorCredentialPair, Credential
+from onyx.redis.redis_connector import RedisConnector
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+TEST_URL = "https://example.com/"
+
+
+def _create_web_cc_pair(
+    db_session: Session,
+    base_url: str,
+) -> ConnectorCredentialPair:
+    connector = Connector(
+        name=f"Test enumeration-spawn Connector {base_url}",
+        source=DocumentSource.WEB,
+        input_type=InputType.LOAD_STATE,
+        connector_specific_config={
+            "base_url": base_url,
+            "web_connector_type": "single",
+        },
+    )
+    db_session.add(connector)
+    db_session.flush()
+
+    credential = Credential(
+        source=DocumentSource.WEB,
+        credential_json={},
+        admin_public=True,
+    )
+    db_session.add(credential)
+    db_session.flush()
+
+    cc_pair = ConnectorCredentialPair(
+        connector_id=connector.id,
+        credential_id=credential.id,
+        name=f"Test enumeration-spawn CC Pair {base_url}",
+        status=ConnectorCredentialPairStatus.ACTIVE,
+        access_type=AccessType.PUBLIC,
+    )
+    db_session.add(cc_pair)
+    db_session.commit()
+    db_session.refresh(cc_pair)
+    return cc_pair
+
+
+@pytest.fixture
+def web_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    cc_pair = _create_web_cc_pair(db_session, TEST_URL)
+    yield cc_pair
+    _cleanup(db_session, cc_pair)
+
+
+@pytest.fixture
+def broken_web_cc_pair(
+    db_session: Session,
+    tenant_context: None,  # noqa: ARG001
+) -> Generator[ConnectorCredentialPair, None, None]:
+    # .invalid is a reserved TLD that can never resolve
+    cc_pair = _create_web_cc_pair(db_session, "https://onyx-test.invalid/")
+    yield cc_pair
+    _cleanup(db_session, cc_pair)
+
+
+def _cleanup(db_session: Session, cc_pair: ConnectorCredentialPair) -> None:
+    connector_id = cc_pair.connector_id
+    credential_id = cc_pair.credential_id
+    db_session.query(ConnectorCredentialPair).filter(
+        ConnectorCredentialPair.id == cc_pair.id
+    ).delete()
+    db_session.query(Connector).filter(Connector.id == connector_id).delete()
+    db_session.query(Credential).filter(Credential.id == credential_id).delete()
+    db_session.commit()
+
+
+def test_spawned_enumeration_success(
+    web_cc_pair: ConnectorCredentialPair,
+) -> None:
+    """The child enumerates a single-URL web connector and the result
+    round-trips through the JSON handoff file."""
+    reacquire_calls: list[int] = []
+
+    result = run_enumeration_in_subprocess(
+        cc_pair_id=web_cc_pair.id,
+        connector_id=web_cc_pair.connector_id,
+        credential_id=web_cc_pair.credential_id,
+        tenant_id=POSTGRES_DEFAULT_SCHEMA,
+        redis_connector=RedisConnector(POSTGRES_DEFAULT_SCHEMA, web_cc_pair.id),
+        reacquire_lock=lambda: reacquire_calls.append(1),
+    )
+
+    # single-page crawl of example.com yields exactly that URL
+    assert set(result.raw_id_to_parent.keys()) == {TEST_URL}
+    assert result.raw_id_to_parent[TEST_URL] is None
+    assert result.hierarchy_nodes == []
+
+
+def test_spawned_enumeration_child_failure(
+    broken_web_cc_pair: ConnectorCredentialPair,
+) -> None:
+    """A child that cannot reach its source fails the enumeration with the
+    child's exception text surfaced to the parent."""
+    with pytest.raises(PruneEnumerationError) as exc_info:
+        run_enumeration_in_subprocess(
+            cc_pair_id=broken_web_cc_pair.id,
+            connector_id=broken_web_cc_pair.connector_id,
+            credential_id=broken_web_cc_pair.credential_id,
+            tenant_id=POSTGRES_DEFAULT_SCHEMA,
+            redis_connector=RedisConnector(
+                POSTGRES_DEFAULT_SCHEMA, broken_web_cc_pair.id
+            ),
+            reacquire_lock=lambda: None,
+        )
+
+    # the child exits nonzero and its traceback is attached
+    assert "exit_code" in str(exc_info.value)


### PR DESCRIPTION
## Description

Long-term fix for the heavy-worker OOM loop ([ENG-4309](https://linear.app/danswer/issue/ENG-4309)); stacked on the short-term mitigation in #13451 (reaper + periodic malloc_trim) and intentionally kept as small as the pattern allows after review feedback that v1 was overbuilt.

Pruning enumeration currently runs the entire multi-hour connector crawl inline in the long-lived heavy worker, ratcheting its RSS until the pod OOMs (details and reproduction in #13451). Full indexing already solved this class of problem by running connectors in an ephemeral spawned process (`docfetching_proxy_task` / `SimpleJobClient`). This PR applies that existing pattern to pruning:

- `connector_pruning_generator_task` becomes a watchdog: owns the redis lock/fence, reacquires the lock periodically, and kills the child on stop signal or `JOB_TIMEOUT`.
- The spawned child instantiates the connector from DB state, runs `extract_ids_from_runnable_connector` unchanged, and hands the result back via a schema-validated JSON file (an mp queue can deadlock on multi-MB payloads).
- Enumeration Prometheus metrics move to the parent — the child's registry is never scraped.

**Simplifications vs the first draft:** no child-side timeout (the watchdog kills the child; one enforcement point), no DB app-name relabeling, callback reduced to liveness + stop fence + orphan reaping.

**Review-bot findings from v1, addressed here:**
- *Watchdog failure abandons child* (real): the watchdog's `finally` now always `terminate_and_wait`s the child, so a lock-reacquisition error can't leave a crawl running unowned.
- *Interrupted crawl returns partial results* (not reproducible): `extract_ids_from_runnable_connector` **raises** when `should_stop()` fires, so the child exits nonzero without writing a result file — a partial enumeration can never be treated as complete. Documented on `SpawnedPruneCallback`.

## How Has This Been Tested?

- External-dependency-unit tests: spawned enumeration success (real WEB connector, result round-trips through the JSON handoff) and child-failure surfacing.
- Linux validation in the deployed `v4.4.0-cloud.6` image: the crawl's memory returns to the OS at child exit; zero zombie processes leak through the spawn harness.
- `pre-commit` green.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run pruning connector enumeration in a spawned child process to stop heavy-worker OOMs and break the prune/redispatch loop (ENG-4309). The parent owns lock control, timeout, and metrics; crawl memory returns to the OS between runs.

- **Bug Fixes**
  - Enumeration now runs in a child via `run_enumeration_in_subprocess`/`pruning_enumeration_task`; the parent watchdog owns the Redis fence, periodically `lock.reacquire`s, enforces `JOB_TIMEOUT` and stop signals, and always terminates the child on exit.
  - The child builds the connector from DB state, runs `extract_ids_from_runnable_connector` with `SpawnedPruneCallback`, and hands back a `SlimConnectorExtractionResult` via a JSON file; interrupted crawls raise and never write results.
  - Prometheus metrics moved to the parent: it observes enumeration duration and counts rate-limit errors by parsing child error text; metrics removed from `extract_ids_from_runnable_connector`.
  - Added periodic `gc.collect()` and `release_freed_native_memory()` during long loops; all enumeration memory is reclaimed on child exit.
  - External-dependency tests cover a successful WEB crawl and a failing child with surfaced error text.

<sup>Written for commit 8994031847a9c30317be280e5fa2cba95e8d6e84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13453?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

