### PR TITLE
fix(sharepoint): retry empty/non-JSON Graph responses instead of aborting indexing

### DIFF
--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1976,34 +1976,49 @@ class SharepointConnector(
                 )
                 if response.status_code in GRAPH_API_RETRYABLE_STATUSES:
                     if attempt < GRAPH_API_MAX_RETRIES:
-                        parsed_retry_after = parse_retry_after_seconds(
-                            response.headers.get("Retry-After")
+                        wait = _backoff_seconds(
+                            attempt, response.headers.get("Retry-After")
                         )
-                        retry_after = (
-                            parsed_retry_after
-                            if parsed_retry_after is not None
-                            else float(2**attempt)
-                        )
-                        wait = min(retry_after, 60)
                         logger.warning(
-                            "Graph API %s on attempt %s, retrying in %ss: %s",
+                            "Graph API %s on attempt %s, retrying in %.1fs: %s",
                             response.status_code,
                             attempt + 1,
                             wait,
                             url,
                         )
                         time.sleep(wait)
-                        # Re-acquire token in case it expired during a long traversal
                         access_token = self._get_graph_access_token()
                         headers = {"Authorization": f"Bearer {access_token}"}
                         continue
                 _log_and_raise_for_status(response)
-                return response.json()
-            except (requests.ConnectionError, requests.Timeout):
+                try:
+                    return response.json()
+                except (ValueError, requests.exceptions.JSONDecodeError):
+                    # Graph intermittently returns an empty/non-JSON 2xx body
+                    # under load; treat it as transient and retry.
+                    if attempt < GRAPH_API_MAX_RETRIES:
+                        wait = _backoff_seconds(
+                            attempt, response.headers.get("Retry-After")
+                        )
+                        logger.warning(
+                            "Graph API non-JSON/empty body (status %s, len=%s) on "
+                            "attempt %s, retrying in %.1fs: %s",
+                            response.status_code,
+                            len(response.content),
+                            attempt + 1,
+                            wait,
+                            url,
+                        )
+                        time.sleep(wait)
+                        access_token = self._get_graph_access_token()
+                        headers = {"Authorization": f"Bearer {access_token}"}
+                        continue
+                    raise
+            except TRANSIENT_TRANSPORT_EXCEPTIONS:
                 if attempt < GRAPH_API_MAX_RETRIES:
-                    wait = min(2**attempt, 60)
+                    wait = _backoff_seconds(attempt, retry_after=None)
                     logger.warning(
-                        "Graph API connection error on attempt %s, retrying in %ss: %s",
+                        "Graph API transport error on attempt %s, retrying in %.1fs: %s",
                         attempt + 1,
                         wait,
                         url,

--- a/backend/onyx/connectors/sharepoint/connector.py
+++ b/backend/onyx/connectors/sharepoint/connector.py
@@ -1963,10 +1963,10 @@ class SharepointConnector(
         params: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Make an authenticated GET request to the Graph API with retry."""
-        access_token = self._get_graph_access_token()
-        headers = {"Authorization": f"Bearer {access_token}"}
-
         for attempt in range(GRAPH_API_MAX_RETRIES + 1):
+            # Tokens can expire during long traversals — re-acquire per attempt.
+            access_token = self._get_graph_access_token()
+            headers = {"Authorization": f"Bearer {access_token}"}
             try:
                 response = requests.get(
                     url,
@@ -1987,41 +1987,20 @@ class SharepointConnector(
                             url,
                         )
                         time.sleep(wait)
-                        access_token = self._get_graph_access_token()
-                        headers = {"Authorization": f"Bearer {access_token}"}
                         continue
                 _log_and_raise_for_status(response)
-                try:
-                    return response.json()
-                except (ValueError, requests.exceptions.JSONDecodeError):
-                    # Graph intermittently returns an empty/non-JSON 2xx body
-                    # under load; treat it as transient and retry.
-                    if attempt < GRAPH_API_MAX_RETRIES:
-                        wait = _backoff_seconds(
-                            attempt, response.headers.get("Retry-After")
-                        )
-                        logger.warning(
-                            "Graph API non-JSON/empty body (status %s, len=%s) on "
-                            "attempt %s, retrying in %.1fs: %s",
-                            response.status_code,
-                            len(response.content),
-                            attempt + 1,
-                            wait,
-                            url,
-                        )
-                        time.sleep(wait)
-                        access_token = self._get_graph_access_token()
-                        headers = {"Authorization": f"Bearer {access_token}"}
-                        continue
-                    raise
-            except TRANSIENT_TRANSPORT_EXCEPTIONS:
+                # ValueError covers the empty/non-JSON 2xx bodies Graph
+                # intermittently returns under load.
+                return response.json()
+            except TRANSIENT_TRANSPORT_EXCEPTIONS + (ValueError,) as e:
                 if attempt < GRAPH_API_MAX_RETRIES:
                     wait = _backoff_seconds(attempt, retry_after=None)
                     logger.warning(
-                        "Graph API transport error on attempt %s, retrying in %.1fs: %s",
+                        "Graph API transient error on attempt %s, retrying in %.1fs: %s (%r)",
                         attempt + 1,
                         wait,
                         url,
+                        e,
                     )
                     time.sleep(wait)
                     continue

--- a/backend/tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py
+++ b/backend/tests/unit/onyx/connectors/sharepoint/test_graph_api_get_json_retry.py
@@ -1,0 +1,101 @@
+"""Unit tests for SharepointConnector._graph_api_get_json retry behavior.
+
+Covers the empty/non-JSON 2xx body case: Microsoft Graph intermittently returns
+a body-less response under load (gateway-shed throttling, backend list-view
+timeouts on large libraries, mid-response connection drops). The bare
+response.json() used to raise an unretried JSONDecodeError that aborted indexing
+of large (>2K file) libraries; it must now be retried like any transient error.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+import requests
+from requests import Response
+
+from onyx.connectors.sharepoint import connector as sp_connector
+from onyx.connectors.sharepoint.connector import (
+    GRAPH_API_MAX_RETRIES,
+    SharepointConnector,
+)
+
+SITE_URL = "https://tenant.sharepoint.com/sites/Big"
+PAGE_URL = "https://graph.microsoft.com/v1.0/drives/abc/root/children"
+
+
+def _response(
+    status: int = 200, body: Any = None, raw: bytes | None = None
+) -> Response:
+    """Build a fake requests.Response. body=None + raw=None => empty body."""
+    resp = Response()
+    resp.status_code = status
+    if raw is not None:
+        resp._content = raw
+    elif body is not None:
+        resp._content = json.dumps(body).encode()
+    else:
+        resp._content = b""  # empty 2xx body -> JSONDecodeError on .json()
+    resp.headers["Content-Type"] = "application/json"
+    return resp
+
+
+def _connector(monkeypatch: pytest.MonkeyPatch) -> SharepointConnector:
+    connector = SharepointConnector(sites=[SITE_URL])
+    connector.graph_api_base = "https://graph.microsoft.com/v1.0"
+    # Avoid real MSAL token acquisition.
+    monkeypatch.setattr(connector, "_get_graph_access_token", lambda: "fake-token")
+    # Never actually sleep between retries.
+    monkeypatch.setattr(sp_connector.time, "sleep", lambda *_a, **_k: None)
+    return connector
+
+
+def test_retries_empty_body_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An empty 2xx body is retried; the next good page is returned."""
+    connector = _connector(monkeypatch)
+    payload = {"value": [{"id": "1", "name": "f.docx"}]}
+    responses = iter([_response(200, body=None), _response(200, body=payload)])
+    monkeypatch.setattr(sp_connector.requests, "get", lambda *_a, **_k: next(responses))
+
+    result = connector._graph_api_get_json(PAGE_URL, {"$top": "200"})
+
+    assert result == payload
+
+
+def test_raises_after_exhausting_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A persistently empty body re-raises JSONDecodeError after all retries."""
+    connector = _connector(monkeypatch)
+    calls = {"n": 0}
+
+    def _always_empty(*_a: Any, **_k: Any) -> Response:
+        calls["n"] += 1
+        return _response(200, body=None)
+
+    monkeypatch.setattr(sp_connector.requests, "get", _always_empty)
+
+    with pytest.raises(requests.exceptions.JSONDecodeError):
+        connector._graph_api_get_json(PAGE_URL)
+
+    assert calls["n"] == GRAPH_API_MAX_RETRIES + 1
+
+
+def test_retries_chunked_encoding_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A mid-stream drop (ChunkedEncodingError) is retried, not fatal."""
+    connector = _connector(monkeypatch)
+    payload = {"value": []}
+    state = {"n": 0}
+
+    def _flaky(*_a: Any, **_k: Any) -> Response:
+        state["n"] += 1
+        if state["n"] == 1:
+            raise requests.exceptions.ChunkedEncodingError("connection dropped")
+        return _response(200, body=payload)
+
+    monkeypatch.setattr(sp_connector.requests, "get", _flaky)
+
+    result = connector._graph_api_get_json(PAGE_URL)
+
+    assert result == payload
+    assert state["n"] == 2


### PR DESCRIPTION
## Description

Microsoft Graph intermittently returns an empty or non-JSON 2xx body under load (gateway-shed throttling, backend list-view timeouts on large libraries, mid-response drops). The bare `response.json()` in `_graph_api_get_json` raised an unhandled `JSONDecodeError`, aborting the entire index attempt — repeatedly, on large SharePoint libraries.

Changes:
- Treat empty/non-JSON bodies as transient: retry with the same backoff (shared `_backoff_seconds` helper honoring `Retry-After`) and token re-acquisition as retryable statuses
- Widen the transport-exception handler from `(ConnectionError, Timeout)` to the file's existing `TRANSIENT_TRANSPORT_EXCEPTIONS` set
- After exhausting retries, the error propagates as before

Credit: adopted from #12556 by @CE11-Kishan — re-opened as a maintainer PR so CI can run (fork PRs can't access the required CI secrets).

Fixes #12554.

## How Has This Been Tested?

- New unit test file `test_graph_api_get_json_retry.py` (included in the adopted change) covering non-JSON-body retry, retry exhaustion, and transport-exception retry; full SharePoint unit suite: 144 passed
- `pre-commit` green on touched files

## Additional Options

- [x] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry empty or non-JSON 2xx Microsoft Graph responses so SharePoint indexing doesn’t abort under load, especially on large libraries. Improves reliability without changing success/error semantics.

- **Bug Fixes**
  - Treat empty/non-JSON 2xx bodies as transient; retry via `_backoff_seconds`, honoring `Retry-After`, and re-acquire the token on each attempt.
  - Broaden transport exception handling to `TRANSIENT_TRANSPORT_EXCEPTIONS` (e.g., mid-stream drops).
  - After max retries, re-raise the original error.
  - Added unit tests for non-JSON retry, retry exhaustion, and transport-error retry.

- **Refactors**
  - Fold JSON decode failures into the transient-exception path (`ValueError`/`JSONDecodeError`) and remove nested try/except.

<sup>Written for commit 58b1528e8bf660826f5b39821443f2375d1fcc4c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

