### PR TITLE
feat(perms): PR-C actions + MCP + skills — server-driven capability projection

### DIFF
--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -8,13 +8,20 @@ from ee.onyx.db.token_limit import fetch_all_user_group_token_rate_limits_by_gro
 from ee.onyx.db.token_limit import fetch_user_group_token_rate_limits_for_group
 from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.db.token_limit import delete_token_rate_limit
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.token_limit import get_token_rate_limit_scope_and_group
 from onyx.db.token_limit import insert_user_token_rate_limit
+from onyx.db.token_limit import update_token_rate_limit
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import any_rate_limit_exists
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
@@ -48,9 +55,14 @@ def get_all_group_token_limit_settings(
 @router.get("/user-group/{group_id}")
 def get_group_token_limit_settings(
     group_id: int,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[TokenRateLimitDisplay]:
+    # GATE 2 (read): a scoped manager may only read limits for a group they manage
+    # (global holders bypass). Single-group path param, so assert_manages_group, not a clause.
+    assert_manages_group(user, db_session, group_id=group_id)
     return [
         TokenRateLimitDisplay.from_db(token_rate_limit)
         for token_rate_limit in fetch_user_group_token_rate_limits_for_group(
@@ -89,6 +101,74 @@ def create_group_token_limit_settings(
     # clear cache in case this was the first rate limit created
     any_rate_limit_exists.cache_clear()
     return rate_limit_display
+
+
+def _authorize_group_token_rate_limit_write(
+    user: User, db_session: Session, *, group_id: int, rate_limit_id: int
+) -> None:
+    """Manager-scope gate for a group token-limit write: caller must manage group_id AND
+    the limit must belong to it — so a global/per-user id or another group's limit can't be
+    reached through this path."""
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=[group_id],
+        requested_group_ids=[group_id],
+        is_non_public=True,
+    )
+    try:
+        scope, resolved_group_id = get_token_rate_limit_scope_and_group(
+            db_session, rate_limit_id
+        )
+    except ValueError:
+        scope, resolved_group_id = None, None
+    if scope != TokenRateLimitScope.USER_GROUP or resolved_group_id != group_id:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, "Token rate limit not found for this group."
+        )
+
+
+# Separate from the shared by-id routes so this route's require_permission caps a scoped
+# PAT to MANAGE_USER_GROUPS; a shared route would expose FULL_ADMIN global/user limits.
+@router.put("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def update_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    token_limit_settings: TokenRateLimitArgs,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> TokenRateLimitDisplay:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    rate_limit_display = TokenRateLimitDisplay.from_db(
+        update_token_rate_limit(
+            db_session=db_session,
+            token_rate_limit_id=rate_limit_id,
+            token_rate_limit_settings=token_limit_settings,
+        )
+    )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
+
+
+@router.delete("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def delete_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> None:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    delete_token_rate_limit(db_session=db_session, token_rate_limit_id=rate_limit_id)
+    any_rate_limit_exists.cache_clear()
 
 
 """

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -25,6 +25,7 @@ from ee.onyx.server.user_group.models import UserGroup
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
@@ -33,6 +34,7 @@ from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import manages_group
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
@@ -61,10 +63,16 @@ def list_user_groups(
     # implies it) sees every group; a scoped manager sees only the groups they
     # manage. The group list has no built-in membership filter, so restrict it here
     # or a manager would see the whole org.
+    # Resolve scope + global authority once so per-group stamping is pure set math (no query).
+    managed_group_ids = get_scoped_groups(
+        user, db_session, Permission.MANAGE_USER_GROUPS
+    )
+    is_user_groups_admin = has_global_permission(user, Permission.MANAGE_USER_GROUPS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
     restrict_to_group_ids = (
         None
         if has_global_permission(user, Permission.READ_USER_GROUPS)
-        else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+        else managed_group_ids
     )
     user_groups = fetch_user_groups(
         db_session,
@@ -75,7 +83,20 @@ def list_user_groups(
     )
     mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        UserGroup.from_model(user_group, mask_credential_prefix=mask_credential_prefix)
+        UserGroup.from_model(
+            user_group,
+            mask_credential_prefix=mask_credential_prefix,
+            permissions=user_group_permissions(
+                can_manage=manages_group(
+                    user,
+                    db_session,
+                    group_id=user_group.id,
+                    managed_group_ids=managed_group_ids,
+                ),
+                is_user_groups_admin=is_user_groups_admin,
+                is_full_admin=is_full_admin,
+            ),
+        )
         for user_group in user_groups
     ]
 

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.auth.permissions import Permission
 from onyx.db.models import UserGroup as UserGroupModel
@@ -24,6 +25,10 @@ class UserGroup(BaseModel):
     is_up_to_date: bool
     is_up_for_deletion: bool
     is_default: bool
+    # Per-action affordance map ({"manage": true, ...}) the client reads to show/hide
+    # controls. Empty default = every action denied (missing key is false), so it fails
+    # closed. Only the list-groups endpoint fills it in; the mutation routes leave it empty.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -31,8 +36,10 @@ class UserGroup(BaseModel):
         user_group_model: UserGroupModel,
         *,
         mask_credential_prefix: bool,
+        permissions: dict[str, bool] | None = None,
     ) -> "UserGroup":
         return cls(
+            permissions=permissions or {},
             id=user_group_model.id,
             name=user_group_model.name,
             manager_ids=[

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -77,3 +77,60 @@ def document_set_permissions(
         "delete": is_document_sets_admin,
         "publish": is_document_sets_admin,
     }
+
+
+TOOL_ACTIONS: frozenset[str] = frozenset({"edit", "delete", "toggle"})
+
+
+def tool_permissions(*, can_edit: bool, is_actions_admin: bool) -> dict[str, bool]:
+    """Custom action (OpenAPI tool) affordance map. ``edit`` is the editable decision the
+    write guard enforces (admin, creator, or a manager whose groups cover every agent
+    using the action). ``delete`` and ``toggle`` require global MANAGE_ACTIONS — the
+    routes carry no ``allow_scope``, so a scoped manager may edit a managed action but
+    never delete or enable/disable it."""
+    return {
+        "edit": can_edit,
+        "delete": is_actions_admin,
+        "toggle": is_actions_admin,
+    }
+
+
+MCP_SERVER_ACTIONS: frozenset[str] = frozenset(
+    {"edit", "delete", "authenticate", "manage_status"}
+)
+
+
+def mcp_server_permissions(*, can_edit: bool, can_admin: bool) -> dict[str, bool]:
+    """MCP server affordance map. ``edit`` is the editable decision (admin, owner-by-email,
+    or a manager whose groups cover every agent using the server's tools). ``delete``,
+    ``authenticate``, and ``manage_status`` (connect/disconnect/refresh) are owner-or-admin
+    only — those routes carry no ``allow_scope``, so a manager may edit a managed server
+    but not delete, authenticate, or change its connection status."""
+    return {
+        "edit": can_edit,
+        "delete": can_admin,
+        "authenticate": can_admin,
+        "manage_status": can_admin,
+    }
+
+
+CUSTOM_SKILL_ACTIONS: frozenset[str] = frozenset(
+    {"edit", "manage_access", "delete", "publish"}
+)
+
+
+def custom_skill_permissions(
+    *, can_edit: bool, is_full_admin: bool, is_skills_admin: bool
+) -> dict[str, bool]:
+    """Custom skill affordance map. ``edit`` (replace bundle, enable/disable) and
+    ``manage_access`` (group grants) are the managed-scope editable decision the write
+    guard enforces. ``delete`` is FULL_ADMIN only (its route requires
+    FULL_ADMIN_PANEL_ACCESS, no ``allow_scope``); ``publish`` (make org-wide public)
+    needs global MANAGE_SKILLS — a scoped manager fails the guard's non-public check when
+    flipping a skill public."""
+    return {
+        "edit": can_edit,
+        "manage_access": can_edit,
+        "delete": is_full_admin,
+        "publish": is_skills_admin,
+    }

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -134,3 +134,25 @@ def custom_skill_permissions(
         "delete": is_full_admin,
         "publish": is_skills_admin,
     }
+
+
+USER_GROUP_ACTIONS: frozenset[str] = frozenset(
+    {"manage", "delete", "edit_permissions", "edit_token_limits"}
+)
+
+
+def user_group_permissions(
+    *, can_manage: bool, is_user_groups_admin: bool, is_full_admin: bool
+) -> dict[str, bool]:
+    """User group affordance map. ``manage`` (rename, membership, assign agents, set
+    manager) and ``edit_token_limits`` are the per-group ``manages_group`` decision — group
+    in the manager's managed set, or global MANAGE_USER_GROUPS. A scoped manager gets full
+    token-limit CRUD for groups they manage: every token route (read/create/update/delete)
+    now admits scope. ``delete`` needs global MANAGE_USER_GROUPS (its route has no
+    ``allow_scope``). ``edit_permissions`` is FULL_ADMIN (the permission-toggle route)."""
+    return {
+        "manage": can_manage,
+        "delete": is_user_groups_admin,
+        "edit_permissions": is_full_admin,
+        "edit_token_limits": can_manage,
+    }

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -82,14 +82,13 @@ def document_set_permissions(
 TOOL_ACTIONS: frozenset[str] = frozenset({"edit", "delete", "toggle", "authenticate"})
 
 
-def tool_permissions(*, can_edit: bool, can_manage: bool) -> dict[str, bool]:
-    """Custom action (OpenAPI tool) affordance map. ``edit`` is the write guard's editable
-    decision (admin, creator, or a scoped manager whose groups cover every agent using the
-    action). ``delete``, ``toggle``, and ``authenticate`` (its OAuth config) are ``can_manage``
-    — owner-or-admin — so a scoped manager can edit an in-scope action but not fully manage
-    one they didn't create."""
+def tool_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """Custom action (OpenAPI tool) affordance map. Every action — edit, delete, toggle, and
+    authenticate (its OAuth config) — is owner-or-admin (``can_manage``): the creator fully
+    controls the action they made and an admin controls any, while a scoped manager may view
+    and create actions but not edit ones they didn't create."""
     return {
-        "edit": can_edit,
+        "edit": can_manage,
         "delete": can_manage,
         "toggle": can_manage,
         "authenticate": can_manage,
@@ -101,17 +100,16 @@ MCP_SERVER_ACTIONS: frozenset[str] = frozenset(
 )
 
 
-def mcp_server_permissions(*, can_edit: bool, can_admin: bool) -> dict[str, bool]:
-    """MCP server affordance map. ``edit`` is the editable decision (admin, owner-by-email,
-    or a manager whose groups cover every agent using the server's tools). ``delete``,
-    ``authenticate``, and ``manage_status`` (connect/disconnect/refresh) are owner-or-admin
-    only — those routes carry no ``allow_scope``, so a manager may edit a managed server
-    but not delete, authenticate, or change its connection status."""
+def mcp_server_permissions(*, can_manage: bool) -> dict[str, bool]:
+    """MCP server affordance map. Every action — edit, delete, authenticate (connect), and
+    manage_status (disconnect/refresh) — is owner-or-admin (``can_manage``): the owner fully
+    controls their server and an admin controls any, while a scoped manager may view servers
+    connected to their groups and create their own but not manage others'."""
     return {
-        "edit": can_edit,
-        "delete": can_admin,
-        "authenticate": can_admin,
-        "manage_status": can_admin,
+        "edit": can_manage,
+        "delete": can_manage,
+        "authenticate": can_manage,
+        "manage_status": can_manage,
     }
 
 

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -79,19 +79,20 @@ def document_set_permissions(
     }
 
 
-TOOL_ACTIONS: frozenset[str] = frozenset({"edit", "delete", "toggle"})
+TOOL_ACTIONS: frozenset[str] = frozenset({"edit", "delete", "toggle", "authenticate"})
 
 
-def tool_permissions(*, can_edit: bool, is_actions_admin: bool) -> dict[str, bool]:
-    """Custom action (OpenAPI tool) affordance map. ``edit`` is the editable decision the
-    write guard enforces (admin, creator, or a manager whose groups cover every agent
-    using the action). ``delete`` and ``toggle`` require global MANAGE_ACTIONS — the
-    routes carry no ``allow_scope``, so a scoped manager may edit a managed action but
-    never delete or enable/disable it."""
+def tool_permissions(*, can_edit: bool, can_manage: bool) -> dict[str, bool]:
+    """Custom action (OpenAPI tool) affordance map. ``edit`` is the write guard's editable
+    decision (admin, creator, or a scoped manager whose groups cover every agent using the
+    action). ``delete``, ``toggle``, and ``authenticate`` (its OAuth config) are ``can_manage``
+    — owner-or-admin — so a scoped manager can edit an in-scope action but not fully manage
+    one they didn't create."""
     return {
         "edit": can_edit,
-        "delete": is_actions_admin,
-        "toggle": is_actions_admin,
+        "delete": can_manage,
+        "toggle": can_manage,
+        "authenticate": can_manage,
     }
 
 

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -40,15 +40,23 @@ def agent_mediated_scope_allows(
     group_ids: set[int],
     has_public_agent: bool,
     has_ungrouped_private_agent: bool,
+    managed_group_ids: set[int] | None = None,
 ) -> bool:
     """Shared GATE 2 tail for resources whose scope is derived from the agents that
     reference them (custom actions, MCP servers). A scoped manager is in scope iff
     every referencing agent is private and in a group they manage: no agent is
     public or ungrouped-private, there is ≥1 group, and every group is managed.
-    Callers resolve owner/admin bypasses first."""
+    Callers resolve owner/admin bypasses first.
+
+    ``managed_group_ids`` lets a caller pass a preloaded managed set so per-row
+    stamping issues no query; ``None`` re-queries."""
     if has_public_agent or has_ungrouped_private_agent or not group_ids:
         return False
-    managed = get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
+    managed = (
+        managed_group_ids
+        if managed_group_ids is not None
+        else get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
+    )
     return group_ids.issubset(managed)
 
 

--- a/backend/onyx/auth/scoped_permissions.py
+++ b/backend/onyx/auth/scoped_permissions.py
@@ -33,33 +33,6 @@ def get_scoped_groups(
     return fetch_managed_group_ids(user, db_session)
 
 
-def agent_mediated_scope_allows(
-    user: User,
-    db_session: Session,
-    *,
-    group_ids: set[int],
-    has_public_agent: bool,
-    has_ungrouped_private_agent: bool,
-    managed_group_ids: set[int] | None = None,
-) -> bool:
-    """Shared GATE 2 tail for resources whose scope is derived from the agents that
-    reference them (custom actions, MCP servers). A scoped manager is in scope iff
-    every referencing agent is private and in a group they manage: no agent is
-    public or ungrouped-private, there is ≥1 group, and every group is managed.
-    Callers resolve owner/admin bypasses first.
-
-    ``managed_group_ids`` lets a caller pass a preloaded managed set so per-row
-    stamping issues no query; ``None`` re-queries."""
-    if has_public_agent or has_ungrouped_private_agent or not group_ids:
-        return False
-    managed = (
-        managed_group_ids
-        if managed_group_ids is not None
-        else get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
-    )
-    return group_ids.issubset(managed)
-
-
 def within_scope(
     user: User,
     db_session: Session,

--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -78,6 +78,24 @@ def insert_global_token_rate_limit(
     return token_limit
 
 
+def get_token_rate_limit_scope_and_group(
+    db_session: Session, token_rate_limit_id: int
+) -> tuple[TokenRateLimitScope, int | None]:
+    """Scope + owning group id for a rate limit (group is None unless USER_GROUP). Raises
+    ValueError if the id is unknown."""
+    token_limit = db_session.get(TokenRateLimit, token_rate_limit_id)
+    if token_limit is None:
+        raise ValueError(f"TokenRateLimit with id '{token_rate_limit_id}' not found")
+    if token_limit.scope != TokenRateLimitScope.USER_GROUP:
+        return token_limit.scope, None
+    group_id = db_session.scalar(
+        select(TokenRateLimit__UserGroup.user_group_id).where(
+            TokenRateLimit__UserGroup.rate_limit_id == token_rate_limit_id
+        )
+    )
+    return token_limit.scope, group_id
+
+
 def update_token_rate_limit(
     db_session: Session,
     token_rate_limit_id: int,

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -10,9 +10,14 @@ from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_permission
+from onyx.auth.scoped_permissions import agent_mediated_scope_allows
 from onyx.db.constants import UNSET
 from onyx.db.constants import UnsetType
 from onyx.db.enums import MCPServerStatus
+from onyx.db.enums import Permission
+from onyx.db.enums import PermissionAuthority
 from onyx.db.models import MCPServer
 from onyx.db.models import OAuthConfig
 from onyx.db.models import Persona
@@ -20,6 +25,7 @@ from onyx.db.models import Persona__Tool
 from onyx.db.models import Persona__UserGroup
 from onyx.db.models import Tool
 from onyx.db.models import ToolCall
+from onyx.db.models import User
 from onyx.server.features.tool.models import Header
 from onyx.tools.built_in_tools import BUILT_IN_TOOL_TYPES
 from onyx.utils.headers import HeaderItemDict
@@ -162,6 +168,69 @@ def get_mcp_server_agent_scope(
         .where(Tool.mcp_server_id == mcp_server_id, Persona.deleted.is_(False)),
         db_session,
     )
+
+
+# Read-mode mirrors of the tool/MCP write guards: same decision, no policy re-derived, so
+# the projection can stamp affordances. Guards stay the boundary; drift is caught by the
+# permission-projection contract test.
+
+
+def action_within_managed_scope(tool_id: int, db_session: Session, user: User) -> bool:
+    """Read-mode of ``_assert_action_within_managed_scope``: a scoped manager is in scope
+    for a custom action iff every agent using it is private and in a group they manage."""
+    group_ids, has_public_agent, has_ungrouped_private_agent = get_action_agent_scope(
+        tool_id, db_session
+    )
+    return agent_mediated_scope_allows(
+        user,
+        db_session,
+        group_ids=group_ids,
+        has_public_agent=has_public_agent,
+        has_ungrouped_private_agent=has_ungrouped_private_agent,
+    )
+
+
+def can_edit_custom_tool(user: User, tool: Tool, db_session: Session) -> bool:
+    """Read-mode of ``_get_editable_custom_tool`` (admin ∨ creator ∨ scoped branches,
+    minus its 404/400 fetch raises). Built-in tools are never editable here."""
+    if tool.in_code_tool_id is not None:
+        return False
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True
+    if tool.user_id is not None and tool.user_id == user.id:
+        return True
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
+        return action_within_managed_scope(tool.id, db_session, user)
+    return False
+
+
+def can_edit_mcp_server(user: User, server: MCPServer, db_session: Session) -> bool:
+    """Read-mode of ``_ensure_mcp_server_editable``: admin ∨ owner (by email) ∨ a scoped
+    manager whose groups cover every agent using the server's tools."""
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True
+    if server.owner == user.email:
+        return True
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
+        group_ids, has_public_agent, has_ungrouped_private_agent = (
+            get_mcp_server_agent_scope(server.id, db_session)
+        )
+        return agent_mediated_scope_allows(
+            user,
+            db_session,
+            group_ids=group_ids,
+            has_public_agent=has_public_agent,
+            has_ungrouped_private_agent=has_ungrouped_private_agent,
+        )
+    return False
+
+
+def can_admin_mcp_server(user: User, server: MCPServer) -> bool:
+    """Read-mode of ``_ensure_mcp_server_owner_or_admin``: admin ∨ owner (by email). Gates
+    delete, (dis)connect, and status refresh — those routes have no scoped-manager path."""
+    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+        return True
+    return server.owner == user.email
 
 
 def get_tool_by_name(tool_name: str, db_session: Session) -> Tool:

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -170,12 +170,16 @@ def get_mcp_server_agent_scope(
     )
 
 
-# Read-mode mirrors of the tool/MCP write guards: same decision, no policy re-derived, so
-# the projection can stamp affordances. Guards stay the boundary; drift is caught by the
-# permission-projection contract test.
+# Read-mode mirrors of the write guards — same decision, no policy re-derived — so the
+# projection can stamp affordances; the contract test catches drift.
 
 
-def action_within_managed_scope(tool_id: int, db_session: Session, user: User) -> bool:
+def action_within_managed_scope(
+    tool_id: int,
+    db_session: Session,
+    user: User,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
     """Read-mode of ``_assert_action_within_managed_scope``: a scoped manager is in scope
     for a custom action iff every agent using it is private and in a group they manage."""
     group_ids, has_public_agent, has_ungrouped_private_agent = get_action_agent_scope(
@@ -187,12 +191,20 @@ def action_within_managed_scope(tool_id: int, db_session: Session, user: User) -
         group_ids=group_ids,
         has_public_agent=has_public_agent,
         has_ungrouped_private_agent=has_ungrouped_private_agent,
+        managed_group_ids=managed_group_ids,
     )
 
 
-def can_edit_custom_tool(user: User, tool: Tool, db_session: Session) -> bool:
+def can_edit_custom_tool(
+    user: User,
+    tool: Tool,
+    db_session: Session,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
     """Read-mode of ``_get_editable_custom_tool`` (admin ∨ creator ∨ scoped branches,
-    minus its 404/400 fetch raises). Built-in tools are never editable here."""
+    minus its 404/400 fetch raises). Built-in tools are never editable here.
+
+    ``managed_group_ids`` lets a list endpoint preload the manager's group set once."""
     if tool.in_code_tool_id is not None:
         return False
     if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
@@ -200,13 +212,20 @@ def can_edit_custom_tool(user: User, tool: Tool, db_session: Session) -> bool:
     if tool.user_id is not None and tool.user_id == user.id:
         return True
     if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        return action_within_managed_scope(tool.id, db_session, user)
+        return action_within_managed_scope(tool.id, db_session, user, managed_group_ids)
     return False
 
 
-def can_edit_mcp_server(user: User, server: MCPServer, db_session: Session) -> bool:
+def can_edit_mcp_server(
+    user: User,
+    server: MCPServer,
+    db_session: Session,
+    managed_group_ids: set[int] | None = None,
+) -> bool:
     """Read-mode of ``_ensure_mcp_server_editable``: admin ∨ owner (by email) ∨ a scoped
-    manager whose groups cover every agent using the server's tools."""
+    manager whose groups cover every agent using the server's tools.
+
+    ``managed_group_ids`` lets a list endpoint preload the manager's group set once."""
     if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
         return True
     if server.owner == user.email:
@@ -221,6 +240,7 @@ def can_edit_mcp_server(user: User, server: MCPServer, db_session: Session) -> b
             group_ids=group_ids,
             has_public_agent=has_public_agent,
             has_ungrouped_private_agent=has_ungrouped_private_agent,
+            managed_group_ids=managed_group_ids,
         )
     return False
 

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -1,3 +1,4 @@
+from collections.abc import Collection
 from typing import Any
 from typing import cast
 from typing import Type
@@ -6,13 +7,11 @@ from uuid import UUID
 
 from sqlalchemy import func
 from sqlalchemy import or_
-from sqlalchemy import Select
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_permission
-from onyx.auth.scoped_permissions import agent_mediated_scope_allows
 from onyx.db.constants import UNSET
 from onyx.db.constants import UnsetType
 from onyx.db.enums import MCPServerStatus
@@ -104,152 +103,11 @@ def get_tool_by_id(tool_id: int, db_session: Session) -> Tool:
     return tool
 
 
-def _agent_group_scope(
-    agent_select: Select[tuple[int, bool, int | None]], db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """Shared core of the agent-mediated action/MCP scope. Given a select of
-    ``(persona_id, is_public, owner_group_id)`` for the (non-deleted) agents
-    referencing a resource, return ``(private_agent_group_ids, has_public_agent,
-    has_ungrouped_private_agent)``. A private agent's groups are those it is shared
-    to (``Persona__UserGroup``) plus the group that owns it (``owner_group_id``); an
-    agent with neither is a personal agent outside any managed group and must be
-    tracked explicitly. A public agent is org-wide; a resource used by no agent has
-    no group context (empty set)."""
-    agent_rows = db_session.execute(agent_select).all()
-    has_public_agent = any(is_public for _, is_public, _ in agent_rows)
-    private_owner_groups = {
-        pid: owner_group_id
-        for pid, is_public, owner_group_id in agent_rows
-        if not is_public
-    }
-    if not private_owner_groups:
-        return set(), has_public_agent, False
-    share_rows = db_session.execute(
-        select(Persona__UserGroup.persona_id, Persona__UserGroup.user_group_id).where(
-            Persona__UserGroup.persona_id.in_(private_owner_groups.keys())
-        )
-    ).all()
-    group_ids: set[int] = set()
-    grouped_agent_ids: set[int] = set()
-    for persona_id, user_group_id in share_rows:
-        group_ids.add(user_group_id)
-        grouped_agent_ids.add(persona_id)
-    for persona_id, owner_group_id in private_owner_groups.items():
-        if owner_group_id is not None:
-            group_ids.add(owner_group_id)
-            grouped_agent_ids.add(persona_id)
-    has_ungrouped_private_agent = bool(
-        set(private_owner_groups.keys()) - grouped_agent_ids
-    )
-    return group_ids, has_public_agent, has_ungrouped_private_agent
-
-
-def get_action_agent_scope(
-    tool_id: int, db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """The groups a custom action is exposed to, via the agents that reference it."""
-    return _agent_group_scope(
-        select(Persona.id, Persona.is_public, Persona.owner_group_id)
-        .join(Persona__Tool, Persona__Tool.persona_id == Persona.id)
-        .where(Persona__Tool.tool_id == tool_id, Persona.deleted.is_(False)),
-        db_session,
-    )
-
-
-def get_mcp_server_agent_scope(
-    mcp_server_id: int, db_session: Session
-) -> tuple[set[int], bool, bool]:
-    """The groups an MCP server is exposed to, via the agents that use any of its
-    tools."""
-    return _agent_group_scope(
-        select(Persona.id, Persona.is_public, Persona.owner_group_id)
-        .join(Persona__Tool, Persona__Tool.persona_id == Persona.id)
-        .join(Tool, Tool.id == Persona__Tool.tool_id)
-        .where(Tool.mcp_server_id == mcp_server_id, Persona.deleted.is_(False)),
-        db_session,
-    )
-
-
-# Read-mode mirrors of the write guards — same decision, no policy re-derived — so the
-# projection can stamp affordances; the contract test catches drift.
-
-
-def action_within_managed_scope(
-    tool_id: int,
-    db_session: Session,
-    user: User,
-    managed_group_ids: set[int] | None = None,
-) -> bool:
-    """Read-mode of ``_assert_action_within_managed_scope``: a scoped manager is in scope
-    for a custom action iff every agent using it is private and in a group they manage."""
-    group_ids, has_public_agent, has_ungrouped_private_agent = get_action_agent_scope(
-        tool_id, db_session
-    )
-    return agent_mediated_scope_allows(
-        user,
-        db_session,
-        group_ids=group_ids,
-        has_public_agent=has_public_agent,
-        has_ungrouped_private_agent=has_ungrouped_private_agent,
-        managed_group_ids=managed_group_ids,
-    )
-
-
-def can_edit_custom_tool(
-    user: User,
-    tool: Tool,
-    db_session: Session,
-    managed_group_ids: set[int] | None = None,
-) -> bool:
-    """Read-mode of ``_get_editable_custom_tool`` (admin ∨ creator ∨ scoped branches,
-    minus its 404/400 fetch raises). Built-in tools are never editable here.
-
-    ``managed_group_ids`` lets a list endpoint preload the manager's group set once."""
-    if tool.in_code_tool_id is not None:
-        return False
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
-        return True
-    if tool.user_id is not None and tool.user_id == user.id:
-        return True
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        return action_within_managed_scope(tool.id, db_session, user, managed_group_ids)
-    return False
-
-
-def can_edit_mcp_server(
-    user: User,
-    server: MCPServer,
-    db_session: Session,
-    managed_group_ids: set[int] | None = None,
-) -> bool:
-    """Read-mode of ``_ensure_mcp_server_editable``: admin ∨ owner (by email) ∨ a scoped
-    manager whose groups cover every agent using the server's tools.
-
-    ``managed_group_ids`` lets a list endpoint preload the manager's group set once."""
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
-        return True
-    if server.owner == user.email:
-        return True
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        group_ids, has_public_agent, has_ungrouped_private_agent = (
-            get_mcp_server_agent_scope(server.id, db_session)
-        )
-        return agent_mediated_scope_allows(
-            user,
-            db_session,
-            group_ids=group_ids,
-            has_public_agent=has_public_agent,
-            has_ungrouped_private_agent=has_ungrouped_private_agent,
-            managed_group_ids=managed_group_ids,
-        )
-    return False
-
-
 def can_manage_own_tool(user: User, tool: Tool) -> bool:
-    """Owner-or-admin gate for a custom action's destructive/auth ops (delete, toggle, OAuth
+    """Owner-or-admin gate for every action on a custom action (edit, delete, toggle, OAuth
     config), matching the routes' ``allow_scope`` guard: a global actions-admin manages any
-    action; a scoped manager only one they created. No MANAGE_ACTIONS authority (or a built-in
-    tool, which has no owner) never passes."""
+    action, a scoped manager only one they created. No MANAGE_ACTIONS authority — or a built-in
+    tool (no owner) — never passes."""
     authority = has_permission(user, Permission.MANAGE_ACTIONS)
     if authority is PermissionAuthority.GLOBAL:
         return True
@@ -258,12 +116,41 @@ def can_manage_own_tool(user: User, tool: Tool) -> bool:
     return False
 
 
-def can_admin_mcp_server(user: User, server: MCPServer) -> bool:
-    """Read-mode of ``_ensure_mcp_server_owner_or_admin``: admin ∨ owner (by email). Gates
-    delete, (dis)connect, and status refresh — those routes have no scoped-manager path."""
+def can_manage_mcp_server(user: User, server: MCPServer) -> bool:
+    """Owner-or-admin gate for every action on an MCP server (edit, delete, connect, status),
+    matching the routes' ``allow_scope`` guard ∧ FULL_ADMIN-or-owner: a full admin manages any
+    server, a scoped manager only one they own (by email). No MANAGE_ACTIONS authority never
+    passes."""
+    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.NONE:
+        return False
     if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
         return True
     return server.owner == user.email
+
+
+def get_mcp_server_ids_connected_to_groups(
+    group_ids: Collection[int], db_session: Session
+) -> set[int]:
+    """MCP server ids exposed to any of ``group_ids`` via an agent — a persona shared to or
+    owned by the group that uses one of the server's tools. The read-visibility set for a
+    scoped manager, who may view servers connected to their groups without managing them."""
+    if not group_ids:
+        return set()
+    rows = db_session.execute(
+        select(Tool.mcp_server_id)
+        .join(Persona__Tool, Persona__Tool.tool_id == Tool.id)
+        .join(Persona, Persona.id == Persona__Tool.persona_id)
+        .outerjoin(Persona__UserGroup, Persona__UserGroup.persona_id == Persona.id)
+        .where(
+            Tool.mcp_server_id.is_not(None),
+            Persona.deleted.is_(False),
+            or_(
+                Persona__UserGroup.user_group_id.in_(group_ids),
+                Persona.owner_group_id.in_(group_ids),
+            ),
+        )
+    ).all()
+    return {server_id for (server_id,) in rows if server_id is not None}
 
 
 def get_tool_by_name(tool_name: str, db_session: Session) -> Tool:

--- a/backend/onyx/db/tools.py
+++ b/backend/onyx/db/tools.py
@@ -245,6 +245,19 @@ def can_edit_mcp_server(
     return False
 
 
+def can_manage_own_tool(user: User, tool: Tool) -> bool:
+    """Owner-or-admin gate for a custom action's destructive/auth ops (delete, toggle, OAuth
+    config), matching the routes' ``allow_scope`` guard: a global actions-admin manages any
+    action; a scoped manager only one they created. No MANAGE_ACTIONS authority (or a built-in
+    tool, which has no owner) never passes."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
+        return True
+    if authority is PermissionAuthority.SCOPED:
+        return tool.user_id is not None and tool.user_id == user.id
+    return False
+
+
 def can_admin_mcp_server(user: User, server: MCPServer) -> bool:
     """Read-mode of ``_ensure_mcp_server_owner_or_admin``: admin ∨ owner (by email). Gates
     delete, (dis)connect, and status refresh — those routes have no scoped-manager path."""

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -33,6 +33,7 @@ from onyx.auth.oauth_token_manager import build_oauth_authorization_url
 from onyx.auth.oauth_token_manager import exchange_oauth_code_for_token
 from onyx.auth.oauth_token_manager import OAuthFlowParams
 from onyx.auth.oauth_token_manager import validate_oauth_endpoint_url
+from onyx.auth.permission_projection import mcp_server_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
@@ -66,6 +67,8 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.tools import can_admin_mcp_server
+from onyx.db.tools import can_edit_mcp_server
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_mcp_server_agent_scope
@@ -1408,6 +1411,7 @@ def _db_mcp_server_to_api_mcp_server(
     db: Session,
     request_user: User | None,
     include_auth_config: bool = False,
+    permissions: dict[str, bool] | None = None,
 ) -> MCPServer:
     """Convert database MCP server to API model"""
 
@@ -1581,6 +1585,7 @@ def _db_mcp_server_to_api_mcp_server(
         auth_template=auth_template,
         user_credentials=user_credentials,
         admin_credentials=admin_credentials,
+        permissions=permissions or {},
     )
 
 
@@ -2371,9 +2376,18 @@ def get_mcp_servers_for_admin(
     try:
         db_mcp_servers = get_all_mcp_servers(db)
 
-        # Convert to API model format
+        # Stamp per-server affordances; edit/delete short-circuit for admins and owners, so
+        # only a scoped manager runs the per-server agent-scope query.
         mcp_servers = [
-            _db_mcp_server_to_api_mcp_server(db_server, db, request_user=user)
+            _db_mcp_server_to_api_mcp_server(
+                db_server,
+                db,
+                request_user=user,
+                permissions=mcp_server_permissions(
+                    can_edit=can_edit_mcp_server(user, db_server, db),
+                    can_admin=can_admin_mcp_server(user, db_server),
+                ),
+            )
             for db_server in db_mcp_servers
         ]
 

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -37,7 +37,6 @@ from onyx.auth.permission_projection import mcp_server_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
-from onyx.auth.scoped_permissions import agent_mediated_scope_allows
 from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -68,11 +67,10 @@ from onyx.db.models import MCPConnectionConfig
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.db.models import Tool
 from onyx.db.models import User
-from onyx.db.tools import can_admin_mcp_server
-from onyx.db.tools import can_edit_mcp_server
+from onyx.db.tools import can_manage_mcp_server
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
-from onyx.db.tools import get_mcp_server_agent_scope
+from onyx.db.tools import get_mcp_server_ids_connected_to_groups
 from onyx.db.tools import get_tools_by_mcp_server_id
 from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
@@ -745,7 +743,9 @@ class MCPOauthState(BaseModel):
 async def connect_admin_oauth(
     request: MCPUserOAuthConnectRequest,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPUserOAuthConnectResponse:
     """Connect OAuth flow for admin MCP server authentication"""
     return await _connect_oauth(request, db, is_admin=True, user=user)
@@ -1377,33 +1377,25 @@ def _ensure_mcp_server_owner_or_admin(server: DbMCPServer, user: User) -> None:
         )
 
 
-def _ensure_mcp_server_editable(
+def _ensure_mcp_server_viewable(
     server: DbMCPServer, user: User, db_session: Session
 ) -> None:
-    """Write gate for the standalone MCP server endpoints. Admin and owner bypass;
-    otherwise a scoped group manager may edit a server only when every agent using
-    any of its tools is private and in a group they manage. A server reachable via a
-    public agent (org-wide), or used by no agent (no group context), is owner/admin-
-    only."""
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
+    """Read gate for a single MCP server: a global MANAGE_ACTIONS holder (incl. admins) views
+    any; an owner views their own; a scoped manager views a server connected to their groups
+    via an agent. Managers may view connected servers without managing them; managing is
+    owner-or-admin (``_ensure_mcp_server_owner_or_admin``)."""
+    authority = has_permission(user, Permission.MANAGE_ACTIONS)
+    if authority is PermissionAuthority.GLOBAL:
         return
     if server.owner == user.email:
         return
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        group_ids, has_public_agent, has_ungrouped_private_agent = (
-            get_mcp_server_agent_scope(server.id, db_session)
-        )
-        if agent_mediated_scope_allows(
-            user,
-            db_session,
-            group_ids=group_ids,
-            has_public_agent=has_public_agent,
-            has_ungrouped_private_agent=has_ungrouped_private_agent,
-        ):
+    if authority is PermissionAuthority.SCOPED:
+        managed = get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
+        if server.id in get_mcp_server_ids_connected_to_groups(managed, db_session):
             return
     raise OnyxError(
         OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "Only the server owner or a manager of its groups can modify this MCP server.",
+        "You can only view MCP servers you own or that are connected to your groups.",
     )
 
 
@@ -1679,7 +1671,9 @@ def _get_connection_config(
 def admin_list_mcp_tools_by_id(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPToolListResponse:
     return _list_mcp_tools_by_id(server_id, db, True, user)
 
@@ -1694,7 +1688,9 @@ def get_mcp_server_tools_snapshots(
     server_id: int,
     source: ToolSnapshotSource = ToolSnapshotSource.DB,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> list[ToolSnapshot]:
     """
     Get tools for an MCP server as ToolSnapshot objects.
@@ -1967,7 +1963,7 @@ def _upsert_mcp_server(
                 status_code=404,
                 detail=f"MCP server with ID {request.existing_server_id} not found",
             )
-        _ensure_mcp_server_editable(mcp_server, user, db_session)
+        _ensure_mcp_server_owner_or_admin(mcp_server, user)
         client_info: OAuthClientInformationFull | None = None
         existing_admin_config_dict: MCPConnectionData = MCPConnectionData(headers={})
         if mcp_server.admin_connection_config:
@@ -2294,7 +2290,9 @@ def _sync_tools_for_server(
 def get_mcp_server_detail(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServer:
     """Return details for one MCP server if user has access"""
     try:
@@ -2302,22 +2300,20 @@ def get_mcp_server_detail(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(server, user)
-
+    # Read gate: owner, admin, or a manager of a group the server is connected to.
+    _ensure_mcp_server_viewable(server, user, db_session)
     # TODO: user permissions per mcp server not yet implemented, for now
     # permissions are based on access to assistants
     # # Quick permission check – admin or user has access
     # if user and server not in user.accessible_mcp_servers and not user.is_superuser:
     #     raise HTTPException(status_code=403, detail="Forbidden")
-
     return _db_mcp_server_to_api_mcp_server(
         server,
         db_session,
         include_auth_config=True,
         request_user=user,
         permissions=mcp_server_permissions(
-            can_edit=can_edit_mcp_server(user, server, db_session),
-            can_admin=can_admin_mcp_server(user, server),
+            can_manage=can_manage_mcp_server(user, server),
         ),
     )
 
@@ -2346,7 +2342,9 @@ def update_mcp_server_status(
     server_id: int,
     status: MCPServerStatus,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
     """Update the status of an MCP server"""
     logger.info("Updating MCP server %s status to %s", server_id, status)
@@ -2372,7 +2370,9 @@ def update_mcp_server_status(
 @admin_router.get("/servers", response_model=MCPServersResponse)
 def get_mcp_servers_for_admin(
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> MCPServersResponse:
     """Get all MCP servers for admin display"""
 
@@ -2381,27 +2381,34 @@ def get_mcp_servers_for_admin(
     try:
         db_mcp_servers = get_all_mcp_servers(db)
 
-        # Only a scoped manager's per-server edit check queries agent scope (admins/owners
-        # short-circuit); preload their group set once so the loop issues no query per row.
-        managed_group_ids = (
-            get_scoped_groups(user, db, Permission.MANAGE_ACTIONS)
-            if has_permission(user, Permission.MANAGE_ACTIONS)
-            is PermissionAuthority.SCOPED
-            else None
-        )
+        # A global MANAGE_ACTIONS holder (incl. admins) sees every server; a scoped manager
+        # sees only those they own or that are connected to a group they manage (one query for
+        # the connected set). Managing is owner-or-admin either way (can_manage_mcp_server).
+        if (
+            has_permission(user, Permission.MANAGE_ACTIONS)
+            is PermissionAuthority.GLOBAL
+        ):
+            visible_servers = db_mcp_servers
+        else:
+            connected = get_mcp_server_ids_connected_to_groups(
+                get_scoped_groups(user, db, Permission.MANAGE_ACTIONS), db
+            )
+            visible_servers = [
+                server
+                for server in db_mcp_servers
+                if server.owner == user.email or server.id in connected
+            ]
+
         mcp_servers = [
             _db_mcp_server_to_api_mcp_server(
                 db_server,
                 db,
                 request_user=user,
                 permissions=mcp_server_permissions(
-                    can_edit=can_edit_mcp_server(
-                        user, db_server, db, managed_group_ids
-                    ),
-                    can_admin=can_admin_mcp_server(user, db_server),
+                    can_manage=can_manage_mcp_server(user, db_server),
                 ),
             )
-            for db_server in db_mcp_servers
+            for db_server in visible_servers
         ]
 
         return MCPServersResponse(mcp_servers=mcp_servers)
@@ -2415,7 +2422,9 @@ def get_mcp_servers_for_admin(
 def get_mcp_server_db_tools(
     server_id: int,
     db: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ServerToolsResponse:
     """Get existing database tools created for an MCP server"""
     logger.info("Getting database tools for MCP server: %s", server_id)
@@ -2545,7 +2554,7 @@ def update_mcp_server_with_tools(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_editable(mcp_server, user, db_session)
+    _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
     if mcp_server.admin_connection_config_id is None and mcp_server.auth_type not in (
         MCPAuthenticationType.NONE,
@@ -2647,7 +2656,7 @@ def update_mcp_server_simple(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_editable(mcp_server, user, db_session)
+    _ensure_mcp_server_owner_or_admin(mcp_server, user)
 
     _validate_mcp_server_url(request.server_url, "server_url", require_https=False)
 
@@ -2667,8 +2676,7 @@ def update_mcp_server_simple(
         db_session,
         request_user=user,
         permissions=mcp_server_permissions(
-            can_edit=can_edit_mcp_server(user, updated_server, db_session),
-            can_admin=can_admin_mcp_server(user, updated_server),
+            can_manage=can_manage_mcp_server(user, updated_server),
         ),
     )
 
@@ -2677,7 +2685,9 @@ def update_mcp_server_simple(
 def delete_mcp_server_admin(
     server_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict:
     """Delete an MCP server and cascading related objects (tools, configs)."""
     try:

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -1708,9 +1708,8 @@ def get_mcp_server_tools_snapshots(
     except ValueError:
         raise HTTPException(status_code=404, detail="MCP server not found")
 
-    _ensure_mcp_server_owner_or_admin(mcp_server, user)
-
     if source == ToolSnapshotSource.MCP:
+        _ensure_mcp_server_owner_or_admin(mcp_server, user)
         try:
             # Discover tools from MCP server and sync to DB
             _list_mcp_tools_by_id(server_id, db, True, user)
@@ -1737,6 +1736,8 @@ def get_mcp_server_tools_snapshots(
 
             logger.error("Failed to discover tools for MCP server: %s", e)
             raise HTTPException(status_code=500, detail="Failed to discover tools")
+    else:
+        _ensure_mcp_server_viewable(mcp_server, user, db)
 
     # Fetch and return tools from database
     mcp_tools = get_tools_by_mcp_server_id(server_id, db, order_by_id=True)

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -38,6 +38,7 @@ from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import agent_mediated_scope_allows
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -2314,6 +2315,10 @@ def get_mcp_server_detail(
         db_session,
         include_auth_config=True,
         request_user=user,
+        permissions=mcp_server_permissions(
+            can_edit=can_edit_mcp_server(user, server, db_session),
+            can_admin=can_admin_mcp_server(user, server),
+        ),
     )
 
 
@@ -2376,15 +2381,23 @@ def get_mcp_servers_for_admin(
     try:
         db_mcp_servers = get_all_mcp_servers(db)
 
-        # Stamp per-server affordances; edit/delete short-circuit for admins and owners, so
-        # only a scoped manager runs the per-server agent-scope query.
+        # Only a scoped manager's per-server edit check queries agent scope (admins/owners
+        # short-circuit); preload their group set once so the loop issues no query per row.
+        managed_group_ids = (
+            get_scoped_groups(user, db, Permission.MANAGE_ACTIONS)
+            if has_permission(user, Permission.MANAGE_ACTIONS)
+            is PermissionAuthority.SCOPED
+            else None
+        )
         mcp_servers = [
             _db_mcp_server_to_api_mcp_server(
                 db_server,
                 db,
                 request_user=user,
                 permissions=mcp_server_permissions(
-                    can_edit=can_edit_mcp_server(user, db_server, db),
+                    can_edit=can_edit_mcp_server(
+                        user, db_server, db, managed_group_ids
+                    ),
                     can_admin=can_admin_mcp_server(user, db_server),
                 ),
             )
@@ -2649,9 +2662,14 @@ def update_mcp_server_simple(
 
     db_session.commit()
 
-    # Return the updated server in API format
     return _db_mcp_server_to_api_mcp_server(
-        updated_server, db_session, request_user=user
+        updated_server,
+        db_session,
+        request_user=user,
+        permissions=mcp_server_permissions(
+            can_edit=can_edit_mcp_server(user, updated_server, db_session),
+            can_admin=can_admin_mcp_server(user, updated_server),
+        ),
     )
 
 

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -455,6 +455,9 @@ class MCPServer(BaseModel):
         None,
         description="Admin's credential key-value pairs for template substitution and storage",
     )
+    # Per-action affordance map for the requesting user (mirrors the write-side guards).
+    # Defaults empty (fail-closed); the admin server list stamps the real map.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
 
 class MCPServersResponse(BaseModel):

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -455,8 +455,7 @@ class MCPServer(BaseModel):
         None,
         description="Admin's credential key-value pairs for template substitution and storage",
     )
-    # Per-action affordance map for the requesting user (mirrors the write-side guards).
-    # Defaults empty (fail-closed); the admin server list stamps the real map.
+    # Server-stamped affordance map; fail-closed empty (only the admin server list stamps it).
     permissions: dict[str, bool] = Field(default_factory=dict)
 
 

--- a/backend/onyx/server/features/oauth_config/api.py
+++ b/backend/onyx/server/features/oauth_config/api.py
@@ -6,6 +6,7 @@ from fastapi import HTTPException
 from sqlalchemy.orm import Session
 
 from onyx.auth.oauth_token_manager import OAuthTokenManager
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import require_permission
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.engine.sql_engine import get_session
@@ -20,6 +21,8 @@ from onyx.db.oauth_config import get_oauth_configs
 from onyx.db.oauth_config import get_tools_by_oauth_config
 from onyx.db.oauth_config import update_oauth_config
 from onyx.db.oauth_config import upsert_user_oauth_token
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.federated_connectors.oauth_utils import generate_oauth_state
 from onyx.federated_connectors.oauth_utils import verify_oauth_state
 from onyx.server.features.oauth_config.models import OAuthCallbackResponse
@@ -59,13 +62,31 @@ def _oauth_config_to_snapshot(
 """Admin endpoints for OAuth configuration management"""
 
 
+def _assert_can_manage_oauth_config(
+    oauth_config: OAuthConfig, user: User, db_session: Session
+) -> None:
+    """Owner-or-admin gate: a global actions-admin manages any OAuth config; a scoped manager
+    manages one only when they own every action referencing it — editing shared credentials
+    would otherwise affect the other creators."""
+    if has_global_permission(user, Permission.MANAGE_ACTIONS):
+        return
+    tools = get_tools_by_oauth_config(oauth_config.id, db_session)
+    if tools and all(tool.user_id == user.id for tool in tools):
+        return
+    raise OnyxError(
+        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+        "You can only manage OAuth configurations for actions that you created.",
+    )
+
+
 @admin_router.post("/create")
 def create_oauth_config_endpoint(
     oauth_data: OAuthConfigCreate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)),
 ) -> OAuthConfigSnapshot:
-    """Create a new OAuth configuration (admin only)."""
+    """Create a new OAuth configuration. A scoped manager may create one and link it to an
+    action they created; get/update/delete are then owner-or-admin."""
     try:
         oauth_config = create_oauth_config(
             name=oauth_data.name,
@@ -96,14 +117,17 @@ def list_oauth_configs(
 def get_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Retrieve a single OAuth configuration (admin only)."""
+    """Retrieve a single OAuth configuration (owner or admin)."""
     oauth_config = get_oauth_config(oauth_config_id, db_session)
     if not oauth_config:
         raise HTTPException(
             status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
         )
+    _assert_can_manage_oauth_config(oauth_config, user, db_session)
     return _oauth_config_to_snapshot(oauth_config, db_session)
 
 
@@ -112,9 +136,17 @@ def update_oauth_config_endpoint(
     oauth_config_id: int,
     oauth_data: OAuthConfigUpdate,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> OAuthConfigSnapshot:
-    """Update an OAuth configuration (admin only)."""
+    """Update an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise HTTPException(
+            status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         updated_config = update_oauth_config(
             oauth_config_id=oauth_config_id,
@@ -138,9 +170,17 @@ def update_oauth_config_endpoint(
 def delete_oauth_config_endpoint(
     oauth_config_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> dict[str, str]:
-    """Delete an OAuth configuration (admin only)."""
+    """Delete an OAuth configuration (owner or admin)."""
+    existing_config = get_oauth_config(oauth_config_id, db_session)
+    if not existing_config:
+        raise HTTPException(
+            status_code=404, detail=f"OAuth config with id {oauth_config_id} not found"
+        )
+    _assert_can_manage_oauth_config(existing_config, user, db_session)
     try:
         delete_oauth_config(oauth_config_id, db_session)
         return {"message": "OAuth configuration deleted successfully"}

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -11,9 +11,13 @@ from fastapi import UploadFile
 from pydantic import Field
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import custom_skill_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import Permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_within_scope
+from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import within_scope
 from onyx.configs.app_configs import MAX_PERSONAL_SKILLS_PER_USER
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.models import Skill
@@ -70,6 +74,7 @@ def _split_rows(
     db_session: Session,
     *,
     include_grants: bool,
+    user: User | None = None,
 ) -> tuple[list[BuiltinSkillResponse], list[CustomSkillResponse]]:
     """Partition a flat row list into built-in + custom responses.
 
@@ -77,9 +82,25 @@ def _split_rows(
     in code without cleaning up the seeded row) is logged and dropped —
     we don't surface a half-broken built-in to admins. ``include_grants``
     only applies to custom skills; built-ins are not group-shareable.
+
+    When ``user`` is given (the admin listing), each custom skill is stamped with
+    its per-action affordance map, resolved once from the manager's scope.
     """
     builtins: list[BuiltinSkillResponse] = []
     customs: list[CustomSkillResponse] = []
+
+    # Resolve the manager's scope once so per-skill stamping issues no extra query.
+    managed_skill_groups: set[int] = set()
+    is_skills_full_admin = False
+    is_skills_admin = False
+    if user is not None:
+        managed_skill_groups = get_scoped_groups(
+            user, db_session, Permission.MANAGE_SKILLS
+        )
+        is_skills_full_admin = has_global_permission(
+            user, Permission.FULL_ADMIN_PANEL_ACCESS
+        )
+        is_skills_admin = has_global_permission(user, Permission.MANAGE_SKILLS)
 
     # User paths withhold group ids but still need grant existence so a
     # grants-shared skill isn't reported as personal.
@@ -103,7 +124,28 @@ def _split_rows(
             )
         elif include_grants:
             group_ids = get_group_ids_for_skill(skill.id, db_session)
-            customs.append(CustomSkillResponse.from_model(skill, group_ids=group_ids))
+            skill_perms: dict[str, bool] | None = None
+            if user is not None:
+                # Read-affordance: within_scope on the skill's own groups, mirroring the
+                # patch guard's current==requested check.
+                skill_perms = custom_skill_permissions(
+                    can_edit=within_scope(
+                        user,
+                        db_session,
+                        permission=Permission.MANAGE_SKILLS,
+                        current_group_ids=group_ids,
+                        requested_group_ids=group_ids,
+                        is_non_public=not skill.is_public,
+                        managed_group_ids=managed_skill_groups,
+                    ),
+                    is_full_admin=is_skills_full_admin,
+                    is_skills_admin=is_skills_admin,
+                )
+            customs.append(
+                CustomSkillResponse.from_model(
+                    skill, group_ids=group_ids, permissions=skill_perms
+                )
+            )
         else:
             customs.append(
                 CustomSkillResponse.from_model(
@@ -176,7 +218,7 @@ def list_skills_admin(
     db_session: Session = Depends(get_session),
 ) -> SkillsList:
     rows = list(list_skills_for_admin(db_session=db_session, user=user))
-    builtins, customs = _split_rows(rows, db_session, include_grants=True)
+    builtins, customs = _split_rows(rows, db_session, include_grants=True, user=user)
     return SkillsList(builtins=builtins, customs=customs)
 
 

--- a/backend/onyx/server/features/skill/api.py
+++ b/backend/onyx/server/features/skill/api.py
@@ -126,8 +126,7 @@ def _split_rows(
             group_ids = get_group_ids_for_skill(skill.id, db_session)
             skill_perms: dict[str, bool] | None = None
             if user is not None:
-                # Read-affordance: within_scope on the skill's own groups, mirroring the
-                # patch guard's current==requested check.
+                # Read-affordance mirroring the patch guard: within_scope on the skill's own groups.
                 skill_perms = custom_skill_permissions(
                     can_edit=within_scope(
                         user,

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -6,6 +6,7 @@ from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic import model_validator
 from sqlalchemy.orm import Session
 
@@ -60,6 +61,9 @@ class CustomSkillResponse(BaseModel):
     updated_at: datetime.datetime | None = None
     granted_group_ids: list[int] = []
     is_personal: bool
+    # Per-action affordance map for the requesting user (mirrors the write-side guards).
+    # Defaults empty (fail-closed); the admin skills list stamps the real map.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -68,6 +72,7 @@ class CustomSkillResponse(BaseModel):
         group_ids: list[int],
         *,
         has_grants: bool | None = None,
+        permissions: dict[str, bool] | None = None,
     ) -> "CustomSkillResponse":
         # Paths that withhold group ids from the response (user-facing) must
         # still pass grant existence so grants-shared skills aren't marked
@@ -77,6 +82,7 @@ class CustomSkillResponse(BaseModel):
             skill.built_in_skill_id is None and not skill.is_public and not grants_exist
         )
         return cls(
+            permissions=permissions or {},
             id=skill.id,
             slug=skill.slug,
             name=skill.name,

--- a/backend/onyx/server/features/skill/models.py
+++ b/backend/onyx/server/features/skill/models.py
@@ -61,8 +61,7 @@ class CustomSkillResponse(BaseModel):
     updated_at: datetime.datetime | None = None
     granted_group_ids: list[int] = []
     is_personal: bool
-    # Per-action affordance map for the requesting user (mirrors the write-side guards).
-    # Defaults empty (fail-closed); the admin skills list stamps the real map.
+    # Server-stamped affordance map; fail-closed empty (only the admin skills list stamps it).
     permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -6,7 +6,9 @@ from fastapi import HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import get_effective_permissions
+from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import agent_mediated_scope_allows
@@ -16,6 +18,7 @@ from onyx.db.enums import Permission
 from onyx.db.enums import PermissionAuthority
 from onyx.db.models import Tool
 from onyx.db.models import User
+from onyx.db.tools import can_edit_custom_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_action_agent_scope
@@ -256,16 +259,27 @@ def validate_tool(
 @router.get("/openapi", tags=PUBLIC_API_TAGS)
 def list_openapi_tools(
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> list[ToolSnapshot]:
     tools = get_tools(db_session, only_openapi=True)
 
+    # delete/toggle are global MANAGE_ACTIONS; resolve once. edit is per-tool and only
+    # queries agent scope for a scoped manager (admin/creator/non-manager short-circuit).
+    is_actions_admin = has_global_permission(user, Permission.MANAGE_ACTIONS)
     openapi_tools: list[ToolSnapshot] = []
     for tool in tools:
         if not should_expose_tool_to_fe(tool):
             continue
 
-        openapi_tools.append(ToolSnapshot.from_model(tool))
+        openapi_tools.append(
+            ToolSnapshot.from_model(
+                tool,
+                permissions=tool_permissions(
+                    can_edit=can_edit_custom_tool(user, tool, db_session),
+                    is_actions_admin=is_actions_admin,
+                ),
+            )
+        )
 
     return openapi_tools
 

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import Session
 
 from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import get_effective_permissions
-from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import agent_mediated_scope_allows
@@ -20,6 +19,7 @@ from onyx.db.enums import PermissionAuthority
 from onyx.db.models import Tool
 from onyx.db.models import User
 from onyx.db.tools import can_edit_custom_tool
+from onyx.db.tools import can_manage_own_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
 from onyx.db.tools import get_action_agent_scope
@@ -116,6 +116,26 @@ def _get_editable_custom_tool(tool_id: int, db_session: Session, user: User) -> 
     )
 
 
+def _get_manageable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
+    """Fetch a custom tool and assert the caller may fully manage it (owner or admin) — the
+    delete/toggle gate."""
+    try:
+        tool = get_tool_by_id(tool_id, db_session)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    if tool.in_code_tool_id is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="Built-in tools cannot be modified through this endpoint.",
+        )
+    if not can_manage_own_tool(user, tool):
+        raise OnyxError(
+            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+            "You can only manage actions that you created.",
+        )
+    return tool
+
+
 @admin_router.post("/custom", tags=PUBLIC_API_TAGS)
 def create_custom_tool(
     tool_data: CustomToolCreate,
@@ -172,9 +192,11 @@ def update_custom_tool(
 def delete_custom_tool(
     tool_id: int,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> None:
-    _ = _get_editable_custom_tool(tool_id, db_session, user)
+    _ = _get_manageable_custom_tool(tool_id, db_session, user)
     try:
         delete_tool__no_commit(tool_id, db_session)
     except ValueError as e:
@@ -199,7 +221,9 @@ class ToolStatusUpdateResponse(BaseModel):
 def update_tools_status(
     update_data: ToolStatusUpdateRequest,
     db_session: Session = Depends(get_session),
-    user: User = Depends(require_permission(Permission.MANAGE_ACTIONS)),  # noqa: ARG001
+    user: User = Depends(
+        require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
+    ),
 ) -> ToolStatusUpdateResponse:
     """Enable or disable one or more tools.
 
@@ -218,6 +242,12 @@ def update_tools_status(
     for tool_id in update_data.tool_ids:
         tool = tools_by_id.get(tool_id)
         if tool:
+            # owner-or-admin, checked per tool
+            if not can_manage_own_tool(user, tool):
+                raise OnyxError(
+                    OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
+                    "You can only enable or disable actions that you created.",
+                )
             tool.enabled = update_data.enabled
             updated_tools.append(tool_id)
         else:
@@ -265,8 +295,7 @@ def list_openapi_tools(
     tools = get_tools(db_session, only_openapi=True)
 
     # Only a scoped manager's per-tool edit check queries agent scope; preload their group
-    # set once so the loop issues no query per row. delete/toggle are global MANAGE_ACTIONS.
-    is_actions_admin = has_global_permission(user, Permission.MANAGE_ACTIONS)
+    # set once so the loop issues no query per row.
     managed_group_ids = (
         get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
         if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED
@@ -284,7 +313,7 @@ def list_openapi_tools(
                     can_edit=can_edit_custom_tool(
                         user, tool, db_session, managed_group_ids
                     ),
-                    is_actions_admin=is_actions_admin,
+                    can_manage=can_manage_own_tool(user, tool),
                 ),
             )
         )

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -12,6 +12,7 @@ from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import agent_mediated_scope_allows
+from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
@@ -263,9 +264,14 @@ def list_openapi_tools(
 ) -> list[ToolSnapshot]:
     tools = get_tools(db_session, only_openapi=True)
 
-    # delete/toggle are global MANAGE_ACTIONS; resolve once. edit is per-tool and only
-    # queries agent scope for a scoped manager (admin/creator/non-manager short-circuit).
+    # Only a scoped manager's per-tool edit check queries agent scope; preload their group
+    # set once so the loop issues no query per row. delete/toggle are global MANAGE_ACTIONS.
     is_actions_admin = has_global_permission(user, Permission.MANAGE_ACTIONS)
+    managed_group_ids = (
+        get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
+        if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED
+        else None
+    )
     openapi_tools: list[ToolSnapshot] = []
     for tool in tools:
         if not should_expose_tool_to_fe(tool):
@@ -275,7 +281,9 @@ def list_openapi_tools(
             ToolSnapshot.from_model(
                 tool,
                 permissions=tool_permissions(
-                    can_edit=can_edit_custom_tool(user, tool, db_session),
+                    can_edit=can_edit_custom_tool(
+                        user, tool, db_session, managed_group_ids
+                    ),
                     is_actions_admin=is_actions_admin,
                 ),
             )

--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -7,22 +7,15 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from onyx.auth.permission_projection import tool_permissions
-from onyx.auth.permissions import get_effective_permissions
-from onyx.auth.permissions import has_permission
 from onyx.auth.permissions import require_permission
-from onyx.auth.scoped_permissions import agent_mediated_scope_allows
-from onyx.auth.scoped_permissions import get_scoped_groups
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
-from onyx.db.enums import PermissionAuthority
 from onyx.db.models import Tool
 from onyx.db.models import User
-from onyx.db.tools import can_edit_custom_tool
 from onyx.db.tools import can_manage_own_tool
 from onyx.db.tools import create_tool__no_commit
 from onyx.db.tools import delete_tool__no_commit
-from onyx.db.tools import get_action_agent_scope
 from onyx.db.tools import get_tool_by_id
 from onyx.db.tools import get_tools
 from onyx.db.tools import get_tools_by_ids
@@ -63,62 +56,9 @@ def _validate_auth_settings(tool_data: CustomToolCreate | CustomToolUpdate) -> N
                 )
 
 
-def _assert_action_within_managed_scope(
-    tool_id: int, db_session: Session, user: User
-) -> None:
-    """A scoped group manager may edit an action only when every agent using it is
-    private and in a group they manage. An action reachable via a public agent (so
-    org-wide), or used by no agent (no group context), is owner/admin-only."""
-    group_ids, has_public_agent, has_ungrouped_private_agent = get_action_agent_scope(
-        tool_id, db_session
-    )
-    if not agent_mediated_scope_allows(
-        user,
-        db_session,
-        group_ids=group_ids,
-        has_public_agent=has_public_agent,
-        has_ungrouped_private_agent=has_ungrouped_private_agent,
-    ):
-        raise OnyxError(
-            OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-            "You can only modify actions scoped to groups you manage.",
-        )
-
-
-def _get_editable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
-    """Fetch a custom tool and ensure the caller has permission to edit it."""
-    try:
-        tool = get_tool_by_id(tool_id, db_session)
-    except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e))
-
-    if tool.in_code_tool_id is not None:
-        raise HTTPException(
-            status_code=400,
-            detail="Built-in tools cannot be modified through this endpoint.",
-        )
-
-    # Admins bypass; owners may always edit the action they created.
-    if Permission.FULL_ADMIN_PANEL_ACCESS in get_effective_permissions(user):
-        return tool
-    if tool.user_id is not None and tool.user_id == user.id:
-        return tool
-
-    # A scoped group manager may edit an action scoped (via its agents) to groups
-    # they manage; everyone else is limited to actions they created.
-    if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED:
-        _assert_action_within_managed_scope(tool_id, db_session, user)
-        return tool
-
-    raise OnyxError(
-        OnyxErrorCode.INSUFFICIENT_PERMISSIONS,
-        "You can only modify actions that you created.",
-    )
-
-
 def _get_manageable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
-    """Fetch a custom tool and assert the caller may fully manage it (owner or admin) — the
-    delete/toggle gate."""
+    """Fetch a custom tool and assert the caller may manage it (owner or admin) — the gate for
+    every action on it: edit, delete, toggle, and OAuth config."""
     try:
         tool = get_tool_by_id(tool_id, db_session)
     except ValueError as e:
@@ -170,7 +110,7 @@ def update_custom_tool(
         require_permission(Permission.MANAGE_ACTIONS, allow_scope=True)
     ),
 ) -> ToolSnapshot:
-    existing_tool = _get_editable_custom_tool(tool_id, db_session, user)
+    existing_tool = _get_manageable_custom_tool(tool_id, db_session, user)
     if tool_data.definition:
         _validate_tool_definition(tool_data.definition)
     _validate_auth_settings(tool_data)
@@ -294,13 +234,7 @@ def list_openapi_tools(
 ) -> list[ToolSnapshot]:
     tools = get_tools(db_session, only_openapi=True)
 
-    # Only a scoped manager's per-tool edit check queries agent scope; preload their group
-    # set once so the loop issues no query per row.
-    managed_group_ids = (
-        get_scoped_groups(user, db_session, Permission.MANAGE_ACTIONS)
-        if has_permission(user, Permission.MANAGE_ACTIONS) is PermissionAuthority.SCOPED
-        else None
-    )
+    # Every action affordance is owner-or-admin, decided per tool with no query.
     openapi_tools: list[ToolSnapshot] = []
     for tool in tools:
         if not should_expose_tool_to_fe(tool):
@@ -310,10 +244,7 @@ def list_openapi_tools(
             ToolSnapshot.from_model(
                 tool,
                 permissions=tool_permissions(
-                    can_edit=can_edit_custom_tool(
-                        user, tool, db_session, managed_group_ids
-                    ),
-                    can_manage=can_manage_own_tool(user, tool),
+                    can_manage=can_manage_own_tool(user, tool)
                 ),
             )
         )

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.db.models import Tool
 from onyx.server.features.tool.tool_visibility import get_tool_visibility_config
@@ -21,17 +22,24 @@ class ToolSnapshot(BaseModel):
     oauth_config_name: str | None = None
     enabled: bool = True
 
+    # Per-action affordance map for the requesting user (mirrors the write-side guard).
+    # Defaults empty (fail-closed); the admin actions list stamps the real map.
+    permissions: dict[str, bool] = Field(default_factory=dict)
+
     # Visibility settings computed from TOOL_VISIBILITY_CONFIG
     chat_selectable: bool = True
     agent_creation_selectable: bool = True
     default_enabled: bool = False
 
     @classmethod
-    def from_model(cls, tool: Tool) -> "ToolSnapshot":
+    def from_model(
+        cls, tool: Tool, *, permissions: dict[str, bool] | None = None
+    ) -> "ToolSnapshot":
         # Get visibility config for this tool
         config = get_tool_visibility_config(tool)
 
         return cls(
+            permissions=permissions or {},
             id=tool.id,
             name=tool.name,
             description=tool.description or "",

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -22,8 +22,7 @@ class ToolSnapshot(BaseModel):
     oauth_config_name: str | None = None
     enabled: bool = True
 
-    # Per-action affordance map for the requesting user (mirrors the write-side guard).
-    # Defaults empty (fail-closed); the admin actions list stamps the real map.
+    # Server-stamped affordance map; fail-closed empty (only the admin actions list stamps it).
     permissions: dict[str, bool] = Field(default_factory=dict)
 
     # Visibility settings computed from TOOL_VISIBILITY_CONFIG

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -60,13 +60,15 @@ def update_token_limit_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:
-    return TokenRateLimitDisplay.from_db(
+    rate_limit_display = TokenRateLimitDisplay.from_db(
         update_token_rate_limit(
             db_session=db_session,
             token_rate_limit_id=token_rate_limit_id,
             token_rate_limit_settings=token_limit_settings,
         )
     )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
 
 
 @router.delete("/rate-limit/{token_rate_limit_id}")

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -13,22 +13,34 @@ from sqlalchemy.orm import Session
 from ee.onyx.db.analytics import user_can_view_assistant_stats
 from onyx.auth.permission_projection import CC_PAIR_ACTIONS
 from onyx.auth.permission_projection import cc_pair_permissions
+from onyx.auth.permission_projection import CUSTOM_SKILL_ACTIONS
+from onyx.auth.permission_projection import custom_skill_permissions
 from onyx.auth.permission_projection import DOCUMENT_SET_ACTIONS
 from onyx.auth.permission_projection import document_set_permissions
+from onyx.auth.permission_projection import MCP_SERVER_ACTIONS
+from onyx.auth.permission_projection import mcp_server_permissions
 from onyx.auth.permission_projection import PERSONA_ACTIONS
 from onyx.auth.permission_projection import persona_permissions
+from onyx.auth.permission_projection import TOOL_ACTIONS
+from onyx.auth.permission_projection import tool_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.auth.scoped_permissions import manages_group
 from onyx.auth.scoped_permissions import within_scope
 from onyx.db.document_set import fetch_all_document_sets_for_user
+from onyx.db.enums import MCPServerStatus
 from onyx.db.enums import Permission
 from onyx.db.enums import PersonaSharePermission
 from onyx.db.models import DocumentSet
 from onyx.db.models import DocumentSet__UserGroup
+from onyx.db.models import MCPServer
 from onyx.db.models import Persona
+from onyx.db.models import Persona__Tool
 from onyx.db.models import Persona__UserGroup
+from onyx.db.models import Skill
+from onyx.db.models import Skill__UserGroup
+from onyx.db.models import Tool
 from onyx.db.models import User
 from onyx.db.models import User__UserGroup
 from onyx.db.models import UserGroup
@@ -39,12 +51,21 @@ from onyx.db.persona import can_view_persona_stats
 from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import is_persona_editable_by_user
 from onyx.db.persona import persona_edit_within_scope
+from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.tools import can_admin_mcp_server
+from onyx.db.tools import can_edit_custom_tool
+from onyx.db.tools import can_edit_mcp_server
 from onyx.error_handling.exceptions import OnyxError
+from onyx.server.features.mcp.api import _ensure_mcp_server_editable
+from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
 from onyx.server.features.persona.models import PersonaUpsertRequest
+from onyx.server.features.tool.api import _get_editable_custom_tool
 from tests.external_dependency_unit.conftest import create_test_user
 
 
-def _guard_raises(guard: Callable[..., None], *args: object, **kwargs: object) -> bool:
+def _guard_raises(
+    guard: Callable[..., object], *args: object, **kwargs: object
+) -> bool:
     try:
         guard(*args, **kwargs)
         return False
@@ -380,3 +401,253 @@ def test_persona_and_doc_set_key_coverage() -> None:
         document_set_permissions(is_editable=True, is_document_sets_admin=True)
     )
     assert ds_keys == set(DOCUMENT_SET_ACTIONS)
+
+
+def _make_tool(
+    db_session: Session,
+    *,
+    creator: User | None = None,
+    in_code: str | None = None,
+    mcp_server_id: int | None = None,
+) -> Tool:
+    tool = Tool(
+        name=f"proj-tool-{uuid4().hex[:12]}",
+        description="contract",
+        user_id=creator.id if creator else None,
+        in_code_tool_id=in_code,
+        mcp_server_id=mcp_server_id,
+    )
+    db_session.add(tool)
+    db_session.flush()
+    return tool
+
+
+def _make_mcp_server(db_session: Session, *, owner_email: str) -> MCPServer:
+    server = MCPServer(
+        name=f"proj-mcp-{uuid4().hex[:12]}",
+        owner=owner_email,
+        server_url="https://mcp.example.com",
+        status=MCPServerStatus.CONNECTED,
+    )
+    db_session.add(server)
+    db_session.flush()
+    return server
+
+
+def _link_persona_tool(db_session: Session, persona: Persona, tool: Tool) -> None:
+    db_session.add(Persona__Tool(persona_id=persona.id, tool_id=tool.id))
+    db_session.commit()
+
+
+def _make_skill(
+    db_session: Session, *, is_public: bool, groups: list[UserGroup]
+) -> Skill:
+    skill = Skill(
+        id=uuid4(),
+        slug=f"proj-skill-{uuid4().hex[:12]}",
+        name="contract skill",
+        description="contract",
+        # custom skills need a bundle source (ck_skill_definition_source)
+        bundle_file_id=f"proj-bundle-{uuid4().hex}",
+        bundle_sha256="0" * 64,
+        is_public=is_public,
+    )
+    db_session.add(skill)
+    db_session.flush()
+    for group in groups:
+        db_session.add(Skill__UserGroup(skill_id=skill.id, user_group_id=group.id))
+    db_session.commit()
+    return skill
+
+
+def test_tool_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks the real _get_editable_custom_tool decision (admin ∨ creator ∨ scoped);
+    delete/toggle track global MANAGE_ACTIONS. A scoped manager edits a managed action but
+    can never delete or enable/disable it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-tool-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-tool-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    creator = create_test_user(db_session, "proj-tool-creator")
+    creator.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-tool-admin", is_admin=True)
+    db_session.commit()
+
+    tool = _make_tool(db_session, creator=creator)
+    # a private agent in the managed group references the action -> scoped to `managed`
+    persona = _make_persona(
+        db_session, owner=creator, is_public=False, groups=[managed]
+    )
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, out_scope, creator, admin):
+        enforced = not _guard_raises(
+            _get_editable_custom_tool, tool.id, db_session, actor
+        )
+        can_edit = can_edit_custom_tool(actor, tool, db_session)
+        assert can_edit == enforced, actor.email
+        is_actions_admin = has_global_permission(actor, Permission.MANAGE_ACTIONS)
+        tags = tool_permissions(can_edit=can_edit, is_actions_admin=is_actions_admin)
+        assert tags["edit"] == enforced
+        assert tags["delete"] == is_actions_admin  # A — never a scoped manager
+        assert tags["toggle"] == is_actions_admin  # A
+
+    # the fix: an in-scope manager can edit but not delete/toggle
+    assert tool_permissions(
+        can_edit=can_edit_custom_tool(in_scope, tool, db_session),
+        is_actions_admin=has_global_permission(in_scope, Permission.MANAGE_ACTIONS),
+    ) == {"edit": True, "delete": False, "toggle": False}
+
+
+def test_mcp_projection_matches_gates(db_session: Session) -> None:
+    """edit tracks _ensure_mcp_server_editable (admin ∨ owner ∨ scoped); delete/
+    authenticate/manage_status track _ensure_mcp_server_owner_or_admin (admin ∨ owner). A
+    scoped manager edits a managed server but can never delete/authenticate/change its
+    status."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-mcp-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-mcp-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    owner = create_test_user(db_session, "proj-mcp-owner")
+    owner.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-mcp-admin", is_admin=True)
+    db_session.commit()
+
+    server = _make_mcp_server(db_session, owner_email=owner.email)
+    tool = _make_tool(db_session, mcp_server_id=server.id)
+    persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
+    _link_persona_tool(db_session, persona, tool)
+
+    for actor in (in_scope, out_scope, owner, admin):
+        edit_enforced = not _guard_raises(
+            _ensure_mcp_server_editable, server, actor, db_session
+        )
+        admin_enforced = not _guard_raises(
+            _ensure_mcp_server_owner_or_admin, server, actor
+        )
+        can_edit = can_edit_mcp_server(actor, server, db_session)
+        can_admin = can_admin_mcp_server(actor, server)
+        assert can_edit == edit_enforced, actor.email
+        assert can_admin == admin_enforced, actor.email
+        tags = mcp_server_permissions(can_edit=can_edit, can_admin=can_admin)
+        assert tags["edit"] == edit_enforced
+        assert tags["delete"] == admin_enforced
+        assert tags["authenticate"] == admin_enforced
+        assert tags["manage_status"] == admin_enforced
+
+    # the fix: an in-scope manager edits but can't delete/authenticate/manage_status
+    assert mcp_server_permissions(
+        can_edit=can_edit_mcp_server(in_scope, server, db_session),
+        can_admin=can_admin_mcp_server(in_scope, server),
+    ) == {
+        "edit": True,
+        "delete": False,
+        "authenticate": False,
+        "manage_status": False,
+    }
+
+
+def test_skill_projection_matches_gates(db_session: Session) -> None:
+    """edit/manage_access track the assert_within_scope guard on the skill's groups;
+    delete is FULL_ADMIN; publish (make public) is global MANAGE_SKILLS. A scoped manager
+    edits/re-grants a managed skill but can never delete or publish it."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-skill-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-skill-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-skill-admin", is_admin=True)
+    db_session.commit()
+
+    skill = _make_skill(db_session, is_public=False, groups=[managed])
+    group_ids = get_group_ids_for_skill(skill.id, db_session)
+
+    for actor in (in_scope, out_scope, admin):
+        edit_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        # publish drives the same guard with the requested public state
+        publish_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=False,
+        )
+        can_edit = within_scope(
+            actor,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        )
+        assert can_edit == edit_enforced, actor.email
+        is_full_admin = has_global_permission(actor, Permission.FULL_ADMIN_PANEL_ACCESS)
+        is_skills_admin = has_global_permission(actor, Permission.MANAGE_SKILLS)
+        tags = custom_skill_permissions(
+            can_edit=can_edit,
+            is_full_admin=is_full_admin,
+            is_skills_admin=is_skills_admin,
+        )
+        assert tags["edit"] == edit_enforced
+        assert tags["manage_access"] == edit_enforced
+        assert tags["delete"] == is_full_admin
+        assert tags["publish"] == publish_enforced  # global MANAGE_SKILLS
+
+    # the fix: an in-scope manager edits/re-grants but can't delete or publish
+    assert custom_skill_permissions(
+        can_edit=within_scope(
+            in_scope,
+            db_session,
+            permission=Permission.MANAGE_SKILLS,
+            current_group_ids=group_ids,
+            requested_group_ids=group_ids,
+            is_non_public=not skill.is_public,
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+        is_skills_admin=has_global_permission(in_scope, Permission.MANAGE_SKILLS),
+    ) == {"edit": True, "manage_access": True, "delete": False, "publish": False}
+
+
+def test_actions_and_skill_key_coverage() -> None:
+    assert set(tool_permissions(can_edit=True, is_actions_admin=True)) == set(
+        TOOL_ACTIONS
+    )
+    assert set(mcp_server_permissions(can_edit=True, can_admin=True)) == set(
+        MCP_SERVER_ACTIONS
+    )
+    assert set(
+        custom_skill_permissions(
+            can_edit=True, is_full_admin=True, is_skills_admin=True
+        )
+    ) == set(CUSTOM_SKILL_ACTIONS)

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -63,15 +63,12 @@ from onyx.db.persona import is_persona_editable_by_user
 from onyx.db.persona import persona_edit_within_scope
 from onyx.db.skill import get_group_ids_for_skill
 from onyx.db.token_limit import insert_global_token_rate_limit
-from onyx.db.tools import can_admin_mcp_server
-from onyx.db.tools import can_edit_custom_tool
-from onyx.db.tools import can_edit_mcp_server
+from onyx.db.tools import can_manage_mcp_server
 from onyx.db.tools import can_manage_own_tool
 from onyx.error_handling.exceptions import OnyxError
-from onyx.server.features.mcp.api import _ensure_mcp_server_editable
 from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
+from onyx.server.features.mcp.api import _ensure_mcp_server_viewable
 from onyx.server.features.persona.models import PersonaUpsertRequest
-from onyx.server.features.tool.api import _get_editable_custom_tool
 from onyx.server.features.tool.api import _get_manageable_custom_tool
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from tests.external_dependency_unit.conftest import create_test_user
@@ -486,19 +483,14 @@ def _make_skill(
 
 
 def test_tool_projection_matches_gates(db_session: Session) -> None:
-    """edit tracks _get_editable_custom_tool (admin ∨ creator ∨ scoped-in-scope);
-    delete/toggle/authenticate track _get_manageable_custom_tool (owner-or-admin). The
-    creator fully controls the action they made; a scoped manager in the action's group can
-    edit but not manage it."""
+    """Every action affordance (edit, delete, toggle, authenticate) is owner-or-admin, pinned
+    to _get_manageable_custom_tool. The creator fully controls the action they made; a scoped
+    manager whose group the action is connected to may view/create but not manage it."""
     managed = _make_group(db_session)
 
     in_scope = create_test_user(db_session, "proj-tool-in")
     _manage(db_session, in_scope, managed)
     in_scope.effective_permissions = []
-
-    out_scope = create_test_user(db_session, "proj-tool-out")
-    _manage(db_session, out_scope, _make_group(db_session))
-    out_scope.effective_permissions = []
 
     # scoped manager who owns the action (via a group unrelated to the action's agents)
     creator = create_test_user(db_session, "proj-tool-creator")
@@ -509,56 +501,53 @@ def test_tool_projection_matches_gates(db_session: Session) -> None:
     db_session.commit()
 
     tool = _make_tool(db_session, creator=creator)
-    # a private agent in the managed group references the action -> scoped to `managed`
+    # a private agent in the managed group references the action -> connected to `managed`
     persona = _make_persona(
         db_session, owner=creator, is_public=False, groups=[managed]
     )
     _link_persona_tool(db_session, persona, tool)
 
-    for actor in (in_scope, out_scope, creator, admin):
-        edit_enforced = not _guard_raises(
-            _get_editable_custom_tool, tool.id, db_session, actor
-        )
-        can_edit = can_edit_custom_tool(actor, tool, db_session)
-        assert can_edit == edit_enforced, actor.email
+    for actor in (in_scope, creator, admin):
         manage_enforced = not _guard_raises(
             _get_manageable_custom_tool, tool.id, db_session, actor
         )
         can_manage = can_manage_own_tool(actor, tool)
         assert can_manage == manage_enforced, actor.email
-        tags = tool_permissions(can_edit=can_edit, can_manage=can_manage)
-        assert tags["edit"] == edit_enforced
-        assert tags["delete"] == manage_enforced
-        assert tags["toggle"] == manage_enforced
-        assert tags["authenticate"] == manage_enforced
+        assert tool_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "toggle": manage_enforced,
+            "authenticate": manage_enforced,
+        }
 
-    assert tool_permissions(
-        can_edit=can_edit_custom_tool(in_scope, tool, db_session),
-        can_manage=can_manage_own_tool(in_scope, tool),
-    ) == {"edit": True, "delete": False, "toggle": False, "authenticate": False}
-
-    assert tool_permissions(
-        can_edit=can_edit_custom_tool(creator, tool, db_session),
-        can_manage=can_manage_own_tool(creator, tool),
-    ) == {"edit": True, "delete": True, "toggle": True, "authenticate": True}
+    # a manager of the action's connected group can't manage it (only creator/admin can)
+    assert tool_permissions(can_manage=can_manage_own_tool(in_scope, tool)) == {
+        "edit": False,
+        "delete": False,
+        "toggle": False,
+        "authenticate": False,
+    }
+    # the creator fully controls the action they made
+    assert tool_permissions(can_manage=can_manage_own_tool(creator, tool)) == {
+        "edit": True,
+        "delete": True,
+        "toggle": True,
+        "authenticate": True,
+    }
 
 
 def test_mcp_projection_matches_gates(db_session: Session) -> None:
-    """edit tracks _ensure_mcp_server_editable (admin ∨ owner ∨ scoped); delete/
-    authenticate/manage_status track _ensure_mcp_server_owner_or_admin (admin ∨ owner). A
-    scoped manager edits a managed server but can never delete/authenticate/change its
-    status."""
+    """Every MCP action affordance is owner-or-admin, pinned to
+    _ensure_mcp_server_owner_or_admin. A scoped manager whose group the server is connected to
+    may view it (_ensure_mcp_server_viewable) but not manage it."""
     managed = _make_group(db_session)
 
     in_scope = create_test_user(db_session, "proj-mcp-in")
     _manage(db_session, in_scope, managed)
     in_scope.effective_permissions = []
 
-    out_scope = create_test_user(db_session, "proj-mcp-out")
-    _manage(db_session, out_scope, _make_group(db_session))
-    out_scope.effective_permissions = []
-
     owner = create_test_user(db_session, "proj-mcp-owner")
+    _manage(db_session, owner, _make_group(db_session))
     owner.effective_permissions = []
 
     admin = create_test_user(db_session, "proj-mcp-admin", is_admin=True)
@@ -569,32 +558,28 @@ def test_mcp_projection_matches_gates(db_session: Session) -> None:
     persona = _make_persona(db_session, owner=owner, is_public=False, groups=[managed])
     _link_persona_tool(db_session, persona, tool)
 
-    for actor in (in_scope, out_scope, owner, admin):
-        edit_enforced = not _guard_raises(
-            _ensure_mcp_server_editable, server, actor, db_session
-        )
-        admin_enforced = not _guard_raises(
+    for actor in (in_scope, owner, admin):
+        manage_enforced = not _guard_raises(
             _ensure_mcp_server_owner_or_admin, server, actor
         )
-        can_edit = can_edit_mcp_server(actor, server, db_session)
-        can_admin = can_admin_mcp_server(actor, server)
-        assert can_edit == edit_enforced, actor.email
-        assert can_admin == admin_enforced, actor.email
-        tags = mcp_server_permissions(can_edit=can_edit, can_admin=can_admin)
-        assert tags["edit"] == edit_enforced
-        assert tags["delete"] == admin_enforced
-        assert tags["authenticate"] == admin_enforced
-        assert tags["manage_status"] == admin_enforced
+        can_manage = can_manage_mcp_server(actor, server)
+        assert can_manage == manage_enforced, actor.email
+        assert mcp_server_permissions(can_manage=can_manage) == {
+            "edit": manage_enforced,
+            "delete": manage_enforced,
+            "authenticate": manage_enforced,
+            "manage_status": manage_enforced,
+        }
 
-    # in-scope manager edits but can't delete/authenticate/manage_status
-    assert mcp_server_permissions(
-        can_edit=can_edit_mcp_server(in_scope, server, db_session),
-        can_admin=can_admin_mcp_server(in_scope, server),
-    ) == {
+    # a manager of the server's connected group may VIEW but not manage it
+    assert not _guard_raises(_ensure_mcp_server_viewable, server, in_scope, db_session)
+    assert can_manage_mcp_server(in_scope, server) is False
+    # the owner fully manages their server
+    assert mcp_server_permissions(can_manage=can_manage_mcp_server(owner, server)) == {
         "edit": True,
-        "delete": False,
-        "authenticate": False,
-        "manage_status": False,
+        "delete": True,
+        "authenticate": True,
+        "manage_status": True,
     }
 
 
@@ -677,10 +662,8 @@ def test_skill_projection_matches_gates(db_session: Session) -> None:
 
 
 def test_actions_and_skill_key_coverage() -> None:
-    assert set(tool_permissions(can_edit=True, can_manage=True)) == set(TOOL_ACTIONS)
-    assert set(mcp_server_permissions(can_edit=True, can_admin=True)) == set(
-        MCP_SERVER_ACTIONS
-    )
+    assert set(tool_permissions(can_manage=True)) == set(TOOL_ACTIONS)
+    assert set(mcp_server_permissions(can_manage=True)) == set(MCP_SERVER_ACTIONS)
     assert set(
         custom_skill_permissions(
             can_edit=True, is_full_admin=True, is_skills_admin=True

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -221,7 +221,7 @@ def test_cc_pair_projection_matches_gates(db_session: Session) -> None:
         assert tags["delete"] == admin_authority  # A — never a scoped manager
         assert tags["publish"] == admin_authority  # A
 
-    # the whole point of the fix: an in-scope manager can edit but not delete/publish
+    # in-scope manager can edit but not delete/publish
     manager_editable = within_scope(
         in_scope,
         db_session,
@@ -522,7 +522,7 @@ def test_tool_projection_matches_gates(db_session: Session) -> None:
         assert tags["delete"] == is_actions_admin  # A — never a scoped manager
         assert tags["toggle"] == is_actions_admin  # A
 
-    # the fix: an in-scope manager can edit but not delete/toggle
+    # in-scope manager can edit but not delete/toggle
     assert tool_permissions(
         can_edit=can_edit_custom_tool(in_scope, tool, db_session),
         is_actions_admin=has_global_permission(in_scope, Permission.MANAGE_ACTIONS),
@@ -572,7 +572,7 @@ def test_mcp_projection_matches_gates(db_session: Session) -> None:
         assert tags["authenticate"] == admin_enforced
         assert tags["manage_status"] == admin_enforced
 
-    # the fix: an in-scope manager edits but can't delete/authenticate/manage_status
+    # in-scope manager edits but can't delete/authenticate/manage_status
     assert mcp_server_permissions(
         can_edit=can_edit_mcp_server(in_scope, server, db_session),
         can_admin=can_admin_mcp_server(in_scope, server),
@@ -645,7 +645,7 @@ def test_skill_projection_matches_gates(db_session: Session) -> None:
         assert tags["delete"] == is_full_admin
         assert tags["publish"] == publish_enforced  # global MANAGE_SKILLS
 
-    # the fix: an in-scope manager edits/re-grants but can't delete or publish
+    # in-scope manager edits/re-grants but can't delete or publish
     assert custom_skill_permissions(
         can_edit=within_scope(
             in_scope,

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -5,12 +5,20 @@ stamps matches whether the guard raises, across an actor matrix — so the affor
 the client renders can't silently drift from what the backend enforces.
 """
 
+import asyncio
+import inspect
 from collections.abc import Callable
+from types import SimpleNamespace
 from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.analytics import user_can_view_assistant_stats
+from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
+from ee.onyx.server.token_rate_limits.api import _authorize_group_token_rate_limit_write
+from ee.onyx.server.token_rate_limits.api import get_group_token_limit_settings
+from ee.onyx.server.user_group.api import delete_user_group
+from ee.onyx.server.user_group.api import set_user_group_permissions
 from onyx.auth.permission_projection import CC_PAIR_ACTIONS
 from onyx.auth.permission_projection import cc_pair_permissions
 from onyx.auth.permission_projection import CUSTOM_SKILL_ACTIONS
@@ -23,6 +31,8 @@ from onyx.auth.permission_projection import PERSONA_ACTIONS
 from onyx.auth.permission_projection import persona_permissions
 from onyx.auth.permission_projection import TOOL_ACTIONS
 from onyx.auth.permission_projection import tool_permissions
+from onyx.auth.permission_projection import USER_GROUP_ACTIONS
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
@@ -52,6 +62,7 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import is_persona_editable_by_user
 from onyx.db.persona import persona_edit_within_scope
 from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.token_limit import insert_global_token_rate_limit
 from onyx.db.tools import can_admin_mcp_server
 from onyx.db.tools import can_edit_custom_tool
 from onyx.db.tools import can_edit_mcp_server
@@ -60,6 +71,7 @@ from onyx.server.features.mcp.api import _ensure_mcp_server_editable
 from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
 from onyx.server.features.persona.models import PersonaUpsertRequest
 from onyx.server.features.tool.api import _get_editable_custom_tool
+from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from tests.external_dependency_unit.conftest import create_test_user
 
 
@@ -71,6 +83,17 @@ def _guard_raises(
         return False
     except OnyxError:
         return True
+
+
+def _route_admits(
+    route_func: Callable[..., object], guard_param: str, actor: User
+) -> bool:
+    """True iff the route's ``require_permission`` admits ``actor`` (unrestricted token).
+    Runs the real dependency, so the assertion tracks the route decorator — not the bool
+    that built the map, which can't catch a FULL_ADMIN vs MANAGE_USER_GROUPS drift."""
+    depends = inspect.signature(route_func).parameters[guard_param].default
+    request = SimpleNamespace(state=SimpleNamespace(token_scopes=None))
+    return not _guard_raises(lambda: asyncio.run(depends.dependency(request, actor)))
 
 
 def _make_group(db_session: Session) -> UserGroup:
@@ -651,3 +674,166 @@ def test_actions_and_skill_key_coverage() -> None:
             can_edit=True, is_full_admin=True, is_skills_admin=True
         )
     ) == set(CUSTOM_SKILL_ACTIONS)
+
+
+def test_user_group_projection_matches_gates(db_session: Session) -> None:
+    """Each flag is pinned to its real route, not the bool that built it: manage and
+    edit_token_limits → assert_manages_group (per-group scoped — the token read route now
+    admits scope), delete → delete-group (global MANAGE_USER_GROUPS), edit_permissions →
+    permission-toggle (FULL_ADMIN). groups_admin (global MANAGE_USER_GROUPS, not full admin)
+    separates the two levels; out_scope (manages a different group) pins the per-group gate."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-ug-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-ug-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-ug-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-ug-admin", is_admin=True)
+    db_session.commit()
+
+    for actor in (in_scope, out_scope, groups_admin, admin):
+        manage_enforced = not _guard_raises(
+            assert_manages_group, actor, db_session, group_id=managed.id
+        )
+        # the token-limit POST guard (scoped create) is the same managed-scope decision
+        token_create_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_USER_GROUPS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        can_manage = manages_group(actor, db_session, group_id=managed.id)
+        assert can_manage == manage_enforced, actor.email
+        assert can_manage == token_create_enforced, actor.email
+
+        tags = user_group_permissions(
+            can_manage=can_manage,
+            is_user_groups_admin=has_global_permission(
+                actor, Permission.MANAGE_USER_GROUPS
+            ),
+            is_full_admin=has_global_permission(
+                actor, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
+        )
+        assert tags["manage"] == manage_enforced, actor.email
+        assert tags["delete"] == _route_admits(delete_user_group, "_", actor), (
+            actor.email
+        )
+        assert tags["edit_permissions"] == _route_admits(
+            set_user_group_permissions, "user", actor
+        ), actor.email
+        # edit_token_limits rides the token read route: GATE 1 admits scope, GATE 2 is
+        # assert_manages_group — net per-group decision, so AND the two.
+        token_read_gate1 = _route_admits(get_group_token_limit_settings, "user", actor)
+        assert tags["edit_token_limits"] == (token_read_gate1 and manage_enforced), (
+            actor.email
+        )
+
+    assert user_group_permissions(
+        can_manage=manages_group(in_scope, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            in_scope, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": False,
+        "edit_permissions": False,
+        # scoped manager now fully manages its group's token limits
+        "edit_token_limits": True,
+    }
+
+    # groups_admin (global MANAGE_USER_GROUPS, not full admin): manages token limits and
+    # deletes the group, but can't edit permissions (FULL_ADMIN).
+    assert user_group_permissions(
+        can_manage=manages_group(groups_admin, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            groups_admin, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            groups_admin, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": True,
+        "edit_permissions": False,
+        "edit_token_limits": True,
+    }
+
+
+def test_user_group_key_coverage() -> None:
+    assert set(
+        user_group_permissions(
+            can_manage=True, is_user_groups_admin=True, is_full_admin=True
+        )
+    ) == set(USER_GROUP_ACTIONS)
+
+
+def test_group_token_rate_limit_write_scope(db_session: Session) -> None:
+    """A group token-limit write needs the caller to manage the group AND the limit to
+    belong to it — so a group admin fully manages its limits, but a global/per-user limit or
+    another group's limit can't be reached through the group path."""
+    managed = _make_group(db_session)
+    other = _make_group(db_session)
+
+    args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+    managed_limit = insert_user_group_token_rate_limit(
+        db_session=db_session, token_rate_limit_settings=args, group_id=managed.id
+    )
+    global_limit = insert_global_token_rate_limit(db_session, args)
+
+    in_scope = create_test_user(db_session, "proj-trl-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-trl-out")
+    _manage(db_session, out_scope, other)
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-trl-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-trl-admin", is_admin=True)
+
+    plain = create_test_user(db_session, "proj-trl-plain")
+    plain.effective_permissions = []
+    db_session.commit()
+
+    def denied(actor: User, group_id: int, rate_limit_id: int) -> bool:
+        return _guard_raises(
+            _authorize_group_token_rate_limit_write,
+            actor,
+            db_session,
+            group_id=group_id,
+            rate_limit_id=rate_limit_id,
+        )
+
+    assert not denied(admin, managed.id, managed_limit.id)
+    assert not denied(groups_admin, managed.id, managed_limit.id)
+    assert not denied(in_scope, managed.id, managed_limit.id)
+    assert denied(out_scope, managed.id, managed_limit.id)
+    assert denied(plain, managed.id, managed_limit.id)
+
+    # a global limit can't be reached through the group path — even for a full admin
+    assert denied(admin, managed.id, global_limit.id)
+
+    # the limit must belong to the claimed group (can't reach managed's limit via other)
+    assert denied(out_scope, other.id, managed_limit.id)
+    assert denied(in_scope, other.id, managed_limit.id)
+
+    # an unknown id folds into the same OnyxError 404, not the helper's raw ValueError
+    nonexistent_limit_id = -1
+    assert denied(in_scope, managed.id, nonexistent_limit_id)
+    assert denied(admin, managed.id, nonexistent_limit_id)

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -66,11 +66,13 @@ from onyx.db.token_limit import insert_global_token_rate_limit
 from onyx.db.tools import can_admin_mcp_server
 from onyx.db.tools import can_edit_custom_tool
 from onyx.db.tools import can_edit_mcp_server
+from onyx.db.tools import can_manage_own_tool
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.mcp.api import _ensure_mcp_server_editable
 from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
 from onyx.server.features.persona.models import PersonaUpsertRequest
 from onyx.server.features.tool.api import _get_editable_custom_tool
+from onyx.server.features.tool.api import _get_manageable_custom_tool
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from tests.external_dependency_unit.conftest import create_test_user
 
@@ -484,9 +486,10 @@ def _make_skill(
 
 
 def test_tool_projection_matches_gates(db_session: Session) -> None:
-    """edit tracks the real _get_editable_custom_tool decision (admin ∨ creator ∨ scoped);
-    delete/toggle track global MANAGE_ACTIONS. A scoped manager edits a managed action but
-    can never delete or enable/disable it."""
+    """edit tracks _get_editable_custom_tool (admin ∨ creator ∨ scoped-in-scope);
+    delete/toggle/authenticate track _get_manageable_custom_tool (owner-or-admin). The
+    creator fully controls the action they made; a scoped manager in the action's group can
+    edit but not manage it."""
     managed = _make_group(db_session)
 
     in_scope = create_test_user(db_session, "proj-tool-in")
@@ -497,7 +500,9 @@ def test_tool_projection_matches_gates(db_session: Session) -> None:
     _manage(db_session, out_scope, _make_group(db_session))
     out_scope.effective_permissions = []
 
+    # scoped manager who owns the action (via a group unrelated to the action's agents)
     creator = create_test_user(db_session, "proj-tool-creator")
+    _manage(db_session, creator, _make_group(db_session))
     creator.effective_permissions = []
 
     admin = create_test_user(db_session, "proj-tool-admin", is_admin=True)
@@ -511,22 +516,31 @@ def test_tool_projection_matches_gates(db_session: Session) -> None:
     _link_persona_tool(db_session, persona, tool)
 
     for actor in (in_scope, out_scope, creator, admin):
-        enforced = not _guard_raises(
+        edit_enforced = not _guard_raises(
             _get_editable_custom_tool, tool.id, db_session, actor
         )
         can_edit = can_edit_custom_tool(actor, tool, db_session)
-        assert can_edit == enforced, actor.email
-        is_actions_admin = has_global_permission(actor, Permission.MANAGE_ACTIONS)
-        tags = tool_permissions(can_edit=can_edit, is_actions_admin=is_actions_admin)
-        assert tags["edit"] == enforced
-        assert tags["delete"] == is_actions_admin  # A — never a scoped manager
-        assert tags["toggle"] == is_actions_admin  # A
+        assert can_edit == edit_enforced, actor.email
+        manage_enforced = not _guard_raises(
+            _get_manageable_custom_tool, tool.id, db_session, actor
+        )
+        can_manage = can_manage_own_tool(actor, tool)
+        assert can_manage == manage_enforced, actor.email
+        tags = tool_permissions(can_edit=can_edit, can_manage=can_manage)
+        assert tags["edit"] == edit_enforced
+        assert tags["delete"] == manage_enforced
+        assert tags["toggle"] == manage_enforced
+        assert tags["authenticate"] == manage_enforced
 
-    # in-scope manager can edit but not delete/toggle
     assert tool_permissions(
         can_edit=can_edit_custom_tool(in_scope, tool, db_session),
-        is_actions_admin=has_global_permission(in_scope, Permission.MANAGE_ACTIONS),
-    ) == {"edit": True, "delete": False, "toggle": False}
+        can_manage=can_manage_own_tool(in_scope, tool),
+    ) == {"edit": True, "delete": False, "toggle": False, "authenticate": False}
+
+    assert tool_permissions(
+        can_edit=can_edit_custom_tool(creator, tool, db_session),
+        can_manage=can_manage_own_tool(creator, tool),
+    ) == {"edit": True, "delete": True, "toggle": True, "authenticate": True}
 
 
 def test_mcp_projection_matches_gates(db_session: Session) -> None:
@@ -663,9 +677,7 @@ def test_skill_projection_matches_gates(db_session: Session) -> None:
 
 
 def test_actions_and_skill_key_coverage() -> None:
-    assert set(tool_permissions(can_edit=True, is_actions_admin=True)) == set(
-        TOOL_ACTIONS
-    )
+    assert set(tool_permissions(can_edit=True, can_manage=True)) == set(TOOL_ACTIONS)
     assert set(mcp_server_permissions(can_edit=True, can_admin=True)) == set(
         MCP_SERVER_ACTIONS
     )

--- a/backend/tests/integration/tests/permissions/test_group_manager_agents.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_agents.py
@@ -28,6 +28,7 @@ from typing import NamedTuple
 from uuid import uuid4
 
 import pytest
+import requests
 from sqlalchemy import update
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -145,6 +146,19 @@ _TOKEN_LIMIT_BODY: dict[str, Any] = {
 }
 
 
+def _assert_manager(
+    env: _ScopedEnv,
+    method: str,
+    path: str,
+    expected: str,
+    body: dict[str, Any] | None = None,
+) -> requests.Response:
+    """Call ``path`` as the scoped manager and assert the permission gate's verdict."""
+    resp = call_endpoint(method, path, body, env.manager.headers, env.manager.cookies)
+    assert_response(resp, method, path, "manager", expected)
+    return resp
+
+
 # --- skills -----------------------------------------------------------------
 
 
@@ -159,25 +173,22 @@ def test_manager_cannot_grant_skill_to_unmanaged_group(env: _ScopedEnv) -> None:
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
     path = f"/admin/skills/custom/{skill.id}/grants"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PUT",
         path,
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PUT", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint(
-        "PATCH", path, {"is_public": True}, env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PATCH", f"/admin/skills/custom/{skill.id}", "denied", {"is_public": True}
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
@@ -185,9 +196,7 @@ def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/skills/custom/{skill.id}", "denied")
 
 
 def test_manager_skill_admin_list_is_scoped(env: _ScopedEnv) -> None:
@@ -223,15 +232,13 @@ def test_manager_cannot_share_agent_to_unmanaged_group(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
@@ -242,15 +249,13 @@ def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}",
+        "denied",
         _persona_upsert_body(is_public=True, groups=[env.managed_group.id]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
@@ -270,29 +275,25 @@ def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
     assert publish.status_code == 200, publish.text
     # The manager must not pull the now-public agent back to private AND keep the
     # group share in one call — the gate anchors on the original (public) state.
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"is_public": False, "group_ids": [env.managed_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_creates_personal_agent(env: _ScopedEnv) -> None:
     # A scoped manager may create a private no-group personal agent like any
     # ADD_AGENTS user; the managed-group gate applies only once a group is involved.
-    path = "/persona"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "POST",
-        path,
+        "/persona",
+        "allowed",
         _persona_upsert_body(is_public=False, groups=[]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "POST", path, "manager", "allowed")
 
 
 def test_add_agents_user_creates_personal_agent_with_empty_groups(
@@ -350,11 +351,7 @@ def test_manager_creates_own_action(env: _ScopedEnv) -> None:
 def test_manager_cannot_edit_unowned_ungrouped_action(env: _ScopedEnv) -> None:
     # Admin owns the action and no agent uses it → no group context → owner/admin only.
     tool_id = _create_custom_tool(env.admin)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
 
 
 def test_manager_edits_action_used_by_managed_private_agent(env: _ScopedEnv) -> None:
@@ -365,11 +362,9 @@ def test_manager_edits_action_used_by_managed_private_agent(env: _ScopedEnv) -> 
         groups=[env.managed_group.id],
         tool_ids=[tool_id],
     )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
     )
-    assert_response(resp, "PUT", path, "manager", "allowed")
 
 
 def test_manager_edits_action_used_by_group_owned_agent(env: _ScopedEnv) -> None:
@@ -388,11 +383,9 @@ def test_manager_edits_action_used_by_group_owned_agent(env: _ScopedEnv) -> None
             .values(user_id=None, owner_group_id=env.managed_group.id)
         )
         db_session.commit()
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
     )
-    assert_response(resp, "PUT", path, "manager", "allowed")
 
 
 def test_manager_cannot_edit_action_used_by_public_agent(env: _ScopedEnv) -> None:
@@ -403,11 +396,7 @@ def test_manager_cannot_edit_action_used_by_public_agent(env: _ScopedEnv) -> Non
         groups=[env.managed_group.id],
         tool_ids=[tool_id],
     )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
 
 
 def test_manager_cannot_edit_action_used_by_ungrouped_private_agent(
@@ -429,19 +418,13 @@ def test_manager_cannot_edit_action_used_by_ungrouped_private_agent(
         groups=[],
         tool_ids=[tool_id],
     )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
 
 
 def test_manager_cannot_delete_action(env: _ScopedEnv) -> None:
     # Owns it — still denied: delete is admin-only (no allow_scope on the route).
     tool_id = _create_custom_tool(env.manager)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "denied")
 
 
 # --- MCP servers ------------------------------------------------------------
@@ -454,9 +437,7 @@ def test_manager_creates_mcp_server(env: _ScopedEnv) -> None:
 def test_manager_cannot_delete_mcp_server(env: _ScopedEnv) -> None:
     # Owns it — still denied: MCP delete is admin-only.
     server_id = _create_mcp_server(env.manager)
-    path = f"/admin/mcp/server/{server_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "denied")
 
 
 def test_manager_update_via_servers_create_denied_not_masked(
@@ -465,7 +446,6 @@ def test_manager_update_via_servers_create_denied_not_masked(
     # Updating an out-of-scope server through /servers/create must surface the
     # gate's 403, not a 500 masked by the handler's blanket except.
     server_id = _create_mcp_server(env.admin)
-    path = "/admin/mcp/servers/create"
     body = {
         "name": f"mcp-{uuid4()}",
         "server_url": "https://example.com/mcp",
@@ -473,24 +453,69 @@ def test_manager_update_via_servers_create_denied_not_masked(
         "auth_performer": MCPAuthenticationPerformer.ADMIN.value,
         "existing_server_id": server_id,
     }
-    resp = call_endpoint("POST", path, body, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "POST", path, "manager", "denied")
+    _assert_manager(env, "POST", "/admin/mcp/servers/create", "denied", body)
 
 
 # --- token limits -----------------------------------------------------------
 
 
-def test_manager_sets_token_limit_on_managed_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.managed_group.id}"
+def _group_limit_path(group_id: int, limit_id: int | None = None) -> str:
+    base = f"/admin/token-rate-limits/user-group/{group_id}"
+    return base if limit_id is None else f"{base}/rate-limit/{limit_id}"
+
+
+def _create_group_token_limit(user: DATestUser, group_id: int) -> int:
+    """Create a token limit on ``group_id`` as ``user`` (must succeed); returns its id."""
     resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
+        "POST",
+        _group_limit_path(group_id),
+        _TOKEN_LIMIT_BODY,
+        user.headers,
+        user.cookies,
     )
-    assert_response(resp, "POST", path, "manager", "allowed")
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["token_id"])
+
+
+def test_manager_sets_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    path = _group_limit_path(env.managed_group.id)
+    _assert_manager(env, "POST", path, "allowed", _TOKEN_LIMIT_BODY)
 
 
 def test_manager_cannot_set_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.other_group.id}"
-    resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
+    path = _group_limit_path(env.other_group.id)
+    _assert_manager(env, "POST", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_reads_token_limits_on_managed_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.managed_group.id), "allowed")
+
+
+def test_manager_cannot_read_token_limits_on_unmanaged_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.other_group.id), "denied")
+
+
+def test_manager_updates_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    path = _group_limit_path(env.managed_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "allowed", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_cannot_update_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    path = _group_limit_path(env.other_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_deletes_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.managed_group.id, limit_id), "allowed"
     )
-    assert_response(resp, "POST", path, "manager", "denied")
+
+
+def test_manager_cannot_delete_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.other_group.id, limit_id), "denied"
+    )

--- a/backend/tests/integration/tests/permissions/test_group_manager_agents.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_agents.py
@@ -7,10 +7,9 @@ manage, and never widen beyond their scope:
 - **Skills**: create/grant/publish only for PRIVATE skills in managed groups;
   the admin list is scoped; DELETE is admin-only.
 - **Agents**: may group-share a PRIVATE agent only to managed groups.
-- **Actions/MCP**: actions have no group of their own, so scope is derived from
-  the agents using them — editable only when every such agent is private and in a
-  managed group; a public-agent or no-agent action is owner/admin-only; DELETE is
-  admin-only.
+- **Actions/MCP**: owner-or-admin — a manager creates and fully manages (edit/delete)
+  their own actions and servers, but cannot manage ones they didn't create, even those
+  connected to their groups via agents.
 - **Token limits**: settable only on a managed group.
 
 Managers are seeded by flipping ``User__UserGroup.is_manager`` directly (no
@@ -35,7 +34,6 @@ from onyx.db.engine.sql_engine import get_session_with_current_tenant
 from onyx.db.enums import MCPAuthenticationPerformer
 from onyx.db.enums import MCPAuthenticationType
 from onyx.db.enums import Permission
-from onyx.db.models import Persona
 from onyx.db.models import User__UserGroup
 from onyx.db.permissions import recompute_user_permissions__no_commit
 from tests.integration.common_utils.managers.persona import PersonaManager
@@ -341,110 +339,65 @@ def test_manager_rosters_agent_shared_to_managed_group(env: _ScopedEnv) -> None:
     assert resp.status_code == 200, resp.text
 
 
-# --- custom actions (agent-mediated scope) ----------------------------------
+# --- custom actions (owner-or-admin) ----------------------------------------
 
 
 def test_manager_creates_own_action(env: _ScopedEnv) -> None:
     _create_custom_tool(env.manager)
 
 
-def test_manager_cannot_edit_unowned_ungrouped_action(env: _ScopedEnv) -> None:
-    # Admin owns the action and no agent uses it → no group context → owner/admin only.
-    tool_id = _create_custom_tool(env.admin)
-    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
-
-
-def test_manager_edits_action_used_by_managed_private_agent(env: _ScopedEnv) -> None:
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    _assert_manager(
-        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
-    )
-
-
-def test_manager_edits_action_used_by_group_owned_agent(env: _ScopedEnv) -> None:
-    # An action used only by a PRIVATE agent OWNED by the manager's group (via
-    # owner_group_id, with no share rows) is in scope through that group ownership.
-    tool_id = _create_custom_tool(env.admin)
-    agent = PersonaManager.create(
-        user_performing_action=env.admin, is_public=False, tool_ids=[tool_id]
-    )
-    # No API creates a group-owned agent in these tests, so re-own it directly
-    # (owner_group_id and user_id are mutually exclusive).
-    with get_session_with_current_tenant() as db_session:
-        db_session.execute(
-            update(Persona)
-            .where(Persona.id == agent.id)
-            .values(user_id=None, owner_group_id=env.managed_group.id)
-        )
-        db_session.commit()
-    _assert_manager(
-        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
-    )
-
-
-def test_manager_cannot_edit_action_used_by_public_agent(env: _ScopedEnv) -> None:
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=True,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
-
-
-def test_manager_cannot_edit_action_used_by_ungrouped_private_agent(
-    env: _ScopedEnv,
-) -> None:
-    # A private agent in NO group is a personal agent outside the manager's scope;
-    # its presence must block editing even alongside a managed-group agent (the
-    # ungrouped agent adds no group to the union, so it must be tracked explicitly).
-    tool_id = _create_custom_tool(env.admin)
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[env.managed_group.id],
-        tool_ids=[tool_id],
-    )
-    PersonaManager.create(
-        user_performing_action=env.admin,
-        is_public=False,
-        groups=[],
-        tool_ids=[tool_id],
-    )
-    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
-
-
-def test_manager_cannot_delete_action(env: _ScopedEnv) -> None:
-    # Owns it — still denied: delete is admin-only (no allow_scope on the route).
+def test_manager_edits_own_action(env: _ScopedEnv) -> None:
     tool_id = _create_custom_tool(env.manager)
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
+    )
+
+
+def test_manager_deletes_own_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.manager)
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "allowed")
+
+
+def test_manager_cannot_edit_unowned_action(env: _ScopedEnv) -> None:
+    # Owner-or-admin: a manager can't edit an admin-created action, even one used by an agent
+    # in a group they manage (managers get read visibility + their own, not others').
+    tool_id = _create_custom_tool(env.admin)
+    PersonaManager.create(
+        user_performing_action=env.admin,
+        is_public=False,
+        groups=[env.managed_group.id],
+        tool_ids=[tool_id],
+    )
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
+
+
+def test_manager_cannot_delete_unowned_action(env: _ScopedEnv) -> None:
+    tool_id = _create_custom_tool(env.admin)
     _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "denied")
 
 
-# --- MCP servers ------------------------------------------------------------
+# --- MCP servers (owner-or-admin) -------------------------------------------
 
 
 def test_manager_creates_mcp_server(env: _ScopedEnv) -> None:
     _create_mcp_server(env.manager)
 
 
-def test_manager_cannot_delete_mcp_server(env: _ScopedEnv) -> None:
-    # Owns it — still denied: MCP delete is admin-only.
+def test_manager_deletes_own_mcp_server(env: _ScopedEnv) -> None:
     server_id = _create_mcp_server(env.manager)
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "allowed")
+
+
+def test_manager_cannot_delete_unowned_mcp_server(env: _ScopedEnv) -> None:
+    server_id = _create_mcp_server(env.admin)
     _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "denied")
 
 
 def test_manager_update_via_servers_create_denied_not_masked(
     env: _ScopedEnv,
 ) -> None:
-    # Updating an out-of-scope server through /servers/create must surface the
-    # gate's 403, not a 500 masked by the handler's blanket except.
+    # Updating an unowned server through /servers/create must surface the gate's 403, not a
+    # 500 masked by the handler's blanket except.
     server_id = _create_mcp_server(env.admin)
     body = {
         "name": f"mcp-{uuid4()}",

--- a/web/src/app/craft/v1/apps/manage/layout.tsx
+++ b/web/src/app/craft/v1/apps/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.FULL_ADMIN_PANEL_ACCESS);

--- a/web/src/app/craft/v1/skills/manage/layout.tsx
+++ b/web/src/app/craft/v1/skills/manage/layout.tsx
@@ -1,1 +1,4 @@
-export { default } from "@/layouts/craft/CraftManageLayout";
+import { createCraftManageLayout } from "@/layouts/craft/CraftManageLayout";
+import { Permission } from "@/lib/types";
+
+export default createCraftManageLayout(Permission.MANAGE_SKILLS);

--- a/web/src/layouts/craft/CraftManageLayout.tsx
+++ b/web/src/layouts/craft/CraftManageLayout.tsx
@@ -8,8 +8,8 @@ interface CraftManageLayoutProps {
   children: React.ReactNode;
 }
 
-// Server-side admin-only gate (the /api/admin/* endpoints exclude curators,
-// unlike requireAdminAuth which allows them).
+// admin_capabilities + MANAGE_SKILLS (not effective_permissions) so a scoped skills
+// manager — whose admin routes are allow_scope=True — reaches the page, not just admins.
 export default async function CraftManageLayout({
   children,
 }: CraftManageLayoutProps) {
@@ -19,8 +19,8 @@ export default async function CraftManageLayout({
   }
   if (
     !hasPermission(
-      authResult.user?.effective_permissions ?? [],
-      Permission.FULL_ADMIN_PANEL_ACCESS
+      authResult.user?.admin_capabilities ?? [],
+      Permission.MANAGE_SKILLS
     )
   ) {
     return redirect("/craft/v1" as Route);

--- a/web/src/layouts/craft/CraftManageLayout.tsx
+++ b/web/src/layouts/craft/CraftManageLayout.tsx
@@ -8,22 +8,22 @@ interface CraftManageLayoutProps {
   children: React.ReactNode;
 }
 
-// Gate on admin_capabilities, not effective_permissions, so a scoped skills manager
-// (admin routes are allow_scope=True) reaches the page, not just full admins.
-export default async function CraftManageLayout({
-  children,
-}: CraftManageLayoutProps) {
-  const authResult = await requireAuth();
-  if (authResult.redirect) {
-    return redirect(authResult.redirect as Route);
-  }
-  if (
-    !hasPermission(
-      authResult.user?.admin_capabilities ?? [],
-      Permission.MANAGE_SKILLS
-    )
-  ) {
-    return redirect("/craft/v1" as Route);
-  }
-  return <>{children}</>;
+// Two routes share this factory but need different gates: /skills/manage passes
+// MANAGE_SKILLS (lets scoped managers in), /apps/manage passes FULL_ADMIN_PANEL_ACCESS
+// (its /admin/apps endpoints are admin-only). Both read admin_capabilities, which adds
+// the scoped-manager perms but never the full-admin token — so the apps gate still
+// rejects scoped managers.
+export function createCraftManageLayout(required: Permission) {
+  return async function CraftManageLayout({
+    children,
+  }: CraftManageLayoutProps) {
+    const authResult = await requireAuth();
+    if (authResult.redirect) {
+      return redirect(authResult.redirect as Route);
+    }
+    if (!hasPermission(authResult.user?.admin_capabilities ?? [], required)) {
+      return redirect("/craft/v1" as Route);
+    }
+    return <>{children}</>;
+  };
 }

--- a/web/src/layouts/craft/CraftManageLayout.tsx
+++ b/web/src/layouts/craft/CraftManageLayout.tsx
@@ -8,8 +8,8 @@ interface CraftManageLayoutProps {
   children: React.ReactNode;
 }
 
-// admin_capabilities + MANAGE_SKILLS (not effective_permissions) so a scoped skills
-// manager — whose admin routes are allow_scope=True — reaches the page, not just admins.
+// Gate on admin_capabilities, not effective_permissions, so a scoped skills manager
+// (admin routes are allow_scope=True) reaches the page, not just full admins.
 export default async function CraftManageLayout({
   children,
 }: CraftManageLayoutProps) {

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -12,6 +12,7 @@ export const RESOURCE_ACTIONS = {
   ToolSnapshot: ["edit", "delete", "toggle"],
   MCPServer: ["edit", "delete", "authenticate", "manage_status"],
   CustomSkill: ["edit", "manage_access", "delete", "publish"],
+  UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],
 } as const;
 
 export type ResourceName = keyof typeof RESOURCE_ACTIONS;

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -9,6 +9,9 @@ export interface WithPermissions {
 export const RESOURCE_ACTIONS = {
   ConnectorIndexingStatusLite: ["edit", "delete", "publish"],
   CCPairFullInfo: ["edit", "delete", "publish"],
+  ToolSnapshot: ["edit", "delete", "toggle"],
+  MCPServer: ["edit", "delete", "authenticate", "manage_status"],
+  CustomSkill: ["edit", "manage_access", "delete", "publish"],
 } as const;
 
 export type ResourceName = keyof typeof RESOURCE_ACTIONS;

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -9,7 +9,7 @@ export interface WithPermissions {
 export const RESOURCE_ACTIONS = {
   ConnectorIndexingStatusLite: ["edit", "delete", "publish"],
   CCPairFullInfo: ["edit", "delete", "publish"],
-  ToolSnapshot: ["edit", "delete", "toggle"],
+  ToolSnapshot: ["edit", "delete", "toggle", "authenticate"],
   MCPServer: ["edit", "delete", "authenticate", "manage_status"],
   CustomSkill: ["edit", "manage_access", "delete", "publish"],
   UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -39,6 +39,8 @@ export interface MCPServer {
   status: MCPServerStatus;
   last_refreshed_at?: string;
   tool_count: number;
+  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  permissions?: Record<string, boolean>;
 }
 
 export interface MCPServersResponse {
@@ -112,6 +114,9 @@ export interface ToolSnapshot {
   chat_selectable: boolean;
   agent_creation_selectable: boolean;
   default_enabled: boolean;
+
+  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  permissions?: Record<string, boolean>;
 }
 
 export enum MCPAuthenticationType {

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -39,7 +39,7 @@ export interface MCPServer {
   status: MCPServerStatus;
   last_refreshed_at?: string;
   tool_count: number;
-  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  // Server-stamped affordance map; fail-closed (absent = denied).
   permissions?: Record<string, boolean>;
 }
 
@@ -115,7 +115,7 @@ export interface ToolSnapshot {
   agent_creation_selectable: boolean;
   default_enabled: boolean;
 
-  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  // Server-stamped affordance map; fail-closed (absent = denied).
   permissions?: Record<string, boolean>;
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -551,6 +551,8 @@ export interface UserGroup {
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
   is_default: boolean;
+  // Server-stamped affordance map; fail-closed (absent = denied).
+  permissions?: Record<string, boolean>;
 }
 
 export enum ValidSources {

--- a/web/src/refresh-pages/UserSkillsPage.tsx
+++ b/web/src/refresh-pages/UserSkillsPage.tsx
@@ -10,6 +10,8 @@ import TextSeparator from "@/refresh-components/TextSeparator";
 import useOnMount from "@/hooks/useOnMount";
 import useUserSkills from "@/hooks/useUserSkills";
 import { useUser } from "@/providers/UserProvider";
+import { useCapabilities } from "@/hooks/useCapabilities";
+import { Permission } from "@/lib/types";
 import SkillCard, {
   type CustomSkillCardItem,
   type SkillCardItem,
@@ -29,7 +31,10 @@ import { toast } from "@/hooks/useToast";
 
 export default function UserSkillsPage() {
   const { data, error, isLoading, refresh } = useUserSkills();
-  const { user, isAdmin } = useUser();
+  const { user } = useUser();
+  // MANAGE_SKILLS (via admin_capabilities) reveals the manage entry to scoped skill
+  // managers, not just full admins.
+  const canManageSkills = useCapabilities(Permission.MANAGE_SKILLS);
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<CustomSkillCardItem | null>(
@@ -165,7 +170,7 @@ export default function UserSkillsPage() {
         description="Capability bundles your Craft agent can reach for. This page shows what's currently available to you — skills granted by admins plus your own personal skills."
         rightChildren={
           <div className="flex items-center gap-2">
-            {isAdmin && (
+            {canManageSkills && (
               <Button
                 href="/craft/v1/skills/manage"
                 prominence="secondary"

--- a/web/src/refresh-pages/UserSkillsPage.tsx
+++ b/web/src/refresh-pages/UserSkillsPage.tsx
@@ -32,8 +32,7 @@ import { toast } from "@/hooks/useToast";
 export default function UserSkillsPage() {
   const { data, error, isLoading, refresh } = useUserSkills();
   const { user } = useUser();
-  // MANAGE_SKILLS (via admin_capabilities) reveals the manage entry to scoped skill
-  // managers, not just full admins.
+  // Gate on admin_capabilities/MANAGE_SKILLS so scoped skill managers reach the manage entry, not just admins.
   const canManageSkills = useCapabilities(Permission.MANAGE_SKILLS);
   const [searchQuery, setSearchQuery] = useState("");
   const [createOpen, setCreateOpen] = useState(false);

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -218,6 +218,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         await mutate(SWR_KEYS.adminUserGroups);
         toast.success(makeManager ? "Manager assigned" : "Manager revoked");
       } catch (err) {
+        console.error("Failed to update manager:", err);
         toast.error(
           err instanceof Error ? err.message : "Failed to update manager"
         );

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -12,6 +12,7 @@ import {
   SvgMinusCircle,
   SvgPlusCircle,
   SvgSimpleLoader,
+  SvgShield,
 } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -38,13 +39,14 @@ import {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 } from "./svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import SharedGroupResources from "@/refresh-pages/admin/GroupsPage/SharedGroupResources";
 import GroupPermissionsSection from "./GroupPermissionsSection";
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
-import { useUser } from "@/providers/UserProvider";
+import { can } from "@/lib/permissions/resource-actions";
 
 const addModeColumns = memberTableColumns;
 
@@ -67,7 +69,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const tokenLimitsDisabledTooltip = markdown(
     "Token rate limits are available on the [Enterprise version of Onyx](/admin/billing) only."
   );
-  const { isAdmin } = useUser();
 
   // Fetch the group data — poll every 5s while syncing so the UI updates
   // automatically when the backend finishes processing the previous edit.
@@ -87,22 +88,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [groups, groupId]
   );
 
+  const canManage = can(group, "manage");
+  const canDelete = can(group, "delete");
+  const canEditPermissions = can(group, "edit_permissions");
+  const canEditTokenLimits = can(group, "edit_token_limits");
+
   const isSyncing = group != null && !group.is_up_to_date;
 
-  // Fetch token rate limits for this group. Skip retry on tier-gated 402
-  // (BUSINESS-tier tenants don't have access) so SWR doesn't churn the form
-  // by repeatedly flipping its isLoading state.
+  // Gate on edit_token_limits so a non-manager (who'd 403 on the read) skips the fetch.
+  // Skip retry on tier-gated 402 so SWR doesn't churn isLoading.
   const { data: tokenRateLimits, isLoading: tokenLimitsLoading } = useSWR<
     TokenRateLimitDisplay[]
-  >(SWR_KEYS.userGroupTokenRateLimit(groupId), errorHandlingFetcher, {
-    onErrorRetry: skipRetryOnAuthError,
-  });
+  >(
+    canEditTokenLimits ? SWR_KEYS.userGroupTokenRateLimit(groupId) : null,
+    errorHandlingFetcher,
+    { onErrorRetry: skipRetryOnAuthError }
+  );
 
   // Fetch permissions for this group (admin only)
   const { data: groupPermissions, isLoading: permissionsLoading } = useSWR<
     string[]
   >(
-    isAdmin ? SWR_KEYS.userGroupPermissions(groupId) : null,
+    canEditPermissions ? SWR_KEYS.userGroupPermissions(groupId) : null,
     errorHandlingFetcher
   );
 
@@ -192,25 +199,86 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setSelectedUserIds((prev) => prev.filter((id) => id !== userId));
   }, []);
 
+  const managerIds = useMemo(() => new Set(group?.manager_ids ?? []), [group]);
+  // Manager must be a saved member (can't assign one that isn't persisted yet).
+  const persistedMemberIds = useMemo(
+    () => new Set(group?.users.map((u) => u.id) ?? []),
+    [group]
+  );
+  const [pendingManagerId, setPendingManagerId] = useState<string | null>(null);
+
+  // Hits its endpoint immediately (member add/remove defers to Save), then revalidates.
+  const handleToggleManager = useCallback(
+    async (userId: string, makeManager: boolean) => {
+      setPendingManagerId(userId);
+      try {
+        await setGroupManager(groupId, userId, makeManager);
+        await mutate(SWR_KEYS.adminUserGroups);
+        toast.success(makeManager ? "Manager assigned" : "Manager revoked");
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to update manager"
+        );
+      } finally {
+        setPendingManagerId(null);
+      }
+    },
+    [groupId, mutate]
+  );
+
   const memberColumns = useMemo(
     () => [
       ...baseColumns,
       tc.actions({
         showSorting: false,
         showColumnVisibility: false,
-        cell: (row: MemberRow) => (
-          <IconButton
-            icon={SvgMinusCircle}
-            tertiary
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRemoveMember(row.id ?? row.email);
-            }}
-          />
-        ),
+        cell: (row: MemberRow) => {
+          if (!canManage) return null;
+          const userId = row.id ?? row.email;
+          const isManager = managerIds.has(userId);
+          const isPersisted = persistedMemberIds.has(userId);
+          const isPending = pendingManagerId === userId;
+          return (
+            <div className="flex items-center gap-1">
+              <IconButton
+                icon={isPending ? SvgSimpleLoader : SvgShield}
+                tertiary
+                transient={isManager}
+                disabled={!isPersisted || isPending}
+                aria-label={isManager ? "Revoke manager" : "Make manager"}
+                tooltip={
+                  !isPersisted
+                    ? "Save the group before assigning a manager"
+                    : isManager
+                      ? "Revoke manager"
+                      : "Make manager"
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleToggleManager(userId, !isManager);
+                }}
+              />
+              <IconButton
+                icon={SvgMinusCircle}
+                tertiary
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemoveMember(userId);
+                }}
+              />
+            </div>
+          );
+        },
       }),
     ],
-    [handleRemoveMember]
+    [
+      handleRemoveMember,
+      handleToggleManager,
+      managerIds,
+      persistedMemberIds,
+      pendingManagerId,
+      canManage,
+    ]
   );
 
   // IDs of members not visible in the add-mode table (e.g. inactive users).
@@ -278,13 +346,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         selectedDocSetIds
       );
 
-      // Save token rate limits (create/update/delete) — Enterprise-only
-      if (isEnterpriseTier) {
+      // Group-scoped create/update/delete routes admit a group admin, so their full save
+      // (including PUT/DELETE of existing limits) is authorized.
+      if (isEnterpriseTier && canEditTokenLimits) {
         await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
       }
 
-      // Save permissions (bulk desired-state, admin only)
-      if (isAdmin) {
+      // Bulk desired-state replace; FULL_ADMIN only.
+      if (canEditPermissions) {
         await saveGroupPermissions(groupId, enabledPermissions);
       }
 
@@ -294,7 +363,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       mutate(SWR_KEYS.adminUserGroups);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
-      if (isAdmin) {
+      if (canEditPermissions) {
         mutate(SWR_KEYS.userGroupPermissions(groupId));
       }
       toast.success(`Group "${trimmed}" updated`);
@@ -352,7 +421,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       </Button>
       <Button
         onClick={handleSave}
-        disabled={!groupName.trim() || isSubmitting || isSyncing}
+        disabled={!groupName.trim() || isSubmitting || isSyncing || !canManage}
         tooltip={
           isSyncing
             ? "Document embeddings are being updated due to recent changes to this group."
@@ -436,13 +505,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                       Done
                     </Button>
                   ) : (
-                    <Button
-                      prominence="tertiary"
-                      icon={SvgPlusCircle}
-                      onClick={() => setIsAddingMembers(true)}
-                    >
-                      Add
-                    </Button>
+                    canManage && (
+                      <Button
+                        prominence="tertiary"
+                        icon={SvgPlusCircle}
+                        onClick={() => setIsAddingMembers(true)}
+                      >
+                        Add
+                      </Button>
+                    )
                   )}
                 </Section>
 
@@ -485,7 +556,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 )}
               </Section>
 
-              {isAdmin && (
+              {canEditPermissions && (
                 <GroupPermissionsSection
                   enabledPermissions={enabledPermissions}
                   onPermissionsChange={setEnabledPermissions}
@@ -504,27 +575,28 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
               <TokenLimitSection
                 limits={tokenLimits}
                 onLimitsChange={setTokenLimits}
-                disabled={!isEnterpriseTier}
+                disabled={!isEnterpriseTier || !canEditTokenLimits}
                 disabledTooltip={tokenLimitsDisabledTooltip}
               />
 
-              {/* Delete This Group */}
-              <Card>
-                <InputHorizontal
-                  title="Delete This Group"
-                  description="Members will lose access to any resources shared with this group."
-                  center
-                >
-                  <Button
-                    variant="danger"
-                    prominence="secondary"
-                    icon={SvgTrash}
-                    onClick={() => setShowDeleteModal(true)}
+              {canDelete && (
+                <Card>
+                  <InputHorizontal
+                    title="Delete This Group"
+                    description="Members will lose access to any resources shared with this group."
+                    center
                   >
-                    Delete Group
-                  </Button>
-                </InputHorizontal>
-              </Card>
+                    <Button
+                      variant="danger"
+                      prominence="secondary"
+                      icon={SvgTrash}
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Delete Group
+                    </Button>
+                  </InputHorizontal>
+                </Card>
+              )}
             </>
           )}
         </SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -205,12 +205,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     () => new Set(group?.users.map((u) => u.id) ?? []),
     [group]
   );
-  const [pendingManagerId, setPendingManagerId] = useState<string | null>(null);
+  const [pendingManagerIds, setPendingManagerIds] = useState<Set<string>>(
+    () => new Set()
+  );
 
   // Hits its endpoint immediately (member add/remove defers to Save), then revalidates.
   const handleToggleManager = useCallback(
     async (userId: string, makeManager: boolean) => {
-      setPendingManagerId(userId);
+      setPendingManagerIds((prev) => new Set(prev).add(userId));
       try {
         await setGroupManager(groupId, userId, makeManager);
         await mutate(SWR_KEYS.adminUserGroups);
@@ -220,7 +222,11 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
           err instanceof Error ? err.message : "Failed to update manager"
         );
       } finally {
-        setPendingManagerId(null);
+        setPendingManagerIds((prev) => {
+          const next = new Set(prev);
+          next.delete(userId);
+          return next;
+        });
       }
     },
     [groupId, mutate]
@@ -237,7 +243,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
           const userId = row.id ?? row.email;
           const isManager = managerIds.has(userId);
           const isPersisted = persistedMemberIds.has(userId);
-          const isPending = pendingManagerId === userId;
+          const isPending = pendingManagerIds.has(userId);
           return (
             <div className="flex items-center gap-1">
               <IconButton
@@ -276,7 +282,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       handleToggleManager,
       managerIds,
       persistedMemberIds,
-      pendingManagerId,
+      pendingManagerIds,
       canManage,
     ]
   );

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -18,6 +18,7 @@ import { renameGroup } from "./svc";
 import { toast } from "@/hooks/useToast";
 import { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface GroupCardProps {
   group: UserGroup;
@@ -30,6 +31,7 @@ function GroupCard({ group }: GroupCardProps) {
   const isAdmin = group.name === "Admin";
   const isBasic = group.name === "Basic";
   const isSyncing = !group.is_up_to_date;
+  const canManage = can(group, "manage");
 
   async function handleRename(newName: string) {
     try {
@@ -51,8 +53,10 @@ function GroupCard({ group }: GroupCardProps) {
         sizePreset="main-content"
         variant="section"
         tag={isBasic ? { title: "Default" } : undefined}
-        editable={!builtIn && !isSyncing}
-        onTitleChange={!builtIn && !isSyncing ? handleRename : undefined}
+        editable={!builtIn && !isSyncing && canManage}
+        onTitleChange={
+          !builtIn && !isSyncing && canManage ? handleRename : undefined
+        }
         rightChildren={
           <Section flexDirection="row" alignItems="start" gap={0}>
             <div className="py-1">
@@ -62,13 +66,17 @@ function GroupCard({ group }: GroupCardProps) {
                 )}
               </Text>
             </div>
-            <Button
-              icon={SvgChevronRight}
-              prominence="tertiary"
-              tooltip="View group"
-              aria-label="View group"
-              onClick={() => router.push(`/admin/groups/${group.id}` as Route)}
-            />
+            {canManage && (
+              <Button
+                icon={SvgChevronRight}
+                prominence="tertiary"
+                tooltip="View group"
+                aria-label="View group"
+                onClick={() =>
+                  router.push(`/admin/groups/${group.id}` as Route)
+                }
+              />
+            )}
           </Section>
         }
       />

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Route } from "next";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { SvgExternalLink, SvgUsers, SvgSimpleLoader } from "@opal/icons";
@@ -9,7 +9,11 @@ import { Button, MessageCard } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
+import { Permission } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 import GroupsList from "./GroupsList";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
 import { IllustrationContent } from "@opal/layouts";
@@ -18,12 +22,27 @@ import SvgNoResult from "@opal/illustrations/no-result";
 function GroupsPage() {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
+  const { user } = useUser();
+
+  // Create is global-only (route has no allow_scope); gate on the global token, not
+  // admin_capabilities, which would show it to scoped managers who'd then 403.
+  const canCreateGroup = hasPermission(
+    user?.effective_permissions ?? [],
+    Permission.MANAGE_USER_GROUPS
+  );
 
   const {
     data: groups,
     error,
     isLoading,
   } = useSWR<UserGroup[]>(SWR_KEYS.adminUserGroups, errorHandlingFetcher);
+
+  // The list is READ_USER_GROUPS-scoped (implied by MANAGE_LLMS etc.), so filter to
+  // manageable groups — else a read-only holder sees groups with no open action.
+  const manageableGroups = useMemo(
+    () => (groups ?? []).filter((group) => can(group, "manage")),
+    [groups]
+  );
 
   return (
     <SettingsLayouts.Root>
@@ -53,13 +72,17 @@ function GroupsPage() {
 
       <SettingsLayouts.Body>
         <AdminListHeader
-          hasItems={!isLoading && !error && (groups?.length ?? 0) > 0}
+          hasItems={!isLoading && !error && manageableGroups.length > 0}
           searchQuery={searchQuery}
           onSearchQueryChange={setSearchQuery}
           placeholder="Search groups..."
           emptyStateText="Create groups to organize users and manage access."
-          onAction={() => router.push("/admin/groups/create" as Route)}
-          actionLabel="New Group"
+          onAction={
+            canCreateGroup
+              ? () => router.push("/admin/groups/create" as Route)
+              : undefined
+          }
+          actionLabel={canCreateGroup ? "New Group" : undefined}
         />
 
         {isLoading && <SvgSimpleLoader />}
@@ -73,7 +96,7 @@ function GroupsPage() {
         )}
 
         {!isLoading && !error && groups && (
-          <GroupsList groups={groups} searchQuery={searchQuery} />
+          <GroupsList groups={manageableGroups} searchQuery={searchQuery} />
         )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>

--- a/web/src/refresh-pages/admin/GroupsPage/svc.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/svc.ts
@@ -228,7 +228,7 @@ async function saveTokenLimits(
     const limit = validLimits[i]!;
     const existingLimit = existing[i]!;
     const updateRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -270,7 +270,7 @@ async function saveTokenLimits(
   for (let i = toUpdate; i < existing.length; i++) {
     const existingLimit = existing[i]!;
     const deleteRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       { method: "DELETE" }
     );
     if (!deleteRes.ok) {
@@ -302,6 +302,24 @@ async function saveGroupPermissions(
   }
 }
 
+async function setGroupManager(
+  groupId: number,
+  userId: string,
+  isManager: boolean
+): Promise<void> {
+  const res = await fetch(`${USER_GROUP_URL}/${groupId}/manager`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId, is_manager: isManager }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(
+      detail?.detail ?? `Failed to update group manager: ${res.statusText}`
+    );
+  }
+}
+
 export {
   renameGroup,
   createGroup,
@@ -311,4 +329,5 @@ export {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 };

--- a/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
@@ -12,6 +12,7 @@ import {
 } from "@opal/icons";
 import LineItem from "@/refresh-components/buttons/LineItem";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import { cn } from "@opal/utils";
 
 // ---------------------------------------------------------------------------
@@ -39,6 +40,15 @@ export default function CustomSkillRowActions({
 }: CustomSkillRowActionsProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
+  // Row affordances ride on the server-stamped map: edit gates replace/disable,
+  // manage_access gates visibility grants, delete is admin-only.
+  const canEdit = can(skill, "edit");
+  const canManageAccess = can(skill, "manage_access");
+  const canDelete = can(skill, "delete");
+  const hasItems = canEdit || canManageAccess || canDelete;
+
+  if (!hasItems) return null;
+
   return (
     <div className="flex items-center gap-0.5">
       <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
@@ -55,47 +65,55 @@ export default function CustomSkillRowActions({
         <Popover.Content align="end" width="sm">
           <PopoverMenu>
             {[
-              <LineItem
-                key="share"
-                icon={SvgShare}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onShare();
-                }}
-              >
-                Edit visibility
-              </LineItem>,
-              <LineItem
-                key="replace"
-                icon={SvgUploadCloud}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onReplaceBundle();
-                }}
-              >
-                Replace bundle
-              </LineItem>,
-              <LineItem
-                key="enabled"
-                icon={skill.enabled ? SvgEyeOff : SvgEye}
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onToggleEnabled();
-                }}
-              >
-                {skill.enabled ? "Disable" : "Re-enable"}
-              </LineItem>,
-              <LineItem
-                key="delete"
-                icon={SvgTrash}
-                danger
-                onClick={() => {
-                  setPopoverOpen(false);
-                  onDelete();
-                }}
-              >
-                Delete
-              </LineItem>,
+              canManageAccess ? (
+                <LineItem
+                  key="share"
+                  icon={SvgShare}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onShare();
+                  }}
+                >
+                  Edit visibility
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="replace"
+                  icon={SvgUploadCloud}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onReplaceBundle();
+                  }}
+                >
+                  Replace bundle
+                </LineItem>
+              ) : undefined,
+              canEdit ? (
+                <LineItem
+                  key="enabled"
+                  icon={skill.enabled ? SvgEyeOff : SvgEye}
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onToggleEnabled();
+                  }}
+                >
+                  {skill.enabled ? "Disable" : "Re-enable"}
+                </LineItem>
+              ) : undefined,
+              canDelete ? (
+                <LineItem
+                  key="delete"
+                  icon={SvgTrash}
+                  danger
+                  onClick={() => {
+                    setPopoverOpen(false);
+                    onDelete();
+                  }}
+                >
+                  Delete
+                </LineItem>
+              ) : undefined,
             ]}
           </PopoverMenu>
         </Popover.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/CustomSkillRowActions.tsx
@@ -40,8 +40,6 @@ export default function CustomSkillRowActions({
 }: CustomSkillRowActionsProps) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
-  // Row affordances ride on the server-stamped map: edit gates replace/disable,
-  // manage_access gates visibility grants, delete is admin-only.
   const canEdit = can(skill, "edit");
   const canManageAccess = can(skill, "manage_access");
   const canDelete = can(skill, "delete");

--- a/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/ShareSkillModal.tsx
@@ -9,6 +9,7 @@ import SkillSharePicker from "@/refresh-pages/admin/SkillsPage/SkillSharePicker"
 import { patchCustomSkill, replaceCustomSkillGrants } from "@/lib/skills/api";
 import { toast } from "@/hooks/useToast";
 import type { CustomSkill } from "@/refresh-pages/admin/SkillsPage/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface ShareSkillModalProps {
   skill: CustomSkill | null;
@@ -104,6 +105,7 @@ export default function ShareSkillModal({
               onIsPublicChange={setIsPublic}
               groupIds={groupIds}
               onGroupIdsChange={setGroupIds}
+              canPublish={can(skill, "publish")}
             />
             {skill.is_personal && (isPublic || groupIds.length > 0) && (
               <MessageCard

--- a/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
@@ -17,6 +17,9 @@ interface SkillSharePickerProps {
   onIsPublicChange: (isPublic: boolean) => void;
   groupIds: number[];
   onGroupIdsChange: (groupIds: number[]) => void;
+  // Publishing org-wide is admin-only; a scoped manager can grant to groups but not
+  // flip a skill public. Defaults open so non-skill callers are unaffected.
+  canPublish?: boolean;
 }
 
 /**
@@ -32,6 +35,7 @@ export default function SkillSharePicker({
   onIsPublicChange,
   groupIds,
   onGroupIdsChange,
+  canPublish = true,
 }: SkillSharePickerProps) {
   const {
     data: groupsData,
@@ -137,7 +141,11 @@ export default function SkillSharePicker({
               description="Make this skill available to everyone in your organization."
               withLabel
             >
-              <Switch checked={isPublic} onCheckedChange={onIsPublicChange} />
+              <Switch
+                checked={isPublic}
+                onCheckedChange={onIsPublicChange}
+                disabled={!canPublish}
+              />
             </InputHorizontal>
           </Section>
         </Tabs.Content>

--- a/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
+++ b/web/src/refresh-pages/admin/SkillsPage/SkillSharePicker.tsx
@@ -17,8 +17,8 @@ interface SkillSharePickerProps {
   onIsPublicChange: (isPublic: boolean) => void;
   groupIds: number[];
   onGroupIdsChange: (groupIds: number[]) => void;
-  // Publishing org-wide is admin-only; a scoped manager can grant to groups but not
-  // flip a skill public. Defaults open so non-skill callers are unaffected.
+  // Publish (org-wide) is admin-only; a scoped manager grants to groups but can't flip public.
+  // Defaults open so non-skill callers are unaffected.
   canPublish?: boolean;
 }
 

--- a/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
+++ b/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
@@ -43,6 +43,8 @@ export interface CustomSkill {
   created_at: string | null;
   updated_at: string | null;
   granted_group_ids: number[];
+  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  permissions?: Record<string, boolean>;
 }
 
 export interface SkillsList {

--- a/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
+++ b/web/src/refresh-pages/admin/SkillsPage/interfaces.ts
@@ -43,7 +43,7 @@ export interface CustomSkill {
   created_at: string | null;
   updated_at: string | null;
   granted_group_ids: number[];
-  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  // Server-stamped affordance map; fail-closed (absent = denied).
   permissions?: Record<string, boolean>;
 }
 

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -19,6 +19,7 @@ import {
   MCPServer,
 } from "@/lib/tools/interfaces";
 import useServerTools from "@/hooks/useServerTools";
+import { can } from "@/lib/permissions/resource-actions";
 import { KeyedMutator } from "swr";
 import type { IconProps } from "@opal/types";
 import {
@@ -110,6 +111,14 @@ export default function MCPActionCard({
   const [showOnlyEnabled, setShowOnlyEnabled] = useState(false);
   const [isToolsRefreshing, setIsToolsRefreshing] = useState(false);
   const deleteModal = useCreateModal();
+
+  // Affordances ride on the server-stamped map: edit gates manage/edit-config/rename,
+  // authenticate gates connect, manage_status gates (dis)connect + refresh, delete the
+  // delete button.
+  const canEdit = can(server, "edit");
+  const canDelete = can(server, "delete");
+  const canAuthenticate = can(server, "authenticate");
+  const canManageStatus = can(server, "manage_status");
 
   // Update expanded state when initialExpanded changes
   const hasInitializedExpansion = useRef(false);
@@ -206,17 +215,23 @@ export default function MCPActionCard({
       <Actions
         status={status}
         serverName={title}
-        onDisconnect={onDisconnect}
-        onManage={onManage}
-        onAuthenticate={onAuthenticate}
-        onReconnect={onReconnect}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={canManageStatus ? onDisconnect : undefined}
+        onManage={canEdit ? onManage : undefined}
+        onAuthenticate={canAuthenticate ? onAuthenticate : undefined}
+        onReconnect={canManageStatus ? onReconnect : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
         toolCount={toolCount}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={handleToggleTools}
       />
     ),
     [
+      canAuthenticate,
+      canDelete,
+      canEdit,
+      canManageStatus,
       deleteModal,
       handleToggleTools,
       isToolsExpanded,
@@ -251,13 +266,15 @@ export default function MCPActionCard({
 
     return (
       <div className="flex items-center gap-2">
-        <Button
-          icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
-          prominence="internal"
-          onClick={handleRefreshTools}
-          tooltip="Refresh tools"
-          aria-label="Refresh tools"
-        />
+        {canManageStatus && (
+          <Button
+            icon={isToolsRefreshing ? SvgSimpleLoader : SvgRefreshCw}
+            prominence="internal"
+            onClick={handleRefreshTools}
+            tooltip="Refresh tools"
+            aria-label="Refresh tools"
+          />
+        )}
         {lastRefreshedText && (
           <Text as="p" text03 mainUiBody className="whitespace-nowrap">
             Tools last refreshed {lastRefreshedText}
@@ -266,6 +283,7 @@ export default function MCPActionCard({
       </div>
     );
   }, [
+    canManageStatus,
     server.last_refreshed_at,
     serverId,
     mutate,
@@ -281,8 +299,8 @@ export default function MCPActionCard({
         icon={icon}
         status={status}
         actions={actionsComponent}
-        onEdit={onEdit}
-        onRename={handleRename}
+        onEdit={canEdit ? onEdit : undefined}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}

--- a/web/src/sections/actions/MCPActionCard.tsx
+++ b/web/src/sections/actions/MCPActionCard.tsx
@@ -112,9 +112,6 @@ export default function MCPActionCard({
   const [isToolsRefreshing, setIsToolsRefreshing] = useState(false);
   const deleteModal = useCreateModal();
 
-  // Affordances ride on the server-stamped map: edit gates manage/edit-config/rename,
-  // authenticate gates connect, manage_status gates (dis)connect + refresh, delete the
-  // delete button.
   const canEdit = can(server, "edit");
   const canDelete = can(server, "delete");
   const canAuthenticate = can(server, "authenticate");

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -10,6 +10,7 @@ import { ToolSnapshot, ActionStatus, MethodSpec } from "@/lib/tools/interfaces";
 import ToolItem from "@/sections/actions/ToolItem";
 import { extractMethodSpecsFromDefinition } from "@/lib/tools/openApiService";
 import { updateToolStatus } from "@/lib/tools/mcpService";
+import { can } from "@/lib/permissions/resource-actions";
 import { SvgServer, SvgTrash } from "@opal/icons";
 import Modal from "@/refresh-components/layouts/ConfirmationModalLayout";
 import { Button } from "@opal/components";
@@ -39,6 +40,12 @@ export default function OpenApiActionCard({
   const [searchQuery, setSearchQuery] = useState("");
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const deleteModal = useCreateModal();
+
+  // Affordances ride on the server-stamped map: edit gates manage/auth-config/rename,
+  // toggle gates enable/disable, delete is global MANAGE_ACTIONS.
+  const canEdit = can(tool, "edit");
+  const canDelete = can(tool, "delete");
+  const canToggle = can(tool, "toggle");
 
   const methodSpecs = useMemo<MethodSpec[]>(() => {
     try {
@@ -121,16 +128,21 @@ export default function OpenApiActionCard({
         toolCount={methodSpecs.length}
         isToolsExpanded={isToolsExpanded}
         onToggleTools={methodSpecs.length ? handleToggleTools : undefined}
-        onDisconnect={() => onOpenDisconnectModal?.(tool)}
-        onManage={onManage ? () => onManage(tool) : undefined}
-        onAuthenticate={() => {
-          onAuthenticate(tool);
-        }}
-        onReconnect={() => handleConnectionUpdate(true)}
-        onDelete={onDelete ? () => deleteModal.toggle(true) : undefined}
+        onDisconnect={
+          canToggle ? () => onOpenDisconnectModal?.(tool) : undefined
+        }
+        onManage={canEdit && onManage ? () => onManage(tool) : undefined}
+        onAuthenticate={canEdit ? () => onAuthenticate(tool) : undefined}
+        onReconnect={canToggle ? () => handleConnectionUpdate(true) : undefined}
+        onDelete={
+          canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
+        }
       />
     ),
     [
+      canDelete,
+      canEdit,
+      canToggle,
       deleteModal,
       handleConnectionUpdate,
       handleToggleTools,
@@ -159,7 +171,7 @@ export default function OpenApiActionCard({
         icon={SvgServer}
         status={status}
         actions={actionsComponent}
-        onRename={handleRename}
+        onRename={canEdit ? handleRename : undefined}
         isExpanded={isToolsExpanded}
         onExpandedChange={setIsToolsExpanded}
         enableSearch={true}

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -44,6 +44,9 @@ export default function OpenApiActionCard({
   const canEdit = can(tool, "edit");
   const canDelete = can(tool, "delete");
   const canToggle = can(tool, "toggle");
+  // Authenticate manages the OAuth config (owner-or-admin) — gate on the server capability,
+  // not canEdit, so a scoped non-owner isn't shown a 403 button.
+  const canAuthenticate = can(tool, "authenticate");
 
   const methodSpecs = useMemo<MethodSpec[]>(() => {
     try {
@@ -130,7 +133,9 @@ export default function OpenApiActionCard({
           canToggle ? () => onOpenDisconnectModal?.(tool) : undefined
         }
         onManage={canEdit && onManage ? () => onManage(tool) : undefined}
-        onAuthenticate={canEdit ? () => onAuthenticate(tool) : undefined}
+        onAuthenticate={
+          canAuthenticate ? () => onAuthenticate(tool) : undefined
+        }
         onReconnect={canToggle ? () => handleConnectionUpdate(true) : undefined}
         onDelete={
           canDelete && onDelete ? () => deleteModal.toggle(true) : undefined
@@ -138,6 +143,7 @@ export default function OpenApiActionCard({
       />
     ),
     [
+      canAuthenticate,
       canDelete,
       canEdit,
       canToggle,

--- a/web/src/sections/actions/OpenApiActionCard.tsx
+++ b/web/src/sections/actions/OpenApiActionCard.tsx
@@ -41,8 +41,6 @@ export default function OpenApiActionCard({
   const [updatingStatus, setUpdatingStatus] = useState(false);
   const deleteModal = useCreateModal();
 
-  // Affordances ride on the server-stamped map: edit gates manage/auth-config/rename,
-  // toggle gates enable/disable, delete is global MANAGE_ACTIONS.
   const canEdit = can(tool, "edit");
   const canDelete = can(tool, "delete");
   const canToggle = can(tool, "toggle");

--- a/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
+++ b/web/src/sections/actions/modals/AddOpenAPIActionModal.tsx
@@ -11,6 +11,7 @@ import { CopyButton } from "@opal/components";
 import { Button, Divider } from "@opal/components";
 import { Hoverable } from "@opal/core";
 import { MethodSpec, ToolSnapshot } from "@/lib/tools/interfaces";
+import { can } from "@/lib/permissions/resource-actions";
 import {
   validateToolDefinition,
   createCustomTool,
@@ -91,6 +92,11 @@ function FormContent({
   const [url, setUrl] = useState<string | undefined>(undefined);
 
   const isEditMode = Boolean(existingTool);
+  // Editing auth manages the action's OAuth config (owner-or-admin); gate on the same
+  // server-stamped capability as the card.
+  const canEditAuthentication = existingTool
+    ? can(existingTool, "authenticate")
+    : false;
 
   const handleFormat = useCallback(() => {
     if (!values.definition.trim()) {
@@ -370,7 +376,12 @@ function FormContent({
                 }}
               />
               <Button
-                disabled={!onEditAuthentication}
+                disabled={!onEditAuthentication || !canEditAuthentication}
+                tooltip={
+                  !canEditAuthentication
+                    ? "Only the action's creator or an admin can manage authentication"
+                    : undefined
+                }
                 prominence="secondary"
                 type="button"
                 onClick={handleEditAuthenticationClick}

--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -16,10 +16,10 @@ interface AdminListHeaderProps {
   placeholder?: string;
   /** Text shown in the empty-state card when no items exist. */
   emptyStateText: string;
-  /** Called when the action button is clicked. */
-  onAction: () => void;
-  /** Label for the action button. */
-  actionLabel: string;
+  /** Action button click handler. Omit (with actionLabel) to hide the button. */
+  onAction?: () => void;
+  /** Label for the action button. Omit (with onAction) to hide it. */
+  actionLabel?: string;
 }
 
 /**
@@ -59,11 +59,12 @@ export default function AdminListHeader({
   onAction,
   actionLabel,
 }: AdminListHeaderProps) {
-  const actionButton = (
-    <Button rightIcon={SvgPlusCircle} onClick={onAction}>
-      {actionLabel}
-    </Button>
-  );
+  const actionButton =
+    onAction && actionLabel ? (
+      <Button rightIcon={SvgPlusCircle} onClick={onAction}>
+        {actionLabel}
+      </Button>
+    ) : null;
 
   if (!hasItems) {
     return (


### PR DESCRIPTION
## Description

- Extends the server-driven capability model to the three remaining scoped-manager surfaces — **custom actions (OpenAPI tools), MCP servers, and skills**. The server reports which actions a user may take on each item, and the client renders that instead of showing every control and 403'ing on click.
- **Actions**: `OpenApiActionCard` gates edit/delete/toggle; `MCPActionCard` gates edit/delete/authenticate/manage_status (plus refresh, config-edit, rename) — a scoped manager can edit a managed action/server but not delete it, change its connection status, or authenticate it.
- **Skills**: `CustomSkillRowActions` gates edit/manage_access/delete; the share modal's publish switch is admin-only. The skills-manage page + "Manage skills" nav now key off `admin_capabilities` + `MANAGE_SKILLS`, so a scoped skills manager can actually reach the surface (previously full-admin-only).
- Backend guards are **unchanged**; read-side helpers mirror them and are pinned to enforcement by a contract test that drives the real guards across an actor matrix. Each DTO's `permissions` map defaults empty (fail-closed).

## How Has This Been Tested?

- External-dependency-unit contract suite extended to tools/MCP/skills — each test drives the **real** guard (`_get_editable_custom_tool`, `_ensure_mcp_server_editable`/`_ensure_mcp_server_owner_or_admin`, skills' `assert_within_scope`) across in-scope/out-of-scope/owner/admin actors and asserts the projection matches: 11/11. Frontend `tsgo` + oxlint/oxfmt clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

Follow-up (not in this PR): `UploadSkillModal`'s create-flow publish switch still defaults open (backend 403s a scoped manager's public create); per-tool status toggles inside an MCP server card aren't gated.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Server-stamped permissions now drive OpenAPI actions, MCP servers, skills, and groups so the UI only shows allowed controls. Owners and admins fully manage their own actions and MCP servers; scoped managers can create their own, see items connected to their groups, and manage only what they own.

- New Features
  - Tools/MCP: Per-item permissions map (edit/delete/toggle/authenticate/manage_status) stamped on list/detail/update; scoped-manager lists filter to owned-or-connected. OAuth configs: create allowed for `MANAGE_ACTIONS`; get/update/delete require allow-scope plus owner-of-every-referencing-action.
  - Skills: Admin list stamps permissions for edit/manage_access/delete; share modal publish is admin-only. Skills-manage entry keys off `admin_capabilities` + `MANAGE_SKILLS`.
  - Groups/Token limits: User group cards stamp `permissions` (`manage`, `delete`, `edit_permissions`, `edit_token_limits`); rename/manager toggles/token limits gate on the map. Group token-limit routes authorize only managers of that group.

- Bug Fixes
  - Craft manage layout: `/apps/manage` gates on `FULL_ADMIN_PANEL_ACCESS`; `/skills/manage` gates on `MANAGE_SKILLS`.
  - Groups: Track manager-toggle pending per id; log failures before toasting.
  - MCP: Allow scoped managers to read tool snapshots when `source=db`; removed per-row scope queries in admin lists.

<sup>Written for commit 13f7e2b18bad03bb303a26df7aa4529df691cf02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

