### PR TITLE
feat(cli): onyx-cli deploy — replace install.sh/install.ps1 with a Go installer

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -148,6 +148,50 @@ jobs:
           gh release upload "$TAG" --clobber \
             cli/dist/*.tar.gz cli/dist/*.zip cli/dist/*_checksums.txt
 
+      # The install.sh/install.ps1 bootstrappers download the newest CLI from
+      # the fixed cli-latest release: the repo-global releases/latest alias
+      # can't be used (it resolves to app/desktop releases — CLI releases are
+      # created with --latest=false), and hitting api.github.com to discover
+      # the newest cli/v* tag would expose installs to rate limits. Assets are
+      # re-published under version-less names so the download URLs are static.
+      - name: Update the cli-latest rolling release
+        if: startsWith(github.ref_name, 'cli/v') && !contains(github.ref_name, '-')
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#cli/}"
+          mkdir -p latest-dist
+          for archive in cli/dist/onyx-cli_"${version#v}"_*; do
+            name="$(basename "$archive")"
+            cp "$archive" "latest-dist/${name/onyx-cli_${version#v}_/onyx-cli_}"
+          done
+          rm -f latest-dist/onyx-cli_checksums.txt
+          (cd latest-dist && sha256sum -- * > onyx-cli_checksums.txt)
+
+          # Move (or create) the cli-latest tag at this commit.
+          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/cli-latest" >/dev/null 2>&1; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/cli-latest" \
+              -f "sha=${GITHUB_SHA}" -F force=true >/dev/null
+          else
+            gh api --method POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f "ref=refs/tags/cli-latest" -f "sha=${GITHUB_SHA}" >/dev/null
+          fi
+
+          release_id="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+            --jq '.[] | select(.tag_name == "cli-latest") | .id' | head -n 1)"
+          notes="Rolling release tracking the newest onyx-cli (currently ${TAG#cli/}). Used by the install.sh/install.ps1 bootstrappers; see the cli/v* releases for changelogs."
+          if [ -z "$release_id" ]; then
+            gh release create cli-latest \
+              --latest=false \
+              --title "onyx-cli latest" \
+              --notes "$notes"
+          else
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
+              -f "body=${notes}" -f make_latest=false >/dev/null
+          fi
+          gh release upload cli-latest --clobber latest-dist/*
+
   docker-amd64:
     runs-on:
       - runs-on

--- a/backend/onyx/server/features/build/sandbox/README.md
+++ b/backend/onyx/server/features/build/sandbox/README.md
@@ -62,7 +62,7 @@ manager and the sandbox client. The Craft Compose overlay defaults it to
 reverse-proxy overrides must include their API path prefix, for example
 `https://onyx.your-org.example/api`.
 
-On EC2 the Docker bridge by default routes to `169.254.169.254` (IMDS), which can hand out IAM credentials. `install.sh --include-craft` installs a host-level `DOCKER-USER` iptables rule to drop sandbox→IMDS traffic when it has sudo/iptables access, and prints the manual command otherwise. There is no application-level fallback — fix this at the host firewall.
+On EC2 the Docker bridge by default routes to `169.254.169.254` (IMDS), which can hand out IAM credentials. The installer does NOT block this automatically — require IMDSv2 (`HttpTokens=required`) on the instance and/or add a host-level `DOCKER-USER` iptables rule dropping sandbox→IMDS traffic. There is no application-level fallback — fix this at the host firewall.
 
 ### Directory Structure
 
@@ -259,7 +259,7 @@ uv run pytest backend/tests/integration/tests/craft/k8s/test_kubernetes_sandbox.
 - **Resource limits** prevent resource exhaustion
 - **Docker containers** run with `--security-opt no-new-privileges`, `--cap-drop ALL`, `user=1000:1000`, no Docker socket, and a fixed env allowlist (`ONYX_PAT` + `ONYX_SERVER_URL` + `ONYX_API_PREFIX`)
 - **Docker network isolation** is enforced by joining only the dedicated `onyx_craft_sandbox` bridge — compose's default network (postgres/redis/minio/model servers) is unreachable by DNS from inside a sandbox
-- **EC2 IMDS** must be blocked at the host firewall (`install.sh --include-craft` installs a `DOCKER-USER` iptables rule on EC2 when sudo is available) — there is no app-level fallback
+- **EC2 IMDS** must be blocked at the host level (require IMDSv2 via `HttpTokens=required`, or add a `DOCKER-USER` iptables rule — the installer does not do this automatically) — there is no app-level fallback
 
 ### Credentials Management
 

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+	"github.com/spf13/cobra"
+)
+
+// newDeployCmd groups the self-hosted deployment lifecycle: the Go
+// replacement for deployment/docker_compose/install.sh.
+func newDeployCmd(ios *iostreams.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "deploy",
+		Short: "Install and manage a self-hosted Onyx deployment",
+		Long: `Install and manage a self-hosted Onyx deployment (docker compose).
+
+New installs live in ~/.config/onyx by default; deployments created by the
+legacy install.sh in ./onyx_data are detected and managed in place. Pass
+--dir (or set ONYX_DEPLOYMENT_DIR) to target a specific location.`,
+	}
+
+	cmd.AddCommand(newDeployInstallCmd(ios))
+
+	return cmd
+}

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -20,6 +20,9 @@ legacy install.sh in ./onyx_data are detected and managed in place. Pass
 
 	cmd.AddCommand(newDeployInstallCmd(ios))
 	cmd.AddCommand(newDeployUpgradeCmd(ios))
+	cmd.AddCommand(newDeployStopCmd(ios))
+	cmd.AddCommand(newDeployStatusCmd(ios))
+	cmd.AddCommand(newDeployUninstallCmd(ios))
 
 	return cmd
 }

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -22,6 +22,7 @@ legacy install.sh in ./onyx_data are detected and managed in place. Pass
 	cmd.AddCommand(newDeployUpgradeCmd(ios))
 	cmd.AddCommand(newDeployStopCmd(ios))
 	cmd.AddCommand(newDeployStatusCmd(ios))
+	cmd.AddCommand(newDeployLogsCmd(ios))
 	cmd.AddCommand(newDeployUninstallCmd(ios))
 
 	return cmd

--- a/cli/cmd/deploy.go
+++ b/cli/cmd/deploy.go
@@ -19,6 +19,7 @@ legacy install.sh in ./onyx_data are detected and managed in place. Pass
 	}
 
 	cmd.AddCommand(newDeployInstallCmd(ios))
+	cmd.AddCommand(newDeployUpgradeCmd(ios))
 
 	return cmd
 }

--- a/cli/cmd/deploy_install.go
+++ b/cli/cmd/deploy_install.go
@@ -1,0 +1,82 @@
+package cmd
+
+import (
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/install"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+	"github.com/spf13/cobra"
+)
+
+func newDeployInstallCmd(ios *iostreams.IOStreams) *cobra.Command {
+	return newDeployInstallCmdWithDeps(ios, nil)
+}
+
+// newDeployInstallCmdWithDeps lets tests inject fake dependencies.
+func newDeployInstallCmdWithDeps(ios *iostreams.IOStreams, deps *install.Deps) *cobra.Command {
+	opts := install.Options{}
+	var legacyShutdown, legacyDeleteData bool
+
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Install or restart a self-hosted Onyx deployment",
+		Long: `Install a self-hosted Onyx deployment with docker compose, or restart /
+update an existing one.
+
+The deployment files bundled with this CLI are used by default; installing a
+pinned release tag fetches the files matching that version from GitHub. On
+Linux, missing Docker Engine and the compose plugin are installed after
+confirmation. Run non-interactively with --no-prompt (defaults are applied to
+every prompt, including Lite mode).`,
+		Example: `  onyx-cli deploy install
+  onyx-cli deploy install --lite --no-prompt
+  onyx-cli deploy install --include-craft
+  onyx-cli deploy install --tag v4.4.6
+  onyx-cli deploy install --dry-run`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if legacyShutdown {
+				return exitcodes.New(exitcodes.BadRequest,
+					"--shutdown has moved: run `onyx-cli deploy stop`")
+			}
+			if legacyDeleteData {
+				return exitcodes.New(exitcodes.BadRequest,
+					"--delete-data has moved: run `onyx-cli deploy uninstall`")
+			}
+			d := install.NewDeps(ios, fullVersion())
+			if deps != nil {
+				d = *deps
+			}
+			return install.RunInstall(cmd.Context(), d, opts)
+		},
+	}
+
+	// Flag names match install.sh so bootstrap passthrough keeps working.
+	cmd.Flags().BoolVar(&opts.Lite, "lite", false, "Deploy Onyx Lite (no Vespa, Redis, or model servers)")
+	cmd.Flags().BoolVar(&opts.IncludeCraft, "include-craft", false, "Enable Onyx Craft (AI-powered web app building)")
+	cmd.Flags().StringVar(&opts.Tag, "tag", "", "Image tag to deploy (default: the latest Onyx release)")
+	cmd.Flags().BoolVar(&opts.Local, "local", false, "Use existing config files on disk instead of downloading")
+	cmd.Flags().BoolVar(&opts.NoPrompt, "no-prompt", false, "Run non-interactively with defaults (for CI/automation)")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be done without making changes")
+	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Show detailed output for debugging")
+	cmd.Flags().BoolVar(&opts.NoWait, "no-wait", false, "Return as soon as containers are started (skip health waiting)")
+	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Deployment directory (default: ~/.config/onyx, or an existing ./onyx_data)")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Overwrite hand-edited managed files (a backup is kept)")
+
+	// Retired install.sh mode flags: recognized so saved one-liners get a
+	// redirect message instead of a raw unknown-flag error.
+	cmd.Flags().BoolVar(&legacyShutdown, "shutdown", false, "")
+	cmd.Flags().BoolVar(&legacyDeleteData, "delete-data", false, "")
+	_ = cmd.Flags().MarkHidden("shutdown")
+	_ = cmd.Flags().MarkHidden("delete-data")
+
+	return cmd
+}
+
+// newInstallOnyxCmd is the documented curl|bash entrypoint: a top-level alias
+// for `deploy install`.
+func newInstallOnyxCmd(ios *iostreams.IOStreams) *cobra.Command {
+	cmd := newDeployInstallCmd(ios)
+	cmd.Use = "install-onyx"
+	cmd.Short = "Install a self-hosted Onyx deployment (alias for `deploy install`)"
+	return cmd
+}

--- a/cli/cmd/deploy_install.go
+++ b/cli/cmd/deploy_install.go
@@ -51,7 +51,7 @@ every prompt, including Lite mode).`,
 	}
 
 	// Flag names match install.sh so bootstrap passthrough keeps working.
-	cmd.Flags().BoolVar(&opts.Lite, "lite", false, "Deploy Onyx Lite (no Vespa, Redis, or model servers)")
+	cmd.Flags().BoolVar(&opts.Lite, "lite", false, "Deploy Onyx Lite (no OpenSearch, Redis, or model servers)")
 	cmd.Flags().BoolVar(&opts.IncludeCraft, "include-craft", false, "Enable Onyx Craft (AI-powered web app building)")
 	cmd.Flags().StringVar(&opts.Tag, "tag", "", "Image tag to deploy (default: the latest Onyx release)")
 	cmd.Flags().BoolVar(&opts.Local, "local", false, "Use existing config files on disk instead of downloading")

--- a/cli/cmd/deploy_install.go
+++ b/cli/cmd/deploy_install.go
@@ -55,6 +55,7 @@ every prompt, including Lite mode).`,
 	cmd.Flags().BoolVar(&opts.IncludeCraft, "include-craft", false, "Enable Onyx Craft (AI-powered web app building)")
 	cmd.Flags().StringVar(&opts.Tag, "tag", "", "Image tag to deploy (default: the latest Onyx release)")
 	cmd.Flags().BoolVar(&opts.Local, "local", false, "Use existing config files on disk instead of downloading")
+	cmd.Flags().BoolVar(&opts.Offline, "offline", false, "Deploy from the images already on this host and contact no network (implies --local)")
 	cmd.Flags().BoolVar(&opts.NoPrompt, "no-prompt", false, "Run non-interactively with defaults (for CI/automation)")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be done without making changes")
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Show detailed output for debugging")

--- a/cli/cmd/deploy_install.go
+++ b/cli/cmd/deploy_install.go
@@ -60,7 +60,7 @@ every prompt, including Lite mode).`,
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Show detailed output for debugging")
 	cmd.Flags().BoolVar(&opts.NoWait, "no-wait", false, "Return as soon as containers are started (skip health waiting)")
 	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Deployment directory (default: ~/.config/onyx, or an existing ./onyx_data)")
-	cmd.Flags().BoolVar(&opts.Force, "force", false, "Overwrite hand-edited managed files (a backup is kept)")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Overwrite hand-edited managed files (a backup is kept) and recreate running services")
 
 	// Retired install.sh mode flags: recognized so saved one-liners get a
 	// redirect message instead of a raw unknown-flag error.

--- a/cli/cmd/deploy_install_test.go
+++ b/cli/cmd/deploy_install_test.go
@@ -75,7 +75,7 @@ func TestInstallOnyxIsAnAlias(t *testing.T) {
 		t.Fatalf("Use = %q", alias.Use)
 	}
 	// Same flag surface as deploy install.
-	for _, name := range []string{"lite", "include-craft", "tag", "local", "no-prompt", "dry-run", "verbose", "no-wait", "dir", "force"} {
+	for _, name := range []string{"lite", "include-craft", "tag", "local", "offline", "no-prompt", "dry-run", "verbose", "no-wait", "dir", "force"} {
 		if alias.Flags().Lookup(name) == nil {
 			t.Errorf("alias missing --%s", name)
 		}

--- a/cli/cmd/deploy_install_test.go
+++ b/cli/cmd/deploy_install_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+	"github.com/onyx-dot-app/onyx/cli/internal/testutil"
+)
+
+func TestDeployInstallDryRun(t *testing.T) {
+	t.Setenv("ONYX_DEPLOYMENT_DIR", "")
+	t.Setenv("INSTALL_PREFIX", "")
+	ios, out, _ := testutil.TestIOStreams()
+	cmd := newDeployInstallCmd(ios)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	// --tag skips the release lookup, so a dry run stays fully offline.
+	cmd.SetArgs([]string{"--dry-run", "--tag", "v1.2.3", "--dir", filepath.Join(t.TempDir(), "onyx")})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	got := out.String()
+	for _, want := range []string{"Dry run complete", "Default image tag: v1.2.3"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestDeployInstallLegacyFlagsRedirect(t *testing.T) {
+	cases := map[string]string{
+		"--shutdown":    "onyx-cli deploy stop",
+		"--delete-data": "onyx-cli deploy uninstall",
+	}
+	for flag, want := range cases {
+		ios, _, _ := testutil.TestIOStreams()
+		cmd := newDeployInstallCmd(ios)
+		cmd.SilenceErrors = true
+		cmd.SilenceUsage = true
+		cmd.SetArgs([]string{flag})
+
+		err := cmd.Execute()
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Errorf("%s: err = %v, want mention of %q", flag, err, want)
+			continue
+		}
+		var exitErr *exitcodes.ExitError
+		if !errors.As(err, &exitErr) || exitErr.Code != exitcodes.BadRequest {
+			t.Errorf("%s: exit code = %v, want BadRequest", flag, err)
+		}
+	}
+}
+
+func TestDeployInstallRejectsLiteWithCraft(t *testing.T) {
+	ios, _, _ := testutil.TestIOStreams()
+	cmd := newDeployInstallCmd(ios)
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--lite", "--include-craft", "--dry-run"})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "cannot be used together") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestInstallOnyxIsAnAlias(t *testing.T) {
+	ios, _, _ := testutil.TestIOStreams()
+	alias := newInstallOnyxCmd(ios)
+	if alias.Use != "install-onyx" {
+		t.Fatalf("Use = %q", alias.Use)
+	}
+	// Same flag surface as deploy install.
+	for _, name := range []string{"lite", "include-craft", "tag", "local", "no-prompt", "dry-run", "verbose", "no-wait", "dir", "force"} {
+		if alias.Flags().Lookup(name) == nil {
+			t.Errorf("alias missing --%s", name)
+		}
+	}
+}

--- a/cli/cmd/deploy_lifecycle.go
+++ b/cli/cmd/deploy_lifecycle.go
@@ -60,6 +60,38 @@ healthy, 9 when no install exists, 1 when stopped or degraded.`,
 	return cmd
 }
 
+func newDeployLogsCmd(ios *iostreams.IOStreams) *cobra.Command {
+	return newDeployLogsCmdWithDeps(ios, nil)
+}
+
+func newDeployLogsCmdWithDeps(ios *iostreams.IOStreams, deps *install.Deps) *cobra.Command {
+	opts := install.Options{}
+	logOpts := install.LogOptions{}
+	cmd := &cobra.Command{
+		Use:   "logs [service...]",
+		Short: "Show the logs of the deployment's containers",
+		Long: `Show the logs of a deployment's services, with no need to find the
+deployment directory or remember which compose overlays it uses.
+
+Name the services to narrow the output ("onyx-cli deploy logs api_server"),
+which is what "onyx-cli deploy status" suggests for a service in trouble.`,
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			d := install.NewDeps(ios, fullVersion())
+			if deps != nil {
+				d = *deps
+			}
+			logOpts.Services = args
+			return install.RunLogs(cmd.Context(), d, opts, logOpts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Deployment directory (default: auto-detected)")
+	cmd.Flags().BoolVarP(&logOpts.Follow, "follow", "f", false, "Keep printing new log lines")
+	cmd.Flags().StringVar(&logOpts.Tail, "tail", "200", `Lines to show from the end of each log ("all" for everything)`)
+	cmd.Flags().StringVar(&logOpts.Since, "since", "", "Only logs since this point (e.g. 10m, 2h, or a timestamp)")
+	return cmd
+}
+
 func newDeployUninstallCmd(ios *iostreams.IOStreams) *cobra.Command {
 	return newDeployUninstallCmdWithDeps(ios, nil)
 }

--- a/cli/cmd/deploy_lifecycle.go
+++ b/cli/cmd/deploy_lifecycle.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/install"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+	"github.com/spf13/cobra"
+)
+
+func newDeployStopCmd(ios *iostreams.IOStreams) *cobra.Command {
+	return newDeployStopCmdWithDeps(ios, nil)
+}
+
+func newDeployStopCmdWithDeps(ios *iostreams.IOStreams, deps *install.Deps) *cobra.Command {
+	opts := install.Options{}
+	cmd := &cobra.Command{
+		Use:   "stop",
+		Short: "Stop (pause) the Onyx containers",
+		Long: `Stop the Onyx containers without removing them or their data.
+Start them again with: onyx-cli deploy install`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			d := install.NewDeps(ios, fullVersion())
+			if deps != nil {
+				d = *deps
+			}
+			return install.RunStop(cmd.Context(), d, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Deployment directory (default: auto-detected)")
+	return cmd
+}
+
+func newDeployStatusCmd(ios *iostreams.IOStreams) *cobra.Command {
+	return newDeployStatusCmdWithDeps(ios, nil)
+}
+
+func newDeployStatusCmdWithDeps(ios *iostreams.IOStreams, deps *install.Deps) *cobra.Command {
+	opts := install.Options{}
+	var jsonOut bool
+	cmd := &cobra.Command{
+		Use:   "status",
+		Short: "Show the deployment's version, containers, and health",
+		Long: `Show the state of a deployment: the installed version as recorded by the
+CLI, by .env, and by the running containers (drift between them is flagged),
+plus per-container status and health.
+
+Read-only. Exit codes make it usable as a probe: 0 when everything is up and
+healthy, 9 when no install exists, 1 when stopped or degraded.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			d := install.NewDeps(ios, fullVersion())
+			if deps != nil {
+				d = *deps
+			}
+			return install.RunStatus(cmd.Context(), d, opts, jsonOut)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Deployment directory (default: auto-detected)")
+	cmd.Flags().BoolVar(&jsonOut, "json", false, "Output machine-readable JSON")
+	return cmd
+}
+
+func newDeployUninstallCmd(ios *iostreams.IOStreams) *cobra.Command {
+	return newDeployUninstallCmdWithDeps(ios, nil)
+}
+
+func newDeployUninstallCmdWithDeps(ios *iostreams.IOStreams, deps *install.Deps) *cobra.Command {
+	opts := install.Options{}
+	cmd := &cobra.Command{
+		Use:   "uninstall",
+		Short: "Permanently delete the Onyx deployment and all its data",
+		Long: `Remove the Onyx containers, volumes, and the deployment directory.
+
+This permanently deletes all user data and documents. Interactive runs must
+type DELETE to confirm; non-interactive runs require --force.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			d := install.NewDeps(ios, fullVersion())
+			if deps != nil {
+				d = *deps
+			}
+			return install.RunUninstall(cmd.Context(), d, opts)
+		},
+	}
+	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Deployment directory (default: auto-detected)")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Skip the confirmation (for scripted teardown)")
+	return cmd
+}

--- a/cli/cmd/deploy_upgrade.go
+++ b/cli/cmd/deploy_upgrade.go
@@ -41,6 +41,7 @@ new version.`,
 	cmd.Flags().StringVar(&opts.Tag, "tag", "", "Image tag to upgrade to (default: the latest Onyx release)")
 	cmd.Flags().BoolVar(&opts.Force, "force", false, "Overwrite hand-edited managed files and allow downgrades")
 	cmd.Flags().BoolVar(&opts.Local, "local", false, "Use existing config files on disk instead of downloading")
+	cmd.Flags().BoolVar(&opts.Offline, "offline", false, "Upgrade to a version already on this host and contact no network (implies --local)")
 	cmd.Flags().BoolVar(&opts.NoPrompt, "no-prompt", false, "Run non-interactively with defaults")
 	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be done without making changes")
 	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Show detailed output for debugging")

--- a/cli/cmd/deploy_upgrade.go
+++ b/cli/cmd/deploy_upgrade.go
@@ -22,8 +22,9 @@ Only the IMAGE_TAG line (plus SANDBOX_BACKEND when Craft is enabled) is
 rewritten in .env — every other setting, including your edits, is preserved.
 Managed files (compose, overlays, nginx config) are refreshed to match the
 target version; files you hand-edited are kept unless you confirm the
-overwrite (or pass --force), and a backup is made first. Services must be
-stopped (onyx-cli deploy stop).`,
+overwrite (or pass --force), and a backup is made first. The running
+services keep serving while images download and are then recreated on the
+new version.`,
 		Example: `  onyx-cli deploy upgrade
   onyx-cli deploy upgrade --tag v4.4.6
   onyx-cli deploy upgrade --tag v4.4.6 --no-prompt --force`,

--- a/cli/cmd/deploy_upgrade.go
+++ b/cli/cmd/deploy_upgrade.go
@@ -1,0 +1,50 @@
+package cmd
+
+import (
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/install"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+	"github.com/spf13/cobra"
+)
+
+func newDeployUpgradeCmd(ios *iostreams.IOStreams) *cobra.Command {
+	return newDeployUpgradeCmdWithDeps(ios, nil)
+}
+
+func newDeployUpgradeCmdWithDeps(ios *iostreams.IOStreams, deps *install.Deps) *cobra.Command {
+	opts := install.Options{}
+
+	cmd := &cobra.Command{
+		Use:   "upgrade",
+		Short: "Upgrade an existing Onyx deployment to a newer version",
+		Long: `Upgrade an existing Onyx deployment to a newer version.
+
+Only the IMAGE_TAG line (plus SANDBOX_BACKEND when Craft is enabled) is
+rewritten in .env — every other setting, including your edits, is preserved.
+Managed files (compose, overlays, nginx config) are refreshed to match the
+target version; files you hand-edited are kept unless you confirm the
+overwrite (or pass --force), and a backup is made first. Services must be
+stopped (onyx-cli deploy stop).`,
+		Example: `  onyx-cli deploy upgrade
+  onyx-cli deploy upgrade --tag v4.4.6
+  onyx-cli deploy upgrade --tag v4.4.6 --no-prompt --force`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			d := install.NewDeps(ios, fullVersion())
+			if deps != nil {
+				d = *deps
+			}
+			return install.RunUpgrade(cmd.Context(), d, opts)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.Tag, "tag", "", "Image tag to upgrade to (default: the latest Onyx release)")
+	cmd.Flags().BoolVar(&opts.Force, "force", false, "Overwrite hand-edited managed files and allow downgrades")
+	cmd.Flags().BoolVar(&opts.Local, "local", false, "Use existing config files on disk instead of downloading")
+	cmd.Flags().BoolVar(&opts.NoPrompt, "no-prompt", false, "Run non-interactively with defaults")
+	cmd.Flags().BoolVar(&opts.DryRun, "dry-run", false, "Show what would be done without making changes")
+	cmd.Flags().BoolVar(&opts.Verbose, "verbose", false, "Show detailed output for debugging")
+	cmd.Flags().BoolVar(&opts.NoWait, "no-wait", false, "Return as soon as containers are started (skip health waiting)")
+	cmd.Flags().StringVar(&opts.Dir, "dir", "", "Deployment directory (default: auto-detected)")
+
+	return cmd
+}

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -103,6 +103,8 @@ func Execute() error {
 	rootCmd.AddCommand(newServeCmd())
 	rootCmd.AddCommand(newInstallSkillCmd(ios))
 	rootCmd.AddCommand(newExperimentsCmd(ios))
+	rootCmd.AddCommand(newDeployCmd(ios))
+	rootCmd.AddCommand(newInstallOnyxCmd(ios))
 
 	rootCmd.RunE = func(cmd *cobra.Command, args []string) error {
 		if showVersion {

--- a/cli/cmd/root.go
+++ b/cli/cmd/root.go
@@ -73,7 +73,11 @@ func Execute() error {
 	rootCmd := &cobra.Command{
 		Use:   "onyx-cli",
 		Short: "CLI for Onyx knowledge and search",
-		Long:  "Onyx CLI — query enterprise knowledge from the terminal or as an agent tool.",
+		// main.go prints the error; without these, cobra prints it a second
+		// time and dumps the full usage text after every runtime failure.
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Long:          "Onyx CLI — query enterprise knowledge from the terminal or as an agent tool.",
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if opts.Debug {
 				log.SetLevel(log.DebugLevel)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.9.4
 	github.com/spf13/cobra v1.10.2
 	github.com/yuin/goldmark v1.8.2
+	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	golang.org/x/text v0.38.0
 	golang.org/x/time v0.15.0
@@ -51,5 +52,4 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20260312153236-7ab1446f8b90 // indirect
 	golang.org/x/sync v0.21.0 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 )

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/README.md
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/README.md
@@ -29,6 +29,22 @@ the install.sh script with --delete-data.
 
 To shut down the deployment without deleting, use install.sh --shutdown.
 
+### Onyx CLI (alternative)
+
+The same guided install also ships inside the Onyx CLI and will eventually
+replace install.sh once it stabilizes:
+
+```
+pip install onyx-cli && onyx-cli deploy install
+```
+
+It understands existing install.sh deployments (an `onyx_data` directory is
+detected and managed in place; new installs default to `~/.config/onyx`) and
+adds lifecycle commands: `onyx-cli deploy status` (versions, containers,
+health), `deploy stop`, `deploy upgrade [--tag vX.Y.Z]` (rewrites only
+IMAGE_TAG, preserves your .env edits, backs up hand-edited files), and
+`deploy uninstall`.
+
 ### Upgrading the deployment
 Onyx maintains backwards compatibility across all minor versions following SemVer. If following the install.sh script (or through Docker Compose), you can
 upgrade it by first bringing down the containers. To do this, use `install.sh --shutdown`

--- a/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
+++ b/cli/internal/deploy/deployfiles/embedded/docker_compose/env.template
@@ -16,12 +16,12 @@
 IMAGE_TAG=latest
 
 ## Onyx Craft Configuration (off by default).
-## When enabling Craft through install.sh --include-craft or by manually adding
+## When enabling Craft through the installer's --include-craft or by manually adding
 ## docker-compose.craft.yml, the sandbox image follows IMAGE_TAG above.
 # ENABLE_CRAFT=true
 #
 ## docker backend drives sandboxes via the host Docker socket (root-equivalent;
-## trusted hosts only) and needs v4.0.6+ images. install.sh picks docker vs
+## trusted hosts only) and needs v4.0.6+ images. The installer picks docker vs
 ## kubernetes by image tag.
 # SANDBOX_BACKEND=docker
 #
@@ -32,7 +32,7 @@ IMAGE_TAG=latest
 ## proxy, including the /api path prefix served by that proxy.
 # ONYX_SERVER_URL=https://onyx.your-org.example/api
 #
-## Sandbox bridge network. Created by install.sh (or manually:
+## Sandbox bridge network. Created by the installer (or manually:
 ##   docker network create onyx_craft_sandbox
 ## Sandboxes join only this network. The firewall forces API and public egress
 ## through sandbox-proxy; postgres, redis, and minio stay off the bridge.
@@ -45,10 +45,9 @@ IMAGE_TAG=latest
 # SANDBOX_DOCKER_CPU_LIMIT=1.0
 ## EC2 IMDS note: on EC2 the Docker daemon's default bridge allows traffic to
 ## 169.254.169.254 (Instance Metadata Service), which can hand out IAM role
-## credentials. The fix is a host-level DOCKER-USER iptables rule that drops
-## bridge traffic to that address. install.sh --include-craft installs this
-## rule automatically when it has sudo/iptables access, and prints manual
-## instructions otherwise.
+## credentials. The installer does not block this automatically: require
+## IMDSv2 (HttpTokens=required) on the instance, and/or add a host-level
+## DOCKER-USER iptables rule that drops bridge traffic to that address.
 
 ## Auth Settings
 ### https://docs.onyx.app/deployment/authentication
@@ -57,7 +56,7 @@ IMAGE_TAG=latest
 # SESSION_EXPIRE_TIME_SECONDS=
 ### Signs password reset, email verification, OAuth login state, and captcha cookies.
 ### REQUIRED: the API server refuses to start with an empty value (secure by default).
-### If using install.sh this is auto-generated; if setting manually, run: openssl rand -hex 32
+### The installer auto-generates this; if setting manually, run: openssl rand -hex 32
 USER_AUTH_SECRET=""
 ### Recommend to set this for security
 # ENCRYPTION_KEY_SECRET=
@@ -174,7 +173,7 @@ COMPOSE_PROFILES=s3-filestore
 FILE_STORE_BACKEND=s3
 
 ## MinIO/S3 Configuration (only needed when FILE_STORE_BACKEND=s3)
-## SECURITY: minioadmin is a local-dev default. install.sh randomizes it; if you
+## SECURITY: minioadmin is a local-dev default. The installer randomizes it; if you
 ## edit .env by hand, change all four values before production. Keep the S3_AWS_*
 ## pair identical to MINIO_ROOT_* (the app uses MinIO's root creds).
 S3_ENDPOINT_URL=http://minio:9000

--- a/cli/internal/deploy/dockercmd/compose.go
+++ b/cli/internal/deploy/dockercmd/compose.go
@@ -1,0 +1,87 @@
+package dockercmd
+
+import (
+	"context"
+)
+
+// Compose invokes docker compose (plugin) or docker-compose (standalone),
+// whichever is available, through the Docker sudo wrapper.
+type Compose struct {
+	docker     *Docker
+	standalone bool
+}
+
+// DetectCompose finds a usable compose command, preferring the plugin
+// (mirrors install.sh's detect_compose_cmd). Returns nil when neither works.
+func DetectCompose(ctx context.Context, d *Docker) *Compose {
+	if _, err := d.Runner.Run(ctx, Command{Name: "docker", Args: []string{"compose", "version"}}); err == nil {
+		return &Compose{docker: d}
+	}
+	if _, err := d.Runner.Run(ctx, Command{Name: "docker-compose", Args: []string{"version"}}); err == nil {
+		return &Compose{docker: d, standalone: true}
+	}
+	return nil
+}
+
+// TypeName describes the detected flavor for user-facing messages.
+func (c *Compose) TypeName() string {
+	if c.standalone {
+		return "standalone"
+	}
+	return "plugin"
+}
+
+// Version returns the compose version, or "dev" when unparsable (non-standard
+// builds report strings like "dev"; treated as recent enough, like install.sh).
+func (c *Compose) Version(ctx context.Context) string {
+	var probe Command
+	if c.standalone {
+		probe = Command{Name: "docker-compose", Args: []string{"--version"}}
+	} else {
+		probe = Command{Name: "docker", Args: []string{"compose", "version"}}
+	}
+	res, err := c.docker.Runner.Run(ctx, probe)
+	if err != nil {
+		return "dev"
+	}
+	if v := versionPattern.FindString(res.Stdout); v != "" {
+		return v
+	}
+	return "dev"
+}
+
+// Command builds a compose invocation in dir: `[sudo env K=V] docker compose
+// -f <file>... <args>` (or docker-compose). Env riding rules follow
+// Docker.Command.
+func (c *Compose) Command(dir string, env map[string]string, composeFiles []string, args ...string) Command {
+	full := make([]string, 0, 2+2*len(composeFiles)+len(args))
+	name := "docker"
+	if c.standalone {
+		name = "docker-compose"
+	} else {
+		full = append(full, "compose")
+	}
+	for _, f := range composeFiles {
+		full = append(full, "-f", f)
+	}
+	full = append(full, args...)
+
+	cmd := c.docker.commandFor(name, env, full...)
+	cmd.Dir = dir
+	return cmd
+}
+
+// commandFor generalizes Docker.Command to any binary needing the sudo/env
+// wrapping treatment.
+func (d *Docker) commandFor(name string, env map[string]string, args ...string) Command {
+	if !d.sudo {
+		return Command{Name: name, Args: args, Env: env}
+	}
+	sudoArgs := []string{"env"}
+	for _, k := range sortedKeys(env) {
+		sudoArgs = append(sudoArgs, k+"="+env[k])
+	}
+	sudoArgs = append(sudoArgs, name)
+	sudoArgs = append(sudoArgs, args...)
+	return Command{Name: "sudo", Args: sudoArgs}
+}

--- a/cli/internal/deploy/dockercmd/compose.go
+++ b/cli/internal/deploy/dockercmd/compose.go
@@ -4,6 +4,12 @@ import (
 	"context"
 )
 
+// ProjectName is the compose project Onyx deployments run under, pinned by
+// `name: onyx` in docker-compose.yml. Containers and volumes carry it as a
+// label, which is what makes an install root movable and what lets docker
+// find the stack without the compose files.
+const ProjectName = "onyx"
+
 // Compose invokes docker compose (plugin) or docker-compose (standalone),
 // whichever is available, through the Docker sudo wrapper.
 type Compose struct {

--- a/cli/internal/deploy/dockercmd/docker.go
+++ b/cli/internal/deploy/dockercmd/docker.go
@@ -1,0 +1,104 @@
+package dockercmd
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"regexp"
+	"runtime"
+	"strings"
+)
+
+var versionPattern = regexp.MustCompile(`\d+\.\d+\.\d+`)
+
+// Docker invokes the docker CLI, transparently prefixing sudo when the
+// current user cannot reach the daemon directly (Linux only; mirrors
+// install.sh's DOCKER_SUDO fallback so a just-added docker group membership
+// doesn't force a re-login mid-install).
+type Docker struct {
+	Runner Runner
+	sudo   bool
+}
+
+func NewDocker(r Runner) *Docker {
+	return &Docker{Runner: r}
+}
+
+// Installed reports whether the docker CLI is on PATH.
+func Installed() bool {
+	_, err := exec.LookPath("docker")
+	return err == nil
+}
+
+// IsWSL reports whether this process runs inside Windows Subsystem for Linux.
+func IsWSL() bool {
+	if os.Getenv("WSL_DISTRO_NAME") != "" {
+		return true
+	}
+	data, err := os.ReadFile("/proc/version")
+	return err == nil && strings.Contains(strings.ToLower(string(data)), "microsoft")
+}
+
+// UsingSudo reports whether docker invocations are being prefixed with sudo.
+func (d *Docker) UsingSudo() bool { return d.sudo }
+
+// RefreshSudo re-evaluates whether docker commands need a sudo prefix: only
+// on Linux/WSL, only for non-root users, and only when `docker info` fails
+// without it.
+func (d *Docker) RefreshSudo(ctx context.Context) {
+	d.sudo = false
+	if !Installed() || os.Geteuid() == 0 {
+		return
+	}
+	if runtime.GOOS != "linux" && !IsWSL() {
+		return
+	}
+	if _, err := d.Runner.Run(ctx, Command{Name: "docker", Args: []string{"info"}}); err == nil {
+		return
+	}
+	d.sudo = true
+}
+
+// Command builds a docker invocation. Without sudo, env entries ride the
+// process environment; with sudo they become argv to `env` (positional args
+// survive sudo's env_reset, inherited environment does not).
+func (d *Docker) Command(env map[string]string, args ...string) Command {
+	return d.commandFor("docker", env, args...)
+}
+
+// DaemonRunning reports whether the docker daemon answers `docker info`.
+func (d *Docker) DaemonRunning(ctx context.Context) bool {
+	_, err := d.Runner.Run(ctx, d.Command(nil, "info"))
+	return err == nil
+}
+
+// Version returns the docker CLI version ("" when unparsable).
+func (d *Docker) Version(ctx context.Context) string {
+	res, err := d.Runner.Run(ctx, Command{Name: "docker", Args: []string{"--version"}})
+	if err != nil {
+		return ""
+	}
+	return versionPattern.FindString(res.Stdout)
+}
+
+// EnsureNetwork creates the named docker network if it doesn't exist.
+func (d *Docker) EnsureNetwork(ctx context.Context, name string) (created bool, err error) {
+	if _, err := d.Runner.Run(ctx, d.Command(nil, "network", "inspect", name)); err == nil {
+		return false, nil
+	}
+	if _, err := d.Runner.Run(ctx, d.Command(nil, "network", "create", name)); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// EnsureVolume creates the named docker volume if it doesn't exist.
+func (d *Docker) EnsureVolume(ctx context.Context, name string) (created bool, err error) {
+	if _, err := d.Runner.Run(ctx, d.Command(nil, "volume", "inspect", name)); err == nil {
+		return false, nil
+	}
+	if _, err := d.Runner.Run(ctx, d.Command(nil, "volume", "create", name)); err != nil {
+		return false, err
+	}
+	return true, nil
+}

--- a/cli/internal/deploy/dockercmd/dockercmd_test.go
+++ b/cli/internal/deploy/dockercmd/dockercmd_test.go
@@ -1,0 +1,168 @@
+package dockercmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// fakeRunner records invocations and delegates results to handler.
+type fakeRunner struct {
+	calls   []Command
+	handler func(c Command) (Result, error)
+}
+
+func (f *fakeRunner) Run(_ context.Context, c Command) (Result, error) {
+	f.calls = append(f.calls, c)
+	if f.handler != nil {
+		return f.handler(c)
+	}
+	return Result{}, nil
+}
+
+func argv(c Command) string {
+	return strings.Join(append([]string{c.Name}, c.Args...), " ")
+}
+
+func TestDockerCommandWithoutSudo(t *testing.T) {
+	d := NewDocker(&fakeRunner{})
+	cmd := d.Command(map[string]string{"IMAGE_TAG": "v1.0.0"}, "info")
+	if got := argv(cmd); got != "docker info" {
+		t.Fatalf("argv = %q", got)
+	}
+	if cmd.Env["IMAGE_TAG"] != "v1.0.0" {
+		t.Fatalf("env not carried: %+v", cmd.Env)
+	}
+}
+
+// TestSudoEnvAnchorArgv asserts the exact sudo argv form: env vars must ride
+// as positional arguments to `env` so sudo's env_reset cannot strip them
+// (mirrors install.sh's DOCKER_SUDO=(sudo env) workaround).
+func TestSudoEnvAnchorArgv(t *testing.T) {
+	d := NewDocker(&fakeRunner{})
+	d.sudo = true
+	cmd := d.Command(map[string]string{"IMAGE_TAG": "edge", "HOST_PORT": "3000"}, "compose", "up", "-d")
+	want := "sudo env HOST_PORT=3000 IMAGE_TAG=edge docker compose up -d"
+	if got := argv(cmd); got != want {
+		t.Fatalf("argv = %q, want %q", got, want)
+	}
+	if len(cmd.Env) != 0 {
+		t.Fatalf("sudo form must not rely on process env: %+v", cmd.Env)
+	}
+}
+
+func TestDetectComposePrefersPlugin(t *testing.T) {
+	r := &fakeRunner{handler: func(c Command) (Result, error) {
+		if argv(c) == "docker compose version" {
+			return Result{Stdout: "Docker Compose version v2.32.1"}, nil
+		}
+		return Result{}, errors.New("not found")
+	}}
+	c := DetectCompose(context.Background(), NewDocker(r))
+	if c == nil || c.standalone {
+		t.Fatalf("got %+v, want plugin compose", c)
+	}
+	if c.TypeName() != "plugin" {
+		t.Fatalf("TypeName = %s", c.TypeName())
+	}
+}
+
+func TestDetectComposeFallsBackToStandalone(t *testing.T) {
+	r := &fakeRunner{handler: func(c Command) (Result, error) {
+		if c.Name == "docker-compose" {
+			return Result{Stdout: "docker-compose version 1.29.2"}, nil
+		}
+		return Result{}, errors.New("no plugin")
+	}}
+	c := DetectCompose(context.Background(), NewDocker(r))
+	if c == nil || !c.standalone {
+		t.Fatalf("got %+v, want standalone compose", c)
+	}
+}
+
+func TestDetectComposeNeither(t *testing.T) {
+	r := &fakeRunner{handler: func(Command) (Result, error) {
+		return Result{}, errors.New("nope")
+	}}
+	if c := DetectCompose(context.Background(), NewDocker(r)); c != nil {
+		t.Fatalf("got %+v, want nil", c)
+	}
+}
+
+func TestComposeVersionParsesAndFallsBackToDev(t *testing.T) {
+	r := &fakeRunner{handler: func(c Command) (Result, error) {
+		return Result{Stdout: "Docker Compose version v2.24.5-desktop.1"}, nil
+	}}
+	c := &Compose{docker: NewDocker(r)}
+	if v := c.Version(context.Background()); v != "2.24.5" {
+		t.Fatalf("Version = %q", v)
+	}
+
+	r.handler = func(Command) (Result, error) { return Result{Stdout: "dev build"}, nil }
+	if v := c.Version(context.Background()); v != "dev" {
+		t.Fatalf("Version = %q, want dev", v)
+	}
+}
+
+func TestComposeCommandStacksFilesInOrder(t *testing.T) {
+	c := &Compose{docker: NewDocker(&fakeRunner{})}
+	cmd := c.Command("/root/deployment",
+		map[string]string{"HOST_PORT": "3000"},
+		[]string{"docker-compose.yml", "docker-compose.onyx-lite.yml"},
+		"up", "-d", "--wait", "--wait-timeout", "600")
+	want := "docker compose -f docker-compose.yml -f docker-compose.onyx-lite.yml up -d --wait --wait-timeout 600"
+	if got := argv(cmd); got != want {
+		t.Fatalf("argv = %q, want %q", got, want)
+	}
+	if cmd.Dir != "/root/deployment" {
+		t.Fatalf("dir = %q", cmd.Dir)
+	}
+}
+
+func TestComposeCommandSudoStandalone(t *testing.T) {
+	d := NewDocker(&fakeRunner{})
+	d.sudo = true
+	c := &Compose{docker: d, standalone: true}
+	cmd := c.Command("/x", map[string]string{"IMAGE_TAG": "edge"}, []string{"docker-compose.yml"}, "stop")
+	want := "sudo env IMAGE_TAG=edge docker-compose -f docker-compose.yml stop"
+	if got := argv(cmd); got != want {
+		t.Fatalf("argv = %q, want %q", got, want)
+	}
+}
+
+func TestEnsureNetworkOnlyCreatesWhenMissing(t *testing.T) {
+	r := &fakeRunner{handler: func(c Command) (Result, error) {
+		if strings.Contains(argv(c), "inspect existing") {
+			return Result{}, nil
+		}
+		if strings.Contains(argv(c), "inspect") {
+			return Result{}, errors.New("no such network")
+		}
+		return Result{}, nil
+	}}
+	d := NewDocker(r)
+
+	created, err := d.EnsureNetwork(context.Background(), "existing")
+	if err != nil || created {
+		t.Fatalf("existing network: created=%v err=%v", created, err)
+	}
+
+	created, err = d.EnsureNetwork(context.Background(), "missing")
+	if err != nil || !created {
+		t.Fatalf("missing network: created=%v err=%v", created, err)
+	}
+	last := argv(r.calls[len(r.calls)-1])
+	if last != "docker network create missing" {
+		t.Fatalf("last call = %q", last)
+	}
+}
+
+func TestDockerVersionParse(t *testing.T) {
+	r := &fakeRunner{handler: func(Command) (Result, error) {
+		return Result{Stdout: "Docker version 27.4.0, build bde2b89"}, nil
+	}}
+	if v := NewDocker(r).Version(context.Background()); v != "27.4.0" {
+		t.Fatalf("Version = %q", v)
+	}
+}

--- a/cli/internal/deploy/dockercmd/provision_darwin_ops.go
+++ b/cli/internal/deploy/dockercmd/provision_darwin_ops.go
@@ -1,0 +1,32 @@
+package dockercmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"time"
+)
+
+// StartDockerDesktopDarwin launches Docker Desktop on macOS and waits for the
+// daemon to answer, mirroring install.sh's `open -a Docker` + poll loop.
+func StartDockerDesktopDarwin(ctx context.Context, d *Docker, progress io.Writer, maxWait time.Duration) error {
+	if _, err := d.Runner.Run(ctx, Command{Name: "open", Args: []string{"-a", "Docker"}}); err != nil {
+		return fmt.Errorf("failed to launch Docker Desktop: %w", err)
+	}
+
+	deadline := time.Now().Add(maxWait)
+	for {
+		if d.DaemonRunning(ctx) {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("Docker Desktop did not start within %s — start it manually and re-run", maxWait)
+		}
+		fmt.Fprintln(progress, "Waiting for Docker Desktop to start...")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(2 * time.Second):
+		}
+	}
+}

--- a/cli/internal/deploy/dockercmd/provision_linux_ops.go
+++ b/cli/internal/deploy/dockercmd/provision_linux_ops.go
@@ -1,0 +1,156 @@
+package dockercmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"os/user"
+	"runtime"
+	"strings"
+	"time"
+)
+
+// Linux provisioning (also used inside WSL). Mirrors install.sh: Docker
+// Engine via get.docker.com (package manager on Amazon Linux), the compose
+// plugin from the docker/compose releases, and docker group membership with
+// the sudo fallback covering the current run.
+
+const composePluginDir = "/usr/local/lib/docker/cli-plugins"
+
+// InstallDockerLinux installs Docker Engine and starts/enables the service.
+// sudo may prompt for a password, so command output streams to progress.
+func InstallDockerLinux(ctx context.Context, r Runner, progress io.Writer) error {
+	if distroID() == "amzn" {
+		pkg := "yum"
+		if _, err := exec.LookPath("dnf"); err == nil {
+			pkg = "dnf"
+		}
+		fmt.Fprintf(progress, "Detected Amazon Linux — installing Docker via %s...\n", pkg)
+		if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{pkg, "install", "-y", "docker"}, Stdout: progress, Stderr: progress}); err != nil {
+			return fmt.Errorf("package manager install failed: %w", err)
+		}
+	} else {
+		fmt.Fprintln(progress, "Installing Docker via get.docker.com...")
+		script, err := os.CreateTemp("", "get-docker-*.sh")
+		if err != nil {
+			return err
+		}
+		defer func() { _ = os.Remove(script.Name()) }()
+		if err := downloadTo(ctx, "https://get.docker.com", script); err != nil {
+			return fmt.Errorf("failed to download the Docker install script: %w", err)
+		}
+		if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{"sh", script.Name()}, Stdout: progress, Stderr: progress}); err != nil {
+			return fmt.Errorf("the Docker install script failed: %w", err)
+		}
+	}
+
+	// Best effort, matching install.sh: systemd hosts start via systemctl,
+	// others via service; enable so Docker survives reboots.
+	if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{"systemctl", "start", "docker"}}); err != nil {
+		_, _ = r.Run(ctx, Command{Name: "sudo", Args: []string{"service", "docker", "start"}})
+	}
+	_, _ = r.Run(ctx, Command{Name: "sudo", Args: []string{"systemctl", "enable", "docker"}})
+	return nil
+}
+
+// InstallComposePluginLinux downloads the docker compose plugin into the
+// system-wide CLI plugin directory.
+func InstallComposePluginLinux(ctx context.Context, r Runner, progress io.Writer) error {
+	arch := runtime.GOARCH
+	switch arch {
+	case "amd64":
+		arch = "x86_64"
+	case "arm64":
+		arch = "aarch64"
+	}
+	url := "https://github.com/docker/compose/releases/latest/download/docker-compose-linux-" + arch
+
+	tmp, err := os.CreateTemp("", "docker-compose-*")
+	if err != nil {
+		return err
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	fmt.Fprintln(progress, "Downloading the Docker Compose plugin...")
+	if err := downloadTo(ctx, url, tmp); err != nil {
+		return fmt.Errorf("failed to download the Docker Compose plugin: %w", err)
+	}
+
+	if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{"mkdir", "-p", composePluginDir}, Stdout: progress, Stderr: progress}); err != nil {
+		return err
+	}
+	dest := composePluginDir + "/docker-compose"
+	if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{"mv", tmp.Name(), dest}, Stdout: progress, Stderr: progress}); err != nil {
+		return err
+	}
+	if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{"chmod", "+x", dest}, Stdout: progress, Stderr: progress}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// EnsureDockerGroup adds the current user to the docker group when they are
+// not already a member (effective on next login; the sudo fallback covers
+// the current run). Callers invoke this only after `docker info` failed
+// without sudo, mirroring install.sh.
+func EnsureDockerGroup(ctx context.Context, r Runner, progress io.Writer) error {
+	u, err := user.Current()
+	if err != nil {
+		return err
+	}
+	res, err := r.Run(ctx, Command{Name: "id", Args: []string{"-nG", u.Username}})
+	if err == nil {
+		for _, g := range strings.Fields(res.Stdout) {
+			if g == "docker" {
+				return nil
+			}
+		}
+	}
+	if _, err := r.Run(ctx, Command{Name: "getent", Args: []string{"group", "docker"}}); err != nil {
+		if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{"groupadd", "docker"}, Stdout: progress, Stderr: progress}); err != nil {
+			return err
+		}
+	}
+	fmt.Fprintf(progress, "Adding %s to the docker group (effective on next login)...\n", u.Username)
+	if _, err := r.Run(ctx, Command{Name: "sudo", Args: []string{"usermod", "-aG", "docker", u.Username}, Stdout: progress, Stderr: progress}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func distroID() string {
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if id, ok := strings.CutPrefix(line, "ID="); ok {
+			return strings.Trim(id, `"`)
+		}
+	}
+	return ""
+}
+
+// downloadTo streams url into f and closes it.
+func downloadTo(ctx context.Context, url string, f *os.File) error {
+	defer func() { _ = f.Close() }()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+	if _, err := io.Copy(f, resp.Body); err != nil {
+		return err
+	}
+	return f.Sync()
+}

--- a/cli/internal/deploy/dockercmd/provision_windows_ops.go
+++ b/cli/internal/deploy/dockercmd/provision_windows_ops.go
@@ -1,0 +1,18 @@
+package dockercmd
+
+// Windows provisioning is detect-and-instruct: when Docker Desktop (with the
+// WSL2 backend) is present, every deploy verb works like on other platforms;
+// when it's missing, the install prints these instructions and exits instead
+// of self-elevating or installing software unattended.
+
+// DockerDesktopInstructionsWindows is printed when no working Docker is found
+// on native Windows.
+const DockerDesktopInstructionsWindows = `Docker Desktop was not found. To run Onyx on Windows:
+
+  1. Install WSL2 (in an elevated PowerShell):  wsl --install
+  2. Install Docker Desktop: https://docs.docker.com/desktop/setup/install/windows-install/
+  3. Start Docker Desktop and enable the WSL2 backend (Settings > General)
+  4. Re-run this command
+
+Alternatively, run the installer inside a WSL2 distribution, where Docker
+Engine can be installed automatically.`

--- a/cli/internal/deploy/dockercmd/runner.go
+++ b/cli/internal/deploy/dockercmd/runner.go
@@ -1,0 +1,91 @@
+// Package dockercmd shells out to docker / docker compose for the deploy
+// commands: command detection, sudo fallback on Linux, and the compose
+// invocations the install lifecycle needs.
+package dockercmd
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"strings"
+)
+
+// Command describes one external process invocation.
+type Command struct {
+	Name string
+	Args []string
+	// Dir is the working directory ("" = inherit).
+	Dir string
+	// Env entries are merged over the current process environment. When the
+	// invocation is wrapped in sudo they are passed as argv to `env` instead,
+	// so sudo's env_reset cannot strip them.
+	Env map[string]string
+	// Stdout/Stderr stream output when set; otherwise output is captured
+	// (stdout into Result, stderr into the returned error).
+	Stdout io.Writer
+	Stderr io.Writer
+}
+
+// Result holds captured output for non-streaming invocations.
+type Result struct {
+	Stdout string
+}
+
+// Runner executes commands. The production implementation is ExecRunner;
+// tests substitute a fake recording invocations.
+type Runner interface {
+	Run(ctx context.Context, c Command) (Result, error)
+}
+
+// ExecRunner runs commands with os/exec.
+type ExecRunner struct{}
+
+var _ Runner = ExecRunner{}
+
+func (ExecRunner) Run(ctx context.Context, c Command) (Result, error) {
+	cmd := exec.CommandContext(ctx, c.Name, c.Args...)
+	cmd.Dir = c.Dir
+	cmd.Env = mergedEnv(c.Env)
+
+	var stdout, stderr strings.Builder
+	if c.Stdout != nil {
+		cmd.Stdout = c.Stdout
+	} else {
+		cmd.Stdout = &stdout
+	}
+	if c.Stderr != nil {
+		cmd.Stderr = c.Stderr
+	} else {
+		cmd.Stderr = &stderr
+	}
+
+	err := cmd.Run()
+	if err != nil && c.Stderr == nil && stderr.Len() > 0 {
+		err = fmt.Errorf("%w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return Result{Stdout: stdout.String()}, err
+}
+
+func mergedEnv(extra map[string]string) []string {
+	if len(extra) == 0 {
+		return nil // inherit as-is
+	}
+	env := os.Environ()
+	for _, k := range sortedKeys(extra) {
+		env = append(env, k+"="+extra[k])
+	}
+	return env
+}
+
+// sortedKeys keeps env ordering deterministic for tests and logs.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/cli/internal/deploy/install/diagnose.go
+++ b/cli/internal/deploy/install/diagnose.go
@@ -1,0 +1,139 @@
+package install
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// containerFacts is what `docker inspect` knows about a container that
+// `docker ps` does not: how often it has been restarted, how it exited, and
+// what its health check last said. A status line can't tell a service that is
+// still coming up from one that has died twenty times — these numbers can.
+type containerFacts struct {
+	Name      string  `json:"name"`
+	Restarts  int     `json:"restarts"`
+	ExitCode  int     `json:"exit"`
+	OOMKilled bool    `json:"oom"`
+	Error     string  `json:"error"`
+	Health    *health `json:"health"`
+}
+
+type health struct {
+	Status        string
+	FailingStreak int
+	Log           []healthProbe
+}
+
+// healthProbe is one run of a container's health check, as docker records it.
+type healthProbe struct {
+	ExitCode int
+	Output   string
+}
+
+// inspectFormat renders one JSON object per container. Health is emitted
+// whole: docker keeps only the last few probe results, and their output is
+// the closest thing to an explanation a failing health check ever gives.
+const inspectFormat = `{"name":{{json .Name}},"restarts":{{.RestartCount}},` +
+	`"exit":{{.State.ExitCode}},"oom":{{.State.OOMKilled}},"error":{{json .State.Error}},` +
+	`"health":{{if .State.Health}}{{json .State.Health}}{{else}}null{{end}}}`
+
+// inspectFacts asks docker about the named containers in one call. A docker
+// that refuses simply leaves the extra detail out of the report — every
+// caller degrades to what `docker ps` already said.
+func (in *installer) inspectFacts(ctx context.Context, names []string) map[string]containerFacts {
+	if len(names) == 0 {
+		return nil
+	}
+	args := append([]string{"inspect", "--format", inspectFormat}, names...)
+	res, err := in.deps.Runner.Run(ctx, in.docker.Command(nil, args...))
+	if err != nil {
+		return nil
+	}
+	facts := make(map[string]containerFacts, len(names))
+	for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
+		var f containerFacts
+		if json.Unmarshal([]byte(line), &f) != nil {
+			continue
+		}
+		// Inspect names containers with a leading slash; ps doesn't.
+		f.Name = strings.TrimPrefix(f.Name, "/")
+		facts[f.Name] = f
+	}
+	return facts
+}
+
+// crashLoop is the restart count past which a container is failing to start
+// rather than being restarted for an ordinary reason (a daemon restart, a
+// one-off kill).
+const crashLoop = 3
+
+// diagnose says what went wrong in the words a user can act on. It reads the
+// facts against the `docker ps` status they came with, and returns "" when
+// nothing it knows adds to what the status line already showed.
+func (f containerFacts) diagnose(status string) string {
+	switch {
+	case f.OOMKilled:
+		return "ran out of memory and was killed — give Docker more memory, or reinstall with --lite"
+	case f.Error != "":
+		return "could not start: " + firstLine(f.Error)
+	case f.Restarts >= crashLoop:
+		return fmt.Sprintf("has restarted %d times (%s) — it is crash-looping, not starting",
+			f.Restarts, exitReason(f.ExitCode))
+	case f.probe() != "":
+		return "is running, but its health check keeps failing: " + f.probe()
+	case strings.Contains(status, "(unhealthy)"):
+		return "is running, but its health check is failing"
+	case strings.HasPrefix(status, "Created"):
+		// Compose creates a container before starting it, so this is a start
+		// that never happened — usually because what it waits on never became
+		// healthy. It has no logs of its own to read.
+		return "was created but never started"
+	case strings.HasPrefix(status, "Exited"), strings.HasPrefix(status, "Restarting"):
+		return fmt.Sprintf("is not running (%s)", exitReason(f.ExitCode))
+	}
+	return ""
+}
+
+// probe is the output of the last health check that failed, on one line.
+func (f containerFacts) probe() string {
+	if f.Health == nil {
+		return ""
+	}
+	for i := len(f.Health.Log) - 1; i >= 0; i-- {
+		if entry := f.Health.Log[i]; entry.ExitCode != 0 {
+			return firstLine(entry.Output)
+		}
+	}
+	return ""
+}
+
+// exitReason translates the exit codes a container dies with. 137 and 143 are
+// the ones worth naming: both are signals rather than the app's own choice,
+// and 137 is what a memory limit looks like from the outside.
+func exitReason(code int) string {
+	switch code {
+	case 0:
+		return "exit 0 — a clean shutdown"
+	case 137:
+		return "exit 137 — killed, usually by a memory limit"
+	case 143:
+		return "exit 143 — stopped by a signal"
+	}
+	return fmt.Sprintf("exit %d", code)
+}
+
+// firstLine trims a message to its first line, so a stack trace or a wall of
+// health-check output can't take over the report.
+func firstLine(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i != -1 {
+		s = strings.TrimSpace(s[:i])
+	}
+	const maxLen = 120
+	if len(s) > maxLen {
+		s = strings.TrimSpace(s[:maxLen]) + "…"
+	}
+	return s
+}

--- a/cli/internal/deploy/install/diagnose_test.go
+++ b/cli/internal/deploy/install/diagnose_test.go
@@ -1,0 +1,75 @@
+package install
+
+import (
+	"strings"
+	"testing"
+)
+
+// The whole point of a diagnosis is that the reader doesn't have to know what
+// a docker exit code, a restart count, or an empty health log means.
+func TestDiagnoseNamesTheFailure(t *testing.T) {
+	probe := &health{Status: "unhealthy", FailingStreak: 4, Log: []healthProbe{
+		{ExitCode: 0, Output: "ok"},
+		{ExitCode: 1, Output: "curl: (7) Failed to connect to localhost port 8080\nafter 0 ms\n"},
+	}}
+	cases := []struct {
+		name   string
+		facts  containerFacts
+		status string
+		want   string
+	}{{
+		// Memory is the one failure the user can fix without reading a log,
+		// and 137 alone doesn't say it.
+		name:   "out of memory",
+		facts:  containerFacts{Restarts: 5, ExitCode: 137, OOMKilled: true},
+		status: "Exited (137) 1 minute ago",
+		want:   "ran out of memory",
+	}, {
+		name:   "crash loop",
+		facts:  containerFacts{Restarts: 18, ExitCode: 255},
+		status: "Restarting (255) 13 seconds ago",
+		want:   "has restarted 18 times (exit 255) — it is crash-looping",
+	}, {
+		name:   "failing health check quotes its own output",
+		facts:  containerFacts{Health: probe},
+		status: "Up 5 minutes (unhealthy)",
+		want:   "curl: (7) Failed to connect to localhost port 8080",
+	}, {
+		// One restart is a daemon restart or a one-off kill, not a loop.
+		name:   "stopped cleanly",
+		facts:  containerFacts{Restarts: 1},
+		status: "Exited (0) 2 hours ago",
+		want:   "exit 0 — a clean shutdown",
+	}, {
+		name:   "nothing to add",
+		facts:  containerFacts{},
+		status: "Up 5 minutes (healthy)",
+		want:   "",
+	}}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := c.facts.diagnose(c.status)
+			if c.want == "" {
+				if got != "" {
+					t.Errorf("diagnose(%q) = %q, want nothing", c.status, got)
+				}
+				return
+			}
+			if !strings.Contains(got, c.want) {
+				t.Errorf("diagnose(%q) = %q, want it to mention %q", c.status, got, c.want)
+			}
+		})
+	}
+}
+
+// A stack trace or a page of probe output would push the rest of the report
+// off the screen.
+func TestFirstLineStaysOnOneLine(t *testing.T) {
+	got := firstLine("  boom: it broke  \nstack frame 1\nstack frame 2\n")
+	if got != "boom: it broke" {
+		t.Errorf("firstLine = %q", got)
+	}
+	if long := firstLine(strings.Repeat("x", 500)); len(long) > 130 || !strings.HasSuffix(long, "…") {
+		t.Errorf("long message not trimmed: %d chars, %q", len(long), long)
+	}
+}

--- a/cli/internal/deploy/install/envfile.go
+++ b/cli/internal/deploy/install/envfile.go
@@ -1,0 +1,63 @@
+package install
+
+import (
+	"strings"
+)
+
+// .env manipulation, matching install.sh's sed/grep semantics: SetVar
+// replaces every uncommented `KEY=...` line (appending when none exists),
+// SetVarUncomment additionally matches commented `# KEY=...` lines and
+// uncomments them, Var reads the first uncommented value with quotes and
+// spaces stripped.
+
+// SetVar sets KEY=value, replacing all `^KEY=` lines or appending.
+func SetVar(content, key, value string) string {
+	return setVar(content, key, value, false)
+}
+
+// SetVarUncomment sets KEY=value, also replacing commented `^#* *KEY=` lines.
+func SetVarUncomment(content, key, value string) string {
+	return setVar(content, key, value, true)
+}
+
+func setVar(content, key, value string, matchCommented bool) string {
+	lines := strings.Split(content, "\n")
+	replaced := false
+	for i, line := range lines {
+		if matchesKey(line, key, matchCommented) {
+			lines[i] = key + "=" + value
+			replaced = true
+		}
+	}
+	if replaced {
+		return strings.Join(lines, "\n")
+	}
+	if !strings.HasSuffix(content, "\n") && content != "" {
+		content += "\n"
+	}
+	return content + key + "=" + value + "\n"
+}
+
+// Var returns the value of the first `KEY=` line ("" if absent), with spaces
+// and quotes stripped (install.sh: cut -d= -f2 | tr -d ' "\” ).
+func Var(content, key string) string {
+	for _, line := range strings.Split(content, "\n") {
+		if rest, ok := strings.CutPrefix(line, key+"="); ok {
+			return strings.NewReplacer(" ", "", `"`, "", "'", "").Replace(rest)
+		}
+	}
+	return ""
+}
+
+func matchesKey(line, key string, matchCommented bool) bool {
+	if strings.HasPrefix(line, key+"=") {
+		return true
+	}
+	if !matchCommented {
+		return false
+	}
+	// `^#* *KEY=`: any number of #, then spaces, then the assignment.
+	rest := strings.TrimLeft(line, "#")
+	rest = strings.TrimLeft(rest, " ")
+	return rest != line && strings.HasPrefix(rest, key+"=")
+}

--- a/cli/internal/deploy/install/envfile.go
+++ b/cli/internal/deploy/install/envfile.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"slices"
 	"strings"
 )
 
@@ -47,6 +48,41 @@ func Var(content, key string) string {
 		}
 	}
 	return ""
+}
+
+// COMPOSE_PROFILES is a list, and only one of its entries belongs to the
+// deployment mode (s3-filestore, which runs MinIO). The rest are the user's,
+// so mode changes add and drop that one entry instead of rewriting the value.
+
+// hasProfile reports whether a COMPOSE_PROFILES value activates profile.
+func hasProfile(list, profile string) bool {
+	return slices.Contains(profileList(list), profile)
+}
+
+// withoutProfile drops profile, keeping every other entry in its order.
+func withoutProfile(list, profile string) string {
+	kept := slices.DeleteFunc(profileList(list), func(p string) bool { return p == profile })
+	return strings.Join(kept, ",")
+}
+
+// withProfile appends profile, leaving a list that already has it untouched.
+func withProfile(list, profile string) string {
+	if hasProfile(list, profile) {
+		return list
+	}
+	return strings.Join(append(profileList(list), profile), ",")
+}
+
+// profileList splits a COMPOSE_PROFILES value, dropping blanks left by an
+// empty value or a stray comma.
+func profileList(list string) []string {
+	var out []string
+	for _, p := range strings.Split(list, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func matchesKey(line, key string, matchCommented bool) bool {

--- a/cli/internal/deploy/install/envfile_test.go
+++ b/cli/internal/deploy/install/envfile_test.go
@@ -1,0 +1,80 @@
+package install
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSetVarReplacesAllUncommentedLines(t *testing.T) {
+	in := "IMAGE_TAG=latest\nOTHER=1\nIMAGE_TAG=stale\n"
+	out := SetVar(in, "IMAGE_TAG", "v1.2.3")
+	if strings.Count(out, "IMAGE_TAG=v1.2.3") != 2 || strings.Contains(out, "latest") {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestSetVarAppendsWhenMissing(t *testing.T) {
+	out := SetVar("OTHER=1", "IMAGE_TAG", "edge")
+	if !strings.HasSuffix(out, "OTHER=1\nIMAGE_TAG=edge\n") {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestSetVarDoesNotTouchCommentedLines(t *testing.T) {
+	in := "# IMAGE_TAG=old\nIMAGE_TAG=latest\n"
+	out := SetVar(in, "IMAGE_TAG", "v1")
+	if !strings.Contains(out, "# IMAGE_TAG=old") {
+		t.Fatalf("commented line was modified: %q", out)
+	}
+	if !strings.Contains(out, "IMAGE_TAG=v1\n") {
+		t.Fatalf("uncommented line not set: %q", out)
+	}
+}
+
+func TestSetVarUncommentUncommentsAndSets(t *testing.T) {
+	in := "# ENABLE_CRAFT=false\nOTHER=1\n"
+	out := SetVarUncomment(in, "ENABLE_CRAFT", "true")
+	if !strings.Contains(out, "ENABLE_CRAFT=true") || strings.Contains(out, "# ENABLE_CRAFT") {
+		t.Fatalf("got %q", out)
+	}
+
+	// Appends when no line matches at all.
+	out = SetVarUncomment("OTHER=1\n", "SANDBOX_BACKEND", "docker")
+	if !strings.HasSuffix(out, "SANDBOX_BACKEND=docker\n") {
+		t.Fatalf("got %q", out)
+	}
+}
+
+func TestVarStripsQuotesAndSpace(t *testing.T) {
+	content := `USER_AUTH_SECRET="abc 123"` + "\nIMAGE_TAG=v1.0.0 \n# IMAGE_TAG=commented\n"
+	if got := Var(content, "USER_AUTH_SECRET"); got != "abc123" {
+		t.Fatalf("got %q", got)
+	}
+	if got := Var(content, "IMAGE_TAG"); got != "v1.0.0" {
+		t.Fatalf("got %q", got)
+	}
+	if got := Var(content, "MISSING"); got != "" {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestSandboxBackendForTag(t *testing.T) {
+	cases := map[string]string{
+		"edge":        "docker",
+		"latest":      "docker",
+		"nightly-x":   "docker",
+		"v4.0.6":      "docker",
+		"4.0.6":       "docker",
+		"v4.1.0":      "docker",
+		"v5.0.0":      "docker",
+		"v4.0.5":      "kubernetes",
+		"v3.9.9":      "kubernetes",
+		"v4.0.6-beta": "docker",
+		"v4.0.5-beta": "kubernetes",
+	}
+	for tag, want := range cases {
+		if got := sandboxBackendForTag(tag); got != want {
+			t.Errorf("sandboxBackendForTag(%q) = %q, want %q", tag, got, want)
+		}
+	}
+}

--- a/cli/internal/deploy/install/envfile_test.go
+++ b/cli/internal/deploy/install/envfile_test.go
@@ -78,3 +78,32 @@ func TestSandboxBackendForTag(t *testing.T) {
 		}
 	}
 }
+
+// COMPOSE_PROFILES is shared: the CLI owns the s3-filestore entry, the user
+// owns the rest, so mode switches edit one entry rather than the value.
+func TestProfileListEditsOneEntry(t *testing.T) {
+	cases := []struct{ list, without, with string }{
+		{"s3-filestore", "", "s3-filestore"},
+		{"s3-filestore,monitoring", "monitoring", "s3-filestore,monitoring"},
+		{"monitoring,s3-filestore,gpu", "monitoring,gpu", "monitoring,s3-filestore,gpu"},
+		{"monitoring", "monitoring", "monitoring,s3-filestore"},
+		{"", "", "s3-filestore"},
+		// Hand-written values are not always tidy.
+		{" monitoring , s3-filestore ", "monitoring", " monitoring , s3-filestore "},
+		{"monitoring,,gpu", "monitoring,gpu", "monitoring,gpu,s3-filestore"},
+	}
+	for _, tc := range cases {
+		if got := withoutProfile(tc.list, s3FilestoreProfile); got != tc.without {
+			t.Errorf("withoutProfile(%q) = %q, want %q", tc.list, got, tc.without)
+		}
+		if got := withProfile(tc.list, s3FilestoreProfile); got != tc.with {
+			t.Errorf("withProfile(%q) = %q, want %q", tc.list, got, tc.with)
+		}
+		if hasProfile(tc.without, s3FilestoreProfile) {
+			t.Errorf("withoutProfile(%q) still activates %s", tc.list, s3FilestoreProfile)
+		}
+		if !hasProfile(tc.with, s3FilestoreProfile) {
+			t.Errorf("withProfile(%q) does not activate %s", tc.list, s3FilestoreProfile)
+		}
+	}
+}

--- a/cli/internal/deploy/install/files.go
+++ b/cli/internal/deploy/install/files.go
@@ -2,12 +2,14 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
 )
 
@@ -31,8 +33,8 @@ func managedFiles(lite, craft bool) []deployfiles.File {
 }
 
 // fileFetcher sources managed-file content for a ref, falling back to the
-// embedded copies. After the first fetch failure it stops trying the network
-// (each fetch retries with delays; once offline, every file would pay that).
+// embedded copies. Once the network itself fails it stops trying (each fetch
+// retries with delays; offline, every remaining file would pay that).
 type fileFetcher struct {
 	in       *installer
 	disabled bool
@@ -46,8 +48,16 @@ func (ff *fileFetcher) content(ctx context.Context, ref string, f deployfiles.Fi
 		if err == nil {
 			return data, ref, nil
 		}
-		ff.disabled = true
-		ff.in.warnf("Could not fetch %s at %s (%v) — using the files bundled with this CLI", f.RepoPath, ref, err)
+		// A file missing from a reachable ref (an overlay added after that
+		// release, say) says nothing about the rest: falling back for the
+		// whole set here would quietly mix one version's compose file with
+		// another's overlays and nginx config.
+		if errors.Is(err, release.ErrNotFound) {
+			ff.in.warnf("%s doesn't exist at %s — using the copy bundled with this CLI, which may not match that version", f.RepoPath, ref)
+		} else {
+			ff.disabled = true
+			ff.in.warnf("Could not fetch %s at %s (%v) — using the files bundled with this CLI", f.RepoPath, ref, err)
+		}
 	}
 	data, err := f.Content()
 	if err != nil {

--- a/cli/internal/deploy/install/files.go
+++ b/cli/internal/deploy/install/files.go
@@ -1,0 +1,203 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+)
+
+// managedFiles returns the files for the selected mode: the base set plus the
+// overlays that apply.
+func managedFiles(lite, craft bool) []deployfiles.File {
+	files := []deployfiles.File{
+		deployfiles.Compose,
+		deployfiles.EnvTemplate,
+		deployfiles.Readme,
+		deployfiles.NginxAppConf,
+		deployfiles.NginxRunScript,
+	}
+	if lite {
+		files = append(files, deployfiles.LiteOverlay)
+	}
+	if craft {
+		files = append(files, deployfiles.CraftOverlay)
+	}
+	return files
+}
+
+// fileFetcher sources managed-file content for a ref, falling back to the
+// embedded copies. After the first fetch failure it stops trying the network
+// (each fetch retries with delays; once offline, every file would pay that).
+type fileFetcher struct {
+	in       *installer
+	disabled bool
+}
+
+// content returns the file's bytes for ref plus a short provenance label.
+// ref == "" means "use embedded" (no fetch attempted).
+func (ff *fileFetcher) content(ctx context.Context, ref string, f deployfiles.File) ([]byte, string, error) {
+	if ref != "" && !ff.disabled {
+		data, err := ff.in.deps.Release.FetchFile(ctx, ref, f.RepoPath)
+		if err == nil {
+			return data, ref, nil
+		}
+		ff.disabled = true
+		ff.in.warnf("Could not fetch %s at %s (%v) — using the files bundled with this CLI", f.RepoPath, ref, err)
+	}
+	data, err := f.Content()
+	if err != nil {
+		return nil, "", fmt.Errorf("embedded copy of %s is unreadable: %w", f.RepoPath, err)
+	}
+	return data, "embedded", nil
+}
+
+// materializeFiles brings every managed file on disk to the wanted state for
+// ref, respecting --local (trust what's on disk, only fill gaps from the
+// embedded copies) and user edits (detected via the manifest; edited files
+// are backed up and only overwritten with consent or --force). The manifest
+// is updated in place; the caller saves it.
+func (in *installer) materializeFiles(
+	ctx context.Context,
+	ref string,
+	files []deployfiles.File,
+	manifest *state.Manifest,
+	fetcher *fileFetcher,
+) error {
+	root := in.root.Dir
+	for _, f := range files {
+		dest := filepath.Join(root, filepath.FromSlash(f.DestRel))
+		if err := os.MkdirAll(filepath.Dir(dest), 0755); err != nil {
+			return fmt.Errorf("failed to create directory for %s: %w", f.DestRel, err)
+		}
+		onDisk, err := os.ReadFile(dest)
+		exists := err == nil
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("failed to read %s: %w", f.DestRel, err)
+		}
+
+		if in.opts.Local {
+			if exists {
+				in.successf("Using existing %s", f.DestRel)
+				if err := manifest.RecordFile(root, f.DestRel, onDisk); err != nil {
+					return err
+				}
+				continue
+			}
+			// install.sh --local errors on missing files; the embedded
+			// copies let the CLI fill the gap instead.
+			in.infof("%s missing — writing the copy bundled with this CLI", f.DestRel)
+		}
+
+		var want []byte
+		source := "embedded"
+		if !in.opts.Local {
+			want, source, err = fetcher.content(ctx, ref, f)
+		} else {
+			want, err = f.Content()
+		}
+		if err != nil {
+			return err
+		}
+
+		if exists && string(onDisk) == string(want) {
+			if err := manifest.RecordFile(root, f.DestRel, want); err != nil {
+				return err
+			}
+			continue
+		}
+
+		if exists {
+			edited, err := manifest.UserEdited(root, f.DestRel)
+			if err != nil {
+				return err
+			}
+			if edited {
+				overwrite, err := in.confirmOverwriteEdited(f.DestRel)
+				if err != nil {
+					return err
+				}
+				if !overwrite {
+					in.warnf("Keeping your %s — it may not match the deployed version", f.DestRel)
+					continue
+				}
+				if err := in.backupFile(dest, f.DestRel, manifest); err != nil {
+					return err
+				}
+			}
+		}
+
+		if err := os.WriteFile(dest, want, f.Mode); err != nil {
+			return fmt.Errorf("failed to write %s: %w", f.DestRel, err)
+		}
+		// WriteFile only applies the mode on creation; keep the exec bit on
+		// updates too.
+		if err := os.Chmod(dest, f.Mode); err != nil {
+			return fmt.Errorf("failed to chmod %s: %w", f.DestRel, err)
+		}
+		if err := manifest.RecordFile(root, f.DestRel, want); err != nil {
+			return err
+		}
+		if exists {
+			in.successf("Updated %s (%s)", f.DestRel, source)
+		} else {
+			in.successf("%s ready (%s)", f.DestRel, source)
+		}
+	}
+	return nil
+}
+
+// removeOverlayIfPresent deletes a deselected overlay (e.g. switching from
+// lite to standard) and drops it from the manifest.
+func (in *installer) removeOverlayIfPresent(f deployfiles.File, manifest *state.Manifest, reason string) error {
+	dest := filepath.Join(in.root.Dir, filepath.FromSlash(f.DestRel))
+	if _, err := os.Stat(dest); os.IsNotExist(err) {
+		return nil
+	}
+	if err := os.Remove(dest); err != nil {
+		return fmt.Errorf("failed to remove %s: %w", f.DestRel, err)
+	}
+	if err := manifest.ForgetFile(in.root.Dir, f.DestRel); err != nil {
+		return err
+	}
+	in.infof("Removed %s (%s)", f.DestRel, reason)
+	return nil
+}
+
+// confirmOverwriteEdited gates replacing a file the CLI cannot vouch for:
+// hand-edited since the last managed write, or present in a deployment that
+// predates the manifest.
+func (in *installer) confirmOverwriteEdited(destRel string) (bool, error) {
+	if in.opts.Force {
+		return true, nil
+	}
+	in.warnf("%s differs from what the CLI last wrote (hand-edited, or from an older installer).", destRel)
+	if in.prompt.AssumeDefaults {
+		in.warnf("Keeping it. Re-run with --force to overwrite (a backup is made).")
+		return false, nil
+	}
+	return in.prompt.Confirm(fmt.Sprintf("Overwrite %s? A backup will be kept. (y/N) ", destRel), false)
+}
+
+// backupFile snapshots dest before an overwrite, versioned so repeated
+// upgrades don't clobber earlier backups.
+func (in *installer) backupFile(dest, destRel string, manifest *state.Manifest) error {
+	fromTag := "unmanaged"
+	if manifest != nil && manifest.InstalledTag != "" {
+		fromTag = manifest.InstalledTag
+	}
+	backup := fmt.Sprintf("%s.bak-%s-%d", dest, fromTag, time.Now().Unix())
+	data, err := os.ReadFile(dest)
+	if err != nil {
+		return err
+	}
+	if err := os.WriteFile(backup, data, 0644); err != nil {
+		return fmt.Errorf("failed to back up %s: %w", destRel, err)
+	}
+	in.infof("Backed up %s to %s", destRel, filepath.Base(backup))
+	return nil
+}

--- a/cli/internal/deploy/install/files.go
+++ b/cli/internal/deploy/install/files.go
@@ -180,7 +180,7 @@ func (in *installer) confirmOverwriteEdited(destRel string) (bool, error) {
 		in.warnf("Keeping it. Re-run with --force to overwrite (a backup is made).")
 		return false, nil
 	}
-	return in.prompt.Confirm(fmt.Sprintf("Overwrite %s? A backup will be kept. (y/N) ", destRel), false)
+	return in.confirmYN(fmt.Sprintf("Overwrite %s? A backup will be kept.", destRel), false)
 }
 
 // backupFile snapshots dest before an overwrite, versioned so repeated

--- a/cli/internal/deploy/install/files.go
+++ b/cli/internal/deploy/install/files.go
@@ -90,7 +90,7 @@ func (in *installer) materializeFiles(
 			return fmt.Errorf("failed to read %s: %w", f.DestRel, err)
 		}
 
-		if in.opts.Local {
+		if in.localFiles() {
 			if exists {
 				in.successf("Using existing %s", f.DestRel)
 				if err := manifest.RecordFile(root, f.DestRel, onDisk); err != nil {
@@ -105,7 +105,7 @@ func (in *installer) materializeFiles(
 
 		var want []byte
 		source := "embedded"
-		if !in.opts.Local {
+		if !in.localFiles() {
 			want, source, err = fetcher.content(ctx, ref, f)
 		} else {
 			want, err = f.Content()

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -106,6 +106,11 @@ func (in *installer) runInstall(ctx context.Context) error {
 	tagCh := make(chan tagLookup, 1)
 	go func() {
 		switch {
+		case in.opts.Offline && pinnedTag == "":
+			// Deliberately not "edge": offline, the only deployable versions
+			// are the ones whose images are already here. errOffline routes
+			// this through the same fallback an unreachable GitHub takes.
+			tagCh <- tagLookup{err: errOffline}
 		case in.opts.Local:
 			tagCh <- tagLookup{tag: "edge"}
 		case pinnedTag != "":
@@ -125,8 +130,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 		if latestTag == "" {
 			got := <-tagCh
 			if got.err != nil {
-				in.warnf("Could not determine latest Onyx release — falling back to main / edge")
-				got.tag = "edge"
+				got.tag = in.unreachableTagFallback(ctx)
 			}
 			latestTag = got.tag
 		}
@@ -301,7 +305,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 		}
 	}
 	initialRef := ""
-	if !in.opts.Local {
+	if !in.localFiles() {
 		initialRef = release.ConfigRef(initialTag)
 	}
 	fetcher := &fileFetcher{in: in}
@@ -340,7 +344,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 	// Pinned tags want config files from their own ref so compose matches
 	// the images; re-materialize when the effective tag needs another ref.
 	configRef := release.ConfigRef(effectiveTag)
-	if !in.opts.Local && configRef != initialRef {
+	if !in.localFiles() && configRef != initialRef {
 		in.infof("Fetching config files matching %s...", configRef)
 		if err := in.materializeFiles(ctx, configRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
 			// .env already names this version and nothing has been deployed
@@ -414,7 +418,7 @@ func (in *installer) validateTag(ctx context.Context, tag string) (string, error
 		in.infof("Using %s (Onyx versions are v-prefixed)", normalized)
 	}
 	// A dry run writes nothing and pulls nothing, so it stays offline.
-	if !checkable || in.opts.Local || in.opts.DryRun {
+	if !checkable || in.localFiles() || in.opts.DryRun {
 		return normalized, nil
 	}
 
@@ -435,6 +439,77 @@ func (in *installer) validateTag(ctx context.Context, tag string) (string, error
 	}
 	return "", exitcodes.Newf(exitcodes.BadRequest,
 		"version %s not found — Onyx releases look like v4.4.6 (https://github.com/onyx-dot-app/onyx/releases)", normalized)
+}
+
+// appImage is the one image every deployment runs whatever its mode, so the
+// tags present for it are the versions this host could deploy right now.
+const appImage = "onyxdotapp/onyx-backend"
+
+// errOffline stands in for the release lookup --offline never makes, so the
+// one place that turns a failed lookup into an offered version handles both.
+var errOffline = errors.New("offline")
+
+// latestAppTag is the release lookup, skipped outright when --offline says
+// the network is not there to be asked.
+func (in *installer) latestAppTag(ctx context.Context) (string, error) {
+	if in.opts.Offline {
+		return "", errOffline
+	}
+	return in.deps.Release.LatestAppTag(ctx)
+}
+
+// unreachableTagFallback picks the version to offer when the latest release
+// could not be looked up. A host that already has released images can still
+// install from them, and offering one is what makes that possible: edge is a
+// floating tag, so choosing it commits the run to another trip to the
+// registry — the one thing an absent network guarantees will fail.
+func (in *installer) unreachableTagFallback(ctx context.Context) string {
+	why := "Could not reach GitHub"
+	if in.opts.Offline {
+		why = "Offline"
+	}
+	if local := in.localAppTag(ctx); local != "" {
+		in.warnf("%s — offering %s, whose images are already on this host", why, local)
+		return local
+	}
+	if in.opts.Offline {
+		// edge may well be here too; it just isn't a version, so it can't be
+		// compared with anything or verified as the one that was meant.
+		in.warnf("%s — no released Onyx images on this host, offering edge", why)
+	} else {
+		in.warnf("Could not determine latest Onyx release — falling back to main / edge")
+	}
+	return "edge"
+}
+
+// localAppTag returns the newest released version already pulled on this
+// host, or "" when there is none. Only released versions count: a floating
+// tag on disk is a copy of whatever main was that day, and deploying it pulls
+// again regardless.
+func (in *installer) localAppTag(ctx context.Context) string {
+	if !dockercmd.Installed() {
+		return ""
+	}
+	in.docker.RefreshSudo(ctx)
+	res, err := in.deps.Runner.Run(ctx, in.docker.Command(nil, "images", "--format", "{{.Tag}}", appImage))
+	if err != nil {
+		return ""
+	}
+	best, bestVer := "", version.Semver{}
+	for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
+		tag := strings.TrimSpace(line)
+		if !release.IsImmutableTag(tag) {
+			continue
+		}
+		ver, ok := version.Parse(tag)
+		if !ok {
+			continue
+		}
+		if best == "" || bestVer.LessThan(ver) {
+			best, bestVer = tag, ver
+		}
+	}
+	return best
 }
 
 // askVersion asks for a deployment version and validates the answer;
@@ -860,6 +935,9 @@ func (in *installer) composeRunEnv(tag string, hostPort int) map[string]string {
 }
 
 func (in *installer) pullImages(ctx context.Context, tag string, hostPort int) error {
+	if in.opts.Offline {
+		return in.checkLocalImages(ctx, tag, hostPort)
+	}
 	phase := composePhase{
 		stage: ui.StagePull,
 		title: "Pulling images",
@@ -896,6 +974,44 @@ func (in *installer) pullImages(ctx context.Context, tag string, hostPort int) e
 	return nil
 }
 
+// checkLocalImages replaces the pull when --offline forbids one. It asks
+// compose what the deployment resolves to and names every image this host
+// doesn't have, because `up` would otherwise stop at the first one it misses
+// and report it as a registry error rather than a missing copy. Note that not
+// every image follows IMAGE_TAG: code-interpreter carries its own version
+// line, so it is pinned separately and is the one most often absent.
+func (in *installer) checkLocalImages(ctx context.Context, tag string, hostPort int) error {
+	in.phase("Checking images")
+	cmd := in.compose.Command(in.deploymentDir(), in.composeRunEnv(tag, hostPort),
+		in.composeFileNames(false), "config", "--images")
+	res, err := in.deps.Runner.Run(ctx, cmd)
+	if err != nil {
+		// No list to check against. `up --pull never` still refuses to reach a
+		// registry, so let it be the one to object.
+		return nil
+	}
+	var missing []string
+	for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
+		image := strings.TrimSpace(line)
+		if image == "" {
+			continue
+		}
+		if _, ierr := in.deps.Runner.Run(ctx, in.docker.Command(nil, "image", "inspect", image)); ierr != nil {
+			missing = append(missing, image)
+		}
+	}
+	if len(missing) == 0 {
+		in.successf("Every image this deployment needs is already on this host")
+		return nil
+	}
+	for _, image := range missing {
+		in.errorf("Not on this host: %s", image)
+	}
+	return exitcodes.Newf(exitcodes.NotAvailable,
+		"%d image(s) missing — load them with `docker load`, or re-run without --offline to fetch them",
+		len(missing))
+}
+
 // startServices brings the stack up. prevTag is the version .env carried
 // before this run ("" on a fresh install), used only to explain what a failed
 // start left behind.
@@ -907,6 +1023,16 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 	upArgs := []string{"up", "-d"}
 	recreate := true
 	switch {
+	case in.opts.Offline:
+		// Compose consults the registry for any service whose own policy says
+		// to, whatever the tag; --pull never is what makes --offline a promise
+		// rather than a preference. No image can have moved under a name while
+		// the host was offline, so nothing needs recreating for its own sake.
+		upArgs = append(upArgs, "--pull", "never")
+		recreate = in.forceRecreate
+		if recreate {
+			upArgs = append(upArgs, "--force-recreate")
+		}
 	case release.IsFloatingTag(tag):
 		// A floating tag names a moving image: the digest changes under the
 		// same name, so neither the pull nor the recreate can be skipped.
@@ -1264,7 +1390,7 @@ func (in *installer) starPrompt(ctx context.Context) {
 // askStarQuestion asks while the UI is still live (the wizard closes on
 // Finish, so callers ask first and run the API call after).
 func (in *installer) askStarQuestion() bool {
-	if in.prompt.AssumeDefaults {
+	if in.prompt.AssumeDefaults || in.opts.Offline {
 		return false
 	}
 	if _, err := exec.LookPath("gh"); err != nil {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -44,6 +45,7 @@ type preflight struct {
 	composeType    string
 	memoryMB       int
 	diskGB         int
+	rootless       bool
 }
 
 // RunInstall implements `deploy install` (and the install-onyx alias): fresh
@@ -352,6 +354,7 @@ func (in *installer) gatherPreflight(ctx context.Context) preflight {
 		dockerInfo = res.Stdout
 	}
 	p.memoryMB = resources.MemoryMB(dockerInfo)
+	p.rootless = strings.Contains(strings.ToLower(dockerInfo), "rootless")
 	return p
 }
 
@@ -447,6 +450,10 @@ func (in *installer) resolveDockerProblems(ctx context.Context, pre preflight) e
 		summary = append(summary, fmt.Sprintf("Compose %s (%s)", in.compose.Version(ctx), in.compose.TypeName()))
 	}
 	summary = append(summary, "daemon running")
+	if pre.rootless {
+		in.rootless = true
+		summary = append(summary, "rootless")
+	}
 	if pre.memoryMB > 0 {
 		summary = append(summary, resources.FormatMemory(pre.memoryMB)+" RAM")
 	}
@@ -481,6 +488,10 @@ func (in *installer) resourceWarnings(pre preflight) error {
 	if pre.diskGB >= 0 && pre.diskGB < diskWant {
 		in.warnf("Less than %dGB disk space available (found: %dGB)", diskWant, pre.diskGB)
 		warning = true
+	}
+	if in.rootless && !in.lite {
+		in.warnf("Rootless Docker: the standard deployment's Vespa index requests unlimited memlock, which a rootless daemon usually can't grant.")
+		in.infof("Either raise the daemon's limits (systemctl --user edit docker: LimitMEMLOCK=infinity, LimitNOFILE=1048576, then systemctl --user restart docker) or use Lite mode, which has no Vespa.")
 	}
 	if !warning {
 		return nil
@@ -743,12 +754,15 @@ func (in *installer) runComposePhase(
 
 	if in.wiz == nil || in.opts.Verbose {
 		in.phase(title)
-		cmd.Stdout, cmd.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+		var seen bytes.Buffer
+		cmd.Stdout = io.MultiWriter(in.deps.IOS.Out, &seen)
+		cmd.Stderr = io.MultiWriter(in.deps.IOS.ErrOut, &seen)
 		_, err := in.deps.Runner.Run(ctx, cmd)
 		if err == nil {
 			in.successf("%s complete", title)
 		} else {
 			in.errorf("%s failed", title)
+			in.printFailureDiagnosis(seen.String())
 		}
 		return err
 	}
@@ -777,8 +791,27 @@ func (in *installer) runComposePhase(
 		for _, l := range lines {
 			in.plainf("  %s", l)
 		}
+		in.printFailureDiagnosis(captured.String())
 	}
 	return err
+}
+
+// printFailureDiagnosis translates known failure signatures in compose
+// output into targeted remedies instead of leaving raw runtime errors.
+func (in *installer) printFailureDiagnosis(output string) {
+	lower := strings.ToLower(output)
+	if strings.Contains(lower, "setting rlimit") || strings.Contains(lower, "memlock") {
+		in.plainf("")
+		in.warnf("This looks like a ulimit failure: the Vespa index container requests unlimited memlock, which rootless Docker (and some hosts) can't grant.")
+		in.infof("Fix one of these ways, then re-run:")
+		in.plainf("  • Raise the daemon limits: systemctl --user edit docker → [Service] LimitMEMLOCK=infinity, LimitNOFILE=1048576 → systemctl --user restart docker")
+		in.plainf("  • Or deploy Lite mode (no Vespa): onyx-cli deploy install --lite")
+		return
+	}
+	if strings.Contains(lower, "address already in use") || strings.Contains(lower, "port is already allocated") {
+		in.plainf("")
+		in.warnf("A required port is taken by another process. Stop it, or set HOST_PORT before re-running.")
+	}
 }
 
 // pollServiceHealth feeds the wizard a live per-service checklist while

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1200,13 +1200,14 @@ func (in *installer) printSuccess(ctx context.Context, hostPort int) {
 		headline,
 		"",
 		"First signup becomes the admin account: " + url + "/auth/signup",
-		"Manage:  onyx-cli deploy status · stop · upgrade · uninstall",
 	}
 	if in.lite {
 		lines = append(lines, "",
 			"Lite mode: no OpenSearch/Redis/model servers or background workers.",
 			"Connectors and RAG search are off; chat, tools, uploads, projects work.")
 	}
+	lines = append(lines, "")
+	lines = append(lines, manageLines()...)
 
 	if in.wiz != nil {
 		// The install is over by the time the star question is on screen, so
@@ -1229,6 +1230,29 @@ func (in *installer) printSuccess(ctx context.Context, hostPort int) {
 	in.starPrompt(ctx)
 }
 
+// manageLines closes a summary card with the verbs that come after the
+// install. The installer is typically run once and then forgotten, so the
+// commands that keep the deployment going get a spelled-out block rather than
+// a single line of "status · stop · upgrade" — the point is that the reader
+// recognizes them months later, when something needs doing.
+func manageLines() []string {
+	cmds := []struct{ cmd, what string }{
+		{"onyx-cli deploy status", "health, version, and URL"},
+		{"onyx-cli deploy upgrade", "move to a newer version"},
+		{"onyx-cli deploy stop", "shut the services down"},
+		{"onyx-cli deploy uninstall", "remove it and its data"},
+	}
+	width := 0
+	for _, c := range cmds {
+		width = max(width, len(c.cmd))
+	}
+	lines := []string{"Manage this deployment any time with:"}
+	for _, c := range cmds {
+		lines = append(lines, "  "+ui.Accent(fmt.Sprintf("%-*s", width, c.cmd))+"   "+c.what)
+	}
+	return lines
+}
+
 // starPrompt ports install.sh's GitHub star prompt: only when interactive
 // and the gh CLI is available.
 func (in *installer) starPrompt(ctx context.Context) {
@@ -1246,7 +1270,7 @@ func (in *installer) askStarQuestion() bool {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return false
 	}
-	ok, err := in.confirmYN("Enjoying Onyx? Star the repo on GitHub?", true)
+	ok, err := in.confirmYN("Enjoying Onyx? ⭐ Star the repo on GitHub?", true)
 	return err == nil && ok
 }
 

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -585,9 +585,10 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 	return effectiveTag, nil
 }
 
-// guardServicesStopped refuses to reconfigure while containers are up. The
-// replacement message points at a command that actually exists after a
-// curl|bash install — unlike install.sh's "./install.sh --shutdown".
+// guardServicesStopped handles reconfiguring while containers are up:
+// interactive runs offer to stop them right here; non-interactive runs
+// refuse with the remedy in the error itself (install.sh printed
+// "./install.sh --shutdown", which doesn't exist after curl|bash).
 func (in *installer) guardServicesStopped(ctx context.Context) error {
 	files := in.composeFileNames(true)
 	cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "ps", "-q")
@@ -595,10 +596,35 @@ func (in *installer) guardServicesStopped(ctx context.Context) error {
 	if err != nil || strings.TrimSpace(res.Stdout) == "" {
 		return nil
 	}
-	in.errorf("Onyx services are currently running!")
-	in.infof("To make configuration changes, first shut them down:")
-	in.plainf("   onyx-cli deploy stop")
-	return exitcodes.New(exitcodes.General, "services are running")
+
+	if in.prompt.AssumeDefaults {
+		return exitcodes.New(exitcodes.General,
+			"Onyx services are running — stop them first with `onyx-cli deploy stop`, then re-run")
+	}
+
+	choice, err := in.selectOne("Onyx is already running. Reconfiguring needs the services stopped.",
+		[]ui.Option{
+			{Label: "Stop and continue", Hint: "pause the containers (no data loss), then proceed"},
+			{Label: "Cancel", Hint: "leave everything running"},
+		}, 0)
+	if err != nil {
+		return err
+	}
+	if choice != 0 {
+		return exitcodes.New(exitcodes.General,
+			"cancelled — services left running (stop them with `onyx-cli deploy stop`)")
+	}
+
+	in.infof("Stopping Onyx services...")
+	stop := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "stop")
+	if in.wiz == nil {
+		stop.Stdout, stop.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+	}
+	if _, err := in.deps.Runner.Run(ctx, stop); err != nil {
+		return exitcodes.Newf(exitcodes.General, "failed to stop the running services: %v", err)
+	}
+	in.successf("Services stopped")
+	return nil
 }
 
 func (in *installer) ensureCraftResources(ctx context.Context) {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -111,8 +111,6 @@ func (in *installer) runInstall(ctx context.Context) error {
 			tagCh <- tagLookup{tag: tag, err: err}
 		}
 	}()
-	preCh := make(chan preflight, 1)
-	go func() { preCh <- in.gatherPreflight(ctx) }()
 
 	// tagCh delivers exactly one value; latestTag memoizes it so every
 	// consumer (question defaults, initialTag) can read it safely. The
@@ -135,6 +133,12 @@ func (in *installer) runInstall(ctx context.Context) error {
 		in.printPlan(getLatestTag())
 		return nil
 	}
+
+	// Started only past the dry-run exit: a dry run inspects nothing about
+	// the host, and leaving docker probes running after the command returns
+	// makes its "no side effects" promise depend on timing.
+	preCh := make(chan preflight, 1)
+	go func() { preCh <- in.gatherPreflight(ctx) }()
 
 	manifest, err := state.Load(in.root.Dir)
 	if err != nil {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -881,6 +881,7 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 	dir := in.deploymentDir()
 
 	upArgs := []string{"up", "-d"}
+	recreate := true
 	switch {
 	case release.IsFloatingTag(tag):
 		// A floating tag names a moving image: the digest changes under the
@@ -891,6 +892,10 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 		// on replacing them; compose would otherwise leave containers whose
 		// config it considers unchanged running the old image.
 		upArgs = append(upArgs, "--force-recreate")
+	default:
+		// Compose decides per container, so a container still on the one it
+		// started on may be one it means to leave alone.
+		recreate = false
 	}
 	wait := !in.opts.NoWait
 	if wait {
@@ -903,20 +908,24 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 		env:   env,
 		files: files,
 		args:  upArgs,
-		// Poll container health so the wizard shows something while
+	}
+	if wait && in.wiz != nil && !in.opts.Verbose {
+		// Watch container states so the wizard shows something while
 		// `up --wait` blocks (it is silent for as long as that takes).
-		poll: wait,
+		phase.watch = &healthWatch{before: in.runningContainers(ctx), recreate: recreate}
 	}
 	if mode := in.progressMode(ctx); mode != "" {
-		// Compose's own event stream says what is happening to each container
-		// — the poll can only see that the outgoing container is still up. The
-		// poll stays on behind it though: a compose that prints no events (a
-		// format we can't read, output swallowed by a wrapper) would otherwise
-		// leave the longest phase of the run with nothing on screen at all.
+		// Compose's own event stream names every transition, which is more than
+		// a container list can show. The watch stays on behind it though: a
+		// compose that prints no events (a format we can't read, output
+		// swallowed by a wrapper) would otherwise leave the longest phase of
+		// the run with nothing on screen at all.
 		phase.args = append([]string{"--progress", mode}, upArgs...)
 		start := newStartProgress(in.wiz.Services, in.wiz.TaskExtra, wait)
 		phase.onLine = start.line
-		phase.pollQuiet = func() bool { return !start.reporting() }
+		if phase.watch != nil {
+			phase.watch.quiet = func() bool { return !start.reporting() }
+		}
 		defer in.wiz.Services(nil)
 	}
 	if err := in.runComposePhase(ctx, phase); err != nil {
@@ -990,10 +999,7 @@ func (in *installer) runningHostPort(ctx context.Context) int {
 	if !dockercmd.Installed() {
 		return 0
 	}
-	cmd := in.docker.Command(nil, "ps",
-		"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
-		"--format", "{{.Ports}}")
-	res, err := in.deps.Runner.Run(ctx, cmd)
+	res, err := in.deps.Runner.Run(ctx, in.psCommand("{{.Ports}}"))
 	if err != nil {
 		return 0
 	}
@@ -1013,12 +1019,9 @@ type composePhase struct {
 	env   map[string]string
 	files []string
 	args  []string
-	// poll watches container health while the command runs (`up --wait` is
-	// silent for as long as it takes everything to come up).
-	poll bool
-	// pollQuiet gates the poll when onLine is also filling the checklist: the
-	// poll then only publishes while the command's own output has said nothing.
-	pollQuiet func() bool
+	// watch reads container states off `docker ps` while the command runs;
+	// nil for phases with no containers to watch.
+	watch *healthWatch
 	// onLine receives each output line while the wizard drives the run, for
 	// phases whose progress can be read off the command's own output.
 	onLine func(string)
@@ -1058,8 +1061,8 @@ func (in *installer) runComposePhase(ctx context.Context, p composePhase) error 
 	cmd.Stdout, cmd.Stderr = sink, sink
 
 	stop := make(chan struct{})
-	if p.poll {
-		go in.pollServiceHealth(stop, p.pollQuiet)
+	if p.watch != nil {
+		go in.pollServiceHealth(*p.watch, stop)
 	}
 	_, err := in.deps.Runner.Run(ctx, cmd)
 	close(stop)
@@ -1102,50 +1105,54 @@ func (in *installer) printFailureDiagnosis(output string) {
 }
 
 // pollServiceHealth feeds the wizard a live per-service checklist while
-// `up --wait` blocks (otherwise silent for up to ten minutes). quiet, when
-// set, is the phase's own progress reader saying it has nothing to show: the
-// poll is the backstop for a compose whose event stream never arrives.
-func (in *installer) pollServiceHealth(stop chan struct{}, quiet func() bool) {
+// `up --wait` blocks (otherwise silent for up to ten minutes).
+func (in *installer) pollServiceHealth(w healthWatch, stop chan struct{}) {
 	ctx := context.Background()
 	for {
 		select {
 		case <-stop:
 			return
-		case <-time.After(2 * time.Second):
+		case <-time.After(healthPollInterval):
 		}
-		if quiet != nil && !quiet() {
+		if w.quiet != nil && !w.quiet() {
 			continue
 		}
-		cmd := in.docker.Command(nil, "ps",
-			"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
-			"--format", "{{.Names}}\t{{.Status}}")
-		res, err := in.deps.Runner.Run(ctx, cmd)
+		res, err := in.deps.Runner.Run(ctx, in.psCommand("{{.Names}}\t{{.ID}}\t{{.Status}}"))
 		if err != nil {
 			continue
 		}
-		var rows []ui.ServiceRow
-		ready := 0
-		for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
-			parts := strings.SplitN(line, "\t", 2)
-			if len(parts) != 2 {
-				continue
-			}
-			ok := strings.Contains(parts[1], "(healthy)") ||
-				(strings.HasPrefix(parts[1], "Up") && !strings.Contains(parts[1], "health"))
-			if ok {
-				ready++
-			}
-			rows = append(rows, ui.ServiceRow{
-				Name:   shortContainerName(parts[0]),
-				Detail: healthDetail(parts[1]),
-				Ready:  ok,
-			})
-		}
+		rows, ready := watchRows(res.Stdout, w)
 		if len(rows) > 0 && in.wiz != nil {
 			in.wiz.Services(rows)
 			in.wiz.TaskExtra(fmt.Sprintf("%d/%d ready", ready, len(rows)))
 		}
 	}
+}
+
+// psCommand lists the deployment's running containers in the given format.
+func (in *installer) psCommand(format string) dockercmd.Command {
+	return in.docker.Command(nil, "ps",
+		"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
+		"--format", format)
+}
+
+// runningContainers maps each running service to the container serving it, so
+// a phase that replaces containers can tell which ones it has got to.
+func (in *installer) runningContainers(ctx context.Context) map[string]string {
+	if !dockercmd.Installed() {
+		return nil
+	}
+	res, err := in.deps.Runner.Run(ctx, in.psCommand("{{.Names}}\t{{.ID}}"))
+	if err != nil {
+		return nil
+	}
+	before := map[string]string{}
+	for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
+		if name, id, ok := strings.Cut(line, "\t"); ok {
+			before[shortContainerName(name)] = id
+		}
+	}
+	return before
 }
 
 func (in *installer) printSuccess(ctx context.Context, hostPort int) {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -102,8 +102,8 @@ func (in *installer) runInstall(ctx context.Context) error {
 	}
 
 	if in.fancy() {
-		in.plainf("%s", ui.AccentURL("Onyx installer"))
-		in.plainf("")
+		in.wiz = ui.StartWizard(in.deps.CLIVersion)
+		defer in.wiz.Abort()
 	}
 
 	// ---- Questions: every decision is made up front ----
@@ -145,6 +145,13 @@ func (in *installer) runInstall(ctx context.Context) error {
 					return err
 				}
 			}
+			if in.wiz != nil {
+				action := "Restart"
+				if updateTag != "" {
+					action = "Upgrade → " + updateTag
+				}
+				in.wiz.Answer("Action", action)
+			}
 		}
 	} else {
 		if err := in.askModeQuestion(); err != nil {
@@ -156,6 +163,9 @@ func (in *installer) runInstall(ctx context.Context) error {
 				return err
 			}
 			in.opts.Tag = tag
+		}
+		if in.wiz != nil {
+			in.wiz.Answer("Version", in.opts.Tag)
 		}
 	}
 
@@ -174,7 +184,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 	}
 
 	// ---- Phase 1: prepare configuration ----
-	in.phase("Preparing configuration", false)
+	in.phase("Preparing configuration")
 	if in.root.Source == paths.SourceLegacyCwd {
 		in.infof("Managing existing install at %s (created by install.sh)", in.root.Dir)
 	}
@@ -297,6 +307,9 @@ func (in *installer) askModeQuestion() error {
 	}
 	in.lite = choice == 0
 	in.craft = choice == 2
+	if in.wiz != nil {
+		in.wiz.Answer("Mode", []string{"Lite", "Standard", "Std+Craft"}[choice])
+	}
 	return nil
 }
 
@@ -337,7 +350,9 @@ func (in *installer) resolveDockerProblems(ctx context.Context, pre preflight) e
 			if !ok {
 				return exitcodes.New(exitcodes.General, "Docker is required to run Onyx")
 			}
-			if err := dockercmd.InstallDockerLinux(ctx, in.deps.Runner, in.deps.IOS.Out); err != nil {
+			if err := in.suspend(func() error {
+				return dockercmd.InstallDockerLinux(ctx, in.deps.Runner, in.deps.IOS.Out)
+			}); err != nil {
 				return exitcodes.Newf(exitcodes.General, "Docker installation failed: %v\n  Visit: https://docs.docker.com/get-docker/", err)
 			}
 			if !dockercmd.Installed() {
@@ -363,7 +378,9 @@ func (in *installer) resolveDockerProblems(ctx context.Context, pre preflight) e
 		if !ok {
 			return exitcodes.New(exitcodes.General, "Docker Compose is required to run Onyx")
 		}
-		if err := dockercmd.InstallComposePluginLinux(ctx, in.deps.Runner, in.deps.IOS.Out); err != nil {
+		if err := in.suspend(func() error {
+			return dockercmd.InstallComposePluginLinux(ctx, in.deps.Runner, in.deps.IOS.Out)
+		}); err != nil {
 			return exitcodes.Newf(exitcodes.General, "Failed to install the Docker Compose plugin: %v\n  Visit: https://docs.docker.com/compose/install/", err)
 		}
 		in.compose = dockercmd.DetectCompose(ctx, in.docker)
@@ -379,7 +396,9 @@ func (in *installer) resolveDockerProblems(ctx context.Context, pre preflight) e
 
 	in.docker.RefreshSudo(ctx)
 	if in.docker.UsingSudo() {
-		if err := dockercmd.EnsureDockerGroup(ctx, in.deps.Runner, in.deps.IOS.Out); err != nil {
+		if err := in.suspend(func() error {
+			return dockercmd.EnsureDockerGroup(ctx, in.deps.Runner, in.deps.IOS.Out)
+		}); err != nil {
 			in.warnf("Could not add you to the docker group: %v", err)
 		}
 		in.infof("Using sudo for docker commands in this run.")
@@ -388,7 +407,9 @@ func (in *installer) resolveDockerProblems(ctx context.Context, pre preflight) e
 	if !in.docker.DaemonRunning(ctx) {
 		if runtime.GOOS == "darwin" {
 			in.infof("Docker daemon is not running. Starting Docker Desktop...")
-			if err := dockercmd.StartDockerDesktopDarwin(ctx, in.docker, in.deps.IOS.Out, 120*time.Second); err != nil {
+			if err := in.suspend(func() error {
+				return dockercmd.StartDockerDesktopDarwin(ctx, in.docker, in.deps.IOS.Out, 120*time.Second)
+			}); err != nil {
 				return exitcodes.Newf(exitcodes.General, "%v", err)
 			}
 		} else {
@@ -610,7 +631,7 @@ func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int)
 	if !in.opts.Verbose {
 		pullArgs = append(pullArgs, "--quiet")
 	}
-	if err := in.runComposePhase(ctx, "Pulling images", dir, env, files, pullArgs, nil); err != nil {
+	if err := in.runComposePhase(ctx, ui.StagePull, "Pulling images", dir, env, files, pullArgs, false); err != nil {
 		in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
 	}
@@ -619,12 +640,12 @@ func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int)
 	if floating {
 		upArgs = append(upArgs, "--pull", "always", "--force-recreate")
 	}
-	var poll func(*ui.Task, chan struct{})
+	poll := false
 	if !in.opts.NoWait {
 		upArgs = append(upArgs, "--wait", "--wait-timeout", fmt.Sprintf("%d", waitTimeoutSeconds))
-		poll = in.pollServiceHealth
+		poll = true
 	}
-	if err := in.runComposePhase(ctx, "Starting services", dir, env, files, upArgs, poll); err != nil {
+	if err := in.runComposePhase(ctx, ui.StageStart, "Starting services", dir, env, files, upArgs, poll); err != nil {
 		in.infof("Current container status:")
 		ps := in.compose.Command(dir, env, files, "ps")
 		ps.Stdout, ps.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
@@ -638,20 +659,21 @@ func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int)
 	return nil
 }
 
-// runComposePhase runs one long compose command as a visible phase: a live
-// spinner with captured output when fancy (the tail is shown on failure),
-// streamed output otherwise.
+// runComposePhase runs one long compose command as a visible phase: a rail
+// stage with a live task (and per-service checklist) in the wizard, streamed
+// output otherwise. On failure only the log tail is shown.
 func (in *installer) runComposePhase(
 	ctx context.Context,
+	stage int,
 	title, dir string,
 	env map[string]string,
 	files, args []string,
-	poll func(*ui.Task, chan struct{}),
+	poll bool,
 ) error {
 	cmd := in.compose.Command(dir, env, files, args...)
 
-	if !in.fancy() || in.opts.Verbose {
-		in.phase(title, false)
+	if in.wiz == nil || in.opts.Verbose {
+		in.phase(title)
 		cmd.Stdout, cmd.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
 		_, err := in.deps.Runner.Run(ctx, cmd)
 		if err == nil {
@@ -662,19 +684,23 @@ func (in *installer) runComposePhase(
 		return err
 	}
 
-	task := in.phase(title, true)
+	in.wiz.Stage(stage)
+	in.wiz.TaskStart(title)
 	var captured bytes.Buffer
 	cmd.Stdout, cmd.Stderr = &captured, &captured
 
 	stop := make(chan struct{})
-	if poll != nil {
-		go poll(task, stop)
+	if poll {
+		go in.pollServiceHealth(stop)
 	}
 	_, err := in.deps.Runner.Run(ctx, cmd)
 	close(stop)
-	task.Done(err == nil, title)
+	in.wiz.TaskDone(err == nil)
 
 	if err != nil {
+		// Tear the wizard down so the tail prints as plain scrollback.
+		in.wiz.Abort()
+		in.wiz = nil
 		lines := strings.Split(strings.TrimSpace(captured.String()), "\n")
 		if len(lines) > failureLogTail {
 			lines = lines[len(lines)-failureLogTail:]
@@ -686,9 +712,9 @@ func (in *installer) runComposePhase(
 	return err
 }
 
-// pollServiceHealth updates the spinner with a live ready/total count while
+// pollServiceHealth feeds the wizard a live per-service checklist while
 // `up --wait` blocks (otherwise silent for up to ten minutes).
-func (in *installer) pollServiceHealth(task *ui.Task, stop chan struct{}) {
+func (in *installer) pollServiceHealth(stop chan struct{}) {
 	ctx := context.Background()
 	for {
 		select {
@@ -698,31 +724,35 @@ func (in *installer) pollServiceHealth(task *ui.Task, stop chan struct{}) {
 		}
 		cmd := in.docker.Command(nil, "ps",
 			"--filter", "label=com.docker.compose.project=onyx",
-			"--format", "{{.Status}}")
+			"--format", "{{.Names}}\t{{.Status}}")
 		res, err := in.deps.Runner.Run(ctx, cmd)
 		if err != nil {
 			continue
 		}
-		total, ready := 0, 0
+		var rows []ui.ServiceRow
+		ready := 0
 		for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
-			if line == "" {
+			parts := strings.SplitN(line, "\t", 2)
+			if len(parts) != 2 {
 				continue
 			}
-			total++
-			if strings.Contains(line, "(healthy)") ||
-				(strings.HasPrefix(line, "Up") && !strings.Contains(line, "health")) {
+			ok := strings.Contains(parts[1], "(healthy)") ||
+				(strings.HasPrefix(parts[1], "Up") && !strings.Contains(parts[1], "health"))
+			if ok {
 				ready++
 			}
+			rows = append(rows, ui.ServiceRow{Name: strings.TrimPrefix(parts[0], "onyx-"), Ready: ok})
 		}
-		if total > 0 {
-			task.Update(fmt.Sprintf("%d/%d services ready", ready, total))
+		if len(rows) > 0 && in.wiz != nil {
+			in.wiz.Services(rows)
+			in.wiz.TaskExtra(fmt.Sprintf("%d/%d ready", ready, len(rows)))
 		}
 	}
 }
 
 func (in *installer) printSuccess(ctx context.Context, hostPort int) {
 	url := fmt.Sprintf("http://localhost:%d", hostPort)
-	headline := "Onyx is ready  →  " + ui.AccentURL(url)
+	headline := "Onyx is ready  →  " + ui.Accent(url)
 	if in.opts.NoWait {
 		headline = "Onyx containers started (still initializing — check: onyx-cli deploy status)"
 	}
@@ -738,32 +768,47 @@ func (in *installer) printSuccess(ctx context.Context, hostPort int) {
 			"Connectors and RAG search are off; chat, tools, uploads, projects work.")
 	}
 
-	in.plainf("")
-	if in.fancy() {
-		ui.Card(in.deps.IOS.Out, lines...)
-	} else {
-		for _, l := range lines {
-			in.plainf("%s", l)
+	if in.wiz != nil {
+		star := in.askStarQuestion()
+		in.wiz.Stage(ui.StageDone)
+		in.wiz.Finish(append([]string{"🎉 " + lines[0]}, lines[1:]...)...)
+		in.wiz = nil
+		if star {
+			in.starRepo(ctx)
 		}
+		return
+	}
+	in.plainf("")
+	for _, l := range lines {
+		in.plainf("%s", l)
 	}
 	in.plainf("")
 	in.infof("For help or issues, contact: founders@onyx.app")
 	in.starPrompt(ctx)
 }
 
-// starPrompt ports install.sh's GitHub star prompt: only when interactive and
-// the gh CLI is available.
+// starPrompt ports install.sh's GitHub star prompt: only when interactive
+// and the gh CLI is available.
 func (in *installer) starPrompt(ctx context.Context) {
+	if in.askStarQuestion() {
+		in.starRepo(ctx)
+	}
+}
+
+// askStarQuestion asks while the UI is still live (the wizard closes on
+// Finish, so callers ask first and run the API call after).
+func (in *installer) askStarQuestion() bool {
 	if in.prompt.AssumeDefaults {
-		return
+		return false
 	}
 	if _, err := exec.LookPath("gh"); err != nil {
-		return
+		return false
 	}
 	ok, err := in.confirmYN("Enjoying Onyx? Star the repo on GitHub?", true)
-	if err != nil || !ok {
-		return
-	}
+	return err == nil && ok
+}
+
+func (in *installer) starRepo(ctx context.Context) {
 	cmd := dockercmd.Command{
 		Name: "gh",
 		Args: []string{"api", "-X", "PUT", "/user/starred/onyx-dot-app/onyx"},

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/resources"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/ui"
 	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
 	"github.com/onyx-dot-app/onyx/cli/internal/version"
 )
@@ -29,24 +31,24 @@ const (
 
 	waitTimeoutSeconds = 600
 	minComposeVersion  = "2.24.0"
+	failureLogTail     = 30
 )
 
-const banner = `
-  ____
- / __ \
-| |  | |_ __  _   ___  __
-| |  | | '_ \| | | \ \/ /
-| |__| | | | | |_| |>  <
- \____/|_| |_|\__, /_/\_\
-               __/ |
-              |___/
-`
+// preflight carries the environment facts gathered concurrently while the
+// user answers the setup questions. Healthy values stay quiet; only problems
+// surface as warnings or provisioning offers.
+type preflight struct {
+	dockerVersion  string
+	composeVersion string
+	composeType    string
+	memoryMB       int
+	diskGB         int
+}
 
 // RunInstall implements `deploy install` (and the install-onyx alias): fresh
 // installs, and restart/update runs against an existing deployment.
 func RunInstall(ctx context.Context, deps Deps, opts Options) error {
 	in := newInstaller(deps, opts)
-	in.totalSteps = 9
 	in.lite = opts.Lite
 	in.craft = opts.IncludeCraft
 	return in.runInstall(ctx)
@@ -58,60 +60,129 @@ func (in *installer) runInstall(ctx context.Context) error {
 			"--lite and --include-craft cannot be used together: Craft requires services (Vespa, Redis, background workers) that lite mode disables")
 	}
 
-	// Resolve the default deploy tag from the latest app release so users
-	// land on a pinned, tested version; fall back to main/edge offline.
-	defaultTag, lookupFailed := "edge", false
-	if !in.opts.Local {
-		if in.opts.Tag != "" {
-			defaultTag = in.opts.Tag
-		} else if tag, err := in.deps.Release.LatestAppTag(ctx); err == nil {
-			defaultTag = tag
-		} else {
-			lookupFailed = true
-		}
-	}
-
 	in.root = paths.Resolve(in.opts.Dir)
+	envPath := filepath.Join(in.deploymentDir(), ".env")
+	_, envErr := os.Stat(envPath)
+	rerun := envErr == nil
+
+	// The latest-release lookup and the environment checks run in the
+	// background while the user answers the questions below.
+	tagCh := make(chan string, 1)
+	go func() {
+		if in.opts.Local {
+			tagCh <- "edge"
+			return
+		}
+		if in.opts.Tag != "" {
+			tagCh <- in.opts.Tag
+			return
+		}
+		if tag, err := in.deps.Release.LatestAppTag(ctx); err == nil {
+			tagCh <- tag
+		} else {
+			in.warnf("Could not determine latest Onyx release — falling back to main / edge")
+			tagCh <- "edge"
+		}
+	}()
+	preCh := make(chan preflight, 1)
+	go func() { preCh <- in.gatherPreflight(ctx) }()
 
 	if in.opts.DryRun {
-		in.printPlan(defaultTag)
+		in.printPlan(<-tagCh)
 		return nil
 	}
 
-	if err := in.ensureDockerAndCompose(ctx); err != nil {
+	manifest, err := state.Load(in.root.Dir)
+	if err != nil {
+		return err
+	}
+	hadManifest := manifest != nil
+	if manifest == nil {
+		manifest = &state.Manifest{}
+	}
+
+	if in.fancy() {
+		in.plainf("%s", ui.AccentURL("Onyx installer"))
+		in.plainf("")
+	}
+
+	// ---- Questions: every decision is made up front ----
+	var updateTag string // rerun: non-empty means update to this tag
+	pre, preSeen := preflight{}, false
+	if rerun {
+		// The running-services guard needs docker handles, so resolve the
+		// environment before asking anything.
+		pre, preSeen = <-preCh, true
+		if err := in.resolveDockerProblems(ctx, pre); err != nil {
+			return err
+		}
+		if err := in.guardServicesStopped(ctx); err != nil {
+			return err
+		}
+		// The mode never changes implicitly on a rerun: the recorded mode
+		// (or the overlays on disk) wins unless --lite/--include-craft say
+		// otherwise. (install.sh re-asked every run, so a --no-prompt rerun
+		// silently flipped standard installs to lite.)
+		in.lite = in.opts.Lite || (!in.opts.IncludeCraft &&
+			(manifest.Mode == state.ModeLite || in.overlayOnDisk(filepath.Base(deployfiles.LiteOverlay.DestRel))))
+		in.craft = in.opts.IncludeCraft || manifest.IncludeCraft ||
+			in.overlayOnDisk(filepath.Base(deployfiles.CraftOverlay.DestRel))
+
+		if in.opts.Tag != "" {
+			updateTag = in.opts.Tag
+		} else if !in.prompt.AssumeDefaults {
+			choice, err := in.selectOne("This deployment already exists. What would you like to do?",
+				[]ui.Option{
+					{Label: "Restart", Hint: "keep the current configuration"},
+					{Label: "Upgrade", Hint: "move to a newer Onyx version"},
+				}, 0)
+			if err != nil {
+				return err
+			}
+			if choice == 1 {
+				updateTag, err = in.askString("Version to deploy", <-tagCh)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	} else {
+		if err := in.askModeQuestion(); err != nil {
+			return err
+		}
+		if in.opts.Tag == "" {
+			tag, err := in.askString("Version to deploy", <-tagCh)
+			if err != nil {
+				return err
+			}
+			in.opts.Tag = tag
+		}
+	}
+
+	// ---- Join the checks; only problems surface ----
+	if !preSeen {
+		pre = <-preCh
+		if err := in.resolveDockerProblems(ctx, pre); err != nil {
+			return err
+		}
+	}
+	if err := in.resourceWarnings(pre); err != nil {
+		return err
+	}
+	if err := in.checkComposeVersion(ctx); err != nil {
 		return err
 	}
 
-	// ASCII banner + acknowledgment (mirrors install.sh).
-	in.plainf("%s", banner)
-	in.plainf("Welcome to the Onyx Installer")
-	in.plainf("=============================")
-	in.plainf("")
-	if lookupFailed {
-		in.warnf("Could not determine latest Onyx release — falling back to main / edge")
-	}
-	in.plainf("This command will:")
-	in.plainf("1. Set up Onyx deployment files in '%s'", in.root.Dir)
-	in.plainf("2. Check your system resources (Docker, memory, disk space)")
-	in.plainf("3. Guide you through deployment options (version, mode)")
-	in.plainf("")
-	if err := in.prompt.AcknowledgeEnter("Please acknowledge and press Enter to continue..."); err != nil {
-		return err
-	}
-
-	if err := in.verifyDocker(ctx); err != nil {
-		return err
-	}
-	if err := in.verifyResources(ctx); err != nil {
-		return err
-	}
-
-	in.stepf("Creating directory structure")
+	// ---- Phase 1: prepare configuration ----
+	in.phase("Preparing configuration", false)
 	if in.root.Source == paths.SourceLegacyCwd {
 		in.infof("Managing existing install at %s (created by install.sh)", in.root.Dir)
 	}
 	for _, alt := range in.root.Ambiguous {
 		in.warnf("Another Onyx install exists at %s — pass --dir to target it instead", alt)
+	}
+	if !hadManifest && paths.IsInstall(in.root.Dir) {
+		in.infof("No %s found — adopting this install; files not written by the CLI are treated as potentially customized", state.FileName)
 	}
 	for _, dir := range []string{
 		filepath.Join(in.root.Dir, "deployment"),
@@ -125,28 +196,14 @@ func (in *installer) runInstall(ctx context.Context) error {
 	if err := os.WriteFile(gitkeep, nil, 0644); err != nil {
 		return fmt.Errorf("failed to create %s: %w", gitkeep, err)
 	}
-	in.successf("Directory structure ready at %s", in.root.Dir)
 
-	manifest, err := state.Load(in.root.Dir)
-	if err != nil {
-		return err
+	initialTag := in.opts.Tag
+	if initialTag == "" {
+		initialTag = <-tagCh
 	}
-	hadManifest := manifest != nil
-	if manifest == nil {
-		manifest = &state.Manifest{}
-		if paths.IsInstall(in.root.Dir) {
-			in.infof("No %s found — adopting this install; files not written by the CLI are treated as potentially customized", state.FileName)
-		}
-	}
-
-	in.stepf("Preparing configuration files")
-	if err := in.chooseMode(manifest.Mode); err != nil {
-		return err
-	}
-
 	initialRef := ""
 	if !in.opts.Local {
-		initialRef = release.ConfigRef(defaultTag)
+		initialRef = release.ConfigRef(initialTag)
 	}
 	fetcher := &fileFetcher{in: in}
 	if err := in.materializeFiles(ctx, initialRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
@@ -162,14 +219,13 @@ func (in *installer) runInstall(ctx context.Context) error {
 			return err
 		}
 	}
-	in.successf("All configuration files ready")
 
-	if err := in.checkComposeVersion(ctx); err != nil {
-		return err
+	var effectiveTag string
+	if rerun {
+		effectiveTag, err = in.reconfigureExistingEnv(envPath, updateTag)
+	} else {
+		effectiveTag, err = in.createFreshEnv(envPath, initialTag)
 	}
-
-	in.stepf("Setting up deployment configs")
-	effectiveTag, err := in.configureEnv(ctx, defaultTag)
 	if err != nil {
 		return err
 	}
@@ -188,15 +244,13 @@ func (in *installer) runInstall(ctx context.Context) error {
 		in.ensureCraftResources(ctx)
 	}
 
-	in.stepf("Checking for available ports")
 	hostPort := resources.FindAvailablePort(3000)
 	if hostPort != 3000 {
-		in.infof("Port 3000 is in use, found available port: %d", hostPort)
-	} else {
-		in.infof("Port 3000 is available")
+		in.infof("Port 3000 is in use — using %d", hostPort)
 	}
-	in.successf("Using port %d for the web server", hostPort)
+	in.successf("Configuration ready at %s (version %s)", in.root.Dir, effectiveTag)
 
+	// ---- Phases 2 + 3: pull and start ----
 	if err := in.pullAndStart(ctx, effectiveTag, hostPort); err != nil {
 		return err
 	}
@@ -221,17 +275,62 @@ func (in *installer) runInstall(ctx context.Context) error {
 	return nil
 }
 
-// ensureDockerAndCompose provisions Docker Engine and compose where install.sh
-// does (Linux/WSL), starts Docker Desktop on macOS later during verification,
-// and detect-and-instructs on native Windows.
-func (in *installer) ensureDockerAndCompose(ctx context.Context) error {
+// askModeQuestion is the single merged deployment-mode select (mode and
+// Craft in one question). Lite stays the default for new installs, matching
+// install.sh's interactive and --no-prompt behavior.
+func (in *installer) askModeQuestion() error {
+	if in.opts.Lite {
+		in.infof("Deployment mode: Lite (set via --lite flag)")
+		return nil
+	}
+	if in.opts.IncludeCraft {
+		return nil // craft implies standard; the conflict was rejected earlier
+	}
+	choice, err := in.selectOne("Deployment mode",
+		[]ui.Option{
+			{Label: "Lite", Hint: "chat, tools, uploads, projects — no vector search (recommended)"},
+			{Label: "Standard", Hint: "full search, connectors, and RAG"},
+			{Label: "Standard + Craft", Hint: "adds AI web-app building (binds the docker socket)"},
+		}, 0)
+	if err != nil {
+		return err
+	}
+	in.lite = choice == 0
+	in.craft = choice == 2
+	return nil
+}
+
+// gatherPreflight collects environment facts without side effects or output.
+func (in *installer) gatherPreflight(ctx context.Context) preflight {
+	p := preflight{diskGB: resources.DiskAvailableGB(".")}
+	if !dockercmd.Installed() {
+		return p
+	}
+	p.dockerVersion = in.docker.Version(ctx)
+	if c := dockercmd.DetectCompose(ctx, in.docker); c != nil {
+		p.composeVersion = c.Version(ctx)
+		p.composeType = c.TypeName()
+	}
+	dockerInfo := ""
+	if res, err := in.deps.Runner.Run(ctx, dockercmd.Command{Name: "docker", Args: []string{"system", "info"}}); err == nil {
+		dockerInfo = res.Stdout
+	}
+	p.memoryMB = resources.MemoryMB(dockerInfo)
+	return p
+}
+
+// resolveDockerProblems provisions or errors for anything missing, then
+// prints one compact summary line. Mirrors install.sh's behaviors: Docker
+// Engine and compose plugin auto-install on Linux/WSL, Docker Desktop
+// start-and-wait on macOS, instructions elsewhere.
+func (in *installer) resolveDockerProblems(ctx context.Context, pre preflight) error {
 	linuxLike := runtime.GOOS == "linux" || dockercmd.IsWSL()
 
 	if !dockercmd.Installed() {
 		switch {
 		case linuxLike:
 			in.infof("Docker is required but not installed.")
-			ok, err := in.prompt.Confirm("Install Docker Engine? (Y/n) [default: Y] ", true)
+			ok, err := in.confirmYN("Install Docker Engine?", true)
 			if err != nil {
 				return err
 			}
@@ -257,7 +356,7 @@ func (in *installer) ensureDockerAndCompose(ctx context.Context) error {
 	in.compose = dockercmd.DetectCompose(ctx, in.docker)
 	if in.compose == nil && linuxLike {
 		in.infof("Docker Compose is required but not installed.")
-		ok, err := in.prompt.Confirm("Install the Docker Compose plugin? (Y/n) [default: Y] ", true)
+		ok, err := in.confirmYN("Install the Docker Compose plugin?", true)
 		if err != nil {
 			return err
 		}
@@ -285,17 +384,6 @@ func (in *installer) ensureDockerAndCompose(ctx context.Context) error {
 		}
 		in.infof("Using sudo for docker commands in this run.")
 	}
-	return nil
-}
-
-func (in *installer) verifyDocker(ctx context.Context) error {
-	in.stepf("Verifying Docker installation")
-	if v := in.docker.Version(ctx); v != "" {
-		in.successf("Docker %s is installed", v)
-	} else {
-		in.successf("Docker is installed")
-	}
-	in.successf("Docker Compose %s is installed (%s)", in.compose.Version(ctx), in.compose.TypeName())
 
 	if !in.docker.DaemonRunning(ctx) {
 		if runtime.GOOS == "darwin" {
@@ -303,109 +391,71 @@ func (in *installer) verifyDocker(ctx context.Context) error {
 			if err := dockercmd.StartDockerDesktopDarwin(ctx, in.docker, in.deps.IOS.Out, 120*time.Second); err != nil {
 				return exitcodes.Newf(exitcodes.General, "%v", err)
 			}
-			in.successf("Docker Desktop is now running")
 		} else {
 			return exitcodes.New(exitcodes.General, "Docker daemon is not running. Please start Docker.")
 		}
-	} else {
-		in.successf("Docker daemon is running")
 	}
+
+	summary := []string{"Docker " + orDetect(pre.dockerVersion, in.docker.Version(ctx))}
+	if pre.composeVersion != "" {
+		summary = append(summary, fmt.Sprintf("Compose %s (%s)", pre.composeVersion, pre.composeType))
+	} else {
+		summary = append(summary, fmt.Sprintf("Compose %s (%s)", in.compose.Version(ctx), in.compose.TypeName()))
+	}
+	summary = append(summary, "daemon running")
+	if pre.memoryMB > 0 {
+		summary = append(summary, resources.FormatMemory(pre.memoryMB)+" RAM")
+	}
+	if pre.diskGB >= 0 {
+		summary = append(summary, fmt.Sprintf("%dGB free", pre.diskGB))
+	}
+	in.successf("%s", strings.Join(summary, " · "))
 	return nil
 }
 
-func (in *installer) verifyResources(ctx context.Context) error {
-	in.stepf("Verifying Docker resources")
-
-	dockerInfo := ""
-	if res, err := in.deps.Runner.Run(ctx, in.docker.Command(nil, "system", "info")); err == nil {
-		dockerInfo = res.Stdout
+func orDetect(v, fallback string) string {
+	if v != "" {
+		return v
 	}
-	memoryMB := resources.MemoryMB(dockerInfo)
-	if memoryMB > 0 {
-		if runtime.GOOS == "darwin" {
-			in.infof("Docker memory allocation: %s", resources.FormatMemory(memoryMB))
-		} else {
-			in.infof("System memory: %s (Docker uses host memory directly)", resources.FormatMemory(memoryMB))
-		}
-	} else {
-		in.warnf("Could not determine memory allocation")
-	}
+	return fallback
+}
 
-	diskGB := resources.DiskAvailableGB(".")
-	if diskGB >= 0 {
-		in.infof("Available disk space: %dGB", diskGB)
-	} else {
-		in.warnf("Could not determine available disk space")
-	}
-
+// resourceWarnings surfaces low-resource conditions only (healthy machines
+// see nothing) and asks whether to continue, like install.sh's warning path.
+func (in *installer) resourceWarnings(pre preflight) error {
 	ramWant, diskWant := expectedRAMGB, expectedDiskGB
+	mode := "standard"
 	if in.lite {
 		ramWant, diskWant = expectedRAMGBLite, expectedDiskGBLite
+		mode = "lite"
 	}
 	warning := false
-	if memoryMB > 0 && memoryMB < ramWant*1024 {
-		in.warnf("Less than %dGB RAM available (found: %s)", ramWant, resources.FormatMemory(memoryMB))
+	if pre.memoryMB > 0 && pre.memoryMB < ramWant*1024 {
+		in.warnf("Less than %dGB RAM available (found: %s)", ramWant, resources.FormatMemory(pre.memoryMB))
 		warning = true
 	}
-	if diskGB >= 0 && diskGB < diskWant {
-		in.warnf("Less than %dGB disk space available (found: %dGB)", diskWant, diskGB)
+	if pre.diskGB >= 0 && pre.diskGB < diskWant {
+		in.warnf("Less than %dGB disk space available (found: %dGB)", diskWant, pre.diskGB)
 		warning = true
 	}
-	if warning {
-		in.plainf("")
-		in.warnf("Onyx recommends at least %dGB RAM and %dGB disk space for optimal performance in standard mode.", ramWant, diskWant)
-		in.warnf("Lite mode requires less resources (1-4GB RAM, 8-16GB disk depending on usage), but does not include a vector database.")
-		in.plainf("")
-		cont, err := in.prompt.Confirm("Do you want to continue anyway? (Y/n): ", true)
-		if err != nil {
-			return err
-		}
-		if !cont {
-			return exitcodes.New(exitcodes.General, "Installation cancelled. Please allocate more resources and try again.")
-		}
-		in.infof("Proceeding with installation despite resource limitations...")
-	}
-	return nil
-}
-
-// chooseMode runs the lite-vs-standard prompt unless --lite already decided
-// it. Lite is the default for new installs (matching install.sh); an existing
-// install defaults to its recorded mode, so a --no-prompt restart cannot
-// silently switch a standard deployment to lite (an install.sh footgun).
-func (in *installer) chooseMode(prevMode state.Mode) error {
-	if in.lite {
-		in.infof("Deployment mode: Lite (set via --lite flag)")
+	if !warning {
 		return nil
 	}
-	if in.craft {
-		// Craft implies standard mode; the flag conflict was checked early.
-		return nil
-	}
-	def := "1"
-	if prevMode == state.ModeStandard {
-		def = "2"
-	}
-	in.infof("Which deployment mode would you like?")
-	in.plainf("")
-	in.plainf("  1) Lite      - Minimal deployment (no OpenSearch, Redis, or model servers)")
-	in.plainf("                  LLM chat, tools, file uploads, and Projects still work")
-	in.plainf("  2) Standard  - Full deployment with search, connectors, and RAG")
-	in.plainf("")
-	choice, err := in.prompt.Ask(fmt.Sprintf("Choose a mode (1 or 2) [default: %s]: ", def), def)
+	in.warnf("Onyx recommends at least %dGB RAM and %dGB disk space in %s mode.", ramWant, diskWant, mode)
+	cont, err := in.confirmYN("Continue anyway?", true)
 	if err != nil {
 		return err
 	}
-	in.plainf("")
-	if choice == "2" {
-		in.infof("Selected: Standard mode")
-	} else {
-		in.lite = true
-		in.infof("Selected: Lite mode")
+	if !cont {
+		return exitcodes.New(exitcodes.General, "Installation cancelled. Please allocate more resources and try again.")
 	}
 	return nil
 }
 
 func (in *installer) checkComposeVersion(ctx context.Context) error {
+	if in.compose == nil {
+		return nil
+	}
 	composeVersion := in.compose.Version(ctx)
 	if composeVersion == "dev" {
 		return nil
@@ -415,68 +465,26 @@ func (in *installer) checkComposeVersion(ctx context.Context) error {
 	if !ok || !have.LessThan(minimum) {
 		return nil
 	}
-	in.warnf("Docker Compose version %s is older than %s", composeVersion, minComposeVersion)
-	in.plainf("")
-	in.warnf("The docker-compose.yml file uses the newer env_file format that requires Docker Compose %s or later.", minComposeVersion)
-	in.infof("Upgrade Docker Compose (https://docs.docker.com/compose/install/) or manually flatten the env_file sections.")
-	in.plainf("")
-	cont, err := in.prompt.Confirm("Do you want to continue anyway? (Y/n): ", true)
+	in.warnf("Docker Compose %s is older than %s; docker-compose.yml uses the newer env_file format.", composeVersion, minComposeVersion)
+	in.infof("Upgrade Docker Compose: https://docs.docker.com/compose/install/")
+	cont, err := in.confirmYN("Continue anyway?", true)
 	if err != nil {
 		return err
 	}
 	if !cont {
 		return exitcodes.New(exitcodes.General, "Installation cancelled. Please upgrade Docker Compose and re-run.")
 	}
-	in.infof("Proceeding despite the Docker Compose version mismatch...")
 	return nil
 }
 
-// configureEnv creates or updates deployment/.env and returns the effective
-// image tag.
-func (in *installer) configureEnv(ctx context.Context, defaultTag string) (string, error) {
-	envPath := filepath.Join(in.root.Dir, "deployment", ".env")
-	existing, err := os.ReadFile(envPath)
-	switch {
-	case err == nil:
-		return in.reconfigureExistingEnv(ctx, envPath, string(existing), defaultTag)
-	case os.IsNotExist(err):
-		return in.createFreshEnv(envPath, defaultTag)
-	default:
-		return "", fmt.Errorf("failed to read %s: %w", envPath, err)
-	}
-}
-
-func (in *installer) createFreshEnv(envPath, defaultTag string) (string, error) {
-	in.infof("No existing .env file found. Setting up new deployment...")
-	in.plainf("")
-
-	tag := in.opts.Tag
-	if tag == "" {
-		in.infof("Which tag would you like to deploy?")
-		in.plainf("")
-		in.plainf("• Press Enter for %s (recommended)", defaultTag)
-		in.plainf("• Type a specific tag (e.g., v1.2.3)")
-		in.plainf("")
-		var err error
-		tag, err = in.prompt.Ask(fmt.Sprintf("Enter tag [default: %s]: ", defaultTag), defaultTag)
-		if err != nil {
-			return "", err
-		}
-		in.plainf("")
-	}
-	if tag == "edge" {
-		in.infof("Selected: edge (latest nightly)")
-	} else {
-		in.infof("Selected: %s", tag)
-	}
-
+// createFreshEnv writes deployment/.env from env.template with the chosen
+// tag, generated secrets, and mode adjustments.
+func (in *installer) createFreshEnv(envPath, tag string) (string, error) {
 	template, err := os.ReadFile(filepath.Join(in.root.Dir, "deployment", "env.template"))
 	if err != nil {
 		return "", fmt.Errorf("failed to read env.template: %w", err)
 	}
 	env := string(template)
-
-	in.infof("Creating .env file with your selections...")
 	env = SetVar(env, "IMAGE_TAG", tag)
 
 	if in.lite {
@@ -484,7 +492,6 @@ func (in *installer) createFreshEnv(envPath, defaultTag string) (string, error) 
 		// postgres file store at runtime; align .env so it isn't misleading.
 		env = SetVar(env, "COMPOSE_PROFILES", "")
 		env = SetVar(env, "FILE_STORE_BACKEND", "postgres")
-		in.successf("Cleared COMPOSE_PROFILES and set FILE_STORE_BACKEND=postgres for lite mode")
 	}
 
 	env = SetVar(env, "USER_AUTH_SECRET", `"`+randomHex(32)+`"`)
@@ -500,65 +507,34 @@ func (in *installer) createFreshEnv(envPath, defaultTag string) (string, error) 
 		env = SetVarUncomment(env, "SANDBOX_BACKEND", backend)
 		in.successf("Onyx Craft enabled (ENABLE_CRAFT=true, SANDBOX_BACKEND=%s)", backend)
 		if backend == "docker" {
-			in.plainf("")
 			in.plainf("%s", craftSecurityWarning)
-			in.plainf("")
 		} else {
 			in.infof("Image tag %s predates the docker sandbox backend (v4.0.6+); using SANDBOX_BACKEND=%s.", tag, backend)
 		}
-	} else {
-		in.infof("Onyx Craft disabled (use --include-craft to enable)")
 	}
 
 	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
 		return "", fmt.Errorf("failed to write .env: %w", err)
 	}
-	in.successf(".env file created with your preferences")
-	in.plainf("")
-	in.infof("You can customize %s later for AI models, domains, and more.", envPath)
-	in.plainf("")
+	in.successf(".env created (auth secret and MinIO credentials generated) — customize it any time")
 	return tag, nil
 }
 
-func (in *installer) reconfigureExistingEnv(ctx context.Context, envPath, env, defaultTag string) (string, error) {
-	if err := in.guardServicesStopped(ctx); err != nil {
-		return "", err
+// reconfigureExistingEnv applies the rerun decision: restart keeps .env
+// untouched except craft/lite alignment; a non-empty updateTag rewrites
+// IMAGE_TAG (and nothing else).
+func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, error) {
+	existing, err := os.ReadFile(envPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read %s: %w", envPath, err)
 	}
+	env := string(existing)
 
-	update := false
-	tag := in.opts.Tag
-	if tag != "" {
-		// An explicit --tag on an existing install is an update request.
-		update = tag != Var(env, "IMAGE_TAG")
+	if updateTag != "" && updateTag != Var(env, "IMAGE_TAG") {
+		env = SetVar(env, "IMAGE_TAG", updateTag)
+		in.successf("Updated IMAGE_TAG to %s (all other settings preserved)", updateTag)
 	} else {
-		in.infof("Existing .env file found. What would you like to do?")
-		in.plainf("")
-		in.plainf("• Press Enter to restart with current configuration")
-		in.plainf("• Type 'update' to update to a newer version")
-		in.plainf("  (scriptable equivalent: onyx-cli deploy upgrade --tag <tag>)")
-		in.plainf("")
-		choice, err := in.prompt.Ask("Choose an option [default: restart]: ", "")
-		if err != nil {
-			return "", err
-		}
-		in.plainf("")
-		if choice == "update" {
-			update = true
-			tag, err = in.prompt.Ask(fmt.Sprintf("Enter tag [default: %s]: ", defaultTag), defaultTag)
-			if err != nil {
-				return "", err
-			}
-			in.plainf("")
-		}
-	}
-
-	if update {
-		in.infof("Updating configuration for version %s...", tag)
-		env = SetVar(env, "IMAGE_TAG", tag)
-		in.successf("Updated IMAGE_TAG to %s in .env file", tag)
-	} else {
-		in.infof("Keeping existing configuration...")
-		in.successf("Will restart with current settings")
+		in.infof("Restarting with the current configuration")
 	}
 
 	effectiveTag := Var(env, "IMAGE_TAG")
@@ -599,11 +575,8 @@ func (in *installer) guardServicesStopped(ctx context.Context) error {
 		return nil
 	}
 	in.errorf("Onyx services are currently running!")
-	in.plainf("")
-	in.infof("To make configuration changes, you must first shut down the services:")
+	in.infof("To make configuration changes, first shut them down:")
 	in.plainf("   onyx-cli deploy stop")
-	in.plainf("")
-	in.infof("Then re-run this command to make your changes.")
 	return exitcodes.New(exitcodes.General, "services are running")
 }
 
@@ -633,88 +606,148 @@ func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int)
 	dir := in.deploymentDir()
 	floating := release.IsFloatingTag(tag)
 
-	in.stepf("Pulling Docker images")
-	in.infof("This may take several minutes depending on your internet connection...")
 	pullArgs := []string{"pull"}
 	if !in.opts.Verbose {
 		pullArgs = append(pullArgs, "--quiet")
 	}
-	pull := in.compose.Command(dir, env, files, pullArgs...)
-	pull.Stdout, pull.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
-	if _, err := in.deps.Runner.Run(ctx, pull); err != nil {
-		in.errorf("Failed to download Docker images")
+	if err := in.runComposePhase(ctx, "Pulling images", dir, env, files, pullArgs, nil); err != nil {
+		in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
 	}
-	in.successf("Docker images downloaded successfully")
 
-	in.stepf("Starting Onyx services")
 	upArgs := []string{"up", "-d"}
 	if floating {
-		in.infof("Using '%s' tag - force pulling latest images and recreating containers...", tag)
 		upArgs = append(upArgs, "--pull", "always", "--force-recreate")
 	}
+	var poll func(*ui.Task, chan struct{})
 	if !in.opts.NoWait {
-		in.infof("Waiting up to %ds for all services to become healthy...", waitTimeoutSeconds)
 		upArgs = append(upArgs, "--wait", "--wait-timeout", fmt.Sprintf("%d", waitTimeoutSeconds))
+		poll = in.pollServiceHealth
 	}
-	in.plainf("")
-	up := in.compose.Command(dir, env, files, upArgs...)
-	up.Stdout, up.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
-	if _, err := in.deps.Runner.Run(ctx, up); err != nil {
-		in.errorf("Failed to start Onyx services")
-		in.plainf("")
+	if err := in.runComposePhase(ctx, "Starting services", dir, env, files, upArgs, poll); err != nil {
 		in.infof("Current container status:")
 		ps := in.compose.Command(dir, env, files, "ps")
 		ps.Stdout, ps.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
 		_, _ = in.deps.Runner.Run(ctx, ps)
-		in.plainf("")
 		in.infof("Check the logs of any unhealthy service:")
 		in.plainf("  onyx-cli deploy status")
 		in.plainf("  (cd %q && docker compose %s logs <service>)", dir, strings.Join(fileArgs(files), " "))
-		in.plainf("")
 		in.infof("If the issue persists, please contact: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose up failed: %v", err)
 	}
 	return nil
 }
 
+// runComposePhase runs one long compose command as a visible phase: a live
+// spinner with captured output when fancy (the tail is shown on failure),
+// streamed output otherwise.
+func (in *installer) runComposePhase(
+	ctx context.Context,
+	title, dir string,
+	env map[string]string,
+	files, args []string,
+	poll func(*ui.Task, chan struct{}),
+) error {
+	cmd := in.compose.Command(dir, env, files, args...)
+
+	if !in.fancy() || in.opts.Verbose {
+		in.phase(title, false)
+		cmd.Stdout, cmd.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+		_, err := in.deps.Runner.Run(ctx, cmd)
+		if err == nil {
+			in.successf("%s complete", title)
+		} else {
+			in.errorf("%s failed", title)
+		}
+		return err
+	}
+
+	task := in.phase(title, true)
+	var captured bytes.Buffer
+	cmd.Stdout, cmd.Stderr = &captured, &captured
+
+	stop := make(chan struct{})
+	if poll != nil {
+		go poll(task, stop)
+	}
+	_, err := in.deps.Runner.Run(ctx, cmd)
+	close(stop)
+	task.Done(err == nil, title)
+
+	if err != nil {
+		lines := strings.Split(strings.TrimSpace(captured.String()), "\n")
+		if len(lines) > failureLogTail {
+			lines = lines[len(lines)-failureLogTail:]
+		}
+		for _, l := range lines {
+			in.plainf("  %s", l)
+		}
+	}
+	return err
+}
+
+// pollServiceHealth updates the spinner with a live ready/total count while
+// `up --wait` blocks (otherwise silent for up to ten minutes).
+func (in *installer) pollServiceHealth(task *ui.Task, stop chan struct{}) {
+	ctx := context.Background()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-time.After(2 * time.Second):
+		}
+		cmd := in.docker.Command(nil, "ps",
+			"--filter", "label=com.docker.compose.project=onyx",
+			"--format", "{{.Status}}")
+		res, err := in.deps.Runner.Run(ctx, cmd)
+		if err != nil {
+			continue
+		}
+		total, ready := 0, 0
+		for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
+			if line == "" {
+				continue
+			}
+			total++
+			if strings.Contains(line, "(healthy)") ||
+				(strings.HasPrefix(line, "Up") && !strings.Contains(line, "health")) {
+				ready++
+			}
+		}
+		if total > 0 {
+			task.Update(fmt.Sprintf("%d/%d services ready", ready, total))
+		}
+	}
+}
+
 func (in *installer) printSuccess(ctx context.Context, hostPort int) {
-	in.stepf("Installation Complete!")
-	in.plainf("")
+	url := fmt.Sprintf("http://localhost:%d", hostPort)
+	headline := "Onyx is ready  →  " + ui.AccentURL(url)
 	if in.opts.NoWait {
-		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-		in.plainf("   ⚠️  Onyx containers started  ⚠️")
-		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-		in.infof("Services may still be initializing. Check status with: onyx-cli deploy status")
-	} else {
-		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-		in.plainf("   🎉 Onyx service is ready! 🎉")
-		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		headline = "Onyx containers started (still initializing — check: onyx-cli deploy status)"
 	}
-	in.plainf("")
-	in.infof("Access Onyx at:")
-	in.plainf("   http://localhost:%d", hostPort)
-	in.plainf("")
-	in.infof("If authentication is enabled, you can create your admin account here:")
-	in.plainf("   • Visit http://localhost:%d/auth/signup to create your admin account", hostPort)
-	in.plainf("   • The first user created will automatically have admin privileges")
-	in.plainf("")
+	lines := []string{
+		headline,
+		"",
+		"First signup becomes the admin account: " + url + "/auth/signup",
+		"Manage:  onyx-cli deploy status · stop · upgrade · uninstall",
+	}
 	if in.lite {
-		in.infof("Running in Lite mode — the following services are NOT started:")
-		in.plainf("  • Vespa (vector database)")
-		in.plainf("  • Redis (cache)")
-		in.plainf("  • Model servers (embedding/inference)")
-		in.plainf("  • Background workers (Celery)")
-		in.plainf("")
-		in.infof("Connectors and RAG search are disabled. LLM chat, tools, user file")
-		in.infof("uploads, Projects, Agent knowledge, and code interpreter still work.")
-		in.plainf("")
+		lines = append(lines, "",
+			"Lite mode: no Vespa/Redis/model servers or background workers.",
+			"Connectors and RAG search are off; chat, tools, uploads, projects work.")
 	}
-	in.infof("Manage this deployment with: onyx-cli deploy status | stop | upgrade | uninstall")
-	in.infof("Refer to the README in the %s directory for more information.", in.root.Dir)
+
+	in.plainf("")
+	if in.fancy() {
+		ui.Card(in.deps.IOS.Out, lines...)
+	} else {
+		for _, l := range lines {
+			in.plainf("%s", l)
+		}
+	}
 	in.plainf("")
 	in.infof("For help or issues, contact: founders@onyx.app")
-	in.plainf("")
 	in.starPrompt(ctx)
 }
 
@@ -727,7 +760,7 @@ func (in *installer) starPrompt(ctx context.Context) {
 	if _, err := exec.LookPath("gh"); err != nil {
 		return
 	}
-	ok, err := in.prompt.Confirm("Enjoying Onyx? Star the repo on GitHub? [Y/n] ", true)
+	ok, err := in.confirmYN("Enjoying Onyx? Star the repo on GitHub?", true)
 	if err != nil || !ok {
 		return
 	}

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -67,7 +67,7 @@ func RunInstall(ctx context.Context, deps Deps, opts Options) error {
 func (in *installer) runInstall(ctx context.Context) error {
 	if in.opts.Lite && in.opts.IncludeCraft {
 		return exitcodes.New(exitcodes.BadRequest,
-			"--lite and --include-craft cannot be used together: Craft requires services (Vespa, Redis, background workers) that lite mode disables")
+			"--lite and --include-craft cannot be used together: Craft requires services (OpenSearch, Redis, background workers) that lite mode disables")
 	}
 
 	in.root = paths.Resolve(in.opts.Dir)
@@ -490,8 +490,8 @@ func (in *installer) resourceWarnings(pre preflight) error {
 		warning = true
 	}
 	if in.rootless && !in.lite {
-		in.warnf("Rootless Docker: the standard deployment's Vespa index requests unlimited memlock, which a rootless daemon usually can't grant.")
-		in.infof("Either raise the daemon's limits (systemctl --user edit docker: LimitMEMLOCK=infinity, LimitNOFILE=1048576, then systemctl --user restart docker) or use Lite mode, which has no Vespa.")
+		in.warnf("Rootless Docker: the standard deployment's OpenSearch index requests unlimited memlock, which a rootless daemon usually can't grant.")
+		in.infof("Either raise the daemon's limits (systemctl --user edit docker: LimitMEMLOCK=infinity, LimitNOFILE=1048576, then systemctl --user restart docker) or use Lite mode, which has no OpenSearch.")
 	}
 	if !warning {
 		return nil
@@ -811,10 +811,11 @@ func (in *installer) printFailureDiagnosis(output string) {
 	lower := strings.ToLower(output)
 	if strings.Contains(lower, "setting rlimit") || strings.Contains(lower, "memlock") {
 		in.plainf("")
-		in.warnf("This looks like a ulimit failure: the Vespa index container requests unlimited memlock, which rootless Docker (and some hosts) can't grant.")
+		in.warnf("This looks like a ulimit failure: the OpenSearch index container requests unlimited memlock, which rootless Docker (and some hosts) can't grant.")
 		in.infof("Fix one of these ways, then re-run:")
 		in.plainf("  • Raise the daemon limits: systemctl --user edit docker → [Service] LimitMEMLOCK=infinity, LimitNOFILE=1048576 → systemctl --user restart docker")
-		in.plainf("  • Or deploy Lite mode (no Vespa): onyx-cli deploy install --lite")
+		in.plainf("    (OpenSearch may also need: sudo sysctl -w vm.max_map_count=262144)")
+		in.plainf("  • Or deploy Lite mode (no OpenSearch): onyx-cli deploy install --lite")
 		return
 	}
 	if strings.Contains(lower, "address already in use") || strings.Contains(lower, "port is already allocated") {
@@ -875,7 +876,7 @@ func (in *installer) printSuccess(ctx context.Context, hostPort int) {
 	}
 	if in.lite {
 		lines = append(lines, "",
-			"Lite mode: no Vespa/Redis/model servers or background workers.",
+			"Lite mode: no OpenSearch/Redis/model servers or background workers.",
 			"Connectors and RAG search are off; chat, tools, uploads, projects work.")
 	}
 

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -844,6 +844,13 @@ func (in *installer) pullImages(ctx context.Context, tag string, hostPort int) e
 		files: in.composeFileNames(false),
 		args:  []string{"pull"},
 	}
+	if release.IsImmutableTag(tag) && in.composeAtLeast(ctx, minPullPolicyVersion) {
+		// A released tag names an image that never changes, so a copy already
+		// on the host is the copy this deployment wants. Without this compose
+		// asks the registry about every service on every run, which is most of
+		// the wait on a re-run that has nothing to fetch.
+		phase.args = append(phase.args, "--policy", "missing")
+	}
 	mode := in.progressMode(ctx)
 	switch {
 	case mode != "":

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -335,7 +335,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 		in.rollbackEnv(envPath, prevEnv)
 		return err
 	}
-	if err := in.startServices(ctx, effectiveTag, hostPort); err != nil {
+	if err := in.startServices(ctx, effectiveTag, Var(string(prevEnv), "IMAGE_TAG"), hostPort); err != nil {
 		return err
 	}
 
@@ -882,7 +882,10 @@ func (in *installer) pullImages(ctx context.Context, tag string, hostPort int) e
 	return nil
 }
 
-func (in *installer) startServices(ctx context.Context, tag string, hostPort int) error {
+// startServices brings the stack up. prevTag is the version .env carried
+// before this run ("" on a fresh install), used only to explain what a failed
+// start left behind.
+func (in *installer) startServices(ctx context.Context, tag, prevTag string, hostPort int) error {
 	env := in.composeRunEnv(tag, hostPort)
 	files := in.composeFileNames(false)
 	dir := in.deploymentDir()
@@ -904,10 +907,31 @@ func (in *installer) startServices(ctx context.Context, tag string, hostPort int
 		in.infof("Check the logs of any unhealthy service:")
 		in.plainf("  onyx-cli deploy status")
 		in.plainf("  (cd %q && docker compose %s logs <service>)", dir, strings.Join(fileArgs(files), " "))
+		in.explainIncompleteStart(tag, prevTag)
 		in.infof("If the issue persists, please contact: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose up failed: %v", err)
 	}
 	return nil
+}
+
+// explainIncompleteStart says what a half-finished `up` left behind. Unlike a
+// failed pull, .env is deliberately NOT reverted here: containers that did
+// come up are running the new images, so putting the old version back would
+// deploy older code over data the new one may already have migrated, and on a
+// fresh install .env holds the secrets the volumes were just initialized with.
+// The manifest still records the previously deployed version, so `deploy
+// status` reports the split rather than claiming the move succeeded.
+func (in *installer) explainIncompleteStart(tag, prevTag string) {
+	switch {
+	case prevTag == "":
+		in.warnf("Keep %s: it holds the secrets any volumes created just now were initialized with.",
+			filepath.Join("deployment", ".env"))
+		in.infof("Fix the problem above and re-run `onyx-cli deploy install`, or start clean with `onyx-cli deploy uninstall`.")
+	case prevTag != tag:
+		in.warnf("Partially deployed: services that started are on %s, the rest are still on %s.", tag, prevTag)
+		in.infof("`.env` stays on %s so a re-run finishes the move; to go back, run `onyx-cli deploy upgrade --tag %s`.",
+			tag, prevTag)
+	}
 }
 
 // rollbackEnv restores .env to its pre-run content after a failed pull, so a

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -958,8 +958,8 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 			// it had already brought up, which is worth saying before the run
 			// reports itself cancelled.
 			in.infof("Services that already started are still running:")
-			in.cmdf("onyx-cli deploy status")
-			in.cmdf("onyx-cli deploy stop")
+			in.cmdf("onyx-cli deploy status%s", in.dirArg())
+			in.cmdf("onyx-cli deploy stop%s", in.dirArg())
 			return err
 		}
 		in.infof("Current container status:")
@@ -967,8 +967,8 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 		ps.Stdout, ps.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
 		_, _ = in.deps.Runner.Run(ctx, ps)
 		in.infof("Check the logs of any unhealthy service:")
-		in.cmdf("onyx-cli deploy status")
-		in.cmdf("(cd %q && docker compose %s logs <service>)", dir, strings.Join(fileArgs(files), " "))
+		in.cmdf("onyx-cli deploy status%s", in.dirArg())
+		in.cmdf("onyx-cli deploy logs%s <service>", in.dirArg())
 		in.explainIncompleteStart(tag, prevTag)
 		in.infof("If the issue persists, please contact: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose up failed: %v", err)
@@ -1317,12 +1317,4 @@ func (in *installer) deploymentDir() string {
 // before .env is known-good (install.sh uses the same pair for shutdown).
 func stopFallbackEnv() map[string]string {
 	return map[string]string{"HOST_PORT": "3000", "IMAGE_TAG": "edge"}
-}
-
-func fileArgs(files []string) []string {
-	args := make([]string, 0, 2*len(files))
-	for _, f := range files {
-		args = append(args, "-f", f)
-	}
-	return args
 }

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -35,6 +35,10 @@ const (
 	waitTimeoutSeconds = 600
 	minComposeVersion  = "2.24.0"
 	failureLogTail     = 30
+
+	// s3FilestoreProfile is the COMPOSE_PROFILES entry that runs MinIO: on in
+	// standard mode, off in lite. It is the only entry the CLI owns.
+	s3FilestoreProfile = "s3-filestore"
 )
 
 // preflight carries the environment facts gathered concurrently while the
@@ -312,6 +316,11 @@ func (in *installer) runInstall(ctx context.Context) error {
 	if !in.opts.Local && configRef != initialRef {
 		in.infof("Fetching config files matching %s...", configRef)
 		if err := in.materializeFiles(ctx, configRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
+			// .env already names this version and nothing has been deployed
+			// yet, so it is put back for the same reason a failed pull does:
+			// a version that never ran must not be left recorded as the
+			// deployment's current one.
+			in.rollbackEnv(envPath, prevEnv)
 			return err
 		}
 	}
@@ -326,6 +335,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 	// run must still know the freshly materialized files were CLI-written,
 	// not hand-edited. InstalledTag advances only after a successful start.
 	if err := manifest.Save(in.root.Dir); err != nil {
+		in.rollbackEnv(envPath, prevEnv)
 		return err
 	}
 
@@ -351,7 +361,9 @@ func (in *installer) runInstall(ctx context.Context) error {
 	}
 	manifest.UpdatedAt = now
 	if err := manifest.Save(in.root.Dir); err != nil {
-		return err
+		// The deployment is already up on this version: say what did happen,
+		// or the error reads as an install that never took place.
+		return fmt.Errorf("deployed %s, but recording it in %s failed: %w", effectiveTag, state.FileName, err)
 	}
 
 	in.printSuccess(ctx, hostPort)
@@ -662,7 +674,7 @@ func (in *installer) createFreshEnv(envPath, tag string) (string, int, error) {
 	if in.lite {
 		// MinIO never starts in lite mode and the overlay forces the
 		// postgres file store at runtime; align .env so it isn't misleading.
-		env = SetVar(env, "COMPOSE_PROFILES", "")
+		env = SetVar(env, "COMPOSE_PROFILES", withoutProfile(Var(env, "COMPOSE_PROFILES"), s3FilestoreProfile))
 		env = SetVar(env, "FILE_STORE_BACKEND", "postgres")
 	}
 
@@ -744,23 +756,26 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 	}
 
 	// Lite mode on an existing .env: the template ships with s3-filestore
-	// enabled; clear it so MinIO doesn't start.
-	if in.lite && strings.Contains(Var(env, "COMPOSE_PROFILES"), "s3-filestore") {
-		env = SetVar(env, "COMPOSE_PROFILES", "")
-		in.successf("Cleared COMPOSE_PROFILES for lite mode")
+	// enabled; drop that entry so MinIO doesn't start. Only that entry — any
+	// other profile in the list was turned on by the user, and clearing the
+	// whole value would switch their services off with no way to name them
+	// again on the way back.
+	if in.lite && hasProfile(Var(env, "COMPOSE_PROFILES"), s3FilestoreProfile) {
+		env = SetVar(env, "COMPOSE_PROFILES", withoutProfile(Var(env, "COMPOSE_PROFILES"), s3FilestoreProfile))
+		in.successf("Dropped %s from COMPOSE_PROFILES for lite mode", s3FilestoreProfile)
 	}
 	// Leaving lite behind: undo those same adjustments, or the "standard"
 	// deployment keeps lite's storage behaviour with MinIO never starting.
-	// Values the user has since changed to something else are left alone.
+	// The rest of the profile list, and a file store the user has since
+	// pointed somewhere else, are left as they are.
 	if !in.lite && in.wasLite {
-		if Var(env, "COMPOSE_PROFILES") == "" {
-			env = SetVar(env, "COMPOSE_PROFILES", "s3-filestore")
-		}
+		env = SetVar(env, "COMPOSE_PROFILES", withProfile(Var(env, "COMPOSE_PROFILES"), s3FilestoreProfile))
 		if Var(env, "FILE_STORE_BACKEND") == "postgres" {
 			env = SetVar(env, "FILE_STORE_BACKEND", "s3")
 			in.warnf("Files stored while in lite mode live in Postgres; standard mode reads the MinIO store, so they won't be listed until you switch back.")
 		}
-		in.successf("Restored the standard file store (COMPOSE_PROFILES=s3-filestore, FILE_STORE_BACKEND=s3)")
+		in.successf("Restored the standard file store (COMPOSE_PROFILES=%s, FILE_STORE_BACKEND=%s)",
+			Var(env, "COMPOSE_PROFILES"), Var(env, "FILE_STORE_BACKEND"))
 	}
 
 	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -48,10 +49,17 @@ type preflight struct {
 // RunInstall implements `deploy install` (and the install-onyx alias): fresh
 // installs, and restart/update runs against an existing deployment.
 func RunInstall(ctx context.Context, deps Deps, opts Options) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	in := newInstaller(deps, opts)
+	in.cancel = cancel
 	in.lite = opts.Lite
 	in.craft = opts.IncludeCraft
-	return in.runInstall(ctx)
+	err := in.runInstall(ctx)
+	if errors.Is(err, ui.ErrAborted) || (err != nil && ctx.Err() != nil) {
+		return exitcodes.New(exitcodes.General, "installation cancelled")
+	}
+	return err
 }
 
 func (in *installer) runInstall(ctx context.Context) error {
@@ -102,7 +110,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 	}
 
 	if in.fancy() {
-		in.wiz = ui.StartWizard(in.deps.CLIVersion)
+		in.wiz = ui.StartWizard(in.deps.CLIVersion, in.cancel)
 		defer in.wiz.Abort()
 	}
 

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -95,8 +95,18 @@ func (in *installer) runInstall(ctx context.Context) error {
 	preCh := make(chan preflight, 1)
 	go func() { preCh <- in.gatherPreflight(ctx) }()
 
+	// tagCh delivers exactly one value; latestTag memoizes it so every
+	// consumer (question defaults, initialTag) can read it safely.
+	var latestTag string
+	getLatestTag := func() string {
+		if latestTag == "" {
+			latestTag = <-tagCh
+		}
+		return latestTag
+	}
+
 	if in.opts.DryRun {
-		in.printPlan(<-tagCh)
+		in.printPlan(getLatestTag())
 		return nil
 	}
 
@@ -148,17 +158,18 @@ func (in *installer) runInstall(ctx context.Context) error {
 				return err
 			}
 			if choice == 1 {
-				updateTag, err = in.askString("Version to deploy", <-tagCh)
+				updateTag, err = in.askString("Version to deploy", getLatestTag())
 				if err != nil {
 					return err
 				}
 			}
 			if in.wiz != nil {
-				action := "Restart"
 				if updateTag != "" {
-					action = "Upgrade → " + updateTag
+					in.wiz.Answer("Action", "Upgrade")
+					in.wiz.Answer("Version", updateTag)
+				} else {
+					in.wiz.Answer("Action", "Restart")
 				}
-				in.wiz.Answer("Action", action)
 			}
 		}
 	} else {
@@ -166,7 +177,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 			return err
 		}
 		if in.opts.Tag == "" {
-			tag, err := in.askString("Version to deploy", <-tagCh)
+			tag, err := in.askString("Version to deploy", getLatestTag())
 			if err != nil {
 				return err
 			}
@@ -217,7 +228,11 @@ func (in *installer) runInstall(ctx context.Context) error {
 
 	initialTag := in.opts.Tag
 	if initialTag == "" {
-		initialTag = <-tagCh
+		if updateTag != "" {
+			initialTag = updateTag
+		} else {
+			initialTag = getLatestTag()
+		}
 	}
 	initialRef := ""
 	if !in.opts.Local {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -839,14 +839,14 @@ func (in *installer) ensureCraftResources(ctx context.Context) {
 	network := sandboxNetworkName()
 	if created, err := in.docker.EnsureNetwork(ctx, network); err != nil {
 		in.warnf("Could not create sandbox network %s — create it manually:", network)
-		in.plainf("    docker network create %s", network)
+		in.cmdf("docker network create %s", network)
 	} else if created {
 		in.successf("Created sandbox bridge network: %s", network)
 	}
 
 	if created, err := in.docker.EnsureVolume(ctx, sandboxProxyCAVolume); err != nil {
 		in.warnf("Could not create sandbox proxy CA volume %s — create it manually:", sandboxProxyCAVolume)
-		in.plainf("    docker volume create %s", sandboxProxyCAVolume)
+		in.cmdf("docker volume create %s", sandboxProxyCAVolume)
 	} else if created {
 		in.successf("Created sandbox proxy CA volume: %s", sandboxProxyCAVolume)
 	}
@@ -958,8 +958,8 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 			// it had already brought up, which is worth saying before the run
 			// reports itself cancelled.
 			in.infof("Services that already started are still running:")
-			in.plainf("  onyx-cli deploy status")
-			in.plainf("  onyx-cli deploy stop")
+			in.cmdf("onyx-cli deploy status")
+			in.cmdf("onyx-cli deploy stop")
 			return err
 		}
 		in.infof("Current container status:")
@@ -967,8 +967,8 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 		ps.Stdout, ps.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
 		_, _ = in.deps.Runner.Run(ctx, ps)
 		in.infof("Check the logs of any unhealthy service:")
-		in.plainf("  onyx-cli deploy status")
-		in.plainf("  (cd %q && docker compose %s logs <service>)", dir, strings.Join(fileArgs(files), " "))
+		in.cmdf("onyx-cli deploy status")
+		in.cmdf("(cd %q && docker compose %s logs <service>)", dir, strings.Join(fileArgs(files), " "))
 		in.explainIncompleteStart(tag, prevTag)
 		in.infof("If the issue persists, please contact: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose up failed: %v", err)

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -172,7 +172,8 @@ func (in *installer) runInstall(ctx context.Context) error {
 		// Read the published port off the running deployment: installs
 		// predating HOST_PORT recording have it nowhere else.
 		in.observedPort = in.runningHostPort(ctx)
-		if err := in.confirmRecreate(ctx, in.opts.Force && in.prompt.AssumeDefaults); err != nil {
+		running, err := in.guardRunningServices(ctx)
+		if err != nil {
 			return err
 		}
 		// The mode never changes implicitly on a rerun: the recorded mode
@@ -186,21 +187,41 @@ func (in *installer) runInstall(ctx context.Context) error {
 			in.overlayOnDisk(filepath.Base(deployfiles.CraftOverlay.DestRel))
 
 		if pinnedTag != "" {
+			// --tag already answers the question below.
 			updateTag = pinnedTag
 		} else if !in.prompt.AssumeDefaults {
-			choice, err := in.selectOne("This deployment already exists. What would you like to do?",
+			// This is also where a live deployment is signed off on: the
+			// choices restart it either way, so a separate "you know this
+			// restarts things" confirmation would only ask it twice.
+			title, restartHint, cancelHint :=
+				"This deployment already exists. What would you like to do?",
+				"keep the current configuration",
+				"leave the deployment as it is"
+			if running {
+				title, cancelHint = "Onyx is already running here. What would you like to do?",
+					"leave everything running"
+			}
+			choice, err := in.selectOne(title,
 				[]ui.Option{
-					{Label: "Restart", Hint: "keep the current configuration"},
+					{Label: "Restart", Hint: restartHint},
 					{Label: "Upgrade", Hint: "move to a newer Onyx version"},
+					{Label: "Cancel", Hint: cancelHint},
 				}, 0)
 			if err != nil {
 				return err
 			}
-			if choice == 1 {
+			switch choice {
+			case 1:
 				updateTag, err = in.askVersion(ctx, "Version to deploy", getLatestTag())
 				if err != nil {
 					return err
 				}
+			case 2:
+				if running {
+					return exitcodes.New(exitcodes.General,
+						"cancelled — services left running (stop them with `onyx-cli deploy stop`)")
+				}
+				return exitcodes.New(exitcodes.General, "cancelled")
 			}
 			if in.wiz != nil {
 				if updateTag != "" {
@@ -210,6 +231,12 @@ func (in *installer) runInstall(ctx context.Context) error {
 					in.wiz.Answer("Action", "Restart")
 				}
 			}
+		}
+		if running {
+			// Said once, whichever way the decision was reached: the run is
+			// about to sit on `pull` for a while, and this is what stops that
+			// looking like downtime.
+			in.infof("Onyx keeps serving while the images download; each service is replaced once, at the end")
 		}
 	} else {
 		if err := in.askModeQuestion(); err != nil {
@@ -784,46 +811,28 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 	return effectiveTag, hostPort, nil
 }
 
-// confirmRecreate gets sign-off for reconfiguring a deployment whose services
-// are up, before anything on disk changes. Nothing is stopped here: the answer
-// is remembered and handed to `up` as --force-recreate, so the current version
-// keeps serving while the images download and each container is replaced only
-// once its replacement is ready. Non-interactive runs refuse with the remedy in
-// the error itself (install.sh printed "./install.sh --shutdown", which doesn't
-// exist after curl|bash).
-func (in *installer) confirmRecreate(ctx context.Context, assumeYes bool) error {
+// guardRunningServices reports whether the deployment's services are up, and
+// settles what that means for a scripted run: reconfiguring a live deployment
+// needs --force, and the refusal carries the remedy (install.sh printed
+// "./install.sh --shutdown", which doesn't exist after curl|bash). Interactive
+// runs are asked instead, by the rerun question — that is where Cancel lives.
+//
+// Nothing is stopped either way: running services are handed to `up` as
+// --force-recreate, so the current version keeps serving while the images
+// download and each container is replaced only once its replacement is ready.
+func (in *installer) guardRunningServices(ctx context.Context) (bool, error) {
 	files := in.composeFileNames(true)
 	cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "ps", "-q")
 	res, err := in.deps.Runner.Run(ctx, cmd)
 	if err != nil || strings.TrimSpace(res.Stdout) == "" {
-		return nil
+		return false, nil
 	}
-
-	if assumeYes {
-		in.infof("Onyx is running — its services will be recreated with the new configuration.")
-		in.forceRecreate = true
-		return nil
-	}
-
-	if in.prompt.AssumeDefaults {
-		return exitcodes.New(exitcodes.General,
+	if in.prompt.AssumeDefaults && !in.opts.Force {
+		return true, exitcodes.New(exitcodes.General,
 			"Onyx services are running — pass --force to recreate them with the new configuration, or stop them first with `onyx-cli deploy stop`")
 	}
-
-	choice, err := in.selectOne("Onyx is already running. Applying this configuration restarts its services.",
-		[]ui.Option{
-			{Label: "Continue", Hint: "keeps serving while images download; each service restarts once, at the end"},
-			{Label: "Cancel", Hint: "leave everything running"},
-		}, 0)
-	if err != nil {
-		return err
-	}
-	if choice != 0 {
-		return exitcodes.New(exitcodes.General,
-			"cancelled — services left running (stop them with `onyx-cli deploy stop`)")
-	}
 	in.forceRecreate = true
-	return nil
+	return true, nil
 }
 
 func (in *installer) ensureCraftResources(ctx context.Context) {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -653,13 +653,33 @@ func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int)
 	dir := in.deploymentDir()
 	floating := release.IsFloatingTag(tag)
 
-	pullArgs := []string{"pull"}
-	if !in.opts.Verbose {
-		pullArgs = append(pullArgs, "--quiet")
-	}
-	if err := in.runComposePhase(ctx, ui.StagePull, "Pulling images", dir, env, files, pullArgs, false); err != nil {
-		in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
-		return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
+	if in.wiz != nil {
+		// Compose's own progress renderer (parallel per-layer bars) beats
+		// anything a spinner can convey: hand it the raw terminal for the
+		// pull, then resume the wizard.
+		in.wiz.Stage(ui.StagePull)
+		began := time.Now()
+		pull := in.compose.Command(dir, env, files, "pull")
+		pull.Stdout, pull.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+		err := in.wiz.Suspend(func() error {
+			_, err := in.deps.Runner.Run(ctx, pull)
+			return err
+		})
+		if err != nil {
+			in.errorf("Pulling images failed")
+			in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
+			return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
+		}
+		in.wiz.Note("ok", fmt.Sprintf("Pulling images (%ds)", int(time.Since(began).Seconds())))
+	} else {
+		pullArgs := []string{"pull"}
+		if !in.opts.Verbose {
+			pullArgs = append(pullArgs, "--quiet")
+		}
+		if err := in.runComposePhase(ctx, ui.StagePull, "Pulling images", dir, env, files, pullArgs, false); err != nil {
+			in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
+			return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
+		}
 	}
 
 	upArgs := []string{"up", "-d"}

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -909,10 +909,14 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 	}
 	if mode := in.progressMode(ctx); mode != "" {
 		// Compose's own event stream says what is happening to each container
-		// — the poll can only see that the outgoing container is still up.
+		// — the poll can only see that the outgoing container is still up. The
+		// poll stays on behind it though: a compose that prints no events (a
+		// format we can't read, output swallowed by a wrapper) would otherwise
+		// leave the longest phase of the run with nothing on screen at all.
 		phase.args = append([]string{"--progress", mode}, upArgs...)
-		phase.onLine = newStartProgress(in.wiz.Services, in.wiz.TaskExtra, wait).line
-		phase.poll = false
+		start := newStartProgress(in.wiz.Services, in.wiz.TaskExtra, wait)
+		phase.onLine = start.line
+		phase.pollQuiet = func() bool { return !start.reporting() }
 		defer in.wiz.Services(nil)
 	}
 	if err := in.runComposePhase(ctx, phase); err != nil {
@@ -1012,6 +1016,9 @@ type composePhase struct {
 	// poll watches container health while the command runs (`up --wait` is
 	// silent for as long as it takes everything to come up).
 	poll bool
+	// pollQuiet gates the poll when onLine is also filling the checklist: the
+	// poll then only publishes while the command's own output has said nothing.
+	pollQuiet func() bool
 	// onLine receives each output line while the wizard drives the run, for
 	// phases whose progress can be read off the command's own output.
 	onLine func(string)
@@ -1052,7 +1059,7 @@ func (in *installer) runComposePhase(ctx context.Context, p composePhase) error 
 
 	stop := make(chan struct{})
 	if p.poll {
-		go in.pollServiceHealth(stop)
+		go in.pollServiceHealth(stop, p.pollQuiet)
 	}
 	_, err := in.deps.Runner.Run(ctx, cmd)
 	close(stop)
@@ -1095,14 +1102,19 @@ func (in *installer) printFailureDiagnosis(output string) {
 }
 
 // pollServiceHealth feeds the wizard a live per-service checklist while
-// `up --wait` blocks (otherwise silent for up to ten minutes).
-func (in *installer) pollServiceHealth(stop chan struct{}) {
+// `up --wait` blocks (otherwise silent for up to ten minutes). quiet, when
+// set, is the phase's own progress reader saying it has nothing to show: the
+// poll is the backstop for a compose whose event stream never arrives.
+func (in *installer) pollServiceHealth(stop chan struct{}, quiet func() bool) {
 	ctx := context.Background()
 	for {
 		select {
 		case <-stop:
 			return
 		case <-time.After(2 * time.Second):
+		}
+		if quiet != nil && !quiet() {
+			continue
 		}
 		cmd := in.docker.Command(nil, "ps",
 			"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
@@ -1123,7 +1135,11 @@ func (in *installer) pollServiceHealth(stop chan struct{}) {
 			if ok {
 				ready++
 			}
-			rows = append(rows, ui.ServiceRow{Name: strings.TrimPrefix(parts[0], "onyx-"), Ready: ok})
+			rows = append(rows, ui.ServiceRow{
+				Name:   shortContainerName(parts[0]),
+				Detail: healthDetail(parts[1]),
+				Ready:  ok,
+			})
 		}
 		if len(rows) > 0 && in.wiz != nil {
 			in.wiz.Services(rows)
@@ -1151,8 +1167,10 @@ func (in *installer) printSuccess(ctx context.Context, hostPort int) {
 	}
 
 	if in.wiz != nil {
+		// The install is over by the time the star question is on screen, so
+		// the rail says so rather than leaving a stage mid-flight behind it.
+		in.wiz.Stage(ui.StageComplete)
 		star := in.askStarQuestion()
-		in.wiz.Stage(ui.StageDone)
 		in.wiz.Finish(append([]string{"🎉 " + lines[0]}, lines[1:]...)...)
 		in.wiz = nil
 		if star {

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1,0 +1,784 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/resources"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+	"github.com/onyx-dot-app/onyx/cli/internal/version"
+)
+
+// Resource expectations (halved thresholds in lite mode), from install.sh.
+const (
+	expectedRAMGB      = 10
+	expectedDiskGB     = 32
+	expectedRAMGBLite  = 4
+	expectedDiskGBLite = 16
+
+	waitTimeoutSeconds = 600
+	minComposeVersion  = "2.24.0"
+)
+
+const banner = `
+  ____
+ / __ \
+| |  | |_ __  _   ___  __
+| |  | | '_ \| | | \ \/ /
+| |__| | | | | |_| |>  <
+ \____/|_| |_|\__, /_/\_\
+               __/ |
+              |___/
+`
+
+// RunInstall implements `deploy install` (and the install-onyx alias): fresh
+// installs, and restart/update runs against an existing deployment.
+func RunInstall(ctx context.Context, deps Deps, opts Options) error {
+	in := newInstaller(deps, opts)
+	in.totalSteps = 9
+	in.lite = opts.Lite
+	in.craft = opts.IncludeCraft
+	return in.runInstall(ctx)
+}
+
+func (in *installer) runInstall(ctx context.Context) error {
+	if in.opts.Lite && in.opts.IncludeCraft {
+		return exitcodes.New(exitcodes.BadRequest,
+			"--lite and --include-craft cannot be used together: Craft requires services (Vespa, Redis, background workers) that lite mode disables")
+	}
+
+	// Resolve the default deploy tag from the latest app release so users
+	// land on a pinned, tested version; fall back to main/edge offline.
+	defaultTag, lookupFailed := "edge", false
+	if !in.opts.Local {
+		if in.opts.Tag != "" {
+			defaultTag = in.opts.Tag
+		} else if tag, err := in.deps.Release.LatestAppTag(ctx); err == nil {
+			defaultTag = tag
+		} else {
+			lookupFailed = true
+		}
+	}
+
+	in.root = paths.Resolve(in.opts.Dir)
+
+	if in.opts.DryRun {
+		in.printPlan(defaultTag)
+		return nil
+	}
+
+	if err := in.ensureDockerAndCompose(ctx); err != nil {
+		return err
+	}
+
+	// ASCII banner + acknowledgment (mirrors install.sh).
+	in.plainf("%s", banner)
+	in.plainf("Welcome to the Onyx Installer")
+	in.plainf("=============================")
+	in.plainf("")
+	if lookupFailed {
+		in.warnf("Could not determine latest Onyx release — falling back to main / edge")
+	}
+	in.plainf("This command will:")
+	in.plainf("1. Set up Onyx deployment files in '%s'", in.root.Dir)
+	in.plainf("2. Check your system resources (Docker, memory, disk space)")
+	in.plainf("3. Guide you through deployment options (version, mode)")
+	in.plainf("")
+	if err := in.prompt.AcknowledgeEnter("Please acknowledge and press Enter to continue..."); err != nil {
+		return err
+	}
+
+	if err := in.verifyDocker(ctx); err != nil {
+		return err
+	}
+	if err := in.verifyResources(ctx); err != nil {
+		return err
+	}
+
+	in.stepf("Creating directory structure")
+	if in.root.Source == paths.SourceLegacyCwd {
+		in.infof("Managing existing install at %s (created by install.sh)", in.root.Dir)
+	}
+	for _, alt := range in.root.Ambiguous {
+		in.warnf("Another Onyx install exists at %s — pass --dir to target it instead", alt)
+	}
+	for _, dir := range []string{
+		filepath.Join(in.root.Dir, "deployment"),
+		filepath.Join(in.root.Dir, "data", "nginx", "local"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return fmt.Errorf("failed to create %s: %w", dir, err)
+		}
+	}
+	gitkeep := filepath.Join(in.root.Dir, "data", "nginx", "local", ".gitkeep")
+	if err := os.WriteFile(gitkeep, nil, 0644); err != nil {
+		return fmt.Errorf("failed to create %s: %w", gitkeep, err)
+	}
+	in.successf("Directory structure ready at %s", in.root.Dir)
+
+	manifest, err := state.Load(in.root.Dir)
+	if err != nil {
+		return err
+	}
+	hadManifest := manifest != nil
+	if manifest == nil {
+		manifest = &state.Manifest{}
+		if paths.IsInstall(in.root.Dir) {
+			in.infof("No %s found — adopting this install; files not written by the CLI are treated as potentially customized", state.FileName)
+		}
+	}
+
+	in.stepf("Preparing configuration files")
+	if err := in.chooseMode(manifest.Mode); err != nil {
+		return err
+	}
+
+	initialRef := ""
+	if !in.opts.Local {
+		initialRef = release.ConfigRef(defaultTag)
+	}
+	fetcher := &fileFetcher{in: in}
+	if err := in.materializeFiles(ctx, initialRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
+		return err
+	}
+	if !in.lite {
+		if err := in.removeOverlayIfPresent(deployfiles.LiteOverlay, manifest, "switching to standard mode"); err != nil {
+			return err
+		}
+	}
+	if !in.craft {
+		if err := in.removeOverlayIfPresent(deployfiles.CraftOverlay, manifest, "Craft disabled this run"); err != nil {
+			return err
+		}
+	}
+	in.successf("All configuration files ready")
+
+	if err := in.checkComposeVersion(ctx); err != nil {
+		return err
+	}
+
+	in.stepf("Setting up deployment configs")
+	effectiveTag, err := in.configureEnv(ctx, defaultTag)
+	if err != nil {
+		return err
+	}
+
+	// Pinned tags want config files from their own ref so compose matches
+	// the images; re-materialize when the effective tag needs another ref.
+	configRef := release.ConfigRef(effectiveTag)
+	if !in.opts.Local && configRef != initialRef {
+		in.infof("Fetching config files matching %s...", configRef)
+		if err := in.materializeFiles(ctx, configRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
+			return err
+		}
+	}
+
+	if in.craft {
+		in.ensureCraftResources(ctx)
+	}
+
+	in.stepf("Checking for available ports")
+	hostPort := resources.FindAvailablePort(3000)
+	if hostPort != 3000 {
+		in.infof("Port 3000 is in use, found available port: %d", hostPort)
+	} else {
+		in.infof("Port 3000 is available")
+	}
+	in.successf("Using port %d for the web server", hostPort)
+
+	if err := in.pullAndStart(ctx, effectiveTag, hostPort); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	manifest.InstalledTag = effectiveTag
+	manifest.CLIVersion = in.deps.CLIVersion
+	manifest.Mode = state.ModeStandard
+	if in.lite {
+		manifest.Mode = state.ModeLite
+	}
+	manifest.IncludeCraft = in.craft
+	if !hadManifest || manifest.InstalledAt.IsZero() {
+		manifest.InstalledAt = now
+	}
+	manifest.UpdatedAt = now
+	if err := manifest.Save(in.root.Dir); err != nil {
+		return err
+	}
+
+	in.printSuccess(ctx, hostPort)
+	return nil
+}
+
+// ensureDockerAndCompose provisions Docker Engine and compose where install.sh
+// does (Linux/WSL), starts Docker Desktop on macOS later during verification,
+// and detect-and-instructs on native Windows.
+func (in *installer) ensureDockerAndCompose(ctx context.Context) error {
+	linuxLike := runtime.GOOS == "linux" || dockercmd.IsWSL()
+
+	if !dockercmd.Installed() {
+		switch {
+		case linuxLike:
+			in.infof("Docker is required but not installed.")
+			ok, err := in.prompt.Confirm("Install Docker Engine? (Y/n) [default: Y] ", true)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				return exitcodes.New(exitcodes.General, "Docker is required to run Onyx")
+			}
+			if err := dockercmd.InstallDockerLinux(ctx, in.deps.Runner, in.deps.IOS.Out); err != nil {
+				return exitcodes.Newf(exitcodes.General, "Docker installation failed: %v\n  Visit: https://docs.docker.com/get-docker/", err)
+			}
+			if !dockercmd.Installed() {
+				return exitcodes.New(exitcodes.General, "Docker installation failed.\n  Visit: https://docs.docker.com/get-docker/")
+			}
+			in.successf("Docker installed successfully")
+		case runtime.GOOS == "windows":
+			in.plainf("%s", dockercmd.DockerDesktopInstructionsWindows)
+			return exitcodes.New(exitcodes.General, "Docker Desktop is required to run Onyx")
+		default:
+			return exitcodes.New(exitcodes.General,
+				"Docker is not installed. Please install Docker Desktop first.\n  Visit: https://docs.docker.com/get-docker/")
+		}
+	}
+
+	in.compose = dockercmd.DetectCompose(ctx, in.docker)
+	if in.compose == nil && linuxLike {
+		in.infof("Docker Compose is required but not installed.")
+		ok, err := in.prompt.Confirm("Install the Docker Compose plugin? (Y/n) [default: Y] ", true)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return exitcodes.New(exitcodes.General, "Docker Compose is required to run Onyx")
+		}
+		if err := dockercmd.InstallComposePluginLinux(ctx, in.deps.Runner, in.deps.IOS.Out); err != nil {
+			return exitcodes.Newf(exitcodes.General, "Failed to install the Docker Compose plugin: %v\n  Visit: https://docs.docker.com/compose/install/", err)
+		}
+		in.compose = dockercmd.DetectCompose(ctx, in.docker)
+		if in.compose == nil {
+			return exitcodes.New(exitcodes.General, "Docker Compose plugin installed but not detected.\n  Visit: https://docs.docker.com/compose/install/")
+		}
+		in.successf("Docker Compose plugin installed")
+	}
+	if in.compose == nil {
+		return exitcodes.New(exitcodes.General,
+			"Docker Compose is not installed. Please install Docker Compose first.\n  Visit: https://docs.docker.com/compose/install/")
+	}
+
+	in.docker.RefreshSudo(ctx)
+	if in.docker.UsingSudo() {
+		if err := dockercmd.EnsureDockerGroup(ctx, in.deps.Runner, in.deps.IOS.Out); err != nil {
+			in.warnf("Could not add you to the docker group: %v", err)
+		}
+		in.infof("Using sudo for docker commands in this run.")
+	}
+	return nil
+}
+
+func (in *installer) verifyDocker(ctx context.Context) error {
+	in.stepf("Verifying Docker installation")
+	if v := in.docker.Version(ctx); v != "" {
+		in.successf("Docker %s is installed", v)
+	} else {
+		in.successf("Docker is installed")
+	}
+	in.successf("Docker Compose %s is installed (%s)", in.compose.Version(ctx), in.compose.TypeName())
+
+	if !in.docker.DaemonRunning(ctx) {
+		if runtime.GOOS == "darwin" {
+			in.infof("Docker daemon is not running. Starting Docker Desktop...")
+			if err := dockercmd.StartDockerDesktopDarwin(ctx, in.docker, in.deps.IOS.Out, 120*time.Second); err != nil {
+				return exitcodes.Newf(exitcodes.General, "%v", err)
+			}
+			in.successf("Docker Desktop is now running")
+		} else {
+			return exitcodes.New(exitcodes.General, "Docker daemon is not running. Please start Docker.")
+		}
+	} else {
+		in.successf("Docker daemon is running")
+	}
+	return nil
+}
+
+func (in *installer) verifyResources(ctx context.Context) error {
+	in.stepf("Verifying Docker resources")
+
+	dockerInfo := ""
+	if res, err := in.deps.Runner.Run(ctx, in.docker.Command(nil, "system", "info")); err == nil {
+		dockerInfo = res.Stdout
+	}
+	memoryMB := resources.MemoryMB(dockerInfo)
+	if memoryMB > 0 {
+		if runtime.GOOS == "darwin" {
+			in.infof("Docker memory allocation: %s", resources.FormatMemory(memoryMB))
+		} else {
+			in.infof("System memory: %s (Docker uses host memory directly)", resources.FormatMemory(memoryMB))
+		}
+	} else {
+		in.warnf("Could not determine memory allocation")
+	}
+
+	diskGB := resources.DiskAvailableGB(".")
+	if diskGB >= 0 {
+		in.infof("Available disk space: %dGB", diskGB)
+	} else {
+		in.warnf("Could not determine available disk space")
+	}
+
+	ramWant, diskWant := expectedRAMGB, expectedDiskGB
+	if in.lite {
+		ramWant, diskWant = expectedRAMGBLite, expectedDiskGBLite
+	}
+	warning := false
+	if memoryMB > 0 && memoryMB < ramWant*1024 {
+		in.warnf("Less than %dGB RAM available (found: %s)", ramWant, resources.FormatMemory(memoryMB))
+		warning = true
+	}
+	if diskGB >= 0 && diskGB < diskWant {
+		in.warnf("Less than %dGB disk space available (found: %dGB)", diskWant, diskGB)
+		warning = true
+	}
+	if warning {
+		in.plainf("")
+		in.warnf("Onyx recommends at least %dGB RAM and %dGB disk space for optimal performance in standard mode.", ramWant, diskWant)
+		in.warnf("Lite mode requires less resources (1-4GB RAM, 8-16GB disk depending on usage), but does not include a vector database.")
+		in.plainf("")
+		cont, err := in.prompt.Confirm("Do you want to continue anyway? (Y/n): ", true)
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return exitcodes.New(exitcodes.General, "Installation cancelled. Please allocate more resources and try again.")
+		}
+		in.infof("Proceeding with installation despite resource limitations...")
+	}
+	return nil
+}
+
+// chooseMode runs the lite-vs-standard prompt unless --lite already decided
+// it. Lite is the default for new installs (matching install.sh); an existing
+// install defaults to its recorded mode, so a --no-prompt restart cannot
+// silently switch a standard deployment to lite (an install.sh footgun).
+func (in *installer) chooseMode(prevMode state.Mode) error {
+	if in.lite {
+		in.infof("Deployment mode: Lite (set via --lite flag)")
+		return nil
+	}
+	if in.craft {
+		// Craft implies standard mode; the flag conflict was checked early.
+		return nil
+	}
+	def := "1"
+	if prevMode == state.ModeStandard {
+		def = "2"
+	}
+	in.infof("Which deployment mode would you like?")
+	in.plainf("")
+	in.plainf("  1) Lite      - Minimal deployment (no OpenSearch, Redis, or model servers)")
+	in.plainf("                  LLM chat, tools, file uploads, and Projects still work")
+	in.plainf("  2) Standard  - Full deployment with search, connectors, and RAG")
+	in.plainf("")
+	choice, err := in.prompt.Ask(fmt.Sprintf("Choose a mode (1 or 2) [default: %s]: ", def), def)
+	if err != nil {
+		return err
+	}
+	in.plainf("")
+	if choice == "2" {
+		in.infof("Selected: Standard mode")
+	} else {
+		in.lite = true
+		in.infof("Selected: Lite mode")
+	}
+	return nil
+}
+
+func (in *installer) checkComposeVersion(ctx context.Context) error {
+	composeVersion := in.compose.Version(ctx)
+	if composeVersion == "dev" {
+		return nil
+	}
+	have, ok := version.Parse(composeVersion)
+	minimum, _ := version.Parse(minComposeVersion)
+	if !ok || !have.LessThan(minimum) {
+		return nil
+	}
+	in.warnf("Docker Compose version %s is older than %s", composeVersion, minComposeVersion)
+	in.plainf("")
+	in.warnf("The docker-compose.yml file uses the newer env_file format that requires Docker Compose %s or later.", minComposeVersion)
+	in.infof("Upgrade Docker Compose (https://docs.docker.com/compose/install/) or manually flatten the env_file sections.")
+	in.plainf("")
+	cont, err := in.prompt.Confirm("Do you want to continue anyway? (Y/n): ", true)
+	if err != nil {
+		return err
+	}
+	if !cont {
+		return exitcodes.New(exitcodes.General, "Installation cancelled. Please upgrade Docker Compose and re-run.")
+	}
+	in.infof("Proceeding despite the Docker Compose version mismatch...")
+	return nil
+}
+
+// configureEnv creates or updates deployment/.env and returns the effective
+// image tag.
+func (in *installer) configureEnv(ctx context.Context, defaultTag string) (string, error) {
+	envPath := filepath.Join(in.root.Dir, "deployment", ".env")
+	existing, err := os.ReadFile(envPath)
+	switch {
+	case err == nil:
+		return in.reconfigureExistingEnv(ctx, envPath, string(existing), defaultTag)
+	case os.IsNotExist(err):
+		return in.createFreshEnv(envPath, defaultTag)
+	default:
+		return "", fmt.Errorf("failed to read %s: %w", envPath, err)
+	}
+}
+
+func (in *installer) createFreshEnv(envPath, defaultTag string) (string, error) {
+	in.infof("No existing .env file found. Setting up new deployment...")
+	in.plainf("")
+
+	tag := in.opts.Tag
+	if tag == "" {
+		in.infof("Which tag would you like to deploy?")
+		in.plainf("")
+		in.plainf("• Press Enter for %s (recommended)", defaultTag)
+		in.plainf("• Type a specific tag (e.g., v1.2.3)")
+		in.plainf("")
+		var err error
+		tag, err = in.prompt.Ask(fmt.Sprintf("Enter tag [default: %s]: ", defaultTag), defaultTag)
+		if err != nil {
+			return "", err
+		}
+		in.plainf("")
+	}
+	if tag == "edge" {
+		in.infof("Selected: edge (latest nightly)")
+	} else {
+		in.infof("Selected: %s", tag)
+	}
+
+	template, err := os.ReadFile(filepath.Join(in.root.Dir, "deployment", "env.template"))
+	if err != nil {
+		return "", fmt.Errorf("failed to read env.template: %w", err)
+	}
+	env := string(template)
+
+	in.infof("Creating .env file with your selections...")
+	env = SetVar(env, "IMAGE_TAG", tag)
+
+	if in.lite {
+		// MinIO never starts in lite mode and the overlay forces the
+		// postgres file store at runtime; align .env so it isn't misleading.
+		env = SetVar(env, "COMPOSE_PROFILES", "")
+		env = SetVar(env, "FILE_STORE_BACKEND", "postgres")
+		in.successf("Cleared COMPOSE_PROFILES and set FILE_STORE_BACKEND=postgres for lite mode")
+	}
+
+	env = SetVar(env, "USER_AUTH_SECRET", `"`+randomHex(32)+`"`)
+	minioAccessKey, minioSecretKey := randomHex(16), randomHex(32)
+	env = SetVar(env, "MINIO_ROOT_USER", minioAccessKey)
+	env = SetVar(env, "MINIO_ROOT_PASSWORD", minioSecretKey)
+	env = SetVar(env, "S3_AWS_ACCESS_KEY_ID", minioAccessKey)
+	env = SetVar(env, "S3_AWS_SECRET_ACCESS_KEY", minioSecretKey)
+
+	if in.craft {
+		env = SetVarUncomment(env, "ENABLE_CRAFT", "true")
+		backend := sandboxBackendForTag(tag)
+		env = SetVarUncomment(env, "SANDBOX_BACKEND", backend)
+		in.successf("Onyx Craft enabled (ENABLE_CRAFT=true, SANDBOX_BACKEND=%s)", backend)
+		if backend == "docker" {
+			in.plainf("")
+			in.plainf("%s", craftSecurityWarning)
+			in.plainf("")
+		} else {
+			in.infof("Image tag %s predates the docker sandbox backend (v4.0.6+); using SANDBOX_BACKEND=%s.", tag, backend)
+		}
+	} else {
+		in.infof("Onyx Craft disabled (use --include-craft to enable)")
+	}
+
+	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
+		return "", fmt.Errorf("failed to write .env: %w", err)
+	}
+	in.successf(".env file created with your preferences")
+	in.plainf("")
+	in.infof("You can customize %s later for AI models, domains, and more.", envPath)
+	in.plainf("")
+	return tag, nil
+}
+
+func (in *installer) reconfigureExistingEnv(ctx context.Context, envPath, env, defaultTag string) (string, error) {
+	if err := in.guardServicesStopped(ctx); err != nil {
+		return "", err
+	}
+
+	update := false
+	tag := in.opts.Tag
+	if tag != "" {
+		// An explicit --tag on an existing install is an update request.
+		update = tag != Var(env, "IMAGE_TAG")
+	} else {
+		in.infof("Existing .env file found. What would you like to do?")
+		in.plainf("")
+		in.plainf("• Press Enter to restart with current configuration")
+		in.plainf("• Type 'update' to update to a newer version")
+		in.plainf("  (scriptable equivalent: onyx-cli deploy upgrade --tag <tag>)")
+		in.plainf("")
+		choice, err := in.prompt.Ask("Choose an option [default: restart]: ", "")
+		if err != nil {
+			return "", err
+		}
+		in.plainf("")
+		if choice == "update" {
+			update = true
+			tag, err = in.prompt.Ask(fmt.Sprintf("Enter tag [default: %s]: ", defaultTag), defaultTag)
+			if err != nil {
+				return "", err
+			}
+			in.plainf("")
+		}
+	}
+
+	if update {
+		in.infof("Updating configuration for version %s...", tag)
+		env = SetVar(env, "IMAGE_TAG", tag)
+		in.successf("Updated IMAGE_TAG to %s in .env file", tag)
+	} else {
+		in.infof("Keeping existing configuration...")
+		in.successf("Will restart with current settings")
+	}
+
+	effectiveTag := Var(env, "IMAGE_TAG")
+	if effectiveTag == "" {
+		effectiveTag = "edge"
+	}
+
+	// Honor --include-craft on existing installs regardless of branch,
+	// aligning SANDBOX_BACKEND with the effective tag.
+	if in.craft {
+		env = SetVarUncomment(env, "ENABLE_CRAFT", "true")
+		backend := sandboxBackendForTag(effectiveTag)
+		env = SetVarUncomment(env, "SANDBOX_BACKEND", backend)
+		in.successf("Onyx Craft enabled (ENABLE_CRAFT=true, SANDBOX_BACKEND=%s, image tag: %s)", backend, effectiveTag)
+	}
+
+	// Lite mode on an existing .env: the template ships with s3-filestore
+	// enabled; clear it so MinIO doesn't start.
+	if in.lite && strings.Contains(Var(env, "COMPOSE_PROFILES"), "s3-filestore") {
+		env = SetVar(env, "COMPOSE_PROFILES", "")
+		in.successf("Cleared COMPOSE_PROFILES for lite mode")
+	}
+
+	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
+		return "", fmt.Errorf("failed to write .env: %w", err)
+	}
+	return effectiveTag, nil
+}
+
+// guardServicesStopped refuses to reconfigure while containers are up. The
+// replacement message points at a command that actually exists after a
+// curl|bash install — unlike install.sh's "./install.sh --shutdown".
+func (in *installer) guardServicesStopped(ctx context.Context) error {
+	files := in.composeFileNames(true)
+	cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "ps", "-q")
+	res, err := in.deps.Runner.Run(ctx, cmd)
+	if err != nil || strings.TrimSpace(res.Stdout) == "" {
+		return nil
+	}
+	in.errorf("Onyx services are currently running!")
+	in.plainf("")
+	in.infof("To make configuration changes, you must first shut down the services:")
+	in.plainf("   onyx-cli deploy stop")
+	in.plainf("")
+	in.infof("Then re-run this command to make your changes.")
+	return exitcodes.New(exitcodes.General, "services are running")
+}
+
+func (in *installer) ensureCraftResources(ctx context.Context) {
+	network := sandboxNetworkName()
+	if created, err := in.docker.EnsureNetwork(ctx, network); err != nil {
+		in.warnf("Could not create sandbox network %s — create it manually:", network)
+		in.plainf("    docker network create %s", network)
+	} else if created {
+		in.successf("Created sandbox bridge network: %s", network)
+	}
+
+	if created, err := in.docker.EnsureVolume(ctx, sandboxProxyCAVolume); err != nil {
+		in.warnf("Could not create sandbox proxy CA volume %s — create it manually:", sandboxProxyCAVolume)
+		in.plainf("    docker volume create %s", sandboxProxyCAVolume)
+	} else if created {
+		in.successf("Created sandbox proxy CA volume: %s", sandboxProxyCAVolume)
+	}
+}
+
+func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int) error {
+	env := map[string]string{
+		"HOST_PORT": fmt.Sprintf("%d", hostPort),
+		"IMAGE_TAG": tag,
+	}
+	files := in.composeFileNames(false)
+	dir := in.deploymentDir()
+	floating := release.IsFloatingTag(tag)
+
+	in.stepf("Pulling Docker images")
+	in.infof("This may take several minutes depending on your internet connection...")
+	pullArgs := []string{"pull"}
+	if !in.opts.Verbose {
+		pullArgs = append(pullArgs, "--quiet")
+	}
+	pull := in.compose.Command(dir, env, files, pullArgs...)
+	pull.Stdout, pull.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+	if _, err := in.deps.Runner.Run(ctx, pull); err != nil {
+		in.errorf("Failed to download Docker images")
+		return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
+	}
+	in.successf("Docker images downloaded successfully")
+
+	in.stepf("Starting Onyx services")
+	upArgs := []string{"up", "-d"}
+	if floating {
+		in.infof("Using '%s' tag - force pulling latest images and recreating containers...", tag)
+		upArgs = append(upArgs, "--pull", "always", "--force-recreate")
+	}
+	if !in.opts.NoWait {
+		in.infof("Waiting up to %ds for all services to become healthy...", waitTimeoutSeconds)
+		upArgs = append(upArgs, "--wait", "--wait-timeout", fmt.Sprintf("%d", waitTimeoutSeconds))
+	}
+	in.plainf("")
+	up := in.compose.Command(dir, env, files, upArgs...)
+	up.Stdout, up.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+	if _, err := in.deps.Runner.Run(ctx, up); err != nil {
+		in.errorf("Failed to start Onyx services")
+		in.plainf("")
+		in.infof("Current container status:")
+		ps := in.compose.Command(dir, env, files, "ps")
+		ps.Stdout, ps.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+		_, _ = in.deps.Runner.Run(ctx, ps)
+		in.plainf("")
+		in.infof("Check the logs of any unhealthy service:")
+		in.plainf("  onyx-cli deploy status")
+		in.plainf("  (cd %q && docker compose %s logs <service>)", dir, strings.Join(fileArgs(files), " "))
+		in.plainf("")
+		in.infof("If the issue persists, please contact: founders@onyx.app")
+		return exitcodes.Newf(exitcodes.General, "docker compose up failed: %v", err)
+	}
+	return nil
+}
+
+func (in *installer) printSuccess(ctx context.Context, hostPort int) {
+	in.stepf("Installation Complete!")
+	in.plainf("")
+	if in.opts.NoWait {
+		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		in.plainf("   ⚠️  Onyx containers started  ⚠️")
+		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		in.infof("Services may still be initializing. Check status with: onyx-cli deploy status")
+	} else {
+		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+		in.plainf("   🎉 Onyx service is ready! 🎉")
+		in.plainf("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	}
+	in.plainf("")
+	in.infof("Access Onyx at:")
+	in.plainf("   http://localhost:%d", hostPort)
+	in.plainf("")
+	in.infof("If authentication is enabled, you can create your admin account here:")
+	in.plainf("   • Visit http://localhost:%d/auth/signup to create your admin account", hostPort)
+	in.plainf("   • The first user created will automatically have admin privileges")
+	in.plainf("")
+	if in.lite {
+		in.infof("Running in Lite mode — the following services are NOT started:")
+		in.plainf("  • Vespa (vector database)")
+		in.plainf("  • Redis (cache)")
+		in.plainf("  • Model servers (embedding/inference)")
+		in.plainf("  • Background workers (Celery)")
+		in.plainf("")
+		in.infof("Connectors and RAG search are disabled. LLM chat, tools, user file")
+		in.infof("uploads, Projects, Agent knowledge, and code interpreter still work.")
+		in.plainf("")
+	}
+	in.infof("Manage this deployment with: onyx-cli deploy status | stop | upgrade | uninstall")
+	in.infof("Refer to the README in the %s directory for more information.", in.root.Dir)
+	in.plainf("")
+	in.infof("For help or issues, contact: founders@onyx.app")
+	in.plainf("")
+	in.starPrompt(ctx)
+}
+
+// starPrompt ports install.sh's GitHub star prompt: only when interactive and
+// the gh CLI is available.
+func (in *installer) starPrompt(ctx context.Context) {
+	if in.prompt.AssumeDefaults {
+		return
+	}
+	if _, err := exec.LookPath("gh"); err != nil {
+		return
+	}
+	ok, err := in.prompt.Confirm("Enjoying Onyx? Star the repo on GitHub? [Y/n] ", true)
+	if err != nil || !ok {
+		return
+	}
+	cmd := dockercmd.Command{
+		Name: "gh",
+		Args: []string{"api", "-X", "PUT", "/user/starred/onyx-dot-app/onyx"},
+		Env:  map[string]string{"GH_PAGER": ""},
+	}
+	if _, err := in.deps.Runner.Run(ctx, cmd); err == nil {
+		in.successf("Thanks for the star!")
+	} else {
+		in.infof("Star us at: https://github.com/onyx-dot-app/onyx")
+	}
+}
+
+// composeFileNames returns the -f list. With autoDetect, previously
+// downloaded overlays are picked up from disk so users don't have to repeat
+// --lite/--include-craft for lifecycle commands (install.sh's
+// build_compose_file_args true).
+func (in *installer) composeFileNames(autoDetect bool) []string {
+	files := []string{"docker-compose.yml"}
+	liteName := filepath.Base(deployfiles.LiteOverlay.DestRel)
+	craftName := filepath.Base(deployfiles.CraftOverlay.DestRel)
+	if in.lite || (autoDetect && in.overlayOnDisk(liteName)) {
+		files = append(files, liteName)
+	}
+	if in.craft || (autoDetect && in.overlayOnDisk(craftName)) {
+		files = append(files, craftName)
+	}
+	return files
+}
+
+func (in *installer) overlayOnDisk(name string) bool {
+	_, err := os.Stat(filepath.Join(in.deploymentDir(), name))
+	return err == nil
+}
+
+func (in *installer) deploymentDir() string {
+	return filepath.Join(in.root.Dir, "deployment")
+}
+
+// stopFallbackEnv supplies safe defaults for compose invocations that may run
+// before .env is known-good (install.sh uses the same pair for shutdown).
+func stopFallbackEnv() map[string]string {
+	return map[string]string{"HOST_PORT": "3000", "IMAGE_TAG": "edge"}
+}
+
+func fileArgs(files []string) []string {
+	args := make([]string, 0, 2*len(files))
+	for _, f := range files {
+		args = append(args, "-f", f)
+	}
+	return args
+}

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -136,7 +136,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 		if err := in.resolveDockerProblems(ctx, pre); err != nil {
 			return err
 		}
-		if err := in.guardServicesStopped(ctx); err != nil {
+		if err := in.guardServicesStopped(ctx, in.opts.Force && in.prompt.AssumeDefaults); err != nil {
 			return err
 		}
 		// The mode never changes implicitly on a rerun: the recorded mode
@@ -623,7 +623,7 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 // interactive runs offer to stop them right here; non-interactive runs
 // refuse with the remedy in the error itself (install.sh printed
 // "./install.sh --shutdown", which doesn't exist after curl|bash).
-func (in *installer) guardServicesStopped(ctx context.Context) error {
+func (in *installer) guardServicesStopped(ctx context.Context, autoStop bool) error {
 	files := in.composeFileNames(true)
 	cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "ps", "-q")
 	res, err := in.deps.Runner.Run(ctx, cmd)
@@ -631,9 +631,14 @@ func (in *installer) guardServicesStopped(ctx context.Context) error {
 		return nil
 	}
 
+	if autoStop {
+		in.infof("Stopping the running services first (they restart at the end)...")
+		return in.stopRunningServices(ctx, files)
+	}
+
 	if in.prompt.AssumeDefaults {
 		return exitcodes.New(exitcodes.General,
-			"Onyx services are running — stop them first with `onyx-cli deploy stop`, then re-run")
+			"Onyx services are running — stop them first with `onyx-cli deploy stop` (or pass --force to stop them automatically), then re-run")
 	}
 
 	choice, err := in.selectOne("Onyx is already running. Reconfiguring needs the services stopped.",
@@ -650,6 +655,10 @@ func (in *installer) guardServicesStopped(ctx context.Context) error {
 	}
 
 	in.infof("Stopping Onyx services...")
+	return in.stopRunningServices(ctx, files)
+}
+
+func (in *installer) stopRunningServices(ctx context.Context, files []string) error {
 	stop := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "stop")
 	if in.wiz == nil {
 		stop.Stdout, stop.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -40,6 +40,14 @@ const (
 // preflight carries the environment facts gathered concurrently while the
 // user answers the setup questions. Healthy values stay quiet; only problems
 // surface as warnings or provisioning offers.
+// tagLookup carries the background release lookup's outcome. The error is
+// reported by the receiving goroutine, not the sender: the output helpers
+// drive the wizard, which only the main goroutine may touch.
+type tagLookup struct {
+	tag string
+	err error
+}
+
 type preflight struct {
 	dockerVersion  string
 	composeVersion string
@@ -76,34 +84,49 @@ func (in *installer) runInstall(ctx context.Context) error {
 	_, envErr := os.Stat(envPath)
 	rerun := envErr == nil
 
+	// --tag is checked before anything else runs: a typo must fail here, not
+	// minutes later as a pull error with the bad version already on disk.
+	// pinnedTag is assigned once, before the goroutines below read it, and
+	// never again — opts stays immutable for the rest of the run.
+	pinnedTag := in.opts.Tag
+	if pinnedTag != "" {
+		validated, verr := in.validateTag(ctx, pinnedTag)
+		if verr != nil {
+			return verr
+		}
+		pinnedTag = validated
+	}
+
 	// The latest-release lookup and the environment checks run in the
 	// background while the user answers the questions below.
-	tagCh := make(chan string, 1)
+	tagCh := make(chan tagLookup, 1)
 	go func() {
-		if in.opts.Local {
-			tagCh <- "edge"
-			return
-		}
-		if in.opts.Tag != "" {
-			tagCh <- in.opts.Tag
-			return
-		}
-		if tag, err := in.deps.Release.LatestAppTag(ctx); err == nil {
-			tagCh <- tag
-		} else {
-			in.warnf("Could not determine latest Onyx release — falling back to main / edge")
-			tagCh <- "edge"
+		switch {
+		case in.opts.Local:
+			tagCh <- tagLookup{tag: "edge"}
+		case pinnedTag != "":
+			tagCh <- tagLookup{tag: pinnedTag}
+		default:
+			tag, err := in.deps.Release.LatestAppTag(ctx)
+			tagCh <- tagLookup{tag: tag, err: err}
 		}
 	}()
 	preCh := make(chan preflight, 1)
 	go func() { preCh <- in.gatherPreflight(ctx) }()
 
 	// tagCh delivers exactly one value; latestTag memoizes it so every
-	// consumer (question defaults, initialTag) can read it safely.
+	// consumer (question defaults, initialTag) can read it safely. The
+	// fallback is reported here rather than in the goroutine: output helpers
+	// touch the wizard, which only the main goroutine may drive.
 	var latestTag string
 	getLatestTag := func() string {
 		if latestTag == "" {
-			latestTag = <-tagCh
+			got := <-tagCh
+			if got.err != nil {
+				in.warnf("Could not determine latest Onyx release — falling back to main / edge")
+				got.tag = "edge"
+			}
+			latestTag = got.tag
 		}
 		return latestTag
 	}
@@ -128,7 +151,8 @@ func (in *installer) runInstall(ctx context.Context) error {
 	}
 
 	// ---- Questions: every decision is made up front ----
-	var updateTag string // rerun: non-empty means update to this tag
+	chosenTag := pinnedTag // the tag this run deploys; "" until answered
+	var updateTag string   // rerun: non-empty means update to this tag
 	pre, preSeen := preflight{}, false
 	if rerun {
 		// The running-services guard needs docker handles, so resolve the
@@ -137,6 +161,10 @@ func (in *installer) runInstall(ctx context.Context) error {
 		if err := in.resolveDockerProblems(ctx, pre); err != nil {
 			return err
 		}
+		// Read the published port while the deployment is still up: installs
+		// predating HOST_PORT recording have it nowhere else, and once the
+		// guard stops the containers docker no longer reports it.
+		in.observedPort = in.runningHostPort(ctx)
 		if err := in.guardServicesStopped(ctx, in.opts.Force && in.prompt.AssumeDefaults); err != nil {
 			return err
 		}
@@ -149,8 +177,8 @@ func (in *installer) runInstall(ctx context.Context) error {
 		in.craft = in.opts.IncludeCraft || manifest.IncludeCraft ||
 			in.overlayOnDisk(filepath.Base(deployfiles.CraftOverlay.DestRel))
 
-		if in.opts.Tag != "" {
-			updateTag = in.opts.Tag
+		if pinnedTag != "" {
+			updateTag = pinnedTag
 		} else if !in.prompt.AssumeDefaults {
 			choice, err := in.selectOne("This deployment already exists. What would you like to do?",
 				[]ui.Option{
@@ -161,7 +189,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 				return err
 			}
 			if choice == 1 {
-				updateTag, err = in.askString("Version to deploy", getLatestTag())
+				updateTag, err = in.askVersion(ctx, "Version to deploy", getLatestTag())
 				if err != nil {
 					return err
 				}
@@ -179,15 +207,15 @@ func (in *installer) runInstall(ctx context.Context) error {
 		if err := in.askModeQuestion(); err != nil {
 			return err
 		}
-		if in.opts.Tag == "" {
-			tag, err := in.askString("Version to deploy", getLatestTag())
+		if chosenTag == "" {
+			tag, err := in.askVersion(ctx, "Version to deploy", getLatestTag())
 			if err != nil {
 				return err
 			}
-			in.opts.Tag = tag
+			chosenTag = tag
 		}
 		if in.wiz != nil {
-			in.wiz.Answer("Version", in.opts.Tag)
+			in.wiz.Answer("Version", chosenTag)
 		}
 	}
 
@@ -229,7 +257,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 		return fmt.Errorf("failed to create %s: %w", gitkeep, err)
 	}
 
-	initialTag := in.opts.Tag
+	initialTag := chosenTag
 	if initialTag == "" {
 		if updateTag != "" {
 			initialTag = updateTag
@@ -254,6 +282,13 @@ func (in *installer) runInstall(ctx context.Context) error {
 		if err := in.removeOverlayIfPresent(deployfiles.CraftOverlay, manifest, "Craft disabled this run"); err != nil {
 			return err
 		}
+	}
+
+	// Captured for rollback: a failed pull must not leave .env pointing at a
+	// version that never ran (nil means there was no .env before this run).
+	prevEnv, prevErr := os.ReadFile(envPath)
+	if prevErr != nil {
+		prevEnv = nil
 	}
 
 	var effectiveTag string
@@ -283,8 +318,19 @@ func (in *installer) runInstall(ctx context.Context) error {
 
 	in.successf("Configuration ready at %s (version %s)", in.root.Dir, effectiveTag)
 
+	// Persist the manifest's file records now: if the pull fails, the next
+	// run must still know the freshly materialized files were CLI-written,
+	// not hand-edited. InstalledTag advances only after a successful start.
+	if err := manifest.Save(in.root.Dir); err != nil {
+		return err
+	}
+
 	// ---- Phases 2 + 3: pull and start ----
-	if err := in.pullAndStart(ctx, effectiveTag, hostPort); err != nil {
+	if err := in.pullImages(ctx, effectiveTag, hostPort); err != nil {
+		in.rollbackEnv(envPath, prevEnv)
+		return err
+	}
+	if err := in.startServices(ctx, effectiveTag, hostPort); err != nil {
 		return err
 	}
 
@@ -306,6 +352,67 @@ func (in *installer) runInstall(ctx context.Context) error {
 
 	in.printSuccess(ctx, hostPort)
 	return nil
+}
+
+// validateTag normalizes a requested version and, when it can, confirms it
+// exists BEFORE anything is written, so a typo fails here instead of
+// surfacing minutes later as a pull error with the bad version already in
+// .env. Only release versions are looked up: floating and hand-built image
+// tags are pullable without a matching git ref. Verification is best-effort
+// by design — an unreachable (or lying) GitHub must never be able to block
+// an install that would otherwise work.
+func (in *installer) validateTag(ctx context.Context, tag string) (string, error) {
+	tag = strings.TrimSpace(tag)
+	if tag == "" {
+		return "", exitcodes.New(exitcodes.BadRequest, "no version given")
+	}
+	normalized, checkable := release.NormalizeVersionTag(tag)
+	if normalized != tag {
+		in.infof("Using %s (Onyx versions are v-prefixed)", normalized)
+	}
+	// A dry run writes nothing and pulls nothing, so it stays offline.
+	if !checkable || in.opts.Local || in.opts.DryRun {
+		return normalized, nil
+	}
+
+	exists, err := in.deps.Release.RefExists(ctx, normalized)
+	if err != nil {
+		in.warnf("Could not verify that version %s exists (%v) — continuing", normalized, err)
+		return normalized, nil
+	}
+	if exists {
+		return normalized, nil
+	}
+	// A 404 is only worth acting on if the same endpoint answers for a ref
+	// that certainly exists: proxies and captive portals 404 everything, and
+	// rejecting a real version would leave no way to install at all.
+	if ok, cerr := in.deps.Release.RefExists(ctx, "main"); cerr != nil || !ok {
+		in.warnf("Could not reach GitHub to verify version %s — continuing", normalized)
+		return normalized, nil
+	}
+	return "", exitcodes.Newf(exitcodes.BadRequest,
+		"version %s not found — Onyx releases look like v4.4.6 (https://github.com/onyx-dot-app/onyx/releases)", normalized)
+}
+
+// askVersion asks for a deployment version and validates the answer;
+// interactive runs re-ask, seeded with the rejected text so a typo can be
+// corrected rather than retyped.
+func (in *installer) askVersion(ctx context.Context, title, def string) (string, error) {
+	for {
+		tag, err := in.askString(title, def)
+		if err != nil {
+			return "", err
+		}
+		resolved, verr := in.validateTag(ctx, tag)
+		if verr == nil {
+			return resolved, nil
+		}
+		if in.prompt.AssumeDefaults {
+			return "", verr
+		}
+		in.errorf("%v", verr)
+		def = tag
+	}
 }
 
 // askModeQuestion is the single merged deployment-mode select (mode and
@@ -591,14 +698,22 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 	}
 	env := string(existing)
 
-	// Keep the port the deployment already uses; scan only for installs that
-	// predate HOST_PORT recording (services are stopped on this path, so the
-	// scan can't collide with our own binding).
+	// Keep the port the deployment already uses. Installs that predate
+	// HOST_PORT recording fall back to the port they were observed
+	// publishing, and only a deployment that was never up gets a fresh scan
+	// (services are stopped on this path, so the scan can't collide with our
+	// own binding — but it would silently move a running deployment).
 	hostPort, perr := strconv.Atoi(Var(env, "HOST_PORT"))
 	if perr != nil {
-		hostPort = resources.FindAvailablePort(3000)
-		if hostPort != 3000 {
-			in.infof("Port 3000 is in use — using %d", hostPort)
+		switch {
+		case in.observedPort != 0:
+			hostPort = in.observedPort
+			in.infof("Recording the port this deployment already uses (%d) in .env", hostPort)
+		default:
+			hostPort = resources.FindAvailablePort(3000)
+			if hostPort != 3000 {
+				in.infof("Port 3000 is in use — using %d", hostPort)
+			}
 		}
 		env = SetVar(env, "HOST_PORT", strconv.Itoa(hostPort))
 	}
@@ -705,14 +820,17 @@ func (in *installer) ensureCraftResources(ctx context.Context) {
 	}
 }
 
-func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int) error {
-	env := map[string]string{
+func (in *installer) composeRunEnv(tag string, hostPort int) map[string]string {
+	return map[string]string{
 		"HOST_PORT": fmt.Sprintf("%d", hostPort),
 		"IMAGE_TAG": tag,
 	}
+}
+
+func (in *installer) pullImages(ctx context.Context, tag string, hostPort int) error {
+	env := in.composeRunEnv(tag, hostPort)
 	files := in.composeFileNames(false)
 	dir := in.deploymentDir()
-	floating := release.IsFloatingTag(tag)
 
 	if in.wiz != nil {
 		// Compose's own progress renderer (parallel per-layer bars) beats
@@ -732,19 +850,27 @@ func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int)
 			return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
 		}
 		in.wiz.Note("ok", fmt.Sprintf("Pulling images (%ds)", int(time.Since(began).Seconds())))
-	} else {
-		pullArgs := []string{"pull"}
-		if !in.opts.Verbose {
-			pullArgs = append(pullArgs, "--quiet")
-		}
-		if err := in.runComposePhase(ctx, ui.StagePull, "Pulling images", dir, env, files, pullArgs, false); err != nil {
-			in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
-			return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
-		}
+		return nil
 	}
 
+	pullArgs := []string{"pull"}
+	if !in.opts.Verbose {
+		pullArgs = append(pullArgs, "--quiet")
+	}
+	if err := in.runComposePhase(ctx, ui.StagePull, "Pulling images", dir, env, files, pullArgs, false); err != nil {
+		in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
+		return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
+	}
+	return nil
+}
+
+func (in *installer) startServices(ctx context.Context, tag string, hostPort int) error {
+	env := in.composeRunEnv(tag, hostPort)
+	files := in.composeFileNames(false)
+	dir := in.deploymentDir()
+
 	upArgs := []string{"up", "-d"}
-	if floating {
+	if release.IsFloatingTag(tag) {
 		upArgs = append(upArgs, "--pull", "always", "--force-recreate")
 	}
 	poll := false
@@ -764,6 +890,48 @@ func (in *installer) pullAndStart(ctx context.Context, tag string, hostPort int)
 		return exitcodes.Newf(exitcodes.General, "docker compose up failed: %v", err)
 	}
 	return nil
+}
+
+// rollbackEnv restores .env to its pre-run content after a failed pull, so a
+// version that never ran isn't left recorded as the deployment's current one.
+// Only .env is reverted: the managed config files have already been refreshed
+// to the target ref, and re-running completes the move.
+func (in *installer) rollbackEnv(envPath string, prev []byte) {
+	if prev == nil {
+		if err := os.Remove(envPath); err != nil {
+			in.warnf("Could not remove the incomplete .env: %v", err)
+			return
+		}
+		in.infof("Removed the incomplete .env — nothing was deployed; re-run to start over")
+		return
+	}
+	if err := os.WriteFile(envPath, prev, 0600); err != nil {
+		in.warnf("Could not restore .env: %v", err)
+		return
+	}
+	in.infof("Restored .env to the previously deployed version — re-run to retry")
+}
+
+// runningHostPort reports the host port the deployment currently publishes,
+// or 0 when nothing is running. It is the only record of the port for
+// installs created by install.sh, which never wrote HOST_PORT to .env.
+func (in *installer) runningHostPort(ctx context.Context) int {
+	if !dockercmd.Installed() {
+		return 0
+	}
+	cmd := in.docker.Command(nil, "ps",
+		"--filter", "label=com.docker.compose.project=onyx",
+		"--format", "{{.Ports}}")
+	res, err := in.deps.Runner.Run(ctx, cmd)
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
+		if port, perr := strconv.Atoi(publishedHostPort(line)); perr == nil {
+			return port
+		}
+	}
+	return 0
 }
 
 // runComposePhase runs one long compose command as a visible phase: a rail

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -165,11 +165,10 @@ func (in *installer) runInstall(ctx context.Context) error {
 		if err := in.resolveDockerProblems(ctx, pre); err != nil {
 			return err
 		}
-		// Read the published port while the deployment is still up: installs
-		// predating HOST_PORT recording have it nowhere else, and once the
-		// guard stops the containers docker no longer reports it.
+		// Read the published port off the running deployment: installs
+		// predating HOST_PORT recording have it nowhere else.
 		in.observedPort = in.runningHostPort(ctx)
-		if err := in.guardServicesStopped(ctx, in.opts.Force && in.prompt.AssumeDefaults); err != nil {
+		if err := in.confirmRecreate(ctx, in.opts.Force && in.prompt.AssumeDefaults); err != nil {
 			return err
 		}
 		// The mode never changes implicitly on a rerun: the recorded mode
@@ -770,11 +769,14 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 	return effectiveTag, hostPort, nil
 }
 
-// guardServicesStopped handles reconfiguring while containers are up:
-// interactive runs offer to stop them right here; non-interactive runs
-// refuse with the remedy in the error itself (install.sh printed
-// "./install.sh --shutdown", which doesn't exist after curl|bash).
-func (in *installer) guardServicesStopped(ctx context.Context, autoStop bool) error {
+// confirmRecreate gets sign-off for reconfiguring a deployment whose services
+// are up, before anything on disk changes. Nothing is stopped here: the answer
+// is remembered and handed to `up` as --force-recreate, so the current version
+// keeps serving while the images download and each container is replaced only
+// once its replacement is ready. Non-interactive runs refuse with the remedy in
+// the error itself (install.sh printed "./install.sh --shutdown", which doesn't
+// exist after curl|bash).
+func (in *installer) confirmRecreate(ctx context.Context, assumeYes bool) error {
 	files := in.composeFileNames(true)
 	cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "ps", "-q")
 	res, err := in.deps.Runner.Run(ctx, cmd)
@@ -782,19 +784,20 @@ func (in *installer) guardServicesStopped(ctx context.Context, autoStop bool) er
 		return nil
 	}
 
-	if autoStop {
-		in.infof("Stopping the running services first (they restart at the end)...")
-		return in.stopRunningServices(ctx, files)
+	if assumeYes {
+		in.infof("Onyx is running — its services will be recreated with the new configuration.")
+		in.forceRecreate = true
+		return nil
 	}
 
 	if in.prompt.AssumeDefaults {
 		return exitcodes.New(exitcodes.General,
-			"Onyx services are running — stop them first with `onyx-cli deploy stop` (or pass --force to stop them automatically), then re-run")
+			"Onyx services are running — pass --force to recreate them with the new configuration, or stop them first with `onyx-cli deploy stop`")
 	}
 
-	choice, err := in.selectOne("Onyx is already running. Reconfiguring needs the services stopped.",
+	choice, err := in.selectOne("Onyx is already running. Applying this configuration restarts its services.",
 		[]ui.Option{
-			{Label: "Stop and continue", Hint: "pause the containers (no data loss), then proceed"},
+			{Label: "Continue", Hint: "keeps serving while images download; each service restarts once, at the end"},
 			{Label: "Cancel", Hint: "leave everything running"},
 		}, 0)
 	if err != nil {
@@ -804,20 +807,7 @@ func (in *installer) guardServicesStopped(ctx context.Context, autoStop bool) er
 		return exitcodes.New(exitcodes.General,
 			"cancelled — services left running (stop them with `onyx-cli deploy stop`)")
 	}
-
-	in.infof("Stopping Onyx services...")
-	return in.stopRunningServices(ctx, files)
-}
-
-func (in *installer) stopRunningServices(ctx context.Context, files []string) error {
-	stop := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), files, "stop")
-	if in.wiz == nil {
-		stop.Stdout, stop.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
-	}
-	if _, err := in.deps.Runner.Run(ctx, stop); err != nil {
-		return exitcodes.Newf(exitcodes.General, "failed to stop the running services: %v", err)
-	}
-	in.successf("Services stopped")
+	in.forceRecreate = true
 	return nil
 }
 
@@ -846,36 +836,26 @@ func (in *installer) composeRunEnv(tag string, hostPort int) map[string]string {
 }
 
 func (in *installer) pullImages(ctx context.Context, tag string, hostPort int) error {
-	env := in.composeRunEnv(tag, hostPort)
-	files := in.composeFileNames(false)
-	dir := in.deploymentDir()
-
-	if in.wiz != nil {
-		// Compose's own progress renderer (parallel per-layer bars) beats
-		// anything a spinner can convey: hand it the raw terminal for the
-		// pull, then resume the wizard.
-		in.wiz.Stage(ui.StagePull)
-		began := time.Now()
-		pull := in.compose.Command(dir, env, files, "pull")
-		pull.Stdout, pull.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
-		err := in.wiz.Suspend(func() error {
-			_, err := in.deps.Runner.Run(ctx, pull)
-			return err
-		})
-		if err != nil {
-			in.errorf("Pulling images failed")
-			in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
-			return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
-		}
-		in.wiz.Note("ok", fmt.Sprintf("Pulling images (%ds)", int(time.Since(began).Seconds())))
-		return nil
+	phase := composePhase{
+		stage: ui.StagePull,
+		title: "Pulling images",
+		dir:   in.deploymentDir(),
+		env:   in.composeRunEnv(tag, hostPort),
+		files: in.composeFileNames(false),
+		args:  []string{"pull"},
 	}
-
-	pullArgs := []string{"pull"}
-	if !in.opts.Verbose {
-		pullArgs = append(pullArgs, "--quiet")
+	mode := in.progressMode(ctx)
+	switch {
+	case mode != "":
+		// The pull drives the wizard's own checklist, so the full-screen view
+		// survives the phase instead of being released to compose's renderer.
+		phase.args = append([]string{"--progress", mode}, phase.args...)
+		phase.onLine = newPullProgress(in.wiz.Services, in.wiz.TaskExtra).line
+		defer in.wiz.Services(nil)
+	case !in.opts.Verbose:
+		phase.args = append(phase.args, "--quiet")
 	}
-	if err := in.runComposePhase(ctx, ui.StagePull, "Pulling images", dir, env, files, pullArgs, false); err != nil {
+	if err := in.runComposePhase(ctx, phase); err != nil {
 		in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
 	}
@@ -891,15 +871,41 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 	dir := in.deploymentDir()
 
 	upArgs := []string{"up", "-d"}
-	if release.IsFloatingTag(tag) {
+	switch {
+	case release.IsFloatingTag(tag):
+		// A floating tag names a moving image: the digest changes under the
+		// same name, so neither the pull nor the recreate can be skipped.
 		upArgs = append(upArgs, "--pull", "always", "--force-recreate")
+	case in.forceRecreate:
+		// Services were up when the run started and the operator signed off
+		// on replacing them; compose would otherwise leave containers whose
+		// config it considers unchanged running the old image.
+		upArgs = append(upArgs, "--force-recreate")
 	}
-	poll := false
-	if !in.opts.NoWait {
+	wait := !in.opts.NoWait
+	if wait {
 		upArgs = append(upArgs, "--wait", "--wait-timeout", fmt.Sprintf("%d", waitTimeoutSeconds))
-		poll = true
 	}
-	if err := in.runComposePhase(ctx, ui.StageStart, "Starting services", dir, env, files, upArgs, poll); err != nil {
+	phase := composePhase{
+		stage: ui.StageStart,
+		title: "Starting services",
+		dir:   dir,
+		env:   env,
+		files: files,
+		args:  upArgs,
+		// Poll container health so the wizard shows something while
+		// `up --wait` blocks (it is silent for as long as that takes).
+		poll: wait,
+	}
+	if mode := in.progressMode(ctx); mode != "" {
+		// Compose's own event stream says what is happening to each container
+		// — the poll can only see that the outgoing container is still up.
+		phase.args = append([]string{"--progress", mode}, upArgs...)
+		phase.onLine = newStartProgress(in.wiz.Services, in.wiz.TaskExtra, wait).line
+		phase.poll = false
+		defer in.wiz.Services(nil)
+	}
+	if err := in.runComposePhase(ctx, phase); err != nil {
 		in.infof("Current container status:")
 		ps := in.compose.Command(dir, env, files, "ps")
 		ps.Stdout, ps.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
@@ -976,41 +982,56 @@ func (in *installer) runningHostPort(ctx context.Context) int {
 	return 0
 }
 
+// composePhase describes one long compose invocation shown as a single phase.
+type composePhase struct {
+	stage int
+	title string
+	dir   string
+	env   map[string]string
+	files []string
+	args  []string
+	// poll watches container health while the command runs (`up --wait` is
+	// silent for as long as it takes everything to come up).
+	poll bool
+	// onLine receives each output line while the wizard drives the run, for
+	// phases whose progress can be read off the command's own output.
+	onLine func(string)
+}
+
 // runComposePhase runs one long compose command as a visible phase: a rail
 // stage with a live task (and per-service checklist) in the wizard, streamed
 // output otherwise. On failure only the log tail is shown.
-func (in *installer) runComposePhase(
-	ctx context.Context,
-	stage int,
-	title, dir string,
-	env map[string]string,
-	files, args []string,
-	poll bool,
-) error {
-	cmd := in.compose.Command(dir, env, files, args...)
+func (in *installer) runComposePhase(ctx context.Context, p composePhase) error {
+	cmd := in.compose.Command(p.dir, p.env, p.files, p.args...)
 
 	if in.wiz == nil || in.opts.Verbose {
-		in.phase(title)
+		in.phase(p.title)
 		var seen bytes.Buffer
 		cmd.Stdout = io.MultiWriter(in.deps.IOS.Out, &seen)
 		cmd.Stderr = io.MultiWriter(in.deps.IOS.ErrOut, &seen)
 		_, err := in.deps.Runner.Run(ctx, cmd)
 		if err == nil {
-			in.successf("%s complete", title)
+			in.successf("%s complete", p.title)
 		} else {
-			in.errorf("%s failed", title)
+			in.errorf("%s failed", p.title)
 			in.printFailureDiagnosis(seen.String())
 		}
 		return err
 	}
 
-	in.wiz.Stage(stage)
-	in.wiz.TaskStart(title)
+	in.wiz.Stage(p.stage)
+	in.wiz.TaskStart(p.title)
 	var captured bytes.Buffer
-	cmd.Stdout, cmd.Stderr = &captured, &captured
+	// One writer for both streams: os/exec then serializes the copies, which
+	// is what lets onLine run without a lock.
+	var sink io.Writer = &captured
+	if p.onLine != nil {
+		sink = io.MultiWriter(&captured, &lineWriter{emit: p.onLine})
+	}
+	cmd.Stdout, cmd.Stderr = sink, sink
 
 	stop := make(chan struct{})
-	if poll {
+	if p.poll {
 		go in.pollServiceHealth(stop)
 	}
 	_, err := in.deps.Runner.Run(ctx, cmd)

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -122,7 +123,7 @@ func (in *installer) runInstall(ctx context.Context) error {
 	}
 
 	if in.fancy() {
-		in.wiz = ui.StartWizard(in.deps.CLIVersion, in.cancel)
+		in.wiz = ui.StartWizard(in.deps.IOS.Out, "Onyx Installer", in.deps.CLIVersion, in.cancel)
 		defer in.wiz.Abort()
 	}
 
@@ -256,10 +257,11 @@ func (in *installer) runInstall(ctx context.Context) error {
 	}
 
 	var effectiveTag string
+	var hostPort int
 	if rerun {
-		effectiveTag, err = in.reconfigureExistingEnv(envPath, updateTag)
+		effectiveTag, hostPort, err = in.reconfigureExistingEnv(envPath, updateTag)
 	} else {
-		effectiveTag, err = in.createFreshEnv(envPath, initialTag)
+		effectiveTag, hostPort, err = in.createFreshEnv(envPath, initialTag)
 	}
 	if err != nil {
 		return err
@@ -279,10 +281,6 @@ func (in *installer) runInstall(ctx context.Context) error {
 		in.ensureCraftResources(ctx)
 	}
 
-	hostPort := resources.FindAvailablePort(3000)
-	if hostPort != 3000 {
-		in.infof("Port 3000 is in use — using %d", hostPort)
-	}
 	in.successf("Configuration ready at %s (version %s)", in.root.Dir, effectiveTag)
 
 	// ---- Phases 2 + 3: pull and start ----
@@ -533,14 +531,22 @@ func (in *installer) checkComposeVersion(ctx context.Context) error {
 }
 
 // createFreshEnv writes deployment/.env from env.template with the chosen
-// tag, generated secrets, and mode adjustments.
-func (in *installer) createFreshEnv(envPath, tag string) (string, error) {
+// tag, generated secrets, port, and mode adjustments.
+func (in *installer) createFreshEnv(envPath, tag string) (string, int, error) {
 	template, err := os.ReadFile(filepath.Join(in.root.Dir, "deployment", "env.template"))
 	if err != nil {
-		return "", fmt.Errorf("failed to read env.template: %w", err)
+		return "", 0, fmt.Errorf("failed to read env.template: %w", err)
 	}
 	env := string(template)
 	env = SetVar(env, "IMAGE_TAG", tag)
+
+	// Recorded in .env so reruns and upgrades reuse the same port instead of
+	// re-scanning (which would collide with the deployment's own binding).
+	hostPort := resources.FindAvailablePort(3000)
+	if hostPort != 3000 {
+		in.infof("Port 3000 is in use — using %d", hostPort)
+	}
+	env = SetVar(env, "HOST_PORT", strconv.Itoa(hostPort))
 
 	if in.lite {
 		// MinIO never starts in lite mode and the overlay forces the
@@ -569,21 +575,33 @@ func (in *installer) createFreshEnv(envPath, tag string) (string, error) {
 	}
 
 	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
-		return "", fmt.Errorf("failed to write .env: %w", err)
+		return "", 0, fmt.Errorf("failed to write .env: %w", err)
 	}
 	in.successf(".env created (auth secret and MinIO credentials generated) — customize it any time")
-	return tag, nil
+	return tag, hostPort, nil
 }
 
 // reconfigureExistingEnv applies the rerun decision: restart keeps .env
 // untouched except craft/lite alignment; a non-empty updateTag rewrites
 // IMAGE_TAG (and nothing else).
-func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, error) {
+func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, int, error) {
 	existing, err := os.ReadFile(envPath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read %s: %w", envPath, err)
+		return "", 0, fmt.Errorf("failed to read %s: %w", envPath, err)
 	}
 	env := string(existing)
+
+	// Keep the port the deployment already uses; scan only for installs that
+	// predate HOST_PORT recording (services are stopped on this path, so the
+	// scan can't collide with our own binding).
+	hostPort, perr := strconv.Atoi(Var(env, "HOST_PORT"))
+	if perr != nil {
+		hostPort = resources.FindAvailablePort(3000)
+		if hostPort != 3000 {
+			in.infof("Port 3000 is in use — using %d", hostPort)
+		}
+		env = SetVar(env, "HOST_PORT", strconv.Itoa(hostPort))
+	}
 
 	if updateTag != "" && updateTag != Var(env, "IMAGE_TAG") {
 		env = SetVar(env, "IMAGE_TAG", updateTag)
@@ -614,9 +632,9 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 	}
 
 	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
-		return "", fmt.Errorf("failed to write .env: %w", err)
+		return "", 0, fmt.Errorf("failed to write .env: %w", err)
 	}
-	return effectiveTag, nil
+	return effectiveTag, hostPort, nil
 }
 
 // guardServicesStopped handles reconfiguring while containers are up:

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -1060,12 +1060,19 @@ func (in *installer) runComposePhase(ctx context.Context, p composePhase) error 
 	}
 	cmd.Stdout, cmd.Stderr = sink, sink
 
-	stop := make(chan struct{})
-	if p.watch != nil {
-		go in.pollServiceHealth(*p.watch, stop)
+	watchCtx, stopWatch := context.WithCancel(ctx)
+	watching := make(chan struct{})
+	if p.watch == nil {
+		close(watching)
+	} else {
+		go in.pollServiceHealth(watchCtx, in.wiz, *p.watch, watching)
 	}
 	_, err := in.deps.Runner.Run(ctx, cmd)
-	close(stop)
+	// The watch has to be off the screen before the phase ends: a repaint
+	// landing after TaskDone would redraw a finished phase as running, and
+	// after a failed one it would race the teardown below.
+	stopWatch()
+	<-watching
 	in.wiz.TaskDone(err == nil)
 
 	if err != nil {
@@ -1105,14 +1112,18 @@ func (in *installer) printFailureDiagnosis(output string) {
 }
 
 // pollServiceHealth feeds the wizard a live per-service checklist while
-// `up --wait` blocks (otherwise silent for up to ten minutes).
-func (in *installer) pollServiceHealth(w healthWatch, stop chan struct{}) {
-	ctx := context.Background()
+// `up --wait` blocks (otherwise silent for up to ten minutes). It runs until
+// ctx is cancelled and closes done on the way out, so the phase can be sure
+// nothing else paints before it reports its own result.
+func (in *installer) pollServiceHealth(ctx context.Context, wiz *ui.Wizard, w healthWatch, done chan struct{}) {
+	defer close(done)
+	tick := time.NewTicker(healthPollInterval)
+	defer tick.Stop()
 	for {
 		select {
-		case <-stop:
+		case <-ctx.Done():
 			return
-		case <-time.After(healthPollInterval):
+		case <-tick.C:
 		}
 		if w.quiet != nil && !w.quiet() {
 			continue
@@ -1122,9 +1133,9 @@ func (in *installer) pollServiceHealth(w healthWatch, stop chan struct{}) {
 			continue
 		}
 		rows, ready := watchRows(res.Stdout, w)
-		if len(rows) > 0 && in.wiz != nil {
-			in.wiz.Services(rows)
-			in.wiz.TaskExtra(fmt.Sprintf("%d/%d ready", ready, len(rows)))
+		if len(rows) > 0 {
+			wiz.Services(rows)
+			wiz.TaskExtra(fmt.Sprintf("%d/%d ready", ready, len(rows)))
 		}
 	}
 }

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -863,6 +863,9 @@ func (in *installer) pullImages(ctx context.Context, tag string, hostPort int) e
 		phase.args = append(phase.args, "--quiet")
 	}
 	if err := in.runComposePhase(ctx, phase); err != nil {
+		if ctx.Err() != nil {
+			return err
+		}
 		in.infof("Check your internet connection and re-run. If the issue persists: founders@onyx.app")
 		return exitcodes.Newf(exitcodes.General, "docker compose pull failed: %v", err)
 	}
@@ -913,6 +916,15 @@ func (in *installer) startServices(ctx context.Context, tag, prevTag string, hos
 		defer in.wiz.Services(nil)
 	}
 	if err := in.runComposePhase(ctx, phase); err != nil {
+		if ctx.Err() != nil {
+			// Cancelled, not broken. Quitting stops compose, not the containers
+			// it had already brought up, which is worth saying before the run
+			// reports itself cancelled.
+			in.infof("Services that already started are still running:")
+			in.plainf("  onyx-cli deploy status")
+			in.plainf("  onyx-cli deploy stop")
+			return err
+		}
 		in.infof("Current container status:")
 		ps := in.compose.Command(dir, env, files, "ps")
 		ps.Stdout, ps.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
@@ -1017,9 +1029,10 @@ func (in *installer) runComposePhase(ctx context.Context, p composePhase) error 
 		cmd.Stdout = io.MultiWriter(in.deps.IOS.Out, &seen)
 		cmd.Stderr = io.MultiWriter(in.deps.IOS.ErrOut, &seen)
 		_, err := in.deps.Runner.Run(ctx, cmd)
-		if err == nil {
+		switch {
+		case err == nil:
 			in.successf("%s complete", p.title)
-		} else {
+		case ctx.Err() == nil:
 			in.errorf("%s failed", p.title)
 			in.printFailureDiagnosis(seen.String())
 		}
@@ -1049,11 +1062,12 @@ func (in *installer) runComposePhase(ctx context.Context, p composePhase) error 
 		// Tear the wizard down so the tail prints as plain scrollback.
 		in.wiz.Abort()
 		in.wiz = nil
-		lines := strings.Split(strings.TrimSpace(captured.String()), "\n")
-		if len(lines) > failureLogTail {
-			lines = lines[len(lines)-failureLogTail:]
+		if ctx.Err() != nil {
+			// Quitting killed the command mid-sentence. What it had written by
+			// then describes nothing that went wrong, so it is not shown.
+			return err
 		}
-		for _, l := range lines {
+		for _, l := range failureTail(captured.String(), failureLogTail) {
 			in.plainf("  %s", l)
 		}
 		in.printFailureDiagnosis(captured.String())

--- a/cli/internal/deploy/install/install.go
+++ b/cli/internal/deploy/install/install.go
@@ -172,8 +172,9 @@ func (in *installer) runInstall(ctx context.Context) error {
 		// (or the overlays on disk) wins unless --lite/--include-craft say
 		// otherwise. (install.sh re-asked every run, so a --no-prompt rerun
 		// silently flipped standard installs to lite.)
-		in.lite = in.opts.Lite || (!in.opts.IncludeCraft &&
-			(manifest.Mode == state.ModeLite || in.overlayOnDisk(filepath.Base(deployfiles.LiteOverlay.DestRel))))
+		in.wasLite = manifest.Mode == state.ModeLite ||
+			in.overlayOnDisk(filepath.Base(deployfiles.LiteOverlay.DestRel))
+		in.lite = in.opts.Lite || (!in.opts.IncludeCraft && in.wasLite)
 		in.craft = in.opts.IncludeCraft || manifest.IncludeCraft ||
 			in.overlayOnDisk(filepath.Base(deployfiles.CraftOverlay.DestRel))
 
@@ -745,6 +746,19 @@ func (in *installer) reconfigureExistingEnv(envPath, updateTag string) (string, 
 		env = SetVar(env, "COMPOSE_PROFILES", "")
 		in.successf("Cleared COMPOSE_PROFILES for lite mode")
 	}
+	// Leaving lite behind: undo those same adjustments, or the "standard"
+	// deployment keeps lite's storage behaviour with MinIO never starting.
+	// Values the user has since changed to something else are left alone.
+	if !in.lite && in.wasLite {
+		if Var(env, "COMPOSE_PROFILES") == "" {
+			env = SetVar(env, "COMPOSE_PROFILES", "s3-filestore")
+		}
+		if Var(env, "FILE_STORE_BACKEND") == "postgres" {
+			env = SetVar(env, "FILE_STORE_BACKEND", "s3")
+			in.warnf("Files stored while in lite mode live in Postgres; standard mode reads the MinIO store, so they won't be listed until you switch back.")
+		}
+		in.successf("Restored the standard file store (COMPOSE_PROFILES=s3-filestore, FILE_STORE_BACKEND=s3)")
+	}
 
 	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
 		return "", 0, fmt.Errorf("failed to write .env: %w", err)
@@ -920,7 +934,7 @@ func (in *installer) runningHostPort(ctx context.Context) int {
 		return 0
 	}
 	cmd := in.docker.Command(nil, "ps",
-		"--filter", "label=com.docker.compose.project=onyx",
+		"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
 		"--format", "{{.Ports}}")
 	res, err := in.deps.Runner.Run(ctx, cmd)
 	if err != nil {
@@ -1021,7 +1035,7 @@ func (in *installer) pollServiceHealth(stop chan struct{}) {
 		case <-time.After(2 * time.Second):
 		}
 		cmd := in.docker.Command(nil, "ps",
-			"--filter", "label=com.docker.compose.project=onyx",
+			"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
 			"--format", "{{.Names}}\t{{.Status}}")
 		res, err := in.deps.Runner.Run(ctx, cmd)
 		if err != nil {

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -445,25 +445,41 @@ func TestUserEditedFileOverwrittenWithForceAndBackedUp(t *testing.T) {
 	}
 }
 
+// A dry run must run no commands and touch no disk, whether or not docker is
+// around: with docker absent it must not need it, and with docker present it
+// must not go probing it (a background preflight that outlives the command
+// would make the promise a matter of timing).
 func TestDryRunHasNoSideEffects(t *testing.T) {
-	isolateEnv(t)
-	// No docker shim: dry-run must not even need docker.
-	runner := &fakeRunner{}
-	deps := testDeps(t, runner, notFoundServer(t))
-	root := filepath.Join(t.TempDir(), "never-created")
+	for _, tc := range []struct {
+		name         string
+		dockerOnPath bool
+	}{
+		{"docker absent", false},
+		{"docker present", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateEnv(t)
+			if tc.dockerOnPath {
+				shimDockerOnPath(t)
+			}
+			runner := &fakeRunner{handler: healthyDockerHandler}
+			deps := testDeps(t, runner, notFoundServer(t))
+			root := filepath.Join(t.TempDir(), "never-created")
 
-	err := RunInstall(context.Background(), deps, Options{DryRun: true, Tag: "v1.0.0", Dir: root})
-	if err != nil {
-		t.Fatalf("RunInstall: %v", err)
-	}
-	if len(runner.calls) != 0 {
-		t.Errorf("dry-run executed commands: %v", runner.calls)
-	}
-	if _, err := os.Stat(root); !os.IsNotExist(err) {
-		t.Error("dry-run created the install dir")
-	}
-	if !strings.Contains(outBuf(deps).String(), "Dry run complete") {
-		t.Errorf("output:\n%s", outBuf(deps).String())
+			err := RunInstall(context.Background(), deps, Options{DryRun: true, Tag: "v1.0.0", Dir: root})
+			if err != nil {
+				t.Fatalf("RunInstall: %v", err)
+			}
+			if len(runner.calls) != 0 {
+				t.Errorf("dry-run executed commands: %v", runner.calls)
+			}
+			if _, err := os.Stat(root); !os.IsNotExist(err) {
+				t.Error("dry-run created the install dir")
+			}
+			if !strings.Contains(outBuf(deps).String(), "Dry run complete") {
+				t.Errorf("output:\n%s", outBuf(deps).String())
+			}
+		})
 	}
 }
 

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -717,6 +717,62 @@ func TestInstallRestoresStandardFileStoreWhenLeavingLite(t *testing.T) {
 	}
 }
 
+// COMPOSE_PROFILES is a list the CLI shares with the user: switching modes
+// owns the s3-filestore entry and nothing else. Clearing the list would stop
+// services the CLI never started, and it could not name them again on the way
+// back.
+func TestInstallModeSwitchKeepsUserProfiles(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0") // lite
+	envPath := filepath.Join(root, "deployment", ".env")
+
+	// Make it a standard deployment carrying a profile of the user's.
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envStr := SetVar(string(env), "COMPOSE_PROFILES", "s3-filestore,my-monitoring")
+	envStr = SetVar(envStr, "FILE_STORE_BACKEND", "s3")
+	if err := os.WriteFile(envPath, []byte(envStr), 0600); err != nil {
+		t.Fatal(err)
+	}
+	m, err := state.Load(root)
+	if err != nil || m == nil {
+		t.Fatalf("manifest: %+v, %v", m, err)
+	}
+	m.Mode = state.ModeStandard
+	if err := m.Save(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Remove(filepath.Join(root, "deployment", "docker-compose.onyx-lite.yml")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Into lite: only the entry the CLI put there goes.
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, Lite: true, Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("switch to lite: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	env, _ = os.ReadFile(envPath)
+	if got := Var(string(env), "COMPOSE_PROFILES"); got != "my-monitoring" {
+		t.Errorf("COMPOSE_PROFILES = %q in lite mode, want the user's profile kept", got)
+	}
+
+	// And back out: s3-filestore returns alongside it.
+	deps = testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, IncludeCraft: true, Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("switch back to standard: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	env, _ = os.ReadFile(envPath)
+	if got := Var(string(env), "COMPOSE_PROFILES"); got != "my-monitoring,s3-filestore" {
+		t.Errorf("COMPOSE_PROFILES = %q leaving lite, want both profiles", got)
+	}
+}
+
 // A file that a pinned ref simply doesn't carry must not take the rest of the
 // deployment with it: the files that do exist at that ref still come from it.
 func TestInstallMissingFileAtRefDoesNotDisableFetching(t *testing.T) {

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -1,0 +1,428 @@
+package install
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+)
+
+// fakeRunner scripts every external command RunInstall issues.
+type fakeRunner struct {
+	calls   []dockercmd.Command
+	handler func(c dockercmd.Command) (dockercmd.Result, error)
+}
+
+func (f *fakeRunner) Run(_ context.Context, c dockercmd.Command) (dockercmd.Result, error) {
+	f.calls = append(f.calls, c)
+	if f.handler != nil {
+		return f.handler(c)
+	}
+	return dockercmd.Result{}, nil
+}
+
+func argv(c dockercmd.Command) string {
+	return strings.Join(append([]string{c.Name}, c.Args...), " ")
+}
+
+// healthyDockerHandler answers like a host with docker + compose plugin, a
+// running daemon, and no Onyx containers.
+func healthyDockerHandler(c dockercmd.Command) (dockercmd.Result, error) {
+	a := argv(c)
+	switch {
+	case a == "docker compose version":
+		return dockercmd.Result{Stdout: "Docker Compose version v2.32.0"}, nil
+	case a == "docker --version":
+		return dockercmd.Result{Stdout: "Docker version 27.4.0, build x"}, nil
+	case a == "docker info":
+		return dockercmd.Result{}, nil
+	case a == "docker system info":
+		return dockercmd.Result{Stdout: " Total Memory: 31.0GiB\n"}, nil
+	case strings.Contains(a, "ps -q"):
+		return dockercmd.Result{Stdout: ""}, nil
+	}
+	return dockercmd.Result{}, nil
+}
+
+// shimDockerOnPath makes exec.LookPath("docker") succeed without a real
+// docker install (actual invocations are intercepted by fakeRunner).
+func shimDockerOnPath(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	shim := filepath.Join(dir, "docker")
+	if err := os.WriteFile(shim, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("shim: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// rawServer serves deployment files with recognizable fetched content.
+func rawServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(body))
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+func notFoundServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.NotFoundHandler())
+	t.Cleanup(s.Close)
+	return s
+}
+
+func testDeps(t *testing.T, runner *fakeRunner, raw *httptest.Server) Deps {
+	t.Helper()
+	ios := &iostreams.IOStreams{
+		In:     &bytes.Buffer{},
+		Out:    &bytes.Buffer{},
+		ErrOut: &bytes.Buffer{},
+	}
+	api := notFoundServer(t)
+	return Deps{
+		IOS:    ios,
+		Runner: runner,
+		Release: &release.Client{
+			HTTP:       &http.Client{Timeout: 2 * time.Second},
+			APIBase:    api.URL,
+			RawBase:    raw.URL,
+			RetryDelay: time.Millisecond,
+		},
+		CLIVersion: "test",
+	}
+}
+
+func outBuf(d Deps) *bytes.Buffer { return d.IOS.Out.(*bytes.Buffer) }
+
+func isolateEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("ONYX_DEPLOYMENT_DIR", "")
+	t.Setenv("INSTALL_PREFIX", "")
+	t.Setenv("SANDBOX_DOCKER_NETWORK", "")
+}
+
+func TestRunInstallFreshLiteNoPrompt(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, runner, notFoundServer(t)) // offline: embedded fallback
+	root := t.TempDir()
+
+	err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, // non-interactive default mode is Lite
+		Tag:      "edge",
+		Dir:      root,
+		NoWait:   true,
+	})
+	if err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	// Files: base set + lite overlay from the embedded copies.
+	for _, rel := range []string{
+		"deployment/docker-compose.yml",
+		"deployment/docker-compose.onyx-lite.yml",
+		"deployment/env.template",
+		"deployment/.env",
+		"README.md",
+		"data/nginx/app.conf.template",
+		"data/nginx/run-nginx.sh",
+	} {
+		if _, err := os.Stat(filepath.Join(root, filepath.FromSlash(rel))); err != nil {
+			t.Errorf("missing %s: %v", rel, err)
+		}
+	}
+
+	// run-nginx.sh keeps its exec bit.
+	info, err := os.Stat(filepath.Join(root, "data", "nginx", "run-nginx.sh"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm()&0111 == 0 {
+		t.Errorf("run-nginx.sh not executable: %v", info.Mode())
+	}
+
+	env, err := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	envStr := string(env)
+	if Var(envStr, "IMAGE_TAG") != "edge" {
+		t.Errorf("IMAGE_TAG = %q", Var(envStr, "IMAGE_TAG"))
+	}
+	for _, key := range []string{"MINIO_ROOT_USER", "MINIO_ROOT_PASSWORD", "S3_AWS_ACCESS_KEY_ID", "S3_AWS_SECRET_ACCESS_KEY"} {
+		if v := Var(envStr, key); v == "minioadmin" || v == "" {
+			t.Errorf("%s not randomized: %q", key, v)
+		}
+	}
+	if len(Var(envStr, "USER_AUTH_SECRET")) != 64 {
+		t.Errorf("USER_AUTH_SECRET not generated: %q", Var(envStr, "USER_AUTH_SECRET"))
+	}
+	if Var(envStr, "FILE_STORE_BACKEND") != "postgres" || Var(envStr, "COMPOSE_PROFILES") != "" {
+		t.Error("lite .env adjustments missing")
+	}
+
+	m, err := state.Load(root)
+	if err != nil || m == nil {
+		t.Fatalf("manifest: %v, %v", m, err)
+	}
+	if m.InstalledTag != "edge" || m.Mode != state.ModeLite || m.IncludeCraft {
+		t.Errorf("manifest = %+v", m)
+	}
+	if len(m.Files) < 6 {
+		t.Errorf("manifest files = %v", m.Files)
+	}
+
+	// The up invocation: floating tag forces pull/recreate, lite overlay
+	// stacked, --wait skipped (NoWait), env carried.
+	var up *dockercmd.Command
+	for i := range runner.calls {
+		if strings.Contains(argv(runner.calls[i]), "up -d") {
+			up = &runner.calls[i]
+		}
+	}
+	if up == nil {
+		t.Fatal("compose up never ran")
+	}
+	a := argv(*up)
+	for _, want := range []string{
+		"-f docker-compose.yml", "-f docker-compose.onyx-lite.yml",
+		"--pull always", "--force-recreate",
+	} {
+		if !strings.Contains(a, want) {
+			t.Errorf("up argv missing %q: %s", want, a)
+		}
+	}
+	if strings.Contains(a, "--wait") {
+		t.Errorf("--no-wait ignored: %s", a)
+	}
+	if up.Env["IMAGE_TAG"] != "edge" || up.Env["HOST_PORT"] == "" {
+		t.Errorf("up env = %+v", up.Env)
+	}
+}
+
+func TestRunInstallPinnedTagFetchesConfigs(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	fetched := "# fetched-from-tag\nname: onyx\n"
+	deps := testDeps(t, runner, rawServer(t, fetched))
+	root := t.TempDir()
+
+	err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true,
+		Tag:      "v4.2.0",
+		Dir:      root,
+		NoWait:   true,
+	})
+	if err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	compose, err := os.ReadFile(filepath.Join(root, "deployment", "docker-compose.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(compose) != fetched {
+		t.Errorf("compose file not fetched from the pinned tag: %q", compose)
+	}
+
+	var up string
+	for _, c := range runner.calls {
+		if strings.Contains(argv(c), "up -d") {
+			up = argv(c)
+			if c.Env["IMAGE_TAG"] != "v4.2.0" {
+				t.Errorf("up env = %+v", c.Env)
+			}
+		}
+	}
+	if up == "" {
+		t.Fatal("compose up never ran")
+	}
+	if strings.Contains(up, "--force-recreate") {
+		t.Errorf("pinned tag must not force-recreate: %s", up)
+	}
+
+	m, _ := state.Load(root)
+	if m == nil || m.InstalledTag != "v4.2.0" {
+		t.Fatalf("manifest = %+v", m)
+	}
+}
+
+func TestRerunRefusesWhileRunning(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	// Seed an existing install.
+	if err := os.MkdirAll(filepath.Join(root, "deployment"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "deployment", ".env"), []byte("IMAGE_TAG=v1.0.0\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -q") {
+			return dockercmd.Result{Stdout: "abc123\n"}, nil // containers up
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, runner, notFoundServer(t))
+
+	err := RunInstall(context.Background(), deps, Options{NoPrompt: true, Dir: root, Tag: "v1.0.0"})
+	if err == nil {
+		t.Fatal("expected refusal while services are running")
+	}
+	if !strings.Contains(outBuf(deps).String(), "onyx-cli deploy stop") {
+		t.Errorf("guard must point at `onyx-cli deploy stop`:\n%s", outBuf(deps).String())
+	}
+}
+
+func TestRerunRestartKeepsEnvUntouched(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "deployment"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	seeded := "IMAGE_TAG=v1.0.0\nUSER_AUTH_SECRET=\"keepme\"\nCUSTOM_VAR=user-added\n"
+	if err := os.WriteFile(filepath.Join(root, "deployment", ".env"), []byte(seeded), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, runner, notFoundServer(t))
+
+	// No --tag: non-interactive rerun takes the restart branch.
+	err := RunInstall(context.Background(), deps, Options{NoPrompt: true, Dir: root, NoWait: true, Local: true})
+	if err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	env, err := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	envStr := string(env)
+	if Var(envStr, "IMAGE_TAG") != "v1.0.0" {
+		t.Errorf("restart changed IMAGE_TAG: %q", envStr)
+	}
+	if !strings.Contains(envStr, `USER_AUTH_SECRET="keepme"`) || !strings.Contains(envStr, "CUSTOM_VAR=user-added") {
+		t.Errorf("restart rewrote user config: %q", envStr)
+	}
+
+	// Restart must run compose with the existing pinned tag.
+	for _, c := range runner.calls {
+		if strings.Contains(argv(c), "up -d") && c.Env["IMAGE_TAG"] != "v1.0.0" {
+			t.Errorf("up used tag %q", c.Env["IMAGE_TAG"])
+		}
+	}
+}
+
+func TestUserEditedFileKeptWithoutForce(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := t.TempDir()
+
+	// First install writes the manifest baseline.
+	deps := testDeps(t, runner, notFoundServer(t))
+	if err := RunInstall(context.Background(), deps, Options{NoPrompt: true, Tag: "edge", Dir: root, NoWait: true}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	// Hand-edit the compose file, then re-run (non-interactive, no --force):
+	// the edit must survive and a warning must be printed.
+	composePath := filepath.Join(root, "deployment", "docker-compose.yml")
+	edited := "# my custom compose\nname: onyx\n"
+	if err := os.WriteFile(composePath, []byte(edited), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	deps2 := testDeps(t, runner, rawServer(t, "# upstream change\n"))
+	if err := RunInstall(context.Background(), deps2, Options{NoPrompt: true, Dir: root, NoWait: true}); err != nil {
+		t.Fatalf("re-run: %v\noutput:\n%s", err, outBuf(deps2).String())
+	}
+
+	got, err := os.ReadFile(composePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != edited {
+		t.Errorf("hand-edited file was overwritten without --force")
+	}
+	if !strings.Contains(outBuf(deps2).String(), "differs from what the CLI last wrote") {
+		t.Errorf("no user-edit warning printed:\n%s", outBuf(deps2).String())
+	}
+}
+
+func TestUserEditedFileOverwrittenWithForceAndBackedUp(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := t.TempDir()
+
+	deps := testDeps(t, runner, notFoundServer(t))
+	if err := RunInstall(context.Background(), deps, Options{NoPrompt: true, Tag: "edge", Dir: root, NoWait: true}); err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+
+	composePath := filepath.Join(root, "deployment", "docker-compose.yml")
+	if err := os.WriteFile(composePath, []byte("# my edit\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	upstream := "# upstream v2\nname: onyx\n"
+	deps2 := testDeps(t, runner, rawServer(t, upstream))
+	if err := RunInstall(context.Background(), deps2, Options{NoPrompt: true, Dir: root, NoWait: true, Force: true, Tag: "v9.0.0"}); err != nil {
+		t.Fatalf("forced re-run: %v\noutput:\n%s", err, outBuf(deps2).String())
+	}
+
+	got, _ := os.ReadFile(composePath)
+	if string(got) != upstream {
+		t.Errorf("--force did not refresh the file: %q", got)
+	}
+
+	backups, err := filepath.Glob(composePath + ".bak-*")
+	if err != nil || len(backups) == 0 {
+		t.Fatalf("no backup created: %v %v", backups, err)
+	}
+	backup, _ := os.ReadFile(backups[0])
+	if string(backup) != "# my edit\n" {
+		t.Errorf("backup content = %q", backup)
+	}
+}
+
+func TestDryRunHasNoSideEffects(t *testing.T) {
+	isolateEnv(t)
+	// No docker shim: dry-run must not even need docker.
+	runner := &fakeRunner{}
+	deps := testDeps(t, runner, notFoundServer(t))
+	root := filepath.Join(t.TempDir(), "never-created")
+
+	err := RunInstall(context.Background(), deps, Options{DryRun: true, Tag: "v1.0.0", Dir: root})
+	if err != nil {
+		t.Fatalf("RunInstall: %v", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Errorf("dry-run executed commands: %v", runner.calls)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Error("dry-run created the install dir")
+	}
+	if !strings.Contains(outBuf(deps).String(), "Dry run complete") {
+		t.Errorf("output:\n%s", outBuf(deps).String())
+	}
+}

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -325,8 +325,60 @@ func TestRerunRefusesWhileRunning(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected refusal while services are running")
 	}
-	if !strings.Contains(err.Error(), "onyx-cli deploy stop") {
-		t.Errorf("guard error must carry the remedy: %v", err)
+	if !strings.Contains(err.Error(), "--force") || !strings.Contains(err.Error(), "onyx-cli deploy stop") {
+		t.Errorf("guard error must carry both remedies: %v", err)
+	}
+}
+
+// A rerun over a running deployment never stops anything up front: the
+// containers keep serving while the images download and `up --force-recreate`
+// replaces them at the end.
+func TestRerunForceRecreatesInsteadOfStopping(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "deployment"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "deployment", ".env"), []byte("IMAGE_TAG=v1.0.0\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	runner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -q") {
+			return dockercmd.Result{Stdout: "abc123\n"}, nil // containers up
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, runner, notFoundServer(t))
+
+	err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true,
+		Force:    true,
+		Dir:      root,
+		Tag:      "v1.0.0",
+		NoWait:   true,
+		Local:    true,
+	})
+	if err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	var up string
+	for _, c := range runner.calls {
+		a := argv(c)
+		if strings.Contains(a, "compose") && strings.HasSuffix(a, " stop") {
+			t.Errorf("services were stopped: %s", a)
+		}
+		if strings.Contains(a, "up -d") {
+			up = a
+		}
+	}
+	if up == "" {
+		t.Fatal("compose up never ran")
+	}
+	if !strings.Contains(up, "--force-recreate") {
+		t.Errorf("up must recreate the running containers: %s", up)
 	}
 }
 

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -285,8 +285,8 @@ func TestRerunRefusesWhileRunning(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected refusal while services are running")
 	}
-	if !strings.Contains(outBuf(deps).String(), "onyx-cli deploy stop") {
-		t.Errorf("guard must point at `onyx-cli deploy stop`:\n%s", outBuf(deps).String())
+	if !strings.Contains(err.Error(), "onyx-cli deploy stop") {
+		t.Errorf("guard error must carry the remedy: %v", err)
 	}
 }
 

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -573,3 +573,78 @@ func TestInstallPullFailureRemovesFreshEnv(t *testing.T) {
 		t.Errorf("manifest tag = %q after failed fresh install, want empty", m.InstalledTag)
 	}
 }
+
+// Leaving lite mode has to undo lite's .env adjustments, or the "standard"
+// deployment keeps storing files in Postgres and never starts MinIO.
+func TestInstallRestoresStandardFileStoreWhenLeavingLite(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0") // lite
+
+	// --include-craft implies standard mode on a rerun.
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, IncludeCraft: true, Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	env, err := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	envStr := string(env)
+	if got := Var(envStr, "COMPOSE_PROFILES"); got != "s3-filestore" {
+		t.Errorf("COMPOSE_PROFILES = %q, want the standard s3-filestore", got)
+	}
+	if got := Var(envStr, "FILE_STORE_BACKEND"); got != "s3" {
+		t.Errorf("FILE_STORE_BACKEND = %q, want s3", got)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "deployment", "docker-compose.onyx-lite.yml")); !os.IsNotExist(statErr) {
+		t.Error("lite overlay still on disk after switching to standard")
+	}
+}
+
+// A file that a pinned ref simply doesn't carry must not take the rest of the
+// deployment with it: the files that do exist at that ref still come from it.
+func TestInstallMissingFileAtRefDoesNotDisableFetching(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	const upstream = "# compose at v4.2.0\nname: onyx\n"
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			return
+		}
+		// The craft overlay is fetched before the nginx files but after the
+		// compose file; only it is absent at this ref.
+		if strings.HasSuffix(r.URL.Path, "docker-compose.craft.yml") {
+			http.NotFound(w, r)
+			return
+		}
+		_, _ = w.Write([]byte(upstream))
+	}))
+	t.Cleanup(raw.Close)
+
+	root := t.TempDir()
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, raw)
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, IncludeCraft: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	// Fetched after the missing overlay: still sourced from the ref.
+	nginx, err := os.ReadFile(filepath.Join(root, "data", "nginx", "app.conf.template"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(nginx) != upstream {
+		t.Errorf("nginx config fell back to embedded after an unrelated 404:\n%s", nginx)
+	}
+	craft, err := os.ReadFile(filepath.Join(root, "deployment", "docker-compose.craft.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(craft) == upstream {
+		t.Error("craft overlay should have come from the embedded copy")
+	}
+}

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -76,7 +77,46 @@ func rawServer(t *testing.T, body string) *httptest.Server {
 	return s
 }
 
+// notFoundServer 404s every download (exercising the embedded fallback) but
+// answers ref-existence HEAD probes, so pinned test tags validate.
 func notFoundServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// refServer answers HEAD probes only for the given refs (plus main, which
+// validation probes as its control) and 404s everything else: a healthy
+// GitHub that simply doesn't have the requested version.
+func refServer(t *testing.T, refs ...string) *httptest.Server {
+	t.Helper()
+	known := map[string]bool{"main": true}
+	for _, r := range refs {
+		known[r] = true
+	}
+	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead {
+			for ref := range known {
+				if strings.Contains(r.URL.Path, "/"+ref+"/") {
+					return
+				}
+			}
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(s.Close)
+	return s
+}
+
+// blackholeServer 404s everything, HEAD probes included — the captive-portal
+// / broken-proxy case, where no ref can be confirmed to exist.
+func blackholeServer(t *testing.T) *httptest.Server {
 	t.Helper()
 	s := httptest.NewServer(http.NotFoundHandler())
 	t.Cleanup(s.Close)
@@ -424,5 +464,112 @@ func TestDryRunHasNoSideEffects(t *testing.T) {
 	}
 	if !strings.Contains(outBuf(deps).String(), "Dry run complete") {
 		t.Errorf("output:\n%s", outBuf(deps).String())
+	}
+}
+
+func TestInstallRejectsUnknownVersion(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, refServer(t))
+	err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v9.9.9", Dir: root, NoWait: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("err = %v, want unknown-version rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "deployment", ".env")); !os.IsNotExist(statErr) {
+		t.Error("rejected install must not create .env")
+	}
+}
+
+// A network that 404s everything (captive portal, broken proxy) must not be
+// able to veto an install: verification is best-effort, so the run proceeds.
+func TestInstallProceedsWhenExistenceCannotBeConfirmed(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, blackholeServer(t))
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.0.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("unverifiable version must not block the install: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if got := Var(string(env), "IMAGE_TAG"); got != "v4.0.0" {
+		t.Errorf("IMAGE_TAG = %q", got)
+	}
+}
+
+// Image tags that aren't git refs (hand-built images, -dev twins) are
+// pullable and must skip the repo lookup rather than be rejected.
+func TestInstallAcceptsNonReleaseImageTag(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, refServer(t))
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.0.0-dev", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("non-release image tag must be accepted: %v", err)
+	}
+}
+
+func TestInstallAddsMissingVersionPrefix(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, refServer(t, "v4.0.0"))
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "4.0.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if got := Var(string(env), "IMAGE_TAG"); got != "v4.0.0" {
+		t.Errorf("IMAGE_TAG = %q, want the v-prefixed form", got)
+	}
+}
+
+// A dry run writes nothing and pulls nothing, so it must not need GitHub.
+func TestInstallDryRunStaysOffline(t *testing.T) {
+	isolateEnv(t)
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("dry run made a network request: %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(raw.Close)
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, raw)
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, DryRun: true, Tag: "v4.0.0", Dir: t.TempDir(),
+	}); err != nil {
+		t.Fatalf("RunInstall: %v", err)
+	}
+}
+
+func TestInstallPullFailureRemovesFreshEnv(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	failPull := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), " pull") {
+			return dockercmd.Result{}, errors.New("manifest for tag not found")
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, failPull, notFoundServer(t))
+	err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.0.0", Dir: root, NoWait: true,
+	})
+	if err == nil {
+		t.Fatal("install must fail when the pull fails")
+	}
+	// A version that never ran must not be recorded anywhere: no .env, and
+	// no InstalledTag in the manifest.
+	if _, statErr := os.Stat(filepath.Join(root, "deployment", ".env")); !os.IsNotExist(statErr) {
+		t.Error("failed fresh install must not leave .env behind")
+	}
+	if m, _ := state.Load(root); m != nil && m.InstalledTag != "" {
+		t.Errorf("manifest tag = %q after failed fresh install, want empty", m.InstalledTag)
 	}
 }

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -251,6 +251,14 @@ func TestRunInstallFreshLiteNoPrompt(t *testing.T) {
 	if up.Env["IMAGE_TAG"] != "edge" || up.Env["HOST_PORT"] == "" {
 		t.Errorf("up env = %+v", up.Env)
 	}
+
+	// A floating tag moves under its own name, so nothing on the host can be
+	// assumed current.
+	for _, c := range runner.calls {
+		if strings.Contains(argv(c), " pull") && strings.Contains(argv(c), "--policy") {
+			t.Errorf("floating tag pull must not skip present images: %s", argv(c))
+		}
+	}
 }
 
 func TestRunInstallPinnedTagFetchesConfigs(t *testing.T) {
@@ -293,6 +301,18 @@ func TestRunInstallPinnedTagFetchesConfigs(t *testing.T) {
 	}
 	if strings.Contains(up, "--force-recreate") {
 		t.Errorf("pinned tag must not force-recreate: %s", up)
+	}
+
+	// A released tag is immutable, so images already on the host are taken as
+	// final instead of being re-checked against the registry one by one.
+	var pull string
+	for _, c := range runner.calls {
+		if strings.Contains(argv(c), " pull") {
+			pull = argv(c)
+		}
+	}
+	if !strings.Contains(pull, "--policy missing") {
+		t.Errorf("pull argv = %q", pull)
 	}
 
 	m, _ := state.Load(root)

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -146,6 +146,31 @@ func testDeps(t *testing.T, runner *fakeRunner, raw *httptest.Server) Deps {
 
 func outBuf(d Deps) *bytes.Buffer { return d.IOS.Out.(*bytes.Buffer) }
 
+// Quitting kills the compose command, which comes back as an error like any
+// other. The run must not dress that up as a failure: nothing failed, and the
+// output compose was in the middle of writing explains nothing.
+func TestCancelledComposePhaseIsNotReportedAsFailure(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, runner, notFoundServer(t))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	in := newInstaller(deps, Options{Verbose: true})
+	in.compose = dockercmd.DetectCompose(ctx, dockercmd.NewDocker(runner))
+	runner.handler = func(dockercmd.Command) (dockercmd.Result, error) {
+		cancel()
+		return dockercmd.Result{}, errors.New("signal: killed")
+	}
+
+	err := in.runComposePhase(ctx, composePhase{title: "Starting services", dir: t.TempDir()})
+	if err == nil {
+		t.Fatal("a killed command must still surface as an error")
+	}
+	if out := outBuf(deps).String(); strings.Contains(out, "failed") {
+		t.Errorf("cancelled phase reported a failure:\n%s", out)
+	}
+}
+
 func isolateEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("ONYX_DEPLOYMENT_DIR", "")

--- a/cli/internal/deploy/install/install_test.go
+++ b/cli/internal/deploy/install/install_test.go
@@ -375,6 +375,76 @@ func TestRerunRefusesWhileRunning(t *testing.T) {
 	}
 }
 
+// A rerun over a live deployment asks once. Restart and Upgrade both replace
+// the running services, so the choice is the sign-off — a second "this
+// restarts things, continue?" question would only ask it again.
+func TestRerunAsksOnceAndCancels(t *testing.T) {
+	seed := func(t *testing.T) (string, *fakeRunner) {
+		t.Helper()
+		isolateEnv(t)
+		shimDockerOnPath(t)
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "deployment"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "deployment", ".env"), []byte("IMAGE_TAG=v1.0.0\n"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		return root, &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+			if strings.Contains(argv(c), "ps -q") {
+				return dockercmd.Result{Stdout: "abc123\n"}, nil // containers up
+			}
+			return healthyDockerHandler(c)
+		}}
+	}
+	interactive := func(deps Deps, answer string) Deps {
+		deps.IOS = &iostreams.IOStreams{
+			In:          strings.NewReader(answer + "\n"),
+			Out:         &bytes.Buffer{},
+			ErrOut:      &bytes.Buffer{},
+			IsStdinTTY:  true,
+			IsStdoutTTY: true,
+		}
+		return deps
+	}
+
+	// Cancel (option 3) leaves the deployment alone.
+	root, runner := seed(t)
+	deps := interactive(testDeps(t, runner, notFoundServer(t)), "3")
+	err := RunInstall(context.Background(), deps, Options{Dir: root, NoWait: true, Local: true})
+	if err == nil || !strings.Contains(err.Error(), "services left running") {
+		t.Fatalf("err = %v, want the run cancelled with the services untouched", err)
+	}
+	for _, c := range runner.calls {
+		if strings.Contains(argv(c), "up -d") || strings.Contains(argv(c), " pull") {
+			t.Errorf("cancelled run still touched the deployment: %s", argv(c))
+		}
+	}
+
+	// Restart (option 1) proceeds, having asked nothing else.
+	root, runner = seed(t)
+	deps = interactive(testDeps(t, runner, notFoundServer(t)), "1")
+	if err := RunInstall(context.Background(), deps, Options{Dir: root, NoWait: true, Local: true}); err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	out := outBuf(deps).String()
+	if n := strings.Count(out, "What would you like to do?"); n != 1 {
+		t.Errorf("the rerun question was asked %d times:\n%s", n, out)
+	}
+	if strings.Contains(out, "Continue") {
+		t.Errorf("restarting was confirmed twice:\n%s", out)
+	}
+	var up string
+	for _, c := range runner.calls {
+		if strings.Contains(argv(c), "up -d") {
+			up = argv(c)
+		}
+	}
+	if !strings.Contains(up, "--force-recreate") {
+		t.Errorf("up must replace the running containers: %s", up)
+	}
+}
+
 // A rerun over a running deployment never stops anything up front: the
 // containers keep serving while the images download and `up --force-recreate`
 // replaces them at the end.

--- a/cli/internal/deploy/install/lifecycle_test.go
+++ b/cli/internal/deploy/install/lifecycle_test.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
@@ -311,6 +314,220 @@ func TestStatusJSON(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("JSON missing %q:\n%s", want, out)
 		}
+	}
+}
+
+// The status list is read by eye, so a container that needs attention has to
+// look different from one that doesn't.
+func TestStatusColorsUnhealthyContainers(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "")
+	deps := testDeps(t, &fakeRunner{}, notFoundServer(t))
+	deps.IOS.IsStdoutTTY = true
+	in := newInstaller(deps, Options{})
+
+	// The verdict and the state carry the color; the elapsed time stays out
+	// of the way.
+	up := "Up 2 hours (healthy)"
+	cases := map[string]string{
+		up:                                in.paint.Dim("Up 2 hours ") + in.paint.Ok("(healthy)"),
+		"Up 2 hours":                      in.paint.Dim("Up 2 hours"),
+		"Up 3 seconds (unhealthy)":        in.paint.Dim("Up 3 seconds ") + in.paint.Err("(unhealthy)"),
+		"Exited (137) 1 minute ago":       in.paint.Err("Exited (137)") + in.paint.Dim(" 1 minute ago"),
+		"Up 3 seconds (health: starting)": in.paint.Dim("Up 3 seconds ") + in.paint.Warn("(health: starting)"),
+		// A container that keeps restarting is crash-looping, not starting.
+		"Restarting (1) 2 seconds ago": in.paint.Err("Restarting (1)") + in.paint.Dim(" 2 seconds ago"),
+		"Created":                      in.paint.Warn("Created"),
+	}
+	for status, want := range cases {
+		if got := in.paintStatus(status); got != want {
+			t.Errorf("paintStatus(%q) = %q, want %q", status, got, want)
+		}
+		if plain := ansi.Strip(in.paintStatus(status)); plain != status {
+			t.Errorf("styling changed the text: %q became %q", status, plain)
+		}
+	}
+	if in.paintStatus(up) == in.paintStatus("Up 3 seconds (unhealthy)") {
+		t.Error("healthy and unhealthy containers render alike")
+	}
+
+	// Color isn't the only signal: the mark says the same thing to a pipe.
+	marks := map[string]string{
+		up:                         "✓",
+		"Up 3 seconds (unhealthy)": "✗",
+		"Exited (0) 1 minute ago":  "✗",
+		"Created":                  "⚠",
+	}
+	for status, want := range marks {
+		if got := severityOf(status).mark(); got != want {
+			t.Errorf("mark for %q = %q, want %q", status, got, want)
+		}
+	}
+
+	// Redirected output carries no escapes, so `deploy status > file` and the
+	// tests below keep reading plain text.
+	plain := newInstaller(testDeps(t, &fakeRunner{}, notFoundServer(t)), Options{})
+	if got := plain.paintStatus("Up 3 seconds (unhealthy)"); got != "Up 3 seconds (unhealthy)" {
+		t.Errorf("non-terminal status should stay plain, got %q", got)
+	}
+}
+
+// A container that keeps dying is the worst state on the board and the one
+// `docker ps` explains least: "Restarting" says nothing about how many times
+// or why. Status has to supply both, and name the command that shows the rest.
+func TestStatusExplainsCrashLoop(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.2.0")
+
+	psOut := "onyx-nginx-1\tnginx:1.25.5-alpine\tUp 2 hours\t0.0.0.0:3000->80/tcp\tnginx\n" +
+		"onyx-api_server-1\tonyxdotapp/onyx-backend:v4.2.0\tRestarting (255) 13 seconds ago\t\tapi_server\n"
+	inspectOut := `{"name":"/onyx-api_server-1","restarts":18,"exit":255,"oom":false,"error":"","health":null}`
+	statusRunner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		switch {
+		case strings.Contains(argv(c), "ps -a"):
+			return dockercmd.Result{Stdout: psOut}, nil
+		case strings.Contains(argv(c), "inspect"):
+			return dockercmd.Result{Stdout: inspectOut}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	shimDockerOnPath(t)
+	deps := testDeps(t, statusRunner, notFoundServer(t))
+	err := RunStatus(context.Background(), deps, Options{Dir: root}, false)
+	if err == nil || !strings.Contains(err.Error(), "partially stopped") {
+		t.Fatalf("err = %v, want a degraded exit", err)
+	}
+
+	out := outBuf(deps).String()
+	for _, want := range []string{
+		"18 restarts",
+		"api_server has restarted 18 times (exit 255)",
+		"crash-looping",
+		// The hint names the compose service, which is what logs takes, not
+		// the container that happens to run it — and repeats the --dir this
+		// run was given, so it works verbatim.
+		"onyx-cli deploy logs --dir " + strconv.Quote(root) + " api_server\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+
+	// Only containers in trouble are inspected: a healthy one has nothing to
+	// explain and shouldn't cost a round-trip.
+	for _, c := range statusRunner.calls {
+		if strings.Contains(argv(c), "inspect") && strings.Contains(argv(c), "nginx") {
+			t.Errorf("healthy container inspected: %s", argv(c))
+		}
+	}
+}
+
+// A container compose created but never started is not running and not
+// crash-looping. The verdict counts it either way, so the explanation under
+// the verdict has to account for it too.
+func TestStatusExplainsEveryContainerItCounted(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.2.0")
+
+	psOut := "onyx-nginx-1\tnginx:1.25.5-alpine\tCreated\t\tnginx\n" +
+		"onyx-api_server-1\tonyxdotapp/onyx-backend:v4.2.0\tUp 2 hours (healthy)\t\tapi_server\n" +
+		"onyx-code-interpreter-1\tonyxdotapp/onyx-backend:v4.2.0\tExited (0) 6 seconds ago\t\tcode-interpreter\n"
+	inspectOut := `{"name":"/onyx-nginx-1","restarts":0,"exit":0,"oom":false,"error":"","health":null}` + "\n" +
+		`{"name":"/onyx-code-interpreter-1","restarts":0,"exit":0,"oom":false,"error":"","health":null}`
+	statusRunner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		switch {
+		case strings.Contains(argv(c), "ps -a"):
+			return dockercmd.Result{Stdout: psOut}, nil
+		case strings.Contains(argv(c), "inspect"):
+			return dockercmd.Result{Stdout: inspectOut}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	shimDockerOnPath(t)
+	deps := testDeps(t, statusRunner, notFoundServer(t))
+	if err := RunStatus(context.Background(), deps, Options{Dir: root}, false); err == nil {
+		t.Fatal("expected a degraded exit")
+	}
+
+	out := outBuf(deps).String()
+	for _, want := range []string{
+		"2 of 3 containers are not running",
+		"nginx was created but never started",
+		"code-interpreter is not running (exit 0",
+		"logs --dir " + strconv.Quote(root) + " nginx code-interpreter\n",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// The healthy service is neither counted nor explained.
+	if strings.Contains(out, "api_server is") || strings.Contains(out, "logs api_server") {
+		t.Errorf("healthy service dragged into the failure report:\n%s", out)
+	}
+}
+
+// The hint is the one line in the report the reader is meant to act on, so
+// the command carries the accent and the words around it don't.
+func TestFailureHintHighlightsTheCommand(t *testing.T) {
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "")
+	deps := testDeps(t, &fakeRunner{}, notFoundServer(t))
+	deps.IOS.IsStdoutTTY = true
+	in := newInstaller(deps, Options{})
+	in.explainFailures([]Service{{
+		Name:      "onyx-api_server-1",
+		Service:   "api_server",
+		Status:    "Restarting (255) 13 seconds ago",
+		Diagnosis: "is crash-looping",
+	}}, notRunning)
+
+	out := outBuf(deps).String()
+	if !strings.Contains(out, in.paint.Accent("onyx-cli deploy logs api_server")) {
+		t.Errorf("the command to run isn't highlighted:\n%q", out)
+	}
+	if strings.Contains(out, in.paint.Accent("See why")) {
+		t.Errorf("the label is highlighted too, so nothing stands out:\n%q", out)
+	}
+	if plain := ansi.Strip(out); !strings.Contains(plain, "See why: onyx-cli deploy logs api_server\n") {
+		t.Errorf("styling changed the text:\n%q", plain)
+	}
+}
+
+// The reason `deploy logs` exists: triage shouldn't begin with finding the
+// deployment directory and remembering which overlays it was installed with.
+func TestLogsRunsAgainstTheDetectedOverlays(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0") // lite install: overlay on disk
+
+	logRunner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, logRunner, notFoundServer(t))
+	logOpts := LogOptions{Services: []string{"api_server"}, Tail: "200"}
+	if err := RunLogs(context.Background(), deps, Options{Dir: root}, logOpts); err != nil {
+		t.Fatalf("RunLogs: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	var logs string
+	for _, c := range logRunner.calls {
+		if strings.Contains(argv(c), " logs") {
+			logs = argv(c)
+		}
+	}
+	if logs == "" {
+		t.Fatal("compose logs never ran")
+	}
+	for _, want := range []string{"-f docker-compose.onyx-lite.yml", "logs --tail 200 api_server"} {
+		if !strings.Contains(logs, want) {
+			t.Errorf("compose logs missing %q: %s", want, logs)
+		}
+	}
+}
+
+func TestLogsWithoutAnInstall(t *testing.T) {
+	isolateEnv(t)
+	deps := testDeps(t, &fakeRunner{}, notFoundServer(t))
+	err := RunLogs(context.Background(), deps, Options{Dir: filepath.Join(t.TempDir(), "none")}, LogOptions{})
+	if err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("err = %v", err)
 	}
 }
 

--- a/cli/internal/deploy/install/lifecycle_test.go
+++ b/cli/internal/deploy/install/lifecycle_test.go
@@ -3,6 +3,7 @@ package install
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,6 +84,66 @@ func TestUninstallForceRemovesEverything(t *testing.T) {
 	}
 	if down == "" {
 		t.Fatal("compose down -v never ran")
+	}
+}
+
+// --dir, ONYX_DEPLOYMENT_DIR and INSTALL_PREFIX name the deletion root
+// freely, so a path that isn't recognizably an Onyx deployment must not be
+// handed to RemoveAll.
+func TestUninstallRefusesUnrecognizedDir(t *testing.T) {
+	isolateEnv(t)
+	root := t.TempDir()
+	keep := filepath.Join(root, "someone-elses-data.txt")
+	if err := os.WriteFile(keep, []byte("important"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	err := RunUninstall(context.Background(), deps, Options{Dir: root, Force: true})
+	if err == nil || !strings.Contains(err.Error(), "doesn't look like an Onyx deployment") {
+		t.Fatalf("err = %v, want a refusal", err)
+	}
+	if _, statErr := os.Stat(keep); statErr != nil {
+		t.Fatal("refused uninstall deleted unrelated data")
+	}
+}
+
+// Removing the directory after a failed teardown would strand the containers
+// and volumes with nothing left describing them.
+func TestUninstallKeepsFilesWhenTeardownFails(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	failDown := func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "down -v") {
+			return dockercmd.Result{}, errors.New("permission denied while removing volume")
+		}
+		return healthyDockerHandler(c)
+	}
+
+	deps := testDeps(t, &fakeRunner{handler: failDown}, notFoundServer(t))
+	deps.IOS = &iostreams.IOStreams{
+		In:          strings.NewReader("DELETE\n"),
+		Out:         &bytes.Buffer{},
+		ErrOut:      &bytes.Buffer{},
+		IsStdinTTY:  true,
+		IsStdoutTTY: true,
+	}
+	err := RunUninstall(context.Background(), deps, Options{Dir: root, Force: false})
+	if err == nil || !strings.Contains(err.Error(), "still present") {
+		t.Fatalf("err = %v, want the teardown failure to stop the delete", err)
+	}
+	if _, statErr := os.Stat(root); statErr != nil {
+		t.Fatal("deployment files were deleted despite the failed teardown")
+	}
+
+	// --force means "delete it regardless".
+	deps2 := testDeps(t, &fakeRunner{handler: failDown}, notFoundServer(t))
+	if err := RunUninstall(context.Background(), deps2, Options{Dir: root, Force: true}); err != nil {
+		t.Fatalf("--force must delete anyway: %v\noutput:\n%s", err, outBuf(deps2).String())
+	}
+	if _, statErr := os.Stat(root); !os.IsNotExist(statErr) {
+		t.Error("install dir still exists after --force")
 	}
 }
 

--- a/cli/internal/deploy/install/lifecycle_test.go
+++ b/cli/internal/deploy/install/lifecycle_test.go
@@ -138,8 +138,10 @@ func TestStatusHealthyAndDrift(t *testing.T) {
 	runner := &fakeRunner{handler: healthyDockerHandler}
 	root := installFixture(t, runner, "v4.2.0")
 
-	psOut := "onyx-api_server-1\tonyxdotapp/onyx-backend:v4.2.0\tUp 2 hours (healthy)\t\n" +
-		"onyx-nginx-1\tonyxdotapp/onyx-web-server:v4.2.0\tUp 2 hours\t0.0.0.0:3000->80/tcp\n"
+	// nginx (a stock image, listed first like the real deployment) must not
+	// be mistaken for the running Onyx version.
+	psOut := "onyx-nginx-1\tnginx:1.25.5-alpine\tUp 2 hours\t0.0.0.0:3000->80/tcp\n" +
+		"onyx-api_server-1\tonyxdotapp/onyx-backend:v4.2.0\tUp 2 hours (healthy)\t\n"
 	statusRunner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
 		if strings.Contains(argv(c), "ps -a") {
 			return dockercmd.Result{Stdout: psOut}, nil
@@ -200,7 +202,8 @@ func TestStatusJSON(t *testing.T) {
 	runner := &fakeRunner{handler: healthyDockerHandler}
 	root := installFixture(t, runner, "v4.2.0")
 
-	psOut := "onyx-nginx-1\tonyxdotapp/onyx-web-server:v4.2.0\tUp 1 minute\t0.0.0.0:3000->80/tcp\n"
+	psOut := "onyx-nginx-1\tnginx:1.25.5-alpine\tUp 1 minute\t0.0.0.0:3000->80/tcp\n" +
+		"onyx-api_server-1\tonyxdotapp/onyx-backend:v4.2.0\tUp 1 minute (healthy)\t\n"
 	statusRunner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
 		if strings.Contains(argv(c), "ps -a") {
 			return dockercmd.Result{Stdout: psOut}, nil

--- a/cli/internal/deploy/install/lifecycle_test.go
+++ b/cli/internal/deploy/install/lifecycle_test.go
@@ -108,6 +108,36 @@ func TestUninstallRefusesUnrecognizedDir(t *testing.T) {
 	}
 }
 
+// Markers are not authorization: a deployment/ under $HOME makes $HOME look
+// like an install, and uninstall removes the root recursively.
+func TestUninstallRefusesBroadRootWithMarkers(t *testing.T) {
+	isolateEnv(t)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	// A real deployment, but installed straight into the home directory.
+	if err := os.MkdirAll(filepath.Join(home, "deployment"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(home, "deployment", ".env"), []byte("IMAGE_TAG=v4.0.0\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	keep := filepath.Join(home, "taxes.pdf")
+	if err := os.WriteFile(keep, []byte("mine"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	deps := testDeps(t, runner, notFoundServer(t))
+	err := RunUninstall(context.Background(), deps, Options{Dir: home, Force: true})
+	if err == nil || !strings.Contains(err.Error(), "refusing to delete everything under") {
+		t.Fatalf("err = %v, want a refusal", err)
+	}
+	if _, statErr := os.Stat(keep); statErr != nil {
+		t.Fatal("refused uninstall deleted the home directory")
+	}
+}
+
 // Removing the directory after a failed teardown would strand the containers
 // and volumes with nothing left describing them.
 func TestUninstallKeepsFilesWhenTeardownFails(t *testing.T) {

--- a/cli/internal/deploy/install/lifecycle_test.go
+++ b/cli/internal/deploy/install/lifecycle_test.go
@@ -1,0 +1,236 @@
+package install
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+)
+
+func TestStopNothingInstalled(t *testing.T) {
+	isolateEnv(t)
+	deps := testDeps(t, &fakeRunner{}, notFoundServer(t))
+	err := RunStop(context.Background(), deps, Options{Dir: filepath.Join(t.TempDir(), "none")})
+	if err != nil {
+		t.Fatalf("stop on nothing must be a no-op success: %v", err)
+	}
+	if !strings.Contains(outBuf(deps).String(), "Nothing to shut down") {
+		t.Errorf("output:\n%s", outBuf(deps).String())
+	}
+}
+
+func TestStopAutoDetectsOverlays(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0") // lite install: overlay on disk
+
+	stopRunner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, stopRunner, notFoundServer(t))
+	if err := RunStop(context.Background(), deps, Options{Dir: root}); err != nil {
+		t.Fatalf("RunStop: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	var stop string
+	for _, c := range stopRunner.calls {
+		if strings.HasSuffix(argv(c), " stop") {
+			stop = argv(c)
+		}
+	}
+	if stop == "" {
+		t.Fatal("compose stop never ran")
+	}
+	if !strings.Contains(stop, "-f docker-compose.onyx-lite.yml") {
+		t.Errorf("lite overlay not auto-detected: %s", stop)
+	}
+}
+
+func TestUninstallNonInteractiveRequiresForce(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	err := RunUninstall(context.Background(), deps, Options{Dir: root})
+	if err == nil {
+		t.Fatal("expected refusal without --force")
+	}
+	if _, statErr := os.Stat(root); statErr != nil {
+		t.Fatal("refused uninstall must not delete anything")
+	}
+}
+
+func TestUninstallForceRemovesEverything(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	unRunner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, unRunner, notFoundServer(t))
+	if err := RunUninstall(context.Background(), deps, Options{Dir: root, Force: true}); err != nil {
+		t.Fatalf("RunUninstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Error("install dir still exists")
+	}
+	var down string
+	for _, c := range unRunner.calls {
+		if strings.Contains(argv(c), "down -v") {
+			down = argv(c)
+		}
+	}
+	if down == "" {
+		t.Fatal("compose down -v never ran")
+	}
+}
+
+func TestUninstallTypedDeleteConfirmation(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	// Wrong confirmation text: cancelled, nothing removed.
+	ios := &iostreams.IOStreams{
+		In:          strings.NewReader("delete\n"),
+		Out:         &bytes.Buffer{},
+		ErrOut:      &bytes.Buffer{},
+		IsStdinTTY:  true,
+		IsStdoutTTY: true,
+	}
+	deps := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	deps.IOS = ios
+	if err := RunUninstall(context.Background(), deps, Options{Dir: root}); err != nil {
+		t.Fatalf("cancelled uninstall must not error: %v", err)
+	}
+	if _, err := os.Stat(root); err != nil {
+		t.Fatal("cancelled uninstall deleted data")
+	}
+
+	// Exact DELETE: proceeds.
+	ios2 := &iostreams.IOStreams{
+		In:          strings.NewReader("DELETE\n"),
+		Out:         &bytes.Buffer{},
+		ErrOut:      &bytes.Buffer{},
+		IsStdinTTY:  true,
+		IsStdoutTTY: true,
+	}
+	deps2 := testDeps(t, &fakeRunner{handler: healthyDockerHandler}, notFoundServer(t))
+	deps2.IOS = ios2
+	if err := RunUninstall(context.Background(), deps2, Options{Dir: root}); err != nil {
+		t.Fatalf("RunUninstall: %v", err)
+	}
+	if _, err := os.Stat(root); !os.IsNotExist(err) {
+		t.Error("install dir still exists after DELETE confirmation")
+	}
+}
+
+func TestStatusNotInstalled(t *testing.T) {
+	isolateEnv(t)
+	deps := testDeps(t, &fakeRunner{}, notFoundServer(t))
+	err := RunStatus(context.Background(), deps, Options{Dir: filepath.Join(t.TempDir(), "none")}, false)
+	if err == nil || !strings.Contains(err.Error(), "not installed") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestStatusHealthyAndDrift(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.2.0")
+
+	psOut := "onyx-api_server-1\tonyxdotapp/onyx-backend:v4.2.0\tUp 2 hours (healthy)\t\n" +
+		"onyx-nginx-1\tonyxdotapp/onyx-web-server:v4.2.0\tUp 2 hours\t0.0.0.0:3000->80/tcp\n"
+	statusRunner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -a") {
+			return dockercmd.Result{Stdout: psOut}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	shimDockerOnPath(t)
+	deps := testDeps(t, statusRunner, notFoundServer(t))
+	if err := RunStatus(context.Background(), deps, Options{Dir: root}, false); err != nil {
+		t.Fatalf("RunStatus: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	out := outBuf(deps).String()
+	for _, want := range []string{"v4.2.0", "All 2 services are up", "http://localhost:3000"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "drift") {
+		t.Errorf("false drift warning:\n%s", out)
+	}
+
+	// Running tag differs from .env/manifest: drift is flagged, exit degraded
+	// only if unhealthy — here still healthy, so err stays nil.
+	driftRunner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -a") {
+			return dockercmd.Result{Stdout: strings.ReplaceAll(psOut, "v4.2.0", "v4.0.0")}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps2 := testDeps(t, driftRunner, notFoundServer(t))
+	if err := RunStatus(context.Background(), deps2, Options{Dir: root}, false); err != nil {
+		t.Fatalf("RunStatus: %v", err)
+	}
+	if !strings.Contains(outBuf(deps2).String(), "drift") {
+		t.Errorf("drift not flagged:\n%s", outBuf(deps2).String())
+	}
+}
+
+func TestStatusStoppedExitsNonZero(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.2.0")
+
+	stopped := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -a") {
+			return dockercmd.Result{Stdout: ""}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	shimDockerOnPath(t)
+	deps := testDeps(t, stopped, notFoundServer(t))
+	err := RunStatus(context.Background(), deps, Options{Dir: root}, false)
+	if err == nil || !strings.Contains(err.Error(), "stopped") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestStatusJSON(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.2.0")
+
+	psOut := "onyx-nginx-1\tonyxdotapp/onyx-web-server:v4.2.0\tUp 1 minute\t0.0.0.0:3000->80/tcp\n"
+	statusRunner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -a") {
+			return dockercmd.Result{Stdout: psOut}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	shimDockerOnPath(t)
+	deps := testDeps(t, statusRunner, notFoundServer(t))
+	if err := RunStatus(context.Background(), deps, Options{Dir: root}, true); err != nil {
+		t.Fatalf("RunStatus: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	out := outBuf(deps).String()
+	for _, want := range []string{`"installed": true`, `"env_tag": "v4.2.0"`, `"running_tag": "v4.2.0"`, `"access_url": "http://localhost:3000"`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("JSON missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestPublishedHostPort(t *testing.T) {
+	cases := map[string]string{
+		"0.0.0.0:3000->80/tcp, [::]:3000->80/tcp": "3000",
+		"[::]:8080->80/tcp":                       "8080",
+		"127.0.0.1:3001->80/tcp":                  "3001",
+		"80/tcp":                                  "",
+		"":                                        "",
+	}
+	for in, want := range cases {
+		if got := publishedHostPort(in); got != want {
+			t.Errorf("publishedHostPort(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cli/internal/deploy/install/logs.go
+++ b/cli/internal/deploy/install/logs.go
@@ -1,0 +1,65 @@
+package install
+
+import (
+	"context"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+)
+
+// LogOptions carries the flags of `deploy logs`, which are passed through to
+// compose rather than reinterpreted.
+type LogOptions struct {
+	// Services limits the output to these compose services (all when empty).
+	Services []string
+	Follow   bool
+	Tail     string
+	Since    string
+}
+
+// RunLogs implements `deploy logs`. It exists so triaging a service doesn't
+// start with finding the deployment directory and remembering which overlays
+// it was installed with — the same auto-detection stop and status already do.
+func RunLogs(ctx context.Context, deps Deps, opts Options, logOpts LogOptions) error {
+	in := newInstaller(deps, opts)
+	return in.runLogs(ctx, logOpts)
+}
+
+func (in *installer) runLogs(ctx context.Context, l LogOptions) error {
+	in.root = paths.Resolve(in.opts.Dir)
+	if !paths.IsInstall(in.root.Dir) {
+		in.infof("No Onyx install found at %s", in.root.Dir)
+		for _, alt := range in.root.Ambiguous {
+			in.infof("(another install exists at %s — pass --dir to read its logs)", alt)
+		}
+		return exitcodes.New(exitcodes.NotAvailable, "not installed")
+	}
+	if err := in.attachDockerCompose(ctx); err != nil {
+		return err
+	}
+
+	args := []string{"logs"}
+	if l.Follow {
+		args = append(args, "--follow")
+	}
+	if l.Tail != "" {
+		args = append(args, "--tail", l.Tail)
+	}
+	if l.Since != "" {
+		args = append(args, "--since", l.Since)
+	}
+	args = append(args, l.Services...)
+
+	// Same fallback env as stop: compose needs HOST_PORT/IMAGE_TAG to resolve
+	// the files, not to read logs, so a half-written .env can't block triage.
+	cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), in.composeFileNames(true), args...)
+	cmd.Stdout, cmd.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+	if _, err := in.deps.Runner.Run(ctx, cmd); err != nil {
+		// Ctrl-C is how a --follow ends, not a failure to report.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return exitcodes.Newf(exitcodes.General, "docker compose logs failed: %v", err)
+	}
+	return nil
+}

--- a/cli/internal/deploy/install/offline_test.go
+++ b/cli/internal/deploy/install/offline_test.go
@@ -1,0 +1,185 @@
+package install
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+)
+
+// offlineDockerHandler answers like a healthy host that already holds images
+// for two releases (and a floating tag, which names nothing reproducible).
+func offlineDockerHandler(c dockercmd.Command) (dockercmd.Result, error) {
+	if strings.Contains(argv(c), "images --format") {
+		return dockercmd.Result{Stdout: "edge\nv4.4.6\nv4.2.0\n"}, nil
+	}
+	return healthyDockerHandler(c)
+}
+
+// A host with no route to GitHub can still install from images it already
+// holds, so the version it is offered has to be one of those — not edge,
+// whose whole meaning is "whatever the registry has today".
+func TestOfflineInstallOffersAVersionOnTheHost(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: offlineDockerHandler}
+	deps := testDeps(t, runner, notFoundServer(t)) // release lookup 404s
+	deps.IOS.IsStdinTTY, deps.IOS.IsStdoutTTY = true, true
+	deps.IOS.In = bytes.NewBufferString(strings.Repeat("\n", 8)) // accept every default
+
+	err := RunInstall(context.Background(), deps, Options{Dir: t.TempDir(), NoWait: true})
+	if err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	out := outBuf(deps).String()
+	if !strings.Contains(out, "Version to deploy [default: v4.4.6]") {
+		t.Errorf("the version question didn't offer the newest release on the host:\n%s", out)
+	}
+	if !strings.Contains(out, "already on this host") {
+		t.Errorf("output doesn't say why that version was offered:\n%s", out)
+	}
+
+	// The point of offering it: a released tag is a fixed image, so compose is
+	// allowed to use the copy already here instead of going back to the
+	// registry — which is what an offline install depends on.
+	var pull, up string
+	for _, c := range runner.calls {
+		switch {
+		case strings.Contains(argv(c), " pull"):
+			pull = argv(c)
+		case strings.Contains(argv(c), " up -d"):
+			up = argv(c)
+		}
+	}
+	if !strings.Contains(pull, "--policy missing") {
+		t.Errorf("pull would contact the registry for images already here: %s", pull)
+	}
+	if strings.Contains(up, "--pull always") {
+		t.Errorf("up forces a re-pull of images already here: %s", up)
+	}
+}
+
+// With nothing installable on the host there is nothing better to offer, and
+// the run must still reach the question rather than stopping at the lookup.
+func TestOfflineInstallFallsBackToEdgeWithNoLocalImages(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "images --format") {
+			return dockercmd.Result{Stdout: "edge\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, runner, notFoundServer(t))
+	deps.IOS.IsStdinTTY, deps.IOS.IsStdoutTTY = true, true
+	deps.IOS.In = bytes.NewBufferString(strings.Repeat("\n", 8))
+
+	if err := RunInstall(context.Background(), deps, Options{Dir: t.TempDir(), NoWait: true}); err != nil {
+		t.Fatalf("RunInstall: %v", err)
+	}
+	if out := outBuf(deps).String(); !strings.Contains(out, "Version to deploy [default: edge]") {
+		t.Errorf("expected the edge fallback to still be asked about:\n%s", out)
+	}
+}
+
+// --offline is a promise, not a preference: no compose invocation in the run
+// may be one that can reach a registry, whatever the tag turns out to be.
+func TestOfflineInstallNeverReachesTheRegistry(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	runner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "config --images") {
+			return dockercmd.Result{Stdout: "onyxdotapp/onyx-backend:v4.4.6\nonyxdotapp/code-interpreter:latest\n"}, nil
+		}
+		return offlineDockerHandler(c)
+	}}
+	// The release server would answer, and is still never asked.
+	deps := testDeps(t, runner, rawServer(t, "fetched"))
+
+	err := RunInstall(context.Background(), deps, Options{
+		Dir: t.TempDir(), NoPrompt: true, NoWait: true, Offline: true,
+	})
+	if err != nil {
+		t.Fatalf("RunInstall: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	var up string
+	for _, c := range runner.calls {
+		a := argv(c)
+		if strings.Contains(a, " pull") {
+			t.Errorf("--offline still pulled: %s", a)
+		}
+		if strings.Contains(a, " up -d") {
+			up = a
+		}
+	}
+	if !strings.Contains(up, "--pull never") {
+		t.Errorf("up may still consult the registry: %s", up)
+	}
+	// Config files come from the embedded copies, so the fetch server that
+	// would have answered is left alone.
+	if out := outBuf(deps).String(); !strings.Contains(out, "v4.4.6") {
+		t.Errorf("expected the host's own version to be deployed:\n%s", out)
+	}
+}
+
+// The images a deployment needs don't all follow IMAGE_TAG, so having the
+// version's own images is not the same as being able to start. Saying which
+// one is absent is the whole difference between a fixable error and a puzzle.
+func TestOfflineInstallNamesTheMissingImage(t *testing.T) {
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	const missing = "onyxdotapp/code-interpreter:latest"
+	runner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		a := argv(c)
+		switch {
+		case strings.Contains(a, "config --images"):
+			return dockercmd.Result{Stdout: "onyxdotapp/onyx-backend:v4.4.6\n" + missing + "\n"}, nil
+		case strings.Contains(a, "image inspect "+missing):
+			return dockercmd.Result{}, errors.New("Error: No such image")
+		}
+		return offlineDockerHandler(c)
+	}}
+	deps := testDeps(t, runner, notFoundServer(t))
+
+	err := RunInstall(context.Background(), deps, Options{
+		Dir: t.TempDir(), NoPrompt: true, NoWait: true, Offline: true,
+	})
+	if err == nil {
+		t.Fatal("expected the install to stop rather than start without an image")
+	}
+	if out := outBuf(deps).String() + deps.IOS.ErrOut.(*bytes.Buffer).String(); !strings.Contains(out, missing) {
+		t.Errorf("the error doesn't say which image is missing:\n%s", out)
+	}
+	for _, c := range runner.calls {
+		if strings.Contains(argv(c), " up -d") {
+			t.Error("started services despite a missing image")
+		}
+	}
+}
+
+func TestLocalAppTagPicksTheNewestRelease(t *testing.T) {
+	shimDockerOnPath(t)
+	cases := map[string]string{
+		"v4.2.0\nv4.4.6\nv4.10.0\n":  "v4.10.0", // ordered as versions, not text
+		"edge\nlatest\nv4.4.6-dev\n": "",        // nothing reproducible on disk
+		"":                           "",
+		"v4.4.6\n":                   "v4.4.6",
+	}
+	for out, want := range cases {
+		runner := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+			if strings.Contains(argv(c), "images --format") {
+				return dockercmd.Result{Stdout: out}, nil
+			}
+			return healthyDockerHandler(c)
+		}}
+		in := newInstaller(testDeps(t, runner, notFoundServer(t)), Options{})
+		if got := in.localAppTag(context.Background()); got != want {
+			t.Errorf("localAppTag(%q) = %q, want %q", out, got, want)
+		}
+	}
+}

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -131,6 +131,13 @@ func (in *installer) plainf(format string, args ...any) {
 	fmt.Fprintf(in.deps.IOS.Out, format+"\n", args...)
 }
 
+// cmdf prints a command on a line of its own, in the accent the summary card
+// marks the URL with. These lines exist to be typed: what introduced them is
+// prose, and the eye should be able to find the part that isn't.
+func (in *installer) cmdf(format string, args ...any) {
+	in.plainf("  %s", ui.Accent(fmt.Sprintf(format, args...)))
+}
+
 // fancy reports whether the interactive renderer drives this run (never
 // under --no-prompt, so scripted output stays line-oriented, and never under
 // --verbose, which streams compose's own output to the normal screen — under

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -60,10 +60,11 @@ type installer struct {
 	compose *dockercmd.Compose
 
 	// Resolved during the run.
-	root  paths.InstallRoot
-	lite  bool
-	craft bool
-	wiz   *ui.Wizard // live wizard when the fancy renderer drives the run
+	root   paths.InstallRoot
+	lite   bool
+	craft  bool
+	wiz    *ui.Wizard // live wizard when the fancy renderer drives the run
+	cancel func()     // cancels in-flight work when the wizard is quit
 
 	// step counter for the "=== title - Step N/M ===" headers.
 	step, totalSteps int

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -63,6 +63,7 @@ type installer struct {
 	root  paths.InstallRoot
 	lite  bool
 	craft bool
+	wiz   *ui.Wizard // live wizard when the fancy renderer drives the run
 
 	// step counter for the "=== title - Step N/M ===" headers.
 	step, totalSteps int
@@ -80,22 +81,42 @@ func newInstaller(deps Deps, opts Options) *installer {
 // Output helpers mirroring install.sh's prefixes (plain text, no color).
 
 func (in *installer) successf(format string, args ...any) {
+	if in.wiz != nil {
+		in.wiz.Note("ok", fmt.Sprintf(format, args...))
+		return
+	}
 	fmt.Fprintf(in.deps.IOS.Out, "✓ "+format+"\n", args...)
 }
 
 func (in *installer) infof(format string, args ...any) {
+	if in.wiz != nil {
+		in.wiz.Note("", fmt.Sprintf(format, args...))
+		return
+	}
 	fmt.Fprintf(in.deps.IOS.Out, "ℹ "+format+"\n", args...)
 }
 
 func (in *installer) warnf(format string, args ...any) {
+	if in.wiz != nil {
+		in.wiz.Note("warn", fmt.Sprintf(format, args...))
+		return
+	}
 	fmt.Fprintf(in.deps.IOS.Out, "⚠ "+format+"\n", args...)
 }
 
 func (in *installer) errorf(format string, args ...any) {
+	if in.wiz != nil {
+		in.wiz.Note("err", fmt.Sprintf(format, args...))
+		return
+	}
 	fmt.Fprintf(in.deps.IOS.ErrOut, "✗ "+format+"\n", args...)
 }
 
 func (in *installer) plainf(format string, args ...any) {
+	if in.wiz != nil {
+		in.wiz.Note("", fmt.Sprintf(format, args...))
+		return
+	}
 	fmt.Fprintf(in.deps.IOS.Out, format+"\n", args...)
 }
 
@@ -116,8 +137,8 @@ func (in *installer) selectOne(title string, options []ui.Option, defaultIdx int
 	if in.prompt.AssumeDefaults {
 		return defaultIdx, nil
 	}
-	if in.fancy() {
-		return ui.Select(in.deps.IOS, title, options, defaultIdx)
+	if in.wiz != nil {
+		return in.wiz.Select(title, options, defaultIdx)
 	}
 	in.infof("%s", title)
 	for i, o := range options {
@@ -144,8 +165,8 @@ func (in *installer) askString(title, defaultVal string) (string, error) {
 	if in.prompt.AssumeDefaults {
 		return defaultVal, nil
 	}
-	if in.fancy() {
-		return ui.Input(in.deps.IOS, title, defaultVal)
+	if in.wiz != nil {
+		return in.wiz.Input(title, defaultVal)
 	}
 	return in.prompt.Ask(fmt.Sprintf("%s [default: %s]: ", title, defaultVal), defaultVal)
 }
@@ -155,23 +176,31 @@ func (in *installer) confirmYN(question string, defaultYes bool) (bool, error) {
 	if in.prompt.AssumeDefaults {
 		return defaultYes, nil
 	}
-	if in.fancy() {
+	if in.wiz != nil {
 		def := 1
 		if defaultYes {
 			def = 0
 		}
-		idx, err := in.selectOne(question, []ui.Option{{Label: "Yes"}, {Label: "No"}}, def)
+		idx, err := in.wiz.Select(question, []ui.Option{{Label: "Yes"}, {Label: "No"}}, def)
 		return idx == 0, err
 	}
 	return in.prompt.Confirm(question+" ", defaultYes)
 }
 
-// phase prints a styled (or plain) phase header for fast sections and
-// returns a live spinner task for long ones when fancy.
-func (in *installer) phase(title string, spinner bool) *ui.Task {
-	if in.fancy() && spinner {
-		return ui.StartTask(in.deps.IOS.Out, title)
+// phase prints a plain phase header (the wizard's rail replaces it when the
+// fancy renderer is active).
+func (in *installer) phase(title string) {
+	if in.wiz != nil {
+		return
 	}
 	fmt.Fprintf(in.deps.IOS.Out, "\n— %s —\n", title)
-	return nil
+}
+
+// suspend hands the terminal back to fn when the wizard is live (sudo
+// password prompts, provisioning output).
+func (in *installer) suspend(fn func() error) error {
+	if in.wiz != nil {
+		return in.wiz.Suspend(fn)
+	}
+	return fn()
 }

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -58,6 +58,7 @@ type installer struct {
 	prompt  *prompt.Prompter
 	docker  *dockercmd.Docker
 	compose *dockercmd.Compose
+	paint   ui.Painter
 
 	// Resolved during the run.
 	root     paths.InstallRoot
@@ -86,17 +87,20 @@ func newInstaller(deps Deps, opts Options) *installer {
 		opts:   opts,
 		prompt: prompt.New(deps.IOS, opts.NoPrompt),
 		docker: dockercmd.NewDocker(deps.Runner),
+		paint:  ui.NewPainter(deps.IOS),
 	}
 }
 
-// Output helpers mirroring install.sh's prefixes (plain text, no color).
+// Output helpers mirroring install.sh's prefixes. Only the mark is colored,
+// the way the wizard colors its notes, so the text stays readable on any
+// background and unstyled when the output isn't a terminal.
 
 func (in *installer) successf(format string, args ...any) {
 	if in.wiz != nil {
 		in.wiz.Note("ok", fmt.Sprintf(format, args...))
 		return
 	}
-	fmt.Fprintf(in.deps.IOS.Out, "✓ "+format+"\n", args...)
+	fmt.Fprintf(in.deps.IOS.Out, in.paint.Ok("✓ ")+format+"\n", args...)
 }
 
 func (in *installer) infof(format string, args ...any) {
@@ -104,7 +108,7 @@ func (in *installer) infof(format string, args ...any) {
 		in.wiz.Note("", fmt.Sprintf(format, args...))
 		return
 	}
-	fmt.Fprintf(in.deps.IOS.Out, "ℹ "+format+"\n", args...)
+	fmt.Fprintf(in.deps.IOS.Out, in.paint.Dim("ℹ ")+format+"\n", args...)
 }
 
 func (in *installer) warnf(format string, args ...any) {
@@ -112,7 +116,7 @@ func (in *installer) warnf(format string, args ...any) {
 		in.wiz.Note("warn", fmt.Sprintf(format, args...))
 		return
 	}
-	fmt.Fprintf(in.deps.IOS.Out, "⚠ "+format+"\n", args...)
+	fmt.Fprintf(in.deps.IOS.Out, in.paint.Warn("⚠ ")+format+"\n", args...)
 }
 
 func (in *installer) errorf(format string, args ...any) {
@@ -120,7 +124,28 @@ func (in *installer) errorf(format string, args ...any) {
 		in.wiz.Note("err", fmt.Sprintf(format, args...))
 		return
 	}
-	fmt.Fprintf(in.deps.IOS.ErrOut, "✗ "+format+"\n", args...)
+	fmt.Fprintf(in.deps.IOS.ErrOut, in.paint.Err("✗ ")+format+"\n", args...)
+}
+
+// failf is errorf's report-side twin: the same mark, but on stdout, for a
+// verb whose failure IS the output that was asked for (status), where
+// splitting the verdict from the list it explains would leave both halves
+// unreadable on their own.
+func (in *installer) failf(format string, args ...any) {
+	if in.wiz != nil {
+		in.wiz.Note("err", fmt.Sprintf(format, args...))
+		return
+	}
+	fmt.Fprintf(in.deps.IOS.Out, in.paint.Err("✗ ")+format+"\n", args...)
+}
+
+// dirArg repeats the --dir this run was given, so a command the output
+// suggests still points at the same deployment when it isn't the default one.
+func (in *installer) dirArg() string {
+	if in.opts.Dir == "" {
+		return ""
+	}
+	return fmt.Sprintf(" --dir %q", in.opts.Dir)
 }
 
 func (in *installer) plainf(format string, args ...any) {

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -74,6 +74,10 @@ type installer struct {
 	// wasLite records that the deployment was in lite mode when the run
 	// started, so a switch to standard can undo lite's .env adjustments.
 	wasLite bool
+	// forceRecreate carries the operator's sign-off to replace containers
+	// that were already running when the run started; `up` gets
+	// --force-recreate so every service ends up on the new configuration.
+	forceRecreate bool
 }
 
 func newInstaller(deps Deps, opts Options) *installer {

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -74,9 +74,9 @@ type installer struct {
 	// wasLite records that the deployment was in lite mode when the run
 	// started, so a switch to standard can undo lite's .env adjustments.
 	wasLite bool
-	// forceRecreate carries the operator's sign-off to replace containers
-	// that were already running when the run started; `up` gets
-	// --force-recreate so every service ends up on the new configuration.
+	// forceRecreate records that services were already running when the run
+	// started, and that this run may replace them; `up` gets --force-recreate
+	// so every service ends up on the new configuration.
 	forceRecreate bool
 }
 

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -10,6 +10,7 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/prompt"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/ui"
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
 )
 
@@ -34,6 +35,9 @@ type Deps struct {
 	Runner     dockercmd.Runner
 	Release    *release.Client
 	CLIVersion string
+	// Fancy enables the Bubble Tea prompts and live progress. Off in tests
+	// and whenever a real TTY isn't driving the run.
+	Fancy bool
 }
 
 // NewDeps wires production dependencies.
@@ -43,6 +47,7 @@ func NewDeps(ios *iostreams.IOStreams, cliVersion string) Deps {
 		Runner:     dockercmd.ExecRunner{},
 		Release:    release.NewClient(),
 		CLIVersion: cliVersion,
+		Fancy:      ui.Enabled(ios),
 	}
 }
 
@@ -97,4 +102,76 @@ func (in *installer) plainf(format string, args ...any) {
 func (in *installer) stepf(title string) {
 	in.step++
 	fmt.Fprintf(in.deps.IOS.Out, "\n=== %s - Step %d/%d ===\n\n", title, in.step, in.totalSteps)
+}
+
+// fancy reports whether the interactive renderer drives this run (never
+// under --no-prompt, so scripted output stays line-oriented).
+func (in *installer) fancy() bool {
+	return in.deps.Fancy && !in.opts.NoPrompt
+}
+
+// selectOne asks a single choice: arrow-key select when fancy, a numbered
+// line prompt otherwise, the default when non-interactive.
+func (in *installer) selectOne(title string, options []ui.Option, defaultIdx int) (int, error) {
+	if in.prompt.AssumeDefaults {
+		return defaultIdx, nil
+	}
+	if in.fancy() {
+		return ui.Select(in.deps.IOS, title, options, defaultIdx)
+	}
+	in.infof("%s", title)
+	for i, o := range options {
+		marker := " "
+		if i == defaultIdx {
+			marker = "*"
+		}
+		in.plainf("  %s %d) %s%s", marker, i+1, o.Label, map[bool]string{true: " — " + o.Hint, false: ""}[o.Hint != ""])
+	}
+	answer, err := in.prompt.Ask(fmt.Sprintf("Choose an option [default: %d]: ", defaultIdx+1), fmt.Sprintf("%d", defaultIdx+1))
+	if err != nil {
+		return 0, err
+	}
+	for i := range options {
+		if answer == fmt.Sprintf("%d", i+1) {
+			return i, nil
+		}
+	}
+	return defaultIdx, nil
+}
+
+// askString asks a free-form value with a prefilled default.
+func (in *installer) askString(title, defaultVal string) (string, error) {
+	if in.prompt.AssumeDefaults {
+		return defaultVal, nil
+	}
+	if in.fancy() {
+		return ui.Input(in.deps.IOS, title, defaultVal)
+	}
+	return in.prompt.Ask(fmt.Sprintf("%s [default: %s]: ", title, defaultVal), defaultVal)
+}
+
+// confirmYN asks a yes/no question (select when fancy).
+func (in *installer) confirmYN(question string, defaultYes bool) (bool, error) {
+	if in.prompt.AssumeDefaults {
+		return defaultYes, nil
+	}
+	if in.fancy() {
+		def := 1
+		if defaultYes {
+			def = 0
+		}
+		idx, err := in.selectOne(question, []ui.Option{{Label: "Yes"}, {Label: "No"}}, def)
+		return idx == 0, err
+	}
+	return in.prompt.Confirm(question+" ", defaultYes)
+}
+
+// phase prints a styled (or plain) phase header for fast sections and
+// returns a live spinner task for long ones when fancy.
+func (in *installer) phase(title string, spinner bool) *ui.Task {
+	if in.fancy() && spinner {
+		return ui.StartTask(in.deps.IOS.Out, title)
+	}
+	fmt.Fprintf(in.deps.IOS.Out, "\n— %s —\n", title)
+	return nil
 }

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -1,0 +1,100 @@
+// Package install orchestrates the deploy lifecycle: install, upgrade, stop,
+// status and uninstall of a docker compose Onyx deployment. It is the Go
+// replacement for deployment/docker_compose/install.sh.
+package install
+
+import (
+	"fmt"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/prompt"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+)
+
+// Options carries the flags shared across the deploy verbs. Flag names match
+// install.sh so bootstrap passthrough keeps working.
+type Options struct {
+	Lite         bool
+	IncludeCraft bool
+	Tag          string
+	Local        bool
+	NoPrompt     bool
+	DryRun       bool
+	Verbose      bool
+	NoWait       bool
+	Dir          string
+	Force        bool
+}
+
+// Deps carries the injectable collaborators (fakes in tests).
+type Deps struct {
+	IOS        *iostreams.IOStreams
+	Runner     dockercmd.Runner
+	Release    *release.Client
+	CLIVersion string
+}
+
+// NewDeps wires production dependencies.
+func NewDeps(ios *iostreams.IOStreams, cliVersion string) Deps {
+	return Deps{
+		IOS:        ios,
+		Runner:     dockercmd.ExecRunner{},
+		Release:    release.NewClient(),
+		CLIVersion: cliVersion,
+	}
+}
+
+// installer bundles the state threaded through one verb invocation.
+type installer struct {
+	deps    Deps
+	opts    Options
+	prompt  *prompt.Prompter
+	docker  *dockercmd.Docker
+	compose *dockercmd.Compose
+
+	// Resolved during the run.
+	root  paths.InstallRoot
+	lite  bool
+	craft bool
+
+	// step counter for the "=== title - Step N/M ===" headers.
+	step, totalSteps int
+}
+
+func newInstaller(deps Deps, opts Options) *installer {
+	return &installer{
+		deps:   deps,
+		opts:   opts,
+		prompt: prompt.New(deps.IOS, opts.NoPrompt),
+		docker: dockercmd.NewDocker(deps.Runner),
+	}
+}
+
+// Output helpers mirroring install.sh's prefixes (plain text, no color).
+
+func (in *installer) successf(format string, args ...any) {
+	fmt.Fprintf(in.deps.IOS.Out, "✓ "+format+"\n", args...)
+}
+
+func (in *installer) infof(format string, args ...any) {
+	fmt.Fprintf(in.deps.IOS.Out, "ℹ "+format+"\n", args...)
+}
+
+func (in *installer) warnf(format string, args ...any) {
+	fmt.Fprintf(in.deps.IOS.Out, "⚠ "+format+"\n", args...)
+}
+
+func (in *installer) errorf(format string, args ...any) {
+	fmt.Fprintf(in.deps.IOS.ErrOut, "✗ "+format+"\n", args...)
+}
+
+func (in *installer) plainf(format string, args ...any) {
+	fmt.Fprintf(in.deps.IOS.Out, format+"\n", args...)
+}
+
+func (in *installer) stepf(title string) {
+	in.step++
+	fmt.Fprintf(in.deps.IOS.Out, "\n=== %s - Step %d/%d ===\n\n", title, in.step, in.totalSteps)
+}

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -60,11 +60,12 @@ type installer struct {
 	compose *dockercmd.Compose
 
 	// Resolved during the run.
-	root   paths.InstallRoot
-	lite   bool
-	craft  bool
-	wiz    *ui.Wizard // live wizard when the fancy renderer drives the run
-	cancel func()     // cancels in-flight work when the wizard is quit
+	root     paths.InstallRoot
+	lite     bool
+	craft    bool
+	wiz      *ui.Wizard // live wizard when the fancy renderer drives the run
+	cancel   func()     // cancels in-flight work when the wizard is quit
+	rootless bool       // daemon runs rootless (limits what compose can grant)
 
 	// step counter for the "=== title - Step N/M ===" headers.
 	step, totalSteps int

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -132,9 +132,11 @@ func (in *installer) plainf(format string, args ...any) {
 }
 
 // fancy reports whether the interactive renderer drives this run (never
-// under --no-prompt, so scripted output stays line-oriented).
+// under --no-prompt, so scripted output stays line-oriented, and never under
+// --verbose, which streams compose's own output to the normal screen — under
+// the alt screen it would be written where nothing can read it).
 func (in *installer) fancy() bool {
-	return in.deps.Fancy && !in.opts.NoPrompt
+	return in.deps.Fancy && !in.opts.NoPrompt && !in.opts.Verbose
 }
 
 // selectOne asks a single choice: arrow-key select when fancy, a numbered

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -66,6 +66,11 @@ type installer struct {
 	wiz      *ui.Wizard // live wizard when the fancy renderer drives the run
 	cancel   func()     // cancels in-flight work when the wizard is quit
 	rootless bool       // daemon runs rootless (limits what compose can grant)
+
+	// observedPort is the host port the deployment published when the run
+	// started (0 if it wasn't running). It recovers the port of installs
+	// that predate recording HOST_PORT in .env.
+	observedPort int
 }
 
 func newInstaller(deps Deps, opts Options) *installer {

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -21,6 +21,7 @@ type Options struct {
 	IncludeCraft bool
 	Tag          string
 	Local        bool
+	Offline      bool
 	NoPrompt     bool
 	DryRun       bool
 	Verbose      bool
@@ -137,6 +138,13 @@ func (in *installer) failf(format string, args ...any) {
 		return
 	}
 	fmt.Fprintf(in.deps.IOS.Out, in.paint.Err("✗ ")+format+"\n", args...)
+}
+
+// localFiles reports whether config files come from disk and the embedded
+// copies rather than GitHub. --offline implies it: a run that promises to
+// touch no network cannot go and fetch them.
+func (in *installer) localFiles() bool {
+	return in.opts.Local || in.opts.Offline
 }
 
 // dirArg repeats the --dir this run was given, so a command the output

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -66,9 +66,6 @@ type installer struct {
 	wiz      *ui.Wizard // live wizard when the fancy renderer drives the run
 	cancel   func()     // cancels in-flight work when the wizard is quit
 	rootless bool       // daemon runs rootless (limits what compose can grant)
-
-	// step counter for the "=== title - Step N/M ===" headers.
-	step, totalSteps int
 }
 
 func newInstaller(deps Deps, opts Options) *installer {
@@ -120,11 +117,6 @@ func (in *installer) plainf(format string, args ...any) {
 		return
 	}
 	fmt.Fprintf(in.deps.IOS.Out, format+"\n", args...)
-}
-
-func (in *installer) stepf(title string) {
-	in.step++
-	fmt.Fprintf(in.deps.IOS.Out, "\n=== %s - Step %d/%d ===\n\n", title, in.step, in.totalSteps)
 }
 
 // fancy reports whether the interactive renderer drives this run (never
@@ -186,7 +178,11 @@ func (in *installer) confirmYN(question string, defaultYes bool) (bool, error) {
 		idx, err := in.wiz.Select(question, []ui.Option{{Label: "Yes"}, {Label: "No"}}, def)
 		return idx == 0, err
 	}
-	return in.prompt.Confirm(question+" ", defaultYes)
+	hint := " (y/N) "
+	if defaultYes {
+		hint = " (Y/n) "
+	}
+	return in.prompt.Confirm(question+hint, defaultYes)
 }
 
 // phase prints a plain phase header (the wizard's rail replaces it when the

--- a/cli/internal/deploy/install/options.go
+++ b/cli/internal/deploy/install/options.go
@@ -71,6 +71,9 @@ type installer struct {
 	// started (0 if it wasn't running). It recovers the port of installs
 	// that predate recording HOST_PORT in .env.
 	observedPort int
+	// wasLite records that the deployment was in lite mode when the run
+	// started, so a switch to standard can undo lite's .env adjustments.
+	wasLite bool
 }
 
 func newInstaller(deps Deps, opts Options) *installer {

--- a/cli/internal/deploy/install/plan.go
+++ b/cli/internal/deploy/install/plan.go
@@ -1,0 +1,25 @@
+package install
+
+import (
+	"runtime"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
+)
+
+// printPlan renders --dry-run: what an install would do, with no side
+// effects (mirrors install.sh's dry-run summary).
+func (in *installer) printPlan(defaultTag string) {
+	in.infof("Dry run mode — showing what would happen:")
+	in.plainf("  • Install root: %s (%s)", in.root.Dir, in.root.Source)
+	in.plainf("  • Lite mode: %t", in.lite)
+	in.plainf("  • Include Craft: %t", in.craft)
+	in.plainf("  • OS: %s/%s (WSL: %t)", runtime.GOOS, runtime.GOARCH, dockercmd.IsWSL())
+	if in.opts.Local {
+		in.plainf("  • Config files: existing files on disk, embedded copies for gaps (--local)")
+	} else {
+		in.plainf("  • Default image tag: %s (config ref: %s)", defaultTag, release.ConfigRef(defaultTag))
+	}
+	in.plainf("")
+	in.successf("Dry run complete (no changes made)")
+}

--- a/cli/internal/deploy/install/plan.go
+++ b/cli/internal/deploy/install/plan.go
@@ -15,9 +15,13 @@ func (in *installer) printPlan(defaultTag string) {
 	in.plainf("  • Lite mode: %t", in.lite)
 	in.plainf("  • Include Craft: %t", in.craft)
 	in.plainf("  • OS: %s/%s (WSL: %t)", runtime.GOOS, runtime.GOARCH, dockercmd.IsWSL())
-	if in.opts.Local {
+	switch {
+	case in.opts.Offline:
+		in.plainf("  • Default image tag: %s (from the images on this host)", defaultTag)
+		in.plainf("  • Config files: existing files on disk, embedded copies for gaps (--offline)")
+	case in.opts.Local:
 		in.plainf("  • Config files: existing files on disk, embedded copies for gaps (--local)")
-	} else {
+	default:
 		in.plainf("  • Default image tag: %s (config ref: %s)", defaultTag, release.ConfigRef(defaultTag))
 	}
 	in.plainf("")

--- a/cli/internal/deploy/install/progress.go
+++ b/cli/internal/deploy/install/progress.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -37,6 +38,10 @@ const (
 	// per downloaded chunk, far more often than a terminal can usefully
 	// repaint.
 	progressRefresh = 150 * time.Millisecond
+	// healthPollInterval is how often the container list is re-read while a
+	// phase runs — often enough to look live, rare enough to stay out of the
+	// daemon's way.
+	healthPollInterval = 2 * time.Second
 	// maxProgressRows caps a checklist. The deployment has a handful of
 	// images and containers, so more rows than this means the output wasn't
 	// what we parsed it as, and the wizard pane must not grow past the screen.
@@ -444,12 +449,75 @@ var startPhases = map[string]string{
 	"Starting":   "starting",
 	"Started":    "started",
 	"Running":    "running",
-	"Waiting":    "waiting for health",
+	"Waiting":    "waiting",
 	"Healthy":    "healthy",
 	"Exited":     "exited",
 	"Skipped":    "skipped",
 	"Error":      "failed",
 	"Restarting": "restarting",
+}
+
+// healthWatch is the per-service checklist read off `docker ps` while a compose
+// command runs — the fallback for a compose whose own progress output says
+// nothing, and the only source of rows while `up --wait` blocks in silence.
+type healthWatch struct {
+	// quiet gates the watch when the command's output also fills the
+	// checklist: it publishes only while that output has said nothing.
+	quiet func() bool
+	// before maps each service to the container that was serving it when the
+	// phase began. `docker ps` cannot see an intent, only containers, so this
+	// is what tells a container still awaiting its turn from its replacement.
+	before map[string]string
+	// recreate records that this run replaces every container, which is what
+	// makes a service still on its original container unfinished rather than
+	// already up.
+	recreate bool
+}
+
+// watchRows renders `docker ps` output ("<name>\t<id>\t<status>" per line) as
+// checklist rows, and counts the services that are done.
+//
+// A rollout is three states, and the container list only shows one of them
+// directly: a service still on the container it started on is waiting its turn,
+// one whose container has disappeared is mid-swap, and one on a container that
+// wasn't there before is the new deployment coming up.
+func watchRows(psOutput string, w healthWatch) (rows []ui.ServiceRow, ready int) {
+	seen := map[string]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(psOutput), "\n") {
+		parts := strings.SplitN(line, "\t", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		name, id, status := shortContainerName(parts[0]), parts[1], parts[2]
+		seen[name] = true
+		if w.recreate && w.before[name] == id {
+			// Still the old container: up and serving, but this run is not
+			// done with it.
+			rows = append(rows, ui.ServiceRow{Name: name, Detail: "pending"})
+			continue
+		}
+		done := healthy(status)
+		if done {
+			ready++
+		}
+		rows = append(rows, ui.ServiceRow{Name: name, Detail: healthDetail(status), Ready: done})
+	}
+	// A service whose container is gone is between its two containers: compose
+	// stopped the old one and hasn't finished starting the new one.
+	for name := range w.before {
+		if !seen[name] {
+			rows = append(rows, ui.ServiceRow{Name: name, Detail: "restarting"})
+		}
+	}
+	slices.SortFunc(rows, func(a, b ui.ServiceRow) int { return strings.Compare(a.Name, b.Name) })
+	return rows, ready
+}
+
+// healthy reports whether a `docker ps` status says the container is up for
+// good: passing its health check, or having none to pass.
+func healthy(status string) bool {
+	return strings.Contains(status, "(healthy)") ||
+		(strings.HasPrefix(status, "Up") && !strings.Contains(status, "health"))
 }
 
 // healthDetail says what a container is doing, read off `docker ps` status
@@ -461,8 +529,8 @@ func healthDetail(status string) string {
 		return "healthy"
 	case strings.Contains(status, "(unhealthy)"):
 		return "unhealthy"
-	case strings.Contains(status, "(health: starting)"), strings.Contains(status, "(starting)"):
-		return "waiting for health"
+	case strings.Contains(status, "health: starting"), strings.Contains(status, "(starting)"):
+		return "waiting"
 	case strings.HasPrefix(status, "Up"):
 		return "running"
 	}

--- a/cli/internal/deploy/install/progress.go
+++ b/cli/internal/deploy/install/progress.go
@@ -1,0 +1,476 @@
+package install
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/ui"
+	"github.com/onyx-dot-app/onyx/cli/internal/version"
+)
+
+// Compose progress formats, richest first: json carries per-layer byte
+// counters, plain only the event stream. Both are read here; compose's default
+// tty renderer is deliberately never used while the wizard is up, because it
+// redraws with cursor moves on a screen the wizard has had to release, leaving
+// the phase invisible until the command finishes.
+const (
+	progressJSON  = "json"
+	progressPlain = "plain"
+
+	// The global --progress flag landed in compose 2.19, its json mode in
+	// 2.29; older versions reject the value outright.
+	minProgressVersion     = "2.19.0"
+	minProgressJSONVersion = "2.29.0"
+)
+
+const (
+	// progressRefresh throttles wizard updates: compose reports a layer event
+	// per downloaded chunk, far more often than a terminal can usefully
+	// repaint.
+	progressRefresh = 150 * time.Millisecond
+	// maxProgressRows caps a checklist. The deployment has a handful of
+	// images and containers, so more rows than this means the output wasn't
+	// what we parsed it as, and the wizard pane must not grow past the screen.
+	maxProgressRows = 24
+)
+
+// progressMode picks the richest progress format this compose understands, or
+// "" when the wizard isn't driving the run (plain output already streams) or
+// compose predates the flag.
+func (in *installer) progressMode(ctx context.Context) string {
+	if in.wiz == nil || in.opts.Verbose || in.compose == nil {
+		return ""
+	}
+	// Unparsable versions ("dev" builds) get the older flag: compose rejects
+	// a mode it doesn't know, and the phase's display is not worth failing a
+	// deployment over.
+	have, ok := version.Parse(in.compose.Version(ctx))
+	if !ok {
+		return progressPlain
+	}
+	if minJSON, _ := version.Parse(minProgressJSONVersion); !have.LessThan(minJSON) {
+		return progressJSON
+	}
+	if minAny, _ := version.Parse(minProgressVersion); !have.LessThan(minAny) {
+		return progressPlain
+	}
+	return ""
+}
+
+// composeEvent is compose's json progress event, narrowed to the fields these
+// phases read. Text is the event's own word ("Pulling", "Downloading"), Status
+// its detail — except for container lifecycle events, which carry the word in
+// Status and leave Text empty.
+type composeEvent struct {
+	ID       string `json:"id"`
+	ParentID string `json:"parent_id"`
+	Text     string `json:"text"`
+	Status   string `json:"status"`
+	Current  int64  `json:"current"`
+	Total    int64  `json:"total"`
+	Percent  int    `json:"percent"`
+}
+
+// checklist is the shared state behind the live per-row panes: insertion
+// ordered rows, capped, pushed to the wizard at a bounded rate.
+type checklist struct {
+	services func([]ui.ServiceRow)
+	extra    func(string)
+
+	order []string
+	last  time.Time
+}
+
+// track reports whether name is a new row, refusing rows past the cap.
+func (c *checklist) track(name string) (known, created bool) {
+	for _, n := range c.order {
+		if n == name {
+			return true, false
+		}
+	}
+	if len(c.order) >= maxProgressRows {
+		return false, false
+	}
+	c.order = append(c.order, name)
+	return true, true
+}
+
+// due reports whether an update should be pushed now. Structural changes (a
+// new row, or one reaching its final state) always are; the churn in between
+// is rate-limited.
+func (c *checklist) due(structural bool) bool {
+	if !structural && time.Since(c.last) < progressRefresh {
+		return false
+	}
+	c.last = time.Now()
+	return true
+}
+
+// pullProgress turns `docker compose pull` progress output into a live
+// per-image checklist with download totals.
+//
+// json events name the image in "id" for image-level phases ("Pulling",
+// "Pulled", "Skipped - …") and in "parent_id" for the layer events carrying
+// the byte counters summed here. plain prints "<id> <text> <status text>"
+// instead, which still identifies images but has no usable counters, so those
+// runs get the checklist alone.
+//
+// Anything unrecognized is ignored: the phase then shows its spinner and
+// elapsed time, exactly as it would with no progress output at all.
+type pullProgress struct {
+	checklist
+	images map[string]*pullImage
+}
+
+type pullImage struct {
+	done   bool
+	layers map[string]*pullLayer
+}
+
+// pullLayer is one layer's download, in bytes.
+type pullLayer struct{ current, total int64 }
+
+func newPullProgress(services func([]ui.ServiceRow), extra func(string)) *pullProgress {
+	return &pullProgress{
+		checklist: checklist{services: services, extra: extra},
+		images:    map[string]*pullImage{},
+	}
+}
+
+// line consumes one output line. It is called from the single goroutine
+// draining the command's output, so the state needs no lock.
+func (p *pullProgress) line(s string) {
+	if e, ok := decodeEvent(s); ok {
+		if known, structural := p.event(e); known && p.due(structural) {
+			p.publish()
+		}
+	}
+}
+
+func (p *pullProgress) event(e composeEvent) (known, structural bool) {
+	if e.ParentID == "" {
+		return p.imageEvent(e.ID, firstWord(e.Text))
+	}
+	img, _ := p.image(e.ParentID)
+	if img == nil {
+		return false, false
+	}
+	layer := img.layers[e.ID]
+	if layer == nil {
+		layer = &pullLayer{}
+		img.layers[e.ID] = layer
+	}
+	// Only the download itself is counted: "Extracting" reports the same
+	// layer's uncompressed size, which would make the total jump around.
+	switch e.Text {
+	case "Downloading":
+		layer.current, layer.total = e.Current, e.Total
+	case "Download complete", "Pull complete", "Already exists":
+		// Finished layers report no counters at all, so hold them at the
+		// last total they announced rather than letting the sum shrink.
+		layer.current = layer.total
+	default:
+		return false, false
+	}
+	return true, false
+}
+
+// imageEvent records an image-level phase. Everything but "Pulling" ends the
+// image: compose reports skipped and failed images once and never mentions
+// them again.
+func (p *pullProgress) imageEvent(name, word string) (known, structural bool) {
+	switch word {
+	case "Pulling", "Pulled", "Skipped", "Warning", "Error":
+	default:
+		return false, false
+	}
+	img, created := p.image(name)
+	if img == nil {
+		return false, false
+	}
+	done := word != "Pulling"
+	structural = created || img.done != done
+	img.done = done
+	return true, structural
+}
+
+// image returns the image's state, adding it to the checklist on first sight
+// (layer events can arrive before the image's own "Pulling"). A nil result
+// means the row cap was reached.
+func (p *pullProgress) image(name string) (img *pullImage, created bool) {
+	known, created := p.track(name)
+	if !known {
+		return nil, false
+	}
+	img = p.images[name]
+	if img == nil {
+		img = &pullImage{layers: map[string]*pullLayer{}}
+		p.images[name] = img
+	}
+	return img, created
+}
+
+// publish repaints the checklist: one row per image, with how much of it has
+// come down, plus the overall total on the task line.
+func (p *pullProgress) publish() {
+	rows := make([]ui.ServiceRow, 0, len(p.order))
+	done := 0
+	var current, total int64
+	for _, name := range p.order {
+		img := p.images[name]
+		cur, tot := img.bytes()
+		current, total = current+cur, total+tot
+		row := ui.ServiceRow{Name: name, Ready: img.done}
+		switch {
+		case img.done:
+			done++
+		case tot > 0:
+			row.Detail = fmt.Sprintf("%d%%  %s / %s", cur*100/tot, humanBytes(cur), humanBytes(tot))
+		}
+		rows = append(rows, row)
+	}
+	p.services(rows)
+
+	extra := fmt.Sprintf("%d/%d images", done, len(rows))
+	if total > 0 {
+		extra += fmt.Sprintf(" · %s / %s", humanBytes(current), humanBytes(total))
+	}
+	p.extra(extra)
+}
+
+// bytes sums the image's layers. Layers already present locally announce no
+// size and simply count as nothing.
+func (img *pullImage) bytes() (current, total int64) {
+	for _, l := range img.layers {
+		current, total = current+l.current, total+l.total
+	}
+	return current, total
+}
+
+// startProgress turns `docker compose up` progress output into a live
+// per-container checklist. Compose names every transition it makes, which is
+// the only way to tell a container that is being replaced from one that is
+// coming up: `docker ps` shows the outgoing container as healthy right up to
+// the moment it is stopped, so a --force-recreate rollout otherwise looks like
+// a stack that is already fully up.
+//
+// Container events carry "Container <name>" as the id and the phase word in
+// "status" ("Recreate", "Starting", "Waiting", "Healthy"). Everything else
+// compose touches (networks, volumes) is ignored.
+type startProgress struct {
+	checklist
+	// waitHealth records that `up --wait` is in play, so a started container
+	// is only halfway there: compose follows it with a health check.
+	waitHealth bool
+	states     map[string]string
+}
+
+func newStartProgress(services func([]ui.ServiceRow), extra func(string), waitHealth bool) *startProgress {
+	return &startProgress{
+		checklist:  checklist{services: services, extra: extra},
+		waitHealth: waitHealth,
+		states:     map[string]string{},
+	}
+}
+
+func (p *startProgress) line(s string) {
+	e, ok := decodeEvent(s)
+	if !ok {
+		return
+	}
+	name, isContainer := strings.CutPrefix(e.ID, "Container ")
+	if !isContainer {
+		return
+	}
+	// "Skipped: <reason>" is the one phase word carrying its own punctuation.
+	word := strings.TrimSuffix(firstWord(e.Status), ":")
+	if _, ok := startPhases[word]; !ok {
+		return
+	}
+	name = shortContainerName(name)
+	known, created := p.track(name)
+	if !known {
+		return
+	}
+	structural := created || p.ready(p.states[name]) != p.ready(word)
+	p.states[name] = word
+	if p.due(structural) {
+		p.publish()
+	}
+}
+
+func (p *startProgress) publish() {
+	rows := make([]ui.ServiceRow, 0, len(p.order))
+	done := 0
+	for _, name := range p.order {
+		ready := p.ready(p.states[name])
+		if ready {
+			done++
+		}
+		rows = append(rows, ui.ServiceRow{Name: name, Detail: startPhases[p.states[name]], Ready: ready})
+	}
+	p.services(rows)
+	p.extra(fmt.Sprintf("%d/%d ready", done, len(rows)))
+}
+
+// ready reports whether a container has reached its final state for this run.
+func (p *startProgress) ready(word string) bool {
+	switch word {
+	case "Healthy", "Exited", "Skipped":
+		return true
+	case "Started", "Running", "Restarted":
+		// Without --wait these are as far as the run goes; with it, compose
+		// keeps polling health and reports again.
+		return !p.waitHealth
+	}
+	return false
+}
+
+// startPhases maps compose's container status words to what the checklist
+// shows next to the container. Words outside this set are compose internals
+// the operator has no use for.
+var startPhases = map[string]string{
+	"Creating":   "creating",
+	"Created":    "created",
+	"Recreate":   "replacing",
+	"Recreated":  "replaced",
+	"Restart":    "restarting",
+	"Restarted":  "restarted",
+	"Stopping":   "stopping",
+	"Stopped":    "stopped",
+	"Killing":    "stopping",
+	"Killed":     "stopped",
+	"Removing":   "removing",
+	"Removed":    "removed",
+	"Starting":   "starting",
+	"Started":    "started",
+	"Running":    "running",
+	"Waiting":    "waiting for health",
+	"Healthy":    "healthy",
+	"Exited":     "exited",
+	"Skipped":    "skipped",
+	"Error":      "failed",
+	"Restarting": "restarting",
+}
+
+// decodeEvent reads one progress line in either format. plain prints the
+// fields space-separated (" <id> <text> <status text>"), which stays
+// unambiguous only because compose's ids are either a single word or the
+// "<Kind> <name>" pair this rejoins.
+func decodeEvent(s string) (composeEvent, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return composeEvent{}, false
+	}
+	if strings.HasPrefix(s, "{") {
+		var e composeEvent
+		if err := json.Unmarshal([]byte(s), &e); err != nil || e.ID == "" {
+			return composeEvent{}, false
+		}
+		return e, true
+	}
+	fields := strings.Fields(s)
+	if len(fields) < 2 {
+		return composeEvent{}, false
+	}
+	if _, ok := composeObjects[fields[0]]; ok {
+		if len(fields) < 3 {
+			return composeEvent{}, false
+		}
+		return composeEvent{ID: fields[0] + " " + fields[1], Status: strings.Join(fields[2:], " ")}, true
+	}
+	if isLayerID(fields[0]) {
+		// A layer's plain line has no parseable counters ("12.3MB/45MB" as
+		// free text), and dropping it keeps layers out of the image list.
+		return composeEvent{}, false
+	}
+	return composeEvent{ID: fields[0], Text: strings.Join(fields[1:], " ")}, true
+}
+
+// composeObjects are the id prefixes compose gives non-image events; they are
+// what makes an id two words long.
+var composeObjects = map[string]struct{}{
+	"Container": {}, "Network": {}, "Volume": {}, "Image": {},
+}
+
+// shortContainerName trims the parts of a compose container name every row
+// would repeat: the project prefix and the replica index.
+func shortContainerName(name string) string {
+	name = strings.TrimPrefix(name, dockercmd.ProjectName+"-")
+	if i := strings.LastIndexByte(name, '-'); i > 0 && isDigits(name[i+1:]) {
+		name = name[:i]
+	}
+	return name
+}
+
+func isDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func firstWord(s string) string {
+	if i := strings.IndexByte(s, ' '); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+// isLayerID reports whether s looks like docker's truncated layer id rather
+// than a compose service name.
+func isLayerID(s string) bool {
+	if len(s) < 8 {
+		return false
+	}
+	for _, r := range s {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			return false
+		}
+	}
+	return true
+}
+
+// humanBytes renders download sizes the way docker does: decimal units, with
+// enough precision to see the number move.
+func humanBytes(n int64) string {
+	const k = 1000
+	switch {
+	case n < k*k:
+		return fmt.Sprintf("%.0f kB", float64(n)/k)
+	case n < k*k*k:
+		return fmt.Sprintf("%.1f MB", float64(n)/(k*k))
+	default:
+		return fmt.Sprintf("%.2f GB", float64(n)/(k*k*k))
+	}
+}
+
+// lineWriter feeds whole lines to emit as they arrive, so a long-running
+// command can drive the UI while it is still writing.
+type lineWriter struct {
+	buf  bytes.Buffer
+	emit func(string)
+}
+
+func (w *lineWriter) Write(p []byte) (int, error) {
+	w.buf.Write(p)
+	for {
+		line, err := w.buf.ReadString('\n')
+		if err != nil {
+			// Partial line: put it back and wait for the rest.
+			w.buf.WriteString(line)
+			return len(p), nil
+		}
+		w.emit(strings.TrimRight(line, "\r\n"))
+	}
+}

--- a/cli/internal/deploy/install/progress.go
+++ b/cli/internal/deploy/install/progress.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
@@ -351,6 +352,11 @@ type startProgress struct {
 	// is only halfway there: compose follows it with a health check.
 	waitHealth bool
 	states     map[string]string
+	// reported records that the event stream has produced a checklist. The
+	// health poll runs alongside as a backstop and reads this to know whether
+	// compose is saying anything, so it is written and read from two
+	// goroutines.
+	reported atomic.Bool
 }
 
 func newStartProgress(services func([]ui.ServiceRow), extra func(string), waitHealth bool) *startProgress {
@@ -399,7 +405,12 @@ func (p *startProgress) publish() {
 	}
 	p.services(rows)
 	p.extra(fmt.Sprintf("%d/%d ready", done, len(rows)))
+	p.reported.Store(true)
 }
+
+// reporting reports whether compose's output has described the rollout. Until
+// it has, the checklist has to come from somewhere else.
+func (p *startProgress) reporting() bool { return p.reported.Load() }
 
 // ready reports whether a container has reached its final state for this run.
 func (p *startProgress) ready(word string) bool {
@@ -439,6 +450,23 @@ var startPhases = map[string]string{
 	"Skipped":    "skipped",
 	"Error":      "failed",
 	"Restarting": "restarting",
+}
+
+// healthDetail says what a container is doing, read off `docker ps` status
+// text. It answers in the same words the event stream uses, so a checklist
+// reads the same whichever of the two filled it in.
+func healthDetail(status string) string {
+	switch {
+	case strings.Contains(status, "(healthy)"):
+		return "healthy"
+	case strings.Contains(status, "(unhealthy)"):
+		return "unhealthy"
+	case strings.Contains(status, "(health: starting)"), strings.Contains(status, "(starting)"):
+		return "waiting for health"
+	case strings.HasPrefix(status, "Up"):
+		return "running"
+	}
+	return strings.ToLower(firstWord(status))
 }
 
 // decodeEvent reads one progress line in either format. plain prints the

--- a/cli/internal/deploy/install/progress.go
+++ b/cli/internal/deploy/install/progress.go
@@ -54,24 +54,34 @@ func (in *installer) progressMode(ctx context.Context) string {
 		return progressJSON
 	case in.composeAtLeast(ctx, minProgressVersion):
 		return progressPlain
+	case !in.composeVersionKnown(ctx):
+		// A version that doesn't parse is a build too new or too odd to have
+		// a number, not a compose from before 2.19: give it the older mode
+		// rather than dropping the phase's display entirely.
+		return progressPlain
 	default:
 		return ""
 	}
 }
 
-// composeAtLeast reports whether the installed compose is at least min. A
-// version that doesn't parse ("dev" builds) counts as too old: an unknown flag
-// fails the command outright, which is not a trade worth making for output.
+// composeAtLeast reports whether the installed compose is known to be at least
+// min. An unreadable version answers no: passing a flag compose might not know
+// fails the command outright.
 func (in *installer) composeAtLeast(ctx context.Context, min string) bool {
+	if !in.composeVersionKnown(ctx) {
+		return false
+	}
+	have, _ := version.Parse(in.compose.Version(ctx))
+	want, _ := version.Parse(min)
+	return !have.LessThan(want)
+}
+
+func (in *installer) composeVersionKnown(ctx context.Context) bool {
 	if in.compose == nil {
 		return false
 	}
-	have, ok := version.Parse(in.compose.Version(ctx))
-	if !ok {
-		return false
-	}
-	want, _ := version.Parse(min)
-	return !have.LessThan(want)
+	_, ok := version.Parse(in.compose.Version(ctx))
+	return ok
 }
 
 // composeEvent is compose's json progress event, narrowed to the fields these
@@ -240,12 +250,11 @@ func (p *pullProgress) imageEvent(name, text string) (known, structural bool) {
 	}
 	switch word {
 	case "Skipped":
-		// Compose skips an image for several reasons ("Skipped - Image is
-		// already present locally", "- No image to be pulled"); the one an
-		// operator is owed an explanation for is the cached image.
-		img.note = "skipped"
-		if strings.Contains(text, "already present") {
-			img.note = "already present"
+		// An image already on the host is as pulled as one that just came
+		// down, and reads better as such. Compose's other skips (nothing to
+		// pull, buildable image) do need naming.
+		if !strings.Contains(text, "already present") {
+			img.note = "skipped"
 		}
 	case "Error":
 		img.note = "failed"
@@ -288,7 +297,7 @@ func (p *pullProgress) publish() {
 		switch {
 		case img.done:
 			done++
-			row.Detail = img.finished(tot)
+			row.Detail = img.finished()
 		case cur < tot:
 			row.Detail = fmt.Sprintf("%d%%  %s / %s", cur*100/tot, humanBytes(cur), humanBytes(tot))
 		default:
@@ -307,17 +316,14 @@ func (p *pullProgress) publish() {
 	p.extra(extra)
 }
 
-// finished is what a completed image's row says: why it was skipped, how much
-// came down, or that there was nothing to fetch.
-func (img *pullImage) finished(total int64) string {
-	switch {
-	case img.note != "":
+// finished is what a completed image's row says. Whether it came down now or
+// was already on the host, the answer to the only question being asked is the
+// same: the image is here.
+func (img *pullImage) finished() string {
+	if img.note != "" {
 		return img.note
-	case total > 0:
-		return humanBytes(total)
-	default:
-		return "up to date"
 	}
+	return "pulled"
 }
 
 // bytes sums the image's layers. Layers already present locally announce no
@@ -467,6 +473,41 @@ func decodeEvent(s string) (composeEvent, bool) {
 		return composeEvent{}, false
 	}
 	return composeEvent{ID: fields[0], Text: strings.Join(fields[1:], " ")}, true
+}
+
+// failureTail is the end of a failed phase's output, as a person should read
+// it. The phases the wizard drives ask compose for json, which is a fine thing
+// to parse and a terrible thing to be shown, so events are rendered back into
+// the line plain progress would have printed; whatever compose wrote outside
+// the event stream — where the error itself arrives — is kept verbatim.
+func failureTail(captured string, limit int) []string {
+	var lines []string
+	for _, raw := range strings.Split(captured, "\n") {
+		line := strings.TrimSpace(raw)
+		if strings.HasPrefix(line, "{") {
+			line = readableEvent(line)
+		}
+		if line == "" {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	if len(lines) > limit {
+		lines = lines[len(lines)-limit:]
+	}
+	return lines
+}
+
+// readableEvent renders one json progress event as "<id> <what happened>",
+// empty when the event has nothing to say. A line that only looked like an
+// event is returned unchanged rather than dropped: compose's own words matter
+// more here than the guess that they were json.
+func readableEvent(line string) string {
+	var e composeEvent
+	if err := json.Unmarshal([]byte(line), &e); err != nil {
+		return line
+	}
+	return strings.TrimSpace(e.ID + " " + strings.TrimSpace(e.Text+" "+e.Status))
 }
 
 // composeObjects are the id prefixes compose gives non-image events; they are

--- a/cli/internal/deploy/install/progress.go
+++ b/cli/internal/deploy/install/progress.go
@@ -26,6 +26,9 @@ const (
 	// 2.29; older versions reject the value outright.
 	minProgressVersion     = "2.19.0"
 	minProgressJSONVersion = "2.29.0"
+
+	// `pull --policy` landed in compose 2.22.
+	minPullPolicyVersion = "2.22.0"
 )
 
 const (
@@ -46,20 +49,29 @@ func (in *installer) progressMode(ctx context.Context) string {
 	if in.wiz == nil || in.opts.Verbose || in.compose == nil {
 		return ""
 	}
-	// Unparsable versions ("dev" builds) get the older flag: compose rejects
-	// a mode it doesn't know, and the phase's display is not worth failing a
-	// deployment over.
+	switch {
+	case in.composeAtLeast(ctx, minProgressJSONVersion):
+		return progressJSON
+	case in.composeAtLeast(ctx, minProgressVersion):
+		return progressPlain
+	default:
+		return ""
+	}
+}
+
+// composeAtLeast reports whether the installed compose is at least min. A
+// version that doesn't parse ("dev" builds) counts as too old: an unknown flag
+// fails the command outright, which is not a trade worth making for output.
+func (in *installer) composeAtLeast(ctx context.Context, min string) bool {
+	if in.compose == nil {
+		return false
+	}
 	have, ok := version.Parse(in.compose.Version(ctx))
 	if !ok {
-		return progressPlain
+		return false
 	}
-	if minJSON, _ := version.Parse(minProgressJSONVersion); !have.LessThan(minJSON) {
-		return progressJSON
-	}
-	if minAny, _ := version.Parse(minProgressVersion); !have.LessThan(minAny) {
-		return progressPlain
-	}
-	return ""
+	want, _ := version.Parse(min)
+	return !have.LessThan(want)
 }
 
 // composeEvent is compose's json progress event, narrowed to the fields these
@@ -128,7 +140,15 @@ type pullProgress struct {
 }
 
 type pullImage struct {
-	done   bool
+	done bool
+	// phase is what the image's layers are busy with, shown when there are no
+	// bytes to show — an image whose layers are all present locally moves
+	// through this checklist without a single counter.
+	phase string
+	rank  int
+	// note is how the image finished, when that is worth more than the tick:
+	// why it was skipped, or that it failed.
+	note   string
 	layers map[string]*pullLayer
 }
 
@@ -154,7 +174,11 @@ func (p *pullProgress) line(s string) {
 
 func (p *pullProgress) event(e composeEvent) (known, structural bool) {
 	if e.ParentID == "" {
-		return p.imageEvent(e.ID, firstWord(e.Text))
+		return p.imageEvent(e.ID, e.Text)
+	}
+	phase, ok := pullPhases[e.Text]
+	if !ok {
+		return false, false
 	}
 	img, _ := p.image(e.ParentID)
 	if img == nil {
@@ -174,16 +198,37 @@ func (p *pullProgress) event(e composeEvent) (known, structural bool) {
 		// Finished layers report no counters at all, so hold them at the
 		// last total they announced rather than letting the sum shrink.
 		layer.current = layer.total
-	default:
-		return false, false
+	}
+	// Layers finish out of order, so the image shows the furthest phase any of
+	// them has reached rather than whichever reported last.
+	if phase.rank > img.rank {
+		img.rank, img.phase = phase.rank, phase.word
 	}
 	return true, false
+}
+
+// pullPhases ranks the per-layer phases docker reports, with what the checklist
+// says while an image sits in each.
+var pullPhases = map[string]struct {
+	rank int
+	word string
+}{
+	"Preparing":          {1, "preparing"},
+	"Pulling fs layer":   {1, "preparing"},
+	"Waiting":            {1, "preparing"},
+	"Already exists":     {2, "already present"},
+	"Downloading":        {3, "downloading"},
+	"Verifying Checksum": {4, "verifying"},
+	"Download complete":  {4, "downloaded"},
+	"Extracting":         {5, "extracting"},
+	"Pull complete":      {6, "unpacked"},
 }
 
 // imageEvent records an image-level phase. Everything but "Pulling" ends the
 // image: compose reports skipped and failed images once and never mentions
 // them again.
-func (p *pullProgress) imageEvent(name, word string) (known, structural bool) {
+func (p *pullProgress) imageEvent(name, text string) (known, structural bool) {
+	word := firstWord(text)
 	switch word {
 	case "Pulling", "Pulled", "Skipped", "Warning", "Error":
 	default:
@@ -192,6 +237,20 @@ func (p *pullProgress) imageEvent(name, word string) (known, structural bool) {
 	img, created := p.image(name)
 	if img == nil {
 		return false, false
+	}
+	switch word {
+	case "Skipped":
+		// Compose skips an image for several reasons ("Skipped - Image is
+		// already present locally", "- No image to be pulled"); the one an
+		// operator is owed an explanation for is the cached image.
+		img.note = "skipped"
+		if strings.Contains(text, "already present") {
+			img.note = "already present"
+		}
+	case "Error":
+		img.note = "failed"
+	case "Warning":
+		img.note = "warning"
 	}
 	done := word != "Pulling"
 	structural = created || img.done != done
@@ -229,8 +288,13 @@ func (p *pullProgress) publish() {
 		switch {
 		case img.done:
 			done++
-		case tot > 0:
+			row.Detail = img.finished(tot)
+		case cur < tot:
 			row.Detail = fmt.Sprintf("%d%%  %s / %s", cur*100/tot, humanBytes(cur), humanBytes(tot))
+		default:
+			// Nothing is moving over the network: either the layers are all
+			// local, or the download is done and the image is being unpacked.
+			row.Detail = img.phase
 		}
 		rows = append(rows, row)
 	}
@@ -241,6 +305,19 @@ func (p *pullProgress) publish() {
 		extra += fmt.Sprintf(" · %s / %s", humanBytes(current), humanBytes(total))
 	}
 	p.extra(extra)
+}
+
+// finished is what a completed image's row says: why it was skipped, how much
+// came down, or that there was nothing to fetch.
+func (img *pullImage) finished(total int64) string {
+	switch {
+	case img.note != "":
+		return img.note
+	case total > 0:
+		return humanBytes(total)
+	default:
+		return "up to date"
+	}
 }
 
 // bytes sums the image's layers. Layers already present locally announce no

--- a/cli/internal/deploy/install/progress_test.go
+++ b/cli/internal/deploy/install/progress_test.go
@@ -49,7 +49,9 @@ func TestPullProgressPlainTracksImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := sink.render(); got != "✓backend up to date, relational_db,✓cache already present" {
+	// An image that was already on the host reads as pulled: the row answers
+	// "is this image here", not "did bytes move".
+	if got := sink.render(); got != "✓backend pulled, relational_db,✓cache pulled" {
 		t.Errorf("rows = %q", got)
 	}
 	if sink.extra != "2/3 images" {
@@ -108,6 +110,36 @@ func TestPullProgressReportsDownloadedBytes(t *testing.T) {
 	}
 	if sink.extra != "0/2 images · 1.6 MB / 3.1 MB" {
 		t.Errorf("extra = %q", sink.extra)
+	}
+}
+
+// The wizard asks compose for json, so a failed phase's captured output has to
+// be turned back into something readable before it is shown as scrollback.
+func TestFailureTailRendersEvents(t *testing.T) {
+	captured := strings.Join([]string{
+		`{"id":"Container onyx-api_server-1","status":"Starting"}`,
+		`{"id":"9d8e18e5f8e4","parent_id":"backend","text":"Downloading","current":5,"total":50}`,
+		`{"dry-run":false}`,
+		`{"tail":true,"text":"container onyx-api_server-1 is unhealthy"}`,
+		`Error response from daemon: no such image`,
+		``,
+	}, "\n")
+
+	got := failureTail(captured, 10)
+	want := []string{
+		"Container onyx-api_server-1 Starting",
+		"9d8e18e5f8e4 Downloading",
+		"container onyx-api_server-1 is unhealthy",
+		"Error response from daemon: no such image",
+	}
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Errorf("tail = %q, want %q", got, want)
+	}
+
+	// The tail is the end of the output, so the error that ended the run is
+	// what survives the cut.
+	if got := failureTail(captured, 1); len(got) != 1 || got[0] != want[len(want)-1] {
+		t.Errorf("capped tail = %q", got)
 	}
 }
 

--- a/cli/internal/deploy/install/progress_test.go
+++ b/cli/internal/deploy/install/progress_test.go
@@ -174,6 +174,39 @@ func TestStartProgressSeparatesStoppingFromStarting(t *testing.T) {
 	}
 }
 
+// The health poll runs behind the event stream, so it has to know when the
+// stream has taken over — and say the same things while it hasn't.
+func TestStartProgressBacksOffOnceComposeSpeaks(t *testing.T) {
+	var sink checklistSink
+	services, extra := sink.hooks()
+	p := newStartProgress(services, extra, true)
+
+	// Networks and volumes are not the rollout: until a container is named,
+	// the checklist is still empty and the poll is what fills it.
+	p.line(`{"id":"Network onyx_default","status":"Created"}`)
+	if p.reporting() {
+		t.Error("a network event is not a per-service report")
+	}
+	p.line(`{"id":"Container onyx-api_server-1","status":"Starting"}`)
+	if !p.reporting() {
+		t.Error("a container event should hand the checklist to the event stream")
+	}
+
+	// Whichever side fills the checklist, a row reads the same.
+	for _, tc := range []struct{ status, want string }{
+		{"Up 2 minutes (healthy)", "healthy"},
+		{"Up 3 seconds (health: starting)", "waiting for health"},
+		{"Up 9 minutes (unhealthy)", "unhealthy"},
+		{"Up About an hour", "running"},
+		{"Restarting (1) 4 seconds ago", "restarting"},
+		{"Exited (0) 1 minute ago", "exited"},
+	} {
+		if got := healthDetail(tc.status); got != tc.want {
+			t.Errorf("healthDetail(%q) = %q, want %q", tc.status, got, tc.want)
+		}
+	}
+}
+
 // Plain progress names containers the same way, just space-separated.
 func TestStartProgressPlainLines(t *testing.T) {
 	var sink checklistSink

--- a/cli/internal/deploy/install/progress_test.go
+++ b/cli/internal/deploy/install/progress_test.go
@@ -49,11 +49,38 @@ func TestPullProgressPlainTracksImages(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := sink.render(); got != "✓backend, relational_db,✓cache" {
+	if got := sink.render(); got != "✓backend up to date, relational_db,✓cache already present" {
 		t.Errorf("rows = %q", got)
 	}
 	if sink.extra != "2/3 images" {
 		t.Errorf("extra = %q", sink.extra)
+	}
+}
+
+// An image whose layers are all on the host reports no byte counters at all,
+// so its row has to say what is happening some other way.
+func TestPullProgressReportsCachedLayers(t *testing.T) {
+	var sink checklistSink
+	p := newPullProgress(sink.hooks())
+	for _, line := range []string{
+		`{"id":"cache","text":"Pulling"}`,
+		`{"id":"9d8e18e5f8e4","parent_id":"cache","text":"Already exists"}`,
+		`{"id":"5f8e4a1b2c3d","parent_id":"cache","text":"Already exists"}`,
+	} {
+		p.line(line)
+	}
+	p.publish()
+
+	if got := sink.render(); got != " cache already present" {
+		t.Errorf("rows = %q", got)
+	}
+
+	// Downloaded layers still have to be unpacked, which is the other phase
+	// with no bytes left to count.
+	p.line(`{"id":"5f8e4a1b2c3d","parent_id":"cache","text":"Extracting","current":2,"total":4}`)
+	p.publish()
+	if got := sink.render(); got != " cache extracting" {
+		t.Errorf("rows = %q", got)
 	}
 }
 

--- a/cli/internal/deploy/install/progress_test.go
+++ b/cli/internal/deploy/install/progress_test.go
@@ -195,7 +195,7 @@ func TestStartProgressBacksOffOnceComposeSpeaks(t *testing.T) {
 	// Whichever side fills the checklist, a row reads the same.
 	for _, tc := range []struct{ status, want string }{
 		{"Up 2 minutes (healthy)", "healthy"},
-		{"Up 3 seconds (health: starting)", "waiting for health"},
+		{"Up 3 seconds (health: starting)", "waiting"},
 		{"Up 9 minutes (unhealthy)", "unhealthy"},
 		{"Up About an hour", "running"},
 		{"Restarting (1) 4 seconds ago", "restarting"},
@@ -204,6 +204,45 @@ func TestStartProgressBacksOffOnceComposeSpeaks(t *testing.T) {
 		if got := healthDetail(tc.status); got != tc.want {
 			t.Errorf("healthDetail(%q) = %q, want %q", tc.status, got, tc.want)
 		}
+	}
+}
+
+// A container list shows what is running, not what a rollout is doing. Against
+// the containers the phase started with, it shows all three states: waiting its
+// turn, mid-swap, and up on the new deployment.
+func TestWatchRowsTellsReplacedFromPending(t *testing.T) {
+	w := healthWatch{
+		before: map[string]string{
+			"api_server":      "aaaa1111",
+			"background":      "bbbb2222",
+			"relational_db":   "cccc3333",
+			"inference_model": "dddd4444",
+		},
+		recreate: true,
+	}
+	// background's container is gone from the list: it is between the two.
+	ps := strings.Join([]string{
+		"onyx-relational_db-1\tcccc3333\tUp 2 hours (healthy)",
+		"onyx-api_server-1\t9999eeee\tUp 4 seconds (health: starting)",
+		"onyx-inference_model-1\t8888ffff\tUp 30 seconds (healthy)",
+	}, "\n")
+
+	rows, ready := watchRows(ps, w)
+	var sink checklistSink
+	sink.rows = rows
+	want := " api_server waiting, background restarting,✓inference_model healthy, relational_db pending"
+	if got := sink.render(); got != want {
+		t.Errorf("rows = %q, want %q", got, want)
+	}
+	if ready != 1 {
+		t.Errorf("ready = %d, want 1", ready)
+	}
+
+	// Without a recreate, compose is free to leave a container alone, so the
+	// one it kept is done rather than pending.
+	w.recreate = false
+	if _, ready := watchRows(ps, w); ready != 2 {
+		t.Errorf("ready = %d, want 2", ready)
 	}
 }
 

--- a/cli/internal/deploy/install/progress_test.go
+++ b/cli/internal/deploy/install/progress_test.go
@@ -1,0 +1,136 @@
+package install
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/ui"
+)
+
+// checklistSink collects what a tracker would push to the wizard.
+type checklistSink struct {
+	rows  []ui.ServiceRow
+	extra string
+}
+
+func (s *checklistSink) hooks() (func([]ui.ServiceRow), func(string)) {
+	return func(r []ui.ServiceRow) { s.rows = r }, func(e string) { s.extra = e }
+}
+
+// render flattens the checklist the way the pane shows it, so assertions read
+// like the screen: "name state" per row, ✓ for finished.
+func (s *checklistSink) render() string {
+	out := make([]string, 0, len(s.rows))
+	for _, r := range s.rows {
+		mark := " "
+		if r.Ready {
+			mark = "✓"
+		}
+		row := mark + r.Name
+		if r.Detail != "" {
+			row += " " + r.Detail
+		}
+		out = append(out, row)
+	}
+	return strings.Join(out, ",")
+}
+
+// Plain progress carries no counters, so the pull checklist is just which
+// images are done. Layer events (hex ids) are noise at this level.
+func TestPullProgressPlainTracksImages(t *testing.T) {
+	var sink checklistSink
+	p := newPullProgress(sink.hooks())
+	w := &lineWriter{emit: p.line}
+	if _, err := w.Write([]byte(" backend Pulling \n relational_db Pulling \n 9d8e18e5f8e4 Pulling fs layer \n" +
+		" 9d8e18e5f8e4 Downloading [====>   ]  5.5MB/50MB\n 9d8e18e5f8e4 Waiting \n cache Skipped ")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := w.Write([]byte("- Image is already present locally\n backend Pulled \n")); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := sink.render(); got != "✓backend, relational_db,✓cache" {
+		t.Errorf("rows = %q", got)
+	}
+	if sink.extra != "2/3 images" {
+		t.Errorf("extra = %q", sink.extra)
+	}
+}
+
+// json progress adds per-layer byte counters, which the checklist sums into
+// per-image download progress.
+func TestPullProgressReportsDownloadedBytes(t *testing.T) {
+	var sink checklistSink
+	p := newPullProgress(sink.hooks())
+	for _, line := range []string{
+		`{"id":"backend","text":"Pulling"}`,
+		`{"id":"5f8e4a1b2c3d","parent_id":"backend","text":"Downloading","current":524288,"total":2097152,"percent":25}`,
+		`{"id":"9d8e18e5f8e4","parent_id":"backend","text":"Downloading","current":1048576,"total":1048576,"percent":100}`,
+		// Completed layers report no counters at all: the total must not drop.
+		`{"id":"9d8e18e5f8e4","parent_id":"backend","text":"Download complete","percent":100}`,
+		// Extraction reports the uncompressed size — not a download.
+		`{"id":"9d8e18e5f8e4","parent_id":"backend","text":"Extracting","current":4194304,"total":8388608}`,
+		`{"id":"relational_db","text":"Pulling"}`,
+	} {
+		p.line(line)
+	}
+	p.publish() // byte updates are rate-limited; render what has accumulated
+
+	if got := sink.render(); got != " backend 50%  1.6 MB / 3.1 MB, relational_db" {
+		t.Errorf("rows = %q", got)
+	}
+	if sink.extra != "0/2 images · 1.6 MB / 3.1 MB" {
+		t.Errorf("extra = %q", sink.extra)
+	}
+}
+
+// The start checklist has to say which container is being replaced and which
+// is coming up: with --force-recreate both happen, and `docker ps` alone can't
+// tell them apart.
+func TestStartProgressSeparatesStoppingFromStarting(t *testing.T) {
+	var sink checklistSink
+	services, extra := sink.hooks()
+	p := newStartProgress(services, extra, true)
+
+	for _, line := range []string{
+		`{"id":"Network onyx_default","status":"Created"}`,
+		`{"id":"Container onyx-relational_db-1","status":"Running"}`,
+		`{"id":"Container onyx-api_server-1","status":"Recreate"}`,
+		`{"id":"Container onyx-api_server-1","status":"Recreated"}`,
+		`{"id":"Container onyx-api_server-1","status":"Starting"}`,
+		`{"id":"Container onyx-api_server-1","status":"Started"}`,
+		`{"id":"Container onyx-relational_db-1","status":"Waiting"}`,
+		`{"id":"Container onyx-relational_db-1","status":"Healthy"}`,
+	} {
+		p.line(line)
+	}
+	p.publish()
+
+	// --wait is in play, so a started container is not done until healthy.
+	if got := sink.render(); got != "✓relational_db healthy, api_server started" {
+		t.Errorf("rows = %q", got)
+	}
+	if sink.extra != "1/2 ready" {
+		t.Errorf("extra = %q", sink.extra)
+	}
+}
+
+// Plain progress names containers the same way, just space-separated.
+func TestStartProgressPlainLines(t *testing.T) {
+	var sink checklistSink
+	services, extra := sink.hooks()
+	p := newStartProgress(services, extra, false)
+	w := &lineWriter{emit: p.line}
+	if _, err := w.Write([]byte(" Volume \"onyx_db_volume\"  Created\n Container onyx-cache-1  Recreate\n" +
+		" Container onyx-cache-1  Recreated\n Container onyx-cache-1  Started\n")); err != nil {
+		t.Fatal(err)
+	}
+
+	// No --wait: started is as far as this run goes.
+	if got := sink.render(); got != "✓cache started" {
+		t.Errorf("rows = %q", got)
+	}
+	if sink.extra != "1/1 ready" {
+		t.Errorf("extra = %q", sink.extra)
+	}
+}

--- a/cli/internal/deploy/install/sandbox.go
+++ b/cli/internal/deploy/install/sandbox.go
@@ -1,0 +1,59 @@
+package install
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"os"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/version"
+)
+
+// Craft sandbox constants (names pinned to match the compose overlay's
+// external declarations and the backend's configs).
+const (
+	defaultSandboxNetwork = "onyx_craft_sandbox"
+	sandboxProxyCAVolume  = "sandbox_proxy_ca"
+)
+
+// sandboxNetworkName honors the same env override install.sh does.
+func sandboxNetworkName() string {
+	if n := os.Getenv("SANDBOX_DOCKER_NETWORK"); n != "" {
+		return n
+	}
+	return defaultSandboxNetwork
+}
+
+// sandboxBackendForTag picks the Craft sandbox backend for an image tag: the
+// docker backend exists only in v4.0.6+, so older pinned tags get
+// "kubernetes" while rolling/non-semver tags (which track newest) get
+// "docker". Mirrors install.sh's sandbox_backend_for_tag.
+func sandboxBackendForTag(tag string) string {
+	v, ok := version.Parse(tag)
+	if !ok {
+		return "docker"
+	}
+	if v.LessThan(version.Semver{Major: 4, Minor: 0, Patch: 6}) {
+		return "kubernetes"
+	}
+	return "docker"
+}
+
+// randomHex returns n random bytes hex-encoded (install.sh: openssl rand -hex n).
+func randomHex(n int) string {
+	buf := make([]byte, n)
+	if _, err := rand.Read(buf); err != nil {
+		// crypto/rand failure means the platform's entropy source is broken;
+		// panicking beats silently generating weak secrets.
+		panic(err)
+	}
+	return hex.EncodeToString(buf)
+}
+
+// craftSecurityWarning is printed when Craft is enabled with the docker
+// sandbox backend (ported verbatim from install.sh).
+const craftSecurityWarning = `⚠  Craft + docker backend: api_server and background bind-mount
+⚠  /var/run/docker.sock (RW = root on host on compromise);
+⚠  sandbox-proxy bind-mounts it RO (still exposes container env,
+⚠  labels, and the events stream). Only enable on hosts you fully
+⚠  control. On EC2, require IMDSv2 (HttpTokens=required) so
+⚠  sandboxes cannot pull IAM credentials from instance metadata.`

--- a/cli/internal/deploy/install/status.go
+++ b/cli/internal/deploy/install/status.go
@@ -157,7 +157,7 @@ func (in *installer) inspectContainers(ctx context.Context) (services []Service,
 	}
 	in.docker.RefreshSudo(ctx)
 	cmd := in.docker.Command(nil, "ps", "-a",
-		"--filter", "label=com.docker.compose.project=onyx",
+		"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
 		"--format", "{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}")
 	res, err := in.deps.Runner.Run(ctx, cmd)
 	if err != nil {

--- a/cli/internal/deploy/install/status.go
+++ b/cli/internal/deploy/install/status.go
@@ -1,0 +1,227 @@
+package install
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+)
+
+// Status is the machine-readable `deploy status --json` payload.
+type Status struct {
+	Installed    bool      `json:"installed"`
+	Dir          string    `json:"dir"`
+	Source       string    `json:"source"`
+	ManifestTag  string    `json:"manifest_tag,omitempty"`
+	EnvTag       string    `json:"env_tag,omitempty"`
+	RunningTag   string    `json:"running_tag,omitempty"`
+	Mode         string    `json:"mode,omitempty"`
+	IncludeCraft bool      `json:"include_craft"`
+	AccessURL    string    `json:"access_url,omitempty"`
+	Services     []Service `json:"services"`
+	Healthy      bool      `json:"healthy"`
+}
+
+// Service is one container of the deployment.
+type Service struct {
+	Name   string `json:"name"`
+	Image  string `json:"image"`
+	Status string `json:"status"`
+}
+
+// RunStatus implements `deploy status`. Read-only: it never provisions or
+// mutates anything. Exit codes make it usable as a probe: 0 when installed
+// with all services up and none unhealthy, NotAvailable when no install
+// exists, General when stopped or degraded.
+func RunStatus(ctx context.Context, deps Deps, opts Options, jsonOut bool) error {
+	in := newInstaller(deps, opts)
+	return in.runStatus(ctx, jsonOut)
+}
+
+func (in *installer) runStatus(ctx context.Context, jsonOut bool) error {
+	in.root = paths.Resolve(in.opts.Dir)
+	st := Status{Dir: in.root.Dir, Source: string(in.root.Source)}
+
+	if !paths.IsInstall(in.root.Dir) {
+		if jsonOut {
+			return in.emitStatus(st, exitcodes.NotAvailable)
+		}
+		in.infof("No Onyx install found at %s", in.root.Dir)
+		for _, alt := range in.root.Ambiguous {
+			in.infof("(another install exists at %s — pass --dir to inspect it)", alt)
+		}
+		in.infof("Install one with: onyx-cli deploy install")
+		return exitcodes.New(exitcodes.NotAvailable, "not installed")
+	}
+	st.Installed = true
+
+	if manifest, err := state.Load(in.root.Dir); err != nil {
+		in.warnf("%v", err)
+	} else if manifest != nil {
+		st.ManifestTag = manifest.InstalledTag
+		st.Mode = string(manifest.Mode)
+		st.IncludeCraft = manifest.IncludeCraft
+	}
+	if env, err := os.ReadFile(filepath.Join(in.deploymentDir(), ".env")); err == nil {
+		st.EnvTag = Var(string(env), "IMAGE_TAG")
+	}
+	if st.Mode == "" {
+		st.Mode = "standard"
+		if in.overlayOnDisk(filepath.Base(deployfiles.LiteOverlay.DestRel)) {
+			st.Mode = "lite"
+		}
+	}
+
+	st.Services, st.RunningTag, st.AccessURL = in.inspectContainers(ctx)
+
+	up, unhealthy := 0, 0
+	for _, s := range st.Services {
+		if strings.HasPrefix(s.Status, "Up") {
+			up++
+		}
+		if strings.Contains(s.Status, "(unhealthy)") {
+			unhealthy++
+		}
+	}
+	st.Healthy = up > 0 && up == len(st.Services) && unhealthy == 0
+
+	if jsonOut {
+		code := exitcodes.Success
+		if !st.Healthy {
+			code = exitcodes.General
+		}
+		return in.emitStatus(st, code)
+	}
+
+	in.plainf("Onyx deployment at %s (%s)", st.Dir, st.Source)
+	in.plainf("  Mode: %s%s", st.Mode, map[bool]string{true: " + craft", false: ""}[st.IncludeCraft])
+	in.plainf("  Version (manifest): %s", orUnknown(st.ManifestTag))
+	in.plainf("  Version (.env):     %s", orUnknown(st.EnvTag))
+	in.plainf("  Version (running):  %s", orUnknown(st.RunningTag))
+	if drift(st.ManifestTag, st.EnvTag, st.RunningTag) {
+		in.warnf("Version drift detected — the manifest, .env, and running containers disagree.")
+		in.infof("A restart applies .env: onyx-cli deploy stop && onyx-cli deploy install")
+	}
+	in.plainf("")
+	if len(st.Services) == 0 {
+		in.infof("No containers found (deployment is stopped)")
+		return exitcodes.New(exitcodes.General, "deployment is stopped")
+	}
+	for _, s := range st.Services {
+		in.plainf("  %-40s %s", s.Name, s.Status)
+	}
+	in.plainf("")
+	if st.AccessURL != "" {
+		in.infof("Access Onyx at: %s", st.AccessURL)
+	}
+	if unhealthy > 0 {
+		in.warnf("%d service(s) unhealthy. Check logs with:", unhealthy)
+		in.plainf("  (cd %q && docker compose logs <service>)", in.deploymentDir())
+		return exitcodes.New(exitcodes.General, "deployment is degraded")
+	}
+	if up < len(st.Services) {
+		in.warnf("%d of %d containers are not running", len(st.Services)-up, len(st.Services))
+		return exitcodes.New(exitcodes.General, "deployment is partially stopped")
+	}
+	in.successf("All %d services are up", up)
+	return nil
+}
+
+func (in *installer) emitStatus(st Status, code exitcodes.Code) error {
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(in.deps.IOS.Out, string(data))
+	if code == exitcodes.Success {
+		return nil
+	}
+	return exitcodes.New(code, "see status output")
+}
+
+// inspectContainers lists the project's containers via the compose project
+// label (the project name is pinned to "onyx" in the compose file, so this
+// works regardless of directory names or which overlays are active).
+func (in *installer) inspectContainers(ctx context.Context) (services []Service, runningTag, accessURL string) {
+	if !dockercmd.Installed() {
+		return nil, "", ""
+	}
+	in.docker.RefreshSudo(ctx)
+	cmd := in.docker.Command(nil, "ps", "-a",
+		"--filter", "label=com.docker.compose.project=onyx",
+		"--format", "{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}")
+	res, err := in.deps.Runner.Run(ctx, cmd)
+	if err != nil {
+		in.warnf("Could not query docker: %v", err)
+		return nil, "", ""
+	}
+	for _, line := range strings.Split(strings.TrimSpace(res.Stdout), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.SplitN(line, "\t", 4)
+		if len(parts) < 3 {
+			continue
+		}
+		svc := Service{Name: parts[0], Image: parts[1], Status: parts[2]}
+		services = append(services, svc)
+		if runningTag == "" && strings.HasPrefix(svc.Status, "Up") {
+			if idx := strings.LastIndex(svc.Image, ":"); idx != -1 {
+				runningTag = svc.Image[idx+1:]
+			}
+		}
+		if accessURL == "" && len(parts) == 4 && strings.HasPrefix(svc.Status, "Up") {
+			if port := publishedHostPort(parts[3]); port != "" {
+				accessURL = "http://localhost:" + port
+			}
+		}
+	}
+	return services, runningTag, accessURL
+}
+
+var hostPortPattern = regexp.MustCompile(`(?:0\.0\.0\.0|\[::\]|127\.0\.0\.1):(\d+)->`)
+
+// publishedHostPort extracts the first published host port from a docker ps
+// Ports column (e.g. "0.0.0.0:3000->80/tcp, [::]:3000->80/tcp").
+func publishedHostPort(ports string) string {
+	m := hostPortPattern.FindStringSubmatch(ports)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// drift reports whether the known version numbers disagree (unknowns are
+// skipped rather than counted as drift).
+func drift(tags ...string) bool {
+	known := ""
+	for _, t := range tags {
+		if t == "" {
+			continue
+		}
+		if known == "" {
+			known = t
+			continue
+		}
+		if t != known {
+			return true
+		}
+	}
+	return false
+}
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}

--- a/cli/internal/deploy/install/status.go
+++ b/cli/internal/deploy/install/status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/ui"
 	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
 )
 
@@ -31,11 +32,28 @@ type Status struct {
 	Healthy      bool      `json:"healthy"`
 }
 
-// Service is one container of the deployment.
+// Service is one container of the deployment. The fields past Status are
+// filled in only for containers in trouble, from `docker inspect`.
 type Service struct {
-	Name   string `json:"name"`
-	Image  string `json:"image"`
-	Status string `json:"status"`
+	Name string `json:"name"`
+	// Service is the compose service behind the container ("api_server"),
+	// which is what the logs and compose commands take.
+	Service   string `json:"service,omitempty"`
+	Image     string `json:"image"`
+	Status    string `json:"status"`
+	Restarts  int    `json:"restarts,omitempty"`
+	ExitCode  int    `json:"exit_code,omitempty"`
+	OOMKilled bool   `json:"oom_killed,omitempty"`
+	Diagnosis string `json:"diagnosis,omitempty"`
+}
+
+// name is what to call the service in a command or a sentence: the compose
+// service when docker labelled it, the container otherwise.
+func (s Service) name() string {
+	if s.Service != "" {
+		return s.Service
+	}
+	return s.Name
 }
 
 // RunStatus implements `deploy status`. Read-only: it never provisions or
@@ -82,13 +100,14 @@ func (in *installer) runStatus(ctx context.Context, jsonOut bool) error {
 	}
 
 	st.Services, st.RunningTag, st.AccessURL = in.inspectContainers(ctx)
+	in.addFailureFacts(ctx, st.Services)
 
 	up, unhealthy := 0, 0
 	for _, s := range st.Services {
-		if strings.HasPrefix(s.Status, "Up") {
+		if isRunning(s) {
 			up++
 		}
-		if strings.Contains(s.Status, "(unhealthy)") {
+		if isUnhealthy(s) {
 			unhealthy++
 		}
 	}
@@ -104,9 +123,9 @@ func (in *installer) runStatus(ctx context.Context, jsonOut bool) error {
 
 	in.plainf("Onyx deployment at %s (%s)", st.Dir, st.Source)
 	in.plainf("  Mode: %s%s", st.Mode, map[bool]string{true: " + craft", false: ""}[st.IncludeCraft])
-	in.plainf("  Version (manifest): %s", orUnknown(st.ManifestTag))
-	in.plainf("  Version (.env):     %s", orUnknown(st.EnvTag))
-	in.plainf("  Version (running):  %s", orUnknown(st.RunningTag))
+	in.plainf("  Version (manifest): %s", in.orUnknown(st.ManifestTag))
+	in.plainf("  Version (.env):     %s", in.orUnknown(st.EnvTag))
+	in.plainf("  Version (running):  %s", in.orUnknown(st.RunningTag))
 	if drift(st.ManifestTag, st.EnvTag, st.RunningTag) {
 		in.warnf("Version drift detected — the manifest, .env, and running containers disagree.")
 		in.infof("A restart applies .env: onyx-cli deploy stop && onyx-cli deploy install")
@@ -117,19 +136,25 @@ func (in *installer) runStatus(ctx context.Context, jsonOut bool) error {
 		return exitcodes.New(exitcodes.General, "deployment is stopped")
 	}
 	for _, s := range st.Services {
-		in.plainf("  %-40s %s", s.Name, s.Status)
+		sev := severityOf(s.Status)
+		line := fmt.Sprintf("  %s %-40s %s", sev.paint(in.paint, sev.mark()), s.Name, in.paintStatus(s.Status))
+		if s.Restarts >= 2 {
+			line += in.paint.Dim(fmt.Sprintf("  ·  %d restarts", s.Restarts))
+		}
+		in.plainf("%s", line)
 	}
 	in.plainf("")
 	if st.AccessURL != "" {
 		in.infof("Access Onyx at: %s", st.AccessURL)
 	}
 	if unhealthy > 0 {
-		in.warnf("%d service(s) unhealthy. Check logs with:", unhealthy)
-		in.plainf("  (cd %q && docker compose logs <service>)", in.deploymentDir())
+		in.failf("%d of %d services unhealthy", unhealthy, len(st.Services))
+		in.explainFailures(st.Services, isUnhealthy)
 		return exitcodes.New(exitcodes.General, "deployment is degraded")
 	}
 	if up < len(st.Services) {
-		in.warnf("%d of %d containers are not running", len(st.Services)-up, len(st.Services))
+		in.failf("%d of %d containers are not running", len(st.Services)-up, len(st.Services))
+		in.explainFailures(st.Services, notRunning)
 		return exitcodes.New(exitcodes.General, "deployment is partially stopped")
 	}
 	in.successf("All %d services are up", up)
@@ -158,7 +183,7 @@ func (in *installer) inspectContainers(ctx context.Context) (services []Service,
 	in.docker.RefreshSudo(ctx)
 	cmd := in.docker.Command(nil, "ps", "-a",
 		"--filter", "label=com.docker.compose.project="+dockercmd.ProjectName,
-		"--format", "{{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}")
+		"--format", `{{.Names}}	{{.Image}}	{{.Status}}	{{.Ports}}	{{.Label "com.docker.compose.service"}}`)
 	res, err := in.deps.Runner.Run(ctx, cmd)
 	if err != nil {
 		in.warnf("Could not query docker: %v", err)
@@ -168,11 +193,14 @@ func (in *installer) inspectContainers(ctx context.Context) (services []Service,
 		if line == "" {
 			continue
 		}
-		parts := strings.SplitN(line, "\t", 4)
+		parts := strings.SplitN(line, "\t", 5)
 		if len(parts) < 3 {
 			continue
 		}
 		svc := Service{Name: parts[0], Image: parts[1], Status: parts[2]}
+		if len(parts) == 5 {
+			svc.Service = parts[4]
+		}
 		services = append(services, svc)
 		// Only Onyx app images carry the deployment version; infrastructure
 		// containers (nginx, postgres, redis, ...) have their own tags.
@@ -182,7 +210,7 @@ func (in *installer) inspectContainers(ctx context.Context) (services []Service,
 				runningTag = svc.Image[idx+1:]
 			}
 		}
-		if accessURL == "" && len(parts) == 4 && strings.HasPrefix(svc.Status, "Up") {
+		if accessURL == "" && len(parts) >= 4 && strings.HasPrefix(svc.Status, "Up") {
 			if port := publishedHostPort(parts[3]); port != "" {
 				accessURL = "http://localhost:" + port
 			}
@@ -222,9 +250,143 @@ func drift(tags ...string) bool {
 	return false
 }
 
-func orUnknown(s string) string {
+// isRunning, isUnhealthy and notRunning are the tests the verdict counts
+// with, so the sentences underneath it can be selected by the same rule the
+// number was.
+func isRunning(s Service) bool   { return strings.HasPrefix(s.Status, "Up") }
+func notRunning(s Service) bool  { return !isRunning(s) }
+func isUnhealthy(s Service) bool { return strings.Contains(s.Status, "(unhealthy)") }
+
+// addFailureFacts fills in what `docker ps` left out, for the containers a
+// verdict could end up reporting. Only those: the extra call costs a
+// round-trip, and a service that is up and healthy has nothing to explain.
+func (in *installer) addFailureFacts(ctx context.Context, services []Service) {
+	var names []string
+	for _, s := range services {
+		if notRunning(s) || isUnhealthy(s) {
+			names = append(names, s.Name)
+		}
+	}
+	facts := in.inspectFacts(ctx, names)
+	for i, s := range services {
+		f, ok := facts[s.Name]
+		if !ok {
+			continue
+		}
+		services[i].Restarts = f.Restarts
+		services[i].ExitCode = f.ExitCode
+		services[i].OOMKilled = f.OOMKilled
+		services[i].Diagnosis = f.diagnose(s.Status)
+	}
+}
+
+// explainFailures says what is wrong with each service the verdict above it
+// counted, and names the one command that shows why. Without it the worst
+// state on the board — a container that keeps dying — is also the only one the
+// report says nothing more about. troubled is the verdict's own test, so the
+// report can't claim two failures and then explain one.
+func (in *installer) explainFailures(services []Service, troubled func(Service) bool) {
+	var names []string
+	for _, s := range services {
+		if !troubled(s) {
+			continue
+		}
+		names = append(names, s.name())
+		if s.Diagnosis != "" {
+			in.plainf("  %s %s", s.name(), s.Diagnosis)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+	// Past a handful of failing services the list stops being a command
+	// worth pasting, and the whole deployment is the thing to look at.
+	named := " " + strings.Join(names, " ")
+	if len(names) > 3 {
+		named = ""
+	}
+	in.infof("See why: %s", in.paint.Accent("onyx-cli deploy logs"+in.dirArg()+named))
+}
+
+// severity is how much attention one container's state deserves.
+type severity int
+
+const (
+	sevOK severity = iota
+	sevWatch
+	sevBad
+)
+
+// severityOf reads a `docker ps` status through the same vocabulary the
+// install watcher uses: green once the container is up for good, red when it
+// is unhealthy or gone (a container restarting is crash-looping, not
+// starting), yellow while it is still on its way to either.
+func severityOf(status string) severity {
+	switch healthDetail(status) {
+	case "healthy", "running":
+		return sevOK
+	case "unhealthy", "exited", "dead", "restarting":
+		return sevBad
+	}
+	return sevWatch // waiting, created, paused, and whatever docker adds next
+}
+
+func (s severity) paint(p ui.Painter, text string) string {
+	switch s {
+	case sevOK:
+		return p.Ok(text)
+	case sevBad:
+		return p.Err(text)
+	}
+	return p.Warn(text)
+}
+
+// mark heads a service line, so a container in trouble stands out without
+// color having to carry it alone — piped output, NO_COLOR, and readers who
+// can't tell the two hues apart all still get the answer.
+func (s severity) mark() string {
+	switch s {
+	case sevOK:
+		return "✓"
+	case sevBad:
+		return "✗"
+	}
+	return "⚠"
+}
+
+var (
+	// trailingHealth is the verdict docker appends to a running container's
+	// status: "Up 5 minutes (healthy)", "(unhealthy)", "(health: starting)".
+	trailingHealth = regexp.MustCompile(`\([^()]*\)$`)
+	// leadingState is the state a stopped or looping container is in, with
+	// the exit code that belongs to it: "Exited (137) 1 minute ago".
+	leadingState = regexp.MustCompile(`^[A-Za-z]+( \(\d+\))?`)
+)
+
+// paintStatus colors what the status actually says about the container and
+// dims the rest. Elapsed time reads the same whatever state it belongs to, so
+// leaving it uncolored keeps the eye on the words that differ between lines.
+func (in *installer) paintStatus(status string) string {
+	sev := severityOf(status)
+	if loc := trailingHealth.FindStringIndex(status); loc != nil {
+		return in.paint.Dim(status[:loc[0]]) + sev.paint(in.paint, status[loc[0]:])
+	}
+	// A container with no health check to report is just up: the mark ahead
+	// of it already says so, and coloring the word again only spends green on
+	// the lines nobody needs to look at.
+	if sev == sevOK {
+		return in.paint.Dim(status)
+	}
+	// Nothing states the verdict, so the state itself carries it.
+	if loc := leadingState.FindStringIndex(status); loc != nil {
+		return sev.paint(in.paint, status[:loc[1]]) + in.paint.Dim(status[loc[1]:])
+	}
+	return status
+}
+
+func (in *installer) orUnknown(s string) string {
 	if s == "" {
-		return "unknown"
+		return in.paint.Dim("unknown")
 	}
 	return s
 }

--- a/cli/internal/deploy/install/status.go
+++ b/cli/internal/deploy/install/status.go
@@ -174,7 +174,10 @@ func (in *installer) inspectContainers(ctx context.Context) (services []Service,
 		}
 		svc := Service{Name: parts[0], Image: parts[1], Status: parts[2]}
 		services = append(services, svc)
-		if runningTag == "" && strings.HasPrefix(svc.Status, "Up") {
+		// Only Onyx app images carry the deployment version; infrastructure
+		// containers (nginx, postgres, redis, ...) have their own tags.
+		if runningTag == "" && strings.HasPrefix(svc.Status, "Up") &&
+			strings.Contains(svc.Image, "onyxdotapp/onyx") {
 			if idx := strings.LastIndex(svc.Image, ":"); idx != -1 {
 				runningTag = svc.Image[idx+1:]
 			}

--- a/cli/internal/deploy/install/stop.go
+++ b/cli/internal/deploy/install/stop.go
@@ -1,0 +1,64 @@
+package install
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+)
+
+// RunStop implements `deploy stop` (install.sh --shutdown): pause the
+// containers without removing them.
+func RunStop(ctx context.Context, deps Deps, opts Options) error {
+	in := newInstaller(deps, opts)
+	return in.runStop(ctx)
+}
+
+func (in *installer) runStop(ctx context.Context) error {
+	in.root = paths.Resolve(in.opts.Dir)
+	composeFile := filepath.Join(in.deploymentDir(), "docker-compose.yml")
+	if _, err := os.Stat(composeFile); os.IsNotExist(err) {
+		in.warnf("No Onyx deployment found at %s. Nothing to shut down.", in.root.Dir)
+		return nil
+	}
+
+	if err := in.attachDockerCompose(ctx); err != nil {
+		return err
+	}
+
+	in.infof("Stopping Onyx containers...")
+	// Overlays are auto-detected from disk so users don't need to remember
+	// which flags they installed with; HOST_PORT/IMAGE_TAG fall back to safe
+	// defaults because compose only needs them to resolve the file, not to
+	// stop containers (same pair install.sh uses here).
+	cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), in.composeFileNames(true), "stop")
+	cmd.Stdout, cmd.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+	if _, err := in.deps.Runner.Run(ctx, cmd); err != nil {
+		in.errorf("Failed to stop containers")
+		return exitcodes.Newf(exitcodes.General, "docker compose stop failed: %v", err)
+	}
+	in.successf("Onyx containers stopped (paused)")
+	in.plainf("")
+	in.infof("Start them again with: onyx-cli deploy install")
+	return nil
+}
+
+// attachDockerCompose wires the docker/compose handles for lifecycle verbs
+// that must not provision anything (stop/status/uninstall).
+func (in *installer) attachDockerCompose(ctx context.Context) error {
+	if !dockercmd.Installed() {
+		return exitcodes.New(exitcodes.General, "docker not found. Is Docker installed?")
+	}
+	in.docker.RefreshSudo(ctx)
+	if in.docker.UsingSudo() {
+		in.infof("Using sudo for docker commands in this run.")
+	}
+	in.compose = dockercmd.DetectCompose(ctx, in.docker)
+	if in.compose == nil {
+		return exitcodes.New(exitcodes.General, "Docker Compose not found.\n  Visit: https://docs.docker.com/compose/install/")
+	}
+	return nil
+}

--- a/cli/internal/deploy/install/uninstall.go
+++ b/cli/internal/deploy/install/uninstall.go
@@ -5,7 +5,9 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
 	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
 )
 
@@ -28,6 +30,14 @@ func (in *installer) runUninstall(ctx context.Context) error {
 	if _, err := os.Stat(in.root.Dir); os.IsNotExist(err) {
 		in.warnf("No Onyx data directory found at %s. Nothing to remove.", in.root.Dir)
 		return nil
+	}
+	// The directory is about to be removed recursively, and --dir,
+	// ONYX_DEPLOYMENT_DIR and the legacy INSTALL_PREFIX all name it freely: a
+	// broad path like /home must not be taken at its word.
+	if !paths.IsInstall(in.root.Dir) && !state.Exists(in.root.Dir) {
+		return exitcodes.Newf(exitcodes.BadRequest,
+			"%s doesn't look like an Onyx deployment (no deployment/docker-compose.yml, deployment/.env or %s) — refusing to delete it",
+			in.root.Dir, state.FileName)
 	}
 
 	in.plainf("")
@@ -67,9 +77,17 @@ func (in *installer) runUninstall(ctx context.Context) error {
 		cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), in.composeFileNames(true), "down", "-v")
 		cmd.Stdout, cmd.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
 		if _, err := in.deps.Runner.Run(ctx, cmd); err != nil {
-			// Keep going like install.sh: the directory should still be
-			// removable even when container cleanup fails.
 			in.errorf("Failed to remove containers and volumes: %v", err)
+			// Deleting the directory now would strand the containers and
+			// volumes with nothing left that describes them, so the files
+			// stay put for a retry unless the user insists.
+			if !in.opts.Force {
+				return exitcodes.Newf(exitcodes.General,
+					"containers or volumes are still present — %s was left in place so you can retry; pass --force to delete it anyway",
+					in.root.Dir)
+			}
+			in.warnf("Deleting %s anyway (--force) — clean up leftovers with `docker compose -p %s down -v`",
+				in.root.Dir, dockercmd.ProjectName)
 		} else {
 			in.successf("Onyx containers and volumes removed")
 		}

--- a/cli/internal/deploy/install/uninstall.go
+++ b/cli/internal/deploy/install/uninstall.go
@@ -1,0 +1,86 @@
+package install
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+)
+
+// RunUninstall implements `deploy uninstall` (install.sh --delete-data):
+// remove containers, volumes and the deployment directory. Destructive, so
+// interactive runs must type DELETE; non-interactive runs require --force
+// (install.sh refused non-interactive deletion outright).
+func RunUninstall(ctx context.Context, deps Deps, opts Options) error {
+	in := newInstaller(deps, opts)
+	return in.runUninstall(ctx)
+}
+
+func (in *installer) runUninstall(ctx context.Context) error {
+	in.root = paths.Resolve(in.opts.Dir)
+	if len(in.root.Ambiguous) > 0 {
+		return exitcodes.Newf(exitcodes.BadRequest,
+			"multiple Onyx installs found (%s and %s) — pass --dir to pick one",
+			in.root.Dir, in.root.Ambiguous[0])
+	}
+	if _, err := os.Stat(in.root.Dir); os.IsNotExist(err) {
+		in.warnf("No Onyx data directory found at %s. Nothing to remove.", in.root.Dir)
+		return nil
+	}
+
+	in.plainf("")
+	in.plainf("=== WARNING: This will permanently delete all Onyx data ===")
+	in.plainf("")
+	in.warnf("This action will remove:")
+	in.plainf("  • All Onyx containers and volumes")
+	in.plainf("  • All files and configuration in %s", in.root.Dir)
+	in.plainf("  • All user data and documents")
+	in.plainf("")
+
+	if in.opts.Force {
+		in.infof("Proceeding without confirmation (--force).")
+	} else {
+		if in.prompt.AssumeDefaults {
+			in.errorf("Cannot confirm destructive operation in non-interactive mode.")
+			in.infof("Run interactively, pass --force, or remove %s manually.", in.root.Dir)
+			return exitcodes.New(exitcodes.BadRequest, "uninstall requires confirmation")
+		}
+		ok, err := in.prompt.ConfirmTyped("Are you sure you want to continue? Type 'DELETE' to confirm: ", "DELETE")
+		if err != nil {
+			return err
+		}
+		in.plainf("")
+		if !ok {
+			in.infof("Operation cancelled.")
+			return nil
+		}
+	}
+
+	composeFile := filepath.Join(in.deploymentDir(), "docker-compose.yml")
+	if _, err := os.Stat(composeFile); err == nil {
+		if err := in.attachDockerCompose(ctx); err != nil {
+			return err
+		}
+		in.infof("Removing Onyx containers and volumes...")
+		cmd := in.compose.Command(in.deploymentDir(), stopFallbackEnv(), in.composeFileNames(true), "down", "-v")
+		cmd.Stdout, cmd.Stderr = in.deps.IOS.Out, in.deps.IOS.ErrOut
+		if _, err := in.deps.Runner.Run(ctx, cmd); err != nil {
+			// Keep going like install.sh: the directory should still be
+			// removable even when container cleanup fails.
+			in.errorf("Failed to remove containers and volumes: %v", err)
+		} else {
+			in.successf("Onyx containers and volumes removed")
+		}
+	}
+
+	in.infof("Removing data directories...")
+	if err := os.RemoveAll(in.root.Dir); err != nil {
+		return exitcodes.Newf(exitcodes.General, "failed to remove %s: %v", in.root.Dir, err)
+	}
+	in.successf("Data directories removed")
+	in.plainf("")
+	in.successf("All Onyx data has been permanently deleted!")
+	return nil
+}

--- a/cli/internal/deploy/install/uninstall.go
+++ b/cli/internal/deploy/install/uninstall.go
@@ -32,12 +32,19 @@ func (in *installer) runUninstall(ctx context.Context) error {
 		return nil
 	}
 	// The directory is about to be removed recursively, and --dir,
-	// ONYX_DEPLOYMENT_DIR and the legacy INSTALL_PREFIX all name it freely: a
-	// broad path like /home must not be taken at its word.
+	// ONYX_DEPLOYMENT_DIR and the legacy INSTALL_PREFIX all name it freely, so
+	// it has to both look like a deployment and be a directory whose entire
+	// contents can be written off. Markers alone don't settle the second
+	// question: a deployment/ under $HOME marks $HOME.
 	if !paths.IsInstall(in.root.Dir) && !state.Exists(in.root.Dir) {
 		return exitcodes.Newf(exitcodes.BadRequest,
 			"%s doesn't look like an Onyx deployment (no deployment/docker-compose.yml, deployment/.env or %s) — refusing to delete it",
 			in.root.Dir, state.FileName)
+	}
+	if err := paths.CheckDeletable(in.root.Dir); err != nil {
+		return exitcodes.Newf(exitcodes.BadRequest,
+			"refusing to delete everything under %s: %v — point --dir at the deployment directory itself, or remove it by hand if Onyx really lives there",
+			in.root.Dir, err)
 	}
 
 	in.plainf("")

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -2,16 +2,18 @@ package install
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
-	"github.com/onyx-dot-app/onyx/cli/internal/deploy/resources"
 	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/ui"
 	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
 	"github.com/onyx-dot-app/onyx/cli/internal/version"
 )
@@ -21,9 +23,15 @@ import (
 // SANDBOX_BACKEND when Craft is enabled) is rewritten in .env; managed files
 // are refreshed to the target tag with user edits preserved via the manifest.
 func RunUpgrade(ctx context.Context, deps Deps, opts Options) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	in := newInstaller(deps, opts)
-	in.totalSteps = 4
-	return in.runUpgrade(ctx)
+	in.cancel = cancel
+	err := in.runUpgrade(ctx)
+	if errors.Is(err, ui.ErrAborted) || (err != nil && ctx.Err() != nil) {
+		return exitcodes.New(exitcodes.General, "upgrade cancelled")
+	}
+	return err
 }
 
 func (in *installer) runUpgrade(ctx context.Context) error {
@@ -36,6 +44,12 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	if !paths.IsInstall(in.root.Dir) {
 		return exitcodes.Newf(exitcodes.NotAvailable,
 			"no Onyx deployment found at %s — run `onyx-cli deploy install` first", in.root.Dir)
+	}
+
+	// Upgrades share the install wizard (dry runs stay line-oriented).
+	if in.fancy() && !in.opts.DryRun {
+		in.wiz = ui.StartWizard(in.deps.IOS.Out, "Onyx Upgrade", in.deps.CLIVersion, in.cancel)
+		defer in.wiz.Abort()
 	}
 
 	manifest, err := state.Load(in.root.Dir)
@@ -65,10 +79,24 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		in.overlayOnDisk(filepath.Base(deployfiles.LiteOverlay.DestRel))
 	in.craft = in.opts.IncludeCraft || manifest.IncludeCraft ||
 		in.overlayOnDisk(filepath.Base(deployfiles.CraftOverlay.DestRel))
+	if in.wiz != nil {
+		mode := "Standard"
+		if in.lite {
+			mode = "Lite"
+		}
+		if in.craft {
+			mode = "Std+Craft"
+		}
+		in.wiz.Answer("Mode", mode)
+		in.wiz.Answer("From", installedTag)
+	}
 
 	targetTag, err := in.resolveUpgradeTag(ctx, installedTag)
 	if err != nil {
 		return err
+	}
+	if in.wiz != nil {
+		in.wiz.Answer("To", targetTag)
 	}
 
 	if err := in.downgradeGuard(installedTag, targetTag); err != nil {
@@ -92,14 +120,12 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	if err := in.resolveDockerProblems(ctx, in.gatherPreflight(ctx)); err != nil {
 		return err
 	}
-	// Upgrading inherently restarts the deployment, and stopping loses no
-	// data — do it automatically instead of bouncing the user to another
-	// command.
-	if err := in.guardServicesStopped(ctx, true); err != nil {
-		return err
-	}
+	// The running services are deliberately NOT stopped here: `up` recreates
+	// any container whose image or config changed, so the old version keeps
+	// serving while images download, and a failed pull leaves it running
+	// instead of a stopped half-upgraded stack.
 
-	in.stepf("Updating configuration")
+	in.phase("Updating configuration")
 	in.infof("Updating configuration for version %s...", targetTag)
 	env = SetVar(env, "IMAGE_TAG", targetTag)
 	if in.craft {
@@ -109,6 +135,14 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		backend := sandboxBackendForTag(targetTag)
 		env = SetVarUncomment(env, "SANDBOX_BACKEND", backend)
 		in.successf("Aligned SANDBOX_BACKEND=%s with image tag %s", backend, targetTag)
+	}
+	// Reuse the port the deployment already runs on — scanning for a free
+	// one here would collide with our own still-running nginx and silently
+	// move Onyx to another port.
+	hostPort, perr := strconv.Atoi(Var(env, "HOST_PORT"))
+	if perr != nil {
+		hostPort = 3000
+		env = SetVar(env, "HOST_PORT", "3000")
 	}
 	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
 		return fmt.Errorf("failed to write .env: %w", err)
@@ -129,7 +163,6 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		in.ensureCraftResources(ctx)
 	}
 
-	hostPort := resources.FindAvailablePort(3000)
 	if err := in.pullAndStart(ctx, targetTag, hostPort); err != nil {
 		return err
 	}
@@ -152,13 +185,31 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		return err
 	}
 
-	in.stepf("Upgrade Complete!")
+	in.printUpgradeSuccess(hostPort, installedTag, targetTag)
+	return nil
+}
+
+// printUpgradeSuccess mirrors printSuccess: a summary card when the wizard
+// drives the run, plain lines otherwise.
+func (in *installer) printUpgradeSuccess(hostPort int, from, to string) {
+	url := fmt.Sprintf("http://localhost:%d", hostPort)
+	headline := fmt.Sprintf("Onyx upgraded: %s → %s", from, to)
+	if in.wiz != nil {
+		in.wiz.Stage(ui.StageDone)
+		in.wiz.Finish(
+			"🎉 "+headline,
+			"",
+			"Access Onyx at: "+ui.Accent(url),
+			"Check service health with: onyx-cli deploy status",
+		)
+		in.wiz = nil
+		return
+	}
 	in.plainf("")
-	in.successf("Onyx upgraded: %s → %s", installedTag, targetTag)
-	in.infof("Access Onyx at: http://localhost:%d", hostPort)
+	in.successf("%s", headline)
+	in.infof("Access Onyx at: %s", url)
 	in.infof("Check service health with: onyx-cli deploy status")
 	in.plainf("")
-	return nil
 }
 
 // resolveUpgradeTag picks the target: --tag, or the latest app release
@@ -174,16 +225,10 @@ func (in *installer) resolveUpgradeTag(ctx context.Context, installedTag string)
 	} else {
 		in.warnf("Could not determine latest Onyx release — falling back to edge")
 	}
-	if in.prompt.AssumeDefaults {
-		return defaultTag, nil
+	if in.wiz == nil && !in.prompt.AssumeDefaults {
+		in.infof("Currently installed: %s", installedTag)
 	}
-	in.infof("Currently installed: %s", installedTag)
-	tag, err := in.prompt.Ask(fmt.Sprintf("Enter tag to upgrade to [default: %s]: ", defaultTag), defaultTag)
-	if err != nil {
-		return "", err
-	}
-	in.plainf("")
-	return tag, nil
+	return in.askString("Version to upgrade to", defaultTag)
 }
 
 // downgradeGuard warns when both tags parse as semver and the target is
@@ -203,7 +248,7 @@ func (in *installer) downgradeGuard(installedTag, targetTag string) error {
 		return exitcodes.New(exitcodes.BadRequest,
 			"refusing to downgrade non-interactively — re-run with --force to override")
 	}
-	ok, err := in.prompt.Confirm("Downgrade anyway? (y/N) ", false)
+	ok, err := in.confirmYN("Downgrade anyway?", false)
 	if err != nil {
 		return err
 	}

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -1,0 +1,211 @@
+package install
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/deployfiles"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/paths"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/release"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/resources"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+	"github.com/onyx-dot-app/onyx/cli/internal/exitcodes"
+	"github.com/onyx-dot-app/onyx/cli/internal/version"
+)
+
+// RunUpgrade implements `deploy upgrade`: install.sh's "type 'update'"
+// sub-flow promoted to a scriptable verb. Only the IMAGE_TAG line (plus
+// SANDBOX_BACKEND when Craft is enabled) is rewritten in .env; managed files
+// are refreshed to the target tag with user edits preserved via the manifest.
+func RunUpgrade(ctx context.Context, deps Deps, opts Options) error {
+	in := newInstaller(deps, opts)
+	in.totalSteps = 4
+	return in.runUpgrade(ctx)
+}
+
+func (in *installer) runUpgrade(ctx context.Context) error {
+	in.root = paths.Resolve(in.opts.Dir)
+	if len(in.root.Ambiguous) > 0 {
+		return exitcodes.Newf(exitcodes.BadRequest,
+			"multiple Onyx installs found (%s and %s) — pass --dir to pick one",
+			in.root.Dir, in.root.Ambiguous[0])
+	}
+	if !paths.IsInstall(in.root.Dir) {
+		return exitcodes.Newf(exitcodes.NotAvailable,
+			"no Onyx deployment found at %s — run `onyx-cli deploy install` first", in.root.Dir)
+	}
+
+	manifest, err := state.Load(in.root.Dir)
+	if err != nil {
+		return err
+	}
+	hadManifest := manifest != nil
+	if manifest == nil {
+		manifest = &state.Manifest{}
+		in.infof("No %s found — adopting this install; files not written by the CLI are treated as potentially customized", state.FileName)
+	}
+
+	envPath := filepath.Join(in.root.Dir, "deployment", ".env")
+	envBytes, err := os.ReadFile(envPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", envPath, err)
+	}
+	env := string(envBytes)
+	installedTag := Var(env, "IMAGE_TAG")
+	if installedTag == "" {
+		installedTag = "edge"
+	}
+
+	// The deployment mode never changes on upgrade; recover it from the
+	// manifest or the overlays on disk.
+	in.lite = manifest.Mode == state.ModeLite ||
+		in.overlayOnDisk(filepath.Base(deployfiles.LiteOverlay.DestRel))
+	in.craft = in.opts.IncludeCraft || manifest.IncludeCraft ||
+		in.overlayOnDisk(filepath.Base(deployfiles.CraftOverlay.DestRel))
+
+	targetTag, err := in.resolveUpgradeTag(ctx, installedTag)
+	if err != nil {
+		return err
+	}
+
+	if err := in.downgradeGuard(installedTag, targetTag); err != nil {
+		return err
+	}
+
+	// Future: surface breaking changes from the GitHub release notes for
+	// every tag between installedTag and targetTag here, before any file is
+	// touched.
+
+	if in.opts.DryRun {
+		in.infof("Dry run mode — showing what would happen:")
+		in.plainf("  • Install root: %s (%s)", in.root.Dir, in.root.Source)
+		in.plainf("  • Upgrade: %s → %s (config ref: %s)", installedTag, targetTag, release.ConfigRef(targetTag))
+		in.plainf("  • Lite mode: %t, Craft: %t", in.lite, in.craft)
+		in.plainf("")
+		in.successf("Dry run complete (no changes made)")
+		return nil
+	}
+
+	if err := in.ensureDockerAndCompose(ctx); err != nil {
+		return err
+	}
+	if err := in.guardServicesStopped(ctx); err != nil {
+		return err
+	}
+
+	in.stepf("Updating configuration")
+	in.infof("Updating configuration for version %s...", targetTag)
+	env = SetVar(env, "IMAGE_TAG", targetTag)
+	if in.craft {
+		if in.opts.IncludeCraft {
+			env = SetVarUncomment(env, "ENABLE_CRAFT", "true")
+		}
+		backend := sandboxBackendForTag(targetTag)
+		env = SetVarUncomment(env, "SANDBOX_BACKEND", backend)
+		in.successf("Aligned SANDBOX_BACKEND=%s with image tag %s", backend, targetTag)
+	}
+	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
+		return fmt.Errorf("failed to write .env: %w", err)
+	}
+	in.successf("Updated IMAGE_TAG to %s in .env file (all other settings preserved)", targetTag)
+
+	configRef := ""
+	if !in.opts.Local {
+		configRef = release.ConfigRef(targetTag)
+		in.infof("Refreshing config files to match %s...", configRef)
+	}
+	fetcher := &fileFetcher{in: in}
+	if err := in.materializeFiles(ctx, configRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
+		return err
+	}
+
+	if in.craft {
+		in.ensureCraftResources(ctx)
+	}
+
+	hostPort := resources.FindAvailablePort(3000)
+	if err := in.pullAndStart(ctx, targetTag, hostPort); err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	manifest.InstalledTag = targetTag
+	manifest.CLIVersion = in.deps.CLIVersion
+	if manifest.Mode == "" {
+		manifest.Mode = state.ModeStandard
+		if in.lite {
+			manifest.Mode = state.ModeLite
+		}
+	}
+	manifest.IncludeCraft = in.craft
+	if !hadManifest || manifest.InstalledAt.IsZero() {
+		manifest.InstalledAt = now
+	}
+	manifest.UpdatedAt = now
+	if err := manifest.Save(in.root.Dir); err != nil {
+		return err
+	}
+
+	in.stepf("Upgrade Complete!")
+	in.plainf("")
+	in.successf("Onyx upgraded: %s → %s", installedTag, targetTag)
+	in.infof("Access Onyx at: http://localhost:%d", hostPort)
+	in.infof("Check service health with: onyx-cli deploy status")
+	in.plainf("")
+	return nil
+}
+
+// resolveUpgradeTag picks the target: --tag, or the latest app release
+// (prompted for interactively; taken as-is with --no-prompt), with the same
+// edge fallback install.sh uses when the release lookup fails.
+func (in *installer) resolveUpgradeTag(ctx context.Context, installedTag string) (string, error) {
+	if in.opts.Tag != "" {
+		return in.opts.Tag, nil
+	}
+	defaultTag := "edge"
+	if tag, err := in.deps.Release.LatestAppTag(ctx); err == nil {
+		defaultTag = tag
+	} else {
+		in.warnf("Could not determine latest Onyx release — falling back to edge")
+	}
+	if in.prompt.AssumeDefaults {
+		return defaultTag, nil
+	}
+	in.infof("Currently installed: %s", installedTag)
+	tag, err := in.prompt.Ask(fmt.Sprintf("Enter tag to upgrade to [default: %s]: ", defaultTag), defaultTag)
+	if err != nil {
+		return "", err
+	}
+	in.plainf("")
+	return tag, nil
+}
+
+// downgradeGuard warns when both tags parse as semver and the target is
+// older; floating and non-semver tags can't be ordered and pass silently.
+func (in *installer) downgradeGuard(installedTag, targetTag string) error {
+	installed, okInstalled := version.Parse(installedTag)
+	target, okTarget := version.Parse(targetTag)
+	if !okInstalled || !okTarget || !target.LessThan(installed) {
+		return nil
+	}
+	in.warnf("Target %s is OLDER than the installed %s. Downgrades are not supported by Onyx and may corrupt data written by newer schema versions.", targetTag, installedTag)
+	if in.opts.Force {
+		in.infof("Proceeding anyway (--force).")
+		return nil
+	}
+	if in.prompt.AssumeDefaults {
+		return exitcodes.New(exitcodes.BadRequest,
+			"refusing to downgrade non-interactively — re-run with --force to override")
+	}
+	ok, err := in.prompt.Confirm("Downgrade anyway? (y/N) ", false)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return exitcodes.New(exitcodes.General, "upgrade cancelled")
+	}
+	return nil
+}

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -144,6 +144,33 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	// instead of a stopped half-upgraded stack.
 
 	in.phase("Updating configuration")
+
+	// Config files and the manifest are written before .env, and not the other
+	// way round: .env is what names the deployment's version, so it must not
+	// name the target until everything else that can still fail on disk has
+	// succeeded. Otherwise a refresh or a save that fails here leaves the
+	// deployment claiming a version it has not so much as pulled.
+	configRef := ""
+	if !in.opts.Local {
+		configRef = release.ConfigRef(targetTag)
+		in.infof("Refreshing config files to match %s...", configRef)
+	}
+	fetcher := &fileFetcher{in: in}
+	if err := in.materializeFiles(ctx, configRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
+		return err
+	}
+
+	if in.craft {
+		in.ensureCraftResources(ctx)
+	}
+
+	// Persist the manifest's file records now: if the pull fails, the next
+	// run must still know the freshly materialized files were CLI-written,
+	// not hand-edited. InstalledTag advances only after a successful start.
+	if err := manifest.Save(in.root.Dir); err != nil {
+		return err
+	}
+
 	in.infof("Updating configuration for version %s...", targetTag)
 	env = SetVar(env, "IMAGE_TAG", targetTag)
 	if in.craft {
@@ -170,27 +197,6 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	}
 	in.successf("Updated IMAGE_TAG to %s in .env file (all other settings preserved)", targetTag)
 
-	configRef := ""
-	if !in.opts.Local {
-		configRef = release.ConfigRef(targetTag)
-		in.infof("Refreshing config files to match %s...", configRef)
-	}
-	fetcher := &fileFetcher{in: in}
-	if err := in.materializeFiles(ctx, configRef, managedFiles(in.lite, in.craft), manifest, fetcher); err != nil {
-		return err
-	}
-
-	if in.craft {
-		in.ensureCraftResources(ctx)
-	}
-
-	// Persist the manifest's file records now: if the pull fails, the next
-	// run must still know the freshly materialized files were CLI-written,
-	// not hand-edited. InstalledTag advances only after a successful start.
-	if err := manifest.Save(in.root.Dir); err != nil {
-		return err
-	}
-
 	if err := in.pullImages(ctx, targetTag, hostPort); err != nil {
 		in.rollbackEnv(envPath, envBytes)
 		return err
@@ -214,7 +220,9 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	}
 	manifest.UpdatedAt = now
 	if err := manifest.Save(in.root.Dir); err != nil {
-		return err
+		// The services are already up on the target: say what did happen, or
+		// the error reads as an upgrade that never took place.
+		return fmt.Errorf("upgraded to %s, but recording it in %s failed: %w", targetTag, state.FileName, err)
 	}
 
 	in.printUpgradeSuccess(hostPort, installedTag, targetTag)

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -195,7 +195,7 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		in.rollbackEnv(envPath, envBytes)
 		return err
 	}
-	if err := in.startServices(ctx, targetTag, hostPort); err != nil {
+	if err := in.startServices(ctx, targetTag, installedTag, hostPort); err != nil {
 		return err
 	}
 

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -46,6 +46,17 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 			"no Onyx deployment found at %s — run `onyx-cli deploy install` first", in.root.Dir)
 	}
 
+	// --tag is checked before the wizard takes over the screen, so a typo
+	// fails as a plain error instead of flashing the alt screen.
+	pinnedTag := in.opts.Tag
+	if pinnedTag != "" {
+		validated, verr := in.validateTag(ctx, pinnedTag)
+		if verr != nil {
+			return verr
+		}
+		pinnedTag = validated
+	}
+
 	// Upgrades share the install wizard (dry runs stay line-oriented).
 	if in.fancy() && !in.opts.DryRun {
 		in.wiz = ui.StartWizard(in.deps.IOS.Out, "Onyx Upgrade", in.deps.CLIVersion, in.cancel)
@@ -64,6 +75,12 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 
 	envPath := filepath.Join(in.root.Dir, "deployment", ".env")
 	envBytes, err := os.ReadFile(envPath)
+	if errors.Is(err, os.ErrNotExist) {
+		// Reachable when a fresh install failed before its first start: the
+		// config files are there, but .env was rolled back.
+		return exitcodes.Newf(exitcodes.NotAvailable,
+			"no deployment/.env at %s — run `onyx-cli deploy install` to finish setting up this deployment", in.root.Dir)
+	}
 	if err != nil {
 		return fmt.Errorf("failed to read %s: %w", envPath, err)
 	}
@@ -91,7 +108,7 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		in.wiz.Answer("From", installedTag)
 	}
 
-	targetTag, err := in.resolveUpgradeTag(ctx, installedTag)
+	targetTag, err := in.resolveUpgradeTag(ctx, installedTag, pinnedTag)
 	if err != nil {
 		return err
 	}
@@ -120,6 +137,7 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	if err := in.resolveDockerProblems(ctx, in.gatherPreflight(ctx)); err != nil {
 		return err
 	}
+	in.observedPort = in.runningHostPort(ctx)
 	// The running services are deliberately NOT stopped here: `up` recreates
 	// any container whose image or config changed, so the old version keeps
 	// serving while images download, and a failed pull leaves it running
@@ -136,13 +154,16 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		env = SetVarUncomment(env, "SANDBOX_BACKEND", backend)
 		in.successf("Aligned SANDBOX_BACKEND=%s with image tag %s", backend, targetTag)
 	}
-	// Reuse the port the deployment already runs on — scanning for a free
-	// one here would collide with our own still-running nginx and silently
-	// move Onyx to another port.
+	// Reuse the port the deployment already runs on — scanning for a free one
+	// here would collide with our own still-running nginx and silently move
+	// Onyx to another port. Installs created by install.sh never recorded
+	// HOST_PORT, so fall back to the port they are publishing right now.
 	hostPort, perr := strconv.Atoi(Var(env, "HOST_PORT"))
 	if perr != nil {
-		hostPort = 3000
-		env = SetVar(env, "HOST_PORT", "3000")
+		if hostPort = in.observedPort; hostPort == 0 {
+			hostPort = 3000
+		}
+		env = SetVar(env, "HOST_PORT", strconv.Itoa(hostPort))
 	}
 	if err := os.WriteFile(envPath, []byte(env), 0600); err != nil {
 		return fmt.Errorf("failed to write .env: %w", err)
@@ -163,7 +184,18 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		in.ensureCraftResources(ctx)
 	}
 
-	if err := in.pullAndStart(ctx, targetTag, hostPort); err != nil {
+	// Persist the manifest's file records now: if the pull fails, the next
+	// run must still know the freshly materialized files were CLI-written,
+	// not hand-edited. InstalledTag advances only after a successful start.
+	if err := manifest.Save(in.root.Dir); err != nil {
+		return err
+	}
+
+	if err := in.pullImages(ctx, targetTag, hostPort); err != nil {
+		in.rollbackEnv(envPath, envBytes)
+		return err
+	}
+	if err := in.startServices(ctx, targetTag, hostPort); err != nil {
 		return err
 	}
 
@@ -212,12 +244,13 @@ func (in *installer) printUpgradeSuccess(hostPort int, from, to string) {
 	in.plainf("")
 }
 
-// resolveUpgradeTag picks the target: --tag, or the latest app release
-// (prompted for interactively; taken as-is with --no-prompt), with the same
-// edge fallback install.sh uses when the release lookup fails.
-func (in *installer) resolveUpgradeTag(ctx context.Context, installedTag string) (string, error) {
-	if in.opts.Tag != "" {
-		return in.opts.Tag, nil
+// resolveUpgradeTag picks the target: the already-validated --tag, or the
+// latest app release (prompted for interactively; taken as-is with
+// --no-prompt), with the same edge fallback install.sh uses when the release
+// lookup fails.
+func (in *installer) resolveUpgradeTag(ctx context.Context, installedTag, pinnedTag string) (string, error) {
+	if pinnedTag != "" {
+		return pinnedTag, nil
 	}
 	defaultTag := "edge"
 	if tag, err := in.deps.Release.LatestAppTag(ctx); err == nil {
@@ -228,7 +261,7 @@ func (in *installer) resolveUpgradeTag(ctx context.Context, installedTag string)
 	if in.wiz == nil && !in.prompt.AssumeDefaults {
 		in.infof("Currently installed: %s", installedTag)
 	}
-	return in.askString("Version to upgrade to", defaultTag)
+	return in.askVersion(ctx, "Version to upgrade to", defaultTag)
 }
 
 // downgradeGuard warns when both tags parse as semver and the target is

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -234,21 +234,18 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 func (in *installer) printUpgradeSuccess(hostPort int, from, to string) {
 	url := fmt.Sprintf("http://localhost:%d", hostPort)
 	headline := fmt.Sprintf("Onyx upgraded: %s → %s", from, to)
+	tail := append([]string{"Access Onyx at: " + ui.Accent(url), ""}, manageLines()...)
 	if in.wiz != nil {
 		in.wiz.Stage(ui.StageComplete)
-		in.wiz.Finish(
-			"🎉 "+headline,
-			"",
-			"Access Onyx at: "+ui.Accent(url),
-			"Check service health with: onyx-cli deploy status",
-		)
+		in.wiz.Finish(append([]string{"🎉 " + headline, ""}, tail...)...)
 		in.wiz = nil
 		return
 	}
 	in.plainf("")
 	in.successf("%s", headline)
-	in.infof("Access Onyx at: %s", url)
-	in.infof("Check service health with: onyx-cli deploy status")
+	for _, l := range tail {
+		in.plainf("%s", l)
+	}
 	in.plainf("")
 }
 

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -127,7 +127,11 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	if in.opts.DryRun {
 		in.infof("Dry run mode — showing what would happen:")
 		in.plainf("  • Install root: %s (%s)", in.root.Dir, in.root.Source)
-		in.plainf("  • Upgrade: %s → %s (config ref: %s)", installedTag, targetTag, release.ConfigRef(targetTag))
+		if in.localFiles() {
+			in.plainf("  • Upgrade: %s → %s (config files: existing on disk, embedded copies for gaps)", installedTag, targetTag)
+		} else {
+			in.plainf("  • Upgrade: %s → %s (config ref: %s)", installedTag, targetTag, release.ConfigRef(targetTag))
+		}
 		in.plainf("  • Lite mode: %t, Craft: %t", in.lite, in.craft)
 		in.plainf("")
 		in.successf("Dry run complete (no changes made)")
@@ -151,7 +155,7 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	// succeeded. Otherwise a refresh or a save that fails here leaves the
 	// deployment claiming a version it has not so much as pulled.
 	configRef := ""
-	if !in.opts.Local {
+	if !in.localFiles() {
 		configRef = release.ConfigRef(targetTag)
 		in.infof("Refreshing config files to match %s...", configRef)
 	}
@@ -257,11 +261,11 @@ func (in *installer) resolveUpgradeTag(ctx context.Context, installedTag, pinned
 	if pinnedTag != "" {
 		return pinnedTag, nil
 	}
-	defaultTag := "edge"
-	if tag, err := in.deps.Release.LatestAppTag(ctx); err == nil {
+	defaultTag := ""
+	if tag, err := in.latestAppTag(ctx); err == nil {
 		defaultTag = tag
 	} else {
-		in.warnf("Could not determine latest Onyx release — falling back to edge")
+		defaultTag = in.unreachableTagFallback(ctx)
 	}
 	if in.wiz == nil && !in.prompt.AssumeDefaults {
 		in.infof("Currently installed: %s", installedTag)

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -92,7 +92,10 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 	if err := in.resolveDockerProblems(ctx, in.gatherPreflight(ctx)); err != nil {
 		return err
 	}
-	if err := in.guardServicesStopped(ctx); err != nil {
+	// Upgrading inherently restarts the deployment, and stopping loses no
+	// data — do it automatically instead of bouncing the user to another
+	// command.
+	if err := in.guardServicesStopped(ctx, true); err != nil {
 		return err
 	}
 

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -89,7 +89,7 @@ func (in *installer) runUpgrade(ctx context.Context) error {
 		return nil
 	}
 
-	if err := in.ensureDockerAndCompose(ctx); err != nil {
+	if err := in.resolveDockerProblems(ctx, in.gatherPreflight(ctx)); err != nil {
 		return err
 	}
 	if err := in.guardServicesStopped(ctx); err != nil {

--- a/cli/internal/deploy/install/upgrade.go
+++ b/cli/internal/deploy/install/upgrade.go
@@ -227,7 +227,7 @@ func (in *installer) printUpgradeSuccess(hostPort int, from, to string) {
 	url := fmt.Sprintf("http://localhost:%d", hostPort)
 	headline := fmt.Sprintf("Onyx upgraded: %s → %s", from, to)
 	if in.wiz != nil {
-		in.wiz.Stage(ui.StageDone)
+		in.wiz.Stage(ui.StageComplete)
 		in.wiz.Finish(
 			"🎉 "+headline,
 			"",

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -131,9 +131,19 @@ func TestUpgradeRequiresExistingInstall(t *testing.T) {
 	}
 }
 
-func TestUpgradeAutoStopsRunningServices(t *testing.T) {
+func TestUpgradeRecreatesWithoutStopping(t *testing.T) {
 	runner := &fakeRunner{handler: healthyDockerHandler}
 	root := installFixture(t, runner, "v4.0.0")
+
+	// Give the fixture a non-default recorded port, as a user might have.
+	envPath := filepath.Join(root, "deployment", ".env")
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(envPath, []byte(SetVar(string(env), "HOST_PORT", "8080")), 0600); err != nil {
+		t.Fatal(err)
+	}
 
 	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
 		if strings.Contains(argv(c), "ps -q") {
@@ -142,20 +152,22 @@ func TestUpgradeAutoStopsRunningServices(t *testing.T) {
 		return healthyDockerHandler(c)
 	}}
 	deps := testDeps(t, running, notFoundServer(t))
-	err := RunUpgrade(context.Background(), deps, Options{
+	err = RunUpgrade(context.Background(), deps, Options{
 		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
 	})
 	if err != nil {
-		t.Fatalf("upgrade must auto-stop running services: %v", err)
+		t.Fatalf("upgrade must proceed with services running: %v", err)
 	}
-	stopped := false
 	for _, c := range running.calls {
 		if strings.HasSuffix(argv(c), " stop") {
-			stopped = true
+			t.Error("upgrade must not stop services — up recreates them with less downtime")
 		}
 	}
-	if !stopped {
-		t.Error("compose stop never ran before the upgrade")
+	// The old stack keeps its port: no re-scan, the recorded value is reused.
+	for _, c := range running.calls {
+		if strings.Contains(argv(c), " up ") && c.Env["HOST_PORT"] != "8080" {
+			t.Errorf("up ran with HOST_PORT=%q, want the recorded 8080", c.Env["HOST_PORT"])
+		}
 	}
 }
 

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -148,8 +148,8 @@ func TestUpgradeRefusesWhileRunning(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected refusal while services run")
 	}
-	if !strings.Contains(outBuf(deps).String(), "onyx-cli deploy stop") {
-		t.Errorf("output:\n%s", outBuf(deps).String())
+	if !strings.Contains(err.Error(), "onyx-cli deploy stop") {
+		t.Errorf("guard error must carry the remedy: %v", err)
 	}
 }
 

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -131,7 +131,7 @@ func TestUpgradeRequiresExistingInstall(t *testing.T) {
 	}
 }
 
-func TestUpgradeRefusesWhileRunning(t *testing.T) {
+func TestUpgradeAutoStopsRunningServices(t *testing.T) {
 	runner := &fakeRunner{handler: healthyDockerHandler}
 	root := installFixture(t, runner, "v4.0.0")
 
@@ -145,11 +145,17 @@ func TestUpgradeRefusesWhileRunning(t *testing.T) {
 	err := RunUpgrade(context.Background(), deps, Options{
 		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
 	})
-	if err == nil {
-		t.Fatal("expected refusal while services run")
+	if err != nil {
+		t.Fatalf("upgrade must auto-stop running services: %v", err)
 	}
-	if !strings.Contains(err.Error(), "onyx-cli deploy stop") {
-		t.Errorf("guard error must carry the remedy: %v", err)
+	stopped := false
+	for _, c := range running.calls {
+		if strings.HasSuffix(argv(c), " stop") {
+			stopped = true
+		}
+	}
+	if !stopped {
+		t.Error("compose stop never ran before the upgrade")
 	}
 }
 

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -1,0 +1,175 @@
+package install
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/dockercmd"
+	"github.com/onyx-dot-app/onyx/cli/internal/deploy/state"
+)
+
+// installFixture runs a real (fake-backed) fresh install and returns the root.
+func installFixture(t *testing.T, runner *fakeRunner, tag string) string {
+	t.Helper()
+	isolateEnv(t)
+	shimDockerOnPath(t)
+	root := t.TempDir()
+	deps := testDeps(t, runner, notFoundServer(t))
+	if err := RunInstall(context.Background(), deps, Options{
+		NoPrompt: true, Tag: tag, Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("fixture install: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	return root
+}
+
+func TestUpgradeRewritesOnlyImageTag(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	// Simulate user configuration between install and upgrade.
+	envPath := filepath.Join(root, "deployment", ".env")
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	customized := string(env) + "GEN_AI_API_KEY=sk-user-added\n"
+	if err := os.WriteFile(envPath, []byte(customized), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	upstream := "# compose at v4.2.0\nname: onyx\n"
+	deps := testDeps(t, runner, rawServer(t, upstream))
+	err = RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUpgrade: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	got, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotStr := string(got)
+	if Var(gotStr, "IMAGE_TAG") != "v4.2.0" {
+		t.Errorf("IMAGE_TAG = %q", Var(gotStr, "IMAGE_TAG"))
+	}
+	if !strings.Contains(gotStr, "GEN_AI_API_KEY=sk-user-added") {
+		t.Error("user-added .env line lost on upgrade")
+	}
+	// Secrets generated at install must be untouched.
+	if Var(gotStr, "USER_AUTH_SECRET") != Var(customized, "USER_AUTH_SECRET") {
+		t.Error("USER_AUTH_SECRET changed on upgrade")
+	}
+
+	// Managed files refreshed to the target ref.
+	compose, _ := os.ReadFile(filepath.Join(root, "deployment", "docker-compose.yml"))
+	if string(compose) != upstream {
+		t.Errorf("compose not refreshed: %q", compose)
+	}
+
+	m, err := state.Load(root)
+	if err != nil || m == nil {
+		t.Fatalf("manifest: %+v, %v", m, err)
+	}
+	if m.InstalledTag != "v4.2.0" {
+		t.Errorf("manifest tag = %q", m.InstalledTag)
+	}
+	if m.Mode != state.ModeLite {
+		t.Errorf("mode changed on upgrade: %q", m.Mode)
+	}
+}
+
+func TestUpgradeRefusesDowngradeNonInteractively(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.2.0")
+
+	deps := testDeps(t, runner, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.0.0", Dir: root, NoWait: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "--force") {
+		t.Fatalf("err = %v, want downgrade refusal", err)
+	}
+
+	// Nothing changed.
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if Var(string(env), "IMAGE_TAG") != "v4.2.0" {
+		t.Errorf("IMAGE_TAG modified by refused downgrade: %q", Var(string(env), "IMAGE_TAG"))
+	}
+}
+
+func TestUpgradeDowngradeAllowedWithForce(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.2.0")
+
+	deps := testDeps(t, runner, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.0.0", Dir: root, NoWait: true, Force: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUpgrade: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if Var(string(env), "IMAGE_TAG") != "v4.0.0" {
+		t.Errorf("IMAGE_TAG = %q", Var(string(env), "IMAGE_TAG"))
+	}
+}
+
+func TestUpgradeRequiresExistingInstall(t *testing.T) {
+	isolateEnv(t)
+	deps := testDeps(t, &fakeRunner{}, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: filepath.Join(t.TempDir(), "empty"),
+	})
+	if err == nil || !strings.Contains(err.Error(), "deploy install") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestUpgradeRefusesWhileRunning(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "ps -q") {
+			return dockercmd.Result{Stdout: "abc\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err == nil {
+		t.Fatal("expected refusal while services run")
+	}
+	if !strings.Contains(outBuf(deps).String(), "onyx-cli deploy stop") {
+		t.Errorf("output:\n%s", outBuf(deps).String())
+	}
+}
+
+func TestUpgradeDryRun(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+	before, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+
+	deps := testDeps(t, runner, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, DryRun: true,
+	})
+	if err != nil {
+		t.Fatalf("RunUpgrade: %v", err)
+	}
+	if !strings.Contains(outBuf(deps).String(), "v4.0.0 → v4.2.0") {
+		t.Errorf("output:\n%s", outBuf(deps).String())
+	}
+	after, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if string(before) != string(after) {
+		t.Error("dry run modified .env")
+	}
+}

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -283,3 +283,44 @@ func TestUpgradePullFailureRollsBackEnv(t *testing.T) {
 		t.Errorf("manifest tag = %q after failed pull, want v4.0.0", m.InstalledTag)
 	}
 }
+
+// A failed start is not a failed pull: containers that came up are already on
+// the new images, so .env stays on the target (reverting it would put the old
+// version back over data the new one may have migrated). The manifest still
+// records what was last deployed successfully, and the user is told both.
+func TestUpgradeStartFailureKeepsTargetAndExplains(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	failUp := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "up -d") {
+			return dockercmd.Result{}, errors.New("container onyx-index-1 is unhealthy")
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, failUp, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err == nil {
+		t.Fatal("upgrade must fail when the start fails")
+	}
+
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if got := Var(string(env), "IMAGE_TAG"); got != "v4.2.0" {
+		t.Errorf("IMAGE_TAG = %q after a failed start, want the target v4.2.0 kept", got)
+	}
+	m, merr := state.Load(root)
+	if merr != nil || m == nil {
+		t.Fatalf("manifest: %+v, %v", m, merr)
+	}
+	if m.InstalledTag != "v4.0.0" {
+		t.Errorf("manifest tag = %q, want the last version that actually started", m.InstalledTag)
+	}
+	out := outBuf(deps).String()
+	for _, want := range []string{"Partially deployed", "deploy upgrade --tag v4.0.0"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -324,3 +324,47 @@ func TestUpgradeStartFailureKeepsTargetAndExplains(t *testing.T) {
 		}
 	}
 }
+
+// Everything that can fail on disk happens before .env is rewritten, so a
+// refresh that fails leaves the deployment naming the version it is actually
+// running — not one it never pulled.
+func TestUpgradeConfigFailureLeavesVersionAlone(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	// A managed file the refresh cannot get at: reading it fails outright.
+	readme := filepath.Join(root, "README.md")
+	if err := os.Remove(readme); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(readme, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	upgradeRunner := &fakeRunner{handler: healthyDockerHandler}
+	deps := testDeps(t, upgradeRunner, rawServer(t, "# compose at v4.2.0\nname: onyx\n"))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err == nil {
+		t.Fatalf("upgrade must fail when a managed file can't be refreshed\noutput:\n%s", outBuf(deps).String())
+	}
+
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if got := Var(string(env), "IMAGE_TAG"); got != "v4.0.0" {
+		t.Errorf("IMAGE_TAG = %q after a failed config refresh, want the running v4.0.0", got)
+	}
+	m, merr := state.Load(root)
+	if merr != nil || m == nil {
+		t.Fatalf("manifest: %+v, %v", m, merr)
+	}
+	if m.InstalledTag != "v4.0.0" {
+		t.Errorf("manifest tag = %q after a failed config refresh, want v4.0.0", m.InstalledTag)
+	}
+	// Nothing should have been deployed either.
+	for _, c := range upgradeRunner.calls {
+		if line := argv(c); strings.Contains(line, " pull") || strings.Contains(line, "up -d") {
+			t.Errorf("deployed despite the failure: %s", line)
+		}
+	}
+}

--- a/cli/internal/deploy/install/upgrade_test.go
+++ b/cli/internal/deploy/install/upgrade_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -171,6 +172,48 @@ func TestUpgradeRecreatesWithoutStopping(t *testing.T) {
 	}
 }
 
+// Installs created by install.sh never recorded HOST_PORT. Defaulting to
+// 3000 would silently move a deployment that runs on another port, so the
+// port is recovered from the containers that are still running.
+func TestUpgradeRecoversUnrecordedPortFromContainers(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	// A legacy .env: no HOST_PORT line at all.
+	envPath := filepath.Join(root, "deployment", ".env")
+	env, err := os.ReadFile(envPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy := strings.ReplaceAll(string(env), "HOST_PORT=3000\n", "")
+	if err := os.WriteFile(envPath, []byte(legacy), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	running := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), "{{.Ports}}") {
+			return dockercmd.Result{Stdout: "0.0.0.0:3001->80/tcp, [::]:3001->80/tcp\n"}, nil
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, running, notFoundServer(t))
+	if err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	}); err != nil {
+		t.Fatalf("RunUpgrade: %v\noutput:\n%s", err, outBuf(deps).String())
+	}
+
+	got, _ := os.ReadFile(envPath)
+	if p := Var(string(got), "HOST_PORT"); p != "3001" {
+		t.Errorf("HOST_PORT = %q, want the observed 3001", p)
+	}
+	for _, c := range running.calls {
+		if strings.Contains(argv(c), " up ") && c.Env["HOST_PORT"] != "3001" {
+			t.Errorf("up ran with HOST_PORT=%q, want 3001", c.Env["HOST_PORT"])
+		}
+	}
+}
+
 func TestUpgradeDryRun(t *testing.T) {
 	runner := &fakeRunner{handler: healthyDockerHandler}
 	root := installFixture(t, runner, "v4.0.0")
@@ -189,5 +232,54 @@ func TestUpgradeDryRun(t *testing.T) {
 	after, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
 	if string(before) != string(after) {
 		t.Error("dry run modified .env")
+	}
+}
+
+func TestUpgradeRejectsUnknownVersion(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	deps := testDeps(t, runner, refServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v9.9.9", Dir: root, NoWait: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("err = %v, want unknown-version rejection", err)
+	}
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if Var(string(env), "IMAGE_TAG") != "v4.0.0" {
+		t.Error("rejected upgrade must not touch .env")
+	}
+}
+
+func TestUpgradePullFailureRollsBackEnv(t *testing.T) {
+	runner := &fakeRunner{handler: healthyDockerHandler}
+	root := installFixture(t, runner, "v4.0.0")
+
+	failPull := &fakeRunner{handler: func(c dockercmd.Command) (dockercmd.Result, error) {
+		if strings.Contains(argv(c), " pull") {
+			return dockercmd.Result{}, errors.New("manifest for tag not found")
+		}
+		return healthyDockerHandler(c)
+	}}
+	deps := testDeps(t, failPull, notFoundServer(t))
+	err := RunUpgrade(context.Background(), deps, Options{
+		NoPrompt: true, Tag: "v4.2.0", Dir: root, NoWait: true,
+	})
+	if err == nil {
+		t.Fatal("upgrade must fail when the pull fails")
+	}
+	// The deployment still runs the old version; .env and the manifest must
+	// keep saying so.
+	env, _ := os.ReadFile(filepath.Join(root, "deployment", ".env"))
+	if got := Var(string(env), "IMAGE_TAG"); got != "v4.0.0" {
+		t.Errorf("IMAGE_TAG = %q after failed pull, want the original v4.0.0", got)
+	}
+	m, merr := state.Load(root)
+	if merr != nil || m == nil {
+		t.Fatalf("manifest: %+v, %v", m, merr)
+	}
+	if m.InstalledTag != "v4.0.0" {
+		t.Errorf("manifest tag = %q after failed pull, want v4.0.0", m.InstalledTag)
 	}
 }

--- a/cli/internal/deploy/paths/paths.go
+++ b/cli/internal/deploy/paths/paths.go
@@ -5,8 +5,10 @@
 package paths
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Source records how the install root was chosen.
@@ -68,6 +70,54 @@ func IsInstall(dir string) bool {
 		}
 	}
 	return false
+}
+
+// CheckDeletable reports whether dir is specific enough to be removed
+// recursively. The install root is named freely by --dir, ONYX_DEPLOYMENT_DIR
+// and the legacy INSTALL_PREFIX, and uninstall removes it with os.RemoveAll,
+// so deployment markers alone are not enough to authorize the delete: a stray
+// deployment/.env anywhere under a home directory would mark it, and the
+// markers say nothing about how much else lives under the same root.
+//
+// Refused are the filesystem (or volume) root, the user's home directory,
+// anything containing it, and top-level directories like /usr or /home. A
+// deployment that really does live in one of those is removed by hand — the
+// error says so.
+func CheckDeletable(dir string) error {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("cannot resolve %s: %w", dir, err)
+	}
+	abs = resolveSymlinks(abs)
+
+	if abs == filepath.Dir(abs) {
+		return fmt.Errorf("%s is the filesystem root", abs)
+	}
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		switch home = resolveSymlinks(home); {
+		case abs == home:
+			return fmt.Errorf("%s is your home directory", abs)
+		case strings.HasPrefix(home, abs+string(os.PathSeparator)):
+			return fmt.Errorf("%s contains your home directory", abs)
+		}
+	}
+	// Two segments below the root ("/opt/onyx", not "/opt") is the line
+	// between a deployment directory and a directory deployments live in.
+	rest := strings.Trim(strings.TrimPrefix(abs, filepath.VolumeName(abs)), string(os.PathSeparator))
+	if len(strings.Split(rest, string(os.PathSeparator))) < 2 {
+		return fmt.Errorf("%s is a top-level directory", abs)
+	}
+	return nil
+}
+
+// resolveSymlinks canonicalizes p when it can, so a symlinked home directory
+// (macOS /tmp, /var, container mounts) still compares equal to the paths
+// derived from it.
+func resolveSymlinks(p string) string {
+	if resolved, err := filepath.EvalSymlinks(p); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return filepath.Clean(p)
 }
 
 // Resolve picks the install root. Precedence: --dir flag, ONYX_DEPLOYMENT_DIR,

--- a/cli/internal/deploy/paths/paths.go
+++ b/cli/internal/deploy/paths/paths.go
@@ -1,0 +1,97 @@
+// Package paths resolves where an Onyx docker compose deployment lives on
+// disk. New installs default to ~/.config/onyx (XDG-style, matching the CLI's
+// own config dir convention); legacy installs created by install.sh in
+// ./onyx_data are detected and managed in place.
+package paths
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Source records how the install root was chosen.
+type Source string
+
+const (
+	// SourceFlag: the --dir flag.
+	SourceFlag Source = "--dir flag"
+	// SourceEnvDeploymentDir: the ONYX_DEPLOYMENT_DIR environment variable.
+	SourceEnvDeploymentDir Source = "ONYX_DEPLOYMENT_DIR"
+	// SourceEnvInstallPrefix: the legacy INSTALL_PREFIX environment variable
+	// honored by install.sh.
+	SourceEnvInstallPrefix Source = "INSTALL_PREFIX"
+	// SourceLegacyCwd: an existing ./onyx_data install relative to the
+	// working directory (the location install.sh used).
+	SourceLegacyCwd Source = "legacy ./onyx_data"
+	// SourceDefault: the XDG-style default for new installs.
+	SourceDefault Source = "default"
+)
+
+// legacyDirName is the cwd-relative install directory install.sh created.
+const legacyDirName = "onyx_data"
+
+// InstallRoot is a resolved deployment location.
+type InstallRoot struct {
+	Dir    string
+	Source Source
+	// Ambiguous lists other existing installs that were NOT chosen. Only
+	// populated for implicit resolution (no flag/env override) when more
+	// than one candidate contains an install.
+	Ambiguous []string
+}
+
+// DefaultDir returns the XDG-style default install root: $XDG_CONFIG_HOME/onyx
+// or ~/.config/onyx. Mirrors config.ConfigDir()'s algorithm (which resolves
+// the CLI's own ~/.config/onyx-cli on every OS, including Windows) so the two
+// directories are siblings everywhere.
+func DefaultDir() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return filepath.Join(xdg, "onyx")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".", ".config", "onyx")
+	}
+	return filepath.Join(home, ".config", "onyx")
+}
+
+// IsInstall reports whether dir contains an Onyx deployment: either the
+// compose file or a .env under deployment/ (the markers install.sh itself
+// checks before operating on a directory).
+func IsInstall(dir string) bool {
+	for _, marker := range []string{
+		filepath.Join(dir, "deployment", "docker-compose.yml"),
+		filepath.Join(dir, "deployment", ".env"),
+	} {
+		if _, err := os.Stat(marker); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// Resolve picks the install root. Precedence: --dir flag, ONYX_DEPLOYMENT_DIR,
+// legacy INSTALL_PREFIX, an existing legacy ./onyx_data install, then the
+// XDG-style default (which need not exist yet — it is the target for fresh
+// installs).
+func Resolve(dirFlag string) InstallRoot {
+	if dirFlag != "" {
+		return InstallRoot{Dir: dirFlag, Source: SourceFlag}
+	}
+	if dir := os.Getenv("ONYX_DEPLOYMENT_DIR"); dir != "" {
+		return InstallRoot{Dir: dir, Source: SourceEnvDeploymentDir}
+	}
+	if dir := os.Getenv("INSTALL_PREFIX"); dir != "" {
+		return InstallRoot{Dir: dir, Source: SourceEnvInstallPrefix}
+	}
+
+	defaultDir := DefaultDir()
+	if IsInstall(legacyDirName) {
+		root := InstallRoot{Dir: legacyDirName, Source: SourceLegacyCwd}
+		if IsInstall(defaultDir) {
+			root.Ambiguous = []string{defaultDir}
+		}
+		return root
+	}
+	return InstallRoot{Dir: defaultDir, Source: SourceDefault}
+}

--- a/cli/internal/deploy/paths/paths_test.go
+++ b/cli/internal/deploy/paths/paths_test.go
@@ -131,3 +131,33 @@ func TestIsInstallEnvMarker(t *testing.T) {
 		t.Fatal(".env marker should count as an install")
 	}
 }
+
+// Install markers say a directory holds a deployment; they say nothing about
+// what else it holds. Since uninstall removes the root recursively, roots
+// whose contents can't be written off wholesale are refused separately.
+func TestCheckDeletableRefusesBroadRoots(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // os.UserHomeDir on Windows
+
+	for _, dir := range []string{
+		string(os.PathSeparator),
+		home,
+		filepath.Dir(home), // contains the home directory
+		filepath.Join(string(os.PathSeparator), "usr"),
+	} {
+		if err := CheckDeletable(dir); err == nil {
+			t.Errorf("CheckDeletable(%q) allowed a recursive delete", dir)
+		}
+	}
+
+	for _, dir := range []string{
+		filepath.Join(home, ".config", "onyx"),
+		filepath.Join(home, "onyx_data"),
+		t.TempDir(),
+	} {
+		if err := CheckDeletable(dir); err != nil {
+			t.Errorf("CheckDeletable(%q) = %v, want a deployment directory to be deletable", dir, err)
+		}
+	}
+}

--- a/cli/internal/deploy/paths/paths_test.go
+++ b/cli/internal/deploy/paths/paths_test.go
@@ -1,0 +1,133 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// isolate points HOME/XDG at temp dirs and runs the test from a fresh cwd so
+// legacy ./onyx_data detection is hermetic.
+func isolate(t *testing.T) (cwd, xdg string) {
+	t.Helper()
+	cwd = t.TempDir()
+	xdg = t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("ONYX_DEPLOYMENT_DIR", "")
+	t.Setenv("INSTALL_PREFIX", "")
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(orig); err != nil {
+			t.Fatalf("restore cwd: %v", err)
+		}
+	})
+	return cwd, xdg
+}
+
+func markInstall(t *testing.T, root string) {
+	t.Helper()
+	dir := filepath.Join(root, "deployment")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "docker-compose.yml"), []byte("name: onyx\n"), 0644); err != nil {
+		t.Fatalf("write marker: %v", err)
+	}
+}
+
+func TestResolveFlagWinsOverEverything(t *testing.T) {
+	isolate(t)
+	t.Setenv("ONYX_DEPLOYMENT_DIR", "/elsewhere")
+	got := Resolve("/explicit")
+	if got.Dir != "/explicit" || got.Source != SourceFlag {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestResolveEnvPrecedence(t *testing.T) {
+	isolate(t)
+	t.Setenv("ONYX_DEPLOYMENT_DIR", "/deployment-dir")
+	t.Setenv("INSTALL_PREFIX", "/install-prefix")
+	got := Resolve("")
+	if got.Dir != "/deployment-dir" || got.Source != SourceEnvDeploymentDir {
+		t.Fatalf("got %+v", got)
+	}
+
+	t.Setenv("ONYX_DEPLOYMENT_DIR", "")
+	got = Resolve("")
+	if got.Dir != "/install-prefix" || got.Source != SourceEnvInstallPrefix {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestResolveDefaultsToXDGDir(t *testing.T) {
+	_, xdg := isolate(t)
+	got := Resolve("")
+	want := filepath.Join(xdg, "onyx")
+	if got.Dir != want || got.Source != SourceDefault {
+		t.Fatalf("got %+v, want dir %s", got, want)
+	}
+	if len(got.Ambiguous) != 0 {
+		t.Fatalf("unexpected ambiguity: %+v", got)
+	}
+}
+
+func TestResolvePrefersLegacyInstallInCwd(t *testing.T) {
+	cwd, _ := isolate(t)
+	markInstall(t, filepath.Join(cwd, "onyx_data"))
+	got := Resolve("")
+	if got.Dir != "onyx_data" || got.Source != SourceLegacyCwd {
+		t.Fatalf("got %+v", got)
+	}
+	if len(got.Ambiguous) != 0 {
+		t.Fatalf("unexpected ambiguity: %+v", got)
+	}
+}
+
+func TestResolveFlagsAmbiguityWhenBothExist(t *testing.T) {
+	cwd, xdg := isolate(t)
+	markInstall(t, filepath.Join(cwd, "onyx_data"))
+	markInstall(t, filepath.Join(xdg, "onyx"))
+	got := Resolve("")
+	if got.Source != SourceLegacyCwd {
+		t.Fatalf("got %+v", got)
+	}
+	if len(got.Ambiguous) != 1 || got.Ambiguous[0] != filepath.Join(xdg, "onyx") {
+		t.Fatalf("ambiguity not reported: %+v", got)
+	}
+}
+
+func TestResolveIgnoresNonInstallLegacyDir(t *testing.T) {
+	cwd, xdg := isolate(t)
+	// A directory named onyx_data without install markers is not adopted.
+	if err := os.MkdirAll(filepath.Join(cwd, "onyx_data"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	got := Resolve("")
+	if got.Source != SourceDefault || got.Dir != filepath.Join(xdg, "onyx") {
+		t.Fatalf("got %+v", got)
+	}
+}
+
+func TestIsInstallEnvMarker(t *testing.T) {
+	root := t.TempDir()
+	if IsInstall(root) {
+		t.Fatal("empty dir should not be an install")
+	}
+	dir := filepath.Join(root, "deployment")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".env"), []byte("IMAGE_TAG=latest\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if !IsInstall(root) {
+		t.Fatal(".env marker should count as an install")
+	}
+}

--- a/cli/internal/deploy/prompt/prompt.go
+++ b/cli/internal/deploy/prompt/prompt.go
@@ -1,0 +1,100 @@
+// Package prompt provides the line-based interactive prompts the deploy
+// commands use. Everything routes through IOStreams (no direct os.Stdin, no
+// TUI dependencies) so tests drive prompts with buffers and non-interactive
+// runs fall back to defaults.
+package prompt
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+)
+
+// Prompter asks questions on ios.Out and reads answers from ios.In. When
+// AssumeDefaults is set (--no-prompt, or no TTY), every prompt resolves to
+// its default without reading input — mirroring install.sh's behavior.
+type Prompter struct {
+	ios            *iostreams.IOStreams
+	reader         *bufio.Reader
+	AssumeDefaults bool
+}
+
+func New(ios *iostreams.IOStreams, assumeDefaults bool) *Prompter {
+	return &Prompter{
+		ios:            ios,
+		reader:         bufio.NewReader(ios.In),
+		AssumeDefaults: assumeDefaults || !ios.IsInteractive(),
+	}
+}
+
+// Ask prints question and returns the entered line, or defaultVal on empty
+// input / non-interactive runs.
+func (p *Prompter) Ask(question, defaultVal string) (string, error) {
+	if p.AssumeDefaults {
+		return defaultVal, nil
+	}
+	fmt.Fprint(p.ios.Out, question)
+	line, err := p.readLine()
+	if err != nil {
+		return "", err
+	}
+	if line == "" {
+		return defaultVal, nil
+	}
+	return line, nil
+}
+
+// Confirm asks a Y/n (or y/N) question.
+func (p *Prompter) Confirm(question string, defaultYes bool) (bool, error) {
+	def := "n"
+	if defaultYes {
+		def = "y"
+	}
+	answer, err := p.Ask(question, def)
+	if err != nil {
+		return false, err
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	if answer == "" {
+		return defaultYes, nil
+	}
+	return strings.HasPrefix(answer, "y"), nil
+}
+
+// ConfirmTyped requires the exact requiredText to be typed (used for
+// destructive actions, e.g. uninstall's DELETE). Never satisfied by default:
+// non-interactive callers must pass an explicit flag instead.
+func (p *Prompter) ConfirmTyped(question, requiredText string) (bool, error) {
+	if p.AssumeDefaults {
+		return false, nil
+	}
+	fmt.Fprint(p.ios.Out, question)
+	line, err := p.readLine()
+	if err != nil {
+		return false, err
+	}
+	return line == requiredText, nil
+}
+
+// AcknowledgeEnter waits for Enter (the "press Enter to continue" pattern);
+// a no-op when non-interactive.
+func (p *Prompter) AcknowledgeEnter(message string) error {
+	if p.AssumeDefaults {
+		return nil
+	}
+	fmt.Fprint(p.ios.Out, message)
+	_, err := p.readLine()
+	return err
+}
+
+func (p *Prompter) readLine() (string, error) {
+	line, err := p.reader.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	// EOF with partial input is fine; EOF with nothing reads as empty.
+	return strings.TrimSpace(line), nil
+}

--- a/cli/internal/deploy/prompt/prompt_test.go
+++ b/cli/internal/deploy/prompt/prompt_test.go
@@ -1,0 +1,131 @@
+package prompt
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+)
+
+// interactiveIOS builds an IOStreams that reads input and claims to be a TTY.
+func interactiveIOS(input string) (*iostreams.IOStreams, *bytes.Buffer) {
+	out := &bytes.Buffer{}
+	return &iostreams.IOStreams{
+		In:          strings.NewReader(input),
+		Out:         out,
+		ErrOut:      &bytes.Buffer{},
+		IsStdinTTY:  true,
+		IsStdoutTTY: true,
+	}, out
+}
+
+func TestAskReturnsInput(t *testing.T) {
+	ios, out := interactiveIOS("v1.2.3\n")
+	p := New(ios, false)
+	got, err := p.Ask("Enter tag: ", "edge")
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if got != "v1.2.3" {
+		t.Fatalf("got %q", got)
+	}
+	if !strings.Contains(out.String(), "Enter tag: ") {
+		t.Fatalf("prompt not printed: %q", out.String())
+	}
+}
+
+func TestAskEmptyInputUsesDefault(t *testing.T) {
+	ios, _ := interactiveIOS("\n")
+	got, err := New(ios, false).Ask("tag? ", "edge")
+	if err != nil || got != "edge" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}
+
+func TestAskNonInteractiveUsesDefaultWithoutReading(t *testing.T) {
+	ios, out := interactiveIOS("should-not-be-read\n")
+	ios.IsStdinTTY = false
+	got, err := New(ios, false).Ask("tag? ", "edge")
+	if err != nil || got != "edge" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+	if out.Len() != 0 {
+		t.Fatalf("prompt printed in non-interactive mode: %q", out.String())
+	}
+}
+
+func TestAskAssumeDefaultsFlag(t *testing.T) {
+	ios, _ := interactiveIOS("typed\n")
+	got, err := New(ios, true).Ask("tag? ", "edge")
+	if err != nil || got != "edge" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}
+
+func TestConfirm(t *testing.T) {
+	cases := []struct {
+		input      string
+		defaultYes bool
+		want       bool
+	}{
+		{"y\n", false, true},
+		{"Y\n", false, true},
+		{"yes\n", false, true},
+		{"n\n", true, false},
+		{"No\n", true, false},
+		{"\n", true, true},
+		{"\n", false, false},
+		{"junk\n", true, false},
+	}
+	for _, c := range cases {
+		ios, _ := interactiveIOS(c.input)
+		got, err := New(ios, false).Confirm("continue? ", c.defaultYes)
+		if err != nil {
+			t.Fatalf("Confirm(%q): %v", c.input, err)
+		}
+		if got != c.want {
+			t.Errorf("Confirm(%q, default=%v) = %v, want %v", c.input, c.defaultYes, got, c.want)
+		}
+	}
+}
+
+func TestConfirmTyped(t *testing.T) {
+	ios, _ := interactiveIOS("DELETE\n")
+	ok, err := New(ios, false).ConfirmTyped("type DELETE: ", "DELETE")
+	if err != nil || !ok {
+		t.Fatalf("got %v, %v", ok, err)
+	}
+
+	ios, _ = interactiveIOS("delete\n")
+	ok, err = New(ios, false).ConfirmTyped("type DELETE: ", "DELETE")
+	if err != nil || ok {
+		t.Fatalf("case-insensitive match must fail: %v, %v", ok, err)
+	}
+
+	// Never satisfied non-interactively.
+	ios, _ = interactiveIOS("DELETE\n")
+	ios.IsStdinTTY = false
+	ok, err = New(ios, false).ConfirmTyped("type DELETE: ", "DELETE")
+	if err != nil || ok {
+		t.Fatalf("non-interactive must refuse: %v, %v", ok, err)
+	}
+}
+
+func TestSequentialPromptsShareReader(t *testing.T) {
+	ios, _ := interactiveIOS("first\nsecond\n")
+	p := New(ios, false)
+	a, _ := p.Ask("a? ", "")
+	b, _ := p.Ask("b? ", "")
+	if a != "first" || b != "second" {
+		t.Fatalf("got %q, %q", a, b)
+	}
+}
+
+func TestEOFReadsAsEmpty(t *testing.T) {
+	ios, _ := interactiveIOS("") // immediate EOF
+	got, err := New(ios, false).Ask("tag? ", "edge")
+	if err != nil || got != "edge" {
+		t.Fatalf("got %q, %v", got, err)
+	}
+}

--- a/cli/internal/deploy/release/release.go
+++ b/cli/internal/deploy/release/release.go
@@ -1,0 +1,180 @@
+// Package release resolves Onyx app release tags and fetches deployment files
+// for a pinned ref from GitHub, so a deployment can match versions other than
+// the snapshot embedded in this binary.
+package release
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"regexp"
+	"time"
+)
+
+const (
+	defaultAPIBase = "https://api.github.com"
+	defaultRawBase = "https://raw.githubusercontent.com"
+	owner          = "onyx-dot-app"
+	repo           = "onyx"
+
+	// fetchAttempts bounds retries for raw-file downloads (mirrors
+	// install.sh's `curl --retry`).
+	fetchAttempts     = 3
+	defaultRetryDelay = 2 * time.Second
+)
+
+// appTagPattern matches Onyx app release tags (vX.Y.Z, optionally suffixed
+// like v4.4.6-beta.1), as opposed to tool releases such as cli/v1.2.3.
+var appTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+`)
+
+// FloatingTags are rolling image tags that track main rather than a pinned
+// release.
+func IsFloatingTag(tag string) bool {
+	return tag == "edge" || tag == "latest"
+}
+
+// ConfigRef maps an image tag to the git ref its deployment files ship at:
+// floating tags track main, pinned tags use their own ref (mirrors
+// install.sh's CONFIG_REF logic).
+func ConfigRef(tag string) string {
+	if IsFloatingTag(tag) {
+		return "main"
+	}
+	return tag
+}
+
+// Client talks to GitHub. The zero-ish defaults from NewClient hit the real
+// API; tests point APIBase/RawBase at httptest servers.
+type Client struct {
+	HTTP    *http.Client
+	APIBase string
+	RawBase string
+	// RetryDelay is the pause between fetch attempts (defaults to 2s).
+	RetryDelay time.Duration
+}
+
+// NewClient returns a client with conservative timeouts: release lookup and
+// file fetches gate interactive install steps, so failing fast (callers fall
+// back to main/edge or embedded files) beats hanging.
+func NewClient() *Client {
+	return &Client{
+		HTTP:       &http.Client{Timeout: 10 * time.Second},
+		APIBase:    defaultAPIBase,
+		RawBase:    defaultRawBase,
+		RetryDelay: defaultRetryDelay,
+	}
+}
+
+type releaseInfo struct {
+	TagName    string `json:"tag_name"`
+	Draft      bool   `json:"draft"`
+	Prerelease bool   `json:"prerelease"`
+}
+
+// LatestAppTag returns the newest Onyx app release tag (vX.Y.Z).
+//
+// /releases/latest is repo-global: this repo also publishes desktop and tool
+// releases (cli/v*, ods/v*) under the same namespace, so the result is
+// verified against appTagPattern and, when it doesn't match, the release list
+// is scanned for the newest app tag instead. install.sh trusts
+// /releases/latest blindly; this hardening keeps the default deploy tag an
+// app version even if another release family is ever marked latest.
+func (c *Client) LatestAppTag(ctx context.Context) (string, error) {
+	var latest releaseInfo
+	if err := c.getJSON(ctx, c.APIBase+"/repos/"+owner+"/"+repo+"/releases/latest", &latest); err == nil {
+		if appTagPattern.MatchString(latest.TagName) {
+			return latest.TagName, nil
+		}
+	}
+
+	var releases []releaseInfo
+	if err := c.getJSON(ctx, c.APIBase+"/repos/"+owner+"/"+repo+"/releases?per_page=100", &releases); err != nil {
+		return "", fmt.Errorf("failed to look up the latest Onyx release: %w", err)
+	}
+	for _, r := range releases {
+		if r.Draft || r.Prerelease {
+			continue
+		}
+		if appTagPattern.MatchString(r.TagName) {
+			return r.TagName, nil
+		}
+	}
+	return "", fmt.Errorf("no Onyx app release found among the repository's releases")
+}
+
+// FetchFile downloads repoPath (e.g. "deployment/docker_compose/env.template")
+// at ref. A 404 fails immediately (the ref or path doesn't exist); transient
+// errors are retried. Callers fall back to the embedded copies on error.
+func (c *Client) FetchFile(ctx context.Context, ref, repoPath string) ([]byte, error) {
+	url := c.RawBase + "/" + owner + "/" + repo + "/" + ref + "/" + repoPath
+
+	var lastErr error
+	for attempt := 0; attempt < fetchAttempts; attempt++ {
+		if attempt > 0 {
+			delay := c.RetryDelay
+			if delay == 0 {
+				delay = defaultRetryDelay
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(delay):
+			}
+		}
+		data, retryable, err := c.fetchOnce(ctx, url)
+		if err == nil {
+			return data, nil
+		}
+		lastErr = err
+		if !retryable {
+			break
+		}
+	}
+	return nil, fmt.Errorf("failed to fetch %s at %s: %w", repoPath, ref, lastErr)
+}
+
+func (c *Client) fetchOnce(ctx context.Context, url string) (data []byte, retryable bool, err error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return nil, true, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, true, err
+		}
+		return body, false, nil
+	case resp.StatusCode == http.StatusNotFound:
+		return nil, false, fmt.Errorf("not found (HTTP 404)")
+	case resp.StatusCode >= 500:
+		return nil, true, fmt.Errorf("HTTP %d", resp.StatusCode)
+	default:
+		return nil, false, fmt.Errorf("HTTP %d", resp.StatusCode)
+	}
+}
+
+func (c *Client) getJSON(ctx context.Context, url string, out any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d from %s", resp.StatusCode, url)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}

--- a/cli/internal/deploy/release/release.go
+++ b/cli/internal/deploy/release/release.go
@@ -6,6 +6,7 @@ package release
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -137,6 +138,12 @@ func (c *Client) LatestAppTag(ctx context.Context) (string, error) {
 	return "", fmt.Errorf("no Onyx app release found among the repository's releases")
 }
 
+// ErrNotFound reports that the ref is reachable but doesn't carry the file.
+// Callers distinguish it from a transport failure: one means this deployment
+// simply didn't ship that file at that version, the other means the network
+// is unusable and nothing more should be fetched.
+var ErrNotFound = errors.New("not found")
+
 // FetchFile downloads repoPath (e.g. "deployment/docker_compose/env.template")
 // at ref. A 404 fails immediately (the ref or path doesn't exist); transient
 // errors are retried. Callers fall back to the embedded copies on error.
@@ -218,7 +225,7 @@ func (c *Client) fetchOnce(ctx context.Context, url string) (data []byte, retrya
 		}
 		return body, false, nil
 	case resp.StatusCode == http.StatusNotFound:
-		return nil, false, fmt.Errorf("not found (HTTP 404)")
+		return nil, false, fmt.Errorf("%w (HTTP 404)", ErrNotFound)
 	case resp.StatusCode >= 500:
 		return nil, true, fmt.Errorf("HTTP %d", resp.StatusCode)
 	default:

--- a/cli/internal/deploy/release/release.go
+++ b/cli/internal/deploy/release/release.go
@@ -69,6 +69,27 @@ func IsFloatingTag(tag string) bool {
 	return tag == "edge" || tag == "latest"
 }
 
+// IsImmutableTag reports whether tag names images that are published once and
+// never re-pushed, so a copy already on the host is the copy this deployment
+// wants. Only released versions qualify: floating tags move by design, and the
+// -dev twins are rebuilt per commit under the same name.
+func IsImmutableTag(tag string) bool {
+	rest, ok := strings.CutPrefix(tag, "v")
+	if !ok {
+		return false
+	}
+	parts := strings.Split(rest, ".")
+	if len(parts) != 3 {
+		return false
+	}
+	for _, p := range parts {
+		if p == "" || strings.TrimLeft(p, "0123456789") != "" {
+			return false
+		}
+	}
+	return true
+}
+
 // ConfigRef maps an image tag to the git ref its deployment files ship at:
 // floating tags track main, pinned tags use their own ref (mirrors
 // install.sh's CONFIG_REF logic).

--- a/cli/internal/deploy/release/release.go
+++ b/cli/internal/deploy/release/release.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 )
 
@@ -28,6 +29,38 @@ const (
 // appTagPattern matches Onyx app release tags (vX.Y.Z, optionally suffixed
 // like v4.4.6-beta.1), as opposed to tool releases such as cli/v1.2.3.
 var appTagPattern = regexp.MustCompile(`^v\d+\.\d+\.\d+`)
+
+// refPattern bounds what may be interpolated into a raw.githubusercontent
+// URL path. The ref comes from user input (--tag), and the files it selects
+// are written to the install root and executed by the deployment, so a ref
+// that could escape the repo (".." segments) must never reach the network.
+var refPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._/-]*$`)
+
+func checkRef(ref string) error {
+	if !refPattern.MatchString(ref) || strings.Contains(ref, "..") {
+		return fmt.Errorf("invalid git ref %q", ref)
+	}
+	return nil
+}
+
+// releaseVersionPattern matches a release version as a user would type it,
+// with or without the conventional "v" prefix. Image tags that are not git
+// refs (beta, nightly, vX.Y.Z-dev, locally built tags) deliberately don't
+// match: they are pullable but can't be looked up in the repo.
+var releaseVersionPattern = regexp.MustCompile(`^v?\d+\.\d+\.\d+$`)
+
+// NormalizeVersionTag adds the conventional "v" prefix to a bare release
+// version ("4.4.6" → "v4.4.6") and reports whether the result is a release
+// version, i.e. one whose existence can be checked with RefExists.
+func NormalizeVersionTag(tag string) (string, bool) {
+	if !releaseVersionPattern.MatchString(tag) {
+		return tag, false
+	}
+	if !strings.HasPrefix(tag, "v") {
+		return "v" + tag, true
+	}
+	return tag, true
+}
 
 // FloatingTags are rolling image tags that track main rather than a pinned
 // release.
@@ -108,6 +141,9 @@ func (c *Client) LatestAppTag(ctx context.Context) (string, error) {
 // at ref. A 404 fails immediately (the ref or path doesn't exist); transient
 // errors are retried. Callers fall back to the embedded copies on error.
 func (c *Client) FetchFile(ctx context.Context, ref, repoPath string) ([]byte, error) {
+	if err := checkRef(ref); err != nil {
+		return nil, err
+	}
 	url := c.RawBase + "/" + owner + "/" + repo + "/" + ref + "/" + repoPath
 
 	var lastErr error
@@ -133,6 +169,34 @@ func (c *Client) FetchFile(ctx context.Context, ref, repoPath string) ([]byte, e
 		}
 	}
 	return nil, fmt.Errorf("failed to fetch %s at %s: %w", repoPath, ref, lastErr)
+}
+
+// RefExists reports whether ref (a tag or branch) exists in the repo, via a
+// HEAD request for a file present at every deployable ref. A definitive 404
+// means the ref doesn't exist; transport errors and other statuses return an
+// error so callers can decide whether to proceed unverified.
+func (c *Client) RefExists(ctx context.Context, ref string) (bool, error) {
+	if err := checkRef(ref); err != nil {
+		return false, err
+	}
+	url := c.RawBase + "/" + owner + "/" + repo + "/" + ref + "/deployment/docker_compose/env.template"
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, url, nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := c.HTTP.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return true, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("HTTP %d checking ref %s", resp.StatusCode, ref)
+	}
 }
 
 func (c *Client) fetchOnce(ctx context.Context, url string) (data []byte, retryable bool, err error) {

--- a/cli/internal/deploy/release/release_test.go
+++ b/cli/internal/deploy/release/release_test.go
@@ -159,6 +159,28 @@ func TestConfigRef(t *testing.T) {
 	}
 }
 
+// Only released versions are safe to treat as already-pulled: everything else
+// is re-published under a name the host has already seen.
+func TestIsImmutableTag(t *testing.T) {
+	cases := map[string]bool{
+		"v4.4.6":     true,
+		"v10.0.12":   true,
+		"4.4.6":      false, // the CLI normalizes tags, but be strict here
+		"v4.4":       false,
+		"v4.4.6-dev": false,
+		"v4.4.x":     false,
+		"latest":     false,
+		"edge":       false,
+		"beta":       false,
+		"":           false,
+	}
+	for tag, want := range cases {
+		if got := IsImmutableTag(tag); got != want {
+			t.Errorf("IsImmutableTag(%q) = %v, want %v", tag, got, want)
+		}
+	}
+}
+
 func TestRefExists(t *testing.T) {
 	raw := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodHead {

--- a/cli/internal/deploy/release/release_test.go
+++ b/cli/internal/deploy/release/release_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 )
@@ -148,5 +149,81 @@ func TestConfigRef(t *testing.T) {
 	}
 	if !IsFloatingTag("edge") || !IsFloatingTag("latest") || IsFloatingTag("v4.4.6") {
 		t.Error("IsFloatingTag misclassifies")
+	}
+}
+
+func TestRefExists(t *testing.T) {
+	raw := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			t.Errorf("expected HEAD, got %s", r.Method)
+		}
+		switch {
+		case strings.Contains(r.URL.Path, "/v4.2.0/"):
+			// 200 by default
+		case strings.Contains(r.URL.Path, "/v9.9.9/"):
+			http.NotFound(w, r)
+		default:
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	c, done := testClient(http.NotFoundHandler(), raw)
+	defer done()
+
+	if ok, err := c.RefExists(context.Background(), "v4.2.0"); err != nil || !ok {
+		t.Errorf("v4.2.0: ok=%v err=%v, want existing tag", ok, err)
+	}
+	if ok, err := c.RefExists(context.Background(), "v9.9.9"); err != nil || ok {
+		t.Errorf("v9.9.9: ok=%v err=%v, want a definitive not-found", ok, err)
+	}
+	if _, err := c.RefExists(context.Background(), "flaky"); err == nil {
+		t.Error("a 5xx must surface as an error, not a verdict")
+	}
+}
+
+func TestNormalizeVersionTag(t *testing.T) {
+	cases := []struct {
+		in        string
+		want      string
+		checkable bool
+	}{
+		{"v4.4.6", "v4.4.6", true},
+		{"4.4.6", "v4.4.6", true},
+		{"edge", "edge", false},
+		{"latest", "latest", false},
+		{"main", "main", false},
+		{"v4.4.6-dev", "v4.4.6-dev", false}, // pullable image, not a git ref
+		{"beta", "beta", false},
+		{"v4.4", "v4.4", false},
+	}
+	for _, c := range cases {
+		got, checkable := NormalizeVersionTag(c.in)
+		if got != c.want || checkable != c.checkable {
+			t.Errorf("NormalizeVersionTag(%q) = (%q, %t), want (%q, %t)",
+				c.in, got, checkable, c.want, c.checkable)
+		}
+	}
+}
+
+// The ref lands in a URL path, and the files it selects are written to the
+// install root and executed, so refs that could escape the repo are refused
+// before any request goes out.
+func TestRefsThatEscapeTheRepoAreRefused(t *testing.T) {
+	var reached bool
+	raw := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+	})
+	c, done := testClient(http.NotFoundHandler(), raw)
+	defer done()
+
+	for _, ref := range []string{"../../other/repo/main", "main/../..", "", "-main", "ma in"} {
+		if _, err := c.FetchFile(context.Background(), ref, "deployment/docker_compose/env.template"); err == nil {
+			t.Errorf("FetchFile(%q) was allowed", ref)
+		}
+		if _, err := c.RefExists(context.Background(), ref); err == nil {
+			t.Errorf("RefExists(%q) was allowed", ref)
+		}
+	}
+	if reached {
+		t.Error("a rejected ref still reached the network")
 	}
 }

--- a/cli/internal/deploy/release/release_test.go
+++ b/cli/internal/deploy/release/release_test.go
@@ -1,0 +1,152 @@
+package release
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func testClient(apiHandler, rawHandler http.Handler) (*Client, func()) {
+	api := httptest.NewServer(apiHandler)
+	raw := httptest.NewServer(rawHandler)
+	c := &Client{
+		HTTP:       &http.Client{Timeout: 2 * time.Second},
+		APIBase:    api.URL,
+		RawBase:    raw.URL,
+		RetryDelay: time.Millisecond,
+	}
+	return c, func() { api.Close(); raw.Close() }
+}
+
+func TestLatestAppTagHappyPath(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/onyx-dot-app/onyx/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": "v4.4.6"}`))
+	})
+	c, done := testClient(mux, http.NotFoundHandler())
+	defer done()
+
+	tag, err := c.LatestAppTag(context.Background())
+	if err != nil {
+		t.Fatalf("LatestAppTag: %v", err)
+	}
+	if tag != "v4.4.6" {
+		t.Fatalf("got %q", tag)
+	}
+}
+
+// TestLatestAppTagSkipsToolReleases is the regression test for the repo-global
+// /releases/latest endpoint returning a non-app release (e.g. cli/v1.2.3):
+// the client must fall back to scanning the release list for an app tag.
+func TestLatestAppTagSkipsToolReleases(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/repos/onyx-dot-app/onyx/releases/latest", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name": "cli/v1.2.3"}`))
+	})
+	mux.HandleFunc("/repos/onyx-dot-app/onyx/releases", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`[
+			{"tag_name": "cli/v1.2.3", "draft": false, "prerelease": false},
+			{"tag_name": "v4.5.0-beta.1", "draft": false, "prerelease": true},
+			{"tag_name": "v9.9.9", "draft": true, "prerelease": false},
+			{"tag_name": "v4.4.6", "draft": false, "prerelease": false}
+		]`))
+	})
+	c, done := testClient(mux, http.NotFoundHandler())
+	defer done()
+
+	tag, err := c.LatestAppTag(context.Background())
+	if err != nil {
+		t.Fatalf("LatestAppTag: %v", err)
+	}
+	if tag != "v4.4.6" {
+		t.Fatalf("got %q, want the newest non-draft, non-prerelease app tag", tag)
+	}
+}
+
+func TestLatestAppTagFailsWhenUnreachable(t *testing.T) {
+	c, done := testClient(http.NotFoundHandler(), http.NotFoundHandler())
+	defer done()
+	if _, err := c.LatestAppTag(context.Background()); err == nil {
+		t.Fatal("expected error when the API is unreachable")
+	}
+}
+
+func TestFetchFileSuccessAndPath(t *testing.T) {
+	var gotPath string
+	raw := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte("IMAGE_TAG=latest\n"))
+	})
+	c, done := testClient(http.NotFoundHandler(), raw)
+	defer done()
+
+	data, err := c.FetchFile(context.Background(), "v4.4.6", "deployment/docker_compose/env.template")
+	if err != nil {
+		t.Fatalf("FetchFile: %v", err)
+	}
+	if string(data) != "IMAGE_TAG=latest\n" {
+		t.Fatalf("got %q", data)
+	}
+	want := "/onyx-dot-app/onyx/v4.4.6/deployment/docker_compose/env.template"
+	if gotPath != want {
+		t.Fatalf("fetched %s, want %s", gotPath, want)
+	}
+}
+
+func TestFetchFile404DoesNotRetry(t *testing.T) {
+	calls := 0
+	raw := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		http.NotFound(w, r)
+	})
+	c, done := testClient(http.NotFoundHandler(), raw)
+	defer done()
+
+	if _, err := c.FetchFile(context.Background(), "v0.0.0", "deployment/nope"); err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("404 was retried %d times", calls)
+	}
+}
+
+func TestFetchFileRetriesServerErrors(t *testing.T) {
+	calls := 0
+	raw := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		_, _ = w.Write([]byte("ok"))
+	})
+	c, done := testClient(http.NotFoundHandler(), raw)
+	defer done()
+
+	data, err := c.FetchFile(context.Background(), "main", "deployment/docker_compose/README.md")
+	if err != nil {
+		t.Fatalf("FetchFile: %v", err)
+	}
+	if string(data) != "ok" || calls != 3 {
+		t.Fatalf("got %q after %d calls", data, calls)
+	}
+}
+
+func TestConfigRef(t *testing.T) {
+	cases := map[string]string{
+		"edge":   "main",
+		"latest": "main",
+		"v4.4.6": "v4.4.6",
+		"main":   "main",
+	}
+	for tag, want := range cases {
+		if got := ConfigRef(tag); got != want {
+			t.Errorf("ConfigRef(%q) = %q, want %q", tag, got, want)
+		}
+	}
+	if !IsFloatingTag("edge") || !IsFloatingTag("latest") || IsFloatingTag("v4.4.6") {
+		t.Error("IsFloatingTag misclassifies")
+	}
+}

--- a/cli/internal/deploy/release/release_test.go
+++ b/cli/internal/deploy/release/release_test.go
@@ -2,6 +2,7 @@ package release
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -105,8 +106,14 @@ func TestFetchFile404DoesNotRetry(t *testing.T) {
 	c, done := testClient(http.NotFoundHandler(), raw)
 	defer done()
 
-	if _, err := c.FetchFile(context.Background(), "v0.0.0", "deployment/nope"); err == nil {
+	_, err := c.FetchFile(context.Background(), "v0.0.0", "deployment/nope")
+	if err == nil {
 		t.Fatal("expected error")
+	}
+	// Callers tell "absent at this ref" apart from "network is down": only
+	// the latter stops them fetching the remaining files.
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("404 error = %v, want it to wrap ErrNotFound", err)
 	}
 	if calls != 1 {
 		t.Fatalf("404 was retried %d times", calls)

--- a/cli/internal/deploy/resources/disk_unix.go
+++ b/cli/internal/deploy/resources/disk_unix.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package resources
+
+import "golang.org/x/sys/unix"
+
+// DiskAvailableGB returns the free space at path in GB (-1 = unknown).
+func DiskAvailableGB(path string) int {
+	var st unix.Statfs_t
+	if err := unix.Statfs(path, &st); err != nil {
+		return -1
+	}
+	return int(uint64(st.Bavail) * uint64(st.Bsize) / (1 << 30))
+}

--- a/cli/internal/deploy/resources/disk_windows.go
+++ b/cli/internal/deploy/resources/disk_windows.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package resources
+
+import "golang.org/x/sys/windows"
+
+// DiskAvailableGB returns the free space at path in GB (-1 = unknown).
+func DiskAvailableGB(path string) int {
+	p, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return -1
+	}
+	var freeBytesAvailable, totalBytes, totalFreeBytes uint64
+	if err := windows.GetDiskFreeSpaceEx(p, &freeBytesAvailable, &totalBytes, &totalFreeBytes); err != nil {
+		return -1
+	}
+	return int(freeBytesAvailable / (1 << 30))
+}

--- a/cli/internal/deploy/resources/resources.go
+++ b/cli/internal/deploy/resources/resources.go
@@ -1,0 +1,128 @@
+// Package resources checks host resources for a deployment: memory and disk
+// against the recommended minimums, and a free TCP port for the web server.
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// MemoryMB returns the memory available to Docker in MB (0 = unknown).
+//
+// Linux containers share host memory (/proc/meminfo). On macOS, Docker
+// Desktop runs a VM whose limit lives in its settings.json; the output of
+// `docker system info` (dockerInfo, may be "") is the fallback there and the
+// primary source elsewhere.
+func MemoryMB(dockerInfo string) int {
+	switch runtime.GOOS {
+	case "linux":
+		if mb := procMeminfoMB(); mb > 0 {
+			return mb
+		}
+	case "darwin":
+		if mb := dockerDesktopSettingsMB(); mb > 0 {
+			return mb
+		}
+	}
+	return dockerInfoMemoryMB(dockerInfo)
+}
+
+func procMeminfoMB() int {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "MemTotal:") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			return 0
+		}
+		kb, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return 0
+		}
+		return kb / 1024
+	}
+	return 0
+}
+
+func dockerDesktopSettingsMB() int {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return 0
+	}
+	path := filepath.Join(home, "Library", "Group Containers", "group.com.docker", "settings.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	var settings struct {
+		MemoryMiB int `json:"memoryMiB"`
+	}
+	if err := json.Unmarshal(data, &settings); err != nil {
+		return 0
+	}
+	return settings.MemoryMiB
+}
+
+var totalMemoryPattern = regexp.MustCompile(`(?i)total memory:\s*([0-9.]+)\s*([KMGT]i?B)`)
+
+func dockerInfoMemoryMB(dockerInfo string) int {
+	m := totalMemoryPattern.FindStringSubmatch(dockerInfo)
+	if m == nil {
+		return 0
+	}
+	value, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0
+	}
+	switch strings.ToUpper(strings.TrimSuffix(m[2], "iB")) {
+	case "K":
+		return int(value / 1024)
+	case "M":
+		return int(value)
+	case "G":
+		return int(value * 1024)
+	case "T":
+		return int(value * 1024 * 1024)
+	}
+	// Plain "B" suffix (unlikely): treat as bytes.
+	return int(value / (1024 * 1024))
+}
+
+// FormatMemory renders an MB amount the way install.sh does (~X.YGB above
+// 1GB, plain MB below).
+func FormatMemory(mb int) string {
+	if mb <= 0 {
+		return "unknown"
+	}
+	if mb >= 1024 {
+		return fmt.Sprintf("~%.1fGB", float64(mb)/1024)
+	}
+	return fmt.Sprintf("%dMB", mb)
+}
+
+// FindAvailablePort returns the first TCP port >= start that doesn't accept
+// connections on localhost (the same connect-probe install.sh uses), falling
+// back to start if every port through 65535 is busy.
+func FindAvailablePort(start int) int {
+	for port := start; port <= 65535; port++ {
+		conn, err := net.DialTimeout("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), 200*time.Millisecond)
+		if err != nil {
+			return port
+		}
+		_ = conn.Close()
+	}
+	return start
+}

--- a/cli/internal/deploy/resources/resources_test.go
+++ b/cli/internal/deploy/resources/resources_test.go
@@ -1,0 +1,83 @@
+package resources
+
+import (
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestDockerInfoMemoryMB(t *testing.T) {
+	cases := map[string]int{
+		"Total Memory: 7.667GiB":                     7851, // 7.667 * 1024
+		" Total Memory: 512MiB":                      512,
+		"Kernel Version: 6.1\n Total Memory: 2GiB\n": 2048,
+		"no memory line":                             0,
+		"":                                           0,
+	}
+	for in, want := range cases {
+		if got := dockerInfoMemoryMB(in); got != want {
+			t.Errorf("dockerInfoMemoryMB(%q) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+func TestFormatMemory(t *testing.T) {
+	cases := map[int]string{
+		0:     "unknown",
+		512:   "512MB",
+		1024:  "~1.0GB",
+		15872: "~15.5GB",
+	}
+	for in, want := range cases {
+		if got := FormatMemory(in); got != want {
+			t.Errorf("FormatMemory(%d) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestFindAvailablePortSkipsBusyPort(t *testing.T) {
+	// Occupy a port, then scan starting at it: the scan must move past.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = l.Close() }()
+	go func() {
+		for {
+			conn, err := l.Accept()
+			if err != nil {
+				return
+			}
+			_ = conn.Close()
+		}
+	}()
+
+	_, portStr, err := net.SplitHostPort(l.Addr().String())
+	if err != nil {
+		t.Fatalf("split: %v", err)
+	}
+	busy, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("atoi: %v", err)
+	}
+
+	got := FindAvailablePort(busy)
+	if got == busy {
+		t.Fatalf("returned the busy port %d", busy)
+	}
+	if got < busy || got > busy+100 {
+		t.Fatalf("unexpected port %d for busy %d", got, busy)
+	}
+}
+
+func TestDiskAvailableGBOnCwd(t *testing.T) {
+	got := DiskAvailableGB(".")
+	if got < 0 {
+		t.Skip("disk space unknown in this environment")
+	}
+	// Sanity only: a working checkout has some free space.
+	if got == 0 && !strings.Contains(t.Name(), "full-disk") {
+		t.Logf("0GB free reported — plausible on a nearly full disk")
+	}
+}

--- a/cli/internal/deploy/state/state.go
+++ b/cli/internal/deploy/state/state.go
@@ -1,0 +1,181 @@
+// Package state persists what the CLI last did to a deployment: the
+// install-state.json manifest (installed tag, mode, per-file hashes) plus
+// pristine copies of every managed file as the CLI wrote it. Hashes detect
+// user edits before an upgrade overwrites a file; the pristine copies are the
+// future base for a 3-way merge of user edits with upstream changes.
+package state
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// FileName is the manifest's name inside the install root.
+const FileName = "install-state.json"
+
+// pristineDirName holds the as-written copies of managed files, keyed by
+// their DestRel paths, inside the install root.
+const pristineDirName = ".onyx-cli-pristine"
+
+// SchemaVersion is the current manifest schema.
+const SchemaVersion = 1
+
+// Mode is the deployment mode recorded in the manifest.
+type Mode string
+
+const (
+	ModeStandard Mode = "standard"
+	ModeLite     Mode = "lite"
+)
+
+// FileEntry records one managed file as last written by the CLI.
+type FileEntry struct {
+	SHA256 string `json:"sha256"`
+}
+
+// Manifest is the persisted install state.
+type Manifest struct {
+	SchemaVersion int                  `json:"schema_version"`
+	InstalledTag  string               `json:"installed_tag"`
+	CLIVersion    string               `json:"cli_version"`
+	Mode          Mode                 `json:"mode"`
+	IncludeCraft  bool                 `json:"include_craft"`
+	Files         map[string]FileEntry `json:"files"` // keyed by DestRel
+	InstalledAt   time.Time            `json:"installed_at"`
+	UpdatedAt     time.Time            `json:"updated_at"`
+}
+
+// Path returns the manifest location for an install root.
+func Path(installRoot string) string {
+	return filepath.Join(installRoot, FileName)
+}
+
+// Load reads the manifest from an install root. A missing manifest returns
+// (nil, nil): the deployment predates the CLI (or was created by install.sh)
+// and callers run their adopt flow.
+func Load(installRoot string) (*Manifest, error) {
+	data, err := os.ReadFile(Path(installRoot))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to read %s: %w", FileName, err)
+	}
+	var m Manifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("failed to parse %s: %w", FileName, err)
+	}
+	if m.SchemaVersion > SchemaVersion {
+		return nil, fmt.Errorf("%s has schema version %d, written by a newer onyx-cli — upgrade the CLI",
+			FileName, m.SchemaVersion)
+	}
+	return &m, nil
+}
+
+// Save atomically writes the manifest into an install root.
+func (m *Manifest) Save(installRoot string) error {
+	m.SchemaVersion = SchemaVersion
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to encode %s: %w", FileName, err)
+	}
+	data = append(data, '\n')
+
+	tmp, err := os.CreateTemp(installRoot, FileName+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file for %s: %w", FileName, err)
+	}
+	tmpName := tmp.Name()
+	defer func() { _ = os.Remove(tmpName) }()
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("failed to write %s: %w", FileName, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("failed to close %s: %w", FileName, err)
+	}
+	if err := os.Rename(tmpName, Path(installRoot)); err != nil {
+		return fmt.Errorf("failed to replace %s: %w", FileName, err)
+	}
+	return nil
+}
+
+// HashBytes returns the manifest-format digest of content.
+func HashBytes(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+// HashFile returns the manifest-format digest of the file at path.
+func HashFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return HashBytes(data), nil
+}
+
+// RecordFile stores content's hash for destRel and writes the pristine copy.
+func (m *Manifest) RecordFile(installRoot, destRel string, content []byte) error {
+	if m.Files == nil {
+		m.Files = make(map[string]FileEntry)
+	}
+	m.Files[destRel] = FileEntry{SHA256: HashBytes(content)}
+
+	path := pristinePath(installRoot, destRel)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("failed to create pristine dir for %s: %w", destRel, err)
+	}
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		return fmt.Errorf("failed to write pristine copy of %s: %w", destRel, err)
+	}
+	return nil
+}
+
+// ForgetFile drops destRel from the manifest and removes its pristine copy
+// (used when an overlay is removed, e.g. switching lite -> standard).
+func (m *Manifest) ForgetFile(installRoot, destRel string) error {
+	delete(m.Files, destRel)
+	if err := os.Remove(pristinePath(installRoot, destRel)); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to remove pristine copy of %s: %w", destRel, err)
+	}
+	return nil
+}
+
+// Pristine returns the as-written copy of destRel, or (nil, nil) if none is
+// stored.
+func Pristine(installRoot, destRel string) ([]byte, error) {
+	data, err := os.ReadFile(pristinePath(installRoot, destRel))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	return data, err
+}
+
+// UserEdited reports whether the on-disk file at destRel differs from the
+// hash recorded in the manifest. Files absent from the manifest report true
+// (no baseline means the CLI cannot vouch for them); files recorded but
+// missing on disk report false (nothing to preserve).
+func (m *Manifest) UserEdited(installRoot, destRel string) (bool, error) {
+	entry, ok := m.Files[destRel]
+	if !ok {
+		return true, nil
+	}
+	onDisk, err := HashFile(filepath.Join(installRoot, filepath.FromSlash(destRel)))
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return onDisk != entry.SHA256, nil
+}
+
+func pristinePath(installRoot, destRel string) string {
+	return filepath.Join(installRoot, pristineDirName, filepath.FromSlash(destRel))
+}

--- a/cli/internal/deploy/state/state.go
+++ b/cli/internal/deploy/state/state.go
@@ -55,6 +55,13 @@ func Path(installRoot string) string {
 	return filepath.Join(installRoot, FileName)
 }
 
+// Exists reports whether an install root carries a manifest, i.e. whether the
+// CLI has ever managed it.
+func Exists(installRoot string) bool {
+	_, err := os.Stat(Path(installRoot))
+	return err == nil
+}
+
 // Load reads the manifest from an install root. A missing manifest returns
 // (nil, nil): the deployment predates the CLI (or was created by install.sh)
 // and callers run their adopt flow.

--- a/cli/internal/deploy/state/state_test.go
+++ b/cli/internal/deploy/state/state_test.go
@@ -1,0 +1,190 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLoadMissingReturnsNilNil(t *testing.T) {
+	m, err := Load(t.TempDir())
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if m != nil {
+		t.Fatalf("expected nil manifest, got %+v", m)
+	}
+}
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	root := t.TempDir()
+	in := &Manifest{
+		InstalledTag: "v4.4.6",
+		CLIVersion:   "v1.2.3",
+		Mode:         ModeLite,
+		IncludeCraft: true,
+		InstalledAt:  time.Now().UTC().Truncate(time.Second),
+	}
+	if err := in.RecordFile(root, "deployment/docker-compose.yml", []byte("name: onyx\n")); err != nil {
+		t.Fatalf("RecordFile: %v", err)
+	}
+	if err := in.Save(root); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	out, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if out.SchemaVersion != SchemaVersion {
+		t.Errorf("schema version not stamped: %d", out.SchemaVersion)
+	}
+	if out.InstalledTag != in.InstalledTag || out.Mode != in.Mode || !out.IncludeCraft {
+		t.Errorf("round trip mismatch: %+v", out)
+	}
+	entry, ok := out.Files["deployment/docker-compose.yml"]
+	if !ok || entry.SHA256 != HashBytes([]byte("name: onyx\n")) {
+		t.Errorf("file entry not preserved: %+v", out.Files)
+	}
+}
+
+func TestLoadCorruptFails(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(Path(root), []byte("{not json"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, err := Load(root); err == nil {
+		t.Fatal("expected error for corrupt manifest")
+	}
+}
+
+func TestLoadNewerSchemaFails(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(Path(root), []byte(`{"schema_version": 999}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := Load(root)
+	if err == nil || !strings.Contains(err.Error(), "newer onyx-cli") {
+		t.Fatalf("expected newer-schema error, got %v", err)
+	}
+}
+
+func TestSaveIsAtomic(t *testing.T) {
+	root := t.TempDir()
+	first := &Manifest{InstalledTag: "v1.0.0"}
+	if err := first.Save(root); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	second := &Manifest{InstalledTag: "v2.0.0"}
+	if err := second.Save(root); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// No temp files left behind, and the content is the latest write.
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".tmp-") {
+			t.Errorf("leftover temp file %s", e.Name())
+		}
+	}
+	got, err := Load(root)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if got.InstalledTag != "v2.0.0" {
+		t.Errorf("got tag %s", got.InstalledTag)
+	}
+}
+
+func TestPristineRoundTripAndForget(t *testing.T) {
+	root := t.TempDir()
+	m := &Manifest{}
+	content := []byte("services: {}\n")
+	if err := m.RecordFile(root, "deployment/docker-compose.onyx-lite.yml", content); err != nil {
+		t.Fatalf("RecordFile: %v", err)
+	}
+
+	got, err := Pristine(root, "deployment/docker-compose.onyx-lite.yml")
+	if err != nil {
+		t.Fatalf("Pristine: %v", err)
+	}
+	if string(got) != string(content) {
+		t.Errorf("pristine content mismatch: %q", got)
+	}
+
+	if err := m.ForgetFile(root, "deployment/docker-compose.onyx-lite.yml"); err != nil {
+		t.Fatalf("ForgetFile: %v", err)
+	}
+	if _, ok := m.Files["deployment/docker-compose.onyx-lite.yml"]; ok {
+		t.Error("entry still in manifest after ForgetFile")
+	}
+	got, err = Pristine(root, "deployment/docker-compose.onyx-lite.yml")
+	if err != nil {
+		t.Fatalf("Pristine after forget: %v", err)
+	}
+	if got != nil {
+		t.Errorf("pristine copy still present after ForgetFile")
+	}
+}
+
+func TestUserEdited(t *testing.T) {
+	root := t.TempDir()
+	m := &Manifest{}
+	destRel := "deployment/docker-compose.yml"
+	content := []byte("name: onyx\n")
+
+	if err := os.MkdirAll(filepath.Join(root, "deployment"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	onDisk := filepath.Join(root, filepath.FromSlash(destRel))
+	if err := os.WriteFile(onDisk, content, 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := m.RecordFile(root, destRel, content); err != nil {
+		t.Fatalf("RecordFile: %v", err)
+	}
+
+	edited, err := m.UserEdited(root, destRel)
+	if err != nil {
+		t.Fatalf("UserEdited: %v", err)
+	}
+	if edited {
+		t.Error("unmodified file reported as edited")
+	}
+
+	if err := os.WriteFile(onDisk, []byte("name: onyx\n# hand edit\n"), 0644); err != nil {
+		t.Fatalf("edit: %v", err)
+	}
+	edited, err = m.UserEdited(root, destRel)
+	if err != nil {
+		t.Fatalf("UserEdited: %v", err)
+	}
+	if !edited {
+		t.Error("edited file not detected")
+	}
+
+	// No baseline recorded -> treated as edited.
+	edited, err = m.UserEdited(root, "deployment/env.template")
+	if err != nil {
+		t.Fatalf("UserEdited: %v", err)
+	}
+	if !edited {
+		t.Error("file without baseline should report edited")
+	}
+
+	// Recorded but deleted on disk -> nothing to preserve.
+	if err := os.Remove(onDisk); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	edited, err = m.UserEdited(root, destRel)
+	if err != nil {
+		t.Fatalf("UserEdited: %v", err)
+	}
+	if edited {
+		t.Error("missing file should not report edited")
+	}
+}

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -229,7 +229,22 @@ func (m wizModel) View() tea.View {
 		return tea.NewView(cardBox.Render(strings.Join(m.card, "\n")) + "\n")
 	}
 	if m.aborted {
-		return tea.NewView("")
+		// Leave the guidance in scrollback instead of wiping the screen —
+		// the notes are exactly what the user needs after a failure.
+		var b strings.Builder
+		for _, n := range m.notes {
+			switch n.level {
+			case "ok":
+				b.WriteString(okStyle.Render("✓ ") + n.text + "\n")
+			case "warn":
+				b.WriteString(warnSt.Render("⚠ ") + n.text + "\n")
+			case "err":
+				b.WriteString(errSt.Render("✗ ") + n.text + "\n")
+			default:
+				b.WriteString("  " + n.text + "\n")
+			}
+		}
+		return tea.NewView(b.String())
 	}
 
 	// Left rail: stages + recorded answers.

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -35,6 +35,10 @@ var (
 	spinners = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 )
 
+// promptMark heads a question. It is the dot the chat TUI marks its own turns
+// with (internal/tui), so being asked something looks the same across the CLI.
+const promptMark = "◉ "
+
 // Enabled reports whether the wizard should drive this run.
 func Enabled(ios *iostreams.IOStreams) bool {
 	return ios.IsInteractive() && os.Getenv("TERM") != "dumb" && os.Getenv("NO_COLOR") == ""
@@ -402,7 +406,7 @@ func (m wizModel) paneLines(inner, maxLines int) []string {
 		}
 		return clip(pane, maxLines)
 	case m.inp != nil:
-		return clip(append(wrap(accent.Render("? ")+m.inp.title, inner),
+		return clip(append(wrap(accent.Render(promptMark)+m.inp.title, inner),
 			truncate("  "+m.typed+accent.Render("▏"), inner)), maxLines)
 	case m.taskActive:
 		return clip(m.taskPane(inner, maxLines), maxLines)
@@ -415,7 +419,7 @@ func (m wizModel) paneLines(inner, maxLines int) []string {
 // opposed to single-line) title are what it gives up, in that order, when the
 // pane has to get shorter.
 func (m wizModel) selectPane(inner int, hints, wrapTitle bool) []string {
-	title := accent.Render("? ") + m.sel.title
+	title := accent.Render(promptMark) + m.sel.title
 	pane := []string{truncate(title, inner)}
 	if wrapTitle {
 		pane = wrap(title, inner)

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -72,6 +72,10 @@ const (
 	// and a padding column on each side. The summary card pads wider.
 	paneChrome = 4
 	cardChrome = 6
+	// An option line is "  Label  hint": a two-column cursor, then at least
+	// this much space before the hint.
+	cursorWidth = 2
+	hintGap     = 2
 	// Sizes assumed until the first window-size message arrives.
 	defaultWidth  = 80
 	defaultHeight = 24
@@ -424,6 +428,7 @@ func (m wizModel) selectPane(inner int, hints, wrapTitle bool) []string {
 	if wrapTitle {
 		pane = wrap(title, inner)
 	}
+	col := hintColumn(m.sel.opts, inner)
 	for i, o := range m.sel.opts {
 		cursor, label := "  ", o.Label
 		if i == m.cursor {
@@ -436,8 +441,9 @@ func (m wizModel) selectPane(inner int, hints, wrapTitle bool) []string {
 		}
 		// Keep the hint beside its option while it fits; otherwise it wraps
 		// underneath rather than being cut off.
-		if lipgloss.Width(line)+2+lipgloss.Width(o.Hint) <= inner {
-			pane = append(pane, line+"  "+dim.Render(o.Hint))
+		pad := max(col-lipgloss.Width(line), hintGap)
+		if lipgloss.Width(line)+pad+lipgloss.Width(o.Hint) <= inner {
+			pane = append(pane, line+strings.Repeat(" ", pad)+dim.Render(o.Hint))
 			continue
 		}
 		pane = append(pane, truncate(line, inner))
@@ -446,6 +452,35 @@ func (m wizModel) selectPane(inner int, hints, wrapTitle bool) []string {
 		}
 	}
 	return pane
+}
+
+// hintColumn is the column the hints all start at, so they read down the pane
+// as one column instead of stepping in and out with the labels. Zero means
+// each hint simply follows its own label.
+func hintColumn(opts []Option, inner int) int {
+	widest := 0
+	for _, o := range opts {
+		if o.Hint != "" {
+			widest = max(widest, lipgloss.Width(o.Label))
+		}
+	}
+	if widest == 0 {
+		return 0
+	}
+	col := cursorWidth + widest + hintGap
+	// Lining the hints up must not cost one of them its place beside its
+	// option: on a screen where the column would push a hint that fits onto
+	// its own line, the ragged layout says the same thing in fewer rows.
+	for _, o := range opts {
+		if o.Hint == "" {
+			continue
+		}
+		fits := cursorWidth+lipgloss.Width(o.Label)+hintGap+lipgloss.Width(o.Hint) <= inner
+		if fits && col+lipgloss.Width(o.Hint) > inner {
+			return 0
+		}
+	}
+	return col
 }
 
 // clip keeps a pane within its row budget, marking what it cut.

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -569,6 +569,23 @@ func wrap(s string, width int) []string {
 	return strings.Split(ansi.WrapWc(s, width, " -/"), "\n")
 }
 
+// wrapHanging wraps a line so what overflows stays under it. Indented card
+// lines (a list of commands under its heading) would otherwise continue at the
+// left margin, where the eye reads them as another entry rather than the rest
+// of one.
+func wrapHanging(s string, width int) []string {
+	body := strings.TrimLeft(s, " ")
+	indent := s[:len(s)-len(body)]
+	if indent == "" || width-len(indent) < 1 {
+		return wrap(s, width)
+	}
+	segs := wrap(body, width-len(indent))
+	for i := range segs {
+		segs[i] = indent + segs[i]
+	}
+	return segs
+}
+
 // Wizard drives the model from the orchestration goroutine.
 type Wizard struct {
 	prog *tea.Program
@@ -622,7 +639,7 @@ func (w *Wizard) printTail(m wizModel) {
 		inner := max(width-cardChrome, minPaneInner)
 		var lines []string
 		for _, l := range m.card {
-			lines = append(lines, wrap(l, inner)...)
+			lines = append(lines, wrapHanging(l, inner)...)
 		}
 		fmt.Fprintln(w.out, cardBox.Width(inner+cardChrome).Render(strings.Join(lines, "\n")))
 		return

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -65,8 +65,9 @@ const (
 	minTwoColumn = 64
 	minPaneInner = 20
 	// paneChrome is what the pane's box costs horizontally: a border column
-	// and a padding column on each side.
+	// and a padding column on each side. The summary card pads wider.
 	paneChrome = 4
+	cardChrome = 6
 	// Sizes assumed until the first window-size message arrives.
 	defaultWidth  = 80
 	defaultHeight = 24
@@ -571,11 +572,15 @@ func (w *Wizard) printTail(m wizModel) {
 		width = defaultWidth
 	}
 	if m.card != nil {
+		// Sized to the terminal for the same reason the pane is: a card that
+		// takes its width from its longest line ends up narrower than the run
+		// it is summarizing, which reads as the layout coming apart at the end.
+		inner := max(width-cardChrome, minPaneInner)
 		var lines []string
 		for _, l := range m.card {
-			lines = append(lines, wrap(l, max(width-6, minPaneInner))...)
+			lines = append(lines, wrap(l, inner)...)
 		}
-		fmt.Fprintln(w.out, cardBox.Render(strings.Join(lines, "\n")))
+		fmt.Fprintln(w.out, cardBox.Width(inner+cardChrome).Render(strings.Join(lines, "\n")))
 		return
 	}
 	for _, n := range m.notes {

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -1,6 +1,9 @@
 // Package ui renders the interactive installer as a single live wizard: a
-// persistent Bubble Tea program with a step rail, an active pane for
-// questions and progress, and a final summary card. The deploy orchestration
+// full-screen (alt-screen) Bubble Tea program with a step rail, an active
+// pane for questions and progress, and a final summary card. The alt screen
+// is discarded when the program exits, so the wizard re-prints whatever the
+// user still needs (the summary card, or the notes after an abort) to the
+// normal screen where it survives in scrollback. The deploy orchestration
 // falls back to plain line output when a real TTY isn't driving the run, so
 // CI logs and --no-prompt behavior stay stable.
 package ui
@@ -8,6 +11,7 @@ package ui
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -84,6 +88,7 @@ type (
 )
 
 type wizModel struct {
+	title   string
 	version string
 	stage   int
 	answers []answerMsg
@@ -100,8 +105,9 @@ type wizModel struct {
 	frame                int
 	services             []ServiceRow
 
-	card    []string
-	aborted bool
+	card     []string
+	aborted  bool
+	userQuit bool // aborted by a key press, not programmatically
 }
 
 func tick() tea.Cmd {
@@ -187,7 +193,7 @@ func (m wizModel) handleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "esc", "q":
 			m.sel.reply <- -1
 			m.sel = nil
-			m.aborted = true
+			m.aborted, m.userQuit = true, true
 			return m, tea.Quit
 		}
 		return m, nil
@@ -204,7 +210,7 @@ func (m wizModel) handleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "esc":
 			m.inp.reply <- nil
 			m.inp = nil
-			m.aborted = true
+			m.aborted, m.userQuit = true, true
 			return m, tea.Quit
 		case "backspace":
 			if len(m.typed) > 0 {
@@ -218,35 +224,31 @@ func (m wizModel) handleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	if s == "ctrl+c" {
-		m.aborted = true
+		m.aborted, m.userQuit = true, true
 		return m, tea.Quit
 	}
 	return m, nil
 }
 
-func (m wizModel) View() tea.View {
-	if m.card != nil {
-		return tea.NewView(cardBox.Render(strings.Join(m.card, "\n")) + "\n")
-	}
-	if m.aborted {
-		// Leave the guidance in scrollback instead of wiping the screen —
-		// the notes are exactly what the user needs after a failure.
-		var b strings.Builder
-		for _, n := range m.notes {
-			switch n.level {
-			case "ok":
-				b.WriteString(okStyle.Render("✓ ") + n.text + "\n")
-			case "warn":
-				b.WriteString(warnSt.Render("⚠ ") + n.text + "\n")
-			case "err":
-				b.WriteString(errSt.Render("✗ ") + n.text + "\n")
-			default:
-				b.WriteString("  " + n.text + "\n")
-			}
+// renderNote styles one note line (shared by the live view and the
+// post-exit tail).
+func renderNote(n noteMsg, live bool) string {
+	switch n.level {
+	case "ok":
+		return okStyle.Render("✓ ") + n.text
+	case "warn":
+		return warnSt.Render("⚠ ") + n.text
+	case "err":
+		return errSt.Render("✗ ") + n.text
+	default:
+		if live {
+			return dim.Render("  " + n.text)
 		}
-		return tea.NewView(b.String())
+		return "  " + n.text
 	}
+}
 
+func (m wizModel) View() tea.View {
 	// Left rail: stages + recorded answers.
 	var rail []string
 	for i, name := range stageNames {
@@ -309,46 +311,63 @@ func (m wizModel) View() tea.View {
 		paneBox.Render(strings.Join(pane, "\n")))
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "%s %s\n\n", accent.Render("🚀 Onyx Installer"), dim.Render(m.version))
+	fmt.Fprintf(&b, "\n %s %s\n\n", accent.Render("🚀 "+m.title), dim.Render(m.version))
 	b.WriteString(body + "\n")
 	for _, n := range m.notes {
-		switch n.level {
-		case "ok":
-			b.WriteString(okStyle.Render("✓ ") + n.text + "\n")
-		case "warn":
-			b.WriteString(warnSt.Render("⚠ ") + n.text + "\n")
-		case "err":
-			b.WriteString(errSt.Render("✗ ") + n.text + "\n")
-		default:
-			b.WriteString(dim.Render("  "+n.text) + "\n")
-		}
+		b.WriteString(renderNote(n, true) + "\n")
 	}
-	b.WriteString(dim.Render("↑/↓ move · enter confirm · ctrl+c quit"))
-	return tea.NewView(b.String())
+	b.WriteString("\n" + dim.Render(" ↑/↓ move · enter confirm · ctrl+c quit"))
+
+	v := tea.NewView(b.String())
+	v.AltScreen = true
+	v.WindowTitle = m.title
+	return v
 }
 
 // Wizard drives the model from the orchestration goroutine.
 type Wizard struct {
 	prog *tea.Program
 	done chan struct{}
+	out  io.Writer
 }
 
-// StartWizard launches the inline wizard program. onAbort fires when the
-// user quits the wizard (ctrl+c/esc) so the orchestration can cancel any
-// in-flight work — without it, killing the UI would leave compose running.
-func StartWizard(version string, onAbort func()) *Wizard {
+// StartWizard launches the full-screen wizard program. onAbort fires only
+// when the user quits the wizard (ctrl+c/esc) so the orchestration can
+// cancel any in-flight work — without it, killing the UI would leave
+// compose running. A programmatic Abort (teardown before plain output) must
+// NOT fire it, or real failures get misreported as cancellations.
+func StartWizard(out io.Writer, title, version string, onAbort func()) *Wizard {
 	w := &Wizard{
-		prog: tea.NewProgram(wizModel{version: version}),
+		prog: tea.NewProgram(wizModel{title: title, version: version}),
 		done: make(chan struct{}),
+		out:  out,
 	}
 	go func() {
 		m, _ := w.prog.Run()
+		wm, ok := m.(wizModel)
+		if ok {
+			w.printTail(wm)
+		}
 		close(w.done)
-		if wm, ok := m.(wizModel); ok && wm.aborted && onAbort != nil {
+		if ok && wm.userQuit && onAbort != nil {
 			onAbort()
 		}
 	}()
 	return w
+}
+
+// printTail re-prints what the discarded alt screen was showing to the
+// normal screen, where it survives in scrollback: the summary card when the
+// run finished, otherwise the accumulated notes — exactly what the user
+// needs after an abort or failure.
+func (w *Wizard) printTail(m wizModel) {
+	if m.card != nil {
+		fmt.Fprintln(w.out, cardBox.Render(strings.Join(m.card, "\n")))
+		return
+	}
+	for _, n := range m.notes {
+		fmt.Fprintln(w.out, renderNote(n, false))
+	}
 }
 
 // Select asks an arrow-key question and blocks for the answer.
@@ -401,13 +420,16 @@ func (w *Wizard) Suspend(fn func() error) error {
 	return fn()
 }
 
-// Finish renders the summary card as the final scrollback view and exits.
+// Finish exits the wizard and prints the summary card to the normal screen.
+// It blocks until the card has been written, so callers can keep printing
+// plain output right after.
 func (w *Wizard) Finish(lines ...string) {
 	w.prog.Send(finishMsg(lines))
-	w.prog.Wait()
+	<-w.done
 }
 
-// Abort tears the wizard down (no-op after Finish).
+// Abort tears the wizard down (no-op after Finish), leaving the accumulated
+// notes on the normal screen. It blocks until they have been written.
 func (w *Wizard) Abort() {
 	select {
 	case <-w.done:
@@ -415,7 +437,7 @@ func (w *Wizard) Abort() {
 	default:
 	}
 	w.prog.Send(abortMsg{})
-	w.prog.Wait()
+	<-w.done
 }
 
 // Accent styles a string for emphasis outside the wizard (plain summaries).

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -125,7 +125,9 @@ func (m wizModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.sel, m.cursor = &msg, msg.def
 		return m, nil
 	case askInputMsg:
-		m.inp, m.typed = &msg, ""
+		// Prefill the default as real, editable text — backspacing to tweak
+		// e.g. just the patch version beats retyping the whole tag.
+		m.inp, m.typed = &msg, msg.def
 		return m, nil
 	case stageMsg:
 		m.stage = int(msg)
@@ -213,9 +215,12 @@ func (m wizModel) handleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.aborted, m.userQuit = true, true
 			return m, tea.Quit
 		case "backspace":
-			if len(m.typed) > 0 {
-				m.typed = m.typed[:len(m.typed)-1]
+			// Rune-wise: byte slicing would split a multi-byte character.
+			if r := []rune(m.typed); len(r) > 0 {
+				m.typed = string(r[:len(r)-1])
 			}
+		case "ctrl+u":
+			m.typed = ""
 		default:
 			if len([]rune(s)) == 1 && !strings.Contains(s, "+") {
 				m.typed += s
@@ -283,11 +288,7 @@ func (m wizModel) View() tea.View {
 			pane = append(pane, line)
 		}
 	case m.inp != nil:
-		shown := m.typed
-		if shown == "" {
-			shown = dim.Render(m.inp.def)
-		}
-		pane = append(pane, accent.Render("? ")+m.inp.title, "  "+shown+accent.Render("▏"))
+		pane = append(pane, accent.Render("? ")+m.inp.title, "  "+m.typed+accent.Render("▏"))
 	case m.taskActive:
 		line := fmt.Sprintf("%s %s %s", accent.Render(spinners[m.frame%len(spinners)]),
 			m.taskLabel, dim.Render(fmt.Sprintf("(%ds)", int(time.Since(m.taskBegan).Seconds()))))

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -1,0 +1,255 @@
+// Package ui renders the interactive installer experience: inline
+// arrow-key prompts (Bubble Tea) and live spinner progress (lipgloss). The
+// deploy orchestration falls back to plain line output when a real TTY isn't
+// driving the run, so CI logs and --no-prompt behavior stay stable.
+package ui
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
+)
+
+var (
+	accent  = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+	dim     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	okMark  = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).SetString("✓").String()
+	errMark = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).SetString("✗").String()
+	boxLine = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 2)
+)
+
+// Enabled reports whether the fancy renderer should drive this run.
+func Enabled(ios *iostreams.IOStreams) bool {
+	return ios.IsInteractive() && os.Getenv("TERM") != "dumb" && os.Getenv("NO_COLOR") == ""
+}
+
+// ErrAborted is returned when the user cancels a prompt (ctrl+c / esc / q).
+var ErrAborted = errors.New("cancelled")
+
+// Option is one selectable choice.
+type Option struct {
+	Label string
+	Hint  string
+}
+
+type selectModel struct {
+	title   string
+	options []Option
+	cursor  int
+	done    bool
+	abort   bool
+}
+
+func (m selectModel) Init() tea.Cmd { return nil }
+
+func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyPressMsg); ok {
+		switch key.String() {
+		case "up", "k":
+			if m.cursor > 0 {
+				m.cursor--
+			}
+		case "down", "j", "tab":
+			if m.cursor < len(m.options)-1 {
+				m.cursor++
+			}
+		case "1", "2", "3", "4":
+			if idx := int(key.String()[0] - '1'); idx < len(m.options) {
+				m.cursor = idx
+			}
+			m.done = true
+			return m, tea.Quit
+		case "enter":
+			m.done = true
+			return m, tea.Quit
+		case "ctrl+c", "esc", "q":
+			m.abort = true
+			return m, tea.Quit
+		}
+	}
+	return m, nil
+}
+
+func (m selectModel) View() tea.View {
+	if m.done || m.abort {
+		return tea.NewView("")
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s\n", accent.Render("?"), m.title)
+	for i, o := range m.options {
+		cursor, label := " ", o.Label
+		if i == m.cursor {
+			cursor, label = accent.Render("›"), accent.Render(o.Label)
+		}
+		hint := ""
+		if o.Hint != "" {
+			hint = "  " + dim.Render(o.Hint)
+		}
+		fmt.Fprintf(&b, "  %s %s%s\n", cursor, label, hint)
+	}
+	b.WriteString(dim.Render("  ↑/↓ to move · enter to confirm"))
+	return tea.NewView(b.String())
+}
+
+// Select runs an inline arrow-key select and echoes the answer.
+func Select(ios *iostreams.IOStreams, title string, options []Option, defaultIdx int) (int, error) {
+	m := selectModel{title: title, options: options, cursor: defaultIdx}
+	out, err := tea.NewProgram(m).Run()
+	if err != nil {
+		return 0, err
+	}
+	final := out.(selectModel)
+	if final.abort {
+		return 0, ErrAborted
+	}
+	fmt.Fprintf(ios.Out, "%s %s %s\n", okMark, title, accent.Render(options[final.cursor].Label))
+	return final.cursor, nil
+}
+
+type inputModel struct {
+	title      string
+	defaultVal string
+	value      string
+	done       bool
+	abort      bool
+}
+
+func (m inputModel) Init() tea.Cmd { return nil }
+
+func (m inputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if key, ok := msg.(tea.KeyPressMsg); ok {
+		s := key.String()
+		switch s {
+		case "enter":
+			m.done = true
+			return m, tea.Quit
+		case "ctrl+c", "esc":
+			m.abort = true
+			return m, tea.Quit
+		case "backspace":
+			if len(m.value) > 0 {
+				m.value = m.value[:len(m.value)-1]
+			}
+		default:
+			if len(s) == 1 || (len(s) > 0 && !strings.Contains(s, "+") && len([]rune(s)) == 1) {
+				m.value += s
+			}
+		}
+	}
+	return m, nil
+}
+
+func (m inputModel) View() tea.View {
+	if m.done || m.abort {
+		return tea.NewView("")
+	}
+	shown := m.value
+	if shown == "" {
+		shown = dim.Render(m.defaultVal)
+	}
+	return tea.NewView(fmt.Sprintf("%s %s %s%s\n%s",
+		accent.Render("?"), m.title, shown, accent.Render("▏"),
+		dim.Render("  enter to accept")))
+}
+
+// Input runs an inline text prompt; empty submission returns defaultVal.
+func Input(ios *iostreams.IOStreams, title, defaultVal string) (string, error) {
+	m := inputModel{title: title, defaultVal: defaultVal}
+	out, err := tea.NewProgram(m).Run()
+	if err != nil {
+		return "", err
+	}
+	final := out.(inputModel)
+	if final.abort {
+		return "", ErrAborted
+	}
+	value := strings.TrimSpace(final.value)
+	if value == "" {
+		value = defaultVal
+	}
+	fmt.Fprintf(ios.Out, "%s %s %s\n", okMark, title, accent.Render(value))
+	return value, nil
+}
+
+// Task is a single-line live spinner: "⠋ label (12s) extra".
+type Task struct {
+	w     io.Writer
+	label string
+
+	mu    sync.Mutex
+	extra string
+	stop  chan struct{}
+	wg    sync.WaitGroup
+	start time.Time
+}
+
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// StartTask begins rendering a spinner line until Done is called.
+func StartTask(w io.Writer, label string) *Task {
+	t := &Task{w: w, label: label, stop: make(chan struct{}), start: time.Now()}
+	t.wg.Add(1)
+	go func() {
+		defer t.wg.Done()
+		frame := 0
+		ticker := time.NewTicker(120 * time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-t.stop:
+				return
+			case <-ticker.C:
+				t.mu.Lock()
+				extra := t.extra
+				t.mu.Unlock()
+				if extra != "" {
+					extra = " " + dim.Render(extra)
+				}
+				elapsed := dim.Render(fmt.Sprintf("(%ds)", int(time.Since(t.start).Seconds())))
+				fmt.Fprintf(t.w, "\r\033[K%s %s %s%s",
+					accent.Render(spinnerFrames[frame%len(spinnerFrames)]), t.label, elapsed, extra)
+				frame++
+			}
+		}
+	}()
+	return t
+}
+
+// Update swaps the trailing status text.
+func (t *Task) Update(extra string) {
+	t.mu.Lock()
+	t.extra = extra
+	t.mu.Unlock()
+}
+
+// Done stops the spinner and prints the final ✓/✗ line.
+func (t *Task) Done(ok bool, finalLabel string) {
+	close(t.stop)
+	t.wg.Wait()
+	mark := okMark
+	if !ok {
+		mark = errMark
+	}
+	if finalLabel == "" {
+		finalLabel = t.label
+	}
+	fmt.Fprintf(t.w, "\r\033[K%s %s %s\n", mark, finalLabel,
+		dim.Render(fmt.Sprintf("(%ds)", int(time.Since(t.start).Seconds()))))
+}
+
+// Card renders the end-of-install summary box.
+func Card(w io.Writer, lines ...string) {
+	fmt.Fprintln(w, boxLine.Render(strings.Join(lines, "\n")))
+}
+
+// AccentURL styles a URL for the summary card.
+func AccentURL(s string) string { return accent.Render(s) }

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -64,6 +64,9 @@ const (
 	railWidth    = 22
 	minTwoColumn = 64
 	minPaneInner = 20
+	// paneChrome is what the pane's box costs horizontally: a border column
+	// and a padding column on each side.
+	paneChrome = 4
 	// Sizes assumed until the first window-size message arrives.
 	defaultWidth  = 80
 	defaultHeight = 24
@@ -75,6 +78,10 @@ const (
 	StagePull
 	StageStart
 	StageDone
+	// StageComplete is past the last stage: the rail shows every entry as
+	// finished. It is what the run is in while anything is still on screen
+	// after the work itself is over.
+	StageComplete
 )
 
 var stageNames = []string{"Configure", "Pull", "Start", "Done"}
@@ -282,9 +289,9 @@ func (m wizModel) View() tea.View {
 	}
 	twoColumn := width >= minTwoColumn
 
-	// Pane content width: the box adds a border and a column of padding on
-	// each side, and the rail (when shown) takes the left of the screen.
-	inner := width - 4
+	// Pane content width: the box costs paneChrome, and the rail (when shown)
+	// takes the left of the screen.
+	inner := width - paneChrome
 	if twoColumn {
 		inner -= railWidth
 	}
@@ -309,7 +316,11 @@ func (m wizModel) View() tea.View {
 	// a short screen: everything else here is fixed height (the box adds a
 	// border row above and below).
 	budget := height - len(head) - len(rail) - len(notes) - len(foot) - 2
-	pane := paneBox.Render(strings.Join(m.paneLines(inner, max(budget, 3)), "\n"))
+	// The box is told its width rather than left to hug its content: a border
+	// that moves with the longest line makes the pane look like it shrinks
+	// whenever a phase has less to say, and leaves the screen's right edge
+	// ragged. Width is the outer size, so the chrome is added back here.
+	pane := paneBox.Width(inner + paneChrome).Render(strings.Join(m.paneLines(inner, max(budget, 3)), "\n"))
 
 	lines := make([]string, 0, height)
 	lines = append(lines, head...)

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -39,9 +39,41 @@ var (
 // with (internal/tui), so being asked something looks the same across the CLI.
 const promptMark = "◉ "
 
+// Color reports whether styled output belongs on this stream: stdout is a
+// terminal and the environment hasn't opted out of color. Piped or redirected
+// output stays plain, so `deploy status | grep` sees what it printed.
+func Color(ios *iostreams.IOStreams) bool {
+	return ios.IsStdoutTTY && os.Getenv("TERM") != "dumb" && os.Getenv("NO_COLOR") == ""
+}
+
 // Enabled reports whether the wizard should drive this run.
 func Enabled(ios *iostreams.IOStreams) bool {
-	return ios.IsInteractive() && os.Getenv("TERM") != "dumb" && os.Getenv("NO_COLOR") == ""
+	return ios.IsStdinTTY && Color(ios)
+}
+
+// Painter styles line-oriented output — the plain renderer the non-wizard
+// verbs (status, stop, uninstall) print through. Its zero value paints
+// nothing, so callers can hold one unconditionally and let it decide.
+type Painter struct{ on bool }
+
+// NewPainter returns a Painter that colors only when ios can take it.
+func NewPainter(ios *iostreams.IOStreams) Painter { return Painter{on: Color(ios)} }
+
+func (p Painter) Ok(s string) string   { return p.render(okStyle, s) }
+func (p Painter) Warn(s string) string { return p.render(warnSt, s) }
+func (p Painter) Err(s string) string  { return p.render(errSt, s) }
+func (p Painter) Dim(s string) string  { return p.render(dim, s) }
+
+// Accent marks the thing to act on — a URL, or a command meant to be typed
+// next. It is the same cyan the wizard's summary card uses, and it earns its
+// place by being rare: a line that highlights everything highlights nothing.
+func (p Painter) Accent(s string) string { return p.render(accent, s) }
+
+func (p Painter) render(st lipgloss.Style, s string) string {
+	if !p.on || s == "" {
+		return s
+	}
+	return st.Render(s)
 }
 
 // ErrAborted is returned when the user cancels (ctrl+c / esc / q).

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -1,16 +1,15 @@
-// Package ui renders the interactive installer experience: inline
-// arrow-key prompts (Bubble Tea) and live spinner progress (lipgloss). The
-// deploy orchestration falls back to plain line output when a real TTY isn't
-// driving the run, so CI logs and --no-prompt behavior stay stable.
+// Package ui renders the interactive installer as a single live wizard: a
+// persistent Bubble Tea program with a step rail, an active pane for
+// questions and progress, and a final summary card. The deploy orchestration
+// falls back to plain line output when a real TTY isn't driving the run, so
+// CI logs and --no-prompt behavior stay stable.
 package ui
 
 import (
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"strings"
-	"sync"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
@@ -20,19 +19,23 @@ import (
 )
 
 var (
-	accent  = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
-	dim     = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
-	okMark  = lipgloss.NewStyle().Foreground(lipgloss.Color("2")).SetString("✓").String()
-	errMark = lipgloss.NewStyle().Foreground(lipgloss.Color("1")).SetString("✗").String()
-	boxLine = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 2)
+	accent   = lipgloss.NewStyle().Foreground(lipgloss.Color("6")).Bold(true)
+	dim      = lipgloss.NewStyle().Foreground(lipgloss.Color("8"))
+	okStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	warnSt   = lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	errSt    = lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	railOn   = lipgloss.NewStyle().Bold(true)
+	cardBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("6")).Padding(0, 2)
+	paneBox  = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).BorderForeground(lipgloss.Color("8")).Padding(0, 1)
+	spinners = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 )
 
-// Enabled reports whether the fancy renderer should drive this run.
+// Enabled reports whether the wizard should drive this run.
 func Enabled(ios *iostreams.IOStreams) bool {
 	return ios.IsInteractive() && os.Getenv("TERM") != "dumb" && os.Getenv("NO_COLOR") == ""
 }
 
-// ErrAborted is returned when the user cancels a prompt (ctrl+c / esc / q).
+// ErrAborted is returned when the user cancels (ctrl+c / esc / q).
 var ErrAborted = errors.New("cancelled")
 
 // Option is one selectable choice.
@@ -41,215 +44,359 @@ type Option struct {
 	Hint  string
 }
 
-type selectModel struct {
-	title   string
-	options []Option
-	cursor  int
-	done    bool
-	abort   bool
+// ServiceRow is one container's live state during startup.
+type ServiceRow struct {
+	Name  string
+	Ready bool
 }
 
-func (m selectModel) Init() tea.Cmd { return nil }
+// Stages of the rail.
+const (
+	StageConfigure = iota
+	StagePull
+	StageStart
+	StageDone
+)
 
-func (m selectModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if key, ok := msg.(tea.KeyPressMsg); ok {
-		switch key.String() {
+var stageNames = []string{"Configure", "Pull", "Start", "Done"}
+
+type (
+	askSelectMsg struct {
+		title string
+		opts  []Option
+		def   int
+		reply chan int // -1 = aborted
+	}
+	askInputMsg struct {
+		title, def string
+		reply      chan *string // nil = aborted
+	}
+	stageMsg     int
+	answerMsg    struct{ label, value string }
+	noteMsg      struct{ level, text string }
+	taskStartMsg string
+	taskExtraMsg string
+	taskDoneMsg  struct{ ok bool }
+	servicesMsg  []ServiceRow
+	finishMsg    []string
+	abortMsg     struct{}
+	tickMsg      struct{}
+)
+
+type wizModel struct {
+	version string
+	stage   int
+	answers []answerMsg
+	notes   []noteMsg
+
+	sel    *askSelectMsg
+	cursor int
+	inp    *askInputMsg
+	typed  string
+
+	taskLabel, taskExtra string
+	taskActive           bool
+	taskBegan            time.Time
+	frame                int
+	services             []ServiceRow
+
+	card    []string
+	aborted bool
+}
+
+func tick() tea.Cmd {
+	return tea.Tick(120*time.Millisecond, func(time.Time) tea.Msg { return tickMsg{} })
+}
+
+func (m wizModel) Init() tea.Cmd { return tick() }
+
+func (m wizModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tickMsg:
+		m.frame++
+		return m, tick()
+	case askSelectMsg:
+		m.sel, m.cursor = &msg, msg.def
+		return m, nil
+	case askInputMsg:
+		m.inp, m.typed = &msg, ""
+		return m, nil
+	case stageMsg:
+		m.stage = int(msg)
+		return m, nil
+	case answerMsg:
+		m.answers = append(m.answers, msg)
+		return m, nil
+	case noteMsg:
+		m.notes = append(m.notes, msg)
+		if len(m.notes) > 6 {
+			m.notes = m.notes[len(m.notes)-6:]
+		}
+		return m, nil
+	case taskStartMsg:
+		m.taskLabel, m.taskExtra, m.taskActive, m.taskBegan = string(msg), "", true, time.Now()
+		m.services = nil
+		return m, nil
+	case taskExtraMsg:
+		m.taskExtra = string(msg)
+		return m, nil
+	case taskDoneMsg:
+		m.taskActive = false
+		level := "ok"
+		if !msg.ok {
+			level = "err"
+		}
+		m.notes = append(m.notes, noteMsg{level, fmt.Sprintf("%s (%ds)", m.taskLabel, int(time.Since(m.taskBegan).Seconds()))})
+		return m, nil
+	case servicesMsg:
+		m.services = msg
+		return m, nil
+	case finishMsg:
+		m.card = msg
+		return m, tea.Quit
+	case abortMsg:
+		m.aborted = true
+		return m, tea.Quit
+	case tea.KeyPressMsg:
+		return m.handleKey(msg)
+	}
+	return m, nil
+}
+
+func (m wizModel) handleKey(key tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	s := key.String()
+	if m.sel != nil {
+		switch s {
 		case "up", "k":
 			if m.cursor > 0 {
 				m.cursor--
 			}
 		case "down", "j", "tab":
-			if m.cursor < len(m.options)-1 {
+			if m.cursor < len(m.sel.opts)-1 {
 				m.cursor++
 			}
 		case "1", "2", "3", "4":
-			if idx := int(key.String()[0] - '1'); idx < len(m.options) {
+			if idx := int(s[0] - '1'); idx < len(m.sel.opts) {
 				m.cursor = idx
+				m.sel.reply <- m.cursor
+				m.sel = nil
 			}
-			m.done = true
-			return m, tea.Quit
 		case "enter":
-			m.done = true
-			return m, tea.Quit
+			m.sel.reply <- m.cursor
+			m.sel = nil
 		case "ctrl+c", "esc", "q":
-			m.abort = true
+			m.sel.reply <- -1
+			m.sel = nil
+			m.aborted = true
 			return m, tea.Quit
 		}
+		return m, nil
+	}
+	if m.inp != nil {
+		switch s {
+		case "enter":
+			v := strings.TrimSpace(m.typed)
+			if v == "" {
+				v = m.inp.def
+			}
+			m.inp.reply <- &v
+			m.inp = nil
+		case "ctrl+c", "esc":
+			m.inp.reply <- nil
+			m.inp = nil
+			m.aborted = true
+			return m, tea.Quit
+		case "backspace":
+			if len(m.typed) > 0 {
+				m.typed = m.typed[:len(m.typed)-1]
+			}
+		default:
+			if len([]rune(s)) == 1 && !strings.Contains(s, "+") {
+				m.typed += s
+			}
+		}
+		return m, nil
+	}
+	if s == "ctrl+c" {
+		m.aborted = true
+		return m, tea.Quit
 	}
 	return m, nil
 }
 
-func (m selectModel) View() tea.View {
-	if m.done || m.abort {
+func (m wizModel) View() tea.View {
+	if m.card != nil {
+		return tea.NewView(cardBox.Render(strings.Join(m.card, "\n")) + "\n")
+	}
+	if m.aborted {
 		return tea.NewView("")
 	}
-	var b strings.Builder
-	fmt.Fprintf(&b, "%s %s\n", accent.Render("?"), m.title)
-	for i, o := range m.options {
-		cursor, label := " ", o.Label
-		if i == m.cursor {
-			cursor, label = accent.Render("›"), accent.Render(o.Label)
+
+	// Left rail: stages + recorded answers.
+	var rail []string
+	for i, name := range stageNames {
+		mark, style := "○", dim
+		switch {
+		case i < m.stage:
+			mark, style = okStyle.Render("✓"), okStyle
+		case i == m.stage:
+			mark, style = accent.Render("●"), railOn
 		}
-		hint := ""
-		if o.Hint != "" {
-			hint = "  " + dim.Render(o.Hint)
-		}
-		fmt.Fprintf(&b, "  %s %s%s\n", cursor, label, hint)
+		rail = append(rail, fmt.Sprintf(" %s %s", mark, style.Render(name)))
 	}
-	b.WriteString(dim.Render("  ↑/↓ to move · enter to confirm"))
+	rail = append(rail, "")
+	for _, a := range m.answers {
+		rail = append(rail, dim.Render(fmt.Sprintf(" %-8s", a.label))+accent.Render(a.value))
+	}
+
+	// Active pane: question, live task, or quiet.
+	var pane []string
+	switch {
+	case m.sel != nil:
+		pane = append(pane, accent.Render("? ")+m.sel.title)
+		for i, o := range m.sel.opts {
+			cursor, label := "  ", o.Label
+			if i == m.cursor {
+				cursor, label = accent.Render("› "), accent.Render(o.Label)
+			}
+			line := cursor + label
+			if o.Hint != "" {
+				line += "  " + dim.Render(o.Hint)
+			}
+			pane = append(pane, line)
+		}
+	case m.inp != nil:
+		shown := m.typed
+		if shown == "" {
+			shown = dim.Render(m.inp.def)
+		}
+		pane = append(pane, accent.Render("? ")+m.inp.title, "  "+shown+accent.Render("▏"))
+	case m.taskActive:
+		line := fmt.Sprintf("%s %s %s", accent.Render(spinners[m.frame%len(spinners)]),
+			m.taskLabel, dim.Render(fmt.Sprintf("(%ds)", int(time.Since(m.taskBegan).Seconds()))))
+		if m.taskExtra != "" {
+			line += " " + dim.Render(m.taskExtra)
+		}
+		pane = append(pane, line)
+		for _, svc := range m.services {
+			mark := dim.Render(spinners[m.frame%len(spinners)])
+			if svc.Ready {
+				mark = okStyle.Render("✓")
+			}
+			pane = append(pane, fmt.Sprintf("  %s %s", mark, svc.Name))
+		}
+	default:
+		pane = append(pane, dim.Render("…"))
+	}
+
+	body := lipgloss.JoinHorizontal(lipgloss.Top,
+		lipgloss.NewStyle().Width(22).Render(strings.Join(rail, "\n")),
+		paneBox.Render(strings.Join(pane, "\n")))
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s %s\n\n", accent.Render("🚀 Onyx Installer"), dim.Render(m.version))
+	b.WriteString(body + "\n")
+	for _, n := range m.notes {
+		switch n.level {
+		case "ok":
+			b.WriteString(okStyle.Render("✓ ") + n.text + "\n")
+		case "warn":
+			b.WriteString(warnSt.Render("⚠ ") + n.text + "\n")
+		case "err":
+			b.WriteString(errSt.Render("✗ ") + n.text + "\n")
+		default:
+			b.WriteString(dim.Render("  "+n.text) + "\n")
+		}
+	}
+	b.WriteString(dim.Render("↑/↓ move · enter confirm · ctrl+c quit"))
 	return tea.NewView(b.String())
 }
 
-// Select runs an inline arrow-key select and echoes the answer.
-func Select(ios *iostreams.IOStreams, title string, options []Option, defaultIdx int) (int, error) {
-	m := selectModel{title: title, options: options, cursor: defaultIdx}
-	out, err := tea.NewProgram(m).Run()
-	if err != nil {
-		return 0, err
+// Wizard drives the model from the orchestration goroutine.
+type Wizard struct {
+	prog *tea.Program
+	done chan struct{}
+}
+
+// StartWizard launches the inline wizard program.
+func StartWizard(version string) *Wizard {
+	w := &Wizard{
+		prog: tea.NewProgram(wizModel{version: version}),
+		done: make(chan struct{}),
 	}
-	final := out.(selectModel)
-	if final.abort {
+	go func() {
+		_, _ = w.prog.Run()
+		close(w.done)
+	}()
+	return w
+}
+
+// Select asks an arrow-key question and blocks for the answer.
+func (w *Wizard) Select(title string, opts []Option, def int) (int, error) {
+	reply := make(chan int, 1)
+	w.prog.Send(askSelectMsg{title: title, opts: opts, def: def, reply: reply})
+	select {
+	case v := <-reply:
+		if v < 0 {
+			return 0, ErrAborted
+		}
+		return v, nil
+	case <-w.done:
 		return 0, ErrAborted
 	}
-	fmt.Fprintf(ios.Out, "%s %s %s\n", okMark, title, accent.Render(options[final.cursor].Label))
-	return final.cursor, nil
 }
 
-type inputModel struct {
-	title      string
-	defaultVal string
-	value      string
-	done       bool
-	abort      bool
-}
-
-func (m inputModel) Init() tea.Cmd { return nil }
-
-func (m inputModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	if key, ok := msg.(tea.KeyPressMsg); ok {
-		s := key.String()
-		switch s {
-		case "enter":
-			m.done = true
-			return m, tea.Quit
-		case "ctrl+c", "esc":
-			m.abort = true
-			return m, tea.Quit
-		case "backspace":
-			if len(m.value) > 0 {
-				m.value = m.value[:len(m.value)-1]
-			}
-		default:
-			if len(s) == 1 || (len(s) > 0 && !strings.Contains(s, "+") && len([]rune(s)) == 1) {
-				m.value += s
-			}
+// Input asks a free-form value with a prefilled default.
+func (w *Wizard) Input(title, def string) (string, error) {
+	reply := make(chan *string, 1)
+	w.prog.Send(askInputMsg{title: title, def: def, reply: reply})
+	select {
+	case v := <-reply:
+		if v == nil {
+			return "", ErrAborted
 		}
-	}
-	return m, nil
-}
-
-func (m inputModel) View() tea.View {
-	if m.done || m.abort {
-		return tea.NewView("")
-	}
-	shown := m.value
-	if shown == "" {
-		shown = dim.Render(m.defaultVal)
-	}
-	return tea.NewView(fmt.Sprintf("%s %s %s%s\n%s",
-		accent.Render("?"), m.title, shown, accent.Render("▏"),
-		dim.Render("  enter to accept")))
-}
-
-// Input runs an inline text prompt; empty submission returns defaultVal.
-func Input(ios *iostreams.IOStreams, title, defaultVal string) (string, error) {
-	m := inputModel{title: title, defaultVal: defaultVal}
-	out, err := tea.NewProgram(m).Run()
-	if err != nil {
-		return "", err
-	}
-	final := out.(inputModel)
-	if final.abort {
+		return *v, nil
+	case <-w.done:
 		return "", ErrAborted
 	}
-	value := strings.TrimSpace(final.value)
-	if value == "" {
-		value = defaultVal
+}
+
+// Stage advances the rail; Answer records a decision beneath it.
+func (w *Wizard) Stage(s int)             { w.prog.Send(stageMsg(s)) }
+func (w *Wizard) Answer(label, v string)  { w.prog.Send(answerMsg{label, v}) }
+func (w *Wizard) Note(level, text string) { w.prog.Send(noteMsg{level, text}) }
+
+// TaskStart/TaskExtra/TaskDone drive the pane's live task line.
+func (w *Wizard) TaskStart(label string)     { w.prog.Send(taskStartMsg(label)) }
+func (w *Wizard) TaskExtra(extra string)     { w.prog.Send(taskExtraMsg(extra)) }
+func (w *Wizard) TaskDone(ok bool)           { w.prog.Send(taskDoneMsg{ok}) }
+func (w *Wizard) Services(rows []ServiceRow) { w.prog.Send(servicesMsg(rows)) }
+
+// Suspend hands the terminal to fn (sudo prompts, provisioning output).
+func (w *Wizard) Suspend(fn func() error) error {
+	if err := w.prog.ReleaseTerminal(); err != nil {
+		return fn()
 	}
-	fmt.Fprintf(ios.Out, "%s %s %s\n", okMark, title, accent.Render(value))
-	return value, nil
+	defer func() { _ = w.prog.RestoreTerminal() }()
+	return fn()
 }
 
-// Task is a single-line live spinner: "⠋ label (12s) extra".
-type Task struct {
-	w     io.Writer
-	label string
-
-	mu    sync.Mutex
-	extra string
-	stop  chan struct{}
-	wg    sync.WaitGroup
-	start time.Time
+// Finish renders the summary card as the final scrollback view and exits.
+func (w *Wizard) Finish(lines ...string) {
+	w.prog.Send(finishMsg(lines))
+	w.prog.Wait()
 }
 
-var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
-
-// StartTask begins rendering a spinner line until Done is called.
-func StartTask(w io.Writer, label string) *Task {
-	t := &Task{w: w, label: label, stop: make(chan struct{}), start: time.Now()}
-	t.wg.Add(1)
-	go func() {
-		defer t.wg.Done()
-		frame := 0
-		ticker := time.NewTicker(120 * time.Millisecond)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-t.stop:
-				return
-			case <-ticker.C:
-				t.mu.Lock()
-				extra := t.extra
-				t.mu.Unlock()
-				if extra != "" {
-					extra = " " + dim.Render(extra)
-				}
-				elapsed := dim.Render(fmt.Sprintf("(%ds)", int(time.Since(t.start).Seconds())))
-				fmt.Fprintf(t.w, "\r\033[K%s %s %s%s",
-					accent.Render(spinnerFrames[frame%len(spinnerFrames)]), t.label, elapsed, extra)
-				frame++
-			}
-		}
-	}()
-	return t
-}
-
-// Update swaps the trailing status text.
-func (t *Task) Update(extra string) {
-	t.mu.Lock()
-	t.extra = extra
-	t.mu.Unlock()
-}
-
-// Done stops the spinner and prints the final ✓/✗ line.
-func (t *Task) Done(ok bool, finalLabel string) {
-	close(t.stop)
-	t.wg.Wait()
-	mark := okMark
-	if !ok {
-		mark = errMark
+// Abort tears the wizard down (no-op after Finish).
+func (w *Wizard) Abort() {
+	select {
+	case <-w.done:
+		return
+	default:
 	}
-	if finalLabel == "" {
-		finalLabel = t.label
-	}
-	fmt.Fprintf(t.w, "\r\033[K%s %s %s\n", mark, finalLabel,
-		dim.Render(fmt.Sprintf("(%ds)", int(time.Since(t.start).Seconds()))))
+	w.prog.Send(abortMsg{})
+	w.prog.Wait()
 }
 
-// Card renders the end-of-install summary box.
-func Card(w io.Writer, lines ...string) {
-	fmt.Fprintln(w, boxLine.Render(strings.Join(lines, "\n")))
-}
-
-// AccentURL styles a URL for the summary card.
-func AccentURL(s string) string { return accent.Render(s) }
+// Accent styles a string for emphasis outside the wizard (plain summaries).
+func Accent(s string) string { return accent.Render(s) }

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -535,6 +535,10 @@ type Wizard struct {
 	prog *tea.Program
 	done chan struct{}
 	out  io.Writer
+	// width is the terminal width the program last knew, kept for output
+	// printed after it has exited. Written before done is closed and read
+	// only once that close has been observed.
+	width int
 }
 
 // StartWizard launches the full-screen wizard program. onAbort fires only
@@ -552,6 +556,7 @@ func StartWizard(out io.Writer, title, version string, onAbort func()) *Wizard {
 		m, _ := w.prog.Run()
 		wm, ok := m.(wizModel)
 		if ok {
+			w.width = wm.width
 			w.printTail(wm)
 		}
 		close(w.done)
@@ -642,6 +647,16 @@ func (w *Wizard) Suspend(fn func() error) error {
 // It blocks until the card has been written, so callers can keep printing
 // plain output right after.
 func (w *Wizard) Finish(lines ...string) {
+	select {
+	case <-w.done:
+		// The program is already gone — the user quit during the last question
+		// the run asks, after the work itself was over. A send now would go
+		// nowhere, so the card is printed directly: quitting a prompt should
+		// not cost the user the URL they just waited for.
+		w.printTail(wizModel{width: w.width, card: lines})
+		return
+	default:
+	}
 	w.prog.Send(finishMsg(lines))
 	<-w.done
 }

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -18,6 +18,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 
 	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
 )
@@ -48,11 +49,25 @@ type Option struct {
 	Hint  string
 }
 
-// ServiceRow is one container's live state during startup.
+// ServiceRow is one item's live state in a phase checklist (an image being
+// pulled, a container being started). Detail is the short right-aligned note
+// after the name — a download total, or what is happening to the container.
 type ServiceRow struct {
-	Name  string
-	Ready bool
+	Name   string
+	Detail string
+	Ready  bool
 }
+
+// Layout constants. The wizard is two columns when there is room for both;
+// narrower screens drop the rail so the pane keeps the full width.
+const (
+	railWidth    = 22
+	minTwoColumn = 64
+	minPaneInner = 20
+	// Sizes assumed until the first window-size message arrives.
+	defaultWidth  = 80
+	defaultHeight = 24
+)
 
 // Stages of the rail.
 const (
@@ -88,11 +103,12 @@ type (
 )
 
 type wizModel struct {
-	title   string
-	version string
-	stage   int
-	answers []answerMsg
-	notes   []noteMsg
+	title         string
+	version       string
+	stage         int
+	answers       []answerMsg
+	notes         []noteMsg
+	width, height int
 
 	sel    *askSelectMsg
 	cursor int
@@ -121,6 +137,9 @@ func (m wizModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		m.frame++
 		return m, tick()
+	case tea.WindowSizeMsg:
+		m.width, m.height = msg.Width, msg.Height
+		return m, nil
 	case askSelectMsg:
 		m.sel, m.cursor = &msg, msg.def
 		return m, nil
@@ -254,7 +273,73 @@ func renderNote(n noteMsg, live bool) string {
 }
 
 func (m wizModel) View() tea.View {
-	// Left rail: stages + recorded answers.
+	width, height := m.width, m.height
+	if width <= 0 {
+		width = defaultWidth
+	}
+	if height <= 0 {
+		height = defaultHeight
+	}
+	twoColumn := width >= minTwoColumn
+
+	// Pane content width: the box adds a border and a column of padding on
+	// each side, and the rail (when shown) takes the left of the screen.
+	inner := width - 4
+	if twoColumn {
+		inner -= railWidth
+	}
+	inner = max(inner, minPaneInner)
+
+	head := []string{"", " " + truncate(accent.Render("🚀 "+m.title)+" "+dim.Render(m.version), width-1), ""}
+	help := " ↑/↓ move · enter confirm · ctrl+c quit"
+	if !twoColumn {
+		help = " ↑/↓ · enter · ctrl+c"
+	}
+	foot := []string{"", dim.Render(help)}
+	var rail []string
+	if !twoColumn {
+		rail = m.compactRail(width - 1)
+	}
+	notes := make([]string, 0, len(m.notes))
+	for _, n := range m.notes {
+		notes = append(notes, truncate(renderNote(n, true), width-1))
+	}
+
+	// The pane is the only part that can shed content, so it is what gives on
+	// a short screen: everything else here is fixed height (the box adds a
+	// border row above and below).
+	budget := height - len(head) - len(rail) - len(notes) - len(foot) - 2
+	pane := paneBox.Render(strings.Join(m.paneLines(inner, max(budget, 3)), "\n"))
+
+	lines := make([]string, 0, height)
+	lines = append(lines, head...)
+	if twoColumn {
+		lines = append(lines, strings.Split(lipgloss.JoinHorizontal(lipgloss.Top,
+			lipgloss.NewStyle().Width(railWidth).Render(strings.Join(m.railLines(railWidth-1), "\n")),
+			pane), "\n")...)
+	} else {
+		lines = append(lines, rail...)
+		lines = append(lines, strings.Split(pane, "\n")...)
+	}
+
+	// Notes are re-printed on the normal screen when the wizard exits, so a
+	// screen with no room for them loses the least by dropping the oldest.
+	for len(notes) > 0 && len(lines)+len(notes)+len(foot) > height {
+		notes = notes[1:]
+	}
+	lines = append(append(lines, notes...), foot...)
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+
+	v := tea.NewView(strings.Join(lines, "\n"))
+	v.AltScreen = true
+	v.WindowTitle = m.title
+	return v
+}
+
+// railLines renders the left rail: stages, then the answers recorded so far.
+func (m wizModel) railLines(width int) []string {
 	var rail []string
 	for i, name := range stageNames {
 		mark, style := "○", dim
@@ -264,65 +349,173 @@ func (m wizModel) View() tea.View {
 		case i == m.stage:
 			mark, style = accent.Render("●"), railOn
 		}
-		rail = append(rail, fmt.Sprintf(" %s %s", mark, style.Render(name)))
+		rail = append(rail, truncate(fmt.Sprintf(" %s %s", mark, style.Render(name)), width))
 	}
 	rail = append(rail, "")
 	for _, a := range m.answers {
-		rail = append(rail, dim.Render(fmt.Sprintf(" %-8s", a.label))+accent.Render(a.value))
+		rail = append(rail, truncate(dim.Render(fmt.Sprintf(" %-8s", a.label))+accent.Render(a.value), width))
 	}
+	return rail
+}
 
-	// Active pane: question, live task, or quiet.
-	var pane []string
+// compactRail is the narrow-screen stand-in for the rail: the current step and
+// the answers on one line each, above the pane instead of beside it.
+func (m wizModel) compactRail(width int) []string {
+	step := dim.Render(fmt.Sprintf("Step %d/%d", min(m.stage+1, len(stageNames)), len(stageNames)))
+	lines := []string{truncate(" "+step+" "+railOn.Render(stageNames[min(m.stage, len(stageNames)-1)]), width)}
+	if len(m.answers) > 0 {
+		parts := make([]string, 0, len(m.answers))
+		for _, a := range m.answers {
+			parts = append(parts, dim.Render(a.label+" ")+accent.Render(a.value))
+		}
+		lines = append(lines, truncate(" "+strings.Join(parts, dim.Render(" · ")), width))
+	}
+	return lines
+}
+
+// paneLines renders the active pane — a question, the live task, or nothing —
+// within inner columns and at most maxLines rows, dropping the optional parts
+// (hints, checklist rows) rather than running off a short screen.
+func (m wizModel) paneLines(inner, maxLines int) []string {
 	switch {
 	case m.sel != nil:
-		pane = append(pane, accent.Render("? ")+m.sel.title)
-		for i, o := range m.sel.opts {
-			cursor, label := "  ", o.Label
-			if i == m.cursor {
-				cursor, label = accent.Render("› "), accent.Render(o.Label)
-			}
-			line := cursor + label
-			if o.Hint != "" {
-				line += "  " + dim.Render(o.Hint)
-			}
-			pane = append(pane, line)
+		// Shed the optional parts before the options themselves: a question
+		// the user can't see the choices for is worse than a terse one.
+		pane := m.selectPane(inner, true, true)
+		if len(pane) > maxLines {
+			pane = m.selectPane(inner, false, true)
 		}
+		if len(pane) > maxLines {
+			pane = m.selectPane(inner, false, false)
+		}
+		return clip(pane, maxLines)
 	case m.inp != nil:
-		pane = append(pane, accent.Render("? ")+m.inp.title, "  "+m.typed+accent.Render("▏"))
+		return clip(append(wrap(accent.Render("? ")+m.inp.title, inner),
+			truncate("  "+m.typed+accent.Render("▏"), inner)), maxLines)
 	case m.taskActive:
-		line := fmt.Sprintf("%s %s %s", accent.Render(spinners[m.frame%len(spinners)]),
-			m.taskLabel, dim.Render(fmt.Sprintf("(%ds)", int(time.Since(m.taskBegan).Seconds()))))
-		if m.taskExtra != "" {
-			line += " " + dim.Render(m.taskExtra)
-		}
-		pane = append(pane, line)
-		for _, svc := range m.services {
-			mark := dim.Render(spinners[m.frame%len(spinners)])
-			if svc.Ready {
-				mark = okStyle.Render("✓")
-			}
-			pane = append(pane, fmt.Sprintf("  %s %s", mark, svc.Name))
-		}
+		return clip(m.taskPane(inner, maxLines), maxLines)
 	default:
-		pane = append(pane, dim.Render("…"))
+		return []string{dim.Render("…")}
+	}
+}
+
+// selectPane renders the question and its options. hints and a wrapped (as
+// opposed to single-line) title are what it gives up, in that order, when the
+// pane has to get shorter.
+func (m wizModel) selectPane(inner int, hints, wrapTitle bool) []string {
+	title := accent.Render("? ") + m.sel.title
+	pane := []string{truncate(title, inner)}
+	if wrapTitle {
+		pane = wrap(title, inner)
+	}
+	for i, o := range m.sel.opts {
+		cursor, label := "  ", o.Label
+		if i == m.cursor {
+			cursor, label = accent.Render("› "), accent.Render(o.Label)
+		}
+		line := cursor + label
+		if o.Hint == "" || !hints {
+			pane = append(pane, truncate(line, inner))
+			continue
+		}
+		// Keep the hint beside its option while it fits; otherwise it wraps
+		// underneath rather than being cut off.
+		if lipgloss.Width(line)+2+lipgloss.Width(o.Hint) <= inner {
+			pane = append(pane, line+"  "+dim.Render(o.Hint))
+			continue
+		}
+		pane = append(pane, truncate(line, inner))
+		for _, h := range wrap(o.Hint, inner-4) {
+			pane = append(pane, "    "+dim.Render(h))
+		}
+	}
+	return pane
+}
+
+// clip keeps a pane within its row budget, marking what it cut.
+func clip(lines []string, maxLines int) []string {
+	if maxLines < 1 || len(lines) <= maxLines {
+		return lines
+	}
+	return append(lines[:maxLines-1:maxLines-1], dim.Render("  …"))
+}
+
+// taskPane renders the running task and its checklist, within maxLines rows.
+func (m wizModel) taskPane(inner, maxLines int) []string {
+	spin := spinners[m.frame%len(spinners)]
+	head := fmt.Sprintf("%s %s %s", accent.Render(spin), m.taskLabel,
+		dim.Render(fmt.Sprintf("(%ds)", int(time.Since(m.taskBegan).Seconds()))))
+	var pane []string
+	switch {
+	case m.taskExtra == "":
+		pane = []string{truncate(head, inner)}
+	case lipgloss.Width(head)+1+lipgloss.Width(m.taskExtra) <= inner:
+		pane = []string{head + " " + dim.Render(m.taskExtra)}
+	default:
+		pane = []string{truncate(head, inner), truncate("  "+dim.Render(m.taskExtra), inner)}
 	}
 
-	body := lipgloss.JoinHorizontal(lipgloss.Top,
-		lipgloss.NewStyle().Width(22).Render(strings.Join(rail, "\n")),
-		paneBox.Render(strings.Join(pane, "\n")))
-
-	var b strings.Builder
-	fmt.Fprintf(&b, "\n %s %s\n\n", accent.Render("🚀 "+m.title), dim.Render(m.version))
-	b.WriteString(body + "\n")
-	for _, n := range m.notes {
-		b.WriteString(renderNote(n, true) + "\n")
+	rows := m.services
+	// One row is held back for the "… n more" line whenever some are cut.
+	if room := maxLines - len(pane); len(rows) > room {
+		rows = rows[:max(room-1, 0)]
 	}
-	b.WriteString("\n" + dim.Render(" ↑/↓ move · enter confirm · ctrl+c quit"))
+	for _, svc := range rows {
+		mark := dim.Render(spin)
+		if svc.Ready {
+			mark = okStyle.Render("✓")
+		}
+		line := fmt.Sprintf("  %s %s", mark, svc.Name)
+		if detail := fitDetail(svc.Detail, inner-lipgloss.Width(line)-1); detail != "" {
+			// Right-aligned so the figures form a column instead of jittering
+			// with every name length.
+			gap := max(inner-lipgloss.Width(line)-lipgloss.Width(detail), 1)
+			line += strings.Repeat(" ", gap) + dim.Render(detail)
+		}
+		pane = append(pane, truncate(line, inner))
+	}
+	if hidden := len(m.services) - len(rows); hidden > 0 {
+		pane = append(pane, dim.Render(fmt.Sprintf("  … %d more", hidden)))
+	}
+	return pane
+}
 
-	v := tea.NewView(b.String())
-	v.AltScreen = true
-	v.WindowTitle = m.title
-	return v
+// fitDetail shortens a checklist note to the room left on its row. Notes are
+// written most-significant-part first and separated by a double space
+// ("62%" then "310.4 MB / 500.1 MB"), so shedding trailing parts keeps the
+// figure worth reading; a note that still doesn't fit is dropped rather than
+// truncated into a unit-less number.
+func fitDetail(detail string, room int) string {
+	if detail == "" || room < 1 {
+		return ""
+	}
+	if lipgloss.Width(detail) <= room {
+		return detail
+	}
+	parts := strings.Split(detail, "  ")
+	for len(parts) > 1 {
+		parts = parts[:len(parts)-1]
+		if s := strings.TrimSpace(strings.Join(parts, "  ")); lipgloss.Width(s) <= room {
+			return s
+		}
+	}
+	return ""
+}
+
+// truncate/wrap are the width guards for every line the wizard prints; both
+// are ANSI-aware, and both refuse widths x/ansi would treat as "no limit".
+func truncate(s string, width int) string {
+	if width < 1 {
+		return ""
+	}
+	return ansi.TruncateWc(s, width, "…")
+}
+
+func wrap(s string, width int) []string {
+	if width < 1 {
+		return []string{}
+	}
+	return strings.Split(ansi.WrapWc(s, width, " -/"), "\n")
 }
 
 // Wizard drives the model from the orchestration goroutine.
@@ -362,12 +555,20 @@ func StartWizard(out io.Writer, title, version string, onAbort func()) *Wizard {
 // run finished, otherwise the accumulated notes — exactly what the user
 // needs after an abort or failure.
 func (w *Wizard) printTail(m wizModel) {
+	width := m.width
+	if width <= 0 {
+		width = defaultWidth
+	}
 	if m.card != nil {
-		fmt.Fprintln(w.out, cardBox.Render(strings.Join(m.card, "\n")))
+		var lines []string
+		for _, l := range m.card {
+			lines = append(lines, wrap(l, max(width-6, minPaneInner))...)
+		}
+		fmt.Fprintln(w.out, cardBox.Render(strings.Join(lines, "\n")))
 		return
 	}
 	for _, n := range m.notes {
-		fmt.Fprintln(w.out, renderNote(n, false))
+		fmt.Fprintln(w.out, truncate(renderNote(n, false), width))
 	}
 }
 

--- a/cli/internal/deploy/ui/ui.go
+++ b/cli/internal/deploy/ui/ui.go
@@ -333,15 +333,20 @@ type Wizard struct {
 	done chan struct{}
 }
 
-// StartWizard launches the inline wizard program.
-func StartWizard(version string) *Wizard {
+// StartWizard launches the inline wizard program. onAbort fires when the
+// user quits the wizard (ctrl+c/esc) so the orchestration can cancel any
+// in-flight work — without it, killing the UI would leave compose running.
+func StartWizard(version string, onAbort func()) *Wizard {
 	w := &Wizard{
 		prog: tea.NewProgram(wizModel{version: version}),
 		done: make(chan struct{}),
 	}
 	go func() {
-		_, _ = w.prog.Run()
+		m, _ := w.prog.Run()
 		close(w.done)
+		if wm, ok := m.(wizModel); ok && wm.aborted && onAbort != nil {
+			onAbort()
+		}
 	}()
 	return w
 }

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/charmbracelet/x/ansi"
+
+	"github.com/onyx-dot-app/onyx/cli/internal/iostreams"
 )
 
 // sampleModels covers the panes that carry the widest content: a question with
@@ -234,5 +236,35 @@ func TestNarrowViewKeepsOptionHints(t *testing.T) {
 	}
 	if !strings.Contains(content, "Step 1/4") {
 		t.Errorf("the rail should collapse to a step line below %d columns:\n%s", minTwoColumn, content)
+	}
+}
+
+// A Painter colors only what the stream can show: styled on a terminal,
+// untouched when the output is piped or the environment opts out.
+func TestPainterFollowsTheStream(t *testing.T) {
+	tty := &iostreams.IOStreams{Out: &bytes.Buffer{}, IsStdoutTTY: true}
+	t.Setenv("TERM", "xterm-256color")
+	t.Setenv("NO_COLOR", "")
+
+	p := NewPainter(tty)
+	for _, styled := range []string{p.Ok("up"), p.Warn("up"), p.Err("up"), p.Dim("up")} {
+		if styled == "up" {
+			t.Error("a terminal stream should be colored")
+		}
+		if ansi.Strip(styled) != "up" {
+			t.Errorf("styling changed the text: %q", ansi.Strip(styled))
+		}
+	}
+	if p.Ok("up") == p.Err("up") {
+		t.Error("healthy and failed states must not look the same")
+	}
+
+	piped := NewPainter(&iostreams.IOStreams{Out: &bytes.Buffer{}})
+	if got := piped.Err("up"); got != "up" {
+		t.Errorf("piped output should stay plain, got %q", got)
+	}
+	t.Setenv("NO_COLOR", "1")
+	if got := NewPainter(tty).Err("up"); got != "up" {
+		t.Errorf("NO_COLOR should stay plain, got %q", got)
 	}
 }

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -40,7 +40,7 @@ func sampleModels() map[string]wizModel {
 				{Name: "backend", Ready: true},
 				{Name: "web_server", Detail: "62%  310.4 MB / 500.1 MB"},
 				{Name: "model_server", Detail: "4%  21.0 MB / 512.5 MB"},
-				{Name: "relational_db", Detail: "waiting for health"},
+				{Name: "relational_db", Detail: "waiting"},
 			},
 			notes: []noteMsg{{"", "Using deployment/.env from the existing install"}},
 		},

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -18,12 +18,12 @@ func sampleModels() map[string]wizModel {
 			title:   "Onyx Installer",
 			version: "v0.1.0",
 			stage:   StageConfigure,
-			answers: []answerMsg{{"Version", "v4.4.6"}},
 			sel: &askSelectMsg{
-				title: "Onyx is already running. Applying this configuration restarts its services.",
+				title: "How should Onyx be deployed?",
 				opts: []Option{
-					{Label: "Continue", Hint: "keeps serving while images download; each service restarts once, at the end"},
-					{Label: "Cancel", Hint: "leave everything running"},
+					{Label: "Lite", Hint: "chat, tools, uploads, projects — no vector search (recommended)"},
+					{Label: "Standard", Hint: "full search, connectors, and RAG"},
+					{Label: "Standard + Craft", Hint: "adds AI web-app building (binds the docker socket)"},
 				},
 			},
 			notes: []noteMsg{{"ok", "Deployment files are up to date"}},
@@ -191,7 +191,7 @@ func TestNarrowViewKeepsOptionHints(t *testing.T) {
 	m := sampleModels()["question"]
 	m.width, m.height = 44, 20
 	content := m.View().Content
-	if !strings.Contains(content, "restarts once") {
+	if !strings.Contains(content, "vector search") {
 		t.Errorf("hint text was dropped at 44 columns:\n%s", content)
 	}
 	if !strings.Contains(content, "Step 1/4") {

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// sampleModels covers the panes that carry the widest content: a question with
+// long hints, and a running phase with a per-service checklist.
+func sampleModels() map[string]wizModel {
+	began := time.Now().Add(-42 * time.Second)
+	return map[string]wizModel{
+		"question": {
+			title:   "Onyx Installer",
+			version: "v0.1.0",
+			stage:   StageConfigure,
+			answers: []answerMsg{{"Version", "v4.4.6"}},
+			sel: &askSelectMsg{
+				title: "Onyx is already running. Applying this configuration restarts its services.",
+				opts: []Option{
+					{Label: "Continue", Hint: "keeps serving while images download; each service restarts once, at the end"},
+					{Label: "Cancel", Hint: "leave everything running"},
+				},
+			},
+			notes: []noteMsg{{"ok", "Deployment files are up to date"}},
+		},
+		"task": {
+			title:      "Onyx Installer",
+			version:    "v0.1.0",
+			stage:      StagePull,
+			answers:    []answerMsg{{"Action", "Upgrade"}, {"Version", "v4.4.6"}},
+			taskLabel:  "Pulling images",
+			taskExtra:  "3/9 images · 1.2 GB / 4.8 GB",
+			taskActive: true,
+			taskBegan:  began,
+			services: []ServiceRow{
+				{Name: "backend", Ready: true},
+				{Name: "web_server", Detail: "62%  310.4 MB / 500.1 MB"},
+				{Name: "model_server", Detail: "4%  21.0 MB / 512.5 MB"},
+				{Name: "relational_db", Detail: "waiting for health"},
+			},
+			notes: []noteMsg{{"", "Using deployment/.env from the existing install"}},
+		},
+	}
+}
+
+// The wizard has to fit the terminal it was given: anything wider wraps and
+// smears the full-screen layout across lines.
+func TestViewFitsTerminalWidth(t *testing.T) {
+	sizes := []struct{ w, h int }{{40, 12}, {52, 16}, {64, 20}, {80, 24}, {120, 40}}
+	for name, base := range sampleModels() {
+		for _, size := range sizes {
+			m := base
+			m.width, m.height = size.w, size.h
+			lines := strings.Split(m.View().Content, "\n")
+			for i, line := range lines {
+				if got := ansi.StringWidthWc(line); got > size.w {
+					t.Errorf("%s at %dx%d: line %d is %d columns wide:\n%s",
+						name, size.w, size.h, i+1, got, line)
+				}
+			}
+			if len(lines) > size.h {
+				t.Errorf("%s at %dx%d: view is %d lines tall", name, size.w, size.h, len(lines))
+			}
+		}
+	}
+}
+
+// A download note that no longer fits sheds whole parts: cutting it mid-figure
+// would leave a unit-less number on screen.
+func TestNarrowChecklistKeepsPercent(t *testing.T) {
+	m := sampleModels()["task"]
+	m.width, m.height = 64, 24
+	content := m.View().Content
+	if !strings.Contains(content, "62%") {
+		t.Errorf("the percentage should outlive the byte figures:\n%s", content)
+	}
+	if strings.Contains(content, "310.4") {
+		t.Errorf("byte figures should be dropped whole, not clipped:\n%s", content)
+	}
+}
+
+// Long option hints must survive a narrow screen, wrapped under their option
+// rather than truncated away.
+func TestNarrowViewKeepsOptionHints(t *testing.T) {
+	m := sampleModels()["question"]
+	m.width, m.height = 44, 20
+	content := m.View().Content
+	if !strings.Contains(content, "restarts once") {
+		t.Errorf("hint text was dropped at 44 columns:\n%s", content)
+	}
+	if !strings.Contains(content, "Step 1/4") {
+		t.Errorf("the rail should collapse to a step line below %d columns:\n%s", minTwoColumn, content)
+	}
+}

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -28,6 +28,18 @@ func sampleModels() map[string]wizModel {
 			},
 			notes: []noteMsg{{"ok", "Deployment files are up to date"}},
 		},
+		// The star question is the one that carries an emoji: a glyph the
+		// terminal draws two columns wide has to be measured as two.
+		"confirm": {
+			title:   "Onyx Installer",
+			version: "v0.1.0",
+			stage:   StageComplete,
+			answers: []answerMsg{{"Mode", "Lite"}, {"Version", "v4.4.6"}},
+			sel: &askSelectMsg{
+				title: "Enjoying Onyx? ⭐ Star the repo on GitHub?",
+				opts:  []Option{{Label: "Yes"}, {Label: "No"}},
+			},
+		},
 		"task": {
 			title:      "Onyx Installer",
 			version:    "v0.1.0",
@@ -93,12 +105,38 @@ func TestBoxesFillTerminalWidth(t *testing.T) {
 		wiz.printTail(wizModel{width: w, card: []string{
 			"🎉 Onyx is ready  →  http://localhost:3000",
 			"",
-			"Manage:  onyx-cli deploy status · stop · upgrade · uninstall",
+			"Manage this deployment any time with:",
+			"  onyx-cli deploy status      health, version, and URL",
 		}})
 		if got := borderWidth(buf.String()); got != w {
 			t.Errorf("summary card at %d columns: border is %d wide", w, got)
 		}
 	}
+}
+
+// An indented card line that outgrows the card continues under itself: the
+// command list the card ends with would otherwise look like twice as many
+// commands as it lists.
+func TestNarrowCardHangsWrappedLines(t *testing.T) {
+	var buf bytes.Buffer
+	wiz := &Wizard{out: &buf}
+	wiz.printTail(wizModel{width: 44, card: []string{
+		"  onyx-cli deploy uninstall   remove it and its data",
+	}})
+
+	for _, line := range strings.Split(buf.String(), "\n") {
+		plain := ansi.Strip(line)
+		if !strings.Contains(plain, "its data") {
+			continue
+		}
+		body := plain[strings.Index(plain, "│")+len("│"):]
+		// Two columns of card padding, then the line's own indent.
+		if !strings.HasPrefix(body, "    it and its data") {
+			t.Errorf("wrapped line lost its indent:\n%s", buf.String())
+		}
+		return
+	}
+	t.Errorf("the line never wrapped:\n%s", buf.String())
 }
 
 // The last thing an install does is ask a question, and quitting it kills the

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -101,6 +101,25 @@ func TestBoxesFillTerminalWidth(t *testing.T) {
 	}
 }
 
+// The last thing an install does is ask a question, and quitting it kills the
+// wizard. The work is over by then, so the summary still has to be printed —
+// there is nowhere else for the user to find the URL.
+func TestFinishPrintsCardAfterQuit(t *testing.T) {
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	close(done)
+	wiz := &Wizard{out: &buf, done: done, width: 80}
+
+	wiz.Finish("🎉 Onyx is ready  →  http://localhost:3000")
+
+	if !strings.Contains(buf.String(), "http://localhost:3000") {
+		t.Errorf("the summary was dropped with the wizard:\n%s", buf.String())
+	}
+	if got := borderWidth(buf.String()); got != 80 {
+		t.Errorf("card border is %d wide, want 80", got)
+	}
+}
+
 // borderWidth is the display width of the first box-drawing line in content,
 // or 0 when there is none.
 func borderWidth(content string) int {

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 	"time"
@@ -67,6 +68,48 @@ func TestViewFitsTerminalWidth(t *testing.T) {
 			}
 		}
 	}
+}
+
+// The boxes are as wide as the terminal, whatever is in them: one that takes
+// its width from its longest line makes the layout look like it shrinks
+// whenever a phase has less to say.
+func TestBoxesFillTerminalWidth(t *testing.T) {
+	sizes := []int{64, 80, 100, 120}
+	for name, base := range sampleModels() {
+		for _, w := range sizes {
+			m := base
+			m.width, m.height = w, 30
+			if got := borderWidth(m.View().Content); got != w {
+				t.Errorf("%s at %d columns: pane border is %d wide", name, w, got)
+			}
+		}
+	}
+
+	// The summary card is printed to the normal screen after the wizard is
+	// gone, and has to line up with what it just replaced.
+	for _, w := range sizes {
+		var buf bytes.Buffer
+		wiz := &Wizard{out: &buf}
+		wiz.printTail(wizModel{width: w, card: []string{
+			"🎉 Onyx is ready  →  http://localhost:3000",
+			"",
+			"Manage:  onyx-cli deploy status · stop · upgrade · uninstall",
+		}})
+		if got := borderWidth(buf.String()); got != w {
+			t.Errorf("summary card at %d columns: border is %d wide", w, got)
+		}
+	}
+}
+
+// borderWidth is the display width of the first box-drawing line in content,
+// or 0 when there is none.
+func borderWidth(content string) int {
+	for _, line := range strings.Split(content, "\n") {
+		if strings.Contains(line, "╭") {
+			return ansi.StringWidthWc(line)
+		}
+	}
+	return 0
 }
 
 // A download note that no longer fits sheds whole parts: cutting it mid-figure

--- a/cli/internal/deploy/ui/ui_test.go
+++ b/cli/internal/deploy/ui/ui_test.go
@@ -145,6 +145,46 @@ func TestNarrowChecklistKeepsPercent(t *testing.T) {
 	}
 }
 
+// Hints read as a column, not as text stepping in and out with the labels —
+// except where the column would cost a hint its place beside its option.
+func TestOptionHintsShareAColumn(t *testing.T) {
+	opts := []Option{
+		{Label: "Lite", Hint: "chat, tools, uploads, projects — no vector search (recommended)"},
+		{Label: "Standard", Hint: "full search, connectors, and RAG"},
+		{Label: "Standard + Craft", Hint: "adds AI web-app building (binds the docker socket)"},
+	}
+	m := wizModel{sel: &askSelectMsg{title: "How should Onyx be deployed?", opts: opts}}
+
+	// Roomy: every hint starts past the widest label, at the same column.
+	want := cursorWidth + ansi.StringWidthWc("Standard + Craft") + hintGap
+	for i, line := range m.selectPane(94, true, false)[1:] {
+		got := hintStart(line, opts[i].Hint)
+		if got != want {
+			t.Errorf("hint %d starts at column %d, want %d:\n%s", i, got, want, line)
+		}
+	}
+
+	// Tight: at 74 columns all three hints still fit beside their own label,
+	// and lining them up would push the first onto a line of its own.
+	pane := m.selectPane(74, true, false)
+	if len(pane) != 1+len(opts) {
+		t.Errorf("the column cost a hint its place beside its option:\n%s", strings.Join(pane, "\n"))
+	}
+	if got := hintStart(pane[1], opts[0].Hint); got != cursorWidth+ansi.StringWidthWc("Lite")+hintGap {
+		t.Errorf("hint 0 should follow its own label at 74 columns, starts at %d", got)
+	}
+}
+
+// hintStart is the column hint begins at within a rendered option line.
+func hintStart(line, hint string) int {
+	plain := ansi.Strip(line)
+	i := strings.Index(plain, hint)
+	if i < 0 {
+		return -1
+	}
+	return ansi.StringWidthWc(plain[:i])
+}
+
 // Long option hints must survive a narrow screen, wrapped under their option
 // rather than truncated away.
 func TestNarrowViewKeepsOptionHints(t *testing.T) {

--- a/deployment/docker_compose/README.md
+++ b/deployment/docker_compose/README.md
@@ -29,6 +29,22 @@ the install.sh script with --delete-data.
 
 To shut down the deployment without deleting, use install.sh --shutdown.
 
+### Onyx CLI (alternative)
+
+The same guided install also ships inside the Onyx CLI and will eventually
+replace install.sh once it stabilizes:
+
+```
+pip install onyx-cli && onyx-cli deploy install
+```
+
+It understands existing install.sh deployments (an `onyx_data` directory is
+detected and managed in place; new installs default to `~/.config/onyx`) and
+adds lifecycle commands: `onyx-cli deploy status` (versions, containers,
+health), `deploy stop`, `deploy upgrade [--tag vX.Y.Z]` (rewrites only
+IMAGE_TAG, preserves your .env edits, backs up hand-edited files), and
+`deploy uninstall`.
+
 ### Upgrading the deployment
 Onyx maintains backwards compatibility across all minor versions following SemVer. If following the install.sh script (or through Docker Compose), you can
 upgrade it by first bringing down the containers. To do this, use `install.sh --shutdown`

--- a/deployment/docker_compose/env.template
+++ b/deployment/docker_compose/env.template
@@ -16,12 +16,12 @@
 IMAGE_TAG=latest
 
 ## Onyx Craft Configuration (off by default).
-## When enabling Craft through install.sh --include-craft or by manually adding
+## When enabling Craft through the installer's --include-craft or by manually adding
 ## docker-compose.craft.yml, the sandbox image follows IMAGE_TAG above.
 # ENABLE_CRAFT=true
 #
 ## docker backend drives sandboxes via the host Docker socket (root-equivalent;
-## trusted hosts only) and needs v4.0.6+ images. install.sh picks docker vs
+## trusted hosts only) and needs v4.0.6+ images. The installer picks docker vs
 ## kubernetes by image tag.
 # SANDBOX_BACKEND=docker
 #
@@ -32,7 +32,7 @@ IMAGE_TAG=latest
 ## proxy, including the /api path prefix served by that proxy.
 # ONYX_SERVER_URL=https://onyx.your-org.example/api
 #
-## Sandbox bridge network. Created by install.sh (or manually:
+## Sandbox bridge network. Created by the installer (or manually:
 ##   docker network create onyx_craft_sandbox
 ## Sandboxes join only this network. The firewall forces API and public egress
 ## through sandbox-proxy; postgres, redis, and minio stay off the bridge.
@@ -45,10 +45,9 @@ IMAGE_TAG=latest
 # SANDBOX_DOCKER_CPU_LIMIT=1.0
 ## EC2 IMDS note: on EC2 the Docker daemon's default bridge allows traffic to
 ## 169.254.169.254 (Instance Metadata Service), which can hand out IAM role
-## credentials. The fix is a host-level DOCKER-USER iptables rule that drops
-## bridge traffic to that address. install.sh --include-craft installs this
-## rule automatically when it has sudo/iptables access, and prints manual
-## instructions otherwise.
+## credentials. The installer does not block this automatically: require
+## IMDSv2 (HttpTokens=required) on the instance, and/or add a host-level
+## DOCKER-USER iptables rule that drops bridge traffic to that address.
 
 ## Auth Settings
 ### https://docs.onyx.app/deployment/authentication
@@ -57,7 +56,7 @@ IMAGE_TAG=latest
 # SESSION_EXPIRE_TIME_SECONDS=
 ### Signs password reset, email verification, OAuth login state, and captcha cookies.
 ### REQUIRED: the API server refuses to start with an empty value (secure by default).
-### If using install.sh this is auto-generated; if setting manually, run: openssl rand -hex 32
+### The installer auto-generates this; if setting manually, run: openssl rand -hex 32
 USER_AUTH_SECRET=""
 ### Recommend to set this for security
 # ENCRYPTION_KEY_SECRET=
@@ -174,7 +173,7 @@ COMPOSE_PROFILES=s3-filestore
 FILE_STORE_BACKEND=s3
 
 ## MinIO/S3 Configuration (only needed when FILE_STORE_BACKEND=s3)
-## SECURITY: minioadmin is a local-dev default. install.sh randomizes it; if you
+## SECURITY: minioadmin is a local-dev default. The installer randomizes it; if you
 ## edit .env by hand, change all four values before production. Keep the S3_AWS_*
 ## pair identical to MINIO_ROOT_* (the app uses MinIO's root creds).
 S3_ENDPOINT_URL=http://minio:9000


### PR DESCRIPTION
## Description

> **Now based on #13524** (the embedding/sync tooling), which should land first.

**The interactive experience is redesigned, not ported** (per review discussion): two up-front questions — a merged mode select (Lite / Standard / Standard + Craft) and the version, prefilled with the latest release — no banner/acknowledge gate, environment checks running concurrently during the questions (collapsing to one summary line; only problems surface), three execution phases with live Bubble Tea/lipgloss spinners on a TTY, a live ready-count while `up --wait` blocks, log-tail-only failures, and a summary card. Reruns ask one Restart/Upgrade question, and the deployment mode can no longer flip implicitly (install.sh re-asked each run, so a --no-prompt rerun silently converted standard installs to lite). Compatibility is kept where it binds: all flags, INSTALL_PREFIX, legacy onyx_data handling, .env/manifest semantics, and plain line output for --no-prompt / no-TTY runs.


Moves the guided self-hosted installer out of the 1389-line bash script (and its drifted 1121-line PowerShell twin) into `onyx-cli` as a `deploy` command group, giving one typed, tested, cross-platform implementation with first-class lifecycle commands:

- **`deploy install`** (alias: `install-onyx`) — full install.sh parity: Docker Engine/compose auto-install on Linux (get.docker.com, Amazon Linux dnf/yum, docker-group management with the `sudo env K=V` argv fallback), Docker Desktop start-and-wait on macOS, detect-and-instruct on native Windows, RAM/disk checks, lite/standard prompt (lite default), tag prompt defaulting to the latest app release, `.env` from template with `crypto/rand` secrets, Craft wiring (`SANDBOX_BACKEND` by version, sandbox network/CA volume pre-create, security warning), free-port scan, floating-vs-pinned config refresh, `pull` + `up -d --wait`, and the restart/update flow for existing installs. New over the script: `--tag` for non-interactive pinned installs.
- **`deploy upgrade`** — the "type 'update'" sub-flow promoted to a scriptable verb. Rewrites only `IMAGE_TAG` (+ `SANDBOX_BACKEND` when Craft is on); refreshes managed files to the target ref; hand-edited files are detected via a new `install-state.json` manifest (per-file sha256 + pristine as-written copies), backed up, and only overwritten with consent or `--force`; semver downgrades warn and require confirmation/`--force`.
- **`deploy stop` / `deploy status` / `deploy uninstall`** — replace `--shutdown`/`--delete-data` (which now print redirects instead of unknown-flag errors). `status` is new: manifest vs `.env` vs running-container version with drift flagging, per-container health, published port, `--json`, and probe-friendly exit codes (0 healthy / 9 not installed / 1 stopped or degraded). `uninstall` keeps the typed-DELETE confirmation and adds `--force` for scripted teardown.

Fixes the long-standing UX bug where the script printed `./install.sh --shutdown` even though that file never exists for curl-pipe users — every follow-up instruction now names a command that exists regardless of install method.

**Layout**: new installs live in `~/.config/onyx` (XDG-aware, sibling of the CLI's own `~/.config/onyx-cli`); legacy `./onyx_data` installs are auto-detected and managed **in place** (safe: the compose project name is pinned to `onyx`, so containers/volumes are path-independent). `--dir`, `ONYX_DEPLOYMENT_DIR`, and the legacy `INSTALL_PREFIX` env var are honored.

**File sourcing**: the shipped deployment files (generated `docker-compose.yml`, lite/craft overlays, `env.template`, nginx config, install-root README) are embedded into the binary via `go:embed`, synced from `deployment/` by the new `ods sync-cli-deploy-files --write` and gated by a drift test in the cli module. Installing a pinned tag fetches the files matching that version from GitHub raw (falling back to embedded offline). `--local` keeps its exact "trust files on disk" meaning, preserving the documented Craft contributor workflow.

**install.sh / install.ps1 are unchanged in this PR** — they stay the canonical guided installers until the CLI stabilizes; converting them to thin bootstrappers is deferred to a follow-up. What ships now: a **cli-latest rolling GitHub release** (version-less asset names, updated on each stable cli/v* publish) so the newest CLI has stable download URLs, and the docker compose README documents `onyx-cli deploy install` + the lifecycle verbs as the alternative install path.

Docs updated accordingly; the sandbox README and env.template also stop claiming the installer installs an EC2 IMDS-blocking iptables rule (no installer version ever did — guidance is now IMDSv2 / a manual DOCKER-USER rule).

### Deliberate behavior deltas
- `--no-prompt` restart of an existing install can no longer silently flip a standard deployment to lite: the mode prompt defaults to the manifest-recorded mode.
- Upgrade friction is new by design: edited-file backup/confirm and the downgrade guard replace install.sh's silent overwrite.
- `.env` is written 0600 (was umask-default).
- Trust-model note: `main`'s install.sh goes from readable bash to download-and-run-binary; assets ship checksums but no signing (cosign/sigstore is a possible follow-up).

### Rollout notes
- **Cutting the first `cli/vX.Y.Z` release is the prerequisite** for the bootstrap download path (and the one-time smoke test of the percent-encoded `cli%2Fv*` asset URLs). Until then, pip and the PATH fast path work.
- The `cli-deploy-files-sync` pre-commit hook entry follows once an `onyx-devtools` release ships the new ods command (hooks run the released package); the cli module's drift test covers CI meanwhile.
- Old pinned-tag deep links to install.sh keep serving the full historical script — no action needed.
- Windows full-provisioning parity (UAC self-elevation, unattended Docker Desktop/WSL2 install, Windows Server handoff) is deliberately deferred to a follow-up; v1 detects and instructs. Future work with hooks already in place: breaking-change warnings from release notes between installed→target tags, and 3-way merge of compose edits (the manifest already stores the pristine base copies this needs).

## How Has This Been Tested?

- `go test ./...` in `cli/` (new suites: deployfiles drift gate, paths, state, release incl. the cli/v*-contamination regression, dockercmd incl. exact sudo-argv assertions, resources, prompt, full fake-driven `RunInstall`/`RunUpgrade`/lifecycle flows, cmd-level dry-run/legacy-flag tests) and in `tools/ods/` (deployfilessync); `golangci-lint run ./...` clean in both modules.
- `pre-commit run` on all touched files (shellcheck on the new bootstrap, zizmor/actionlint on the workflow, env drift baseline).
- Smoke tests: `onyx-cli deploy install --dry-run` variants; bootstrap fast path (`install.sh` with a built CLI on PATH execs `deploy install` with args passed through); `bash -n` on the bootstrap.
- Not yet run (no Docker daemon in the dev environment): live end-to-end install/upgrade/uninstall on a Docker-capable host, and the bootstrap download path (blocked on the first `cli/v*` release).

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [ ] [Optional] Override Linear Check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the shell installers with a Go-based `onyx-cli deploy` lifecycle and a full-screen TUI wizard. Adds safer upgrades, status/stop/logs/uninstall verbs, smarter reruns, a rolling `cli-latest` release, faster pinned‑tag pulls with clearer progress, and offline installs from local images; `install.sh`/`install.ps1` remain for now.

- **New Features**
  - Commands: `install`, `upgrade`, `status`, `stop`, `logs`, `uninstall` (alias: `install-onyx`).
  - TUI wizard: full-screen prompts and per-service readiness with live compose progress; falls back to plain output for `--no-prompt`/non‑TTY; reruns use a single Restart/Upgrade question with a Cancel option.
  - Status/logs: `status` reports versions, health, and now explains why a service is down (restarts, exit code, OOM, last failing health probe); `deploy logs` shows service logs without hunting for the compose files; `--json` and probe-friendly exit codes stay.
  - Offline installs: `--offline` deploys from images already on the host, skipping release lookup and config fetch; uses `up --pull never` and names any missing images.
  - Cross‑platform: auto‑provisions Docker on Linux; starts/waits for Docker Desktop on macOS; clear guidance on Windows; RAM/disk checks; free port scan; `.env` with random secrets; `--tag` for pinned installs; compose detection with sudo fallback.
  - Rollouts: zero‑stop upgrades via `compose up`; preserves `HOST_PORT`; smarter reruns with “Stop and continue”; non‑interactive auto‑stop with `--force`.
  - Safety: `install-state.json` manifest (mode/tag + per‑file hashes) with backups and overwrite confirm/`--force`; downgrade guard.

- **Bug Fixes**
  - Version recording: `.env` is updated only after config refresh and manifest save; install reverts `.env` on failures; if manifest save fails after a successful start, the deployment is reported as running; switching Lite mode now adds/removes only the s3‑filestore profile and keeps other user profiles.
  - Safer uninstall: refuses broad paths; keeps files when `compose down -v` fails so teardown can be retried.
  - `--tag` validation and lookup: syntactic-first checks, non‑blocking best‑effort existence; fixed race with background release lookup; rejects refs that escape `raw.githubusercontent` paths.
  - Status: reads the running Onyx version from `onyxdotapp/onyx-*` images, not nginx.
  - Dry run: no preflight probes during `deploy install --dry-run`; leaves no background processes.
  - Progress/cancel: finished image rows end in “pulled”; cancellations don’t print a failure report; real failures render a readable tail.
  - Wizard polish: full‑width pane and summary card; rail shows “Done” at the final prompt; health polling backstops compose events; `--verbose` stays on plain, line‑oriented output; prompts use dot‑headed questions; summary card lists lifecycle commands; the star question shows a star.
  - Diagnostics: failure messages style follow‑up commands as commands so they stand out.

<sup>Written for commit ec8aa4ed1575d3ed689e6ec4c0c6b588038b8ecc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13522?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

