### PR TITLE
chore: exclude sharepoint site from tests (#13447) to release v4.2

### DIFF
--- a/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
+++ b/backend/tests/daily/connectors/sharepoint/test_sharepoint_connector.py
@@ -31,6 +31,7 @@ pytestmark = pytest.mark.secrets(
 )
 
 # NOTE: Sharepoint site for tests is "sharepoint-tests"
+SCALE_TEST_SITE_URL = "https://danswerai.sharepoint.com/sites/OnyxTesting2"
 
 
 @dataclass
@@ -171,9 +172,10 @@ def test_sharepoint_connector_all_sites__docs_only(
         "onyx.connectors.sharepoint.connector.store_image_and_create_section",
         mock_store_image,
     ):
-        # Initialize connector with no sites
         connector = SharepointConnector(
-            include_site_pages=False, include_site_documents=True
+            excluded_sites=[SCALE_TEST_SITE_URL],
+            include_site_pages=False,
+            include_site_documents=True,
         )
 
         # Load credentials
@@ -198,9 +200,10 @@ def test_sharepoint_connector_all_sites__pages_only(
         "onyx.connectors.sharepoint.connector.store_image_and_create_section",
         mock_store_image,
     ):
-        # Initialize connector with no docs
         connector = SharepointConnector(
-            include_site_pages=True, include_site_documents=False
+            excluded_sites=[SCALE_TEST_SITE_URL],
+            include_site_pages=True,
+            include_site_documents=False,
         )
 
         # Load credentials


### PR DESCRIPTION
Cherry-pick of commit f564bce9923f8ef2f9097c2f1546c995fe78ad0e to release/v4.2 branch.

Original PR: #13447

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exclude the SharePoint site at https://danswerai.sharepoint.com/sites/OnyxTesting2 from connector tests to avoid hitting the scale testing environment. Adds `SCALE_TEST_SITE_URL` and passes `excluded_sites` in the docs-only and pages-only tests.

<sup>Written for commit 0c8e84e47b0ce3e61f23b5eba36d81f94dfbef07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

