### PR TITLE
feat(craft): pre-pull the sandbox image onto the sandbox node pool

### DIFF
--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py
@@ -1,0 +1,309 @@
+"""Invariants for the sandbox image-prepull DaemonSet.
+
+The DaemonSet exists to keep the sandbox image resident on every node in the
+sandbox pool so a user's first sandbox there doesn't pay the pull. Three
+properties make it work, and each fails silently if broken:
+
+  - It must reference the *same* image as the sandbox pods. A drifted tag pins
+    layers nobody uses while every sandbox still cold-pulls.
+  - It must land on the same nodes (nodeSelector + tolerations), or it warms
+    the wrong pool.
+  - It must resolve the same pull credentials, or a private registry leaves it
+    in ImagePullBackOff while it appears deployed.
+  - It must stay running, because the kubelet only skips image GC for images a
+    running pod references. Hence the long-lived, shell-portable command.
+
+Skips if the ``helm`` binary or chart deps are unavailable.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+# backend/tests/unit/onyx/server/features/build/sandbox/ -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[8]
+_CHART_DIR = _REPO_ROOT / "deployment" / "helm" / "charts" / "onyx"
+_PREPULLER_TEMPLATE = "templates/sandbox-image-prepuller.yaml"
+_PODTEMPLATE_TEMPLATE = "templates/sandbox-podtemplate.yaml"
+
+# The chart refuses to render without a push keypair; any valid base64 seed works.
+_FAKE_PUSH_KEY = "ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleWZha2VrZXk="
+
+
+def _run_helm(
+    template: str, extra_args: list[str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    helm = shutil.which("helm")
+    if helm is None:
+        pytest.skip("helm binary not available")
+    cmd = [
+        helm,
+        "template",
+        "onyx",
+        str(_CHART_DIR),
+        "-n",
+        "onyx",
+        "-f",
+        str(_CHART_DIR / "values-ci.yaml"),
+        "--kube-version",
+        "1.33.0",
+        "--set",
+        f"auth.sandboxPushSecret.values.private_key={_FAKE_PUSH_KEY}",
+        *(extra_args or []),
+        "--show-only",
+        template,
+    ]
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def _render(template: str, extra_args: list[str] | None = None) -> str:
+    result = _run_helm(template, extra_args)
+    if result.returncode != 0:
+        pytest.skip(f"helm template failed (chart deps?): {result.stderr.strip()}")
+    return result.stdout
+
+
+def _renders_nothing(extra_args: list[str]) -> bool:
+    """True when the template produced no manifest at all.
+
+    ``--show-only`` on a template that rendered empty is a helm *error*
+    ("could not find template"), not empty stdout — so a plain string check on
+    stdout would pass for a genuinely broken chart too.
+    """
+    result = _run_helm(_PREPULLER_TEMPLATE, extra_args)
+    if result.returncode == 0:
+        return not result.stdout.strip().strip("-")
+    if "could not find template" in result.stderr:
+        return True
+    pytest.skip(f"helm template failed (chart deps?): {result.stderr.strip()}")
+
+
+def _prepuller(extra_args: list[str] | None = None) -> dict:
+    """The DaemonSet. The template also emits a PriorityClass, so select by kind
+    rather than assuming a single document."""
+    docs = yaml.safe_load_all(_render(_PREPULLER_TEMPLATE, extra_args))
+    return next(d for d in docs if d and d["kind"] == "DaemonSet")
+
+
+def _prepuller_pod_spec(extra_args: list[str] | None = None) -> dict:
+    return _prepuller(extra_args)["spec"]["template"]["spec"]
+
+
+def test_prepuller_image_matches_the_sandbox_pod_image() -> None:
+    """The whole mechanism is a no-op unless both resolve to the same ref, and
+    a mismatch is invisible at runtime."""
+    args = [
+        "--set",
+        "global.version=v9.8.7",
+        "--set-string",
+        "configMap.SANDBOX_CONTAINER_IMAGE=",
+    ]
+
+    prepuller_image = _prepuller_pod_spec(args)["containers"][0]["image"]
+    pod_template = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE, args))
+    sandbox_images = {
+        c["image"]
+        for c in pod_template["template"]["spec"]["containers"]
+        + pod_template["template"]["spec"]["initContainers"]
+    }
+
+    assert sandbox_images == {"onyxdotapp/sandbox:v9.8.7"}
+    assert prepuller_image == "onyxdotapp/sandbox:v9.8.7"
+
+
+def test_prepuller_image_follows_explicit_override() -> None:
+    spec = _prepuller_pod_spec(
+        ["--set-string", "configMap.SANDBOX_CONTAINER_IMAGE=onyxdotapp/sandbox:dev"]
+    )
+    assert spec["containers"][0]["image"] == "onyxdotapp/sandbox:dev"
+
+
+def test_prepuller_scheduling_matches_the_sandbox_pod() -> None:
+    """Warming a node the sandboxes can't be scheduled onto buys nothing."""
+    prepuller = _prepuller_pod_spec()
+    sandbox = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE))["template"]["spec"]
+
+    assert prepuller["nodeSelector"] == sandbox["nodeSelector"]
+    assert prepuller["tolerations"] == sandbox["tolerations"]
+
+
+def test_prepuller_stays_running_to_pin_layers() -> None:
+    """The kubelet only exempts images referenced by a *running* pod from image
+    GC, so a one-shot pull would leave the layers evictable.
+
+    The command must also be portable: `sleep infinity` is a GNU coreutils
+    extension that dies on busybox/alpine, and a CrashLooping prepuller unpins
+    the image silently.
+    """
+    container = _prepuller_pod_spec()["containers"][0]
+    assert container["command"] == ["sh", "-c", "while :; do sleep 86400; done"]
+
+
+def test_prepuller_pull_policy_is_if_not_present() -> None:
+    """`Always` would re-pull on every pod restart, defeating the point."""
+    container = _prepuller_pod_spec(
+        ["--set", "configMap.SANDBOX_IMAGE_PULL_POLICY=Always"]
+    )["containers"][0]
+    assert container["imagePullPolicy"] == "IfNotPresent"
+
+
+def test_prepuller_requests_ephemeral_storage() -> None:
+    """A container with no ephemeral-storage request is invisible to the
+    scheduler's disk accounting — which this repo treats as a bug (see
+    test_pod_spec.test_all_containers_set_ephemeral_storage_requests). The
+    prepuller writes nothing, but it must still be accounted for."""
+    resources = _prepuller_pod_spec()["containers"][0]["resources"]
+    assert "ephemeral-storage" in resources["requests"]
+    assert "ephemeral-storage" in resources["limits"]
+    assert resources["requests"] == resources["limits"]
+
+
+def test_prepuller_yields_to_pending_sandbox_pods() -> None:
+    """A do-nothing pod must never be the reason a sandbox fails to schedule and
+    triggers a scale-up. Negative priority lets a pending sandbox preempt it;
+    preemptionPolicy Never means the prepuller evicts nothing itself."""
+    docs = list(yaml.safe_load_all(_render(_PREPULLER_TEMPLATE)))
+    pc = next(d for d in docs if d and d["kind"] == "PriorityClass")
+    ds = next(d for d in docs if d and d["kind"] == "DaemonSet")
+
+    assert pc["value"] < 0
+    assert pc["globalDefault"] is False
+    assert pc["preemptionPolicy"] == "Never"
+    assert ds["spec"]["template"]["spec"]["priorityClassName"] == pc["metadata"]["name"]
+
+
+def test_existing_priority_class_skips_creation() -> None:
+    """An operator supplying their own class must not also get ours."""
+    docs = [
+        d
+        for d in yaml.safe_load_all(
+            _render(
+                _PREPULLER_TEMPLATE,
+                ["--set", "sandboxImagePrepull.priorityClassName=system-node-critical"],
+            )
+        )
+        if d
+    ]
+    assert [d["kind"] for d in docs] == ["DaemonSet"]
+    assert (
+        docs[0]["spec"]["template"]["spec"]["priorityClassName"]
+        == "system-node-critical"
+    )
+
+
+def test_priority_class_creation_can_be_declined() -> None:
+    """Regression: sprig's ``merge`` treats ``false`` as empty and overwrites it
+    with the default, so a merge-based defaults block silently ignored
+    ``create: false``. Falsy values must survive."""
+    docs = [
+        d
+        for d in yaml.safe_load_all(
+            _render(
+                _PREPULLER_TEMPLATE,
+                ["--set", "sandboxImagePrepull.priorityClass.create=false"],
+            )
+        )
+        if d
+    ]
+    assert [d["kind"] for d in docs] == ["DaemonSet"]
+    assert "priorityClassName" not in docs[0]["spec"]["template"]["spec"]
+
+
+def test_priority_class_value_zero_survives() -> None:
+    """Same trap for ints: ``value: 0`` must not silently become -10."""
+    pc = next(
+        d
+        for d in yaml.safe_load_all(
+            _render(
+                _PREPULLER_TEMPLATE,
+                ["--set", "sandboxImagePrepull.priorityClass.value=0"],
+            )
+        )
+        if d and d["kind"] == "PriorityClass"
+    )
+    assert pc["value"] == 0
+
+
+def test_repull_fanout_is_tunable_for_large_pools() -> None:
+    """N nodes pulling ~1GB at once is a thundering herd against the registry."""
+    ds = next(
+        d
+        for d in yaml.safe_load_all(
+            _render(
+                _PREPULLER_TEMPLATE,
+                ["--set-string", "sandboxImagePrepull.updateMaxUnavailable=25%"],
+            )
+        )
+        if d and d["kind"] == "DaemonSet"
+    )
+    assert ds["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"] == "25%"
+
+
+def test_prepuller_pull_credentials_match_the_sandbox_pod() -> None:
+    """A private registry must not leave the prepuller in ImagePullBackOff while
+    it silently warms nothing. Credentials reach a pod two ways — the chart-wide
+    secrets and the ServiceAccount — and both must match the sandbox pods'."""
+    args = ["--set", "imagePullSecrets[0].name=regcred"]
+    prepuller = _prepuller_pod_spec(args)
+    sandbox = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE, args))["template"]["spec"]
+
+    assert prepuller["imagePullSecrets"] == [{"name": "regcred"}]
+    assert prepuller["serviceAccountName"] == sandbox["serviceAccountName"]
+    # The SA is for pull credentials only; this pod makes no API calls.
+    assert prepuller["automountServiceAccountToken"] is False
+
+
+def test_prepuller_service_account_follows_the_configured_name() -> None:
+    spec = _prepuller_pod_spec(
+        ["--set-string", "configMap.SANDBOX_SERVICE_ACCOUNT_NAME=custom-sandbox-sa"]
+    )
+    assert spec["serviceAccountName"] == "custom-sandbox-sa"
+
+
+def test_priority_class_name_is_namespace_scoped() -> None:
+    """PriorityClass is cluster-scoped. Two same-named releases in different
+    namespaces must not render the same object — the second install would fail
+    Helm's ownership check, and either release's upgrade could disrupt the
+    other."""
+
+    def pc_name(namespace: str) -> str:
+        docs = yaml.safe_load_all(
+            _render(_PREPULLER_TEMPLATE, ["--namespace", namespace])
+        )
+        pc = next(d for d in docs if d and d["kind"] == "PriorityClass")
+        return pc["metadata"]["name"]
+
+    assert pc_name("onyx") != pc_name("onyx-staging")
+
+
+def test_priority_class_name_stays_within_k8s_limits() -> None:
+    """Long release/namespace pairs must hash down rather than emit an invalid
+    name, matching the trunc+sha shape used for the RBAC names."""
+    long_ns = "a" * 60
+    docs = yaml.safe_load_all(_render(_PREPULLER_TEMPLATE, ["--namespace", long_ns]))
+    name = next(d for d in docs if d and d["kind"] == "PriorityClass")["metadata"][
+        "name"
+    ]
+    assert len(name) <= 253
+    assert re.fullmatch(r"[a-z0-9]([-a-z0-9]*[a-z0-9])?", name), name
+
+
+def test_prepuller_is_excluded_from_sandbox_network_policies() -> None:
+    """The sandbox NetworkPolicies select `component: sandbox`. The prepuller is
+    not a sandbox and must not be swept into that default-deny selector."""
+    labels = _prepuller()["spec"]["template"]["metadata"]["labels"]
+    assert labels["app.kubernetes.io/component"] == "sandbox-image-prepuller"
+
+
+def test_prepuller_can_be_disabled() -> None:
+    assert _renders_nothing(["--set", "sandboxImagePrepull.enabled=false"])
+
+
+def test_prepuller_absent_when_craft_disabled() -> None:
+    assert _renders_nothing(["--set-string", "configMap.ENABLE_CRAFT=false"])

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py
@@ -1,17 +1,24 @@
 """Invariants for the sandbox image-prepull DaemonSet.
 
-The DaemonSet exists to keep the sandbox image resident on every node in the
-sandbox pool so a user's first sandbox there doesn't pay the pull. Three
-properties make it work, and each fails silently if broken:
+The DaemonSet keeps the sandbox image resident on every node in the sandbox
+pool so a user's first sandbox there doesn't pay the pull. Four properties make
+it work:
 
-  - It must reference the *same* image as the sandbox pods. A drifted tag pins
-    layers nobody uses while every sandbox still cold-pulls.
-  - It must land on the same nodes (nodeSelector + tolerations), or it warms
-    the wrong pool.
-  - It must resolve the same pull credentials, or a private registry leaves it
-    in ImagePullBackOff while it appears deployed.
-  - It must stay running, because the kubelet only skips image GC for images a
+  - It references the same image as the sandbox pods. A drifted tag pins layers
+    nobody uses while every sandbox still cold-pulls.
+  - It lands on the same nodes (nodeSelector + tolerations), or it warms the
+    wrong pool.
+  - It resolves pull credentials, or a private registry leaves it in
+    ImagePullBackOff.
+  - It stays running, because the kubelet only skips image GC for images a
     running pod references. Hence the long-lived, shell-portable command.
+
+These are tested rather than asserted at runtime because none of them surface
+as an error: the DaemonSet reports Ready (or, on the credentials case,
+ImagePullBackOff on a pod nobody watches) while sandboxes go on cold-pulling at
+the original latency. The only signal is provisioning being slow, which is what
+the feature was meant to fix. All four are fixed at chart-render time, so a
+render test catches them before deploy.
 
 Skips if the ``helm`` binary or chart deps are unavailable.
 """
