### PR TITLE
fix(opal): only default CopyButton tooltip when icon-only

### DIFF
--- a/web/lib/opal/src/components/buttons/copy-button/README.md
+++ b/web/lib/opal/src/components/buttons/copy-button/README.md
@@ -36,7 +36,7 @@ import { CopyButton } from "@opal/components";
 | `getCopyText` | `() => string` | — | **Required.** Returns the text written to the clipboard. |
 | `getHtmlContent` | `() => string` | `undefined` | Optional HTML content for rich copy. Falls back to `getCopyText` when the Clipboard API is unavailable. |
 | `children` | `string` | `undefined` | Optional label. When provided the button renders with text; when omitted it is icon-only. |
-| `tooltip` | `string` | `"Copy"` | Tooltip text shown in the idle state. Overridden by `"Copied!"` / `"Failed to copy"` on state change. |
+| `tooltip` | `string` | `"Copy"` (icon-only) / none (labeled) | Tooltip text shown on hover. Icon-only buttons default to `"Copy"`; labeled buttons show no tooltip unless one is passed explicitly. |
 | `prominence` | `ButtonProminence` | `"tertiary"` | Visual prominence level. |
 | `size` | `ContainerSizeVariants` | `"lg"` | Size preset. |
 

--- a/web/lib/opal/src/components/buttons/copy-button/components.tsx
+++ b/web/lib/opal/src/components/buttons/copy-button/components.tsx
@@ -42,7 +42,8 @@ export type CopyButtonProps = DistributiveOmit<
  * `SvgAlertTriangle` (error) — callers cannot override it.
  *
  * When `children` is provided, the button renders with a text label.
- * When omitted, it renders as an icon-only button.
+ * When omitted, it renders as an icon-only button with a default "Copy"
+ * tooltip (labeled buttons get no tooltip unless one is passed explicitly).
  */
 export function CopyButton({
   getCopyText,
@@ -109,7 +110,9 @@ export function CopyButton({
     children,
     icon: getIcon(),
     onClick: handleCopy,
-    tooltip: tooltip ?? "Copy",
+    // A labeled button already says what it does, so only icon-only buttons
+    // get the default tooltip.
+    tooltip: tooltip ?? (children === undefined ? "Copy" : undefined),
   } as ButtonProps;
 
   return <Button {...resolvedProps} />;


### PR DESCRIPTION
## Summary

`CopyButton` unconditionally defaulted its tooltip to `"Copy"`, so labeled buttons like the **Copy Token** button on the Settings page showed a redundant "Copy" tooltip on top of their own label.

- Only apply the default `"Copy"` tooltip when the button is icon-only (no `children`). Opal's `Tooltip` already passes children through untouched when `tooltip` is `undefined`, so labeled buttons now render with no tooltip wrapper at all.
- An explicit `tooltip` prop still works in both modes, so callers can opt back in.
- Updated the component JSDoc and README to match (the README also claimed the tooltip changes to "Copied!" / "Failed to copy" on state change, which the implementation doesn't do).

All existing callers either render icon-only (keep the default tooltip) or pass an explicit `tooltip`, so the only behavior change is the redundant tooltip disappearing from the Settings page's "Copy Token" button.

## Testing

- `pre-commit run --files ...` on the touched files: oxfmt and oxlint pass. The `TypeScript type check` hook fails, but identically on a clean tree (pre-existing repo-wide `ButtonProps` errors plus a stale `.next` types reference), so it's unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CopyButton now only defaults its tooltip to "Copy" when the button is icon-only. Labeled buttons show no tooltip unless one is passed; explicit tooltips still work, and docs were updated to match.

<sup>Written for commit df3f08dc567e10d05a73e46f8307c7327958bb36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13546?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

