### PR TITLE
chore(build): publish -dev tags for the web, model-server, and sandbox images

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -702,16 +702,38 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
             type=semver,pattern={{major}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
 
+      # Same tag set with a -dev suffix. Only the backend has a genuinely different dev image
+      # (runtime + debugging tools); the web -dev tags point at the same manifest as their
+      # plain counterparts so that one version string (IMAGE_TAG / helm global.version) selects
+      # a whole deployment. The suffix is spelled out per tag rather than via flavor `suffix=`
+      # so that disabled (empty) raw tags stay empty instead of degenerating to a bare "-dev".
+      - name: Docker meta (dev)
+        id: meta-dev
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        with:
+          images: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('web-{0}-dev', needs.determine-builds.outputs.sanitized-tag) || format('{0}-dev', github.ref_name) }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta == 'true' && 'beta-dev' || '' }}
+            type=semver,pattern={{version}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}.{{minor}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+
       - name: Create and push manifest
         env:
           IMAGE_REPO: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           AMD64_DIGEST: ${{ needs.build-web-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.build-web-arm64.outputs.digest }}
           META_TAGS: ${{ steps.meta.outputs.tags }}
+          META_DEV_TAGS: ${{ steps.meta-dev.outputs.tags }}
         run: |
           IMAGES="${IMAGE_REPO}@${AMD64_DIGEST} ${IMAGE_REPO}@${ARM64_DIGEST}"
           docker buildx imagetools create \
-            $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
+            $(printf '%s\n%s\n' "${META_TAGS}" "${META_DEV_TAGS}" | sed '/^$/d' | xargs -I {} echo -t {}) \
             $IMAGES
 
   build-web-cloud-amd64:
@@ -952,16 +974,30 @@ jobs:
           tags: |
             type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('web-cloud-{0}', needs.determine-builds.outputs.sanitized-tag) || github.ref_name }}
 
+      # -dev twin of the tag above, pointing at the same manifest — see the merge-web dev note.
+      # Cloud tags build the web image here rather than in merge-web, so without this a cloud
+      # deployment couldn't set a single -dev version across all of its images.
+      - name: Docker meta (dev)
+        id: meta-dev
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        with:
+          images: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('web-cloud-{0}-dev', needs.determine-builds.outputs.sanitized-tag) || format('{0}-dev', github.ref_name) }}
+
       - name: Create and push manifest
         env:
           IMAGE_REPO: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           AMD64_DIGEST: ${{ needs.build-web-cloud-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.build-web-cloud-arm64.outputs.digest }}
           META_TAGS: ${{ steps.meta.outputs.tags }}
+          META_DEV_TAGS: ${{ steps.meta-dev.outputs.tags }}
         run: |
           IMAGES="${IMAGE_REPO}@${AMD64_DIGEST} ${IMAGE_REPO}@${ARM64_DIGEST}"
           docker buildx imagetools create \
-            $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
+            $(printf '%s\n%s\n' "${META_TAGS}" "${META_DEV_TAGS}" | sed '/^$/d' | xargs -I {} echo -t {}) \
             $IMAGES
 
   build-backend-amd64:
