### PR TITLE
fix(craft): resolve aliased model token limits

### DIFF
--- a/backend/onyx/llm/model_capabilities.py
+++ b/backend/onyx/llm/model_capabilities.py
@@ -185,9 +185,7 @@ def get_llm_max_output_tokens(
     """Best effort attempt to get the max output tokens for the LLM."""
     default_output_tokens = int(GEN_AI_MODEL_FALLBACK_MAX_TOKENS)
 
-    model_obj = model_map.get(f"{model_provider}/{model_name}")
-    if not model_obj:
-        model_obj = model_map.get(model_name)
+    model_obj = find_model_obj(model_map, model_provider, model_name)
 
     if not model_obj:
         logger.warning(

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -18,12 +18,6 @@ from onyx.server.features.build.sandbox.models import (
     CraftMCPServerConfig,
 )
 
-# Fallback output budget for gateway models the litellm map has no entry for
-# (build_onyx_gateway_config derives the real per-model value). 128k matches the
-# recommended Craft models (Claude Fable/Opus 4.8, GPT-5.6) per models.dev;
-# providers enforce their own real caps regardless.
-_GATEWAY_DEFAULT_MAX_OUTPUT_TOKENS = 128_000
-
 # The gateway is an OpenAI-compatible endpoint, wired via opencode's
 # openai-compatible SDK package.
 _OPENAI_COMPATIBLE_NPM = "@ai-sdk/openai-compatible"
@@ -181,11 +175,14 @@ def _build_provider_block(
             entry["interleaved"] = True
         if capabilities.supports_reasoning:
             entry["options"] = {"reasoningEffort": "high"}
-        if model.max_input_tokens:
-            # opencode's schema requires both keys when "limit" is present.
+        if (
+            model.max_input_tokens is not None
+            and model.max_output_tokens is not None
+            and model.max_input_tokens > model.max_output_tokens
+        ):
             entry["limit"] = {
                 "context": model.max_input_tokens,
-                "output": model.max_output_tokens or _GATEWAY_DEFAULT_MAX_OUTPUT_TOKENS,
+                "output": model.max_output_tokens,
             }
         models[model.id] = entry
     block["models"] = models

--- a/backend/onyx/server/features/build/sandbox/util/opencode_config.py
+++ b/backend/onyx/server/features/build/sandbox/util/opencode_config.py
@@ -175,13 +175,13 @@ def _build_provider_block(
             entry["interleaved"] = True
         if capabilities.supports_reasoning:
             entry["options"] = {"reasoningEffort": "high"}
-        if (
-            model.max_input_tokens is not None
-            and model.max_output_tokens is not None
-            and model.max_input_tokens > model.max_output_tokens
-        ):
+        if model.max_input_tokens is not None and model.max_output_tokens is not None:
+            # OpenCode 1.15.x subtracts output from context when input is absent.
+            # LiteLLM reports input and output budgets independently, so include
+            # input explicitly to keep compaction from collapsing to zero.
             entry["limit"] = {
                 "context": model.max_input_tokens,
+                "input": model.max_input_tokens,
                 "output": model.max_output_tokens,
             }
         models[model.id] = entry

--- a/backend/onyx/server/gateway/model_catalog.py
+++ b/backend/onyx/server/gateway/model_catalog.py
@@ -43,7 +43,7 @@ def _capability_model_name(
     model_map: dict[str, Any],
     provider: LLMProviderView,
     model: ModelConfigurationView,
-) -> str | None:
+) -> str:
     if find_model_obj(model_map, provider.provider, model.name) is not None:
         return model.name
 
@@ -59,24 +59,15 @@ def _capability_model_name(
         )
         return deployment_name
 
-    return None
+    return model.name
 
 
 def _gateway_token_limits(
     model_map: dict[str, Any],
     provider: LLMProviderView,
     model: ModelConfigurationView,
-) -> tuple[int | None, int | None]:
+) -> tuple[int, int]:
     capability_model_name = _capability_model_name(model_map, provider, model)
-    if capability_model_name is None:
-        logger.warning(
-            "No capability metadata found for gateway model %s/%s; omitting "
-            "token limits",
-            provider.provider,
-            model.name,
-        )
-        return None, None
-
     max_input_tokens = model.configured_max_input_tokens or llm_max_input_tokens(
         model_map=model_map,
         model_name=capability_model_name,
@@ -87,17 +78,6 @@ def _gateway_token_limits(
         model_name=capability_model_name,
         model_provider=provider.provider,
     )
-    if max_input_tokens <= max_output_tokens:
-        logger.warning(
-            "Capability metadata for gateway model %s/%s has output limit %s "
-            "greater than or equal to input limit %s; omitting token limits",
-            provider.provider,
-            model.name,
-            max_output_tokens,
-            max_input_tokens,
-        )
-        return None, None
-
     return max_input_tokens, max_output_tokens
 
 

--- a/backend/onyx/server/gateway/model_catalog.py
+++ b/backend/onyx/server/gateway/model_catalog.py
@@ -1,7 +1,13 @@
 from collections import Counter
 from collections.abc import Sequence
+from typing import Any
 
-from onyx.llm.model_capabilities import get_llm_max_output_tokens, get_model_map
+from onyx.llm.model_capabilities import (
+    find_model_obj,
+    get_llm_max_output_tokens,
+    get_model_map,
+    llm_max_input_tokens,
+)
 from onyx.llm.well_known_providers.llm_provider_options import (
     get_provider_display_name,
 )
@@ -11,6 +17,9 @@ from onyx.server.gateway.models import (
     GatewayModelDescriptor,
 )
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
+from onyx.utils.logger import setup_logger
+
+logger = setup_logger()
 
 
 def gateway_provider_label(provider: LLMProviderView) -> str:
@@ -28,6 +37,68 @@ def ordered_gateway_providers(
 
 def _model_display_name(model: ModelConfigurationView) -> str:
     return model.custom_display_name or model.display_name or model.name
+
+
+def _capability_model_name(
+    model_map: dict[str, Any],
+    provider: LLMProviderView,
+    model: ModelConfigurationView,
+) -> str | None:
+    if find_model_obj(model_map, provider.provider, model.name) is not None:
+        return model.name
+
+    deployment_name = provider.deployment_name
+    if (
+        deployment_name
+        and find_model_obj(model_map, provider.provider, deployment_name) is not None
+    ):
+        logger.info(
+            "Using deployment %r capabilities for gateway model alias %r",
+            deployment_name,
+            model.name,
+        )
+        return deployment_name
+
+    return None
+
+
+def _gateway_token_limits(
+    model_map: dict[str, Any],
+    provider: LLMProviderView,
+    model: ModelConfigurationView,
+) -> tuple[int | None, int | None]:
+    capability_model_name = _capability_model_name(model_map, provider, model)
+    if capability_model_name is None:
+        logger.warning(
+            "No capability metadata found for gateway model %s/%s; omitting "
+            "token limits",
+            provider.provider,
+            model.name,
+        )
+        return None, None
+
+    max_input_tokens = model.configured_max_input_tokens or llm_max_input_tokens(
+        model_map=model_map,
+        model_name=capability_model_name,
+        model_provider=provider.provider,
+    )
+    max_output_tokens = get_llm_max_output_tokens(
+        model_map=model_map,
+        model_name=capability_model_name,
+        model_provider=provider.provider,
+    )
+    if max_input_tokens <= max_output_tokens:
+        logger.warning(
+            "Capability metadata for gateway model %s/%s has output limit %s "
+            "greater than or equal to input limit %s; omitting token limits",
+            provider.provider,
+            model.name,
+            max_output_tokens,
+            max_input_tokens,
+        )
+        return None, None
+
+    return max_input_tokens, max_output_tokens
 
 
 def build_gateway_model_catalog(
@@ -59,6 +130,9 @@ def build_gateway_model_catalog(
         input_modalities: tuple[GatewayModality, ...] = (
             ("text", "image") if model.supports_image_input else ("text",)
         )
+        max_input_tokens, max_output_tokens = _gateway_token_limits(
+            model_map, provider, model
+        )
         catalog.append(
             GatewayModelDescriptor(
                 id=f"{provider.id}/{model.name}",
@@ -68,10 +142,8 @@ def build_gateway_model_catalog(
                     input_modalities=input_modalities,
                     supports_reasoning=model.supports_reasoning,
                 ),
-                max_input_tokens=model.max_input_tokens,
-                max_output_tokens=get_llm_max_output_tokens(
-                    model_map, model.name, provider.provider
-                ),
+                max_input_tokens=max_input_tokens,
+                max_output_tokens=max_output_tokens,
             )
         )
     return catalog

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -225,6 +225,10 @@ class ModelConfigurationView(BaseModel):
     name: str
     is_visible: bool
     max_input_tokens: int | None = None
+    # The persisted override/source value, before static-provider capability
+    # enrichment. Internal consumers use this to distinguish an intentional
+    # limit from a fallback inferred from the display model name.
+    configured_max_input_tokens: int | None = Field(default=None, exclude=True)
     supports_image_input: bool
     supports_reasoning: bool = False
     # True when this is the provider's recommended default model.
@@ -258,6 +262,7 @@ class ModelConfigurationView(BaseModel):
                 name=model_configuration_model.name,
                 is_visible=model_configuration_model.is_visible,
                 max_input_tokens=model_configuration_model.max_input_tokens,
+                configured_max_input_tokens=model_configuration_model.max_input_tokens,
                 # Dynamic/custom-config providers under-report vision; fall back
                 # to the LiteLLM cost map when no VISION flow is stored.
                 supports_image_input=(
@@ -317,6 +322,7 @@ class ModelConfigurationView(BaseModel):
                     model_provider=provider_name,
                 )
             ),
+            configured_max_input_tokens=model_configuration_model.max_input_tokens,
             supports_image_input=(
                 True
                 if LLMModelFlowType.VISION

--- a/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
+++ b/backend/tests/unit/onyx/llm/test_token_limit_lookups.py
@@ -138,6 +138,17 @@ class TestGetLlmMaxOutputTokens:
             == 4096
         )
 
+    def test_lookup_strips_proxy_provider_prefix(self) -> None:
+        model_map = {"azure/gpt-5": {"max_output_tokens": 128000}}
+        assert (
+            get_llm_max_output_tokens(
+                model_map=model_map,
+                model_name="openai/gpt-5",
+                model_provider="azure",
+            )
+            == 128000
+        )
+
     def test_model_not_found_returns_fallback(self) -> None:
         assert get_llm_max_output_tokens(
             model_map={},

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -42,6 +42,7 @@ def _gateway(*, default: str = "7/gpt-5.5") -> CraftLLMProviderConfig:
                     supports_reasoning=True,
                 ),
                 max_input_tokens=200_000,
+                max_output_tokens=128_000,
             ),
         ],
     )
@@ -139,6 +140,36 @@ def test_gateway_capabilities_are_adapted_instead_of_hardcoded() -> None:
             "output": ["text", "audio"],
         },
     }
