### PR TITLE
fix: omit empty tools array from litellm.completion instead of sending []

### DIFF
--- a/backend/onyx/llm/multi_llm.py
+++ b/backend/onyx/llm/multi_llm.py
@@ -886,7 +886,7 @@ class LitellmLLM(LLM):
                         api_version=api_version,
                         custom_llm_provider=self._custom_llm_provider or None,
                         messages=messages,
-                        tools=tools,
+                        tools=tools or None,
                         stream=stream,
                         timeout=timeout_override or self._timeout,
                         max_tokens=max_tokens,

--- a/backend/tests/unit/onyx/llm/test_multi_llm.py
+++ b/backend/tests/unit/onyx/llm/test_multi_llm.py
@@ -2294,6 +2294,42 @@ def test_no_tool_choice_sent_when_no_tools(default_multi_llm: LitellmLLM) -> Non
         )
 
 
+def test_no_empty_tools_array_sent_when_no_tools(
+    default_multi_llm: LitellmLLM,
+) -> None:
+    """Regression test for OpenAI-compatible providers (e.g. vLLM) that reject
+    an explicitly empty `tools` array with a 400.
+
+    When no tools are provided, `tools` must be omitted (None), not passed
+    through as `[]`.
+    """
+    messages: LanguageModelInput = [UserMessage(content="Hello!")]
+
+    mock_stream_chunks = [
+        litellm.ModelResponse(
+            id="chatcmpl-123",
+            choices=[
+                litellm.Choices(
+                    delta=_create_delta(role="assistant", content="Hello!"),
+                    finish_reason="stop",
+                    index=0,
+                )
+            ],
+            model="gpt-3.5-turbo",
+        ),
+    ]
+
+    with patch("litellm.completion") as mock_completion:
+        mock_completion.return_value = mock_stream_chunks
+
+        default_multi_llm.invoke(messages, tools=[])
+
+        _, kwargs = mock_completion.call_args
+        assert kwargs.get("tools") is None, (
+            "tools must be None (omitted), not [], when no tools are provided"
+        )
+
+
 _TOOL_CHOICE_DOWNGRADE_TOOLS = [
     {
         "type": "function",


### PR DESCRIPTION
## Summary

`LitellmLLM._completion` always passed `tools=tools` to `litellm.completion`, even when `tools` was an empty list — e.g. Deep Research's planning step, which has no tools available for that turn. Some OpenAI-compatible endpoints (e.g. vLLM) reject an explicitly empty `tools` array with a 400, requiring the field to be omitted entirely rather than sent as `[]`.

`tool_choice` was already correctly gated on `tools` being truthy (`if tools and tool_choice is not None`); `tools` itself was not.

## Fix

Change the `litellm.completion(...)` call in `backend/onyx/llm/multi_llm.py` from `tools=tools` to `tools=tools or None`, so an empty list is omitted from the request just like `tool_choice` already is. This mirrors the codebase's existing convention elsewhere in the same method of passing `None` instead of a falsy value to make LiteLLM omit a field entirely.

## Test plan

- Added `test_no_empty_tools_array_sent_when_no_tools` in `test_multi_llm.py`, mirroring the existing `test_no_tool_choice_sent_when_no_tools` pattern: invokes with `tools=[]` and asserts `litellm.completion` receives `tools=None`, not `tools=[]`.
- Verified the new test fails without the fix (`tools=[]` reaches the mock) and passes with it.
- Ran the full `test_multi_llm.py` + `test_multi_llm_stream_retry.py` suite: 148 passed, no regressions.

Fixes #13493

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Omit empty `tools` arrays when calling `litellm.completion` to prevent 400s from OpenAI-compatible providers (e.g., vLLM). Adds a regression test to ensure `tools=None` is sent when no tools are available.

- **Bug Fixes**
  - Pass `tools=tools or None` in `backend/onyx/llm/multi_llm.py` so empty lists are omitted, matching existing `tool_choice` gating.
  - Added `test_no_empty_tools_array_sent_when_no_tools` to verify `tools=None` is sent to `litellm.completion`; test suite passes with no regressions.

<sup>Written for commit 729dcac607edc02ed7df6dce02891e33fff7c99b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

