### PR TITLE
fix: index calculated value instead of formula text for xlsx cells

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -678,7 +678,7 @@ def _load_readonly_workbook(file: IO[Any], file_name: str) -> openpyxl.Workbook 
     / known-openpyxl-bug cases the xlsx indexers treat as skip-and-continue rather
     than a hard failure."""
     try:
-        return openpyxl.load_workbook(file, read_only=True)
+        return openpyxl.load_workbook(file, read_only=True, data_only=True)
     except BadZipFile as e:
         error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
         if file_name.startswith("~"):

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -1,4 +1,5 @@
 import io
+import zipfile
 from typing import cast
 from unittest.mock import patch
 
@@ -25,6 +26,40 @@ def _make_xlsx(sheets: dict[str, list[list[str]]]) -> io.BytesIO:
     wb.save(buf)
     buf.seek(0)
     return buf
+
+
+def _make_xlsx_with_cached_formula(formula: str, cached_value: str) -> io.BytesIO:
+    """Build an xlsx where a formula cell also carries a cached calculated
+    value, mimicking what Excel writes to the file. openpyxl itself never
+    computes formulas, so a plain ``ws["B1"] = formula`` save leaves an
+    empty ``<v></v>`` cache; patch it in directly at the XML level."""
+    wb = openpyxl.Workbook()
+    ws = wb.active
+    assert ws is not None
+    ws["A1"] = 1
+    ws["B1"] = formula
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+
+    with zipfile.ZipFile(buf) as zin:
+        contents = {name: zin.read(name) for name in zin.namelist()}
+
+    formula_body = formula.lstrip("=")
+    empty_cache = f"<f>{formula_body}</f><v></v>"
+    cached = f"<f>{formula_body}</f><v>{cached_value}</v>"
+    xml = contents["xl/worksheets/sheet1.xml"].decode("utf-8")
+    assert empty_cache in xml
+    contents["xl/worksheets/sheet1.xml"] = xml.replace(empty_cache, cached).encode(
+        "utf-8"
+    )
+
+    out = io.BytesIO()
+    with zipfile.ZipFile(out, "w", zipfile.ZIP_DEFLATED) as zout:
+        for name, data in contents.items():
+            zout.writestr(name, data)
+    out.seek(0)
+    return out
 
 
 class TestXlsxToText:
@@ -201,6 +236,14 @@ class TestXlsxToText:
         assert "r1c1" in lines[0] and "r1c2" in lines[0]
         assert "r2c1" in lines[1] and "r2c2" in lines[1]
         assert "r3c1" in lines[2] and "r3c2" in lines[2]
+
+    def test_formula_cell_extracts_cached_value_not_formula_text(self) -> None:
+        """Regression: formula cells must index their calculated value, not
+        the raw formula string (requires load_workbook(..., data_only=True))."""
+        xlsx = _make_xlsx_with_cached_formula("=SUM(A1:A1)", "42")
+        result = xlsx_to_text(xlsx)
+        assert "42" in result
+        assert "SUM" not in result
 
 
 class TestSheetToCsvJaggedRows:


### PR DESCRIPTION
## Summary

`_load_readonly_workbook` in `backend/onyx/file_processing/extract_file_text.py` called `openpyxl.load_workbook(file, read_only=True)` without `data_only=True`. For cells containing a formula (e.g. `=SUM(A1:A1)`), this indexed the raw formula string instead of the value Excel last calculated for that cell, making that content unsearchable/misleading wherever xlsx files are indexed or attached to chat.

## Fix

Pass `data_only=True` so formula cells resolve to their cached calculated value instead of the formula text. Both call sites (`xlsx_sheet_extraction`, and the sheet-listing path) go through `_load_readonly_workbook`, and neither needs the raw formula string, so this is safe everywhere it's used.

## Test plan

- Added `test_formula_cell_extracts_cached_value_not_formula_text`, which builds an xlsx with a formula cell carrying a cached value (patched in at the XML level, since openpyxl itself never computes formulas) and asserts the extracted text contains the calculated value, not the formula.
- Verified the new test fails without the fix (extracts `=SUM(A1:A1)`) and passes with it.
- Ran the full `test_xlsx_to_text.py` suite: 38 passed.

Fixes #13353

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Index the calculated value for XLSX formula cells instead of the formula text to keep search and chat context accurate. Use `openpyxl.load_workbook(..., data_only=True)` and add a regression test covering cached formula values.

<sup>Written for commit 8cf3410006249a0110038dea3d3f33e6f72ba800. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13530?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