+
+
+@pytest.mark.parametrize(
+    ("max_input_tokens", "max_output_tokens"),
+    [(32_000, 32_000), (32_000, None)],
+)
+def test_gateway_omits_incoherent_token_limits(
+    max_input_tokens: int,
+    max_output_tokens: int | None,
+) -> None:
+    gateway = CraftLLMProviderConfig(
+        provider="onyx",
+        model_name="7/broken-model",
+        api_key=None,
+        api_base="https://onyx.test/api/gateway/v1",
+        models=[
+            GatewayModelDescriptor(
+                id="7/broken-model",
+                display_name="Broken",
+                provider="custom",
+                max_input_tokens=max_input_tokens,
+                max_output_tokens=max_output_tokens,
+            )
+        ],
+    )
+
+    model = build_provider_opencode_config(gateway)["provider"]["onyx"]["models"][
+        "7/broken-model"
+    ]
+    assert "limit" not in model
 
 
 def test_default_must_exist_in_gateway_catalog() -> None:

--- a/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
+++ b/backend/tests/unit/onyx/server/features/build/sandbox/test_opencode_config.py
@@ -71,6 +71,7 @@ def test_gateway_is_the_only_enabled_provider() -> None:
     assert set(provider["models"]) == {"7/gpt-5.5", "9/claude-opus-4-8"}
     assert provider["models"]["9/claude-opus-4-8"]["limit"] == {
         "context": 200_000,
+        "input": 200_000,
         "output": 128_000,
     }
     assert provider["models"]["7/gpt-5.5"] == {
@@ -97,6 +98,7 @@ def test_gateway_is_the_only_enabled_provider() -> None:
         "options": {"reasoningEffort": "high"},
         "limit": {
             "context": 200_000,
+            "input": 200_000,
             "output": 128_000,
         },
     }
