### PR TITLE
feat(craft): Prometheus telemetry for sandbox provisioning latency

### DIFF
--- a/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
+++ b/backend/onyx/server/features/build/sandbox/kubernetes/kubernetes_sandbox_manager.py
@@ -133,6 +133,10 @@ from onyx.server.features.build.sandbox.util.opencode_config import (
     build_opencode_base_config,
     build_provider_opencode_config,
 )
+from onyx.server.metrics.craft_sandbox import (
+    SandboxProvisionPhase,
+    time_provision_phase,
+)
 from onyx.server.settings.store import load_settings
 from onyx.utils.logger import setup_logger
 
@@ -337,6 +341,7 @@ class KubernetesSandboxManager(SandboxManager):
     _OPENCODE_PASSWORD_SECRET_KEY = "password"
     _OPENCODE_CONFIG_SECRET_KEY = "config"
 
+    @time_provision_phase(SandboxProvisionPhase.OPENCODE_SECRET)
     def _provision_opencode_secret(self, sandbox_id: str, config_json: str) -> None:
         """Per-pod Secret with ``password`` (HTTP Basic) + ``config``
         (full opencode.json, surfaced as ``OPENCODE_CONFIG_CONTENT``).
@@ -634,6 +639,7 @@ class KubernetesSandboxManager(SandboxManager):
             ),
         )
 
+    @time_provision_phase(SandboxProvisionPhase.SERVICE_ENSURE)
     def _ensure_service_exists(
         self,
         sandbox_id: UUID,
@@ -845,6 +851,7 @@ class KubernetesSandboxManager(SandboxManager):
             )
         return False
 
+    @time_provision_phase(SandboxProvisionPhase.POD_READY_WAIT)
     def _wait_for_pod_ready(
         self,
         pod_name: str,
@@ -930,6 +937,7 @@ class KubernetesSandboxManager(SandboxManager):
         logger.warning("Timeout waiting for pod %s to become ready", pod_name)
         return False
 
+    @time_provision_phase(SandboxProvisionPhase.POD_IP_WAIT)
     def _wait_for_pod_ip(self, pod_name: str, deadline: float) -> bool:
         """Poll until the pod is assigned an IP, or the monotonic deadline.
 
@@ -1111,10 +1119,11 @@ class KubernetesSandboxManager(SandboxManager):
                     tenant_id=tenant_id,
                 )
                 try:
-                    self._core_api.create_namespaced_pod(
-                        namespace=self._namespace,
-                        body=pod,
-                    )
+                    with time_provision_phase(SandboxProvisionPhase.POD_CREATE):
+                        self._core_api.create_namespaced_pod(
+                            namespace=self._namespace,
+                            body=pod,
+                        )
                     created_pod = True
                 except ApiException as e:
                     if e.status == 409:
@@ -1661,6 +1670,7 @@ echo "Session cleanup complete"
         )
         return True
 
