### PR TITLE
feat(connector-stability): credential capability report generation

### DIFF
--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -60,7 +60,9 @@ class CapabilityCheckContext(BaseModel):
 
     ``connector`` and ``connector_specific_config`` are None for config-less
     credential-time runs; the runner skips checks that declare a requirement on
-    them.
+    them. ``instantiation_error`` is set when connector construction failed
+    for a supplied config; the runner surfaces it on instance-requiring checks
+    instead of skipping them.
     """
 
     # ``BaseConnector`` is not a pydantic type; validate by isinstance.
@@ -70,6 +72,7 @@ class CapabilityCheckContext(BaseModel):
     credential_json: dict[str, Any]
     connector: BaseConnector | None = None
     connector_specific_config: dict[str, Any] | None = None
+    instantiation_error: Exception | None = None
 
 
 class CapabilityCheck(ABC):

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -60,8 +60,8 @@ class CapabilityCheckContext(BaseModel):
 
     ``connector`` and ``connector_specific_config`` are None for config-less
     credential-time runs; the runner skips checks that declare a requirement on
-    them. ``instantiation_error`` is set when connector construction failed
-    for a supplied config; the runner surfaces it on instance-requiring checks
+    them. ``instantiation_error`` is set when connector construction failed for
+    a supplied config; the runner surfaces it on instance-requiring checks
     instead of skipping them.
     """
 

--- a/backend/onyx/connectors/capability_checks/models.py
+++ b/backend/onyx/connectors/capability_checks/models.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
+from datetime import datetime
 from enum import Enum
 from typing import Any
 
@@ -41,6 +42,17 @@ class CapabilityVerdict(str, Enum):
     SKIPPED = "skipped"
     # The source does not have this capability (e.g. no group sync for Slack).
     NOT_APPLICABLE = "not_applicable"
+
+
+class CapabilityCheckTrigger(str, Enum):
+    """What initiated a capability-check run."""
+
+    MANUAL = "manual"
+    CREDENTIAL_CREATED = "credential_created"
+    # Recorded from the blocking validation at cc-pair creation/swap time.
+    CC_PAIR_VALIDATION = "cc_pair_validation"
+    # Recorded from the blocking validation at indexing-run start.
+    INDEXING_ATTEMPT = "indexing_attempt"
 
 
 class CapabilityCheckContext(BaseModel):
@@ -121,6 +133,19 @@ class CapabilityCheckResult(BaseModel):
     remediation: str | None = None
     docs_link: str | None = None
     duration_ms: int | None = None
