### PR TITLE
chore(cli): clean up release build atomicity and govulncheck flags

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -22,18 +22,28 @@ jobs:
         with:
           enable-cache: false
           version: "0.11.25"
+      # Build every platform wheel first, then publish once. Publishing per
+      # platform would leave a partial release on PyPI if a later platform
+      # failed; building all up front keeps the release atomic. Remove the
+      # cached Go binary before each build so the build hook recompiles for the
+      # target platform instead of reusing the previous platform's binary.
       - run: |
+          rm -f onyx-cli
           GOOS=linux GOARCH=amd64 CGO_ENABLED=0 uv build --wheel
-          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 ONYX_CLI_REUSE_BINARY=1 \
+          rm -f onyx-cli
+          GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
             ONYX_CLI_WHEEL_PLATFORM_TAG=musllinux_1_2_x86_64 \
             uv build --wheel
+          rm -f onyx-cli
           GOOS=linux GOARCH=arm64 CGO_ENABLED=0 uv build --wheel
-          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 ONYX_CLI_REUSE_BINARY=1 \
+          rm -f onyx-cli
+          GOOS=linux GOARCH=arm64 CGO_ENABLED=0 \
             ONYX_CLI_WHEEL_PLATFORM_TAG=musllinux_1_2_aarch64 \
             uv build --wheel
 
           for goos in windows darwin; do
             for goarch in amd64 arm64; do
+              rm -f onyx-cli
               GOOS="$goos" GOARCH="$goarch" uv build --wheel
             done
           done
@@ -225,23 +235,15 @@ jobs:
           fi
 
   govulncheck:
-    needs:
-      - pypi
     runs-on: ubuntu-latest
     permissions:
       contents: read # needed to checkout the repo for SARIF source locations
-      actions: read # needed to download the wheel artifact from the release job
       security-events: write # needed for SARIF uploads
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
         with:
           persist-credentials: false
-
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # ratchet:actions/download-artifact@v4
-        with:
-          name: onyx-cli-wheels
-          path: cli/dist
 
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # zizmor: ignore[cache-poisoning]
         with:
@@ -253,33 +255,36 @@ jobs:
           GOBIN="${RUNNER_TEMP}/bin" go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           echo "${RUNNER_TEMP}/bin" >> "$GITHUB_PATH"
 
-      - name: Run govulncheck on released wheel binaries
+      # Build unstripped binaries just for scanning, rather than trimming symbols
+      # from (and thereby bloating) the released production binaries. govulncheck
+      # only needs the symbol table, not the ldflags version/commit stamping the
+      # release build does, so a plain `go build` per platform is enough.
+      - name: Build binaries for scanning
+        working-directory: cli
+        run: |
+          set -euo pipefail
+          mkdir -p ../govulncheck-binaries
+
+          for goos in linux darwin windows; do
+            for goarch in amd64 arm64; do
+              out="../govulncheck-binaries/onyx-cli-${goos}-${goarch}"
+              if [ "$goos" = "linux" ]; then
+                GOOS="$goos" GOARCH="$goarch" CGO_ENABLED=0 go build -o "$out" .
+              else
+                GOOS="$goos" GOARCH="$goarch" go build -o "$out" .
+              fi
+            done
+          done
+
+      - name: Run govulncheck on freshly built binaries
         run: |
           set -euo pipefail
           scan_exit=0
-          mkdir -p wheel-binaries govulncheck-results/raw
+          mkdir -p govulncheck-results/raw
 
