### PR TITLE
feat(perms): PR-D groups + token limits — close out the capability matrix

### DIFF
--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -117,9 +117,12 @@ def _authorize_group_token_rate_limit_write(
         requested_group_ids=[group_id],
         is_non_public=True,
     )
-    scope, resolved_group_id = get_token_rate_limit_scope_and_group(
-        db_session, rate_limit_id
-    )
+    try:
+        scope, resolved_group_id = get_token_rate_limit_scope_and_group(
+            db_session, rate_limit_id
+        )
+    except ValueError:
+        scope, resolved_group_id = None, None
     if scope != TokenRateLimitScope.USER_GROUP or resolved_group_id != group_id:
         raise OnyxError(
             OnyxErrorCode.NOT_FOUND, "Token rate limit not found for this group."

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -8,13 +8,20 @@ from ee.onyx.db.token_limit import fetch_all_user_group_token_rate_limits_by_gro
 from ee.onyx.db.token_limit import fetch_user_group_token_rate_limits_for_group
 from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
 from onyx.auth.permissions import require_permission
+from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
 from onyx.configs.constants import PUBLIC_API_TAGS
+from onyx.configs.constants import TokenRateLimitScope
 from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import Permission
 from onyx.db.models import User
+from onyx.db.token_limit import delete_token_rate_limit
 from onyx.db.token_limit import fetch_all_user_token_rate_limits
+from onyx.db.token_limit import get_token_rate_limit_scope_and_group
 from onyx.db.token_limit import insert_user_token_rate_limit
+from onyx.db.token_limit import update_token_rate_limit
+from onyx.error_handling.error_codes import OnyxErrorCode
+from onyx.error_handling.exceptions import OnyxError
 from onyx.server.query_and_chat.token_limit import any_rate_limit_exists
 from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from onyx.server.token_rate_limits.models import TokenRateLimitDisplay
@@ -48,9 +55,14 @@ def get_all_group_token_limit_settings(
 @router.get("/user-group/{group_id}")
 def get_group_token_limit_settings(
     group_id: int,
-    _: User = Depends(require_permission(Permission.MANAGE_USER_GROUPS)),
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
     db_session: Session = Depends(get_session),
 ) -> list[TokenRateLimitDisplay]:
+    # GATE 2 (read): a scoped manager may only read limits for a group they manage
+    # (global holders bypass). Single-group path param, so assert_manages_group, not a clause.
+    assert_manages_group(user, db_session, group_id=group_id)
     return [
         TokenRateLimitDisplay.from_db(token_rate_limit)
         for token_rate_limit in fetch_user_group_token_rate_limits_for_group(
@@ -89,6 +101,69 @@ def create_group_token_limit_settings(
     # clear cache in case this was the first rate limit created
     any_rate_limit_exists.cache_clear()
     return rate_limit_display
+
+
+def _authorize_group_token_rate_limit_write(
+    user: User, db_session: Session, *, group_id: int, rate_limit_id: int
+) -> None:
+    """Manager-scope gate for a group token-limit write: caller must manage group_id AND
+    the limit must belong to it — so a global/per-user id or another group's limit can't be
+    reached through this path."""
+    assert_within_scope(
+        user,
+        db_session,
+        permission=Permission.MANAGE_USER_GROUPS,
+        current_group_ids=[group_id],
+        requested_group_ids=[group_id],
+        is_non_public=True,
+    )
+    scope, resolved_group_id = get_token_rate_limit_scope_and_group(
+        db_session, rate_limit_id
+    )
+    if scope != TokenRateLimitScope.USER_GROUP or resolved_group_id != group_id:
+        raise OnyxError(
+            OnyxErrorCode.NOT_FOUND, "Token rate limit not found for this group."
+        )
+
+
+# Separate from the shared by-id routes so this route's require_permission caps a scoped
+# PAT to MANAGE_USER_GROUPS; a shared route would expose FULL_ADMIN global/user limits.
+@router.put("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def update_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    token_limit_settings: TokenRateLimitArgs,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> TokenRateLimitDisplay:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    return TokenRateLimitDisplay.from_db(
+        update_token_rate_limit(
+            db_session=db_session,
+            token_rate_limit_id=rate_limit_id,
+            token_rate_limit_settings=token_limit_settings,
+        )
+    )
+
+
+@router.delete("/user-group/{group_id}/rate-limit/{rate_limit_id}")
+def delete_group_token_limit_settings(
+    group_id: int,
+    rate_limit_id: int,
+    user: User = Depends(
+        require_permission(Permission.MANAGE_USER_GROUPS, allow_scope=True)
+    ),
+    db_session: Session = Depends(get_session),
+) -> None:
+    _authorize_group_token_rate_limit_write(
+        user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
+    )
+    delete_token_rate_limit(db_session=db_session, token_rate_limit_id=rate_limit_id)
+    any_rate_limit_exists.cache_clear()
 
 
 """

--- a/backend/ee/onyx/server/token_rate_limits/api.py
+++ b/backend/ee/onyx/server/token_rate_limits/api.py
@@ -141,13 +141,15 @@ def update_group_token_limit_settings(
     _authorize_group_token_rate_limit_write(
         user, db_session, group_id=group_id, rate_limit_id=rate_limit_id
     )
-    return TokenRateLimitDisplay.from_db(
+    rate_limit_display = TokenRateLimitDisplay.from_db(
         update_token_rate_limit(
             db_session=db_session,
             token_rate_limit_id=rate_limit_id,
             token_rate_limit_settings=token_limit_settings,
         )
     )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
 
 
 @router.delete("/user-group/{group_id}/rate-limit/{rate_limit_id}")

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -25,6 +25,7 @@ from ee.onyx.server.user_group.models import UserGroup
 from ee.onyx.server.user_group.models import UserGroupCreate
 from ee.onyx.server.user_group.models import UserGroupRename
 from ee.onyx.server.user_group.models import UserGroupUpdate
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import get_effective_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.permissions import NON_TOGGLEABLE_PERMISSIONS
@@ -33,6 +34,7 @@ from onyx.auth.permissions import PermissionRegistryEntry
 from onyx.auth.permissions import require_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import get_scoped_groups
+from onyx.auth.scoped_permissions import manages_group
 from onyx.configs.app_configs import DISABLE_VECTOR_DB
 from onyx.configs.constants import PUBLIC_API_TAGS
 from onyx.db.engine.sql_engine import get_session
@@ -61,10 +63,17 @@ def list_user_groups(
     # implies it) sees every group; a scoped manager sees only the groups they
     # manage. The group list has no built-in membership filter, so restrict it here
     # or a manager would see the whole org.
+    # Resolve the manager's scope + global authority once; per-group stamping is then
+    # pure set math (manages_group with a preloaded set issues no query).
+    managed_group_ids = get_scoped_groups(
+        user, db_session, Permission.MANAGE_USER_GROUPS
+    )
+    is_user_groups_admin = has_global_permission(user, Permission.MANAGE_USER_GROUPS)
+    is_full_admin = has_global_permission(user, Permission.FULL_ADMIN_PANEL_ACCESS)
     restrict_to_group_ids = (
         None
         if has_global_permission(user, Permission.READ_USER_GROUPS)
-        else get_scoped_groups(user, db_session, Permission.MANAGE_USER_GROUPS)
+        else managed_group_ids
     )
     user_groups = fetch_user_groups(
         db_session,
@@ -75,7 +84,20 @@ def list_user_groups(
     )
     mask_credential_prefix = get_security_settings().mask_credential_prefix
     return [
-        UserGroup.from_model(user_group, mask_credential_prefix=mask_credential_prefix)
+        UserGroup.from_model(
+            user_group,
+            mask_credential_prefix=mask_credential_prefix,
+            permissions=user_group_permissions(
+                can_manage=manages_group(
+                    user,
+                    db_session,
+                    group_id=user_group.id,
+                    managed_group_ids=managed_group_ids,
+                ),
+                is_user_groups_admin=is_user_groups_admin,
+                is_full_admin=is_full_admin,
+            ),
+        )
         for user_group in user_groups
     ]
 

--- a/backend/ee/onyx/server/user_group/api.py
+++ b/backend/ee/onyx/server/user_group/api.py
@@ -63,8 +63,7 @@ def list_user_groups(
     # implies it) sees every group; a scoped manager sees only the groups they
     # manage. The group list has no built-in membership filter, so restrict it here
     # or a manager would see the whole org.
-    # Resolve the manager's scope + global authority once; per-group stamping is then
-    # pure set math (manages_group with a preloaded set issues no query).
+    # Resolve scope + global authority once so per-group stamping is pure set math (no query).
     managed_group_ids = get_scoped_groups(
         user, db_session, Permission.MANAGE_USER_GROUPS
     )

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from pydantic import BaseModel
+from pydantic import Field
 
 from onyx.auth.permissions import Permission
 from onyx.db.models import UserGroup as UserGroupModel
@@ -24,6 +25,9 @@ class UserGroup(BaseModel):
     is_up_to_date: bool
     is_up_for_deletion: bool
     is_default: bool
+    # Per-action affordance map for the requesting user (mirrors the write-side guards).
+    # Defaults empty (fail-closed); the admin group list stamps the real map.
+    permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod
     def from_model(
@@ -31,8 +35,10 @@ class UserGroup(BaseModel):
         user_group_model: UserGroupModel,
         *,
         mask_credential_prefix: bool,
+        permissions: dict[str, bool] | None = None,
     ) -> "UserGroup":
         return cls(
+            permissions=permissions or {},
             id=user_group_model.id,
             name=user_group_model.name,
             manager_ids=[

--- a/backend/ee/onyx/server/user_group/models.py
+++ b/backend/ee/onyx/server/user_group/models.py
@@ -25,8 +25,9 @@ class UserGroup(BaseModel):
     is_up_to_date: bool
     is_up_for_deletion: bool
     is_default: bool
-    # Per-action affordance map for the requesting user (mirrors the write-side guards).
-    # Defaults empty (fail-closed); the admin group list stamps the real map.
+    # Per-action affordance map ({"manage": true, ...}) the client reads to show/hide
+    # controls. Empty default = every action denied (missing key is false), so it fails
+    # closed. Only the list-groups endpoint fills it in; the mutation routes leave it empty.
     permissions: dict[str, bool] = Field(default_factory=dict)
 
     @classmethod

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -134,3 +134,25 @@ def custom_skill_permissions(
         "delete": is_full_admin,
         "publish": is_skills_admin,
     }
+
+
+USER_GROUP_ACTIONS: frozenset[str] = frozenset(
+    {"manage", "delete", "edit_permissions", "edit_token_limits"}
+)
+
+
+def user_group_permissions(
+    *, can_manage: bool, is_user_groups_admin: bool, is_full_admin: bool
+) -> dict[str, bool]:
+    """User group affordance map. ``manage`` (rename, membership, assign agents, set
+    manager) is the per-group ``manages_group`` decision — group in the manager's managed
+    set, or global MANAGE_USER_GROUPS. ``delete`` needs global MANAGE_USER_GROUPS (its
+    route has no ``allow_scope``). ``edit_permissions`` and ``edit_token_limits`` are
+    FULL_ADMIN (the permission-toggle route and the token-limit PUT/DELETE routes require
+    it); the scoped token-limit create folds into ``manage``."""
+    return {
+        "manage": can_manage,
+        "delete": is_user_groups_admin,
+        "edit_permissions": is_full_admin,
+        "edit_token_limits": is_full_admin,
+    }

--- a/backend/onyx/auth/permission_projection.py
+++ b/backend/onyx/auth/permission_projection.py
@@ -145,14 +145,14 @@ def user_group_permissions(
     *, can_manage: bool, is_user_groups_admin: bool, is_full_admin: bool
 ) -> dict[str, bool]:
     """User group affordance map. ``manage`` (rename, membership, assign agents, set
-    manager) is the per-group ``manages_group`` decision — group in the manager's managed
-    set, or global MANAGE_USER_GROUPS. ``delete`` needs global MANAGE_USER_GROUPS (its
-    route has no ``allow_scope``). ``edit_permissions`` and ``edit_token_limits`` are
-    FULL_ADMIN (the permission-toggle route and the token-limit PUT/DELETE routes require
-    it); the scoped token-limit create folds into ``manage``."""
+    manager) and ``edit_token_limits`` are the per-group ``manages_group`` decision — group
+    in the manager's managed set, or global MANAGE_USER_GROUPS. A scoped manager gets full
+    token-limit CRUD for groups they manage: every token route (read/create/update/delete)
+    now admits scope. ``delete`` needs global MANAGE_USER_GROUPS (its route has no
+    ``allow_scope``). ``edit_permissions`` is FULL_ADMIN (the permission-toggle route)."""
     return {
         "manage": can_manage,
         "delete": is_user_groups_admin,
         "edit_permissions": is_full_admin,
-        "edit_token_limits": is_full_admin,
+        "edit_token_limits": can_manage,
     }

--- a/backend/onyx/db/token_limit.py
+++ b/backend/onyx/db/token_limit.py
@@ -78,6 +78,24 @@ def insert_global_token_rate_limit(
     return token_limit
 
 
+def get_token_rate_limit_scope_and_group(
+    db_session: Session, token_rate_limit_id: int
+) -> tuple[TokenRateLimitScope, int | None]:
+    """Scope + owning group id for a rate limit (group is None unless USER_GROUP). Raises
+    ValueError if the id is unknown."""
+    token_limit = db_session.get(TokenRateLimit, token_rate_limit_id)
+    if token_limit is None:
+        raise ValueError(f"TokenRateLimit with id '{token_rate_limit_id}' not found")
+    if token_limit.scope != TokenRateLimitScope.USER_GROUP:
+        return token_limit.scope, None
+    group_id = db_session.scalar(
+        select(TokenRateLimit__UserGroup.user_group_id).where(
+            TokenRateLimit__UserGroup.rate_limit_id == token_rate_limit_id
+        )
+    )
+    return token_limit.scope, group_id
+
+
 def update_token_rate_limit(
     db_session: Session,
     token_rate_limit_id: int,

--- a/backend/onyx/server/token_rate_limits/api.py
+++ b/backend/onyx/server/token_rate_limits/api.py
@@ -60,13 +60,15 @@ def update_token_limit_settings(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
     db_session: Session = Depends(get_session),
 ) -> TokenRateLimitDisplay:
-    return TokenRateLimitDisplay.from_db(
+    rate_limit_display = TokenRateLimitDisplay.from_db(
         update_token_rate_limit(
             db_session=db_session,
             token_rate_limit_id=token_rate_limit_id,
             token_rate_limit_settings=token_limit_settings,
         )
     )
+    any_rate_limit_exists.cache_clear()
+    return rate_limit_display
 
 
 @router.delete("/rate-limit/{token_rate_limit_id}")

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -23,6 +23,8 @@ from onyx.auth.permission_projection import PERSONA_ACTIONS
 from onyx.auth.permission_projection import persona_permissions
 from onyx.auth.permission_projection import TOOL_ACTIONS
 from onyx.auth.permission_projection import tool_permissions
+from onyx.auth.permission_projection import USER_GROUP_ACTIONS
+from onyx.auth.permission_projection import user_group_permissions
 from onyx.auth.permissions import has_global_permission
 from onyx.auth.scoped_permissions import assert_manages_group
 from onyx.auth.scoped_permissions import assert_within_scope
@@ -651,3 +653,78 @@ def test_actions_and_skill_key_coverage() -> None:
             can_edit=True, is_full_admin=True, is_skills_admin=True
         )
     ) == set(CUSTOM_SKILL_ACTIONS)
+
+
+def test_user_group_projection_matches_gates(db_session: Session) -> None:
+    """manage tracks the real assert_manages_group guard (per-group); delete tracks global
+    MANAGE_USER_GROUPS; edit_permissions/edit_token_limits track FULL_ADMIN. The scoped
+    token-limit create (assert_within_scope on the group) equals manage, so the add-limit
+    affordance rides on manage."""
+    managed = _make_group(db_session)
+
+    in_scope = create_test_user(db_session, "proj-ug-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-ug-out")
+    _manage(db_session, out_scope, _make_group(db_session))
+    out_scope.effective_permissions = []
+
+    admin = create_test_user(db_session, "proj-ug-admin", is_admin=True)
+    db_session.commit()
+
+    for actor in (in_scope, out_scope, admin):
+        manage_enforced = not _guard_raises(
+            assert_manages_group, actor, db_session, group_id=managed.id
+        )
+        # the token-limit POST guard (scoped create) is the same managed-scope decision
+        token_create_enforced = not _guard_raises(
+            assert_within_scope,
+            actor,
+            db_session,
+            permission=Permission.MANAGE_USER_GROUPS,
+            current_group_ids=[managed.id],
+            requested_group_ids=[managed.id],
+            is_non_public=True,
+        )
+        can_manage = manages_group(actor, db_session, group_id=managed.id)
+        assert can_manage == manage_enforced, actor.email
+        assert can_manage == token_create_enforced, actor.email
+
+        is_user_groups_admin = has_global_permission(
+            actor, Permission.MANAGE_USER_GROUPS
+        )
+        is_full_admin = has_global_permission(actor, Permission.FULL_ADMIN_PANEL_ACCESS)
+        tags = user_group_permissions(
+            can_manage=can_manage,
+            is_user_groups_admin=is_user_groups_admin,
+            is_full_admin=is_full_admin,
+        )
+        assert tags["manage"] == manage_enforced
+        assert tags["delete"] == is_user_groups_admin  # A — global MANAGE_USER_GROUPS
+        assert tags["edit_permissions"] == is_full_admin  # A — FULL_ADMIN
+        assert tags["edit_token_limits"] == is_full_admin  # A — FULL_ADMIN
+
+    # the fix: an in-scope manager manages their group but can't delete/edit-perms/tokens
+    assert user_group_permissions(
+        can_manage=manages_group(in_scope, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            in_scope, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            in_scope, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": False,
+        "edit_permissions": False,
+        "edit_token_limits": False,
+    }
+
+
+def test_user_group_key_coverage() -> None:
+    assert set(
+        user_group_permissions(
+            can_manage=True, is_user_groups_admin=True, is_full_admin=True
+        )
+    ) == set(USER_GROUP_ACTIONS)

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -5,12 +5,20 @@ stamps matches whether the guard raises, across an actor matrix — so the affor
 the client renders can't silently drift from what the backend enforces.
 """
 
+import asyncio
+import inspect
 from collections.abc import Callable
+from types import SimpleNamespace
 from uuid import uuid4
 
 from sqlalchemy.orm import Session
 
 from ee.onyx.db.analytics import user_can_view_assistant_stats
+from ee.onyx.db.token_limit import insert_user_group_token_rate_limit
+from ee.onyx.server.token_rate_limits.api import _authorize_group_token_rate_limit_write
+from ee.onyx.server.token_rate_limits.api import get_group_token_limit_settings
+from ee.onyx.server.user_group.api import delete_user_group
+from ee.onyx.server.user_group.api import set_user_group_permissions
 from onyx.auth.permission_projection import CC_PAIR_ACTIONS
 from onyx.auth.permission_projection import cc_pair_permissions
 from onyx.auth.permission_projection import CUSTOM_SKILL_ACTIONS
@@ -54,6 +62,7 @@ from onyx.db.persona import get_persona_by_id
 from onyx.db.persona import is_persona_editable_by_user
 from onyx.db.persona import persona_edit_within_scope
 from onyx.db.skill import get_group_ids_for_skill
+from onyx.db.token_limit import insert_global_token_rate_limit
 from onyx.db.tools import can_admin_mcp_server
 from onyx.db.tools import can_edit_custom_tool
 from onyx.db.tools import can_edit_mcp_server
@@ -62,6 +71,7 @@ from onyx.server.features.mcp.api import _ensure_mcp_server_editable
 from onyx.server.features.mcp.api import _ensure_mcp_server_owner_or_admin
 from onyx.server.features.persona.models import PersonaUpsertRequest
 from onyx.server.features.tool.api import _get_editable_custom_tool
+from onyx.server.token_rate_limits.models import TokenRateLimitArgs
 from tests.external_dependency_unit.conftest import create_test_user
 
 
@@ -73,6 +83,17 @@ def _guard_raises(
         return False
     except OnyxError:
         return True
+
+
+def _route_admits(
+    route_func: Callable[..., object], guard_param: str, actor: User
+) -> bool:
+    """True iff the route's ``require_permission`` admits ``actor`` (unrestricted token).
+    Runs the real dependency, so the assertion tracks the route decorator — not the bool
+    that built the map, which can't catch a FULL_ADMIN vs MANAGE_USER_GROUPS drift."""
+    depends = inspect.signature(route_func).parameters[guard_param].default
+    request = SimpleNamespace(state=SimpleNamespace(token_scopes=None))
+    return not _guard_raises(lambda: asyncio.run(depends.dependency(request, actor)))
 
 
 def _make_group(db_session: Session) -> UserGroup:
@@ -656,10 +677,11 @@ def test_actions_and_skill_key_coverage() -> None:
 
 
 def test_user_group_projection_matches_gates(db_session: Session) -> None:
-    """manage tracks the real assert_manages_group guard (per-group); delete tracks global
-    MANAGE_USER_GROUPS; edit_permissions/edit_token_limits track FULL_ADMIN. The scoped
-    token-limit create (assert_within_scope on the group) equals manage, so the add-limit
-    affordance rides on manage."""
+    """Each flag is pinned to its real route, not the bool that built it: manage and
+    edit_token_limits → assert_manages_group (per-group scoped — the token read route now
+    admits scope), delete → delete-group (global MANAGE_USER_GROUPS), edit_permissions →
+    permission-toggle (FULL_ADMIN). groups_admin (global MANAGE_USER_GROUPS, not full admin)
+    separates the two levels; out_scope (manages a different group) pins the per-group gate."""
     managed = _make_group(db_session)
 
     in_scope = create_test_user(db_session, "proj-ug-in")
@@ -670,10 +692,13 @@ def test_user_group_projection_matches_gates(db_session: Session) -> None:
     _manage(db_session, out_scope, _make_group(db_session))
     out_scope.effective_permissions = []
 
+    groups_admin = create_test_user(db_session, "proj-ug-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
     admin = create_test_user(db_session, "proj-ug-admin", is_admin=True)
     db_session.commit()
 
-    for actor in (in_scope, out_scope, admin):
+    for actor in (in_scope, out_scope, groups_admin, admin):
         manage_enforced = not _guard_raises(
             assert_manages_group, actor, db_session, group_id=managed.id
         )
@@ -691,21 +716,29 @@ def test_user_group_projection_matches_gates(db_session: Session) -> None:
         assert can_manage == manage_enforced, actor.email
         assert can_manage == token_create_enforced, actor.email
 
-        is_user_groups_admin = has_global_permission(
-            actor, Permission.MANAGE_USER_GROUPS
-        )
-        is_full_admin = has_global_permission(actor, Permission.FULL_ADMIN_PANEL_ACCESS)
         tags = user_group_permissions(
             can_manage=can_manage,
-            is_user_groups_admin=is_user_groups_admin,
-            is_full_admin=is_full_admin,
+            is_user_groups_admin=has_global_permission(
+                actor, Permission.MANAGE_USER_GROUPS
+            ),
+            is_full_admin=has_global_permission(
+                actor, Permission.FULL_ADMIN_PANEL_ACCESS
+            ),
         )
-        assert tags["manage"] == manage_enforced
-        assert tags["delete"] == is_user_groups_admin  # A — global MANAGE_USER_GROUPS
-        assert tags["edit_permissions"] == is_full_admin  # A — FULL_ADMIN
-        assert tags["edit_token_limits"] == is_full_admin  # A — FULL_ADMIN
+        assert tags["manage"] == manage_enforced, actor.email
+        assert tags["delete"] == _route_admits(delete_user_group, "_", actor), (
+            actor.email
+        )
+        assert tags["edit_permissions"] == _route_admits(
+            set_user_group_permissions, "user", actor
+        ), actor.email
+        # edit_token_limits rides the token read route: GATE 1 admits scope, GATE 2 is
+        # assert_manages_group — net per-group decision, so AND the two.
+        token_read_gate1 = _route_admits(get_group_token_limit_settings, "user", actor)
+        assert tags["edit_token_limits"] == (token_read_gate1 and manage_enforced), (
+            actor.email
+        )
 
-    # the fix: an in-scope manager manages their group but can't delete/edit-perms/tokens
     assert user_group_permissions(
         can_manage=manages_group(in_scope, db_session, group_id=managed.id),
         is_user_groups_admin=has_global_permission(
@@ -718,7 +751,25 @@ def test_user_group_projection_matches_gates(db_session: Session) -> None:
         "manage": True,
         "delete": False,
         "edit_permissions": False,
-        "edit_token_limits": False,
+        # scoped manager now fully manages its group's token limits
+        "edit_token_limits": True,
+    }
+
+    # groups_admin (global MANAGE_USER_GROUPS, not full admin): manages token limits and
+    # deletes the group, but can't edit permissions (FULL_ADMIN).
+    assert user_group_permissions(
+        can_manage=manages_group(groups_admin, db_session, group_id=managed.id),
+        is_user_groups_admin=has_global_permission(
+            groups_admin, Permission.MANAGE_USER_GROUPS
+        ),
+        is_full_admin=has_global_permission(
+            groups_admin, Permission.FULL_ADMIN_PANEL_ACCESS
+        ),
+    ) == {
+        "manage": True,
+        "delete": True,
+        "edit_permissions": False,
+        "edit_token_limits": True,
     }
 
 
@@ -728,3 +779,56 @@ def test_user_group_key_coverage() -> None:
             can_manage=True, is_user_groups_admin=True, is_full_admin=True
         )
     ) == set(USER_GROUP_ACTIONS)
+
+
+def test_group_token_rate_limit_write_scope(db_session: Session) -> None:
+    """A group token-limit write needs the caller to manage the group AND the limit to
+    belong to it — so a group admin fully manages its limits, but a global/per-user limit or
+    another group's limit can't be reached through the group path."""
+    managed = _make_group(db_session)
+    other = _make_group(db_session)
+
+    args = TokenRateLimitArgs(enabled=True, token_budget=1000, period_hours=24)
+    managed_limit = insert_user_group_token_rate_limit(
+        db_session=db_session, token_rate_limit_settings=args, group_id=managed.id
+    )
+    global_limit = insert_global_token_rate_limit(db_session, args)
+
+    in_scope = create_test_user(db_session, "proj-trl-in")
+    _manage(db_session, in_scope, managed)
+    in_scope.effective_permissions = []
+
+    out_scope = create_test_user(db_session, "proj-trl-out")
+    _manage(db_session, out_scope, other)
+    out_scope.effective_permissions = []
+
+    groups_admin = create_test_user(db_session, "proj-trl-groupsadmin")
+    groups_admin.effective_permissions = [Permission.MANAGE_USER_GROUPS.value]
+
+    admin = create_test_user(db_session, "proj-trl-admin", is_admin=True)
+
+    plain = create_test_user(db_session, "proj-trl-plain")
+    plain.effective_permissions = []
+    db_session.commit()
+
+    def denied(actor: User, group_id: int, rate_limit_id: int) -> bool:
+        return _guard_raises(
+            _authorize_group_token_rate_limit_write,
+            actor,
+            db_session,
+            group_id=group_id,
+            rate_limit_id=rate_limit_id,
+        )
+
+    assert not denied(admin, managed.id, managed_limit.id)
+    assert not denied(groups_admin, managed.id, managed_limit.id)
+    assert not denied(in_scope, managed.id, managed_limit.id)
+    assert denied(out_scope, managed.id, managed_limit.id)
+    assert denied(plain, managed.id, managed_limit.id)
+
+    # a global limit can't be reached through the group path — even for a full admin
+    assert denied(admin, managed.id, global_limit.id)
+
+    # the limit must belong to the claimed group (can't reach managed's limit via other)
+    assert denied(out_scope, other.id, managed_limit.id)
+    assert denied(in_scope, other.id, managed_limit.id)

--- a/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
+++ b/backend/tests/external_dependency_unit/auth/test_permission_projection_contract.py
@@ -832,3 +832,8 @@ def test_group_token_rate_limit_write_scope(db_session: Session) -> None:
     # the limit must belong to the claimed group (can't reach managed's limit via other)
     assert denied(out_scope, other.id, managed_limit.id)
     assert denied(in_scope, other.id, managed_limit.id)
+
+    # an unknown id folds into the same OnyxError 404, not the helper's raw ValueError
+    nonexistent_limit_id = -1
+    assert denied(in_scope, managed.id, nonexistent_limit_id)
+    assert denied(admin, managed.id, nonexistent_limit_id)

--- a/backend/tests/integration/tests/permissions/test_group_manager_agents.py
+++ b/backend/tests/integration/tests/permissions/test_group_manager_agents.py
@@ -28,6 +28,7 @@ from typing import NamedTuple
 from uuid import uuid4
 
 import pytest
+import requests
 from sqlalchemy import update
 
 from onyx.db.engine.sql_engine import get_session_with_current_tenant
@@ -145,6 +146,19 @@ _TOKEN_LIMIT_BODY: dict[str, Any] = {
 }
 
 
+def _assert_manager(
+    env: _ScopedEnv,
+    method: str,
+    path: str,
+    expected: str,
+    body: dict[str, Any] | None = None,
+) -> requests.Response:
+    """Call ``path`` as the scoped manager and assert the permission gate's verdict."""
+    resp = call_endpoint(method, path, body, env.manager.headers, env.manager.cookies)
+    assert_response(resp, method, path, "manager", expected)
+    return resp
+
+
 # --- skills -----------------------------------------------------------------
 
 
@@ -159,25 +173,22 @@ def test_manager_cannot_grant_skill_to_unmanaged_group(env: _ScopedEnv) -> None:
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
     path = f"/admin/skills/custom/{skill.id}/grants"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PUT",
         path,
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PUT", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint(
-        "PATCH", path, {"is_public": True}, env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PATCH", f"/admin/skills/custom/{skill.id}", "denied", {"is_public": True}
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
@@ -185,9 +196,7 @@ def test_manager_cannot_delete_skill(env: _ScopedEnv) -> None:
     skill = SkillManager.create_custom(
         env.manager, is_public=False, group_ids=[env.managed_group.id]
     )
-    path = f"/admin/skills/custom/{skill.id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/skills/custom/{skill.id}", "denied")
 
 
 def test_manager_skill_admin_list_is_scoped(env: _ScopedEnv) -> None:
@@ -223,15 +232,13 @@ def test_manager_cannot_share_agent_to_unmanaged_group(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"group_ids": [env.managed_group.id, env.other_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
@@ -242,15 +249,13 @@ def test_manager_cannot_publish_agent(env: _ScopedEnv) -> None:
         is_public=False,
         groups=[env.managed_group.id],
     )
-    path = f"/persona/{agent.id}"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}",
+        "denied",
         _persona_upsert_body(is_public=True, groups=[env.managed_group.id]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
@@ -270,29 +275,25 @@ def test_manager_cannot_capture_public_agent_via_share(env: _ScopedEnv) -> None:
     assert publish.status_code == 200, publish.text
     # The manager must not pull the now-public agent back to private AND keep the
     # group share in one call — the gate anchors on the original (public) state.
-    path = f"/persona/{agent.id}/share"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "PATCH",
-        path,
+        f"/persona/{agent.id}/share",
+        "denied",
         {"is_public": False, "group_ids": [env.managed_group.id]},
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "PATCH", path, "manager", "denied")
 
 
 def test_manager_creates_personal_agent(env: _ScopedEnv) -> None:
     # A scoped manager may create a private no-group personal agent like any
     # ADD_AGENTS user; the managed-group gate applies only once a group is involved.
-    path = "/persona"
-    resp = call_endpoint(
+    _assert_manager(
+        env,
         "POST",
-        path,
+        "/persona",
+        "allowed",
         _persona_upsert_body(is_public=False, groups=[]),
-        env.manager.headers,
-        env.manager.cookies,
     )
-    assert_response(resp, "POST", path, "manager", "allowed")
 
 
 def test_add_agents_user_creates_personal_agent_with_empty_groups(
@@ -350,11 +351,7 @@ def test_manager_creates_own_action(env: _ScopedEnv) -> None:
 def test_manager_cannot_edit_unowned_ungrouped_action(env: _ScopedEnv) -> None:
     # Admin owns the action and no agent uses it → no group context → owner/admin only.
     tool_id = _create_custom_tool(env.admin)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
 
 
 def test_manager_edits_action_used_by_managed_private_agent(env: _ScopedEnv) -> None:
@@ -365,11 +362,9 @@ def test_manager_edits_action_used_by_managed_private_agent(env: _ScopedEnv) -> 
         groups=[env.managed_group.id],
         tool_ids=[tool_id],
     )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
     )
-    assert_response(resp, "PUT", path, "manager", "allowed")
 
 
 def test_manager_edits_action_used_by_group_owned_agent(env: _ScopedEnv) -> None:
@@ -388,11 +383,9 @@ def test_manager_edits_action_used_by_group_owned_agent(env: _ScopedEnv) -> None
             .values(user_id=None, owner_group_id=env.managed_group.id)
         )
         db_session.commit()
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
+    _assert_manager(
+        env, "PUT", f"/admin/tool/custom/{tool_id}", "allowed", _tool_body()
     )
-    assert_response(resp, "PUT", path, "manager", "allowed")
 
 
 def test_manager_cannot_edit_action_used_by_public_agent(env: _ScopedEnv) -> None:
@@ -403,11 +396,7 @@ def test_manager_cannot_edit_action_used_by_public_agent(env: _ScopedEnv) -> Non
         groups=[env.managed_group.id],
         tool_ids=[tool_id],
     )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
 
 
 def test_manager_cannot_edit_action_used_by_ungrouped_private_agent(
@@ -429,19 +418,13 @@ def test_manager_cannot_edit_action_used_by_ungrouped_private_agent(
         groups=[],
         tool_ids=[tool_id],
     )
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint(
-        "PUT", path, _tool_body(), env.manager.headers, env.manager.cookies
-    )
-    assert_response(resp, "PUT", path, "manager", "denied")
+    _assert_manager(env, "PUT", f"/admin/tool/custom/{tool_id}", "denied", _tool_body())
 
 
 def test_manager_cannot_delete_action(env: _ScopedEnv) -> None:
     # Owns it — still denied: delete is admin-only (no allow_scope on the route).
     tool_id = _create_custom_tool(env.manager)
-    path = f"/admin/tool/custom/{tool_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/tool/custom/{tool_id}", "denied")
 
 
 # --- MCP servers ------------------------------------------------------------
@@ -454,9 +437,7 @@ def test_manager_creates_mcp_server(env: _ScopedEnv) -> None:
 def test_manager_cannot_delete_mcp_server(env: _ScopedEnv) -> None:
     # Owns it — still denied: MCP delete is admin-only.
     server_id = _create_mcp_server(env.manager)
-    path = f"/admin/mcp/server/{server_id}"
-    resp = call_endpoint("DELETE", path, None, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "DELETE", path, "manager", "denied")
+    _assert_manager(env, "DELETE", f"/admin/mcp/server/{server_id}", "denied")
 
 
 def test_manager_update_via_servers_create_denied_not_masked(
@@ -465,7 +446,6 @@ def test_manager_update_via_servers_create_denied_not_masked(
     # Updating an out-of-scope server through /servers/create must surface the
     # gate's 403, not a 500 masked by the handler's blanket except.
     server_id = _create_mcp_server(env.admin)
-    path = "/admin/mcp/servers/create"
     body = {
         "name": f"mcp-{uuid4()}",
         "server_url": "https://example.com/mcp",
@@ -473,24 +453,69 @@ def test_manager_update_via_servers_create_denied_not_masked(
         "auth_performer": MCPAuthenticationPerformer.ADMIN.value,
         "existing_server_id": server_id,
     }
-    resp = call_endpoint("POST", path, body, env.manager.headers, env.manager.cookies)
-    assert_response(resp, "POST", path, "manager", "denied")
+    _assert_manager(env, "POST", "/admin/mcp/servers/create", "denied", body)
 
 
 # --- token limits -----------------------------------------------------------
 
 
-def test_manager_sets_token_limit_on_managed_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.managed_group.id}"
+def _group_limit_path(group_id: int, limit_id: int | None = None) -> str:
+    base = f"/admin/token-rate-limits/user-group/{group_id}"
+    return base if limit_id is None else f"{base}/rate-limit/{limit_id}"
+
+
+def _create_group_token_limit(user: DATestUser, group_id: int) -> int:
+    """Create a token limit on ``group_id`` as ``user`` (must succeed); returns its id."""
     resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
+        "POST",
+        _group_limit_path(group_id),
+        _TOKEN_LIMIT_BODY,
+        user.headers,
+        user.cookies,
     )
-    assert_response(resp, "POST", path, "manager", "allowed")
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["token_id"])
+
+
+def test_manager_sets_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    path = _group_limit_path(env.managed_group.id)
+    _assert_manager(env, "POST", path, "allowed", _TOKEN_LIMIT_BODY)
 
 
 def test_manager_cannot_set_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
-    path = f"/admin/token-rate-limits/user-group/{env.other_group.id}"
-    resp = call_endpoint(
-        "POST", path, _TOKEN_LIMIT_BODY, env.manager.headers, env.manager.cookies
+    path = _group_limit_path(env.other_group.id)
+    _assert_manager(env, "POST", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_reads_token_limits_on_managed_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.managed_group.id), "allowed")
+
+
+def test_manager_cannot_read_token_limits_on_unmanaged_group(env: _ScopedEnv) -> None:
+    _assert_manager(env, "GET", _group_limit_path(env.other_group.id), "denied")
+
+
+def test_manager_updates_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    path = _group_limit_path(env.managed_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "allowed", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_cannot_update_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    path = _group_limit_path(env.other_group.id, limit_id)
+    _assert_manager(env, "PUT", path, "denied", _TOKEN_LIMIT_BODY)
+
+
+def test_manager_deletes_token_limit_on_managed_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.manager, env.managed_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.managed_group.id, limit_id), "allowed"
     )
-    assert_response(resp, "POST", path, "manager", "denied")
+
+
+def test_manager_cannot_delete_token_limit_on_unmanaged_group(env: _ScopedEnv) -> None:
+    limit_id = _create_group_token_limit(env.admin, env.other_group.id)
+    _assert_manager(
+        env, "DELETE", _group_limit_path(env.other_group.id, limit_id), "denied"
+    )

--- a/web/src/lib/permissions/resource-actions.ts
+++ b/web/src/lib/permissions/resource-actions.ts
@@ -12,6 +12,7 @@ export const RESOURCE_ACTIONS = {
   ToolSnapshot: ["edit", "delete", "toggle"],
   MCPServer: ["edit", "delete", "authenticate", "manage_status"],
   CustomSkill: ["edit", "manage_access", "delete", "publish"],
+  UserGroup: ["manage", "delete", "edit_permissions", "edit_token_limits"],
 } as const;
 
 export type ResourceName = keyof typeof RESOURCE_ACTIONS;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -551,6 +551,8 @@ export interface UserGroup {
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
   is_default: boolean;
+  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  permissions?: Record<string, boolean>;
 }
 
 export enum ValidSources {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -551,7 +551,7 @@ export interface UserGroup {
   is_up_to_date: boolean;
   is_up_for_deletion: boolean;
   is_default: boolean;
-  // Per-action affordance map for the requesting user (server-stamped, fail-closed).
+  // Server-stamped affordance map; fail-closed (absent = denied).
   permissions?: Record<string, boolean>;
 }
 

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -12,6 +12,7 @@ import {
   SvgMinusCircle,
   SvgPlusCircle,
   SvgSimpleLoader,
+  SvgShield,
 } from "@opal/icons";
 import { markdown } from "@opal/utils";
 import IconButton from "@/refresh-components/buttons/IconButton";
@@ -38,13 +39,14 @@ import {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 } from "./svc";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import SharedGroupResources from "@/refresh-pages/admin/GroupsPage/SharedGroupResources";
 import GroupPermissionsSection from "./GroupPermissionsSection";
 import TokenLimitSection from "./TokenLimitSection";
 import type { TokenLimit } from "./TokenLimitSection";
-import { useUser } from "@/providers/UserProvider";
+import { can } from "@/lib/permissions/resource-actions";
 
 const addModeColumns = memberTableColumns;
 
@@ -67,7 +69,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const tokenLimitsDisabledTooltip = markdown(
     "Token rate limits are available on the [Enterprise version of Onyx](/admin/billing) only."
   );
-  const { isAdmin } = useUser();
 
   // Fetch the group data — poll every 5s while syncing so the UI updates
   // automatically when the backend finishes processing the previous edit.
@@ -87,6 +88,13 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [groups, groupId]
   );
 
+  // Server-stamped per-group affordances. manage (M) gates membership/rename/save;
+  // delete is global MANAGE_USER_GROUPS; edit_permissions/edit_token_limits are FULL_ADMIN.
+  const canManage = can(group, "manage");
+  const canDelete = can(group, "delete");
+  const canEditPermissions = can(group, "edit_permissions");
+  const canEditTokenLimits = can(group, "edit_token_limits");
+
   const isSyncing = group != null && !group.is_up_to_date;
 
   // Fetch token rate limits for this group. Skip retry on tier-gated 402
@@ -102,7 +110,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   const { data: groupPermissions, isLoading: permissionsLoading } = useSWR<
     string[]
   >(
-    isAdmin ? SWR_KEYS.userGroupPermissions(groupId) : null,
+    canEditPermissions ? SWR_KEYS.userGroupPermissions(groupId) : null,
     errorHandlingFetcher
   );
 
@@ -192,25 +200,87 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     setSelectedUserIds((prev) => prev.filter((id) => id !== userId));
   }, []);
 
+  const managerIds = useMemo(() => new Set(group?.manager_ids ?? []), [group]);
+  // A manager must be an existing member, so a not-yet-saved member can't be assigned.
+  const persistedMemberIds = useMemo(
+    () => new Set(group?.users.map((u) => u.id) ?? []),
+    [group]
+  );
+  const [pendingManagerId, setPendingManagerId] = useState<string | null>(null);
+
+  // The manager toggle hits its dedicated endpoint immediately (unlike member
+  // add/remove, which defers to Save), then revalidates the group.
+  const handleToggleManager = useCallback(
+    async (userId: string, makeManager: boolean) => {
+      setPendingManagerId(userId);
+      try {
+        await setGroupManager(groupId, userId, makeManager);
+        await mutate(SWR_KEYS.adminUserGroups);
+        toast.success(makeManager ? "Manager assigned" : "Manager revoked");
+      } catch (err) {
+        toast.error(
+          err instanceof Error ? err.message : "Failed to update manager"
+        );
+      } finally {
+        setPendingManagerId(null);
+      }
+    },
+    [groupId, mutate]
+  );
+
   const memberColumns = useMemo(
     () => [
       ...baseColumns,
       tc.actions({
         showSorting: false,
         showColumnVisibility: false,
-        cell: (row: MemberRow) => (
-          <IconButton
-            icon={SvgMinusCircle}
-            tertiary
-            onClick={(e) => {
-              e.stopPropagation();
-              handleRemoveMember(row.id ?? row.email);
-            }}
-          />
-        ),
+        cell: (row: MemberRow) => {
+          if (!canManage) return null;
+          const userId = row.id ?? row.email;
+          const isManager = managerIds.has(userId);
+          const isPersisted = persistedMemberIds.has(userId);
+          const isPending = pendingManagerId === userId;
+          return (
+            <div className="flex items-center gap-1">
+              <IconButton
+                icon={isPending ? SvgSimpleLoader : SvgShield}
+                tertiary
+                transient={isManager}
+                disabled={!isPersisted || isPending}
+                aria-label={isManager ? "Revoke manager" : "Make manager"}
+                tooltip={
+                  !isPersisted
+                    ? "Save the group before assigning a manager"
+                    : isManager
+                      ? "Revoke manager"
+                      : "Make manager"
+                }
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleToggleManager(userId, !isManager);
+                }}
+              />
+              <IconButton
+                icon={SvgMinusCircle}
+                tertiary
+                onClick={(e) => {
+                  e.stopPropagation();
+                  handleRemoveMember(userId);
+                }}
+              />
+            </div>
+          );
+        },
       }),
     ],
