### PR TITLE
fix(auth): treat the backend login redirect as SSO callback success

### DIFF
--- a/web/src/app/auth/__tests__/ssoCallbackRoutes.test.ts
+++ b/web/src/app/auth/__tests__/ssoCallbackRoutes.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Guards the OAuth and OIDC callback wrappers: a 302 from the FastAPI callback
+ * is a completed login and must reach the post-login destination with its
+ * cookies intact and un-merged, while 4xx/5xx and cookieless 302s go to
+ * /auth/error.
+ */
+import { NextRequest } from "next/server";
+import { GET as oauthCallback } from "@/app/auth/oauth/callback/route";
+import { GET as oidcCallback } from "@/app/auth/oidc/callback/route";
+
+const APP_DOMAIN = "https://onyx.example.com";
+
+// Next resolves this build-time marker itself, so it has no module to load here.
+jest.mock("server-only", () => ({}), { virtual: true });
+
+jest.mock("@/lib/utilsSS", () => ({
+  buildUrl: (path: string) => `http://api-server:8080${path}`,
+}));
+
+jest.mock("@/lib/redirectSS", () => ({
+  getDomain: () => APP_DOMAIN,
+}));
+
+const SESSION_COOKIE =
+  "fastapiusersauth=session-token; Path=/; HttpOnly; Secure; SameSite=lax";
+const PKCE_CLEANUP_COOKIE = "pkce_verifier=; Path=/; Max-Age=0";
+
+// Models the FastAPI GET /auth/{oauth,oidc}/callback responses: success is a
+// 302 with cookies, rejection is JSON carrying a detail.
+function loginSucceeded(): Response {
+  const headers = new Headers({ location: "/app?new_team=true" });
+  headers.append("set-cookie", SESSION_COOKIE);
+  headers.append("set-cookie", PKCE_CLEANUP_COOKIE);
+  return new Response(null, { status: 302, headers });
+}
+
+function loginRejected(detail: string): Response {
+  const headers = new Headers({ "content-type": "application/json" });
+  headers.append("set-cookie", PKCE_CLEANUP_COOKIE);
+  return new Response(
+    JSON.stringify({ error_code: "VALIDATION_ERROR", detail }),
+    {
+      status: 400,
+      headers,
+    }
+  );
+}
+
+function callbackRequest(path: string): NextRequest {
+  return new NextRequest(
+    `${APP_DOMAIN}${path}?state=state-value&code=auth-code`
+  );
+}
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe.each([
+  { name: "oauth", handler: oauthCallback, path: "/auth/oauth/callback" },
+  { name: "oidc", handler: oidcCallback, path: "/auth/oidc/callback" },
+])("$name callback wrapper", ({ handler, path }) => {
+  it("sends a completed login to the post-login destination", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(loginSucceeded());
+
+    const result = await handler(callbackRequest(path));
+
+    expect(result.headers.get("location")).toBe(
+      `${APP_DOMAIN}/app?new_team=true`
+    );
+    expect(result.headers.getSetCookie()).toContain(SESSION_COOKIE);
+  });
+
+  it("re-emits each Set-Cookie separately so attributes cannot bleed", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(loginSucceeded());
+
+    const result = await handler(callbackRequest(path));
+
+    expect(result.headers.getSetCookie()).toEqual([
+      SESSION_COOKIE,
+      PKCE_CLEANUP_COOKIE,
+    ]);
+  });
+
+  it("sends a rejected login to the error page with the backend detail", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(loginRejected("Authorization code exchange failed"));
+
+    const result = await handler(callbackRequest(path));
+
+    const location = new URL(result.headers.get("location") ?? "");
+    expect(location.pathname).toBe("/auth/error");
+    expect(location.searchParams.get("error")).toBe(
+      "Authorization code exchange failed"
+    );
+    expect(result.headers.getSetCookie()).toContain(PKCE_CLEANUP_COOKIE);
+  });
+
+  it("sends an unknown account to account creation", async () => {
+    jest
+      .spyOn(global, "fetch")
+      .mockResolvedValue(new Response(null, { status: 401 }));
+
+    const result = await handler(callbackRequest(path));
+
+    expect(new URL(result.headers.get("location") ?? "").pathname).toBe(
+      "/auth/create-account"
+    );
+  });
+
+  it("sends a cookieless success to the error page", async () => {
+    jest.spyOn(global, "fetch").mockResolvedValue(
+      new Response(null, {
+        status: 302,
+        headers: new Headers({ location: "/app" }),
+      })
+    );
+
+    const result = await handler(callbackRequest(path));
+
+    expect(new URL(result.headers.get("location") ?? "").pathname).toBe(
+      "/auth/error"
+    );
+  });
+});

