### PR TITLE
feat(connectors): allow GitHub connector to index files from a specific branch

### DIFF
--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -839,7 +839,10 @@ class GithubConnector(
         caller should return the checkpoint to resume), False once drained.
         """
         branch = self._resolve_branch(repo)
-        if checkpoint.file_paths is not None and checkpoint.file_paths_branch != branch:
+        branch_changed = (
+            checkpoint.file_paths is not None and checkpoint.file_paths_branch != branch
+        )
+        if branch_changed:
             # The cached listing came from a different branch (resumed
             # checkpoint after a connector edit or default-branch change) —
             # discard it so paths and content come from the same branch.
@@ -851,7 +854,14 @@ class GithubConnector(
             pushed_at = (
                 repo.pushed_at.replace(tzinfo=timezone.utc) if repo.pushed_at else None
             )
-            if start is not None and pushed_at is not None and pushed_at < start:
+            # After a branch change the new branch was never indexed, so the
+            # pushed_at freshness gate must not skip the re-listing.
+            if (
+                not branch_changed
+                and start is not None
+                and pushed_at is not None
+                and pushed_at < start
+            ):
                 # Nothing changed in this repo since the last poll — skip.
                 logger.info("Skipping files for repo %s (pushed_at < start)", repo.name)
                 checkpoint.file_paths = []

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -508,13 +508,13 @@ def _convert_file_to_document(
     path: str,
     content_text: str,
     repo_external_access: ExternalAccess | None,
+    branch: str,
 ) -> Document:
     repo_full_name = repo.full_name
     parts = repo_full_name.split("/", 1)
     owner_name = parts[0] if parts else ""
     repo_name = parts[1] if len(parts) > 1 else repo_full_name
 
-    branch = repo.default_branch
     html_url = f"{repo.html_url}/blob/{branch}/{path}"
     _, extension = os.path.splitext(path)
 
@@ -610,6 +610,7 @@ class GithubConnector(
         include_prs: bool = True,
         include_issues: bool = False,
         include_files: bool = False,
+        branch: str | None = None,
     ) -> None:
         self.repo_owner = repo_owner
         self.repositories = repositories
@@ -617,6 +618,8 @@ class GithubConnector(
         self.include_prs = include_prs
         self.include_issues = include_issues
         self.include_files = include_files
+        # Branch to index files from; None means each repo's default branch.
+        self.branch = (branch or "").strip() or None
         self.github_client: Github | None = None
 
     def load_credentials(self, credentials: dict[str, Any]) -> dict[str, Any] | None:
@@ -732,10 +735,13 @@ class GithubConnector(
             state=self.state_filter, sort="updated", direction="desc"
         )
 
+    def _resolve_branch(self, repo: Repository.Repository) -> str:
+        return self.branch or repo.default_branch
+
     def _list_indexable_files(
         self, repo: Repository.Repository, attempt_num: int = 0
     ) -> tuple[list[str], bool]:
-        """Resolve the repo's default-branch tree and return indexable file paths.
+        """Resolve the configured (or default) branch tree and return indexable file paths.
 
         Returns (sorted paths, truncated) where `truncated` is True when GitHub
         capped the recursive tree (>100k entries or >7MB), meaning some files
@@ -748,7 +754,7 @@ class GithubConnector(
             )
         assert self.github_client is not None  # for type-checking
         try:
-            git_tree = repo.get_git_tree(repo.default_branch, recursive=True)
+            git_tree = repo.get_git_tree(self._resolve_branch(repo), recursive=True)
             truncated = bool(git_tree.raw_data.get("truncated"))
             if truncated:
                 logger.error(
@@ -768,6 +774,13 @@ class GithubConnector(
             sleep_after_rate_limit_exception(self.github_client)
             return self._list_indexable_files(repo, attempt_num + 1)
         except GithubException as e:
+            if e.status == 404 and self.branch:
+                raise ConnectorValidationError(
+                    f"Branch '{self.branch}' not found in repository "
+                    f"{repo.full_name}. Leave the branch setting blank to use "
+                    f"the repository's default branch."
+                ) from e
+
             error_message = (
                 e.data.get("message") if isinstance(e.data, dict) else e.message
             )
@@ -793,7 +806,7 @@ class GithubConnector(
             )
         assert self.github_client is not None  # for type-checking
         try:
-            content = repo.get_contents(path, ref=repo.default_branch)
+            content = repo.get_contents(path, ref=self._resolve_branch(repo))
             if isinstance(content, list):
                 raise ValueError(f"Expected a file at {path}, got a directory")
             if content.decoded_content is None:
@@ -855,8 +868,9 @@ class GithubConnector(
         batch = file_paths[page * FILE_BATCH_SIZE : (page + 1) * FILE_BATCH_SIZE]
         checkpoint.curr_page += 1
 
+        branch = self._resolve_branch(repo)
         for path in batch:
-            html_url = f"{repo.html_url}/blob/{repo.default_branch}/{path}"
+            html_url = f"{repo.html_url}/blob/{branch}/{path}"
             if is_slim:
                 yield Document(
                     id=html_url,
@@ -880,7 +894,7 @@ class GithubConnector(
                     )
                     continue
                 yield _convert_file_to_document(
-                    repo, path, content_text, repo_external_access
+                    repo, path, content_text, repo_external_access, branch
                 )
             except Exception as e:
                 error_msg = f"Error converting file {path} to document: {e}"
@@ -1321,6 +1335,16 @@ class GithubConnector(
                         f"{self.repo_owner}/{self.repositories}"
                     )
                     test_repo.get_contents("")
+                    if self.branch:
+                        try:
+                            test_repo.get_branch(self.branch)
+                        except GithubException as e:
+                            if e.status == 404:
+                                raise ConnectorValidationError(
+                                    f"Branch '{self.branch}' not found in repository "
+                                    f"{self.repo_owner}/{self.repositories}."
+                                )
+                            raise
             else:
                 # Try to get organization first
                 try:

--- a/backend/onyx/connectors/github/connector.py
+++ b/backend/onyx/connectors/github/connector.py
@@ -568,6 +568,9 @@ class GithubConnectorCheckpoint(ConnectorCheckpoint):
     # Resolved + filtered file paths for the current repo's FILES stage.
     # Populated once when the stage begins, then paginated via curr_page.
     file_paths: list[str] | None = None
+    # Branch file_paths was listed from; a resumed checkpoint whose branch no
+    # longer matches (connector edited, default branch changed) is re-listed.
+    file_paths_branch: str | None = None
 
     # Used for the fallback cursor-based pagination strategy
     num_retrieved: int
@@ -575,13 +578,14 @@ class GithubConnectorCheckpoint(ConnectorCheckpoint):
 
     def reset(self) -> None:
         """
