### PR TITLE
fix(llm): omit empty tools list from litellm completion requests

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -886,7 +886,9 @@ class LitellmLLM(LLM):
                         api_version=api_version,
                         custom_llm_provider=self._custom_llm_provider or None,
                         messages=messages,
-                        tools=tools,
+                        # None (omitted) rather than [] — some OpenAI-compatible
+                        # servers reject requests with an empty tools array.
+                        tools=tools or None,
                         stream=stream,
                         timeout=timeout_override or self._timeout,
                         max_tokens=max_tokens,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -478,6 +478,18 @@ def test_omits_temperature_for_no_sampling_params_models(model_name: str) -> Non
         assert "temperature" not in kwargs
 
 
+def test_empty_tools_list_is_omitted(default_multi_llm: LitellmLLM) -> None:
+    # Some OpenAI-compatible servers reject requests carrying `tools: []`;
+    # an empty list must be dropped from the request entirely.
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = []
+
+        messages: LanguageModelInput = [UserMessage(content="Hi")]
+        list(default_multi_llm.stream(messages, tools=[]))
+
+        assert mock_completion.call_args.kwargs["tools"] is None
+
+
 def test_claude_only_in_deployment_name_omits_temperature_and_reasons() -> None:
     # Custom providers (e.g. Azure AI Foundry) may carry the model identity only
     # in the deployment alias — the string actually sent to LiteLLM — while


### PR DESCRIPTION
## Description

Deep Research (and any flow that resolves to zero tools) passed `tools=[]` through to `litellm.completion`, which forwards it as `"tools": []` in the request body. Strict OpenAI-compatible servers (vLLM, LM Studio, various gateways) reject that with a 400. Pass `None` instead so the field is omitted from the request entirely.

Fixes #13493.

## How Has This Been Tested?

- New unit test `test_empty_tools_list_is_omitted` in `backend/tests/unit/onyx/llm/test_multi_llm.py`; existing tool-call tests confirm non-empty tools still pass through
- `pre-commit` green on touched files

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit empty tools lists from `litellm` completion requests to prevent 400 errors from strict OpenAI-compatible servers (e.g., vLLM, LM Studio). Deep Research and zero-tool flows now send `tools=None`, which omits the field from the request.

<sup>Written for commit c490120ad2b8af719855a52c23c34221f202a1fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13532?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

