### PR TITLE
fix(slack): resolve workspace metadata lazily instead of on credential load

### DIFF
--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -1061,35 +1061,24 @@ class SlackConnector(
             self._workspace_metadata = self._resolve_workspace_metadata(self.client)
 
     def _resolve_workspace_metadata(self, client: WebClient) -> _WorkspaceMetadata:
-        try:
-            auth_response = client.auth_test()
-        except Exception as e:
-            logger.warning("Failed to get workspace URL from auth_test: %s", e)
-            return _WorkspaceMetadata()
+        """Fails closed: nothing is cached and the index attempt surfaces the error.
+
+        Grid public-channel ACLs derive from ``team_id_to_user_emails``, and
+        ``get_channel_access`` falls back to org-wide ``is_public=True`` when it
+        is empty. Swallowing a failure here would silently widen
+        workspace-scoped permissions, so only cosmetic lookups may degrade.
+        """
+        auth_response = client.auth_test()
 
         url = auth_response.get("url")
         if not auth_response.get("enterprise_id"):
             return _WorkspaceMetadata(url=url)
 
-        try:
-            team_ids = list_grid_team_ids(client)
-        except SlackApiError as e:
-            logger.warning(
-                "auth.teams.list failed on Grid org: %s", e.response.get("error", "")
-            )
-            team_ids = []
-
+        team_ids = list_grid_team_ids(client)
         team_id_to_url = self._fetch_team_urls(client, team_ids) if team_ids else {}
-        team_id_to_user_emails: dict[str, set[str]] = {}
-        if team_ids:
-            try:
-                team_id_to_user_emails = fetch_team_user_emails(client, team_ids)
-            except SlackApiError as e:
-                # Grid public-channel access stays org-wide instead of per-workspace.
-                logger.warning(
-                    "users.list per-team failed on Grid org: %s",
-                    e.response.get("error", ""),
-                )
+        team_id_to_user_emails = (
+            fetch_team_user_emails(client, team_ids) if team_ids else {}
+        )
 
         logger.info(
             "Slack Enterprise Grid detected: teams=%s urls_resolved=%s users_scoped=%s",
@@ -1513,9 +1502,13 @@ class SlackConnector(
                     f"Slack API returned a failure: {error_msg}"
                 )
 
-            # 3) Grid: verify team:read by calling auth.teams.list
+            # 3) Grid: verify team:read, and the users scopes that public-channel
+            # ACLs depend on, so a missing scope fails here instead of at index time.
             if auth_response.get("enterprise_id"):
-                self.fast_client.auth_teams_list(limit=1)
+                teams_response = self.fast_client.auth_teams_list(limit=1)
+                teams = teams_response.get("teams", [])
+                if teams:
+                    self.fast_client.users_list(team_id=teams[0]["id"], limit=1)
 
             # 4) If channels are specified and regex is not enabled, verify each is accessible
             # NOTE: removed this for now since it may be too slow for large workspaces which may
@@ -1562,6 +1555,12 @@ class SlackConnector(
                         "Slack Enterprise Grid org detected but the bot token "
                         "lacks the `team:read` scope required to list workspaces "
                         "(auth.teams.list)."
+                    )
+                if needed_scope in ("users:read", "users:read.email"):
+                    raise InsufficientPermissionsError(
+                        "Slack Enterprise Grid org detected but the bot token "
+                        f"lacks the `{needed_scope}` scope required to scope "
+                        "public channels to workspace members (users.list)."
                     )
                 raise InsufficientPermissionsError(
                     "Slack bot token lacks the necessary scope to list/access channels. "

--- a/backend/onyx/connectors/slack/connector.py
+++ b/backend/onyx/connectors/slack/connector.py
@@ -2,6 +2,7 @@ import contextvars
 import copy
 import itertools
 import re
+import threading
 from collections.abc import Callable, Generator
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
@@ -11,7 +12,7 @@ from typing import Any, cast
 from urllib.error import URLError
 from urllib.parse import urlparse
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from slack_sdk.http_retry import ConnectionErrorRetryHandler, RetryHandler
@@ -797,6 +798,18 @@ def _process_message(
         )
 
 
+class _WorkspaceMetadata(BaseModel):
+    """Workspace URL and Enterprise Grid topology for a single bot token."""
+
+    model_config = ConfigDict(frozen=True)
+
+    url: str | None = None
+    is_grid: bool = False
+    team_ids: list[str] = []
+    team_id_to_url: dict[str, str] = {}
+    team_id_to_user_emails: dict[str, set[str]] = {}
+
+
 class SlackConnector(
     SlimConnectorWithPermSync,
     CredentialsConnector,
@@ -853,25 +866,33 @@ class SlackConnector(
         self.credentials_provider: CredentialsProviderInterface | None = None
         self.credential_prefix: str | None = None
         self.use_redis: bool = use_redis
-        self._workspace_url: str | None = None
-        self._is_grid: bool = False
-        self._team_ids: list[str] = []
-        self._team_id_to_url: dict[str, str] = {}
-        self._team_id_to_user_emails: dict[str, set[str]] = {}
+        # None until _ensure_workspace_metadata() resolves it.
+        self._workspace_metadata: _WorkspaceMetadata | None = None
+        self._workspace_metadata_lock = threading.Lock()
         # self.delay_lock: str | None = None  # the redis key for the shared lock
         # self.delay_key: str | None = None  # the redis key for the shared delay
 
     @property
+    def workspace_url(self) -> str | None:
+        metadata = self._workspace_metadata
+        return metadata.url if metadata else None
+
+    @property
     def grid_team_ids(self) -> list[str] | None:
-        return self._team_ids if self._is_grid else None
+        metadata = self._workspace_metadata
+        return metadata.team_ids if metadata and metadata.is_grid else None
 
     @property
     def grid_team_id_to_url(self) -> dict[str, str] | None:
-        return self._team_id_to_url if self._is_grid else None
+        metadata = self._workspace_metadata
+        return metadata.team_id_to_url if metadata and metadata.is_grid else None
 
     @property
     def grid_team_id_to_user_emails(self) -> dict[str, set[str]] | None:
-        return self._team_id_to_user_emails if self._is_grid else None
+        metadata = self._workspace_metadata
+        return (
+            metadata.team_id_to_user_emails if metadata and metadata.is_grid else None
+        )
 
     @classmethod
     @override
@@ -1016,67 +1037,92 @@ class SlackConnector(
         self.text_cleaner = SlackTextCleaner(client=self.client)
         self.credentials_provider = credentials_provider
 
-        is_grid = False
+        with self._workspace_metadata_lock:
+            self._workspace_metadata = None
+
+    def _ensure_workspace_metadata(self) -> None:
+        """Resolves workspace metadata once, for the indexing paths.
+
+        Deliberately not resolved in ``set_credentials_provider``: validation
+        instantiates the connector but never reads this metadata, and
+        ``self.client`` serializes on a Redis lock shared with running indexing
+        jobs, so resolving eagerly lets a rate-limited indexing job block
+        connector creation for the length of its backoff.
+
+        ``workspace_url`` and the ``grid_*`` properties are plain accessors, so
+        every entry point that reads them must call this first.
+        """
+        if self._workspace_metadata is not None:
+            return
+
+        with self._workspace_metadata_lock:
+            if self._workspace_metadata is not None or self.client is None:
+                return
+            self._workspace_metadata = self._resolve_workspace_metadata(self.client)
+
+    def _resolve_workspace_metadata(self, client: WebClient) -> _WorkspaceMetadata:
         try:
-            auth_response = self.client.auth_test()
-            self._workspace_url = auth_response.get("url")
-            is_grid = bool(auth_response.get("enterprise_id"))
+            auth_response = client.auth_test()
         except Exception as e:
             logger.warning("Failed to get workspace URL from auth_test: %s", e)
-            self._workspace_url = None
+            return _WorkspaceMetadata()
 
-        self._is_grid = is_grid
-        self._team_ids = []
-        self._team_id_to_url = {}
-        self._team_id_to_user_emails = {}
-        if self._is_grid and self.client is not None:
+        url = auth_response.get("url")
+        if not auth_response.get("enterprise_id"):
+            return _WorkspaceMetadata(url=url)
+
+        try:
+            team_ids = list_grid_team_ids(client)
+        except SlackApiError as e:
+            logger.warning(
+                "auth.teams.list failed on Grid org: %s", e.response.get("error", "")
+            )
+            team_ids = []
+
+        team_id_to_url = self._fetch_team_urls(client, team_ids) if team_ids else {}
+        team_id_to_user_emails: dict[str, set[str]] = {}
+        if team_ids:
             try:
-                self._team_ids = list_grid_team_ids(self.client)
+                team_id_to_user_emails = fetch_team_user_emails(client, team_ids)
             except SlackApiError as e:
+                # Grid public-channel access stays org-wide instead of per-workspace.
                 logger.warning(
-                    "auth.teams.list failed on Grid org: %s",
+                    "users.list per-team failed on Grid org: %s",
                     e.response.get("error", ""),
                 )
-                self._team_ids = []
-            if self._team_ids:
-                grid_client = self.client
-                with ThreadPoolExecutor(
-                    max_workers=min(8, len(self._team_ids))
-                ) as executor:
-                    url_futures = {
-                        executor.submit(fetch_team_url, grid_client, tid): tid
-                        for tid in self._team_ids
-                    }
-                    for future in as_completed(url_futures):
-                        tid = url_futures[future]
-                        try:
-                            url = future.result()
-                        except Exception as e:
-                            # swallow per-team failures so one bad team.info doesn't abort init
-                            logger.warning(
-                                "team.info failed for team_id=%s: %s", tid, e
-                            )
-                            continue
-                        if url:
-                            self._team_id_to_url[tid] = url
+
+        logger.info(
+            "Slack Enterprise Grid detected: teams=%s urls_resolved=%s users_scoped=%s",
+            len(team_ids),
+            len(team_id_to_url),
+            sum(len(v) for v in team_id_to_user_emails.values()),
+        )
+        return _WorkspaceMetadata(
+            url=url,
+            is_grid=True,
+            team_ids=team_ids,
+            team_id_to_url=team_id_to_url,
+            team_id_to_user_emails=team_id_to_user_emails,
+        )
+
+    @staticmethod
+    def _fetch_team_urls(client: WebClient, team_ids: list[str]) -> dict[str, str]:
+        team_id_to_url: dict[str, str] = {}
+        with ThreadPoolExecutor(max_workers=min(8, len(team_ids))) as executor:
+            futures = {
+                executor.submit(fetch_team_url, client, tid): tid for tid in team_ids
+            }
+            for future in as_completed(futures):
+                tid = futures[future]
                 try:
-                    self._team_id_to_user_emails = fetch_team_user_emails(
-                        grid_client, self._team_ids
-                    )
-                except SlackApiError as e:
-                    # Public-channel access on Grid stays org-wide instead of
-                    # per-workspace if this fails. Surfaced via missing_scope etc.
-                    logger.warning(
-                        "users.list per-team failed on Grid org: %s",
-                        e.response.get("error", ""),
-                    )
-                    self._team_id_to_user_emails = {}
-            logger.info(
-                "Slack Enterprise Grid detected: teams=%s urls_resolved=%s users_scoped=%s",
-                len(self._team_ids),
-                len(self._team_id_to_url),
-                sum(len(v) for v in self._team_id_to_user_emails.values()),
-            )
+                    url = future.result()
+                except Exception as e:
+                    # one bad team.info must not abort the whole resolution
+                    logger.warning("team.info failed for team_id=%s: %s", tid, e)
+                    continue
+                if url:
+                    team_id_to_url[tid] = url
+        return team_id_to_url
 
     def retrieve_all_slim_docs_perm_sync(
         self,
@@ -1087,6 +1133,8 @@ class SlackConnector(
         if self.client is None:
             raise ConnectorMissingCredentialError("Slack")
 
+        self._ensure_workspace_metadata()
+
         return _get_all_doc_ids(
             client=self.client,
             channels_to_include=self.channels,
@@ -1095,7 +1143,7 @@ class SlackConnector(
             exclude_regex_enabled=self.exclude_channel_regex_enabled,
             msg_filter_func=self.msg_filter_func,
             callback=callback,
-            workspace_url=self._workspace_url,
+            workspace_url=self.workspace_url,
             start=start,
             end=end,
             team_ids=self.grid_team_ids,
@@ -1127,14 +1175,17 @@ class SlackConnector(
         if self.client is None or self.text_cleaner is None:
             raise ConnectorMissingCredentialError("Slack")
 
+        self._ensure_workspace_metadata()
+
         checkpoint = copy.deepcopy(checkpoint)
 
         # if this is the very first time we've called this, need to
         # get all relevant channels and save them into the checkpoint
         if checkpoint.channel_ids is None:
-            if self._is_grid and self._team_ids:
+            grid_team_ids = self.grid_team_ids
+            if grid_team_ids:
                 raw_channels = get_channels_across_teams(
-                    client=self.client, team_ids=self._team_ids
+                    client=self.client, team_ids=grid_team_ids
                 )
             else:
                 raw_channels = get_channels(self.client)
@@ -1210,7 +1261,7 @@ class SlackConnector(
                 yield _channel_to_hierarchy_node(
                     channel,
                     checkpoint.current_channel_access,
-                    self._workspace_url,
+                    self.workspace_url,
                     team_id_to_url=self.grid_team_id_to_url,
                 )
 

--- a/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_enterprise_grid.py
@@ -14,6 +14,7 @@ from onyx.connectors.slack.connector import (
     SlackConnector,
     _channel_team_id,
     _channel_to_hierarchy_node,
+    _WorkspaceMetadata,
     channel_team_ids,
     fetch_team_url,
     get_channels_across_teams,
@@ -296,10 +297,12 @@ class TestSlackConnectorGridProperties:
         team_id_to_user_emails: dict[str, set[str]],
     ) -> SlackConnector:
         c = SlackConnector(channels=None, use_redis=False)
-        c._is_grid = is_grid
-        c._team_ids = team_ids
-        c._team_id_to_url = team_id_to_url
-        c._team_id_to_user_emails = team_id_to_user_emails
+        c._workspace_metadata = _WorkspaceMetadata(
+            is_grid=is_grid,
+            team_ids=team_ids,
+            team_id_to_url=team_id_to_url,
+            team_id_to_user_emails=team_id_to_user_emails,
+        )
         return c
 
     def test_grid_properties_return_underlying_fields_on_grid(self) -> None:

--- a/backend/tests/unit/onyx/connectors/slack/test_lazy_workspace_metadata.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_lazy_workspace_metadata.py
@@ -10,6 +10,10 @@ that client, and that the exposed properties stay side-effect free.
 
 from unittest.mock import MagicMock, patch
 
+import pytest
+from slack_sdk.errors import SlackApiError
+
+from onyx.connectors.exceptions import InsufficientPermissionsError
 from onyx.connectors.slack.connector import SlackConnector
 
 _AUTH_NON_GRID = {"url": "https://workspace.slack.com"}
@@ -78,15 +82,56 @@ class TestLazyResolution:
         assert connector.workspace_url == "https://workspace.slack.com"
         client.auth_test.assert_called_once()
 
-    def test_failed_resolution_is_not_retried(self) -> None:
+    def test_failed_resolution_raises_and_caches_nothing(self) -> None:
+        """Fails closed: an empty Grid mapping would widen public-channel ACLs."""
         connector, client, _ = _connector()
-        client.auth_test.side_effect = Exception("rate limited")
+        client.auth_test.side_effect = SlackApiError("boom", MagicMock())
 
-        connector._ensure_workspace_metadata()
-        connector._ensure_workspace_metadata()
+        with pytest.raises(SlackApiError):
+            connector._ensure_workspace_metadata()
 
-        assert connector.workspace_url is None
-        client.auth_test.assert_called_once()
+        assert connector._workspace_metadata is None
+
+        client.auth_test.side_effect = None
+        client.auth_test.return_value = _AUTH_NON_GRID
+        connector._ensure_workspace_metadata()
+        assert connector.workspace_url == "https://workspace.slack.com"
+
+    def test_grid_team_enumeration_failure_raises(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.return_value = _AUTH_GRID
+
+        with patch(
+            "onyx.connectors.slack.connector.list_grid_team_ids",
+            side_effect=SlackApiError("missing_scope", MagicMock()),
+        ):
+            with pytest.raises(SlackApiError):
+                connector._ensure_workspace_metadata()
+
+        assert connector._workspace_metadata is None
+
+    def test_grid_user_email_failure_raises(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.return_value = _AUTH_GRID
+
+        with (
+            patch(
+                "onyx.connectors.slack.connector.list_grid_team_ids",
+                return_value=["T1"],
+            ),
+            patch(
+                "onyx.connectors.slack.connector.fetch_team_url",
+                return_value="https://t1.slack.com",
+            ),
+            patch(
+                "onyx.connectors.slack.connector.fetch_team_user_emails",
+                side_effect=SlackApiError("missing_scope", MagicMock()),
+            ),
+        ):
+            with pytest.raises(SlackApiError):
+                connector._ensure_workspace_metadata()
+
+        assert connector._workspace_metadata is None
 
     def test_new_credentials_invalidate_cached_metadata(self) -> None:
         connector, client, _ = _connector()
@@ -137,6 +182,41 @@ class TestLazyGridResolution:
         assert connector.grid_team_id_to_user_emails == {"T1": {"a@example.com"}}
         list_teams.assert_called_once()
         client.auth_test.assert_called_once()
+
+    def test_validation_probes_users_scope_on_grid(self) -> None:
+        connector, _, fast_client = _connector()
+        fast_client.auth_test.return_value = {"ok": True, "enterprise_id": "E1"}
+        fast_client.conversations_list.return_value = {"ok": True}
+        fast_client.auth_teams_list.return_value = {"teams": [{"id": "T1"}]}
+
+        connector.validate_connector_settings()
+
+        fast_client.users_list.assert_called_once_with(team_id="T1", limit=1)
+
+    def test_validation_surfaces_missing_users_scope(self) -> None:
+        connector, _, fast_client = _connector()
+        fast_client.auth_test.return_value = {"ok": True, "enterprise_id": "E1"}
+        fast_client.conversations_list.return_value = {"ok": True}
+        fast_client.auth_teams_list.return_value = {"teams": [{"id": "T1"}]}
+        error_response = MagicMock()
+        error_response.get.side_effect = lambda key, default=None: {
+            "error": "missing_scope",
+            "needed": "users:read.email",
+        }.get(key, default)
+        fast_client.users_list.side_effect = SlackApiError("boom", error_response)
+
+        with pytest.raises(InsufficientPermissionsError, match="users:read.email"):
+            connector.validate_connector_settings()
+
+    def test_validation_skips_users_probe_off_grid(self) -> None:
+        connector, _, fast_client = _connector()
+        fast_client.auth_test.return_value = {"ok": True}
+        fast_client.conversations_list.return_value = {"ok": True}
+
+        connector.validate_connector_settings()
+
+        fast_client.auth_teams_list.assert_not_called()
+        fast_client.users_list.assert_not_called()
 
     def test_non_grid_workspace_skips_team_enumeration(self) -> None:
         connector, client, _ = _connector()

--- a/backend/tests/unit/onyx/connectors/slack/test_lazy_workspace_metadata.py
+++ b/backend/tests/unit/onyx/connectors/slack/test_lazy_workspace_metadata.py
@@ -1,0 +1,149 @@
+"""Unit tests for lazy resolution of Slack workspace metadata.
+
+Workspace URL and Enterprise Grid topology are resolved when an indexing entry
+point primes them, not when credentials are set. ``self.client`` serializes on a
+Redis lock shared with running indexing jobs, so resolving eagerly let a
+rate-limited indexing job block connector creation for the length of its
+backoff. These tests pin the guarantee that the validation path never touches
+that client, and that the exposed properties stay side-effect free.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from onyx.connectors.slack.connector import SlackConnector
+
+_AUTH_NON_GRID = {"url": "https://workspace.slack.com"}
+_AUTH_GRID = {"url": "https://workspace.slack.com", "enterprise_id": "E1"}
+
+
+def _set_credentials(connector: SlackConnector) -> tuple[MagicMock, MagicMock]:
+    """Attaches mocked clients, returning ``(client, fast_client)``.
+
+    ``set_credentials_provider`` builds the coordinated client first and the
+    fast client second, so ``side_effect`` order matters here.
+    """
+    client = MagicMock()
+    fast_client = MagicMock()
+
+    provider = MagicMock()
+    provider.get_credentials.return_value = {"slack_bot_token": "xoxb-test"}
+    provider.get_tenant_id.return_value = "public"
+    provider.get_provider_key.return_value = "18"
+
+    with patch(
+        "onyx.connectors.slack.connector.WebClient",
+        side_effect=[client, fast_client],
+    ):
+        connector.set_credentials_provider(provider)
+
+    return client, fast_client
+
+
+def _connector() -> tuple[SlackConnector, MagicMock, MagicMock]:
+    connector = SlackConnector(channels=None, use_redis=False)
+    client, fast_client = _set_credentials(connector)
+    return connector, client, fast_client
+
+
+class TestLazyResolution:
+    def test_setting_credentials_does_not_call_auth_test(self) -> None:
+        _, client, _ = _connector()
+        client.auth_test.assert_not_called()
+
+    def test_validation_never_touches_the_coordinated_client(self) -> None:
+        connector, client, fast_client = _connector()
+        fast_client.auth_test.return_value = {"ok": True}
+        fast_client.conversations_list.return_value = {"ok": True}
+
+        connector.validate_connector_settings()
+
+        client.auth_test.assert_not_called()
+        fast_client.auth_test.assert_called_once()
+
+    def test_properties_do_no_work_until_primed(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.return_value = _AUTH_NON_GRID
+
+        assert connector.workspace_url is None
+        assert connector.grid_team_ids is None
+        client.auth_test.assert_not_called()
+
+    def test_priming_resolves_and_result_is_cached(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.return_value = _AUTH_NON_GRID
+
+        connector._ensure_workspace_metadata()
+        connector._ensure_workspace_metadata()
+
+        assert connector.workspace_url == "https://workspace.slack.com"
+        client.auth_test.assert_called_once()
+
+    def test_failed_resolution_is_not_retried(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.side_effect = Exception("rate limited")
+
+        connector._ensure_workspace_metadata()
+        connector._ensure_workspace_metadata()
+
+        assert connector.workspace_url is None
+        client.auth_test.assert_called_once()
+
+    def test_new_credentials_invalidate_cached_metadata(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.return_value = _AUTH_NON_GRID
+        connector._ensure_workspace_metadata()
+        assert connector.workspace_url == "https://workspace.slack.com"
+
+        new_client, _ = _set_credentials(connector)
+        new_client.auth_test.return_value = {"url": "https://other.slack.com"}
+        connector._ensure_workspace_metadata()
+
+        assert connector.workspace_url == "https://other.slack.com"
+        new_client.auth_test.assert_called_once()
+
+    def test_unconfigured_connector_reads_defaults_without_raising(self) -> None:
+        connector = SlackConnector(channels=None, use_redis=False)
+
+        connector._ensure_workspace_metadata()
+
+        assert connector.workspace_url is None
+        assert connector.grid_team_ids is None
+
+
+class TestLazyGridResolution:
+    def test_grid_topology_resolved_when_primed(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.return_value = _AUTH_GRID
+
+        with (
+            patch(
+                "onyx.connectors.slack.connector.list_grid_team_ids",
+                return_value=["T1"],
+            ) as list_teams,
+            patch(
+                "onyx.connectors.slack.connector.fetch_team_url",
+                return_value="https://t1.slack.com",
+            ),
+            patch(
+                "onyx.connectors.slack.connector.fetch_team_user_emails",
+                return_value={"T1": {"a@example.com"}},
+            ),
+        ):
+            list_teams.assert_not_called()
+            connector._ensure_workspace_metadata()
+
+        assert connector.grid_team_ids == ["T1"]
+        assert connector.grid_team_id_to_url == {"T1": "https://t1.slack.com"}
+        assert connector.grid_team_id_to_user_emails == {"T1": {"a@example.com"}}
+        list_teams.assert_called_once()
+        client.auth_test.assert_called_once()
+
+    def test_non_grid_workspace_skips_team_enumeration(self) -> None:
+        connector, client, _ = _connector()
+        client.auth_test.return_value = _AUTH_NON_GRID
+
+        with patch("onyx.connectors.slack.connector.list_grid_team_ids") as list_teams:
+            connector._ensure_workspace_metadata()
+
+        assert connector.grid_team_ids is None
+        list_teams.assert_not_called()


### PR DESCRIPTION
## Problem

Creating a Slack connector can time out with **"Operation timed out after 10 seconds. Check your configuration for errors?"** while another Slack connector is indexing on the same credential — with no error logged anywhere, and nothing actually wrong with the configuration.

`SlackConnector.set_credentials_provider` eagerly called `auth_test()` on `self.client` to populate the workspace URL and Enterprise Grid topology. That client is `OnyxSlackWebClient`, which before every request:

1. acquires a per-credential Redis lock (`connector:slack:credential_<id>:delay_lock`), and
2. sleeps off the shared rate-limit delay (`…:delay`) **while holding that lock**.

Connector validation goes `associate_credential_to_connector` → `validate_ccpair_for_user` → `instantiate_connector` → `set_credentials_provider`, so a user-facing request with a 10s budget ended up waiting on a lock whose TTL is 1800s, behind indexing jobs backing off on Slack 429s.

Observed on a customer cluster with four Slack connectors on one bot token: the delay key never dropped below ~12s and the lock was refreshed continuously, making connector creation fail 100% of the time. The frontend races creation against a 10s timer (`AddConnectorPage.tsx`) and **deletes the connector** when it loses, which is why nothing surfaced as an error — the backend never failed, it was just slow.

## Fix

Resolve the metadata lazily, on first use from the indexing entry points, rather than when credentials are set.

Validation never reads the workspace URL or `grid_*` values, and `validate_connector_settings` already uses the uncoordinated `fast_client` — so after this change the entire creation path is free of the Redis lock and bounded by `FAST_TIMEOUT`.

Indexing behaviour is unchanged: it still uses the coordinated client with full retries, just resolved at the start of the run instead of at credential load.

### Why not just use `fast_client` for that `auth_test`

It's the obvious one-line fix, but the metadata is load-bearing for indexing — `workspace_url` builds document permalinks and `is_grid` gates all Grid team resolution. `fast_client` has `timeout=1` and no 429 coordination, so it would fail *precisely* when the workspace is rate-limited, and the failure is a `logger.warning`. That trades a loud timeout for silently degraded documents.

## Notes

- State collapses into a single frozen `_WorkspaceMetadata` model, assigned in one operation, so readers observe either `None` or fully-formed metadata rather than a partially-populated object.
- The exposed properties are plain accessors — they do **not** resolve on read. Any new entry point that reads them must call `_ensure_workspace_metadata()` first; this is documented on that method.
- Failure semantics preserved: a failed `auth_test` caches empty metadata, so it costs one attempt per credential load rather than retrying per document.

## Tests

New `test_lazy_workspace_metadata.py` pins the guarantee that neither `set_credentials_provider` nor `validate_connector_settings` touches the coordinated client, plus caching, failure-not-retried, credential-swap invalidation, and Grid resolution.

`test_enterprise_grid.py` updated to construct the single value object instead of setting four private fields.

```
943 passed, 22 skipped   # backend/tests/unit/onyx/connectors
```

- [x] [Optional] Override Linear Check

## Not addressed here

Deliberately scoped to the Slack connector. Still worth separate fixes:

- `OnyxSlackWebClient._perform_urllib_http_request` can spin unbounded — the `if self._redis.exists(self._delay_lock): continue` branch skips the `ONYX_SLACK_LOCK_TOTAL_BLOCKING_TIMEOUT` check.
- Validation has no server-side timeout, so any other slow path still yields the same unhelpful message. Wrapping it in `run_with_timeout` would turn it into an actionable error.
- The frontend deleting a connector the backend is still working on.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve Slack workspace metadata lazily to remove creation-time timeouts, and fail closed on resolution errors to avoid widening Slack ACLs. Validation stays off the coordinated client and now verifies Grid users scopes up front.

- **Bug Fixes**
  - Moved `auth_test` and Grid topology into `_ensure_workspace_metadata()` used only by indexing; removed eager resolution from `set_credentials_provider`.
  - Failure handling: let `auth_test`, `list_grid_team_ids`, and `fetch_team_user_emails` raise; cache nothing on failure; only per-team URL lookups swallow errors. Metadata is a frozen `_WorkspaceMetadata`, invalidated on credential change; properties are read-only accessors.
  - Validation: uses the uncoordinated `fast_client`; on Grid, probes `users_list(team_id=…)` after `auth_teams_list` to surface missing `users:read`/`users:read.email` at creation time, within `FAST_TIMEOUT`.
  - Tests: added `test_lazy_workspace_metadata.py`; updated `test_enterprise_grid.py`. Indexing behavior is otherwise unchanged.

<sup>Written for commit f9ce3a9b95674c2425825955e444f0356cbc124c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13520?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



