### PR TITLE
chore(devcontainer): install the go toolchain

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,10 +3,11 @@
 # Hub rate limits.
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-# bun + node binary sources. Pinned via the registry prefix in their own stages because buildx
+# bun + node + go binary sources. Pinned via the registry prefix in their own stages because buildx
 # rejects variable expansion directly in `COPY --from=` -- the ARG is only expandable in a FROM.
 FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
 FROM ${BASE_IMAGE_REGISTRY}/library/node:24.16.0-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c AS node_source
+FROM ${BASE_IMAGE_REGISTRY}/library/golang:1.26.4-trixie@sha256:68b7145ec43d1820b9a56704554b53d1520aa2a15cb5233e374188a31b2a1bce AS go_source
 
 FROM ${BASE_IMAGE_REGISTRY}/library/ubuntu:26.04@sha256:cc925e589b7543b910fea57a240468940003fbfc0515245a495dd0ad8fe7cef1
 
@@ -134,6 +135,19 @@ RUN UV_PYTHON_BIN_DIR=/usr/local/bin uv python install 3.13 \
   && ln -s python3.13 /usr/local/bin/python3 \
   && ln -s python3.13 /usr/local/bin/python \
   && python --version
+
+# Install the Go toolchain. `tools/ods` and `cli` both pin `go 1.26.4` in their go.mod,
+# and the golangci-lint pre-commit hook builds against the same version — keep this in
+# sync with them and with GO_VERSION in .github/workflows/pr-golang-tests.yml.
+#
+# Copied from the official golang image (digest-pinned in the go_source stage at the top,
+# routed through BASE_IMAGE_REGISTRY) rather than fetched from go.dev, for the same reasons
+# as the node install above: no MITM surface on the download, and buildkit resolves the
+# right arch from the manifest list. Module and build caches are not baked in; they live in
+# the dev user's home (see .devcontainer/zshrc).
+COPY --from=go_source /usr/local/go /usr/local/go
+ENV PATH=/usr/local/go/bin:$PATH
+RUN go version
 
 # Create non-root dev user with passwordless sudo
 RUN useradd -m -s /bin/zsh dev && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,11 +3,10 @@
 # Hub rate limits.
 ARG BASE_IMAGE_REGISTRY=docker.io
 
-# bun + node + go binary sources. Pinned via the registry prefix in their own stages because buildx
+# bun + node binary sources. Pinned via the registry prefix in their own stages because buildx
 # rejects variable expansion directly in `COPY --from=` -- the ARG is only expandable in a FROM.
 FROM ${BASE_IMAGE_REGISTRY}/oven/bun:1@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS bun_source
 FROM ${BASE_IMAGE_REGISTRY}/library/node:24.16.0-trixie-slim@sha256:05c08ce4291e9a58f59456a7985176defb12cdd42271f35ff81a3e167ea61d4c AS node_source
-FROM ${BASE_IMAGE_REGISTRY}/library/golang:1.26.4-trixie@sha256:68b7145ec43d1820b9a56704554b53d1520aa2a15cb5233e374188a31b2a1bce AS go_source
 
 FROM ${BASE_IMAGE_REGISTRY}/library/ubuntu:26.04@sha256:cc925e589b7543b910fea57a240468940003fbfc0515245a495dd0ad8fe7cef1
 
@@ -140,12 +139,29 @@ RUN UV_PYTHON_BIN_DIR=/usr/local/bin uv python install 3.13 \
 # and the golangci-lint pre-commit hook builds against the same version — keep this in
 # sync with them and with GO_VERSION in .github/workflows/pr-golang-tests.yml.
 #
-# Copied from the official golang image (digest-pinned in the go_source stage at the top,
-# routed through BASE_IMAGE_REGISTRY) rather than fetched from go.dev, for the same reasons
-# as the node install above: no MITM surface on the download, and buildkit resolves the
-# right arch from the manifest list. Module and build caches are not baked in; they live in
-# the dev user's home (see .devcontainer/zshrc).
-COPY --from=go_source /usr/local/go /usr/local/go
+# Fetched from go.dev with a pinned per-arch checksum (same shape as the prek install
+# above) rather than copied out of the official golang image: base images here route
+# through the ECR pull-through cache, which only populates on tag-based pulls, so a
+# `golang:...@sha256:...` stage fails to resolve until something has already pulled that
+# exact digest by tag. The sha256 pin is what defeats a compromised mirror or MITM, so
+# nothing is given up by not going through a registry.
+#
+# Module and build caches are not baked in; they live in the dev user's home
+# (see .devcontainer/zshrc).
+ARG GO_VERSION=1.26.4
+RUN set -eux; \
+  case "$(dpkg --print-architecture)" in \
+    amd64) GO_ARCH=amd64; \
+           GO_SHA256=1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f ;; \
+    arm64) GO_ARCH=arm64; \
+           GO_SHA256=ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768 ;; \
+    *) echo "unsupported arch for go: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+  esac; \
+  curl -fsSL -o /tmp/go.tar.gz \
+    "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"; \
+  echo "${GO_SHA256}  /tmp/go.tar.gz" | sha256sum -c -; \
+  tar -C /usr/local -xzf /tmp/go.tar.gz; \
+  rm -f /tmp/go.tar.gz
 ENV PATH=/usr/local/go/bin:$PATH
 RUN go version
 

