### PR TITLE
fix(web): apply oxfmt 0.59 formatting

### DIFF
--- a/web/lib/opal/src/components/checkbox/styles.css
+++ b/web/lib/opal/src/components/checkbox/styles.css
@@ -44,8 +44,8 @@
 }
 
 .opal-checkbox-surface[data-state="unchecked"]:focus-visible:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply border-border-05;
 }
 
@@ -65,8 +65,8 @@
 
 .opal-checkbox-surface[data-state="checked"]:focus-visible:not([data-disabled]),
 .opal-checkbox-surface[data-state="indeterminate"]:focus-visible:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply border-border-05;
 }
 

--- a/web/lib/opal/src/components/tag/styles.css
+++ b/web/lib/opal/src/components/tag/styles.css
@@ -116,8 +116,8 @@
 }
 
 .opal-auxiliary-tag[data-type="editable"][data-color="gray"]:not(
-    [data-disabled]
-  ):hover {
+  [data-disabled]
+):hover {
   @apply bg-background-tint-03;
 }
 

--- a/web/lib/opal/src/core/interactive/stateful/styles.css
+++ b/web/lib/opal/src/core/interactive/stateful/styles.css
@@ -32,20 +32,20 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="empty"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="empty"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="empty"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="empty"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-neutral-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -65,19 +65,19 @@
   --interactive-foreground-icon: var(--action-link-05);
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="filled"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="filled"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="filled"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="filled"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="filled"][data-disabled] {
@@ -95,19 +95,19 @@
   --interactive-foreground-icon: var(--action-link-05);
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="selected"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="selected"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="selected"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="selected"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-heavy"][data-interactive-state="selected"][data-disabled] {
@@ -131,20 +131,20 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="select-card"][data-interactive-state="empty"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-card"][data-interactive-state="empty"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="select-card"][data-interactive-state="empty"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-card"][data-interactive-state="empty"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-neutral-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -164,20 +164,20 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="select-card"][data-interactive-state="filled"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-card"][data-interactive-state="filled"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="select-card"][data-interactive-state="filled"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-card"][data-interactive-state="filled"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -197,19 +197,19 @@
   --interactive-foreground-icon: var(--action-link-05);
 }
 .interactive[data-interactive-variant="select-card"][data-interactive-state="selected"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-card"][data-interactive-state="selected"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="select-card"][data-interactive-state="selected"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-card"][data-interactive-state="selected"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-card"][data-interactive-state="selected"][data-disabled] {
@@ -231,20 +231,20 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="empty"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-light"][data-interactive-state="empty"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="empty"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-light"][data-interactive-state="empty"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-neutral-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -264,19 +264,19 @@
   --interactive-foreground-icon: var(--action-link-05);
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="filled"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-light"][data-interactive-state="filled"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="filled"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-light"][data-interactive-state="filled"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="filled"][data-disabled] {
@@ -294,19 +294,19 @@
   --interactive-foreground-icon: var(--action-link-05);
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="selected"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-light"][data-interactive-state="selected"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="selected"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-light"][data-interactive-state="selected"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-light"][data-interactive-state="selected"][data-disabled] {
@@ -328,20 +328,20 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="empty"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="empty"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="empty"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="empty"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-neutral-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -362,21 +362,21 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="select-input"][data-interactive-state="empty"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-input"][data-interactive-state="empty"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-neutral-03;
   --interactive-foreground: var(--text-04);
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="select-input"][data-interactive-state="empty"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-input"][data-interactive-state="empty"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-neutral-03;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -396,19 +396,19 @@
   --interactive-foreground-icon: var(--action-link-05);
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="filled"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="filled"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="filled"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="filled"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="filled"][data-disabled] {
@@ -426,19 +426,19 @@
   --interactive-foreground-icon: var(--action-link-05);
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="selected"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="selected"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="selected"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="selected"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="select-tinted"][data-interactive-state="selected"][data-disabled] {
@@ -456,41 +456,41 @@
    Select-Filter — Empty & Filled (identical colors)
    --------------------------------------------------------------------------- */
 .interactive[data-interactive-variant="select-filter"]:is(
-    [data-interactive-state="empty"],
-    [data-interactive-state="filled"]
-  ) {
+  [data-interactive-state="empty"],
+  [data-interactive-state="filled"]
+) {
   @apply bg-background-tint-01;
   --interactive-foreground: var(--text-02);
   --interactive-foreground-icon: var(--text-02);
 }
 .interactive[data-interactive-variant="select-filter"]:is(
-    [data-interactive-state="empty"],
-    [data-interactive-state="filled"]
-  ):hover:not([data-disabled]),
+  [data-interactive-state="empty"],
+  [data-interactive-state="filled"]
+):hover:not([data-disabled]),
 .interactive[data-interactive-variant="select-filter"]:is(
-    [data-interactive-state="empty"],
-    [data-interactive-state="filled"]
-  )[data-interaction="hover"]:not([data-disabled]) {
+  [data-interactive-state="empty"],
+  [data-interactive-state="filled"]
+)[data-interaction="hover"]:not([data-disabled]) {
   @apply bg-background-tint-02;
   --interactive-foreground: var(--text-04);
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="select-filter"]:is(
-    [data-interactive-state="empty"],
-    [data-interactive-state="filled"]
-  ):active:not([data-disabled]),
+  [data-interactive-state="empty"],
+  [data-interactive-state="filled"]
+):active:not([data-disabled]),
 .interactive[data-interactive-variant="select-filter"]:is(
-    [data-interactive-state="empty"],
-    [data-interactive-state="filled"]
-  )[data-interaction="active"]:not([data-disabled]) {
+  [data-interactive-state="empty"],
+  [data-interactive-state="filled"]
+)[data-interaction="active"]:not([data-disabled]) {
   @apply bg-background-neutral-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
 }
 .interactive[data-interactive-variant="select-filter"]:is(
-    [data-interactive-state="empty"],
-    [data-interactive-state="filled"]
-  )[data-disabled] {
+  [data-interactive-state="empty"],
+  [data-interactive-state="filled"]
+)[data-disabled] {
   @apply bg-transparent;
   --interactive-foreground: var(--text-01);
   --interactive-foreground-icon: var(--text-01);
@@ -505,21 +505,21 @@
   --interactive-foreground-icon: var(--text-inverted-05);
 }
 .interactive[data-interactive-variant="select-filter"][data-interactive-state="selected"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-filter"][data-interactive-state="selected"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-inverted-04;
   --interactive-foreground: var(--text-inverted-05);
   --interactive-foreground-icon: var(--text-inverted-05);
 }
 .interactive[data-interactive-variant="select-filter"][data-interactive-state="selected"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="select-filter"][data-interactive-state="selected"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-inverted-04;
   --interactive-foreground: var(--text-inverted-04);
   --interactive-foreground-icon: var(--text-inverted-04);
@@ -546,11 +546,11 @@
   --interactive-foreground-icon: var(--text-02);
 }
 .interactive[data-interactive-variant="sidebar-heavy"][data-interactive-state="empty"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="sidebar-heavy"][data-interactive-state="empty"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-03;
 }
 
