### PR TITLE
fix(craft): split aggregator providers by vendor in the model picker

### DIFF
--- a/web/src/app/craft/components/BuildLLMPopover.test.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.test.tsx
@@ -106,7 +106,6 @@ describe("BuildLLMPopover aggregator vendors", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Choose model" }));
 
-    // Groups are sorted by display name, so Meta precedes OpenAI precedes ZAI.
     expect(
       screen.getAllByText(/^Amazon Bedrock\//).map((label) => label.textContent)
     ).toEqual([
@@ -122,7 +121,6 @@ describe("BuildLLMPopover aggregator vendors", () => {
     expect(screen.getByText("Llama 3 70B")).toBeInTheDocument();
     expect(screen.queryByText("GLM 4.6")).not.toBeInTheDocument();
 
-    // The vendor split is display-only: the emitted selection stays per-model.
     fireEvent.click(screen.getByRole("button", { name: /Llama 3 70B/ }));
     expect(onSelectionChange).toHaveBeenCalledWith({
       providerId: 21,

--- a/web/src/app/craft/components/BuildLLMPopover.test.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.test.tsx
@@ -14,7 +14,8 @@ Element.prototype.scrollIntoView = jest.fn();
 function model(
   name: string,
   displayName: string,
-  recommended = false
+  recommended = false,
+  vendor?: string
 ): ModelConfiguration {
   return {
     name,
@@ -25,6 +26,7 @@ function model(
     max_input_tokens: null,
     supports_image_input: false,
     supports_reasoning: true,
+    vendor,
   };
 }
 
@@ -72,5 +74,142 @@ describe("BuildLLMPopover recommended models", () => {
     expect(screen.getByText("GPT-5.6 Sol")).toBeInTheDocument();
     expect(screen.getByText("GPT-5.5")).toBeInTheDocument();
     expect(screen.queryByText("GPT-5 Mini")).not.toBeInTheDocument();
+  });
+});
+
+describe("BuildLLMPopover aggregator vendors", () => {
+  const bedrock: LLMProviderDescriptor[] = [
+    {
+      id: 21,
+      name: null,
+      provider: "bedrock",
+      provider_display_name: "Amazon Bedrock",
+      model_configurations: [
+        model("openai.gpt-oss-120b", "GPT OSS 120B", true, "OpenAI"),
+        model("meta.llama3-70b", "Llama 3 70B", true, "Meta"),
+        model("zai.glm-4.6", "GLM 4.6", true, "ZAI"),
+      ],
+    },
+  ];
+
+  it("splits a Bedrock provider into one group per hosted vendor", () => {
+    const onSelectionChange = jest.fn();
+    render(
+      <BuildLLMPopover
+        currentSelection={null}
+        onSelectionChange={onSelectionChange}
+        llmProviders={bedrock}
+      >
+        <button>Choose model</button>
+      </BuildLLMPopover>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model" }));
+
+    // Groups are sorted by display name, so Meta precedes OpenAI precedes ZAI.
+    expect(
+      screen.getAllByText(/^Amazon Bedrock\//).map((label) => label.textContent)
+    ).toEqual([
+      "Amazon Bedrock/Meta",
+      "Amazon Bedrock/OpenAI",
+      "Amazon Bedrock/ZAI",
+    ]);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Amazon Bedrock\/Meta/ })
+    );
+
+    expect(screen.getByText("Llama 3 70B")).toBeInTheDocument();
+    expect(screen.queryByText("GLM 4.6")).not.toBeInTheDocument();
+
+    // The vendor split is display-only: the emitted selection stays per-model.
+    fireEvent.click(screen.getByRole("button", { name: /Llama 3 70B/ }));
+    expect(onSelectionChange).toHaveBeenCalledWith({
+      providerId: 21,
+      providerName: "",
+      provider: "bedrock",
+      modelName: "meta.llama3-70b",
+    });
+  });
+
+  it("keeps vendorless aggregator models under the plain provider group", () => {
+    const mixed: LLMProviderDescriptor[] = [
+      {
+        id: 22,
+        name: null,
+        provider: "bedrock",
+        provider_display_name: "Amazon Bedrock",
+        model_configurations: [
+          model("meta.llama3-70b", "Llama 3 70B", true, "Meta"),
+          model("custom-imported-model", "Custom Imported", true),
+        ],
+      },
+    ];
+
+    render(
+      <BuildLLMPopover
+        currentSelection={null}
+        onSelectionChange={jest.fn()}
+        llmProviders={mixed}
+      >
+        <button>Choose model</button>
+      </BuildLLMPopover>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model" }));
+
+    expect(screen.getByText("Amazon Bedrock/Meta")).toBeInTheDocument();
+    expect(screen.getByText("Amazon Bedrock")).toBeInTheDocument();
+  });
+
+  it("does not split a non-aggregator provider that reports a vendor", () => {
+    const anthropic: LLMProviderDescriptor[] = [
+      {
+        id: 23,
+        name: null,
+        provider: "anthropic",
+        provider_display_name: "Anthropic",
+        model_configurations: [
+          model("claude-opus-4-7", "Claude Opus 4.7", true, "Anthropic"),
+        ],
+      },
+    ];
+
+    render(
+      <BuildLLMPopover
+        currentSelection={null}
+        onSelectionChange={jest.fn()}
+        llmProviders={anthropic}
+      >
+        <button>Choose model</button>
+      </BuildLLMPopover>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model" }));
+
+    expect(screen.getByText("Anthropic")).toBeInTheDocument();
+    expect(screen.queryByText("Anthropic/Anthropic")).not.toBeInTheDocument();
+  });
+
+  it("auto-expands the vendor group holding the current selection", () => {
+    render(
+      <BuildLLMPopover
+        currentSelection={{
+          providerId: 21,
+          providerName: "",
+          provider: "bedrock",
+          modelName: "zai.glm-4.6",
+        }}
+        onSelectionChange={jest.fn()}
+        llmProviders={bedrock}
+      >
+        <button>Choose model</button>
+      </BuildLLMPopover>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Choose model" }));
+
+    expect(screen.getByText("GLM 4.6")).toBeInTheDocument();
+    expect(screen.queryByText("Llama 3 70B")).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -46,9 +46,8 @@ function modelDisplayName(model: ModelConfiguration): string {
   return model.effectiveDisplayName || model.display_name || model.name;
 }
 
-// Mirrors the main app's `groupLlmOptions`: aggregator providers (Bedrock,
-// OpenRouter, ...) get one group per hosted vendor. Keyed by provider id rather
-// than name so two providers sharing a display name stay distinct.
+// Keyed by provider id, unlike the main app's `groupLlmOptions`, so two
+// providers sharing a display name stay distinct.
 function craftGroupKey(
   providerId: number,
   providerKey: string,
@@ -88,7 +87,6 @@ export function BuildLLMPopover({
           providerKey: provider.provider,
           groupKey,
           providerName: provider.name ?? "",
-          // vendor arrives display-cased from the backend (e.g. "OpenAI", "xAI")
           groupDisplayName:
             groupKey === String(provider.id)
               ? providerDisplayName
@@ -148,8 +146,8 @@ export function BuildLLMPopover({
       provider?.model_configurations.find(
         (model) => model.name === currentSelection.modelName
       )?.vendor || null;
-    // Prefer the live provider slug so this key is derived from the same source
-    // as the group keys above; a persisted selection can carry a stale one.
+    // Must use the same slug source as the group keys above; a persisted
+    // selection can carry a stale one.
     return craftGroupKey(
       currentSelection.providerId,
       provider?.provider ?? currentSelection.provider,

--- a/web/src/app/craft/components/BuildLLMPopover.tsx
+++ b/web/src/app/craft/components/BuildLLMPopover.tsx
@@ -14,6 +14,7 @@ import {
   isCraftRecommendedModel,
 } from "@/app/craft/onboarding/constants";
 import { getModelIcon } from "@/lib/languageModels";
+import { AGGREGATOR_PROVIDERS } from "@/lib/languageModels/svc";
 import { Section } from "@/layouts/general-layouts";
 import {
   Accordion,
@@ -35,7 +36,7 @@ interface ModelOption {
   providerKey: string;
   groupKey: string;
   providerName: string;
-  providerDisplayName: string;
+  groupDisplayName: string;
   modelName: string;
   displayName: string;
   isRecommended: boolean;
@@ -43,6 +44,19 @@ interface ModelOption {
 
 function modelDisplayName(model: ModelConfiguration): string {
   return model.effectiveDisplayName || model.display_name || model.name;
+}
+
+// Mirrors the main app's `groupLlmOptions`: aggregator providers (Bedrock,
+// OpenRouter, ...) get one group per hosted vendor. Keyed by provider id rather
+// than name so two providers sharing a display name stay distinct.
+function craftGroupKey(
+  providerId: number,
+  providerKey: string,
+  vendor: string | null
+): string {
+  return AGGREGATOR_PROVIDERS.has(providerKey.toLowerCase()) && vendor
+    ? `${providerId}/${vendor.toLowerCase()}`
+    : String(providerId);
 }
 
 export function BuildLLMPopover({
@@ -65,13 +79,20 @@ export function BuildLLMPopover({
       const models = showRecommendedOnly
         ? provider.model_configurations.filter(isCraftRecommendedModel)
         : provider.model_configurations.filter((model) => model.is_visible);
+      const providerDisplayName = craftProviderDisplayName(provider);
       models.forEach((model) => {
+        const vendor = model.vendor || null;
+        const groupKey = craftGroupKey(provider.id, provider.provider, vendor);
         options.push({
           providerId: provider.id,
           providerKey: provider.provider,
-          groupKey: String(provider.id),
+          groupKey,
           providerName: provider.name ?? "",
-          providerDisplayName: craftProviderDisplayName(provider),
+          // vendor arrives display-cased from the backend (e.g. "OpenAI", "xAI")
+          groupDisplayName:
+            groupKey === String(provider.id)
+              ? providerDisplayName
+              : `${providerDisplayName}/${vendor}`,
           modelName: model.name,
           displayName: modelDisplayName(model),
           isRecommended: isCraftRecommendedModel(model),
@@ -101,7 +122,7 @@ export function BuildLLMPopover({
         groups.set(groupKey, {
           groupKey,
           providerKey: option.providerKey,
-          displayName: option.providerDisplayName,
+          displayName: option.groupDisplayName,
           options: [],
         });
       }
@@ -120,8 +141,21 @@ export function BuildLLMPopover({
   // Determine current group for auto-expand
   const currentGroupKey = useMemo(() => {
     if (!currentSelection) return "";
-    return String(currentSelection.providerId);
-  }, [currentSelection]);
+    const provider = llmProviders?.find(
+      (candidate) => candidate.id === currentSelection.providerId
+    );
+    const vendor =
+      provider?.model_configurations.find(
+        (model) => model.name === currentSelection.modelName
+      )?.vendor || null;
+    // Prefer the live provider slug so this key is derived from the same source
+    // as the group keys above; a persisted selection can carry a stale one.
+    return craftGroupKey(
+      currentSelection.providerId,
+      provider?.provider ?? currentSelection.provider,
+      vendor
+    );
+  }, [currentSelection, llmProviders]);
 
   // Track expanded groups
   const [expandedGroups, setExpandedGroups] = useState<string[]>([


### PR DESCRIPTION
## Description

The Craft model picker grouped models by provider row alone (`groupKey: String(provider.id)`), so a single **Amazon Bedrock** accordion held every hosted vendor's models mixed together. The main chat picker already splits these into separate groups — `Amazon Bedrock/OpenAI`, `Amazon Bedrock/Meta`, `Amazon Bedrock/ZAI` — via `groupLlmOptions` in `web/src/lib/languageModels/options.ts`.

The backend already ships a `vendor` on each model configuration (derived from the model name in `extract_vendor_from_model_name`), and both pickers read the same `/api/llm/provider` payload. Craft was simply ignoring the field. This mirrors the main app's rule in `BuildLLMPopover.tsx`:

- New `craftGroupKey(providerId, providerKey, vendor)` appends `/<vendor>` for providers in `AGGREGATOR_PROVIDERS` — imported from `@/lib/languageModels/svc`, the same set `groupLlmOptions` uses (there is a second, divergent copy in `index.ts` used only for icon resolution).
- Group labels become `<provider>/<vendor>`, matching the main app's format. The existing alphabetical sort now orders the vendor groups.
- `currentGroupKey` (accordion auto-expand) resolves the selected model's vendor through the same helper, so opening the picker still expands the group holding your selection. Without this the vendor-suffixed key would never match and the selected group would stop expanding.
- Keyed by provider **id** rather than the main app's display-name keying, so two providers sharing a display name stay distinct.
- Dropped the now-unused `ModelOption.providerDisplayName` (file-local interface, no external callers).

Two deliberate parity choices: group header icons stay `getModelIcon(providerKey)` (AWS for every Bedrock group) — the main app does the same at `options.ts:175`; row icons still resolve per-vendor, so rows inside show Claude/GPT/etc.

Display-only change: `applySelection` still emits `{providerId, providerName, provider, modelName}` untouched, so server-side access control and persisted `agent_provider`/`agent_model` resolution are unaffected.

## How Has This Been Tested?

- Added 4 cases to `web/src/app/craft/components/BuildLLMPopover.test.tsx` (5 total, all passing): vendor split renders one group per vendor **in sorted order**; selecting a model from a vendor group emits the unchanged per-model payload; vendorless aggregator models stay under the plain provider group; a non-aggregator provider reporting a vendor does **not** split; auto-expand lands on the selected model's vendor group.
- Both original tests were verified non-vacuous by mutation testing — disabling `craftGroupKey` fails the split test, and reverting `currentGroupKey` fails only the auto-expand test.
- `bun run jest src/app/craft src/lib/languageModels src/refresh-components/popovers` → 32 suites, 230 tests passing.
- `oxfmt --check`, `oxlint`, and `bun run types:check` all clean; full pre-commit hook run passed.
- Reviewed by four parallel agents (correctness, regressions, tests, security): no critical or high findings.

## Known minor items

- `vendor` is not trimmed before keying, so hypothetical whitespace variants (`"OpenAI"` vs `" OpenAI"`) would form separate groups. `vendor` is a backend-derived enum-like value, not user input.
- When models in one vendor group disagree on `vendor` casing, the group label takes the casing of the first model encountered. Inherited from the reference `groupLlmOptions` (`options.ts:166-168`), not introduced here.
- An aggregator provider with a mix of vendored and vendorless models renders as N+1 groups (one per vendor, plus a plain provider group). This matches main-app behavior and is now covered by a test.
- Recommended-only mode is on by default and `is_recommended_default` is set per provider type, so a Bedrock provider usually surfaces a single recommended model — the split is mostly visible with the toggle off. Unchanged by this PR.
- Pre-existing and out of scope: the two divergent `AGGREGATOR_PROVIDERS` sets (`svc.ts` drives grouping, `index.ts` drives icons and additionally lists nebius/portkey), and a latent `extract_vendor_from_model_name` edge case where a two-part model name whose first segment is a region yields vendor `"Us"`.

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check

Override ticked because this change came from an ad-hoc request with no Linear ticket; link one if you would rather track it there.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split aggregator providers (e.g., Amazon Bedrock) by vendor in the Craft model picker so models appear under <provider>/<vendor> groups (e.g., Amazon Bedrock/OpenAI), matching the main app. Display-only change; the selection payload and backend behavior are unchanged.

- **Bug Fixes**
  - Aggregators keyed by provider id + vendor; labels `<provider>/<vendor>`.
  - Auto-expand opens the selected vendor group.
  - Non-aggregators don’t split; vendorless models stay under the provider group.
  - Tests cover split, sort, payload, non-aggregators, vendorless, and auto-expand.

- **Refactors**
  - Trimmed narration comments; no behavior change.

<sup>Written for commit 413704e68713903e02ddfb1c83dad3e663aa99b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/onyx-dot-app/onyx/pull/13552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

