### PR TITLE
fix(craft): honor the admin-configured default model

### DIFF
--- a/backend/onyx/server/features/build/session/llm_config.py
+++ b/backend/onyx/server/features/build/session/llm_config.py
@@ -81,26 +81,43 @@ def parse_agent_selection(
     return None
 
 
+def _matching_visible_model(
+    providers: list[LLMProviderView], selection: AgentSelection
+) -> tuple[int, str] | None:
+    for provider in providers:
+        matches_request = (
+            provider.id == selection.provider_id
+            if isinstance(selection, GatewaySelection)
+            else provider.provider == selection.provider_type
+        )
+        if matches_request and any(
+            model.is_visible and model.name == selection.model_name
+            for model in provider.model_configurations
+        ):
+            return provider.id, selection.model_name
+    return None
+
+
 def _select_gateway_default(
     providers: list[LLMProviderView],
     selection: AgentSelection | None,
+    configured_default: GatewaySelection | None = None,
 ) -> tuple[int, str] | None:
     if selection is not None:
-        for provider in providers:
-            matches_request = (
-                provider.id == selection.provider_id
-                if isinstance(selection, GatewaySelection)
-                else provider.provider == selection.provider_type
-            )
-            if matches_request and any(
-                model.is_visible and model.name == selection.model_name
-                for model in provider.model_configurations
-            ):
-                return provider.id, selection.model_name
+        resolved = _matching_visible_model(providers, selection)
+        if resolved is not None:
+            return resolved
         logger.warning(
             "Requested Craft gateway provider/model is not accessible or visible; "
             "falling back"
         )
+
+    # The admin's configured default model (shared with chat) outranks the
+    # built-in recommendation.
+    if configured_default is not None:
+        resolved = _matching_visible_model(providers, configured_default)
+        if resolved is not None:
+            return resolved
 
     # Auto-pick a default: prefer each provider's recommended default model
     # (recommended-models.json, kept current by the update-recommended-models
@@ -123,12 +140,15 @@ def _select_gateway_default(
 def build_onyx_gateway_config(
     gateway_providers: list[LLMProviderView],
     selection: AgentSelection | None = None,
+    configured_default: GatewaySelection | None = None,
 ) -> CraftLLMProviderConfig | None:
     if not ONYX_SERVER_URL:
         return None
 
     models = build_gateway_model_catalog(gateway_providers)
-    default_selection = _select_gateway_default(gateway_providers, selection)
+    default_selection = _select_gateway_default(
+        gateway_providers, selection, configured_default
+    )
     if not models or default_selection is None:
         return None
 

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -27,7 +27,7 @@ from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.configs.constants import MessageType
 from onyx.db.enums import BuildSessionStatus, SandboxStatus, SessionOrigin
 from onyx.db.external_app import get_connectable_apps_for_user
-from onyx.db.llm import fetch_all_accessible_llm_providers
+from onyx.db.llm import fetch_all_accessible_llm_providers, fetch_default_llm_model
 from onyx.db.models import BuildMessage, BuildSession, Sandbox, User
 from onyx.db.users import fetch_user_by_id
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -85,6 +85,7 @@ from onyx.server.features.build.session.errors import (
 from onyx.server.features.build.session.interrupt_signal import request_interrupt
 from onyx.server.features.build.session.llm_config import (
     AgentSelection,
+    GatewaySelection,
     build_onyx_gateway_config,
     parse_agent_selection,
 )
@@ -194,9 +195,18 @@ class SessionManager:
         user: User,
         selection: AgentSelection | None = None,
     ) -> CraftLLMProviderConfig:
+        configured_default_model = fetch_default_llm_model(self._db_session)
         gateway_config = build_onyx_gateway_config(
             fetch_all_accessible_llm_providers(self._db_session, user),
             selection,
+            (
+                GatewaySelection(
+                    configured_default_model.llm_provider_id,
+                    configured_default_model.name,
+                )
+                if configured_default_model is not None
+                else None
+            ),
         )
         if gateway_config is None:
             raise OnyxError(

--- a/backend/onyx/server/features/build/session/manager.py
+++ b/backend/onyx/server/features/build/session/manager.py
@@ -26,7 +26,7 @@ from onyx.cache.factory import get_cache_backend
 from onyx.configs.app_configs import WEB_DOMAIN
 from onyx.db.enums import SandboxStatus, SessionOrigin
 from onyx.db.external_app import get_connectable_apps_for_user
-from onyx.db.llm import fetch_all_accessible_llm_providers
+from onyx.db.llm import fetch_all_accessible_llm_providers, fetch_default_llm_model
 from onyx.db.models import BuildMessage, BuildSession, Sandbox, User
 from onyx.db.users import fetch_user_by_id
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -84,6 +84,7 @@ from onyx.server.features.build.session.errors import (
 from onyx.server.features.build.session.interrupt_signal import request_interrupt
 from onyx.server.features.build.session.llm_config import (
     AgentSelection,
+    GatewaySelection,
     build_onyx_gateway_config,
     parse_agent_selection,
 )
@@ -198,9 +199,18 @@ class SessionManager:
         user: User,
         selection: AgentSelection | None = None,
     ) -> CraftLLMProviderConfig:
+        configured_default_model = fetch_default_llm_model(self._db_session)
         gateway_config = build_onyx_gateway_config(
             fetch_all_accessible_llm_providers(self._db_session, user),
             selection,
+            (
+                GatewaySelection(
+                    configured_default_model.llm_provider_id,
+                    configured_default_model.name,
+                )
+                if configured_default_model is not None
+                else None
+            ),
         )
         if gateway_config is None:
             raise OnyxError(

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -447,6 +447,38 @@ def test_manager_falls_back_to_recommendation_when_configured_default_not_visibl
     assert config.model_name == "7/bedrock-pro"
 
 
+def test_selection_outranks_configured_default() -> None:
+    """A session's own pick must survive an org default pointing elsewhere —
+    reversing these two would silently move every existing session's model."""
+    anthropic = _provider(3, "anthropic", [_model("claude-sonnet-5")])
+    bedrock = _provider(7, "bedrock", [_model("bedrock-pro")])
+
+    with patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"):
+        config = llm_config.build_onyx_gateway_config(
+            [anthropic, bedrock],
+            llm_config.GatewaySelection(7, "bedrock-pro"),
+            llm_config.GatewaySelection(3, "claude-sonnet-5"),
+        )
+
+    assert config is not None
+    assert config.model_name == "7/bedrock-pro"
+
+
+def test_stale_selection_falls_through_to_configured_default() -> None:
+    anthropic = _provider(3, "anthropic", [_model("claude-sonnet-5")])
+    bedrock = _provider(7, "bedrock", [_model("bedrock-pro")])
+
+    with patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"):
+        config = llm_config.build_onyx_gateway_config(
+            [anthropic, bedrock],
+            llm_config.GatewaySelection(7, "retired-model"),
+            llm_config.GatewaySelection(3, "claude-sonnet-5"),
+        )
+
+    assert config is not None
+    assert config.model_name == "3/claude-sonnet-5"
+
+
 def _gateway_config() -> CraftLLMProviderConfig:
     return CraftLLMProviderConfig(
         provider="onyx",

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -364,6 +364,7 @@ def test_manager_prefers_provider_recommended_default_in_provider_order() -> Non
             "fetch_all_accessible_llm_providers",
             return_value=[anthropic, bedrock],
         ) as fetch_providers,
+        patch.object(manager_module, "fetch_default_llm_model", return_value=None),
     ):
         config = manager.build_llm_configs(user)
 
@@ -372,6 +373,78 @@ def test_manager_prefers_provider_recommended_default_in_provider_order() -> Non
     assert config.provider == "onyx"
     assert config.model_name == "7/bedrock-pro"
     fetch_providers.assert_called_once_with(manager._db_session, user)  # type: ignore[attr-defined]
+
+
+def test_manager_prefers_configured_default_over_recommendation() -> None:
+    anthropic = _provider(
+        3,
+        "anthropic",
+        [_model("claude-sonnet-5"), _model("claude-opus-5")],
+        name="Zulu provider",
+    )
+    bedrock = _provider(
+        7,
+        "bedrock",
+        [_model("bedrock-lite"), _model("bedrock-pro")],
+        name="Alpha provider",
+    )
+    manager = SessionManager.__new__(SessionManager)
+    manager._db_session = cast(Session, MagicMock(spec=Session))  # type: ignore[attr-defined]
+    user = cast(User, MagicMock(spec=User))
+
+    configured_default = MagicMock()
+    configured_default.configure_mock(llm_provider_id=3, name="claude-sonnet-5")
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(
+            manager_module,
+            "fetch_all_accessible_llm_providers",
+            return_value=[anthropic, bedrock],
+        ),
+        patch.object(
+            manager_module, "fetch_default_llm_model", return_value=configured_default
+        ),
+    ):
+        config = manager.build_llm_configs(user)
+
+    assert config.model_name == "3/claude-sonnet-5"
+
+
+def test_manager_falls_back_to_recommendation_when_configured_default_not_visible() -> (
+    None
+):
+    anthropic = _provider(
+        3,
+        "anthropic",
+        [_model("claude-sonnet-5", is_visible=False), _model("claude-opus-5")],
+        name="Zulu provider",
+    )
+    bedrock = _provider(
+        7,
+        "bedrock",
+        [_model("bedrock-lite"), _model("bedrock-pro")],
+        name="Alpha provider",
+    )
+    manager = SessionManager.__new__(SessionManager)
+    manager._db_session = cast(Session, MagicMock(spec=Session))  # type: ignore[attr-defined]
+    user = cast(User, MagicMock(spec=User))
+
+    configured_default = MagicMock()
+    configured_default.configure_mock(llm_provider_id=3, name="claude-sonnet-5")
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(
+            manager_module,
+            "fetch_all_accessible_llm_providers",
+            return_value=[anthropic, bedrock],
+        ),
+        patch.object(
+            manager_module, "fetch_default_llm_model", return_value=configured_default
+        ),
+    ):
+        config = manager.build_llm_configs(user)
+
+    assert config.model_name == "7/bedrock-pro"
 
 
 def _gateway_config() -> CraftLLMProviderConfig:

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -360,6 +360,7 @@ def test_manager_prefers_provider_recommended_default_in_provider_order() -> Non
             "fetch_all_accessible_llm_providers",
             return_value=[anthropic, bedrock],
         ) as fetch_providers,