+
+
+class CredentialCapabilityReport(BaseModel):
+    """The full outcome of one capability-check run for a credential."""
+
+    credential_id: int
+    source: DocumentSource
+    # None means a config-less credential-time run.
+    connector_id: int | None = None
+    checked_at: datetime
+    trigger: CapabilityCheckTrigger
+    verdicts: dict[CredentialCapability, CapabilityVerdict]
+    check_results: list[CapabilityCheckResult]
 
 
 def aggregate_capability_verdict(

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -83,6 +83,35 @@ def _build_result(
     )
 
 
+def _missing_instance_outcome(instantiation_error: Exception | None) -> _CheckOutcome:
+    """
+    Maps a missing connector instance to an outcome for an instance-requiring
+    check.
+
+    A config-less run skips: most connectors cannot be constructed without
+    configuration, and that is not a credential problem. A construction
+    failure with a supplied config is real signal and follows the check
+    exception contract (``ConnectorValidationError`` is FAILED, anything else
+    INDETERMINATE).
+    """
+    if instantiation_error is None:
+        return _CheckOutcome(
+            status=CapabilityCheckStatus.SKIPPED,
+            message=_SKIP_NEEDS_INSTANCE_MESSAGE,
+        )
+    if isinstance(instantiation_error, ConnectorValidationError):
+        return _CheckOutcome(
+            status=CapabilityCheckStatus.FAILED,
+            message=str(instantiation_error),
+            error_type=type(instantiation_error).__name__,
+        )
+    return _CheckOutcome(
+        status=CapabilityCheckStatus.INDETERMINATE,
+        message=str(instantiation_error),
+        error_type=type(instantiation_error).__name__,
+    )
+
+
 def _execute_check(
     check: CapabilityCheck, context: CapabilityCheckContext
 ) -> _CheckOutcome:
@@ -183,24 +212,19 @@ def run_capability_checks(
     results: list[CapabilityCheckResult] = []
     outcome_by_check_id: dict[str, _CheckOutcome] = {}
     for check in checks:
-        skip_message: str | None = None
+        unrunnable_outcome: _CheckOutcome | None = None
         if (
             check.requires_connector_config
             and context.connector_specific_config is None
         ):
-            skip_message = _SKIP_NEEDS_CONFIG_MESSAGE
-        elif check.requires_connector_instance and context.connector is None:
-            skip_message = _SKIP_NEEDS_INSTANCE_MESSAGE
-        if skip_message is not None:
-            results.append(
-                _build_result(
-                    check,
-                    _CheckOutcome(
-                        status=CapabilityCheckStatus.SKIPPED,
-                        message=skip_message,
-                    ),
-                )
+            unrunnable_outcome = _CheckOutcome(
+                status=CapabilityCheckStatus.SKIPPED,
+                message=_SKIP_NEEDS_CONFIG_MESSAGE,
             )
+        elif check.requires_connector_instance and context.connector is None:
+            unrunnable_outcome = _missing_instance_outcome(context.instantiation_error)
+        if unrunnable_outcome is not None:
+            results.append(_build_result(check, unrunnable_outcome))
             continue
 
         if check.check_id not in outcome_by_check_id:
@@ -221,38 +245,47 @@ def generate_capability_report(
 
     Check failures are report content; this raises only for programmer errors
     (e.g. a source with no connector class). Without a
-    ``connector_specific_config``, instantiation falls back to the source's
-    ``minimal_probe_config()``; when that is None or instantiation fails,
-    instance-requiring checks are SKIPPED. Unlike ``validate_ccpair_for_user``,
-    no source is exempted: MOCK_CONNECTOR must run so integration tests can
-    exercise the full pipeline.
+    ``connector_specific_config``, instantiation is attempted with an empty
+    config; when construction raises, instance-requiring checks are SKIPPED.
+    When a supplied config fails to instantiate, the failure is surfaced on
+    instance-requiring checks instead (see ``_missing_instance_outcome``).
+    Unlike ``validate_ccpair_for_user``, no source is exempted: MOCK_CONNECTOR
+    must run so integration tests can exercise the full pipeline.
     """
     source = credential.source
     checks = get_capability_checks(source)
-    connector_class = identify_connector_class(source, input_type)
+    # Fail loudly for programmer errors (a source with no connector class)
+    # rather than degrading them to skips in the guarded instantiation below.
+    identify_connector_class(source, input_type)
 
+    # Config-less runs attempt instantiation with an empty config: some
+    # connectors happen to construct with one, giving unmigrated sources a
+    # basic credential-time probe. There is deliberately no per-connector
+    # extension point for this.
     instantiation_config = (
-        connector_specific_config
-        if connector_specific_config is not None
-        else connector_class.minimal_probe_config()
+        connector_specific_config if connector_specific_config is not None else {}
     )
     connector: BaseConnector | None = None
-    if instantiation_config is not None:
-        try:
-            connector = instantiate_connector(
-                db_session=db_session,
-                source=source,
-                input_type=input_type,
-                connector_specific_config=instantiation_config,
-                credential=credential,
-            )
-        except Exception as e:
-            logger.warning(
-                "Could not instantiate %s connector for capability checks; "
-                "instance-requiring checks will be skipped: %s",
-                source,
-                e,
-            )
+    instantiation_error: Exception | None = None
+    try:
+        connector = instantiate_connector(
+            db_session=db_session,
+            source=source,
+            input_type=input_type,
+            connector_specific_config=instantiation_config,
+            credential=credential,
+        )
+    except Exception as e:
+        # A config-less probe construction fails routinely and stays a skip;
+        # a failure with the real config is actionable and is surfaced on
+        # instance-requiring checks.
+        if connector_specific_config is not None:
+            instantiation_error = e
+        logger.warning(
+            "Could not instantiate %s connector for capability checks: %s",
+            source,
+            e,
+        )
 
     credential_json = (
         credential.credential_json.get_value(apply_mask=False)
@@ -266,6 +299,7 @@ def generate_capability_report(
         # The real config only, never the probe config: checks marked
         # requires_connector_config must skip on config-less runs.
         connector_specific_config=connector_specific_config,
+        instantiation_error=instantiation_error,
     )
     results = run_capability_checks(checks, context)
     return CredentialCapabilityReport(

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -89,9 +89,9 @@ def _missing_instance_outcome(instantiation_error: Exception | None) -> _CheckOu
     check.
 
     A config-less run skips: most connectors cannot be constructed without
-    configuration, and that is not a credential problem. A construction
-    failure with a supplied config is real signal and follows the check
-    exception contract (``ConnectorValidationError`` is FAILED, anything else
+    configuration, and that is not a credential problem. A construction failure
+    with a supplied config is real signal and follows the check exception
+    contract (``ConnectorValidationError`` is FAILED, anything else
     INDETERMINATE).
     """
     if instantiation_error is None:
@@ -259,9 +259,9 @@ def generate_capability_report(
     identify_connector_class(source, input_type)
 
     # Config-less runs attempt instantiation with an empty config: some
-    # connectors happen to construct with one, giving unmigrated sources a
-    # basic credential-time probe. There is deliberately no per-connector
-    # extension point for this.
+    # connectors happen to construct with one, giving unmigrated sources a basic
+    # credential-time probe. There is deliberately no per-connector extension
+    # point for this.
     instantiation_config = (
         connector_specific_config if connector_specific_config is not None else {}
     )
@@ -276,8 +276,8 @@ def generate_capability_report(
             credential=credential,
         )
     except Exception as e:
-        # A config-less probe construction fails routinely and stays a skip;
-        # a failure with the real config is actionable and is surfaced on
+        # A config-less probe construction fails routinely and stays a skip; a
+        # failure with the real config is actionable and is surfaced on
         # instance-requiring checks.
         if connector_specific_config is not None:
             instantiation_error = e
@@ -296,8 +296,9 @@ def generate_capability_report(
         source=source,
         credential_json=credential_json,
         connector=connector,
-        # The real config only, never the probe config: checks marked
-        # requires_connector_config must skip on config-less runs.
+        # The supplied config only, never the empty instantiation config: checks
+        # marked requires_connector_config must skip on config-less runs rather
+        # than probe an empty dict.
         connector_specific_config=connector_specific_config,
         instantiation_error=instantiation_error,
     )

--- a/backend/onyx/connectors/capability_checks/runner.py
+++ b/backend/onyx/connectors/capability_checks/runner.py
@@ -1,19 +1,33 @@
 import time
 from collections.abc import Sequence
+from datetime import datetime, timezone
+from typing import Any
 
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
 
 from onyx.connectors.capability_checks.models import (
     CapabilityCheck,
     CapabilityCheckContext,
     CapabilityCheckResult,
     CapabilityCheckStatus,
+    CapabilityCheckTrigger,
     CredentialCapability,
+    CredentialCapabilityReport,
+    compute_capability_verdicts,
+)
+from onyx.connectors.capability_checks.registry import (
+    get_applicable_capabilities,
+    get_capability_checks,
 )
 from onyx.connectors.exceptions import (
     ConnectorValidationError,
     UnexpectedValidationError,
 )
+from onyx.connectors.factory import identify_connector_class, instantiate_connector
+from onyx.connectors.interfaces import BaseConnector
+from onyx.connectors.models import InputType
+from onyx.db.models import Credential
 from onyx.utils.logger import setup_logger
 from onyx.utils.threadpool_concurrency import run_with_timeout
 
@@ -193,3 +207,75 @@ def run_capability_checks(
             outcome_by_check_id[check.check_id] = _execute_check(check, context)
         results.append(_build_result(check, outcome_by_check_id[check.check_id]))
     return results
+
+
+def generate_capability_report(
+    db_session: Session,
+    credential: Credential,
+    connector_specific_config: dict[str, Any] | None = None,
+    connector_id: int | None = None,
+    input_type: InputType | None = None,
+    trigger: CapabilityCheckTrigger = CapabilityCheckTrigger.MANUAL,
+) -> CredentialCapabilityReport:
+    """Runs every capability check for a credential and packages a report.
+
+    Check failures are report content; this raises only for programmer errors
+    (e.g. a source with no connector class). Without a
+    ``connector_specific_config``, instantiation falls back to the source's
+    ``minimal_probe_config()``; when that is None or instantiation fails,
+    instance-requiring checks are SKIPPED. Unlike ``validate_ccpair_for_user``,
+    no source is exempted: MOCK_CONNECTOR must run so integration tests can
+    exercise the full pipeline.
+    """
+    source = credential.source
+    checks = get_capability_checks(source)
+    connector_class = identify_connector_class(source, input_type)
+
+    instantiation_config = (
+        connector_specific_config
+        if connector_specific_config is not None
+        else connector_class.minimal_probe_config()
+    )
+    connector: BaseConnector | None = None
+    if instantiation_config is not None:
+        try:
+            connector = instantiate_connector(
+                db_session=db_session,
+                source=source,
+                input_type=input_type,
+                connector_specific_config=instantiation_config,
+                credential=credential,
+            )
+        except Exception as e:
+            logger.warning(
+                "Could not instantiate %s connector for capability checks; "
+                "instance-requiring checks will be skipped: %s",
+                source,
+                e,
+            )
+
+    credential_json = (
+        credential.credential_json.get_value(apply_mask=False)
+        if credential.credential_json
+        else {}
+    )
+    context = CapabilityCheckContext(
+        source=source,
+        credential_json=credential_json,
+        connector=connector,
+        # The real config only, never the probe config: checks marked
+        # requires_connector_config must skip on config-less runs.
+        connector_specific_config=connector_specific_config,
+    )
+    results = run_capability_checks(checks, context)
+    return CredentialCapabilityReport(
+        credential_id=credential.id,
+        source=source,
+        connector_id=connector_id,
+        checked_at=datetime.now(timezone.utc),
+        trigger=trigger,
+        verdicts=compute_capability_verdicts(
+            get_applicable_capabilities(source), results
+        ),
+        check_results=results,
+    )

--- a/backend/onyx/connectors/factory.py
+++ b/backend/onyx/connectors/factory.py
@@ -106,7 +106,7 @@ def identify_connector_class(
 def instantiate_connector(
     db_session: Session,
     source: DocumentSource,
-    input_type: InputType,
+    input_type: InputType | None,
     connector_specific_config: dict[str, Any],
     credential: Credential,
     raw_file_callback: RawFileCallback | None = None,

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -90,16 +90,6 @@ class BaseConnector(abc.ABC, Generic[CT]):
         )
         validate_connector_settings_fn(self)
 
-    @classmethod
-    def minimal_probe_config(cls) -> dict[str, Any] | None:
-        """
-        Returns the smallest connector_specific_config this connector can be
-        instantiated with, used for config-less credential-time capability
-        checks. None means the connector cannot be instantiated without real
-        configuration, in which case instance-requiring checks are skipped.
-        """
-        return {}
-
     def set_allow_images(self, value: bool) -> None:
         """Implement if the underlying connector wants to skip/allow image downloading
         based on the application level image analysis setting."""

--- a/backend/onyx/connectors/interfaces.py
+++ b/backend/onyx/connectors/interfaces.py
@@ -90,6 +90,16 @@ class BaseConnector(abc.ABC, Generic[CT]):
         )
         validate_connector_settings_fn(self)
 
+    @classmethod
+    def minimal_probe_config(cls) -> dict[str, Any] | None:
+        """
+        Returns the smallest connector_specific_config this connector can be
+        instantiated with, used for config-less credential-time capability
+        checks. None means the connector cannot be instantiated without real
+        configuration, in which case instance-requiring checks are skipped.
+        """
+        return {}
+
     def set_allow_images(self, value: bool) -> None:
         """Implement if the underlying connector wants to skip/allow image downloading
         based on the application level image analysis setting."""

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_capability_check_runner.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_capability_check_runner.py
@@ -57,12 +57,14 @@ class _OtherCallableCheck(_CallableCheck):
 def _context(
     connector: BaseConnector | None = None,
     connector_specific_config: dict | None = None,
+    instantiation_error: Exception | None = None,
 ) -> CapabilityCheckContext:
     return CapabilityCheckContext(
         source=DocumentSource.SLACK,
         credential_json={},
         connector=connector,
         connector_specific_config=connector_specific_config,
+        instantiation_error=instantiation_error,
     )
 
 
@@ -146,6 +148,46 @@ def test_skips_instance_requiring_check_without_connector() -> None:
     # Postcondition.
     assert results[0].status == CapabilityCheckStatus.SKIPPED
     run.assert_not_called()
+
+
+def test_validation_instantiation_error_fails_instance_checks() -> None:
+    """
+    Verifies a validation-family construction failure is FAILED, not SKIPPED.
+    """
+    # Precondition.
+    run = MagicMock()
+    check = _CallableCheck(run, requires_connector_instance=True)
+    context = _context(
+        connector=None,
+        instantiation_error=InsufficientPermissionsError("Token lacks scopes."),
+    )
+
+    # Under test.
+    results = run_capability_checks([check], context)
+
+    # Postcondition.
+    assert results[0].status == CapabilityCheckStatus.FAILED
+    assert results[0].error_type == "InsufficientPermissionsError"
+    assert "Token lacks scopes." in results[0].message
+    run.assert_not_called()
+
+
+def test_unexpected_instantiation_error_is_indeterminate() -> None:
+    """
+    Verifies an unrecognized construction failure maps to INDETERMINATE.
+    """
+    # Precondition.
+    check = _CallableCheck(MagicMock(), requires_connector_instance=True)
+    context = _context(
+        connector=None, instantiation_error=RuntimeError("Redis unreachable.")
+    )
+
+    # Under test.
+    results = run_capability_checks([check], context)
+
+    # Postcondition.
+    assert results[0].status == CapabilityCheckStatus.INDETERMINATE
+    assert results[0].error_type == "RuntimeError"
 
 
 def test_skips_config_requiring_check_even_with_connector() -> None:

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
@@ -1,5 +1,4 @@
 from collections.abc import Callable
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,23 +14,31 @@ from onyx.connectors.capability_checks.models import (
     CredentialCapability,
 )
 from onyx.connectors.capability_checks.runner import generate_capability_report
+from onyx.connectors.exceptions import CredentialInvalidError
 from onyx.connectors.interfaces import BaseConnector
 
 
-def _make_check(
-    run: Callable[[CapabilityCheckContext], None],
-    check_id: str,
-    requires_connector_instance: bool = True,
-    requires_connector_config: bool = False,
-) -> CapabilityCheck:
-    return CapabilityCheck(
-        capability=CredentialCapability.INDEXING,
-        check_id=check_id,
-        display_name="Dummy check",
-        run=run,
-        requires_connector_instance=requires_connector_instance,
-        requires_connector_config=requires_connector_config,
-    )
+class _CallableCheck(CapabilityCheck):
+    """Concrete check that delegates ``run`` to an injected callable."""
+
+    def __init__(
+        self,
+        run: Callable[[CapabilityCheckContext], None],
+        check_id: str,
+        requires_connector_instance: bool = True,
+        requires_connector_config: bool = False,
+    ) -> None:
+        super().__init__(
+            capability=CredentialCapability.INDEXING,
+            check_id=check_id,
+            display_name="Dummy check",
+            requires_connector_instance=requires_connector_instance,
+            requires_connector_config=requires_connector_config,
+        )
+        self._run = run
+
+    def run(self, context: CapabilityCheckContext) -> None:
+        self._run(context)
 
 
 def _make_credential() -> MagicMock:
@@ -45,19 +52,16 @@ def _make_credential() -> MagicMock:
 def _patch_runner_environment(
     monkeypatch: pytest.MonkeyPatch,
     checks: list[CapabilityCheck],
-    probe_config: dict[str, Any] | None,
     instantiate_error: Exception | None = None,
 ) -> MagicMock:
     """Stubs registry lookup and connector construction around the orchestrator.
 
     Returns the ``instantiate_connector`` mock for call-shape assertions.
     """
-    connector_class = MagicMock()
-    connector_class.minimal_probe_config.return_value = probe_config
     monkeypatch.setattr(
         runner_module,
         "identify_connector_class",
-        MagicMock(return_value=connector_class),
+        MagicMock(return_value=MagicMock()),
     )
     # The instantiated connector must satisfy ``CapabilityCheckContext``'s
     # isinstance validation, hence the spec.
@@ -76,11 +80,13 @@ def _patch_runner_environment(
     return instantiate
 
 
-def test_configless_run_uses_probe_config(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verifies a config-less run instantiates via ``minimal_probe_config``."""
+def test_configless_run_attempts_empty_config_instantiation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies a config-less run instantiates with an empty config."""
     # Precondition.
-    check = _make_check(MagicMock(return_value=None), check_id="instance_check")
-    instantiate = _patch_runner_environment(monkeypatch, [check], probe_config={})
+    check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
+    instantiate = _patch_runner_environment(monkeypatch, [check])
     db_session = MagicMock()
     credential = _make_credential()
 
@@ -107,29 +113,30 @@ def test_configless_run_uses_probe_config(monkeypatch: pytest.MonkeyPatch) -> No
     }
 
 
-def test_probe_config_none_skips_instance_requiring_checks(
+def test_instantiation_failure_still_runs_credential_only_checks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Verifies that a None probe config degrades to skips, not a crash."""
+    """Verifies a raising constructor degrades to skips, not a crash."""
     # Precondition.
     # One check needs an instance, the other is a pure credential-shape check.
-    instance_check = _make_check(
+    instance_check = _CallableCheck(
         MagicMock(return_value=None), check_id="instance_check"
     )
-    shape_check = _make_check(
+    shape_check = _CallableCheck(
         MagicMock(return_value=None),
         check_id="shape_check",
         requires_connector_instance=False,
     )
-    instantiate = _patch_runner_environment(
-        monkeypatch, [instance_check, shape_check], probe_config=None
+    _patch_runner_environment(
+        monkeypatch,
+        [instance_check, shape_check],
+        instantiate_error=RuntimeError("Constructor requires a real config."),
     )
 
     # Under test.
     report = generate_capability_report(MagicMock(), _make_credential())
 
     # Postcondition.
-    instantiate.assert_not_called()
     statuses = {result.check_id: result.status for result in report.check_results}
     assert statuses == {
         "instance_check": CapabilityCheckStatus.SKIPPED,
@@ -144,11 +151,10 @@ def test_instantiation_failure_degrades_to_skip(
     Verifies that a raising constructor skips instance checks, not the run.
     """
     # Precondition.
-    check = _make_check(MagicMock(return_value=None), check_id="instance_check")
+    check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
     _patch_runner_environment(
         monkeypatch,
         [check],
-        probe_config={},
         instantiate_error=RuntimeError("Constructor requires a real config."),
     )
 
@@ -160,6 +166,34 @@ def test_instantiation_failure_degrades_to_skip(
     assert report.verdicts[CredentialCapability.INDEXING] == CapabilityVerdict.SKIPPED
 
 
+def test_supplied_config_instantiation_failure_is_surfaced(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verifies construction failure with a real config is FAILED, not SKIPPED.
+    """
+    # Precondition.
+    check = _CallableCheck(MagicMock(return_value=None), check_id="instance_check")
+    _patch_runner_environment(
+        monkeypatch,
+        [check],
+        instantiate_error=CredentialInvalidError("Missing `slack_bot_token` key."),
+    )
+
+    # Under test.
+    report = generate_capability_report(
+        MagicMock(),
+        _make_credential(),
+        connector_specific_config={"channels": ["general"]},
+        connector_id=42,
+    )
+
+    # Postcondition.
+    assert report.check_results[0].status == CapabilityCheckStatus.FAILED
+    assert report.check_results[0].error_type == "CredentialInvalidError"
+    assert report.verdicts[CredentialCapability.INDEXING] == CapabilityVerdict.FAILED
+
+
 def test_real_config_unlocks_config_requiring_checks(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -167,12 +201,12 @@ def test_real_config_unlocks_config_requiring_checks(
     Verifies that a supplied config is used to instantiate and reaches checks.
     """
     # Precondition.
-    check = _make_check(
+    check = _CallableCheck(
         MagicMock(return_value=None),
         check_id="config_check",
         requires_connector_config=True,
     )
-    instantiate = _patch_runner_environment(monkeypatch, [check], probe_config=None)
+    instantiate = _patch_runner_environment(monkeypatch, [check])
     connector_specific_config = {"repositories": "onyx"}
 
     # Under test.
@@ -185,7 +219,7 @@ def test_real_config_unlocks_config_requiring_checks(
     )
 
     # Postcondition.
-    # The real config wins over the None probe config.
+    # The real config, not the empty-config fallback, reaches instantiation.
     assert (
         instantiate.call_args.kwargs["connector_specific_config"]
         == connector_specific_config

--- a/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
+++ b/backend/tests/unit/onyx/connectors/capability_checks/test_generate_capability_report.py
@@ -1,0 +1,195 @@
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from onyx.configs.constants import DocumentSource
+from onyx.connectors.capability_checks import runner as runner_module
+from onyx.connectors.capability_checks.models import (
+    CapabilityCheck,
+    CapabilityCheckContext,
+    CapabilityCheckStatus,
+    CapabilityCheckTrigger,
+    CapabilityVerdict,
+    CredentialCapability,
+)
+from onyx.connectors.capability_checks.runner import generate_capability_report
+from onyx.connectors.interfaces import BaseConnector
+
+
+def _make_check(
+    run: Callable[[CapabilityCheckContext], None],
+    check_id: str,
+    requires_connector_instance: bool = True,
+    requires_connector_config: bool = False,
+) -> CapabilityCheck:
+    return CapabilityCheck(
+        capability=CredentialCapability.INDEXING,
+        check_id=check_id,
+        display_name="Dummy check",
+        run=run,
+        requires_connector_instance=requires_connector_instance,
+        requires_connector_config=requires_connector_config,
+    )
+
+
+def _make_credential() -> MagicMock:
+    credential = MagicMock()
+    credential.id = 7
+    credential.source = DocumentSource.GITHUB
+    credential.credential_json = None
+    return credential
+
+
+def _patch_runner_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    checks: list[CapabilityCheck],
+    probe_config: dict[str, Any] | None,
+    instantiate_error: Exception | None = None,
+) -> MagicMock:
+    """Stubs registry lookup and connector construction around the orchestrator.
+
+    Returns the ``instantiate_connector`` mock for call-shape assertions.
+    """
+    connector_class = MagicMock()
+    connector_class.minimal_probe_config.return_value = probe_config
+    monkeypatch.setattr(
+        runner_module,
+        "identify_connector_class",
+        MagicMock(return_value=connector_class),
+    )
+    # The instantiated connector must satisfy ``CapabilityCheckContext``'s
+    # isinstance validation, hence the spec.
+    instantiate = MagicMock(return_value=MagicMock(spec=BaseConnector))
+    if instantiate_error is not None:
+        instantiate.side_effect = instantiate_error
+    monkeypatch.setattr(runner_module, "instantiate_connector", instantiate)
+    monkeypatch.setattr(
+        runner_module, "get_capability_checks", MagicMock(return_value=checks)
+    )
+    monkeypatch.setattr(
+        runner_module,
+        "get_applicable_capabilities",
+        MagicMock(return_value={CredentialCapability.INDEXING}),
+    )
+    return instantiate
+
+
+def test_configless_run_uses_probe_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verifies a config-less run instantiates via ``minimal_probe_config``."""
+    # Precondition.
+    check = _make_check(MagicMock(return_value=None), check_id="instance_check")
+    instantiate = _patch_runner_environment(monkeypatch, [check], probe_config={})
+    db_session = MagicMock()
+    credential = _make_credential()
+
+    # Under test.
+    report = generate_capability_report(db_session, credential)
+
+    # Postcondition.
+    instantiate.assert_called_once_with(
+        db_session=db_session,
+        source=DocumentSource.GITHUB,
+        input_type=None,
+        connector_specific_config={},
+        credential=credential,
+    )
+    assert report.credential_id == 7
+    assert report.source == DocumentSource.GITHUB
+    assert report.connector_id is None
+    assert report.trigger == CapabilityCheckTrigger.MANUAL
+    assert report.check_results[0].status == CapabilityCheckStatus.PASSED
+    assert report.verdicts == {
+        CredentialCapability.INDEXING: CapabilityVerdict.PASSED,
+        CredentialCapability.DOC_PERMISSION_SYNC: CapabilityVerdict.NOT_APPLICABLE,
+        CredentialCapability.EXTERNAL_GROUP_SYNC: CapabilityVerdict.NOT_APPLICABLE,
+    }
+
+
+def test_probe_config_none_skips_instance_requiring_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verifies that a None probe config degrades to skips, not a crash."""
+    # Precondition.
+    # One check needs an instance, the other is a pure credential-shape check.
+    instance_check = _make_check(
+        MagicMock(return_value=None), check_id="instance_check"
+    )
+    shape_check = _make_check(
+        MagicMock(return_value=None),
+        check_id="shape_check",
+        requires_connector_instance=False,
+    )
+    instantiate = _patch_runner_environment(
+        monkeypatch, [instance_check, shape_check], probe_config=None
+    )
+
+    # Under test.
+    report = generate_capability_report(MagicMock(), _make_credential())
+
+    # Postcondition.
+    instantiate.assert_not_called()
+    statuses = {result.check_id: result.status for result in report.check_results}
+    assert statuses == {
+        "instance_check": CapabilityCheckStatus.SKIPPED,
+        "shape_check": CapabilityCheckStatus.PASSED,
+    }
+
+
+def test_instantiation_failure_degrades_to_skip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verifies that a raising constructor skips instance checks, not the run.
+    """
+    # Precondition.
+    check = _make_check(MagicMock(return_value=None), check_id="instance_check")
+    _patch_runner_environment(
+        monkeypatch,
+        [check],
+        probe_config={},
+        instantiate_error=RuntimeError("Constructor requires a real config."),
+    )
+
+    # Under test.
+    report = generate_capability_report(MagicMock(), _make_credential())
+
+    # Postcondition.
+    assert report.check_results[0].status == CapabilityCheckStatus.SKIPPED
+    assert report.verdicts[CredentialCapability.INDEXING] == CapabilityVerdict.SKIPPED
+
+
+def test_real_config_unlocks_config_requiring_checks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """
+    Verifies that a supplied config is used to instantiate and reaches checks.
+    """
+    # Precondition.
+    check = _make_check(
+        MagicMock(return_value=None),
+        check_id="config_check",
+        requires_connector_config=True,
+    )
+    instantiate = _patch_runner_environment(monkeypatch, [check], probe_config=None)
+    connector_specific_config = {"repositories": "onyx"}
+
+    # Under test.
+    report = generate_capability_report(
+        MagicMock(),
+        _make_credential(),
+        connector_specific_config=connector_specific_config,
+        connector_id=42,
+        trigger=CapabilityCheckTrigger.CC_PAIR_VALIDATION,
+    )
+
+    # Postcondition.
+    # The real config wins over the None probe config.
+    assert (
+        instantiate.call_args.kwargs["connector_specific_config"]
+        == connector_specific_config
+    )
+    assert report.connector_id == 42
+    assert report.trigger == CapabilityCheckTrigger.CC_PAIR_VALIDATION
+    assert report.check_results[0].status == CapabilityCheckStatus.PASSED


### PR DESCRIPTION
## Description

Second layer on the capability check framework (follows #13519): `generate_capability_report` takes a credential row and produces a full `CredentialCapabilityReport` (per-capability verdicts, per-check results, trigger, timestamp). This is the entry point every future consumer (API endpoint, indexing-start recorder, Celery task) will call; there are still no production call sites.

**Behavior delta: two signature-compatible edits, everything else additive.**

## How Has This Been Tested?

Added unit tests for new logic.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `generate_capability_report` to run all capability checks for a credential and return a full `CredentialCapabilityReport` with per-capability verdicts and per-check results. This is the single entry point for future consumers; no production call sites yet.

- New Features
  - Orchestrates checks via registry (`get_capability_checks`) and computes verdicts with `compute_capability_verdicts` and `get_applicable_capabilities`.
  - Instantiates the connector with provided `connector_specific_config`, else attempts an empty config. Instance-requiring checks: SKIPPED for config-less runs; FAILED on validation-family instantiation errors; INDETERMINATE on unexpected instantiation errors.
  - Fast-fails if no connector class exists via `identify_connector_class`; check failures are captured in the report rather than raised.
  - Records metadata: `credential_id`, `source`, optional `connector_id`, `trigger` (`CapabilityCheckTrigger`), and `checked_at` (UTC).
  - Adds `CapabilityCheckTrigger`, `CredentialCapabilityReport`, and `instantiation_error` on `CapabilityCheckContext`; updates `instantiate_connector` to accept `input_type: InputType | None`.

<sup>Written for commit cd61c99f71b24afb8a28a03e884b0d46ffa3e3af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

