### PR TITLE
fix(craft): expose gateway model capabilities

### DIFF
--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -14,6 +14,7 @@ FileSet: TypeAlias = dict[str, bytes]
 class GatewayModelConfig(BaseModel):
     id: str
     display_name: str
+    supports_image_input: bool = False
     supports_reasoning: bool = False
     max_input_tokens: int | None = None
     max_output_tokens: int | None = None

--- a/backend/onyx/server/features/build/sandbox/models.py
+++ b/backend/onyx/server/features/build/sandbox/models.py
@@ -7,17 +7,9 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from onyx.db.enums import SandboxStatus
+from onyx.server.gateway.models import GatewayModelDescriptor
 
 FileSet: TypeAlias = dict[str, bytes]
-
-
-class GatewayModelConfig(BaseModel):
-    id: str
-    display_name: str
-    supports_image_input: bool = False
-    supports_reasoning: bool = False
-    max_input_tokens: int | None = None
-    max_output_tokens: int | None = None
 
 
 class CraftLLMProviderConfig(BaseModel):
@@ -26,7 +18,7 @@ class CraftLLMProviderConfig(BaseModel):
     api_key: str | None
     api_base: str | None
     display_name: str | None = None
-    models: list[GatewayModelConfig] | None = None
+    models: list[GatewayModelDescriptor] | None = None
 
 
 class CraftMCPServerConfig(BaseModel):

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -172,12 +172,13 @@ def _build_provider_block(
             "reasoning": capabilities.supports_reasoning,
             "temperature": capabilities.supports_temperature,
             "tool_call": capabilities.supports_tool_calls,
-            "interleaved": capabilities.supports_interleaved_reasoning,
             "modalities": {
                 "input": list(capabilities.input_modalities),
                 "output": list(capabilities.output_modalities),
             },
         }
