### PR TITLE
fix(bookstack): index documents updated on the current day

### DIFF
--- a/backend/onyx/connectors/bookstack/connector.py
+++ b/backend/onyx/connectors/bookstack/connector.py
@@ -63,15 +63,20 @@ class BookstackConnector(LoadConnector, PollConnector):
             "sort": "+id",
         }
 
+        # BookStack interprets a date-only "updated_at" filter (YYYY-MM-DD) as
+        # "<= YYYY-MM-DD 00:00:00", which silently excludes documents updated
+        # later on the boundary day. Since every poll uses end=now, this drops
+        # anything edited "today" until the next calendar day. Full ISO-8601
+        # datetime granularity makes the gte/lte bounds inclusive as intended.
         if start:
             params["filter[updated_at:gte]"] = datetime.fromtimestamp(
                 start, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+            ).strftime("%Y-%m-%dT%H:%M:%S")
 
         if end:
             params["filter[updated_at:lte]"] = datetime.fromtimestamp(
                 end, tz=timezone.utc
-            ).strftime("%Y-%m-%d")
+            ).strftime("%Y-%m-%dT%H:%M:%S")
 
         batch = bookstack_client.get(endpoint, params=params).get("data", [])
         doc_batch: list[Document | HierarchyNode] = [


### PR DESCRIPTION
## Description

BookStack interprets a date-only `filter[updated_at:lte]` (`YYYY-MM-DD`) as `<= YYYY-MM-DD 00:00:00`, so with `end=now` every poll silently excluded documents updated on the boundary day. In practice: new connectors indexed **0 documents on first sync**, and same-day edits never appeared until the next calendar day. This has been reported three separate times over ~8 months.

Send full ISO-8601 datetimes (`%Y-%m-%dT%H:%M:%S`) for both bounds, which BookStack's API supports.

Credit: adopted from #11914 by @markk-ns — re-opened as a maintainer PR so CI can run (fork PRs can't access the required CI secrets). Supersedes the +1-day workaround in #11845.

Fixes #11913. Fixes #11805. Fixes #6428.

## How Has This Been Tested?

- `pre-commit` green on the touched file; change is limited to the two strftime format strings plus an explanatory comment
- BookStack API datetime-filter support confirmed by the BookStack maintainer in the #6428 thread

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing “today” updates in the `BookStack` connector by sending full ISO-8601 datetimes in `updated_at` filters. First sync now indexes documents, and same-day edits show up immediately.

- **Bug Fixes**
  - Use `%Y-%m-%dT%H:%M:%S` for `filter[updated_at:gte]` and `filter[updated_at:lte]` to prevent midnight truncation.
  - Eliminates the boundary-day gap from `<= YYYY-MM-DD 00:00:00` interpretation.

<sup>Written for commit 92cafe7d100941ea2eeb11b46d6cdeba44f5b93c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

