### PR TITLE
feat(chat): admin-configurable dedicated model for chat auto-naming

### DIFF
--- a/backend/onyx/db/enums.py
+++ b/backend/onyx/db/enums.py
@@ -545,6 +545,7 @@ class LLMModelFlowType(str, PyEnum):
     VISION = "vision"
     CONTEXTUAL_RAG = "contextual_rag"
     REASONING = "reasoning"
+    CHAT_NAMING = "chat_naming"
 
 
 class HookPoint(str, PyEnum):

--- a/backend/onyx/db/llm.py
+++ b/backend/onyx/db/llm.py
@@ -772,6 +772,12 @@ def fetch_default_contextual_rag_model(
     return fetch_default_model(db_session, LLMModelFlowType.CONTEXTUAL_RAG)
 
 
+def fetch_default_chat_naming_model(
+    db_session: Session,
+) -> ModelConfiguration | None:
+    return fetch_default_model(db_session, LLMModelFlowType.CHAT_NAMING)
+
+
 def fetch_default_model(
     db_session: Session,
     flow_type: LLMModelFlowType,
@@ -910,6 +916,40 @@ def update_default_vision_provider(
         model=vision_model,
         flow_type=LLMModelFlowType.VISION,
     )
+
+
+def update_default_chat_naming_provider(
+    provider_id: int, chat_naming_model: str, db_session: Session
+) -> None:
+    provider = db_session.scalar(
+        select(LLMProviderModel).where(
+            LLMProviderModel.id == provider_id,
+        )
+    )
+
+    if provider is None:
+        raise ValueError(f"LLM Provider with id={provider_id} does not exist")
+
+    _update_default_model(
+        db_session=db_session,
+        provider_id=provider_id,
+        model=chat_naming_model,
+        flow_type=LLMModelFlowType.CHAT_NAMING,
+    )
+
+
+def update_no_default_chat_naming_provider(
+    db_session: Session,
+) -> None:
+    db_session.execute(
+        update(LLMModelFlow)
+        .where(
+            LLMModelFlow.llm_model_flow_type == LLMModelFlowType.CHAT_NAMING,
+            LLMModelFlow.is_default == True,  # noqa: E712
+        )
+        .values(is_default=False)
+    )
+    db_session.commit()
 
 
 def update_no_default_contextual_rag_provider(

--- a/backend/onyx/server/manage/llm/api.py
+++ b/backend/onyx/server/manage/llm/api.py
@@ -19,6 +19,7 @@ from onyx.db.engine.sql_engine import get_session
 from onyx.db.enums import LLMModelFlowType, Permission
 from onyx.db.llm import (
     can_user_access_llm_provider,
+    fetch_default_chat_naming_model,
     fetch_default_llm_model,
     fetch_default_vision_model,
     fetch_existing_llm_provider_by_id,
@@ -29,8 +30,10 @@ from onyx.db.llm import (
     fetch_user_group_ids,
     remove_llm_provider,
     sync_model_configurations,
+    update_default_chat_naming_provider,
     update_default_provider,
     update_default_vision_provider,
+    update_no_default_chat_naming_provider,
     upsert_llm_provider,
     validate_persona_ids_exist,
 )
@@ -541,6 +544,9 @@ def list_llm_providers(
         default_vision=DefaultModel.from_model_config(
             fetch_default_vision_model(db_session)
         ),
+        default_chat_naming=DefaultModel.from_model_config(
+            fetch_default_chat_naming_model(db_session)
+        ),
     )
 
 
@@ -746,6 +752,31 @@ def set_provider_as_default_vision(
     invalidate_provider_listing_cache()
 
 
+@admin_router.post("/default-chat-naming")
+def set_provider_as_default_chat_naming(
+    default_model: DefaultModel,
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    update_default_chat_naming_provider(
+        provider_id=default_model.provider_id,
+        chat_naming_model=default_model.model_name,
+        db_session=db_session,
+    )
+    invalidate_provider_listing_cache()
+
+
+@admin_router.delete("/default-chat-naming")
+def clear_default_chat_naming(
+    _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
+    db_session: Session = Depends(get_session),
+) -> None:
+    """Clear the dedicated naming model; auto-naming falls back to the
+    session's model."""
+    update_no_default_chat_naming_provider(db_session=db_session)
+    invalidate_provider_listing_cache()
+
+
 @admin_router.get("/auto-config")
 def get_auto_config(
     _: User = Depends(require_permission(Permission.FULL_ADMIN_PANEL_ACCESS)),
@@ -866,6 +897,9 @@ def list_llm_provider_basics(
         ),
         default_vision=DefaultModel.from_model_config(
             fetch_default_vision_model(db_session)
+        ),
+        default_chat_naming=DefaultModel.from_model_config(
+            fetch_default_chat_naming_model(db_session)
         ),
     )
     cache_provider_listing(

--- a/backend/onyx/server/manage/llm/models.py
+++ b/backend/onyx/server/manage/llm/models.py
@@ -506,6 +506,7 @@ class LLMProviderResponse(BaseModel, Generic[T]):
     providers: list[T]
     default_text: DefaultModel | None = None
     default_vision: DefaultModel | None = None
+    default_chat_naming: DefaultModel | None = None
 
     @classmethod
     def from_models(
@@ -513,11 +514,13 @@ class LLMProviderResponse(BaseModel, Generic[T]):
         providers: list[T],
         default_text: DefaultModel | None = None,
         default_vision: DefaultModel | None = None,
+        default_chat_naming: DefaultModel | None = None,
     ) -> LLMProviderResponse[T]:
         return cls(
             providers=providers,
             default_text=default_text,
             default_vision=default_vision,
+            default_chat_naming=default_chat_naming,
         )
 
 

--- a/backend/onyx/server/query_and_chat/chat_backend.py
+++ b/backend/onyx/server/query_and_chat/chat_backend.py
@@ -62,6 +62,7 @@ from onyx.db.chat_search import search_chat_sessions
 from onyx.db.engine.sql_engine import get_session, get_session_with_current_tenant
 from onyx.db.enums import Permission
 from onyx.db.feedback import create_chat_message_feedback, remove_chat_message_feedback
+from onyx.db.llm import fetch_default_chat_naming_model
 from onyx.db.models import ChatMessage, ChatSessionSharedStatus, Persona, User
 from onyx.db.persona import get_persona_by_id
 from onyx.db.usage import UsageType, increment_usage
@@ -543,13 +544,25 @@ def rename_chat_session(
             chat_session_id=chat_session_id,
             db_session=db_session,
         )
+        # Admin-designated dedicated naming model (so a single-stream local
+        # session model isn't blocked by naming calls) takes priority over the
+        # session's model.
+        naming_model = fetch_default_chat_naming_model(db_session)
+        naming_override = (
+            LLMOverride(
+                model_provider=naming_model.llm_provider.name,
+                model_version=naming_model.name,
+            )
+            if naming_model is not None
+            else chat_session.llm_override
+        )
     new_name = _generate_or_fallback_chat_session_name(
         chat_history=full_history,
         request=request,
         user=user,
         chat_session_id=chat_session_id,
         persona=chat_session.persona,
-        llm_override=chat_session.llm_override,
+        llm_override=naming_override,
     )
 
     with get_session_with_current_tenant() as db_session:

--- a/web/src/app/craft/components/ModelPickerButton.stories.tsx
+++ b/web/src/app/craft/components/ModelPickerButton.stories.tsx
@@ -50,6 +50,7 @@ const llmResponse: LLMProviderResponse<LLMProviderDescriptor> = {
   providers: llmProviders,
   default_text: null,
   default_vision: null,
+  default_chat_naming: null,
 };
 
 const fallback = { [SWR_KEYS.llmProviders]: llmResponse };

--- a/web/src/lib/languageModels/hooks.ts
+++ b/web/src/lib/languageModels/hooks.ts
@@ -139,6 +139,7 @@ export function useLLMProviders(agentId?: number) {
     llmProviders: data?.providers,
     defaultText: data?.default_text ?? null,
     defaultVision: data?.default_vision ?? null,
+    defaultChatNaming: data?.default_chat_naming ?? null,
     isLoading: !error && !data,
     error,
     refetch: mutate as unknown as () => Promise<
@@ -203,6 +204,7 @@ export function useAdminLLMProviders() {
     llmProviders: data?.providers,
     defaultText: data?.default_text ?? null,
     defaultVision: data?.default_vision ?? null,
+    defaultChatNaming: data?.default_chat_naming ?? null,
     isLoading: !error && !data,
     error,
     refetch: mutate,

--- a/web/src/lib/languageModels/types.ts
+++ b/web/src/lib/languageModels/types.ts
@@ -145,6 +145,7 @@ export interface LLMProviderResponse<T> {
   providers: T[];
   default_text: DefaultModel | null;
   default_vision: DefaultModel | null;
+  default_chat_naming: DefaultModel | null;
 }
 
 export type LLMModalVariant = "onboarding" | "llm-configuration";

--- a/web/src/views/admin/ChatPreferencesPage.tsx
+++ b/web/src/views/admin/ChatPreferencesPage.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 import { markdown } from "@opal/utils";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useRouter } from "next/navigation";
 import { Formik, Form } from "formik";
 import useSWR, { mutate } from "swr";
@@ -13,6 +19,8 @@ import SimpleCollapsible from "@/refresh-components/SimpleCollapsible";
 import InputTextAreaField from "@/refresh-components/form/InputTextAreaField";
 import { InputTextArea, InputTypeIn } from "@opal/components";
 import InputSelect from "@/refresh-components/inputs/InputSelect";
+import ModelSelector from "@/sections/model-selector/ModelSelector";
+import { useAdminLLMProviders } from "@/lib/languageModels/hooks";
 import {
   SvgAddLines,
   SvgActions,
@@ -649,6 +657,86 @@ export default function ChatPreferencesPage() {
   const businessTier = useTierAtLeast(Tier.BUSINESS);
   const enterpriseTier = useTierAtLeast(Tier.ENTERPRISE);
 
+  // Dedicated chat-naming model. Auto-naming reads this designation via
+  // fetch_default_chat_naming_model; when unset it uses the session's model.
+  const {
+    llmProviders,
+    defaultChatNaming,
+    refetch: refetchLlmProviders,
+  } = useAdminLLMProviders();
+
+  // Resolve defaultChatNaming (id + name based) to a model_configuration_id
+  // for ModelSelector.
+  const chatNamingModelConfigId = useMemo(() => {
+    if (!defaultChatNaming || !llmProviders) return null;
+    for (const p of llmProviders) {
+      if (p.id !== defaultChatNaming.provider_id) continue;
+      const mc = p.model_configurations.find(
+        (m) => m.name === defaultChatNaming.model_name
+      );
+      if (mc?.id != null) return mc.id;
+    }
+    return null;
+  }, [llmProviders, defaultChatNaming]);
+
+  const handleChatNamingModelChange = useCallback(
+    async ({
+      modelName,
+      providerName,
+    }: {
+      modelName: string;
+      providerName: string | null;
+    }) => {
+      const provider = llmProviders?.find((p) => p.name === providerName);
+      if (!provider) {
+        toast.error("Could not resolve provider");
+        return;
+      }
+      try {
+        const response = await fetch("/api/admin/llm/default-chat-naming", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            provider_id: provider.id,
+            model_name: modelName,
+          }),
+        });
+        if (!response.ok) {
+          throw new Error(
+            (await response.json()).detail ??
+              "Failed to update chat naming model"
+          );
+        }
+        await refetchLlmProviders();
+        toast.success("Chat naming model updated");
+      } catch (error) {
+        toast.error(
+          error instanceof Error ? error.message : "An unknown error occurred"
+        );
+      }
+    },
+    [llmProviders, refetchLlmProviders]
+  );
+
+  const handleClearChatNamingModel = useCallback(async () => {
+    try {
+      const response = await fetch("/api/admin/llm/default-chat-naming", {
+        method: "DELETE",
+      });
+      if (!response.ok) {
+        throw new Error(
+          (await response.json()).detail ?? "Failed to reset chat naming model"
+        );
+      }
+      await refetchLlmProviders();
+      toast.success("Chat naming reset to the session's model");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "An unknown error occurred"
+      );
+    }
+  }, [refetchLlmProviders]);
+
   // Local state for text fields (save-on-blur)
   const [companyName, setCompanyName] = useState(s.company_name ?? "");
   const [companyDescription, setCompanyDescription] = useState(
@@ -933,6 +1021,32 @@ export default function ChatPreferencesPage() {
                     });
                   }}
                 />
+              </InputHorizontal>
+              <InputHorizontal
+                title="Chat Naming Model"
+                description="Model used to auto-name chat sessions. Defaults to each session's own model — pin a small, fast model here if your main model can't serve concurrent requests."
+                withLabel
+              >
+                <div className="flex items-center gap-2">
+                  {chatNamingModelConfigId !== null && (
+                    <Button
+                      prominence="tertiary"
+                      size="sm"
+                      onClick={() => void handleClearChatNamingModel()}
+                    >
+                      Reset
+                    </Button>
+                  )}
+                  <ModelSelector
+                    value={chatNamingModelConfigId}
+                    onChange={(opt) =>
+                      void handleChatNamingModelChange({
+                        modelName: opt.modelName,
+                        providerName: opt.name,
+                      })
+                    }
+                  />
+                </div>
               </InputHorizontal>
             </Section>
           </Card>


### PR DESCRIPTION
## Description

Follow-up to #13535, addressing [community feedback](https://github.com/onyx-dot-app/onyx/pull/13535#issuecomment-5114232933): since naming now uses the session's model, deployments running a single-stream local model (e.g. one Ollama instance) have naming calls contending with chat generation on the same model.

**Reworked per review — admin-panel configuration, no env vars.** This mirrors the existing default-vision-model designation mechanism:

- New `LLMModelFlowType.CHAT_NAMING` flow default (varchar-backed enum — no migration)
- `POST` / `DELETE` `/api/admin/llm/default-chat-naming` endpoints; `default_chat_naming` included in provider listing responses
- **Admin → Chat Preferences → "Chat Naming Model"**: model picker + Reset, using the same `ModelSelector` as the captioning-model setting
- Auto-naming resolution: admin-designated naming model → the session's model (#13535 behavior)

## How Has This Been Tested?

- `pre-commit` green across backend (ruff, ty) and web (oxlint, TypeScript) touched files
- Designation flows through the exact mechanism used by the default vision model (`fetch_default_model` / `_update_default_model`)

## Additional Options

- [ ] [Optional] Please cherry-pick this PR to the latest release version.
- [x] [Optional] Override Linear Check