@@ -245,10 +252,14 @@ def test_repull_fanout_is_tunable_for_large_pools() -> None:
     assert ds["spec"]["updateStrategy"]["rollingUpdate"]["maxUnavailable"] == "25%"
 
 
-def test_prepuller_pull_credentials_match_the_sandbox_pod() -> None:
-    """A private registry must not leave the prepuller in ImagePullBackOff while
-    it silently warms nothing. Credentials reach a pod two ways — the chart-wide
-    secrets and the ServiceAccount — and both must match the sandbox pods'."""
+def test_prepuller_resolves_pull_credentials() -> None:
+    """A private registry must not leave the prepuller in ImagePullBackOff.
+
+    Credentials reach a pod two ways: the chart-wide secrets and the
+    ServiceAccount. The prepuller takes both. Note this is a superset of what
+    the sandbox PodTemplate resolves — it renders no imagePullSecrets and relies
+    on the sandbox SA alone — so the SA is the route that must agree.
+    """
     args = ["--set", "imagePullSecrets[0].name=regcred"]
     prepuller = _prepuller_pod_spec(args)
     sandbox = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE, args))["template"]["spec"]

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py
@@ -20,7 +20,14 @@ the original latency. The only signal is provisioning being slow, which is what
 the feature was meant to fix. All four are fixed at chart-render time, so a
 render test catches them before deploy.
 
-Skips if the ``helm`` binary or chart deps are unavailable.
+Rendering needs the ``helm`` binary and the chart's subchart tarballs, which are
+gitignored, so these skip unless you have run ``helm dependency build`` on the
+chart. No CI lane currently supplies both, so treat them as a local guard for
+now: run them when you touch the sandbox chart templates.
+
+Only a missing-dependency error is treated as "can't run here". Any other helm
+failure is the chart being broken and fails the test — a render test that
+reports a broken chart as a skip is worse than no test.
 """
 
 from __future__ import annotations
@@ -29,6 +36,7 @@ import re
 import shutil
 import subprocess
 from pathlib import Path
+from typing import NoReturn
 
 import pytest
 import yaml
@@ -41,6 +49,21 @@ _PODTEMPLATE_TEMPLATE = "templates/sandbox-podtemplate.yaml"
 
 # The chart refuses to render without a push keypair; any valid base64 seed works.
 _FAKE_PUSH_KEY = "ZmFrZWtleWZha2VrZXlmYWtla2V5ZmFrZWtleWZha2VrZXk="
+
+# Substrings helm uses when the gitignored subchart tarballs are absent.
+_MISSING_DEPS_MARKERS = (
+    "found in Chart.yaml, but missing in charts/",
+    "missing in charts/ directory",
+    "no cached repository",
+)
+
+
+def _handle_render_failure(stderr: str) -> NoReturn:
+    """A missing-deps error means we can't run here; anything else is a real
+    chart defect and must not be laundered into a skip."""
+    if any(marker in stderr for marker in _MISSING_DEPS_MARKERS):
+        pytest.skip(f"chart dependencies not built: {stderr.strip()}")
+    pytest.fail(f"helm template failed: {stderr.strip()}")
 
 
 def _run_helm(
@@ -72,7 +95,7 @@ def _run_helm(
 def _render(template: str, extra_args: list[str] | None = None) -> str:
     result = _run_helm(template, extra_args)
     if result.returncode != 0:
-        pytest.skip(f"helm template failed (chart deps?): {result.stderr.strip()}")
+        _handle_render_failure(result.stderr)
     return result.stdout
 
 
@@ -88,7 +111,7 @@ def _renders_nothing(extra_args: list[str]) -> bool:
         return not result.stdout.strip().strip("-")
     if "could not find template" in result.stderr:
         return True
-    pytest.skip(f"helm template failed (chart deps?): {result.stderr.strip()}")
+    _handle_render_failure(result.stderr)
 
 
 def _prepuller(extra_args: list[str] | None = None) -> dict:
@@ -152,11 +175,22 @@ def test_prepuller_stays_running_to_pin_layers() -> None:
     assert container["command"] == ["sh", "-c", "while :; do sleep 86400; done"]
 
 
-def test_prepuller_pull_policy_is_if_not_present() -> None:
-    """`Always` would re-pull on every pod restart, defeating the point."""
-    container = _prepuller_pod_spec(
-        ["--set", "configMap.SANDBOX_IMAGE_PULL_POLICY=Always"]
-    )["containers"][0]
+def test_prepuller_pull_policy_matches_the_sandbox_pod() -> None:
+    """Pinning the prepuller to IfNotPresent while the sandbox pods run Always
+    is the tag drift this template exists to prevent, just one level down: on a
+    mutable tag the sandboxes fetch the new digest and the prepuller holds the
+    old one resident and GC-exempt, with nothing to restart it."""
+    args = ["--set", "configMap.SANDBOX_IMAGE_PULL_POLICY=Always"]
+    prepuller = _prepuller_pod_spec(args)["containers"][0]
+    sandbox = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE, args))["template"]["spec"]
+
+    assert prepuller["imagePullPolicy"] == "Always"
+    assert {c["imagePullPolicy"] for c in sandbox["containers"]} == {"Always"}
+
+
+def test_prepuller_pull_policy_defaults_to_if_not_present() -> None:
+    """The chart default must not re-pull on every restart."""
+    container = _prepuller_pod_spec()["containers"][0]
     assert container["imagePullPolicy"] == "IfNotPresent"
 
 
@@ -179,47 +213,36 @@ def test_prepuller_yields_to_pending_sandbox_pods() -> None:
     pc = next(d for d in docs if d and d["kind"] == "PriorityClass")
     ds = next(d for d in docs if d and d["kind"] == "DaemonSet")
 
-    assert pc["value"] < 0
+    # Strictly below -10, cluster-autoscaler's default expendable-pods cutoff:
+    # at exactly -10 the prepuller is non-expendable and a pending one can be
+    # read as demand for a new node.
+    assert pc["value"] < -10
     assert pc["globalDefault"] is False
     assert pc["preemptionPolicy"] == "Never"
     assert ds["spec"]["template"]["spec"]["priorityClassName"] == pc["metadata"]["name"]
 
 
+def _rendered_kinds(extra_args: list[str]) -> list[str]:
+    docs = yaml.safe_load_all(_render(_PREPULLER_TEMPLATE, extra_args))
+    return [d["kind"] for d in docs if d]
+
+
 def test_existing_priority_class_skips_creation() -> None:
     """An operator supplying their own class must not also get ours."""
-    docs = [
-        d
-        for d in yaml.safe_load_all(
-            _render(
-                _PREPULLER_TEMPLATE,
-                ["--set", "sandboxImagePrepull.priorityClassName=system-node-critical"],
-            )
-        )
-        if d
-    ]
-    assert [d["kind"] for d in docs] == ["DaemonSet"]
-    assert (
-        docs[0]["spec"]["template"]["spec"]["priorityClassName"]
-        == "system-node-critical"
-    )
+    args = ["--set", "sandboxImagePrepull.priorityClassName=system-node-critical"]
+
+    assert "PriorityClass" not in _rendered_kinds(args)
+    assert _prepuller_pod_spec(args)["priorityClassName"] == "system-node-critical"
 
 
 def test_priority_class_creation_can_be_declined() -> None:
     """Regression: sprig's ``merge`` treats ``false`` as empty and overwrites it
     with the default, so a merge-based defaults block silently ignored
     ``create: false``. Falsy values must survive."""
-    docs = [
-        d
-        for d in yaml.safe_load_all(
-            _render(
-                _PREPULLER_TEMPLATE,
-                ["--set", "sandboxImagePrepull.priorityClass.create=false"],
-            )
-        )
-        if d
-    ]
-    assert [d["kind"] for d in docs] == ["DaemonSet"]
-    assert "priorityClassName" not in docs[0]["spec"]["template"]["spec"]
+    args = ["--set", "sandboxImagePrepull.priorityClass.create=false"]
+
+    assert "PriorityClass" not in _rendered_kinds(args)
+    assert "priorityClassName" not in _prepuller_pod_spec(args)
 
 
 def test_priority_class_value_zero_survives() -> None:
@@ -255,19 +278,28 @@ def test_repull_fanout_is_tunable_for_large_pools() -> None:
 def test_prepuller_resolves_pull_credentials() -> None:
     """A private registry must not leave the prepuller in ImagePullBackOff.
 