@@ -563,11 +563,11 @@
   --interactive-foreground-icon: var(--text-02);
 }
 .interactive[data-interactive-variant="sidebar-heavy"][data-interactive-state="filled"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="sidebar-heavy"][data-interactive-state="filled"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-03;
 }
 
@@ -580,11 +580,11 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="sidebar-heavy"][data-interactive-state="selected"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="sidebar-heavy"][data-interactive-state="selected"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-03;
 }
 /* ---------------------------------------------------------------------------
@@ -611,11 +611,11 @@
   --interactive-foreground-icon: var(--text-02);
 }
 .interactive[data-interactive-variant="sidebar-light"][data-interactive-state="empty"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="sidebar-light"][data-interactive-state="empty"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-03;
 }
 
@@ -628,11 +628,11 @@
   --interactive-foreground-icon: var(--text-02);
 }
 .interactive[data-interactive-variant="sidebar-light"][data-interactive-state="filled"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="sidebar-light"][data-interactive-state="filled"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-03;
 }
 
@@ -645,11 +645,11 @@
   --interactive-foreground-icon: var(--text-02);
 }
 .interactive[data-interactive-variant="sidebar-light"][data-interactive-state="selected"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="sidebar-light"][data-interactive-state="selected"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-03;
 }
 /* ---------------------------------------------------------------------------

--- a/web/lib/opal/src/core/interactive/stateless/styles.css
+++ b/web/lib/opal/src/core/interactive/stateless/styles.css
@@ -25,19 +25,19 @@
   --interactive-foreground-icon: var(--text-inverted-05);
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="primary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="primary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-[var(--theme-primary-04)];
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="primary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="primary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-[var(--theme-primary-06)];
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="primary"][data-disabled] {
@@ -55,21 +55,21 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="secondary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="secondary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
   --interactive-foreground: var(--text-04);
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="secondary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="secondary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -89,21 +89,21 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="tertiary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="tertiary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
   --interactive-foreground: var(--text-04);
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="tertiary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="tertiary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -123,21 +123,21 @@
   --interactive-foreground-icon: var(--text-03);
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="internal"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="internal"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
   --interactive-foreground: var(--text-04);
   --interactive-foreground-icon: var(--text-04);
 }
 .interactive[data-interactive-variant="default"][data-interactive-prominence="internal"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="default"][data-interactive-prominence="internal"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
   --interactive-foreground: var(--text-05);
   --interactive-foreground-icon: var(--text-05);
@@ -157,19 +157,19 @@
   --interactive-foreground-icon: var(--text-light-05);
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="primary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="primary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-[var(--action-link-04)];
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="primary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="primary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-[var(--action-link-06)];
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="primary"][data-disabled] {
@@ -187,19 +187,19 @@
   --interactive-foreground-icon: var(--action-text-link-05);
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="secondary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="secondary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="secondary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="secondary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="secondary"][data-disabled] {
@@ -217,19 +217,19 @@
   --interactive-foreground-icon: var(--action-text-link-05);
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="tertiary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="tertiary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="tertiary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="tertiary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="tertiary"][data-disabled] {
@@ -247,19 +247,19 @@
   --interactive-foreground-icon: var(--action-text-link-05);
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="internal"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="internal"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="internal"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="action"][data-interactive-prominence="internal"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="action"][data-interactive-prominence="internal"][data-disabled] {
@@ -277,19 +277,19 @@
   --interactive-foreground-icon: var(--text-light-05);
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="primary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="primary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-[var(--action-danger-04)];
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="primary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="primary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-[var(--action-danger-06)];
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="primary"][data-disabled] {
@@ -307,19 +307,19 @@
   --interactive-foreground-icon: var(--action-text-danger-05);
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="secondary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="secondary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="secondary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="secondary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="secondary"][data-disabled] {
@@ -337,19 +337,19 @@
   --interactive-foreground-icon: var(--action-text-danger-05);
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="tertiary"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="tertiary"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-02;
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="tertiary"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="tertiary"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="tertiary"][data-disabled] {
@@ -367,19 +367,19 @@
   --interactive-foreground-icon: var(--action-text-danger-05);
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="internal"]:hover:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="internal"][data-interaction="hover"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="internal"]:active:not(
-    [data-disabled]
-  ),
+  [data-disabled]
+),
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="internal"][data-interaction="active"]:not(
-    [data-disabled]
-  ) {
+  [data-disabled]
+) {
   @apply bg-background-tint-00;
 }
 .interactive[data-interactive-variant="danger"][data-interactive-prominence="internal"][data-disabled] {


### PR DESCRIPTION
## Description

Apply the pinned oxfmt 0.59.0 output to the four Opal CSS files reported by the all-files pre-commit hook.

This is a formatting-only change that makes the `oxfmt` CI hook idempotent after the formatter version bump. It intentionally excludes the broader Markdown and package metadata formatting.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applied `oxfmt` 0.59.0 formatting to four Opal CSS files to align with the pinned formatter and make the `oxfmt` CI hook idempotent. No visual or behavior changes; formatting only.

<sup>Written for commit 59b0253619306f1f8ee65b8acc009e4c16274934. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