-        Resets curr_page, num_retrieved, cursor_url, and file_paths to their
-        initial values (0, 0, None, None)
+        Resets curr_page, num_retrieved, cursor_url, file_paths, and
+        file_paths_branch to their initial values (0, 0, None, None, None)
         """
         self.curr_page = 0
         self.num_retrieved = 0
         self.cursor_url = None
         self.file_paths = None
+        self.file_paths_branch = None
 
 
 def make_cursor_url_callback(
@@ -834,6 +838,15 @@ class GithubConnector(
         truncation as a failure. Returns True if more file batches remain (the
         caller should return the checkpoint to resume), False once drained.
         """
+        branch = self._resolve_branch(repo)
+        if checkpoint.file_paths is not None and checkpoint.file_paths_branch != branch:
+            # The cached listing came from a different branch (resumed
+            # checkpoint after a connector edit or default-branch change) —
+            # discard it so paths and content come from the same branch.
+            checkpoint.file_paths = None
+            checkpoint.file_paths_branch = None
+            checkpoint.curr_page = 0
+
         if checkpoint.file_paths is None:
             pushed_at = (
                 repo.pushed_at.replace(tzinfo=timezone.utc) if repo.pushed_at else None
@@ -842,10 +855,12 @@ class GithubConnector(
                 # Nothing changed in this repo since the last poll — skip.
                 logger.info("Skipping files for repo %s (pushed_at < start)", repo.name)
                 checkpoint.file_paths = []
+                checkpoint.file_paths_branch = branch
             else:
                 logger.info("Listing files for repo: %s", repo.name)
                 paths, truncated = self._list_indexable_files(repo)
                 checkpoint.file_paths = paths
+                checkpoint.file_paths_branch = branch
                 logger.info(
                     "Found %s indexable files for repo: %s", len(paths), repo.name
                 )
@@ -868,7 +883,6 @@ class GithubConnector(
         batch = file_paths[page * FILE_BATCH_SIZE : (page + 1) * FILE_BATCH_SIZE]
         checkpoint.curr_page += 1
 
-        branch = self._resolve_branch(repo)
         for path in batch:
             html_url = f"{repo.html_url}/blob/{branch}/{path}"
             if is_slim:

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -9,6 +9,7 @@ from github.GithubException import GithubException, UnknownObjectException
 from github.RateLimit import RateLimit
 from github.Requester import Requester
 
+from onyx.connectors.exceptions import ConnectorValidationError
 from onyx.connectors.github.connector import GithubConnector, _is_indexable_path
 from onyx.connectors.github.models import SerializedRepository
 from onyx.connectors.models import ConnectorFailure, Document
@@ -110,7 +111,9 @@ def create_mock_repo() -> Callable[..., MagicMock]:
 
 
 def _build_connector(
-    mock_github_client: MagicMock, include_files: bool = True
+    mock_github_client: MagicMock,
+    include_files: bool = True,
+    branch: str | None = None,
 ) -> GithubConnector:
     connector = GithubConnector(
         repo_owner="test-org",
@@ -118,6 +121,7 @@ def _build_connector(
         include_prs=False,
         include_issues=False,
         include_files=include_files,
+        branch=branch,
     )
     connector.github_client = mock_github_client
     return connector
@@ -327,6 +331,74 @@ def test_empty_repository_tree_skips_file_stage(
 
     assert _all_items(outputs) == []
     assert outputs[-1].next_checkpoint.has_more is False
+
+
+def test_branch_override_threads_through_listing_fetching_and_urls(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client, branch="gh-pages")
+    mock_repo = create_mock_repo(
+        {
+            "index.md": b"# Site home",
+            "docs/setup.md": b"setup guide",
+        }
+    )
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        outputs = load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    docs = [i for i in _all_items(outputs) if isinstance(i, Document)]
+    ids = sorted(d.id for d in docs)
+    assert ids == [
+        "https://github.com/test-org/test-repo/blob/gh-pages/docs/setup.md",
+        "https://github.com/test-org/test-repo/blob/gh-pages/index.md",
+    ]
+    for doc in docs:
+        assert doc.metadata.get("branch") == "gh-pages"
+
+    # Both the tree listing and every content fetch must target the branch.
+    mock_repo.get_git_tree.assert_called_once_with("gh-pages", recursive=True)
+    for call in mock_repo.get_contents.call_args_list:
+        assert call.kwargs["ref"] == "gh-pages"
+
+
+def test_default_branch_used_when_branch_unset(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client)
+    mock_repo = create_mock_repo({"README.md": b"# Hello"})
+    mock_github_client.get_repo.return_value = mock_repo
+
+    with patch.object(SerializedRepository, "to_Repository", return_value=mock_repo):
+        load_everything_from_checkpoint_connector(connector, 0, time.time())
+
+    mock_repo.get_git_tree.assert_called_once_with("main", recursive=True)
+    for call in mock_repo.get_contents.call_args_list:
+        assert call.kwargs["ref"] == "main"
+
+
+def test_blank_branch_normalized_to_none() -> None:
+    assert GithubConnector(repo_owner="o", branch="").branch is None
+    assert GithubConnector(repo_owner="o", branch="   ").branch is None
+    assert GithubConnector(repo_owner="o", branch=None).branch is None
+    assert GithubConnector(repo_owner="o", branch=" gh-pages ").branch == "gh-pages"
+
+
+def test_nonexistent_branch_raises_clear_error(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    connector = _build_connector(mock_github_client, branch="no-such-branch")
+    mock_repo = create_mock_repo({})
+    mock_repo.get_git_tree.side_effect = GithubException(
+        404, {"message": "Not Found"}, {}
+    )
+
+    with pytest.raises(ConnectorValidationError, match="no-such-branch"):
+        connector._list_indexable_files(mock_repo)
 
 
 def test_prs_disabled_404_does_not_crash_files(

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -10,7 +10,11 @@ from github.RateLimit import RateLimit
 from github.Requester import Requester
 
 from onyx.connectors.exceptions import ConnectorValidationError
-from onyx.connectors.github.connector import GithubConnector, _is_indexable_path
+from onyx.connectors.github.connector import (
+    GithubConnector,
+    GithubConnectorStage,
+    _is_indexable_path,
+)
 from onyx.connectors.github.models import SerializedRepository
 from onyx.connectors.models import ConnectorFailure, Document
 from tests.unit.onyx.connectors.utils import load_everything_from_checkpoint_connector
@@ -385,6 +389,43 @@ def test_blank_branch_normalized_to_none() -> None:
     assert GithubConnector(repo_owner="o", branch="   ").branch is None
     assert GithubConnector(repo_owner="o", branch=None).branch is None
     assert GithubConnector(repo_owner="o", branch=" gh-pages ").branch == "gh-pages"
+
+
+def test_resumed_checkpoint_from_other_branch_relists(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    """A checkpoint resumed after the branch setting changed must re-list.
+
+    Otherwise paths listed from the old branch pair with content fetches from
+    the new branch — deleted paths fail and new-branch-only files are skipped.
+    """
+    connector = _build_connector(mock_github_client, branch="gh-pages")
+    mock_repo = create_mock_repo({"new-only.md": b"new content"})
+
+    checkpoint = connector.build_dummy_checkpoint()
+    checkpoint.stage = GithubConnectorStage.FILES
+    checkpoint.file_paths = ["old-only.md"]  # listed from the previous branch
+    checkpoint.file_paths_branch = "main"
+    checkpoint.curr_page = 1
+
+    items = list(
+        connector._fetch_repo_files(
+            mock_repo,
+            checkpoint,
+            start=None,
+            is_slim=False,
+            repo_external_access=None,
+        )
+    )
+
+    docs = [i for i in items if isinstance(i, Document)]
+    assert [d.id for d in docs] == [
+        "https://github.com/test-org/test-repo/blob/gh-pages/new-only.md"
+    ]
+    mock_repo.get_git_tree.assert_called_once_with("gh-pages", recursive=True)
+    assert checkpoint.file_paths == ["new-only.md"]
+    assert checkpoint.file_paths_branch == "gh-pages"
 
 
 def test_nonexistent_branch_raises_clear_error(

--- a/backend/tests/unit/onyx/connectors/github/test_github_files.py
+++ b/backend/tests/unit/onyx/connectors/github/test_github_files.py
@@ -428,6 +428,45 @@ def test_resumed_checkpoint_from_other_branch_relists(
     assert checkpoint.file_paths_branch == "gh-pages"
 
 
+def test_resumed_branch_change_bypasses_pushed_at_gate(
+    mock_github_client: MagicMock,
+    create_mock_repo: Callable[..., MagicMock],
+) -> None:
+    """Re-listing after a branch change must ignore the pushed_at gate.
+
+    The new branch was never indexed, so an old pushed_at must not cause the
+    re-listing to be skipped with an empty path list.
+    """
+    connector = _build_connector(mock_github_client, branch="gh-pages")
+    mock_repo = create_mock_repo(
+        {"new-only.md": b"new content"},
+        pushed_at=datetime(2020, 1, 1),
+    )
+
+    checkpoint = connector.build_dummy_checkpoint()
+    checkpoint.stage = GithubConnectorStage.FILES
+    checkpoint.file_paths = ["old-only.md"]  # listed from the previous branch
+    checkpoint.file_paths_branch = "main"
+    checkpoint.curr_page = 1
+
+    # poll window starts well after the repo's last push
+    items = list(
+        connector._fetch_repo_files(
+            mock_repo,
+            checkpoint,
+            start=datetime(2023, 1, 1, tzinfo=timezone.utc),
+            is_slim=False,
+            repo_external_access=None,
+        )
+    )
+
+    docs = [i for i in items if isinstance(i, Document)]
+    assert [d.id for d in docs] == [
+        "https://github.com/test-org/test-repo/blob/gh-pages/new-only.md"
+    ]
+    assert checkpoint.file_paths_branch == "gh-pages"
+
+
 def test_nonexistent_branch_raises_clear_error(
     mock_github_client: MagicMock,
     create_mock_repo: Callable[..., MagicMock],

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -313,11 +313,21 @@ export const connectorConfigs: Record<
         label: "Include Documents?",
         name: "include_files",
         description:
-          "Index text-based documents (markdown, text, etc.) from the default branch of repositories",
+          "Index text-based documents (markdown, text, etc.) from repositories",
         optional: true,
       },
     ],
-    advanced_values: [],
+    advanced_values: [
+      {
+        type: "text",
+        query: "Enter the branch to index documents from:",
+        label: "Branch",
+        name: "branch",
+        optional: true,
+        description:
+          "Branch to index documents from (e.g. gh-pages). Leave blank to use each repository's default branch. Only applies when 'Include Documents?' is enabled.",
+      },
+    ],
   },
   testrail: {
     description: "Configure TestRail connector",
@@ -2084,6 +2094,7 @@ export interface GithubConfig {
   include_prs: boolean;
   include_issues: boolean;
   include_files: boolean;
+  branch?: string;
 }
 
 export interface GitlabConfig {

--- a/web/src/lib/connectors/connectors.tsx
+++ b/web/src/lib/connectors/connectors.tsx
@@ -325,7 +325,7 @@ export const connectorConfigs: Record<
         name: "branch",
         optional: true,
         description:
-          "Branch to index documents from (e.g. gh-pages). Leave blank to use each repository's default branch. Only applies when 'Include Documents?' is enabled.",
+          "Branch to index documents from (e.g. gh-pages). Leave blank to use each repository's default branch. Only applies when 'Include Documents?' is enabled. After changing this on an existing connector, trigger a re-index to pick up the new branch immediately.",
       },
     ],
   },


### PR DESCRIPTION
## Description

The GitHub connector's "Include Documents?" option indexes prose files (`.md`, `.mdx`, `.markdown`, `.rst`, `.txt`, plus extensionless docs like README) but always uses each repo's default branch. This adds an optional **Branch** setting (Advanced section of the connector form) so documents can be indexed from a different branch — e.g. `gh-pages` for repos whose published docs live there.

- Blank branch = default branch; existing connectors are unchanged.
- The branch is threaded through the tree listing, the per-file content fetch, and blob URL construction — including the slim-document path, so pruning stays consistent with what was indexed.
- A nonexistent branch surfaces a clear `ConnectorValidationError` (both at connector creation for single-repo configs and at indexing time) instead of a raw 404.
- PRs and issues are not branch-scoped and are unaffected.

Same shape as the community GitLab change proposed in #12676.

Linear: https://linear.app/onyx-app/issue/CS-83

## How Has This Been Tested?

- New mocked unit tests in `backend/tests/unit/onyx/connectors/github/test_github_files.py`: branch override threads to `get_git_tree`/`get_contents` and blob URLs, default-branch behavior unchanged when unset, blank/whitespace branch normalizes to unset, nonexistent branch raises a clear validation error. Full GitHub connector unit suite passes (61 tests).
- `pre-commit` on touched files passes (the `typescript-check` failure is pre-existing on main in unrelated `.stories.tsx` files — verified identical on a clean checkout).
<img width="881" height="1249" alt="Screenshot 2026-07-27 at 4 52 03 PM" src="https://github.com/user-attachments/assets/fd935486-f5e5-46b2-9632-dd0ca47ad958" />

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional Branch setting to the GitHub connector to index documents from a specific branch (e.g., gh-pages) instead of the default. Addresses Linear CS-83; blank keeps current behavior. Resumed runs now re-list and bypass the pushed_at gate after a branch change so the new branch is indexed.

- New Features
  - Added Branch field in Advanced settings (applies only when "Include Documents?" is enabled); UI copy notes to re-index after changing it.
  - Branch is threaded through tree listing, content fetch (`ref`), and blob URLs (including slim); validates branch existence with a clear `ConnectorValidationError`; blank/whitespace normalizes to unset.

- Bug Fixes
  - Resuming after a branch change re-lists files; checkpoints record the listing branch to avoid mixing paths from different branches.
  - Re-listing after a branch change bypasses the pushed_at freshness gate so indexing doesn’t get skipped.

<sup>Written for commit ceb63824bf57a8bba0f1b8ba4b3a7a185cf3470e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13486?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