-    Credentials reach a pod two ways: the chart-wide secrets and the
-    ServiceAccount. The prepuller takes both. Note this is a superset of what
-    the sandbox PodTemplate resolves — it renders no imagePullSecrets and relies
-    on the sandbox SA alone — so the SA is the route that must agree.
+    The sandbox ServiceAccount is the only route that works here, and the only
+    one the sandbox PodTemplate uses. `.Values.imagePullSecrets` must NOT be
+    rendered: those names refer to secrets in the release namespace, and an
+    imagePullSecret is resolved in the pod's own namespace, so in the sandbox
+    namespace they name nothing — a "Unable to retrieve pull secret" event and,
+    on a genuinely private registry, the ImagePullBackOff this is meant to
+    avoid.
     """
     args = ["--set", "imagePullSecrets[0].name=regcred"]
     prepuller = _prepuller_pod_spec(args)
     sandbox = yaml.safe_load(_render(_PODTEMPLATE_TEMPLATE, args))["template"]["spec"]
 
-    assert prepuller["imagePullSecrets"] == [{"name": "regcred"}]
+    assert "imagePullSecrets" not in prepuller
+    assert "imagePullSecrets" not in sandbox
     assert prepuller["serviceAccountName"] == sandbox["serviceAccountName"]
     # The SA is for pull credentials only; this pod makes no API calls.
     assert prepuller["automountServiceAccountToken"] is False
+
+
+def test_prepuller_runs_in_the_sandbox_namespace() -> None:
+    """Which is why the release-namespace imagePullSecrets above can't be used."""
+    assert _prepuller()["metadata"]["namespace"] == "onyx-sandboxes"
 
 
 def test_prepuller_service_account_follows_the_configured_name() -> None:
@@ -310,6 +342,24 @@ def test_prepuller_is_excluded_from_sandbox_network_policies() -> None:
     not a sandbox and must not be swept into that default-deny selector."""
     labels = _prepuller()["spec"]["template"]["metadata"]["labels"]
     assert labels["app.kubernetes.io/component"] == "sandbox-image-prepuller"
+
+
+def test_prepuller_carries_its_own_deny_all_network_policy() -> None:
+    """Being out of the `component: sandbox` selector above means the sandbox
+    default-deny doesn't cover it either, which would make this the one
+    unrestricted pod in the sandbox namespace. It needs no network — the pull is
+    the kubelet's — so it gets its own deny-all instead."""
+    docs = list(yaml.safe_load_all(_render(_PREPULLER_TEMPLATE)))
+    np = next(d for d in docs if d and d["kind"] == "NetworkPolicy")
+    pod_labels = _prepuller()["spec"]["template"]["metadata"]["labels"]
+
+    assert set(np["spec"]["policyTypes"]) == {"Ingress", "Egress"}
+    # No `ingress`/`egress` key at all is deny-all for the listed types; an
+    # empty-dict rule would be allow-all and is the easy way to get this wrong.
+    assert "ingress" not in np["spec"]
+    assert "egress" not in np["spec"]
+    # Must actually select the prepuller pods.
+    assert np["spec"]["podSelector"]["matchLabels"].items() <= pod_labels.items()
 
 
 def test_prepuller_can_be_disabled() -> None:

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.5
+version: 0.8.6
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -16,11 +16,12 @@ annotations:
     - name: background
       image: docker.io/onyxdotapp/onyx-backend:latest
   artifacthub.io/changes: |
-    - kind: changed
-      description: Documented that every Onyx image now publishes a -dev twin for each
-        of its tags, so a -dev suffixed global.version (e.g. v1.2.3-dev) selects the dev
-        variant of the whole deployment — including the backend image that carries the
-        debugging tools the opt-in tooling.pgInto helper needs.
+    - kind: added
+      description: Pre-pull the Craft sandbox image onto the sandbox node pool with a
+        DaemonSet, so a user's first sandbox on a node doesn't pay the ~31s image pull.
+        Rendered only when configMap.ENABLE_CRAFT is true; disable with
+        sandboxImagePrepull.enabled=false. Costs ~3.3 GB of unreclaimable disk per
+        sandbox node.
 dependencies:
   # Helm uses the first condition path that exists: `postgresqlOperator.enabled`
   # is unset by default, so this falls through to `postgresql.enabled`. Set it

--- a/deployment/helm/charts/onyx/templates/_helpers.tpl
+++ b/deployment/helm/charts/onyx/templates/_helpers.tpl
@@ -218,6 +218,20 @@ Return the configured autoscaling engine; defaults to HPA when unset.
 {{- if eq (toString (index .Values.configMap "ENABLE_CRAFT" | default "")) "true" -}}true{{- end -}}
 {{- end }}
 