@@ -142,14 +144,7 @@ def test_gateway_capabilities_are_adapted_instead_of_hardcoded() -> None:
     }
 
 
-@pytest.mark.parametrize(
-    ("max_input_tokens", "max_output_tokens"),
-    [(32_000, 32_000), (32_000, None)],
-)
-def test_gateway_omits_incoherent_token_limits(
-    max_input_tokens: int,
-    max_output_tokens: int | None,
-) -> None:
+def test_gateway_omits_partial_token_limits() -> None:
     gateway = CraftLLMProviderConfig(
         provider="onyx",
         model_name="7/broken-model",
@@ -160,8 +155,7 @@ def test_gateway_omits_incoherent_token_limits(
                 id="7/broken-model",
                 display_name="Broken",
                 provider="custom",
-                max_input_tokens=max_input_tokens,
-                max_output_tokens=max_output_tokens,
+                max_input_tokens=32_000,
             )
         ],
     )

--- a/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
@@ -233,6 +233,7 @@ def test_custom_azure_alias_renders_deployment_limits_for_opencode() -> None:
         "limit"
     ] == {
         "context": 272_000,
+        "input": 272_000,
         "output": 128_000,
     }
 
@@ -269,11 +270,12 @@ def test_gateway_config_preserves_explicit_context_override() -> None:
         "limit"
     ] == {
         "context": 200_000,
+        "input": 200_000,
         "output": 128_000,
     }
 
 
