### PR TITLE
fix(chat): stop citation processor from corrupting code fences

### DIFF
--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -317,8 +317,14 @@ class DynamicCitationProcessor:
                 if len(parts) > 1 and len(parts[1]) > 0:
                     piece_that_comes_after = parts[1][0]
                     if piece_that_comes_after == "\n" and in_code_block(self.llm_out):
-                        self.curr_segment = self.curr_segment.replace(
-                            "```", "```plaintext"
+                        # Only label the specific bare fence we just detected (the
+                        # first ``` in the segment). Using replace() here rewrote
+                        # *every* ``` in the buffer, so any other fence in the same
+                        # segment was corrupted -- e.g. a following ```bash became
+                        # ```plaintextbash, and a closing ``` became ```plaintext
+                        # (which starts a spurious code block).
+                        self.curr_segment = (
+                            parts[0] + "```plaintext" + "```".join(parts[1:])
                         )
 
         # Look for citations in current segment

--- a/backend/onyx/chat/citation_processor.py
+++ b/backend/onyx/chat/citation_processor.py
@@ -317,12 +317,8 @@ class DynamicCitationProcessor:
                 if len(parts) > 1 and len(parts[1]) > 0:
                     piece_that_comes_after = parts[1][0]
                     if piece_that_comes_after == "\n" and in_code_block(self.llm_out):
-                        # Only label the specific bare fence we just detected (the
-                        # first ``` in the segment). Using replace() here rewrote
-                        # *every* ``` in the buffer, so any other fence in the same
-                        # segment was corrupted -- e.g. a following ```bash became
-                        # ```plaintextbash, and a closing ``` became ```plaintext
-                        # (which starts a spurious code block).
+                        # Label only this first bare fence; other fences in the
+                        # buffered segment must stay untouched.
                         self.curr_segment = (
                             parts[0] + "```plaintext" + "```".join(parts[1:])
                         )

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -809,14 +809,8 @@ def test_code_block_plaintext_added(
 def test_bare_fence_labeling_does_not_corrupt_other_fences(
     mock_search_docs: CitationMapping,  # noqa: ARG001
 ) -> None:
-    """Labeling a bare fence must not rewrite other fences in the same
-    buffered segment (regression: replace() turned the closing fence into
-    ```plaintext, opening a spurious block, and ```bash into
-    ```plaintextbash).
-
-    The segment must hold a bare fence, its closing fence, AND a labeled
-    fence at the moment the labeling branch fires (odd fence count so
-    in_code_block is True)."""
+    """Labeling a bare fence must leave the segment's other fences untouched
+    (the first token buffers three fences at labeling time)."""
     processor = DynamicCitationProcessor()
 
     tokens: list[str | None] = [
@@ -825,11 +819,8 @@ def test_bare_fence_labeling_does_not_corrupt_other_fences(
     ]
     output, _ = process_tokens(processor, tokens)
 
-    # Only the bare opening fence gets the plaintext label.
     assert output.count("```plaintext") == 1
-    # The closing fence of the first block stays bare.
     assert "x\n```\nB:" in output
-    # The labeled fence is untouched.
     assert "```plaintextbash" not in output
     assert "```bash" in output
 

--- a/backend/tests/unit/onyx/chat/test_citation_processor.py
+++ b/backend/tests/unit/onyx/chat/test_citation_processor.py
@@ -806,6 +806,34 @@ def test_code_block_plaintext_added(
     assert "```plaintext" in output
 
 
+def test_bare_fence_labeling_does_not_corrupt_other_fences(
+    mock_search_docs: CitationMapping,  # noqa: ARG001
+) -> None:
+    """Labeling a bare fence must not rewrite other fences in the same
+    buffered segment (regression: replace() turned the closing fence into
+    ```plaintext, opening a spurious block, and ```bash into
+    ```plaintextbash).
+
+    The segment must hold a bare fence, its closing fence, AND a labeled
+    fence at the moment the labeling branch fires (odd fence count so
+    in_code_block is True)."""
+    processor = DynamicCitationProcessor()
+
+    tokens: list[str | None] = [
+        "A:\n```\nx\n```\nB:\n```bash",
+        "\necho hi\n```\nDone.\n",
+    ]
+    output, _ = process_tokens(processor, tokens)
+
+    # Only the bare opening fence gets the plaintext label.
+    assert output.count("```plaintext") == 1
+    # The closing fence of the first block stays bare.
+    assert "x\n```\nB:" in output
+    # The labeled fence is untouched.
+    assert "```plaintextbash" not in output
+    assert "```bash" in output
+
+
 def test_citation_outside_code_block_processed(
     mock_search_docs: CitationMapping,
 ) -> None:


### PR DESCRIPTION
## Description

When the streaming citation processor labels a bare code fence (``` → ```plaintext), it used `replace()` over the entire buffered segment — rewriting **every** fence in it. A closing fence became ```plaintext (opening a spurious code block that swallowed the following prose as "code"), and an already-labeled fence like ```bash became ```plaintextbash. The corruption also persisted into the stored `chat_message.message`. Now only the specific bare fence that was just detected gets the label.

Credit: adopted from #12685 by @markk-ns — re-opened as a maintainer PR so CI can run (fork PRs can't access the required CI secrets). #12976 is a duplicate of the same fix and can be closed alongside.

Fixes #12684.

## How Has This Been Tested?

- New regression test `test_bare_fence_labeling_does_not_corrupt_other_fences` — verified it fails against the old `replace()` behavior (3 corrupted fences) and passes with the fix (exactly 1 label)
- Full `test_citation_processor.py` suite: 130 passed
- `pre-commit` green on touched files

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes code fence corruption in the streaming citation processor by labeling only the detected bare opening fence instead of replacing all backticks in the buffered segment. Prevents closing fences turning into ```plaintext and avoids mangling labeled fences like ```bash. Fixes #12684.

- **Bug Fixes**
  - Scope labeling to the first bare fence in the current segment when inside a code block.
  - Add regression test to ensure only one fence is labeled and other fences remain intact.

- **Refactors**
  - Trim comments per review.

<sup>Written for commit 539ce0e083070bfa411009aa0c800c5914a261cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13538?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

