### PR TITLE
fix(craft): stop the apps page shifting when switching tabs

### DIFF
--- a/web/src/app/craft/v1/apps/page.test.tsx
+++ b/web/src/app/craft/v1/apps/page.test.tsx
@@ -171,12 +171,9 @@ describe("Apps associated-skill setup notice", () => {
     render(<ExternalAppsPage />);
 
     expect(
-      screen.getByText(
-        "Connected · Not all associated skills are enabled. This app may not work correctly."
-      )
+      screen.getByText("Connected · not all associated skills are enabled")
     ).toBeInTheDocument();
     expect(screen.getByLabelText("Skill setup required")).toBeInTheDocument();
-    expect(screen.queryByLabelText("App ready")).not.toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Review skills" })).toHaveAttribute(
       "href",
       "/craft/v1/skills?externalAppId=42"
@@ -192,20 +189,17 @@ describe("Apps associated-skill setup notice", () => {
     render(<ExternalAppsPage />);
 
     expect(
-      screen.queryByText(
-        "Connected · Not all associated skills are enabled. This app may not work correctly."
-      )
+      screen.queryByText("Connected · not all associated skills are enabled")
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole("link", { name: "Review skills" })
     ).not.toBeInTheDocument();
-    expect(screen.getByLabelText("App ready")).toBeInTheDocument();
     expect(
       screen.queryByLabelText("Skill setup required")
     ).not.toBeInTheDocument();
   });
 
-  it("does not claim an external app is ready before skills load", () => {
+  it("does not warn about skills before they load", () => {
     mockUseUserSkills.mockReturnValue({
       data: undefined,
       refresh: mockRefreshSkills,
@@ -213,9 +207,11 @@ describe("Apps associated-skill setup notice", () => {
 
     render(<ExternalAppsPage />);
 
-    expect(screen.queryByLabelText("App ready")).not.toBeInTheDocument();
     expect(
       screen.queryByLabelText("Skill setup required")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "Review skills" })
     ).not.toBeInTheDocument();
   });
 
@@ -228,9 +224,7 @@ describe("Apps associated-skill setup notice", () => {
     render(<ExternalAppsPage />);
 
     expect(
-      screen.getByText(
-        "Connected · Not all associated skills are enabled. This app may not work correctly."
-      )
+      screen.getByText("Connected · not all associated skills are enabled")
     ).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Review skills" })).toHaveAttribute(
       "href",
@@ -292,7 +286,6 @@ describe("Apps vs MCP servers", () => {
 
     // MCP servers expose MCP tools, not skills, so neither skill glyph applies —
     // the green check used to render here purely because no skill data existed.
-    expect(activeTab().queryByLabelText("App ready")).not.toBeInTheDocument();
     expect(
       activeTab().queryByLabelText("Skill setup required")
     ).not.toBeInTheDocument();
@@ -317,6 +310,42 @@ describe("Apps vs MCP servers", () => {
     expect(
       activeTab().getByText(/Not available for your account/)
     ).toBeInTheDocument();
+  });
+
+  it("leads with connected cards, then orders the rest by name", () => {
+    mockEndpoints([
+      appFixture({
+        id: 1,
+        name: "Zulip",
+        app_type: "CUSTOM",
+        authenticated: true,
+      }),
+      appFixture({
+        id: 2,
+        name: "Asana",
+        app_type: "CUSTOM",
+        authenticated: false,
+      }),
+      appFixture({
+        id: 3,
+        name: "Monday",
+        app_type: "CUSTOM",
+        authenticated: true,
+      }),
+      appFixture({
+        id: 4,
+        name: "Basecamp",
+        app_type: "CUSTOM",
+        authenticated: false,
+      }),
+    ]);
+
+    render(<ExternalAppsPage />);
+
+    const names = activeTab()
+      .getAllByText(/^(Zulip|Asana|Monday|Basecamp)$/)
+      .map((node) => node.textContent);
+    expect(names).toEqual(["Monday", "Zulip", "Asana", "Basecamp"]);
   });
 
   it("reserves the inactive kind's space so switching tabs cannot move the page", async () => {
@@ -369,6 +398,5 @@ describe("Apps vs MCP servers", () => {
     render(<ExternalAppsPage />);
 
     expect(screen.getByLabelText("Skill setup required")).toBeInTheDocument();
-    expect(screen.queryByLabelText("App ready")).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/craft/v1/apps/page.test.tsx
+++ b/web/src/app/craft/v1/apps/page.test.tsx
@@ -1,4 +1,10 @@
-import { render, screen, setupUser, waitFor } from "@tests/setup/test-utils";
+import {
+  render,
+  screen,
+  setupUser,
+  waitFor,
+  within,
+} from "@tests/setup/test-utils";
 import ExternalAppsPage from "@/app/craft/v1/apps/page";
 import type { SkillsList } from "@/lib/skills/types";
 import {
@@ -140,6 +146,12 @@ function mockEndpoints(
   });
 }
 
+/** Queries scoped to the visible tab: every kind stays mounted so the page
+ * keeps its geometry, so "on screen" means "inside the active panel". */
+function activeTab() {
+  return within(screen.getByRole("tabpanel"));
+}
+
 describe("Apps associated-skill setup notice", () => {
   beforeEach(() => {
     mockMutateApps.mockReset();
@@ -262,13 +274,13 @@ describe("Apps vs MCP servers", () => {
 
     render(<ExternalAppsPage />);
 
-    expect(screen.getByText("Acme CRM")).toBeInTheDocument();
-    expect(screen.queryByText("Asana MCP")).not.toBeInTheDocument();
+    expect(activeTab().getByText("Acme CRM")).toBeInTheDocument();
+    expect(activeTab().queryByText("Asana MCP")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("tab", { name: /MCP servers/ }));
 
-    expect(screen.getByText("Asana MCP")).toBeInTheDocument();
-    expect(screen.queryByText("Acme CRM")).not.toBeInTheDocument();
+    expect(activeTab().getByText("Asana MCP")).toBeInTheDocument();
+    expect(activeTab().queryByText("Acme CRM")).not.toBeInTheDocument();
   });
 
   it("does not claim a connected MCP server is skill-ready", async () => {
@@ -280,14 +292,14 @@ describe("Apps vs MCP servers", () => {
 
     // MCP servers expose MCP tools, not skills, so neither skill glyph applies —
     // the green check used to render here purely because no skill data existed.
-    expect(screen.queryByLabelText("App ready")).not.toBeInTheDocument();
+    expect(activeTab().queryByLabelText("App ready")).not.toBeInTheDocument();
     expect(
-      screen.queryByLabelText("Skill setup required")
+      activeTab().queryByLabelText("Skill setup required")
     ).not.toBeInTheDocument();
     // Still listed as connected — the row's presence is the status.
-    expect(screen.getAllByText("Connected").length).toBeGreaterThan(0);
+    expect(activeTab().getAllByText("Connected").length).toBeGreaterThan(0);
     expect(
-      screen.queryByText(/Not available for your account/)
+      activeTab().queryByText(/Not available for your account/)
     ).not.toBeInTheDocument();
   });
 
@@ -300,11 +312,39 @@ describe("Apps vs MCP servers", () => {
     render(<ExternalAppsPage />);
     await user.click(screen.getByRole("tab", { name: /MCP servers/ }));
 
-    expect(screen.getByText("Asana MCP")).toBeInTheDocument();
-    expect(screen.queryByText("Connected")).not.toBeInTheDocument();
+    expect(activeTab().getByText("Asana MCP")).toBeInTheDocument();
+    expect(activeTab().queryByText("Connected")).not.toBeInTheDocument();
     expect(
-      screen.getByText(/Not available for your account/)
+      activeTab().getByText(/Not available for your account/)
     ).toBeInTheDocument();
+  });
+
+  it("reserves the inactive kind's space so switching tabs cannot move the page", async () => {
+    const user = setupUser();
+    mockEndpoints([ACME_CRM_APP], [mcpServer()]);
+
+    render(<ExternalAppsPage />);
+
+    // Each kind's blurb and list stay mounted in a shared slot — that is what
+    // holds the taller kind's height on either tab — but only the active kind
+    // is visible and reachable.
+    const hiddenState = (matcher: RegExp | string) =>
+      screen
+        .getByText(matcher)
+        .closest("[aria-hidden]")
+        ?.getAttribute("aria-hidden");
+
+    expect(hiddenState(/Integrations Onyx supports/)).toBe("false");
+    expect(hiddenState("Acme CRM")).toBe("false");
+    expect(hiddenState(/Servers an admin made available/)).toBe("true");
+    expect(hiddenState("Asana MCP")).toBe("true");
+
+    await user.click(screen.getByRole("tab", { name: /MCP servers/ }));
+
+    expect(hiddenState(/Integrations Onyx supports/)).toBe("true");
+    expect(hiddenState("Acme CRM")).toBe("true");
+    expect(hiddenState(/Servers an admin made available/)).toBe("false");
+    expect(hiddenState("Asana MCP")).toBe("false");
   });
 
   it("reads built-in skills when deciding whether an app needs setup", () => {

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { errorHandlingFetcher } from "@/lib/fetcher";
@@ -221,20 +221,71 @@ function AppConnections({ query }: AppConnectionsProps) {
           >{`${KIND_COPY[kind].label} · ${byKind[kind].length}`}</Tabs.Trigger>
         ))}
       </Tabs.List>
-      {KIND_ORDER.map((kind) => (
-        <Tabs.Content key={kind} value={kind}>
+      <KindSlot tab={tab}>
+        {(kind) => (
+          <Text font="secondary-body" color="text-03">
+            {KIND_COPY[kind].blurb}
+          </Text>
+        )}
+      </KindSlot>
+      <KindSlot tab={tab} panel>
+        {(kind, active) => (
           <ConnectableList
             kind={kind}
             items={byKind[kind]}
             searching={searching}
-            connectParam={connectParam}
+            // Only the visible kind may claim a deep link; the others are
+            // rendered purely to hold their height.
+            connectParam={active ? connectParam : null}
             skillsLoaded={skillsData !== undefined}
             skillSetupByAppId={skillSetupByAppId}
             onChange={refresh}
           />
-        </Tabs.Content>
-      ))}
+        )}
+      </KindSlot>
     </Tabs>
+  );
+}
+
+interface KindSlotProps {
+  tab: ConnectableKind;
+  /** Wire the active kind up as the tab's panel (`role="tabpanel"`). */
+  panel?: boolean;
+  children: (kind: ConnectableKind, active: boolean) => ReactNode;
+}
+
+/**
+ * Renders one piece of the page for every kind, stacked in a single grid cell
+ * with only the active kind visible. Apps and MCP servers share the layout but
+ * not their content lengths, so every slot reserves the tallest kind's height:
+ * the page's geometry — and with it the scrollbar, which would otherwise
+ * re-center the whole page sideways — stays put when the tab changes.
+ */
+function KindSlot({ tab, panel, children }: KindSlotProps) {
+  return (
+    <div className={cn("grid", !panel && "pt-6 pb-2")}>
+      {KIND_ORDER.map((kind) => {
+        const active = kind === tab;
+        const content = children(kind, active);
+        return (
+          <div
+            key={kind}
+            className={cn("col-start-1 row-start-1", !active && "invisible")}
+            aria-hidden={!active}
+          >
+            {!panel ? (
+              content
+            ) : active ? (
+              <Tabs.Content value={kind}>{content}</Tabs.Content>
+            ) : (
+              // Mirrors the top padding Tabs.Content applies, so the height an
+              // unselected kind holds matches what it occupies once selected.
+              <div className="w-full pt-4">{content}</div>
+            )}
+          </div>
+        );
+      })}
+    </div>
   );
 }
 
@@ -297,11 +348,7 @@ function ConnectableList({
   }
 
   return (
-    <div className="flex flex-col gap-6 pt-2">
-      <Text font="secondary-body" color="text-03">
-        {copy.blurb}
-      </Text>
-
+    <div className="flex flex-col gap-6">
       {connected.length > 0 && (
         <section className="flex flex-col gap-2">
           <Text font="secondary-body" color="text-03">

--- a/web/src/app/craft/v1/apps/page.tsx
+++ b/web/src/app/craft/v1/apps/page.tsx
@@ -7,23 +7,24 @@ import { errorHandlingFetcher } from "@/lib/fetcher";
 import { SWR_KEYS } from "@/lib/swr-keys";
 import useOnMount from "@/hooks/useOnMount";
 import { cn } from "@opal/utils";
-import { Button, Card, InputTypeIn, Tabs, Text } from "@opal/components";
 import {
-  Content,
+  Button,
+  Card,
+  InputTypeIn,
+  Tabs,
+  Text,
+  Tooltip,
+} from "@opal/components";
+import {
   ContentAction,
   IllustrationContent,
+  Section,
   SettingsLayouts,
   toast,
 } from "@opal/layouts";
 import { SvgNoResult, SvgUnPlugged } from "@opal/illustrations";
-import {
-  SvgAlertCircle,
-  SvgCheckCircle,
-  SvgPlug,
-  SvgSettings,
-} from "@opal/icons";
+import { SvgAlertCircle, SvgPlug, SvgSettings } from "@opal/icons";
 import { ExternalAppUserResponse } from "@/app/craft/v1/apps/registry";
-import { MCPServersResponse } from "@/lib/tools/interfaces";
 import {
   ConnectableApp,
   ConnectableKind,
@@ -45,7 +46,6 @@ const KIND_COPY: Record<
   {
     label: string;
     blurb: string;
-    browseLabel: string;
     emptyTitle: string;
     empty: string;
   }
@@ -54,7 +54,6 @@ const KIND_COPY: Record<
     label: "Apps",
     blurb:
       "Integrations Onyx supports directly. Each comes with skills that teach Craft how to use it — start here.",
-    browseLabel: "Browse apps",
     emptyTitle: "No apps yet",
     empty: "No apps are configured for your organization yet.",
   },
@@ -62,23 +61,12 @@ const KIND_COPY: Record<
     label: "MCP servers",
     blurb:
       "Servers an admin made available to Craft. Use these when the app you need isn't listed under Apps, or when you specifically want a server's own MCP tools.",
-    browseLabel: "Browse servers",
     emptyTitle: "No MCP servers yet",
     empty: "No MCP servers have been made available to Craft.",
   },
 };
 
 const KIND_ORDER: ConnectableKind[] = ["app", "mcp"];
-
-interface SkillSetup {
-  total: number;
-  selected: number;
-}
-
-/** Readiness of an app's associated skills. `"unknown"` covers both "skills
- * haven't loaded" and "not an external app", neither of which should claim
- * readiness. */
-type SkillStatus = "unknown" | "ready" | "needs-setup";
 
 // The user's own app connections. Org-wide configuration lives in the admin
 // panel's Craft section; admins get a shortcut button to it here.
@@ -147,23 +135,23 @@ function AppConnections({ query }: AppConnectionsProps) {
   const [tab, setTab] = useState<ConnectableKind>(urlTab);
   useEffect(() => setTab(urlTab), [urlTab]);
 
-  const skillSetupByAppId = useMemo(() => {
-    const setup = new Map<number, SkillSetup>();
-    // Both lists matter: a built-in provider's associated skill is a built-in
-    // skill row, so reading only `customs` misses every built-in app.
-    const skills = [
+  // Apps with at least one associated skill switched off. Both skill lists
+  // matter: a built-in provider's associated skill is a built-in row, so
+  // reading only `customs` misses every built-in app. Empty until the fetch
+  // resolves, which is also what keeps an app from being warned about before
+  // its skills are known.
+  const appsNeedingSkillSetup = useMemo(() => {
+    const needsSetup = new Set<number>();
+    for (const skill of [
       ...(skillsData?.builtins ?? []),
       ...(skillsData?.customs ?? []),
-    ];
-    for (const skill of skills) {
+    ]) {
       const externalAppId = skill.external_app?.external_app_id;
-      if (externalAppId === undefined) continue;
-      const current = setup.get(externalAppId) ?? { total: 0, selected: 0 };
-      current.total += 1;
-      if (skill.enabled) current.selected += 1;
-      setup.set(externalAppId, current);
+      if (externalAppId !== undefined && !skill.enabled) {
+        needsSetup.add(externalAppId);
+      }
     }
-    return setup;
+    return needsSetup;
   }, [skillsData]);
 
   const refresh = () => {
@@ -176,10 +164,16 @@ function AppConnections({ query }: AppConnectionsProps) {
     const allApps = (externalApps ?? []).map(externalAppToConnectable);
     const allMcp = (mcpData?.mcp_servers ?? []).map(mcpServerToConnectable);
     const q = query.trim().toLowerCase();
+    // Connected first, then by name: what you already have is what you most
+    // often come here to check on or disconnect.
     const visible = (items: ConnectableApp[]) =>
       items
         .filter((item) => (q ? item.name.toLowerCase().includes(q) : true))
-        .sort(compareByName);
+        .sort(
+          (a, b) =>
+            Number(b.authenticated) - Number(a.authenticated) ||
+            compareByName(a, b)
+        );
     return {
       byKind: { app: visible(allApps), mcp: visible(allMcp) },
       searching: q.length > 0,
@@ -237,8 +231,7 @@ function AppConnections({ query }: AppConnectionsProps) {
             // Only the visible kind may claim a deep link; the others are
             // rendered purely to hold their height.
             connectParam={active ? connectParam : null}
-            skillsLoaded={skillsData !== undefined}
-            skillSetupByAppId={skillSetupByAppId}
+            appsNeedingSkillSetup={appsNeedingSkillSetup}
             onChange={refresh}
           />
         )}
@@ -294,9 +287,8 @@ interface ConnectableListProps {
   items: ConnectableApp[];
   searching: boolean;
   connectParam: string | null;
-  /** False until the skills fetch resolves; readiness is unknown until then. */
-  skillsLoaded: boolean;
-  skillSetupByAppId: Map<number, SkillSetup>;
+  /** Ids of external apps with a disabled associated skill. */
+  appsNeedingSkillSetup: Set<number>;
   onChange: () => void;
 }
 
@@ -305,31 +297,10 @@ function ConnectableList({
   items,
   searching,
   connectParam,
-  skillsLoaded,
-  skillSetupByAppId,
+  appsNeedingSkillSetup,
   onChange,
 }: ConnectableListProps) {
   const copy = KIND_COPY[kind];
-  const connected = items.filter((item) => item.authenticated);
-  const browse = items.filter((item) => !item.authenticated);
-
-  // Skill enablement is an external-app concept — MCP servers expose MCP tools,
-  // not skills, so their rows carry no readiness state at all.
-  function skillStatusOf(item: ConnectableApp): SkillStatus {
-    if (item.kind !== "app" || !skillsLoaded) return "unknown";
-    const setup =
-      item.externalAppId === null
-        ? undefined
-        : skillSetupByAppId.get(item.externalAppId);
-    if (
-      setup !== undefined &&
-      setup.total > 0 &&
-      setup.selected < setup.total
-    ) {
-      return "needs-setup";
-    }
-    return "ready";
-  }
 
   if (items.length === 0) {
     return searching ? (
@@ -347,71 +318,66 @@ function ConnectableList({
     );
   }
 
+  // One grid for both states — connected cards lead, then the rest. A card that
+  // connects moves up into that group but keeps its shape, so the page's
+  // geometry never changes. The tab's count carries the totals.
   return (
-    <div className="flex flex-col gap-6">
-      {connected.length > 0 && (
-        <section className="flex flex-col gap-2">
-          <Text font="secondary-body" color="text-03">
-            Connected
-          </Text>
-          <div className="flex flex-col gap-2">
-            {connected.map((item) => (
-              <ProviderConnectCard
-                key={item.key}
-                variant="row"
-                app={item}
-                skillStatus={skillStatusOf(item)}
-                onChange={onChange}
-              />
-            ))}
-          </div>
-        </section>
-      )}
-
-      <section className="flex flex-col gap-2">
-        <Text font="secondary-body" color="text-03">
-          {copy.browseLabel}
-        </Text>
-        {browse.length === 0 ? (
-          <Text font="secondary-body" color="text-03">
-            Everything is connected.
-          </Text>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
-            {browse.map((item) => (
-              <ProviderConnectCard
-                key={item.key}
-                variant="tile"
-                app={item}
-                highlight={
-                  connectParam !== null && connectParam === item.connectId
-                }
-                onChange={onChange}
-              />
-            ))}
-          </div>
-        )}
-      </section>
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+      {items.map((item) => (
+        <ConnectableCard
+          key={item.key}
+          app={item}
+          // Skills are an external-app concept, and only apps carry an id.
+          needsSkillSetup={
+            item.externalAppId !== null &&
+            appsNeedingSkillSetup.has(item.externalAppId)
+          }
+          highlight={connectParam !== null && connectParam === item.connectId}
+          onChange={onChange}
+        />
+      ))}
     </div>
   );
 }
 
-interface ProviderConnectCardProps {
+/**
+ * The card's one-line status. Connecting swaps this and the action beside it;
+ * clamped to a single line, it is also what holds every card to one height.
+ */
+function statusLine(app: ConnectableApp, needsSkillSetup: boolean): string {
+  if (app.authenticated) {
+    return needsSkillSetup
+      ? "Connected · not all associated skills are enabled"
+      : "Connected";
+  }
+  // Org-managed and not usable by this account (e.g. an admin config that
+  // yields no credentials, or pass-through OAuth for a password-login user).
+  // There is no user-side action.
+  if (app.connectMode === null) {
+    return "Not available for your account — ask an admin";
+  }
+  return app.description;
+}
+
+interface ConnectableCardProps {
   app: ConnectableApp;
-  variant: "row" | "tile";
   highlight?: boolean;
-  /** Row variant only: whether the app's skills are ready to use. */
-  skillStatus?: SkillStatus;
+  /** Whether some of the app's associated skills are disabled. Always false
+   * for MCP servers, which have no skills. */
+  needsSkillSetup?: boolean;
   onChange: () => void;
 }
 
-function ProviderConnectCard({
+/**
+ * One card shape for every connectable, connected or not. Connecting swaps the
+ * status line and the action row only — the card keeps its place in the grid.
+ */
+function ConnectableCard({
   app,
-  variant,
   highlight,
-  skillStatus = "unknown",
+  needsSkillSetup = false,
   onChange,
-}: ProviderConnectCardProps) {
+}: ConnectableCardProps) {
   const [isStarting, setIsStarting] = useState(false);
   const [credModalOpen, setCredModalOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -456,7 +422,6 @@ function ProviderConnectCard({
   }
 
   const Logo = app.logo;
-  const needsSkillSetup = skillStatus === "needs-setup";
 
   return (
     <>
@@ -468,76 +433,59 @@ function ProviderConnectCard({
         )}
       >
         <Card background="light" border="solid" rounding="lg">
-          {variant === "row" ? (
-            <ContentAction
-              sizePreset="main-ui"
-              variant="section"
-              padding="fit"
-              center
-              icon={Logo}
-              title={app.name}
-              description={
-                needsSkillSetup
-                  ? "Connected · Not all associated skills are enabled. This app may not work correctly."
-                  : "Connected"
-              }
-              rightChildren={
-                <div className="flex items-center gap-2">
-                  {needsSkillSetup ? (
-                    <SvgAlertCircle
-                      className="w-4 h-4 text-status-warning-05"
-                      aria-label="Skill setup required"
-                    />
-                  ) : skillStatus === "ready" ? (
-                    <SvgCheckCircle
-                      className="w-4 h-4 text-status-success-05"
-                      aria-label="App ready"
-                    />
-                  ) : null}
-                  {needsSkillSetup && app.externalAppId !== null && (
-                    <Button
-                      prominence="secondary"
-                      href={`/craft/v1/skills?externalAppId=${app.externalAppId}`}
-                    >
-                      Review skills
+          <ContentAction
+            sizePreset="main-ui"
+            variant="section"
+            padding="fit"
+            center
+            icon={Logo}
+            title={app.name}
+            titleMaxLines={1}
+            description={statusLine(app, needsSkillSetup)}
+            descriptionMaxLines={1}
+            rightChildren={
+              <Section flexDirection="row" width="fit" height="fit" gap={0.5}>
+                {app.authenticated ? (
+                  <>
+                    {/* Only the problem state gets a glyph — "Connected" in the
+                        status line already says the happy path. */}
+                    {needsSkillSetup && (
+                      <Tooltip tooltip="Not all associated skills are enabled. This app may not work correctly.">
+                        <SvgAlertCircle
+                          size={16}
+                          className="text-status-warning-05"
+                          aria-label="Skill setup required"
+                        />
+                      </Tooltip>
+                    )}
+                    {needsSkillSetup && app.externalAppId !== null && (
+                      <Button
+                        prominence="secondary"
+                        href={`/craft/v1/skills?externalAppId=${app.externalAppId}`}
+                      >
+                        Review skills
+                      </Button>
+                    )}
+                    {app.disconnect && (
+                      <Button
+                        prominence={needsSkillSetup ? "tertiary" : "secondary"}
+                        disabled={isStarting}
+                        onClick={disconnect}
+                      >
+                        {isStarting ? "…" : "Disconnect"}
+                      </Button>
+                    )}
+                  </>
+                ) : (
+                  app.connectMode !== null && (
+                    <Button disabled={isStarting} onClick={connect}>
+                      {isStarting ? "Redirecting…" : "Connect"}
                     </Button>
-                  )}
-                  {app.disconnect && (
-                    <Button
-                      prominence={needsSkillSetup ? "tertiary" : "secondary"}
-                      disabled={isStarting}
-                      onClick={disconnect}
-                    >
-                      {isStarting ? "…" : "Disconnect"}
-                    </Button>
-                  )}
-                </div>
-              }
-            />
-          ) : (
-            <div className="flex flex-col gap-3 w-full">
-              <Content
-                sizePreset="main-ui"
-                variant="section"
-                icon={Logo}
-                title={app.name}
-                description={app.description}
-              />
-              {app.connectMode === null ? (
-                // Org-managed and not usable by this account (e.g. an admin
-                // config that yields no credentials, or pass-through OAuth for a
-                // password-login user). There is no user-side action.
-                <Text font="secondary-body" color="text-03">
-                  Not available for your account — ask an admin to check this
-                  connection.
-                </Text>
-              ) : (
-                <Button disabled={isStarting} onClick={connect}>
-                  {isStarting ? "Redirecting…" : "Connect"}
-                </Button>
-              )}
-            </div>
-          )}
+                  )
+                )}
+              </Section>
+            }
+          />
         </Card>
       </div>
 


### PR DESCRIPTION
## Problem

On `/craft/v1/apps`, switching between the **Apps** and **MCP servers** tabs moved the whole page, and connecting an app moved its card out from under the cursor.

Three causes, all from the two tabs sharing a layout without sharing a shape:

1. **~7px sideways on tab switch.** The panels differ in height, so on a viewport where one tab overflows and the other doesn't, the settings scroll container gains/loses its scrollbar. Where scrollbars take up space (Windows/Linux, or macOS with "always show scrollbars") that narrows the centering box by 15px and re-centers the entire page — header, tabs and cards — by half that. Invisible on default macOS, where scrollbars are overlays.
2. **16–24px vertically on tab switch.** Below ~1150px the MCP blurb wraps to 2–3 lines where the Apps one is 1, so each tab's list started at a different height.
3. **A card jumping on connect.** Connected items rendered as full-width rows in a "Connected" section, unconnected ones as tiles in a "Browse" grid, so connecting an app teleported its card up the page and shoved everything below it. The two variants also disagreed on height (118px vs 114px), leaving the grid ragged.

<img width="1416" height="796" alt="Screenshot 2026-07-28 at 3 36 22 PM" src="https://github.com/user-attachments/assets/df52d234-b814-471b-92d8-450b98a8aaac" />
<img width="1259" height="791" alt="Screenshot 2026-07-28 at 3 36 24 PM" src="https://github.com/user-attachments/assets/0a791c24-b526-47d5-91e1-2a0d32a4adc8" />


## Fix

**Stacked slots (commit 1).** Every kind renders through one `KindSlot`, which stacks all kinds in a single CSS grid cell with only the selected one visible (`invisible` + `aria-hidden`). Each slot holds the tallest kind's height, so the page's geometry — and with it the scrollbar — can't change when the tab changes. Used twice: once for the blurb, once for the panels. The selected kind is still a real `Tabs.Content`, so there is exactly one `role="tabpanel"` and Radix's trigger/panel wiring is untouched; an unselected kind renders a stand-in mirroring `Tabs.Content`'s own `pt-4`. `connectParam` only reaches the visible kind, so the `?connect=` deep link can't focus a hidden card.

**One card shape (commit 2).** The row/tile variants collapse into a single `ContentAction` card whose connected state only swaps the status line and the action beside it, in one uniform 2-column grid. Titles and status lines are clamped to one line via `titleMaxLines`/`descriptionMaxLines`, so the card is a fixed height *by construction* rather than by hand-rolled sizing — the inner flex column, `mt-auto`, `min-h-8`, `h-full` and `*:h-full` are gone, and a long app name or wordy server description ellipsizes instead of growing the card. Connected items sort first, then by name. The green "ready" tick next to Disconnect is dropped, since the status line already says Connected.

That last change made some state redundant: with no tick, "skills all enabled" and "skills not loaded" render identically, so the per-app skill counts collapse to a `Set` of ids needing setup, which retires the `skillsLoaded` prop and its guard. `page.tsx` ends up **504 lines, down from 556** on `main`, despite gaining `KindSlot`.

No shared or Opal components were changed — the whole fix is contained to the page.

## Verification

Sideways shift, in a real Chrome launched with `--disable-features=OverlayScrollbar` (i.e. behaving like a space-taking-scrollbar machine), 24 apps vs 1 server so the Apps tab overflows and the MCP tab doesn't:

| | gutter (Apps → MCP) | tab-bar x | shift |
|---|---|---|---|
| before | 15 → 0 | 333 → 340 | **7px** |
| after | 15 → 15 | 333 → 333 | **0px** |

Pixel diff of the header/tab region between the two tabs: **5006** differing pixels before, **0** after.

- Overlay-scrollbar Chromium, 1000–1440px: `scrollHeight` identical per tab at every width, no positional difference in the tab list, panel origin or first section.
- Card geometry: every card on both tabs measures exactly **70px**, including a connected pass-through-OAuth server with no user action at all, a 75-character app name and a 185-character server description (both ellipsize).
- `bun run jest src/app/craft/v1/apps` — 39 passed. Three existing tests asserted the unselected kind was *unmounted*, which is no longer true; they're re-scoped to the active `role="tabpanel"` via an `activeTab()` helper. New tests cover the reserved-space mechanism and the connected-first ordering.

## Trade-offs

- The shorter tab scrolls into blank space, bounded by the taller tab's height. That's the cost of holding geometry page-side rather than reserving a scrollbar gutter in the shared settings layout.
- Connecting an item now reorders it into the connected group. Cards no longer move on their own, but a connect/disconnect does move one — inherent to grouping, and it's a deliberate action.
- Two user-visible copy changes: the skill-setup line is now `Connected · not all associated skills are enabled` with the full sentence in a tooltip on the warning glyph, and the unavailable state reads `Not available for your account — ask an admin` in the status line rather than a wrapped paragraph in the card body.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check