### PR TITLE
feat(perms): frontend spine for server-driven UI capability model

### DIFF
--- a/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
+++ b/backend/alembic/versions/c71a18ea7d07_add_is_manager_and_is_group_manager.py
@@ -16,7 +16,6 @@ Create Date: 2026-06-29 14:15:32.889597
 from alembic import op
 import sqlalchemy as sa
 
-# revision identifiers, used by Alembic.
 revision = "c71a18ea7d07"
 down_revision = "c8e316473aaa"
 branch_labels = None

--- a/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
+++ b/backend/alembic/versions/c8e316473aaa_make_user_role_nullable.py
@@ -20,7 +20,6 @@ import sqlalchemy as sa
 from alembic import op
 
 
-# revision identifiers, used by Alembic.
 revision = "c8e316473aaa"
 down_revision = "8f2c4a1d9e3b"
 branch_labels: str | None = None
@@ -37,9 +36,8 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    # Backfill any NULLs written while the column was optional before we
-    # restore the NOT NULL constraint, otherwise the downgrade would fail
-    # against rows inserted after the upgrade.
+    # Backfill NULLs written while the column was optional; otherwise
+    # restoring NOT NULL fails against rows inserted after the upgrade.
     op.execute("UPDATE \"user\" SET role = 'BASIC' WHERE role IS NULL")
     op.alter_column(
         "user",

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -8,13 +8,20 @@ from ee.onyx.db.token_limit import fetch_all_user_group_token_rate_limits_by_gro
 from ee.onyx.db.token_limit import fetch_user_group_token_rate_limits_for_group
 from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.db.token_limit import delete_token_rate_limit
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.token_limit import get_token_rate_limit_scope_and_group
 from onyx.db.token_limit import insert_user_token_rate_limit
+from onyx.db.token_limit import update_token_rate_limit
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import any_rate_limit_exists
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
@@ -48,9 +55,14 @@ def get_all_group_token_limit_settings(
 @router.get("/user-group/{group_id}")
 def get_group_token_limit_settings(
     group_id: int,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[TokenRateLimitDisplay]:
+    # GATE 2 (read): a scoped manager may only read limits for a group they manage
+    # (global holders bypass). Single-group path param, so assert_manages_group, not a clause.
+    assert_manages_group(user, db_session, group_id=group_id)
     return [
         TokenRateLimitDisplay.from_db(token_rate_limit)
         for token_rate_limit in fetch_user_group_token_rate_limits_for_group(
@@ -89,6 +101,74 @@ def create_group_token_limit_settings(
     # clear cache in case this was the first rate limit created
     any_rate_limit_exists.cache_clear()
     return rate_limit_display
+
+
+def _authorize_group_token_rate_limit_write(
+    user: User, db_session: Session, *, group_id: int, rate_limit_id: int
+) -> None:
+    """Manager-scope gate for a group token-limit write: caller must manage group_id AND
+    the limit must belong to it — so a global/per-user id or another group's limit can't be
+    reached through this path."""
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=[group_id],
+        requested_group_ids=[group_id],
+        is_non_public=True,
+    )
+    try:
+        scope, resolved_group_id = get_token_rate_limit_scope_and_group(
+            db_session, rate_limit_id
+        )
+    except ValueError:
+        scope, resolved_group_id = None, None
+    if scope != TokenRateLimitScope.USER_GROUP or resolved_group_id != group_id:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, "Token rate limit not found for this group."
+        )
+
+
+# Separate from the shared by-id routes so this route's require_permission caps a scoped
+# PAT to MANAGE_USER_GROUPS; a shared route would expose FULL_ADMIN global/user limits.
+@router.put("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def update_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    token_limit_settings: TokenRateLimitArgs,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> TokenRateLimitDisplay:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    rate_limit_display = TokenRateLimitDisplay.from_db(
+        update_token_rate_limit(
+            db_session=db_session,
+            token_rate_limit_id=rate_limit_id,
+            token_rate_limit_settings=token_limit_settings,
+        )
+    )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
+
+
+@router.delete("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def delete_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> None:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    delete_token_rate_limit(db_session=db_session, token_rate_limit_id=rate_limit_id)
+    any_rate_limit_exists.cache_clear()
 
 
 """

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -25,6 +25,7 @@ from ee.onyx.server.user_group.models import UserGroup
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
@@ -33,6 +34,7 @@ from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import manages_group
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
@@ -61,10 +63,16 @@ def list_user_groups(
     # implies it) sees every group; a scoped manager sees only the groups they
     # manage. The group list has no built-in membership filter, so restrict it here
     # or a manager would see the whole org.
+    # Resolve scope + global authority once so per-group stamping is pure set math (no query).
+    managed_group_ids = get_scoped_groups(
+        user, db_session, Permission.MANAGE_USER_GROUPS
+    )
+    is_user_groups_admin = has_global_permission(user, Permission.MANAGE_USER_GROUPS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
     restrict_to_group_ids = (
         None
         if has_global_permission(user, Permission.READ_USER_GROUPS)
-        else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+        else managed_group_ids
     )
     user_groups = fetch_user_groups(
         db_session,
@@ -75,7 +83,20 @@ def list_user_groups(
     )
     mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        UserGroup.from_model(user_group, mask_credential_prefix=mask_credential_prefix)
+        UserGroup.from_model(
+            user_group,
+            mask_credential_prefix=mask_credential_prefix,
+            permissions=user_group_permissions(
+                can_manage=manages_group(
+                    user,
+                    db_session,
+                    group_id=user_group.id,
+                    managed_group_ids=managed_group_ids,
+                ),
+                is_user_groups_admin=is_user_groups_admin,
+                is_full_admin=is_full_admin,
+            ),
+        )
         for user_group in user_groups
     ]
 

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.auth.permissions import Permission
 from onyx.db.models import UserGroup as UserGroupModel
@@ -24,6 +25,10 @@ class UserGroup(BaseModel):
     is_up_to_date: bool
     is_up_for_deletion: bool
     is_default: bool
+    # Per-action affordance map ({"manage": true, ...}) the client reads to show/hide
+    # controls. Empty default = every action denied (missing key is false), so it fails
+    # closed. Only the list-groups endpoint fills it in; the mutation routes leave it empty.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -31,8 +36,10 @@ class UserGroup(BaseModel):
         user_group_model: UserGroupModel,
         *,
         mask_credential_prefix: bool,
+        permissions: dict[str, bool] | None = None,
     ) -> "UserGroup":
         return cls(
+            permissions=permissions or {},
             id=user_group_model.id,
             name=user_group_model.name,
             manager_ids=[

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -26,3 +26,137 @@ def cc_pair_permissions(
         "delete": is_connectors_admin,
         "publish": is_connectors_admin,
     }
+
+
+PERSONA_ACTIONS: frozenset[str] = frozenset(
+    {"edit", "share", "view_stats", "delete", "publish", "feature", "list", "reorder"}
+)
+
+
+def persona_permissions(
+    *,
+    can_edit: bool,
+    can_share: bool,
+    can_view_stats: bool,
+    can_delete: bool,
+    holds_add_agents: bool,
+    is_manage_agents_admin: bool,
+    is_full_admin: bool,
+) -> dict[str, bool]:
+    """Agent (persona) affordance map. ``edit``/``share`` gate on editable alone (their routes are
+    BASIC_ACCESS) — an editor-shared user without ADD_AGENTS may still edit and manage sharing.
+    ``edit`` is the editable-AND-managed-scope decision the update guard enforces; ``share`` is the
+    broader editable decision the share guard enforces (get_editable, no scope AND). ``publish``
+    (make org-wide public, via the share route's is_owner_or_admin gate) is owner-or-admin — no
+    ADD_AGENTS. ``delete`` ANDs ``holds_add_agents``: its route gates on ADD_AGENTS at GATE 1
+    (allow_scope), so an owner lacking it is 403'd there. ``view_stats`` is owner-or-full-admin.
+    ``feature``/``list`` need global MANAGE_AGENTS (which implies ADD_AGENTS) and ``reorder`` full
+    admin."""
+    return {
+        "edit": can_edit,
+        "share": can_share,
+        "view_stats": can_view_stats,
+        "delete": can_delete and holds_add_agents,
+        "publish": can_delete,
+        "feature": is_manage_agents_admin,
+        "list": is_manage_agents_admin,
+        "reorder": is_full_admin,
+    }
+
+
+DOCUMENT_SET_ACTIONS: frozenset[str] = frozenset(
+    {"edit", "manage_access", "delete", "publish"}
+)
+
+
+def document_set_permissions(
+    *, is_editable: bool, is_document_sets_admin: bool
+) -> dict[str, bool]:
+    """Document set affordance map. ``edit`` and ``manage_access`` are the managed-scope
+    editable decision the write guard enforces (a doc set has no editor-share arm, so
+    editable membership is that decision). ``delete`` and ``publish`` (make org-wide
+    public) are global MANAGE_DOCUMENT_SETS only."""
+    return {
+        "edit": is_editable,
+        "manage_access": is_editable,
+        "delete": is_document_sets_admin,
+        "publish": is_document_sets_admin,
+    }
+
+
+TOOL_ACTIONS: frozenset[str] = frozenset({"edit", "delete", "toggle", "authenticate"})
+
+
+def tool_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """Custom action (OpenAPI tool) affordance map. Every action — edit, delete, toggle, and
+    authenticate (its OAuth config) — is owner-or-admin (``can_manage``): the creator fully
+    controls the action they made and an admin controls any, while a scoped manager may view
+    and create actions but not edit ones they didn't create."""
+    return {
+        "edit": can_manage,
+        "delete": can_manage,
+        "toggle": can_manage,
+        "authenticate": can_manage,
+    }
+
+
+MCP_SERVER_ACTIONS: frozenset[str] = frozenset(
+    {"edit", "delete", "authenticate", "manage_status"}
+)
+
+
+def mcp_server_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """MCP server affordance map. Every action — edit, delete, authenticate (connect), and
+    manage_status (disconnect/refresh) — is owner-or-admin (``can_manage``): the owner fully
+    controls their server and an admin controls any, while a scoped manager may view servers
+    connected to their groups and create their own but not manage others'."""
+    return {
+        "edit": can_manage,
+        "delete": can_manage,
+        "authenticate": can_manage,
+        "manage_status": can_manage,
+    }
+
+
+CUSTOM_SKILL_ACTIONS: frozenset[str] = frozenset(
+    {"edit", "manage_access", "delete", "publish"}
+)
+
+
+def custom_skill_permissions(
+    *, can_edit: bool, is_full_admin: bool, is_skills_admin: bool
+) -> dict[str, bool]:
+    """Custom skill affordance map. ``edit`` (replace bundle, enable/disable) and
+    ``manage_access`` (group grants) are the managed-scope editable decision the write
+    guard enforces. ``delete`` is FULL_ADMIN only (its route requires
+    FULL_ADMIN_PANEL_ACCESS, no ``allow_scope``); ``publish`` (make org-wide public)
+    needs global MANAGE_SKILLS — a scoped manager fails the guard's non-public check when
+    flipping a skill public."""
+    return {
+        "edit": can_edit,
+        "manage_access": can_edit,
+        "delete": is_full_admin,
+        "publish": is_skills_admin,
+    }
+
+
+USER_GROUP_ACTIONS: frozenset[str] = frozenset(
+    {"manage", "delete", "edit_permissions", "edit_token_limits"}
+)
+
+
+def user_group_permissions(
+    *, can_manage: bool, is_user_groups_admin: bool, is_full_admin: bool
+) -> dict[str, bool]:
+    """User group affordance map. ``manage`` (rename, membership, assign agents, set
+    manager) and ``edit_token_limits`` are the per-group ``manages_group`` decision — group
+    in the manager's managed set, or global MANAGE_USER_GROUPS. A scoped manager gets full
+    token-limit CRUD for groups they manage: every token route (read/create/update/delete)
+    now admits scope. ``delete`` needs global MANAGE_USER_GROUPS (its route has no
+    ``allow_scope``). ``edit_permissions`` is FULL_ADMIN (the permission-toggle route)."""
+    return {
+        "manage": can_manage,
+        "delete": is_user_groups_admin,
+        "edit_permissions": is_full_admin,
+        "edit_token_limits": can_manage,
+    }

--- a/backend/onyx/auth/permissions.py
+++ b/backend/onyx/auth/permissions.py
@@ -30,8 +30,10 @@ logger = setup_logger()
 ALL_PERMISSIONS: frozenset[str] = frozenset(p.value for p in Permission)
 
 # Implication map: granted permission -> set of permissions it implies.
+# NOTE: ADD_AGENTS does NOT imply READ_AGENTS — creating your own agents must not grant
+# see-all-agents visibility. READ_AGENTS (browse every agent) comes only from the
+# MANAGE_* admin bundles below.
 IMPLIED_PERMISSIONS: dict[str, set[str]] = {
-    Permission.ADD_AGENTS.value: {Permission.READ_AGENTS.value},
     Permission.MANAGE_AGENTS.value: {
         Permission.ADD_AGENTS.value,
         Permission.READ_AGENTS.value,

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -33,25 +33,6 @@ def get_scoped_groups(
     return fetch_managed_group_ids(user, db_session)
 
 
-def agent_mediated_scope_allows(
-    user: User,
-    db_session: Session,
-    *,
-    group_ids: set[int],
-    has_public_agent: bool,
-    has_ungrouped_private_agent: bool,
-) -> bool:
-    """Shared GATE 2 tail for resources whose scope is derived from the agents that
-    reference them (custom actions, MCP servers). A scoped manager is in scope iff
-    every referencing agent is private and in a group they manage: no agent is
-    public or ungrouped-private, there is ≥1 group, and every group is managed.
-    Callers resolve owner/admin bypasses first."""
-    if has_public_agent or has_ungrouped_private_agent or not group_ids:
-        return False
-    managed = get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
-    return group_ids.issubset(managed)
-
-
 def within_scope(
     user: User,
     db_session: Session,

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -48,7 +48,6 @@ from onyx.db.persona_sharing import get_user_group_ids_for_user
 from onyx.db.scoped_permissions import fetch_managed_group_ids
 from onyx.db.scoped_permissions import scoped_group_ids_subquery
 from onyx.db.scoped_permissions import within_managed_scope_clause
-from onyx.db.users import user_is_admin
 from onyx.server.features.persona.models import FullPersonaSnapshot
 from onyx.server.features.persona.models import MinimalPersonaSnapshot
 from onyx.server.features.persona.models import PersonaSharedNotificationData
@@ -657,19 +656,11 @@ def update_persona_shared(
         db_session=db_session, persona_id=persona_id, user=user, get_editable=True
     )
 
-    # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may
-    # edit user/group shares but must not flip is_public / public_permission
-    # (the same guard update_persona_public_status enforces).
-    is_owner_or_admin: bool = (
-        user_is_admin(user)
-        or persona.user_id == user.id
-        or (
-            persona.owner_group_id is not None
-            and persona.owner_group_id
-            in get_user_group_ids_for_user(db_session, user.id)
-        )
-    )
-    if not is_owner_or_admin:
+    # Org-wide visibility is an owner/admin decision. EDITOR-level sharees may edit
+    # user/group shares but must not flip is_public / public_permission. Reuse the
+    # delete/publish predicate so this exactly matches the `publish` projection and the
+    # /public route (global MANAGE_AGENTS, owner, or owner-group) — not just FULL_ADMIN.
+    if not can_delete_persona(user, persona, db_session):
         is_public = None
         public_permission = None
 

--- a/backend/onyx/db/persona.py
+++ b/backend/onyx/db/persona.py
@@ -15,9 +15,11 @@ from sqlalchemy.orm import selectinload
 from sqlalchemy.orm import Session
 
 from onyx.access.hierarchy_access import get_user_external_group_ids
+from onyx.auth.permission_projection import persona_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
 from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import within_scope
 from onyx.configs.constants import DEFAULT_PERSONA_ID
 from onyx.configs.constants import NotificationType
 from onyx.db.constants import SLACK_BOT_PERSONA_PREFIX
@@ -43,6 +45,7 @@ from onyx.db.models import UserGroup
 from onyx.db.notification import create_notification
 from onyx.db.persona_sharing import get_persona_access_level
 from onyx.db.persona_sharing import get_user_group_ids_for_user
+from onyx.db.scoped_permissions import fetch_managed_group_ids
 from onyx.db.scoped_permissions import scoped_group_ids_subquery
 from onyx.db.scoped_permissions import within_managed_scope_clause
 from onyx.db.users import user_is_admin
@@ -380,6 +383,162 @@ def _assert_persona_update_within_managed_scope(
     )
 
 
+def persona_edit_within_scope(
+    user: User,
+    db_session: Session,
+    *,
+    group_ids: list[int],
+    is_public: bool,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """Read-mode of ``_assert_persona_update_within_managed_scope`` (requested := current).
+    Non-SCOPED holders and personal (no-group) agents pass; a scoped manager passes only
+    when within_scope holds. Pinned to that guard by the contract test."""
+    if has_permission(user, Permission.MANAGE_AGENTS) is not PermissionAuthority.SCOPED:
+        return True
+    if not group_ids:
+        return True
+    return within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_AGENTS,
+        current_group_ids=group_ids,
+        requested_group_ids=group_ids,
+        is_non_public=not is_public,
+        managed_group_ids=managed_group_ids,
+    )
+
+
+def can_edit_persona(
+    user: User,
+    persona: Persona,
+    db_session: Session,
+    *,
+    is_editable: bool,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
+    """The get_editable filter is a superset (owner ∪ EDITOR-share ∪ managed-scope), so a
+    scoped manager EDITOR-shared on an out-of-scope grouped agent qualifies there but is
+    ANDed out by the managed-scope gate — matching the write path. ``is_editable`` is that
+    filter's result."""
+    if not is_editable:
+        return False
+    return persona_edit_within_scope(
+        user,
+        db_session,
+        group_ids=[group.id for group in persona.groups],
+        is_public=persona.is_public,
+        managed_group_ids=managed_group_ids,
+    )
+
+
+def is_persona_editable_by_user(
+    db_session: Session, persona_id: int, user: User
+) -> bool:
+    """Non-raising editability check via the same get_editable filter the edit affordance
+    should reflect (superset: owner ∪ EDITOR-share ∪ managed-scope)."""
+    stmt = select(Persona).where(Persona.id == persona_id).distinct()
+    stmt = _add_user_filters(stmt=stmt, user=user, get_editable=True)
+    return db_session.scalars(stmt).one_or_none() is not None
+
+
+def can_view_persona_stats(user: User, persona: Persona) -> bool:
+    """Owner-or-full-admin — mirrors ee ``user_can_view_assistant_stats`` (pinned by the
+    contract test). Stats are EE-only but the gate itself is trivially MIT-computable."""
+    return has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS) or (
+        persona.user_id == user.id
+    )
+
+
+def can_delete_persona(
+    user: User,
+    persona: Persona,
+    db_session: Session,
+    *,
+    user_group_ids: set[int] | None = None,
+) -> bool:
+    """Owner-or-admin — mirrors the delete/publish handlers' ownership check (via
+    ``get_persona_by_id(is_for_edit=True)``): a global MANAGE_AGENTS holder, the owner,
+    or an owner-group member. A scoped manager is NOT included: deleting or publishing a
+    managed-group agent is owner/admin only, not a manager scope.
+
+    ``user_group_ids`` lets a caller pass a preloaded set so per-row stamping issues no
+    DB query; ``None`` re-queries."""
+    if has_global_permission(user, Permission.MANAGE_AGENTS):
+        return True
+    if persona.user_id == user.id:
+        return True
+    if persona.owner_group_id is not None:
+        group_ids = (
+            user_group_ids
+            if user_group_ids is not None
+            else get_user_group_ids_for_user(db_session, user.id)
+        )
+        return persona.owner_group_id in group_ids
+    return False
+
+
+def _editable_persona_ids_among(
+    db_session: Session, user: User, persona_ids: list[int]
+) -> set[int]:
+    """Subset of ``persona_ids`` the user may edit, via the same get_editable filter the
+    write path enforces — one query for the whole page instead of a per-persona check."""
+    if not persona_ids:
+        return set()
+    stmt = select(Persona).where(Persona.id.in_(persona_ids))
+    stmt = _add_user_filters(stmt=stmt, user=user, get_editable=True)
+    return {persona.id for persona in db_session.scalars(stmt).all()}
+
+
+def stamp_minimal_persona_permissions(
+    snapshots: list[MinimalPersonaSnapshot],
+    personas: Sequence[Persona],
+    user: User,
+    db_session: Session,
+    user_group_ids: set[int],
+) -> None:
+    """Stamp each list snapshot with the same affordance map the single-agent GET does,
+    so cards gate their icons without a per-card refetch. Shared inputs (editable set,
+    managed scope, admin flags) are batched so a page costs a fixed number of queries,
+    not one per persona. ``snapshots`` and ``personas`` must be in the same order."""
+    editable_ids = _editable_persona_ids_among(
+        db_session, user, [persona.id for persona in personas]
+    )
+    # Only scoped managers consult the managed set (GLOBAL/NONE short-circuit earlier);
+    # preload it once so per-row can_edit_persona issues no query.
+    managed_group_ids = (
+        fetch_managed_group_ids(user, db_session)
+        if has_permission(user, Permission.MANAGE_AGENTS) is PermissionAuthority.SCOPED
+        else None
+    )
+    is_manage_agents_admin = has_global_permission(user, Permission.MANAGE_AGENTS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
+    # delete/publish also gate on ADD_AGENTS (GATE 1); edit/share don't. Per-user, not per-row.
+    holds_add_agents = (
+        has_permission(user, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    for snapshot, persona in zip(snapshots, personas):
+        is_editable = persona.id in editable_ids
+        snapshot.permissions = persona_permissions(
+            can_edit=can_edit_persona(
+                user,
+                persona,
+                db_session,
+                is_editable=is_editable,
+                managed_group_ids=managed_group_ids,
+            ),
+            # share tracks the share guard (get_editable), broader than edit's scope gate
+            can_share=is_editable,
+            can_view_stats=can_view_persona_stats(user, persona),
+            can_delete=can_delete_persona(
+                user, persona, db_session, user_group_ids=user_group_ids
+            ),
+            holds_add_agents=holds_add_agents,
+            is_manage_agents_admin=is_manage_agents_admin,
+            is_full_admin=is_full_admin,
+        )
+
+
 def create_update_persona(
     persona_id: int | None,
     create_persona_request: PersonaUpsertRequest,
@@ -639,19 +798,26 @@ def get_minimal_persona_snapshots_for_user(
             Document.parent_hierarchy_node
         ),
         selectinload(Persona.user),
+        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
+        # eager-load it so stamping the page's permissions isn't an N+1.
+        selectinload(Persona.groups),
         selectinload(Persona.owner_group),
         selectinload(Persona.user_shares),
         selectinload(Persona.group_shares),
     )
     results = db_session.scalars(stmt).all()
     user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
+    snapshots = [
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
         )
         for persona in results
     ]
+    stamp_minimal_persona_permissions(
+        snapshots, results, user, db_session, user_group_ids
+    )
+    return snapshots
 
 
 def get_persona_snapshots_for_user(
@@ -794,6 +960,9 @@ def get_minimal_persona_snapshots_paginated(
             ),
         ),
         selectinload(Persona.user),
+        # groups feeds the per-agent edit affordance (persona_edit_within_scope);
+        # eager-load it so stamping the page's permissions isn't an N+1.
+        selectinload(Persona.groups),
         selectinload(Persona.owner_group),
         selectinload(Persona.user_shares),
         selectinload(Persona.group_shares),
@@ -801,13 +970,17 @@ def get_minimal_persona_snapshots_paginated(
 
     results = db_session.scalars(stmt).all()
     user_group_ids = get_user_group_ids_for_user(db_session, user.id)
-    return [
+    snapshots = [
         MinimalPersonaSnapshot.from_model(
             persona,
             user_permission=get_persona_access_level(persona, user, user_group_ids),
         )
         for persona in results
     ]
+    stamp_minimal_persona_permissions(
+        snapshots, results, user, db_session, user_group_ids
+    )
+    return snapshots
 
 
 def get_persona_snapshots_paginated(
@@ -1253,7 +1426,12 @@ def upsert_persona(
         existing_persona.default_model_configuration_id = default_model_configuration_id
         existing_persona.starter_messages = starter_messages
         existing_persona.deleted = False  # Un-delete if previously deleted
-        if is_public is not None:
+        # Publishing (org-wide public) is owner-or-admin — matches the share route and the
+        # publish projection. An editor-shared user may edit content but not flip an agent
+        # they don't own to public; the change is silently dropped, like is_listed/is_featured.
+        if is_public is not None and (
+            user is None or can_delete_persona(user, existing_persona, db_session)
+        ):
             existing_persona.is_public = is_public
         if remove_image or uploaded_image_id:
             existing_persona.uploaded_image_id = uploaded_image_id

--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -78,6 +78,24 @@ def insert_global_token_rate_limit(
     return token_limit
 
 
+def get_token_rate_limit_scope_and_group(
+    db_session: Session, token_rate_limit_id: int
+) -> tuple[TokenRateLimitScope, int | None]:
+    """Scope + owning group id for a rate limit (group is None unless USER_GROUP). Raises
+    ValueError if the id is unknown."""
+    token_limit = db_session.get(TokenRateLimit, token_rate_limit_id)
+    if token_limit is None:
+        raise ValueError(f"TokenRateLimit with id '{token_rate_limit_id}' not found")
+    if token_limit.scope != TokenRateLimitScope.USER_GROUP:
+        return token_limit.scope, None
+    group_id = db_session.scalar(
+        select(TokenRateLimit__UserGroup.user_group_id).where(
+            TokenRateLimit__UserGroup.rate_limit_id == token_rate_limit_id
+        )
+    )
+    return token_limit.scope, group_id
+
+
 def update_token_rate_limit(
     db_session: Session,
     token_rate_limit_id: int,

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from typing import Any
 from typing import cast
 from typing import Type
@@ -6,13 +7,16 @@ from uuid import UUID
 
 from sqlalchemy import func
 from sqlalchemy import or_
-from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_permission
 from onyx.db.constants import UNSET
 from onyx.db.constants import UnsetType
 from onyx.db.enums import MCPServerStatus
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import MCPServer
 from onyx.db.models import OAuthConfig
 from onyx.db.models import Persona
@@ -20,6 +24,7 @@ from onyx.db.models import Persona__Tool
 from onyx.db.models import Persona__UserGroup
 from onyx.db.models import Tool
 from onyx.db.models import ToolCall
+from onyx.db.models import User
 from onyx.server.features.tool.models import Header
 from onyx.tools.built_in_tools import BUILT_IN_TOOL_TYPES
 from onyx.utils.headers import HeaderItemDict
@@ -98,70 +103,54 @@ def get_tool_by_id(tool_id: int, db_session: Session) -> Tool:
     return tool
 
 
-def _agent_group_scope(
-    agent_select: Select[tuple[int, bool, int | None]], db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """Shared core of the agent-mediated action/MCP scope. Given a select of
-    ``(persona_id, is_public, owner_group_id)`` for the (non-deleted) agents
-    referencing a resource, return ``(private_agent_group_ids, has_public_agent,
-    has_ungrouped_private_agent)``. A private agent's groups are those it is shared
-    to (``Persona__UserGroup``) plus the group that owns it (``owner_group_id``); an
-    agent with neither is a personal agent outside any managed group and must be
-    tracked explicitly. A public agent is org-wide; a resource used by no agent has
-    no group context (empty set)."""
-    agent_rows = db_session.execute(agent_select).all()
-    has_public_agent = any(is_public for _, is_public, _ in agent_rows)
-    private_owner_groups = {
-        pid: owner_group_id
-        for pid, is_public, owner_group_id in agent_rows
-        if not is_public
-    }
-    if not private_owner_groups:
-        return set(), has_public_agent, False
-    share_rows = db_session.execute(
-        select(Persona__UserGroup.persona_id, Persona__UserGroup.user_group_id).where(
-            Persona__UserGroup.persona_id.in_(private_owner_groups.keys())
+def can_manage_own_tool(user: User, tool: Tool) -> bool:
+    """Owner-or-admin gate for every action on a custom action (edit, delete, toggle, OAuth
+    config), matching the routes' ``allow_scope`` guard: a global actions-admin manages any
+    action, a scoped manager only one they created. No MANAGE_ACTIONS authority — or a built-in
+    tool (no owner) — never passes."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        return tool.user_id is not None and tool.user_id == user.id
+    return False
+
+
+def can_manage_mcp_server(user: User, server: MCPServer) -> bool:
+    """Owner-or-admin gate for every action on an MCP server (edit, delete, connect, status),
+    matching the routes' ``allow_scope`` guard ∧ FULL_ADMIN-or-owner: a full admin manages any
+    server, a scoped manager only one they own (by email). No MANAGE_ACTIONS authority never
+    passes."""
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.NONE:
+        return False
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True
+    return server.owner == user.email
+
+
+def get_mcp_server_ids_connected_to_groups(
+    group_ids: Collection[int], db_session: Session
+) -> set[int]:
+    """MCP server ids exposed to any of ``group_ids`` via an agent — a persona shared to or
+    owned by the group that uses one of the server's tools. The read-visibility set for a
+    scoped manager, who may view servers connected to their groups without managing them."""
+    if not group_ids:
+        return set()
+    rows = db_session.execute(
+        select(Tool.mcp_server_id)
+        .join(Persona__Tool, Persona__Tool.tool_id == Tool.id)
+        .join(Persona, Persona.id == Persona__Tool.persona_id)
+        .outerjoin(Persona__UserGroup, Persona__UserGroup.persona_id == Persona.id)
+        .where(
+            Tool.mcp_server_id.is_not(None),
+            Persona.deleted.is_(False),
+            or_(
+                Persona__UserGroup.user_group_id.in_(group_ids),
+                Persona.owner_group_id.in_(group_ids),
+            ),
         )
     ).all()
-    group_ids: set[int] = set()
-    grouped_agent_ids: set[int] = set()
-    for persona_id, user_group_id in share_rows:
-        group_ids.add(user_group_id)
-        grouped_agent_ids.add(persona_id)
-    for persona_id, owner_group_id in private_owner_groups.items():
-        if owner_group_id is not None:
-            group_ids.add(owner_group_id)
-            grouped_agent_ids.add(persona_id)
-    has_ungrouped_private_agent = bool(
-        set(private_owner_groups.keys()) - grouped_agent_ids
-    )
-    return group_ids, has_public_agent, has_ungrouped_private_agent
-
-
-def get_action_agent_scope(
-    tool_id: int, db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """The groups a custom action is exposed to, via the agents that reference it."""
-    return _agent_group_scope(
-        select(Persona.id, Persona.is_public, Persona.owner_group_id)
-        .join(Persona__Tool, Persona__Tool.persona_id == Persona.id)
-        .where(Persona__Tool.tool_id == tool_id, Persona.deleted.is_(False)),
-        db_session,
-    )
-
-
-def get_mcp_server_agent_scope(
-    mcp_server_id: int, db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """The groups an MCP server is exposed to, via the agents that use any of its
-    tools."""
-    return _agent_group_scope(
-        select(Persona.id, Persona.is_public, Persona.owner_group_id)
-        .join(Persona__Tool, Persona__Tool.persona_id == Persona.id)
-        .join(Tool, Tool.id == Persona__Tool.tool_id)
-        .where(Tool.mcp_server_id == mcp_server_id, Persona.deleted.is_(False)),
-        db_session,
-    )
+    return {server_id for (server_id,) in rows if server_id is not None}
 
 
 def get_tool_by_name(tool_name: str, db_session: Session) -> Tool:

--- a/backend/onyx/server/features/document_set/api.py
+++ b/backend/onyx/server/features/document_set/api.py
@@ -3,8 +3,12 @@ from fastapi import Depends
 from fastapi import Query
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import document_set_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import within_scope
 from onyx.background.celery.versioned_apps.client import app as client_app
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import OnyxCeleryPriority
@@ -165,7 +169,37 @@ def list_document_sets_for_user(
     document_sets = fetch_all_document_sets_for_user(
         db_session=db_session, user=user, get_editable=get_editable
     )
-    return [DocumentSetSummary.from_model(ds) for ds in document_sets]
+    # Stamp editability from the shared within_scope decision on each row's
+    # already-loaded groups, with the managed-group set resolved once — no second
+    # document-set query, and no client-side double-fetch.
+    managed_group_ids = get_scoped_groups(
+        user, db_session, Permission.MANAGE_DOCUMENT_SETS
+    )
+    is_document_sets_admin = has_global_permission(
+        user, Permission.MANAGE_DOCUMENT_SETS
+    )
+    summaries: list[DocumentSetSummary] = []
+    for ds in document_sets:
+        group_ids = [group.id for group in ds.groups]
+        is_editable = within_scope(
+            user,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not ds.is_public,
+            managed_group_ids=managed_group_ids,
+        )
+        summaries.append(
+            DocumentSetSummary.from_model(
+                ds,
+                permissions=document_set_permissions(
+                    is_editable=is_editable,
+                    is_document_sets_admin=is_document_sets_admin,
+                ),
+            )
+        )
+    return summaries
 
 
 @router.get("/document-set-public")

--- a/backend/onyx/server/features/document_set/models.py
+++ b/backend/onyx/server/features/document_set/models.py
@@ -152,14 +152,26 @@ class DocumentSetSummary(BaseModel):
     is_public: bool
     users: list[UUID]
     groups: list[int]
+    # per-action affordance map for the requesting user (mirrors the write-side gate).
+    # Defaults empty (fail-closed); the list endpoint stamps the real map.
+    permissions: dict[str, bool] = Field(default_factory=dict)
     federated_connector_summaries: list[FederatedConnectorSummary] = Field(
         default_factory=list
     )
 
     @classmethod
-    def from_model(cls, document_set: DocumentSetDBModel) -> "DocumentSetSummary":
-        """Create a summary from a DocumentSet database model"""
+    def from_model(
+        cls,
+        document_set: DocumentSetDBModel,
+        *,
+        permissions: dict[str, bool] | None = None,
+    ) -> "DocumentSetSummary":
+        """Create a summary from a DocumentSet database model. ``permissions`` defaults to
+        an empty (fail-closed) map — the document-set list endpoint stamps the real one;
+        summaries embedded in other snapshots (e.g. a persona's attached sets) carry no
+        affordances since there is no per-user edit surface there."""
         return cls(
+            permissions=permissions or {},
             id=document_set.id,
             name=document_set.name,
             description=document_set.description,

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -33,10 +33,11 @@ from onyx.auth.oauth_token_manager import build_oauth_authorization_url
 from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
 from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.auth.oauth_token_manager import validate_oauth_endpoint_url
+from onyx.auth.permission_projection import mcp_server_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
-from onyx.auth.scoped_permissions import agent_mediated_scope_allows
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -66,9 +67,10 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.tools import can_manage_mcp_server
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
-from onyx.db.tools import get_mcp_server_agent_scope
+from onyx.db.tools import get_mcp_server_ids_connected_to_groups
 from onyx.db.tools import get_tools_by_mcp_server_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -741,7 +743,9 @@ class MCPOauthState(BaseModel):
 async def connect_admin_oauth(
     request: MCPUserOAuthConnectRequest,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPUserOAuthConnectResponse:
     """Connect OAuth flow for admin MCP server authentication"""
     return await _connect_oauth(request, db, is_admin=True, user=user)
@@ -1373,33 +1377,25 @@ def _ensure_mcp_server_owner_or_admin(server: DbMCPServer, user: User) -> None:
         )
 
 
-def _ensure_mcp_server_editable(
+def _ensure_mcp_server_viewable(
     server: DbMCPServer, user: User, db_session: Session
 ) -> None:
-    """Write gate for the standalone MCP server endpoints. Admin and owner bypass;
-    otherwise a scoped group manager may edit a server only when every agent using
-    any of its tools is private and in a group they manage. A server reachable via a
-    public agent (org-wide), or used by no agent (no group context), is owner/admin-
-    only."""
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+    """Read gate for a single MCP server: a global MANAGE_ACTIONS holder (incl. admins) views
+    any; an owner views their own; a scoped manager views a server connected to their groups
+    via an agent. Managers may view connected servers without managing them; managing is
+    owner-or-admin (``_ensure_mcp_server_owner_or_admin``)."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
         return
     if server.owner == user.email:
         return
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        group_ids, has_public_agent, has_ungrouped_private_agent = (
-            get_mcp_server_agent_scope(server.id, db_session)
-        )
-        if agent_mediated_scope_allows(
-            user,
-            db_session,
-            group_ids=group_ids,
-            has_public_agent=has_public_agent,
-            has_ungrouped_private_agent=has_ungrouped_private_agent,
-        ):
+    if authority is PermissionAuthority.SCOPED:
+        managed = get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
+        if server.id in get_mcp_server_ids_connected_to_groups(managed, db_session):
             return
     raise OnyxError(
         OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "Only the server owner or a manager of its groups can modify this MCP server.",
+        "You can only view MCP servers you own or that are connected to your groups.",
     )
 
 
@@ -1408,6 +1404,7 @@ def _db_mcp_server_to_api_mcp_server(
     db: Session,
     request_user: User | None,
     include_auth_config: bool = False,
+    permissions: dict[str, bool] | None = None,
 ) -> MCPServer:
     """Convert database MCP server to API model"""
 
@@ -1581,6 +1578,7 @@ def _db_mcp_server_to_api_mcp_server(
         auth_template=auth_template,
         user_credentials=user_credentials,
         admin_credentials=admin_credentials,
+        permissions=permissions or {},
     )
 
 
@@ -1673,7 +1671,9 @@ def _get_connection_config(
 def admin_list_mcp_tools_by_id(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPToolListResponse:
     return _list_mcp_tools_by_id(server_id, db, True, user)
 
@@ -1688,7 +1688,9 @@ def get_mcp_server_tools_snapshots(
     server_id: int,
     source: ToolSnapshotSource = ToolSnapshotSource.DB,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> list[ToolSnapshot]:
     """
     Get tools for an MCP server as ToolSnapshot objects.
@@ -1706,9 +1708,8 @@ def get_mcp_server_tools_snapshots(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(mcp_server, user)
-
     if source == ToolSnapshotSource.MCP:
+        _ensure_mcp_server_owner_or_admin(mcp_server, user)
         try:
             # Discover tools from MCP server and sync to DB
             _list_mcp_tools_by_id(server_id, db, True, user)
@@ -1735,6 +1736,8 @@ def get_mcp_server_tools_snapshots(
 
             logger.error("Failed to discover tools for MCP server: %s", e)
             raise HTTPException(status_code=500, detail="Failed to discover tools")
+    else:
+        _ensure_mcp_server_viewable(mcp_server, user, db)
 
     # Fetch and return tools from database
     mcp_tools = get_tools_by_mcp_server_id(server_id, db, order_by_id=True)
@@ -1961,7 +1964,7 @@ def _upsert_mcp_server(
                 status_code=404,
                 detail=f"MCP server with ID {request.existing_server_id} not found",
             )
-        _ensure_mcp_server_editable(mcp_server, user, db_session)
+        _ensure_mcp_server_owner_or_admin(mcp_server, user)
         client_info: OAuthClientInformationFull | None = None
         existing_admin_config_dict: MCPConnectionData = MCPConnectionData(headers={})
         if mcp_server.admin_connection_config:
@@ -2288,7 +2291,9 @@ def _sync_tools_for_server(
 def get_mcp_server_detail(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServer:
     """Return details for one MCP server if user has access"""
     try:
@@ -2296,19 +2301,21 @@ def get_mcp_server_detail(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(server, user)
-
+    # Read gate: owner, admin, or a manager of a group the server is connected to.
+    _ensure_mcp_server_viewable(server, user, db_session)
     # TODO: user permissions per mcp server not yet implemented, for now
     # permissions are based on access to assistants
     # # Quick permission check – admin or user has access
     # if user and server not in user.accessible_mcp_servers and not user.is_superuser:
     #     raise HTTPException(status_code=403, detail="Forbidden")
-
     return _db_mcp_server_to_api_mcp_server(
         server,
         db_session,
         include_auth_config=True,
         request_user=user,
+        permissions=mcp_server_permissions(
+            can_manage=can_manage_mcp_server(user, server),
+        ),
     )
 
 
@@ -2336,7 +2343,9 @@ def update_mcp_server_status(
     server_id: int,
     status: MCPServerStatus,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
     """Update the status of an MCP server"""
     logger.info("Updating MCP server %s status to %s", server_id, status)
@@ -2362,7 +2371,9 @@ def update_mcp_server_status(
 @admin_router.get("/servers", response_model=MCPServersResponse)
 def get_mcp_servers_for_admin(
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServersResponse:
     """Get all MCP servers for admin display"""
 
@@ -2371,10 +2382,34 @@ def get_mcp_servers_for_admin(
     try:
         db_mcp_servers = get_all_mcp_servers(db)
 
-        # Convert to API model format
+        # A global MANAGE_ACTIONS holder (incl. admins) sees every server; a scoped manager
+        # sees only those they own or that are connected to a group they manage (one query for
+        # the connected set). Managing is owner-or-admin either way (can_manage_mcp_server).
+        if (
+            has_permission(user, Permission.MANAGE_ACTIONS)
+            is PermissionAuthority.GLOBAL
+        ):
+            visible_servers = db_mcp_servers
+        else:
+            connected = get_mcp_server_ids_connected_to_groups(
+                get_scoped_groups(user, db, Permission.MANAGE_ACTIONS), db
+            )
+            visible_servers = [
+                server
+                for server in db_mcp_servers
+                if server.owner == user.email or server.id in connected
+            ]
+
         mcp_servers = [
-            _db_mcp_server_to_api_mcp_server(db_server, db, request_user=user)
-            for db_server in db_mcp_servers
+            _db_mcp_server_to_api_mcp_server(
+                db_server,
+                db,
+                request_user=user,
+                permissions=mcp_server_permissions(
+                    can_manage=can_manage_mcp_server(user, db_server),
+                ),
+            )
+            for db_server in visible_servers
         ]
 
         return MCPServersResponse(mcp_servers=mcp_servers)
@@ -2388,7 +2423,9 @@ def get_mcp_servers_for_admin(
 def get_mcp_server_db_tools(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ServerToolsResponse:
     """Get existing database tools created for an MCP server"""
     logger.info("Getting database tools for MCP server: %s", server_id)
@@ -2518,7 +2555,7 @@ def update_mcp_server_with_tools(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_editable(mcp_server, user, db_session)
+    _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
     if mcp_server.admin_connection_config_id is None and mcp_server.auth_type not in (
         MCPAuthenticationType.NONE,
@@ -2620,7 +2657,7 @@ def update_mcp_server_simple(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_editable(mcp_server, user, db_session)
+    _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
     _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
 
@@ -2635,9 +2672,13 @@ def update_mcp_server_simple(
 
     db_session.commit()
 
-    # Return the updated server in API format
     return _db_mcp_server_to_api_mcp_server(
-        updated_server, db_session, request_user=user
+        updated_server,
+        db_session,
+        request_user=user,
+        permissions=mcp_server_permissions(
+            can_manage=can_manage_mcp_server(user, updated_server),
+        ),
     )
 
 
@@ -2645,7 +2686,9 @@ def update_mcp_server_simple(
 def delete_mcp_server_admin(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict:
     """Delete an MCP server and cascading related objects (tools, configs)."""
     try:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -34,6 +34,7 @@ from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
 from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.auth.oauth_token_manager import validate_oauth_endpoint_url
 from onyx.auth.permission_projection import mcp_server_permissions
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
@@ -68,6 +69,7 @@ from onyx.db.models import MCPServer as DbMCPServer
 from onyx.db.models import Tool
 from onyx.db.models import User
 from onyx.db.tools import can_manage_mcp_server
+from onyx.db.tools import can_manage_own_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_mcp_server_ids_connected_to_groups
@@ -1739,9 +1741,17 @@ def get_mcp_server_tools_snapshots(
     else:
         _ensure_mcp_server_viewable(mcp_server, user, db)
 
-    # Fetch and return tools from database
+    # Fetch and return tools from database. Stamp each tool's toggle affordance
+    # (owner-or-admin, per tool) so the UI gates per tool, matching the status route:
+    # a global actions-admin toggles any tool, at parity with OpenAPI actions.
     mcp_tools = get_tools_by_mcp_server_id(server_id, db, order_by_id=True)
-    return [ToolSnapshot.from_model(tool) for tool in mcp_tools]
+    return [
+        ToolSnapshot.from_model(
+            tool,
+            permissions=tool_permissions(can_manage=can_manage_own_tool(user, tool)),
+        )
+        for tool in mcp_tools
+    ]
 
 
 @router.get("/server/{server_id}/tools")

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -455,6 +455,8 @@ class MCPServer(BaseModel):
         None,
         description="Admin's credential key-value pairs for template substitution and storage",
     )
+    # Server-stamped affordance map; fail-closed empty (only the admin server list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
 
 class MCPServersResponse(BaseModel):

--- a/backend/onyx/server/features/oauth_config/api.py
+++ b/backend/onyx/server/features/oauth_config/api.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import OAuthTokenManager
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -20,6 +21,8 @@ from onyx.db.oauth_config import get_oauth_configs
 from onyx.db.oauth_config import get_tools_by_oauth_config
 from onyx.db.oauth_config import update_oauth_config
 from onyx.db.oauth_config import upsert_user_oauth_token
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.oauth_utils import generate_oauth_state
 from onyx.federated_connectors.oauth_utils import verify_oauth_state
 from onyx.server.features.oauth_config.models import OAuthCallbackResponse
@@ -59,13 +62,31 @@ def _oauth_config_to_snapshot(
 """Admin endpoints for OAuth configuration management"""
 
 
+def _assert_can_manage_oauth_config(
+    oauth_config: OAuthConfig, user: User, db_session: Session
+) -> None:
+    """Owner-or-admin gate: a global actions-admin manages any OAuth config; a scoped manager
+    manages one only when they own every action referencing it — editing shared credentials
+    would otherwise affect the other creators."""
+    if has_global_permission(user, Permission.MANAGE_ACTIONS):
+        return
+    tools = get_tools_by_oauth_config(oauth_config.id, db_session)
+    if tools and all(tool.user_id == user.id for tool in tools):
+        return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "You can only manage OAuth configurations for actions that you created.",
+    )
+
+
 @admin_router.post("/create")
 def create_oauth_config_endpoint(
     oauth_data: OAuthConfigCreate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)),
 ) -> OAuthConfigSnapshot:
-    """Create a new OAuth configuration (admin only)."""
+    """Create a new OAuth configuration. A scoped manager may create one and link it to an
+    action they created; get/update/delete are then owner-or-admin."""
     try:
         oauth_config = create_oauth_config(
             name=oauth_data.name,
@@ -96,14 +117,17 @@ def list_oauth_configs(
 def get_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Retrieve a single OAuth configuration (admin only)."""
+    """Retrieve a single OAuth configuration (owner or admin)."""
     oauth_config = get_oauth_config(oauth_config_id, db_session)
     if not oauth_config:
         raise HTTPException(
             status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
         )
+    _assert_can_manage_oauth_config(oauth_config, user, db_session)
     return _oauth_config_to_snapshot(oauth_config, db_session)
 
 
@@ -112,9 +136,17 @@ def update_oauth_config_endpoint(
     oauth_config_id: int,
     oauth_data: OAuthConfigUpdate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Update an OAuth configuration (admin only)."""
+    """Update an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise HTTPException(
+            status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         updated_config = update_oauth_config(
             oauth_config_id=oauth_config_id,
@@ -138,9 +170,17 @@ def update_oauth_config_endpoint(
 def delete_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
-    """Delete an OAuth configuration (admin only)."""
+    """Delete an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise HTTPException(
+            status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         delete_oauth_config(oauth_config_id, db_session)
         return {"message": "OAuth configuration deleted successfully"}

--- a/backend/onyx/server/features/persona/api.py
+++ b/backend/onyx/server/features/persona/api.py
@@ -13,6 +13,9 @@ from pydantic import model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.users import current_chat_accessible_user
 from onyx.auth.users import current_limited_user
@@ -22,9 +25,13 @@ from onyx.configs.constants import MilestoneRecordType
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.file_record import get_filerecord_by_file_id_optional
 from onyx.db.models import User
+from onyx.db.persona import can_delete_persona
+from onyx.db.persona import can_edit_persona
+from onyx.db.persona import can_view_persona_stats
 from onyx.db.persona import create_assistant_label
 from onyx.db.persona import create_update_persona
 from onyx.db.persona import delete_persona_label
@@ -35,6 +42,7 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import get_persona_count_for_user
 from onyx.db.persona import get_persona_snapshots_for_user
 from onyx.db.persona import get_persona_snapshots_paginated
+from onyx.db.persona import is_persona_editable_by_user
 from onyx.db.persona import mark_persona_as_deleted
 from onyx.db.persona import mark_persona_as_not_deleted
 from onyx.db.persona import update_persona_featured
@@ -337,7 +345,9 @@ def create_persona(
 def update_persona(
     persona_id: int,
     persona_upsert_request: PersonaUpsertRequest,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
+    # Editable is the gate (get_editable fetch in create_update_persona), not ADD_AGENTS — an
+    # editor-shared user should be able to edit the agent they were granted access to.
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> PersonaSnapshot:
     _validate_user_knowledge_enabled(persona_upsert_request, "update")
@@ -444,7 +454,9 @@ class PersonaShareRequest(BaseModel):
 def share_persona(
     persona_id: int,
     persona_share_request: PersonaShareRequest,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
+    # Editable is the gate (get_editable fetch in update_persona_shared), not ADD_AGENTS — an
+    # editor-shared user should still manage the agent's sharing.
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> None:
     user_shares = (
@@ -487,14 +499,24 @@ def share_persona(
 @basic_router.delete("/{persona_id}", tags=PUBLIC_API_TAGS)
 def delete_persona(
     persona_id: int,
-    user: User = Depends(require_permission(Permission.ADD_AGENTS)),
+    # allow_scope admits an owner who holds ADD_AGENTS only by scope; ownership is enforced
+    # below (mark_persona_as_deleted → get_persona_by_id).
+    user: User = Depends(require_permission(Permission.ADD_AGENTS, allow_scope=True)),
     db_session: Session = Depends(get_session),
 ) -> None:
-    mark_persona_as_deleted(
-        persona_id=persona_id,
-        user=user,
-        db_session=db_session,
-    )
+    try:
+        mark_persona_as_deleted(
+            persona_id=persona_id,
+            user=user,
+            db_session=db_session,
+        )
+    except ValueError as e:
+        # A non-owner failed the ownership check; its ValueError would 400 via the global
+        # handler, so surface the real authorization failure as a 403.
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You can only delete agents you created.",
+        ) from e
 
 
 @basic_router.get("")
@@ -596,6 +618,25 @@ def get_persona(
     if user is not None:
         snapshot.user_permission = get_persona_access_level(
             persona, user, user_group_ids
+        )
+        is_editable = is_persona_editable_by_user(db_session, persona.id, user)
+        snapshot.permissions = persona_permissions(
+            can_edit=can_edit_persona(
+                user, persona, db_session, is_editable=is_editable
+            ),
+            # share tracks the share guard (get_editable), broader than edit's scope gate
+            can_share=is_editable,
+            can_view_stats=can_view_persona_stats(user, persona),
+            can_delete=can_delete_persona(user, persona, db_session),
+            # delete/publish also gate on ADD_AGENTS (GATE 1); edit/share don't
+            holds_add_agents=has_permission(user, Permission.ADD_AGENTS)
+            is not PermissionAuthority.NONE,
+            is_manage_agents_admin=has_global_permission(
+                user, Permission.MANAGE_AGENTS
+            ),
+            is_full_admin=has_global_permission(
+                user, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
         )
     return snapshot
 

--- a/backend/onyx/server/features/persona/models.py
+++ b/backend/onyx/server/features/persona/models.py
@@ -229,6 +229,10 @@ class MinimalPersonaSnapshot(BaseModel):
     owner_group: PersonaOwnerGroupSnapshot | None
     # Computed for the requesting user when the list endpoint provides it
     user_permission: PersonaAccessLevel | None = None
+    # Per-action affordance map for the requesting user; empty on paths that don't
+    # stamp it (fail-closed on the client). List endpoints stamp it so each card
+    # doesn't refetch the full agent just to gate its icons.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -396,6 +400,8 @@ class FullPersonaSnapshot(PersonaSnapshot):
     search_start_date: datetime | None = None
     # Per-requesting-user context, set by the single-persona endpoint
     user_permission: PersonaAccessLevel | None = None
+    # per-action affordance map for the requesting user; stamped by the endpoint
+    permissions: dict[str, bool] = Field(default_factory=dict)
     admin_count: int = 0
     ownership_vacant: bool = False
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -11,9 +11,13 @@ from fastapi import UploadFile
 from pydantic import Field
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import custom_skill_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import Permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import within_scope
 from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import Skill
@@ -70,6 +74,7 @@ def _split_rows(
     db_session: Session,
     *,
     include_grants: bool,
+    user: User | None = None,
 ) -> tuple[list[BuiltinSkillResponse], list[CustomSkillResponse]]:
     """Partition a flat row list into built-in + custom responses.
 
@@ -77,9 +82,25 @@ def _split_rows(
     in code without cleaning up the seeded row) is logged and dropped —
     we don't surface a half-broken built-in to admins. ``include_grants``
     only applies to custom skills; built-ins are not group-shareable.
+
+    When ``user`` is given (the admin listing), each custom skill is stamped with
+    its per-action affordance map, resolved once from the manager's scope.
     """
     builtins: list[BuiltinSkillResponse] = []
     customs: list[CustomSkillResponse] = []
+
+    # Resolve the manager's scope once so per-skill stamping issues no extra query.
+    managed_skill_groups: set[int] = set()
+    is_skills_full_admin = False
+    is_skills_admin = False
+    if user is not None:
+        managed_skill_groups = get_scoped_groups(
+            user, db_session, Permission.MANAGE_SKILLS
+        )
+        is_skills_full_admin = has_global_permission(
+            user, Permission.FULL_ADMIN_PANEL_ACCESS
+        )
+        is_skills_admin = has_global_permission(user, Permission.MANAGE_SKILLS)
 
     # User paths withhold group ids but still need grant existence so a
     # grants-shared skill isn't reported as personal.
@@ -103,7 +124,27 @@ def _split_rows(
             )
         elif include_grants:
             group_ids = get_group_ids_for_skill(skill.id, db_session)
-            customs.append(CustomSkillResponse.from_model(skill, group_ids=group_ids))
+            skill_perms: dict[str, bool] | None = None
+            if user is not None:
+                # Read-affordance mirroring the patch guard: within_scope on the skill's own groups.
+                skill_perms = custom_skill_permissions(
+                    can_edit=within_scope(
+                        user,
+                        db_session,
+                        permission=Permission.MANAGE_SKILLS,
+                        current_group_ids=group_ids,
+                        requested_group_ids=group_ids,
+                        is_non_public=not skill.is_public,
+                        managed_group_ids=managed_skill_groups,
+                    ),
+                    is_full_admin=is_skills_full_admin,
+                    is_skills_admin=is_skills_admin,
+                )
+            customs.append(
+                CustomSkillResponse.from_model(
+                    skill, group_ids=group_ids, permissions=skill_perms
+                )
+            )
         else:
             customs.append(
                 CustomSkillResponse.from_model(
@@ -176,7 +217,7 @@ def list_skills_admin(
     db_session: Session = Depends(get_session),
 ) -> SkillsList:
     rows = list(list_skills_for_admin(db_session=db_session, user=user))
-    builtins, customs = _split_rows(rows, db_session, include_grants=True)
+    builtins, customs = _split_rows(rows, db_session, include_grants=True, user=user)
     return SkillsList(builtins=builtins, customs=customs)
 
 

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -6,6 +6,7 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic import model_validator
 from sqlalchemy.orm import Session
 
@@ -60,6 +61,8 @@ class CustomSkillResponse(BaseModel):
     updated_at: datetime.datetime | None = None
     granted_group_ids: list[int] = []
     is_personal: bool
+    # Server-stamped affordance map; fail-closed empty (only the admin skills list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -68,6 +71,7 @@ class CustomSkillResponse(BaseModel):
         group_ids: list[int],
         *,
         has_grants: bool | None = None,
+        permissions: dict[str, bool] | None = None,
     ) -> "CustomSkillResponse":
         # Paths that withhold group ids from the response (user-facing) must
         # still pass grant existence so grants-shared skills aren't marked
@@ -77,6 +81,7 @@ class CustomSkillResponse(BaseModel):
             skill.built_in_skill_id is None and not skill.is_public and not grants_exist
         )
         return cls(
+            permissions=permissions or {},
             id=skill.id,
             slug=skill.slug,
             name=skill.name,

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -6,19 +6,16 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from onyx.auth.permissions import get_effective_permissions
-from onyx.auth.permissions import has_permission
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import require_permission
-from onyx.auth.scoped_permissions import agent_mediated_scope_allows
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
-from onyx.db.enums import PermissionAuthority
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.tools import can_manage_own_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
-from onyx.db.tools import get_action_agent_scope
 from onyx.db.tools import get_tool_by_id
 from onyx.db.tools import get_tools
 from onyx.db.tools import get_tools_by_ids
@@ -59,57 +56,24 @@ def _validate_auth_settings(tool_data: CustomToolCreate | CustomToolUpdate) -> N
                 )
 
 
-def _assert_action_within_managed_scope(
-    tool_id: int, db_session: Session, user: User
-) -> None:
-    """A scoped group manager may edit an action only when every agent using it is
-    private and in a group they manage. An action reachable via a public agent (so
-    org-wide), or used by no agent (no group context), is owner/admin-only."""
-    group_ids, has_public_agent, has_ungrouped_private_agent = get_action_agent_scope(
-        tool_id, db_session
-    )
-    if not agent_mediated_scope_allows(
-        user,
-        db_session,
-        group_ids=group_ids,
-        has_public_agent=has_public_agent,
-        has_ungrouped_private_agent=has_ungrouped_private_agent,
-    ):
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "You can only modify actions scoped to groups you manage.",
-        )
-
-
-def _get_editable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
-    """Fetch a custom tool and ensure the caller has permission to edit it."""
+def _get_manageable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
+    """Fetch a custom tool and assert the caller may manage it (owner or admin) — the gate for
+    every action on it: edit, delete, toggle, and OAuth config."""
     try:
         tool = get_tool_by_id(tool_id, db_session)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-
     if tool.in_code_tool_id is not None:
         raise HTTPException(
             status_code=400,
             detail="Built-in tools cannot be modified through this endpoint.",
         )
-
-    # Admins bypass; owners may always edit the action they created.
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
-        return tool
-    if tool.user_id is not None and tool.user_id == user.id:
-        return tool
-
-    # A scoped group manager may edit an action scoped (via its agents) to groups
-    # they manage; everyone else is limited to actions they created.
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        _assert_action_within_managed_scope(tool_id, db_session, user)
-        return tool
-
-    raise OnyxError(
-        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "You can only modify actions that you created.",
-    )
+    if not can_manage_own_tool(user, tool):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You can only manage actions that you created.",
+        )
+    return tool
 
 
 @admin_router.post("/custom", tags=PUBLIC_API_TAGS)
@@ -146,7 +110,7 @@ def update_custom_tool(
         require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
     ),
 ) -> ToolSnapshot:
-    existing_tool = _get_editable_custom_tool(tool_id, db_session, user)
+    existing_tool = _get_manageable_custom_tool(tool_id, db_session, user)
     if tool_data.definition:
         _validate_tool_definition(tool_data.definition)
     _validate_auth_settings(tool_data)
@@ -168,9 +132,11 @@ def update_custom_tool(
 def delete_custom_tool(
     tool_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> None:
-    _ = _get_editable_custom_tool(tool_id, db_session, user)
+    _ = _get_manageable_custom_tool(tool_id, db_session, user)
     try:
         delete_tool__no_commit(tool_id, db_session)
     except ValueError as e:
@@ -195,7 +161,9 @@ class ToolStatusUpdateResponse(BaseModel):
 def update_tools_status(
     update_data: ToolStatusUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),  # noqa: ARG001
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ToolStatusUpdateResponse:
     """Enable or disable one or more tools.
 
@@ -214,6 +182,12 @@ def update_tools_status(
     for tool_id in update_data.tool_ids:
         tool = tools_by_id.get(tool_id)
         if tool:
+            # owner-or-admin, checked per tool
+            if not can_manage_own_tool(user, tool):
+                raise OnyxError(
+                    OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                    "You can only enable or disable actions that you created.",
+                )
             tool.enabled = update_data.enabled
             updated_tools.append(tool_id)
         else:
@@ -256,16 +230,24 @@ def validate_tool(
 @router.get("/openapi", tags=PUBLIC_API_TAGS)
 def list_openapi_tools(
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> list[ToolSnapshot]:
     tools = get_tools(db_session, only_openapi=True)
 
+    # Every action affordance is owner-or-admin, decided per tool with no query.
     openapi_tools: list[ToolSnapshot] = []
     for tool in tools:
         if not should_expose_tool_to_fe(tool):
             continue
 
-        openapi_tools.append(ToolSnapshot.from_model(tool))
+        openapi_tools.append(
+            ToolSnapshot.from_model(
+                tool,
+                permissions=tool_permissions(
+                    can_manage=can_manage_own_tool(user, tool)
+                ),
+            )
+        )
 
     return openapi_tools
 

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.db.models import Tool
 from onyx.server.features.tool.tool_visibility import get_tool_visibility_config
@@ -21,17 +22,23 @@ class ToolSnapshot(BaseModel):
     oauth_config_name: str | None = None
     enabled: bool = True
 
+    # Server-stamped affordance map; fail-closed empty (only the admin actions list stamps it).
+    permissions: dict[str, bool] = Field(default_factory=dict)
+
     # Visibility settings computed from TOOL_VISIBILITY_CONFIG
     chat_selectable: bool = True
     agent_creation_selectable: bool = True
     default_enabled: bool = False
 
     @classmethod
-    def from_model(cls, tool: Tool) -> "ToolSnapshot":
+    def from_model(
+        cls, tool: Tool, *, permissions: dict[str, bool] | None = None
+    ) -> "ToolSnapshot":
         # Get visibility config for this tool
         config = get_tool_visibility_config(tool)
 
         return cls(
+            permissions=permissions or {},
             id=tool.id,
             name=tool.name,
             description=tool.description or "",

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -60,13 +60,15 @@ def update_token_limit_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:
-    return TokenRateLimitDisplay.from_db(
+    rate_limit_display = TokenRateLimitDisplay.from_db(
         update_token_rate_limit(
             db_session=db_session,
             token_rate_limit_id=token_rate_limit_id,
             token_rate_limit_settings=token_limit_settings,
         )
     )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
 
 
 @router.delete("/rate-limit/{token_rate_limit_id}")

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -5,32 +5,100 @@ stamps matches whether the guard raises, across an actor matrix — so the affor
 the client renders can't silently drift from what the backend enforces.
 """
 
+import asyncio
+import inspect
 from collections.abc import Callable
+from types import SimpleNamespace
 from uuid import uuid4
 
+from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from ee.onyx.db.analytics import user_can_view_assistant_stats
+from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
+from ee.onyx.server.token_rate_limits.api import _authorize_group_token_rate_limit_write
+from ee.onyx.server.token_rate_limits.api import get_group_token_limit_settings
+from ee.onyx.server.user_group.api import delete_user_group
+from ee.onyx.server.user_group.api import set_user_group_permissions
 from onyx.auth.permission_projection import CC_PAIR_ACTIONS
 from onyx.auth.permission_projection import cc_pair_permissions
+from onyx.auth.permission_projection import CUSTOM_SKILL_ACTIONS
+from onyx.auth.permission_projection import custom_skill_permissions
+from onyx.auth.permission_projection import DOCUMENT_SET_ACTIONS
+from onyx.auth.permission_projection import document_set_permissions
+from onyx.auth.permission_projection import MCP_SERVER_ACTIONS
+from onyx.auth.permission_projection import mcp_server_permissions
+from onyx.auth.permission_projection import PERSONA_ACTIONS
+from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permission_projection import TOOL_ACTIONS
+from onyx.auth.permission_projection import tool_permissions
+from onyx.auth.permission_projection import USER_GROUP_ACTIONS
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import has_global_permission
+from onyx.auth.permissions import has_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.auth.scoped_permissions import manages_group
 from onyx.auth.scoped_permissions import within_scope
+from onyx.db.document_set import fetch_all_document_sets_for_user
+from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
+from onyx.db.enums import PersonaSharePermission
+from onyx.db.models import DocumentSet
+from onyx.db.models import DocumentSet__UserGroup
+from onyx.db.models import MCPServer
+from onyx.db.models import Persona
+from onyx.db.models import Persona__Tool
+from onyx.db.models import Persona__User
+from onyx.db.models import Persona__UserGroup
+from onyx.db.models import Skill
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import Tool
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
+from onyx.db.persona import _assert_persona_update_within_managed_scope
+from onyx.db.persona import can_delete_persona
+from onyx.db.persona import can_edit_persona
+from onyx.db.persona import can_view_persona_stats
+from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona import get_persona_by_id
+from onyx.db.persona import is_persona_editable_by_user
+from onyx.db.persona import persona_edit_within_scope
+from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.token_limit import insert_global_token_rate_limit
+from onyx.db.tools import can_manage_mcp_server
+from onyx.db.tools import can_manage_own_tool
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
+from onyx.server.features.mcp.api import _ensure_mcp_server_viewable
+from onyx.server.features.persona.api import delete_persona
+from onyx.server.features.persona.models import PersonaUpsertRequest
+from onyx.server.features.tool.api import _get_manageable_custom_tool
+from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from tests.external_dependency_unit.conftest import create_test_user
 
 
-def _guard_raises(guard: Callable[..., None], *args: object, **kwargs: object) -> bool:
+def _guard_raises(
+    guard: Callable[..., object], *args: object, **kwargs: object
+) -> bool:
     try:
         guard(*args, **kwargs)
         return False
     except OnyxError:
         return True
+
+
+def _route_admits(
+    route_func: Callable[..., object], guard_param: str, actor: User
+) -> bool:
+    """True iff the route's ``require_permission`` admits ``actor`` (unrestricted token).
+    Runs the real dependency, so the assertion tracks the route decorator — not the bool
+    that built the map, which can't catch a FULL_ADMIN vs MANAGE_USER_GROUPS drift."""
+    depends = inspect.signature(route_func).parameters[guard_param].default
+    request = SimpleNamespace(state=SimpleNamespace(token_scopes=None))
+    return not _guard_raises(lambda: asyncio.run(depends.dependency(request, actor)))
 
 
 def _make_group(db_session: Session) -> UserGroup:
@@ -158,7 +226,7 @@ def test_cc_pair_projection_matches_gates(db_session: Session) -> None:
         assert tags["delete"] == admin_authority  # A — never a scoped manager
         assert tags["publish"] == admin_authority  # A
 
-    # the whole point of the fix: an in-scope manager can edit but not delete/publish
+    # in-scope manager can edit but not delete/publish
     manager_editable = within_scope(
         in_scope,
         db_session,
@@ -180,3 +248,757 @@ def test_cc_pair_projection_key_coverage() -> None:
     assert stamped == set(CC_PAIR_ACTIONS), (
         "cc_pair projection keys drifted from the declared CC_PAIR_ACTIONS vocabulary"
     )
+
+
+def _make_persona(
+    db_session: Session, *, owner: User, is_public: bool, groups: list[UserGroup]
+) -> Persona:
+    persona = Persona(
+        name=f"proj-persona-{uuid4().hex[:12]}",
+        description="contract",
+        public_permission=PersonaSharePermission.EDITOR,
+        user_id=owner.id,
+        is_public=is_public,
+    )
+    db_session.add(persona)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            Persona__UserGroup(persona_id=persona.id, user_group_id=group.id)
+        )
+    db_session.commit()
+    return persona
+
+
+def _make_doc_set(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> DocumentSet:
+    doc_set = DocumentSet(name=f"proj-ds-{uuid4().hex[:12]}", is_public=is_public)
+    db_session.add(doc_set)
+    db_session.flush()
+    for group in groups:
+        db_session.add(
+            DocumentSet__UserGroup(document_set_id=doc_set.id, user_group_id=group.id)
+        )
+    db_session.commit()
+    return doc_set
+
+
+def test_persona_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks the read-editable AND managed-scope decision the write guard enforces;
+    view_stats tracks the real owner-or-admin stats gate; the rest are global-only."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "b-persona-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "b-persona-out")
+    _manage(db_session, out_scope, unmanaged)
+    out_scope.effective_permissions = []
+
+    owner = create_test_user(db_session, "b-persona-owner")
+    owner.effective_permissions = []
+
+    admin = create_test_user(db_session, "b-persona-admin", is_admin=True)
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    group_ids = [group.id for group in persona.groups]
+
+    def edit_guard_raises(actor: User) -> bool:
+        request = PersonaUpsertRequest(
+            name=persona.name,
+            description=persona.description or "",
+            system_prompt="",
+            task_prompt="",
+            datetime_aware=False,
+            document_set_ids=[],
+            tool_ids=[],
+            groups=group_ids,
+            is_public=persona.is_public,
+        )
+        return _guard_raises(
+            _assert_persona_update_within_managed_scope,
+            persona.id,
+            request,
+            actor,
+            db_session,
+        )
+
+    for actor in (in_scope, out_scope, owner, admin):
+        # read bool == the real write guard's managed-scope decision
+        assert persona_edit_within_scope(
+            actor, db_session, group_ids=group_ids, is_public=persona.is_public
+        ) == (not edit_guard_raises(actor)), actor.email
+        # view_stats == the real owner-or-admin stats gate
+        assert can_view_persona_stats(actor, persona) == user_can_view_assistant_stats(
+            db_session, actor, persona.id
+        ), actor.email
+        # delete == the real delete handler's ownership gate (get_persona_by_id is_for_edit)
+        try:
+            get_persona_by_id(persona_id=persona.id, user=actor, db_session=db_session)
+            delete_allowed = True
+        except ValueError:
+            delete_allowed = False
+        assert can_delete_persona(actor, persona, db_session) == delete_allowed, (
+            actor.email
+        )
+
+    # concrete: an in-scope manager can edit/share but not view_stats/delete/feature/reorder
+    in_scope_editable = is_persona_editable_by_user(db_session, persona.id, in_scope)
+    mgr_map = persona_permissions(
+        can_edit=can_edit_persona(
+            in_scope, persona, db_session, is_editable=in_scope_editable
+        ),
+        can_share=in_scope_editable,
+        can_view_stats=can_view_persona_stats(in_scope, persona),
+        can_delete=can_delete_persona(in_scope, persona, db_session),
+        holds_add_agents=has_permission(in_scope, Permission.ADD_AGENTS)
+        is not PermissionAuthority.NONE,
+        is_manage_agents_admin=has_global_permission(
+            in_scope, Permission.MANAGE_AGENTS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    )
+    assert mgr_map["edit"] is True and mgr_map["share"] is True
+    assert mgr_map["view_stats"] is False
+    assert not any(mgr_map[a] for a in ("delete", "publish", "feature", "reorder"))
+
+
+def test_delete_persona_route_admits_scoped_owner(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """The delete route must admit a scoped ADD_AGENTS holder (allow_scope=True); otherwise an
+    owner who holds ADD_AGENTS only by scope is 403'd before the GATE-2 ownership check, making
+    the projection's delete=true a lie for them. The gate checks above can't catch a missing
+    allow_scope. enable_ee so ADD_AGENTS is genuinely scoped — CE auto-grants it globally, which
+    would pass the gate regardless and prove nothing."""
+    manager = create_test_user(db_session, "del-route-mgr")
+    _manage(db_session, manager, _make_group(db_session))
+    manager.effective_permissions = []
+    db_session.commit()
+
+    # Premise: if the manager ever holds ADD_AGENTS globally, the route check below tests
+    # nothing — fail loudly here instead of passing vacuously.
+    assert (
+        has_permission(manager, Permission.ADD_AGENTS) is PermissionAuthority.SCOPED
+    ), "manager should hold ADD_AGENTS only by scope"
+    assert _route_admits(delete_persona, "user", manager), (
+        "delete route must admit scoped managers at GATE 1 (allow_scope=True)"
+    )
+
+
+def test_persona_share_projection_tracks_share_guard_not_edit(
+    db_session: Session,
+) -> None:
+    """share follows the share guard (fetch_persona_by_id_for_user / get_editable), which is
+    broader than edit's managed-scope AND gate: an EDITOR-shared manager outside the agent's
+    groups may share it but not update it, so ``share`` must not reuse ``can_edit``."""
+    managed = _make_group(db_session)
+    unmanaged = _make_group(db_session)
+
+    # Manager of `unmanaged`, EDITOR-shared on an agent grouped in `managed` (out of scope).
+    editor = create_test_user(db_session, "share-editor")
+    _manage(db_session, editor, unmanaged)
+    editor.effective_permissions = []
+
+    owner = create_test_user(db_session, "share-owner")
+    owner.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    db_session.add(
+        Persona__User(
+            persona_id=persona.id,
+            user_id=editor.id,
+            permission=PersonaSharePermission.EDITOR,
+        )
+    )
+    db_session.commit()
+
+    is_editable = is_persona_editable_by_user(db_session, persona.id, editor)
+    can_edit = can_edit_persona(editor, persona, db_session, is_editable=is_editable)
+
+    # The real share-endpoint gate: does the editable fetch admit them?
+    try:
+        fetch_persona_by_id_for_user(
+            db_session=db_session, persona_id=persona.id, user=editor, get_editable=True
+        )
+        share_allowed = True
+    except HTTPException:
+        share_allowed = False
+
+    assert is_editable is True  # EDITOR-shared → in the editable set
+    assert can_edit is False  # ...but out of managed scope → can't update
+    assert share_allowed is True  # ...yet the share endpoint admits them
+
+    tags = persona_permissions(
+        can_edit=can_edit,
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(editor, persona),
+        can_delete=can_delete_persona(editor, persona, db_session),
+        holds_add_agents=has_permission(editor, Permission.ADD_AGENTS)
+        is not PermissionAuthority.NONE,
+        is_manage_agents_admin=has_global_permission(editor, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(editor, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert tags["share"] == share_allowed  # share tracks the share guard...
+    assert tags["edit"] is False  # ...not the stricter edit guard
+
+
+def test_persona_edit_share_editable_without_add_agents(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """edit and share gate on editable alone (their routes are BASIC_ACCESS): an EDITOR-shared
+    user without ADD_AGENTS may still edit and manage sharing, so both are True. enable_ee
+    because CE auto-grants ADD_AGENTS, which would mask that they need no create permission."""
+    owner = create_test_user(db_session, "add-share-owner")
+    owner.effective_permissions = []
+    # EDITOR-shared, but no ADD_AGENTS authority: not a manager, empty permissions.
+    editor = create_test_user(db_session, "add-share-editor")
+    editor.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[])
+    db_session.add(
+        Persona__User(
+            persona_id=persona.id,
+            user_id=editor.id,
+            permission=PersonaSharePermission.EDITOR,
+        )
+    )
+    db_session.commit()
+
+    is_editable = is_persona_editable_by_user(db_session, persona.id, editor)
+    holds_add_agents = (
+        has_permission(editor, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    assert is_editable is True  # EDITOR-shared → editable
+    assert holds_add_agents is False  # ...but no ADD_AGENTS authority under EE
+
+    tags = persona_permissions(
+        can_edit=can_edit_persona(editor, persona, db_session, is_editable=is_editable),
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(editor, persona),
+        can_delete=can_delete_persona(editor, persona, db_session),
+        holds_add_agents=holds_add_agents,
+        is_manage_agents_admin=has_global_permission(editor, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(editor, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert tags["share"] is True  # editable is enough to share (no ADD_AGENTS needed)
+    assert (
+        tags["edit"] is True
+    )  # ...and to edit — both routes gate on editable, not ADD_AGENTS
+
+
+def test_persona_publish_projection_is_owner_not_add_agents(
+    enable_ee: None,  # noqa: ARG001 -- side-effect fixture: forces EE for the whole test
+    db_session: Session,
+) -> None:
+    """publish (org-wide public, via the share route's is_owner_or_admin gate) is owner-or-admin,
+    NOT ADD_AGENTS-gated. An owner without ADD_AGENTS can publish but cannot delete (delete's
+    route requires ADD_AGENTS). enable_ee because CE auto-grants ADD_AGENTS, masking this."""
+    owner = create_test_user(db_session, "publish-owner")
+    owner.effective_permissions = []
+    db_session.commit()
+
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[])
+    is_editable = is_persona_editable_by_user(db_session, persona.id, owner)
+    holds_add_agents = (
+        has_permission(owner, Permission.ADD_AGENTS) is not PermissionAuthority.NONE
+    )
+    assert holds_add_agents is False  # owner holds no ADD_AGENTS authority under EE
+
+    tags = persona_permissions(
+        can_edit=can_edit_persona(owner, persona, db_session, is_editable=is_editable),
+        can_share=is_editable,
+        can_view_stats=can_view_persona_stats(owner, persona),
+        can_delete=can_delete_persona(owner, persona, db_session),
+        holds_add_agents=holds_add_agents,
+        is_manage_agents_admin=has_global_permission(owner, Permission.MANAGE_AGENTS),
+        is_full_admin=has_global_permission(owner, Permission.FULL_ADMIN_PANEL_ACCESS),
+    )
+    assert (
+        tags["publish"] is True
+    )  # owner may publish via the share route (no ADD_AGENTS)
+    assert tags["delete"] is False  # ...but delete's route requires ADD_AGENTS
+
+
+def test_document_set_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks the editable filter, which equals the within_scope decision the write
+    guard enforces; delete/publish track global MANAGE_DOCUMENT_SETS."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "b-ds-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "b-ds-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "b-ds-admin", is_admin=True)
+    db_session.commit()
+
+    doc_set = _make_doc_set(db_session, is_public=False, groups=[managed])
+
+    for actor in (in_scope, out_scope, admin):
+        editable_ids = {
+            ds.id
+            for ds in fetch_all_document_sets_for_user(
+                db_session=db_session, user=actor, get_editable=True
+            )
+        }
+        is_editable = doc_set.id in editable_ids
+        # the editable filter equals the write guard's scope decision
+        scope_decision = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_DOCUMENT_SETS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        assert is_editable == scope_decision, actor.email
+
+        is_ds_admin = has_global_permission(actor, Permission.MANAGE_DOCUMENT_SETS)
+        tags = document_set_permissions(
+            is_editable=is_editable, is_document_sets_admin=is_ds_admin
+        )
+        assert tags["edit"] == scope_decision
+        assert tags["manage_access"] == scope_decision
+        assert tags["delete"] == is_ds_admin
+
+
+def test_persona_and_doc_set_key_coverage() -> None:
+    persona_keys = set(
+        persona_permissions(
+            can_edit=True,
+            can_share=True,
+            can_view_stats=True,
+            can_delete=True,
+            holds_add_agents=True,
+            is_manage_agents_admin=True,
+            is_full_admin=True,
+        )
+    )
+    assert persona_keys == set(PERSONA_ACTIONS)
+    ds_keys = set(
+        document_set_permissions(is_editable=True, is_document_sets_admin=True)
+    )
+    assert ds_keys == set(DOCUMENT_SET_ACTIONS)
+
+
+def _make_tool(
+    db_session: Session,
+    *,
+    creator: User | None = None,
+    in_code: str | None = None,
+    mcp_server_id: int | None = None,
+) -> Tool:
+    tool = Tool(
+        name=f"proj-tool-{uuid4().hex[:12]}",
+        description="contract",
+        user_id=creator.id if creator else None,
+        in_code_tool_id=in_code,
+        mcp_server_id=mcp_server_id,
+    )
+    db_session.add(tool)
+    db_session.flush()
+    return tool
+
+
+def _make_mcp_server(db_session: Session, *, owner_email: str) -> MCPServer:
+    server = MCPServer(
+        name=f"proj-mcp-{uuid4().hex[:12]}",
+        owner=owner_email,
+        server_url="https://mcp.example.com",
+        status=MCPServerStatus.CONNECTED,
+    )
+    db_session.add(server)
+    db_session.flush()
+    return server
+
+
+def _link_persona_tool(db_session: Session, persona: Persona, tool: Tool) -> None:
+    db_session.add(Persona__Tool(persona_id=persona.id, tool_id=tool.id))
+    db_session.commit()
+
+
+def _make_skill(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> Skill:
+    skill = Skill(
+        id=uuid4(),
+        slug=f"proj-skill-{uuid4().hex[:12]}",
+        name="contract skill",
+        description="contract",
+        # custom skills need a bundle source (ck_skill_definition_source)
+        bundle_file_id=f"proj-bundle-{uuid4().hex}",
+        bundle_sha256="0" * 64,
+        is_public=is_public,
+    )
+    db_session.add(skill)
+    db_session.flush()
+    for group in groups:
+        db_session.add(Skill__UserGroup(skill_id=skill.id, user_group_id=group.id))
+    db_session.commit()
+    return skill
+
+
+def test_tool_projection_matches_gates(db_session: Session) -> None:
+    """Every action affordance (edit, delete, toggle, authenticate) is owner-or-admin, pinned
+    to _get_manageable_custom_tool. The creator fully controls the action they made; a scoped
+    manager whose group the action is connected to may view/create but not manage it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-tool-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    # scoped manager who owns the action (via a group unrelated to the action's agents)
+    creator = create_test_user(db_session, "proj-tool-creator")
+    _manage(db_session, creator, _make_group(db_session))
+    creator.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-tool-admin", is_admin=True)
+    db_session.commit()
+
+    tool = _make_tool(db_session, creator=creator)
+    # a private agent in the managed group references the action -> connected to `managed`
+    persona = _make_persona(
+        db_session, owner=creator, is_public=False, groups=[managed]
+    )
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, creator, admin):
+        manage_enforced = not _guard_raises(
+            _get_manageable_custom_tool, tool.id, db_session, actor
+        )
+        can_manage = can_manage_own_tool(actor, tool)
+        assert can_manage == manage_enforced, actor.email
+        assert tool_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "toggle": manage_enforced,
+            "authenticate": manage_enforced,
+        }
+
+    # a manager of the action's connected group can't manage it (only creator/admin can)
+    assert tool_permissions(can_manage=can_manage_own_tool(in_scope, tool)) == {
+        "edit": False,
+        "delete": False,
+        "toggle": False,
+        "authenticate": False,
+    }
+    # the creator fully controls the action they made
+    assert tool_permissions(can_manage=can_manage_own_tool(creator, tool)) == {
+        "edit": True,
+        "delete": True,
+        "toggle": True,
+        "authenticate": True,
+    }
+
+
+def test_mcp_projection_matches_gates(db_session: Session) -> None:
+    """Every MCP action affordance is owner-or-admin, pinned to
+    _ensure_mcp_server_owner_or_admin. A scoped manager whose group the server is connected to
+    may view it (_ensure_mcp_server_viewable) but not manage it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-mcp-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    owner = create_test_user(db_session, "proj-mcp-owner")
+    _manage(db_session, owner, _make_group(db_session))
+    owner.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-mcp-admin", is_admin=True)
+    db_session.commit()
+
+    server = _make_mcp_server(db_session, owner_email=owner.email)
+    tool = _make_tool(db_session, mcp_server_id=server.id)
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, owner, admin):
+        manage_enforced = not _guard_raises(
+            _ensure_mcp_server_owner_or_admin, server, actor
+        )
+        can_manage = can_manage_mcp_server(actor, server)
+        assert can_manage == manage_enforced, actor.email
+        assert mcp_server_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "authenticate": manage_enforced,
+            "manage_status": manage_enforced,
+        }
+
+    # a manager of the server's connected group may VIEW but not manage it
+    assert not _guard_raises(_ensure_mcp_server_viewable, server, in_scope, db_session)
+    assert can_manage_mcp_server(in_scope, server) is False
+    # the owner fully manages their server
+    assert mcp_server_permissions(can_manage=can_manage_mcp_server(owner, server)) == {
+        "edit": True,
+        "delete": True,
+        "authenticate": True,
+        "manage_status": True,
+    }
+
+
+def test_skill_projection_matches_gates(db_session: Session) -> None:
+    """edit/manage_access track the assert_within_scope guard on the skill's groups;
+    delete is FULL_ADMIN; publish (make public) is global MANAGE_SKILLS. A scoped manager
+    edits/re-grants a managed skill but can never delete or publish it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-skill-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-skill-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-skill-admin", is_admin=True)
+    db_session.commit()
+
+    skill = _make_skill(db_session, is_public=False, groups=[managed])
+    group_ids = get_group_ids_for_skill(skill.id, db_session)
+
+    for actor in (in_scope, out_scope, admin):
+        edit_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        # publish drives the same guard with the requested public state
+        publish_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=False,
+        )
+        can_edit = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        assert can_edit == edit_enforced, actor.email
+        is_full_admin = has_global_permission(actor, Permission.FULL_ADMIN_PANEL_ACCESS)
+        is_skills_admin = has_global_permission(actor, Permission.MANAGE_SKILLS)
+        tags = custom_skill_permissions(
+            can_edit=can_edit,
+            is_full_admin=is_full_admin,
+            is_skills_admin=is_skills_admin,
+        )
+        assert tags["edit"] == edit_enforced
+        assert tags["manage_access"] == edit_enforced
+        assert tags["delete"] == is_full_admin
+        assert tags["publish"] == publish_enforced  # global MANAGE_SKILLS
+
+    # in-scope manager edits/re-grants but can't delete or publish
+    assert custom_skill_permissions(
+        can_edit=within_scope(
+            in_scope,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+        is_skills_admin=has_global_permission(in_scope, Permission.MANAGE_SKILLS),
+    ) == {"edit": True, "manage_access": True, "delete": False, "publish": False}
+
+
+def test_actions_and_skill_key_coverage() -> None:
+    assert set(tool_permissions(can_manage=True)) == set(TOOL_ACTIONS)
+    assert set(mcp_server_permissions(can_manage=True)) == set(MCP_SERVER_ACTIONS)
+    assert set(
+        custom_skill_permissions(
+            can_edit=True, is_full_admin=True, is_skills_admin=True
+        )
+    ) == set(CUSTOM_SKILL_ACTIONS)
+
+
+def test_user_group_projection_matches_gates(db_session: Session) -> None:
+    """Each flag is pinned to its real route, not the bool that built it: manage and
+    edit_token_limits → assert_manages_group (per-group scoped — the token read route now
+    admits scope), delete → delete-group (global MANAGE_USER_GROUPS), edit_permissions →
+    permission-toggle (FULL_ADMIN). groups_admin (global MANAGE_USER_GROUPS, not full admin)
+    separates the two levels; out_scope (manages a different group) pins the per-group gate."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-ug-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-ug-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-ug-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-ug-admin", is_admin=True)
+    db_session.commit()
+
+    for actor in (in_scope, out_scope, groups_admin, admin):
+        manage_enforced = not _guard_raises(
+            assert_manages_group, actor, db_session, group_id=managed.id
+        )
+        # the token-limit POST guard (scoped create) is the same managed-scope decision
+        token_create_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_USER_GROUPS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        can_manage = manages_group(actor, db_session, group_id=managed.id)
+        assert can_manage == manage_enforced, actor.email
+        assert can_manage == token_create_enforced, actor.email
+
+        tags = user_group_permissions(
+            can_manage=can_manage,
+            is_user_groups_admin=has_global_permission(
+                actor, Permission.MANAGE_USER_GROUPS
+            ),
+            is_full_admin=has_global_permission(
+                actor, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
+        )
+        assert tags["manage"] == manage_enforced, actor.email
+        assert tags["delete"] == _route_admits(delete_user_group, "_", actor), (
+            actor.email
+        )
+        assert tags["edit_permissions"] == _route_admits(
+            set_user_group_permissions, "user", actor
+        ), actor.email
+        # edit_token_limits rides the token read route: GATE 1 admits scope, GATE 2 is
+        # assert_manages_group — net per-group decision, so AND the two.
+        token_read_gate1 = _route_admits(get_group_token_limit_settings, "user", actor)
+        assert tags["edit_token_limits"] == (token_read_gate1 and manage_enforced), (
+            actor.email
+        )
+
+    assert user_group_permissions(
+        can_manage=manages_group(in_scope, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            in_scope, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": False,
+        "edit_permissions": False,
+        # scoped manager now fully manages its group's token limits
+        "edit_token_limits": True,
+    }
+
+    # groups_admin (global MANAGE_USER_GROUPS, not full admin): manages token limits and
+    # deletes the group, but can't edit permissions (FULL_ADMIN).
+    assert user_group_permissions(
+        can_manage=manages_group(groups_admin, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            groups_admin, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            groups_admin, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": True,
+        "edit_permissions": False,
+        "edit_token_limits": True,
+    }
+
+
+def test_user_group_key_coverage() -> None:
+    assert set(
+        user_group_permissions(
+            can_manage=True, is_user_groups_admin=True, is_full_admin=True
+        )
+    ) == set(USER_GROUP_ACTIONS)
+
+
+def test_group_token_rate_limit_write_scope(db_session: Session) -> None:
+    """A group token-limit write needs the caller to manage the group AND the limit to
+    belong to it — so a group admin fully manages its limits, but a global/per-user limit or
+    another group's limit can't be reached through the group path."""
+    managed = _make_group(db_session)
+    other = _make_group(db_session)
+
+    args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+    managed_limit = insert_user_group_token_rate_limit(
+        db_session=db_session, token_rate_limit_settings=args, group_id=managed.id
+    )
+    global_limit = insert_global_token_rate_limit(db_session, args)
+
+    in_scope = create_test_user(db_session, "proj-trl-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-trl-out")
+    _manage(db_session, out_scope, other)
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-trl-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-trl-admin", is_admin=True)
+
+    plain = create_test_user(db_session, "proj-trl-plain")
+    plain.effective_permissions = []
+    db_session.commit()
+
+    def denied(actor: User, group_id: int, rate_limit_id: int) -> bool:
+        return _guard_raises(
+            _authorize_group_token_rate_limit_write,
+            actor,
+            db_session,
+            group_id=group_id,
+            rate_limit_id=rate_limit_id,
+        )
+
+    assert not denied(admin, managed.id, managed_limit.id)
+    assert not denied(groups_admin, managed.id, managed_limit.id)
+    assert not denied(in_scope, managed.id, managed_limit.id)
+    assert denied(out_scope, managed.id, managed_limit.id)
+    assert denied(plain, managed.id, managed_limit.id)
+
+    # a global limit can't be reached through the group path — even for a full admin
+    assert denied(admin, managed.id, global_limit.id)
+
+    # the limit must belong to the claimed group (can't reach managed's limit via other)
+    assert denied(out_scope, other.id, managed_limit.id)
+    assert denied(in_scope, other.id, managed_limit.id)
+
+    # an unknown id folds into the same OnyxError 404, not the helper's raw ValueError
+    nonexistent_limit_id = -1
+    assert denied(in_scope, managed.id, nonexistent_limit_id)
+    assert denied(admin, managed.id, nonexistent_limit_id)

--- a/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
+++ b/backend/tests/external_dependency_unit/db/test_agent_sharing_permissions.py
@@ -7,15 +7,21 @@ import pytest
 from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
+from onyx.db.enums import Permission
 from onyx.db.enums import PersonaAccessLevel
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.enums import PersonaSharingStatus
 from onyx.db.models import Persona__User
 from onyx.db.models import User
 from onyx.db.persona import fetch_persona_by_id_for_user
+from onyx.db.persona import get_minimal_persona_snapshots_for_user
 from onyx.db.persona import update_persona_access
+from onyx.db.persona import upsert_persona
 from onyx.db.persona_sharing import derive_persona_sharing_status
 from onyx.db.persona_sharing import get_persona_access_level
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.persona.api import delete_persona
 from tests.external_dependency_unit.conftest import create_test_user
 from tests.external_dependency_unit.db.agent_sharing_helpers import create_test_persona
 from tests.external_dependency_unit.db.agent_sharing_helpers import (
@@ -221,3 +227,110 @@ def test_sharing_status_derivation(db_session: Session) -> None:
 
     public_persona = create_test_persona(db_session, owner, is_public=True)
     assert derive_persona_sharing_status(public_persona) == PersonaSharingStatus.PUBLIC
+
+
+def _list_snapshot(db_session: Session, user: User, persona_id: int):
+    snapshots = get_minimal_persona_snapshots_for_user(
+        user=user, db_session=db_session, get_editable=False
+    )
+    return next(s for s in snapshots if s.id == persona_id)
+
+
+def test_list_stamps_affordance_map_for_owner(db_session: Session) -> None:
+    """The list endpoint stamps the per-agent permissions map, so a card gates its icons
+    from list data instead of a per-card full-agent refetch (the flicker Nik flagged)."""
+    owner = create_test_user(db_session, "list-owner")
+    persona = create_test_persona(db_session, owner)
+
+    snap = _list_snapshot(db_session, owner, persona.id)
+    assert snap.permissions.get("edit") is True
+    assert snap.permissions.get("delete") is True
+
+
+def test_list_affordance_map_fail_closed_for_viewer(db_session: Session) -> None:
+    """A viewer-shared user gets the map stamped but every mutating affordance false —
+    the client can't render an edit/delete control the write guard would 403."""
+    owner = create_test_user(db_session, "list-owner2")
+    viewer = create_test_user(db_session, "list-viewer")
+    persona = create_test_persona(db_session, owner)
+    share_persona_with_user(db_session, persona, viewer, PersonaSharePermission.VIEWER)
+
+    snap = _list_snapshot(db_session, viewer, persona.id)
+    assert snap.permissions.get("edit") is False
+    assert snap.permissions.get("delete") is False
+
+
+def test_delete_persona_unowned_raises_403_not_400(db_session: Session) -> None:
+    """A non-owner admitted past GATE 1 (allow_scope) must get a 403 authorization denial, not
+    the generic 400 the global ValueError handler produces for get_persona_by_id's raise."""
+    owner = create_test_user(db_session, "del-owner")
+    stranger = create_test_user(db_session, "del-stranger")
+    persona = create_test_persona(db_session, owner)
+
+    with pytest.raises(OnyxError) as exc_info:
+        delete_persona(persona_id=persona.id, user=stranger, db_session=db_session)
+    assert exc_info.value.error_code == OnyxErrorCode.INSUFFICIENT_PERMISSIONS
+    assert exc_info.value.status_code == 403
+
+
+def test_add_agents_user_does_not_see_others_private_agents(
+    db_session: Session,
+) -> None:
+    """ADD_AGENTS must not imply READ_AGENTS (see-all): the browse list shows own / shared /
+    public, never another user's private agent."""
+    creator = create_test_user(db_session, "add-agents-creator")
+    creator.effective_permissions = [Permission.ADD_AGENTS.value]
+    stranger = create_test_user(db_session, "agent-stranger")
+    db_session.commit()
+
+    own = create_test_persona(db_session, creator)
+    public = create_test_persona(db_session, stranger, is_public=True)
+    shared = create_test_persona(db_session, stranger)
+    share_persona_with_user(db_session, shared, creator, PersonaSharePermission.VIEWER)
+    others_private = create_test_persona(db_session, stranger)
+
+    visible = {
+        snap.id
+        for snap in get_minimal_persona_snapshots_for_user(
+            user=creator, db_session=db_session, get_editable=False
+        )
+    }
+    assert own.id in visible
+    assert public.id in visible
+    assert shared.id in visible
+    assert others_private.id not in visible  # ADD_AGENTS no longer grants see-all
+
+
+def _edit_persona(
+    db_session: Session, persona_id: int, user: User, is_public: bool
+) -> None:
+    """Run the update-path setter as ``user`` requesting ``is_public``."""
+    upsert_persona(
+        user=user,
+        name=f"edit-{is_public}",
+        description="",
+        starter_messages=None,
+        system_prompt="",
+        task_prompt="",
+        datetime_aware=False,
+        is_public=is_public,
+        db_session=db_session,
+        persona_id=persona_id,
+    )
+
+
+def test_editor_cannot_publish_via_update(db_session: Session) -> None:
+    """An EDITOR-shared user may edit the agent but not flip it public via the update path —
+    is_public from a non-owner is dropped (owner-or-admin only, matching the share route)."""
+    owner = create_test_user(db_session, "pub-owner")
+    editor = create_test_user(db_session, "pub-editor")
+    persona = create_test_persona(db_session, owner, is_public=False)
+    share_persona_with_user(db_session, persona, editor, PersonaSharePermission.EDITOR)
+
+    _edit_persona(db_session, persona.id, editor, is_public=True)
+    db_session.refresh(persona)
+    assert persona.is_public is False  # editor's publish attempt is dropped
+
+    _edit_persona(db_session, persona.id, owner, is_public=True)
+    db_session.refresh(persona)
+    assert persona.is_public is True  # owner can publish

--- a/backend/tests/integration/tests/permissions/test_group_manager_agents.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_agents.py
@@ -7,10 +7,9 @@ manage, and never widen beyond their scope:
 - **Skills**: create/grant/publish only for PRIVATE skills in managed groups;
   the admin list is scoped; DELETE is admin-only.
 - **Agents**: may group-share a PRIVATE agent only to managed groups.
-- **Actions/MCP**: actions have no group of their own, so scope is derived from
-  the agents using them — editable only when every such agent is private and in a
-  managed group; a public-agent or no-agent action is owner/admin-only; DELETE is
-  admin-only.
+- **Actions/MCP**: owner-or-admin — a manager creates and fully manages (edit/delete)
+  their own actions and servers, but cannot manage ones they didn't create, even those
+  connected to their groups via agents.
 - **Token limits**: settable only on a managed group.
 
 Managers are seeded by flipping ``User__UserGroup.is_manager`` directly (no
@@ -28,13 +27,13 @@ from typing import NamedTuple
 from uuid import uuid4
 
 import pytest
+import requests
 from sqlalchemy import update
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import Permission
-from onyx.db.models import Persona
 from onyx.db.models import User__UserGroup
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from tests.integration.common_utils.managers.persona import PersonaManager
@@ -113,7 +112,7 @@ def _create_custom_tool(user: DATestUser) -> int:
 
 
 def _create_mcp_server(user: DATestUser) -> int:
-    """Create a simple MCP server as ``user`` (must succeed); returns its id."""
+    """Create an MCP server as ``user`` (must succeed); returns its id."""
     body = {
         "name": f"mcp-{uuid4()}",
         "description": "escalation test",
@@ -145,7 +144,17 @@ _TOKEN_LIMIT_BODY: dict[str, Any] = {
 }
 
 
-# --- skills -----------------------------------------------------------------
+def _assert_manager(
+    env: _ScopedEnv,
+    method: str,
+    path: str,
+    expected: str,
+    body: dict[str, Any] | None = None,
+) -> requests.Response:
+    """Call ``path`` as the scoped manager and assert the permission gate's verdict."""
+    resp = call_endpoint(method, path, body, env.manager.headers, env.manager.cookies)
+    assert_response(resp, method, path, "manager", expected)
+    return resp
 
 
 def test_manager_creates_private_skill_in_managed_group(env: _ScopedEnv) -> None:
@@ -159,25 +168,22 @@ def test_manager_cannot_grant_skill_to_unmanaged_group(env: _ScopedEnv) -> None:
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
     path = f"/admin/skills/custom/{skill.id}/grants"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PUT",
         path,
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PUT", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint(
-        "PATCH", path, {"is_public": True}, env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PATCH", f"/admin/skills/custom/{skill.id}", "denied", {"is_public": True}
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
@@ -185,9 +191,7 @@ def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/skills/custom/{skill.id}", "denied")
 
 
 def test_manager_skill_admin_list_is_scoped(env: _ScopedEnv) -> None:
@@ -206,9 +210,6 @@ def test_manager_skill_admin_list_is_scoped(env: _ScopedEnv) -> None:
     assert str(theirs.id) not in custom_ids
 
 
-# --- agents -----------------------------------------------------------------
-
-
 def test_manager_shares_agent_to_managed_group(env: _ScopedEnv) -> None:
     PersonaManager.create(
         user_performing_action=env.manager,
@@ -223,15 +224,13 @@ def test_manager_cannot_share_agent_to_unmanaged_group(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
@@ -242,15 +241,13 @@ def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}",
+        "denied",
         _persona_upsert_body(is_public=True, groups=[env.managed_group.id]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
@@ -270,29 +267,25 @@ def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
     assert publish.status_code == 200, publish.text
     # The manager must not pull the now-public agent back to private AND keep the
     # group share in one call — the gate anchors on the original (public) state.
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"is_public": False, "group_ids": [env.managed_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_creates_personal_agent(env: _ScopedEnv) -> None:
     # A scoped manager may create a private no-group personal agent like any
     # ADD_AGENTS user; the managed-group gate applies only once a group is involved.
-    path = "/persona"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "POST",
-        path,
+        "/persona",
+        "allowed",
         _persona_upsert_body(is_public=False, groups=[]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "POST", path, "manager", "allowed")
 
 
 def test_add_agents_user_creates_personal_agent_with_empty_groups(
@@ -340,132 +333,62 @@ def test_manager_rosters_agent_shared_to_managed_group(env: _ScopedEnv) -> None:
     assert resp.status_code == 200, resp.text
 
 
-# --- custom actions (agent-mediated scope) ----------------------------------
-
-
+# Custom actions: owner-or-admin gating (not group-scoped like skills/agents).
 def test_manager_creates_own_action(env: _ScopedEnv) -> None:
     _create_custom_tool(env.manager)
 
 
-def test_manager_cannot_edit_unowned_ungrouped_action(env: _ScopedEnv) -> None:
-    # Admin owns the action and no agent uses it → no group context → owner/admin only.
-    tool_id = _create_custom_tool(env.admin)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
-
-
-def test_manager_edits_action_used_by_managed_private_agent(env: _ScopedEnv) -> None:
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "allowed")
-
-
-def test_manager_edits_action_used_by_group_owned_agent(env: _ScopedEnv) -> None:
-    # An action used only by a PRIVATE agent OWNED by the manager's group (via
-    # owner_group_id, with no share rows) is in scope through that group ownership.
-    tool_id = _create_custom_tool(env.admin)
-    agent = PersonaManager.create(
-        user_performing_action=env.admin, is_public=False, tool_ids=[tool_id]
-    )
-    # No API creates a group-owned agent in these tests, so re-own it directly
-    # (owner_group_id and user_id are mutually exclusive).
-    with get_session_with_current_tenant() as db_session:
-        db_session.execute(
-            update(Persona)
-            .where(Persona.id == agent.id)
-            .values(user_id=None, owner_group_id=env.managed_group.id)
-        )
-        db_session.commit()
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "allowed")
-
-
-def test_manager_cannot_edit_action_used_by_public_agent(env: _ScopedEnv) -> None:
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=True,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
-
-
-def test_manager_cannot_edit_action_used_by_ungrouped_private_agent(
-    env: _ScopedEnv,
-) -> None:
-    # A private agent in NO group is a personal agent outside the manager's scope;
-    # its presence must block editing even alongside a managed-group agent (the
-    # ungrouped agent adds no group to the union, so it must be tracked explicitly).
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[],
-        tool_ids=[tool_id],
-    )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
-
-
-def test_manager_cannot_delete_action(env: _ScopedEnv) -> None:
-    # Owns it — still denied: delete is admin-only (no allow_scope on the route).
+def test_manager_edits_own_action(env: _ScopedEnv) -> None:
     tool_id = _create_custom_tool(env.manager)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
+    )
 
 
-# --- MCP servers ------------------------------------------------------------
+def test_manager_deletes_own_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.manager)
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "allowed")
 
 
+def test_manager_cannot_edit_unowned_action(env: _ScopedEnv) -> None:
+    # Owner-or-admin: a manager can't edit an admin-created action, even one used by an agent
+    # in a group they manage (managers get read visibility + their own, not others').
+    tool_id = _create_custom_tool(env.admin)
+    PersonaManager.create(
+        user_performing_action=env.admin,
+        is_public=False,
+        groups=[env.managed_group.id],
+        tool_ids=[tool_id],
+    )
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
+
+
+def test_manager_cannot_delete_unowned_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.admin)
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "denied")
+
+
+# MCP servers: owner-or-admin gating (not group-scoped like skills/agents).
 def test_manager_creates_mcp_server(env: _ScopedEnv) -> None:
     _create_mcp_server(env.manager)
 
 
-def test_manager_cannot_delete_mcp_server(env: _ScopedEnv) -> None:
-    # Owns it — still denied: MCP delete is admin-only.
+def test_manager_deletes_own_mcp_server(env: _ScopedEnv) -> None:
     server_id = _create_mcp_server(env.manager)
-    path = f"/admin/mcp/server/{server_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "allowed")
+
+
+def test_manager_cannot_delete_unowned_mcp_server(env: _ScopedEnv) -> None:
+    server_id = _create_mcp_server(env.admin)
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "denied")
 
 
 def test_manager_update_via_servers_create_denied_not_masked(
     env: _ScopedEnv,
 ) -> None:
-    # Updating an out-of-scope server through /servers/create must surface the
-    # gate's 403, not a 500 masked by the handler's blanket except.
+    # Updating an unowned server through /servers/create must surface the gate's 403, not a
+    # 500 masked by the handler's blanket except.
     server_id = _create_mcp_server(env.admin)
-    path = "/admin/mcp/servers/create"
     body = {
         "name": f"mcp-{uuid4()}",
         "server_url": "https://example.com/mcp",
@@ -473,24 +396,66 @@ def test_manager_update_via_servers_create_denied_not_masked(
         "auth_performer": MCPAuthenticationPerformer.ADMIN.value,
         "existing_server_id": server_id,
     }
-    resp = call_endpoint("POST", path, body, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "POST", path, "manager", "denied")
+    _assert_manager(env, "POST", "/admin/mcp/servers/create", "denied", body)
 
 
-# --- token limits -----------------------------------------------------------
+def _group_limit_path(group_id: int, limit_id: int | None = None) -> str:
+    base = f"/admin/token-rate-limits/user-group/{group_id}"
+    return base if limit_id is None else f"{base}/rate-limit/{limit_id}"
+
+
+def _create_group_token_limit(user: DATestUser, group_id: int) -> int:
+    """Create a token limit on ``group_id`` as ``user`` (must succeed); returns its id."""
+    resp = call_endpoint(
+        "POST",
+        _group_limit_path(group_id),
+        _TOKEN_LIMIT_BODY,
+        user.headers,
+        user.cookies,
+    )
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["token_id"])
 
 
 def test_manager_sets_token_limit_on_managed_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.managed_group.id}"
-    resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "POST", path, "manager", "allowed")
+    path = _group_limit_path(env.managed_group.id)
+    _assert_manager(env, "POST", path, "allowed", _TOKEN_LIMIT_BODY)
 
 
 def test_manager_cannot_set_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.other_group.id}"
-    resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
+    path = _group_limit_path(env.other_group.id)
+    _assert_manager(env, "POST", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_reads_token_limits_on_managed_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.managed_group.id), "allowed")
+
+
+def test_manager_cannot_read_token_limits_on_unmanaged_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.other_group.id), "denied")
+
+
+def test_manager_updates_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    path = _group_limit_path(env.managed_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "allowed", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_cannot_update_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    path = _group_limit_path(env.other_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_deletes_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.managed_group.id, limit_id), "allowed"
     )
-    assert_response(resp, "POST", path, "manager", "denied")
+
+
+def test_manager_cannot_delete_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.other_group.id, limit_id), "denied"
+    )

--- a/backend/tests/integration/tests/permissions/test_group_manager_membership.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_membership.py
@@ -121,9 +121,7 @@ def _insert_stale_cc_pair_junction(group_id: int, cc_pair_id: int) -> None:
         db_session.commit()
 
 
-# --- manager assignment endpoint (GATE 2 = admin or manager-of-that-group) ---
-
-
+# Manager-assignment endpoint — GATE 2 = admin or manager-of-that-group.
 def test_admin_assigns_manager(env: _ScopedEnv) -> None:
     path = _manager_path(env.managed_group.id)
     resp = call_endpoint(
@@ -214,9 +212,6 @@ def test_plain_member_cannot_assign(env: _ScopedEnv) -> None:
     assert_response(resp, "PUT", path, "member", "denied")
 
 
-# --- membership edits (group ∈ managed) -------------------------------------
-
-
 def test_manager_adds_user_to_managed_group(env: _ScopedEnv) -> None:
     UserGroupManager.add_users(
         env.managed_group, [env.outsider.id], user_performing_action=env.manager
@@ -269,9 +264,7 @@ def test_manager_cannot_patch_unmanaged_group(env: _ScopedEnv) -> None:
     assert_response(resp, "PATCH", path, "manager", "denied")
 
 
-# --- cc_pair re-attach gate (§ junction-rewrite escalation) ------------------
-
-
+# cc_pair re-attach gate — the junction-rewrite escalation vector.
 def test_manager_cannot_attach_public_cc_pair(env: _ScopedEnv) -> None:
     public_cc_pair = CCPairManager.create_from_scratch(
         user_performing_action=env.admin, access_type=AccessType.PUBLIC, groups=[]
@@ -341,9 +334,6 @@ def test_manager_attaches_groupless_private_cc_pair(env: _ScopedEnv) -> None:
     assert resp.status_code == 200, resp.text
 
 
-# --- scoped group list + /me/permissions ------------------------------------
-
-
 def test_manager_group_list_only_managed(env: _ScopedEnv) -> None:
     groups = UserGroupManager.get_all(user_performing_action=env.manager)
     group_ids = {g.id for g in groups}
@@ -383,9 +373,7 @@ def test_member_me_permissions_not_manager(env: _ScopedEnv) -> None:
     assert set(info.admin_capabilities) == set(info.effective_permissions)
 
 
-# --- group create / delete / permissions stay admin-only --------------------
-
-
+# Group create/delete/set-permissions stay admin-only.
 def test_manager_cannot_create_group(env: _ScopedEnv) -> None:
     resp = call_endpoint(
         "POST",

--- a/backend/tests/integration/tests/permissions/test_group_manager_resources.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_resources.py
@@ -116,9 +116,6 @@ def _doc_set_body(
     return body
 
 
-# --- cc_pair create (GATE 2) ------------------------------------------------
-
-
 def test_admin_creates_public_cc_pair_bypasses_gate(env: _ScopedEnv) -> None:
     # Control: a global holder is not scope-restricted (PUBLIC, no groups).
     CCPairManager.create_from_scratch(
@@ -172,9 +169,6 @@ def test_manager_cannot_create_cc_pair_without_groups(env: _ScopedEnv) -> None:
         env.manager.cookies,
     )
     assert_response(resp, "PUT", path, "manager", "denied")
-
-
-# --- document set create / edit (GATE 2) ------------------------------------
 
 
 def test_manager_creates_private_doc_set_in_managed_group(env: _ScopedEnv) -> None:
@@ -270,9 +264,6 @@ def test_manager_edits_doc_set_within_managed_group(env: _ScopedEnv) -> None:
     DocumentSetManager.edit(doc_set, user_performing_action=env.manager)
 
 
-# --- DELETE stays admin-only ------------------------------------------------
-
-
 def test_manager_cannot_delete_doc_set(env: _ScopedEnv) -> None:
     cc_pair = CCPairManager.create_from_scratch(
         user_performing_action=env.manager,
@@ -308,10 +299,9 @@ def test_manager_cannot_delete_cc_pair(env: _ScopedEnv) -> None:
     assert_response(resp, "POST", path, "manager", "denied")
 
 
-# --- re-keyed read filter authorizes the mutate routes ----------------------
-
-
 def test_manager_pauses_own_managed_cc_pair(env: _ScopedEnv) -> None:
+    # Pause/status (mutate routes) authorize via the re-keyed read/editable filter,
+    # not a separate scope check — so managed-scope access gates mutation too.
     cc_pair = CCPairManager.create_from_scratch(
         user_performing_action=env.manager,
         access_type=AccessType.PRIVATE,
@@ -338,9 +328,6 @@ def test_manager_cannot_pause_unmanaged_cc_pair(env: _ScopedEnv) -> None:
     assert_response(resp, "PUT", path, "manager", "denied")
 
 
-# --- membership is not managership ------------------------------------------
-
-
 def test_plain_member_cannot_create_doc_set(env: _ScopedEnv) -> None:
     # A group member without is_manager has NONE authority — rejected at GATE 1.
     member = UserManager.create(name="plain_member")
@@ -355,9 +342,6 @@ def test_plain_member_cannot_create_doc_set(env: _ScopedEnv) -> None:
         member.cookies,
     )
     assert_response(resp, "POST", _DOC_SET_PATH, "member", "denied")
-
-
-# --- cc_pair permissions map on the DTO -------------------------------------
 
 
 def test_admin_cc_pair_detail_carries_permissions_map(env: _ScopedEnv) -> None:

--- a/backend/tests/integration/tests/permissions/test_manage_user_groups.py
+++ b/backend/tests/integration/tests/permissions/test_manage_user_groups.py
@@ -71,10 +71,9 @@ def test_access_matrix(
 
 
 # PUT /manage/admin/user-group/{id}/permissions is admin-only (not
-# MANAGE_USER_GROUPS) to prevent privilege escalation — a group manager
-# could otherwise grant their own group any toggleable permission. The
-# endpoint must remain gated on FULL_ADMIN_PANEL_ACCESS, so holders of
-# MANAGE_USER_GROUPS are expected to be denied here.
+# MANAGE_USER_GROUPS) to prevent privilege escalation: a group manager
+# could otherwise grant their own group any toggleable permission. Gated
+# on FULL_ADMIN_PANEL_ACCESS, so MANAGE_USER_GROUPS holders are denied here.
 _SET_PERMISSIONS_USER_KINDS: list[tuple[str, str]] = [
     ("admin", "allowed"),
     ("holder", "denied"),

--- a/backend/tests/unit/onyx/auth/test_permissions.py
+++ b/backend/tests/unit/onyx/auth/test_permissions.py
@@ -68,8 +68,12 @@ class TestResolveEffectivePermissions:
         assert "read:search" not in resolve_effective_permissions({"write:chat"})
 
     def test_single_implication(self) -> None:
-        result = resolve_effective_permissions({"add:agents"})
-        assert result == {"add:agents", "read:agents"}
+        result = resolve_effective_permissions({"manage:connectors"})
+        assert result == {"manage:connectors", "read:connectors"}
+
+    def test_add_agents_implies_nothing(self) -> None:
+        """ADD_AGENTS must NOT imply READ_AGENTS — creating agents grants no see-all."""
+        assert resolve_effective_permissions({"add:agents"}) == {"add:agents"}
 
     def test_manage_agents_implies_add_and_reads(self) -> None:
         """manage:agents implies add:agents, read:agents, and read:document_sets."""
@@ -132,7 +136,6 @@ class TestResolveEffectivePermissions:
             "read:chat",
             "write:chat",
             "add:agents",
-            "read:agents",
             "manage:connectors",
             "read:connectors",
         }
@@ -164,11 +167,12 @@ class TestGetEffectivePermissions:
         global_version.unset_ee()
 
     def test_expands_implied_permissions(self) -> None:
-        """Column stores only granted; get_effective_permissions expands implied."""
+        """Column stores only granted; get_effective_permissions expands implied. ADD_AGENTS
+        implies nothing — it must not grant READ_AGENTS (see-all-agents)."""
         user = MagicMock()
         user.effective_permissions = ["add:agents"]
         result = get_effective_permissions(user)
-        assert result == {Permission.ADD_AGENTS, Permission.READ_AGENTS}
+        assert result == {Permission.ADD_AGENTS}
 
     def test_admin_expands_to_all(self) -> None:
         user = MagicMock()
@@ -208,7 +212,7 @@ class TestCEUngatedPermissions:
         user.effective_permissions = ["basic"]
         result = get_effective_permissions(user)
         assert Permission.ADD_AGENTS in result
-        assert Permission.READ_AGENTS in result
+        assert Permission.READ_AGENTS not in result  # ADD_AGENTS doesn't grant see-all
         assert Permission.BASIC_ACCESS in result
 
     def test_empty_user_gets_ungated_permissions_in_ce(self) -> None:
@@ -216,7 +220,7 @@ class TestCEUngatedPermissions:
         user.effective_permissions = []
         result = get_effective_permissions(user)
         assert Permission.ADD_AGENTS in result
-        assert Permission.READ_AGENTS in result
+        assert Permission.READ_AGENTS not in result  # ADD_AGENTS doesn't grant see-all
 
     def test_basic_user_does_not_get_ungated_permissions_in_ee(self) -> None:
         global_version.set_ee()

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -51,7 +51,7 @@ import {
 } from "lucide-react";
 import IndexAttemptErrorsModal from "./IndexAttemptErrorsModal";
 import usePaginatedFetch from "@/hooks/usePaginatedFetch";
-import { IndexAttemptSnapshot, Permission } from "@/lib/types";
+import { IndexAttemptSnapshot } from "@/lib/types";
 import { Spinner } from "@/components/Spinner";
 import { Callout } from "@/components/ui/callout";
 import { Card } from "@/components/ui/card";
@@ -69,7 +69,7 @@ import { SvgSettings } from "@opal/icons";
 import { useUser } from "@/providers/UserProvider";
 import { resolveAllErrorsForCCPair } from "@/lib/targeted_reindex";
 import { SWR_KEYS } from "@/lib/swr-keys";
-import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 // synchronize these validations with the SQLAlchemy connector class until we have a
 // centralized schema for both frontend and backend
 const RefreshFrequencySchema = Yup.object().shape({
@@ -95,7 +95,7 @@ const PAGES_PER_BATCH = 8;
 
 function Main({ ccPairId }: { ccPairId: number }) {
   const router = useRouter();
-  const { user, permissions } = useUser();
+  const { user } = useUser();
 
   const {
     data: ccPair,
@@ -184,11 +184,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
 
   const latestIndexAttempt = indexAttempts?.[0];
   const canManageInlineFileConnectorFiles =
-    ccPair?.connector.source === "file" &&
-    (ccPair.is_editable_for_current_user ||
-      (hasPermission(permissions, Permission.MANAGE_CONNECTORS) &&
-        !hasPermission(permissions, Permission.FULL_ADMIN_PANEL_ACCESS) &&
-        ccPair.access_type === "public"));
+    ccPair?.connector.source === "file" && can(ccPair, "edit");
 
   const isResolvingErrors =
     (latestIndexAttempt?.status === "in_progress" ||
@@ -478,14 +474,14 @@ function Main({ ccPairId }: { ccPairId: number }) {
         <div className="ml-2 overflow-hidden text-ellipsis whitespace-nowrap flex-1 mr-4">
           <EditableStringFieldDisplay
             value={ccPair.name}
-            isEditable={ccPair.is_editable_for_current_user}
+            isEditable={can(ccPair, "edit")}
             onUpdate={handleUpdateName}
             scale={2.1}
           />
         </div>
 
         <div className="ml-auto flex gap-x-2">
-          {ccPair.is_editable_for_current_user && (
+          {can(ccPair, "edit") && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button prominence="secondary" icon={SvgSettings}>
@@ -691,22 +687,21 @@ function Main({ ccPairId }: { ccPairId: number }) {
         </div>
       </Card>
 
-      {credentialTemplates[ccPair.connector.source] &&
-        ccPair.is_editable_for_current_user && (
-          <>
-            <Title size="md" className="mt-10 mb-2">
-              Credential
-            </Title>
+      {credentialTemplates[ccPair.connector.source] && can(ccPair, "edit") && (
+        <>
+          <Title size="md" className="mt-10 mb-2">
+            Credential
+          </Title>
 
-            <div className="mt-2">
-              <CredentialSection
-                ccPair={ccPair}
-                sourceType={ccPair.connector.source}
-                refresh={() => refresh()}
-              />
-            </div>
-          </>
-        )}
+          <div className="mt-2">
+            <CredentialSection
+              ccPair={ccPair}
+              sourceType={ccPair.connector.source}
+              refresh={() => refresh()}
+            />
+          </div>
+        </>
+      )}
 
       {ccPair.connector.connector_specific_config &&
         Object.keys(ccPair.connector.connector_specific_config).length > 0 && (

--- a/web/src/app/admin/connector/[ccPairId]/page.tsx
+++ b/web/src/app/admin/connector/[ccPairId]/page.tsx
@@ -546,7 +546,7 @@ function Main({ ccPairId }: { ccPairId: number }) {
                     </span>
                   </DropdownMenuItemWithTooltip>
                 )}
-                {!isDeleting && (
+                {!isDeleting && can(ccPair, "delete") && (
                   <DropdownMenuItemWithTooltip
                     onClick={() => {
                       setShowDeleteConnectorConfirmModal(true);

--- a/web/src/app/admin/connector/[ccPairId]/types.ts
+++ b/web/src/app/admin/connector/[ccPairId]/types.ts
@@ -51,6 +51,8 @@ export interface CCPairFullInfo {
   latest_deletion_attempt: DeletionAttemptSnapshot | null;
   access_type: AccessType;
   is_editable_for_current_user: boolean;
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: Record<string, boolean>;
   deletion_failure_message: string | null;
   indexing: boolean;
   creator: UUID | null;

--- a/web/src/app/admin/documents/sets/page.tsx
+++ b/web/src/app/admin/documents/sets/page.tsx
@@ -17,6 +17,7 @@ import Title from "@/components/ui/title";
 import { DocumentSetSummary } from "@/lib/types";
 import { useState } from "react";
 import { useDocumentSets } from "./hooks";
+import { can } from "@/lib/permissions/resource-actions";
 import { ConnectorTitle } from "@/components/admin/connectors/ConnectorTitle";
 import { deleteDocumentSet } from "./lib";
 import { toast } from "@/hooks/useToast";
@@ -147,35 +148,20 @@ const EditRow = ({
 interface DocumentFeedbackTableProps {
   documentSets: DocumentSetSummary[];
   refresh: () => void;
-  refreshEditable: () => void;
-  editableDocumentSets: DocumentSetSummary[];
 }
 
 const DocumentSetTable = ({
   documentSets,
-  editableDocumentSets,
   refresh,
-  refreshEditable,
 }: DocumentFeedbackTableProps) => {
   const [page, setPage] = useState(1);
 
-  // sort by name for consistent ordering
-  documentSets.sort((a, b) => {
-    if (a.name < b.name) {
-      return -1;
-    } else if (a.name > b.name) {
-      return 1;
-    } else {
-      return 0;
-    }
+  // editable rows first, then by name — editability now rides on each row's
+  // permissions map, so no second fetch + set-diff is needed.
+  const sortedDocumentSets = [...documentSets].sort((a, b) => {
+    const editDiff = Number(can(b, "edit")) - Number(can(a, "edit"));
+    return editDiff !== 0 ? editDiff : a.name.localeCompare(b.name);
   });
-
-  const sortedDocumentSets = [
-    ...editableDocumentSets,
-    ...documentSets.filter(
-      (ds) => !editableDocumentSets.some((eds) => eds.id === ds.id)
-    ),
-  ];
 
   return (
     <div>
@@ -194,9 +180,7 @@ const DocumentSetTable = ({
           {sortedDocumentSets
             .slice((page - 1) * numToDisplay, page * numToDisplay)
             .map((documentSet) => {
-              const isEditable = editableDocumentSets.some(
-                (eds) => eds.id === documentSet.id
-              );
+              const isEditable = can(documentSet, "edit");
               return (
                 <TableRow key={documentSet.id}>
                   <TableCell className="whitespace-normal break-all">
@@ -322,7 +306,6 @@ const DocumentSetTable = ({
                             );
                           }
                           refresh();
-                          refreshEditable();
                         }}
                       />
                     ) : (
@@ -356,14 +339,7 @@ function Main() {
     refreshDocumentSets,
   } = useDocumentSets();
 
-  const {
-    data: editableDocumentSets,
-    isLoading: isEditableDocumentSetsLoading,
-    error: editableDocumentSetsError,
-    refreshDocumentSets: refreshEditableDocumentSets,
-  } = useDocumentSets(true);
-
-  if (isDocumentSetsLoading || isEditableDocumentSetsLoading) {
+  if (isDocumentSetsLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
         <ThreeDotsLoader />
@@ -373,10 +349,6 @@ function Main() {
 
   if (documentSetsError || !documentSets) {
     return <div>Error: {documentSetsError}</div>;
-  }
-
-  if (editableDocumentSetsError || !editableDocumentSets) {
-    return <div>Error: {editableDocumentSetsError}</div>;
   }
 
   return (
@@ -405,9 +377,7 @@ function Main() {
           <Divider />
           <DocumentSetTable
             documentSets={documentSets}
-            editableDocumentSets={editableDocumentSets}
             refresh={refreshDocumentSets}
-            refreshEditable={refreshEditableDocumentSets}
           />
         </>
       )}

--- a/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
+++ b/web/src/app/admin/indexing/status/CCPairIndexingStatusTable.tsx
@@ -302,6 +302,7 @@ export function CCPairIndexingStatusTable({
             last_status: "success",
             source: ValidSources.File,
             access_type: "public",
+            permissions: {},
             docs_indexed: 1000,
             last_success: "2023-07-01T12:00:00Z",
             last_finished_status: "success",

--- a/web/src/app/craft/v1/apps/manage/layout.tsx
+++ b/web/src/app/craft/v1/apps/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.FULL_ADMIN_PANEL_ACCESS);

--- a/web/src/app/craft/v1/skills/manage/layout.tsx
+++ b/web/src/app/craft/v1/skills/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.MANAGE_SKILLS);

--- a/web/src/hooks/useCapabilities.ts
+++ b/web/src/hooks/useCapabilities.ts
@@ -1,0 +1,11 @@
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { Permission } from "@/lib/types";
+
+// Coarse "may this user reach X at all" check for affordances not tied to a fetched
+// resource (nav, a global "New X" button). Uses admin_capabilities, so a group manager
+// is included — unlike raw effective_permissions.
+export function useCapabilities(...required: Permission[]): boolean {
+  const { adminCapabilities } = useUser();
+  return hasPermission(adminCapabilities, ...required);
+}

--- a/web/src/hooks/useServerTools.ts
+++ b/web/src/hooks/useServerTools.ts
@@ -98,6 +98,7 @@ export default function useServerTools(
         description: tool.description,
         isAvailable: true,
         isEnabled: tool.enabled,
+        permissions: tool.permissions,
       }))
     : [];
 

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import AdminSidebar from "@/sections/sidebar/AdminSidebar";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import type { Route } from "next";
+import { useEffect } from "react";
 import { useSettingsContext } from "@/providers/SettingsProvider";
+import { useUser } from "@/providers/UserProvider";
 import { ApplicationStatus } from "@/interfaces/settings";
 import { Button, Text } from "@opal/components";
 import { markdown } from "@opal/utils";
@@ -10,7 +13,8 @@ import useScreenSize from "@/hooks/useScreenSize";
 import { SvgSidebar, SvgSimpleLoader } from "@opal/icons";
 import { RootLayout, useSidebarState } from "@opal/layouts";
 import { Section } from "@/layouts/general-layouts";
-import { isVectorDbRequiredRoute } from "@/lib/admin-routes";
+import { isVectorDbRequiredRoute, matchAdminRoute } from "@/lib/admin-routes";
+import { getFirstPermittedAdminRoute, hasPermission } from "@/lib/permissions";
 import LiteModeIndexingNotice from "@/sections/admin/LiteModeIndexingNotice";
 
 export interface AdminChromeProps {
@@ -22,6 +26,22 @@ export default function AdminChrome({ children }: AdminChromeProps) {
   const { isMobile } = useScreenSize();
   const pathname = usePathname();
   const settings = useSettingsContext();
+  const router = useRouter();
+  const { adminCapabilities } = useUser();
+
+  // Match-only per-page gate: if this page is a known admin route the user lacks the
+  // permission for (a group manager landing on a full-admin page), send them to their
+  // first permitted admin page. Unlisted detail sub-pages are left to the backend gate.
+  const matched = matchAdminRoute(pathname);
+  const denied =
+    matched !== undefined &&
+    !hasPermission(adminCapabilities, matched.requiredPermission);
+
+  useEffect(() => {
+    if (denied) {
+      router.replace(getFirstPermittedAdminRoute(adminCapabilities) as Route);
+    }
+  }, [denied, router, adminCapabilities]);
 
   // Certain admin panels have their own custom sidebar.
   // For those pages, we skip rendering the default `AdminSidebar` and let those individual pages render their own.
@@ -41,6 +61,8 @@ export default function AdminChrome({ children }: AdminChromeProps) {
       content = <LiteModeIndexingNotice />;
     }
   }
+
+  if (denied) return null;
 
   return (
     <RootLayout.Root>

--- a/web/src/layouts/chromes/AdminChrome.tsx
+++ b/web/src/layouts/chromes/AdminChrome.tsx
@@ -19,15 +19,27 @@ import LiteModeIndexingNotice from "@/sections/admin/LiteModeIndexingNotice";
 
 export interface AdminChromeProps {
   children: React.ReactNode;
+  // Server-fetched seed (AdminSSChrome) used until /api/me loads client-side.
+  initialAdminCapabilities: string[];
 }
 
-export default function AdminChrome({ children }: AdminChromeProps) {
+export default function AdminChrome({
+  children,
+  initialAdminCapabilities,
+}: AdminChromeProps) {
   const { setFolded } = useSidebarState();
   const { isMobile } = useScreenSize();
   const pathname = usePathname();
   const settings = useSettingsContext();
   const router = useRouter();
-  const { adminCapabilities } = useUser();
+  const { adminCapabilities: liveAdminCapabilities } = useUser();
+
+  // Prefer the live value so mid-session changes reflect without a reload; an empty client
+  // set means still-loading (every admin here has capabilities), so use the server seed then.
+  const adminCapabilities =
+    liveAdminCapabilities.length > 0
+      ? liveAdminCapabilities
+      : initialAdminCapabilities;
 
   // Match-only per-page gate: if this page is a known admin route the user lacks the
   // permission for (a group manager landing on a full-admin page), send them to their

--- a/web/src/layouts/chromes/AdminSSChrome.tsx
+++ b/web/src/layouts/chromes/AdminSSChrome.tsx
@@ -17,8 +17,11 @@ export default async function AdminSSChrome({ children }: AdminSSChromeProps) {
     return redirect(authResult.redirect as Route);
   }
 
+  // Seed the client gate so a cold deep-link doesn't self-redirect before /api/me loads.
   return (
-    <AdminChrome>
+    <AdminChrome
+      initialAdminCapabilities={authResult.user?.admin_capabilities ?? []}
+    >
       <AnnouncementBanner />
       {children}
     </AdminChrome>

--- a/web/src/layouts/craft/CraftManageLayout.tsx
+++ b/web/src/layouts/craft/CraftManageLayout.tsx
@@ -8,22 +8,22 @@ interface CraftManageLayoutProps {
   children: React.ReactNode;
 }
 
-// Server-side admin-only gate (the /api/admin/* endpoints exclude curators,
-// unlike requireAdminAuth which allows them).
-export default async function CraftManageLayout({
-  children,
-}: CraftManageLayoutProps) {
-  const authResult = await requireAuth();
-  if (authResult.redirect) {
-    return redirect(authResult.redirect as Route);
-  }
-  if (
-    !hasPermission(
-      authResult.user?.effective_permissions ?? [],
-      Permission.FULL_ADMIN_PANEL_ACCESS
-    )
-  ) {
-    return redirect("/craft/v1" as Route);
-  }
-  return <>{children}</>;
+// Two routes share this factory but need different gates: /skills/manage passes
+// MANAGE_SKILLS (lets scoped managers in), /apps/manage passes FULL_ADMIN_PANEL_ACCESS
+// (its /admin/apps endpoints are admin-only). Both read admin_capabilities, which adds
+// the scoped-manager perms but never the full-admin token — so the apps gate still
+// rejects scoped managers.
+export function createCraftManageLayout(required: Permission) {
+  return async function CraftManageLayout({
+    children,
+  }: CraftManageLayoutProps) {
+    const authResult = await requireAuth();
+    if (authResult.redirect) {
+      return redirect(authResult.redirect as Route);
+    }
+    if (!hasPermission(authResult.user?.admin_capabilities ?? [], required)) {
+      return redirect("/craft/v1" as Route);
+    }
+    return <>{children}</>;
+  };
 }

--- a/web/src/lib/admin-routes.ts
+++ b/web/src/lib/admin-routes.ts
@@ -487,3 +487,18 @@ export function isVectorDbRequiredRoute(pathname: string): boolean {
     pathname.startsWith(prefix)
   );
 }
+
+/**
+ * The admin route whose path is the longest prefix of `pathname`, or undefined if none
+ * matches. Detail sub-pages covered by no entry return undefined, so the per-page gate
+ * leaves them alone rather than default-denying.
+ */
+export function matchAdminRoute(pathname: string): AdminRouteEntry | undefined {
+  let match: AdminRouteEntry | undefined;
+  for (const route of Object.values(ADMIN_ROUTES) as AdminRouteEntry[]) {
+    if (pathname === route.path || pathname.startsWith(route.path + "/")) {
+      if (!match || route.path.length > match.path.length) match = route;
+    }
+  }
+  return match;
+}

--- a/web/src/lib/admin-sidebar-utils.ts
+++ b/web/src/lib/admin-sidebar-utils.ts
@@ -47,7 +47,7 @@ export function buildItems(
       requiredTier: route.requiredTier,
     };
 
-    // Special case: INDEX_SETTINGS shows reindexing error indicator
+    // INDEX_SETTINGS surfaces a reindexing-needed error indicator
     if (route.path === ADMIN_ROUTES.INDEX_SETTINGS.path) {
       item.error = settings?.settings.needs_reindexing;
     }
@@ -55,7 +55,6 @@ export function buildItems(
     items.push(item);
   }
 
-  // Upgrade Plan — only for full admins without a subscription
   if (
     userCanAccess(Permission.FULL_ADMIN_PANEL_ACCESS) &&
     !flags.hasSubscription

--- a/web/src/lib/agents/types.ts
+++ b/web/src/lib/agents/types.ts
@@ -53,6 +53,8 @@ export interface MinimalAgent {
   builtin_persona: boolean;
   labels?: AgentLabel[];
   owner: MinimalUserSnapshot | null;
+  // per-action affordance map stamped by the list endpoints; empty/absent → fail-closed
+  permissions?: Record<string, boolean>;
 }
 
 export interface Agent extends MinimalAgent {
@@ -69,6 +71,8 @@ export interface Agent extends MinimalAgent {
 
 export interface FullAgent extends Agent {
   search_start_date: string | null;
+  // per-action affordance map for the requesting user; stamped by GET /persona/{id}
+  permissions: Record<string, boolean>;
 }
 
 // ── Upsert / API parameter types ──────────────────────────────────────────────

--- a/web/src/lib/auth/requireAuth.ts
+++ b/web/src/lib/auth/requireAuth.ts
@@ -100,8 +100,9 @@ export async function requireAdminAuth(): Promise<AuthCheckResult> {
 
   const { user, authTypeMetadata } = authResult;
 
-  // Check if user has any admin permission
-  if (user && !hasAnyAdminPermission(user.effective_permissions ?? [])) {
+  // Admit anyone who can reach any admin area — a group manager qualifies via the
+  // scoped bundle in admin_capabilities. Per-page and backend gates scope from here.
+  if (user && !hasAnyAdminPermission(user.admin_capabilities ?? [])) {
     return {
       user,
       authTypeMetadata,

--- a/web/src/lib/permissions.test.ts
+++ b/web/src/lib/permissions.test.ts
@@ -67,7 +67,7 @@ describe("hasAnyAdminPermission", () => {
   });
 
   it("returns false when the user only holds non-admin permissions", () => {
-    // BASIC_ACCESS is not gating any admin route — it should not unlock admin.
+    // BASIC_ACCESS gates no admin route, so it must not unlock admin.
     expect(hasAnyAdminPermission([Permission.BASIC_ACCESS])).toBe(false);
   });
 
@@ -86,9 +86,8 @@ describe("hasAnyAdminPermission", () => {
 
 describe("getFirstPermittedAdminRoute", () => {
   it("returns the first sidebar-labelled route for a full admin", () => {
-    // FULL_ADMIN_PANEL_ACCESS unlocks every route — we expect the very first
-    // entry in ADMIN_ROUTES declaration order that has a non-empty
-    // sidebarLabel. Today that is LLM_MODELS.
+    // FULL_ADMIN_PANEL_ACCESS unlocks every route, so the first ADMIN_ROUTES
+    // entry (declaration order) with a non-empty sidebarLabel wins — today LLM_MODELS.
     expect(
       getFirstPermittedAdminRoute([Permission.FULL_ADMIN_PANEL_ACCESS])
     ).toBe(ADMIN_ROUTES.LLM_MODELS.path);

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -1,0 +1,25 @@
+// Per-resource action vocabularies, hand-written to match the keys the server stamps
+// on each resource's `permissions` map. A backend coverage test guards that the server
+// never stamps a key absent here, so this stays in sync without a codegen pipeline.
+
+export interface WithPermissions {
+  permissions?: Record<string, boolean>;
+}
+
+export const RESOURCE_ACTIONS = {
+  ConnectorIndexingStatusLite: ["edit", "delete", "publish"],
+  CCPairFullInfo: ["edit", "delete", "publish"],
+} as const;
+
+export type ResourceName = keyof typeof RESOURCE_ACTIONS;
+export type ResourceAction<R extends ResourceName> =
+  (typeof RESOURCE_ACTIONS)[R][number];
+
+// Fail-closed: a missing resource or unstamped key reads as false, so a control the
+// server hasn't authorized (or a new action an older client predates) never renders.
+export function can(
+  resource: WithPermissions | null | undefined,
+  action: string
+): boolean {
+  return resource?.permissions?.[action] ?? false;
+}

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -13,17 +13,30 @@ export const RESOURCE_ACTIONS = {
   MCPServer: ["edit", "delete", "authenticate", "manage_status"],
   CustomSkill: ["edit", "manage_access", "delete", "publish"],
   UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],
+  Agent: [
+    "edit",
+    "share",
+    "view_stats",
+    "delete",
+    "publish",
+    "feature",
+    "list",
+    "reorder",
+  ],
 } as const;
 
 export type ResourceName = keyof typeof RESOURCE_ACTIONS;
 export type ResourceAction<R extends ResourceName> =
   (typeof RESOURCE_ACTIONS)[R][number];
 
+// Union of all actions — makes a typo a compile error, not a silent false.
+export type AnyResourceAction = ResourceAction<ResourceName>;
+
 // Fail-closed: a missing resource or unstamped key reads as false, so a control the
 // server hasn't authorized (or a new action an older client predates) never renders.
 export function can(
   resource: WithPermissions | null | undefined,
-  action: string
+  action: AnyResourceAction
 ): boolean {
   return resource?.permissions?.[action] ?? false;
 }

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -9,6 +9,10 @@ export interface WithPermissions {
 export const RESOURCE_ACTIONS = {
   ConnectorIndexingStatusLite: ["edit", "delete", "publish"],
   CCPairFullInfo: ["edit", "delete", "publish"],
+  ToolSnapshot: ["edit", "delete", "toggle", "authenticate"],
+  MCPServer: ["edit", "delete", "authenticate", "manage_status"],
+  CustomSkill: ["edit", "manage_access", "delete", "publish"],
+  UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],
 } as const;
 
 export type ResourceName = keyof typeof RESOURCE_ACTIONS;

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -67,6 +67,7 @@ export interface MCPTool {
   icon?: React.FunctionComponent<IconProps>;
   isAvailable: boolean;
   isEnabled: boolean;
+  permissions?: Record<string, boolean>;
 }
 
 export interface MethodSpec {

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -39,6 +39,8 @@ export interface MCPServer {
   status: MCPServerStatus;
   last_refreshed_at?: string;
   tool_count: number;
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export interface MCPServersResponse {
@@ -112,6 +114,9 @@ export interface ToolSnapshot {
   chat_selectable: boolean;
   agent_creation_selectable: boolean;
   default_enabled: boolean;
+
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export enum MCPAuthenticationType {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -78,6 +78,7 @@ export enum Permission {
   MANAGE_ACTIONS = "manage:actions",
   READ_QUERY_HISTORY = "read:query_history",
   MANAGE_USER_GROUPS = "manage:user_groups",
+  MANAGE_SKILLS = "manage:skills",
   CREATE_USER_API_KEYS = "create:user_api_keys",
   MANAGE_SERVICE_ACCOUNT_API_KEYS = "manage:service_account_api_keys",
   MANAGE_BOTS = "manage:bots",
@@ -132,6 +133,9 @@ export interface User {
   is_admin?: boolean;
   // True if the user manages any group (drives manager nav visibility).
   is_group_manager?: boolean;
+  // effective tokens plus the scoped manager bundle; source for coarse admin-reach
+  // checks (nav, page access). Server-computed so the client never re-derives policy.
+  admin_capabilities?: string[];
 }
 
 export interface TenantInfo {
@@ -300,6 +304,8 @@ export interface ConnectorIndexingStatusLite {
   last_status: ValidStatuses | null;
   last_success: string | null;
   is_editable: boolean;
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: Record<string, boolean>;
   docs_indexed: number;
   in_repeated_error_state: boolean;
   latest_index_attempt_docs_indexed: number | null;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -452,6 +452,8 @@ export interface DocumentSetSummary {
   is_public: boolean;
   users: string[];
   groups: number[];
+  // per-action affordance map for the requesting user (mirrors the write-side gate)
+  permissions: Record<string, boolean>;
   federated_connector_summaries: FederatedConnectorSummary[];
 }
 
@@ -549,6 +551,8 @@ export interface UserGroup {
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
   is_default: boolean;
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export enum ValidSources {

--- a/web/src/providers/UserProvider.tsx
+++ b/web/src/providers/UserProvider.tsx
@@ -34,6 +34,9 @@ interface UserContextType {
   isAdmin: boolean;
   hasAdminAccess: boolean;
   permissions: string[];
+  // Coarse admin-reach set: effective tokens plus the scoped manager bundle. Feeds
+  // nav/page gates so a group manager is included; org-wide checks still use isAdmin.
+  adminCapabilities: string[];
   refreshUser: () => Promise<void>;
   isCloudSuperuser: boolean;
   authTypeMetadata: AuthTypeMetadata;
@@ -569,9 +572,11 @@ export function UserProvider({ children }: { children: React.ReactNode }) {
           upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS
         ).includes(Permission.FULL_ADMIN_PANEL_ACCESS),
         hasAdminAccess: hasAnyAdminPermission(
-          upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS
+          upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS
         ),
         permissions: upToDateUser?.effective_permissions ?? EMPTY_PERMISSIONS,
+        adminCapabilities:
+          upToDateUser?.admin_capabilities ?? EMPTY_PERMISSIONS,
         isCloudSuperuser: upToDateUser?.is_cloud_superuser ?? false,
       }}
     >

--- a/web/src/refresh-components/auth/Can.tsx
+++ b/web/src/refresh-components/auth/Can.tsx
@@ -1,0 +1,19 @@
+import { can, WithPermissions } from "@/lib/permissions/resource-actions";
+
+interface CanProps {
+  resource: WithPermissions | null | undefined;
+  action: string;
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+}
+
+// Renders children only when the server authorized `action` on `resource`. The client
+// reads that answer; it never recomputes policy.
+export default function Can({
+  resource,
+  action,
+  children,
+  fallback = null,
+}: CanProps) {
+  return <>{can(resource, action) ? children : fallback}</>;
+}

--- a/web/src/refresh-components/auth/Can.tsx
+++ b/web/src/refresh-components/auth/Can.tsx
@@ -1,8 +1,12 @@
-import { can, WithPermissions } from "@/lib/permissions/resource-actions";
+import {
+  AnyResourceAction,
+  can,
+  WithPermissions,
+} from "@/lib/permissions/resource-actions";
 
 interface CanProps {
   resource: WithPermissions | null | undefined;
-  action: string;
+  action: AnyResourceAction;
   children: React.ReactNode;
   fallback?: React.ReactNode;
 }

--- a/web/src/refresh-pages/UserSkillsPage.tsx
+++ b/web/src/refresh-pages/UserSkillsPage.tsx
@@ -10,6 +10,8 @@ import TextSeparator from "@/refresh-components/TextSeparator";
 import useOnMount from "@/hooks/useOnMount";
 import useUserSkills from "@/hooks/useUserSkills";
 import { useUser } from "@/providers/UserProvider";
+import { useCapabilities } from "@/hooks/useCapabilities";
+import { Permission } from "@/lib/types";
 import SkillCard, {
   type CustomSkillCardItem,
   type SkillCardItem,
@@ -29,7 +31,9 @@ import { toast } from "@/hooks/useToast";
 
 export default function UserSkillsPage() {
   const { data, error, isLoading, refresh } = useUserSkills();
-  const { user, isAdmin } = useUser();
+  const { user } = useUser();
+  // Gate on admin_capabilities/MANAGE_SKILLS so scoped skill managers reach the manage entry, not just admins.
+  const canManageSkills = useCapabilities(Permission.MANAGE_SKILLS);
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CustomSkillCardItem | null>(
@@ -165,7 +169,7 @@ export default function UserSkillsPage() {
         description="Capability bundles your Craft agent can reach for. This page shows what's currently available to you — skills granted by admins plus your own personal skills."
         rightChildren={
           <div className="flex items-center gap-2">
-            {isAdmin && (
+            {canManageSkills && (
               <Button
                 href="/craft/v1/skills/manage"
                 prominence="secondary"

--- a/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
+++ b/web/src/refresh-pages/admin/AgentsPage/AgentRowActions.tsx
@@ -37,9 +37,7 @@ import {
 } from "@/lib/agents/svc";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
-import { useUser } from "@/providers/UserProvider";
-import { hasPermission } from "@/lib/permissions";
-import { Permission } from "@/lib/types";
+import { can } from "@/lib/permissions/resource-actions";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -59,14 +57,20 @@ export default function AgentRowActions({
   onMutate,
 }: AgentRowActionsProps) {
   const router = useRouter();
-  const { isAdmin, permissions } = useUser();
- const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
-    Permission.MANAGE_AGENTS
-  );
+  const businessTier = useTierAtLeast(Tier.BUSINESS);
   const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
   const shareModal = useCreateModal();
+
+  // Per-row affordances ride on the full agent's server-stamped permission map,
+  // so a scoped manager only sees actions the backend will actually allow.
+  const canEdit = can(fullAgent, "edit");
+  const canList = can(fullAgent, "list");
+  const canUpdateFeaturedStatus = can(fullAgent, "feature");
+  const canShare = can(fullAgent, "share");
+  const canViewStats = can(fullAgent, "view_stats");
+  const canDeleteRow = !agent.builtin_persona && can(fullAgent, "delete");
+  const hasOverflowItems =
+    canList || canShare || (businessTier && canViewStats) || canDeleteRow;
 
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -148,7 +152,7 @@ export default function AgentRowActions({
             appear-on-hover animation. Making Hoverable more extensible
             (e.g. supporting table row groups) would let us use it here
             instead of raw Tailwind group-hover. */}
-        {!agent.builtin_persona && (
+        {!agent.builtin_persona && canEdit && (
           <div className="opacity-0 group-hover/row:opacity-100 transition-opacity">
             <Button
               prominence="tertiary"
@@ -164,112 +168,119 @@ export default function AgentRowActions({
             />
           </div>
         )}
-        {!agent.is_listed ? (
-          <Button
-            prominence="tertiary"
-            icon={SvgEyeOff}
-            tooltip="Re-list Agent"
-            onClick={() =>
-              handleAction(
-                () => toggleAgentListed(agent.id, agent.is_listed),
-                () => {}
-              )
-            }
-          />
-        ) : (
-          <div
-            className={cn(
-              !agent.is_featured &&
-                "opacity-0 group-hover/row:opacity-100 transition-opacity"
+        {!agent.is_listed
+          ? canList && (
+              <Button
+                prominence="tertiary"
+                icon={SvgEyeOff}
+                tooltip="Re-list Agent"
+                onClick={() =>
+                  handleAction(
+                    () => toggleAgentListed(agent.id, agent.is_listed),
+                    () => {}
+                  )
+                }
+              />
+            )
+          : canUpdateFeaturedStatus && (
+              <div
+                className={cn(
+                  !agent.is_featured &&
+                    "opacity-0 group-hover/row:opacity-100 transition-opacity"
+                )}
+              >
+                <Button
+                  prominence="tertiary"
+                  icon={SvgStar}
+                  interaction={featuredOpen ? "hover" : "rest"}
+                  tooltip={
+                    agent.is_featured ? "Remove Featured" : "Set as Featured"
+                  }
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    setFeaturedOpen(true);
+                  }}
+                />
+              </div>
             )}
-          >
-            <Button
-              prominence="tertiary"
-              icon={SvgStar}
-              interaction={featuredOpen ? "hover" : "rest"}
-              tooltip={
-                agent.is_featured ? "Remove Featured" : "Set as Featured"
-              }
-              onClick={() => {
-                setPopoverOpen(false);
-                setFeaturedOpen(true);
-              }}
-            />
-          </div>
-        )}
 
         {/* Overflow menu */}
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <div
-            className={cn(
-              !popoverOpen &&
-                "opacity-0 group-hover/row:opacity-100 transition-opacity"
-            )}
-          >
-            <Popover.Trigger asChild>
-              <Button prominence="tertiary" icon={SvgMoreHorizontal} />
-            </Popover.Trigger>
-          </div>
-          <Popover.Content align="end" width="sm">
-            <PopoverMenu>
-              {[
-                <LineItem
-                  key="visibility"
-                  icon={agent.is_listed ? SvgEyeOff : SvgEye}
-                  onClick={() => {
-                    setPopoverOpen(false);
-                    if (agent.is_listed) {
-                      setUnlistOpen(true);
-                    } else {
-                      handleAction(
-                        () => toggleAgentListed(agent.id, agent.is_listed),
-                        () => {}
-                      );
-                    }
-                  }}
-                >
-                  {agent.is_listed ? "Unlist Agent" : "List Agent"}
-                </LineItem>,
-                <LineItem
-                  key="share"
-                  icon={SvgShare}
-                  onClick={() => {
-                    setPopoverOpen(false);
-                    shareModal.toggle(true);
-                  }}
-                >
-                  Share
-                </LineItem>,
-                businessTier ? (
-                  <LineItem
-                    key="stats"
-                    icon={SvgBarChart}
-                    onClick={() => {
-                      setPopoverOpen(false);
-                      router.push(`/ee/agents/stats/${agent.id}` as Route);
-                    }}
-                  >
-                    Stats
-                  </LineItem>
-                ) : undefined,
-                !agent.builtin_persona ? null : undefined,
-                !agent.builtin_persona ? (
-                  <LineItem
-                    key="delete"
-                    icon={SvgTrash}
-                    danger
-                    onClick={() => {
-                      setPopoverOpen(false);
-                      setDeleteOpen(true);
-                    }}
-                  >
-                    Delete
-                  </LineItem>
-                ) : undefined,
-              ]}
-            </PopoverMenu>
-          </Popover.Content>
-        </Popover>
+        {hasOverflowItems && (
+          <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+            <div
+              className={cn(
+                !popoverOpen &&
+                  "opacity-0 group-hover/row:opacity-100 transition-opacity"
+              )}
+            >
+              <Popover.Trigger asChild>
+                <Button prominence="tertiary" icon={SvgMoreHorizontal} />
+              </Popover.Trigger>
+            </div>
+            <Popover.Content align="end" width="sm">
+              <PopoverMenu>
+                {[
+                  canList ? (
+                    <LineItem
+                      key="visibility"
+                      icon={agent.is_listed ? SvgEyeOff : SvgEye}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        if (agent.is_listed) {
+                          setUnlistOpen(true);
+                        } else {
+                          handleAction(
+                            () => toggleAgentListed(agent.id, agent.is_listed),
+                            () => {}
+                          );
+                        }
+                      }}
+                    >
+                      {agent.is_listed ? "Unlist Agent" : "List Agent"}
+                    </LineItem>
+                  ) : undefined,
+                  canShare ? (
+                    <LineItem
+                      key="share"
+                      icon={SvgShare}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        shareModal.toggle(true);
+                      }}
+                    >
+                      Share
+                    </LineItem>
+                  ) : undefined,
+                  businessTier && canViewStats ? (
+                    <LineItem
+                      key="stats"
+                      icon={SvgBarChart}
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        router.push(`/ee/agents/stats/${agent.id}` as Route);
+                      }}
+                    >
+                      Stats
+                    </LineItem>
+                  ) : undefined,
+                  canDeleteRow ? (
+                    <LineItem
+                      key="delete"
+                      icon={SvgTrash}
+                      danger
+                      onClick={() => {
+                        setPopoverOpen(false);
+                        setDeleteOpen(true);
+                      }}
+                    >
+                      Delete
+                    </LineItem>
+                  ) : undefined,
+                ]}
+              </PopoverMenu>
+            </Popover.Content>
+          </Popover>
+        )}
       </div>
 
       {deleteOpen && (

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -12,6 +12,7 @@ import {
   SvgMinusCircle,
   SvgPlusCircle,
   SvgSimpleLoader,
+  SvgShield,
 } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -38,13 +39,14 @@ import {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 } from "./svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import SharedGroupResources from "@/refresh-pages/admin/GroupsPage/SharedGroupResources";
 import GroupPermissionsSection from "./GroupPermissionsSection";
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
-import { useUser } from "@/providers/UserProvider";
+import { can } from "@/lib/permissions/resource-actions";
 
 const addModeColumns = memberTableColumns;
 
@@ -67,7 +69,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const tokenLimitsDisabledTooltip = markdown(
     "Token rate limits are available on the [Enterprise version of Onyx](/admin/billing) only."
   );
-  const { isAdmin } = useUser();
 
   // Fetch the group data — poll every 5s while syncing so the UI updates
   // automatically when the backend finishes processing the previous edit.
@@ -87,22 +88,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [groups, groupId]
   );
 
+  const canManage = can(group, "manage");
+  const canDelete = can(group, "delete");
+  const canEditPermissions = can(group, "edit_permissions");
+  const canEditTokenLimits = can(group, "edit_token_limits");
+
   const isSyncing = group != null && !group.is_up_to_date;
 
-  // Fetch token rate limits for this group. Skip retry on tier-gated 402
-  // (BUSINESS-tier tenants don't have access) so SWR doesn't churn the form
-  // by repeatedly flipping its isLoading state.
+  // Gate on edit_token_limits so a non-manager (who'd 403 on the read) skips the fetch.
+  // Skip retry on tier-gated 402 so SWR doesn't churn isLoading.
   const { data: tokenRateLimits, isLoading: tokenLimitsLoading } = useSWR<
     TokenRateLimitDisplay[]
-  >(SWR_KEYS.userGroupTokenRateLimit(groupId), errorHandlingFetcher, {
-    onErrorRetry: skipRetryOnAuthError,
-  });
+  >(
+    canEditTokenLimits ? SWR_KEYS.userGroupTokenRateLimit(groupId) : null,
+    errorHandlingFetcher,
+    { onErrorRetry: skipRetryOnAuthError }
+  );
 
   // Fetch permissions for this group (admin only)
   const { data: groupPermissions, isLoading: permissionsLoading } = useSWR<
     string[]
   >(
-    isAdmin ? SWR_KEYS.userGroupPermissions(groupId) : null,
+    canEditPermissions ? SWR_KEYS.userGroupPermissions(groupId) : null,
     errorHandlingFetcher
   );
 
@@ -192,25 +199,93 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setSelectedUserIds((prev) => prev.filter((id) => id !== userId));
   }, []);
 
+  const managerIds = useMemo(() => new Set(group?.manager_ids ?? []), [group]);
+  // Manager must be a saved member (can't assign one that isn't persisted yet).
+  const persistedMemberIds = useMemo(
+    () => new Set(group?.users.map((u) => u.id) ?? []),
+    [group]
+  );
+  const [pendingManagerIds, setPendingManagerIds] = useState<Set<string>>(
+    () => new Set()
+  );
+
+  // Hits its endpoint immediately (member add/remove defers to Save), then revalidates.
+  const handleToggleManager = useCallback(
+    async (userId: string, makeManager: boolean) => {
+      setPendingManagerIds((prev) => new Set(prev).add(userId));
+      try {
+        await setGroupManager(groupId, userId, makeManager);
+        await mutate(SWR_KEYS.adminUserGroups);
+        toast.success(makeManager ? "Manager assigned" : "Manager revoked");
+      } catch (err) {
+        console.error("Failed to update manager:", err);
+        toast.error(
+          err instanceof Error ? err.message : "Failed to update manager"
+        );
+      } finally {
+        setPendingManagerIds((prev) => {
+          const next = new Set(prev);
+          next.delete(userId);
+          return next;
+        });
+      }
+    },
+    [groupId, mutate]
+  );
+
   const memberColumns = useMemo(
     () => [
       ...baseColumns,
       tc.actions({
         showSorting: false,
         showColumnVisibility: false,
-        cell: (row: MemberRow) => (
-          <IconButton
-            icon={SvgMinusCircle}
-            tertiary
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRemoveMember(row.id ?? row.email);
-            }}
-          />
-        ),
+        cell: (row: MemberRow) => {
+          if (!canManage) return null;
+          const userId = row.id ?? row.email;
+          const isManager = managerIds.has(userId);
+          const isPersisted = persistedMemberIds.has(userId);
+          const isPending = pendingManagerIds.has(userId);
+          return (
+            <div className="flex items-center gap-1">
+              <IconButton
+                icon={isPending ? SvgSimpleLoader : SvgShield}
+                tertiary
+                transient={isManager}
+                disabled={!isPersisted || isPending}
+                aria-label={isManager ? "Revoke manager" : "Make manager"}
+                tooltip={
+                  !isPersisted
+                    ? "Save the group before assigning a manager"
+                    : isManager
+                      ? "Revoke manager"
+                      : "Make manager"
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleToggleManager(userId, !isManager);
+                }}
+              />
+              <IconButton
+                icon={SvgMinusCircle}
+                tertiary
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemoveMember(userId);
+                }}
+              />
+            </div>
+          );
+        },
       }),
     ],
-    [handleRemoveMember]
+    [
+      handleRemoveMember,
+      handleToggleManager,
+      managerIds,
+      persistedMemberIds,
+      pendingManagerIds,
+      canManage,
+    ]
   );
 
   // IDs of members not visible in the add-mode table (e.g. inactive users).
@@ -278,13 +353,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         selectedDocSetIds
       );
 
-      // Save token rate limits (create/update/delete) — Enterprise-only
-      if (isEnterpriseTier) {
+      // Group-scoped create/update/delete routes admit a group admin, so their full save
+      // (including PUT/DELETE of existing limits) is authorized.
+      if (isEnterpriseTier && canEditTokenLimits) {
         await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
       }
 
-      // Save permissions (bulk desired-state, admin only)
-      if (isAdmin) {
+      // Bulk desired-state replace; FULL_ADMIN only.
+      if (canEditPermissions) {
         await saveGroupPermissions(groupId, enabledPermissions);
       }
 
@@ -294,7 +370,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       mutate(SWR_KEYS.adminUserGroups);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
-      if (isAdmin) {
+      if (canEditPermissions) {
         mutate(SWR_KEYS.userGroupPermissions(groupId));
       }
       toast.success(`Group "${trimmed}" updated`);
@@ -352,7 +428,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       </Button>
       <Button
         onClick={handleSave}
-        disabled={!groupName.trim() || isSubmitting || isSyncing}
+        disabled={!groupName.trim() || isSubmitting || isSyncing || !canManage}
         tooltip={
           isSyncing
             ? "Document embeddings are being updated due to recent changes to this group."
@@ -436,13 +512,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                       Done
                     </Button>
                   ) : (
-                    <Button
-                      prominence="tertiary"
-                      icon={SvgPlusCircle}
-                      onClick={() => setIsAddingMembers(true)}
-                    >
-                      Add
-                    </Button>
+                    canManage && (
+                      <Button
+                        prominence="tertiary"
+                        icon={SvgPlusCircle}
+                        onClick={() => setIsAddingMembers(true)}
+                      >
+                        Add
+                      </Button>
+                    )
                   )}
                 </Section>
 
@@ -485,7 +563,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 )}
               </Section>
 
-              {isAdmin && (
+              {canEditPermissions && (
                 <GroupPermissionsSection
                   enabledPermissions={enabledPermissions}
                   onPermissionsChange={setEnabledPermissions}
@@ -504,27 +582,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
               <TokenLimitSection
                 limits={tokenLimits}
                 onLimitsChange={setTokenLimits}
-                disabled={!isEnterpriseTier}
+                disabled={!isEnterpriseTier || !canEditTokenLimits}
                 disabledTooltip={tokenLimitsDisabledTooltip}
               />
 
-              {/* Delete This Group */}
-              <Card>
-                <InputHorizontal
-                  title="Delete This Group"
-                  description="Members will lose access to any resources shared with this group."
-                  center
-                >
-                  <Button
-                    variant="danger"
-                    prominence="secondary"
-                    icon={SvgTrash}
-                    onClick={() => setShowDeleteModal(true)}
+              {canDelete && (
+                <Card>
+                  <InputHorizontal
+                    title="Delete This Group"
+                    description="Members will lose access to any resources shared with this group."
+                    center
                   >
-                    Delete Group
-                  </Button>
-                </InputHorizontal>
-              </Card>
+                    <Button
+                      variant="danger"
+                      prominence="secondary"
+                      icon={SvgTrash}
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Delete Group
+                    </Button>
+                  </InputHorizontal>
+                </Card>
+              )}
             </>
           )}
         </SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -18,6 +18,7 @@ import { renameGroup } from "./svc";
 import { toast } from "@/hooks/useToast";
 import { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface GroupCardProps {
   group: UserGroup;
@@ -30,6 +31,7 @@ function GroupCard({ group }: GroupCardProps) {
   const isAdmin = group.name === "Admin";
   const isBasic = group.name === "Basic";
   const isSyncing = !group.is_up_to_date;
+  const canManage = can(group, "manage");
 
   async function handleRename(newName: string) {
     try {
@@ -51,8 +53,10 @@ function GroupCard({ group }: GroupCardProps) {
         sizePreset="main-content"
         variant="section"
         tag={isBasic ? { title: "Default" } : undefined}
-        editable={!builtIn && !isSyncing}
-        onTitleChange={!builtIn && !isSyncing ? handleRename : undefined}
+        editable={!builtIn && !isSyncing && canManage}
+        onTitleChange={
+          !builtIn && !isSyncing && canManage ? handleRename : undefined
+        }
         rightChildren={
           <Section flexDirection="row" alignItems="start" gap={0}>
             <div className="py-1">
@@ -62,13 +66,17 @@ function GroupCard({ group }: GroupCardProps) {
                 )}
               </Text>
             </div>
-            <Button
-              icon={SvgChevronRight}
-              prominence="tertiary"
-              tooltip="View group"
-              aria-label="View group"
-              onClick={() => router.push(`/admin/groups/${group.id}` as Route)}
-            />
+            {canManage && (
+              <Button
+                icon={SvgChevronRight}
+                prominence="tertiary"
+                tooltip="View group"
+                aria-label="View group"
+                onClick={() =>
+                  router.push(`/admin/groups/${group.id}` as Route)
+                }
+              />
+            )}
           </Section>
         }
       />

--- a/web/src/refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupPermissionsSection.tsx
@@ -30,11 +30,8 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import type { PermissionRegistryEntry } from "@/refresh-pages/admin/GroupsPage/interfaces";
 
-// ---------------------------------------------------------------------------
-// Icon mapping — the only permission metadata maintained in the frontend.
-// The `id` keys must match the backend PERMISSION_REGISTRY entries.
-// ---------------------------------------------------------------------------
-
+// Icon mapping — the only permission metadata kept in the frontend.
+// `id` keys must match the backend PERMISSION_REGISTRY entries.
 const ICON_MAP: Record<string, IconFunctionComponent> = {
   manage_llms: SvgCpu,
   manage_connectors_and_document_sets: SvgFiles,
@@ -48,10 +45,6 @@ const ICON_MAP: Record<string, IconFunctionComponent> = {
   view_query_history: SvgHistory,
   create_user_access_token: SvgKey,
 };
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
 
 interface GroupPermissionsSectionProps {
   enabledPermissions: Set<string>;

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Route } from "next";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { SvgExternalLink, SvgUsers, SvgSimpleLoader } from "@opal/icons";
@@ -9,7 +9,11 @@ import { Button, MessageCard } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
+import { Permission } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 import GroupsList from "./GroupsList";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
 import { IllustrationContent } from "@opal/layouts";
@@ -18,12 +22,27 @@ import SvgNoResult from "@opal/illustrations/no-result";
 function GroupsPage() {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
+  const { user } = useUser();
+
+  // Create is global-only (route has no allow_scope); gate on the global token, not
+  // admin_capabilities, which would show it to scoped managers who'd then 403.
+  const canCreateGroup = hasPermission(
+    user?.effective_permissions ?? [],
+    Permission.MANAGE_USER_GROUPS
+  );
 
   const {
     data: groups,
     error,
     isLoading,
   } = useSWR<UserGroup[]>(SWR_KEYS.adminUserGroups, errorHandlingFetcher);
+
+  // The list is READ_USER_GROUPS-scoped (implied by MANAGE_LLMS etc.), so filter to
+  // manageable groups — else a read-only holder sees groups with no open action.
+  const manageableGroups = useMemo(
+    () => (groups ?? []).filter((group) => can(group, "manage")),
+    [groups]
+  );
 
   return (
     <SettingsLayouts.Root>
@@ -53,13 +72,17 @@ function GroupsPage() {
 
       <SettingsLayouts.Body>
         <AdminListHeader
-          hasItems={!isLoading && !error && (groups?.length ?? 0) > 0}
+          hasItems={!isLoading && !error && manageableGroups.length > 0}
           searchQuery={searchQuery}
           onSearchQueryChange={setSearchQuery}
           placeholder="Search groups..."
           emptyStateText="Create groups to organize users and manage access."
-          onAction={() => router.push("/admin/groups/create" as Route)}
-          actionLabel="New Group"
+          onAction={
+            canCreateGroup
+              ? () => router.push("/admin/groups/create" as Route)
+              : undefined
+          }
+          actionLabel={canCreateGroup ? "New Group" : undefined}
         />
 
         {isLoading && <SvgSimpleLoader />}
@@ -73,7 +96,7 @@ function GroupsPage() {
         )}
 
         {!isLoading && !error && groups && (
-          <GroupsList groups={groups} searchQuery={searchQuery} />
+          <GroupsList groups={manageableGroups} searchQuery={searchQuery} />
         )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>

--- a/web/src/refresh-pages/admin/GroupsPage/svc.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/svc.ts
@@ -228,7 +228,7 @@ async function saveTokenLimits(
     const limit = validLimits[i]!;
     const existingLimit = existing[i]!;
     const updateRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -270,7 +270,7 @@ async function saveTokenLimits(
   for (let i = toUpdate; i < existing.length; i++) {
     const existingLimit = existing[i]!;
     const deleteRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       { method: "DELETE" }
     );
     if (!deleteRes.ok) {
@@ -302,6 +302,24 @@ async function saveGroupPermissions(
   }
 }
 
+async function setGroupManager(
+  groupId: number,
+  userId: string,
+  isManager: boolean
+): Promise<void> {
+  const res = await fetch(`${USER_GROUP_URL}/${groupId}/manager`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId, is_manager: isManager }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(
+      detail?.detail ?? `Failed to update group manager: ${res.statusText}`
+    );
+  }
+}
+
 export {
   renameGroup,
   createGroup,
@@ -311,4 +329,5 @@ export {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 };

--- a/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
@@ -12,6 +12,7 @@ import {
 } from "@opal/icons";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,13 @@ export default function CustomSkillRowActions({
 }: CustomSkillRowActionsProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
+  const canEdit = can(skill, "edit");
+  const canManageAccess = can(skill, "manage_access");
+  const canDelete = can(skill, "delete");
+  const hasItems = canEdit || canManageAccess || canDelete;
+
+  if (!hasItems) return null;
+
   return (
     <div className="flex items-center gap-0.5">
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
@@ -55,47 +63,55 @@ export default function CustomSkillRowActions({
         <Popover.Content align="end" width="sm">
           <PopoverMenu>
             {[
-              <LineItem
-                key="share"
-                icon={SvgShare}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onShare();
-                }}
-              >
-                Edit visibility
-              </LineItem>,
-              <LineItem
-                key="replace"
-                icon={SvgUploadCloud}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onReplaceBundle();
-                }}
-              >
-                Replace bundle
-              </LineItem>,
-              <LineItem
-                key="enabled"
-                icon={skill.enabled ? SvgEyeOff : SvgEye}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onToggleEnabled();
-                }}
-              >
-                {skill.enabled ? "Disable" : "Re-enable"}
-              </LineItem>,
-              <LineItem
-                key="delete"
-                icon={SvgTrash}
-                danger
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onDelete();
-                }}
-              >
-                Delete
-              </LineItem>,
+              canManageAccess ? (
+                <LineItem
+                  key="share"
+                  icon={SvgShare}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onShare();
+                  }}
+                >
+                  Edit visibility
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="replace"
+                  icon={SvgUploadCloud}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onReplaceBundle();
+                  }}
+                >
+                  Replace bundle
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="enabled"
+                  icon={skill.enabled ? SvgEyeOff : SvgEye}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onToggleEnabled();
+                  }}
+                >
+                  {skill.enabled ? "Disable" : "Re-enable"}
+                </LineItem>
+              ) : undefined,
+              canDelete ? (
+                <LineItem
+                  key="delete"
+                  icon={SvgTrash}
+                  danger
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onDelete();
+                  }}
+                >
+                  Delete
+                </LineItem>
+              ) : undefined,
             ]}
           </PopoverMenu>
         </Popover.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
@@ -9,6 +9,7 @@ import SkillSharePicker from "@/refresh-pages/admin/SkillsPage/SkillSharePicker"
 import { patchCustomSkill, replaceCustomSkillGrants } from "@/lib/skills/api";
 import { toast } from "@/hooks/useToast";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface ShareSkillModalProps {
   skill: CustomSkill | null;
@@ -104,6 +105,7 @@ export default function ShareSkillModal({
               onIsPublicChange={setIsPublic}
               groupIds={groupIds}
               onGroupIdsChange={setGroupIds}
+              canPublish={can(skill, "publish")}
             />
             {skill.is_personal && (isPublic || groupIds.length > 0) && (
               <MessageCard

--- a/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
@@ -17,6 +17,8 @@ interface SkillSharePickerProps {
   onIsPublicChange: (isPublic: boolean) => void;
   groupIds: number[];
   onGroupIdsChange: (groupIds: number[]) => void;
+  // Org-wide publish is admin-only; fail closed so an omitted value disables the switch.
+  canPublish?: boolean;
 }
 
 /**
@@ -32,6 +34,7 @@ export default function SkillSharePicker({
   onIsPublicChange,
   groupIds,
   onGroupIdsChange,
+  canPublish = false,
 }: SkillSharePickerProps) {
   const {
     data: groupsData,
@@ -137,7 +140,11 @@ export default function SkillSharePicker({
               description="Make this skill available to everyone in your organization."
               withLabel
             >
-              <Switch checked={isPublic} onCheckedChange={onIsPublicChange} />
+              <Switch
+                checked={isPublic}
+                onCheckedChange={onIsPublicChange}
+                disabled={!canPublish}
+              />
             </InputHorizontal>
           </Section>
         </Tabs.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.test.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from "@tests/setup/test-utils";
+import UploadSkillModal from "./UploadSkillModal";
+import { Permission } from "@/lib/types";
+import { useUser } from "@/providers/UserProvider";
+
+jest.mock("@/providers/UserProvider", () => ({
+  useUser: jest.fn(),
+}));
+
+jest.mock("@/hooks/useShareableGroups", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [] })),
+}));
+
+jest.mock("@/lib/skills/api", () => ({
+  createCustomSkill: jest.fn(),
+}));
+
+const mockUseUser = useUser as jest.Mock;
+
+function noop() {}
+
+describe("UploadSkillModal publish default", () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it("opens public-by-default for an admin whose permissions load after mount", async () => {
+    // Mount closed while permissions are still loading (empty set) — the stale-capture case.
+    mockUseUser.mockReturnValue({ permissions: [] });
+    const { rerender } = render(
+      <UploadSkillModal open={false} onClose={noop} onUploaded={noop} />
+    );
+
+    // Permissions resolve (global skill admin) and the dialog opens.
+    mockUseUser.mockReturnValue({ permissions: [Permission.MANAGE_SKILLS] });
+    rerender(<UploadSkillModal open onClose={noop} onUploaded={noop} />);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("tab", { name: "Your Organization" })
+      ).toHaveAttribute("data-state", "active")
+    );
+  });
+
+  it("opens private for a scoped manager without publish permission", async () => {
+    mockUseUser.mockReturnValue({ permissions: [] });
+    render(<UploadSkillModal open onClose={noop} onUploaded={noop} />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("tab", { name: "Groups" })).toHaveAttribute(
+        "data-state",
+        "active"
+      )
+    );
+  });
+});

--- a/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/UploadSkillModal.tsx
@@ -9,6 +9,9 @@ import { Section } from "@/layouts/general-layouts";
 import SkillSharePicker from "@/refresh-pages/admin/SkillsPage/SkillSharePicker";
 import { createCustomSkill } from "@/lib/skills/api";
 import { toast } from "@/hooks/useToast";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { Permission } from "@/lib/types";
 
 interface UploadSkillModalProps {
   open: boolean;
@@ -22,15 +25,33 @@ export default function UploadSkillModal({
   onClose,
   onUploaded,
 }: UploadSkillModalProps) {
+  // Publish is global MANAGE_SKILLS; read effective (global) permissions, not
+  // adminCapabilities — the scoped bundle would over-grant a group manager.
+  const { permissions } = useUser();
+  const canPublish = hasPermission(permissions, Permission.MANAGE_SKILLS);
+
   const [file, setFile] = useState<File | null>(null);
-  const [isPublic, setIsPublic] = useState(true);
+  // Default private for scoped managers; the server 403s their public create.
+  const [isPublic, setIsPublic] = useState(canPublish);
   const [groupIds, setGroupIds] = useState<number[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  // Always-mounted modal: the useState above can capture a stale canPublish while permissions
+  // are still loading. Re-sync the default each time the dialog opens (by then permissions have
+  // loaded). Done during render, not in an effect, so the picker's tab mounts from the corrected
+  // value instead of a frame late.
+  const [wasOpen, setWasOpen] = useState(open);
+  if (open !== wasOpen) {
+    setWasOpen(open);
+    if (open) {
+      setIsPublic(canPublish);
+    }
+  }
+
   function reset() {
     setFile(null);
-    setIsPublic(true);
+    setIsPublic(canPublish);
     setGroupIds([]);
   }
 
@@ -117,6 +138,7 @@ export default function UploadSkillModal({
                 onIsPublicChange={setIsPublic}
                 groupIds={groupIds}
                 onGroupIdsChange={setGroupIds}
+                canPublish={canPublish}
               />
             </Section>
           </Section>

--- a/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
+++ b/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
@@ -43,6 +43,8 @@ export interface CustomSkill {
   created_at: string | null;
   updated_at: string | null;
   granted_group_ids: number[];
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export interface SkillsList {

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -316,7 +316,9 @@ export default function MCPActionCard({
           showOnlyEnabled={showOnlyEnabled}
           onToggleShowOnlyEnabled={handleToggleShowOnlyEnabled}
           onUpdateToolsStatus={
-            canManageStatus
+            // Bulk toggles all tools; the status route 403s the whole batch unless every
+            // tool is manageable, so only offer it when the user can toggle each one.
+            tools.length > 0 && tools.every((tool) => can(tool, "toggle"))
               ? (enabled) => {
                   const toolIds = tools.map((tool) => parseInt(tool.id));
                   onUpdateToolsStatus?.(serverId, toolIds, enabled, mutate);
@@ -337,7 +339,7 @@ export default function MCPActionCard({
               icon={tool.icon}
               isAvailable={tool.isAvailable}
               isEnabled={tool.isEnabled}
-              canToggle={canManageStatus}
+              canToggle={can(tool, "toggle")}
               onToggle={(enabled) =>
                 onToolToggle?.(serverId, tool.id, enabled, mutate)
               }

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -19,6 +19,7 @@ import {
   MCPServer,
 } from "@/lib/tools/interfaces";
 import useServerTools from "@/hooks/useServerTools";
+import { can } from "@/lib/permissions/resource-actions";
 import { KeyedMutator } from "swr";
 import type { IconProps } from "@opal/types";
 import {
@@ -110,6 +111,11 @@ export default function MCPActionCard({
   const [showOnlyEnabled, setShowOnlyEnabled] = useState(false);
   const [isToolsRefreshing, setIsToolsRefreshing] = useState(false);
   const deleteModal = useCreateModal();
+
+  const canEdit = can(server, "edit");
+  const canDelete = can(server, "delete");
+  const canAuthenticate = can(server, "authenticate");
+  const canManageStatus = can(server, "manage_status");
 
   // Update expanded state when initialExpanded changes
   const hasInitializedExpansion = useRef(false);
@@ -206,17 +212,23 @@ export default function MCPActionCard({
       <Actions
         status={status}
         serverName={title}
-        onDisconnect={onDisconnect}
-        onManage={onManage}
-        onAuthenticate={onAuthenticate}
-        onReconnect={onReconnect}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={canManageStatus ? onDisconnect : undefined}
+        onManage={canEdit ? onManage : undefined}
+        onAuthenticate={canAuthenticate ? onAuthenticate : undefined}
+        onReconnect={canManageStatus ? onReconnect : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
         toolCount={toolCount}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={handleToggleTools}
       />
     ),
     [
+      canAuthenticate,
+      canDelete,
+      canEdit,
+      canManageStatus,
       deleteModal,
       handleToggleTools,
       isToolsExpanded,
@@ -251,13 +263,15 @@ export default function MCPActionCard({
 
     return (
       <div className="flex items-center gap-2">
-        <Button
-          icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
-          prominence="internal"
-          onClick={handleRefreshTools}
-          tooltip="Refresh tools"
-          aria-label="Refresh tools"
-        />
+        {canManageStatus && (
+          <Button
+            icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
+            prominence="internal"
+            onClick={handleRefreshTools}
+            tooltip="Refresh tools"
+            aria-label="Refresh tools"
+          />
+        )}
         {lastRefreshedText && (
           <Text as="p" text03 mainUiBody className="whitespace-nowrap">
             Tools last refreshed {lastRefreshedText}
@@ -266,6 +280,7 @@ export default function MCPActionCard({
       </div>
     );
   }, [
+    canManageStatus,
     server.last_refreshed_at,
     serverId,
     mutate,
@@ -281,8 +296,8 @@ export default function MCPActionCard({
         icon={icon}
         status={status}
         actions={actionsComponent}
-        onEdit={onEdit}
-        onRename={handleRename}
+        onEdit={canEdit ? onEdit : undefined}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}
@@ -300,10 +315,14 @@ export default function MCPActionCard({
           enabledCount={tools.filter((tool) => tool.isEnabled).length}
           showOnlyEnabled={showOnlyEnabled}
           onToggleShowOnlyEnabled={handleToggleShowOnlyEnabled}
-          onUpdateToolsStatus={(enabled) => {
-            const toolIds = tools.map((tool) => parseInt(tool.id));
-            onUpdateToolsStatus?.(serverId, toolIds, enabled, mutate);
-          }}
+          onUpdateToolsStatus={
+            canManageStatus
+              ? (enabled) => {
+                  const toolIds = tools.map((tool) => parseInt(tool.id));
+                  onUpdateToolsStatus?.(serverId, toolIds, enabled, mutate);
+                }
+              : undefined
+          }
           isEmpty={filteredTools.length === 0}
           searchQuery={searchQuery}
           emptyMessage="No tools available"
@@ -318,6 +337,7 @@ export default function MCPActionCard({
               icon={tool.icon}
               isAvailable={tool.isAvailable}
               isEnabled={tool.isEnabled}
+              canToggle={canManageStatus}
               onToggle={(enabled) =>
                 onToolToggle?.(serverId, tool.id, enabled, mutate)
               }

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -10,6 +10,7 @@ import { ToolSnapshot, ActionStatus, MethodSpec } from "@/lib/tools/interfaces";
 import ToolItem from "@/sections/actions/ToolItem";
 import { extractMethodSpecsFromDefinition } from "@/lib/tools/openApiService";
 import { updateToolStatus } from "@/lib/tools/mcpService";
+import { can } from "@/lib/permissions/resource-actions";
 import { SvgServer, SvgTrash } from "@opal/icons";
 import Modal from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { Button } from "@opal/components";
@@ -39,6 +40,13 @@ export default function OpenApiActionCard({
   const [searchQuery, setSearchQuery] = useState("");
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const deleteModal = useCreateModal();
+
+  const canEdit = can(tool, "edit");
+  const canDelete = can(tool, "delete");
+  const canToggle = can(tool, "toggle");
+  // Authenticate manages the OAuth config (owner-or-admin) — gate on the server capability,
+  // not canEdit, so a scoped non-owner isn't shown a 403 button.
+  const canAuthenticate = can(tool, "authenticate");
 
   const methodSpecs = useMemo<MethodSpec[]>(() => {
     try {
@@ -121,16 +129,24 @@ export default function OpenApiActionCard({
         toolCount={methodSpecs.length}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={methodSpecs.length ? handleToggleTools : undefined}
-        onDisconnect={() => onOpenDisconnectModal?.(tool)}
-        onManage={onManage ? () => onManage(tool) : undefined}
-        onAuthenticate={() => {
-          onAuthenticate(tool);
-        }}
-        onReconnect={() => handleConnectionUpdate(true)}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={
+          canToggle ? () => onOpenDisconnectModal?.(tool) : undefined
+        }
+        onManage={canEdit && onManage ? () => onManage(tool) : undefined}
+        onAuthenticate={
+          canAuthenticate ? () => onAuthenticate(tool) : undefined
+        }
+        onReconnect={canToggle ? () => handleConnectionUpdate(true) : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
       />
     ),
     [
+      canAuthenticate,
+      canDelete,
+      canEdit,
+      canToggle,
       deleteModal,
       handleConnectionUpdate,
       handleToggleTools,
@@ -159,7 +175,7 @@ export default function OpenApiActionCard({
         icon={SvgServer}
         status={status}
         actions={actionsComponent}
-        onRename={handleRename}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}

--- a/web/src/sections/actions/ToolItem.tsx
+++ b/web/src/sections/actions/ToolItem.tsx
@@ -73,6 +73,7 @@ export interface ToolItemProps {
 
   // Handlers
   onToggle?: (enabled: boolean) => void;
+  canToggle?: boolean;
 
   // Optional styling
   className?: string;
@@ -87,6 +88,7 @@ const ToolItem: React.FC<ToolItemProps> = ({
   variant = "mcp",
   openApiMetadata,
   onToggle,
+  canToggle = true,
   className,
 }) => {
   const isMcpVariant = variant === "mcp";
@@ -226,7 +228,7 @@ const ToolItem: React.FC<ToolItemProps> = ({
             <Switch
               checked={isEnabled}
               onCheckedChange={onToggle}
-              disabled={!isAvailable}
+              disabled={!isAvailable || !canToggle}
               aria-label={`tool-toggle-${name}`}
             />
           </div>

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -11,6 +11,7 @@ import { CopyButton } from "@opal/components";
 import { Button, Divider } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { MethodSpec, ToolSnapshot } from "@/lib/tools/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import {
   validateToolDefinition,
   createCustomTool,
@@ -91,6 +92,11 @@ function FormContent({
   const [url, setUrl] = useState<string | undefined>(undefined);
 
   const isEditMode = Boolean(existingTool);
+  // Editing auth manages the action's OAuth config (owner-or-admin); gate on the same
+  // server-stamped capability as the card.
+  const canEditAuthentication = existingTool
+    ? can(existingTool, "authenticate")
+    : false;
 
   const handleFormat = useCallback(() => {
     if (!values.definition.trim()) {
@@ -370,7 +376,12 @@ function FormContent({
                 }}
               />
               <Button
-                disabled={!onEditAuthentication}
+                disabled={!onEditAuthentication || !canEditAuthentication}
+                tooltip={
+                  !canEditAuthentication
+                    ? "Only the action's creator or an admin can manage authentication"
+                    : undefined
+                }
                 prominence="secondary"
                 type="button"
                 onClick={handleEditAuthenticationClick}

--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -16,10 +16,10 @@ interface AdminListHeaderProps {
   placeholder?: string;
   /** Text shown in the empty-state card when no items exist. */
   emptyStateText: string;
-  /** Called when the action button is clicked. */
-  onAction: () => void;
-  /** Label for the action button. */
-  actionLabel: string;
+  /** Action button click handler. Omit (with actionLabel) to hide the button. */
+  onAction?: () => void;
+  /** Label for the action button. Omit (with onAction) to hide it. */
+  actionLabel?: string;
 }
 
 /**
@@ -59,11 +59,12 @@ export default function AdminListHeader({
   onAction,
   actionLabel,
 }: AdminListHeaderProps) {
-  const actionButton = (
-    <Button rightIcon={SvgPlusCircle} onClick={onAction}>
-      {actionLabel}
-    </Button>
-  );
+  const actionButton =
+    onAction && actionLabel ? (
+      <Button rightIcon={SvgPlusCircle} onClick={onAction}>
+        {actionLabel}
+      </Button>
+    ) : null;
 
   if (!hasItems) {
     return (

--- a/web/src/sections/agents/AgentCard.tsx
+++ b/web/src/sections/agents/AgentCard.tsx
@@ -11,7 +11,7 @@ import { noProp } from "@/lib/utils";
 import { cn } from "@opal/utils";
 import { useRouter } from "next/navigation";
 import type { Route } from "next";
-import { checkUserOwnsAgent } from "@/lib/agents/utils";
+import { can } from "@/lib/permissions/resource-actions";
 import { useTierAtLeast } from "@/hooks/useTierAtLeast";
 import { Tier } from "@/interfaces/settings";
 import {
@@ -19,8 +19,6 @@ import {
   updateAgentFeaturedStatus,
 } from "@/lib/agents/svc";
 import { useUser } from "@/providers/UserProvider";
-import { hasPermission } from "@/lib/permissions";
-import { Permission } from "@/lib/types";
 import {
   SvgActions,
   SvgBarChart,
@@ -52,16 +50,14 @@ export default function AgentCard({ agent }: AgentCardProps) {
     () => pinnedAgents.some((pinnedAgent) => pinnedAgent.id === agent.id),
     [agent.id, pinnedAgents]
   );
-  const { user, isAdmin, permissions } = useUser();
+  const { isAdmin } = useUser();
   const businessTier = useTierAtLeast(Tier.BUSINESS);
-  const canUpdateFeaturedStatus = hasPermission(
-    permissions,
-    Permission.MANAGE_AGENTS
-  );
-  const isOwnedByUser = checkUserOwnsAgent(user, agent);
   const shareAgentModal = useCreateModal();
   const agentViewerModal = useCreateModal();
   const { agent: fullAgent, refresh: refreshAgent } = useAgent(agent.id);
+  // Affordances read the map the list endpoint stamped on `agent`, so icons render with
+  // the card instead of popping in after the per-card fullAgent fetch resolves.
+  const canUpdateFeaturedStatus = can(agent, "feature");
 
   // Start chat and auto-pin unpinned agents to the sidebar
   const handleStartChat = useCallback(() => {
@@ -146,7 +142,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
               description={agent.description}
               rightChildren={
                 <>
-                  {isOwnedByUser && businessTier && (
+                  {can(agent, "view_stats") && businessTier && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgBarChart}
@@ -158,7 +154,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {can(agent, "edit") && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgEdit}
@@ -170,7 +166,7 @@ export default function AgentCard({ agent }: AgentCardProps) {
                       className="hidden group-hover/AgentCard:flex"
                     />
                   )}
-                  {isOwnedByUser && (
+                  {can(agent, "share") && (
                     // TODO(@raunakab): migrate to opal Button once className/iconClassName is resolved
                     <IconButton
                       icon={SvgShare}

--- a/web/src/sections/sidebar/AdminSidebar.tsx
+++ b/web/src/sections/sidebar/AdminSidebar.tsx
@@ -41,7 +41,7 @@ export default function AdminSidebar() {
   }, [focusSearch, folded]);
   const pathname = usePathname();
   const { customAnalyticsEnabled } = useCustomAnalyticsEnabled();
-  const { permissions } = useUser();
+  const { adminCapabilities } = useUser();
   const settings = useSettingsContext();
   const tier = settings?.settings.tier;
   const { data: billingData, isLoading: billingLoading } =
@@ -69,7 +69,7 @@ export default function AdminSidebar() {
       !settings?.settings.hide_query_history_from_admin_panel,
   };
 
-  const allItems = buildItems(permissions, flags, settings);
+  const allItems = buildItems(adminCapabilities, flags, settings);
 
   const itemExtractor = useCallback((item: SidebarItemEntry) => item.name, []);
 

--- a/web/src/sections/sidebar/AppSidebar.tsx
+++ b/web/src/sections/sidebar/AppSidebar.tsx
@@ -470,7 +470,7 @@ const AppSidebar = memo(function AppSidebarInner() {
     ]
   );
 
-  const { isAdmin, hasAdminAccess, permissions, user } = useUser();
+  const { isAdmin, hasAdminAccess, adminCapabilities, user } = useUser();
   const activeSidebarTab = useAppFocus();
   const createProjectModal = useCreateModal();
   const showLogoWhenFolded = useShowLogoWhenFolded();
@@ -578,7 +578,7 @@ const AppSidebar = memo(function AppSidebarInner() {
       <div>
         {hasAdminAccess && (
           <SidebarTab
-            href={getFirstPermittedAdminRoute(permissions)}
+            href={getFirstPermittedAdminRoute(adminCapabilities)}
             icon={SvgSettings}
             folded={folded}
           >
@@ -596,7 +596,7 @@ const AppSidebar = memo(function AppSidebarInner() {
     [
       folded,
       hasAdminAccess,
-      permissions,
+      adminCapabilities,
       handleShowBuildIntro,
       isOnyxCraftEnabled,
     ]

--- a/web/tests/e2e/admin/permissions/permission_gating.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_gating.spec.ts
@@ -73,7 +73,6 @@ test.describe("Permission gating — MANAGE_AGENTS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a custom agent
     const agentName = `E2E Manage Agent ${Date.now()}`;
     const agentId = await adminClient.createAgent(agentName, "Test agent");
 
@@ -114,7 +113,6 @@ test.describe("Permission gating — MANAGE_AGENTS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the agent
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -139,7 +137,6 @@ test.describe("Permission gating — MANAGE_LLMS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates an LLM provider
     const providerName = `E2E Manage LLM ${Date.now()}`;
     const providerId = await adminClient.createProvider(providerName);
 
@@ -182,7 +179,6 @@ test.describe("Permission gating — MANAGE_LLMS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the provider
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -207,7 +203,6 @@ test.describe("Permission gating — MANAGE_CONNECTORS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a file connector
     const connectorName = `E2E Manage Connector ${Date.now()}`;
     const ccPairId = await adminClient.createFileConnector(connectorName);
 
@@ -261,7 +256,6 @@ test.describe("Permission gating — MANAGE_CONNECTORS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the connector
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -286,7 +280,6 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a public file connector
     const connectorName = `E2E DocSet Connector ${Date.now()}`;
     const ccPairId = await adminClient.createFileConnector(
       connectorName,
@@ -340,17 +333,17 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
         page.getByLabel("admin-page-title").getByText("New Document Set")
       ).toBeVisible({ timeout: 10000 });
 
-      // Open the connector dropdown and verify the admin-created connector is listed
+      // Open the connector dropdown
       const connectorSearchInput = page.getByTestId("connector-search-input");
       await expect(connectorSearchInput).toBeVisible({ timeout: 10000 });
       await connectorSearchInput.click();
 
-      // Verify the connector is visible (proves implied READ_CONNECTORS)
+      // Connector visible proves implied READ_CONNECTORS
       await expect(page.getByText(connectorName)).toBeVisible({
         timeout: 10000,
       });
 
-      // Verify group selector loaded successfully (proves implied READ_USER_GROUPS)
+      // Group selector loaded proves implied READ_USER_GROUPS
       await expect(
         page.getByText("Assign group access for this document set")
       ).toBeVisible({ timeout: 10000 });
@@ -381,7 +374,6 @@ test.describe("Permission gating — MANAGE_DOCUMENT_SETS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the connector and extra group
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -407,7 +399,6 @@ test.describe("Permission gating — MANAGE_ACTIONS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates an OpenAPI custom tool and an MCP server
     const toolName = `E2E Manage Tool ${Date.now()}`;
     const toolId = await adminClient.createCustomTool(toolName);
 
@@ -473,7 +464,6 @@ test.describe("Permission gating — MANAGE_ACTIONS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the tool and MCP server
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -499,7 +489,6 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
 
     const { groupId, email, password } = testUserContext;
 
-    // Admin creates a service account
     const accountName = `E2E Service Account ${Date.now()}`;
     const apiKeyId = await adminClient.createServiceAccount(accountName);
 
@@ -561,7 +550,6 @@ test.describe("Permission gating — MANAGE_SERVICE_ACCOUNT_API_KEYS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the service account and extra group
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -647,7 +635,6 @@ test.describe("Permission gating — MANAGE_BOTS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the Discord guild
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -713,7 +700,6 @@ test.describe("Permission gating — READ_QUERY_HISTORY", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete the chat session
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);
@@ -803,7 +789,7 @@ test.describe("Permission gating — CREATE_USER_API_KEYS", () => {
       await expect(newTokenButton).toBeVisible({ timeout: 10000 });
       await expect(newTokenButton).toBeDisabled();
     } finally {
-      // Cleanup: delete the PAT (only requires BASIC_ACCESS)
+      // Delete the PAT (only requires BASIC_ACCESS)
       if (createdPatId !== undefined) {
         await page.context().clearCookies();
         await apiLogin(page, email, password);
@@ -910,7 +896,7 @@ test.describe("Permission gating — MANAGE_USER_GROUPS", () => {
         timeout: 10000,
       });
 
-      // Dismiss the connectors popover by pressing Escape before opening agents
+      // Dismiss the connectors popover before opening agents
       await page.keyboard.press("Escape");
 
       // Open agents popover and verify item (proves READ_AGENTS)
@@ -932,7 +918,7 @@ test.describe("Permission gating — MANAGE_USER_GROUPS", () => {
       await page.waitForLoadState("networkidle");
       expect(page.url()).toContain("/app");
     } finally {
-      // Cleanup: delete resources (doc set before connector since it references it)
+      // Delete doc set before connector since it references it
       await page.context().clearCookies();
       await loginAs(page, "admin");
       const cleanupClient = new OnyxApiClient(page.request);

--- a/web/tests/e2e/admin/permissions/permission_system.spec.ts
+++ b/web/tests/e2e/admin/permissions/permission_system.spec.ts
@@ -50,8 +50,8 @@ test("group permissions apply immediately when a user is added to the group", as
       Permission.MANAGE_LLMS,
     ]);
 
-    // This is intentionally not followed by waitForGroupSync. Auth permission
-    // recomputation is expected to complete before add-users returns.
+    // Intentionally no waitForGroupSync: auth permission recomputation
+    // is expected to complete before add-users returns.
     await adminClient.addUsersToGroup(groupId, [user.id]);
 
     await page.context().clearCookies();


### PR DESCRIPTION
## Description

- Client side of the group-manager UI redesign — components render the server's permission answers instead of re-deriving policy.
- Group managers now see the scoped admin nav: admin-area reach is sourced from the server's `admin_capabilities`.
- New primitives: `<Can resource action>` / `can()` for per-item controls and `useCapabilities()` for coarse "New X"/nav checks.
- A match-only per-page gate redirects a user off a *listed* admin page they lack access to; unlisted detail sub-pages are left alone.
- Connectors read their per-action permission map instead of re-deriving editability client-side.

## How Has This Been Tested?

- `tsgo` type-check + oxlint/oxfmt clean. Runtime nav/gate behavior isn't yet covered by an e2e; the permission data it renders is verified by the backend contract tests in the stacked base PR (#13495).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
