### PR TITLE
feat: mcp shared api key header [edit of #13278] (#13335) to release v4.4

### DIFF
--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -5383,6 +5383,8 @@ class MCPConnectionConfig(Base):
     #   "refresh_token": "<token>",  # OAuth only
     #   "access_token": "<token>",   # OAuth only
     #   "headers": {"key": "value", "key2": "value2"},
+    #   "header_template": {"Authorization": "Bearer {api_key}"}, # shared API-token config
+    #   "api_token": "<token>",  # shared API-token config
     #   "header_substitutions": {"<key>": "<value>"}, # stored header template substitutions
     #   "request_body": ["path/in/body:value", "path2/in2/body2:value2"] # TBD
     #   "client_id": "<id>",  # For dynamically registered OAuth clients

--- a/backend/onyx/server/features/mcp/api.py
+++ b/backend/onyx/server/features/mcp/api.py
@@ -107,7 +107,11 @@ from onyx.server.features.mcp.oauth import (
 )
 from onyx.server.features.mcp.ssrf import validate_mcp_outbound_url
 from onyx.server.features.tool.models import ToolSnapshot
-from onyx.utils.encryption import mask_string, reject_masked_credentials
+from onyx.utils.encryption import (
+    is_masked_credential,
+    mask_string,
+    reject_masked_credentials,
+)
 from onyx.utils.logger import setup_logger
 from onyx.utils.url import BLOCKED_HOSTNAMES, SSRFException
 from onyx.utils.variable_functionality import (
@@ -262,6 +266,94 @@ def _resolve_admin_credentials(
             reject_masked_credentials({key: request_value})
         resolved[key] = request_value
     return resolved
+
+
+def _default_shared_api_token_template() -> MCPAuthTemplate:
+    """Return the legacy shared API-token template."""
+    return MCPAuthTemplate(
+        headers={"Authorization": "Bearer {api_key}"},
+        required_fields=["api_key"],
+    )
+
+
+def _extract_shared_api_token(config_data: MCPConnectionData) -> str:
+    """Read the encrypted shared token, with compatibility for old configs."""
+    if api_token := config_data.get("api_token"):
+        return api_token
+
+    authorization = config_data.get("headers", {}).get("Authorization", "")
+    if authorization:
+        return authorization.rsplit(" ", 1)[-1]
+
+    raise OnyxError(
+        OnyxErrorCode.INVALID_INPUT,
+        "Existing shared MCP API token could not be recovered; please re-enter it.",
+    )
+
+
+def _resolve_shared_api_token(
+    *,
+    request_api_token: str | None,
+    request_api_token_changed: bool,
+    existing_config: MCPConnectionData | None,
+) -> str | None:
+    """Preserve masked shared tokens when only configuration is edited."""
+    if request_api_token_changed:
+        if request_api_token:
+            reject_masked_credentials({"api_token": request_api_token})
+        return request_api_token
+
+    # A real token in the request takes precedence during auth-mode
+    # conversion, even when older clients omit the changed flag.
+    if request_api_token and not is_masked_credential(request_api_token):
+        return request_api_token
+
+    if existing_config and (
+        "api_token" in existing_config
+        or "Authorization" in existing_config.get("headers", {})
+    ):
+        return _extract_shared_api_token(existing_config)
+
+    if request_api_token:
+        reject_masked_credentials({"api_token": request_api_token})
+    return request_api_token
+
+
+def _resolve_shared_api_token_template(
+    *,
+    request_template: MCPAuthTemplate | None,
+    existing_config: MCPConnectionData | None,
+) -> MCPAuthTemplate | None:
+    """Preserve an existing shared header template when omitted on update."""
+    if request_template is not None:
+        return request_template
+
+    if existing_config:
+        stored_template: dict[str, str] | None = existing_config.get("header_template")
+        if stored_template:
+            return MCPAuthTemplate(
+                headers=stored_template,
+                required_fields=["api_key"],
+            )
+
+    return None
+
+
+def _build_shared_api_token_config_data(
+    *,
+    api_token: str,
+    auth_template: MCPAuthTemplate | None,
+    user_email: str,
+) -> MCPConnectionData:
+    """Render and persist a shared API-token header template."""
+    template = auth_template or _default_shared_api_token_template()
+    return MCPConnectionData(
+        headers=_build_headers_from_template(
+            template, {"api_key": api_token}, user_email
+        ),
+        header_template=template.headers,
+        api_token=api_token,
+    )
 
 
 def _build_oauth_admin_config_data(
@@ -1117,9 +1209,7 @@ def _db_mcp_server_to_api_mcp_server(
                 db_server.admin_connection_config, apply_mask=False
             )
             if db_server.auth_type == MCPAuthenticationType.API_TOKEN:
-                raw_api_key = admin_config_dict["headers"]["Authorization"].split(" ")[
-                    -1
-                ]
+                raw_api_key = _extract_shared_api_token(admin_config_dict)
                 admin_credentials = {
                     "api_key": mask_string(raw_api_key),
                 }
@@ -1187,16 +1277,19 @@ def _db_mcp_server_to_api_mcp_server(
                 admin_credentials = {}
                 logger.warning("No client info found for server %s", db_server.name)
 
-    # The header template is only meaningful for per-user API_TOKEN
-    # servers, where it surfaces placeholder strings (e.g.
-    # `Bearer {API_KEY}`) for the user-side credential prompt. OAuth
-    # per-user servers do not get an `auth_template`: OAuth uses the
-    # handshake URL (`/oauth/connect`) rather than a header template,
-    # so the frontend never consumes one for OAuth flows.
+    # Surface the placeholder header template without exposing rendered
+    # credentials. OAuth servers do not get an auth_template because OAuth
+    # uses the handshake URL rather than a header template.
+    #
+    # Per-user templates are surfaced to any accessible user because they
+    # drive the per-user credential prompt. Shared/admin templates are only
+    # surfaced to the owner/admin auth-config response: basic users never
+    # supply shared credentials, and the template can legitimately carry
+    # literal header values that must not leak.
     auth_template = None
-    if (
+    if db_server.auth_type != MCPAuthenticationType.OAUTH and (
         auth_performer == MCPAuthenticationPerformer.PER_USER
-        and db_server.auth_type != MCPAuthenticationType.OAUTH
+        or can_view_admin_credentials
     ):
         try:
             template_config = db_server.admin_connection_config
@@ -1204,7 +1297,13 @@ def _db_mcp_server_to_api_mcp_server(
                 template_config_dict = extract_connection_data(
                     template_config, apply_mask=False
                 )
-                headers = template_config_dict.get("headers", {})
+                if auth_performer == MCPAuthenticationPerformer.ADMIN:
+                    headers = (
+                        template_config_dict.get("header_template")
+                        or _default_shared_api_token_template().headers
+                    )
+                else:
+                    headers = template_config_dict.get("headers", {})
                 # Prefer the explicitly persisted list; fall back to deriving
                 # from header placeholders for servers created before
                 # `required_fields` was persisted.
@@ -1716,10 +1815,44 @@ def _upsert_mcp_server(
         # against the admin's stored per-user row
         existing_admin_per_user_creds: dict[str, str] = {}
         existing_template_headers: dict[str, str] = {}
+        existing_shared_template_headers: dict[str, str] = {}
         if mcp_server.admin_connection_config:
             existing_template_headers = (
                 existing_admin_config_dict.get("headers", {}) or {}
             )
+            existing_shared_template_headers = (
+                existing_admin_config_dict.get("header_template")
+                or _default_shared_api_token_template().headers
+            )
+
+        if (
+            request.auth_type == MCPAuthenticationType.API_TOKEN
+            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+        ):
+            request.auth_template = _resolve_shared_api_token_template(
+                request_template=request.auth_template,
+                existing_config=(
+                    existing_admin_config_dict
+                    if mcp_server.admin_connection_config
+                    else None
+                ),
+            )
+            request.api_token = _resolve_shared_api_token(
+                request_api_token=request.api_token,
+                request_api_token_changed=request.api_token_changed,
+                existing_config=(
+                    existing_admin_config_dict
+                    if mcp_server.admin_connection_config
+                    else None
+                ),
+            )
+            # The validator allows an omitted token on update so the stored
+            # one can be reused; enforce that a token actually resolved.
+            if not request.api_token:
+                raise OnyxError(
+                    OnyxErrorCode.INVALID_INPUT,
+                    "A shared API token is required for admin-managed API-token servers.",
+                )
         if (
             request.auth_type == MCPAuthenticationType.API_TOKEN
             and request.auth_performer == MCPAuthenticationPerformer.PER_USER
@@ -1752,6 +1885,12 @@ def _upsert_mcp_server(
             and request.auth_performer == MCPAuthenticationPerformer.PER_USER
             and request.auth_template is not None
             and request.auth_template.headers != existing_template_headers
+        )
+        shared_api_token_template_changed = (
+            request.auth_type == MCPAuthenticationType.API_TOKEN
+            and request.auth_performer == MCPAuthenticationPerformer.ADMIN
+            and request.auth_template is not None
+            and request.auth_template.headers != existing_shared_template_headers
         )
         api_token_scheme_changed = (
             request.auth_type == MCPAuthenticationType.API_TOKEN
@@ -1793,6 +1932,11 @@ def _upsert_mcp_server(
                 and (
                     api_token_creds_changed
                     or api_token_template_changed
+                    or shared_api_token_template_changed
+                    or (
+                        request.auth_performer == MCPAuthenticationPerformer.ADMIN
+                        and request.api_token_changed
+                    )
                     or api_token_scheme_changed
                 )
             )
@@ -1898,8 +2042,10 @@ def _upsert_mcp_server(
     if request.auth_performer == MCPAuthenticationPerformer.ADMIN and request.api_token:
         # Admin-managed server: create admin config with API token
         admin_config = create_connection_config(
-            config_data=MCPConnectionData(
-                headers={"Authorization": f"Bearer {request.api_token}"},
+            config_data=_build_shared_api_token_config_data(
+                api_token=request.api_token,
+                auth_template=request.auth_template,
+                user_email=user.email,
             ),
             mcp_server_id=mcp_server.id,
             db_session=db_session,

--- a/backend/onyx/server/features/mcp/models.py
+++ b/backend/onyx/server/features/mcp/models.py
@@ -17,6 +17,8 @@ from onyx.db.enums import (
 
 # Matches `{placeholder_name}` inside header value templates.
 _PLACEHOLDER_RE = re.compile(r"\{([^}]+)\}")
+# RFC 9110 field-name syntax: a non-empty sequence of HTTP token characters.
+_HTTP_FIELD_NAME_RE = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 
 
 def _build_auto_substitution_map(*, user_email: str) -> dict[str, str]:
@@ -74,6 +76,12 @@ class MCPConnectionData(TypedDict):
     in Postgres"""
 
     headers: dict[str, str]
+    # The placeholder form of shared API-token headers. The rendered headers
+    # above remain the source used for outbound requests.
+    header_template: NotRequired[dict[str, str]]
+    # Stored in the encrypted connection config so an admin can edit the
+    # header template without re-entering the masked API token.
+    api_token: NotRequired[str]
     header_substitutions: NotRequired[dict[str, str]]
     # Names of fields the user must supply for header substitution. Persisted
     # only on the per-user template config (the admin's connection config that
@@ -136,6 +144,13 @@ class MCPToolCreateRequest(BaseModel):
     api_token: Optional[str] = Field(
         None, description="API token for api_token auth type"
     )
+    api_token_changed: bool = Field(
+        default=False,
+        description=(
+            "True if the shared API token was edited. When False on an update, "
+            "the stored token is reused instead of the masked request value."
+        ),
+    )
     oauth_client_id: Optional[str] = Field(None, description="OAuth client ID")
     oauth_client_secret: Optional[str] = Field(None, description="OAuth client secret")
     oauth_provider_mode: MCPOAuthProviderMode = Field(
@@ -178,7 +193,11 @@ class MCPToolCreateRequest(BaseModel):
         None, description="MCP transport type (STREAMABLE_HTTP or SSE)"
     )
     auth_template: Optional[MCPAuthTemplate] = Field(
-        None, description="Template configuration for per-user authentication"
+        None,
+        description=(
+            "Authentication header template for API-token authentication. "
+            "Shared templates support the {api_key} placeholder."
+        ),
     )
     admin_credentials: Optional[dict[str, str]] = Field(
         None,
@@ -214,15 +233,57 @@ class MCPToolCreateRequest(BaseModel):
 
     @model_validator(mode="after")
     def validate_auth_configuration(self) -> "MCPToolCreateRequest":
-        # Validate API token requirements for admin auth
+        # A shared API token is required to create an admin-managed server.
+        # On update (`existing_server_id` set) it may be omitted: the upsert
+        # path reuses the stored token, so requiring it here would reject
+        # legitimate template-only edits from clients that don't replay it.
         if (
             self.auth_type == MCPAuthenticationType.API_TOKEN
             and self.auth_performer == MCPAuthenticationPerformer.ADMIN
+            and self.existing_server_id is None
             and not self.api_token
         ):
             raise ValueError(
                 "api_token is required when auth_type is 'api_token' and auth_performer is 'admin'"
             )
+
+        if (
+            self.auth_type == MCPAuthenticationType.API_TOKEN
+            and self.auth_performer == MCPAuthenticationPerformer.ADMIN
+        ):
+            # An omitted template is resolved against the existing server
+            # configuration during an update, or defaults to Bearer when a
+            # server is created. Do not materialize that default here, since
+            # doing so makes an omitted template look like an explicit edit.
+            if self.auth_template is not None:
+                placeholders: set[str] = {
+                    match
+                    for value in self.auth_template.headers.values()
+                    for match in _PLACEHOLDER_RE.findall(value)
+                }
+                unsupported_placeholders: set[str] = placeholders - {"api_key"}
+                if unsupported_placeholders:
+                    raise ValueError(
+                        "Shared API-token header templates only support the "
+                        f"{{api_key}} placeholder; unsupported placeholders: "
+                        f"{', '.join(sorted(unsupported_placeholders))}"
+                    )
+                if not any(
+                    "{api_key}" in value
+                    for value in self.auth_template.headers.values()
+                ):
+                    raise ValueError(
+                        "Shared API-token header templates must include the {api_key} placeholder"
+                    )
+                if any(
+                    _HTTP_FIELD_NAME_RE.fullmatch(name) is None
+                    or name.strip().lower() in DENYLISTED_MCP_HEADERS
+                    for name in self.auth_template.headers
+                ):
+                    raise ValueError(
+                        "Shared API-token header templates contain an invalid header name"
+                    )
+                self.auth_template.required_fields = ["api_key"]
 
         # Validate that API token is not provided for per-user auth
         if (

--- a/backend/tests/external_dependency_unit/server/features/mcp/test_shared_api_token_template_visibility.py
+++ b/backend/tests/external_dependency_unit/server/features/mcp/test_shared_api_token_template_visibility.py
@@ -1,0 +1,108 @@
+"""A shared (admin-managed) API-token template must only be serialized in
+the owner/admin auth-config response. Basic users who can merely attach the
+server never supply shared credentials and must not receive the template,
+which can carry literal header values alongside the `{api_key}` placeholder.
+Per-user templates stay visible to basic users because they drive the
+per-user credential prompt."""
+
+from uuid import uuid4
+
+from sqlalchemy.orm import Session
+
+from onyx.auth.schemas import UserRole
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.db.mcp import get_mcp_server_by_id
+from onyx.server.features.mcp.api import (
+    _db_mcp_server_to_api_mcp_server,
+    _upsert_mcp_server,
+)
+from onyx.server.features.mcp.models import (
+    MCPAuthTemplate,
+    MCPToolCreateRequest,
+)
+from tests.external_dependency_unit.conftest import create_test_user
+
+_LITERAL_HEADER_VALUE = "literal-secret-value"
+
+
+def _create_shared_api_token_server(db_session: Session, admin_email: str) -> int:
+    admin = create_test_user(db_session, admin_email, role=UserRole.ADMIN)
+    request = MCPToolCreateRequest(
+        name=f"shared-token-{uuid4().hex[:8]}",
+        description="shared token server",
+        server_url="http://upstream.example.com/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        transport=MCPTransport.STREAMABLE_HTTP,
+        api_token="shared-secret",
+        # A second header carries a literal value alongside `{api_key}` to
+        # prove literals are never surfaced to basic users.
+        auth_template=MCPAuthTemplate(
+            headers={
+                "Authorization": "Bearer {api_key}",
+                "X-Literal": _LITERAL_HEADER_VALUE,
+            },
+            required_fields=["api_key"],
+        ),
+    )
+    mcp_server = _upsert_mcp_server(request, db_session, admin)
+    return mcp_server.id
+
+
+def test_basic_user_does_not_receive_shared_template(db_session: Session) -> None:
+    server_id = _create_shared_api_token_server(db_session, "admin_shared_vis")
+    basic_user = create_test_user(db_session, "basic_shared_vis")
+
+    server = get_mcp_server_by_id(server_id, db_session)
+    view = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=basic_user)
+
+    assert view.auth_template is None
+
+
+def test_admin_receives_shared_template_with_auth_config(
+    db_session: Session,
+) -> None:
+    server_id = _create_shared_api_token_server(db_session, "admin_shared_vis_owner")
+    admin = create_test_user(db_session, "admin_shared_vis_viewer", role=UserRole.ADMIN)
+
+    server = get_mcp_server_by_id(server_id, db_session)
+    view = _db_mcp_server_to_api_mcp_server(
+        server, db_session, request_user=admin, include_auth_config=True
+    )
+
+    assert view.auth_template is not None
+    assert view.auth_template.headers == {
+        "Authorization": "Bearer {api_key}",
+        "X-Literal": _LITERAL_HEADER_VALUE,
+    }
+
+
+def test_basic_user_still_receives_per_user_template(db_session: Session) -> None:
+    """Guard against over-restricting: per-user templates must remain visible
+    to basic users so the credential prompt can render."""
+    admin = create_test_user(db_session, "admin_per_user_vis", role=UserRole.ADMIN)
+    request = MCPToolCreateRequest(
+        name=f"per-user-token-{uuid4().hex[:8]}",
+        description="per-user token server",
+        server_url="http://upstream.example.com/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.PER_USER,
+        transport=MCPTransport.STREAMABLE_HTTP,
+        auth_template=MCPAuthTemplate(
+            headers={"Authorization": "Bearer {api_key}"},
+            required_fields=["api_key"],
+        ),
+        admin_credentials={"api_key": "admin-key"},
+    )
+    mcp_server = _upsert_mcp_server(request, db_session, admin)
+    basic_user = create_test_user(db_session, "basic_per_user_vis")
+
+    server = get_mcp_server_by_id(mcp_server.id, db_session)
+    view = _db_mcp_server_to_api_mcp_server(server, db_session, request_user=basic_user)
+
+    assert view.auth_template is not None
+    assert view.auth_template.headers == {"Authorization": "Bearer {api_key}"}

--- a/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_shared_api_token_headers.py
@@ -1,0 +1,167 @@
+import pytest
+
+from onyx.db.enums import (
+    MCPAuthenticationPerformer,
+    MCPAuthenticationType,
+    MCPTransport,
+)
+from onyx.server.features.mcp.api import (
+    _build_shared_api_token_config_data,
+    _resolve_shared_api_token,
+    _resolve_shared_api_token_template,
+)
+from onyx.server.features.mcp.models import (
+    MCPAuthTemplate,
+    MCPConnectionData,
+    MCPToolCreateRequest,
+)
+
+
+def _shared_request(
+    auth_template: MCPAuthTemplate | None = None,
+) -> MCPToolCreateRequest:
+    return MCPToolCreateRequest(
+        name="Semrush",
+        description="Shared API-token MCP server",
+        server_url="https://mcp.semrush.com/v2/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        api_token="shared-secret",
+        auth_template=auth_template,
+        transport=MCPTransport.STREAMABLE_HTTP,
+    )
+
+
+def test_shared_api_token_template_renders_and_persists_template() -> None:
+    template = MCPAuthTemplate(
+        headers={"Authorization": "Apikey {api_key}"},
+        required_fields=["api_key"],
+    )
+
+    config_data = _build_shared_api_token_config_data(
+        api_token="shared-secret",
+        auth_template=template,
+        user_email="admin@example.com",
+    )
+
+    assert config_data["headers"] == {"Authorization": "Apikey shared-secret"}
+    assert config_data["header_template"] == {"Authorization": "Apikey {api_key}"}
+    assert config_data["api_token"] == "shared-secret"
+
+
+def test_shared_api_token_template_defaults_to_bearer() -> None:
+    request = _shared_request()
+
+    assert request.auth_template is None
+
+    config_data = _build_shared_api_token_config_data(
+        api_token="shared-secret",
+        auth_template=request.auth_template,
+        user_email="admin@example.com",
+    )
+
+    assert config_data["headers"] == {"Authorization": "Bearer shared-secret"}
+
+
+def test_shared_api_token_template_rejects_non_api_key_placeholders() -> None:
+    with pytest.raises(ValueError, match=r"only support the \{api_key\}"):
+        _shared_request(
+            MCPAuthTemplate(
+                headers={"Authorization": "Apikey {user_email}"},
+                required_fields=[],
+            )
+        )
+
+
+@pytest.mark.parametrize(
+    "header_name",
+    [
+        "X-API-Key\r\nInjected",
+        "X API-Key",
+        "X:API-Key",
+        "X-API-Kéy",
+    ],
+)
+def test_shared_api_token_template_rejects_invalid_header_name(
+    header_name: str,
+) -> None:
+    with pytest.raises(ValueError, match="invalid header name"):
+        _shared_request(
+            MCPAuthTemplate(
+                headers={header_name: "{api_key}"},
+                required_fields=[],
+            )
+        )
+
+
+def test_shared_api_token_update_reuses_existing_token() -> None:
+    existing = MCPConnectionData(
+        headers={"Authorization": "Bearer shared-secret"},
+    )
+
+    token = _resolve_shared_api_token(
+        request_api_token="••••••••••••",
+        request_api_token_changed=False,
+        existing_config=existing,
+    )
+
+    assert token == "shared-secret"
+
+
+def test_shared_api_token_prefers_new_token_during_auth_mode_conversion() -> None:
+    existing = MCPConnectionData(
+        headers={},
+        client_info={"client_id": "oauth-client"},
+    )
+
+    token = _resolve_shared_api_token(
+        request_api_token="new-shared-secret",
+        request_api_token_changed=False,
+        existing_config=existing,
+    )
+
+    assert token == "new-shared-secret"
+
+
+def test_shared_api_token_create_requires_token() -> None:
+    with pytest.raises(ValueError, match="api_token is required"):
+        MCPToolCreateRequest(
+            name="Semrush",
+            server_url="https://mcp.semrush.com/v2/mcp",
+            auth_type=MCPAuthenticationType.API_TOKEN,
+            auth_performer=MCPAuthenticationPerformer.ADMIN,
+            api_token=None,
+            transport=MCPTransport.STREAMABLE_HTTP,
+        )
+
+
+def test_shared_api_token_update_allows_omitted_token() -> None:
+    # On update the stored token is reused, so the request may omit it.
+    request = MCPToolCreateRequest(
+        name="Semrush",
+        server_url="https://mcp.semrush.com/v2/mcp",
+        auth_type=MCPAuthenticationType.API_TOKEN,
+        auth_performer=MCPAuthenticationPerformer.ADMIN,
+        api_token=None,
+        existing_server_id=123,
+        transport=MCPTransport.STREAMABLE_HTTP,
+    )
+
+    assert request.api_token is None
+    assert request.existing_server_id == 123
+
+
+def test_shared_api_token_template_update_preserves_omitted_template() -> None:
+    existing = MCPConnectionData(
+        headers={"X-API-Key": "shared-secret"},
+        header_template={"X-API-Key": "{api_key}"},
+        api_token="shared-secret",
+    )
+
+    template = _resolve_shared_api_token_template(
+        request_template=None,
+        existing_config=existing,
+    )
+
+    assert template is not None
+    assert template.headers == {"X-API-Key": "{api_key}"}

--- a/web/src/lib/tools/interfaces.ts
+++ b/web/src/lib/tools/interfaces.ts
@@ -33,7 +33,7 @@ export interface MCPServer {
   oauth_additional_auth_params?: Record<string, string>;
   is_authenticated: boolean;
   user_authenticated?: boolean;
-  auth_template?: any;
+  auth_template?: MCPAuthTemplate | null;
   admin_credentials?: Record<string, string>;
   user_credentials?: Record<string, string>;
   status: MCPServerStatus;
@@ -42,6 +42,11 @@ export interface MCPServer {
   users: string[];
   last_refreshed_at?: string;
   tool_count: number;
+}
+
+export interface MCPAuthTemplate {
+  headers: Record<string, string>;
+  required_fields: string[];
 }
 
 export interface AgentEditorMCPServer extends MCPServer {

--- a/web/src/lib/tools/mcpService.ts
+++ b/web/src/lib/tools/mcpService.ts
@@ -12,6 +12,7 @@ import {
   MCPAuthenticationType,
   MCPAuthenticationPerformer,
   MCPOAuthProviderMode,
+  MCPAuthTemplate,
 } from "@/lib/tools/interfaces";
 export interface ToolStatusUpdateRequest {
   tool_ids: number[];
@@ -187,6 +188,7 @@ export async function upsertMCPServer(serverData: {
   auth_type: MCPAuthenticationType;
   auth_performer: MCPAuthenticationPerformer;
   api_token?: string;
+  api_token_changed?: boolean;
   oauth_client_id?: string;
   oauth_client_secret?: string;
   oauth_provider_mode?: MCPOAuthProviderMode;
@@ -199,7 +201,7 @@ export async function upsertMCPServer(serverData: {
   // overwrite stored values with masked placeholders on resubmit.
   oauth_client_id_changed?: boolean;
   oauth_client_secret_changed?: boolean;
-  auth_template?: any;
+  auth_template?: MCPAuthTemplate;
   admin_credentials?: Record<string, string>;
   // Per-key analogue of `oauth_client_*_changed` for `admin_credentials`.
   admin_credentials_changed?: Record<string, boolean>;

--- a/web/src/sections/actions/PerUserAuthConfig.tsx
+++ b/web/src/sections/actions/PerUserAuthConfig.tsx
@@ -17,11 +17,13 @@ interface PerUserAuthConfigProps {
     field: keyof MCPAuthFormValues | string,
     value: unknown
   ) => void;
+  mode?: "per-user" | "shared";
 }
 
 export function PerUserAuthConfig({
   values,
   setFieldValue,
+  mode = "per-user",
 }: PerUserAuthConfigProps) {
   // Use draft state for KeyValue array (like in LLMConnectionFieldsCustom)
   const [headersDraft, setHeadersDraft] = useState<KeyValue[]>(
@@ -100,10 +102,21 @@ export function PerUserAuthConfig({
     : computeRequiredFieldsFromHeaders(values.auth_template?.headers || {});
   const userCredentials = values.user_credentials || {};
 
+  // Shared templates must render the org's single shared key, so at least one
+  // header value has to contain `{api_key}`. Surface this inline rather than
+  // relying on the backend validator's generic toast.
+  const hasApiKeyPlaceholder = Object.values(
+    values.auth_template?.headers || {}
+  ).some((value) => typeof value === "string" && value.includes("{api_key}"));
+  const missingSharedApiKey = mode === "shared" && !hasApiKeyPlaceholder;
+
   return (
     <div className="flex flex-col gap-4 -mx-2 px-2 py-2 bg-background-tint-00 rounded-12">
       {/* Authentication Headers */}
-      <FormField name="auth_template.headers" state="idle">
+      <FormField
+        name="auth_template.headers"
+        state={missingSharedApiKey ? "error" : "idle"}
+      >
         <FormField.Label>Authentication Headers</FormField.Label>
         <FormField.Control asChild>
           <InputKeyValue
@@ -117,22 +130,39 @@ export function PerUserAuthConfig({
           />
         </FormField.Control>
         <FormField.Description>
-          Format headers for each user to fill in their individual credentials.
+          {mode === "per-user"
+            ? "Format headers for each user to fill in their individual credentials."
+            : "Format the headers sent with your organization's shared credentials."}{" "}
           Use placeholders like{" "}
           <Text text03 secondaryMono className="inline">
             {"{api_key}"}
           </Text>{" "}
-          or{" "}
-          <Text text03 secondaryMono className="inline">
-            {"{user_email}"}
-          </Text>
-          . Users will be prompted to provide values for placeholders (except
-          user_email).
+          {mode === "per-user" ? (
+            <>
+              or{" "}
+              <Text text03 secondaryMono className="inline">
+                {"{user_email}"}
+              </Text>
+              . Users will be prompted to provide values for placeholders
+              (except user_email).
+            </>
+          ) : (
+            <>
+              in at least one header value; it is replaced with your
+              organization&apos;s shared key.
+            </>
+          )}
         </FormField.Description>
+        <FormField.Message
+          messages={{
+            error:
+              "At least one header value must include the {api_key} placeholder.",
+          }}
+        />
       </FormField>
 
       {/* Only show user credentials section if there are required fields */}
-      {requiredFields.length > 0 && (
+      {mode === "per-user" && requiredFields.length > 0 && (
         <>
           <Divider paddingParallel="fit" paddingPerpendicular="fit" />
 

--- a/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
+++ b/web/src/sections/actions/modals/MCPAuthenticationModal.tsx
@@ -31,6 +31,7 @@ import {
   MCPServerStatus,
   MCPServer,
   MCPServersResponse,
+  MCPAuthTemplate,
 } from "@/lib/tools/interfaces";
 import { PerUserAuthConfig } from "@/sections/actions/PerUserAuthConfig";
 import { updateMCPServerStatus, upsertMCPServer } from "@/lib/tools/mcpService";
@@ -43,11 +44,6 @@ interface MCPAuthenticationModalProps {
   skipOverlay?: boolean;
   onTriggerFetchTools?: (serverId: number) => Promise<void> | void;
   mutateMcpServers: KeyedMutator<MCPServersResponse>;
-}
-
-interface MCPAuthTemplate {
-  headers: Record<string, string>;
-  required_fields: string[];
 }
 
 export interface MCPAuthFormValues {
@@ -303,6 +299,9 @@ export default function MCPAuthenticationModal({
     const isPerUserApiToken =
       values.auth_performer === MCPAuthenticationPerformer.PER_USER &&
       authType === MCPAuthenticationType.API_TOKEN;
+    const isAdminApiToken =
+      values.auth_performer === MCPAuthenticationPerformer.ADMIN &&
+      authType === MCPAuthenticationType.API_TOKEN;
     const isKnownProviderOauth =
       authType === MCPAuthenticationType.OAUTH &&
       values.oauth_provider_mode === MCPOAuthProviderMode.KNOWN_PROVIDER;
@@ -342,12 +341,14 @@ export default function MCPAuthenticationModal({
       transport: values.transport,
       auth_type: values.auth_type,
       auth_performer: values.auth_performer,
-      api_token:
-        authType === MCPAuthenticationType.API_TOKEN &&
-        values.auth_performer === MCPAuthenticationPerformer.ADMIN
-          ? values.api_token
+      api_token: isAdminApiToken ? values.api_token : undefined,
+      api_token_changed: isAdminApiToken
+        ? values.api_token !== initialValues.api_token
+        : false,
+      auth_template:
+        authType === MCPAuthenticationType.API_TOKEN
+          ? values.auth_template
           : undefined,
-      auth_template: isPerUserApiToken ? values.auth_template : undefined,
       admin_credentials: isPerUserApiToken
         ? values.user_credentials || {}
         : undefined,
@@ -892,7 +893,12 @@ export default function MCPAuthenticationModal({
 
                         {/* Admin Tab Content */}
                         <Tabs.Content value="admin">
-                          <div className="flex flex-col gap-4 px-2 py-2 bg-background-tint-00 rounded-12">
+                          <div className="flex flex-col gap-4">
+                            <PerUserAuthConfig
+                              values={values}
+                              setFieldValue={setFieldValue}
+                              mode="shared"
+                            />
                             <FormField
                               name="api_token"
                               state={


### PR DESCRIPTION
Cherry-pick of commit ee3bdf0bfcea100668f0e38404017ae52155b0ac to release/v4.4 branch.

Original PR: #13278, #13335

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add admin-managed “shared API token” for MCP servers with header templates and strict validation. Preserves masked tokens on update and only shows shared templates to admins; per-user flows stay unchanged.

- New Features
  - Admin-shared API token with header templates; defaults to Authorization: Bearer {api_key}, stores template and encrypted token, and renders outbound headers.
  - Upsert API adds api_token_changed; masked tokens are reused unless changed, and tokens are recovered from existing Authorization headers for backward compatibility.
  - Visibility: shared templates appear only in admin auth-config responses; per-user templates remain visible to all users for prompts.
  - Web updates: typed auth_template, api_token_changed support, shared mode in auth form with inline {api_key} check, and modal wiring for admin token flow.

- Migration
  - Existing admin-token servers auto-recover tokens; re-enter only if prompted.
  - No changes for per-user servers; basic users won’t see shared templates.

<sup>Written for commit dfdb3182e6a9ccf88720061c412f83fc07fbf41d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

