### PR TITLE
fix(files): extract cached calculated values from xlsx, not formula strings

### DIFF
--- a/backend/onyx/file_processing/extract_file_text.py
+++ b/backend/onyx/file_processing/extract_file_text.py
@@ -678,7 +678,7 @@ def _load_readonly_workbook(file: IO[Any], file_name: str) -> openpyxl.Workbook 
     / known-openpyxl-bug cases the xlsx indexers treat as skip-and-continue rather
     than a hard failure."""
     try:
-        return openpyxl.load_workbook(file, read_only=True)
+        return openpyxl.load_workbook(file, read_only=True, data_only=True)
     except BadZipFile as e:
         error_str = f"Failed to extract text from {file_name or 'xlsx file'}: {e}"
         if file_name.startswith("~"):

--- a/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
+++ b/backend/tests/unit/onyx/file_processing/test_xlsx_to_text.py
@@ -28,6 +28,22 @@ def _make_xlsx(sheets: dict[str, list[list[str]]]) -> io.BytesIO:
 
 
 class TestXlsxToText:
+    def test_formula_strings_are_not_indexed(self) -> None:
+        # Workbooks are read with data_only=True: cached calculated values are
+        # extracted instead of formula source. A cell whose formula was never
+        # evaluated by a spreadsheet app has no cached value and is omitted —
+        # the accepted tradeoff for not indexing raw "=SUM(...)" strings.
+        wb = openpyxl.Workbook()
+        ws = cast(Worksheet, wb.active)
+        ws.append(["Total", "=SUM(B2:B10)"])
+        buf = io.BytesIO()
+        wb.save(buf)
+        buf.seek(0)
+
+        result = xlsx_to_text(buf)
+        assert "=SUM" not in result
+        assert "Total" in result
+
     def test_single_sheet_basic(self) -> None:
         xlsx = _make_xlsx(
             {


### PR DESCRIPTION
## Description

`load_workbook` without `data_only=True` returns formula source strings (`=SUM(B2:B10)`) for formula cells, so xlsx content was indexed with formulas instead of the values users actually search for. Reading with `data_only=True` extracts the cached calculated values. Cells never evaluated by a spreadsheet app have no cached value and are omitted — the accepted tradeoff for not indexing raw formula text (now documented in a regression test).

Credit: adopted from #13354 by @swissmike-zh — re-opened as a maintainer PR so CI can run (fork PRs can't access the required CI secrets). 

Fixes #13353.

## How Has This Been Tested?

- New regression test `test_formula_strings_are_not_indexed`; full `test_xlsx_to_text.py` suite passes (38)
- `pre-commit` green on touched files

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Index XLSX files using cached calculated values, not raw formula strings, by loading workbooks with `data_only=True` in `openpyxl`. This removes "=SUM(...)" and similar from the index so search reflects visible spreadsheet values.

- **Bug Fixes**
  - Use `openpyxl.load_workbook(..., read_only=True, data_only=True)` to read cached values and avoid indexing formulas.
  - Added regression test `test_formula_strings_are_not_indexed`; cells without cached values (never evaluated) are omitted by design.

<sup>Written for commit dec79cb537058aa7a8fe90429d9616b02674625b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

