### PR TITLE
feat(db): enumerate tenants across every shard

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 from onyx.db.engine.iam_auth import get_iam_auth_token
 from onyx.db.engine.pg_ssl import create_pg_ssl_context
@@ -7,8 +8,10 @@ from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USER
 from onyx.configs.app_configs import AWS_REGION_NAME
 from onyx.db.engine.shard_registry import ALEMBIC_TARGET_URL_ATTRIBUTE
+from onyx.db.engine.shard_registry import get_shard_spec
+from onyx.db.engine.shard_registry import is_sharded
 from onyx.db.engine.sql_engine import build_connection_string
-from onyx.db.engine.tenant_utils import get_all_tenant_ids
+from onyx.db.engine.tenant_utils import get_tenant_ids_by_shard
 from sqlalchemy import event
 from sqlalchemy import pool
 from sqlalchemy import text
@@ -21,6 +24,7 @@ import logging
 from logging.config import fileConfig
 
 from alembic import context
+from sqlalchemy.ext.asyncio import AsyncEngine
 from sqlalchemy.ext.asyncio import create_async_engine
 from onyx.configs.constants import SSL_CERT_FILE
 from shared_configs.configs import (
@@ -58,15 +62,27 @@ target_metadata = [Base.metadata, ResultModelBase.metadata]
 logger = logging.getLogger(__name__)
 
 
-def connection_url() -> str:
+def connection_url(shard_name: str | None = None) -> str:
     """Database URL for this migration run.
 
-    Defaults to the process-wide POSTGRES_* settings. A caller that has already
-    decided which database to target — notably per-tenant migrations, which must
-    follow the tenant's shard — passes it via `ALEMBIC_TARGET_URL_ATTRIBUTE`.
+    In precedence order: a caller that has already decided which database to target
+    (per-tenant migrations, via `ALEMBIC_TARGET_URL_ATTRIBUTE`), then an explicit
+    shard, then the process-wide POSTGRES_* settings.
     """
-    return (
-        config.attributes.get(ALEMBIC_TARGET_URL_ATTRIBUTE) or build_connection_string()
+    configured = config.attributes.get(ALEMBIC_TARGET_URL_ATTRIBUTE)
+    if configured:
+        return configured
+
+    if shard_name is None:
+        return build_connection_string()
+
+    spec = get_shard_spec(shard_name)
+    return build_connection_string(
+        user=spec.user,
+        password=spec.password,
+        host=spec.host,
+        port=spec.port,
+        db=spec.db,
     )
 
 
@@ -127,7 +143,7 @@ def filter_tenants_by_range(
 
 
 def get_schema_options() -> tuple[
-    bool, bool, bool, int | None, int | None, list[str] | None
+    bool, bool, bool, int | None, int | None, list[str] | None, str | None
 ]:
     x_args_raw = context.get_x_argument()
     x_args = {}
@@ -212,6 +228,13 @@ def get_schema_options() -> tuple[
             "or provide schemas. Cannot run default migration."
         )
 
+    # Pins the run to one physical database. Omitted means the default shard for a
+    # named-schema run, and every shard for upgrade_all_tenants.
+    shard = x_args.get("shard") or None
+    if shard is not None:
+        # Fails here rather than after connecting to the wrong database.
+        get_shard_spec(shard)
+
     return (
         create_schema,
         upgrade_all_tenants,
@@ -219,6 +242,7 @@ def get_schema_options() -> tuple[
         tenant_range_start,
         tenant_range_end,
         schemas,
+        shard,
     )
 
 
@@ -251,29 +275,112 @@ def do_run_migrations(
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
-def provide_iam_token_for_alembic(
-    dialect: Any,  # noqa: ARG001
-    conn_rec: Any,  # noqa: ARG001
-    cargs: Any,  # noqa: ARG001
-    cparams: Any,
-) -> None:
-    if USE_IAM_AUTH:
-        # Derived from the URL actually being migrated, not the global POSTGRES_*
-        # settings: an RDS IAM token is only valid for the host/port/user it was
-        # minted for, so a tenant on a shard with different coordinates would be
-        # rejected if we used the defaults here.
-        url = make_url(connection_url())
-        region = AWS_REGION_NAME
-        host = url.host or POSTGRES_HOST
-        port = str(url.port) if url.port else POSTGRES_PORT
-        user = url.username or POSTGRES_USER
+def make_provide_iam_token_for_alembic(
+    target_url: str,
+) -> Callable[[Any, Any, Any, Any], None]:
+    """Build a `do_connect` listener bound to one database's coordinates.
 
-        # Get IAM authentication token
-        token = get_iam_auth_token(host, port, user, region)
+    An RDS IAM token is only valid for the host/port/user it was minted for, so the
+    listener has to close over the URL its engine actually connects to rather than
+    re-deriving it from process-wide settings.
+    """
+    url = make_url(target_url)
+    host = url.host or POSTGRES_HOST
+    port = str(url.port) if url.port else POSTGRES_PORT
+    user = url.username or POSTGRES_USER
 
-        # For Alembic / SQLAlchemy in this context, set SSL and password
-        cparams["password"] = token
+    def provide_iam_token_for_alembic(
+        dialect: Any,  # noqa: ARG001
+        conn_rec: Any,  # noqa: ARG001
+        cargs: Any,  # noqa: ARG001
+        cparams: Any,
+    ) -> None:
+        cparams["password"] = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
         cparams["ssl"] = ssl_context
+
+    return provide_iam_token_for_alembic
+
+
+def create_migration_engine(target_url: str) -> AsyncEngine:
+    """Async engine for one database, with IAM bound to that database."""
+    engine = create_async_engine(
+        target_url,
+        poolclass=pool.NullPool,
+        connect_args={"ssl": create_pg_ssl_context()},
+    )
+    if USE_IAM_AUTH:
+        event.listen(
+            engine.sync_engine,
+            "do_connect",
+            make_provide_iam_token_for_alembic(target_url),
+        )
+    return engine
+
+
+async def _migrate_schemas(
+    engine: AsyncEngine,
+    schemas: list[str],
+    create_schema: bool,
+    continue_on_error: bool,
+    label: str,
+) -> None:
+    """Run migrations for a list of schemas against one database."""
+    num_schemas = len(schemas)
+    for i_schema, schema in enumerate(schemas, start=1):
+        logger.info(
+            "Migrating schema: index=%s num_%s=%s schema=%s",
+            i_schema,
+            label,
+            num_schemas,
+            schema,
+        )
+        try:
+            async with engine.connect() as connection:
+                await connection.run_sync(
+                    do_run_migrations,
+                    schema_name=schema,
+                    create_schema=create_schema,
+                )
+                await connection.commit()
+        except Exception as e:
+            logger.error("Error migrating schema %s: %s", schema, e)
+            if not continue_on_error:
+                logger.error("--continue=true is not set, raising exception!")
+                raise
+
+            logger.warning("--continue=true is set, continuing to next schema.")
+
+
+def _tenants_to_migrate(
+    shard: str | None,
+    tenant_range_start: int | None,
+    tenant_range_end: int | None,
+) -> dict[str, list[str]]:
+    """Tenants needing migration, grouped by the shard that physically holds them."""
+    tenants_by_shard = get_tenant_ids_by_shard()
+    if shard is not None:
+        tenants_by_shard = {shard: tenants_by_shard.get(shard, [])}
+
+    if tenant_range_start is None and tenant_range_end is None:
+        return tenants_by_shard
+
+    # The range is positional over *all* tenants, so it has to be applied before
+    # partitioning — filtering per shard would select the range N times over.
+    all_tenants = sorted({t for ts in tenants_by_shard.values() for t in ts})
+    selected = set(
+        filter_tenants_by_range(all_tenants, tenant_range_start, tenant_range_end)
+    )
+    logger.info(
+        "Filtering tenants by range: start=%s, end=%s. Total tenants: %s, Filtered tenants: %s",
+        tenant_range_start,
+        tenant_range_end,
+        len(all_tenants),
+        len(selected),
+    )
+    return {
+        shard_name: [t for t in tenants if t in selected]
+        for shard_name, tenants in tenants_by_shard.items()
+    }
 
 
 async def run_async_migrations() -> None:
@@ -284,6 +391,7 @@ async def run_async_migrations() -> None:
         tenant_range_start,
         tenant_range_end,
         schemas,
+        shard,
     ) = get_schema_options()
 
     if not schemas and not MULTI_TENANT:
@@ -292,94 +400,35 @@ async def run_async_migrations() -> None:
     # without init_engine, subsequent engine calls fail hard intentionally
     SqlEngine.init_engine(pool_size=20, max_overflow=5)
 
-    engine = create_async_engine(
-        connection_url(),
-        poolclass=pool.NullPool,
-        connect_args={"ssl": create_pg_ssl_context()},
-    )
-
-    if USE_IAM_AUTH:
-
-        @event.listens_for(engine.sync_engine, "do_connect")
-        def event_provide_iam_token_for_alembic(
-            dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
-        ) -> None:
-            provide_iam_token_for_alembic(dialect, conn_rec, cargs, cparams)
-
     if schemas:
         # Use specific schema names directly without fetching all tenants
         logger.info("Migrating specific schema names: %s", schemas)
 
-        i_schema = 0
-        num_schemas = len(schemas)
-        for schema in schemas:
-            i_schema += 1
-            logger.info(
-                "Migrating schema: index=%s num_schemas=%s schema=%s",
-                i_schema,
-                num_schemas,
-                schema,
+        engine = create_migration_engine(connection_url(shard))
+        try:
+            await _migrate_schemas(
+                engine, schemas, create_schema, continue_on_error, "schemas"
             )
-            try:
-                async with engine.connect() as connection:
-                    await connection.run_sync(
-                        do_run_migrations,
-                        schema_name=schema,
-                        create_schema=create_schema,
-                    )
-                    await connection.commit()
-            except Exception as e:
-                logger.error("Error migrating schema %s: %s", schema, e)
-                if not continue_on_error:
-                    logger.error("--continue=true is not set, raising exception!")
-                    raise
-
-                logger.warning("--continue=true is set, continuing to next schema.")
+        finally:
+            await engine.dispose()
 
     elif upgrade_all_tenants:
-        tenant_schemas = get_all_tenant_ids()
-
-        filtered_tenant_schemas = filter_tenants_by_range(
-            tenant_schemas, tenant_range_start, tenant_range_end
-        )
-
-        if tenant_range_start is not None or tenant_range_end is not None:
-            logger.info(
-                "Filtering tenants by range: start=%s, end=%s",
-                tenant_range_start,
-                tenant_range_end,
-            )
-            logger.info(
-                "Total tenants: %s, Filtered tenants: %s",
-                len(tenant_schemas),
-                len(filtered_tenant_schemas),
-            )
-
-        i_tenant = 0
-        num_tenants = len(filtered_tenant_schemas)
-        for schema in filtered_tenant_schemas:
-            i_tenant += 1
-            logger.info(
-                "Migrating schema: index=%s num_tenants=%s schema=%s",
-                i_tenant,
-                num_tenants,
-                schema,
-            )
+        # One engine per shard: a tenant's schema only exists on the database holding
+        # it, so migrating every tenant against a single engine would skip every
+        # tenant that has been moved off it.
+        for shard_name, tenants in sorted(
+            _tenants_to_migrate(shard, tenant_range_start, tenant_range_end).items()
+        ):
+            if not tenants:
+                continue
+            logger.info("Migrating %s tenant(s) on shard %s", len(tenants), shard_name)
+            engine = create_migration_engine(connection_url(shard_name))
             try:
-                async with engine.connect() as connection:
-                    await connection.run_sync(
-                        do_run_migrations,
-                        schema_name=schema,
-                        create_schema=create_schema,
-                    )
-                    await connection.commit()
-            except Exception as e:
-                logger.error("Error migrating schema %s: %s", schema, e)
-                if not continue_on_error:
-                    logger.error("--continue=true is not set, raising exception!")
-                    raise
-
-                logger.warning("--continue=true is set, continuing to next schema.")
+                await _migrate_schemas(
+                    engine, tenants, create_schema, continue_on_error, "tenants"
+                )
+            finally:
+                await engine.dispose()
 
     else:
         # This should not happen in the new design since we require either
@@ -388,8 +437,6 @@ async def run_async_migrations() -> None:
         raise ValueError(
             "No migration target specified. Use either upgrade_all_tenants=true for all tenants or schemas for specific schemas."
         )
-
-    await engine.dispose()
 
 
 def run_migrations_offline() -> None:
@@ -415,8 +462,16 @@ def run_migrations_offline() -> None:
         tenant_range_start,
         tenant_range_end,
         schemas,
+        shard,
     ) = get_schema_options()
-    url = connection_url()
+
+    # An offline run emits one SQL script, which can only be applied to one database.
+    if shard is None and is_sharded():
+        raise ValueError(
+            "Offline migrations must target a single database. Pass -x shard=<name>."
+        )
+
+    url = connection_url(shard)
 
     if schemas:
         # Use specific schema names directly without fetching all tenants
@@ -438,34 +493,14 @@ def run_migrations_offline() -> None:
                 context.run_migrations()
 
     elif upgrade_all_tenants:
-        engine = create_async_engine(url)
-
-        if USE_IAM_AUTH:
-
-            @event.listens_for(engine.sync_engine, "do_connect")
-            def event_provide_iam_token_for_alembic_offline(
-                dialect: Any, conn_rec: Any, cargs: Any, cparams: Any
-            ) -> None:
-                provide_iam_token_for_alembic(dialect, conn_rec, cargs, cparams)
-
-        tenant_schemas = get_all_tenant_ids()
-        engine.sync_engine.dispose()
-
-        filtered_tenant_schemas = filter_tenants_by_range(
-            tenant_schemas, tenant_range_start, tenant_range_end
-        )
-
-        if tenant_range_start is not None or tenant_range_end is not None:
-            logger.info(
-                "Filtering tenants by range: start=%s, end=%s",
-                tenant_range_start,
-                tenant_range_end,
-            )
-            logger.info(
-                "Total tenants: %s, Filtered tenants: %s",
-                len(tenant_schemas),
-                len(filtered_tenant_schemas),
-            )
+        # Single shard, enforced above, so this is the only group.
+        filtered_tenant_schemas = [
+            schema
+            for schemas_on_shard in _tenants_to_migrate(
+                shard, tenant_range_start, tenant_range_end
+            ).values()
+            for schema in schemas_on_shard
+        ]
 
         for schema in filtered_tenant_schemas:
             logger.info("Migrating schema: %s", schema)

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -1,14 +1,12 @@
-from collections.abc import Callable
-from typing import Any
-from onyx.db.engine.iam_auth import get_iam_auth_token
+from onyx.db.engine.iam_auth import make_provide_iam_token_async
 from onyx.db.engine.pg_ssl import create_pg_ssl_context
 from onyx.configs.app_configs import USE_IAM_AUTH
 from onyx.configs.app_configs import POSTGRES_HOST
 from onyx.configs.app_configs import POSTGRES_PORT
 from onyx.configs.app_configs import POSTGRES_USER
-from onyx.configs.app_configs import AWS_REGION_NAME
 from onyx.db.engine.shard_registry import ALEMBIC_TARGET_URL_ATTRIBUTE
 from onyx.db.engine.shard_registry import get_shard_spec
+from onyx.db.engine.shard_registry import validate_shard_name
 from onyx.db.engine.shard_registry import is_sharded
 from onyx.db.engine.sql_engine import build_connection_string
 from onyx.db.engine.tenant_utils import get_tenant_ids_by_shard
@@ -18,7 +16,7 @@ from sqlalchemy import text
 from sqlalchemy.engine.url import make_url
 from sqlalchemy.engine.base import Connection
 import os
-import ssl
+from itertools import chain
 import asyncio
 import logging
 from logging.config import fileConfig
@@ -86,11 +84,10 @@ def connection_url(shard_name: str | None = None) -> str:
     )
 
 
-ssl_context: ssl.SSLContext | None = None
-if USE_IAM_AUTH:
-    if not os.path.exists(SSL_CERT_FILE):
-        raise FileNotFoundError(f"Expected {SSL_CERT_FILE} when USE_IAM_AUTH is true.")
-    ssl_context = ssl.create_default_context(cafile=SSL_CERT_FILE)
+# Fail at import rather than on the first connection. The context itself is built by
+# `create_pg_ssl_context`, which both the engine and the IAM listener use.
+if USE_IAM_AUTH and not os.path.exists(SSL_CERT_FILE):
+    raise FileNotFoundError(f"Expected {SSL_CERT_FILE} when USE_IAM_AUTH is true.")
 
 
 def filter_tenants_by_range(
@@ -233,7 +230,7 @@ def get_schema_options() -> tuple[
     shard = x_args.get("shard") or None
     if shard is not None:
         # Fails here rather than after connecting to the wrong database.
-        get_shard_spec(shard)
+        validate_shard_name(shard)
 
     return (
         create_schema,
@@ -275,44 +272,28 @@ def do_run_migrations(
         CURRENT_TENANT_ID_CONTEXTVAR.reset(token)
 
 
-def make_provide_iam_token_for_alembic(
-    target_url: str,
-) -> Callable[[Any, Any, Any, Any], None]:
-    """Build a `do_connect` listener bound to one database's coordinates.
+def create_migration_engine(target_url: str) -> AsyncEngine:
+    """Async engine for one database, with IAM bound to that database.
 
     An RDS IAM token is only valid for the host/port/user it was minted for, so the
-    listener has to close over the URL its engine actually connects to rather than
-    re-deriving it from process-wide settings.
+    listener is built from the URL this engine connects to rather than from the
+    process-wide POSTGRES_* settings.
     """
-    url = make_url(target_url)
-    host = url.host or POSTGRES_HOST
-    port = str(url.port) if url.port else POSTGRES_PORT
-    user = url.username or POSTGRES_USER
-
-    def provide_iam_token_for_alembic(
-        dialect: Any,  # noqa: ARG001
-        conn_rec: Any,  # noqa: ARG001
-        cargs: Any,  # noqa: ARG001
-        cparams: Any,
-    ) -> None:
-        cparams["password"] = get_iam_auth_token(host, port, user, AWS_REGION_NAME)
-        cparams["ssl"] = ssl_context
-
-    return provide_iam_token_for_alembic
-
-
-def create_migration_engine(target_url: str) -> AsyncEngine:
-    """Async engine for one database, with IAM bound to that database."""
     engine = create_async_engine(
         target_url,
         poolclass=pool.NullPool,
         connect_args={"ssl": create_pg_ssl_context()},
     )
     if USE_IAM_AUTH:
+        url = make_url(target_url)
         event.listen(
             engine.sync_engine,
             "do_connect",
-            make_provide_iam_token_for_alembic(target_url),
+            make_provide_iam_token_async(
+                url.host or POSTGRES_HOST,
+                str(url.port) if url.port else POSTGRES_PORT,
+                url.username or POSTGRES_USER,
+            ),
         )
     return engine
 
@@ -366,7 +347,7 @@ def _tenants_to_migrate(
 
     # The range is positional over *all* tenants, so it has to be applied before
     # partitioning — filtering per shard would select the range N times over.
-    all_tenants = sorted({t for ts in tenants_by_shard.values() for t in ts})
+    all_tenants = sorted(set(chain.from_iterable(tenants_by_shard.values())))
     selected = set(
         filter_tenants_by_range(all_tenants, tenant_range_start, tenant_range_end)
     )

--- a/backend/alembic/run_multitenant_migrations.py
+++ b/backend/alembic/run_multitenant_migrations.py
@@ -268,10 +268,13 @@ def main() -> int:
         print("Could not determine head revision.", file=sys.stderr)
         return 1
 
+    schemas_by_shard: dict[str, list[str]] = {}
     with SqlEngine.scoped_engine(pool_size=5, max_overflow=2):
+        # The prefix filter drops `public`, which enumeration reports as the sole
+        # "tenant" outside multi-tenant mode. That is what makes the hint below fire.
         tenants_by_shard = {
-            shard_name: [tid for tid in tenant_ids if tid.startswith(TENANT_ID_PREFIX)]
-            for shard_name, tenant_ids in get_tenant_ids_by_shard().items()
+            shard_name: [t for t in tenants if t.startswith(TENANT_ID_PREFIX)]
+            for shard_name, tenants in get_tenant_ids_by_shard().items()
         }
         total_tenants = sum(len(s) for s in tenants_by_shard.values())
 
@@ -284,12 +287,12 @@ def main() -> int:
 
         # Per shard: alembic_version lives in the schema, so each shard has to be
         # asked about its own tenants.
-        schemas_by_shard = {
-            shard_name: get_schemas_needing_migration(schemas, head_rev, shard_name)
-            for shard_name, schemas in tenants_by_shard.items()
-            if schemas
-        }
-        schemas_by_shard = {k: v for k, v in schemas_by_shard.items() if v}
+        for shard_name, tenants in tenants_by_shard.items():
+            if not tenants:
+                continue
+            needing = get_schemas_needing_migration(tenants, head_rev, shard_name)
+            if needing:
+                schemas_by_shard[shard_name] = needing
 
     total_to_migrate = sum(len(s) for s in schemas_by_shard.values())
     if not total_to_migrate:

--- a/backend/alembic/run_multitenant_migrations.py
+++ b/backend/alembic/run_multitenant_migrations.py
@@ -28,8 +28,8 @@ from alembic.config import Config
 from alembic.script import ScriptDirectory
 
 from onyx.db.engine.sql_engine import SqlEngine
-from onyx.db.engine.tenant_utils import get_all_tenant_ids
 from onyx.db.engine.tenant_utils import get_schemas_needing_migration
+from onyx.db.engine.tenant_utils import get_tenant_ids_by_shard
 from shared_configs.configs import TENANT_ID_PREFIX
 
 # ---------------------------------------------------------------------------
@@ -40,6 +40,11 @@ from shared_configs.configs import TENANT_ID_PREFIX
 class Args(NamedTuple):
     jobs: int
     batch_size: int
+
+
+class Batch(NamedTuple):
+    shard_name: str
+    schemas: list[str]
 
 
 class BatchResult(NamedTuple):
@@ -54,7 +59,7 @@ class BatchResult(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
-def run_alembic_for_batch(schemas: list[str]) -> BatchResult:
+def run_alembic_for_batch(batch: Batch) -> BatchResult:
     """Run ``alembic upgrade head`` for a batch of schemas in one subprocess.
 
     If the batch fails, it is automatically retried with ``-x continue=true``
@@ -62,8 +67,10 @@ def run_alembic_for_batch(schemas: list[str]) -> BatchResult:
     output (which contains alembic's per-schema error messages) is returned
     for diagnosis.
     """
+    schemas = batch.schemas
     csv = ",".join(schemas)
-    base_cmd = ["alembic", "-x", f"schemas={csv}"]
+    # `shard` pins the subprocess to the database holding these schemas.
+    base_cmd = ["alembic", "-x", f"schemas={csv}", "-x", f"shard={batch.shard_name}"]
 
     start = time.monotonic()
     result = subprocess.run(
@@ -105,19 +112,27 @@ def get_head_revision() -> str | None:
 
 
 def run_migrations_parallel(
-    schemas: list[str],
+    schemas_by_shard: dict[str, list[str]],
     max_workers: int,
     batch_size: int,
 ) -> bool:
-    """Chunk *schemas* into batches and run them in parallel.
+    """Chunk each shard's schemas into batches and run them in parallel.
+
+    Batches never span shards, so one subprocess talks to exactly one database.
 
     A background monitor thread prints a status line every 60 s listing
     which batches are still in-flight, making it easy to spot hung tenants.
     """
-    batches = [schemas[i : i + batch_size] for i in range(0, len(schemas), batch_size)]
+    batches = [
+        Batch(shard_name, shard_schemas[i : i + batch_size])
+        for shard_name, shard_schemas in sorted(schemas_by_shard.items())
+        for i in range(0, len(shard_schemas), batch_size)
+    ]
     total_batches = len(batches)
+    total_schemas = sum(len(s) for s in schemas_by_shard.values())
     print(
-        f"{len(schemas)} schemas in {total_batches} batch(es) with {max_workers} workers (batch size: {batch_size})...",
+        f"{total_schemas} schemas across {len(schemas_by_shard)} shard(s) in "
+        f"{total_batches} batch(es) with {max_workers} workers (batch size: {batch_size})...",
         flush=True,
     )
     all_success = True
@@ -161,11 +176,13 @@ def run_migrations_parallel(
     try:
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
 
-            def _run(batch_idx: int, batch: list[str]) -> BatchResult:
+            def _run(batch_idx: int, batch: Batch) -> BatchResult:
                 with lock:
-                    in_flight[batch_idx] = batch
+                    in_flight[batch_idx] = batch.schemas
                 print(
-                    f"Batch {batch_idx + 1}/{total_batches} started ({len(batch)} schemas): {', '.join(batch)}",
+                    f"Batch {batch_idx + 1}/{total_batches} started on shard "
+                    f"{batch.shard_name} ({len(batch.schemas)} schemas): "
+                    f"{', '.join(batch.schemas)}",
                     flush=True,
                 )
                 result = run_alembic_for_batch(batch)
@@ -252,30 +269,39 @@ def main() -> int:
         return 1
 
     with SqlEngine.scoped_engine(pool_size=5, max_overflow=2):
-        tenant_ids = get_all_tenant_ids()
-        tenant_schemas = [tid for tid in tenant_ids if tid.startswith(TENANT_ID_PREFIX)]
+        tenants_by_shard = {
+            shard_name: [tid for tid in tenant_ids if tid.startswith(TENANT_ID_PREFIX)]
+            for shard_name, tenant_ids in get_tenant_ids_by_shard().items()
+        }
+        total_tenants = sum(len(s) for s in tenants_by_shard.values())
 
-        if not tenant_schemas:
+        if not total_tenants:
             print(
                 "No tenant schemas found. Is MULTI_TENANT=true set?",
                 file=sys.stderr,
             )
             return 1
 
-        schemas_to_migrate = get_schemas_needing_migration(tenant_schemas, head_rev)
+        # Per shard: alembic_version lives in the schema, so each shard has to be
+        # asked about its own tenants.
+        schemas_by_shard = {
+            shard_name: get_schemas_needing_migration(schemas, head_rev, shard_name)
+            for shard_name, schemas in tenants_by_shard.items()
+            if schemas
+        }
+        schemas_by_shard = {k: v for k, v in schemas_by_shard.items() if v}
 
-    if not schemas_to_migrate:
-        print(
-            f"All {len(tenant_schemas)} tenants are already at head revision ({head_rev})."
-        )
+    total_to_migrate = sum(len(s) for s in schemas_by_shard.values())
+    if not total_to_migrate:
+        print(f"All {total_tenants} tenants are already at head revision ({head_rev}).")
         return 0
 
     print(
-        f"{len(schemas_to_migrate)}/{len(tenant_schemas)} tenants need migration (head: {head_rev})."
+        f"{total_to_migrate}/{total_tenants} tenants need migration (head: {head_rev})."
     )
 
     success = run_migrations_parallel(
-        schemas_to_migrate,
+        schemas_by_shard,
         max_workers=args.jobs,
         batch_size=args.batch_size,
     )

--- a/backend/onyx/db/engine/async_sql_engine.py
+++ b/backend/onyx/db/engine/async_sql_engine.py
@@ -9,14 +9,13 @@ from sqlalchemy import event, pool
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, create_async_engine
 
 from onyx.configs.app_configs import (
-    AWS_REGION_NAME,
     POSTGRES_API_SERVER_POOL_OVERFLOW,
     POSTGRES_API_SERVER_POOL_SIZE,
     POSTGRES_POOL_PRE_PING,
     POSTGRES_POOL_RECYCLE,
     POSTGRES_USE_NULL_POOL,
 )
-from onyx.db.engine.iam_auth import get_iam_auth_token
+from onyx.db.engine.iam_auth import make_provide_iam_token_async
 from onyx.db.engine.pg_ssl import create_pg_ssl_context
 from onyx.db.engine.shard_registry import (
     ShardSpec,
@@ -87,21 +86,11 @@ def _build_async_engine(spec: ShardSpec) -> AsyncEngine:
         # Bound to this shard's coordinates: an RDS IAM token is only valid for the
         # host/port/user it was minted for, so the global POSTGRES_* values would be
         # rejected for a shard on a different instance.
-        iam_host = spec.host
-        iam_port = spec.port
-        iam_user = spec.user
-
-        @event.listens_for(engine.sync_engine, "do_connect")
-        def provide_iam_token_async(
-            dialect: Any,  # noqa: ARG001
-            conn_rec: Any,  # noqa: ARG001
-            cargs: Any,  # noqa: ARG001
-            cparams: Any,
-        ) -> None:
-            # For async engine using asyncpg, we still need to set the IAM token here.
-            token = get_iam_auth_token(iam_host, iam_port, iam_user, AWS_REGION_NAME)
-            cparams["password"] = token
-            cparams["ssl"] = create_pg_ssl_context()
+        event.listen(
+            engine.sync_engine,
+            "do_connect",
+            make_provide_iam_token_async(spec.host, spec.port, spec.user),
+        )
 
     return engine
 
@@ -145,6 +134,19 @@ def get_sqlalchemy_async_engine() -> AsyncEngine:
     the default database regardless of where the tenant actually lives.
     """
     return get_async_engine_for_shard(get_default_shard_name())
+
+
+def abandon_async_engines() -> None:
+    """Drop the cached async engines without closing their connections.
+
+    For when the loop that owns them is gone — a forked child, or a test whose event
+    loop has been closed. Awaiting `dispose()` there fails, because asyncpg schedules
+    the close on the originating loop. Prefer `reset_sqlalchemy_async_engine` whenever
+    that loop is still running.
+    """
+    global _ASYNC_ENGINES
+    with _ASYNC_ENGINES_LOCK:
+        _ASYNC_ENGINES = {}
 
 
 async def reset_sqlalchemy_async_engine() -> None:

--- a/backend/onyx/db/engine/iam_auth.py
+++ b/backend/onyx/db/engine/iam_auth.py
@@ -62,6 +62,29 @@ def make_provide_iam_token(host: str, port: str, user: str) -> Any:
     return _provide
 
 
+def make_provide_iam_token_async(host: str, port: str, user: str) -> Any:
+    """`do_connect` handler for an asyncpg engine, bound to these coordinates.
+
+    Same scoping rule as `make_provide_iam_token`; separate because asyncpg takes an
+    `ssl` context where psycopg2 takes `sslmode`/`sslrootcert`.
+    """
+    from onyx.db.engine.pg_ssl import create_pg_ssl_context
+
+    def _provide(
+        dialect: Any,  # noqa: ARG001
+        conn_rec: Any,  # noqa: ARG001
+        cargs: Any,  # noqa: ARG001
+        cparams: Any,
+    ) -> None:
+        if not USE_IAM_AUTH:
+            return
+        region = os.getenv("AWS_REGION_NAME", "us-east-2")
+        cparams["password"] = get_iam_auth_token(host, port, user, region)
+        cparams["ssl"] = create_pg_ssl_context()
+
+    return _provide
+
+
 # The default engine's handler: the general one bound to the global coordinates.
 provide_iam_token = make_provide_iam_token(POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER)
 

--- a/backend/onyx/db/engine/shard_registry.py
+++ b/backend/onyx/db/engine/shard_registry.py
@@ -348,6 +348,15 @@ def get_shard_spec(shard_name: str) -> ShardSpec:
     return spec
 
 
+def validate_shard_name(shard_name: str) -> None:
+    """Raise unless this names a configured shard.
+
+    For callers that want the check without the spec, so a bad `-x shard=` fails at
+    argument-parsing time rather than after connecting somewhere unintended.
+    """
+    get_shard_spec(shard_name)
+
+
 def get_engine_for_shard(shard_name: str) -> Engine:
     return ShardRegistry.get_engine(shard_name)
 

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -1,8 +1,13 @@
 import re
 
 from sqlalchemy import text
+from sqlalchemy.engine import Engine
 
-from onyx.db.engine.sql_engine import SqlEngine, get_session_with_shared_schema
+from onyx.db.engine.shard_registry import (
+    get_default_shard_name,
+    get_engine_for_shard,
+    get_shard_specs,
+)
 from shared_configs.configs import (
     MULTI_TENANT,
     POSTGRES_DEFAULT_SCHEMA,
@@ -33,7 +38,7 @@ def validate_tenant_id(tenant_id: str) -> bool:
 
 
 def get_schemas_needing_migration(
-    tenant_schemas: list[str], head_rev: str
+    tenant_schemas: list[str], head_rev: str, shard_name: str
 ) -> list[str]:
     """Return only schemas whose current alembic version is not at head.
 
@@ -45,7 +50,9 @@ def get_schemas_needing_migration(
     if not tenant_schemas:
         return []
 
-    engine = SqlEngine.get_engine()
+    # Named rather than defaulted: alembic_version lives in the schema, so this has to
+    # read the database that actually holds these schemas.
+    engine = get_engine_for_shard(shard_name)
 
     with engine.connect() as conn:
         # Populate a temp input table with exactly the schemas we care about.
@@ -118,16 +125,10 @@ def get_schemas_needing_migration(
     return [s for s in tenant_schemas if version_by_schema.get(s) != head_rev]
 
 
-def get_all_tenant_ids() -> list[str]:
-    """Returning [None] means the only tenant is the 'public' or self hosted tenant."""
-
-    tenant_ids: list[str]
-
-    if not MULTI_TENANT:
-        return [POSTGRES_DEFAULT_SCHEMA]
-
-    with get_session_with_shared_schema() as session:
-        result = session.execute(
+def _tenant_schemas_on(engine: Engine) -> list[str]:
+    """Tenant schemas physically present in one database."""
+    with engine.connect() as connection:
+        result = connection.execute(
             text(
                 """
                 SELECT schema_name
@@ -136,9 +137,41 @@ def get_all_tenant_ids() -> list[str]:
             ),
             {"default_schema": POSTGRES_DEFAULT_SCHEMA},
         )
-        tenant_ids = [row[0] for row in result]
+        return [row[0] for row in result if validate_tenant_id(row[0])]
 
-    valid_tenants = [
-        tenant for tenant in tenant_ids if tenant is None or validate_tenant_id(tenant)
-    ]
-    return valid_tenants
+
+def get_tenant_ids_by_shard() -> dict[str, list[str]]:
+    """Tenant schemas on each configured shard, keyed by shard name.
+
+    Grouped by where a schema physically lives rather than by what `tenant_shard` says,
+    because the callers that need the grouping — migrations — must reach the database
+    actually holding the schema. A tenant mid-copy appears under both its old and its
+    new shard, which is the safe way round: it gets migrated in both places.
+    """
+    if not MULTI_TENANT:
+        return {get_default_shard_name(): [POSTGRES_DEFAULT_SCHEMA]}
+
+    return {
+        shard_name: _tenant_schemas_on(get_engine_for_shard(shard_name))
+        for shard_name in sorted(get_shard_specs())
+    }
+
+
+def get_all_tenant_ids() -> list[str]:
+    """Every tenant, across every shard.
+
+    Returning [POSTGRES_DEFAULT_SCHEMA] means the only tenant is the 'public' or self
+    hosted tenant. Enumerating a single shard would silently drop every tenant that has
+    been moved off it — they would keep working, but stop being scheduled any work.
+    """
+    if not MULTI_TENANT:
+        return [POSTGRES_DEFAULT_SCHEMA]
+
+    # Deduped: a tenant mid-copy exists on two shards but is still one tenant.
+    return sorted(
+        {
+            tenant_id
+            for tenant_ids in get_tenant_ids_by_shard().values()
+            for tenant_id in tenant_ids
+        }
+    )

--- a/backend/onyx/db/engine/tenant_utils.py
+++ b/backend/onyx/db/engine/tenant_utils.py
@@ -1,4 +1,5 @@
 import re
+from itertools import chain
 
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
@@ -168,10 +169,4 @@ def get_all_tenant_ids() -> list[str]:
         return [POSTGRES_DEFAULT_SCHEMA]
 
     # Deduped: a tenant mid-copy exists on two shards but is still one tenant.
-    return sorted(
-        {
-            tenant_id
-            for tenant_ids in get_tenant_ids_by_shard().values()
-            for tenant_id in tenant_ids
-        }
-    )
+    return sorted(set(chain.from_iterable(get_tenant_ids_by_shard().values())))

--- a/backend/tests/external_dependency_unit/db/test_shard_enumeration.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_enumeration.py
@@ -1,0 +1,302 @@
+"""Tenant enumeration across shards, exercised against two real databases.
+
+Enumeration is what tells beat which tenants to schedule and tells the migration
+runner which schemas to upgrade. Reading it from a single database silently drops
+every tenant that has been moved off that database: no error, they just stop being
+given work. These tests put schemas on two databases and check nothing is lost.
+
+A second database on the same server stands in for a second instance — the seam
+routes per-DSN, not per-host.
+"""
+
+from collections.abc import Generator
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from onyx.configs.app_configs import POSTGRES_DB
+from onyx.db.engine import shard_registry, tenant_utils
+from onyx.db.engine.shard_registry import get_engine_for_shard
+from onyx.db.engine.sql_engine import (
+    SYNC_DB_API,
+    SqlEngine,
+    build_connection_string,
+)
+from onyx.db.engine.tenant_utils import (
+    get_all_tenant_ids,
+    get_schemas_needing_migration,
+    get_tenant_ids_by_shard,
+)
+
+DEFAULT_SHARD = "default"
+SECOND_SHARD = "shard-enum-b"
+
+
+class _CapturedAlembicURL(Exception):
+    """Aborts a migration run once the database it targets is known."""
+
+    def __init__(self, url: str) -> None:
+        super().__init__(url)
+        self.url = url
+
+
+def _admin_engine() -> Engine:
+    """Engine on the `postgres` maintenance DB, for CREATE/DROP DATABASE."""
+    from sqlalchemy import create_engine
+
+    return create_engine(
+        build_connection_string(db_api=SYNC_DB_API, db="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+
+
+def _create_schema(engine: Engine, schema: str) -> None:
+    with engine.connect() as conn:
+        conn.execute(text(f'CREATE SCHEMA IF NOT EXISTS "{schema}"'))
+        conn.commit()
+
+
+def _drop_schema(engine: Engine, schema: str) -> None:
+    with engine.connect() as conn:
+        conn.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        conn.commit()
+
+
+def _stamp_alembic_version(engine: Engine, schema: str, revision: str) -> None:
+    """Mark a schema as sitting at `revision`, as a completed migration would."""
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                f'CREATE TABLE IF NOT EXISTS "{schema}".alembic_version '
+                "(version_num VARCHAR(32) NOT NULL PRIMARY KEY)"
+            )
+        )
+        conn.execute(text(f'DELETE FROM "{schema}".alembic_version'))
+        conn.execute(
+            text(f'INSERT INTO "{schema}".alembic_version VALUES (:rev)'),
+            {"rev": revision},
+        )
+        conn.commit()
+
+
+@pytest.fixture(scope="module")
+def second_database() -> Generator[str, None, None]:
+    """Create a throwaway second database for the duration of the module."""
+    db_name = f"onyx_enum_test_{uuid4().hex[:8]}"
+    admin = _admin_engine()
+    with admin.connect() as conn:
+        conn.execute(text(f'CREATE DATABASE "{db_name}"'))
+    try:
+        yield db_name
+    finally:
+        with admin.connect() as conn:
+            conn.execute(
+                text(
+                    "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                    "WHERE datname = :db AND pid <> pg_backend_pid()"
+                ),
+                {"db": db_name},
+            )
+            conn.execute(text(f'DROP DATABASE IF EXISTS "{db_name}"'))
+        admin.dispose()
+
+
+@pytest.fixture(scope="function")
+def two_shards(
+    second_database: str, monkeypatch: pytest.MonkeyPatch
+) -> Generator[dict[str, Any], None, None]:
+    """Two shards with one tenant schema on each.
+
+    Yields the tenant ids plus the name of the second database.
+    """
+    SqlEngine.init_engine(pool_size=5, max_overflow=2)
+
+    monkeypatch.setattr(
+        shard_registry,
+        "ONYX_DB_SHARDS_JSON",
+        f'{{"{SECOND_SHARD}": {{"db": "{second_database}"}}}}',
+    )
+    monkeypatch.setattr(shard_registry, "ONYX_DB_DEFAULT_SHARD", DEFAULT_SHARD)
+    monkeypatch.setattr(shard_registry, "ONYX_DB_CATALOG_SHARD", DEFAULT_SHARD)
+    # Enumeration short-circuits to the default schema outside multi-tenant mode.
+    monkeypatch.setattr(tenant_utils, "MULTI_TENANT", True)
+    shard_registry.reset_shard_specs()
+
+    tenant_a = f"tenant_{uuid4()}"
+    tenant_b = f"tenant_{uuid4()}"
+
+    _create_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_a)
+    _create_schema(get_engine_for_shard(SECOND_SHARD), tenant_b)
+
+    yield {"tenant_a": tenant_a, "tenant_b": tenant_b, "second_db": second_database}
+
+    _drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_a)
+    _drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_b)
+    shard_registry.reset_shard_specs()
+
+
+@pytest.fixture(scope="function")
+def one_shard(monkeypatch: pytest.MonkeyPatch) -> Generator[str, None, None]:
+    """No `ONYX_DB_SHARDS`, i.e. every deployment that exists today."""
+    SqlEngine.init_engine(pool_size=5, max_overflow=2)
+
+    monkeypatch.setattr(shard_registry, "ONYX_DB_SHARDS_JSON", "")
+    monkeypatch.setattr(shard_registry, "ONYX_DB_DEFAULT_SHARD", DEFAULT_SHARD)
+    monkeypatch.setattr(shard_registry, "ONYX_DB_CATALOG_SHARD", DEFAULT_SHARD)
+    monkeypatch.setattr(tenant_utils, "MULTI_TENANT", True)
+    shard_registry.reset_shard_specs()
+
+    tenant_id = f"tenant_{uuid4()}"
+    _create_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+
+    yield tenant_id
+
+    _drop_schema(get_engine_for_shard(DEFAULT_SHARD), tenant_id)
+    shard_registry.reset_shard_specs()
+
+
+def test_enumeration_spans_every_shard(two_shards: dict[str, Any]) -> None:
+    """The whole point: a tenant on the second database is still enumerated."""
+    all_tenants = get_all_tenant_ids()
+
+    assert two_shards["tenant_a"] in all_tenants
+    assert two_shards["tenant_b"] in all_tenants
+
+
+def test_grouping_reports_where_a_schema_physically_lives(
+    two_shards: dict[str, Any],
+) -> None:
+    by_shard = get_tenant_ids_by_shard()
+
+    assert set(by_shard) == {DEFAULT_SHARD, SECOND_SHARD}
+    assert two_shards["tenant_a"] in by_shard[DEFAULT_SHARD]
+    assert two_shards["tenant_a"] not in by_shard[SECOND_SHARD]
+    assert two_shards["tenant_b"] in by_shard[SECOND_SHARD]
+    assert two_shards["tenant_b"] not in by_shard[DEFAULT_SHARD]
+
+
+def test_tenant_present_on_two_shards_is_enumerated_once(
+    two_shards: dict[str, Any],
+) -> None:
+    """Mid-copy a schema exists on both its old and new shard. It is one tenant.
+
+    Beat schedules one set of tasks per returned id, so a duplicate would double up
+    every periodic task for that tenant.
+    """
+    tenant_a = two_shards["tenant_a"]
+    _create_schema(get_engine_for_shard(SECOND_SHARD), tenant_a)
+    try:
+        by_shard = get_tenant_ids_by_shard()
+        assert tenant_a in by_shard[DEFAULT_SHARD]
+        assert tenant_a in by_shard[SECOND_SHARD]
+
+        assert get_all_tenant_ids().count(tenant_a) == 1
+    finally:
+        _drop_schema(get_engine_for_shard(SECOND_SHARD), tenant_a)
+
+
+def test_non_tenant_schemas_are_excluded(two_shards: dict[str, Any]) -> None:
+    """Only schemas matching the tenant pattern count, on every shard."""
+    engine = get_engine_for_shard(SECOND_SHARD)
+    _create_schema(engine, "definitely_not_a_tenant")
+    try:
+        all_tenants = get_all_tenant_ids()
+        assert "definitely_not_a_tenant" not in all_tenants
+        assert "public" not in all_tenants
+        # The real tenant on that same shard is still found.
+        assert two_shards["tenant_b"] in all_tenants
+        assert "definitely_not_a_tenant" not in get_tenant_ids_by_shard()[SECOND_SHARD]
+    finally:
+        _drop_schema(engine, "definitely_not_a_tenant")
+
+
+def test_single_shard_enumeration_is_unchanged(one_shard: str) -> None:
+    """With no sharding configured, enumeration is one query against one database."""
+    by_shard = get_tenant_ids_by_shard()
+
+    assert set(by_shard) == {DEFAULT_SHARD}
+    assert one_shard in by_shard[DEFAULT_SHARD]
+    assert get_all_tenant_ids() == sorted(by_shard[DEFAULT_SHARD])
+
+
+def test_migration_check_reads_the_named_shard(two_shards: dict[str, Any]) -> None:
+    """`get_schemas_needing_migration` must consult the shard holding the schema.
+
+    It previously always used the default engine. A tenant already at head on another
+    shard looks unmigrated from there — its schema isn't visible at all — so the
+    runner would keep re-targeting it forever.
+    """
+    tenant_b = two_shards["tenant_b"]
+    head = "abc123def456"
+    _stamp_alembic_version(get_engine_for_shard(SECOND_SHARD), tenant_b, head)
+
+    assert get_schemas_needing_migration([tenant_b], head, SECOND_SHARD) == []
+    assert get_schemas_needing_migration([tenant_b], head, DEFAULT_SHARD) == [tenant_b]
+
+
+def test_alembic_shard_option_selects_that_database(
+    two_shards: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`-x shard=<name>` must change the database alembic connects to.
+
+    Asserting on a generated URL is not enough — env.py builds its own engine, and a
+    previous version of this seam accepted a target it then ignored. This intercepts
+    `create_async_engine` inside the real alembic -> env.py path and aborts as soon
+    as the target is known, so the migration tree never has to run.
+    """
+    import os
+
+    import sqlalchemy.ext.asyncio as sa_asyncio
+    from alembic import command
+    from alembic.config import Config
+
+    def _capture(url: Any, *_: Any, **__: Any) -> Any:
+        raise _CapturedAlembicURL(str(url))
+
+    # env.py imports `create_async_engine` at module scope and alembic re-executes
+    # env.py per run, so patching the source module is picked up by the real path.
+    monkeypatch.setattr(sa_asyncio, "create_async_engine", _capture)
+
+    root_dir = os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..", "..", "..")
+    )
+
+    for shard_name, expected_db in (
+        (DEFAULT_SHARD, POSTGRES_DB),
+        (SECOND_SHARD, two_shards["second_db"]),
+    ):
+        cfg = Config(os.path.join(root_dir, "alembic.ini"))
+        cfg.set_main_option("script_location", os.path.join(root_dir, "alembic"))
+        cfg.attributes["configure_logger"] = False
+        cfg.cmd_opts = _x_args(
+            [f"schemas={two_shards['tenant_a']}", f"shard={shard_name}"]
+        )
+
+        captured: str | None = None
+        try:
+            command.upgrade(cfg, "head")
+        except Exception as e:
+            captured = _unwrap_captured_url(e)
+
+        assert captured is not None, f"never reached engine creation for {shard_name}"
+        assert captured.endswith(f"/{expected_db}"), (
+            f"-x shard={shard_name} targeted {captured}, expected database {expected_db}"
+        )
+
+
+def _x_args(x: list[str]) -> Any:
+    from types import SimpleNamespace
+
+    return SimpleNamespace(x=x)
+
+
+def _unwrap_captured_url(exc: BaseException) -> str | None:
+    cause: BaseException | None = exc
+    while cause is not None:
+        if isinstance(cause, _CapturedAlembicURL):
+            return cause.url
+        cause = cause.__cause__ or cause.__context__
+    return None

--- a/backend/tests/external_dependency_unit/db/test_shard_routing.py
+++ b/backend/tests/external_dependency_unit/db/test_shard_routing.py
@@ -9,11 +9,12 @@ routes per-DSN, not per-host, so a second database is a faithful stand-in for a
 second instance and keeps the tests self-contained.
 """
 
-from collections.abc import Generator
+from collections.abc import AsyncGenerator, Generator
 from typing import Any
 from uuid import uuid4
 
 import pytest
+import pytest_asyncio
 from sqlalchemy import Column, Integer, MetaData, String, Table, select, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import OperationalError, ProgrammingError
@@ -754,9 +755,31 @@ def test_sqlalchemy_url_option_is_still_ignored_by_env_py(
     )
 
 
+@pytest_asyncio.fixture
+async def isolated_async_engines() -> AsyncGenerator[None, None]:
+    """Async engines belonging to *this* test's event loop.
+
+    asyncpg binds a pool to the loop that created it, and pytest-asyncio gives every
+    test a fresh loop. An engine cached by an earlier test therefore belongs to a
+    closed loop: using it raises "attached to a different loop", and disposing it
+    raises "Event loop is closed" because asyncpg schedules the close there. So drop
+    whatever is cached on the way in without touching it, and dispose properly on the
+    way out, when the engines do belong to this loop.
+    """
+    from onyx.db.engine.async_sql_engine import (
+        abandon_async_engines,
+        reset_sqlalchemy_async_engine,
+    )
+
+    abandon_async_engines()
+    yield
+    await reset_sqlalchemy_async_engine()
+
+
 @pytest.mark.asyncio
 async def test_async_sessions_reach_different_physical_databases(
     two_shards: dict[str, Any],
+    isolated_async_engines: None,  # noqa: ARG001
 ) -> None:
     """Async sessions must route by shard, not just by schema.
 
@@ -764,42 +787,27 @@ async def test_async_sessions_reach_different_physical_databases(
     PAT, SAML, and token-refresh work for a migrated tenant would read a stale
     schema on the old database and write to an abandoned copy.
     """
-    from onyx.db.engine.async_sql_engine import (
-        get_async_session_context_manager,
-        reset_sqlalchemy_async_engine,
-    )
+    from onyx.db.engine.async_sql_engine import get_async_session_context_manager
 
-    try:
-        async with get_async_session_context_manager(two_shards["tenant_a"]) as session:
-            db_a = str(
-                (await session.execute(text("SELECT current_database()"))).scalar()
-            )
-        async with get_async_session_context_manager(two_shards["tenant_b"]) as session:
-            db_b = str(
-                (await session.execute(text("SELECT current_database()"))).scalar()
-            )
+    async with get_async_session_context_manager(two_shards["tenant_a"]) as session:
+        db_a = str((await session.execute(text("SELECT current_database()"))).scalar())
+    async with get_async_session_context_manager(two_shards["tenant_b"]) as session:
+        db_b = str((await session.execute(text("SELECT current_database()"))).scalar())
 
-        assert db_a == POSTGRES_DB
-        assert db_b == two_shards["second_db"]
-        assert db_a != db_b
-    finally:
-        # Async pools are bound to this test's event loop; leaving them open leaks
-        # connections and makes a later test fail depending on selection order.
-        await reset_sqlalchemy_async_engine()
+    assert db_a == POSTGRES_DB
+    assert db_b == two_shards["second_db"]
+    assert db_a != db_b
 
 
 @pytest.mark.asyncio
-async def test_async_engine_is_reused_per_shard(two_shards: dict[str, Any]) -> None:
+async def test_async_engine_is_reused_per_shard(
+    two_shards: dict[str, Any],
+    isolated_async_engines: None,  # noqa: ARG001
+) -> None:
     """One engine per shard, not one per call — pools must not multiply."""
-    from onyx.db.engine.async_sql_engine import (
-        get_async_engine_for_tenant,
-        reset_sqlalchemy_async_engine,
-    )
+    from onyx.db.engine.async_sql_engine import get_async_engine_for_tenant
 
-    try:
-        first = await get_async_engine_for_tenant(two_shards["tenant_b"])
-        second = await get_async_engine_for_tenant(two_shards["tenant_b"])
-        assert first is second
-        assert first is not await get_async_engine_for_tenant(two_shards["tenant_a"])
-    finally:
-        await reset_sqlalchemy_async_engine()
+    first = await get_async_engine_for_tenant(two_shards["tenant_b"])
+    second = await get_async_engine_for_tenant(two_shards["tenant_b"])
+    assert first is second
+    assert first is not await get_async_engine_for_tenant(two_shards["tenant_a"])

--- a/backend/tests/integration/multitenant_tests/test_get_schemas_needing_migration.py
+++ b/backend/tests/integration/multitenant_tests/test_get_schemas_needing_migration.py
@@ -18,6 +18,7 @@ import pytest
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
+from onyx.db.engine.shard_registry import get_default_shard_name
 from onyx.db.engine.sql_engine import SqlEngine
 from onyx.db.engine.tenant_utils import get_schemas_needing_migration
 
@@ -134,7 +135,9 @@ def test_classifies_all_cases(
     - stale rev    → included (needs migration)
     """
     all_schemas = [tenant_schema_at_head, tenant_schema_empty, tenant_schema_stale_rev]
-    result = get_schemas_needing_migration(all_schemas, current_head_rev)
+    result = get_schemas_needing_migration(
+        all_schemas, current_head_rev, get_default_shard_name()
+    )
 
     assert tenant_schema_at_head not in result
     assert tenant_schema_empty in result
@@ -153,12 +156,19 @@ def test_idempotent(
     """
     schemas = [tenant_schema_at_head, tenant_schema_empty]
 
-    first = get_schemas_needing_migration(schemas, current_head_rev)
-    second = get_schemas_needing_migration(schemas, current_head_rev)
+    first = get_schemas_needing_migration(
+        schemas, current_head_rev, get_default_shard_name()
+    )
+    second = get_schemas_needing_migration(
+        schemas, current_head_rev, get_default_shard_name()
+    )
 
     assert first == second
 
 
 def test_empty_input(current_head_rev: str) -> None:
     """An empty input list returns immediately without touching the DB."""
-    assert get_schemas_needing_migration([], current_head_rev) == []
+    assert (
+        get_schemas_needing_migration([], current_head_rev, get_default_shard_name())
+        == []
+    )


### PR DESCRIPTION
## Description

Follow-up to #13368, which added the tenant → database routing seam. That PR routed
*sessions*. This one fixes *enumeration*, which was still single-database.

`get_all_tenant_ids()` listed schemas from `information_schema.schemata` on the catalog
database. That is right only while every tenant lives there. Once a tenant is moved to
another shard, its schema is gone from the database being asked, so it drops out of the
list — no error, it just stops being handed work. The callers that matter:

- `celery/apps/beat.py` — the `DynamicTenantScheduler`. A dropped tenant stops being
  scheduled for indexing, pruning and sync.
- `monitoring/tasks.py`, `ee/.../cloud/tasks.py`
- `onyxbot/slack/listener.py`, `onyxbot/discord/cache.py`
- `alembic/env.py`, `alembic/run_multitenant_migrations.py`
- four scripts under `backend/scripts/`

Enumeration now unions every configured shard, and `get_tenant_ids_by_shard()` exposes
the grouping. Both are keyed on where a schema physically lives rather than on the
`tenant_shard` map, because the consumer that needs the grouping is migrations, which
must reach the database actually holding the schema. A tenant mid-copy shows up under
both shards and gets migrated in both — the safe way round — while
`get_all_tenant_ids()` dedupes so beat still schedules it once.

Fixing the primitive is what makes the 11 call sites above correct; none of them
needed changing.

Migrations then follow the same axis:

- `-x shard=<name>` pins an alembic run to one database.
- `upgrade_all_tenants` builds one engine per shard instead of running every tenant
  against the default.
- `get_schemas_needing_migration()` takes the shard to read. It reads `alembic_version`
  *inside each schema*, so asking the wrong database reports an already-migrated tenant
  as unmigrated, forever.
- The tenant range filter is applied before partitioning by shard. Filtering per shard
  would select the range once per database.
- Offline mode refuses to run across shards — it emits one SQL script, which can only
  be applied to one database.

Also binds the alembic IAM listener to the URL its engine connects to. It derived
host/port/user from process-wide settings, which mints a token for the wrong host as
soon as a shard is on a different instance.

**Unchanged with one shard**, which is every deployment today: the union degenerates to
the same single query, and every call site keeps its current behaviour.

Resolves the bulk-migration finding raised on #13368 and the all-tenant enumeration gap
deferred there.

## How Has This Been Tested?

New `backend/tests/external_dependency_unit/db/test_shard_enumeration.py` (7 tests)
runs against two real databases:

- a tenant on the second database is still enumerated
- grouping reports where each schema physically lives
- a tenant present on both shards mid-copy is enumerated once
- non-tenant schemas excluded on every shard
- single-shard enumeration unchanged
- `get_schemas_needing_migration` consults the named shard — a tenant at head on
  another shard is reported as needing migration when the default is asked
- `-x shard=<name>` actually changes the database alembic connects to, asserted by
  intercepting `create_async_engine` inside the real alembic → `env.py` path rather
  than by inspecting a generated URL

Mutation-tested — each of the three fixes fails the suite when reverted:

| mutation | result |
|---|---|
| enumerate only the default shard | caught |
| ignore `shard_name` in the migration check | caught |
| drop the shard from the alembic URL | caught |

Also run: the 4 `test_run_multitenant_migrations.py` integration tests (real subprocess
against a live deployment), 466 db/onyxbot unit tests, and the full
`external_dependency_unit/db/` directory — its 17 failures are identical on `main` and
on this branch (pre-existing, unrelated files).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enumerates tenants across all shards and makes `alembic` and the migration runner shard-aware so scheduling and migrations stay correct after tenants move. Single‑shard deployments behave the same.

- **New Features**
  - `get_all_tenant_ids()` now unions tenants across every shard; `get_tenant_ids_by_shard()` groups them by the database that physically holds each schema. Mid-copy tenants appear on both shards; the union dedupes.
  - Alembic is shard-aware: `-x shard=<name>` targets a specific DB (validated); `upgrade_all_tenants` migrates per shard; `get_schemas_needing_migration(…, shard)` reads the right DB; offline runs require one `shard`. IAM auth binds tokens to the engine’s URL.
  - The multi-tenant migration runner groups tenants by shard and passes `-x shard=<name>` to each batch; batches never span shards.

- **Refactors**
  - Introduced `make_provide_iam_token_async` and reused it in `alembic` and async engines to remove duplicate IAM listeners.
  - Added `validate_shard_name()` to fail fast on bad `-x shard` inputs.

<sup>Written for commit cef0aee07ff4104c0873b7316072381ae9adbff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

