### PR TITLE
fix(craft): omit unverified limits for unknown models

### DIFF
--- a/backend/onyx/server/gateway/model_catalog.py
+++ b/backend/onyx/server/gateway/model_catalog.py
@@ -66,8 +66,11 @@ def _gateway_token_limits(
     model_map: dict[str, Any],
     provider: LLMProviderView,
     model: ModelConfigurationView,
-) -> tuple[int, int]:
+) -> tuple[int | None, int | None]:
     capability_model_name = _capability_model_name(model_map, provider, model)
+    if find_model_obj(model_map, provider.provider, capability_model_name) is None:
+        return None, None
+
     max_input_tokens = model.configured_max_input_tokens or llm_max_input_tokens(
         model_map=model_map,
         model_name=capability_model_name,

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -275,7 +275,7 @@ def test_gateway_config_preserves_explicit_context_override() -> None:
     }
 
 
-def test_unknown_model_renders_explicit_fallback_with_input_budget() -> None:
+def test_unknown_model_omits_unverified_token_limits() -> None:
     provider = _provider(
         7,
         "custom",
@@ -290,13 +290,8 @@ def test_unknown_model_renders_explicit_fallback_with_input_budget() -> None:
 
     assert gateway_config is not None
     opencode_config = build_provider_opencode_config(gateway_config)
-    assert opencode_config["provider"]["onyx"]["models"]["7/unknown-model"][
-        "limit"
-    ] == {
-        "context": 32_000,
-        "input": 32_000,
-        "output": 32_000,
-    }
+    model_config = opencode_config["provider"]["onyx"]["models"]["7/unknown-model"]
+    assert "limit" not in model_config
 
 
 def test_small_input_override_does_not_reduce_provider_output() -> None:


### PR DESCRIPTION
## Problem

Craft routes every configured LLM through the synthetic `onyx` OpenCode provider. For models present in LiteLLM, the gateway can attach verified context and output limits to that synthetic model entry. For newly released or custom models absent from LiteLLM, the gateway previously replaced missing metadata with `GEN_AI_MODEL_FALLBACK_MAX_TOKENS` and emitted those fallback values as if they were known limits.

This surfaced while testing OpenRouter `moonshotai/kimi-k3`. Kimi K3 has a much larger real context window, but because it was not yet in the pinned LiteLLM catalog, its generated OpenCode configuration asserted a 32k context/output window. OpenCode uses configured context metadata for proactive compaction and reserves substantial headroom before sending a request. The resulting usable prompt budget was smaller than Craft’s prompt and tool context, so OpenCode repeatedly compacted the session without making progress. The provider and gateway requests themselves were healthy.

The core issue is not specific to Kimi or OpenRouter: the gateway was collapsing “metadata unavailable” into “the limit is known to be 32k.” Any new, aliased, private, or self-hosted model missing from LiteLLM could receive misleading compaction metadata.

## Solution

Preserve uncertainty at the Craft gateway boundary:

- If LiteLLM has metadata for the model, emit its resolved input/output limits as before.
- If an alias resolves through a known provider deployment, continue using the deployment limits.
- If neither the model nor deployment has verifiable metadata, keep both limits unset.
- The existing OpenCode config renderer then omits the model’s `limit` block.

For a custom OpenCode model with no supplied context limit, OpenCode treats the context as unknown and skips proactive metadata-driven compaction. Requests still use OpenCode’s normal output ceiling, and the upstream provider continues to enforce its real context window. If the provider returns a recognized context-overflow response, OpenCode can still use its reactive overflow handling.

This is preferable to choosing another arbitrary fallback ratio: OpenCode currently reserves a 20k compaction buffer, so even reducing the output fallback to 10% of 32k would leave only about 12k tokens of usable prompt budget and could reproduce the same loop.

## Before

An unknown model was rendered with asserted fallback limits:

```json
{
  "limit": {
    "context": 32000,
    "input": 32000,
    "output": 32000
  }
}
```

## After

The same model remains available, but no unverified `limit` block is emitted:

```json
{
  "name": "Kimi K3",
  "reasoning": true,
  "tool_call": true
}
```

## Scope

This changes only the Craft gateway catalog representation for models with no LiteLLM or deployment metadata. It does not change the global Onyx token fallback helpers or the limits emitted for known models.

## Test plan

- `uv run pytest -q backend/tests/unit/onyx/llm/test_token_limit_lookups.py backend/tests/unit/onyx/server/gateway/test_model_catalog.py backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py backend/tests/unit/onyx/server/features/craft/sandbox/test_opencode_config.py`
- `pre-commit run --files backend/onyx/server/gateway/model_catalog.py backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py`

## Linear

- [x] Override Linear Check