@@ -1487,16 +1523,34 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
             type=semver,pattern={{major}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
 
+      # -dev twins of the tags above, pointing at the same manifest — see the merge-web dev note.
+      - name: Docker meta (dev)
+        id: meta-dev
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        with:
+          images: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('model-server-{0}-dev', needs.determine-builds.outputs.sanitized-tag) || format('{0}-dev', github.ref_name) }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta-dev' || '' }}
+            type=semver,pattern={{version}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}.{{minor}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+
       - name: Create and push manifest
         env:
           IMAGE_REPO: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
           AMD64_DIGEST: ${{ needs.build-model-server-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.build-model-server-arm64.outputs.digest }}
           META_TAGS: ${{ steps.meta.outputs.tags }}
+          META_DEV_TAGS: ${{ steps.meta-dev.outputs.tags }}
         run: |
           IMAGES="${IMAGE_REPO}@${AMD64_DIGEST} ${IMAGE_REPO}@${ARM64_DIGEST}"
           docker buildx imagetools create \
-            $(printf '%s\n' "${META_TAGS}" | xargs -I {} echo -t {}) \
+            $(printf '%s\n%s\n' "${META_TAGS}" "${META_DEV_TAGS}" | sed '/^$/d' | xargs -I {} echo -t {}) \
             $IMAGES
 
   prepare-sandbox:
@@ -1776,6 +1830,25 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
             type=semver,pattern={{major}},enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
 
+      # -dev twins of the tags above, pointing at the same manifest — see the merge-web dev note.
+      # The sandbox image resolves off the same version knob as the rest of the deployment
+      # (IMAGE_TAG in compose, global.version in the helm chart), so it needs the twins too.
+      - name: Docker meta (dev)
+        id: meta-dev
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9
+        with:
+          images: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
+          flavor: |
+            latest=false
+          tags: |
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run == 'true' && format('sandbox-{0}-dev', needs.determine-builds.outputs.sanitized-tag) || format('{0}-dev', github.ref_name) }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-latest == 'true' && 'latest-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && env.EDGE_TAG == 'true' && 'edge-dev' || '' }}
+            type=raw,value=${{ needs.determine-builds.outputs.is-test-run != 'true' && needs.determine-builds.outputs.is-beta-standalone == 'true' && 'beta-dev' || '' }}
+            type=semver,pattern={{version}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}.{{minor}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+            type=semver,pattern={{major}}-dev,enable=${{ needs.determine-builds.outputs.is-stable == 'true' }}
+
       - name: Create and push manifest
         env:
           IMAGE_REPO: ${{ needs.determine-builds.outputs.is-test-run == 'true' && env.RUNS_ON_ECR_CACHE || env.REGISTRY_IMAGE }}
@@ -1783,10 +1856,11 @@ jobs:
           AMD64_DIGEST: ${{ needs.build-sandbox-amd64.outputs.digest }}
           ARM64_DIGEST: ${{ needs.build-sandbox-arm64.outputs.digest }}
           META_TAGS: ${{ steps.meta.outputs.tags }}
+          META_DEV_TAGS: ${{ steps.meta-dev.outputs.tags }}
           DOCKER_NO_CACHE: ${{ vars.DOCKER_NO_CACHE == 'true' && 'true' || 'false' }}
           IS_TEST_RUN: ${{ needs.determine-builds.outputs.is-test-run }}
         run: |
-          mapfile -t tags < <(printf '%s\n' "${META_TAGS}" | sed '/^$/d')
+          mapfile -t tags < <(printf '%s\n%s\n' "${META_TAGS}" "${META_DEV_TAGS}" | sed '/^$/d')
           tag_args=()
           for tag in "${tags[@]}"; do
             tag_args+=("-t" "$tag")

--- a/deployment/docker_compose/README.md
+++ b/deployment/docker_compose/README.md
@@ -45,7 +45,9 @@ downloaded during the initial setup. Feel free to edit the .env file to customiz
 located near the top of the file.
 
 IMAGE_TAG is the version of Onyx to run. It is recommended to leave it as latest to get all updates with each redeployment.
-The backend image also publishes a `-dev` twin for every tag (e.g. `latest-dev`, `v1.2.3-dev`) that adds interactive
-debugging tools (vim, nano, curl, ps, psql); the default images ship without them to stay minimal. Only the backend has
-`-dev` tags, so select it with `ONYX_BACKEND_IMAGE=onyxdotapp/onyx-backend:latest-dev` rather than `IMAGE_TAG`, which
-the web-server and model-server images share.
+
+Every image publishes a `-dev` twin for each of its tags (e.g. `latest-dev`, `v1.2.3-dev`), so a single
+`IMAGE_TAG=latest-dev` selects the dev variant of the whole deployment. Today only the backend image actually differs:
+its `-dev` twin adds interactive debugging tools (vim, nano, curl, ps, psql) that the default image leaves out to stay
+minimal. The web-server, model-server, and sandbox `-dev` tags are identical to their plain counterparts and exist so
+that one version string covers every image.

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -9,12 +9,11 @@
 ## Version of Onyx to deploy, default is latest (main built nightly).
 ## Craft uses this same tag for the sandbox image; do not set a separate
 ## sandbox image for normal deployments.
-## The backend image also publishes a -dev twin for every tag (e.g. latest-dev,
-## v1.2.3-dev) with debugging tools (vim, nano, curl, ps, psql). Only the backend
-## has -dev tags, so select it via ONYX_BACKEND_IMAGE below — NOT via IMAGE_TAG,
-## which the web-server and model-server images share.
+## Every image publishes a -dev twin for each of its tags (e.g. latest-dev,
+## v1.2.3-dev), so IMAGE_TAG=latest-dev selects the dev variant of the whole
+## deployment. Today only the backend image actually differs: its -dev twin adds
+## debugging tools (vim, nano, curl, ps, psql) that the default image leaves out.
 IMAGE_TAG=latest
-# ONYX_BACKEND_IMAGE=onyxdotapp/onyx-backend:latest-dev
 
 ## Onyx Craft Configuration (off by default).
 ## When enabling Craft through install.sh --include-craft or by manually adding

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: latest
 annotations:
   category: Productivity
@@ -17,8 +17,10 @@ annotations:
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
     - kind: changed
-      description: Made the Kubernetes CI profile coordinate API startup migrations
-        through deployment readiness before running tests.
+      description: Documented that every Onyx image now publishes a -dev twin for each
+        of its tags, so a -dev suffixed global.version (e.g. v1.2.3-dev) selects the dev
+        variant of the whole deployment — including the backend image that carries the
+        debugging tools the opt-in tooling.pgInto helper needs.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -9,6 +9,10 @@
 
 global:
   # Global version for all Onyx components (overrides .Chart.AppVersion)
+  # Every Onyx image publishes a -dev twin for each of its tags (e.g. "latest-dev",
+  # "v1.2.3-dev"), so this single value can select the dev variant of the whole
+  # deployment. Today only the backend image actually differs: its -dev twin adds
+  # debugging tools (vim, nano, curl, ps, psql) that the default image leaves out.
   version: "latest"
   # Global pull policy for all Onyx component images
   pullPolicy: "IfNotPresent"
@@ -308,8 +312,8 @@ config:
 tooling:
   pgInto:
     # -- Mounts a small helper script into app pods that opens psql using the pod's POSTGRES_* env vars.
-    # NOTE: the default backend images do not ship psql; use a -dev suffixed image tag
-    # (e.g. v1.2.3-dev) or an image that provides the client binary.
+    # NOTE: the default backend images do not ship psql; set a -dev suffixed global.version
+    # (e.g. v1.2.3-dev) or use an image that provides the client binary.
     enabled: false
     # -- Where to place the helper inside the container.
     mountPath: /usr/local/bin/pginto


### PR DESCRIPTION
## Description

Follow-up to e52d68d0ab (#13441), which gave the backend a real `-dev` image variant (runtime + vim/nano/curl/ps/psql).

The problem: `IMAGE_TAG` (compose) and `global.version` (helm) pick the tag for *every* Onyx image at once, so `-dev` was unusable as a deployment-wide version — `latest-dev` resolved for the backend and failed to pull for everything else. The previous docs worked around this by telling users to set `ONYX_BACKEND_IMAGE` per component.

This publishes `-dev` twins of the existing tag set for the remaining images that `global.version` covers:

- `merge-web` (`onyx-web-server`)
- `merge-web-cloud` (`onyx-web-server`, cloud tags — where `merge-web` doesn't run)
- `merge-model-server` (`onyx-model-server`)
- `merge-sandbox` (`sandbox`, resolved from the same version knob in both compose and the chart)

They point at the **same manifests** as their plain counterparts — no extra builds, no extra push time. They're placeholders: today only the backend image actually differs. When one of these grows a genuine dev variant, it splits out the way the backend already does (separate build target + its own digest).

Docs updated accordingly: `IMAGE_TAG=latest-dev` / `global.version: v1.2.3-dev` is now the documented way in, replacing the per-component `ONYX_BACKEND_IMAGE` override. Chart version bumped to 0.8.3.

## How Has This Been Tested?

- `pre-commit run --files` on all touched files — zizmor, actionlint, check-yaml, env drift baseline all pass.
- Verified `install.sh`'s `sandbox_backend_for_tag` already strips at the first `-`, so `v4.1.0-dev` and `latest-dev` resolve the same backend as their plain tags.
- Sanity-checked the merged tag list shell (`printf | sed | xargs`) against real and empty `META_DEV_TAGS` values.
- Not exercised end-to-end: the tags only materialize on a real release run of `deployment.yml`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `-dev` tags for the web, cloud-web, model-server, and sandbox images so a single `IMAGE_TAG`/`global.version` can select a deployment-wide dev build. Only the backend image differs today; other `-dev` tags point to the same manifests. Helm chart bumped to 0.8.4 and docs updated.

- **New Features**
  - Publish `-dev` twins for `merge-web`, `merge-web-cloud`, `merge-model-server`, and `merge-sandbox`.
  - CI now creates/pushes both normal and `-dev` tags via imagetools (no extra builds).

- **Migration**
  - Use `IMAGE_TAG=latest-dev` (compose) or `global.version: vX.Y.Z-dev` (helm) to select dev across the stack.
  - Remove per-component overrides like `ONYX_BACKEND_IMAGE`; chart version is now `0.8.4`.

<sup>Written for commit 9c7e6e74f36b3b0bea665e39289d56ccc6062f39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