-    [handleRemoveMember]
+    [
+      handleRemoveMember,
+      handleToggleManager,
+      managerIds,
+      persistedMemberIds,
+      pendingManagerId,
+      canManage,
+    ]
   );
 
   // IDs of members not visible in the add-mode table (e.g. inactive users).
@@ -278,13 +348,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         selectedDocSetIds
       );
 
-      // Save token rate limits (create/update/delete) — Enterprise-only
-      if (isEnterpriseTier) {
+      // Enterprise + FULL_ADMIN only — token PUT/DELETE are admin-only, so a scoped
+      // manager skips this.
+      if (isEnterpriseTier && canEditTokenLimits) {
         await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
       }
 
-      // Save permissions (bulk desired-state, admin only)
-      if (isAdmin) {
+      // Bulk desired-state replace; FULL_ADMIN only.
+      if (canEditPermissions) {
         await saveGroupPermissions(groupId, enabledPermissions);
       }
 
@@ -294,7 +365,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
       mutate(SWR_KEYS.adminUserGroups);
       mutate(SWR_KEYS.userGroupTokenRateLimit(groupId));
-      if (isAdmin) {
+      if (canEditPermissions) {
         mutate(SWR_KEYS.userGroupPermissions(groupId));
       }
       toast.success(`Group "${trimmed}" updated`);
@@ -352,7 +423,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
       </Button>
       <Button
         onClick={handleSave}
-        disabled={!groupName.trim() || isSubmitting || isSyncing}
+        disabled={!groupName.trim() || isSubmitting || isSyncing || !canManage}
         tooltip={
           isSyncing
             ? "Document embeddings are being updated due to recent changes to this group."
@@ -436,13 +507,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                       Done
                     </Button>
                   ) : (
-                    <Button
-                      prominence="tertiary"
-                      icon={SvgPlusCircle}
-                      onClick={() => setIsAddingMembers(true)}
-                    >
-                      Add
-                    </Button>
+                    canManage && (
+                      <Button
+                        prominence="tertiary"
+                        icon={SvgPlusCircle}
+                        onClick={() => setIsAddingMembers(true)}
+                      >
+                        Add
+                      </Button>
+                    )
                   )}
                 </Section>
 
@@ -485,7 +558,7 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 )}
               </Section>
 
