### PR TITLE
chore(dependabot): ignore types-* stub packages in uv updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
       - "jmelahman"
     labels:
       - "dependabot:python"
+    ignore:
+      - dependency-name: "types-*"
   - package-ecosystem: "bun"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Adds an `ignore` rule to the `uv` Dependabot config so `types-*` stub-only packages no longer trigger update PRs

## Test plan
- [ ] Confirm Dependabot config is valid (no schema errors on next Dependabot run)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ignore `types-*` stub packages in `uv` Dependabot updates to reduce PR noise from non-functional stub releases. Adds an `ignore` rule in `.github/dependabot.yml`.

<sup>Written for commit 28da2d24580bbc4e790ac18c9ece7662293ccadb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13454?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