-          for wheel in cli/dist/*.whl; do
-            wheel_name="$(basename "$wheel" .whl)"
-            if [[ "$wheel_name" == *-musllinux_* ]]; then
-              echo "Skipping duplicate static Linux binary scan for $wheel_name"
-              continue
-            fi
-
-            extract_dir="wheel-binaries/${wheel_name}"
-            sarif_file="govulncheck-results/raw/${wheel_name}.sarif"
-
-            unzip -q "$wheel" -d "$extract_dir"
-            binary="$(
-              find "$extract_dir" \
-                \( -path '*.data/scripts/onyx-cli' -o -path '*.data/scripts/onyx-cli.exe' \) \
-                -type f \
-                -print -quit
-            )"
-            if [ -z "$binary" ]; then
-              echo "No onyx-cli binary found in $wheel" >&2
-              exit 1
-            fi
+          for binary in govulncheck-binaries/*; do
+            binary_name="$(basename "$binary")"
+            sarif_file="govulncheck-results/raw/${binary_name}.sarif"
 
             if ! govulncheck -mode=binary "$binary"; then
               scan_exit=1

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -48,13 +48,6 @@ jobs:
             done
           done
         working-directory: cli
-      - name: Upload built wheels
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: onyx-cli-wheels
-          path: cli/dist/*.whl
-          if-no-files-found: error
-          retention-days: 7
 
       - run: uv publish
         working-directory: cli

--- a/cli/hatch_build.py
+++ b/cli/hatch_build.py
@@ -36,14 +36,9 @@ class CustomBuildHook(BuildHookInterface):
         tag = os.getenv("GITHUB_REF_NAME", "dev").removeprefix(f"{tag_prefix}/")
         commit = os.getenv("GITHUB_SHA", "none")
 
-        if os.getenv("ONYX_CLI_REUSE_BINARY") == "1":
-            if not os.path.exists(binary_name):
-                msg = f"ONYX_CLI_REUSE_BINARY=1 set, but {binary_name!r} does not exist"
-                raise FileNotFoundError(msg)
-            print(f"Reusing Go binary '{binary_name}'...")
-        else:
+        if not os.path.exists(binary_name):
             print(f"Building Go binary '{binary_name}'...")
-            ldflags = f"-X main.version={tag} -X main.commit={commit} -w"
+            ldflags = f"-X main.version={tag} -X main.commit={commit} -s -w"
             env = os.environ.copy()
             if goos == "linux":
                 env.setdefault("CGO_ENABLED", "0")


### PR DESCRIPTION
## Summary
- Drop the `ONYX_CLI_REUSE_BINARY` hack in `cli/hatch_build.py` / `release-cli.yml`. `release-devtools.yml` already achieves an atomic multi-platform release by `rm -f`-ing the previous binary before each `uv build --wheel` call and letting the build hook's `if not os.path.exists(binary_name)` guard recompile per platform; `release-cli.yml` now does the same instead of special-casing the musllinux wheel variants with a "reuse the last binary" env flag.
- Drop the `-s -w` → `-w`-only ldflags change that was made so `govulncheck` could inspect symbols in the *released* (production) wheel binaries. Production binaries are now built fully stripped (`-s -w`) again, as small as possible. The `govulncheck` job in `release-cli.yml` instead builds its own unstripped binaries directly (one per GOOS/GOARCH) with a plain `go build`, purely for scanning — this also means it no longer needs to download/unzip the wheel artifacts, drops the `actions: read` permission, and no longer needs to wait on the `pypi` job (`needs: pypi` removed), so it can run in parallel.
- Drop the `Upload built wheels` (`onyx-cli-wheels`) CI artifact step from the `pypi` job. Nothing in the workflow downloads it anymore (`govulncheck` no longer needs it either, per above), and #13506 attaches standalone binary archives to the GitHub release itself for anyone who needs a downloadable artifact — the wheels are still published to PyPI regardless.

Investigated de-duplicating `release-cli.yml` and `release-devtools.yml`'s wheel-building steps into a shared composite action, but the two build loops differ meaningfully (musllinux platform-tag variants and `CGO_ENABLED=0` handling for `cli`), so a shared action would only capture the boilerplate (setup-uv/upload-artifact/publish) while the actual build logic stays duplicated — not worth the added indirection.

### Binary size: stripped (production) vs. `-w`-only (previous state) vs. unstripped (govulncheck-only)

Built locally for `linux/amd64` with `CGO_ENABLED=0` to confirm the size impact of restoring `-s -w`, including the missing `-s` on its own (the state this PR replaces only had `-w`, added by #12787 so govulncheck could inspect symbols):

| build | ldflags | size |
| --- | --- | --- |
| production (stripped, this PR) | `-s -w` | 18,608,290 bytes (17.75 MiB) |
| previous state (`-w` only, #12787) | `-w` | 20,149,332 bytes (19.22 MiB) |
| govulncheck-only (unstripped) | *(none)* | 25,177,406 bytes (24.01 MiB) |

- Adding back just the missing **`-s`** shrinks the binary by **1,541,042 bytes (1.47 MiB, 7.6%)** relative to the `-w`-only build that shipped before this PR.
- `-w` alone (dropping DWARF debug info) accounts for **5,028,074 bytes (4.80 MiB, 20.0%)** of the unstripped size.
- `-s -w` together shave off **6,569,116 bytes (6.26 MiB, 26.1%)** versus fully unstripped — that's the size no longer paid for in every released wheel/Docker image now that stripping isn't held back for govulncheck's sake.

## Test plan
- [x] `pre-commit run --files cli/hatch_build.py .github/workflows/release-cli.yml` (ruff, zizmor, actionlint, etc.) — all passed
- [x] `zizmor .github/workflows/release-cli.yml` — no findings
- [x] Verified locally with the repo's cached Go 1.26.4 toolchain that `go build -o <name>` on `GOOS=windows` writes the literal output name (no automatic `.exe` suffix when `-o` is explicit), confirming `rm -f onyx-cli` works uniformly across all target platforms
- [x] Built `cli` locally for `linux/amd64` with `-s -w`, `-w`-only, and no strip flags, to measure and confirm the production binary size savings, including the `-s`-only delta (table above)
- [ ] Next real `cli/vX.Y.Z` tag push will exercise the actual release workflow end-to-end (wheel builds, publish, govulncheck scan)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up the CLI release workflow for atomic per-platform wheel builds and fully stripped production binaries, with `govulncheck` running on fresh unstripped builds. Also removes the unused wheel artifact upload.

- **Refactors**
  - Remove `ONYX_CLI_REUSE_BINARY`; delete the previous `onyx-cli` before each `uv build --wheel` to force per-`GOOS/GOARCH` rebuilds, including musllinux variants.
  - Restore `-s -w` for production; build separate unstripped binaries with `go build` only for `govulncheck`.
  - Simplify `govulncheck`: build binaries per platform locally, drop artifact download and `actions: read`, and run independently of `pypi`.
  - Remove the `onyx-cli-wheels` artifact upload step (no longer used).

<sup>Written for commit 7a5d8ad92b298096ee9b0694c3d38a0ea84240d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13512?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

