### PR TITLE
feat(search): temporary env to force Search-UI document-set scope

### DIFF
--- a/backend/ee/onyx/search/process_search_query.py
+++ b/backend/ee/onyx/search/process_search_query.py
@@ -61,6 +61,8 @@ def _run_single_search(
         user=user,
         persona_search_info=None,
         db_session=db_session,
+        # Search UI is the only surface that enforces FORCED_DOCUMENT_SET_NAMES.
+        force_configured_document_set_scope=True,
     )
 
 

--- a/backend/onyx/configs/app_configs.py
+++ b/backend/onyx/configs/app_configs.py
@@ -79,6 +79,17 @@ DISABLE_USER_KNOWLEDGE = os.environ.get("DISABLE_USER_KNOWLEDGE", "").lower() ==
 # are disabled but core chat, tools, user file uploads, and Projects still work.
 DISABLE_VECTOR_DB = os.environ.get("DISABLE_VECTOR_DB", "").lower() == "true"
 
+# TEMPORARY (will be removed soon): operator-forced Search-UI scope (self-hosted only) —
+# comma-separated document set NAMES. When set, the Onyx Search UI is restricted to those sets
+# (AND'd on top of any persona/user scope; ACL still enforced) — chat/other flows are unaffected,
+# and it is disabled under MULTI_TENANT. Empty = no restriction. Names match the index directly; a
+# name that doesn't exist matches nothing (fail-closed) and is logged. Read at import — restart to change.
+FORCED_DOCUMENT_SET_NAMES: list[str] = [
+    name.strip()
+    for name in os.environ.get("FORCED_DOCUMENT_SET_NAMES", "").split(",")
+    if name.strip()
+]
+
 # Which backend to use for caching, locks, and ephemeral state.
 # "redis" (default) or "postgres" (only valid when DISABLE_VECTOR_DB=true).
 CACHE_BACKEND = CacheBackendType(

--- a/backend/onyx/context/search/forced_document_set.py
+++ b/backend/onyx/context/search/forced_document_set.py
@@ -1,0 +1,46 @@
+"""Operator-forced document-set search scope (self-hosted Search UI only).
+
+When ``FORCED_DOCUMENT_SET_NAMES`` is set, the Onyx Search UI is hard-restricted to
+those document sets. The vector index stores document set NAMES, so the configured
+names are used directly — no resolution needed. Disabled under MULTI_TENANT.
+
+Fail-closed by construction: a name that doesn't exist matches no chunk, so the
+scope can only ever narrow results. The names are verified against the DB and any
+missing one is logged as an error (the operator's signal that a name is a typo or
+was renamed).
+"""
+
+from sqlalchemy.orm import Session
+
+from onyx.configs.app_configs import FORCED_DOCUMENT_SET_NAMES
+from onyx.db.document_set import get_document_sets_by_name
+from onyx.utils.logger import setup_logger
+from shared_configs.configs import MULTI_TENANT
+
+logger = setup_logger()
+
+
+def get_forced_document_set_names(db_session: Session | None) -> list[str] | None:
+    """The operator-forced document set names, or None when the feature is disabled
+    (multitenant, or ``FORCED_DOCUMENT_SET_NAMES`` empty).
+
+    Verifies the names exist (when a session is available) and logs an error for any
+    that don't — a missing name simply matches nothing, so the scope stays safe.
+    """
+    if MULTI_TENANT or not FORCED_DOCUMENT_SET_NAMES:
+        return None
+
+    if db_session is not None:
+        existing = {
+            ds.name
+            for ds in get_document_sets_by_name(db_session, FORCED_DOCUMENT_SET_NAMES)
+        }
+        missing = [name for name in FORCED_DOCUMENT_SET_NAMES if name not in existing]
+        if missing:
+            logger.error(
+                "FORCED_DOCUMENT_SET_NAMES references document sets that do not exist: "
+                "%s. Search returns nothing for those names.",
+                missing,
+            )
+
+    return FORCED_DOCUMENT_SET_NAMES

--- a/backend/onyx/context/search/models.py
+++ b/backend/onyx/context/search/models.py
@@ -146,6 +146,11 @@ class IndexFilters(BaseFilters, UserFileFilters, AssistantKnowledgeFilters):
     # DocumentAccess::to_acl.
     access_control_list: list[str] | None
     tenant_id: str | None = None
+    # Operator-forced document-set scope (NAMES, not IDs). When set, retrieval is
+    # restricted to these sets via a standalone AND clause — distinct from
+    # `document_set` (a user/persona OR-scope). Set only on the Search UI path
+    # (from FORCED_DOCUMENT_SET_NAMES); None = no restriction.
+    forced_document_set: list[str] | None = None
 
 
 class BasicChunkRequest(BaseModel):

--- a/backend/onyx/context/search/pipeline.py
+++ b/backend/onyx/context/search/pipeline.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from sqlalchemy.orm import Session
 
+from onyx.context.search.forced_document_set import get_forced_document_set_names
 from onyx.context.search.models import (
     BaseFilters,
     ChunkIndexRequest,
@@ -50,6 +51,10 @@ def _build_index_filters(
     hierarchy_node_ids: list[int] | None = None,
     # Pre-fetched ACL filters (skips DB query when provided)
     acl_filters: list[str] | None = None,
+    # Search UI only: apply the operator-forced document-set scope
+    # (FORCED_DOCUMENT_SET_NAMES) as a hard AND restriction. Left False for chat and
+    # every other caller, so they are unaffected.
+    force_configured_document_set_scope: bool = False,
 ) -> IndexFilters:
     base_filters = user_provided_filters or BaseFilters()
 
@@ -111,6 +116,13 @@ def _build_index_filters(
             raise ValueError("Either db_session or acl_filters must be provided")
         user_acl_filters = build_access_filters_for_user(user, db_session)
 
+    # Enforced downstream as an AND clause in _get_search_filters (Search UI only).
+    forced_document_set = (
+        get_forced_document_set_names(db_session)
+        if force_configured_document_set_scope
+        else None
+    )
+
     final_filters = IndexFilters(
         project_id_filter=project_id_filter,
         persona_id_filter=persona_id_filter,
@@ -124,6 +136,7 @@ def _build_index_filters(
         # Assistant knowledge filters
         attached_document_ids=attached_document_ids,
         hierarchy_node_ids=hierarchy_node_ids,
+        forced_document_set=forced_document_set,
     )
 
     return final_filters
@@ -267,6 +280,9 @@ def search_pipeline(
     acl_filters: list[str] | None = None,
     embedding_model: EmbeddingModel | None = None,
     prefetched_federated_retrieval_infos: list[FederatedRetrievalInfo] | None = None,
+    # Search UI only: apply the operator-forced document-set scope
+    # (FORCED_DOCUMENT_SET_NAMES). Chat and other callers leave this False.
+    force_configured_document_set_scope: bool = False,
 ) -> list[InferenceChunk]:
     persona_document_sets: list[str] | None = (
         persona_search_info.document_set_names if persona_search_info else None
@@ -295,6 +311,7 @@ def search_pipeline(
         attached_document_ids=attached_document_ids,
         hierarchy_node_ids=hierarchy_node_ids,
         acl_filters=acl_filters,
+        force_configured_document_set_scope=force_configured_document_set_scope,
     )
 
     query_keywords = strip_stopwords(chunk_search_request.query)

--- a/backend/onyx/document_index/opensearch/search.py
+++ b/backend/onyx/document_index/opensearch/search.py
@@ -398,6 +398,7 @@ class DocumentQuery:
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
             hierarchy_node_ids=index_filters.hierarchy_node_ids,
+            forced_document_sets=index_filters.forced_document_set,
         )
 
         # See https://docs.opensearch.org/latest/query-dsl/compound/hybrid/
@@ -494,6 +495,7 @@ class DocumentQuery:
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
             hierarchy_node_ids=index_filters.hierarchy_node_ids,
+            forced_document_sets=index_filters.forced_document_set,
         )
 
         keyword_search_query = (
@@ -577,6 +579,7 @@ class DocumentQuery:
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
             hierarchy_node_ids=index_filters.hierarchy_node_ids,
+            forced_document_sets=index_filters.forced_document_set,
         )
 
         semantic_search_query = (
@@ -639,6 +642,7 @@ class DocumentQuery:
             max_chunk_index=None,
             attached_document_ids=index_filters.attached_document_ids,
             hierarchy_node_ids=index_filters.hierarchy_node_ids,
+            forced_document_sets=index_filters.forced_document_set,
         )
         final_random_search_query = {
             "query": {
@@ -882,6 +886,8 @@ class DocumentQuery:
         # Assistant knowledge filters
         attached_document_ids: list[str] | None = None,
         hierarchy_node_ids: list[int] | None = None,
+        # Operator-forced document-set scope (NAMES), applied as a standalone AND clause.
+        forced_document_sets: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Returns filters to be passed into the "filter" key of a search query.
 
@@ -1268,6 +1274,12 @@ class DocumentQuery:
             # there is explicitly no list provided, we make no restrictions on
             # the documents that can be retrieved.
             filter_clauses.append(_get_acl_visibility_filter(access_control_list))
+
+        if forced_document_sets:
+            # Its own top-level AND clause (not merged into the OR-based
+            # knowledge_filter below), so it INTERSECTS rather than widens; placed
+            # after the ACL clause so it never loosens permissions.
+            filter_clauses.append(_get_document_set_filter(forced_document_sets))
 
         if source_types:
             # If at least one source type is provided, the caller will only

--- a/backend/tests/external_dependency_unit/opensearch/test_forced_document_set_filter.py
+++ b/backend/tests/external_dependency_unit/opensearch/test_forced_document_set_filter.py
@@ -1,0 +1,115 @@
+"""Tests for the operator-forced document-set scope in OpenSearch query construction.
+
+The forced scope (from FORCED_DOCUMENT_SET_NAMES) must be applied as a STANDALONE
+top-level AND filter clause — distinct from the user/persona ``document_set`` scope,
+which lives inside the OR-based knowledge filter. This is what makes the forced scope
+INTERSECT with (restrict), rather than widen, any existing scope, while leaving ACL
+enforcement intact.
+"""
+
+from typing import Any
+
+from onyx.configs.constants import DocumentSource
+from onyx.document_index.interfaces_new import TenantState
+from onyx.document_index.opensearch.schema import (
+    ACCESS_CONTROL_LIST_FIELD_NAME,
+    DOCUMENT_SETS_FIELD_NAME,
+)
+from onyx.document_index.opensearch.search import DocumentQuery
+from shared_configs.configs import POSTGRES_DEFAULT_SCHEMA
+
+
+def _get_search_filters(
+    document_sets: list[str] | None = None,
+    forced_document_sets: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    return DocumentQuery._get_search_filters(
+        tenant_state=TenantState(tenant_id=POSTGRES_DEFAULT_SCHEMA, multitenant=False),
+        include_hidden=False,
+        access_control_list=["user_email:test@example.com"],
+        source_types=[DocumentSource.FILE],
+        tags=[],
+        document_sets=document_sets or [],
+        project_id_filter=None,
+        persona_id_filter=None,
+        created_at_range=None,
+        updated_at_range=None,
+        min_chunk_index=None,
+        max_chunk_index=None,
+        forced_document_sets=forced_document_sets,
+    )
+
+
+def _top_level_document_set_terms(
+    filter_clauses: list[dict[str, Any]],
+) -> list[list[str]]:
+    """Values of every top-level (AND) ``terms`` clause on the document_sets field.
+
+    The forced scope is emitted here; a user/persona document_set scope is NOT — it
+    is nested inside the knowledge ``bool.should`` clause, so it never appears at the
+    top level.
+    """
+    return [
+        clause["terms"][DOCUMENT_SETS_FIELD_NAME]
+        for clause in filter_clauses
+        if "terms" in clause and DOCUMENT_SETS_FIELD_NAME in clause["terms"]
+    ]
+
+
+def _has_acl_clause(filter_clauses: list[dict[str, Any]]) -> bool:
+    return ACCESS_CONTROL_LIST_FIELD_NAME in str(filter_clauses)
+
+
+class TestForcedDocumentSetFilter:
+    def test_forced_scope_is_top_level_and_clause(self) -> None:
+        """A forced scope with no user scope produces exactly one top-level terms
+        clause on document_sets (an AND restriction), NOT a knowledge OR-scope."""
+        filter_clauses = _get_search_filters(forced_document_sets=["Forced"])
+
+        top_level = _top_level_document_set_terms(filter_clauses)
+        assert top_level == [["Forced"]], (
+            f"Expected the forced set as a single top-level AND clause. Got: {filter_clauses}"
+        )
+
+    def test_forced_scope_intersects_user_document_set(self) -> None:
+        """With both a user document_set and a forced scope, the user set stays in the
+        OR knowledge scope while the forced set is its own top-level AND clause — so a
+        document must belong to BOTH (intersection)."""
+        filter_clauses = _get_search_filters(
+            document_sets=["UserPicked"],
+            forced_document_sets=["Forced"],
+        )
+
+        # Forced set: top-level AND clause.
+        assert _top_level_document_set_terms(filter_clauses) == [["Forced"]], (
+            f"Expected only the forced set at top level. Got: {filter_clauses}"
+        )
+        # User set: nested inside the knowledge bool/should scope (not top level).
+        knowledge_should = [
+            clause["bool"]["should"]
+            for clause in filter_clauses
+            if isinstance(clause.get("bool"), dict) and clause["bool"].get("should")
+        ]
+        assert any("UserPicked" in str(should) for should in knowledge_should), (
+            f"Expected the user document_set inside the knowledge OR-scope. "
+            f"Got: {filter_clauses}"
+        )
+
+    def test_forced_scope_preserves_acl(self) -> None:
+        """The forced clause is added alongside — never in place of — the ACL clause."""
+        filter_clauses = _get_search_filters(forced_document_sets=["Forced"])
+        assert _has_acl_clause(filter_clauses), (
+            f"ACL clause must still be present with a forced scope. Got: {filter_clauses}"
+        )
+
+    def test_no_forced_clause_when_unset(self) -> None:
+        """When no forced scope is set, no top-level document_sets clause is emitted; a
+        user document_set stays confined to the knowledge OR-scope."""
+        for forced in (None, []):
+            filter_clauses = _get_search_filters(
+                document_sets=["UserPicked"], forced_document_sets=forced
+            )
+            assert _top_level_document_set_terms(filter_clauses) == [], (
+                f"No top-level forced clause expected for forced={forced!r}. "
+                f"Got: {filter_clauses}"
+            )

--- a/backend/tests/unit/onyx/context/search/test_forced_document_set.py
+++ b/backend/tests/unit/onyx/context/search/test_forced_document_set.py
@@ -1,0 +1,98 @@
+"""Unit tests for the operator-forced document-set scope.
+
+Covers the name verifier (disabled when multitenant/unset, logs an error for a
+missing name) and that _build_index_filters applies the scope only when the
+Search-UI force flag is set. The DB is mocked so these run without external deps.
+"""
+
+from types import SimpleNamespace
+from typing import Any, Iterator, cast
+
+import pytest
+from sqlalchemy.orm import Session
+
+import onyx.context.search.forced_document_set as fds
+import onyx.context.search.pipeline as pipeline
+from onyx.context.search.models import IndexFilters
+from onyx.db.models import User
+
+_DB = cast(Session, object())
+
+
+@pytest.fixture(autouse=True)
+def _single_tenant(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    monkeypatch.setattr(fds, "MULTI_TENANT", False)
+    yield
+
+
+def _patch_names_and_db(
+    monkeypatch: pytest.MonkeyPatch, names: list[str], existing: list[str]
+) -> None:
+    monkeypatch.setattr(fds, "FORCED_DOCUMENT_SET_NAMES", names)
+    monkeypatch.setattr(
+        fds,
+        "get_document_sets_by_name",
+        lambda _db, _names: [SimpleNamespace(name=n) for n in existing],
+    )
+
+
+def test_disabled_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_names_and_db(monkeypatch, names=[], existing=[])
+    assert fds.get_forced_document_set_names(_DB) is None
+
+
+def test_disabled_in_multitenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(fds, "MULTI_TENANT", True)
+    _patch_names_and_db(monkeypatch, names=["HR"], existing=["HR"])
+    assert fds.get_forced_document_set_names(_DB) is None
+
+
+def test_returns_configured_names(monkeypatch: pytest.MonkeyPatch) -> None:
+    _patch_names_and_db(monkeypatch, names=["HR", "Legal"], existing=["HR", "Legal"])
+    assert fds.get_forced_document_set_names(_DB) == ["HR", "Legal"]
+
+
+def test_missing_name_is_logged_but_still_returned(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_names_and_db(monkeypatch, names=["HR", "Typo"], existing=["HR"])
+    errors: list[Any] = []
+    monkeypatch.setattr(fds.logger, "error", lambda msg, *a: errors.append((msg, a)))
+
+    names = fds.get_forced_document_set_names(_DB)
+
+    # Missing names are still returned — they just match nothing (fail-closed).
+    assert names == ["HR", "Typo"]
+    assert errors and "Typo" in str(errors[0]), "a missing name must log an error"
+
+
+def _build_filters(monkeypatch: pytest.MonkeyPatch, *, force: bool) -> IndexFilters:
+    """Call _build_index_filters with the resolver stubbed to return ["Eng"]."""
+    monkeypatch.setattr(pipeline, "get_forced_document_set_names", lambda _db: ["Eng"])
+    return pipeline._build_index_filters(
+        user_provided_filters=None,
+        user=cast(User, SimpleNamespace(is_anonymous=False)),
+        project_id_filter=None,
+        persona_id_filter=None,
+        persona_document_sets=None,
+        persona_time_cutoff=None,
+        db_session=None,
+        bypass_acl=True,
+        force_configured_document_set_scope=force,
+    )
+
+
+def test_build_index_filters_applies_scope_with_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Search UI path (flag on) → the forced scope is set on IndexFilters."""
+    filters = _build_filters(monkeypatch, force=True)
+    assert filters.forced_document_set == ["Eng"]
+
+
+def test_build_index_filters_no_scope_without_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chat / other callers (flag off) → the forced scope is NOT applied."""
+    filters = _build_filters(monkeypatch, force=False)
+    assert filters.forced_document_set is None

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -79,6 +79,12 @@ USER_AUTH_SECRET=""
 ### accounts or share agents with individual users; group sharing still works.
 # USER_DIRECTORY_ADMIN_ONLY=
 
+## Search Configuration
+## TEMPORARY (self-hosted only, will be removed soon): comma-separated document set
+## NAMES. When set, the Onyx Search UI returns results only from those sets (chat is
+## unaffected). A name that doesn't exist matches nothing and is logged. Empty = off.
+# FORCED_DOCUMENT_SET_NAMES=
+
 ## Chat Configuration
 # HARD_DELETE_CHATS=
 # MAX_ALLOWED_UPLOAD_SIZE_MB=250

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -79,6 +79,12 @@ USER_AUTH_SECRET=""
 ### accounts or share agents with individual users; group sharing still works.
 # USER_DIRECTORY_ADMIN_ONLY=
 
+## Search Configuration
+## TEMPORARY (self-hosted only, will be removed soon): comma-separated document set
+## NAMES. When set, the Onyx Search UI returns results only from those sets (chat is
+## unaffected). A name that doesn't exist matches nothing and is logged. Empty = off.
+# FORCED_DOCUMENT_SET_NAMES=
+
 ## Chat Configuration
 # HARD_DELETE_CHATS=
 # MAX_ALLOWED_UPLOAD_SIZE_MB=250

--- a/deployment/helm/charts/onyx/Chart.yaml
+++ b/deployment/helm/charts/onyx/Chart.yaml
@@ -5,7 +5,7 @@ home: https://www.onyx.app/
 sources:
   - "https://github.com/onyx-dot-app/onyx"
 type: application
-version: 0.8.8
+version: 0.8.9
 appVersion: latest
 annotations:
   category: Productivity

--- a/deployment/helm/charts/onyx/values.yaml
+++ b/deployment/helm/charts/onyx/values.yaml
@@ -1544,6 +1544,10 @@ configMap:
   # Query Options
   DOC_TIME_DECAY: ""
   HYBRID_ALPHA: ""
+  # TEMPORARY (self-hosted only, will be removed soon): comma-separated document set
+  # NAMES. When set, the Onyx Search UI returns results only from those sets (chat is
+  # unaffected). Empty = no restriction.
+  FORCED_DOCUMENT_SET_NAMES: ""
   # Don't change the NLP models unless you know what you're doing
   EMBEDDING_BATCH_SIZE: ""
   DOCUMENT_ENCODER_MODEL: ""


### PR DESCRIPTION
## Description

- Add `FORCED_DOCUMENT_SET_NAMES` (self-hosted only): when set, the Onyx Search UI returns results only from the named document sets, intersected with any persona/user scope and with ACL still enforced.
- Chat, the programmatic `/api/search`, and admin search are unaffected; the scope is disabled under multitenant.
- A missing/typo'd name matches nothing (fail-closed) and is logged; the env var is documented in `env.template` and Helm `values.yaml` with a note that it is temporary and will be removed soon.

## How Has This Been Tested?

- Unit tests added: the name verifier (off under multitenant/unset, logs a missing name), the Search-UI-only flag gating in `_build_index_filters`, and the OpenSearch AND-clause construction.
- Manually verified end-to-end via the Search UI (results scoped to the configured document sets; chat unaffected).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
