### PR TITLE
ci(storybook): add advisory Storybook build to presubmit

### DIFF
--- a/.github/workflows/pr-storybook-build.yml
+++ b/.github/workflows/pr-storybook-build.yml
@@ -1,0 +1,51 @@
+name: Storybook Build
+concurrency:
+  group: Storybook-Build-${{ github.workflow }}-${{ github.head_ref || github.event.workflow_run.head_branch || github.run_id }}
+  cancel-in-progress: true
+
+# Advisory. Storybook builds through its own Vite pipeline, so it breaks
+# independently of the Next build and nothing else in presubmit exercises it.
+# This surfaces that breakage on the PR without gating the merge.
+on:
+  merge_group:
+  pull_request:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - "web/**"
+      - ".github/workflows/pr-storybook-build.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  storybook-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # ratchet:oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13"
+
+      - name: Cache bun install cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('web/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install node dependencies
+        working-directory: ./web
+        run: bun install --frozen-lockfile
+
+      - name: Build Storybook
+        working-directory: ./web
+        run: bun run storybook:build


### PR DESCRIPTION
## Description

`bun run storybook:build` runs only in `storybook-deploy.yml`, on push to main. Nothing builds Storybook on a PR, so a break is invisible until it has already landed. That is how #13313 got in. Dependabot bumped `storybook` to 10.5.0 and left the `@storybook/*` addons on 8.6.18, and `Deploy-Storybook` went red three seconds after the merge commit.

This runs the build on PRs as its own check. It is deliberately **not** a required check, so a red X surfaces the breakage without gating anyone's merge, per Jamison's call that visibility matters more here than enforcement. It runs in parallel with the rest of CI, so it costs no wall clock.

Gated on all of `web/`. Stories import across the tree and the build also reads postcss/tailwind/tsconfig, so scoping to the `stories` globs in `.storybook/main.ts` would leave the same blind spot in smaller form.

`pr-jest-tests.yml` and the `Jest Tests` required check are untouched. No branch protection change is needed to merge this.

## How Has This Been Tested?

- This exact workflow ran green on an earlier revision of this branch: 1m24s, install 29s, build 42s.
- `pre-commit run --files .github/workflows/pr-storybook-build.yml`: actionlint, zizmor, and Check YAML all pass.
- `ty check` from repo root: `All checks passed!`. No Python or TypeScript changed.
- The workflow sits inside its own paths filter, so this PR runs the check on itself.

## Follow-ups (not in this PR)

- `.github/dependabot.yml` has no `groups:` entry, which is why Dependabot split `storybook` from its addons in the first place. Grouping `storybook` and `@storybook/*` prevents a repeat at Storybook 11.
- `storybook-deploy.yml`'s `paths:` list misses `web/src/sections/**` and most of `web/src/app/craft/**`, both globbed by `.storybook/main.ts`, so changes there never trigger a deploy.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
