### PR TITLE
chore(claude): add merge-dependabot-prs skill

### DIFF
--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -69,6 +69,11 @@ Summarize buckets and proposed actions, confirm with `AskUserQuestion`, then act
 
 ## 3. Green: approve and enqueue
 
+On `web/**` bumps, also wait for the advisory `storybook-build` check. It
+never gates the queue, but don't enqueue while it's red — post-merge breakage
+pages Slack ("Storybook Deploy"). If it fails, treat it like any other failure
+(mechanical fix per step 5, or diagnosis per step 6).
+
 ```bash
 gh pr review <pr> --approve
 gh pr merge <pr> --auto
@@ -93,11 +98,12 @@ per-PR confirmation. Known Onyx cases:
 - **bun bumps** (`dependabot:javascript`): stale `bun.lock` — run
   `bun install` in the bumped directory (repo root or `web/`).
 
-Do the work in a worktree so the active checkout stays untouched — the
-convention here is `~/code/worktrees-onyx/<branch-name>`. Keep worktrees on a
-real disk: a tmpfs `/tmp` can hit "Disk quota exceeded" mid-post-checkout hook
-(`uv sync`/`bun install`) even when it looks roomy. Commit, push to the PR
-branch, remove the worktree.
+Getting the branch: prefer the harness's isolated-worktree feature if it has
+one (Claude Code: `EnterWorktree`). Otherwise, if the current checkout is
+clean, work in place — `gh pr checkout <pr>`, fix, push, and return to the
+previous branch. Only create a manual `git worktree` when the checkout is
+dirty; keep it on a real disk — a tmpfs `/tmp` can hit "Disk quota exceeded"
+mid-post-checkout hook (`uv sync`/`bun install`) even when it looks roomy.
 
 ## 6. Needs diagnosis: read the failing job's log, then classify
 

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -109,9 +109,10 @@ per-PR confirmation. Known Onyx cases:
 Getting the branch: prefer the harness's isolated-worktree feature if it has
 one (Claude Code: `EnterWorktree`). Otherwise, if the current checkout is
 clean, work in place — `gh pr checkout <pr>`, fix, push, and return to the
-previous branch. Only create a manual `git worktree` when the checkout is
-dirty; keep it on a real disk — a tmpfs `/tmp` can hit "Disk quota exceeded"
-mid-post-checkout hook (`uv sync`/`bun install`) even when it looks roomy.
+previous branch. If neither applies (e.g. dirty checkout), ask the user where
+to resolve (`AskUserQuestion`) rather than picking a spot — and steer away
+from tmpfs paths like `/tmp`, which can hit "Disk quota exceeded"
+mid-post-checkout hook (`uv sync`/`bun install`) even when they look roomy.
 
 ## 6. Needs diagnosis: read the failing job's log, then classify
 

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: merge-dependabot-prs
+description: >
+  Triages and lands a batch of open Dependabot PRs in the Onyx repo, where main
+  is gated exclusively by GitHub's merge queue: approves and enqueues green PRs,
+  closes superseded duplicates, fixes mechanical CI failures (stale
+  backend/requirements exports, stale bun.lock), tells real regressions apart
+  from pre-existing breakage and flakes, and tracks every PR through to merge.
+  Use when the user asks to merge, clean up, clear out, or land Dependabot (or
+  similar bot-authored) PRs.
+license: MIT
+compatibility: Requires git, pre-commit, uv, bun, and gh (GitHub CLI) authenticated with write access to onyx-dot-app/onyx.
+metadata:
+  author: jmelahman
+  version: "1.0"
+allowed-tools: Bash(gh:*), Bash(git:*), Bash(pre-commit:*), Bash(bun install:*)
+---
+
+# Merge Dependabot PRs
+
+Treat each blocked PR as its own small diagnosis, not one "just merge it" action.
+
+**Confirm before anything consequential.** Approving, closing, pushing to a PR
+branch, merging main into someone's branch, and rerunning CI all touch shared
+state. Triage everything into buckets first, then confirm the plan per bucket
+with `AskUserQuestion` — not per PR, and not after the fact. Re-confirm if a
+genuinely new kind of problem appears mid-flight (e.g. a real regression where
+a mechanical fix was expected).
+
+## How Onyx gates merges
+
+- `main` merges **exclusively through the merge queue** ("Main Protection"
+  ruleset). Enqueue with `gh pr merge <pr> --auto` — no strategy flag; the
+  queue picks the method. `--squash`/`--merge`/`--rebase` will be rejected.
+- Required checks: `quality-checks`, `playwright-required`, `database-tests`,
+  `backend-check`, `mypy-check`, `Jest Tests`, `required`.
+- `required` (in `pr-integration-tests.yml`) and `playwright-required` (in
+  `pr-playwright-tests.yml`) are aggregate `needs: [...]` + `if: always()`
+  jobs over the slow integration/playwright matrices. If either is *absent*
+  from `gh pr checks`, its matrix is still running — the PR isn't blocked.
+  (`merge-group.yml` provides instant-pass stubs of the same names inside the
+  queue itself.)
+- `mergeStateStatus`/`autoMergeRequest` are unreliable for "is it actually
+  queued" — query the queue directly: [references/graphql-queries.md](references/graphql-queries.md).
+
+## 1. Discover the batch
+
+```bash
+gh pr list --search "is:open author:app/dependabot assignee:<user>" \
+  --json number,title,headRefName,mergeable,mergeStateStatus,reviewDecision,statusCheckRollup
+```
+
+PRs are labeled by ecosystem (`dependabot:python`, `dependabot:javascript`,
+`dependabot:docker`, `dependabot:actions`, plus `dependabot:sandbox`) and
+assigned per `.github/dependabot.yml`. Flag duplicates: two PRs bumping the
+same package, or a manual bump PR overlapping a bot one.
+
+## 2. Triage into buckets, confirm the plan
+
+- **Green & ready** — all required checks passing.
+- **Failing — mechanical** — only a generated/lock file wasn't regenerated
+  after the bump (see step 5 for the Onyx cases).
+- **Failing — needs diagnosis** — anything else; requires reading the failing
+  job's log first, never just the check name.
+- **Conflicting** — real merge conflict against main.
+- **Superseded** — a newer PR in the batch covers it.
+
+Summarize buckets and proposed actions, confirm with `AskUserQuestion`, then act.
+
+## 3. Green: approve and enqueue
+
+```bash
+gh pr review <pr> --approve
+gh pr merge <pr> --auto
+```
+
+If a PR falls out of the queue (e.g. `head_ref_force_pushed` after a Dependabot
+rebase), re-running `gh pr merge <pr> --auto` is routine, not a failure.
+
+## 4. Superseded: comment which PR supersedes it, then `gh pr close`
+
+## 5. Mechanical: fix in an isolated worktree
+
+Once the bucket is approved, individual stale-generated-file fixes don't need
+per-PR confirmation. Known Onyx cases:
+
+- **uv bumps** (`dependabot:python`): the exported `backend/requirements/*.txt`
+  files go stale when only `pyproject.toml`/`uv.lock` were bumped. Regenerate
+  via the same pre-commit hooks CI uses:
+  ```bash
+  pre-commit run --files pyproject.toml uv.lock backend/requirements/*.txt
+  ```
+- **bun bumps** (`dependabot:javascript`): stale `bun.lock` — run
+  `bun install` in the bumped directory (repo root or `web/`).
+
+Do the work in a worktree so the active checkout stays untouched — the
+convention here is `~/code/worktrees-onyx/<branch-name>`. Keep worktrees on a
+real disk: a tmpfs `/tmp` can hit "Disk quota exceeded" mid-post-checkout hook
+(`uv sync`/`bun install`) even when it looks roomy. Commit, push to the PR
+branch, remove the worktree.
+
+## 6. Needs diagnosis: read the failing job's log, then classify
+
+- **Pre-existing** — the same job also fails on main's current HEAD
+  ([references/graphql-queries.md](references/graphql-queries.md)). Not this
+  PR's problem; leave it and say so.
+- **External flake** (rate limit, transient network, shared infra) — confirm
+  from the log, rerun once (`gh run rerun <runId> --failed`). If the same
+  failure recurs, stop and ask — a persisting "flake" may not be one.
+- **Real regression from the bump** — diagnose the root cause, then ask whether
+  to fix or leave it. Never patch unrelated source just to force CI green.
+
+## 7. Conflicts
+
+- **Bot-authored branch**: comment `@dependabot rebase` (or `recreate`) —
+  Dependabot owns the branch and will redo it properly.
+- **User-authored branch**: get explicit approval, then merge main in, resolve
+  keeping both sides' intent, regenerate any lockfile a manual edit could
+  desync (step 5 commands), and verify `git diff origin/main...HEAD --stat`
+  shows only the intended change. A noisy `git status` after merging
+  long-diverged main is expected. If a pre-push hook fails on a stale local
+  cache (e.g. dev type-gen referencing a file deleted upstream), clear the
+  cache and retry — don't skip the hook.
+
+## 8. Track to completion
+
+Prefer one polling loop (e.g. `Monitor`) over repeated manual checks: watch
+both queue state and PR state (`MERGED`/`CLOSED`), and surface new failures as
+they appear rather than staying silent until success.
+
+## 9. Report
+
+```
+Merged (N): #A, #B, #C
+Closed as superseded (N): #D (superseded by #E)
+Left for you (N): #F — <specific unresolved reason>
+```

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -57,7 +57,12 @@ same package, or a manual bump PR overlapping a bot one.
 
 ## 2. Triage into buckets, confirm the plan
 
-- **Green & ready** — all required checks passing.
+These PRs aren't in a rush. Wait for every check to complete — required and
+advisory alike (e.g. `storybook-build` on `web/**` changes, which never gates
+the queue but pages Slack if broken post-merge) — and treat any red check as
+a failure to classify, never as noise to skip.
+
+- **Green & ready** — every check completed and passing, advisory included.
 - **Failing — mechanical** — only a generated/lock file wasn't regenerated
   after the bump (see step 5 for the Onyx cases).
 - **Failing — needs diagnosis** — anything else; requires reading the failing
@@ -76,11 +81,6 @@ in per PR.
 Summarize buckets and proposed actions, confirm with `AskUserQuestion`, then act.
 
 ## 3. Green: approve and enqueue
-
-On `web/**` bumps, also wait for the advisory `storybook-build` check. It
-never gates the queue, but don't enqueue while it's red — post-merge breakage
-pages Slack ("Storybook Deploy"). If it fails, treat it like any other failure
-(mechanical fix per step 5, or diagnosis per step 6).
 
 ```bash
 gh pr review <pr> --approve

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -126,13 +126,13 @@ mid-post-checkout hook (`uv sync`/`bun install`) even when it looks roomy.
 
 ## 7. Conflicts
 
-- **Bot-authored branch**: comment `@dependabot rebase` (or `recreate`) —
-  Dependabot owns the branch and will redo it properly.
-- **User-authored branch**: get explicit approval, then merge main in, resolve
-  keeping both sides' intent, regenerate any lockfile a manual edit could
-  desync (step 5 commands), and verify `git diff origin/main...HEAD --stat`
-  shows only the intended change. A noisy `git status` after merging
-  long-diverged main is expected. If a pre-push hook fails on a stale local
+- **Untouched Dependabot branch**: comment `@dependabot rebase` (or
+  `recreate`) — Dependabot owns the branch and will redo it properly.
+- **Branch we already pushed fixes to**: `@dependabot rebase` discards
+  non-Dependabot commits. Instead rebase onto `origin/main` yourself, rerun
+  the step 5 regeneration if lockfiles conflicted, push with
+  `--force-with-lease`, and verify `git diff origin/main...HEAD --stat` still
+  shows only the intended bump. If a pre-push hook trips on a stale local
   cache (e.g. dev type-gen referencing a file deleted upstream), clear the
   cache and retry — don't skip the hook.
 

--- a/.cursor/skills/merge-dependabot-prs/SKILL.md
+++ b/.cursor/skills/merge-dependabot-prs/SKILL.md
@@ -65,6 +65,14 @@ same package, or a manual bump PR overlapping a bot one.
 - **Conflicting** — real merge conflict against main.
 - **Superseded** — a newer PR in the batch covers it.
 
+Independent of bucket, assess compatibility: note each PR's semver jump and
+whether the package is production or dev-only. Major bumps (and 0.x minors,
+which semver allows to break) are never covered by a blanket "enqueue the
+green ones" — green CI proves the build, not the behavior. Surface each one
+individually in the confirmation with a one-line breaking-changes summary
+from the release notes Dependabot embeds in the PR body, and let the user opt
+in per PR.
+
 Summarize buckets and proposed actions, confirm with `AskUserQuestion`, then act.
 
 ## 3. Green: approve and enqueue

--- a/.cursor/skills/merge-dependabot-prs/references/graphql-queries.md
+++ b/.cursor/skills/merge-dependabot-prs/references/graphql-queries.md
@@ -1,0 +1,49 @@
+# GraphQL Queries Reference
+
+Useful GitHub GraphQL queries for merge-queue triage in onyx-dot-app/onyx.
+
+## Real merge-queue status for a PR
+
+`mergeStateStatus` and `autoMergeRequest` on their own can lag or mislead. Query the queue entry directly:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "onyx-dot-app", name: "onyx") {
+    pullRequest(number: PR_NUMBER) {
+      isInMergeQueue
+      mergeQueueEntry {
+        position
+        state
+      }
+    }
+  }
+}'
+```
+
+`mergeQueueEntry: null` with `isInMergeQueue: false` means it isn't queued (either never enqueued, fell out after a force-push, or already merged/closed — check `state` separately).
+
+## Check whether a failure is pre-existing on main
+
+Before treating a failing check as "caused by this PR," see if the same check already fails on main's current HEAD:
+
+```bash
+gh api graphql -f query='
+{
+  repository(owner: "onyx-dot-app", name: "onyx") {
+    object(expression: "main") {
+      ... on Commit {
+        checkSuites(first: 20) {
+          nodes {
+            checkRuns(first: 50, filterBy: {checkName: "CHECK_NAME"}) {
+              nodes { name conclusion status }
+            }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+If it shows the same `FAILURE` there, the PR didn't cause it.


### PR DESCRIPTION
## Description

Adds a project-level agent skill for triaging and landing batches of Dependabot PRs, shared with the team via `.cursor/skills/` (which `.claude/skills` symlinks to, so it works in both Cursor and Claude Code).

The skill encodes the repo-specific knowledge that otherwise gets rediscovered every batch:

- `main` merges exclusively through the merge queue — enqueue with `gh pr merge --auto`, no strategy flag.
- The required-check list, and why an absent `required`/`playwright-required` check means "slow matrix still running," not "blocked" (aggregate `if: always()` jobs in `pr-integration-tests.yml`/`pr-playwright-tests.yml`, with instant-pass stubs in `merge-group.yml`).
- Exact mechanical fixes: `pre-commit run --files pyproject.toml uv.lock backend/requirements/*.txt` for stale uv requirement exports, `bun install` in the bumped directory for stale `bun.lock`.
- Bucketed triage with per-bucket confirmation before anything consequential (approve/close/push/rerun), plus classification of pre-existing failures vs. external flakes vs. real regressions before touching anything.
- Copy-pasteable GraphQL queries (in `references/`) for true merge-queue state, since `mergeStateStatus` alone can mislead.

Note: files are force-added since `.gitignore`'s `!/.cursor/skills/` re-include can't override the excluded `.cursor` parent directory — same as the existing `playwright` and `onyx-cli` skills.

## How Has This Been Tested?

Structure follows Anthropic's skill-authoring best practices (description-for-discovery, progressive disclosure via `references/`). Commands were verified against the live repo: rulesets via `gh api`, hook definitions in `.pre-commit-config.yaml`, and workflow files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a project-level skill to triage and merge Dependabot PRs via the GitHub merge queue. It waits for all checks (advisory included), gates major/0.x bumps behind per-PR opt-in, and asks the user where to resolve when the checkout is dirty; shared via `.cursor/skills/` (symlinked from `.claude/skills`).

- **New Features**
  - Approves and auto-enqueues green PRs with `gh pr merge --auto`; documents required checks and why missing `required`/`playwright-required` means the slow matrices are still running; waits for all checks to finish before enqueueing; surfaces majors/0.x minors with a short breaking-changes summary for per-PR opt-in.
  - Mechanical fixes with exact commands: `pre-commit run --files pyproject.toml uv.lock backend/requirements/*.txt` and `bun install` in the bumped directory.
  - Bucketed triage (green, mechanical, needs diagnosis, conflicts, superseded) with per-bucket confirmation; classifies failures (pre-existing vs. flake vs. regression); uses GraphQL for true merge-queue state and to detect pre-existing failures on `main`.
  - Conflicts: `@dependabot rebase` for untouched bot branches; if we already pushed fixes, manually rebase onto `origin/main` and push with `--force-with-lease`.
  - Harness-first worktree flow to keep the main checkout clean; if the checkout isn’t clean or neither option applies, ask the user where to resolve; avoid tmpfs paths.

<sup>Written for commit 7fe2927e52a2deeba4e994fe1fed647c480d93c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

