### PR TITLE
fix(gateway): strip empty message text before it reaches LiteLLM

### DIFF
--- a/backend/onyx/server/gateway/api.py
+++ b/backend/onyx/server/gateway/api.py
@@ -23,7 +23,14 @@ from onyx.llm.model_response import (
     ModelResponseStream,
     Usage,
 )
-from onyx.llm.models import ChatCompletionMessage, ReasoningEffort, ToolChoiceOptions
+from onyx.llm.models import (
+    AssistantMessage,
+    ChatCompletionMessage,
+    ReasoningEffort,
+    TextContentPart,
+    ToolChoiceOptions,
+    UserMessage,
+)
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.llm.prompt_cache.processor import process_with_prompt_cache
 from onyx.llm.tracing_wrap import _finalize_tool_calls, _merge_tool_call_delta
@@ -107,6 +114,33 @@ def _parse_reasoning_effort(raw: str | None) -> ReasoningEffort:
         return ReasoningEffort.AUTO
 
 
+def _drop_empty_text(message: ChatCompletionMessage) -> ChatCompletionMessage | None:
+    """Remove empty/whitespace-only text from a message; returns None when the
+    whole message carries no information. Clients routinely send ``content: ""``
+    on assistant tool-call turns, which LiteLLM would rewrite into a visible
+    "[System: Empty message content sanitised ...]" placeholder for Anthropic."""
+    if isinstance(message, AssistantMessage):
+        if isinstance(message.content, str) and not message.content.strip():
+            message = message.model_copy(update={"content": None})
+        if message.content is None and not message.tool_calls:
+            return None
+        return message
+    if isinstance(message, UserMessage):
+        if isinstance(message.content, str):
+            return message if message.content.strip() else None
+        parts = [
+            part
+            for part in message.content
+            if not (isinstance(part, TextContentPart) and not part.text.strip())
+        ]
+        if not parts:
+            return None
+        if len(parts) != len(message.content):
+            message = message.model_copy(update={"content": parts})
+        return message
+    return message
+
+
 def _prepare_messages(
     llm: LLM, raw_messages: list[dict[str, Any]]
 ) -> list[ChatCompletionMessage]:
@@ -116,6 +150,9 @@ def _prepare_messages(
         raise OnyxError(
             OnyxErrorCode.INVALID_INPUT, f"Invalid messages: {e.error_count()} errors"
         ) from e
+    messages = [
+        message for message in map(_drop_empty_text, messages) if message is not None
+    ]
     if not messages:
         raise OnyxError(OnyxErrorCode.INVALID_INPUT, "messages must not be empty")
     cacheable_prefix = messages[:-1] or None

--- a/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
+++ b/backend/tests/unit/onyx/server/gateway/test_llm_gateway_api.py
@@ -28,12 +28,18 @@ from onyx.llm.model_response import (
     Usage,
 )
 from onyx.llm.models import (
+    AssistantMessage,
     ChatCompletionMessage,
+    ImageContentPart,
+    ImageUrlDetail,
     ReasoningEffort,
     SystemMessage,
+    TextContentPart,
+    ToolCall,
     ToolChoiceOptions,
     UserMessage,
 )
+from onyx.llm.models import FunctionCall as ToolFunctionCall
 from onyx.llm.multi_llm import LLMRateLimitError, LLMTimeoutError
 from onyx.server.auth_check import check_router_auth
 from onyx.server.features.build.craft_gateway import is_craft_gateway_request
@@ -348,6 +354,48 @@ def test_prepare_messages_uses_no_cacheable_prefix_for_single_message() -> None:
 
     assert process_prompt.call_args.kwargs["cacheable_prefix"] is None
     assert process_prompt.call_args.kwargs["suffix"] == messages
+
+
+def test_drop_empty_text() -> None:
+    tool_call = ToolCall(
+        id="call_1", function=ToolFunctionCall(name="bash", arguments="{}")
+    )
+    image_part = ImageContentPart(image_url=ImageUrlDetail(url="https://x/y.png"))
+    messages: list[ChatCompletionMessage] = [
+        SystemMessage(content="instructions"),
+        UserMessage(content="build me an app"),
+        AssistantMessage(content="", tool_calls=[tool_call]),
+        AssistantMessage(content="  "),
+        UserMessage(content=" "),
+        UserMessage(content=[TextContentPart(text=""), image_part]),
+    ]
+
+    result = [
+        message
+        for message in map(gateway_api._drop_empty_text, messages)
+        if message is not None
+    ]
+
+    assert result == [
+        SystemMessage(content="instructions"),
+        UserMessage(content="build me an app"),
+        AssistantMessage(content=None, tool_calls=[tool_call]),
+        UserMessage(content=[image_part]),
+    ]
+
+
+def test_prepare_messages_rejects_all_empty_messages() -> None:
+    llm = _ConfigOnlyLLM(
+        LLMConfig(
+            model_provider="anthropic",
+            model_name="claude-sonnet",
+            temperature=0,
+            max_input_tokens=200_000,
+        )
+    )
+    with pytest.raises(OnyxError) as exc_info:
+        gateway_api._prepare_messages(llm, [{"role": "user", "content": ""}])
+    assert exc_info.value.error_code == OnyxErrorCode.INVALID_INPUT
 
 
 def test_prepare_messages_rejects_invalid_messages() -> None:


### PR DESCRIPTION
## Description
<img width="788" height="227" alt="image" src="https://github.com/user-attachments/assets/effa1f60-1398-4996-aa25-02b772a7060e" />

Craft chats were showing the literal string `[System: Empty message content sanitised to satisfy protocol]` in assistant replies.

Root cause: OpenAI-compatible clients of the LLM gateway (opencode / AI SDK) send `content: ""` on every assistant tool-call turn. LiteLLM's Anthropic converter rewrites empty user/assistant text into that visible placeholder to satisfy Anthropic's non-empty-text requirement, so the model saw the placeholder at the start of each of its own prior turns and started parroting it into its visible output.

Fix: normalize messages in the gateway's `_prepare_messages` before they reach LiteLLM — empty assistant string content becomes `None` (converts cleanly to a tool-use-only message), fully empty user/assistant turns are dropped, and empty text parts are filtered out of multimodal user content. Internal message builders already uphold this invariant (`content=... or None`); the gateway is the one ingress for foreign-format histories.

## How Has This Been Tested?

- Reproduced the placeholder injection locally via LiteLLM's `anthropic_messages_pt` (`content: ""` + tool_calls → placeholder; `content: None` → clean tool-use-only message).
- New unit tests covering each normalization rule plus rejection of all-empty requests; full gateway unit suite passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize incoming chat messages in the gateway to strip empty text before it reaches `LiteLLM`, preventing the "[System: Empty message content sanitised …]" placeholder from showing up in assistant replies. This cleans tool-call turns and avoids polluted model output.

- **Bug Fixes**
  - Convert empty/whitespace assistant text to None so tool-call turns are tool-use-only.
  - Drop fully empty user/assistant messages.
  - Filter empty text parts from multimodal user content while keeping non-text parts.
  - Reject requests that collapse to no messages; added unit tests for all rules.

<sup>Written for commit 5fb72302b96f96fc004fd645191bb3553dc2a6e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13549?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