+{{/*
+Sandbox container image and pull policy. Shared by the sandbox-pod PodTemplate
+and the image-prepull DaemonSet: the prepull only pins layers the sandbox pods
+actually use if both resolve to the identical reference, and a drift here is
+invisible (the DaemonSet looks healthy while every sandbox still cold-pulls).
+*/}}
+{{- define "onyx.sandboxImage" -}}
+{{- (index .Values.configMap "SANDBOX_CONTAINER_IMAGE") | default (printf "onyxdotapp/sandbox:%s" (.Values.global.version | default .Chart.AppVersion)) -}}
+{{- end }}
+
+{{- define "onyx.sandboxImagePullPolicy" -}}
+{{- (index .Values.configMap "SANDBOX_IMAGE_PULL_POLICY") | default .Values.global.pullPolicy -}}
+{{- end }}
+
 {{- define "onyx.sandboxProxyHost" -}}
 {{- (index .Values.configMap "SANDBOX_PROXY_HOST") | default (printf "%s-sandbox-proxy.%s.svc.cluster.local" (include "onyx.fullname" .) .Release.Namespace) -}}
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
@@ -1,0 +1,169 @@
+{{/*
+Defaults are resolved field by field, NOT with `merge`: sprig's merge treats
+`false` and `0` as empty and silently overwrites them with the default, so
+`priorityClass.create: false` would be ignored and `value: 0` would become -10.
+Strings use `default` (empty string is not a meaningful setting); booleans and
+ints go through `hasKey`.
+*/}}
+{{- $prepull := .Values.sandboxImagePrepull | default dict }}
+{{- $res := $prepull.resources | default dict }}
+{{- $cpu := $res.cpu | default "10m" }}
+{{- $mem := $res.memory | default "32Mi" }}
+{{- $eph := $res.ephemeralStorage | default "64Mi" }}
+{{- $maxUnavailable := $prepull.updateMaxUnavailable | default "100%" }}
+{{- $pc := $prepull.priorityClass | default dict }}
+{{- $pcCreate := true }}
+{{- if hasKey $pc "create" }}{{- $pcCreate = $pc.create }}{{- end }}
+{{- $pcValue := -10 }}
+{{- if hasKey $pc "value" }}{{- $pcValue = $pc.value }}{{- end }}
+{{- if and (eq (include "onyx.craftEnabled" .) "true") $prepull.enabled }}
+{{- /*
+Pre-pulls the sandbox image onto every node in the sandbox pool so a user's
+first sandbox there doesn't pay the pull.
+
+Why a DaemonSet running `sleep infinity` and not a one-shot pre-pull Job: the
+kubelet never garbage-collects an image referenced by a running pod. A Job pulls
+and exits, leaving the layers GC-eligible (default imageGCHighThresholdPercent
+85%), so they silently evaporate under node disk pressure and the next sandbox
+cold-pulls again with no signal. A long-lived pod pins them. It also covers nodes
+that join *after* install, which a Job cannot.
+
+Cost of that pinning, which operators must size for: the sandbox image is ~3.3 GB
+extracted and it becomes UNRECLAIMABLE on every sandbox node. It shares a disk
+with the sandbox workspaces (`workspace` emptyDir, 50Gi sizeLimit), so node disk
+must have headroom for both — otherwise pressure that image GC used to absorb
+now resolves by evicting pods instead. Set `enabled: false` on pools too small
+to carry it.
+
+Priority is deliberately negative: a pending sandbox pod should be able to
+preempt the prepuller rather than fail to schedule (and trigger a needless
+scale-up) because a do-nothing pod held the last scrap of capacity. Preemption
+is safe — a sandbox running on the node pins the image itself, so the prepuller
+is redundant exactly when it would compete. Note this does NOT reorder
+disk-pressure *eviction*: kubelet ranks "exceeds ephemeral-storage request"
+ahead of priority, and evicting the prepuller would free ~0 bytes anyway.
+
+What this does NOT fix: the node that triggered an autoscale-up races this
+DaemonSet's own pull, so the pod that caused the scale-out may still cold-start.
+Closing that needs pre-booted spare capacity, node-image baking, or lazy-pull;
+see docs/craft/sandbox/image-and-spinup.md.
+*/}}
+{{- $cm := .Values.configMap }}
+{{- $sandboxNs := $cm.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
+{{- $saName := (index $cm "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox" }}
+{{- $image := include "onyx.sandboxImage" . }}
+{{- $sandboxPod := .Values.sandboxPod | default dict }}
+{{- /* PriorityClass is CLUSTER-scoped, so the name must include the release
+namespace: `onyx.fullname` omits it, so two same-named releases in different
+namespaces would render the same object, and the second install fails Helm's
+ownership check (then either release's upgrade/uninstall disrupts the other).
+Same trunc+hash shape as the RBAC names in sandbox-rbac.yaml. */}}
+{{- $pcBase := printf "%s-%s" (include "onyx.fullname" .) .Release.Namespace }}
+{{- if gt (len $pcBase) 47 }}
+{{- $pcBase = printf "%s-%s" ($pcBase | trunc 38 | trimSuffix "-") (sha256sum $pcBase | trunc 8) }}
+{{- end }}
+{{- $pcName := $prepull.priorityClassName | default (ternary (printf "%s-sandbox-image-prepuller" $pcBase) "" $pcCreate) }}
+{{- if and $pcCreate (not $prepull.priorityClassName) }}
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: {{ $pcName }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-image-prepuller
+value: {{ $pcValue }}
+globalDefault: false
+description: >-
+  Sandbox image prepuller. Below the default so a pending sandbox pod preempts
+  it instead of failing to schedule; the sandbox then pins the image itself.
+preemptionPolicy: Never
+---
+{{- end }}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-image-prepuller
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-image-prepuller
+spec:
+  {{- /* A tag bump should repull on every node at once, not node-by-node. Lower
+  this on large pools: N nodes pulling ~1 GB simultaneously is a thundering herd
+  against the registry, and Docker Hub rate limits are already a known problem
+  here (see BASE_IMAGE_REGISTRY in the sandbox Dockerfile). */}}
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ $maxUnavailable | quote }}
+  selector:
+    matchLabels:
+      {{- include "onyx.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sandbox-image-prepuller
+  template:
+    metadata:
+      labels:
+        {{- include "onyx.selectorLabels" . | nindent 8 }}
+        {{- /* Deliberately NOT `component: sandbox` — that label is the selector
+        for the sandbox NetworkPolicies, and this pod is not a sandbox. */}}
+        app.kubernetes.io/component: sandbox-image-prepuller
+        admission.datadoghq.com/enabled: "false"
+    spec:
+      {{- /* Same placement as the sandbox pods, or the wrong nodes get warmed. */}}
+      nodeSelector:
+        {{- (index $sandboxPod "nodeSelector" | default (dict "onyx.app/workload" "sandbox")) | toYaml | nindent 8 }}
+      tolerations:
+        {{- (index $sandboxPod "tolerations" | default (list (dict "key" "workload" "operator" "Equal" "value" "sandbox" "effect" "NoSchedule"))) | toYaml | nindent 8 }}
+      {{- with $pcName }}
+      priorityClassName: {{ . }}
+      {{- end }}
+      {{- /* Pull credentials must match the sandbox pods' exactly, or the
+      prepuller ImagePullBackOffs against a private registry and silently warms
+      nothing. Both routes are covered: the chart-wide secrets, and the sandbox
+      ServiceAccount, which an operator may have attached secrets to. The token
+      stays unmounted — this pod makes no API calls; it is here only so image
+      pull resolves the same credentials a sandbox pod would. */}}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ $saName }}
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      terminationGracePeriodSeconds: 0
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: prepuller
+          image: {{ $image }}
+          {{- /* Always would defeat the purpose on every pod restart. */}}
+          imagePullPolicy: IfNotPresent
+          {{- /* Portable idle loop, NOT `sleep infinity`: "infinity" is a GNU
+          coreutils extension. It works on today's Debian-based sandbox image but
+          dies on busybox/alpine, and the failure is quiet — a CrashLooping
+          prepuller unpins the image with nothing to signal it. This survives a
+          base-image change. */}}
+          command: ["sh", "-c", "while :; do sleep 86400; done"]
+          {{- /* ephemeral-storage is requested even though `sleep` writes nothing:
+          a container with no request is invisible to the scheduler's disk
+          accounting, which this repo treats as a bug (see
+          test_pod_spec.test_all_containers_set_ephemeral_storage_requests). */}}
+          resources:
+            requests:
+              cpu: {{ $cpu | quote }}
+              memory: {{ $mem | quote }}
+              ephemeral-storage: {{ $eph | quote }}
+            limits:
+              cpu: {{ $cpu | quote }}
+              memory: {{ $mem | quote }}
+              ephemeral-storage: {{ $eph | quote }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            privileged: false
+            capabilities:
+              drop: ["ALL"]
+{{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
@@ -1,9 +1,9 @@
 {{/*
+Pre-pulls the sandbox image onto every node in the sandbox pool so a user's
+first sandbox there doesn't pay the pull. See docs/craft/sandbox/image-and-spinup.md.
+
 Defaults are resolved field by field, NOT with `merge`: sprig's merge treats
-`false` and `0` as empty and silently overwrites them with the default, so
-`priorityClass.create: false` would be ignored and `value: 0` would become -10.
-Strings use `default` (empty string is not a meaningful setting); booleans and
-ints go through `hasKey`.
+`false` and `0` as empty, so `create: false` and `value: 0` would be overwritten.
 */}}
 {{- $prepull := .Values.sandboxImagePrepull | default dict }}
 {{- $res := $prepull.resources | default dict }}
@@ -17,47 +17,13 @@ ints go through `hasKey`.
 {{- $pcValue := -10 }}
 {{- if hasKey $pc "value" }}{{- $pcValue = $pc.value }}{{- end }}
 {{- if and (eq (include "onyx.craftEnabled" .) "true") $prepull.enabled }}
-{{- /*
-Pre-pulls the sandbox image onto every node in the sandbox pool so a user's
-first sandbox there doesn't pay the pull.
-
-Why a DaemonSet running `sleep infinity` and not a one-shot pre-pull Job: the
-kubelet never garbage-collects an image referenced by a running pod. A Job pulls
-and exits, leaving the layers GC-eligible (default imageGCHighThresholdPercent
-85%), so they silently evaporate under node disk pressure and the next sandbox
-cold-pulls again with no signal. A long-lived pod pins them. It also covers nodes
-that join *after* install, which a Job cannot.
-
-Cost of that pinning, which operators must size for: the sandbox image is ~3.3 GB
-extracted and it becomes UNRECLAIMABLE on every sandbox node. It shares a disk
-with the sandbox workspaces (`workspace` emptyDir, 50Gi sizeLimit), so node disk
-must have headroom for both — otherwise pressure that image GC used to absorb
-now resolves by evicting pods instead. Set `enabled: false` on pools too small
-to carry it.
-
-Priority is deliberately negative: a pending sandbox pod should be able to
-preempt the prepuller rather than fail to schedule (and trigger a needless
-scale-up) because a do-nothing pod held the last scrap of capacity. Preemption
-is safe — a sandbox running on the node pins the image itself, so the prepuller
-is redundant exactly when it would compete. Note this does NOT reorder
-disk-pressure *eviction*: kubelet ranks "exceeds ephemeral-storage request"
-ahead of priority, and evicting the prepuller would free ~0 bytes anyway.
-
-What this does NOT fix: the node that triggered an autoscale-up races this
-DaemonSet's own pull, so the pod that caused the scale-out may still cold-start.
-Closing that needs pre-booted spare capacity, node-image baking, or lazy-pull;
-see docs/craft/sandbox/image-and-spinup.md.
-*/}}
 {{- $cm := .Values.configMap }}
 {{- $sandboxNs := $cm.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 {{- $saName := (index $cm "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox" }}
 {{- $image := include "onyx.sandboxImage" . }}
 {{- $sandboxPod := .Values.sandboxPod | default dict }}
-{{- /* PriorityClass is CLUSTER-scoped, so the name must include the release
-namespace: `onyx.fullname` omits it, so two same-named releases in different
-namespaces would render the same object, and the second install fails Helm's
-ownership check (then either release's upgrade/uninstall disrupts the other).
-Same trunc+hash shape as the RBAC names in sandbox-rbac.yaml. */}}
+{{- /* PriorityClass is cluster-scoped, so the name includes the release
+namespace. Same trunc+hash shape as the RBAC names in sandbox-rbac.yaml. */}}
 {{- $pcBase := printf "%s-%s" (include "onyx.fullname" .) .Release.Namespace }}
 {{- if gt (len $pcBase) 47 }}
 {{- $pcBase = printf "%s-%s" ($pcBase | trunc 38 | trimSuffix "-") (sha256sum $pcBase | trunc 8) }}
@@ -88,10 +54,6 @@ metadata:
     {{- include "onyx.labels" . | nindent 4 }}
     app.kubernetes.io/component: sandbox-image-prepuller
 spec:
-  {{- /* A tag bump should repull on every node at once, not node-by-node. Lower
-  this on large pools: N nodes pulling ~1 GB simultaneously is a thundering herd
-  against the registry, and Docker Hub rate limits are already a known problem
-  here (see BASE_IMAGE_REGISTRY in the sandbox Dockerfile). */}}
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -104,8 +66,8 @@ spec:
     metadata:
       labels:
         {{- include "onyx.selectorLabels" . | nindent 8 }}
-        {{- /* Deliberately NOT `component: sandbox` — that label is the selector
-        for the sandbox NetworkPolicies, and this pod is not a sandbox. */}}
+        {{- /* Not `component: sandbox` — that label is the selector for the
+        sandbox NetworkPolicies, and this pod is not a sandbox. */}}
         app.kubernetes.io/component: sandbox-image-prepuller
         admission.datadoghq.com/enabled: "false"
     spec:
@@ -117,12 +79,9 @@ spec:
       {{- with $pcName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- /* Pull credentials must match the sandbox pods' exactly, or the
-      prepuller ImagePullBackOffs against a private registry and silently warms
-      nothing. Both routes are covered: the chart-wide secrets, and the sandbox
-      ServiceAccount, which an operator may have attached secrets to. The token
-      stays unmounted — this pod makes no API calls; it is here only so image
-      pull resolves the same credentials a sandbox pod would. */}}
+      {{- /* Pull credentials must resolve the same as the sandbox pods', or a
+      private registry leaves the prepuller in ImagePullBackOff. The SA is here
+      for its attached pull secrets only; this pod makes no API calls. */}}
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -139,18 +98,12 @@ spec:
       containers:
         - name: prepuller
           image: {{ $image }}
-          {{- /* Always would defeat the purpose on every pod restart. */}}
+          {{- /* Always would re-pull on every pod restart. */}}
           imagePullPolicy: IfNotPresent
-          {{- /* Portable idle loop, NOT `sleep infinity`: "infinity" is a GNU
-          coreutils extension. It works on today's Debian-based sandbox image but
-          dies on busybox/alpine, and the failure is quiet — a CrashLooping
-          prepuller unpins the image with nothing to signal it. This survives a
-          base-image change. */}}
+          {{- /* Portable idle loop, not `sleep infinity` (a GNU coreutils
+          extension that dies on busybox/alpine). The pod must stay running:
+          kubelet only exempts images a running pod references from image GC. */}}
           command: ["sh", "-c", "while :; do sleep 86400; done"]
-          {{- /* ephemeral-storage is requested even though `sleep` writes nothing:
-          a container with no request is invisible to the scheduler's disk
-          accounting, which this repo treats as a bug (see
-          test_pod_spec.test_all_containers_set_ephemeral_storage_requests). */}}
           resources:
             requests:
               cpu: {{ $cpu | quote }}

--- a/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-image-prepuller.yaml
@@ -10,17 +10,18 @@ Defaults are resolved field by field, NOT with `merge`: sprig's merge treats
 {{- $cpu := $res.cpu | default "10m" }}
 {{- $mem := $res.memory | default "32Mi" }}
 {{- $eph := $res.ephemeralStorage | default "64Mi" }}
-{{- $maxUnavailable := $prepull.updateMaxUnavailable | default "100%" }}
+{{- $maxUnavailable := $prepull.updateMaxUnavailable | default "25%" }}
 {{- $pc := $prepull.priorityClass | default dict }}
 {{- $pcCreate := true }}
 {{- if hasKey $pc "create" }}{{- $pcCreate = $pc.create }}{{- end }}
-{{- $pcValue := -10 }}
+{{- $pcValue := -11 }}
 {{- if hasKey $pc "value" }}{{- $pcValue = $pc.value }}{{- end }}
 {{- if and (eq (include "onyx.craftEnabled" .) "true") $prepull.enabled }}
 {{- $cm := .Values.configMap }}
 {{- $sandboxNs := $cm.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 {{- $saName := (index $cm "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox" }}
 {{- $image := include "onyx.sandboxImage" . }}
+{{- $pullPolicy := include "onyx.sandboxImagePullPolicy" . }}
 {{- $sandboxPod := .Values.sandboxPod | default dict }}
 {{- /* PriorityClass is cluster-scoped, so the name includes the release
 namespace. Same trunc+hash shape as the RBAC names in sandbox-rbac.yaml. */}}
@@ -40,8 +41,8 @@ metadata:
 value: {{ $pcValue }}
 globalDefault: false
 description: >-
-  Sandbox image prepuller. Below the default so a pending sandbox pod preempts
-  it instead of failing to schedule; the sandbox then pins the image itself.
+  Sandbox image prepuller. Below cluster-autoscaler's expendable cutoff (-10) so
+  it never justifies a scale-up, and below a sandbox pod so one can preempt it.
 preemptionPolicy: Never
 ---
 {{- end }}
@@ -79,13 +80,9 @@ spec:
       {{- with $pcName }}
       priorityClassName: {{ . }}
       {{- end }}
-      {{- /* Pull credentials must resolve the same as the sandbox pods', or a
-      private registry leaves the prepuller in ImagePullBackOff. The SA is here
-      for its attached pull secrets only; this pod makes no API calls. */}}
-      {{- with .Values.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- /* Pull credentials come from the sandbox SA only, same as the
+      PodTemplate. `.Values.imagePullSecrets` names release-namespace secrets,
+      which don't resolve for a pod in the sandbox namespace. */}}
       serviceAccountName: {{ $saName }}
       automountServiceAccountToken: false
       enableServiceLinks: false
@@ -98,8 +95,9 @@ spec:
       containers:
         - name: prepuller
           image: {{ $image }}
-          {{- /* Always would re-pull on every pod restart. */}}
-          imagePullPolicy: IfNotPresent
+          {{- /* Shared with the sandbox pods: pinning this to IfNotPresent
+          would hold a stale digest on a mutable tag. */}}
+          imagePullPolicy: {{ $pullPolicy }}
           {{- /* Portable idle loop, not `sleep infinity` (a GNU coreutils
           extension that dies on busybox/alpine). The pod must stay running:
           kubelet only exempts images a running pod references from image GC. */}}
@@ -119,4 +117,22 @@ spec:
             privileged: false
             capabilities:
               drop: ["ALL"]
+---
+{{- /* Not being `component: sandbox` also leaves this out of the sandbox
+default-deny, so it carries its own. The pod needs no network — the pull is the
+kubelet's. Listing a policyType with no rules is deny-all. */}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "onyx.fullname" . }}-sandbox-image-prepuller
+  namespace: {{ $sandboxNs }}
+  labels:
+    {{- include "onyx.labels" . | nindent 4 }}
+    app.kubernetes.io/component: sandbox-image-prepuller
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "onyx.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: sandbox-image-prepuller
+  policyTypes: [Ingress, Egress]
 {{- end }}

--- a/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
+++ b/deployment/helm/charts/onyx/templates/sandbox-podtemplate.yaml
@@ -7,8 +7,9 @@ opencode-auth + push-key env, proxy hostAliases IP).
 {{- $cm := .Values.configMap }}
 {{- $sandboxNs := $cm.SANDBOX_NAMESPACE | default "onyx-sandboxes" }}
 {{- $saName := (index $cm "SANDBOX_SERVICE_ACCOUNT_NAME") | default "sandbox" }}
-{{- $image := (index $cm "SANDBOX_CONTAINER_IMAGE") | default (printf "onyxdotapp/sandbox:%s" (.Values.global.version | default .Chart.AppVersion)) }}
-{{- $pullPolicy := (index $cm "SANDBOX_IMAGE_PULL_POLICY") | default .Values.global.pullPolicy }}
+{{/* Shared with the image-prepull DaemonSet so the pinned ref can't drift. */}}
+{{- $image := include "onyx.sandboxImage" . }}
+{{- $pullPolicy := include "onyx.sandboxImagePullPolicy" . }}
 {{- $cpuReq := (index $cm "SANDBOX_POD_CPU_REQUEST") | default "1000m" }}
 {{- $memReq := (index $cm "SANDBOX_POD_MEMORY_REQUEST") | default "2Gi" }}
 {{- $cpuLim := (index $cm "SANDBOX_POD_CPU_LIMIT") | default "2000m" }}

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1654,6 +1654,41 @@ sandboxPod:
       value: sandbox
       effect: NoSchedule
 
+# -- Pre-pull the sandbox image onto the sandbox node pool (DaemonSet), so a
+# user's first sandbox on a node doesn't pay the image pull (~31s measured; see
+# docs/craft/sandbox/image-and-spinup.md). Image and pull policy are shared with
+# the sandbox-pod PodTemplate; scheduling follows sandboxPod above.
+#
+# The cost is disk, not CPU: holding the image makes ~3.3 GB UNRECLAIMABLE on
+# every sandbox node, on the same disk as the sandbox workspaces. Turn this off
+# when either applies:
+#   - Single-node / fixed tiny deployments: the image stays resident anyway and
+#     nothing evicts it, so the DaemonSet is pure overhead.
+#   - Nodes without headroom for 3.3 GB on top of the workspace ephemeral-storage
+#     limits. Disk pressure that image GC used to absorb would otherwise resolve
+#     by evicting pods instead.
+sandboxImagePrepull:
+  enabled: true
+  # Held for the pod's whole life, so keep it minimal. ephemeral-storage is
+  # requested despite `sleep` writing nothing: a container with no request is
+  # invisible to the scheduler's disk accounting.
+  resources:
+    cpu: 10m
+    memory: 32Mi
+    ephemeralStorage: 64Mi
+  # Below the cluster default on purpose, so a pending sandbox pod preempts the
+  # prepuller rather than failing to schedule (and triggering a needless
+  # scale-up). Safe: a sandbox running on the node pins the image itself, so the
+  # prepuller is redundant exactly when it would compete.
+  priorityClass:
+    create: true
+    value: -10
+  # Set to use an existing PriorityClass instead; skips creating the one above.
+  priorityClassName: ""
+  # Nodes that repull at once on a tag bump. Lower on large pools — N nodes
+  # pulling ~1 GB simultaneously is a thundering herd against the registry.
+  updateMaxUnavailable: "100%"
+
 # -- Sandbox egress proxy.
 sandboxProxy:
   # Allow IPv6 (::/0 minus link-local/IMDS) egress from the proxy. OFF by default: the AWS

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1660,23 +1660,25 @@ sandboxPod:
 # follows sandboxPod above. Only rendered when configMap.ENABLE_CRAFT is true.
 #
 # Costs ~3.3 GB of unreclaimable disk per sandbox node, on the same disk as the
-# sandbox workspaces. Disable on nodes without that headroom.
+# sandbox workspaces. Disable on nodes without that headroom. Pin global.version
+# to an immutable tag when using this: a mutable tag like `latest` gets held at
+# whichever digest the node pulled first.
 sandboxImagePrepull:
   enabled: true
   resources:
     cpu: 10m
     memory: 32Mi
     ephemeralStorage: 64Mi
-  # Negative so a pending sandbox pod preempts the prepuller rather than failing
-  # to schedule and triggering a needless scale-up.
+  # Below cluster-autoscaler's expendable-pods cutoff (-10), so a pending
+  # prepuller is never itself a reason to scale up.
   priorityClass:
     create: true
-    value: -10
+    value: -11
   # Set to use an existing PriorityClass instead; skips creating the one above.
   priorityClassName: ""
-  # Nodes that repull at once on a tag bump. Lower on large pools to avoid a
-  # thundering herd against the registry.
-  updateMaxUnavailable: "100%"
+  # Nodes that repull at once on a tag bump. Raise to warm a large pool faster,
+  # at the cost of a thundering herd against the registry.
+  updateMaxUnavailable: "25%"
 
 # -- Sandbox egress proxy.
 sandboxProxy:

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1655,38 +1655,27 @@ sandboxPod:
       effect: NoSchedule
 
 # -- Pre-pull the sandbox image onto the sandbox node pool (DaemonSet), so a
-# user's first sandbox on a node doesn't pay the image pull (~31s measured; see
-# docs/craft/sandbox/image-and-spinup.md). Image and pull policy are shared with
-# the sandbox-pod PodTemplate; scheduling follows sandboxPod above.
+# user's first sandbox on a node doesn't pay the image pull (~31s measured).
+# Image and pull policy are shared with the sandbox-pod PodTemplate; scheduling
+# follows sandboxPod above. Only rendered when configMap.ENABLE_CRAFT is true.
 #
-# The cost is disk, not CPU: holding the image makes ~3.3 GB UNRECLAIMABLE on
-# every sandbox node, on the same disk as the sandbox workspaces. Turn this off
-# when either applies:
-#   - Single-node / fixed tiny deployments: the image stays resident anyway and
-#     nothing evicts it, so the DaemonSet is pure overhead.
-#   - Nodes without headroom for 3.3 GB on top of the workspace ephemeral-storage
-#     limits. Disk pressure that image GC used to absorb would otherwise resolve
-#     by evicting pods instead.
+# Costs ~3.3 GB of unreclaimable disk per sandbox node, on the same disk as the
+# sandbox workspaces. Disable on nodes without that headroom.
 sandboxImagePrepull:
   enabled: true
-  # Held for the pod's whole life, so keep it minimal. ephemeral-storage is
-  # requested despite `sleep` writing nothing: a container with no request is
-  # invisible to the scheduler's disk accounting.
   resources:
     cpu: 10m
     memory: 32Mi
     ephemeralStorage: 64Mi
-  # Below the cluster default on purpose, so a pending sandbox pod preempts the
-  # prepuller rather than failing to schedule (and triggering a needless
-  # scale-up). Safe: a sandbox running on the node pins the image itself, so the
-  # prepuller is redundant exactly when it would compete.
+  # Negative so a pending sandbox pod preempts the prepuller rather than failing
+  # to schedule and triggering a needless scale-up.
   priorityClass:
     create: true
     value: -10
   # Set to use an existing PriorityClass instead; skips creating the one above.
   priorityClassName: ""
-  # Nodes that repull at once on a tag bump. Lower on large pools — N nodes
-  # pulling ~1 GB simultaneously is a thundering herd against the registry.
+  # Nodes that repull at once on a tag bump. Lower on large pools to avoid a
+  # thundering herd against the registry.
   updateMaxUnavailable: "100%"
 
 # -- Sandbox egress proxy.

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1675,6 +1675,8 @@ sandboxImagePrepull:
     create: true
     value: -11
   # Set to use an existing PriorityClass instead; skips creating the one above.
+  # create: false with this left empty is a valid opt-out, but drops the pod to
+  # the cluster default priority, where it competes with sandbox pods.
   priorityClassName: ""
   # Nodes that repull at once on a tag bump. Raise to warm a large pool faster,
   # at the cost of a thundering herd against the registry.

--- a/docs/craft/sandbox/image-and-spinup.md
+++ b/docs/craft/sandbox/image-and-spinup.md
@@ -122,33 +122,94 @@ so the prod image still has it but dev/CI images can opt out.
 
 ## Cold pulls vs. image warming — decision and roadmap
 
-**Current state: we accept cold image pulls on freshly-scheduled nodes.**
+**Current state: we pre-pull the sandbox image onto the sandbox node
+pool with a DaemonSet.** Chart: `sandboxImagePrepull` in `values.yaml`,
+template `sandbox-image-prepuller.yaml`. On by default when
+`ENABLE_CRAFT` is set.
 
-The first sandbox pod scheduled to a new node pays the registry-pull cost
-(~3–6 s for the trimmed image at typical AZ-local bandwidth; see the
-benchmark below). Every subsequent pod on that node hits warm-start
-(~900 ms) until the kubelet GCs the image.
+This section previously recorded the opposite decision — that we accept
+cold pulls — on an estimate of ~3–6 s per pull from AZ-local bandwidth.
+Measurement contradicted it. Evicting `onyxdotapp/sandbox:latest` from a
+kind node and timing `crictl pull` (1070 MB compressed, 34 MB/s
+effective) gave:
 
-### What we considered and rejected
+| | pull | create → Ready |
+|---|---|---|
+| cold pull | **31.4 s** | 32.6 s |
+| blobs cached, image record dropped | 1.4 s | 3.3 s |
 
-A DaemonSet (`sandbox-image-warmer`) that runs the sandbox image with
-`sleep infinity` on every node in the `onyx.app/workload=sandbox` pool.
-The kubelet won't GC images that are referenced by a running pod, so
-this pins the layers on disk indefinitely and every real sandbox pod
-sees warm-start latency.
+~5x the old estimate, which had assumed a same-region registry. The
+realistic case is a self-hosted install pulling Docker Hub over its own
+link.
 
-Rejected because the cost (an always-on pod per node, more Helm
-template surface, another workload to monitor) outweighs the win for
-our current scale and image size. The warmer also doesn't help the
-*first* pod on a freshly-autoscaled node — the warmer pod itself still
-has to pull before it can pin anything.
+It also isn't only latency. That cost lands inside the 90 s budget
+`_wait_for_pod_ip` shares with the opencode-history restore, so on a
+slower link the download alone blows the deadline and provisioning
+*fails* with `Timeout waiting for sandbox pod ... to be assigned an IP`
+— or succeeds and starves the restore. Nodes lack the image whenever
+they're new, whenever no sandbox has landed on them yet, after a tag
+bump, or after kubelet image GC reclaims it.
 
-### Optimal solution if cold pulls ever become painful
+### Why the DaemonSet is shaped the way it is
+
+Each of these fails *silently* if changed — the DaemonSet reports Ready
+while sandboxes go on cold-pulling, and the only symptom is the slow
+provisioning the feature was meant to remove. There are render-time
+tests for all of them in
+`backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py`.
+
+- **A DaemonSet, not a one-shot pre-pull Job.** The kubelet only exempts
+  images referenced by a *running* pod from image GC. A Job pulls and
+  exits, leaving the layers evictable (default
+  `imageGCHighThresholdPercent` 85%) with nothing to signal it. A
+  long-lived pod pins them, and a DaemonSet also covers nodes that join
+  after install.
+- **The image ref is shared with the sandbox PodTemplate**, via the
+  `onyx.sandboxImage` / `onyx.sandboxImagePullPolicy` helpers. A drifted
+  tag pins layers nobody uses while every sandbox still cold-pulls.
+- **Scheduling mirrors `sandboxPod`** (nodeSelector + tolerations), or
+  it warms the wrong pool.
+- **Negative priority** (`-10`, `preemptionPolicy: Never`) so a pending
+  sandbox preempts the prepuller rather than failing to schedule and
+  triggering a needless scale-up. Safe: a sandbox running on the node
+  pins the image itself, so the prepuller is redundant exactly when it
+  would compete. This does *not* reorder disk-pressure eviction —
+  kubelet ranks "exceeds ephemeral-storage request" ahead of priority,
+  and evicting the prepuller frees ~0 bytes anyway.
+- **A portable idle loop**, not `sleep infinity` — a GNU coreutils
+  extension that dies on busybox/alpine. A CrashLooping prepuller unpins
+  the image.
+- **Labelled `component: sandbox-image-prepuller`**, not
+  `component: sandbox`, which is the selector for the sandbox
+  NetworkPolicies.
+
+### What it costs, and when to turn it off
+
+The sandbox image is ~3.3 GB extracted and becomes **unreclaimable** on
+every sandbox node, on the same disk as the sandbox workspaces
+(`workspace` emptyDir, 50Gi sizeLimit). Disk pressure that image GC used
+to absorb now resolves by evicting pods instead. Set
+`sandboxImagePrepull.enabled: false` when either applies:
+
+- Single-node / fixed tiny deployments: the image stays resident anyway
+  and nothing evicts it, so the DaemonSet is pure overhead.
+- Nodes without headroom for 3.3 GB on top of the workspace
+  ephemeral-storage limits.
+
+### What it does not fix
+
+Autoscale-up. Node boot (60–120 s) dominates the pull there, and the
+DaemonSet lands on the new node simultaneously with the sandbox that
+triggered the scale-out, so that pod may still cold-start.
+
+### Next step, when autoscale-up cold starts start hurting
 
 **Bake the sandbox image into the node image** (AMI on AWS / custom
 node image on GCP/Azure). The autoscaler boots nodes that already have
 the layers on disk — zero runtime workload, zero cold pulls, works
-even for the very first pod on a brand-new node.
+even for the very first pod on a brand-new node. This is the piece the
+prepuller can't cover; lazy pull (GKE Image Streaming, SOCI) is the
+other option.
 
 Sketch:
 
@@ -162,18 +223,16 @@ Sketch:
    pulling for that version).
 
 Tradeoff: adds a build pipeline keyed to sandbox image versions, and
-re-baking takes ~10–20 min per cloud. Worth it once cold-pull latency
-is measurably hurting users, not before.
+re-baking takes ~10–20 min per cloud.
 
 ### Trigger to revisit
 
-Bring this section back up if any of:
-- The sandbox image grows materially past ~1 GB compressed (cold pulls
-  start climbing past ~10 s).
+Pick up node-image baking if either of:
 - The sandbox node pool starts churning frequently (autoscale events
-  measured in minutes, not hours).
-- Product surface shows cold-pull spinups dominating a measurable
-  fraction of "open sandbox" latency p95.
+  measured in minutes, not hours), so scale-out cold starts — which the
+  prepuller does not fix — become common rather than incidental.
+- Product surface shows cold-pull spinups still dominating a measurable
+  fraction of "open sandbox" latency p95 with the prepuller deployed.
 
 ## Recorded benchmark — 2026-05-21
 
@@ -199,11 +258,13 @@ install` any of those on demand if a skill needs them.
 Caveats:
 
 - **Cold p50 is dominated by `kind load`'s tar-shuffle overhead**, not by
-  actual container start. In prod the equivalent op is a registry pull,
-  which at typical AZ-local bandwidth (150–300 MB/s) translates to
-  roughly 3–6 s for a 700 MB manifest, less for the noskills variant.
-  Treat the *delta* between images as meaningful, the *absolute* cold
-  number as transport overhead.
+  actual container start. Treat the *delta* between images as meaningful,
+  the *absolute* cold number as transport overhead.
+- This row originally extrapolated the prod registry pull at 3–6 s from
+  150–300 MB/s AZ-local bandwidth. **That was wrong** — see the measured
+  31.4 s in "Cold pulls vs. image warming" above. The estimate assumed a
+  same-region registry; the realistic case is a self-hosted install
+  pulling Docker Hub over its own link (34 MB/s effective, measured).
 - Warm spinup is essentially image-size-insensitive (~900 ms regardless)
   because layers are already extracted in the kubelet. Once a node has
   pulled the image once, every subsequent pod sees warm-start latency.

--- a/docs/craft/sandbox/image-and-spinup.md
+++ b/docs/craft/sandbox/image-and-spinup.md
@@ -195,7 +195,12 @@ you touch these templates, and don't assume CI caught a drift for you.
   / 2Gi. It mainly guarantees the prepuller is never the *reason* for a
   scale-up. This does *not* reorder disk-pressure eviction — kubelet
   ranks "exceeds ephemeral-storage request" ahead of priority, and
-  evicting the prepuller frees ~0 bytes anyway.
+  evicting the prepuller frees ~0 bytes anyway. Setting
+  `priorityClass.create: false` without also setting `priorityClassName`
+  is a supported opt-out (for clusters where PriorityClasses are managed
+  centrally) but forfeits all of the above: the pod falls to the cluster
+  default priority and competes with sandbox pods. Point
+  `priorityClassName` at an existing low-priority class instead.
 - **A portable idle loop**, not `sleep infinity` — a GNU coreutils
   extension that dies on busybox/alpine. A CrashLooping prepuller unpins
   the image.

--- a/docs/craft/sandbox/image-and-spinup.md
+++ b/docs/craft/sandbox/image-and-spinup.md
@@ -230,11 +230,24 @@ secrets in the *release* namespace — and a kubelet resolves an
 imagePullSecret in the pod's own namespace. Listing those names on a
 sandbox-namespace pod points at secrets that do not exist there.
 
+Both the namespace and the account name are configurable, and both pods
+follow whatever the configMap sets — patching the default `sandbox`
+account on a deployment that overrode `SANDBOX_SERVICE_ACCOUNT_NAME`
+leaves the real account uncredentialed and every pull failing:
+
 ```bash
-kubectl -n onyx-sandboxes create secret docker-registry regcred \
+# Chart defaults. Override to match configMap.SANDBOX_NAMESPACE and
+# configMap.SANDBOX_SERVICE_ACCOUNT_NAME if your deployment sets them.
+SANDBOX_NS=onyx-sandboxes
+SANDBOX_SA=sandbox
+
+kubectl -n "$SANDBOX_NS" create secret docker-registry regcred \
   --docker-server=... --docker-username=... --docker-password=...
-kubectl -n onyx-sandboxes patch serviceaccount sandbox \
+kubectl -n "$SANDBOX_NS" patch serviceaccount "$SANDBOX_SA" \
   -p '{"imagePullSecrets":[{"name":"regcred"}]}'
+
+# Confirm it took, on the account the pods actually use.
+kubectl -n "$SANDBOX_NS" get sa "$SANDBOX_SA" -o jsonpath='{.imagePullSecrets}'
 ```
 
 This is also why the prepuller renders no `imagePullSecrets` block. An

--- a/docs/craft/sandbox/image-and-spinup.md
+++ b/docs/craft/sandbox/image-and-spinup.md
@@ -158,30 +158,92 @@ provisioning the feature was meant to remove. There are render-time
 tests for all of them in
 `backend/tests/unit/onyx/server/features/build/sandbox/test_sandbox_image_prepuller.py`.
 
+Those tests need `helm` and the chart's subchart tarballs, which are
+gitignored, so they skip in the `backend/tests/unit` lane and no CI lane
+currently supplies both. Until one does they are a local guard — run
+them (after `helm dependency build deployment/helm/charts/onyx`) when
+you touch these templates, and don't assume CI caught a drift for you.
+
 - **A DaemonSet, not a one-shot pre-pull Job.** The kubelet only exempts
   images referenced by a *running* pod from image GC. A Job pulls and
   exits, leaving the layers evictable (default
   `imageGCHighThresholdPercent` 85%) with nothing to signal it. A
   long-lived pod pins them, and a DaemonSet also covers nodes that join
   after install.
-- **The image ref is shared with the sandbox PodTemplate**, via the
-  `onyx.sandboxImage` / `onyx.sandboxImagePullPolicy` helpers. A drifted
-  tag pins layers nobody uses while every sandbox still cold-pulls.
+- **The image ref *and pull policy* are shared with the sandbox
+  PodTemplate**, via the `onyx.sandboxImage` /
+  `onyx.sandboxImagePullPolicy` helpers. A drifted tag pins layers nobody
+  uses while every sandbox still cold-pulls. The pull policy is part of
+  that, not a detail: pinning the prepuller to `IfNotPresent` while the
+  sandbox pods run `Always` reproduces the same drift one level down —
+  on a mutable tag the sandboxes fetch the new digest and the prepuller
+  keeps the old one resident and GC-exempt.
 - **Scheduling mirrors `sandboxPod`** (nodeSelector + tolerations), or
   it warms the wrong pool.
-- **Negative priority** (`-10`, `preemptionPolicy: Never`) so a pending
-  sandbox preempts the prepuller rather than failing to schedule and
-  triggering a needless scale-up. Safe: a sandbox running on the node
-  pins the image itself, so the prepuller is redundant exactly when it
-  would compete. This does *not* reorder disk-pressure eviction —
-  kubelet ranks "exceeds ephemeral-storage request" ahead of priority,
-  and evicting the prepuller frees ~0 bytes anyway.
+- **Pull credentials come from the sandbox ServiceAccount only**, the
+  same single route the sandbox PodTemplate uses. See "Private
+  registries" below for why the chart-wide `.Values.imagePullSecrets`
+  is not an option here.
+- **Priority `-11`, `preemptionPolicy: Never`.** Strictly below
+  cluster-autoscaler's default `--expendable-pods-priority-cutoff` of
+  -10, so a pending prepuller is never itself read as demand for a new
+  node — at exactly -10 it is *not* expendable. It also sits below a
+  sandbox pod, so one can preempt it; a sandbox running on the node pins
+  the image itself, making the prepuller redundant exactly when it would
+  compete. Don't over-read the preemption half: the prepuller holds 10m
+  CPU / 32Mi, so evicting it will not unblock a sandbox that wants 1000m
+  / 2Gi. It mainly guarantees the prepuller is never the *reason* for a
+  scale-up. This does *not* reorder disk-pressure eviction — kubelet
+  ranks "exceeds ephemeral-storage request" ahead of priority, and
+  evicting the prepuller frees ~0 bytes anyway.
 - **A portable idle loop**, not `sleep infinity` — a GNU coreutils
   extension that dies on busybox/alpine. A CrashLooping prepuller unpins
   the image.
 - **Labelled `component: sandbox-image-prepuller`**, not
   `component: sandbox`, which is the selector for the sandbox
-  NetworkPolicies.
+  NetworkPolicies — *and* given its own deny-all NetworkPolicy as a
+  result. Staying out of that selector also leaves it out of the sandbox
+  default-deny, which would otherwise make the prepuller the one
+  unrestricted pod in the sandbox namespace, running the sandbox image.
+  It needs no network: the pull is the kubelet's, not the pod's.
+
+Pin `global.version` (or `configMap.SANDBOX_CONTAINER_IMAGE`) to an
+immutable tag when running the prepuller. Holding a mutable tag like
+`latest` keeps whichever digest a node pulled first resident and
+GC-exempt: the DaemonSet spec doesn't change when the tag is repointed,
+so nothing restarts the pod to re-resolve it, and the image GC pass that
+used to let the node drift back to a fresh `latest` no longer runs on
+it. Under `pullPolicy: Always` the restart does re-resolve, which is why
+the policy is shared rather than hardcoded.
+
+### Private registries
+
+Relevant only if you mirror the sandbox image into your own registry;
+the default `onyxdotapp/sandbox` on Docker Hub is public and needs no
+credentials.
+
+**Attach the pull secret to the sandbox ServiceAccount. Chart-level
+`imagePullSecrets` will not work for sandbox workloads.** Both the
+prepuller and the sandbox pods run in `SANDBOX_NAMESPACE`
+(`onyx-sandboxes` by default), while `.Values.imagePullSecrets` names
+secrets in the *release* namespace — and a kubelet resolves an
+imagePullSecret in the pod's own namespace. Listing those names on a
+sandbox-namespace pod points at secrets that do not exist there.
+
+```bash
+kubectl -n onyx-sandboxes create secret docker-registry regcred \
+  --docker-server=... --docker-username=... --docker-password=...
+kubectl -n onyx-sandboxes patch serviceaccount sandbox \
+  -p '{"imagePullSecrets":[{"name":"regcred"}]}'
+```
+
+This is also why the prepuller renders no `imagePullSecrets` block. An
+earlier revision gave the prepuller the chart-wide secrets and left the
+PodTemplate on the SA alone, which is the worst arrangement available:
+on a cluster where the release-namespace secret name happens to also
+exist in the sandbox namespace, the prepuller goes Ready and warms an
+image the sandbox pods still cannot pull. One route for both, and a
+render test asserts neither pod spec carries the block.
 
 ### What it costs, and when to turn it off
 


### PR DESCRIPTION
## Problem

The first sandbox pod on a node that lacks the image pays the pull. Measured by evicting `onyxdotapp/sandbox:latest` from a kind node and timing `crictl pull` (1070 MB compressed, **34 MB/s effective**):

| | pull | create → Ready |
|---|---|---|
| cold pull | **31.4 s** | 32.6 s |
| blobs cached, image record dropped | 1.4 s | 3.3 s |

Roughly **5x worse** than the 3–6 s previously assumed from "150–300 MB/s AZ-local bandwidth" — that figure assumed a same-region registry, and self-hosted installs pulling from Docker Hub over their own link are the realistic case.

It isn't only latency. That cost lands inside the 90 s budget `_wait_for_pod_ip` shares with the opencode-history restore, so on a slower link the download alone blows the deadline and provisioning **fails** with `Timeout waiting for sandbox pod ... to be assigned an IP` — or succeeds and starves the restore.

Nodes lack the image whenever they're new, whenever no sandbox has landed on them yet, after a tag bump, or after kubelet image GC reclaims it. Previously the first user onto each cold node did the pre-pull, unpaid, on their own latency budget.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

## Change

A DaemonSet holding the sandbox image on every node matching `sandboxPod.nodeSelector`, so the pull happens at deploy time instead of on a user's first request. On by default when `ENABLE_CRAFT` is set; `sandboxImagePrepull.enabled: false` to opt out.

Load-bearing details, each of which fails silently if wrong:

- **DaemonSet, not a one-shot pre-pull Job.** The kubelet only exempts images referenced by a *running* pod from image GC. A Job pulls and exits, leaving the layers evictable with nothing to signal it. It also covers nodes that join after install.
- **Image ref shared with the PodTemplate** via new `onyx.sandboxImage` / `onyx.sandboxImagePullPolicy` helpers. A drifted tag pins layers nobody uses while every sandbox still cold-pulls — and it looks healthy. A test asserts the two agree; the PodTemplate refactor is a verified byte-identical no-op.
- **Negative priority** (`-10`, `preemptionPolicy: Never`) so a pending sandbox preempts the prepuller rather than failing to schedule and triggering a needless scale-up. Safe because a sandbox running on the node pins the image itself — the prepuller is redundant exactly when it would compete.
- **Portable idle loop**, not `sleep infinity` (a GNU coreutils extension that dies on busybox/alpine; hit this for real while testing).
- **Labelled `component: sandbox-image-prepuller`**, not `component: sandbox` — the latter is the selector for the sandbox NetworkPolicies.
- **Defaults resolved field by field, not via sprig `merge`**, which treats `false`/`0` as empty and was silently overwriting `priorityClass.create: false`.

## Verification

Ran real image GC on `kind-onyx-dev` by lowering `imageGCHighThresholdPercent` to 30 — kind ships **100**, i.e. image GC is off, which is why this behaviour is invisible on a dev cluster:

```
17:37:39  images=61  sandbox_present=1
17:41:40  images=63  sandbox_present=1
17:43:11  images=25  sandbox_present=1   <- 38 images / 33.5 GB reclaimed
17:44:41  images=25  sandbox_present=1
```

Every in-use image survived; the 38 that went were unreferenced. The sandbox image had been resident for days, so it was age-eligible and spared on the in-use rule.

Also verified live: `priority=-10`, ephemeral-storage request present, 0 restarts on the portable command, and real sandbox pods at `priority=0` (strictly above the prepuller, so preemption works as intended).

**Not fully isolated:** on that node the sandbox image was held by the prepuller *and* a live sandbox pod, so "prepuller alone suffices" rests on kubelet's in-use rule rather than a single-holder demonstration. A clean control was set up but never resolved (both images too recently pulled for that GC pass).

## Tradeoffs

- **~3.3 GB becomes unreclaimable per sandbox node**, on the same disk as the sandbox workspaces. Disk pressure that image GC used to absorb now resolves by evicting pods instead. Documented in `values.yaml` with the two cases where you should disable it.
- Eviction ordering is *not* a lever: kubelet ranks "exceeds ephemeral-storage request" ahead of priority, and evicting the prepuller frees ~0 bytes anyway.
- **Does not fix autoscale-up.** Node boot (60–120 s) dominates the pull there, and the DaemonSet lands on the new node simultaneously with the sandbox that triggered it. That needs pre-booted spare capacity, node-image baking, or lazy pull (GKE Image Streaming / SOCI).

## Follow-ups, deliberately not in this PR

1. **`docs/craft/sandbox/image-and-spinup.md` still documents the opposite decision.** Its "Cold pulls vs. image warming" section says *"Current state: we accept cold image pulls"* and lists this exact DaemonSet under *"What we considered and rejected."* Merging this makes that section wrong. A doc update is written and ready to land separately.
2. **`test_pod_spec.py` skips silently.** It renders the chart without a push keypair, so all 24 sandbox-pod security-invariant tests skip everywhere including CI (only the full-cluster lane supplies a key). One-line fix, separate PR.
3. **`provision()` has no retry**, and `_wait_for_pod_ip`'s 90 s deadline must cover autoscaler scan + node boot + pull. That looks like it fails outright on a cold scale-up. Grepping prod logs for `Timeout waiting for sandbox pod` against node-creation events would confirm.
4. `test_event_bus_per_directory.py` has 9 pre-existing failures (`Engine not initialized`) unrelated to this change — confirmed identical at `HEAD`.