--- a/.devcontainer/zshrc
+++ b/.devcontainer/zshrc
@@ -6,5 +6,11 @@ if [ -f /workspace/.venv/bin/activate ]; then
   . /workspace/.venv/bin/activate
 fi
 
+# Go: park the module cache under ~/.cache (a named volume, like GOCACHE's default
+# ~/.cache/go-build) so the dep trees in tools/ods and cli survive container recreation,
+# and put `go install` output on PATH.
+export GOMODCACHE="$HOME/.cache/go-mod"
+export PATH="$HOME/go/bin:$PATH"
+
 # Source host zshrc if bind-mounted
 [ -f ~/.zshrc.host ] && . ~/.zshrc.host


### PR DESCRIPTION
## Issues to Address

`tools/ods/go.mod` and `cli/go.mod` both pin `go 1.26.4`, but the devcontainer image ships no Go toolchain. Building either module — or running the `golangci-lint` pre-commit hook, which walks every `go.mod` in the tree — required installing Go by hand inside the container.

## Changes

**`.devcontainer/Dockerfile`** — install Go 1.26.4 at `/usr/local/go`, with `/usr/local/go/bin` on `PATH`.

The toolchain is fetched from go.dev with a pinned per-arch sha256, matching the shape of the `prek` install directly above it (arch via `dpkg --print-architecture`, checksum verified before extract).

I first tried the `bun_source` / `node_source` convention — a digest-pinned `FROM ... AS go_source` plus `COPY --from=` — and it failed in CI:

```
.../docker-hub/library/golang:1.26.4-trixie@sha256:68b7145...: not found
```

Base images route through the ECR pull-through cache, which only populates on **tag**-based pulls. buildkit resolves a `name:tag@digest` reference by digest, so a manifest the cache has never seen 404s. `node`/`bun`/`ubuntu` resolve only because earlier builds already cached those digests; nothing has ever pulled `library/golang` through this cache (`release-cli.yml` is the only workflow building `cli/Dockerfile`, and it doesn't set `BASE_IMAGE_REGISTRY`). The digest itself was valid — it resolves fine against Docker Hub directly.

The tarball approach sidesteps that entirely and gives up nothing on integrity: the sha256 pin is what actually defeats a compromised mirror or MITM, which was the stated reason for preferring a registry in the first place. It also avoids asking infra to seed a new pull-through repo.

The version now appears in four places — the two `go.mod` files, `GO_VERSION` in `.github/workflows/pr-golang-tests.yml`, and the `golangci-lint` hook's `language_version` — so the comment calls out the sync requirement.

**`.devcontainer/zshrc`** — a smaller companion change, reviewable separately.

`GOCACHE` defaults to `~/.cache/go-build`, which already lands on the `onyx-devcontainer-cache` volume, but `GOMODCACHE` defaults to `~/go/pkg/mod`, which does not — so every container recreate would re-download the osv-scalibr and charm dep trees. Repointing it at `~/.cache/go-mod` fixes that. `~/go/bin` on `PATH` makes `go install .` behave as `tools/ods/README.md` describes.

## Testing

Ran the exact install steps against the `ubuntu:26.04` base this image is built on:

- checksum verifies against the pinned value
- `go version` → `go version go1.26.4 linux/amd64`
- `go build ./...` succeeds for **both** `tools/ods` and `cli`

The image build in CI (`build-devcontainer-image`) covers the arm64 path and the Dockerfile as a whole.

## Caveats

- Only the amd64 path was verified locally; arm64 relies on the published checksum and CI.
- `/usr/local/go` adds roughly 350–500 MB to the image.
- `.devcontainer/devcontainer.json` pins the image by digest, so this doesn't reach devs until that digest is bumped to a build containing this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
