### PR TITLE
fix: form-encoded MCP OAuth refresh responses [edit of #13331] (#13336) to release v4.4

### DIFF
--- a/backend/onyx/server/features/mcp/oauth.py
+++ b/backend/onyx/server/features/mcp/oauth.py
@@ -9,9 +9,12 @@ Routes and route-only flow helpers stay in `api.py`.
 import asyncio
 import json
 import time
-from typing import Any
-from urllib.parse import urlparse
+from collections.abc import Awaitable, Callable
+from typing import Any, TypedDict
+from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
 
+import httpx
 from mcp.client.auth import OAuthClientProvider, TokenStorage
 from mcp.client.auth.oauth2 import OAuthContext
 from mcp.shared.auth import (
@@ -20,7 +23,7 @@ from mcp.shared.auth import (
     OAuthMetadata,
     OAuthToken,
 )
-from pydantic import AnyUrl, BaseModel
+from pydantic import AnyUrl, BaseModel, ValidationError
 from sqlalchemy.orm import Session
 
 from onyx.configs.app_configs import WEB_DOMAIN
@@ -40,6 +43,7 @@ from onyx.server.features.mcp.models import MCPOAuthKeys
 from onyx.server.features.mcp.ssrf import mcp_ssrf_httpx_client_factory
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_async_sync_no_cancel
+from shared_configs.contextvars import ONYX_REQUEST_ID_CONTEXTVAR
 
 logger = setup_logger()
 
@@ -82,6 +86,71 @@ class MCPOauthState(BaseModel):
     is_admin: bool
     state: str
     code_verifier: str | None = None
+
+
+class MCPRefreshLogContext(TypedDict):
+    mcp_server_id: int | None
+    mcp_server_name: str
+    connection_config_id: int
+    transport: str
+    oauth_provider_mode: str
+
+
+def _refresh_log_context(
+    mcp_server: DbMCPServer, connection_config_id: int
+) -> MCPRefreshLogContext:
+    return {
+        "mcp_server_id": mcp_server.id,
+        "mcp_server_name": mcp_server.name,
+        "connection_config_id": connection_config_id,
+        "transport": mcp_server.transport.value if mcp_server.transport else "UNKNOWN",
+        "oauth_provider_mode": mcp_server.oauth_provider_mode.value,
+    }
+
+
+def _oauth_error_from_response(
+    body: bytes, content_type: str | None
+) -> tuple[str | None, str]:
+    """Extract only the safe OAuth error code and body format from a response."""
+    normalized_content_type = (content_type or "").split(";", 1)[0].strip().lower()
+    body_format = (
+        "form"
+        if normalized_content_type == "application/x-www-form-urlencoded"
+        else "json"
+    )
+
+    try:
+        payload = json.loads(body)
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        if body_format != "form":
+            body_format = "unknown"
+        form_payload = parse_qs(body.decode("utf-8", errors="replace"))
+        return (form_payload.get("error", [None])[0], body_format)
+
+    if isinstance(payload, dict):
+        return (payload.get("error"), body_format)
+    return None, body_format
+
+
+def _response_request_hostname(response: httpx.Response) -> str | None:
+    """Return the response hostname when httpx attached the originating request."""
+    try:
+        return response.request.url.host
+    except RuntimeError:
+        return None
+
+
+def _oauth_token_from_response(body: bytes) -> OAuthToken:
+    """Parse JSON or form-encoded OAuth token responses."""
+    try:
+        return OAuthToken.model_validate_json(body)
+    except ValidationError as json_error:
+        form_payload = parse_qs(body.decode("utf-8", errors="replace"))
+        payload = {key: values[0] for key, values in form_payload.items() if values}
+        try:
+            return OAuthToken.model_validate(payload)
+        except ValidationError:
+            raise json_error from None
 
 
 def _token_dict_with_preserved_refresh(
@@ -205,9 +274,16 @@ class OnyxTokenStorage(TokenStorage):
     store auth info in a particular user's connection config in postgres
     """
 
-    def __init__(self, connection_config_id: int, alt_config_id: int | None = None):
+    def __init__(
+        self,
+        connection_config_id: int,
+        alt_config_id: int | None = None,
+        refresh_log_context: MCPRefreshLogContext | None = None,
+    ):
         self.alt_config_id = alt_config_id
         self.connection_config_id = connection_config_id
+        self.refresh_log_context = refresh_log_context
+        self.refresh_attempt_id: str | None = None
         # When bound, `get_tokens` hydrates its `token_expiry_time` from the
         # config read it already does — no separate query for the expiry.
         self._oauth_context: OAuthContext | None = None
@@ -251,8 +327,12 @@ class OnyxTokenStorage(TokenStorage):
             config = self._ensure_connection_config(db_session)
             config_data = extract_connection_data(config)
             existing_tokens_raw = config_data.get(MCPOAuthKeys.TOKENS.value)
-            config_data[MCPOAuthKeys.TOKENS.value] = _token_dict_with_preserved_refresh(
+            persisted_token_dict = _token_dict_with_preserved_refresh(
                 tokens, existing_tokens_raw
+            )
+            config_data[MCPOAuthKeys.TOKENS.value] = persisted_token_dict
+            token_expires_at_before_refresh = config_data.get(
+                MCPOAuthKeys.TOKEN_EXPIRES_AT.value
             )
             expires_at = _absolute_token_expiry(tokens)
             if expires_at is not None:
@@ -274,6 +354,30 @@ class OnyxTokenStorage(TokenStorage):
                 "Authorization": f"{tokens.token_type} {tokens.access_token}"
             }
             update_connection_config(config.id, db_session, config_data)
+
+        if self.refresh_attempt_id and self.refresh_log_context:
+            logger.info(
+                "mcp_oauth.refresh.persisted",
+                extra={
+                    **self.refresh_log_context,
+                    "request_id": ONYX_REQUEST_ID_CONTEXTVAR.get(),
+                    "refresh_attempt_id": self.refresh_attempt_id,
+                    "access_token_persisted": bool(
+                        persisted_token_dict.get("access_token")
+                    ),
+                    "refresh_token_persisted": bool(
+                        persisted_token_dict.get("refresh_token")
+                    ),
+                    "refresh_token_replaced": bool(
+                        tokens.refresh_token
+                        and tokens.refresh_token
+                        != (existing_tokens_raw or {}).get("refresh_token")
+                    ),
+                    "token_expires_at_before_refresh": token_expires_at_before_refresh,
+                    "token_expires_at_after_refresh": expires_at,
+                    "token_expiry_persisted": expires_at is not None,
+                },
+            )
 
         # The shared admin row is intentionally NOT written here: it
         # serves as the OAuth `client_info` registry shared across all
@@ -335,6 +439,119 @@ class OnyxTokenStorage(TokenStorage):
                 update_connection_config(
                     self.alt_config_id, db_session, alt_config_data
                 )
+
+
+class OnyxOAuthClientProvider(OAuthClientProvider):
+    """MCP SDK OAuth provider with safe refresh telemetry and error parsing."""
+
+    def __init__(
+        self,
+        server_url: str,
+        client_metadata: OAuthClientMetadata,
+        storage: TokenStorage,
+        redirect_handler: Callable[[str], Awaitable[None]] | None = None,
+        callback_handler: Callable[[], Awaitable[tuple[str, str | None]]] | None = None,
+        timeout: float = 300.0,
+        client_metadata_url: str | None = None,
+        *,
+        refresh_log_context: MCPRefreshLogContext,
+    ) -> None:
+        super().__init__(
+            server_url=server_url,
+            client_metadata=client_metadata,
+            storage=storage,
+            redirect_handler=redirect_handler,
+            callback_handler=callback_handler,
+            timeout=timeout,
+            client_metadata_url=client_metadata_url,
+        )
+        self.refresh_log_context = refresh_log_context
+        self.refresh_attempt_id: str | None = None
+        self.token_expiry_before_refresh: float | None = None
+
+    def _refresh_log_fields(self, **fields: Any) -> dict[str, Any]:
+        log_fields: dict[str, Any] = {
+            **self.refresh_log_context,
+            "request_id": ONYX_REQUEST_ID_CONTEXTVAR.get(),
+            "refresh_attempt_id": self.refresh_attempt_id,
+        }
+        log_fields.update(fields)
+        return log_fields
+
+    async def _refresh_token(self) -> httpx.Request:
+        self.refresh_attempt_id = uuid4().hex
+        self.token_expiry_before_refresh = self.context.token_expiry_time
+
+        request = await super()._refresh_token()
+        logger.info(
+            "mcp_oauth.refresh.started",
+            extra=self._refresh_log_fields(
+                token_expires_at_before_refresh=self.token_expiry_before_refresh,
+                token_endpoint_hostname=request.url.host,
+                access_token_present=bool(
+                    self.context.current_tokens
+                    and self.context.current_tokens.access_token
+                ),
+                refresh_token_present=bool(
+                    self.context.current_tokens
+                    and self.context.current_tokens.refresh_token
+                ),
+            ),
+        )
+        return request
+
+    async def _persist_refresh_tokens(self, tokens: OAuthToken) -> None:
+        storage = self.context.storage
+        if not isinstance(storage, OnyxTokenStorage):
+            await storage.set_tokens(tokens)
+            return
+
+        storage.refresh_attempt_id = self.refresh_attempt_id
+        try:
+            await storage.set_tokens(tokens)
+        finally:
+            storage.refresh_attempt_id = None
+
+    async def _handle_refresh_response(self, response: httpx.Response) -> bool:
+        """Handle JSON and form-encoded refresh responses without logging secrets."""
+        body = await response.aread()
+        content_type = response.headers.get("content-type")
+        oauth_error, body_format = _oauth_error_from_response(body, content_type)
+        token_endpoint_hostname = _response_request_hostname(response)
+
+        response_fields = self._refresh_log_fields(
+            http_status=response.status_code,
+            response_content_type=content_type,
+            response_body_format=body_format,
+            oauth_error=oauth_error,
+            token_endpoint_hostname=token_endpoint_hostname,
+        )
+
+        if response.status_code != 200:
+            logger.warning("mcp_oauth.refresh.failed", extra=response_fields)
+            self.context.clear_tokens()
+            return False
+
+        try:
+            token_response = _oauth_token_from_response(body)
+        except ValidationError:
+            logger.warning("mcp_oauth.refresh.invalid_response", extra=response_fields)
+            self.context.clear_tokens()
+            return False
+
+        self.context.current_tokens = token_response
+        self.context.update_token_expiry(token_response)
+        await self._persist_refresh_tokens(token_response)
+        logger.info(
+            "mcp_oauth.refresh.succeeded",
+            extra=self._refresh_log_fields(
+                http_status=response.status_code,
+                response_content_type=content_type,
+                response_body_format=body_format,
+                token_endpoint_hostname=token_endpoint_hostname,
+            ),
+        )
+        return True
 
 
 def make_oauth_provider(
@@ -401,8 +618,14 @@ def make_oauth_provider(
         r.delete(key_auth_url(user_id), key_state(user_id))
         return code, state_obj.state
 
-    storage = OnyxTokenStorage(connection_config_id, admin_config_id)
-    provider = OAuthClientProvider(
+    refresh_log_context = _refresh_log_context(mcp_server, connection_config_id)
+    storage = OnyxTokenStorage(
+        connection_config_id,
+        admin_config_id,
+        refresh_log_context,
+    )
+    provider = OnyxOAuthClientProvider(
+        refresh_log_context=refresh_log_context,
         server_url=mcp_server.server_url,
         client_metadata=OAuthClientMetadata(
             client_name=f"Onyx - {mcp_server.name}",

--- a/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
+++ b/backend/tests/unit/onyx/server/features/mcp/test_mcp_oauth_refresh.py
@@ -10,13 +10,13 @@ the DB layer and the outbound network call.
 import time
 from types import SimpleNamespace
 from typing import Any, cast
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, urlencode
 
 import httpx
 import pytest
 
 import onyx.server.features.mcp.oauth as mcp_oauth
-from onyx.db.enums import MCPOAuthProviderMode
+from onyx.db.enums import MCPOAuthProviderMode, MCPTransport
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.server.features.mcp.models import MCPOAuthKeys
 from onyx.server.features.mcp.oauth import refresh_mcp_oauth_token_if_expired
@@ -32,8 +32,10 @@ def _server_stub() -> DbMCPServer:
     return cast(
         DbMCPServer,
         SimpleNamespace(
+            id=1,
             name="gitlab",
             server_url="https://mcp.gitlab.example.com",
+            transport=MCPTransport.SSE,
             oauth_provider_mode=MCPOAuthProviderMode.AUTO_DISCOVERY,
             oauth_authorization_endpoint=None,
             oauth_token_endpoint=None,
@@ -116,6 +118,22 @@ def _token_response(**overrides: Any) -> httpx.Response:
     return httpx.Response(200, json=payload)
 
 
+def _form_token_response(
+    *,
+    content_type: str | None = "application/x-www-form-urlencoded; charset=utf-8",
+    **overrides: Any,
+) -> httpx.Response:
+    payload: dict[str, Any] = {
+        "access_token": "NEW",
+        "token_type": "bearer",
+        "expires_in": 7200,
+        "refresh_token": "REFRESH_2",
+    }
+    payload.update(overrides)
+    headers = {} if content_type is None else {"content-type": content_type}
+    return httpx.Response(200, content=urlencode(payload).encode(), headers=headers)
+
+
 def test_refreshes_expired_token_with_client_secret_post(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -161,6 +179,60 @@ def test_refreshes_expired_token_with_client_secret_post(
     assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
     assert persisted["headers"]["Authorization"] == "Bearer NEW"
     assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+
+
+@pytest.mark.parametrize(
+    "content_type",
+    ["application/x-www-form-urlencoded; charset=utf-8", None, "application/json"],
+)
+def test_refreshes_form_encoded_token_response_with_rotated_refresh_token(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    content_type: str | None,
+) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD",
+            "token_type": "Bearer",
+            "expires_in": 7200,
+            "refresh_token": "REFRESH_1",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "redirect_uris": [_REDIRECT_URI],
+            "token_endpoint_auth_method": "client_secret_post",
+        },
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://gitlab.example.com",
+            "authorization_endpoint": "https://gitlab.example.com/oauth/authorize",
+            "token_endpoint": _TOKEN_ENDPOINT,
+        },
+    }
+    captured = _install_mocks(
+        monkeypatch,
+        config_data,
+        response=_form_token_response(content_type=content_type),
+    )
+
+    header = refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    assert header == "Bearer NEW"
+    persisted = captured["updated_config_data"]
+    assert persisted[MCPOAuthKeys.TOKENS.value]["access_token"] == "NEW"
+    assert persisted[MCPOAuthKeys.TOKENS.value]["refresh_token"] == "REFRESH_2"
+    assert persisted["headers"]["Authorization"] == "Bearer NEW"
+    assert persisted[MCPOAuthKeys.TOKEN_EXPIRES_AT.value] > time.time()
+    assert any(
+        record.getMessage() == "mcp_oauth.refresh.succeeded"
+        for record in caplog.records
+    )
+    assert any(
+        record.getMessage() == "mcp_oauth.refresh.persisted"
+        for record in caplog.records
+    )
 
 
 def test_refresh_uses_basic_auth_for_client_secret_basic(
@@ -351,3 +423,62 @@ def test_refresh_failure_is_non_fatal_to_caller(
 
     with pytest.raises(RuntimeError):
         refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+
+def test_form_encoded_refresh_error_is_logged_without_secrets(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    config_data: dict[str, Any] = {
+        "headers": {"Authorization": "Bearer OLD"},
+        MCPOAuthKeys.TOKENS.value: {
+            "access_token": "OLD_ACCESS_TOKEN",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "refresh_token": "ROTATING_REFRESH_TOKEN",
+        },
+        MCPOAuthKeys.TOKEN_EXPIRES_AT.value: time.time() - 60,
+        MCPOAuthKeys.CLIENT_INFO.value: {
+            "client_id": "cid",
+            "client_secret": "csecret",
+            "redirect_uris": [_REDIRECT_URI],
+            "token_endpoint_auth_method": "client_secret_post",
+        },
+        MCPOAuthKeys.METADATA.value: {
+            "issuer": "https://github.example.com",
+            "authorization_endpoint": "https://github.example.com/oauth/authorize",
+            "token_endpoint": "https://github.example.com/oauth/token",
+        },
+    }
+    response = httpx.Response(
+        400,
+        content=b"error=bad_refresh_token&error_description=refresh+token+expired",
+        headers={"content-type": "application/x-www-form-urlencoded"},
+    )
+    _install_mocks(monkeypatch, config_data, response=response)
+
+    with pytest.raises(RuntimeError):
+        refresh_mcp_oauth_token_if_expired(_server_stub(), 42, "user-1")
+
+    failed_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "mcp_oauth.refresh.failed"
+    )
+    started_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "mcp_oauth.refresh.started"
+    )
+    assert getattr(failed_record, "oauth_error") == "bad_refresh_token"
+    assert (
+        getattr(failed_record, "response_content_type")
+        == "application/x-www-form-urlencoded"
+    )
+    assert getattr(failed_record, "response_body_format") == "form"
+    assert getattr(failed_record, "refresh_attempt_id") == getattr(
+        started_record, "refresh_attempt_id"
+    )
+    assert "OLD_ACCESS_TOKEN" not in caplog.text
+    assert "ROTATING_REFRESH_TOKEN" not in caplog.text
+    assert "csecret" not in caplog.text

--- a/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
+++ b/backend/tests/unit/onyx/server/test_mcp_known_provider_oauth_helpers.py
@@ -16,7 +16,7 @@ from onyx.auth.oauth_token_manager import (
     build_oauth_authorization_url,
     exchange_oauth_code_for_token,
 )
-from onyx.db.enums import MCPOAuthProviderMode
+from onyx.db.enums import MCPOAuthProviderMode, MCPTransport
 from onyx.db.models import MCPServer as DbMCPServer
 from onyx.error_handling.exceptions import OnyxError
 from onyx.server.features.mcp.api import _mcp_known_provider_flow_params
@@ -48,6 +48,7 @@ def _make_mcp_server_stub(
             server_url="https://mcp.example.com/mcp",
             name="Example MCP",
             id=1,
+            transport=MCPTransport.STREAMABLE_HTTP,
         ),
     )
 
@@ -454,6 +455,7 @@ async def _drive_refresh(
 
 def test_proactive_refresh_targets_configured_endpoint_and_persists(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
     config_data = _seed_refreshable_config(expires_at=time.time() - 60)
@@ -484,6 +486,31 @@ def test_proactive_refresh_targets_configured_endpoint_and_persists(
     assert persisted_tokens["access_token"] == "access-new"
     assert persisted_tokens["refresh_token"] == "refresh-new"
     assert cast(float, config_data[MCPOAuthKeys.TOKEN_EXPIRES_AT.value]) > time.time()
+    storage = cast(mcp_oauth.OnyxTokenStorage, provider.context.storage)
+    assert storage.refresh_attempt_id is None
+
+    started_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "mcp_oauth.refresh.started"
+    )
+    persisted_record = next(
+        record
+        for record in caplog.records
+        if record.getMessage() == "mcp_oauth.refresh.persisted"
+    )
+    assert getattr(persisted_record, "refresh_attempt_id") == getattr(
+        started_record, "refresh_attempt_id"
+    )
+
+    caplog.clear()
+    asyncio.run(
+        storage.set_tokens(OAuthToken(access_token="reauth", token_type="Bearer"))
+    )
+    assert not any(
+        record.getMessage() == "mcp_oauth.refresh.persisted"
+        for record in caplog.records
+    )
 
 
 def test_proactive_refresh_preserves_refresh_token_when_response_omits_it(
@@ -512,8 +539,14 @@ def test_proactive_refresh_preserves_refresh_token_when_response_omits_it(
     assert persisted_tokens["refresh_token"] == "refresh-old"
 
 
-def test_proactive_refresh_failure_clears_tokens(
+@pytest.mark.parametrize(
+    ("refresh_status", "refresh_body"),
+    [(400, {"error": "invalid_grant"}), (200, {})],
+)
+def test_proactive_refresh_failure_clears_tokens_and_attempt_id(
     monkeypatch: pytest.MonkeyPatch,
+    refresh_status: int,
+    refresh_body: dict[str, object],
 ) -> None:
     provider = _build_provider(MCPOAuthProviderMode.KNOWN_PROVIDER)
     config_data = _seed_refreshable_config(expires_at=time.time() - 60)
@@ -522,12 +555,12 @@ def test_proactive_refresh_failure_clears_tokens(
     refresh_request, authed_request = asyncio.run(
         _drive_refresh(
             provider,
-            refresh_status=400,
-            refresh_body={"error": "invalid_grant"},
+            refresh_status=refresh_status,
+            refresh_body=refresh_body,
         )
     )
 
-    # A rejected refresh clears the in-memory token so the SDK falls through to
+    # A failed refresh clears the in-memory token so the SDK falls through to
     # re-auth (which surfaces as "please reconnect" at the tool layer) rather
     # than retrying a dead access token.
     assert str(refresh_request.url) == "https://accounts.example.com/oauth/token"
@@ -536,3 +569,5 @@ def test_proactive_refresh_failure_clears_tokens(
         "SDK no longer yields original request on refresh failure"
     )
     assert authed_request.headers.get("Authorization") is None
+    storage = cast(mcp_oauth.OnyxTokenStorage, provider.context.storage)
+    assert storage.refresh_attempt_id is None


### PR DESCRIPTION
Cherry-pick of commit 9f8146c1f94f394c83eee0a545961857015597b0 to release/v4.4 branch.

Original PR: #13331, #13336

- [x] [Optional] Override Linear Check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP OAuth refresh when providers return form-encoded responses and adds safe, structured telemetry for refresh attempts. Prevents refresh failures and token loss, and improves debuggability in v4.4.

- **Bug Fixes**
  - Parse `application/x-www-form-urlencoded` token responses (and fallback when missing/incorrect content-type); still support JSON.
  - Preserve existing refresh token when the response omits it; handle rotated refresh tokens.
  - Clear in-memory tokens on refresh failure to avoid retry loops; SDK will re-auth instead.
  - Add structured logs for refresh started/failed/succeeded/persisted with per-attempt IDs and `request_id`; capture endpoint hostname and body format; never log secrets.
  - Introduce `OnyxOAuthClientProvider` and enhance `OnyxTokenStorage` to persist refresh results with telemetry.
  - Expand unit tests to cover form-encoded success/failure paths, telemetry fields, and known-provider flows.

<sup>Written for commit d3be85c7e592367e40332dfeecc61cb0c0bb241b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

