### PR TITLE
fix(connectors): keep Google Drive checkpoint frontier monotonic across shortcut resolution

### DIFF
--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -37,6 +37,7 @@ from onyx.connectors.google_drive.doc_conversion import (
     onyx_document_id_from_drive_file,
 )
 from onyx.connectors.google_drive.file_retrieval import (
+    LISTING_MODIFIED_TIME_KEY,
     DriveFileFieldType,
     crawl_folders_for_files,
     get_all_files_for_oauth,
@@ -215,6 +216,15 @@ def _is_shared_drive_root(folder: GoogleDriveFileType) -> bool:
 
     # For shared drive content, the root has id == driveId
     return bool(drive_id and folder_id == drive_id)
+
+
+def _resume_start(
+    completed_until: SecondsSinceUnixEpoch,
+    start: SecondsSinceUnixEpoch | None,
+) -> SecondsSinceUnixEpoch:
+    """Resume from the checkpointed frontier, but never before the configured
+    range start (a corrupted frontier must not widen the requested time range)."""
+    return max(completed_until, start) if start is not None else completed_until
 
 
 def _public_access() -> ExternalAccess:
@@ -946,7 +956,11 @@ class GoogleDriveConnector(
                         field_type=field_type,
                         include_shared_with_me=self.include_files_shared_with_me,
                         max_num_pages=MY_DRIVE_PAGES_PER_CHECKPOINT,
-                        start=curr_stage.completed_until if resuming else start,
+                        start=(
+                            _resume_start(curr_stage.completed_until, start)
+                            if resuming
+                            else start
+                        ),
                         end=end,
                         cache_folders=not bool(curr_stage.completed_until),
                         page_token=curr_stage.next_page_token,
@@ -995,7 +1009,7 @@ class GoogleDriveConnector(
             if resuming:
                 drive_id = curr_stage.current_folder_or_drive_id
                 if drive_id:
-                    resume_start = curr_stage.completed_until
+                    resume_start = _resume_start(curr_stage.completed_until, start)
                     for file_or_token in _yield_from_drive(drive_id, resume_start):
                         if isinstance(file_or_token, str):
                             checkpoint.completion_map[
@@ -1061,7 +1075,7 @@ class GoogleDriveConnector(
                         user_email,
                     )
                 else:
-                    resume_start = curr_stage.completed_until
+                    resume_start = _resume_start(curr_stage.completed_until, start)
                     yield from _yield_from_folder_crawl(folder_id, resume_start)
                 last_processed_folder = folder_id
 
@@ -1546,7 +1560,11 @@ class GoogleDriveConnector(
             completion = checkpoint.completion_map[file.user_email]
 
             completed_until = completion.completed_until
-            modified_time = drive_file.get(GoogleFields.MODIFIED_TIME.value)
+            # for resolved shortcuts, the shortcut's own modifiedTime is the
+            # position in the modifiedTime-ordered listing
+            modified_time = drive_file.get(LISTING_MODIFIED_TIME_KEY) or drive_file.get(
+                GoogleFields.MODIFIED_TIME.value
+            )
             if isinstance(modified_time, str):
                 try:
                     completed_until = datetime.fromisoformat(modified_time).timestamp()
@@ -1557,6 +1575,16 @@ class GoogleDriveConnector(
                         file.completion_stage,
                         file.user_email,
                     )
+
+            # Never move the frontier backward within the same stage and
+            # drive/folder: a regression changes the listing query, invalidates
+            # the saved page token, and restarts retrieval from the regressed
+            # timestamp — which can loop forever.
+            if (
+                file.completion_stage == completion.stage
+                and file.parent_id == completion.current_folder_or_drive_id
+            ):
+                completed_until = max(completed_until, completion.completed_until)
 
             completion.update(
                 stage=file.completion_stage,
@@ -1614,7 +1642,7 @@ class GoogleDriveConnector(
             all_files_start = start
             # if resuming from a checkpoint
             if completion.stage == DriveRetrievalStage.OAUTH_FILES:
-                all_files_start = completion.completed_until
+                all_files_start = _resume_start(completion.completed_until, start)
 
             for file_or_token in self._oauth_retrieval_all_files(
                 field_type=field_type,

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -37,7 +37,6 @@ from onyx.connectors.google_drive.doc_conversion import (
     onyx_document_id_from_drive_file,
 )
 from onyx.connectors.google_drive.file_retrieval import (
-    LISTING_MODIFIED_TIME_KEY,
     DriveFileFieldType,
     crawl_folders_for_files,
     get_all_files_for_oauth,
@@ -1562,11 +1561,7 @@ class GoogleDriveConnector(
             completion = checkpoint.completion_map[file.user_email]
 
             completed_until = completion.completed_until
-            # for resolved shortcuts, the shortcut's own modifiedTime is the
-            # position in the modifiedTime-ordered listing
-            modified_time = drive_file.get(LISTING_MODIFIED_TIME_KEY) or drive_file.get(
-                GoogleFields.MODIFIED_TIME.value
-            )
+            modified_time = drive_file.get(GoogleFields.MODIFIED_TIME.value)
             if isinstance(modified_time, str):
                 try:
                     completed_until = datetime.fromisoformat(modified_time).timestamp()

--- a/backend/onyx/connectors/google_drive/connector.py
+++ b/backend/onyx/connectors/google_drive/connector.py
@@ -1434,9 +1434,10 @@ class GoogleDriveConnector(
             ].current_folder_or_drive_id
             if drive_id is None:
                 raise ValueError("drive id not set in checkpoint")
-            resume_start = checkpoint.completion_map[
-                self.primary_admin_email
-            ].completed_until
+            resume_start = _resume_start(
+                checkpoint.completion_map[self.primary_admin_email].completed_until,
+                start,
+            )
             for file_or_token in _yield_from_drive(drive_id, resume_start):
                 if isinstance(file_or_token, str):
                     checkpoint.completion_map[
@@ -1514,9 +1515,10 @@ class GoogleDriveConnector(
                 self.primary_admin_email
             ].current_folder_or_drive_id
         ):
-            resume_start = checkpoint.completion_map[
-                self.primary_admin_email
-            ].completed_until
+            resume_start = _resume_start(
+                checkpoint.completion_map[self.primary_admin_email].completed_until,
+                start,
+            )
             yield from _yield_from_folder_crawl(
                 folder_id,  # ty: ignore[possibly-unresolved-reference]
                 resume_start,

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -39,6 +39,11 @@ logger = setup_logger()
 DRIVE_RESOURCE_KEY_HEADER = "X-Goog-Drive-Resource-Keys"
 DRIVE_RESOURCE_KEY_FIELD = "resourceKey"
 
+# Set on resolved shortcut targets: the shortcut's own modifiedTime, i.e. the
+# file's position in the modifiedTime-ordered listing. The target's modifiedTime
+# can lie far outside the listing position and must not drive checkpoint progress.
+LISTING_MODIFIED_TIME_KEY = "_onyx_listing_modified_time"
+
 
 class DriveFileFieldType(Enum):
     """Enum to specify which fields to retrieve from Google Drive files"""
@@ -368,6 +373,11 @@ def _resolve_file_or_shortcut(
     logger.debug(
         "Resolved Drive shortcut %s to target %s", file.get("id"), target.get("id")
     )
+    # Keep the shortcut's own modifiedTime: listings are ordered by it, so
+    # checkpoint progress must be tracked against it, not the target's.
+    listing_modified_time = file.get(GoogleFields.MODIFIED_TIME.value)
+    if listing_modified_time is not None:
+        target[LISTING_MODIFIED_TIME_KEY] = listing_modified_time
     return target
 
 

--- a/backend/onyx/connectors/google_drive/file_retrieval.py
+++ b/backend/onyx/connectors/google_drive/file_retrieval.py
@@ -39,11 +39,6 @@ logger = setup_logger()
 DRIVE_RESOURCE_KEY_HEADER = "X-Goog-Drive-Resource-Keys"
 DRIVE_RESOURCE_KEY_FIELD = "resourceKey"
 
-# Set on resolved shortcut targets: the shortcut's own modifiedTime, i.e. the
-# file's position in the modifiedTime-ordered listing. The target's modifiedTime
-# can lie far outside the listing position and must not drive checkpoint progress.
-LISTING_MODIFIED_TIME_KEY = "_onyx_listing_modified_time"
-
 
 class DriveFileFieldType(Enum):
     """Enum to specify which fields to retrieve from Google Drive files"""
@@ -373,11 +368,13 @@ def _resolve_file_or_shortcut(
     logger.debug(
         "Resolved Drive shortcut %s to target %s", file.get("id"), target.get("id")
     )
-    # Keep the shortcut's own modifiedTime: listings are ordered by it, so
-    # checkpoint progress must be tracked against it, not the target's.
+    # Use the shortcut's own modifiedTime: listings are filtered and ordered by
+    # it, so this preserves the invariant that a retrieved item's modifiedTime
+    # lies within the requested time range — the target's can sit far outside
+    # it, which would corrupt the checkpoint frontier and re-poll windows.
     listing_modified_time = file.get(GoogleFields.MODIFIED_TIME.value)
     if listing_modified_time is not None:
-        target[LISTING_MODIFIED_TIME_KEY] = listing_modified_time
+        target[GoogleFields.MODIFIED_TIME.value] = listing_modified_time
     return target
 
 

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_checkpoint_frontier.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_checkpoint_frontier.py
@@ -4,8 +4,8 @@ The retrieval listing is ordered by modifiedTime and resumes from
 completed_until, so the frontier must never move backward within a stage +
 drive/folder. A regression changes the listing query, invalidates the saved
 page token, and restarts retrieval from the regressed timestamp — looping
-forever if the same file causes the same regression on every pass (as happens
-when a shortcut resolves to a target with an older modifiedTime).
+forever if the same file causes the same regression on every pass (as happened
+when shortcut resolution replaced a file's modifiedTime with its target's).
 """
 
 from collections.abc import Iterator
@@ -16,10 +16,7 @@ from onyx.connectors.google_drive.connector import (
     GoogleDriveConnector,
     _resume_start,
 )
-from onyx.connectors.google_drive.file_retrieval import (
-    LISTING_MODIFIED_TIME_KEY,
-    DriveFileFieldType,
-)
+from onyx.connectors.google_drive.file_retrieval import DriveFileFieldType
 from onyx.connectors.google_drive.models import (
     DriveRetrievalStage,
     GoogleDriveCheckpoint,
@@ -38,7 +35,6 @@ def _ts(iso: str) -> float:
 def _file(
     file_id: str,
     modified_time: str,
-    listing_modified_time: str | None = None,
     parent_id: str | None = None,
     stage: DriveRetrievalStage = DriveRetrievalStage.MY_DRIVE_FILES,
 ) -> RetrievedDriveFile:
@@ -48,8 +44,6 @@ def _file(
         "modifiedTime": modified_time,
         "webViewLink": f"https://drive.google.com/file/d/{file_id}",
     }
-    if listing_modified_time is not None:
-        drive_file[LISTING_MODIFIED_TIME_KEY] = listing_modified_time
     return RetrievedDriveFile(
         completion_stage=stage,
         drive_file=drive_file,
@@ -100,32 +94,6 @@ def _funnel(
     )
 
 
-def test_resolved_shortcut_uses_listing_position_not_target_mtime() -> None:
-    checkpoint = _checkpoint()
-    completion = checkpoint.completion_map[_USER]
-    gen = _funnel(
-        checkpoint,
-        [
-            _file("f1", "2024-06-01T00:00:00Z"),
-            # resolved shortcut: target was last modified in January, but the
-            # shortcut sits at June 2nd in the listing
-            _file(
-                "f2",
-                "2024-01-15T00:00:00Z",
-                listing_modified_time="2024-06-02T00:00:00Z",
-            ),
-            _file("f3", "2024-06-03T00:00:00Z"),
-        ],
-    )
-
-    next(gen)
-    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
-    next(gen)
-    assert completion.completed_until == _ts("2024-06-02T00:00:00Z")
-    next(gen)
-    assert completion.completed_until == _ts("2024-06-03T00:00:00Z")
-
-
 def test_out_of_order_mtime_never_regresses_frontier() -> None:
     checkpoint = _checkpoint()
     completion = checkpoint.completion_map[_USER]
@@ -133,7 +101,7 @@ def test_out_of_order_mtime_never_regresses_frontier() -> None:
         checkpoint,
         [
             _file("f1", "2024-06-01T00:00:00Z"),
-            _file("f2", "2024-01-15T00:00:00Z"),  # no listing timestamp available
+            _file("f2", "2024-01-15T00:00:00Z"),  # unexpected out-of-order timestamp
             _file("f3", "2024-06-03T00:00:00Z"),
         ],
     )

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_checkpoint_frontier.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_checkpoint_frontier.py
@@ -1,0 +1,185 @@
+"""Checkpoint frontier (completed_until) semantics for Google Drive retrieval.
+
+The retrieval listing is ordered by modifiedTime and resumes from
+completed_until, so the frontier must never move backward within a stage +
+drive/folder. A regression changes the listing query, invalidates the saved
+page token, and restarts retrieval from the regressed timestamp — looping
+forever if the same file causes the same regression on every pass (as happens
+when a shortcut resolves to a target with an older modifiedTime).
+"""
+
+from collections.abc import Iterator
+from datetime import datetime
+from typing import Any
+
+from onyx.connectors.google_drive.connector import (
+    GoogleDriveConnector,
+    _resume_start,
+)
+from onyx.connectors.google_drive.file_retrieval import (
+    LISTING_MODIFIED_TIME_KEY,
+    DriveFileFieldType,
+)
+from onyx.connectors.google_drive.models import (
+    DriveRetrievalStage,
+    GoogleDriveCheckpoint,
+    RetrievedDriveFile,
+    StageCompletion,
+)
+from onyx.utils.threadpool_concurrency import ThreadSafeDict
+
+_USER = "user@example.com"
+
+
+def _ts(iso: str) -> float:
+    return datetime.fromisoformat(iso).timestamp()
+
+
+def _file(
+    file_id: str,
+    modified_time: str,
+    listing_modified_time: str | None = None,
+    parent_id: str | None = None,
+    stage: DriveRetrievalStage = DriveRetrievalStage.MY_DRIVE_FILES,
+) -> RetrievedDriveFile:
+    drive_file: dict[str, Any] = {
+        "id": file_id,
+        "name": file_id,
+        "modifiedTime": modified_time,
+        "webViewLink": f"https://drive.google.com/file/d/{file_id}",
+    }
+    if listing_modified_time is not None:
+        drive_file[LISTING_MODIFIED_TIME_KEY] = listing_modified_time
+    return RetrievedDriveFile(
+        completion_stage=stage,
+        drive_file=drive_file,
+        user_email=_USER,
+        parent_id=parent_id,
+    )
+
+
+def _checkpoint(
+    stage: DriveRetrievalStage = DriveRetrievalStage.MY_DRIVE_FILES,
+    current_folder_or_drive_id: str | None = None,
+) -> GoogleDriveCheckpoint:
+    return GoogleDriveCheckpoint(
+        has_more=True,
+        retrieved_folder_and_drive_ids=set(),
+        completion_stage=stage,
+        completion_map=ThreadSafeDict(
+            {
+                _USER: StageCompletion(
+                    stage=stage,
+                    completed_until=0,
+                    current_folder_or_drive_id=current_folder_or_drive_id,
+                )
+            }
+        ),
+    )
+
+
+def _funnel(
+    checkpoint: GoogleDriveCheckpoint, files: list[RetrievedDriveFile]
+) -> Iterator[RetrievedDriveFile]:
+    connector = GoogleDriveConnector(include_my_drives=True)
+
+    def retrieval_method(
+        field_type: DriveFileFieldType,  # noqa: ARG001
+        checkpoint: GoogleDriveCheckpoint,  # noqa: ARG001
+        start: float | None = None,  # noqa: ARG001
+        end: float | None = None,  # noqa: ARG001
+    ) -> Iterator[RetrievedDriveFile]:
+        yield from files
+
+    return connector._checkpointed_retrieval(
+        retrieval_method=retrieval_method,
+        field_type=DriveFileFieldType.STANDARD,
+        checkpoint=checkpoint,
+        start=None,
+        end=None,
+    )
+
+
+def test_resolved_shortcut_uses_listing_position_not_target_mtime() -> None:
+    checkpoint = _checkpoint()
+    completion = checkpoint.completion_map[_USER]
+    gen = _funnel(
+        checkpoint,
+        [
+            _file("f1", "2024-06-01T00:00:00Z"),
+            # resolved shortcut: target was last modified in January, but the
+            # shortcut sits at June 2nd in the listing
+            _file(
+                "f2",
+                "2024-01-15T00:00:00Z",
+                listing_modified_time="2024-06-02T00:00:00Z",
+            ),
+            _file("f3", "2024-06-03T00:00:00Z"),
+        ],
+    )
+
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-02T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-03T00:00:00Z")
+
+
+def test_out_of_order_mtime_never_regresses_frontier() -> None:
+    checkpoint = _checkpoint()
+    completion = checkpoint.completion_map[_USER]
+    gen = _funnel(
+        checkpoint,
+        [
+            _file("f1", "2024-06-01T00:00:00Z"),
+            _file("f2", "2024-01-15T00:00:00Z"),  # no listing timestamp available
+            _file("f3", "2024-06-03T00:00:00Z"),
+        ],
+    )
+
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-03T00:00:00Z")
+
+
+def test_frontier_resets_when_drive_changes() -> None:
+    checkpoint = _checkpoint(
+        stage=DriveRetrievalStage.SHARED_DRIVE_FILES,
+        current_folder_or_drive_id="drive_1",
+    )
+    completion = checkpoint.completion_map[_USER]
+    gen = _funnel(
+        checkpoint,
+        [
+            _file(
+                "f1",
+                "2024-06-01T00:00:00Z",
+                parent_id="drive_1",
+                stage=DriveRetrievalStage.SHARED_DRIVE_FILES,
+            ),
+            # next drive starts over at an earlier timestamp; this is a
+            # legitimate reset, not a regression
+            _file(
+                "f2",
+                "2024-02-01T00:00:00Z",
+                parent_id="drive_2",
+                stage=DriveRetrievalStage.SHARED_DRIVE_FILES,
+            ),
+        ],
+    )
+
+    next(gen)
+    assert completion.completed_until == _ts("2024-06-01T00:00:00Z")
+    next(gen)
+    assert completion.completed_until == _ts("2024-02-01T00:00:00Z")
+    assert completion.current_folder_or_drive_id == "drive_2"
+
+
+def test_resume_start_clamps_to_range_start() -> None:
+    assert _resume_start(100.0, 200.0) == 200.0
+    assert _resume_start(300.0, 200.0) == 300.0
+    assert _resume_start(300.0, None) == 300.0

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
@@ -16,7 +16,6 @@ from onyx.connectors.google_drive.doc_conversion import (
 from onyx.connectors.google_drive.file_retrieval import (
     DRIVE_RESOURCE_KEY_FIELD,
     DRIVE_RESOURCE_KEY_HEADER,
-    LISTING_MODIFIED_TIME_KEY,
     DriveFileFieldType,
     _get_files_in_parent,
     crawl_folders_for_files,
@@ -149,7 +148,7 @@ def test_shortcut_to_file_yields_target_with_true_parent() -> None:
     assert len(service.files_resource.get_calls) == 1
 
 
-def test_shortcut_resolution_stamps_listing_modified_time() -> None:
+def test_shortcut_resolution_uses_shortcut_modified_time() -> None:
     target = _target_file("target_file", "true_parent")
     target["modifiedTime"] = "2024-01-15T00:00:00Z"
     service = _FakeDriveService(
@@ -177,10 +176,10 @@ def test_shortcut_resolution_stamps_listing_modified_time() -> None:
         )
 
     assert len(files) == 1
-    # the target's own modifiedTime is preserved for doc metadata; the
-    # shortcut's listing position is stamped for checkpoint tracking
-    assert files[0]["modifiedTime"] == "2024-01-15T00:00:00Z"
-    assert files[0][LISTING_MODIFIED_TIME_KEY] == "2026-06-02T00:00:00Z"
+    # the retrieved item keeps the shortcut's modifiedTime — the value the
+    # listing was filtered/ordered by — so it stays within the requested range
+    assert files[0]["modifiedTime"] == "2026-06-02T00:00:00Z"
+    assert files[0]["id"] == "target_file"
 
 
 def test_shortcut_to_resource_key_file_uses_header() -> None:

--- a/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
+++ b/backend/tests/unit/onyx/connectors/google_drive/test_drive_shortcut_following.py
@@ -16,6 +16,7 @@ from onyx.connectors.google_drive.doc_conversion import (
 from onyx.connectors.google_drive.file_retrieval import (
     DRIVE_RESOURCE_KEY_FIELD,
     DRIVE_RESOURCE_KEY_HEADER,
+    LISTING_MODIFIED_TIME_KEY,
     DriveFileFieldType,
     _get_files_in_parent,
     crawl_folders_for_files,
@@ -146,6 +147,40 @@ def test_shortcut_to_file_yields_target_with_true_parent() -> None:
     assert files == [target]
     assert service.files_resource.get_calls[0]["fileId"] == "target_file"
     assert len(service.files_resource.get_calls) == 1
+
+
+def test_shortcut_resolution_stamps_listing_modified_time() -> None:
+    target = _target_file("target_file", "true_parent")
+    target["modifiedTime"] = "2024-01-15T00:00:00Z"
+    service = _FakeDriveService(
+        {
+            "shortcut_file": _shortcut("shortcut_file", "target_file", _PDF_MIME_TYPE),
+            "target_file": target,
+        }
+    )
+
+    def _fake_paginated_retrieval(**_kwargs: object) -> Iterator[dict[str, Any]]:
+        shortcut = _shortcut("shortcut_file", "target_file", _PDF_MIME_TYPE)
+        shortcut["modifiedTime"] = "2026-06-02T00:00:00Z"
+        yield shortcut
+
+    with patch(
+        f"{_FILE_RETRIEVAL_MODULE}.execute_paginated_retrieval",
+        side_effect=_fake_paginated_retrieval,
+    ):
+        files = list(
+            _get_files_in_parent(
+                service=cast(Resource, service),
+                parent_id="shortcut_parent",
+                field_type=DriveFileFieldType.STANDARD,
+            )
+        )
+
+    assert len(files) == 1
+    # the target's own modifiedTime is preserved for doc metadata; the
+    # shortcut's listing position is stamped for checkpoint tracking
+    assert files[0]["modifiedTime"] == "2024-01-15T00:00:00Z"
+    assert files[0][LISTING_MODIFIED_TIME_KEY] == "2026-06-02T00:00:00Z"
 
 
 def test_shortcut_to_resource_key_file_uses_header() -> None:


### PR DESCRIPTION
## Description

Google Drive initial indexing can loop forever and never complete when any user's My Drive contains a shortcut pointing at a file with an older `modifiedTime`.

Drive listings are ordered by `modifiedTime` and resume from the per-user checkpoint frontier (`StageCompletion.completed_until`). When retrieval resolves a shortcut, the target's metadata replaces the shortcut's — so the frontier was being overwritten with the **target's** `modifiedTime`, which can sit far before the shortcut's actual position in the listing:

1. Frontier snaps backward months/years.
2. Next checkpoint cycle rebuilds the listing query with `modifiedTime >= <polluted frontier>`.
3. The saved page token no longer matches the query → Google rejects it → `google_utils` "Invalid page token ... retrying from start of request" silently restarts the listing from the polluted timestamp.
4. Retrieval re-walks the same window (all dedup-skipped), hits the same shortcut, and repeats — a deterministic infinite loop. `new_docs_indexed` flatlines while the attempt heartbeat stays alive.

Observed live on a cloud tenant: 3 of 125 users' My Drives cycled with ~8-minute periods (same `completed_until` + page-token pair recurring), pinning the connector in `INITIAL_INDEXING` for days. A shortcut to a *newer* file has the mirror failure: the frontier jumps forward and silently skips every file in between.

Fixes:
- `_resolve_file_or_shortcut` replaces the resolved target's `modifiedTime` with the shortcut's own, preserving the invariant that a retrieved item's `modifiedTime` lies within the requested time range (checkpoint frontier and re-poll windows both rely on it).
- `_checkpointed_retrieval` never moves the frontier backward within the same stage + drive/folder (legitimate per-drive/folder resets are unaffected).
- Resume starts are clamped to the configured range start (`_resume_start`), so checkpoints already corrupted by this bug recover on upgrade instead of widening the requested time range (frontiers polluted to pre-range timestamps were observed live).

## How Has This Been Tested?

- New unit tests (`test_drive_checkpoint_frontier.py`) replay the failure: a resolved shortcut with an older target mid-listing keeps the frontier at the listing position; an unexplained backward timestamp is clamped; per-drive resets still work; `_resume_start` clamps to range start.
- New unit test in `test_drive_shortcut_following.py` verifies the resolver stamps the listing timestamp while preserving the target's `modifiedTime`.
- Full `backend/tests/unit/onyx/connectors/` + `backend/tests/unit/ee/onyx/external_permissions/google_drive/` suites: 955 passed, 22 skipped, 0 failures.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an infinite loop and skipped-file risk in Google Drive indexing by keeping the checkpoint frontier monotonic and using the shortcut’s modifiedTime on resolved targets. Resumes are clamped to the configured start across My Drive, Shared Drives, and OAuth.

- **Bug Fixes**
  - On resolved shortcuts, replace the target’s `modifiedTime` with the shortcut’s value so the item stays within the listing range and checkpoint progress stays monotonic.
  - Never move `StageCompletion.completed_until` backward within the same stage and parent (drive/folder) to avoid invalid page tokens and retry loops.
  - Clamp resume starts via `_resume_start` to the configured range start for both service-account and OAuth paths so corrupted checkpoints recover without widening the range.

<sup>Written for commit b225f21bfa8e03bfbefdee093c5853f32ed8917d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