-def test_unknown_model_omits_limits_instead_of_inventing_invalid_pair() -> None:
+def test_unknown_model_renders_explicit_fallback_with_input_budget() -> None:
     provider = _provider(
         7,
         "custom",
@@ -288,19 +290,23 @@ def test_unknown_model_omits_limits_instead_of_inventing_invalid_pair() -> None:
 
     assert gateway_config is not None
     opencode_config = build_provider_opencode_config(gateway_config)
-    assert (
-        "limit" not in opencode_config["provider"]["onyx"]["models"]["7/unknown-model"]
-    )
+    assert opencode_config["provider"]["onyx"]["models"]["7/unknown-model"][
+        "limit"
+    ] == {
+        "context": 32_000,
+        "input": 32_000,
+        "output": 32_000,
+    }
 
 
-def test_incoherent_override_omits_limits_without_reducing_provider_output() -> None:
+def test_small_input_override_does_not_reduce_provider_output() -> None:
     provider = _provider(
         7,
         "azure",
         [
             _model(
                 "tiny-model",
-                configured_max_input_tokens=1_000,
+                configured_max_input_tokens=25_000,
             )
         ],
         deployment_name="gpt-5",
@@ -320,7 +326,11 @@ def test_incoherent_override_omits_limits_without_reducing_provider_output() -> 
 
     assert gateway_config is not None
     opencode_config = build_provider_opencode_config(gateway_config)
-    assert "limit" not in opencode_config["provider"]["onyx"]["models"]["7/tiny-model"]
+    assert opencode_config["provider"]["onyx"]["models"]["7/tiny-model"]["limit"] == {
+        "context": 25_000,
+        "input": 25_000,
+        "output": 128_000,
+    }
 
 
 def test_gateway_selection_renders_storage_columns() -> None:

--- a/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/build/test_session_gateway_config.py
@@ -22,6 +22,7 @@ from onyx.server.features.build.sandbox.util.opencode_config import (
 from onyx.server.features.build.session import llm_config
 from onyx.server.features.build.session import manager as manager_module
 from onyx.server.features.build.session.manager import SessionManager
+from onyx.server.gateway import model_catalog
 from onyx.server.gateway.models import GatewayModelDescriptor
 from onyx.server.manage.llm.models import LLMProviderView, ModelConfigurationView
 
@@ -34,6 +35,7 @@ def _model(
     supports_image_input: bool = False,
     supports_reasoning: bool = False,
     max_input_tokens: int | None = None,
+    configured_max_input_tokens: int | None = None,
 ) -> ModelConfigurationView:
     return ModelConfigurationView(
         name=name,
@@ -42,6 +44,7 @@ def _model(
         supports_image_input=supports_image_input,
         supports_reasoning=supports_reasoning,
         max_input_tokens=max_input_tokens,
+        configured_max_input_tokens=configured_max_input_tokens,
     )
 
 
@@ -51,12 +54,14 @@ def _provider(
     models: list[ModelConfigurationView],
     *,
     name: str | None = None,
+    deployment_name: str | None = None,
 ) -> LLMProviderView:
     return LLMProviderView(
         id=provider_id,
         name=name,
         provider=provider_type,
         api_key="test-key",
+        deployment_name=deployment_name,
         model_configurations=models,
     )
 
@@ -193,6 +198,129 @@ def test_gateway_config_preserves_url_path_prefix() -> None:
 
     assert config is not None
     assert config.api_base == "https://onyx.example/api/gateway/v1"
+
+
+def test_custom_azure_alias_renders_deployment_limits_for_opencode() -> None:
+    provider = _provider(
+        300,
+        "azure",
+        [
+            _model(
+                "GPT-5.6-SOL",
+                # This is the misleading fallback produced when the alias itself
+                # is absent from LiteLLM, matching the production regression.
+                max_input_tokens=30_976,
+            )
+        ],
+        deployment_name="gpt-5",
+    )
+    model_map = {
+        "azure/gpt-5": {
+            "max_input_tokens": 272_000,
+            "max_output_tokens": 128_000,
+        }
+    }
+
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(model_catalog, "get_model_map", return_value=model_map),
+    ):
+        gateway_config = llm_config.build_onyx_gateway_config([provider])
+
+    assert gateway_config is not None
+    opencode_config = build_provider_opencode_config(gateway_config)
+    assert opencode_config["provider"]["onyx"]["models"]["300/GPT-5.6-SOL"][
+        "limit"
+    ] == {
+        "context": 272_000,
+        "output": 128_000,
+    }
+
+
+def test_gateway_config_preserves_explicit_context_override() -> None:
+    provider = _provider(
+        300,
+        "azure",
+        [
+            _model(
+                "Customer Alias",
+                max_input_tokens=30_976,
+                configured_max_input_tokens=200_000,
+            )
+        ],
+        deployment_name="gpt-5",
+    )
+    model_map = {
+        "azure/gpt-5": {
+            "max_input_tokens": 272_000,
+            "max_output_tokens": 128_000,
+        }
+    }
+
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(model_catalog, "get_model_map", return_value=model_map),
+    ):
+        gateway_config = llm_config.build_onyx_gateway_config([provider])
+
+    assert gateway_config is not None
+    opencode_config = build_provider_opencode_config(gateway_config)
+    assert opencode_config["provider"]["onyx"]["models"]["300/Customer Alias"][
+        "limit"
+    ] == {
+        "context": 200_000,
+        "output": 128_000,
+    }
+
+
+def test_unknown_model_omits_limits_instead_of_inventing_invalid_pair() -> None:
+    provider = _provider(
+        7,
+        "custom",
+        [_model("unknown-model", max_input_tokens=30_976)],
+    )
+
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(model_catalog, "get_model_map", return_value={}),
+    ):
+        gateway_config = llm_config.build_onyx_gateway_config([provider])
+
+    assert gateway_config is not None
+    opencode_config = build_provider_opencode_config(gateway_config)
+    assert (
+        "limit" not in opencode_config["provider"]["onyx"]["models"]["7/unknown-model"]
+    )
+
+
+def test_incoherent_override_omits_limits_without_reducing_provider_output() -> None:
+    provider = _provider(
+        7,
+        "azure",
+        [
+            _model(
+                "tiny-model",
+                configured_max_input_tokens=1_000,
+            )
+        ],
+        deployment_name="gpt-5",
+    )
+    model_map = {
+        "azure/gpt-5": {
+            "max_input_tokens": 272_000,
+            "max_output_tokens": 128_000,
+        }
+    }
+
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(model_catalog, "get_model_map", return_value=model_map),
+    ):
+        gateway_config = llm_config.build_onyx_gateway_config([provider])
+
+    assert gateway_config is not None
+    opencode_config = build_provider_opencode_config(gateway_config)
+    assert "limit" not in opencode_config["provider"]["onyx"]["models"]["7/tiny-model"]
 
 
 def test_gateway_selection_renders_storage_columns() -> None:

