### PR TITLE
fix(security): mask custom-tool secret header values for non-privileged reads

### DIFF
--- a/backend/onyx/server/features/tool/api.py
+++ b/backend/onyx/server/features/tool/api.py
@@ -54,6 +54,13 @@ def _validate_auth_settings(tool_data: CustomToolCreate | CustomToolUpdate) -> N
                 )
 
 
+def _can_view_secret_header_values(tool: Tool, user: User) -> bool:
+    """Real header values only for callers who could edit the tool anyway."""
+    return user.role == UserRole.ADMIN or (
+        tool.user_id is not None and tool.user_id == user.id
+    )
+
+
 def _get_editable_custom_tool(tool_id: int, db_session: Session, user: User) -> Tool:
     """Fetch a custom tool and ensure the caller has permission to edit it."""
     try:
@@ -100,7 +107,7 @@ def create_custom_tool(
         enabled=True,
     )
     db_session.commit()
-    return ToolSnapshot.from_model(tool)
+    return ToolSnapshot.from_model(tool, include_secret_header_values=True)
 
 
 @admin_router.put("/custom/{tool_id}", tags=PUBLIC_API_TAGS)
@@ -125,7 +132,7 @@ def update_custom_tool(
         passthrough_auth=tool_data.passthrough_auth,
         oauth_config_id=tool_data.oauth_config_id,
     )
-    return ToolSnapshot.from_model(updated_tool)
+    return ToolSnapshot.from_model(updated_tool, include_secret_header_values=True)
 
 
 @admin_router.delete("/custom/{tool_id}", tags=PUBLIC_API_TAGS)