-              {isAdmin && (
+              {canEditPermissions && (
                 <GroupPermissionsSection
                   enabledPermissions={enabledPermissions}
                   onPermissionsChange={setEnabledPermissions}
@@ -504,27 +577,29 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
               <TokenLimitSection
                 limits={tokenLimits}
                 onLimitsChange={setTokenLimits}
-                disabled={!isEnterpriseTier}
+                disabled={!isEnterpriseTier || !canEditTokenLimits}
                 disabledTooltip={tokenLimitsDisabledTooltip}
               />
 
-              {/* Delete This Group */}
-              <Card>
-                <InputHorizontal
-                  title="Delete This Group"
-                  description="Members will lose access to any resources shared with this group."
-                  center
-                >
-                  <Button
-                    variant="danger"
-                    prominence="secondary"
-                    icon={SvgTrash}
-                    onClick={() => setShowDeleteModal(true)}
+              {/* Delete This Group — global MANAGE_USER_GROUPS only */}
+              {canDelete && (
+                <Card>
+                  <InputHorizontal
+                    title="Delete This Group"
+                    description="Members will lose access to any resources shared with this group."
+                    center
                   >
-                    Delete Group
-                  </Button>
-                </InputHorizontal>
-              </Card>
+                    <Button
+                      variant="danger"
+                      prominence="secondary"
+                      icon={SvgTrash}
+                      onClick={() => setShowDeleteModal(true)}
+                    >
+                      Delete Group
+                    </Button>
+                  </InputHorizontal>
+                </Card>
+              )}
             </>
           )}
         </SettingsLayouts.Body>

--- a/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/EditGroupPage.tsx
@@ -88,8 +88,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
     [groups, groupId]
   );
 
-  // Server-stamped per-group affordances. manage (M) gates membership/rename/save;
-  // delete is global MANAGE_USER_GROUPS; edit_permissions/edit_token_limits are FULL_ADMIN.
   const canManage = can(group, "manage");
   const canDelete = can(group, "delete");
   const canEditPermissions = can(group, "edit_permissions");
@@ -97,14 +95,15 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
 
   const isSyncing = group != null && !group.is_up_to_date;
 
-  // Fetch token rate limits for this group. Skip retry on tier-gated 402
-  // (BUSINESS-tier tenants don't have access) so SWR doesn't churn the form
-  // by repeatedly flipping its isLoading state.
+  // Gate on edit_token_limits so a non-manager (who'd 403 on the read) skips the fetch.
+  // Skip retry on tier-gated 402 so SWR doesn't churn isLoading.
   const { data: tokenRateLimits, isLoading: tokenLimitsLoading } = useSWR<
     TokenRateLimitDisplay[]
-  >(SWR_KEYS.userGroupTokenRateLimit(groupId), errorHandlingFetcher, {
-    onErrorRetry: skipRetryOnAuthError,
-  });
+  >(
+    canEditTokenLimits ? SWR_KEYS.userGroupTokenRateLimit(groupId) : null,
+    errorHandlingFetcher,
+    { onErrorRetry: skipRetryOnAuthError }
+  );
 
   // Fetch permissions for this group (admin only)
   const { data: groupPermissions, isLoading: permissionsLoading } = useSWR<
@@ -201,15 +200,14 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
   }, []);
 
   const managerIds = useMemo(() => new Set(group?.manager_ids ?? []), [group]);
