### PR TITLE
fix(web): don't flash raw 'Loading...' text in connector access selector

### DIFF
--- a/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
+++ b/web/src/components/admin/connectors/AccessTypeGroupSelector.tsx
@@ -83,7 +83,7 @@ export function AccessTypeGroupSelector({
   ]);
 
   if (userGroupsIsLoading) {
-    return <div>Loading...</div>;
+    return null;
   }
   if (!businessTier) {
     return null;


### PR DESCRIPTION
## Description

`AccessTypeGroupSelector` (rendered on every connector creation form, between the access-type dropdown and the Advanced Options toggle) returns a bare `<div>Loading...</div>` while `useUserGroups()` is in flight. For the common case (public access type) the component then resolves to rendering nothing, so users see an unstyled `Loading...` text flash for a split second on every connector form.

Render nothing while loading instead. The group-selector content still appears once groups resolve for the private/curator flows, same as before — it just no longer flashes placeholder text in the meantime.

## How Has This Been Tested?

- `pre-commit` (oxfmt, oxlint) passes on the touched file. The `typescript-check` hook failure is pre-existing on main (unrelated `.stories.tsx` errors).
- Visually confirmed the flash on the GitHub connector creation form at `?step=1` before the change; with the change the space simply stays empty until the fetch resolves.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop flashing raw "Loading..." text in `AccessTypeGroupSelector` by rendering nothing while user groups load. This removes the brief flicker on connector creation forms and keeps group content appearing as before for private/curator flows once data resolves.

<sup>Written for commit d9a7b0c98d9ddc1019ab2a451fe9b20de9510513. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