+        patch.object(manager_module, "fetch_default_llm_model", return_value=None),
     ):
         config = manager.build_llm_configs(user)
 
@@ -368,6 +369,78 @@ def test_manager_prefers_provider_recommended_default_in_provider_order() -> Non
     assert config.provider == "onyx"
     assert config.model_name == "7/bedrock-pro"
     fetch_providers.assert_called_once_with(manager._db_session, user)
+
+
+def test_manager_prefers_configured_default_over_recommendation() -> None:
+    anthropic = _provider(
+        3,
+        "anthropic",
+        [_model("claude-sonnet-5"), _model("claude-opus-5")],
+        name="Zulu provider",
+    )
+    bedrock = _provider(
+        7,
+        "bedrock",
+        [_model("bedrock-lite"), _model("bedrock-pro")],
+        name="Alpha provider",
+    )
+    manager = SessionManager.__new__(SessionManager)
+    manager._db_session = cast(Session, MagicMock(spec=Session))  # type: ignore[attr-defined]
+    user = cast(User, MagicMock(spec=User))
+
+    configured_default = MagicMock()
+    configured_default.configure_mock(llm_provider_id=3, name="claude-sonnet-5")
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(
+            manager_module,
+            "fetch_all_accessible_llm_providers",
+            return_value=[anthropic, bedrock],
+        ),
+        patch.object(
+            manager_module, "fetch_default_llm_model", return_value=configured_default
+        ),
+    ):
+        config = manager.build_llm_configs(user)
+
+    assert config.model_name == "3/claude-sonnet-5"
+
+
+def test_manager_falls_back_to_recommendation_when_configured_default_not_visible() -> (
+    None
+):
+    anthropic = _provider(
+        3,
+        "anthropic",
+        [_model("claude-sonnet-5", is_visible=False), _model("claude-opus-5")],
+        name="Zulu provider",
+    )
+    bedrock = _provider(
+        7,
+        "bedrock",
+        [_model("bedrock-lite"), _model("bedrock-pro")],
+        name="Alpha provider",
+    )
+    manager = SessionManager.__new__(SessionManager)
+    manager._db_session = cast(Session, MagicMock(spec=Session))  # type: ignore[attr-defined]
+    user = cast(User, MagicMock(spec=User))
+
+    configured_default = MagicMock()
+    configured_default.configure_mock(llm_provider_id=3, name="claude-sonnet-5")
+    with (
+        patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"),
+        patch.object(
+            manager_module,
+            "fetch_all_accessible_llm_providers",
+            return_value=[anthropic, bedrock],
+        ),
+        patch.object(
+            manager_module, "fetch_default_llm_model", return_value=configured_default
+        ),
+    ):
+        config = manager.build_llm_configs(user)
+
+    assert config.model_name == "7/bedrock-pro"
 
 
 def _gateway_config() -> CraftLLMProviderConfig:

--- a/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
+++ b/backend/tests/unit/onyx/server/features/craft/test_session_gateway_config.py
@@ -443,6 +443,38 @@ def test_manager_falls_back_to_recommendation_when_configured_default_not_visibl
     assert config.model_name == "7/bedrock-pro"
 
 
+def test_selection_outranks_configured_default() -> None:
+    """A session's own pick must survive an org default pointing elsewhere —
+    reversing these two would silently move every existing session's model."""
+    anthropic = _provider(3, "anthropic", [_model("claude-sonnet-5")])
+    bedrock = _provider(7, "bedrock", [_model("bedrock-pro")])
+
+    with patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"):
+        config = llm_config.build_onyx_gateway_config(
+            [anthropic, bedrock],
+            llm_config.GatewaySelection(7, "bedrock-pro"),
+            llm_config.GatewaySelection(3, "claude-sonnet-5"),
+        )
+
+    assert config is not None
+    assert config.model_name == "7/bedrock-pro"
+
+
+def test_stale_selection_falls_through_to_configured_default() -> None:
+    anthropic = _provider(3, "anthropic", [_model("claude-sonnet-5")])
+    bedrock = _provider(7, "bedrock", [_model("bedrock-pro")])
+
+    with patch.object(llm_config, "ONYX_SERVER_URL", "https://onyx.test"):
+        config = llm_config.build_onyx_gateway_config(
+            [anthropic, bedrock],
+            llm_config.GatewaySelection(7, "retired-model"),
+            llm_config.GatewaySelection(3, "claude-sonnet-5"),
+        )
+
+    assert config is not None
+    assert config.model_name == "3/claude-sonnet-5"
+
+
 def _gateway_config() -> CraftLLMProviderConfig:
     return CraftLLMProviderConfig(
         provider="onyx",

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -121,7 +121,7 @@ export default function BuildChatPanel({
   const toggleOutputPanel = useToggleOutputPanel();
   const onWakeIntent = useWakeOnIntent();
 
-  const { llmProviders } = useLLMProviders();
+  const { llmProviders, defaultText } = useLLMProviders();
   // Sessions can outlive the org's supported providers — gate sends until one
   // exists (the model picker stays enabled so admins can connect from it).
   const hasProvider = hasSupportedCraftProvider(llmProviders);
@@ -142,7 +142,7 @@ export default function BuildChatPanel({
   const selectedModel =
     (sessionId ? modelBySession[sessionId] : undefined) ??
     sessionModel ??
-    getDefaultLlmSelection(llmProviders);
+    getDefaultLlmSelection(llmProviders, defaultText);
 
   const contextUsage = useMemo(() => {
     const usage = session?.contextUsage;

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -144,7 +144,14 @@ export default function BuildChatPanel({
       (sessionId ? modelBySession[sessionId] : undefined) ??
       sessionModel ??
       getPreferredLlmSelection(user?.id, llmProviders, defaultText),
-    [sessionId, modelBySession, sessionModel, user?.id, llmProviders, defaultText]
+    [
+      sessionId,
+      modelBySession,
+      sessionModel,
+      user?.id,
+      llmProviders,
+      defaultText,
+    ]
   );
 
   const contextUsage = useMemo(() => {

--- a/web/src/app/craft/components/ChatPanel.tsx
+++ b/web/src/app/craft/components/ChatPanel.tsx
@@ -118,7 +118,7 @@ export default function BuildChatPanel({
   const toggleOutputPanel = useToggleOutputPanel();
   const onWakeIntent = useWakeOnIntent();
 
-  const { llmProviders } = useLLMProviders();
+  const { llmProviders, defaultText } = useLLMProviders();
   // Sessions can outlive the org's supported providers — gate sends until one
   // exists (the model picker stays enabled so admins can connect from it).
   const hasProvider = hasSupportedCraftProvider(llmProviders);
@@ -143,8 +143,8 @@ export default function BuildChatPanel({
     () =>
       (sessionId ? modelBySession[sessionId] : undefined) ??
       sessionModel ??
-      getPreferredLlmSelection(user?.id, llmProviders),
-    [sessionId, modelBySession, sessionModel, user?.id, llmProviders]
+      getPreferredLlmSelection(user?.id, llmProviders, defaultText),
+    [sessionId, modelBySession, sessionModel, user?.id, llmProviders, defaultText]
   );
 
   const contextUsage = useMemo(() => {

--- a/web/src/app/craft/components/ModelPickerButton.tsx
+++ b/web/src/app/craft/components/ModelPickerButton.tsx
@@ -23,11 +23,11 @@ export default function ModelPickerButton({
   onChange,
   disabled = false,
 }: ModelPickerButtonProps) {
-  const { llmProviders } = useLLMProviders();
+  const { llmProviders, defaultText } = useLLMProviders();
 
   const effective = useMemo(
-    () => selection ?? getDefaultLlmSelection(llmProviders),
-    [selection, llmProviders]
+    () => selection ?? getDefaultLlmSelection(llmProviders, defaultText),
+    [selection, llmProviders, defaultText]
   );
 
   const displayName = useMemo(() => {

--- a/web/src/app/craft/components/ModelPickerButton.tsx
+++ b/web/src/app/craft/components/ModelPickerButton.tsx
@@ -26,7 +26,9 @@ export default function ModelPickerButton({
   const { user } = useUser();
 
   const effective = useMemo(
-    () => selection ?? getPreferredLlmSelection(user?.id, llmProviders, defaultText),
+    () =>
+      selection ??
+      getPreferredLlmSelection(user?.id, llmProviders, defaultText),
     [selection, user?.id, llmProviders, defaultText]
   );
 

--- a/web/src/app/craft/components/ModelPickerButton.tsx
+++ b/web/src/app/craft/components/ModelPickerButton.tsx
@@ -22,12 +22,12 @@ export default function ModelPickerButton({
   onChange,
   disabled = false,
 }: ModelPickerButtonProps) {
-  const { llmProviders } = useLLMProviders();
+  const { llmProviders, defaultText } = useLLMProviders();
   const { user } = useUser();
 
   const effective = useMemo(
-    () => selection ?? getPreferredLlmSelection(user?.id, llmProviders),
-    [selection, user?.id, llmProviders]
+    () => selection ?? getPreferredLlmSelection(user?.id, llmProviders, defaultText),
+    [selection, user?.id, llmProviders, defaultText]
   );
 
   const displayName = useMemo(() => {

--- a/web/src/app/craft/onboarding/__tests__/constants.test.ts
+++ b/web/src/app/craft/onboarding/__tests__/constants.test.ts
@@ -131,6 +131,47 @@ describe("getDefaultLlmSelection", () => {
     expect(getDefaultLlmSelection(undefined)).toBeNull();
   });
 
+  it("prefers the configured default over the recommended model", () => {
+    const result = getDefaultLlmSelection(
+      [
+        provider(
+          "anthropic",
+          [model("claude-opus-5", { craft: true }), model("claude-haiku-4-5")],
+          3
+        ),
+      ],
+      { provider_id: 3, model_name: "claude-haiku-4-5" }
+    );
+    expect(result).toEqual({
+      providerId: 3,
+      providerName: "anthropic",
+      provider: "anthropic",
+      modelName: "claude-haiku-4-5",
+    });
+  });
+
+  it("ignores a configured default that is not visible", () => {
+    const result = getDefaultLlmSelection(
+      [
+        provider(
+          "anthropic",
+          [
+            model("claude-opus-5", { craft: true }),
+            model("claude-haiku-4-5", { visible: false }),
+          ],
+          3
+        ),
+      ],
+      { provider_id: 3, model_name: "claude-haiku-4-5" }
+    );
+    expect(result).toEqual({
+      providerId: 3,
+      providerName: "anthropic",
+      provider: "anthropic",
+      modelName: "claude-opus-5",
+    });
+  });
+
   it("orders providers by codepoint like the backend, not locale rules", () => {
     // localeCompare puts "aäb" before "azb"; codepoint order ("z" < "ä") —
     // what Python's sorted() uses in _gateway_provider_order — is the reverse.

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -2,7 +2,7 @@
 // LLM Selection Types and Utilities
 // =============================================================================
 
-import { ModelConfiguration } from "@/lib/languageModels/types";
+import { DefaultModel, ModelConfiguration } from "@/lib/languageModels/types";
 import {
   readStorageItem,
   writeStorageItem,
@@ -88,9 +88,31 @@ export function hasSupportedCraftProvider(
 
 // Access control is enforced server-side at session create.
 export function getDefaultLlmSelection(
-  llmProviders: MinimalLlmProvider[] | undefined
+  llmProviders: MinimalLlmProvider[] | undefined,
+  configuredDefault?: DefaultModel | null
 ): BuildLlmSelection | null {
   if (!llmProviders) return null;
+
+  // The admin's configured default model (shared with chat) outranks the
+  // built-in recommendation — mirrors the backend's _select_gateway_default.
+  if (configuredDefault) {
+    const provider = llmProviders.find(
+      (candidate) => candidate.id === configuredDefault.provider_id
+    );
+    if (
+      provider?.model_configurations.some(
+        (model) =>
+          model.is_visible && model.name === configuredDefault.model_name
+      )
+    ) {
+      return {
+        providerId: provider.id,
+        providerName: provider.name ?? "",
+        provider: provider.provider,
+        modelName: configuredDefault.model_name,
+      };
+    }
+  }
 
   // Must match the backend's casefold-then-id ordering in
   // _gateway_provider_order; localeCompare would diverge.

--- a/web/src/app/craft/onboarding/constants.ts
+++ b/web/src/app/craft/onboarding/constants.ts
@@ -2,7 +2,7 @@
 // LLM Selection Types and Utilities
 // =============================================================================
 
-import { ModelConfiguration } from "@/lib/languageModels/types";
+import { DefaultModel, ModelConfiguration } from "@/lib/languageModels/types";
 
 export interface BuildLlmSelection {
   providerId: number;
@@ -63,9 +63,31 @@ export function hasSupportedCraftProvider(
 
 // Access control is enforced server-side at session create.
 export function getDefaultLlmSelection(
-  llmProviders: MinimalLlmProvider[] | undefined
+  llmProviders: MinimalLlmProvider[] | undefined,
+  configuredDefault?: DefaultModel | null
 ): BuildLlmSelection | null {
   if (!llmProviders) return null;
+
+  // The admin's configured default model (shared with chat) outranks the
+  // built-in recommendation — mirrors the backend's _select_gateway_default.
+  if (configuredDefault) {
+    const provider = llmProviders.find(
+      (candidate) => candidate.id === configuredDefault.provider_id
+    );
+    if (
+      provider?.model_configurations.some(
+        (model) =>
+          model.is_visible && model.name === configuredDefault.model_name
+      )
+    ) {
+      return {
+        providerId: provider.id,
+        providerName: provider.name ?? "",
+        provider: provider.provider,
+        modelName: configuredDefault.model_name,
+      };
+    }
+  }
 
   // Must match the backend's casefold-then-id ordering in
   // _gateway_provider_order; localeCompare would diverge.

--- a/web/src/app/craft/utils/llmPreferences.ts
+++ b/web/src/app/craft/utils/llmPreferences.ts
@@ -5,6 +5,7 @@ import {
   providerHasVisibleModel,
   toLlmSelection,
 } from "@/app/craft/onboarding/constants";
+import { DefaultModel } from "@/lib/languageModels/types";
 import {
   readStorageItem,
   writeStorageItem,
@@ -71,14 +72,15 @@ function getStoredLlmSelection(
   return match ? toLlmSelection(match, modelName) : null;
 }
 
-// The user's last pick when still available, else the recommended default.
+// The user's last pick when still available, else the workspace default.
 export function getPreferredLlmSelection(
   userId: string | undefined,
-  llmProviders: MinimalLlmProvider[] | undefined
+  llmProviders: MinimalLlmProvider[] | undefined,
+  configuredDefault?: DefaultModel | null
 ): BuildLlmSelection | null {
   if (!llmProviders) return null;
   return (
     (userId ? getStoredLlmSelection(userId, llmProviders) : null) ??
-    getDefaultLlmSelection(llmProviders)
+    getDefaultLlmSelection(llmProviders, configuredDefault)
   );
 }


### PR DESCRIPTION
## Description

Fixes #13499.

Craft resolved its default model from the built-in recommendation list (`recommended-models.json`), falling back to the alphabetically-first visible model. It never consulted the org's **configured default model** — the `LLMModelFlowType.CHAT` default an admin sets via `POST /admin/llm/default`, which regular chat already honors through `get_default_llm`. So an admin who had deliberately picked a default model still got Craft running on whatever the recommendation list named, with no way to steer it.

Concretely, on the current stable line an org that had not enabled `claude-opus-5` could still see Craft select it, because the pre-gateway `_recommended_model` returned the recommendation for the provider *type* without checking visibility at all. The visibility hole was already closed by the Onyx-gateway rework (#13249), which added an `in visible` guard. What remained — and what this PR fixes — is that admin intent was still ignored entirely.

**Resolution order is now:** the session's stored pick → the configured default → the built-in recommendation → first visible model.

The configured default is validated against the calling user's accessible + visible providers using the same matching logic as a stored pick (extracted into `_matching_visible_model`), so it can never select a model the admin has not enabled or a provider the user cannot access. `fetch_default_llm_model` is a global, unscoped read; re-validating it against `fetch_all_accessible_llm_providers` output is what keeps it safe.

Scope notes:

- Orgs with no configured default get byte-identical behavior to before.
- Existing sessions are unaffected: they already carry a stored `agent_provider`/`agent_model`, which still resolves first. The configured default applies to new sessions (and to sessions whose stored pick has since become inaccessible or hidden).
- All Craft entry points — interactive turns, session create, and scheduled tasks — share `SessionManager.build_llm_configs`, so they all pick this up.
- The Craft model picker mirrors the same order client-side, using the `default_text` that `useLLMProviders()` already returns, so the picker keeps showing the model a new session will actually use rather than disagreeing with the backend.

A dedicated "Default Craft model" setting — a new `LLMModelFlowType` plus admin UI — remains a possible follow-up. This PR intentionally reuses the existing shared chat default instead, since that needs no migration, no new endpoint, and no new admin surface, and it resolves the reported loss of admin control on its own.

## How Has This Been Tested?

Automated:

- New backend unit tests in `test_session_gateway_config.py`: the configured default wins over a competing recommendation, and a configured default whose model is not visible correctly falls through to the recommendation.
- New frontend unit tests in `constants.test.ts` covering the same two cases for the picker mirror.
- `uv run pytest backend/tests/unit/onyx/server/features/craft backend/tests/unit/onyx/server/gateway` — 697 passed.
- `bun run test src/app/craft` — 222 passed across 30 suites.
- `pre-commit run --files <changed>` — clean (ty, ruff, ruff format, oxfmt, oxlint, TypeScript type check).

Manually verified while tracing the change:

- `fetch_all_accessible_llm_providers` filters via `can_user_access_llm_provider`, and it builds views with `include_api_key=False`, so an out-of-reach configured default can neither be selected nor leak a key.
- Existing sessions keep their model, confirmed by tracing `session_llm_config` → `parse_agent_selection` → the stored-selection branch.

## Known minor items (left for the reviewer)

Surfaced by review, deliberately not changed here:

- The frontend test "ignores a configured default that is not visible" also passes against pre-change code, because the old single-argument signature simply dropped the second argument. It is kept because it still pins the visibility guard against a *future* regression (someone trusting `configuredDefault.model_name` without re-checking `is_visible`), which is the behavior worth protecting.
- `build_llm_configs` now issues one extra single-row query (`fetch_default_llm_model`) per call. It runs once per turn, never in a loop, and its result is always re-validated, so the added load is negligible.
- A legacy session row with both `agent_provider` and `agent_model` null would adopt the configured default on its next reconcile. That is a pre-existing nullable-column edge case rather than something this change introduces, and the new behavior is the better of the two outcomes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
