### PR TITLE
fix(slackbot): restore forced document search for Slack bot answers

### DIFF
--- a/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
+++ b/backend/onyx/onyxbot/slack/handlers/handle_regular_answer.py
@@ -34,6 +34,8 @@ from onyx.server.query_and_chat.models import (
     MessageOrigin,
     SendMessageRequest,
 )
+from onyx.tools.constants import SEARCH_TOOL_ID
+from onyx.tools.tool_implementations.search.search_tool import SearchTool
 from onyx.utils.logger import OnyxLoggingAdapter
 from onyx.utils.retry_wrapper import retry_builder
 from shared_configs.contextvars import CURRENT_USER_ID_CONTEXTVAR
@@ -331,10 +333,27 @@ def handle_regular_answer(
             tags=channel_tags if channel_tags else None,
         )
 
+        # Slack answers should be grounded in retrieval (pre-#7399 behavior):
+        # force the search tool on the first LLM cycle, but only when the
+        # channel persona actually has a usable one — non-search personas and
+        # deployments without connectors keep the unforced behavior.
+        forced_search_tool_id = next(
+            (
+                tool.id
+                for tool in persona.tools
+                if tool.in_code_tool_id == SEARCH_TOOL_ID
+            ),
+            None,
+        )
+        if forced_search_tool_id is not None and not SearchTool.is_available(
+            db_session
+        ):
+            forced_search_tool_id = None
+
         new_message_request = SendMessageRequest(
             message=user_message.message,
             allowed_tool_ids=None,
-            forced_tool_id=None,
+            forced_tool_id=forced_search_tool_id,
             file_descriptors=[],
             internal_search_filters=filters,
             deep_research=False,

--- a/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
+++ b/backend/tests/unit/onyx/onyxbot/test_handle_regular_answer.py
@@ -100,6 +100,7 @@ def _make_slack_channel_config(
     persona.id = 123
     persona.name = "Scoped Agent"
     persona.document_sets = []
+    persona.tools = []
 
     slack_channel_config = MagicMock()
     slack_channel_config.persona = persona
@@ -579,3 +580,78 @@ def test_private_channel_non_ephemeral_attributes_usage(
     assert mock_respond.call_args.kwargs["receiver_ids"] is None
     mock_update_react.assert_called_once()
     assert mock_update_react.call_args.kwargs["remove"] is True
+
+
+@pytest.mark.parametrize(
+    "has_search_tool,search_available,expected_forced_id",
+    [
+        (True, True, 77),  # persona has SearchTool and it is usable -> forced
+        (True, False, None),  # SearchTool attached but unavailable -> not forced
+        (False, True, None),  # persona without SearchTool -> not forced
+    ],
+)
+def test_search_tool_forced_only_when_usable(
+    has_search_tool: bool,
+    search_available: bool,
+    expected_forced_id: int | None,
+) -> None:
+    """Slack answers force the persona's search tool on the first LLM cycle
+    (regression for the #7399 refactor dropping guaranteed retrieval), but
+    never for personas without a usable search tool."""
+    slack_channel_config = _make_slack_channel_config()
+    persona = slack_channel_config.persona
+    if has_search_tool:
+        search_tool = MagicMock()
+        search_tool.id = 77
+        search_tool.in_code_tool_id = "SearchTool"
+        persona.tools = [search_tool]
+
+    user = MagicMock()
+    user.id = uuid4()
+
+    def _gather_stream(_: object) -> ChatBasicResponse:
+        return ChatBasicResponse(
+            answer="answer",
+            answer_citationless="answer",
+            top_documents=[],
+            error_msg=None,
+            message_id=1,
+            citation_info=[],
+        )
+
+    with (
+        patch(f"{_HANDLE_REGULAR_ANSWER}.get_user_by_email", return_value=user),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.get_anonymous_user", return_value=MagicMock()),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.get_persona_by_id", return_value=persona),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.rate_limits", side_effect=_identity_decorator),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.retry_builder", side_effect=_identity_decorator
+        ),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.get_channel_name_from_id",
+            return_value=("channel", False),
+        ),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.gather_stream", side_effect=_gather_stream),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.build_slack_response_blocks", return_value=[]),
+        patch(
+            f"{_HANDLE_REGULAR_ANSWER}.handle_stream_message_objects",
+            return_value=iter(()),
+        ) as mock_handle_stream_message_objects,
+        patch(f"{_HANDLE_REGULAR_ANSWER}.SearchTool") as mock_search_tool_cls,
+        patch(f"{_HANDLE_REGULAR_ANSWER}.respond_in_thread_or_channel"),
+        patch(f"{_HANDLE_REGULAR_ANSWER}.update_emote_react"),
+    ):
+        mock_search_tool_cls.is_available.return_value = search_available
+        handle_regular_answer(
+            message_info=_make_slack_message_info(ChannelType.IM),
+            slack_channel_config=slack_channel_config,
+            receiver_ids=None,
+            client=MagicMock(),
+            channel="C123",
+            logger=_mock_logger(),
+            db_session=MagicMock(),
+            feedback_reminder_id=None,
+        )
+
+    stream_call_kwargs = mock_handle_stream_message_objects.call_args.kwargs
+    assert stream_call_kwargs["new_msg_req"].forced_tool_id == expected_forced_id


### PR DESCRIPTION
## Description

**Regression, verified via git archaeology:** before #7399, `stream_chat_message_objects` translated the Slack handler's `run_search=ALWAYS` into `forced_tool_id=<search tool>`, so every Slack bot message was grounded in retrieval. #7399 (framed as dead-code cleanup, 2026-01-14, first broken release v2.10.0) removed that shim and hardcoded `forced_tool_id=None` — since then the LLM freely answers Slack questions without ever searching documents. Channels configured with the answer-only-with-citations filter stop answering entirely ("Unable to find citations to answer"), which is exactly what #8169 reported (their v2.9.7→v2.10.x bisection matches the merge exactly).

This restores parity through the standard forced-tool mechanism: the persona's search tool is forced on the **first LLM cycle only** (later cycles stay AUTO, so MCP/custom tools remain usable), guarded so it only applies when the channel persona actually has a SearchTool attached **and** `SearchTool.is_available()` — personas without a usable search tool (MCP-only agents, `DISABLE_VECTOR_DB`, no connectors) keep today's behavior instead of crashing on an unknown forced tool (the reporter's proposed unconditional version would have).

Known trade-off (same as v2.9.7): every Slack message to a search-persona channel pays one retrieval, including smalltalk. A per-channel toggle would be a follow-up if wanted.

Fixes #8169.

## How Has This Been Tested?

- 3 new parametrized unit tests in `test_handle_regular_answer.py` asserting `forced_tool_id` is set when the persona has a usable SearchTool, and stays `None` when the tool is missing or unavailable — verified they fail without the fix
- Full `test_handle_regular_answer.py` suite: 26 passed; `pre-commit` green

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore forced document search for Slack bot answers by forcing the persona’s search tool on the first LLM cycle, bringing back grounded replies and fixing citation-only channels. Fixes #8169 (regression introduced by #7399).

- **Bug Fixes**
  - Force the persona’s search tool only when present and available; otherwise leave unforced.
  - Apply forcing on the first cycle only; later cycles remain AUTO so other tools still work.
  - Add unit tests to verify `forced_tool_id` behavior across available/unavailable/missing search tool cases.

<sup>Written for commit 9056dfcfbccb19b6be8ec77aa7786fb1273ad7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