-  // A manager must be an existing member, so a not-yet-saved member can't be assigned.
+  // Manager must be a saved member (can't assign one that isn't persisted yet).
   const persistedMemberIds = useMemo(
     () => new Set(group?.users.map((u) => u.id) ?? []),
     [group]
   );
   const [pendingManagerId, setPendingManagerId] = useState<string | null>(null);
 
-  // The manager toggle hits its dedicated endpoint immediately (unlike member
-  // add/remove, which defers to Save), then revalidates the group.
+  // Hits its endpoint immediately (member add/remove defers to Save), then revalidates.
   const handleToggleManager = useCallback(
     async (userId: string, makeManager: boolean) => {
       setPendingManagerId(userId);
@@ -348,8 +346,8 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
         selectedDocSetIds
       );
 
-      // Enterprise + FULL_ADMIN only — token PUT/DELETE are admin-only, so a scoped
-      // manager skips this.
+      // Group-scoped create/update/delete routes admit a group admin, so their full save
+      // (including PUT/DELETE of existing limits) is authorized.
       if (isEnterpriseTier && canEditTokenLimits) {
         await saveTokenLimits(groupId, tokenLimits, tokenRateLimits ?? []);
       }
@@ -581,7 +579,6 @@ function EditGroupPage({ groupId }: EditGroupPageProps) {
                 disabledTooltip={tokenLimitsDisabledTooltip}
               />
 
-              {/* Delete This Group — global MANAGE_USER_GROUPS only */}
               {canDelete && (
                 <Card>
                   <InputHorizontal

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -18,6 +18,7 @@ import { renameGroup } from "./svc";
 import { toast } from "@/hooks/useToast";
 import { useSWRConfig } from "swr";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { can } from "@/lib/permissions/resource-actions";
 
 interface GroupCardProps {
   group: UserGroup;
@@ -30,6 +31,8 @@ function GroupCard({ group }: GroupCardProps) {
   const isAdmin = group.name === "Admin";
   const isBasic = group.name === "Basic";
   const isSyncing = !group.is_up_to_date;
+  // Per-group manage gate: rename and the row → edit entry are manages_group (M).
+  const canManage = can(group, "manage");
 
   async function handleRename(newName: string) {
     try {
@@ -51,8 +54,10 @@ function GroupCard({ group }: GroupCardProps) {
         sizePreset="main-content"
         variant="section"
         tag={isBasic ? { title: "Default" } : undefined}
-        editable={!builtIn && !isSyncing}
-        onTitleChange={!builtIn && !isSyncing ? handleRename : undefined}
+        editable={!builtIn && !isSyncing && canManage}
+        onTitleChange={
+          !builtIn && !isSyncing && canManage ? handleRename : undefined
+        }
         rightChildren={
           <Section flexDirection="row" alignItems="start" gap={0}>
             <div className="py-1">
@@ -62,13 +67,17 @@ function GroupCard({ group }: GroupCardProps) {
                 )}
               </Text>
             </div>
-            <Button
-              icon={SvgChevronRight}
-              prominence="tertiary"
-              tooltip="View group"
-              aria-label="View group"
-              onClick={() => router.push(`/admin/groups/${group.id}` as Route)}
-            />
+            {canManage && (
+              <Button
+                icon={SvgChevronRight}
+                prominence="tertiary"
+                tooltip="View group"
+                aria-label="View group"
+                onClick={() =>
+                  router.push(`/admin/groups/${group.id}` as Route)
+                }
+              />
+            )}
           </Section>
         }
       />

--- a/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/GroupCard.tsx
@@ -31,7 +31,6 @@ function GroupCard({ group }: GroupCardProps) {
   const isAdmin = group.name === "Admin";
   const isBasic = group.name === "Basic";
   const isSyncing = !group.is_up_to_date;
-  // Per-group manage gate: rename and the row → edit entry are manages_group (M).
   const canManage = can(group, "manage");
 
   async function handleRename(newName: string) {

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -9,7 +9,10 @@ import { Button, MessageCard } from "@opal/components";
 import { SettingsLayouts } from "@opal/layouts";
 import { errorHandlingFetcher } from "@/lib/fetcher";
 import type { UserGroup } from "@/lib/types";
+import { Permission } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
+import { useUser } from "@/providers/UserProvider";
+import { hasPermission } from "@/lib/permissions";
 import GroupsList from "./GroupsList";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
 import { IllustrationContent } from "@opal/layouts";
@@ -18,6 +21,15 @@ import SvgNoResult from "@opal/illustrations/no-result";
 function GroupsPage() {
   const router = useRouter();
   const [searchQuery, setSearchQuery] = useState("");
+  const { user } = useUser();
+
+  // Creating a group is global-only (the create route has no allow_scope), so gate on
+  // the global token — not admin_capabilities, which would show it to scoped managers
+  // who would then 403.
+  const canCreateGroup = hasPermission(
+    user?.effective_permissions ?? [],
+    Permission.MANAGE_USER_GROUPS
+  );
 
   const {
     data: groups,
@@ -58,8 +70,12 @@ function GroupsPage() {
           onSearchQueryChange={setSearchQuery}
           placeholder="Search groups..."
           emptyStateText="Create groups to organize users and manage access."
-          onAction={() => router.push("/admin/groups/create" as Route)}
-          actionLabel="New Group"
+          onAction={
+            canCreateGroup
+              ? () => router.push("/admin/groups/create" as Route)
+              : undefined
+          }
+          actionLabel={canCreateGroup ? "New Group" : undefined}
         />
 
         {isLoading && <SvgSimpleLoader />}

--- a/web/src/refresh-pages/admin/GroupsPage/index.tsx
+++ b/web/src/refresh-pages/admin/GroupsPage/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { Route } from "next";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import useSWR from "swr";
 import { SvgExternalLink, SvgUsers, SvgSimpleLoader } from "@opal/icons";
@@ -13,6 +13,7 @@ import { Permission } from "@/lib/types";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import { useUser } from "@/providers/UserProvider";
 import { hasPermission } from "@/lib/permissions";
+import { can } from "@/lib/permissions/resource-actions";
 import GroupsList from "./GroupsList";
 import AdminListHeader from "@/sections/admin/AdminListHeader";
 import { IllustrationContent } from "@opal/layouts";
@@ -23,9 +24,8 @@ function GroupsPage() {
   const [searchQuery, setSearchQuery] = useState("");
   const { user } = useUser();
 
-  // Creating a group is global-only (the create route has no allow_scope), so gate on
-  // the global token — not admin_capabilities, which would show it to scoped managers
-  // who would then 403.
+  // Create is global-only (route has no allow_scope); gate on the global token, not
+  // admin_capabilities, which would show it to scoped managers who'd then 403.
   const canCreateGroup = hasPermission(
     user?.effective_permissions ?? [],
     Permission.MANAGE_USER_GROUPS
@@ -36,6 +36,13 @@ function GroupsPage() {
     error,
     isLoading,
   } = useSWR<UserGroup[]>(SWR_KEYS.adminUserGroups, errorHandlingFetcher);
+
+  // The list is READ_USER_GROUPS-scoped (implied by MANAGE_LLMS etc.), so filter to
+  // manageable groups — else a read-only holder sees groups with no open action.
+  const manageableGroups = useMemo(
+    () => (groups ?? []).filter((group) => can(group, "manage")),
+    [groups]
+  );
 
   return (
     <SettingsLayouts.Root>
@@ -65,7 +72,7 @@ function GroupsPage() {
 
       <SettingsLayouts.Body>
         <AdminListHeader
-          hasItems={!isLoading && !error && (groups?.length ?? 0) > 0}
+          hasItems={!isLoading && !error && manageableGroups.length > 0}
           searchQuery={searchQuery}
           onSearchQueryChange={setSearchQuery}
           placeholder="Search groups..."
@@ -89,7 +96,7 @@ function GroupsPage() {
         )}
 
         {!isLoading && !error && groups && (
-          <GroupsList groups={groups} searchQuery={searchQuery} />
+          <GroupsList groups={manageableGroups} searchQuery={searchQuery} />
         )}
       </SettingsLayouts.Body>
     </SettingsLayouts.Root>

--- a/web/src/refresh-pages/admin/GroupsPage/svc.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/svc.ts
@@ -302,6 +302,25 @@ async function saveGroupPermissions(
   }
 }
 
+// Make/revoke a member as a manager of the group (dedicated PR5 endpoint).
+async function setGroupManager(
+  groupId: number,
+  userId: string,
+  isManager: boolean
+): Promise<void> {
+  const res = await fetch(`${USER_GROUP_URL}/${groupId}/manager`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ user_id: userId, is_manager: isManager }),
+  });
+  if (!res.ok) {
+    const detail = await res.json().catch(() => null);
+    throw new Error(
+      detail?.detail ?? `Failed to update group manager: ${res.statusText}`
+    );
+  }
+}
+
 export {
   renameGroup,
   createGroup,
@@ -311,4 +330,5 @@ export {
   updateDocSetGroupSharing,
   saveTokenLimits,
   saveGroupPermissions,
+  setGroupManager,
 };

--- a/web/src/refresh-pages/admin/GroupsPage/svc.ts
+++ b/web/src/refresh-pages/admin/GroupsPage/svc.ts
@@ -228,7 +228,7 @@ async function saveTokenLimits(
     const limit = validLimits[i]!;
     const existingLimit = existing[i]!;
     const updateRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
@@ -270,7 +270,7 @@ async function saveTokenLimits(
   for (let i = toUpdate; i < existing.length; i++) {
     const existingLimit = existing[i]!;
     const deleteRes = await fetch(
-      `/api/admin/token-rate-limits/rate-limit/${existingLimit.token_id}`,
+      `/api/admin/token-rate-limits/user-group/${groupId}/rate-limit/${existingLimit.token_id}`,
       { method: "DELETE" }
     );
     if (!deleteRes.ok) {
@@ -302,7 +302,6 @@ async function saveGroupPermissions(
   }
 }
 
-// Make/revoke a member as a manager of the group (dedicated PR5 endpoint).
 async function setGroupManager(
   groupId: number,
   userId: string,

--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -16,10 +16,11 @@ interface AdminListHeaderProps {
   placeholder?: string;
   /** Text shown in the empty-state card when no items exist. */
   emptyStateText: string;
-  /** Called when the action button is clicked. */
-  onAction: () => void;
-  /** Label for the action button. */
-  actionLabel: string;
+  /** Called when the action button is clicked. Omit (with actionLabel) to hide it —
+   *  e.g. a scoped manager who may view the list but can't create. */
+  onAction?: () => void;
+  /** Label for the action button. Omit (with onAction) to hide it. */
+  actionLabel?: string;
 }
 
 /**
@@ -59,11 +60,12 @@ export default function AdminListHeader({
   onAction,
   actionLabel,
 }: AdminListHeaderProps) {
-  const actionButton = (
-    <Button rightIcon={SvgPlusCircle} onClick={onAction}>
-      {actionLabel}
-    </Button>
-  );
+  const actionButton =
+    onAction && actionLabel ? (
+      <Button rightIcon={SvgPlusCircle} onClick={onAction}>
+        {actionLabel}
+      </Button>
+    ) : null;
 
   if (!hasItems) {
     return (

--- a/web/src/sections/admin/AdminListHeader.tsx
+++ b/web/src/sections/admin/AdminListHeader.tsx
@@ -16,8 +16,7 @@ interface AdminListHeaderProps {
   placeholder?: string;
   /** Text shown in the empty-state card when no items exist. */
   emptyStateText: string;
-  /** Called when the action button is clicked. Omit (with actionLabel) to hide it —
-   *  e.g. a scoped manager who may view the list but can't create. */
+  /** Action button click handler. Omit (with actionLabel) to hide the button. */
   onAction?: () => void;
   /** Label for the action button. Omit (with onAction) to hide it. */
   actionLabel?: string;


### PR DESCRIPTION
## Description

- Closes out the server-driven capability model with the final scoped-manager surface — **user groups** (+ token rate limits). Groups previously had *no per-group manager signal at all*, so every group control rendered unconditionally; the server now stamps a per-group affordance map and the client renders only what the backend allows.
- **GroupsPage**: opening/renaming a group and editing its members/agents now gate on per-group `manage`; deleting a group gates on global `MANAGE_USER_GROUPS`; the permissions + token-limit sections gate on `FULL_ADMIN`. "New Group" is hidden from scoped managers (create is global-only).
- **Gate classification** verified against the real routes (and correcting the design doc): `delete` is global `MANAGE_USER_GROUPS` (not FULL_ADMIN), and "New Group" gates on the global token — not `useCapabilities`, which would show it to scoped managers who'd then 403.
- Backend guards are **unchanged**; the read side reuses A1's `manages_group` and is pinned to enforcement by the contract test. The per-group stamp resolves the manager's scope once, so the list has no N+1. DTO map defaults empty (fail-closed).

## How Has This Been Tested?

- External-dependency-unit contract suite extended to user groups — drives the **real** `assert_manages_group` guard across in-scope/out-of-scope/admin actors, and asserts the scoped token-limit create (`assert_within_scope`) equals `manage`: 13/13 total. Frontend `tsgo` + oxlint/oxfmt clean.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

---

Notes / pre-existing gaps (out of scope): PR5's "Make/Revoke Manager" toggle UI is not in the tree — the route/DTO/type exist but no UI consumes them; when built, gate it on `can(group, "manage")`. Federated connectors have no per-affordance gate (route-gated only).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes the server-driven capability model for user groups and lets group managers fully manage their groups’ token limits. The UI now shows only allowed actions, avoiding 403s and extra queries.

- **New Features**
  - Backend stamps per-group `permissions` on `UserGroup` via `user_group_permissions` (`manage`, `delete`, `edit_permissions`, `edit_token_limits`), with `edit_token_limits` keyed to `manage`; manager scope/global authority are resolved once (no N+1); DTO defaults fail-closed.
  - Group token limits admit scope: GET allows_scope + `assert_manages_group`; group-scoped PUT/DELETE at `/user-group/{group_id}/rate-limit/{id}` fence by `group_id` via `_authorize_group_token_rate_limit_write` and `get_token_rate_limit_scope_and_group`.
  - Frontend gates with `can(group, ...)`: manage (rename/members/save + Make/Revoke Manager via `setGroupManager`), delete card, permissions section, and token limit section (fetch/save only when allowed); save uses group-scoped endpoints; “New Group” shows only for global `MANAGE_USER_GROUPS`; list filters to manageable groups; `GroupCard` open/rename require manage; `AdminListHeader` action is optional.
  - Contract tests pin the projection to real guards and routes; token-limit read GATE1 ∧ `assert_manages_group`; group write guard is enforced; action-key coverage added. Integration tests cover manager GET/POST/PUT/DELETE for group limits.

- **Bug Fixes**
  - Token-limit read was global-only; scoped managers can now read and CRUD limits for groups they manage, while group paths cannot reach global/user limits.
  - Unknown `rate_limit_id` on group writes now returns a structured 404 (not a generic 400), consistent with wrong-group IDs and without leaking existence.
  - Cleared `any_rate_limit_exists` cache on token-limit updates to apply changes immediately (shared by-id and group-scoped routes).
  - Gate classification matches routes: delete requires global `MANAGE_USER_GROUPS`; scoped managers no longer see create or admin-only controls that would 403.

<sup>Written for commit 5557e513ee1b5412eafcc253063164215a8c8a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

