### PR TITLE
fix(auth): route tenants by IdP subject and keep access across an email change

### DIFF
--- a/backend/alembic/versions/4662f8c3e038_add_prior_emails_to_user.py
+++ b/backend/alembic/versions/4662f8c3e038_add_prior_emails_to_user.py
@@ -1,0 +1,34 @@
+"""add prior emails to user
+
+Revision ID: 4662f8c3e038
+Revises: f57f35403f6c
+Create Date: 2026-07-28 22:17:13.333593
+
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "4662f8c3e038"
+down_revision = "f57f35403f6c"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user",
+        sa.Column(
+            "prior_emails",
+            postgresql.ARRAY(sa.String()),
+            nullable=False,
+            server_default="{}",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user", "prior_emails")

--- a/backend/alembic_tenants/versions/d4be69bf7b54_add_oauth_identity_to_user_tenant_.py
+++ b/backend/alembic_tenants/versions/d4be69bf7b54_add_oauth_identity_to_user_tenant_.py
@@ -1,0 +1,51 @@
+"""add oauth identity to user tenant mapping
+
+Revision ID: d4be69bf7b54
+Revises: b1c4e9d72f38
+Create Date: 2026-07-28 21:50:27.740918
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d4be69bf7b54"
+down_revision = "b1c4e9d72f38"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Widths mirror the `oauth_account` columns these values are copied from.
+    op.add_column(
+        "user_tenant_mapping",
+        sa.Column("oauth_name", sa.String(length=100), nullable=True),
+        schema="public",
+    )
+    op.add_column(
+        "user_tenant_mapping",
+        sa.Column("account_id", sa.String(length=320), nullable=True),
+        schema="public",
+    )
+
+    # Not unique: one identity holds a row per tenant it belongs to.
+    # Partial so it covers only stamped rows.
+    op.create_index(
+        "ix_user_tenant_mapping_oauth_identity",
+        "user_tenant_mapping",
+        ["oauth_name", "account_id"],
+        schema="public",
+        postgresql_where=sa.text("oauth_name IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_user_tenant_mapping_oauth_identity",
+        table_name="user_tenant_mapping",
+        schema="public",
+    )
+    op.drop_column("user_tenant_mapping", "account_id", schema="public")
+    op.drop_column("user_tenant_mapping", "oauth_name", schema="public")

--- a/backend/ee/onyx/server/tenants/provisioning.py
+++ b/backend/ee/onyx/server/tenants/provisioning.py
@@ -22,10 +22,9 @@ from ee.onyx.server.tenants.schema_management import (
 )
 from ee.onyx.server.tenants.user_mapping import (
     add_users_to_tenant,
-    get_tenant_id_for_email,
+    resolve_tenant_id,
     user_owns_a_tenant,
 )
-from onyx.auth.users import exceptions
 from onyx.configs.app_configs import (
     ANTHROPIC_DEFAULT_API_KEY,
     AUTO_PROVISION_DEFAULT_LLM_PROVIDERS,
@@ -90,11 +89,16 @@ async def get_or_provision_tenant(
     email: str,
     referral_source: str | None = None,
     request: Request | None = None,
+    oauth_name: str | None = None,
+    account_id: str | None = None,
 ) -> str:
     """
     Get existing tenant ID for an email or create a new tenant if none exists.
     This function should only be called after we have verified we want this user's tenant to exist.
     It returns the tenant ID associated with the email, creating a new tenant if necessary.
+
+    When the caller knows the IdP subject it is tried before the email, which is
+    what stops a renamed user being treated as a brand new signup.
     """
     # Early return for non-multi-tenant mode
     if not MULTI_TENANT:
@@ -103,14 +107,9 @@ async def get_or_provision_tenant(
     if referral_source and request:
         await submit_to_hubspot(email, referral_source, request)
 
-    # First, check if the user already has a tenant
-    tenant_id: str | None = None
-    try:
-        tenant_id = get_tenant_id_for_email(email)
+    tenant_id = resolve_tenant_id(email, oauth_name, account_id)
+    if tenant_id:
         return tenant_id
-    except exceptions.UserNotExists:
-        # User doesn't exist, so we need to create a new tenant or assign an existing one
-        pass
 
     try:
         # Try to get a pre-provisioned tenant

--- a/backend/ee/onyx/server/tenants/user_mapping.py
+++ b/backend/ee/onyx/server/tenants/user_mapping.py
@@ -23,40 +23,80 @@ logger = setup_logger()
 def get_tenant_id_for_email(email: str) -> str:
     if not MULTI_TENANT:
         return POSTGRES_DEFAULT_SCHEMA
-    # Implement logic to get tenant_id from the mapping table
-    try:
-        with get_session_with_shared_schema() as db_session:
-            # First try to get an active tenant
+
+    with get_session_with_shared_schema() as db_session:
+        # First try to get an active tenant
+        result = db_session.execute(
+            select(UserTenantMapping).where(
+                UserTenantMapping.email == email,
+                UserTenantMapping.active == True,  # noqa: E712
+            )
+        )
+        mapping = result.scalar_one_or_none()
+        tenant_id = mapping.tenant_id if mapping else None
+
+        # If no active tenant found, try to get the first inactive one
+        if tenant_id is None:
             result = db_session.execute(
                 select(UserTenantMapping).where(
                     UserTenantMapping.email == email,
-                    UserTenantMapping.active == True,  # noqa: E712
+                    UserTenantMapping.active == False,  # noqa: E712
                 )
             )
-            mapping = result.scalar_one_or_none()
-            tenant_id = mapping.tenant_id if mapping else None
-
-            # If no active tenant found, try to get the first inactive one
-            if tenant_id is None:
-                result = db_session.execute(
-                    select(UserTenantMapping).where(
-                        UserTenantMapping.email == email,
-                        UserTenantMapping.active == False,  # noqa: E712
-                    )
-                )
-                mapping = result.scalar_one_or_none()
-                if mapping:
-                    # Mark this mapping as active
-                    mapping.active = True
-                    db_session.commit()
-                    tenant_id = mapping.tenant_id
-    except Exception as e:
-        logger.exception("Error getting tenant id for email %s: %s", email, e)
-        raise exceptions.UserNotExists()
+            mapping = result.scalars().first()
+            if mapping:
+                # Mark this mapping as active
+                mapping.active = True
+                db_session.commit()
+                tenant_id = mapping.tenant_id
 
     if tenant_id is None:
         raise exceptions.UserNotExists()
     return tenant_id
+
+
+def resolve_tenant_id(
+    email: str, oauth_name: str | None = None, account_id: str | None = None
+) -> str | None:
+    """Tenant this login belongs to, or None when it maps nowhere.
+
+    Subject before email: only the subject survives an address change at the
+    provider. Email remains the fallback for password logins and for rows with
+    no subject stamped.
+    """
+    if oauth_name and account_id:
+        tenant_id = get_tenant_id_for_oauth_account(oauth_name, account_id)
+        if tenant_id:
+            return tenant_id
+
+    try:
+        return get_tenant_id_for_email(email)
+    except exceptions.UserNotExists:
+        return None
+
+
+def get_tenant_id_for_oauth_account(oauth_name: str, account_id: str) -> str | None:
+    """Tenant for an IdP subject, or None when it maps nowhere.
+
+    Returns the default schema outside multi-tenant, matching its siblings.
+    """
+    if not MULTI_TENANT:
+        return POSTGRES_DEFAULT_SCHEMA
+
+    with get_session_with_shared_schema() as db_session:
+        mapping = (
+            db_session.execute(
+                select(UserTenantMapping).where(
+                    UserTenantMapping.oauth_name == oauth_name,
+                    UserTenantMapping.account_id == account_id,
+                    UserTenantMapping.active == True,  # noqa: E712
+                )
+            )
+            .scalars()
+            .first()
+        )
+
+    return mapping.tenant_id if mapping else None
 
 
 def user_owns_a_tenant(email: str) -> bool:
@@ -67,6 +107,59 @@ def user_owns_a_tenant(email: str) -> bool:
             .first()
         )
         return result is not None
+
+
+def record_oauth_identity(
+    email: str, tenant_id: str, oauth_name: str, account_id: str
+) -> None:
+    """Stamp the IdP subject onto this user's mapping row so resolution survives
+    an address change at the provider.
+
+    Holds one provider at a time, so resolution still falls back to email for
+    whichever one is not stamped.
+
+    No-op outside multi-tenant, where the mapping table is not provisioned.
+    """
+    if not MULTI_TENANT:
+        return
+
+    with get_session_with_shared_schema() as db_session:
+        db_session.query(UserTenantMapping).filter(
+            UserTenantMapping.email == email.lower(),
+            UserTenantMapping.tenant_id == tenant_id,
+        ).update({"oauth_name": oauth_name, "account_id": account_id})
+        db_session.commit()
+
+
+def rekey_user_mapping_email(old_email: str, new_email: str, tenant_id: str) -> None:
+    """Move this tenant's membership row onto the user's new address.
+
+    Otherwise the row keeps routing the old address and leaves the new one
+    unmapped, which is the state that provisions a second tenant.
+
+    Lowercases explicitly: a bulk update bypasses the column's `@validates`
+    hook, and every read of this table assumes lowercase.
+
+    No-op outside multi-tenant, where the mapping table is not provisioned.
+    """
+    if not MULTI_TENANT:
+        return
+
+    with get_session_with_shared_schema() as db_session:
+        updated = (
+            db_session.query(UserTenantMapping)
+            .filter(
+                UserTenantMapping.email == old_email.lower(),
+                UserTenantMapping.tenant_id == tenant_id,
+            )
+            .update({"email": new_email.lower()})
+        )
+        db_session.commit()
+
+    if not updated:
+        logger.warning(
+            "No mapping row to rekey for %s in tenant %s", old_email, tenant_id
+        )
 
 
 def add_users_to_tenant(emails: list[str], tenant_id: str) -> None:

--- a/backend/onyx/access/access.py
+++ b/backend/onyx/access/access.py
@@ -121,10 +121,16 @@ def _get_acl_for_user(
     matches one entry in the returned set.
 
     Anonymous users only have access to public documents.
+
+    Prior addresses are included because indexed documents still carry whichever
+    address permission sync last wrote. Entries are live grants, see
+    `User.prior_emails`.
     """
     if user.is_anonymous:
         return {PUBLIC_DOC_PAT}
-    return {prefix_user_email(user.email), PUBLIC_DOC_PAT}
+
+    emails = [user.email, *user.prior_emails]
+    return {prefix_user_email(email) for email in emails} | {PUBLIC_DOC_PAT}
 
 
 def get_acl_for_user(user: User, db_session: Session | None = None) -> set[str]:

--- a/backend/onyx/auth/users.py
+++ b/backend/onyx/auth/users.py
@@ -108,12 +108,16 @@ from onyx.configs.constants import (
     ANONYMOUS_USER_COOKIE_NAME,
     ANONYMOUS_USER_EMAIL,
     ANONYMOUS_USER_UUID,
+    CELERY_DOCUMENT_SYNC_TASK_EXPIRES,
     DANSWER_API_KEY_DUMMY_EMAIL_DOMAIN,
     DANSWER_API_KEY_PREFIX,
     FASTAPI_USERS_AUTH_COOKIE_NAME,
     PASSWORD_SPECIAL_CHARS,
     UNNAMED_KEY_PLACEHOLDER,
     MilestoneRecordType,
+    OnyxCeleryPriority,
+    OnyxCeleryQueues,
+    OnyxCeleryTask,
     OnyxRedisLocks,
 )
 from onyx.db.api_key import fetch_user_for_api_key
@@ -137,7 +141,9 @@ from onyx.db.models import AccessToken, OAuthAccount, Persona, User
 from onyx.db.pat import resolve_pat
 from onyx.db.users import (
     assign_user_to_default_groups__no_commit,
+    build_email_reconcile_update,
     get_user_by_email,
+    get_user_by_oauth_account,
     is_limited_user,
 )
 from onyx.error_handling.error_codes import OnyxErrorCode
@@ -333,9 +339,44 @@ def verify_email_is_invited(email: str) -> None:
     )
 
 
-def verify_email_in_whitelist(email: str, tenant_id: str) -> None:
+def repair_user_email_acls(
+    user_id: uuid.UUID, old_email: str, new_email: str, tenant_id: str
+) -> None:
+    """Queue the indexed-ACL rewrite for a user who just changed address.
+
+    Deliberately not awaited on the login path: `User.prior_emails` already
+    keeps their access intact, so this only needs to land eventually.
+    """
+    from onyx.background.celery.versioned_apps.client import app as client_app
+
+    client_app.send_task(
+        OnyxCeleryTask.REPAIR_USER_EMAIL_ACLS_TASK,
+        kwargs=dict(
+            user_id=str(user_id),
+            old_email=old_email,
+            new_email=new_email,
+            tenant_id=tenant_id,
+        ),
+        queue=OnyxCeleryQueues.VESPA_METADATA_SYNC,
+        priority=OnyxCeleryPriority.MEDIUM,
+        expires=CELERY_DOCUMENT_SYNC_TASK_EXPIRES,
+        ignore_result=True,
+    )
+
+
+def verify_email_in_whitelist(
+    email: str,
+    tenant_id: str,
+    oauth_name: str | None = None,
+    account_id: str | None = None,
+) -> None:
     with get_session_with_tenant(tenant_id=tenant_id) as db_session:
         user = get_user_by_email(email, db_session)
+        if user is None and oauth_name and account_id:
+            # A linked OAuth account is proof of membership. The address may
+            # have changed at the provider since they joined.
+            user = get_user_by_oauth_account(oauth_name, account_id, db_session)
+
         # A permission-sync placeholder is not a member: appearing in a
         # connector's ACLs must not satisfy invite-only, so the invite check
         # applies until the person actually joins.
@@ -901,6 +942,8 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
             email=account_email,
             referral_source=referral_source,
             request=request,
+            oauth_name=oauth_name,
+            account_id=account_id,
         )
 
         if not tenant_id:
@@ -911,7 +954,7 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         async with get_async_session_context_manager(tenant_id) as db_session:
             token = CURRENT_TENANT_ID_CONTEXTVAR.set(tenant_id)
 
-            verify_email_in_whitelist(account_email, tenant_id)
+            verify_email_in_whitelist(account_email, tenant_id, oauth_name, account_id)
             oauth_security_settings = get_security_settings()
             effective_valid_email_domains = (
                 allowed_email_domains_override
@@ -1008,6 +1051,29 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
                                 existing_oauth_account,  # ty: ignore[invalid-argument-type]
                                 oauth_account_dict,
                             )
+
+            # Keyed on the stored email rather than the one the IdP just sent:
+            # that is the address this user's membership row is filed under.
+            fetch_ee_implementation_or_noop(
+                "onyx.server.tenants.user_mapping", "record_oauth_identity", None
+            )(user.email, tenant_id, oauth_name, account_id)
+
+            # The provider is authoritative for the address, so adopt it when it
+            # has moved. Runs in every deployment: single-tenant reaches the
+            # right user by subject and so hits this with a stale email too.
+            email_update = build_email_reconcile_update(user, account_email)
+            if email_update:
+                replaced_email = user.email
+                user = await self.user_db.update(user, update_dict=email_update)
+                fetch_ee_implementation_or_noop(
+                    "onyx.server.tenants.user_mapping", "rekey_user_mapping_email", None
+                )(replaced_email, account_email, tenant_id)
+                repair_user_email_acls(
+                    user_id=user.id,
+                    old_email=replaced_email,
+                    new_email=account_email,
+                    tenant_id=tenant_id,
+                )
 
             # NOTE: Most IdPs have very short expiry times, and we don't want to force the user to
             # re-authenticate that frequently, so by default this is disabled
@@ -2432,12 +2498,11 @@ async def complete_login_flow(
 
     next_url = sanitize_next_url(state_data.get("next_url"))
     referral_source = state_data.get("referral_source", None)
-    try:
-        tenant_id = fetch_ee_implementation_or_noop(
-            "onyx.server.tenants.user_mapping", "get_tenant_id_for_email", None
-        )(account_email)
-    except exceptions.UserNotExists:
-        tenant_id = None
+    # Drives the new_team redirect below, so it shares oauth_callback's resolver
+    # rather than restating the order. Disagreeing greets a returning user as new.
+    tenant_id = fetch_ee_implementation_or_noop(
+        "onyx.server.tenants.user_mapping", "resolve_tenant_id", None
+    )(account_email, oauth_client.name, account_id)
 
     request.state.referral_source = referral_source
 

--- a/backend/onyx/background/celery/tasks/vespa/tasks.py
+++ b/backend/onyx/background/celery/tasks/vespa/tasks.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 from datetime import datetime
 from http import HTTPStatus
 from typing import Any, cast
+from uuid import UUID
 
 import httpx
 from celery import Celery, Task, shared_task
@@ -35,9 +36,11 @@ from onyx.configs.constants import (
 )
 from onyx.db.document import (
     document_has_indexable_cc_pair,
+    documents_pending_sync,
     get_document,
     mark_document_as_synced,
     mark_document_synced_secondary_pending,
+    swap_document_acl_email,
 )
 from onyx.db.document_set import (
     delete_document_set,
@@ -56,6 +59,7 @@ from onyx.db.sync_record import (
     insert_sync_record,
     update_sync_record_status,
 )
+from onyx.db.users import expire_prior_emails
 from onyx.document_index.factory import get_all_document_indices
 from onyx.document_index.interfaces_new import (
     MetadataUpdateRequest,
@@ -638,3 +642,44 @@ def document_index_metadata_sync_task(
         )
 
     return completion_status == OnyxCeleryTaskCompletionStatus.SUCCEEDED
+
+
+@shared_task(
+    name=OnyxCeleryTask.REPAIR_USER_EMAIL_ACLS_TASK,
+    ignore_result=True,
+    soft_time_limit=LIGHT_SOFT_TIME_LIMIT,
+    time_limit=LIGHT_TIME_LIMIT,
+    max_retries=10,
+    bind=True,
+)
+def repair_user_email_acls_task(
+    self: Task,
+    *,
+    user_id: str,
+    old_email: str,
+    new_email: str,
+    tenant_id: str,
+) -> int:
+    """Move one user's ACLs onto their new address, then drop the bridge.
+
+    Rewriting Postgres only bumps `last_modified`; the metadata sync sweep is
+    what carries the change into the index. Until that lands the index still
+    matches on the old address, so the `User.prior_emails` grant has to outlive
+    it - hence the retry rather than expiring inline.
+    """
+    with get_session_with_current_tenant() as db_session:
+        document_ids = swap_document_acl_email(old_email, new_email, db_session)
+        pending = documents_pending_sync(document_ids, db_session)
+
+    if pending:
+        # Bounded by max_retries. The swap above is idempotent, so a re-run
+        # that finds nothing left to rewrite still reaches the expiry below.
+        raise self.retry(countdown=60)
+
+    with get_session_with_current_tenant() as db_session:
+        expire_prior_emails(UUID(user_id), [old_email], db_session)
+
+    task_logger.info(
+        f"repair_user_email_acls_task: docs={len(document_ids)} tenant={tenant_id}"
+    )
+    return len(document_ids)

--- a/backend/onyx/configs/constants.py
+++ b/backend/onyx/configs/constants.py
@@ -650,6 +650,7 @@ class OnyxCeleryTask:
     CONNECTOR_HIERARCHY_FETCHING_TASK = "connector_hierarchy_fetching_task"
     DOCUMENT_BY_CC_PAIR_CLEANUP_TASK = "document_by_cc_pair_cleanup_task"
     DOCUMENT_INDEX_METADATA_SYNC_TASK = "document_index_metadata_sync_task"
+    REPAIR_USER_EMAIL_ACLS_TASK = "repair_user_email_acls_task"
 
     # chat retention
     CHECK_TTL_MANAGEMENT_TASK = "check_ttl_management_task"

--- a/backend/onyx/db/document.py
+++ b/backend/onyx/db/document.py
@@ -43,6 +43,7 @@ from onyx.db.models import (
     ConnectorCredentialPair,
     Credential,
     DocumentByConnectorCredentialPair,
+    HierarchyNode,
     KGEntity,
     KGRelationship,
     User,
@@ -1028,6 +1029,61 @@ def backfill_docs_created_at__no_commit(
             continue
         document.doc_created_at = new_created_at
         document.last_modified = now
+
+
+def swap_document_acl_email(
+    old_email: str, new_email: str, db_session: Session
+) -> list[str]:
+    """Rewrite `old_email` to `new_email` in the ACLs carrying it.
+
+    Covers `HierarchyNode` as well as `Document`: both hold the same external
+    permission fields. Returns the touched document ids, bumped so the metadata
+    sync sweep picks them up. Re-running is a no-op once nothing matches.
+
+    Unindexed ACL column, so this is one pass over each table per rename.
+    """
+    now = datetime.now(timezone.utc)
+
+    def _swap(emails: list[str] | None) -> list[str]:
+        return [new_email if email == old_email else email for email in emails or []]
+
+    nodes = (
+        db_session.query(HierarchyNode)
+        .filter(HierarchyNode.external_user_emails.contains([old_email]))
+        .all()
+    )
+    for node in nodes:
+        node.external_user_emails = _swap(node.external_user_emails)
+
+    documents = (
+        db_session.query(DbDocument)
+        .filter(DbDocument.external_user_emails.contains([old_email]))
+        .all()
+    )
+    for document in documents:
+        document.external_user_emails = _swap(document.external_user_emails)
+        document.last_modified = now
+
+    db_session.commit()
+    return [document.id for document in documents]
+
+
+def documents_pending_sync(document_ids: list[str], db_session: Session) -> bool:
+    """Whether any of these documents still owe the index an update."""
+    if not document_ids:
+        return False
+
+    return db_session.query(
+        db_session.query(DbDocument)
+        .filter(
+            DbDocument.id.in_(document_ids),
+            or_(
+                DbDocument.last_modified > DbDocument.last_synced,
+                DbDocument.last_synced.is_(None),
+            ),
+        )
+        .exists()
+    ).scalar()
 
 
 def update_docs_last_modified__no_commit(

--- a/backend/onyx/db/models.py
+++ b/backend/onyx/db/models.py
@@ -338,6 +338,14 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         Boolean, nullable=True, default=None
     )
 
+    # Addresses this user previously authenticated under. Indexed documents keep
+    # whichever address permission sync last wrote, so an entry bridges access
+    # until the ACL rewrite lands. Every entry is a live grant, dropped via
+    # `expire_prior_emails`.
+    prior_emails: Mapped[list[str]] = mapped_column(
+        postgresql.ARRAY(String), nullable=False, default=list, server_default="{}"
+    )
+
     """
     Preferences probably should be in a separate table at some point, but for now
     putting here for simpicity
@@ -5371,6 +5379,12 @@ class UserTenantMapping(PublicBase):
     email: Mapped[str] = mapped_column(String, nullable=False, primary_key=True)
     tenant_id: Mapped[str] = mapped_column(String, nullable=False, primary_key=True)
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+
+    # Copy of this user's `OAuthAccount` subject, which survives an email change
+    # at the provider. Null whenever it isn't known, so resolution must still
+    # fall back to email. Widths mirror the source columns.
+    oauth_name: Mapped[str | None] = mapped_column(String(length=100), nullable=True)
+    account_id: Mapped[str | None] = mapped_column(String(length=320), nullable=True)
 
     @validates("email")
     def validate_email(self, key: str, value: str) -> str:  # noqa: ARG002

--- a/backend/onyx/db/users.py
+++ b/backend/onyx/db/users.py
@@ -337,6 +337,66 @@ def get_user_by_email(email: str, db_session: Session) -> User | None:
     return user
 
 
+def get_user_by_oauth_account(
+    oauth_name: str, account_id: str, db_session: Session
+) -> User | None:
+    """Find a user by the IdP subject their account is linked to.
+
+    Survives a rename at the provider, unlike the email lookup.
+    """
+    return (
+        db_session.query(User)
+        .join(
+            OAuthAccount,
+            OAuthAccount.user_id == User.id,  # ty: ignore[invalid-argument-type]
+        )
+        .filter(
+            OAuthAccount.oauth_name == oauth_name,  # ty: ignore[invalid-argument-type]
+            OAuthAccount.account_id == account_id,  # ty: ignore[invalid-argument-type]
+        )
+        .first()
+    )
+
+
+def build_email_reconcile_update(user: User, new_email: str) -> dict[str, Any] | None:
+    """Fields that move `user` onto `new_email`, or None when they already match
+    case-insensitively.
+
+    The replaced address is kept in `prior_emails` because indexed document ACLs
+    still match on it.
+    """
+    if user.email.lower() == new_email.lower():
+        return None
+
+    prior_emails = user.prior_emails
+    if user.email not in prior_emails:
+        # Rebuilt rather than appended: ARRAY columns are not mutation-tracked,
+        # so an in-place append would never be persisted.
+        prior_emails = [*prior_emails, user.email]
+
+    return {"email": new_email, "prior_emails": prior_emails}
+
+
+def expire_prior_emails(
+    user_id: UUID, expired_emails: list[str], db_session: Session
+) -> None:
+    """Drop addresses whose document ACLs have been rewritten.
+
+    Each entry is a live grant, so an address must only be expired once nothing
+    in the index still matches on it.
+    """
+    user = fetch_user_by_id(db_session, user_id)
+    if user is None:
+        return
+
+    remaining = [email for email in user.prior_emails if email not in expired_emails]
+    if remaining == user.prior_emails:
+        return
+
+    user.prior_emails = remaining
+    db_session.commit()
+
+
 def fetch_user_by_id(db_session: Session, user_id: UUID) -> User | None:
     return (
         db_session.query(User)

--- a/backend/scripts/backfill_user_tenant_mapping_oauth.py
+++ b/backend/scripts/backfill_user_tenant_mapping_oauth.py
@@ -1,0 +1,151 @@
+"""Populate `oauth_name` / `account_id` on `public.user_tenant_mapping`.
+
+Reads each tenant's `oauth_account` table and copies the IdP subject onto that
+user's mapping row, so tenant resolution can key on a stable identity instead of
+the email string.
+
+Only fills rows whose `oauth_name` is still NULL, so it is safe to re-run and
+will not overwrite values written by a live login.
+
+Usage (kubernetes):
+    kubectl exec -it <pod> -- \
+        python -m scripts.backfill_user_tenant_mapping_oauth --all-tenants --dry-run
+"""
+
+import argparse
+import os
+import sys
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(parent_dir)
+
+from sqlalchemy import select  # noqa: E402
+
+from onyx.db.engine.sql_engine import (  # noqa: E402
+    SqlEngine,
+    get_session_with_shared_schema,
+    get_session_with_tenant,
+)
+from onyx.db.models import User, UserTenantMapping  # noqa: E402
+from onyx.utils.variable_functionality import global_version  # noqa: E402
+
+
+def _tenant_ids_from_mapping() -> list[str]:
+    """Every tenant with at least one mapping row, including those on
+    non-default shards."""
+    with get_session_with_shared_schema() as db_session:
+        rows = db_session.execute(select(UserTenantMapping.tenant_id).distinct()).all()
+    return sorted(tenant_id for (tenant_id,) in rows)
+
+
+def _oauth_identities(tenant_id: str) -> dict[str, tuple[str, str]]:
+    """email -> (oauth_name, account_id) for users with exactly one OAuth account.
+
+    Users with several linked providers are skipped: the mapping row holds one
+    identity, and picking between them is a judgment call this sweep shouldn't make.
+    """
+    by_email: dict[str, tuple[str, str]] = {}
+    with get_session_with_tenant(tenant_id=tenant_id) as db_session:
+        users = (
+            db_session.execute(select(User).where(User.oauth_accounts.any()))
+            .scalars()
+            .unique()
+            .all()
+        )
+
+        for user in users:
+            accounts = user.oauth_accounts
+            if len(accounts) > 1:
+                print(f"    skipping {user.email}: multiple linked OAuth accounts")
+                continue
+            if not accounts:
+                continue
+            by_email[user.email] = (accounts[0].oauth_name, accounts[0].account_id)
+
+    return by_email
+
+
+def _run_for_tenant(tenant_id: str, dry_run: bool) -> int:
+    identities = _oauth_identities(tenant_id)
+    if not identities:
+        return 0
+
+    updated = 0
+    with get_session_with_shared_schema() as db_session:
+        mappings = (
+            db_session.execute(
+                select(UserTenantMapping).where(
+                    UserTenantMapping.tenant_id == tenant_id,
+                    UserTenantMapping.oauth_name.is_(None),
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        for mapping in mappings:
+            identity = identities.get(mapping.email)
+            if identity is None:
+                continue
+
+            if dry_run:
+                print(f"    would set {mapping.email} -> {identity}")
+            else:
+                mapping.oauth_name, mapping.account_id = identity
+            updated += 1
+
+        if not dry_run:
+            db_session.commit()
+
+    return updated
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tenant-id", help="Backfill a single tenant.")
+    parser.add_argument(
+        "--all-tenants", action="store_true", help="Backfill every tenant."
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Report changes without writing."
+    )
+    args = parser.parse_args()
+
+    if not args.tenant_id and not args.all_tenants:
+        parser.error("pass --tenant-id or --all-tenants")
+
+    global_version.set_ee()
+    SqlEngine.init_engine(pool_size=5, max_overflow=2)
+
+    if args.dry_run:
+        print("DRY RUN - no changes will be made")
+
+    tenant_ids = [args.tenant_id] if args.tenant_id else _tenant_ids_from_mapping()
+    if not tenant_ids:
+        print("No mapping rows found - nothing to backfill")
+        return
+
+    print(f"Found {len(tenant_ids)} tenant(s)")
+
+    total = 0
+    failed: list[str] = []
+    for tenant_id in tenant_ids:
+        try:
+            count = _run_for_tenant(tenant_id, dry_run=args.dry_run)
+        except Exception as e:
+            print(f"  ERROR for tenant {tenant_id}: {e}")
+            failed.append(tenant_id)
+            continue
+
+        if count:
+            print(f"  {tenant_id}: {count} row(s)")
+        total += count
+
+    print(f"Backfilled {total} mapping row(s)")
+    if failed:
+        print(f"FAILED tenants ({len(failed)}): {failed}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_record_oauth_identity.py
@@ -1,0 +1,42 @@
+"""Guards that `record_oauth_identity` only touches the mapping table on cloud.
+
+`public.user_tenant_mapping` is created by the `alembic_tenants` tree, which only
+multi-tenant deployments run. Opening a session against it anywhere else would
+raise on every OAuth login, so the `MULTI_TENANT` guard is load-bearing rather
+than an optimization.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from ee.onyx.server.tenants.user_mapping import record_oauth_identity
+
+_MAPPING_MODULE = "ee.onyx.server.tenants.user_mapping"
+
+
+def _run(*, multi_tenant: bool) -> MagicMock:
+    with (
+        patch(f"{_MAPPING_MODULE}.MULTI_TENANT", multi_tenant),
+        patch(f"{_MAPPING_MODULE}.get_session_with_shared_schema") as session_ctx,
+    ):
+        record_oauth_identity(
+            email="user@example.com",
+            tenant_id="tenant_abc",
+            oauth_name="google",
+            account_id="sub-123",
+        )
+    return session_ctx
+
+
+def test_single_tenant_opens_no_session() -> None:
+    assert _run(multi_tenant=False).call_count == 0
+
+
+def test_multi_tenant_updates_the_mapping_row() -> None:
+    session_ctx = _run(multi_tenant=True)
+    assert session_ctx.call_count == 1
+
+    db_session = session_ctx.return_value.__enter__.return_value
+    db_session.query.return_value.filter.return_value.update.assert_called_once_with(
+        {"oauth_name": "google", "account_id": "sub-123"}
+    )
+    db_session.commit.assert_called_once()

--- a/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
+++ b/backend/tests/unit/ee/onyx/server/tenants/test_tenant_resolution_by_oauth_account.py
@@ -1,0 +1,95 @@
+"""Guards the resolution order that keeps a renamed user out of a fresh tenant.
+
+`resolve_tenant_id` must consult the IdP subject before the email, because the
+subject is the only identifier that survives an address change at the provider.
+If the order inverts, a renamed user resolves nowhere and `get_or_provision_tenant`
+hands them a newly provisioned empty workspace instead of the one they belong to.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi_users import exceptions
+
+from ee.onyx.server.tenants.provisioning import get_or_provision_tenant
+from ee.onyx.server.tenants.user_mapping import resolve_tenant_id
+
+_MAPPING_MODULE = "ee.onyx.server.tenants.user_mapping"
+_PROVISIONING_MODULE = "ee.onyx.server.tenants.provisioning"
+
+
+def test_subject_wins_over_a_stale_email() -> None:
+    """The renamed-user case: the address maps nowhere but the subject still does."""
+    by_email = MagicMock(side_effect=exceptions.UserNotExists())
+    with (
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account",
+            return_value="tenant_existing",
+        ),
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_email", by_email),
+    ):
+        tenant_id = resolve_tenant_id("new-address@example.com", "google", "sub-123")
+
+    assert tenant_id == "tenant_existing"
+    by_email.assert_not_called()
+
+
+def test_falls_back_to_email_when_subject_is_unstamped() -> None:
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            return_value="tenant_from_email",
+        ),
+    ):
+        tenant_id = resolve_tenant_id("user@example.com", "google", "sub-123")
+
+    assert tenant_id == "tenant_from_email"
+
+
+def test_password_login_skips_the_subject_lookup() -> None:
+    by_subject = MagicMock()
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", by_subject),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            return_value="tenant_from_email",
+        ),
+    ):
+        tenant_id = resolve_tenant_id("user@example.com")
+
+    assert tenant_id == "tenant_from_email"
+    by_subject.assert_not_called()
+
+
+def test_returns_none_when_nothing_maps() -> None:
+    with (
+        patch(f"{_MAPPING_MODULE}.get_tenant_id_for_oauth_account", return_value=None),
+        patch(
+            f"{_MAPPING_MODULE}.get_tenant_id_for_email",
+            side_effect=exceptions.UserNotExists(),
+        ),
+    ):
+        assert resolve_tenant_id("nobody@example.com", "google", "sub-123") is None
+
+
+@pytest.mark.asyncio
+async def test_provisioning_is_skipped_when_the_login_already_resolves() -> None:
+    """A resolved tenant must short-circuit before any pool or control-plane call."""
+    available = MagicMock()
+    with (
+        patch(f"{_PROVISIONING_MODULE}.MULTI_TENANT", True),
+        patch(
+            f"{_PROVISIONING_MODULE}.resolve_tenant_id",
+            return_value="tenant_existing",
+        ),
+        patch(f"{_PROVISIONING_MODULE}.get_available_tenant", available),
+    ):
+        tenant_id = await get_or_provision_tenant(
+            email="new-address@example.com",
+            oauth_name="google",
+            account_id="sub-123",
+        )
+
+    assert tenant_id == "tenant_existing"
+    available.assert_not_called()

--- a/backend/tests/unit/onyx/access/test_acl_prior_emails.py
+++ b/backend/tests/unit/onyx/access/test_acl_prior_emails.py
@@ -1,0 +1,61 @@
+"""Guards the bridge that keeps access alive across an email change.
+
+Query-time ACLs match on the email string, but indexed documents keep whichever
+address permission sync last wrote. Including prior addresses in the user's ACL
+set is what stops a renamed user losing every externally permissioned document
+between the rename and the ACL rewrite. Each entry is a live grant, so the set
+must also shrink back once the rewrite lands.
+"""
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+from onyx.access.access import _get_acl_for_user
+from onyx.access.utils import prefix_user_email
+from onyx.configs.constants import PUBLIC_DOC_PAT
+from onyx.db.models import User
+
+
+def _user(email: str, prior_emails: list[str], is_anonymous: bool = False) -> User:
+    return cast(
+        User,
+        SimpleNamespace(
+            email=email, prior_emails=prior_emails, is_anonymous=is_anonymous
+        ),
+    )
+
+
+def _acl(user: User) -> set[str]:
+    return _get_acl_for_user(user, cast(Any, None))
+
+
+def test_current_email_alone_when_there_are_no_prior_addresses() -> None:
+    assert _acl(_user("now@example.com", [])) == {
+        prefix_user_email("now@example.com"),
+        PUBLIC_DOC_PAT,
+    }
+
+
+def test_prior_address_still_grants_access() -> None:
+    acl = _acl(_user("now@example.com", ["before@example.com"]))
+
+    # The indexed documents still carry the old address, so it has to match.
+    assert prefix_user_email("before@example.com") in acl
+    assert prefix_user_email("now@example.com") in acl
+
+
+def test_every_prior_address_is_included() -> None:
+    acl = _acl(_user("c@example.com", ["a@example.com", "b@example.com"]))
+
+    assert acl == {
+        prefix_user_email("c@example.com"),
+        prefix_user_email("a@example.com"),
+        prefix_user_email("b@example.com"),
+        PUBLIC_DOC_PAT,
+    }
+
+
+def test_anonymous_users_get_nothing_but_public() -> None:
+    acl = _acl(_user("now@example.com", ["before@example.com"], is_anonymous=True))
+
+    assert acl == {PUBLIC_DOC_PAT}

--- a/backend/tests/unit/onyx/db/test_email_reconcile.py
+++ b/backend/tests/unit/onyx/db/test_email_reconcile.py
@@ -1,0 +1,66 @@
+"""Guards how a user is moved onto a new address after an IdP rename.
+
+The replaced address must survive in `prior_emails`, because it is what indexed
+document ACLs still match on. Losing it here revokes access instead of bridging
+it.
+"""
+
+from types import SimpleNamespace
+from typing import cast
+
+from onyx.db.models import User
+from onyx.db.users import build_email_reconcile_update
+
+
+def _user(email: str, prior_emails: list[str] | None = None) -> User:
+    return cast(User, SimpleNamespace(email=email, prior_emails=prior_emails or []))
+
+
+def test_no_update_when_the_address_is_unchanged() -> None:
+    assert (
+        build_email_reconcile_update(_user("same@example.com"), "same@example.com")
+        is None
+    )
+
+
+def test_case_only_difference_is_not_a_change() -> None:
+    assert (
+        build_email_reconcile_update(_user("User@example.com"), "user@example.com")
+        is None
+    )
+
+
+def test_replaced_address_is_retained() -> None:
+    update = build_email_reconcile_update(_user("old@example.com"), "new@example.com")
+
+    assert update == {
+        "email": "new@example.com",
+        "prior_emails": ["old@example.com"],
+    }
+
+
+def test_earlier_addresses_are_kept_alongside() -> None:
+    update = build_email_reconcile_update(
+        _user("second@example.com", ["first@example.com"]), "third@example.com"
+    )
+
+    assert update is not None
+    assert update["prior_emails"] == ["first@example.com", "second@example.com"]
+
+
+def test_a_readopted_address_is_not_duplicated() -> None:
+    update = build_email_reconcile_update(
+        _user("b@example.com", ["b@example.com"]), "c@example.com"
+    )
+
+    assert update is not None
+    assert update["prior_emails"] == ["b@example.com"]
+
+
+def test_prior_emails_list_is_rebuilt_not_mutated() -> None:
+    original: list[str] = []
+    user = _user("old@example.com", original)
+
+    build_email_reconcile_update(user, "new@example.com")
+
+    assert original == []


### PR DESCRIPTION
## Description

Fixes #13553.

**Bug:** when an IdP renames a user, Cloud provisions them an empty tenant instead of returning their workspace, and on every deployment they silently lose externally permissioned documents.

**Why:** tenant lookup keys on the email string (`get_or_provision_tenant`), so a changed address resolves nowhere and looks like a signup. `User.email` was also never updated, so forgot-password missed, invite-only workspaces rejected an existing member, and permission sync eventually rewrote document ACLs under the new address while the user still matched the old one.

**Fix:**
- Carry the IdP subject on `user_tenant_mapping` and resolve on it before the email. Falls back to email for password logins and unstamped rows.
- Adopt the provider's address on login, keeping the replaced one in `User.prior_emails` so query-time ACLs match both while a task rewrites `Document` and `HierarchyNode` ACLs. The bridge expires only once nothing is pending sync, since each entry is a live grant.
- Treat a linked OAuth account as proof of membership in the invite-only check.
- Backfill script for existing rows (`--dry-run` supported).

Reconcile and ACL bridge are unconditional. Only the two mapping writes are `MULTI_TENANT`-gated.

**Known window:** if the old address is reassigned to someone else before the rewrite drains, the renamed user keeps access to those documents. Bounded by sync drain.

## How Has This Been Tested?

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check
