### PR TITLE
chore: exclude sharepoint site from tests (#13447) to release v4.3

### DIFF
--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.secrets(
 )
 
 # NOTE: Sharepoint site for tests is "sharepoint-tests"
+SCALE_TEST_SITE_URL = "https://danswerai.sharepoint.com/sites/OnyxTesting2"
 
 
 @dataclass
@@ -171,9 +172,10 @@ def test_sharepoint_connector_all_sites__docs_only(
         "onyx.connectors.sharepoint.connector.store_image_and_create_section",
         mock_store_image,
     ):
-        # Initialize connector with no sites
         connector = SharepointConnector(
-            include_site_pages=False, include_site_documents=True
+            excluded_sites=[SCALE_TEST_SITE_URL],
+            include_site_pages=False,
+            include_site_documents=True,
         )
 
         # Load credentials
@@ -198,9 +200,10 @@ def test_sharepoint_connector_all_sites__pages_only(
         "onyx.connectors.sharepoint.connector.store_image_and_create_section",
         mock_store_image,
     ):
-        # Initialize connector with no docs
         connector = SharepointConnector(
-            include_site_pages=True, include_site_documents=False
+            excluded_sites=[SCALE_TEST_SITE_URL],
+            include_site_pages=True,
+            include_site_documents=False,
         )
 
         # Load credentials


### PR DESCRIPTION
Cherry-pick of commit f564bce9923f8ef2f9097c2f1546c995fe78ad0e to release/v4.3 branch.

Original PR: #13447

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the OnyxTesting2 SharePoint site from SharePoint connector tests to avoid hitting the scale test environment and reduce flakiness. Adds a site URL constant and passes it to excluded_sites in the docs-only and pages-only tests.

<sup>Written for commit 5c5ba81b06a2167e741f225ec328126ba5ba4e80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