+        if capabilities.supports_interleaved_reasoning:
+            entry["interleaved"] = True
         if capabilities.supports_reasoning:
             entry["options"] = {"reasoningEffort": "high"}
         if model.max_input_tokens:

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -165,7 +165,21 @@ def _build_provider_block(
         block["name"] = llm_provider_config.display_name
     models: dict[str, Any] = {}
     for model in llm_provider_config.models or []:
-        entry: dict[str, Any] = {"name": model.display_name}
+        input_modalities = ["text"]
+        if model.supports_image_input:
+            input_modalities.append("image")
+        entry: dict[str, Any] = {
+            "name": model.display_name,
+            "attachment": model.supports_image_input,
+            "reasoning": model.supports_reasoning,
+            "temperature": False,
+            "tool_call": True,
+            "interleaved": False,
+            "modalities": {
+                "input": input_modalities,
+                "output": ["text"],
+            },
+        }
         if model.supports_reasoning:
             entry["options"] = {"reasoningEffort": "high"}
         if model.max_input_tokens:

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -165,22 +165,20 @@ def _build_provider_block(
         block["name"] = llm_provider_config.display_name
     models: dict[str, Any] = {}
     for model in llm_provider_config.models or []:
-        input_modalities = ["text"]
-        if model.supports_image_input:
-            input_modalities.append("image")
+        capabilities = model.capabilities
         entry: dict[str, Any] = {
             "name": model.display_name,
-            "attachment": model.supports_image_input,
-            "reasoning": model.supports_reasoning,
-            "temperature": False,
-            "tool_call": True,
-            "interleaved": False,
+            "attachment": "image" in capabilities.input_modalities,
+            "reasoning": capabilities.supports_reasoning,
+            "temperature": capabilities.supports_temperature,
+            "tool_call": capabilities.supports_tool_calls,
+            "interleaved": capabilities.supports_interleaved_reasoning,
             "modalities": {
-                "input": input_modalities,
-                "output": ["text"],
+                "input": list(capabilities.input_modalities),
+                "output": list(capabilities.output_modalities),
             },
         }
-        if model.supports_reasoning:
+        if capabilities.supports_reasoning:
             entry["options"] = {"reasoningEffort": "high"}
         if model.max_input_tokens:
             # opencode's schema requires both keys when "limit" is present.

--- a/backend/onyx/server/features/build/session/llm_config.py
+++ b/backend/onyx/server/features/build/session/llm_config.py
@@ -1,9 +1,6 @@
-from collections import Counter
 from dataclasses import dataclass
 
-from onyx.llm.model_capabilities import get_llm_max_output_tokens, get_model_map
 from onyx.llm.well_known_providers.llm_provider_options import (
-    get_provider_display_name,
     get_recommendations,
 )
 from onyx.server.features.build.configs import (
@@ -13,10 +10,13 @@ from onyx.server.features.build.configs import (
 )
 from onyx.server.features.build.sandbox.models import (
     CraftLLMProviderConfig,
-    GatewayModelConfig,
 )
 from onyx.server.gateway.configs import GATEWAY_PATH_PREFIX
-from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+from onyx.server.gateway.model_catalog import (
+    build_gateway_model_catalog,
+    ordered_gateway_providers,
+)
+from onyx.server.manage.llm.models import LLMProviderView
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -28,14 +28,6 @@ def _visible_models_by_name(provider: LLMProviderView) -> list[str]:
     return sorted(
         model.name for model in provider.model_configurations if model.is_visible
     )
-
-
-def _provider_label(provider: LLMProviderView) -> str:
-    return provider.name or get_provider_display_name(provider.provider)
-
-
-def _model_display_name(model: ModelConfigurationView) -> str:
-    return model.custom_display_name or model.display_name or model.name
 
 
 @dataclass(frozen=True)
@@ -89,15 +81,6 @@ def parse_agent_selection(
     return None
 
 
-def _gateway_provider_order(
-    providers: list[LLMProviderView],
-) -> list[LLMProviderView]:
-    return sorted(
-        providers,
-        key=lambda provider: (_provider_label(provider).casefold(), provider.id),
-    )
-
-
 def _select_gateway_default(
     providers: list[LLMProviderView],
     selection: AgentSelection | None,
@@ -123,7 +106,7 @@ def _select_gateway_default(
     # (recommended-models.json, kept current by the update-recommended-models
     # workflow) in provider order, else the first provider's first visible model.
     recommendations = get_recommendations()
-    ordered = _gateway_provider_order(providers)
+    ordered = ordered_gateway_providers(providers)
     fallback: tuple[int, str] | None = None
     for provider in ordered:
         visible = _visible_models_by_name(provider)
@@ -144,45 +127,10 @@ def build_onyx_gateway_config(
     if not ONYX_SERVER_URL:
         return None
 
-    # Sorted so the rendered config is byte-stable across DB reads: the
-    # model_configurations relationship has no ORDER BY, and the per-turn
-    # reconcile compares the rendered JSON byte-for-byte to decide whether to
-    # restart the opencode instance.
-    visible_models = [
-        (provider, model)
-        for provider in _gateway_provider_order(gateway_providers)
-        for model in sorted(
-            (m for m in provider.model_configurations if m.is_visible),
-            key=lambda m: m.name,
-        )
-    ]
+    models = build_gateway_model_catalog(gateway_providers)
     default_selection = _select_gateway_default(gateway_providers, selection)
-    if not visible_models or default_selection is None:
+    if not models or default_selection is None:
         return None
-
-    display_name_counts = Counter(
-        _model_display_name(model) for _, model in visible_models
-    )
-    # Model configs don't track max output tokens; derive it from the litellm
-    # map (as the main app does) so opencode's per-model limit is accurate.
-    model_map = get_model_map()
-    models: list[GatewayModelConfig] = []
-    for provider, model in visible_models:
-        display_name = _model_display_name(model)
-        if display_name_counts[display_name] > 1:
-            display_name = f"{display_name} ({_provider_label(provider)})"
-        models.append(
-            GatewayModelConfig(
-                id=f"{provider.id}/{model.name}",
-                display_name=display_name,
-                supports_image_input=model.supports_image_input,
-                supports_reasoning=model.supports_reasoning,
-                max_input_tokens=model.max_input_tokens,
-                max_output_tokens=get_llm_max_output_tokens(
-                    model_map, model.name, provider.provider
-                ),
-            )
-        )
 
     api_root = ONYX_SERVER_URL.rstrip("/")
     api_base = f"{api_root}{GATEWAY_PATH_PREFIX}/v1"

--- a/backend/onyx/server/features/build/session/llm_config.py
+++ b/backend/onyx/server/features/build/session/llm_config.py
@@ -175,6 +175,7 @@ def build_onyx_gateway_config(
             GatewayModelConfig(
                 id=f"{provider.id}/{model.name}",
                 display_name=display_name,
+                supports_image_input=model.supports_image_input,
                 supports_reasoning=model.supports_reasoning,
                 max_input_tokens=model.max_input_tokens,
                 max_output_tokens=get_llm_max_output_tokens(

--- a/backend/onyx/server/gateway/model_catalog.py
+++ b/backend/onyx/server/gateway/model_catalog.py
@@ -1,0 +1,77 @@
+from collections import Counter
+from collections.abc import Sequence
+
+from onyx.llm.model_capabilities import get_llm_max_output_tokens, get_model_map
+from onyx.llm.well_known_providers.llm_provider_options import (
+    get_provider_display_name,
+)
+from onyx.server.gateway.models import (
+    GatewayModality,
+    GatewayModelCapabilities,
+    GatewayModelDescriptor,
+)
+from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+
+
+def gateway_provider_label(provider: LLMProviderView) -> str:
+    return provider.name or get_provider_display_name(provider.provider)
+
+
+def ordered_gateway_providers(
+    providers: Sequence[LLMProviderView],
+) -> list[LLMProviderView]:
+    return sorted(
+        providers,
+        key=lambda provider: (gateway_provider_label(provider).casefold(), provider.id),
+    )
+
+
+def _model_display_name(model: ModelConfigurationView) -> str:
+    return model.custom_display_name or model.display_name or model.name
+
+
+def build_gateway_model_catalog(
+    providers: Sequence[LLMProviderView],
+) -> list[GatewayModelDescriptor]:
+    """Build provider-neutral metadata for every visible accessible model.
+
+    The order is deterministic because consumers reconcile serialized catalogs.
+    """
+    visible_models = [
+        (provider, model)
+        for provider in ordered_gateway_providers(providers)
+        for model in sorted(
+            (model for model in provider.model_configurations if model.is_visible),
+            key=lambda model: model.name,
+        )
+    ]
+    display_name_counts = Counter(
+        _model_display_name(model) for _, model in visible_models
+    )
+    model_map = get_model_map()
+
+    catalog: list[GatewayModelDescriptor] = []
+    for provider, model in visible_models:
+        display_name = _model_display_name(model)
+        if display_name_counts[display_name] > 1:
+            display_name = f"{display_name} ({gateway_provider_label(provider)})"
+
+        input_modalities: tuple[GatewayModality, ...] = (
+            ("text", "image") if model.supports_image_input else ("text",)
+        )
+        catalog.append(
+            GatewayModelDescriptor(
+                id=f"{provider.id}/{model.name}",
+                display_name=display_name,
+                provider=provider.provider,
+                capabilities=GatewayModelCapabilities(
+                    input_modalities=input_modalities,
+                    supports_reasoning=model.supports_reasoning,
+                ),
+                max_input_tokens=model.max_input_tokens,
+                max_output_tokens=get_llm_max_output_tokens(
+                    model_map, model.name, provider.provider
+                ),
+            )
+        )
+    return catalog

--- a/backend/onyx/server/gateway/models.py
+++ b/backend/onyx/server/gateway/models.py
@@ -1,8 +1,38 @@
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from onyx.llm.model_response import ModelResponse, ModelResponseStream, Usage
+
+GatewayModality: TypeAlias = Literal["text", "audio", "image", "video", "pdf"]
+
+
+class GatewayModelCapabilities(BaseModel):
+    """Effective capabilities exposed by the Onyx OpenAI-compatible gateway."""
+
+    model_config = ConfigDict(frozen=True)
+
+    input_modalities: tuple[GatewayModality, ...] = ("text",)
+    output_modalities: tuple[GatewayModality, ...] = ("text",)
+    supports_reasoning: bool = False
+    supports_tool_calls: bool = True
+    supports_temperature: bool = False
+    supports_interleaved_reasoning: bool = False
+
+
+class GatewayModelDescriptor(BaseModel):
+    """Provider-neutral model metadata shared by gateway protocol adapters."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    display_name: str
+    provider: str
+    capabilities: GatewayModelCapabilities = Field(
+        default_factory=GatewayModelCapabilities
+    )
+    max_input_tokens: int | None = None
+    max_output_tokens: int | None = None
 
 
 class ChatCompletionRequest(BaseModel):

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_docker_serve_plumbing.py
@@ -30,10 +30,8 @@ from onyx.server.features.build.configs import (
 from onyx.server.features.build.sandbox.docker.docker_sandbox_manager import (
     DockerSandboxManager,
 )
-from onyx.server.features.build.sandbox.models import (
-    CraftLLMProviderConfig,
-    GatewayModelConfig,
-)
+from onyx.server.features.build.sandbox.models import CraftLLMProviderConfig
+from onyx.server.gateway.models import GatewayModelDescriptor
 
 _SBX = UUID("12345678-1234-1234-1234-1234567890ab")
 
@@ -281,9 +279,10 @@ def test_setup_writes_fresh_gateway_catalog_before_instance_start(
         api_key="proxy-placeholder",
         api_base="https://onyx.example.com/gateway/v1",
         models=[
-            GatewayModelConfig(
+            GatewayModelDescriptor(
                 id="13/gpt-5-mini",
                 display_name="GPT-5 Mini",
+                provider="openai",
             )
         ],
     )

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -8,12 +8,15 @@ from onyx.server.features.build.configs import MCP_SESSION_TAG_HEADER
 from onyx.server.features.build.sandbox.models import (
     CraftLLMProviderConfig,
     CraftMCPServerConfig,
-    GatewayModelConfig,
 )
 from onyx.server.features.build.sandbox.util.mcp_config import craft_mcp_fingerprint
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_opencode_base_config,
     build_provider_opencode_config,
+)
+from onyx.server.gateway.models import (
+    GatewayModelCapabilities,
+    GatewayModelDescriptor,
 )
 
 
@@ -25,12 +28,19 @@ def _gateway(*, default: str = "7/gpt-5.5") -> CraftLLMProviderConfig:
         api_base="https://onyx.test/api/gateway/v1",
         display_name="Onyx",
         models=[
-            GatewayModelConfig(id="7/gpt-5.5", display_name="GPT-5.5"),
-            GatewayModelConfig(
+            GatewayModelDescriptor(
+                id="7/gpt-5.5",
+                display_name="GPT-5.5",
+                provider="openai",
+            ),
+            GatewayModelDescriptor(
                 id="9/claude-opus-4-8",
                 display_name="Claude Opus 4.8",
-                supports_image_input=True,
-                supports_reasoning=True,
+                provider="anthropic",
+                capabilities=GatewayModelCapabilities(
+                    input_modalities=("text", "image"),
+                    supports_reasoning=True,
+                ),
                 max_input_tokens=200_000,
             ),
         ],

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -103,6 +103,46 @@ def test_gateway_is_the_only_enabled_provider() -> None:
     }
 
 
+def test_gateway_capabilities_are_adapted_instead_of_hardcoded() -> None:
+    gateway = CraftLLMProviderConfig(
+        provider="onyx",
+        model_name="4/custom-model",
+        api_key=None,
+        api_base="https://onyx.test/api/gateway/v1",
+        models=[
+            GatewayModelDescriptor(
+                id="4/custom-model",
+                display_name="Custom Model",
+                provider="custom",
+                capabilities=GatewayModelCapabilities(
+                    input_modalities=("text", "image", "pdf"),
+                    output_modalities=("text", "audio"),
+                    supports_tool_calls=False,
+                    supports_temperature=True,
+                    supports_interleaved_reasoning=True,
+                ),
+            )
+        ],
+    )
+
+    model = build_provider_opencode_config(gateway)["provider"]["onyx"]["models"][
+        "4/custom-model"
+    ]
+
+    assert model == {
+        "name": "Custom Model",
+        "attachment": True,
+        "reasoning": False,
+        "temperature": True,
+        "tool_call": False,
+        "interleaved": True,
+        "modalities": {
+            "input": ["text", "image", "pdf"],
+            "output": ["text", "audio"],
+        },
+    }
+
+
 def test_default_must_exist_in_gateway_catalog() -> None:
     with pytest.raises(ValueError, match="not in the provider catalog"):
         build_provider_opencode_config(_gateway(default="missing"))

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -29,6 +29,7 @@ def _gateway(*, default: str = "7/gpt-5.5") -> CraftLLMProviderConfig:
             GatewayModelConfig(
                 id="9/claude-opus-4-8",
                 display_name="Claude Opus 4.8",
+                supports_image_input=True,
                 supports_reasoning=True,
                 max_input_tokens=200_000,
             ),
@@ -60,6 +61,35 @@ def test_gateway_is_the_only_enabled_provider() -> None:
     assert provider["models"]["9/claude-opus-4-8"]["limit"] == {
         "context": 200_000,
         "output": 128_000,
+    }
+    assert provider["models"]["7/gpt-5.5"] == {
+        "name": "GPT-5.5",
+        "attachment": False,
+        "reasoning": False,
+        "temperature": False,
+        "tool_call": True,
+        "interleaved": False,
+        "modalities": {
+            "input": ["text"],
+            "output": ["text"],
+        },
+    }
+    assert provider["models"]["9/claude-opus-4-8"] == {
+        "name": "Claude Opus 4.8",
+        "attachment": True,
+        "reasoning": True,
+        "temperature": False,
+        "tool_call": True,
+        "interleaved": False,
+        "modalities": {
+            "input": ["text", "image"],
+            "output": ["text"],
+        },
+        "options": {"reasoningEffort": "high"},
+        "limit": {
+            "context": 200_000,
+            "output": 128_000,
+        },
     }
 
 

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -78,7 +78,6 @@ def test_gateway_is_the_only_enabled_provider() -> None:
         "reasoning": False,
         "temperature": False,
         "tool_call": True,
-        "interleaved": False,
         "modalities": {
             "input": ["text"],
             "output": ["text"],
@@ -90,7 +89,6 @@ def test_gateway_is_the_only_enabled_provider() -> None:
         "reasoning": True,
         "temperature": False,
         "tool_call": True,
-        "interleaved": False,
         "modalities": {
             "input": ["text", "image"],
             "output": ["text"],

--- a/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
@@ -15,16 +15,14 @@ from onyx.llm.well_known_providers.auto_update_models import (
     LLMRecommendations,
 )
 from onyx.llm.well_known_providers.models import SimpleKnownModel
-from onyx.server.features.build.sandbox.models import (
-    CraftLLMProviderConfig,
-    GatewayModelConfig,
-)
+from onyx.server.features.build.sandbox.models import CraftLLMProviderConfig
 from onyx.server.features.build.sandbox.util.opencode_config import (
     build_provider_opencode_config,
 )
 from onyx.server.features.build.session import llm_config
 from onyx.server.features.build.session import manager as manager_module
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.gateway.models import GatewayModelDescriptor
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 
 
@@ -245,9 +243,10 @@ def _gateway_config() -> CraftLLMProviderConfig:
         api_key="proxy-placeholder",
         api_base="https://onyx.test/gateway/v1",
         models=[
-            GatewayModelConfig(
+            GatewayModelDescriptor(
                 id="13/gpt-5-mini",
                 display_name="GPT-5 Mini",
+                provider="openai",
             )
         ],
     )

--- a/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
@@ -33,6 +33,7 @@ def _model(
     *,
     display_name: str | None = None,
     is_visible: bool = True,
+    supports_image_input: bool = False,
     supports_reasoning: bool = False,
     max_input_tokens: int | None = None,
 ) -> ModelConfigurationView:
@@ -40,7 +41,7 @@ def _model(
         name=name,
         display_name=display_name,
         is_visible=is_visible,
-        supports_image_input=False,
+        supports_image_input=supports_image_input,
         supports_reasoning=supports_reasoning,
         max_input_tokens=max_input_tokens,
     )
@@ -133,6 +134,47 @@ def test_gateway_config_fallback_supports_any_provider() -> None:
 
     assert config is not None
     assert config.model_name == "2/bedrock-model"
+
+
+def test_gateway_model_capabilities_reach_opencode_catalog() -> None:
+    provider = _provider(
+        3,
+        "anthropic",
+        [
+            _model(
+                "claude-opus-5",
+                supports_image_input=True,
+                supports_reasoning=True,
+            ),
+            _model("claude-text-only"),
+        ],
+    )
+
+    with patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"):
+        gateway_config = llm_config.build_onyx_gateway_config([provider])
+
+    assert gateway_config is not None
+    opencode_models = build_provider_opencode_config(gateway_config)["provider"][
+        "onyx"
+    ]["models"]
+
+    vision_model = opencode_models["3/claude-opus-5"]
+    assert vision_model["modalities"] == {
+        "input": ["text", "image"],
+        "output": ["text"],
+    }
+    assert vision_model["attachment"] is True
+    assert vision_model["reasoning"] is True
+    assert vision_model["options"] == {"reasoningEffort": "high"}
+
+    text_model = opencode_models["3/claude-text-only"]
+    assert text_model["modalities"] == {
+        "input": ["text"],
+        "output": ["text"],
+    }
+    assert text_model["attachment"] is False
+    assert text_model["reasoning"] is False
+    assert "options" not in text_model
 
 
 def test_gateway_config_can_target_direct_api_service() -> None:

--- a/backend/tests/unit/onyx/server/gateway/test_model_catalog.py
+++ b/backend/tests/unit/onyx/server/gateway/test_model_catalog.py
@@ -1,0 +1,77 @@
+from onyx.server.gateway.model_catalog import build_gateway_model_catalog
+from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+
+
+def _model(
+    name: str,
+    *,
+    visible: bool = True,
+    supports_image_input: bool = False,
+    supports_reasoning: bool = False,
+) -> ModelConfigurationView:
+    return ModelConfigurationView(
+        name=name,
+        display_name=name,
+        is_visible=visible,
+        supports_image_input=supports_image_input,
+        supports_reasoning=supports_reasoning,
+    )
+
+
+def _provider(
+    provider_id: int,
+    provider_type: str,
+    display_name: str,
+    models: list[ModelConfigurationView],
+) -> LLMProviderView:
+    return LLMProviderView(
+        id=provider_id,
+        name=display_name,
+        provider=provider_type,
+        api_key=None,
+        model_configurations=models,
+    )
+
+
+def test_catalog_filters_and_resolves_effective_gateway_capabilities() -> None:
+    later_provider = _provider(
+        8,
+        "openai",
+        "Zulu",
+        [
+            _model("text-model"),
+            _model("hidden-model", visible=False, supports_image_input=True),
+        ],
+    )
+    earlier_provider = _provider(
+        3,
+        "anthropic",
+        "Alpha",
+        [
+            _model(
+                "vision-reasoner",
+                supports_image_input=True,
+                supports_reasoning=True,
+            )
+        ],
+    )
+
+    catalog = build_gateway_model_catalog([later_provider, earlier_provider])
+
+    assert [model.id for model in catalog] == [
+        "3/vision-reasoner",
+        "8/text-model",
+    ]
+
+    vision_model, text_model = catalog
+    assert vision_model.provider == "anthropic"
+    assert vision_model.capabilities.input_modalities == ("text", "image")
+    assert vision_model.capabilities.output_modalities == ("text",)
+    assert vision_model.capabilities.supports_reasoning is True
+    assert vision_model.capabilities.supports_tool_calls is True
+    assert vision_model.capabilities.supports_temperature is False
+    assert vision_model.capabilities.supports_interleaved_reasoning is False
+
+    assert text_model.provider == "openai"
+    assert text_model.capabilities.input_modalities == ("text",)
+    assert text_model.capabilities.supports_reasoning is False


### PR DESCRIPTION
## Description

Fix Craft custom OpenCode model metadata so model capabilities reach the sandbox accurately, and establish one shared gateway capability catalog for future protocol adapters.

OpenCode treats custom OpenAI-compatible models as lacking image input when its catalog entry omits `modalities`, causing it to reject image attachments before the model receives them. This change:

- defines provider-neutral gateway model descriptors and effective capabilities
- builds the visible model catalog once with deterministic ordering, qualified display-name collisions, provider identity, modalities, reasoning support, and token limits
- makes Craft transport the shared descriptors instead of maintaining a parallel model type
- makes OpenCode a thin adapter from the shared capability schema to its native model configuration
- keeps reasoning-effort choices owned by OpenCode rather than mirroring Onyx internal reasoning variants

This restores visual input for capable models such as Claude Opus 5 while preserving text-only behavior for models without image support. No public models API is added in this PR; a future gateway API can serialize the same shared catalog.

Regression coverage exercises both catalog construction and the complete model-configuration → shared catalog → OpenCode path.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