--- a/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
+++ b/backend/tests/unit/onyx/server/manage/llm/test_model_configuration.py
@@ -246,6 +246,28 @@ class TestModelConfigurationViewFromModelStatic:
     # NOT in DYNAMIC_LLM_PROVIDERS
     STATIC_PROVIDER = "openai"
 
+    def test_distinguishes_persisted_limit_from_capability_enrichment(self) -> None:
+        persisted = self._patched_static_view(
+            _make_model_config(
+                name="gpt-4o",
+                display_name=None,
+                max_input_tokens=90_000,
+            )
+        )
+        inferred = self._patched_static_view(
+            _make_model_config(
+                name="gpt-4o",
+                display_name=None,
+                max_input_tokens=None,
+            )
+        )
+
+        assert persisted.max_input_tokens == 90_000
+        assert persisted.configured_max_input_tokens == 90_000
+        assert inferred.max_input_tokens == 128_000
+        assert inferred.configured_max_input_tokens is None
+        assert "configured_max_input_tokens" not in persisted.model_dump()
+
     def test_supports_reasoning_from_stored_flow(self) -> None:
         """Stored REASONING flow → True even when model_is_reasoning_model returns False."""
         mc = _make_model_config(


### PR DESCRIPTION
## Description

Fix Craft sessions entering repeated OpenCode compaction when a configured model alias is absent from LiteLLM's capability map.

The gateway catalog now resolves an unrecognized alias through the provider's underlying deployment name, preserving the provider's actual input and output limits. Persisted administrator overrides remain distinguishable from inferred fallback values.

Because the Onyx LLM gateway is a custom OpenCode provider, OpenCode cannot recover limits from models.dev. The generated model configuration therefore includes explicit `context`, `input`, and `output` limits. Supplying the separate input budget is important for OpenCode 1.15.x: without it, OpenCode subtracts output from context during compaction accounting, which can collapse the usable budget to zero. Unknown models retain the repository's existing token fallbacks rather than relying on OpenCode's custom-provider defaults, while partial limit metadata is omitted at the adapter boundary.

This preserves Azure GPT-5's full 128k output capability metadata, applies across providers, and introduces no configuration variables. It builds on the shared gateway model capability catalog merged in #13502.

## How Has This Been Tested?


## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
