### PR TITLE
fix(chat): auto-name chat sessions with the session's model, not the global default

### DIFF
--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -70,7 +70,7 @@ from onyx.error_handling.error_codes import OnyxErrorCode
 from onyx.error_handling.exceptions import OnyxError
 from onyx.file_store.file_store import get_default_file_store
 from onyx.llm.constants import LlmProviderNames
-from onyx.llm.factory import get_default_llm, get_llm_for_persona, get_llm_token_counter
+from onyx.llm.factory import get_llm_for_persona, get_llm_token_counter
 from onyx.llm.models import (
     USER_SELECTABLE_REASONING_EFFORTS,
     ReasoningEffort,
@@ -482,18 +482,29 @@ def rename_chat_session(
     # send-message. Manual renames return above and stay free.
     check_token_rate_limits(user)
 
-    llm = get_default_llm(
-        additional_headers=extract_headers(
-            request.headers, LITELLM_PASS_THROUGH_HEADERS
-        )
-    )
-
     # Read-phase short session: usage check + history fetch. Closed before the
     # LLM call so the underlying pool connection is fully released for the
     # 2-10s generation window. (db_session.close() alone is insufficient in
     # multi-tenant mode where the session is bound to an explicit Connection
     # held by get_session_with_tenant's outer with-block.)
     with get_session_with_current_tenant() as db_session:
+        chat_session = get_chat_session_by_id(
+            chat_session_id=chat_session_id,
+            user_id=user_id,
+            db_session=db_session,
+            eager_load_persona=True,
+        )
+        # Name with the model the session actually uses (session override →
+        # persona default → global default) — the global default may be a
+        # provider this user's session deliberately avoids.
+        llm = get_llm_for_persona(
+            persona=chat_session.persona,
+            user=user,
+            llm_override=chat_session.llm_override,
+            additional_headers=extract_headers(
+                request.headers, LITELLM_PASS_THROUGH_HEADERS
+            ),
+        )
         check_llm_cost_limit_for_provider(
             db_session=db_session,
             tenant_id=get_current_tenant_id(),


### PR DESCRIPTION
## Description

The `PUT /rename-chat-session` auto-naming path always called `get_default_llm()`, ignoring the session's model override and the persona's configured model. On deployments where the global default provider is gated or unavailable to some users, chat naming silently failed or billed to the wrong model.

Auto-naming now resolves the LLM exactly the way send-message does (`get_llm_for_persona` with `chat_session.llm_override`): session override → persona default → global default. Fetching the chat session up front (with `user_id`) also validates ownership before any LLM call is made.

Fixes #8330.

Follow-up: #13557 adds an optional dedicated naming model (env-configured) for single-stream local-model deployments.

## How Has This Been Tested?

- `pre-commit` (ruff, ruff format, ty) green on the touched file
- Resolution mirrors the existing `process_message` path (`new_msg_req.llm_override or chat_session.llm_override` → `get_llm_for_persona`), which is covered by the chat streaming integration tests

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check