@@ -220,7 +227,7 @@ def validate_tool(
 @router.get("/openapi", tags=PUBLIC_API_TAGS)
 def list_openapi_tools(
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> list[ToolSnapshot]:
     tools = get_tools(db_session, only_openapi=True)
 
@@ -229,7 +236,12 @@ def list_openapi_tools(
         if not should_expose_tool_to_fe(tool):
             continue
 
-        openapi_tools.append(ToolSnapshot.from_model(tool))
+        openapi_tools.append(
+            ToolSnapshot.from_model(
+                tool,
+                include_secret_header_values=_can_view_secret_header_values(tool, user),
+            )
+        )
 
     return openapi_tools
 
@@ -238,13 +250,16 @@ def list_openapi_tools(
 def get_custom_tool(
     tool_id: int,
     db_session: Session = Depends(get_session),
-    _: User = Depends(require_permission(Permission.BASIC_ACCESS)),
+    user: User = Depends(require_permission(Permission.BASIC_ACCESS)),
 ) -> ToolSnapshot:
     try:
         tool = get_tool_by_id(tool_id, db_session)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e))
-    return ToolSnapshot.from_model(tool)
+    return ToolSnapshot.from_model(
+        tool,
+        include_secret_header_values=_can_view_secret_header_values(tool, user),
+    )
 
 
 @router.get("", tags=PUBLIC_API_TAGS)
@@ -280,6 +295,11 @@ def list_tools(
                 pass
 
         # All custom tools and available built-in tools are included
-        filtered_tools.append(ToolSnapshot.from_model(tool))
+        filtered_tools.append(
+            ToolSnapshot.from_model(
+                tool,
+                include_secret_header_values=_can_view_secret_header_values(tool, user),
+            )
+        )
 
     return filtered_tools

--- a/backend/onyx/server/features/tool/models.py
+++ b/backend/onyx/server/features/tool/models.py
@@ -2,8 +2,23 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from onyx.configs.constants import MASK_CREDENTIAL_CHAR
 from onyx.db.models import Tool
 from onyx.server.features.tool.tool_visibility import get_tool_visibility_config
+
+_MASKED_HEADER_VALUE = MASK_CREDENTIAL_CHAR * 12
+
+
+def _mask_header_values(headers: list[Any] | None) -> list[Any] | None:
+    if not headers:
+        return headers
+    masked: list[Any] = []
+    for header in headers:
+        if isinstance(header, dict) and "value" in header:
+            masked.append({**header, "value": _MASKED_HEADER_VALUE})
+        else:
+            masked.append(header)
+    return masked
 
 
 class ToolSnapshot(BaseModel):
@@ -27,7 +42,9 @@ class ToolSnapshot(BaseModel):
     default_enabled: bool = False
 
     @classmethod
-    def from_model(cls, tool: Tool) -> "ToolSnapshot":
+    def from_model(
+        cls, tool: Tool, include_secret_header_values: bool = False
+    ) -> "ToolSnapshot":
         # Get visibility config for this tool
         config = get_tool_visibility_config(tool)
 
@@ -38,7 +55,13 @@ class ToolSnapshot(BaseModel):
             definition=tool.openapi_schema,
             display_name=tool.display_name or tool.name,
             in_code_tool_id=tool.in_code_tool_id,
-            custom_headers=tool.custom_headers,
+            # Header values are admin-configured secrets (API keys etc.) — only
+            # callers that may edit the tool get the real values back.
+            custom_headers=(
+                tool.custom_headers
+                if include_secret_header_values
+                else _mask_header_values(tool.custom_headers)
+            ),
             passthrough_auth=tool.passthrough_auth,
             mcp_server_id=tool.mcp_server_id,
             user_id=str(tool.user_id) if tool.user_id else None,

--- a/backend/tests/unit/onyx/server/features/tool/test_tool_snapshot_masking.py
+++ b/backend/tests/unit/onyx/server/features/tool/test_tool_snapshot_masking.py
@@ -1,0 +1,54 @@
+from onyx.configs.constants import MASK_CREDENTIAL_CHAR
+from onyx.db.models import Tool
+from onyx.server.features.tool.models import ToolSnapshot
+
+
+def _make_tool() -> Tool:
+    return Tool(
+        id=1,
+        name="my_custom_tool",
+        description="calls an internal API",
+        display_name="My Custom Tool",
+        in_code_tool_id=None,
+        openapi_schema={"openapi": "3.0.0"},
+        custom_headers=[
+            {"key": "Authorization", "value": "Bearer super-secret-token-12345"},
+            {"key": "X-Api-Key", "value": "sk-abcdef0123456789"},
+        ],
+        passthrough_auth=False,
+        user_id=None,
+        enabled=True,
+    )
+
+
+def test_from_model_masks_header_values_by_default() -> None:
+    snapshot = ToolSnapshot.from_model(_make_tool())
+
+    assert snapshot.custom_headers is not None
+    for header in snapshot.custom_headers:
+        assert MASK_CREDENTIAL_CHAR in header["value"]
+        assert "secret" not in header["value"]
+        assert "sk-" not in header["value"]
+    # Keys stay visible so the admin UI can still show which headers exist.
+    assert [h["key"] for h in snapshot.custom_headers] == [
+        "Authorization",
+        "X-Api-Key",
+    ]
+
+
+def test_from_model_returns_raw_values_when_explicitly_requested() -> None:
+    snapshot = ToolSnapshot.from_model(_make_tool(), include_secret_header_values=True)
+
+    assert snapshot.custom_headers == [
+        {"key": "Authorization", "value": "Bearer super-secret-token-12345"},
+        {"key": "X-Api-Key", "value": "sk-abcdef0123456789"},
+    ]
+
+
+def test_from_model_handles_missing_headers() -> None:
+    tool = _make_tool()
+    tool.custom_headers = None
+    assert ToolSnapshot.from_model(tool).custom_headers is None
+
+    tool.custom_headers = []
+    assert ToolSnapshot.from_model(tool).custom_headers == []


### PR DESCRIPTION
## Description

`ToolSnapshot` serialized `custom_headers` verbatim, so admin-configured secret header values (API tokens for custom actions) were disclosed to any authenticated `BASIC_ACCESS` user via `GET /api/tool`, `GET /api/tool/{id}`, `GET /api/tool/openapi` — and via every persona snapshot that embeds tools (`MinimalPersonaSnapshot.tools`), i.e. the normal chat surface.

This makes `ToolSnapshot.from_model` mask header values by default (`••••••••••••`, keys stay visible). Raw values are explicit opt-in and only returned to callers who could edit the tool anyway:

- admin/curator create + update responses (they just submitted the values)
- the three `/tool` read endpoints when the caller is an admin or the tool's owner — this keeps the admin actions page working, since its edit modal loads via `GET /api/tool/openapi` and replays `custom_headers` on save (blanket masking would have overwritten stored secrets with placeholders)

Persona and MCP call sites of `from_model` get masking automatically via the new default.

Fixes #13165 (GHSA-r85j-wg6g-vj83).

## How Has This Been Tested?

- New unit tests: `backend/tests/unit/onyx/server/features/tool/test_tool_snapshot_masking.py` (masked by default, raw on opt-in, None/empty handling)
- `pre-commit run` (ruff, ruff format, ty) green on touched files

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Masks secret header values for custom tools on non-privileged reads to prevent API token leaks. Admins and tool owners still see raw values where needed; admin edit flows continue to work. Fixes #13165 (GHSA-r85j-wg6g-vj83).

- **Bug Fixes**
  - `ToolSnapshot.from_model` now masks `custom_headers` values by default; keys remain visible.
  - Raw values returned only to admins or the tool owner, and in admin create/update responses; read endpoints updated to enforce this.
  - Added unit tests for default masking, opt-in raw values, and None/empty headers.

<sup>Written for commit e2c30bf6ae47646fc07b72c30f4c1a720a09ca67. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