+    @time_provision_phase(SandboxProvisionPhase.HISTORY_RESTORE)
     def restore_opencode_history_snapshot(
         self,
         sandbox_id: UUID,

--- a/backend/onyx/server/features/build/sandbox/serve_transport.py
+++ b/backend/onyx/server/features/build/sandbox/serve_transport.py
@@ -47,6 +47,10 @@ from onyx.server.features.build.sandbox.opencode.serve_client import (
     translate_opencode_event,
 )
 from onyx.server.features.build.sandbox.sse import SSEKeepalive
+from onyx.server.metrics.craft_sandbox import (
+    SandboxProvisionPhase,
+    time_provision_phase,
+)
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -338,6 +342,7 @@ class _ServeMixin:
                 return children
         return []
 
+    @time_provision_phase(SandboxProvisionPhase.OPENCODE_SERVE_WAIT)
     def _wait_for_opencode_serve_ready(
         self,
         sandbox_id: UUID,

--- a/backend/onyx/server/features/build/session/sandbox_lifecycle.py
+++ b/backend/onyx/server/features/build/session/sandbox_lifecycle.py
@@ -48,6 +48,13 @@ from onyx.server.features.build.sandbox.util.mcp_config import (
     resolve_craft_mcp_servers,
 )
 from onyx.server.features.build.session.errors import SandboxProvisioningError
+from onyx.server.metrics.craft_sandbox import (
+    SandboxProvisionPhase,
+    SandboxReadyOutcome,
+    observe_sandbox_ready,
+    time_provision_phase,
+    track_sandbox_provision_in_progress,
+)
 from onyx.skills.push import (
     build_user_skills_payload,
     compute_skill_runtime_hash,
@@ -260,7 +267,8 @@ def provision_sandbox(
     Updates the sandbox row's status to whatever the manager returns.
     Caller is responsible for committing.
     """
-    onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
+    with time_provision_phase(SandboxProvisionPhase.ENSURE_PAT):
+        onyx_pat = ensure_sandbox_pat(db_session, sandbox, user)
     sandbox_info = sandbox_manager.provision(
         sandbox_id=sandbox.id,
         user_id=user_id,
@@ -268,10 +276,12 @@ def provision_sandbox(
         onyx_pat=onyx_pat,
     )
     if sandbox_info.status == SandboxStatus.RUNNING:
-        hydrate_managed_content(sandbox_manager, sandbox.id, user, db_session)
+        with time_provision_phase(SandboxProvisionPhase.HYDRATE_MANAGED_CONTENT):
+            hydrate_managed_content(sandbox_manager, sandbox.id, user, db_session)
     update_sandbox_status__no_commit(db_session, sandbox.id, sandbox_info.status)
 
 
+@time_provision_phase(SandboxProvisionPhase.PROVISIONING_WAIT)
 def _wait_for_provisioning_to_complete(
     db_session: DBSession,
     sandbox: Sandbox,
@@ -362,8 +372,35 @@ def ensure_sandbox_ready(
         RuntimeError: Pod provisioning failed, or sandbox is mid-provision
             under FAIL policy.
     """
+    started_at = time.monotonic()
+    outcome = SandboxReadyOutcome.FAILED
+    try:
+        sandbox, outcome = _resolve_ready_sandbox(
+            db_session,
+            sandbox_manager,
+            user_id,
+            policy=policy,
+            provisioning_wait_seconds=provisioning_wait_seconds,
+            user=user,
+        )
+        return sandbox
+    finally:
+        observe_sandbox_ready(outcome, time.monotonic() - started_at)
+
+
+def _resolve_ready_sandbox(
+    db_session: DBSession,
+    sandbox_manager: SandboxManager,
+    user_id: UUID,
+    *,
+    policy: ProvisioningPolicy,
+    provisioning_wait_seconds: float,
+    user: User | None,
+) -> tuple[Sandbox, SandboxReadyOutcome]:
+    """State machine behind ``ensure_sandbox_ready``, plus the path it took."""
     sandbox = get_sandbox_by_user_id(db_session, user_id)
     tenant_id = get_current_tenant_id()
+    recovered = False
 
     # Resolve PROVISIONING upfront so the rest of the state machine sees a
     # stable status (or knows there isn't one).
@@ -379,16 +416,20 @@ def ensure_sandbox_ready(
 
     # Hot path: pod is up; nothing else to do.
     if sandbox is not None and sandbox.status == SandboxStatus.RUNNING:
-        if sandbox_manager.health_check(
-            sandbox.id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
-        ):
-            return sandbox
+        with time_provision_phase(SandboxProvisionPhase.HEALTH_CHECK):
+            healthy = sandbox_manager.health_check(
+                sandbox.id, timeout=_HEALTHCHECK_TIMEOUT_SECONDS
+            )
+        if healthy:
+            return sandbox, SandboxReadyOutcome.ALREADY_RUNNING
         logger.warning(
             "Sandbox %s marked RUNNING but pod is unhealthy/missing; recovering.",
             sandbox.id,
         )
         recover_unhealthy_sandbox(db_session, sandbox_manager, sandbox, tenant_id)
-        # Fall through into the re-provision path below.
+        # Falls through to re-provision, which cannot otherwise be told apart
+        # from an ordinary revive.
+        recovered = True
 
     if sandbox is not None and sandbox.status not in _REPROVISIONABLE_STATUSES:
         raise RuntimeError(
@@ -407,6 +448,7 @@ def ensure_sandbox_ready(
     if sandbox is None:
         sandbox = create_sandbox__no_commit(db_session=db_session, user_id=user_id)
         logger.info("Created sandbox %s for user %s", sandbox.id, user_id)
+        outcome = SandboxReadyOutcome.CREATED
     else:
         logger.info(
             "Reviving sandbox %s (status=%s) for user %s",
@@ -414,16 +456,20 @@ def ensure_sandbox_ready(
             sandbox.status.value,
             user_id,
         )
+        outcome = (
+            SandboxReadyOutcome.RECOVERED if recovered else SandboxReadyOutcome.REVIVED
+        )
 
-    provision_sandbox(
-        db_session,
-        sandbox_manager,
-        sandbox,
-        user,
-        user_id,
-        tenant_id,
-    )
-    return sandbox
+    with track_sandbox_provision_in_progress():
+        provision_sandbox(
+            db_session,
+            sandbox_manager,
+            sandbox,
+            user,
+            user_id,
+            tenant_id,
+        )
+    return sandbox, outcome
 
 
 def is_sandbox_idle(sandbox: Sandbox, now: datetime) -> bool:

--- a/backend/onyx/server/metrics/craft_sandbox.py
+++ b/backend/onyx/server/metrics/craft_sandbox.py
@@ -1,0 +1,154 @@
+"""Prometheus metrics for Craft sandbox provisioning latency.
+
+Tracks how long a caller waits for a ready sandbox, and where that time went.
+
+The ``outcome`` label is load-bearing rather than descriptive: obtaining a sandbox
+takes milliseconds when the pod is already running and seconds when it has to be
+provisioned, so collapsing those into one series would make every percentile
+meaningless.
+"""
+
+import logging
+import time
+from collections.abc import Generator
+from contextlib import contextmanager
+from enum import Enum
+
+from prometheus_client import Gauge, Histogram
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxReadyOutcome(str, Enum):
+    """Which path produced the sandbox."""
+
+    ALREADY_RUNNING = "already_running"
+    CREATED = "created"
+    # Row existed in a re-provisionable status (SLEEPING/TERMINATED/FAILED).
+    REVIVED = "revived"
+    # Row claimed RUNNING but the pod was gone or unhealthy.
+    RECOVERED = "recovered"
+    FAILED = "failed"
+
+
+class SandboxProvisionPhase(str, Enum):
+    """Closed set of phase labels, so cardinality has one source of truth.
+
+    Each phase is emitted only by the layer that has it; the Docker backend never
+    reports the pod-level ones.
+    """
+
+    # Backend-agnostic lifecycle.
+    PROVISIONING_WAIT = "provisioning_wait"
+    HEALTH_CHECK = "health_check"
+    ENSURE_PAT = "ensure_pat"
+    HYDRATE_MANAGED_CONTENT = "hydrate_managed_content"
+
+    # Kubernetes pod provisioning.
+    OPENCODE_SECRET = "opencode_secret"
+    POD_CREATE = "pod_create"
+    SERVICE_ENSURE = "service_ensure"
+    POD_IP_WAIT = "pod_ip_wait"
+    HISTORY_RESTORE = "history_restore"
+    POD_READY_WAIT = "pod_ready_wait"
+
+    # Both sandbox backends.
+    OPENCODE_SERVE_WAIT = "opencode_serve_wait"
+
+
+OUTCOME_LABEL_NAME = "outcome"
+PHASE_LABEL_NAME = "phase"
+
+# Reaches well past the 10s ceiling of the FastAPI instrumentator's per-handler
+# histogram, which is why request duration alone cannot measure provisioning.
+_PROVISION_DURATION_BUCKETS = (
+    0.25,
+    0.5,
+    1.0,
+    2.0,
+    3.0,
+    5.0,
+    7.5,
+    10.0,
+    15.0,
+    20.0,
+    30.0,
+    45.0,
+    60.0,
+    120.0,
+)
+
+_ready_duration = Histogram(
+    "onyx_craft_sandbox_ready_duration_seconds",
+    "Time from requesting a Craft sandbox to it being ready, by which path was taken.",
+    [OUTCOME_LABEL_NAME],
+    buckets=_PROVISION_DURATION_BUCKETS,
+)
+
+_provision_phase_duration = Histogram(
+    "onyx_craft_sandbox_provision_phase_duration_seconds",
+    "Duration of an individual Craft sandbox provisioning phase.",
+    [PHASE_LABEL_NAME],
+    buckets=_PROVISION_DURATION_BUCKETS,
+)
+
+_provisions_in_progress = Gauge(
+    "onyx_craft_sandbox_provisions_in_progress",
+    "Number of Craft sandbox provisions currently in flight.",
+)
+
+
+def observe_sandbox_ready(outcome: SandboxReadyOutcome, duration_s: float) -> None:
+    """Records a completed attempt to obtain a ready sandbox."""
+    try:
+        _ready_duration.labels(outcome=outcome.value).observe(duration_s)
+    except Exception:
+        logger.warning("Failed to record sandbox readiness metric.", exc_info=True)
+
+
+def _observe_phase_duration(phase: SandboxProvisionPhase, duration_s: float) -> None:
+    try:
+        _provision_phase_duration.labels(phase=phase.value).observe(duration_s)
+    except Exception:
+        logger.warning(
+            "Failed to record sandbox provision phase metric.", exc_info=True
+        )
+
+
+@contextmanager
+def time_provision_phase(phase: SandboxProvisionPhase) -> Generator[None]:
+    """Records how long the block took, including when it raises.
+
+    Usable as a decorator, which is how a method that owns a whole phase should
+    claim it. A phase that failed still consumed the caller's time; dropping it
+    would make a slow failure look free.
+    """
+    started_at = time.monotonic()
+    try:
+        yield
+    finally:
+        _observe_phase_duration(phase, time.monotonic() - started_at)
+
+
+@contextmanager
+def track_sandbox_provision_in_progress() -> Generator[None]:
+    """Holds the in-flight gauge up for the duration of the block."""
+    incremented = False
+    try:
+        _provisions_in_progress.inc()
+        incremented = True
+    except Exception:
+        logger.warning(
+            "Failed to increment sandbox provisions in-progress gauge.", exc_info=True
+        )
+    try:
+        yield
+    finally:
+        if incremented:
+            try:
+                _provisions_in_progress.dec()
+            except Exception:
+                logger.warning(
+                    "Failed to decrement sandbox provisions in-progress gauge.",
+                    exc_info=True,
+                )

--- a/backend/tests/unit/server/metrics/test_craft_sandbox_metrics.py
+++ b/backend/tests/unit/server/metrics/test_craft_sandbox_metrics.py
@@ -1,0 +1,186 @@
+"""Tests for Craft sandbox provisioning Prometheus metrics.
+
+Values are read through ``REGISTRY.get_sample_value`` rather than collector
+internals, so the assertions cover the samples Prometheus actually scrapes.
+Metrics are process-global, so every assertion is a delta against a baseline.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from prometheus_client import REGISTRY
+
+from onyx.server.metrics.craft_sandbox import (
+    OUTCOME_LABEL_NAME,
+    PHASE_LABEL_NAME,
+    SandboxProvisionPhase,
+    SandboxReadyOutcome,
+    _provision_phase_duration,
+    _provisions_in_progress,
+    _ready_duration,
+    observe_sandbox_ready,
+    time_provision_phase,
+    track_sandbox_provision_in_progress,
+)
+
+_READY = "onyx_craft_sandbox_ready_duration_seconds"
+_PHASE = "onyx_craft_sandbox_provision_phase_duration_seconds"
+_IN_PROGRESS = "onyx_craft_sandbox_provisions_in_progress"
+
+
+def _sample(name: str, labels: dict[str, str] | None = None) -> float:
+    """Current value of a sample, treating a not-yet-created series as zero."""
+    return REGISTRY.get_sample_value(name, labels) or 0.0
+
+
+def _ready_count(outcome: SandboxReadyOutcome) -> float:
+    return _sample(f"{_READY}_count", {OUTCOME_LABEL_NAME: outcome.value})
+
+
+def _ready_sum(outcome: SandboxReadyOutcome) -> float:
+    return _sample(f"{_READY}_sum", {OUTCOME_LABEL_NAME: outcome.value})
+
+
+def _phase_count(phase: SandboxProvisionPhase) -> float:
+    return _sample(f"{_PHASE}_count", {PHASE_LABEL_NAME: phase.value})
+
+
+class TestObserveSandboxReady:
+    def test_records_duration_under_its_outcome(self) -> None:
+        before_sum = _ready_sum(SandboxReadyOutcome.CREATED)
+        before_count = _ready_count(SandboxReadyOutcome.CREATED)
+
+        observe_sandbox_ready(SandboxReadyOutcome.CREATED, 7.5)
+
+        assert _ready_sum(SandboxReadyOutcome.CREATED) == pytest.approx(
+            before_sum + 7.5
+        )
+        assert _ready_count(SandboxReadyOutcome.CREATED) == before_count + 1
+
+    def test_hot_and_cold_paths_are_separate_series(self) -> None:
+        """The design rests on this: a millisecond hot path must not pollute the
+        cold-provision percentiles."""
+        before_hot = _ready_count(SandboxReadyOutcome.ALREADY_RUNNING)
+        before_cold = _ready_count(SandboxReadyOutcome.CREATED)
+
+        observe_sandbox_ready(SandboxReadyOutcome.ALREADY_RUNNING, 0.004)
+
+        assert _ready_count(SandboxReadyOutcome.ALREADY_RUNNING) == before_hot + 1
+        assert _ready_count(SandboxReadyOutcome.CREATED) == before_cold
+
+    def test_every_outcome_is_recordable(self) -> None:
+        for outcome in SandboxReadyOutcome:
+            before = _ready_count(outcome)
+            observe_sandbox_ready(outcome, 1.0)
+            assert _ready_count(outcome) == before + 1
+
+    def test_collector_failure_does_not_propagate(self) -> None:
+        """Instrumentation must never be able to break provisioning."""
+        with patch.object(
+            _ready_duration, "labels", side_effect=RuntimeError("registry exploded")
+        ):
+            observe_sandbox_ready(SandboxReadyOutcome.CREATED, 1.0)
+
+
+class TestTimeProvisionPhase:
+    def test_records_under_expected_phase(self) -> None:
+        before = _phase_count(SandboxProvisionPhase.ENSURE_PAT)
+
+        with time_provision_phase(SandboxProvisionPhase.ENSURE_PAT):
+            pass
+
+        assert _phase_count(SandboxProvisionPhase.ENSURE_PAT) == before + 1
+
+    def test_phases_are_separate_series(self) -> None:
+        before_other = _phase_count(SandboxProvisionPhase.OPENCODE_SERVE_WAIT)
+
+        with time_provision_phase(SandboxProvisionPhase.POD_CREATE):
+            pass
+
+        assert _phase_count(SandboxProvisionPhase.OPENCODE_SERVE_WAIT) == before_other
+
+    def test_records_even_when_block_raises(self) -> None:
+        """A phase that failed still consumed the caller's time."""
+        before = _phase_count(SandboxProvisionPhase.HISTORY_RESTORE)
+
+        with pytest.raises(RuntimeError):
+            with time_provision_phase(SandboxProvisionPhase.HISTORY_RESTORE):
+                raise RuntimeError("restore failed")
+
+        assert _phase_count(SandboxProvisionPhase.HISTORY_RESTORE) == before + 1
+
+    def test_every_phase_is_recordable(self) -> None:
+        """The label space is closed, so every member must be usable."""
+        for phase in SandboxProvisionPhase:
+            before = _phase_count(phase)
+            with time_provision_phase(phase):
+                pass
+            assert _phase_count(phase) == before + 1
+
+    def test_collector_failure_does_not_propagate(self) -> None:
+        with patch.object(
+            _provision_phase_duration,
+            "labels",
+            side_effect=RuntimeError("registry exploded"),
+        ):
+            with time_provision_phase(SandboxProvisionPhase.POD_CREATE):
+                pass
+
+
+class TestTimeProvisionPhaseAsDecorator:
+    """Methods that own a whole phase claim it by decoration, so the decorator
+    form has to survive repeated calls and preserve the wrapped return value."""
+
+    def test_preserves_return_value_and_records_each_call(self) -> None:
+        @time_provision_phase(SandboxProvisionPhase.POD_READY_WAIT)
+        def wait_for_something() -> bool:
+            return True
+
+        before = _phase_count(SandboxProvisionPhase.POD_READY_WAIT)
+
+        assert wait_for_something() is True
+        assert wait_for_something() is True
+
+        assert _phase_count(SandboxProvisionPhase.POD_READY_WAIT) == before + 2
+
+    def test_records_and_reraises_when_wrapped_call_raises(self) -> None:
+        @time_provision_phase(SandboxProvisionPhase.POD_IP_WAIT)
+        def wait_and_fail() -> None:
+            raise RuntimeError("timeout")
+
+        before = _phase_count(SandboxProvisionPhase.POD_IP_WAIT)
+
+        with pytest.raises(RuntimeError):
+            wait_and_fail()
+
+        assert _phase_count(SandboxProvisionPhase.POD_IP_WAIT) == before + 1
+
+
+class TestTrackSandboxProvisionInProgress:
+    def test_returns_to_baseline_on_success(self) -> None:
+        before = _sample(_IN_PROGRESS)
+
+        with track_sandbox_provision_in_progress():
+            assert _sample(_IN_PROGRESS) == before + 1
+
+        assert _sample(_IN_PROGRESS) == before
+
+    def test_returns_to_baseline_when_block_raises(self) -> None:
+        before = _sample(_IN_PROGRESS)
+
+        with pytest.raises(RuntimeError):
+            with track_sandbox_provision_in_progress():
+                raise RuntimeError("provision failed")
+
+        assert _sample(_IN_PROGRESS) == before
+
+    def test_does_not_decrement_when_increment_failed(self) -> None:
+        """A failed inc must not be followed by a dec, or the gauge drifts
+        negative and stays wrong for the life of the process."""
+        with patch.object(
+            _provisions_in_progress, "inc", side_effect=RuntimeError("boom")
+        ):
+            with patch.object(_provisions_in_progress, "dec") as mock_dec:
+                with track_sandbox_provision_in_progress():
+                    pass
+                mock_dec.assert_not_called()


### PR DESCRIPTION
## Problem

There is no way to answer *"how long does it take from request to a ready Craft sandbox"* from telemetry.

- None of the **95 existing Prometheus metrics** cover sandbox / Craft / provisioning. The only sandbox-adjacent metric is queue depth (`sandbox_queue_length`), not latency.
- `onyx_celery_task_duration_seconds` doesn't apply — provisioning runs inline in the request path (`session/manager.py` → `sandbox_lifecycle.ensure_sandbox_ready`), not as a Celery task.
- The closest existing signal is the FastAPI instrumentator's per-handler histogram, but the two halves of what's needed are split across two metrics:

| Metric | `handler` label? | Top finite bucket |
|---|---|---|
| `http_request_duration_seconds` | yes | **10s** (overridden by `prometheus_setup.py:_LATENCY_BUCKETS`) |
| `http_request_duration_highr_seconds` | no | 30s, 60s |

The one that can isolate the Craft endpoint tops out at 10s; the one with the range has no endpoint label. So there is no endpoint-scoped latency metric in the range that matters for a provisioning-latency target.

## What this adds

A new `backend/onyx/server/metrics/craft_sandbox.py`, modelled closely on `metrics/embedding.py`:

| Metric | Labels |
|---|---|
| `onyx_craft_sandbox_ready_duration_seconds` | `outcome` ∈ `already_running` / `created` / `revived` / `recovered` / `failed` |
| `onyx_craft_sandbox_provision_phase_duration_seconds` | `phase` (11 values) |
| `onyx_craft_sandbox_provisions_in_progress` | — |

Buckets span 0.25s–120s with deliberate resolution at the 10s and 30s marks.

## Design notes for reviewers

**The `outcome` label is load-bearing, not descriptive.** Obtaining a sandbox takes milliseconds when the pod is already running and seconds when it has to be provisioned. Collapsing those into one series would make every percentile meaningless, so the paths are kept apart.

**Instrumentation sits with the work, not at the call site — where it can.** A phase whose work is owned by one function claims it by decorating that function (`time_provision_phase` is a `@contextmanager`, so it doubles as a decorator — same pattern as the existing `@log_function_time`):

```python
@time_provision_phase(SandboxProvisionPhase.POD_READY_WAIT)
def _wait_for_pod_ready(self, ...) -> bool:
```

That leaves `provision()` unchanged, and a future caller can't forget to time it. Six phases work this way. The exceptions are principled: `health_check` (6 call sites), `hydrate_managed_content` (4) and `ensure_sandbox_pat` are shared with non-provisioning paths, so decorating them would pollute the phase — those three are timed at the provisioning call site instead.

Decorating `_wait_for_opencode_serve_ready` in `serve_transport.py` also picks up the Docker backend for free, which is why that phase is grouped as shared in the enum.

**Telemetry is kept out of the branching logic.** `ensure_sandbox_ready` now delegates to `_resolve_ready_sandbox`, which returns the path it took alongside the sandbox. The state machine is otherwise untouched — no re-indentation — and the outcome cannot be misreported on failure, because the wrapper defaults to `FAILED` and only sees a success value if the state machine returned one.

**Phase names live in one closed enum**, so cardinality has a single source of truth.

**No new plumbing needed.** Both processes that provision — the api server and the `scheduled_tasks` worker, which both import `session/manager.py` — already expose `/metrics`, so module-level collectors register in either.

**Instrumentation can never break provisioning.** Every metric write is wrapped and logged. Phases record in a `finally`, so a phase that timed out is still attributed rather than appearing free.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

## Testing

14 unit tests in `tests/unit/server/metrics/test_craft_sandbox_metrics.py`, read through the public `REGISTRY.get_sample_value` rather than collector internals so assertions cover the samples Prometheus actually scrapes. They pin the hot/cold series separation, per-phase series isolation, that a phase which raises is still recorded, gauge symmetry on success *and* on raise, that a failing collector never propagates, and that a failed increment is not followed by a decrement (which would leave the gauge permanently negative).

The decorator form gets its own coverage since it's now load-bearing: it must preserve the wrapped return value and record once per call across repeated calls.

Also verified against a live cluster by provisioning a real sandbox — all 7 Kubernetes phases populated and summed to **99% of provision wall-clock**:

```
opencode_secret       0.005s
pod_create            0.018s
service_ensure        0.015s
pod_ip_wait           1.547s
history_restore       1.143s
pod_ready_wait        3.518s
opencode_serve_wait   1.386s
```

Confirmed no regressions by stashing the change and re-running `backend/tests/unit/onyx/server/features/build/`: identical **11 failed, 594 passed** either way. Those 11 are pre-existing and environmental (a missing `helm dependency build` for `onyx-cnpg-crds`, and tests needing a DB engine a bare unit run doesn't provide).

## Deliberately out of scope

- **Widening `_LATENCY_BUCKETS`.** Would fix the 10s ceiling for every endpoint, but multiplies series across every handler × method × status. A dedicated histogram is the cheaper answer to this question.
- **A Craft Grafana dashboard.** Better authored once these metrics have been observed in prod and the useful cuts are known.
- **Per-tenant labels.** Tenant cardinality on a latency histogram needs its own justification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
