### PR TITLE
chore: centralize common trace metadata

### DIFF
--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -34,7 +34,7 @@ from onyx.prompts.compression_prompts import (
     USER_REMINDER,
 )
 from onyx.tracing.flows import LLMFlow
-from onyx.tracing.framework.create import TraceMetadata, ensure_trace
+from onyx.tracing.framework.create import ChatTraceMetadata, ensure_trace
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.logger import setup_logger
 
@@ -387,7 +387,7 @@ def compress_chat_history(
     with ensure_trace(
         "chat_history_compression",
         group_id=str(chat_session_id),
-        metadata=TraceMetadata(chat_session_id=str(chat_session_id)).model_dump(),
+        metadata=ChatTraceMetadata(chat_session_id=str(chat_session_id)).model_dump(),
     ):
         try:
             # Read phase: existing summary + tool name map. Closed before LLM call.

--- a/backend/onyx/chat/compression.py
+++ b/backend/onyx/chat/compression.py
@@ -34,10 +34,9 @@ from onyx.prompts.compression_prompts import (
     USER_REMINDER,
 )
 from onyx.tracing.flows import LLMFlow
-from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.create import TraceMetadata, ensure_trace
 from onyx.tracing.llm_utils import llm_generation_span, record_llm_response
 from onyx.utils.logger import setup_logger
-from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -388,10 +387,7 @@ def compress_chat_history(
     with ensure_trace(
         "chat_history_compression",
         group_id=str(chat_session_id),
-        metadata={
-            "tenant_id": get_current_tenant_id(),
-            "chat_session_id": str(chat_session_id),
-        },
+        metadata=TraceMetadata(chat_session_id=str(chat_session_id)).model_dump(),
     ):
         try:
             # Read phase: existing summary + tool name map. Closed before LLM call.

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -75,9 +75,8 @@ from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 from onyx.tools.tool_runner import run_tool_calls
 from onyx.tools.utils import compute_all_tool_tokens
-from onyx.tracing.framework.create import trace
+from onyx.tracing.framework.create import TraceMetadata, trace
 from onyx.utils.logger import setup_logger
-from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -664,11 +663,10 @@ def run_llm_loop(
     with trace(
         "run_llm_loop",
         group_id=chat_session_id,
-        metadata={
-            "tenant_id": get_current_tenant_id(),
-            "chat_session_id": chat_session_id,
-            "user_id": user_identity.user_id if user_identity else None,
-        },
+        metadata=TraceMetadata(
+            chat_session_id=chat_session_id,
+            user_id=user_identity.user_id if user_identity else None,
+        ).model_dump(),
     ):
         # Fix some LiteLLM issues,
         from onyx.llm.litellm_singleton.config import (

--- a/backend/onyx/chat/llm_loop.py
+++ b/backend/onyx/chat/llm_loop.py
@@ -75,7 +75,7 @@ from onyx.tools.tool_implementations.web_search.utils import extract_url_snippet
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
 from onyx.tools.tool_runner import run_tool_calls
 from onyx.tools.utils import compute_all_tool_tokens
-from onyx.tracing.framework.create import TraceMetadata, trace
+from onyx.tracing.framework.create import ChatTraceMetadata, trace
 from onyx.utils.logger import setup_logger
 
 logger = setup_logger()
@@ -663,7 +663,7 @@ def run_llm_loop(
     with trace(
         "run_llm_loop",
         group_id=chat_session_id,
-        metadata=TraceMetadata(
+        metadata=ChatTraceMetadata(
             chat_session_id=chat_session_id,
             user_id=user_identity.user_id if user_identity else None,
         ).model_dump(),

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -70,7 +70,7 @@ from onyx.tools.models import ToolCallInfo, ToolCallKickoff
 from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
-from onyx.tracing.framework.create import TraceMetadata, function_span, trace
+from onyx.tracing.framework.create import ChatTraceMetadata, function_span, trace
 from onyx.utils.logger import setup_logger
 from onyx.utils.timing import log_function_time
 
@@ -214,7 +214,7 @@ def run_deep_research_llm_loop(
     with trace(
         "run_deep_research_llm_loop",
         group_id=chat_session_id,
-        metadata=TraceMetadata(
+        metadata=ChatTraceMetadata(
             chat_session_id=chat_session_id,
             user_id=user_identity.user_id if user_identity else None,
         ).model_dump(),

--- a/backend/onyx/deep_research/dr_loop.py
+++ b/backend/onyx/deep_research/dr_loop.py
@@ -70,10 +70,9 @@ from onyx.tools.models import ToolCallInfo, ToolCallKickoff
 from onyx.tools.tool_implementations.open_url.open_url_tool import OpenURLTool
 from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.tools.tool_implementations.web_search.web_search_tool import WebSearchTool
-from onyx.tracing.framework.create import function_span, trace
+from onyx.tracing.framework.create import TraceMetadata, function_span, trace
 from onyx.utils.logger import setup_logger
 from onyx.utils.timing import log_function_time
-from shared_configs.contextvars import get_current_tenant_id
 
 logger = setup_logger()
 
@@ -215,11 +214,10 @@ def run_deep_research_llm_loop(
     with trace(
         "run_deep_research_llm_loop",
         group_id=chat_session_id,
-        metadata={
-            "tenant_id": get_current_tenant_id(),
-            "chat_session_id": chat_session_id,
-            "user_id": user_identity.user_id if user_identity else None,
-        },
+        metadata=TraceMetadata(
+            chat_session_id=chat_session_id,
+            user_id=user_identity.user_id if user_identity else None,
+        ).model_dump(),
     ):
         # Here for lazy load LiteLLM
         from onyx.llm.litellm_singleton.config import initialize_litellm

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -115,7 +115,7 @@ from onyx.server.usage_limits import (
     is_usage_limits_enabled,
 )
 from onyx.server.utils import get_json_line
-from onyx.tracing.framework.create import TraceMetadata, ensure_trace
+from onyx.tracing.framework.create import ChatTraceMetadata, ensure_trace
 from onyx.utils.headers import get_custom_tool_additional_request_headers
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
@@ -514,7 +514,7 @@ def rename_chat_session(
     with ensure_trace(
         "chat_session_naming",
         group_id=str(chat_session_id),
-        metadata=TraceMetadata(
+        metadata=ChatTraceMetadata(
             chat_session_id=str(chat_session_id),
             user_id=str(user_id) if user_id else None,
         ).model_dump(),

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -115,7 +115,7 @@ from onyx.server.usage_limits import (
     is_usage_limits_enabled,
 )
 from onyx.server.utils import get_json_line
-from onyx.tracing.framework.create import ensure_trace
+from onyx.tracing.framework.create import TraceMetadata, ensure_trace
 from onyx.utils.headers import get_custom_tool_additional_request_headers
 from onyx.utils.logger import setup_logger
 from onyx.utils.telemetry import mt_cloud_telemetry
@@ -514,11 +514,10 @@ def rename_chat_session(
     with ensure_trace(
         "chat_session_naming",
         group_id=str(chat_session_id),
-        metadata={
-            "tenant_id": get_current_tenant_id(),
-            "chat_session_id": str(chat_session_id),
-            "user_id": str(user_id) if user_id else None,
-        },
+        metadata=TraceMetadata(
+            chat_session_id=str(chat_session_id),
+            user_id=str(user_id) if user_id else None,
+        ).model_dump(),
     ):
         new_name = generate_chat_session_name(chat_history=simple_chat_history, llm=llm)
 

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -4,7 +4,10 @@ from collections.abc import Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
+from pydantic import BaseModel, Field
+
 from onyx.utils.logger import setup_logger
+from shared_configs.contextvars import get_current_tenant_id
 
 from .setup import get_trace_provider
 from .span_data import AgentSpanData, FunctionSpanData, GenerationSpanData
@@ -15,6 +18,12 @@ if TYPE_CHECKING:
     pass
 
 logger = setup_logger(__name__)
+
+
+class TraceMetadata(BaseModel):
+    tenant_id: str = Field(default_factory=get_current_tenant_id)
+    chat_session_id: str | None = None
+    user_id: str | None = None
 
 
 def trace(

--- a/backend/onyx/tracing/framework/create.py
+++ b/backend/onyx/tracing/framework/create.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 logger = setup_logger(__name__)
 
 
-class TraceMetadata(BaseModel):
+class ChatTraceMetadata(BaseModel):
     tenant_id: str = Field(default_factory=get_current_tenant_id)
     chat_session_id: str | None = None
     user_id: str | None = None

--- a/backend/tests/unit/onyx/tracing/test_trace_metadata.py
+++ b/backend/tests/unit/onyx/tracing/test_trace_metadata.py
@@ -1,11 +1,11 @@
-from onyx.tracing.framework.create import TraceMetadata
+from onyx.tracing.framework.create import ChatTraceMetadata
 from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
 
 
-def test_trace_metadata_uses_current_tenant() -> None:
+def test_chat_trace_metadata_uses_current_tenant() -> None:
     token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant")
     try:
-        metadata = TraceMetadata(chat_session_id="session", user_id="user")
+        metadata = ChatTraceMetadata(chat_session_id="session", user_id="user")
     finally:
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 

--- a/backend/tests/unit/onyx/tracing/test_trace_metadata.py
+++ b/backend/tests/unit/onyx/tracing/test_trace_metadata.py
@@ -1,0 +1,16 @@
+from onyx.tracing.framework.create import TraceMetadata
+from shared_configs.contextvars import CURRENT_TENANT_ID_CONTEXTVAR
+
+
+def test_trace_metadata_uses_current_tenant() -> None:
+    token = CURRENT_TENANT_ID_CONTEXTVAR.set("tenant")
+    try:
+        metadata = TraceMetadata(chat_session_id="session", user_id="user")
+    finally:
+        CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
+
+    assert metadata.model_dump() == {
+        "tenant_id": "tenant",
+        "chat_session_id": "session",
+        "user_id": "user",
+    }


### PR DESCRIPTION
## Description

- Add a typed `TraceMetadata` model beside `trace` and `ensure_trace`.
- Reuse it across chat, deep research, compression, and session naming traces.

## How Has This Been Tested?

- `uv run pytest -q backend/tests/unit/onyx/tracing/test_trace_metadata.py`
- `uv run pre-commit run --files backend/onyx/tracing/framework/create.py backend/onyx/chat/llm_loop.py backend/onyx/deep_research/dr_loop.py backend/onyx/server/query_and_chat/chat_backend.py backend/onyx/chat/compression.py backend/tests/unit/onyx/tracing/test_trace_metadata.py`

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized common chat trace metadata with a typed `ChatTraceMetadata` model and applied it across chat and research flows. This keeps tenant, session, and user attribution consistent and removes repeated dicts.

- **Refactors**
  - Added `ChatTraceMetadata` (Pydantic) to `onyx.tracing.framework.create` with `tenant_id` (defaults from `shared_configs.contextvars`), `chat_session_id`, and `user_id`.
  - Replaced inline metadata dicts with `ChatTraceMetadata(...).model_dump()` in `chat/llm_loop.py`, `deep_research/dr_loop.py`, `chat/compression.py`, and `server/query_and_chat/chat_backend.py`.
  - Added a unit test to verify the current tenant context is used for `tenant_id`.

<sup>Written for commit 70c809dfe620bd96755e13540f74755d6bce9076. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13515?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

