### PR TITLE
fix(ci): coordinate Kubernetes startup migrations

### DIFF
--- a/.github/workflows/pr-craft-k8s-tests.yml
+++ b/.github/workflows/pr-craft-k8s-tests.yml
@@ -440,11 +440,12 @@ jobs:
           cat "${RUNNER_TEMP}/postgres-port-forward.log" || true
           exit 1
 
-      - name: Run migrations
+      - name: Wait for API startup migrations
         run: |
-          cd backend
-          alembic upgrade head
-          alembic heads --verbose
+          kubectl -n "${HELM_RELEASE_NAMESPACE}" rollout status \
+            deployment/onyx-api-server --timeout=360s
+          kubectl -n "${HELM_RELEASE_NAMESPACE}" exec deployment/onyx-api-server -- \
+            alembic current --check-heads
 
       - name: Wait for chart OpenSearch ready
         run: |

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.2
+version: 0.8.3
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,10 +17,8 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Documented that the default backend images no longer ship psql (it
-        moved to the -dev suffixed image variants); the opt-in tooling.pgInto helper
-        now needs a -dev backend image tag or a custom image providing the client
-        binary.
+      description: Made the Kubernetes CI profile coordinate API startup migrations
+        through deployment readiness before running tests.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/values-ci.yaml
+++ b/deployment/helm/charts/onyx/values-ci.yaml
@@ -123,9 +123,15 @@ webserver:
 
 api:
   replicaCount: 1
-  # The workflow runs `alembic upgrade head` once after Postgres is reachable.
-  # Keep API startup from racing that centralized migration step.
-  runStartupMigrations: false
+  runStartupMigrations: true
+  # The API port opens only after startup migrations finish and Uvicorn starts.
+  # This makes rollout status a reliable migration-completion barrier.
+  readinessProbe:
+    tcpSocket:
+      port: api-server-port
+    periodSeconds: 2
+    timeoutSeconds: 1
+    failureThreshold: 180
   resources:
     requests:
       cpu: 250m


### PR DESCRIPTION
## Description

Run Craft Kubernetes CI database migrations through the deployed API container instead of from the runner. Add a TCP readiness probe to the CI API deployment so rollout completion is a reliable barrier for startup migrations, then verify that the database is on every Alembic head before tests begin.

This removes the race where Kubernetes reported the API deployment ready while its startup migration was still running and a concurrent `alembic current --check-heads` failed against the partially migrated database.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coordinate Kubernetes CI startup migrations through the API deployment’s readiness to remove race conditions and ensure the DB is on all Alembic heads before tests.

- Bug Fixes
  - Run migrations inside the API pod; wait on `kubectl rollout status` for `deployment/onyx-api-server`.
  - Enable `api.runStartupMigrations: true` and add a TCP readiness probe so readiness passes only after migrations and Uvicorn start.
  - Replace runner-side `alembic upgrade head` with `alembic current --check-heads` executed in the API pod; bump Helm chart to `0.8.3`.

<sup>Written for commit 9ea559b896a3c271b3719ddadcc40df3b4a44320. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

