### PR TITLE
fix(craft): add icon to main agent row in agent switcher

### DIFF
--- a/web/src/app/craft/components/AgentSwitcher.tsx
+++ b/web/src/app/craft/components/AgentSwitcher.tsx
@@ -5,6 +5,7 @@ import { Popover, PopoverMenu, Text, LineItemButton } from "@opal/components";
 import {
   SvgChevronDown,
   SvgCpu,
+  SvgSparkle,
   SvgCheckCircle,
   SvgAlertTriangle,
 } from "@opal/icons";
@@ -132,6 +133,7 @@ export default function AgentSwitcher() {
               key="main"
               sizePreset="main-ui"
               variant="section"
+              icon={SvgSparkle}
               state={!isViewingSubagent ? "selected" : "empty"}
               onClick={selectMainAgent}
               title={titleLabel ?? "Main agent"}


### PR DESCRIPTION
## Description

In the Craft agent-switcher dropdown (top-left when subagents exist), subagent rows show a chip icon but the main agent row had no icon. This adds a sparkle icon to the main agent row, matching the glyph Craft already uses for the agent elsewhere (build entry menu, tool cards).

## How Has This Been Tested?

- `pre-commit run --files web/src/app/craft/components/AgentSwitcher.tsx` (oxfmt, oxlint, TypeScript type check) passes.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a sparkle icon to the main agent row in the Craft agent switcher for visual consistency with subagent rows and the agent glyph used elsewhere.

<sup>Written for commit 883fcfd741203f3cc0c377ccec7a719a15a64de4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

