### PR TITLE
fix(auth): only auto-request offline_access when the IdP advertises it

### DIFF
--- a/backend/onyx/server/oidc_multi.py
+++ b/backend/onyx/server/oidc_multi.py
@@ -103,15 +103,30 @@ def _pkce_enabled(config: dict[str, Any]) -> bool:
     return bool(config.get("pkce_enabled")) or OIDC_PKCE_ENABLED
 
 
+def _drop_unadvertised_offline_access(client: BaseOAuth2[Any]) -> None:
+    """Some IdPs (e.g. Amazon Cognito) fail the entire authorize request on
+    scopes they don't support, so the auto-added offline_access scope only
+    survives when the discovery doc advertises it. A discovery doc without
+    scopes_supported keeps the scope, since support can't be ruled out."""
+    discovery = getattr(client, "openid_configuration", None) or {}
+    supported = discovery.get("scopes_supported")
+    if supported is None or "offline_access" in supported:
+        return
+    client.base_scopes = [
+        scope for scope in (client.base_scopes or []) if scope != "offline_access"
+    ]
+
+
 def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[Any]:
     if provider.provider_type is SSOProviderType.OIDC:
         # Scope overrides let providers request extra API scopes (e.g. MS Graph
         # User.Read for claims capture): the row's scopes win, then the env
         # override while it exists. offline_access secures refresh tokens.
         scopes = list(config.get("scopes") or OIDC_SCOPE_OVERRIDE or BASE_SCOPES)
-        if "offline_access" not in scopes:
+        offline_access_auto_added = "offline_access" not in scopes
+        if offline_access_auto_added:
             scopes.append("offline_access")
-        return VerifiedEmailOpenID(
+        client = VerifiedEmailOpenID(
             config["client_id"],
             config["client_secret"],
             config["openid_config_url"],
@@ -119,6 +134,10 @@ def _build_client(provider: SSOProvider, config: dict[str, Any]) -> BaseOAuth2[A
             base_scopes=scopes,
             require_verified_email=config.get("require_verified_email", False),
         )
+        # Explicitly configured offline_access is always respected as-is.
+        if offline_access_auto_added:
+            _drop_unadvertised_offline_access(client)
+        return client
     if provider.provider_type is SSOProviderType.GOOGLE_OAUTH:
         return GoogleOAuth2(
             config["client_id"],

--- a/backend/tests/unit/onyx/server/test_oidc_multi.py
+++ b/backend/tests/unit/onyx/server/test_oidc_multi.py
@@ -138,6 +138,78 @@ def test_build_client_oidc_uses_provider_name(monkeypatch: pytest.MonkeyPatch) -
     assert client.name == "okta"
 
 
+def _openid_stub_with_discovery(scopes_supported: list[str] | None) -> Any:
+    class _FakeOpenID:
+        def __init__(
+            self,
+            _client_id: str,
+            _client_secret: str,
+            _config_url: str,
+            *,
+            name: str,
+            base_scopes: list[str] | None = None,
+            **_kwargs: Any,
+        ) -> None:
+            self.name = name
+            self.base_scopes = list(base_scopes or [])
+            self.openid_configuration: dict[str, Any] = (
+                {}
+                if scopes_supported is None
+                else {"scopes_supported": scopes_supported}
+            )
+
+    return _FakeOpenID
+
+
+def test_offline_access_dropped_when_idp_does_not_advertise_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Amazon Cognito advertises scopes_supported without offline_access and
+    # rejects the whole authorize request when it is included.
+    monkeypatch.setattr(
+        oidc_multi,
+        "VerifiedEmailOpenID",
+        _openid_stub_with_discovery(["openid", "email", "profile"]),
+    )
+    client = oidc_multi._build_client(_provider(), dict(_OIDC_CONFIG))
+    assert "offline_access" not in (client.base_scopes or [])
+
+
+def test_offline_access_kept_when_idp_advertises_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oidc_multi,
+        "VerifiedEmailOpenID",
+        _openid_stub_with_discovery(["openid", "email", "offline_access"]),
+    )
+    client = oidc_multi._build_client(_provider(), dict(_OIDC_CONFIG))
+    assert "offline_access" in (client.base_scopes or [])
+
+
+def test_offline_access_kept_when_discovery_has_no_scopes_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oidc_multi, "VerifiedEmailOpenID", _openid_stub_with_discovery(None)
+    )
+    client = oidc_multi._build_client(_provider(), dict(_OIDC_CONFIG))
+    assert "offline_access" in (client.base_scopes or [])
+
+
+def test_explicitly_configured_offline_access_is_never_dropped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        oidc_multi,
+        "VerifiedEmailOpenID",
+        _openid_stub_with_discovery(["openid", "email"]),
+    )
+    config = {**_OIDC_CONFIG, "scopes": ["openid", "email", "offline_access"]}
+    client = oidc_multi._build_client(_provider(), config)
+    assert "offline_access" in (client.base_scopes or [])
+
+
 @pytest.mark.asyncio
 async def test_client_cache_hits_and_rebuilds_on_config_change(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Description

The multi-provider OIDC login client unconditionally appended `offline_access` to the scope list. IdPs like Amazon Cognito reject the **entire authorize request** when an unsupported scope is present, which made OIDC login with Cognito impossible.

The auto-added `offline_access` now only survives when the IdP's own discovery document advertises it in `scopes_supported`:

- Cognito (no `offline_access` in `scopes_supported`) → scope dropped, login works
- Azure AD / Okta / Keycloak (advertise it) → unchanged, refresh tokens still requested
- Discovery doc without `scopes_supported` → unchanged (support can't be ruled out)
- `offline_access` explicitly present in the provider row's configured scopes → always respected as-is

Fixes #11931.

## How Has This Been Tested?

- 4 new unit tests in `backend/tests/unit/onyx/server/test_oidc_multi.py` covering dropped / advertised / silent-discovery / explicitly-configured cases (full file: 32 passed)
- `pre-commit` (ruff, ruff format, ty) green on touched files

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only auto-request `offline_access` for OIDC when the IdP’s discovery doc advertises it. Fixes authorize request failures with providers like Amazon Cognito while keeping refresh-token behavior for IdPs that support it.

- **Bug Fixes**
  - Drop auto-added `offline_access` when `scopes_supported` doesn’t include it (e.g., Cognito) to prevent authorize request rejection.
  - Keep `offline_access` when the IdP advertises it or when `scopes_supported` is absent.
  - Always keep `offline_access` if explicitly set in the provider’s configured scopes.

<sup>Written for commit e57ce135fc840cd5bf8a9bf944ab8474ce85625e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