--- a/web/src/app/auth/oauth/callback/route.ts
+++ b/web/src/app/auth/oauth/callback/route.ts
@@ -40,10 +40,9 @@ export const GET = async (request: NextRequest) => {
     );
   }
 
-  // Error responses can carry a Set-Cookie too (PKCE cleanup), so status is
-  // the success signal, not cookie presence. Forward those cookies so the
-  // cleanup still reaches the browser.
-  if (!response.ok) {
+  // A completed login arrives as a 302, so 4xx/5xx is the failure signal here.
+  // Error responses carry the PKCE cleanup cookie, so forward it too.
+  if (response.status >= 400) {
     const errorRedirect = await authErrorRedirect(request, response);
     for (const cookie of response.headers.getSetCookie()) {
       errorRedirect.headers.append("set-cookie", cookie);

--- a/web/src/app/auth/oidc/callback/route.ts
+++ b/web/src/app/auth/oidc/callback/route.ts
@@ -21,10 +21,9 @@ export const GET = async (request: NextRequest) => {
     );
   }
 
-  // Error responses can carry a Set-Cookie too (PKCE cleanup), so status is
-  // the success signal, not cookie presence. Forward those cookies so the
-  // cleanup still reaches the browser.
-  if (!response.ok) {
+  // A completed login arrives as a 302, so 4xx/5xx is the failure signal here.
+  // Error responses carry the PKCE cleanup cookie, so forward it too.
+  if (response.status >= 400) {
     const errorRedirect = await authErrorRedirect(request, response);
     for (const cookie of response.headers.getSetCookie()) {
       errorRedirect.headers.append("set-cookie", cookie);

--- a/web/src/app/auth/saml/callback/route.ts
+++ b/web/src/app/auth/saml/callback/route.ts
@@ -51,8 +51,8 @@ async function handleSamlCallback(
 
   const response = await fetch(url.toString(), fetchOptions);
 
-  // Error responses can carry a Set-Cookie too, so status is the success
-  // signal, not cookie presence.
+  // This backend returns 204 with the session cookie rather than a redirect
+  // like the oauth/oidc callbacks, so 2xx is the success signal here.
   if (!response.ok) {
     return authErrorRedirect(request, response, SEE_OTHER_REDIRECT_STATUS);
   }


### PR DESCRIPTION
## Description

**Bug:** every Google/OIDC login on main lands on the "Authentication Error" page, with no message, even though the login succeeds.

**Cause:** #13364 changed the OAuth and OIDC callback wrappers to gate success on `response.ok`. The FastAPI callback completes a login with a 302, and `Response.ok` is only true for 200-299, so every completed login takes the error branch. The page is blank because `authErrorRedirect` reads its message from the JSON body and a redirect has none. The session cookie is still forwarded onto the error redirect, so the user is signed in behind the error page, which is why it reads as flaky rather than broken.

**Fix:** gate on `status >= 400`, which is what the backend uses to report failure.

SAML keeps `!response.ok` — its callback returns 204, not a redirect. Added a comment there so nobody "harmonizes" the three wrappers back into this bug.

Follow-ups, not in scope: dedup the oauth/oidc tail into `libSS.ts`, and cover the `isProviderRowState` dispatch.

## How Has This Been Tested?

New jest suite over both wrappers (10 cases): completed login reaches the post-login destination, Set-Cookie headers re-emitted separately, rejected login reaches `/auth/error` with the backend detail, 401 reaches `/auth/create-account`, cookieless 302 fails closed.

Confirmed it is a real regression guard — reverting to `!response.ok` fails the two "completed login" cases, green again with the fix.

Traced on st-dev before fixing: nginx logs show both login attempts returning 307 to `/auth/error` while the api-server audit log records `auth.login outcome=success`; confirmed in the pod that the backend's 302 does carry `set-cookie`.

`types:check`, oxlint, oxfmt, `ty check` all clean. No Python in this change.

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
